### PR TITLE
fix(monitor): "All Values" over time fired on a single check (#2321)

### DIFF
--- a/App/FeatureSet/APIReference/Service/DataTypeDetail.ts
+++ b/App/FeatureSet/APIReference/Service/DataTypeDetail.ts
@@ -2014,7 +2014,7 @@ const dataTypeDetails: Dictionary<DataTypePageData> = {
         type: "object",
         required: false,
         description:
-          "Configuration for time-based evaluation. Contains 'timeValueInMinutes' (number of minutes to evaluate) and 'evaluateOverTimeType' (aggregation: 'Average', 'Sum', 'Maximum Value', 'Minimum Value', 'All Values', 'Any Value').",
+          "Configuration for time-based evaluation. Contains 'timeValueInMinutes' (number of minutes to evaluate), 'evaluateOverTimeType' (aggregation: 'Average', 'Sum', 'Maximum Value', 'Minimum Value', 'All Values', 'Any Value'), and 'onNoDataPolicy' ('Ignore' (default), 'Treat As Zero' or 'Trigger') which decides what happens while the window does not hold enough data to judge the filter. Note that 'All Values' only matches once the window is actually covered by data, so a monitor that has just been created waits for the window to fill instead of matching on its first check.",
       },
       {
         name: "serverMonitorOptions",
@@ -2125,6 +2125,19 @@ const dataTypeDetails: Dictionary<DataTypePageData> = {
           evaluateOverTimeOptions: {
             timeValueInMinutes: 5,
             evaluateOverTimeType: "Average",
+          },
+        },
+        "// Example 13: Require the whole window to breach":
+          "Only matches after 5 minutes of consecutive non-200 responses",
+        filter13: {
+          checkOn: "Response Status Code",
+          filterType: "Not Equal To",
+          value: 200,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: "All Values",
+            onNoDataPolicy: "Ignore",
           },
         },
       },

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
@@ -530,6 +530,65 @@ const CriteriaFilterElement: FunctionComponent<ComponentProps> = (
           <></>
         )}
 
+        {criteriaFilter?.checkOn &&
+        CriteriaFilterUtil.isEvaluateOverTimeFilter(criteriaFilter?.checkOn) &&
+        criteriaFilter.evaluateOverTime ? (
+          <div className="mt-1">
+            <FieldLabelElement
+              title="If No Data"
+              description={
+                "What should happen while the window does not have enough data yet — for example a monitor that has only just started, or one whose checks stopped being recorded?"
+              }
+            />
+            <Dropdown
+              value={(() => {
+                const policy: NoDataPolicy =
+                  criteriaFilter?.evaluateOverTimeOptions?.onNoDataPolicy ||
+                  NoDataPolicy.Ignore;
+                return { value: policy, label: policy };
+              })()}
+              options={[
+                {
+                  value: NoDataPolicy.Ignore,
+                  label: NoDataPolicy.Ignore,
+                },
+                {
+                  value: NoDataPolicy.TreatAsZero,
+                  label: NoDataPolicy.TreatAsZero,
+                },
+                {
+                  value: NoDataPolicy.Trigger,
+                  label: NoDataPolicy.Trigger,
+                },
+              ]}
+              onChange={(
+                value: DropdownValue | Array<DropdownValue> | null,
+              ) => {
+                const evaluateOverTimeOption: EvaluateOverTimeOptions =
+                  criteriaFilter?.evaluateOverTimeOptions
+                    ? {
+                        ...criteriaFilter?.evaluateOverTimeOptions,
+                      }
+                    : {
+                        timeValueInMinutes: 5,
+                        evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+                      };
+
+                props.onChange?.({
+                  ...criteriaFilter,
+                  evaluateOverTime: true,
+                  evaluateOverTimeOptions: {
+                    ...evaluateOverTimeOption,
+                    onNoDataPolicy: value?.toString() as NoDataPolicy,
+                  },
+                });
+              }}
+            />
+          </div>
+        ) : (
+          <></>
+        )}
+
         {!criteriaFilter?.checkOn ||
           (criteriaFilter?.checkOn && (
             <div className="mt-1">

--- a/App/FeatureSet/Docs/Content/en/monitor/api-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/api-monitor.md
@@ -116,3 +116,15 @@ You can configure criteria to determine when your API is considered online, degr
 - **Response Body** - Check if the response body contains or matches specific content
 - **Response Headers** - Verify specific response headers are present or match expected values
 - **JavaScript Expression** - Write custom expressions to evaluate the response. See [JavaScript Expressions](/docs/monitor/javascript-expression) for details.
+
+### Evaluating over a period of time
+
+**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare a window of past checks — the aggregate chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
+
+**All Values** only matches once the window is genuinely covered by data. A monitor that has just been created, or one whose checks stopped being recorded, does not have enough history to say anything about the last N minutes, so the criteria waits rather than matching on the one reading it does have. **Any Value** is the setting for "tell me the moment a single check breaches" and still fires immediately.
+
+**If No Data** controls what happens while the window cannot back the criteria:
+
+- **Ignore** (default) — the criteria does not match. Use this for ordinary threshold alerting.
+- **Trigger** — treat the missing data as the problem. Use this for heartbeat-style checks where silence is itself a failure.
+- **Treat As Zero** — compare the window as a single zero. Use this for counters where "no events" genuinely means zero.

--- a/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
@@ -55,6 +55,14 @@ For **Response Time**, **Packet Loss**, and **Jitter**:
 
 **Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
 
+**All Values** only matches once the window is genuinely covered by data. A monitor that has just been created, or one whose checks stopped being recorded, does not have enough history to say anything about the last N minutes, so the criteria waits rather than matching on the one reading it does have. **Any Value** is the setting for "tell me the moment a single check breaches" and still fires immediately.
+
+**If No Data** controls what happens while the window cannot back the criteria:
+
+- **Ignore** (default) — the criteria does not match. Use this for ordinary threshold alerting.
+- **Trigger** — treat the missing data as the problem. Use this for heartbeat-style checks where silence is itself a failure.
+- **Treat As Zero** — compare the window as a single zero. Use this for counters where "no events" genuinely means zero.
+
 ### Example Criteria
 
 #### Mark as offline if IP is unreachable

--- a/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
@@ -55,6 +55,14 @@ For **Response Time**, **Packet Loss**, and **Jitter**:
 
 **Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
 
+**All Values** only matches once the window is genuinely covered by data. A monitor that has just been created, or one whose checks stopped being recorded, does not have enough history to say anything about the last N minutes, so the criteria waits rather than matching on the one reading it does have. **Any Value** is the setting for "tell me the moment a single check breaches" and still fires immediately.
+
+**If No Data** controls what happens while the window cannot back the criteria:
+
+- **Ignore** (default) — the criteria does not match. Use this for ordinary threshold alerting.
+- **Trigger** — treat the missing data as the problem. Use this for heartbeat-style checks where silence is itself a failure.
+- **Treat As Zero** — compare the window as a single zero. Use this for counters where "no events" genuinely means zero.
+
 ### Example Criteria
 
 #### Mark as offline if host is unreachable

--- a/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
@@ -81,6 +81,14 @@ For **Total Connection Time (DNS + TCP)**, **Port DNS Lookup Time**, and **Port 
 
 **Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
 
+**All Values** only matches once the window is genuinely covered by data. A monitor that has just been created, or one whose checks stopped being recorded, does not have enough history to say anything about the last N minutes, so the criteria waits rather than matching on the one reading it does have. **Any Value** is the setting for "tell me the moment a single check breaches" and still fires immediately.
+
+**If No Data** controls what happens while the window cannot back the criteria:
+
+- **Ignore** (default) — the criteria does not match. Use this for ordinary threshold alerting.
+- **Trigger** — treat the missing data as the problem. Use this for heartbeat-style checks where silence is itself a failure.
+- **Treat As Zero** — compare the window as a single zero. Use this for counters where "no events" genuinely means zero.
+
 DNS lookup criteria have no value to evaluate when the target is already an IP address. Use the total or TCP connection time for criteria that must work with both hostnames and IP addresses.
 
 ### Example Criteria

--- a/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
@@ -141,6 +141,14 @@ For numeric metrics (CPU, memory, disk, swap, CPU IO wait, load average):
 
 **Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
 
+**All Values** only matches once the window is genuinely covered by data. A monitor that has just been created, or one whose checks stopped being recorded, does not have enough history to say anything about the last N minutes, so the criteria waits rather than matching on the one reading it does have. **Any Value** is the setting for "tell me the moment a single check breaches" and still fires immediately.
+
+**If No Data** controls what happens while the window cannot back the criteria:
+
+- **Ignore** (default) — the criteria does not match. Use this for ordinary threshold alerting.
+- **Trigger** — treat the missing data as the problem. Use this for heartbeat-style checks where silence is itself a failure.
+- **Treat As Zero** — compare the window as a single zero. Use this for counters where "no events" genuinely means zero.
+
 For process checks:
 
 - **Is Executing** — The process is currently running

--- a/App/FeatureSet/Docs/Content/en/monitor/website-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/website-monitor.md
@@ -93,3 +93,15 @@ You can configure criteria to determine when your website is considered online, 
 - **Response Time** - Monitor if response time exceeds a threshold
 - **Response Body** - Check if the response body contains or matches specific content
 - **Response Headers** - Verify specific response headers are present or match expected values
+
+### Evaluating over a period of time
+
+**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare a window of past checks — the aggregate chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
+
+**All Values** only matches once the window is genuinely covered by data. A monitor that has just been created, or one whose checks stopped being recorded, does not have enough history to say anything about the last N minutes, so the criteria waits rather than matching on the one reading it does have. **Any Value** is the setting for "tell me the moment a single check breaches" and still fires immediately.
+
+**If No Data** controls what happens while the window cannot back the criteria:
+
+- **Ignore** (default) — the criteria does not match. Use this for ordinary threshold alerting.
+- **Trigger** — treat the missing data as the problem. Use this for heartbeat-style checks where silence is itself a failure.
+- **Treat As Zero** — compare the window as a single zero. Use this for counters where "no events" genuinely means zero.

--- a/App/FeatureSet/Docs/Content/en/terraform/monitor-steps.md
+++ b/App/FeatureSet/Docs/Content/en/terraform/monitor-steps.md
@@ -227,6 +227,10 @@ criteria = [
 
 A filter has `check_on` (what to inspect), `filter_type` (the comparison), and `value` (the operand — a string; omit it for boolean comparisons like `True` / `False`). Filters that evaluate over a time window additionally take `evaluate_over_time = true`, `evaluate_over_time_minutes`, and `evaluate_over_time_type` (`Average`, `Sum`, `Maximum Value`, `Minimum Value`, `All Values`, `Any Value`).
 
+`All Values` means "every check in the window breached", so it only matches once the window is actually covered by data — a monitor that has just been created waits for the window to fill rather than matching on its first check. Give it a window at least twice the monitor's `monitoring_interval`, otherwise the window can only ever hold one sample and "all values" means the same thing as "any value". `Any Value` matches on a single breaching check by design.
+
+`evaluate_over_time_no_data_policy` decides what the filter does while the window cannot back it: `Ignore` (the default) does not match, `Trigger` treats the missing data as the failure (heartbeat semantics), and `Treat As Zero` compares the window as a single zero.
+
 Common `check_on` values by monitor type:
 
 | Monitor type | Typical `check_on` values |

--- a/Common/Server/Utils/CronTab.ts
+++ b/Common/Server/Utils/CronTab.ts
@@ -15,4 +15,77 @@ export default class CronTab {
       throw new BadDataException(`Invalid cron expression: ${crontab}`);
     }
   }
+
+  /**
+   * Longest gap (in seconds) between two consecutive runs of this cron.
+   *
+   * Used to reason about how much data an evaluation window can possibly
+   * contain: a monitor polled once every five minutes produces at most one
+   * sample per five minutes, so "all values over the last 5 minutes" can
+   * never be backed by more than one sample. Callers use this to decide
+   * whether a window is actually covered by data or is merely still
+   * filling up.
+   *
+   * The *longest* gap is deliberate. Irregular expressions (say
+   * `0,1,30 * * * *`) have both very short and very long gaps; taking the
+   * shortest would make callers demand data at a cadence the cron does not
+   * actually deliver, and they would wait forever.
+   *
+   * Returns null when the expression is missing or unparseable so callers
+   * can fall back to inferring the cadence from the data itself.
+   */
+  @CaptureSpan()
+  public static getIntervalInSeconds(
+    crontab: string | undefined | null,
+    referenceDate?: Date | undefined,
+  ): number | null {
+    if (!crontab) {
+      return null;
+    }
+
+    try {
+      const interval: CronExpression = CronParser.parseExpression(crontab, {
+        currentDate: referenceDate || new Date(),
+      });
+
+      /*
+       * Six executions -> five gaps. Enough to cover a full hour-wrap for
+       * every interval offered in the UI without walking the schedule far
+       * into the future.
+       */
+      const executionTimes: Array<Date> = [];
+
+      for (let i: number = 0; i < 6; i++) {
+        executionTimes.push(interval.next().toDate());
+      }
+
+      let longestGapInSeconds: number = 0;
+
+      for (let i: number = 1; i < executionTimes.length; i++) {
+        const gapInSeconds: number =
+          (executionTimes[i]!.getTime() - executionTimes[i - 1]!.getTime()) /
+          1000;
+
+        if (gapInSeconds > longestGapInSeconds) {
+          longestGapInSeconds = gapInSeconds;
+        }
+      }
+
+      if (longestGapInSeconds <= 0) {
+        return null;
+      }
+
+      return longestGapInSeconds;
+    } catch (error) {
+      /*
+       * Debug rather than error: this runs on the criteria-evaluation hot
+       * path, and monitors created before the interval was a cron (or
+       * through a Terraform example using the "Every 5 minutes" label) would
+       * otherwise log on every single check. Callers treat null as "cadence
+       * unknown" and fall back to inferring it from the data.
+       */
+      logger.debug(error);
+      return null;
+    }
+  }
 }

--- a/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
@@ -1,6 +1,6 @@
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import { JSONObject } from "../../../../Types/JSON";
 import {
   CheckOn,
@@ -10,50 +10,65 @@ import {
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import Typeof from "../../../../Types/Typeof";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class APIRequestCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        /*
+         * Only the disk-usage series carries a diskPath attribute, so
+         * scoping any other series by it would filter against an attribute
+         * no row has - and an empty window now means "cannot judge yet"
+         * rather than "compare the live value", which would silence the
+         * filter outright.
+         */
+        miscData:
+          input.criteriaFilter.checkOn === CheckOn.DiskUsagePercent
+            ? (input.criteriaFilter.serverMonitorOptions as JSONObject)
+            : undefined,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-          miscData: input.criteriaFilter.serverMonitorOptions as JSONObject,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -64,7 +79,7 @@ export default class APIRequestCriteria {
 
     if (input.criteriaFilter.checkOn === CheckOn.IsRequestTimeout) {
       const currentIsTimeout: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isTimeout;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -78,7 +93,7 @@ export default class APIRequestCriteria {
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const value: Array<number> | number =
-        (overTimeValue as Array<number>) ||
+        (overTimeValue as Array<number>) ??
         (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs!;
 
       return CompareCriteria.compareCriteriaNumbers({
@@ -124,7 +139,7 @@ export default class APIRequestCriteria {
       ).pingResponse?.packetLossPercent;
 
       const value: Array<number> | number | undefined =
-        (overTimeValue as Array<number>) || packetLossPercent;
+        (overTimeValue as Array<number>) ?? packetLossPercent;
 
       if (value === undefined) {
         return null;
@@ -146,7 +161,7 @@ export default class APIRequestCriteria {
       ).pingResponse?.jitterInMs;
 
       const value: Array<number> | number | undefined =
-        (overTimeValue as Array<number>) || jitterInMs;
+        (overTimeValue as Array<number>) ?? jitterInMs;
 
       if (value === undefined) {
         return null;
@@ -169,7 +184,7 @@ export default class APIRequestCriteria {
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const value: Array<number> | number =
-        (overTimeValue as Array<number>) ||
+        (overTimeValue as Array<number>) ??
         (input.dataToProcess as ProbeMonitorResponse).responseCode!;
 
       return CompareCriteria.compareCriteriaNumbers({

--- a/Common/Server/Utils/Monitor/Criteria/DnsMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DnsMonitorCriteria.ts
@@ -7,15 +7,21 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import DnsMonitorResponse from "../../../../Types/Monitor/DnsMonitor/DnsMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class DnsMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -26,37 +32,36 @@ export default class DnsMonitorCriteria {
     const dnsResponse: DnsMonitorResponse | undefined =
       dataToProcess.dnsResponse;
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     // Check if DNS is online
     if (input.criteriaFilter.checkOn === CheckOn.DnsIsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -74,9 +79,9 @@ export default class DnsMonitorCriteria {
       }
 
       const currentResponseTime: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        dnsResponse?.responseTimeInMs ||
-        (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs;
+        (overTimeValue as Array<number>) ??
+        (dnsResponse?.responseTimeInMs ||
+          (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs);
 
       if (currentResponseTime === null || currentResponseTime === undefined) {
         return null;

--- a/Common/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.ts
@@ -8,14 +8,20 @@ import {
 import DomainMonitorResponse from "../../../../Types/Monitor/DomainMonitor/DomainMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import EvaluateOverTime from "./EvaluateOverTime";
-import logger from "../../Logger";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 
 export default class DomainMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -26,32 +32,31 @@ export default class DomainMonitorCriteria {
     const domainResponse: DomainMonitorResponse | undefined =
       dataToProcess.domainResponse;
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: dataToProcess.projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: dataToProcess.projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     /*
      * Whether the registration lookup itself succeeded. Without this, a
@@ -62,7 +67,7 @@ export default class DomainMonitorCriteria {
      */
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) || dataToProcess.isOnline;
+        (overTimeValue as Array<boolean>) ?? dataToProcess.isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
         value: currentIsOnline,
@@ -72,7 +77,7 @@ export default class DomainMonitorCriteria {
 
     if (input.criteriaFilter.checkOn === CheckOn.IsRequestTimeout) {
       const currentIsTimeout: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) || dataToProcess.isTimeout;
+        (overTimeValue as Array<boolean>) ?? dataToProcess.isTimeout;
 
       return CompareCriteria.compareCriteriaBoolean({
         value: currentIsTimeout,

--- a/Common/Server/Utils/Monitor/Criteria/EvaluateOverTime.ts
+++ b/Common/Server/Utils/Monitor/Criteria/EvaluateOverTime.ts
@@ -4,87 +4,515 @@ import OneUptimeDate from "../../../../Types/Date";
 import { JSONObject } from "../../../../Types/JSON";
 import {
   CheckOn,
+  CriteriaFilter,
   EvaluateOverTimeOptions,
   EvaluateOverTimeType,
+  NoDataPolicy,
 } from "../../../../Types/Monitor/CriteriaFilter";
 import ObjectID from "../../../../Types/ObjectID";
 import Metric from "../../../../Models/AnalyticsModels/Metric";
 import MonitorMetricTypeUtil from "../../../../Utils/Monitor/MonitorMetricType";
+import MonitorMetricType from "../../../../Types/Monitor/MonitorMetricType";
 import MetricService from "../../../Services/MetricService";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import CronTab from "../../CronTab";
+import logger from "../../Logger";
+
+/**
+ * Outcome of trying to turn an "evaluate over time" filter into a value the
+ * comparators can act on.
+ */
+export enum OverTimeEvaluationStatus {
+  /** The filter is not configured to evaluate over time at all. */
+  NotConfigured = "NotConfigured",
+  /**
+   * No metric series backs this CheckOn, so there is nothing to look back
+   * over. Callers keep their historical behaviour (compare the value that
+   * arrived with this check) rather than silently never firing.
+   */
+  Unsupported = "Unsupported",
+  /**
+   * The window is usable and `value` holds every sample in it (for
+   * All Values / Any Value) or the aggregate (for Average / Sum / Min / Max).
+   */
+  Evaluated = "Evaluated",
+  /**
+   * The window is empty, still filling up, or could not be read. The filter
+   * cannot be judged yet — what happens next is up to the no-data policy.
+   */
+  InsufficientData = "InsufficientData",
+}
+
+export interface OverTimeEvaluation {
+  status: OverTimeEvaluationStatus;
+  value: Array<number | boolean> | number | boolean | undefined;
+  /** Number of samples the window returned. */
+  sampleCount: number;
+  /** Why the window was judged insufficient. Null otherwise. */
+  noDataReason: string | null;
+  /**
+   * True when InsufficientData was caused by the metric read failing rather
+   * than by a genuinely empty or partial window. A read failure must never
+   * be reported as a breach, whatever the no-data policy says.
+   */
+  isReadError: boolean;
+}
+
+/**
+ * What the calling criteria evaluator should do with an over-time filter.
+ *
+ * `earlyReturn` set means the filter has already been decided and the
+ * evaluator must return that result verbatim - crucially WITHOUT falling
+ * back to the value that arrived with this single check. That fallback was
+ * the reason "All values over the last 5 minutes" fired off one bad probe.
+ */
+export interface OverTimeCriteriaValue {
+  earlyReturn: { result: string | null } | null;
+  value: Array<number | boolean> | number | boolean | undefined;
+}
 
 export default class EvaluateOverTime {
-  @CaptureSpan()
-  public static async getValueOverTime(data: {
+  /**
+   * Multiple of the monitor's polling interval that either end of the window
+   * is allowed to sit away from the nearest sample before the window counts
+   * as "not covered yet".
+   *
+   * One whole interval is the theoretical minimum (a window that starts
+   * mid-cycle legitimately has its first sample up to one interval in). The
+   * extra half absorbs scheduling jitter - and the lag between a sample
+   * being written and being readable - so a monitor does not flip between
+   * "covered" and "not covered" on adjacent checks.
+   */
+  private static readonly WINDOW_COVERAGE_TOLERANCE_FACTOR: number = 1.5;
+
+  /**
+   * Resolve an "evaluate over time" criteria filter into the value its
+   * comparator should use, applying the filter's no-data policy.
+   *
+   * This is the single entry point every monitor-type criteria evaluator
+   * uses. It exists so the "window has no usable data" decision is made in
+   * exactly one place: previously each evaluator did
+   * `overTimeValue || <value from this check>`, which quietly turned every
+   * over-time filter into an instantaneous one whenever the window came back
+   * empty.
+   *
+   * Deliberately not span-decorated: this runs for every criteria filter on
+   * every check and the vast majority return at the guard below without
+   * doing any work. evaluateOverTime, which issues the metric read, carries
+   * the span instead.
+   */
+  public static async getOverTimeValueForCriteriaFilter(data: {
     projectId: ObjectID;
     monitorId: ObjectID;
-    evaluateOverTimeOptions: EvaluateOverTimeOptions;
-    metricType: CheckOn;
+    criteriaFilter: CriteriaFilter;
     miscData?: JSONObject | undefined;
-  }): Promise<number | boolean | Array<number | boolean>> {
-    // get values over time
-
-    const lastMinutesDate: Date = OneUptimeDate.getSomeMinutesAgo(
-      data.evaluateOverTimeOptions.timeValueInMinutes!,
-    );
-
-    // TODO: Query over miscData
-
-    const now: Date = OneUptimeDate.getCurrentDate();
-
-    const query: Query<Metric> = {
-      projectId: data.projectId,
-      time: new InBetween(lastMinutesDate, now),
-      primaryEntityId: data.monitorId,
-      name: MonitorMetricTypeUtil.getMonitorMeticTypeByCheckOn(data.metricType),
-    };
-
-    if (data.miscData) {
-      query.attributes = data.miscData;
+    /** Monitor's monitoringInterval cron. Used to size the expected window. */
+    monitoringInterval?: string | undefined;
+  }): Promise<OverTimeCriteriaValue> {
+    /*
+     * Every criteria evaluator calls this for every filter, so the common
+     * case - a filter that does not evaluate over time - returns before any
+     * of the machinery below runs.
+     */
+    if (
+      !data.criteriaFilter.evaluateOverTime ||
+      !data.criteriaFilter.evaluateOverTimeOptions
+    ) {
+      return {
+        earlyReturn: null,
+        value: undefined,
+      };
     }
 
-    const monitorMetricsItems: Array<Metric> = await MetricService.findBy({
-      query: query,
-      limit: LIMIT_PER_PROJECT,
-      skip: 0,
-      props: {
-        isRoot: true,
-      },
-      select: {
-        value: true,
-      },
+    const evaluation: OverTimeEvaluation = await this.evaluateOverTime({
+      projectId: data.projectId,
+      monitorId: data.monitorId,
+      criteriaFilter: data.criteriaFilter,
+      miscData: data.miscData,
+      monitoringInterval: data.monitoringInterval,
     });
 
-    const values: Array<number | boolean> = monitorMetricsItems
-      .map((item: Metric) => {
-        if (
-          data.metricType === CheckOn.IsOnline ||
-          data.metricType === CheckOn.IsRequestTimeout
-        ) {
-          return item.value === 1;
-        }
+    if (
+      evaluation.status === OverTimeEvaluationStatus.NotConfigured ||
+      evaluation.status === OverTimeEvaluationStatus.Unsupported
+    ) {
+      // Historical behaviour: the caller compares this check's own value.
+      return {
+        earlyReturn: null,
+        value: undefined,
+      };
+    }
 
-        return item.value;
-      })
-      .filter((value: number | boolean | undefined) => {
-        return value !== undefined;
-      }) as Array<number | boolean>;
+    if (evaluation.status === OverTimeEvaluationStatus.Evaluated) {
+      return {
+        earlyReturn: null,
+        value: evaluation.value,
+      };
+    }
+
+    // InsufficientData - the no-data policy decides.
+    const policy: NoDataPolicy = evaluation.isReadError
+      ? NoDataPolicy.Ignore
+      : data.criteriaFilter.evaluateOverTimeOptions?.onNoDataPolicy ||
+        NoDataPolicy.Ignore;
+
+    if (policy === NoDataPolicy.Trigger) {
+      return {
+        earlyReturn: {
+          result:
+            `${data.criteriaFilter.checkOn} has no data over the last ${data.criteriaFilter.evaluateOverTimeOptions?.timeValueInMinutes} minutes. ${evaluation.noDataReason || ""}`.trim(),
+        },
+        value: undefined,
+      };
+    }
+
+    if (policy === NoDataPolicy.TreatAsZero) {
+      /*
+       * Zero for numeric series, and its boolean equivalent (false) for the
+       * online/timeout series, which EvaluateOverTime already maps 1 -> true.
+       */
+      const isBooleanSeries: boolean =
+        data.criteriaFilter.checkOn === CheckOn.IsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.IsRequestTimeout ||
+        data.criteriaFilter.checkOn === CheckOn.DnsIsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.SnmpIsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.ExternalStatusPageIsOnline;
+
+      return {
+        earlyReturn: null,
+        value: isBooleanSeries ? [false] : [0],
+      };
+    }
+
+    // NoDataPolicy.Ignore - the filter simply does not fire yet.
+    logger.debug(
+      `Over time filter for ${data.criteriaFilter.checkOn} not evaluated: ${evaluation.noDataReason}`,
+    );
+
+    return {
+      earlyReturn: { result: null },
+      value: undefined,
+    };
+  }
+
+  /**
+   * Read the evaluation window and decide whether it can back the filter.
+   */
+  @CaptureSpan()
+  public static async evaluateOverTime(data: {
+    projectId: ObjectID;
+    monitorId: ObjectID;
+    criteriaFilter: CriteriaFilter;
+    miscData?: JSONObject | undefined;
+    monitoringInterval?: string | undefined;
+  }): Promise<OverTimeEvaluation> {
+    const evaluateOverTimeOptions: EvaluateOverTimeOptions | undefined =
+      data.criteriaFilter.evaluateOverTimeOptions;
+
+    if (!data.criteriaFilter.evaluateOverTime || !evaluateOverTimeOptions) {
+      return {
+        status: OverTimeEvaluationStatus.NotConfigured,
+        value: undefined,
+        sampleCount: 0,
+        noDataReason: null,
+        isReadError: false,
+      };
+    }
+
+    const metricName: MonitorMetricType | null =
+      MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(
+        data.criteriaFilter.checkOn,
+      );
+
+    if (!metricName) {
+      /*
+       * Nothing writes a series for this CheckOn, so there is no history to
+       * look back over. Say so instead of throwing - the callers used to
+       * swallow that throw and silently compare the instantaneous value.
+       */
+      return {
+        status: OverTimeEvaluationStatus.Unsupported,
+        value: undefined,
+        sampleCount: 0,
+        noDataReason: `${data.criteriaFilter.checkOn} is not recorded as a metric, so it cannot be evaluated over time.`,
+        isReadError: false,
+      };
+    }
+
+    /*
+     * The dashboard persists the dropdown's string value while Terraform and
+     * the API send a number, so coerce before doing arithmetic with it.
+     */
+    const windowInMinutes: number =
+      Number(evaluateOverTimeOptions.timeValueInMinutes) || 0;
+
+    if (windowInMinutes <= 0) {
+      return {
+        status: OverTimeEvaluationStatus.InsufficientData,
+        value: undefined,
+        sampleCount: 0,
+        noDataReason: "No evaluation window configured.",
+        isReadError: false,
+      };
+    }
+
+    const now: Date = OneUptimeDate.getCurrentDate();
+    const windowStart: Date = OneUptimeDate.getSomeMinutesAgo(windowInMinutes);
+
+    let metricItems: Array<Metric> = [];
+
+    try {
+      const query: Query<Metric> = {
+        projectId: data.projectId,
+        time: new InBetween(windowStart, now),
+        primaryEntityId: data.monitorId,
+        name: metricName,
+      };
+
+      if (data.miscData) {
+        query.attributes = data.miscData;
+      }
+
+      metricItems = await MetricService.findBy({
+        query: query,
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+        select: {
+          value: true,
+          time: true,
+        },
+      });
+    } catch (err) {
+      logger.error(
+        `Error in getting over time value for ${data.criteriaFilter.checkOn}`,
+      );
+      logger.error(err);
+
+      return {
+        status: OverTimeEvaluationStatus.InsufficientData,
+        value: undefined,
+        sampleCount: 0,
+        noDataReason: "The metric store could not be read.",
+        isReadError: true,
+      };
+    }
+
+    const sampleTimes: Array<Date> = [];
+
+    const values: Array<number | boolean> = [];
+
+    for (const item of metricItems) {
+      if (item.value === undefined || item.value === null) {
+        continue;
+      }
+
+      if (
+        data.criteriaFilter.checkOn === CheckOn.IsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.IsRequestTimeout ||
+        data.criteriaFilter.checkOn === CheckOn.DnsIsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.SnmpIsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.ExternalStatusPageIsOnline
+      ) {
+        values.push(item.value === 1);
+      } else {
+        values.push(item.value);
+      }
+
+      if (item.time) {
+        sampleTimes.push(OneUptimeDate.fromString(item.time));
+      }
+    }
+
+    if (values.length === 0) {
+      return {
+        status: OverTimeEvaluationStatus.InsufficientData,
+        value: undefined,
+        sampleCount: 0,
+        noDataReason: `No data was recorded for ${data.criteriaFilter.checkOn} in the last ${windowInMinutes} minutes.`,
+        isReadError: false,
+      };
+    }
+
+    /*
+     * "All Values" is the only evaluation type that claims something about
+     * the WHOLE window, so it is the only one that needs the whole window to
+     * be there. Array.every() is trivially true on a single sample, which is
+     * exactly how one bad probe used to satisfy
+     * "all values over the last 5 minutes".
+     *
+     * "Any Value" fires on a single breaching sample by design, and the
+     * aggregates (Average / Sum / Min / Max) are meaningful over a partial
+     * window, so they are left alone.
+     */
+    if (
+      evaluateOverTimeOptions.evaluateOverTimeType ===
+      EvaluateOverTimeType.AllValues
+    ) {
+      const isCovered: boolean = this.isWindowCovered({
+        windowStart: windowStart,
+        windowEnd: now,
+        sampleTimes: sampleTimes,
+        monitoringInterval: data.monitoringInterval,
+      });
+
+      if (!isCovered) {
+        return {
+          status: OverTimeEvaluationStatus.InsufficientData,
+          value: undefined,
+          sampleCount: values.length,
+          noDataReason: `Only ${values.length} data point(s) recorded so far - not enough to cover the last ${windowInMinutes} minutes.`,
+          isReadError: false,
+        };
+      }
+    }
 
     if (
-      data.evaluateOverTimeOptions.evaluateOverTimeType ===
+      evaluateOverTimeOptions.evaluateOverTimeType ===
         EvaluateOverTimeType.AnyValue ||
-      data.evaluateOverTimeOptions.evaluateOverTimeType ===
+      evaluateOverTimeOptions.evaluateOverTimeType ===
         EvaluateOverTimeType.AllValues
     ) {
       // if its any or all then return the values. Otherwise compute the value based on the type
-      return values;
+      return {
+        status: OverTimeEvaluationStatus.Evaluated,
+        value: values,
+        sampleCount: values.length,
+        noDataReason: null,
+        isReadError: false,
+      };
     }
 
-    return this.getValueByEvaluationType({
-      values: values as Array<number>,
-      evaluateOverTimeType: data.evaluateOverTimeOptions.evaluateOverTimeType!,
+    return {
+      status: OverTimeEvaluationStatus.Evaluated,
+      value: this.getValueByEvaluationType({
+        values: values as Array<number>,
+        evaluateOverTimeType: evaluateOverTimeOptions.evaluateOverTimeType!,
+      }),
+      sampleCount: values.length,
+      noDataReason: null,
+      isReadError: false,
+    };
+  }
+
+  /**
+   * Whether the samples actually reach back to the start of the window.
+   *
+   * A monitor that has only been running for a minute has one sample in a
+   * five minute window. That sample says nothing about the other four
+   * minutes, so "all values over the last 5 minutes" must not be considered
+   * satisfied by it.
+   *
+   * The check is expressed in time rather than in sample count so it is
+   * immune to a probe skipping a beat, to several probes writing into the
+   * same series, and to a sample landing a fraction of a second outside the
+   * window.
+   */
+  private static isWindowCovered(data: {
+    windowStart: Date;
+    windowEnd: Date;
+    sampleTimes: Array<Date>;
+    monitoringInterval?: string | undefined;
+  }): boolean {
+    if (data.sampleTimes.length === 0) {
+      return false;
+    }
+
+    const sortedTimes: Array<number> = data.sampleTimes
+      .map((time: Date) => {
+        return time.getTime();
+      })
+      .filter((time: number) => {
+        return !isNaN(time);
+      })
+      .sort((a: number, b: number) => {
+        return a - b;
+      });
+
+    if (sortedTimes.length === 0) {
+      /*
+       * Timestamps were unreadable. Fall back to requiring more than one
+       * sample so a brand new monitor still cannot satisfy the window off a
+       * single reading.
+       */
+      return data.sampleTimes.length > 1;
+    }
+
+    const intervalInSeconds: number | null = this.getSamplingIntervalInSeconds({
+      monitoringInterval: data.monitoringInterval,
+      sortedSampleTimes: sortedTimes,
     });
+
+    if (intervalInSeconds === null) {
+      /*
+       * A single sample and no configured interval - there is no way to tell
+       * whether the monitor is polled once an hour or once a second, so the
+       * window cannot be called covered.
+       */
+      return false;
+    }
+
+    const oldestSampleMs: number = sortedTimes[0]!;
+    const newestSampleMs: number = sortedTimes[sortedTimes.length - 1]!;
+
+    const allowedGapMs: number =
+      intervalInSeconds * 1000 * this.WINDOW_COVERAGE_TOLERANCE_FACTOR;
+
+    const leadingGapMs: number = oldestSampleMs - data.windowStart.getTime();
+
+    /*
+     * The trailing edge matters as much as the leading one: samples that
+     * stop part way through the window say nothing about the minutes since,
+     * so "all values over the last N minutes" must not be satisfied by
+     * stale data either.
+     */
+    const trailingGapMs: number = data.windowEnd.getTime() - newestSampleMs;
+
+    return leadingGapMs <= allowedGapMs && trailingGapMs <= allowedGapMs;
+  }
+
+  /**
+   * How far apart consecutive samples are expected to be, in seconds.
+   *
+   * The monitor's own schedule is authoritative when we have it. Otherwise
+   * infer it from the data: the widest gap actually observed between
+   * consecutive samples is the longest wait the window has demonstrated, so
+   * it is the safest estimate of the cadence.
+   */
+  private static getSamplingIntervalInSeconds(data: {
+    monitoringInterval?: string | undefined;
+    sortedSampleTimes: Array<number>;
+  }): number | null {
+    const configuredIntervalInSeconds: number | null =
+      CronTab.getIntervalInSeconds(data.monitoringInterval);
+
+    if (configuredIntervalInSeconds !== null) {
+      return configuredIntervalInSeconds;
+    }
+
+    if (data.sortedSampleTimes.length < 2) {
+      return null;
+    }
+
+    let widestGapInSeconds: number = 0;
+
+    for (let i: number = 1; i < data.sortedSampleTimes.length; i++) {
+      const gapInSeconds: number =
+        (data.sortedSampleTimes[i]! - data.sortedSampleTimes[i - 1]!) / 1000;
+
+      if (gapInSeconds > widestGapInSeconds) {
+        widestGapInSeconds = gapInSeconds;
+      }
+    }
+
+    if (widestGapInSeconds <= 0) {
+      return null;
+    }
+
+    return widestGapInSeconds;
   }
 
   private static getValueByEvaluationType(data: {

--- a/Common/Server/Utils/Monitor/Criteria/ExternalStatusPageMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ExternalStatusPageMonitorCriteria.ts
@@ -6,15 +6,21 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import ExternalStatusPageMonitorResponse from "../../../../Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class ExternalStatusPageMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -26,37 +32,36 @@ export default class ExternalStatusPageMonitorCriteria {
       | ExternalStatusPageMonitorResponse
       | undefined = dataToProcess.externalStatusPageResponse;
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     // Check if external status page is online
     if (input.criteriaFilter.checkOn === CheckOn.ExternalStatusPageIsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -76,9 +81,9 @@ export default class ExternalStatusPageMonitorCriteria {
       }
 
       const currentResponseTime: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        externalStatusPageResponse?.responseTimeInMs ||
-        (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs;
+        (overTimeValue as Array<number>) ??
+        (externalStatusPageResponse?.responseTimeInMs ||
+          (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs);
 
       if (currentResponseTime === null || currentResponseTime === undefined) {
         return null;

--- a/Common/Server/Utils/Monitor/Criteria/IncomingRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/IncomingRequestCriteria.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import IncomingMonitorRequest from "../../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import Typeof from "../../../../Types/Typeof";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import CompareCriteria from "./CompareCriteria";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
@@ -19,6 +19,13 @@ export default class IncomingRequestCriteria {
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
@@ -37,36 +44,35 @@ export default class IncomingRequestCriteria {
 
     let value: number | string | undefined = input.criteriaFilter.value;
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as IncomingMonitorRequest).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as IncomingMonitorRequest).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -78,7 +84,7 @@ export default class IncomingRequestCriteria {
     // timeout.
     if (input.criteriaFilter.checkOn === CheckOn.IsRequestTimeout) {
       const currentIsTimeout: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isTimeout;
 
       return CompareCriteria.compareCriteriaBoolean({

--- a/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
@@ -8,15 +8,21 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import SslMonitorResponse from "../../../../Types/Monitor/SSLMonitor/SslMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class ServerMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -27,36 +33,35 @@ export default class ServerMonitorCriteria {
     const sslResponse: SslMonitorResponse | undefined =
       dataToProcess.sslResponse;
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -68,7 +73,7 @@ export default class ServerMonitorCriteria {
     // timeout.
     if (input.criteriaFilter.checkOn === CheckOn.IsRequestTimeout) {
       const currentIsTimeout: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isTimeout;
 
       return CompareCriteria.compareCriteriaBoolean({

--- a/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
@@ -1,6 +1,6 @@
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import OneUptimeDate from "../../../../Types/Date";
 import { BasicDiskMetrics } from "../../../../Types/Infrastructure/BasicMetrics";
 import { JSONObject } from "../../../../Types/JSON";
@@ -20,38 +20,59 @@ export default class ServerMonitorCriteria {
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as ServerMonitorResponse).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        /*
+         * Only the disk-usage series carries a diskPath attribute, so
+         * scoping any other series by it would filter against an attribute
+         * no row has - and an empty window now means "cannot judge yet"
+         * rather than "compare the live value", which would silence the
+         * filter outright.
+         */
+        miscData:
+          input.criteriaFilter.checkOn === CheckOn.DiskUsagePercent
+            ? (input.criteriaFilter.serverMonitorOptions as JSONObject)
+            : undefined,
+        monitoringInterval: input.monitoringInterval,
+      });
 
+    /*
+     * The window could not back this over-time filter, so the no-data policy
+     * has already decided it - do not fall through to the value that arrived
+     * with this one check.
+     *
+     * "Is Online" is exempt: for a server monitor the absence of data IS the
+     * signal, and the differenceInMinutes check below already implements the
+     * "wait this long before calling it offline" behaviour off the agent's
+     * last check-in time. Letting it fall through preserves that.
+     */
     if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
+      overTime.earlyReturn &&
+      input.criteriaFilter.checkOn !== CheckOn.IsOnline
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as ServerMonitorResponse).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-          miscData: input.criteriaFilter.serverMonitorOptions as JSONObject,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     const lastCheckTime: Date = (input.dataToProcess as ServerMonitorResponse)
       .requestReceivedAt;
@@ -108,7 +129,7 @@ export default class ServerMonitorCriteria {
       differenceInMinutes >= offlineIfNotCheckedInMinutes
     ) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) || false; // false because no request receieved in the last 2 minutes
+        (overTimeValue as Array<boolean>) ?? false; // false because no request receieved in the last 2 minutes
 
       logger.debug(`Current Is Online: ${currentIsOnline}`);
 
@@ -127,7 +148,7 @@ export default class ServerMonitorCriteria {
       differenceInMinutes < offlineIfNotCheckedInMinutes
     ) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) || true; // true because request receieved in the last 2 minutes
+        (overTimeValue as Array<boolean>) ?? true; // true because request receieved in the last 2 minutes
 
       logger.debug(`Current Is Online: ${currentIsOnline}`);
 
@@ -148,10 +169,10 @@ export default class ServerMonitorCriteria {
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const currentCpuPercent: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        (input.dataToProcess as ServerMonitorResponse)
+        (overTimeValue as Array<number>) ??
+        ((input.dataToProcess as ServerMonitorResponse)
           .basicInfrastructureMetrics?.cpuMetrics.percentUsed ||
-        0;
+          0);
 
       return CompareCriteria.compareCriteriaNumbers({
         value: currentCpuPercent,
@@ -167,10 +188,10 @@ export default class ServerMonitorCriteria {
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const memoryPercent: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        (input.dataToProcess as ServerMonitorResponse)
+        (overTimeValue as Array<number>) ??
+        ((input.dataToProcess as ServerMonitorResponse)
           .basicInfrastructureMetrics?.memoryMetrics.percentUsed ||
-        0;
+          0);
 
       return CompareCriteria.compareCriteriaNumbers({
         value: memoryPercent,
@@ -201,8 +222,16 @@ export default class ServerMonitorCriteria {
       const diskUsagePercent: number =
         diskMetric?.percentUsed ?? diskMetric?.percentFree ?? 0;
 
+      /*
+       * Disk usage was the one server metric that computed its over-time
+       * window and then threw it away, comparing the reading from this check
+       * instead - so "evaluate over time" was a no-op here.
+       */
+      const value: number | Array<number> =
+        (overTimeValue as Array<number>) ?? diskUsagePercent;
+
       return CompareCriteria.compareCriteriaNumbers({
-        value: diskUsagePercent,
+        value: value,
         threshold: threshold as number,
         criteriaFilter: input.criteriaFilter,
       });
@@ -232,7 +261,7 @@ export default class ServerMonitorCriteria {
       }
 
       const value: number | Array<number> =
-        (overTimeValue as Array<number>) || currentLoad || 0;
+        (overTimeValue as Array<number>) ?? (currentLoad || 0);
 
       return CompareCriteria.compareCriteriaNumbers({
         value: value,
@@ -248,10 +277,10 @@ export default class ServerMonitorCriteria {
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const swapPercent: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        (input.dataToProcess as ServerMonitorResponse)
+        (overTimeValue as Array<number>) ??
+        ((input.dataToProcess as ServerMonitorResponse)
           .basicInfrastructureMetrics?.memoryMetrics?.swapPercentUsed ||
-        0;
+          0);
 
       return CompareCriteria.compareCriteriaNumbers({
         value: swapPercent,
@@ -267,10 +296,10 @@ export default class ServerMonitorCriteria {
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const ioWaitPercent: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        (input.dataToProcess as ServerMonitorResponse)
+        (overTimeValue as Array<number>) ??
+        ((input.dataToProcess as ServerMonitorResponse)
           .basicInfrastructureMetrics?.cpuMetrics?.timeIoWaitPercent ||
-        0;
+          0);
 
       return CompareCriteria.compareCriteriaNumbers({
         value: ioWaitPercent,

--- a/Common/Server/Utils/Monitor/Criteria/SnmpMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SnmpMonitorCriteria.ts
@@ -16,7 +16,7 @@ import SnmpMonitorResponse, {
 } from "../../../../Types/Monitor/SnmpMonitor/SnmpMonitorResponse";
 import SnmpTrap from "../../../../Types/Monitor/SnmpMonitor/SnmpTrap";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import MetricBaselineService, {
   BaselineSummary,
   MetricBaselineService as MetricBaselineServiceClass,
@@ -173,6 +173,13 @@ export default class SnmpMonitorCriteria {
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -240,37 +247,36 @@ export default class SnmpMonitorCriteria {
       return null;
     }
 
-    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
-      undefined;
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
 
-    if (
-      input.criteriaFilter.evaluateOverTime &&
-      input.criteriaFilter.evaluateOverTimeOptions
-    ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
-          projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
-          monitorId: input.dataToProcess.monitorId!,
-          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
-          metricType: input.criteriaFilter.checkOn,
-        });
-
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
-        }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
-      }
+    /*
+     * The window could not back this over-time filter (nothing recorded yet,
+     * or the monitor has not been running long enough to cover it). Return
+     * the decision the no-data policy already made instead of falling
+     * through to the value that arrived with this one check - that fallback
+     * is what let "all values over the last N minutes" fire off a single
+     * bad reading.
+     */
+    if (overTime.earlyReturn) {
+      return overTime.earlyReturn.result;
     }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
 
     // Check if SNMP device is online
     if (input.criteriaFilter.checkOn === CheckOn.SnmpIsOnline) {
       const currentIsOnline: boolean | Array<boolean> =
-        (overTimeValue as Array<boolean>) ||
+        (overTimeValue as Array<boolean>) ??
         (input.dataToProcess as ProbeMonitorResponse).isOnline;
 
       return CompareCriteria.compareCriteriaBoolean({
@@ -288,9 +294,9 @@ export default class SnmpMonitorCriteria {
       }
 
       const currentResponseTime: number | Array<number> =
-        (overTimeValue as Array<number>) ||
-        snmpResponse?.responseTimeInMs ||
-        (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs;
+        (overTimeValue as Array<number>) ??
+        (snmpResponse?.responseTimeInMs ||
+          (input.dataToProcess as ProbeMonitorResponse).responseTimeInMs);
 
       if (currentResponseTime === null || currentResponseTime === undefined) {
         return null;

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -666,6 +666,7 @@ ${contextBlock}
         await APIRequestCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (apiRequestCriteriaResult) {
@@ -711,6 +712,7 @@ ${contextBlock}
         await IncomingRequestCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (incomingRequestResult) {
@@ -735,6 +737,7 @@ ${contextBlock}
         await SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (sslMonitorResult) {
@@ -747,6 +750,7 @@ ${contextBlock}
         await ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (serverMonitorResult) {
@@ -830,6 +834,7 @@ ${contextBlock}
         await SnmpMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (snmpMonitorResult) {
@@ -842,6 +847,7 @@ ${contextBlock}
         await DnsMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (dnsMonitorResult) {
@@ -854,6 +860,7 @@ ${contextBlock}
         await DomainMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
         });
 
       if (domainMonitorResult) {
@@ -891,6 +898,7 @@ ${contextBlock}
           {
             dataToProcess: input.dataToProcess,
             criteriaFilter: input.criteriaFilter,
+            monitoringInterval: input.monitor.monitoringInterval,
           },
         );
 

--- a/Common/Server/Utils/Monitor/MonitorResource.ts
+++ b/Common/Server/Utils/Monitor/MonitorResource.ts
@@ -24,6 +24,7 @@ import MonitorType, {
 } from "../../../Types/Monitor/MonitorType";
 import ServerMonitorResponse from "../../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
 import ObjectID from "../../../Types/ObjectID";
+import { JSONObject } from "../../../Types/JSON";
 import ProbeApiIngestResponse from "../../../Types/Probe/ProbeApiIngestResponse";
 import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
@@ -141,6 +142,13 @@ export default class MonitorResourceUtil {
         _id: true,
         name: true,
         minimumProbeAgreement: true,
+        /*
+         * How often this monitor is checked. Over-time criteria filters need
+         * it to work out how many samples a fully covered evaluation window
+         * should hold - without it a monitor that has only just started
+         * looks the same as one whose whole window is breaching.
+         */
+        monitoringInterval: true,
         /*
          * Recorded as oneuptime.label.* / oneuptime.customField.* attributes on
          * every monitor metric this result produces, so response time and
@@ -737,6 +745,7 @@ export default class MonitorResourceUtil {
             monitorStep: monitorStep,
             currentCriteriaMetId: response.criteriaMetId || null,
             currentRootCause: response.rootCause || null,
+            currentProbeId: (dataToProcess as ProbeMonitorResponse).probeId,
             monitorProbes: monitorProbesForMonitor || undefined,
           });
 
@@ -1238,12 +1247,115 @@ export default class MonitorResourceUtil {
     }
   }
 
+  /**
+   * Turn a probe response read back out of MonitorProbe.lastMonitoringLog
+   * into one the criteria evaluators can actually use.
+   *
+   * The column stores `JSON.parse(JSON.stringify(response))`, which turns
+   * every ObjectID into a plain `{ _type: "ObjectID", value: "..." }` object
+   * and every Date into a string. Those plain objects are not `instanceof
+   * ObjectID`, so the analytics query builder binds them as-is and the
+   * "evaluate over time" lookup silently matches zero rows - which used to
+   * be indistinguishable from "this monitor has no history" and sent the
+   * evaluator down its instantaneous-value fallback. The result was a
+   * decision that disagreed with the evaluation summary shown beside it.
+   */
+  public static hydrateStoredProbeResponse(
+    probeResponse: ProbeMonitorResponse,
+  ): ProbeMonitorResponse {
+    const hydrated: ProbeMonitorResponse = {
+      ...probeResponse,
+    };
+
+    const toObjectID: (value: unknown) => ObjectID | undefined = (
+      value: unknown,
+    ): ObjectID | undefined => {
+      if (!value) {
+        return undefined;
+      }
+
+      if (value instanceof ObjectID) {
+        return value;
+      }
+
+      if (typeof value === "string") {
+        return new ObjectID(value);
+      }
+
+      if (typeof value === "object") {
+        const asJson: JSONObject = value as JSONObject;
+
+        if (asJson["value"]) {
+          return new ObjectID(asJson["value"].toString());
+        }
+      }
+
+      return undefined;
+    };
+
+    const toDate: (value: unknown) => Date | undefined = (
+      value: unknown,
+    ): Date | undefined => {
+      if (!value) {
+        return undefined;
+      }
+
+      if (value instanceof Date) {
+        return value;
+      }
+
+      const parsed: Date = new Date(value as string);
+
+      return isNaN(parsed.getTime()) ? undefined : parsed;
+    };
+
+    const projectId: ObjectID | undefined = toObjectID(probeResponse.projectId);
+    if (projectId) {
+      hydrated.projectId = projectId;
+    }
+
+    const monitorId: ObjectID | undefined = toObjectID(probeResponse.monitorId);
+    if (monitorId) {
+      hydrated.monitorId = monitorId;
+    }
+
+    const monitorStepId: ObjectID | undefined = toObjectID(
+      probeResponse.monitorStepId,
+    );
+    if (monitorStepId) {
+      hydrated.monitorStepId = monitorStepId;
+    }
+
+    const probeId: ObjectID | undefined = toObjectID(probeResponse.probeId);
+    if (probeId) {
+      hydrated.probeId = probeId;
+    }
+
+    const monitoredAt: Date | undefined = toDate(probeResponse.monitoredAt);
+    if (monitoredAt) {
+      hydrated.monitoredAt = monitoredAt;
+    }
+
+    const ingestedAt: Date | undefined = toDate(probeResponse.ingestedAt);
+    if (ingestedAt) {
+      hydrated.ingestedAt = ingestedAt;
+    }
+
+    return hydrated;
+  }
+
   @CaptureSpan()
   private static async checkProbeAgreement(input: {
     monitor: Monitor;
     monitorStep: MonitorStep;
     currentCriteriaMetId: string | null;
     currentRootCause: string | null;
+    /*
+     * Probe that produced the result being handled right now. Its verdict is
+     * already in currentCriteriaMetId / currentRootCause, so it is reused
+     * rather than recomputed - see the loop below.
+     */
+    currentProbeId?: ObjectID | undefined;
     /*
      * Pre-fetched MonitorProbe rows for this monitor (probeId, isEnabled,
      * lastMonitoringLog, probe.name/connectionStatus). The probe-result hot
@@ -1342,30 +1454,58 @@ export default class MonitorResourceUtil {
         continue;
       }
 
-      // Evaluate this probe's response against criteria
-      const tempResponse: ProbeApiIngestResponse = {
-        monitorId: monitor.id!,
-        criteriaMetId: undefined,
-        rootCause: null,
-      };
+      let evaluatedCriteriaMetId: string | undefined = undefined;
+      let evaluatedRootCause: string | null = null;
 
-      const tempEvaluationSummary: MonitorEvaluationSummary = {
-        evaluatedAt: OneUptimeDate.getCurrentDate(),
-        criteriaResults: [],
-        events: [],
-      };
+      const isCurrentProbe: boolean = Boolean(
+        input.currentProbeId &&
+          monitorProbe.probeId?.toString() === input.currentProbeId.toString(),
+      );
 
-      const evaluatedResponse: ProbeApiIngestResponse =
-        await MonitorCriteriaEvaluator.processMonitorStep({
-          dataToProcess: probeResponse as DataToProcess,
-          monitorStep: monitorStep,
-          monitor: monitor,
-          probeApiIngestResponse: tempResponse,
-          evaluationSummary: tempEvaluationSummary,
-        });
+      if (isCurrentProbe) {
+        /*
+         * The probe whose result we are handling right now was already
+         * evaluated by the caller, and that evaluation is the one the user
+         * sees in the evaluation summary. Re-running it here would evaluate
+         * a *different* window for any "evaluate over time" filter - seconds
+         * have passed, and this pass reads the payload back out of
+         * lastMonitoringLog rather than using the live object. That is how
+         * an incident could be created citing a criteria the summary right
+         * next to it reported as not met.
+         */
+        evaluatedCriteriaMetId = currentCriteriaMetId || undefined;
+        evaluatedRootCause = currentRootCause;
+      } else {
+        // Evaluate this probe's response against criteria
+        const tempResponse: ProbeApiIngestResponse = {
+          monitorId: monitor.id!,
+          criteriaMetId: undefined,
+          rootCause: null,
+        };
+
+        const tempEvaluationSummary: MonitorEvaluationSummary = {
+          evaluatedAt: OneUptimeDate.getCurrentDate(),
+          criteriaResults: [],
+          events: [],
+        };
+
+        const evaluatedResponse: ProbeApiIngestResponse =
+          await MonitorCriteriaEvaluator.processMonitorStep({
+            dataToProcess: MonitorResourceUtil.hydrateStoredProbeResponse(
+              probeResponse,
+            ) as DataToProcess,
+            monitorStep: monitorStep,
+            monitor: monitor,
+            probeApiIngestResponse: tempResponse,
+            evaluationSummary: tempEvaluationSummary,
+          });
+
+        evaluatedCriteriaMetId = evaluatedResponse.criteriaMetId;
+        evaluatedRootCause = evaluatedResponse.rootCause;
+      }
 
       // Record the result
-      const criteriaKey: string = evaluatedResponse.criteriaMetId || "none";
+      const criteriaKey: string = evaluatedCriteriaMetId || "none";
       const existing:
         | { count: number; rootCause: string | null; probeNames: Array<string> }
         | undefined = criteriaAgreements.get(criteriaKey);
@@ -1379,7 +1519,7 @@ export default class MonitorResourceUtil {
       } else {
         criteriaAgreements.set(criteriaKey, {
           count: 1,
-          rootCause: evaluatedResponse.rootCause,
+          rootCause: evaluatedRootCause,
           probeNames: [probeName],
         });
       }

--- a/Common/Tests/Server/Services/MonitorResourceProbeAgreementHydration.test.ts
+++ b/Common/Tests/Server/Services/MonitorResourceProbeAgreementHydration.test.ts
@@ -1,0 +1,459 @@
+/*
+ * Probe agreement re-runs the criteria evaluator over every OTHER probe's
+ * stored result before a status change is allowed. Two things about that
+ * pass used to make it disagree with the evaluation summary shown to the
+ * user on the very same incident:
+ *
+ *   1. The stored result is `JSON.parse(JSON.stringify(response))`, so its
+ *      ObjectIDs come back as plain `{ _type, value }` objects. Those are
+ *      not `instanceof ObjectID`, so an "evaluate over time" lookup bound
+ *      them as-is and matched zero rows - indistinguishable from "this
+ *      monitor has no history", which sent the evaluator down its
+ *      instantaneous-value fallback.
+ *   2. The probe whose result triggered this whole pass was re-evaluated
+ *      from that stored copy rather than reusing the verdict the caller had
+ *      just computed, so its "over time" window was a different window.
+ *
+ * Together those produced incidents whose stored root cause quoted a single
+ * sample while the summary beside it reported the full window and said the
+ * criteria was not met. See
+ * https://github.com/OneUptime/oneuptime/issues/2321.
+ *
+ * As in the sibling reuse suite, everything heavy is mocked BEFORE
+ * importing MonitorResource.
+ */
+
+/*
+ * MonitorResource's import chain reaches the native isolated-vm addon
+ * through the sandbox runner. Nothing here touches the sandbox and the
+ * prebuilt binary cannot always dlopen in the test environment, so stub it
+ * out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+jest.mock("../../../Server/Utils/Monitor/MonitorCriteriaEvaluator", () => {
+  return {
+    __esModule: true,
+    default: {
+      processMonitorStep: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/MonitorProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import MonitorResourceUtil from "../../../Server/Utils/Monitor/MonitorResource";
+import MonitorCriteriaEvaluator from "../../../Server/Utils/Monitor/MonitorCriteriaEvaluator";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorProbe, {
+  MonitorStepProbeResponse,
+} from "../../../Models/DatabaseModels/MonitorProbe";
+import Probe, {
+  ProbeConnectionStatus,
+} from "../../../Models/DatabaseModels/Probe";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import ObjectID from "../../../Types/ObjectID";
+import ProbeApiIngestResponse from "../../../Types/Probe/ProbeApiIngestResponse";
+import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
+import DataToProcess from "../../../Server/Utils/Monitor/DataToProcess";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+interface ProbeAgreementResult {
+  hasAgreement: boolean;
+  agreementCount: number;
+  requiredCount: number;
+  totalActiveProbes: number;
+  agreedCriteriaId: string | null;
+  agreedRootCause: string | null;
+  agreedProbeNames: Array<string>;
+}
+
+const processMonitorStepMock: jest.Mock =
+  MonitorCriteriaEvaluator.processMonitorStep as unknown as jest.Mock;
+
+type CheckProbeAgreementFunction = (input: {
+  monitor: Monitor;
+  monitorStep: MonitorStep;
+  currentCriteriaMetId: string | null;
+  currentRootCause: string | null;
+  currentProbeId?: ObjectID | undefined;
+  monitorProbes?: Array<MonitorProbe> | undefined;
+}) => Promise<ProbeAgreementResult>;
+
+const checkProbeAgreement: CheckProbeAgreementFunction = (
+  MonitorResourceUtil as any
+)["checkProbeAgreement"].bind(MonitorResourceUtil);
+
+const PROJECT_ID: string = "11111111-1111-4111-8111-111111111111";
+const MONITOR_ID: string = "22222222-2222-4222-8222-222222222222";
+const STEP_ID: string = "33333333-3333-4333-8333-333333333333";
+const PROBE_ID: string = "44444444-4444-4444-8444-444444444444";
+
+/**
+ * A probe response exactly as it comes back out of the lastMonitoringLog
+ * jsonb column - every ObjectID flattened to `{ _type, value }` and every
+ * Date to an ISO string.
+ */
+function storedProbeResponse(
+  overrides: Record<string, unknown> = {},
+): ProbeMonitorResponse {
+  return {
+    projectId: { _type: "ObjectID", value: PROJECT_ID },
+    monitorId: { _type: "ObjectID", value: MONITOR_ID },
+    monitorStepId: { _type: "ObjectID", value: STEP_ID },
+    probeId: { _type: "ObjectID", value: PROBE_ID },
+    monitoredAt: "2026-08-20T12:00:00.000Z",
+    ingestedAt: "2026-08-20T12:00:01.000Z",
+    isOnline: false,
+    responseCode: 404,
+    failureCause: "",
+    ...overrides,
+  } as unknown as ProbeMonitorResponse;
+}
+
+function makeMonitorProbe(input: {
+  probeName: string;
+  probeId?: ObjectID | undefined;
+  lastMonitoringLog?: MonitorStepProbeResponse | undefined;
+}): MonitorProbe {
+  const probe: Probe = new Probe();
+  probe.name = input.probeName;
+  probe.connectionStatus = ProbeConnectionStatus.Connected;
+
+  const monitorProbe: MonitorProbe = new MonitorProbe();
+  monitorProbe.id = ObjectID.generate();
+  monitorProbe.probeId = input.probeId || ObjectID.generate();
+  monitorProbe.isEnabled = true;
+  monitorProbe.probe = probe;
+
+  if (input.lastMonitoringLog !== undefined) {
+    monitorProbe.lastMonitoringLog = input.lastMonitoringLog;
+  }
+
+  return monitorProbe;
+}
+
+function makeMonitor(): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.id = ObjectID.generate();
+  return monitor;
+}
+
+describe("MonitorResourceUtil.hydrateStoredProbeResponse", () => {
+  const hydrate: (response: ProbeMonitorResponse) => ProbeMonitorResponse = (
+    response: ProbeMonitorResponse,
+  ): ProbeMonitorResponse => {
+    return MonitorResourceUtil.hydrateStoredProbeResponse(response);
+  };
+
+  test("turns serialized ObjectIDs back into ObjectID instances", () => {
+    const hydrated: ProbeMonitorResponse = hydrate(storedProbeResponse());
+
+    expect(hydrated.projectId).toBeInstanceOf(ObjectID);
+    expect(hydrated.monitorId).toBeInstanceOf(ObjectID);
+    expect(hydrated.monitorStepId).toBeInstanceOf(ObjectID);
+    expect(hydrated.probeId).toBeInstanceOf(ObjectID);
+  });
+
+  test("preserves the id values themselves", () => {
+    const hydrated: ProbeMonitorResponse = hydrate(storedProbeResponse());
+
+    expect(hydrated.projectId.toString()).toBe(PROJECT_ID);
+    expect(hydrated.monitorId.toString()).toBe(MONITOR_ID);
+    expect(hydrated.monitorStepId.toString()).toBe(STEP_ID);
+    expect(hydrated.probeId.toString()).toBe(PROBE_ID);
+  });
+
+  test("accepts a bare id string too", () => {
+    const hydrated: ProbeMonitorResponse = hydrate(
+      storedProbeResponse({ projectId: PROJECT_ID }),
+    );
+
+    expect(hydrated.projectId).toBeInstanceOf(ObjectID);
+    expect(hydrated.projectId.toString()).toBe(PROJECT_ID);
+  });
+
+  test("leaves a real ObjectID alone", () => {
+    const projectId: ObjectID = new ObjectID(PROJECT_ID);
+
+    const hydrated: ProbeMonitorResponse = hydrate(
+      storedProbeResponse({ projectId: projectId }),
+    );
+
+    expect(hydrated.projectId).toBe(projectId);
+  });
+
+  test("turns serialized dates back into Date instances", () => {
+    const hydrated: ProbeMonitorResponse = hydrate(storedProbeResponse());
+
+    expect(hydrated.monitoredAt).toBeInstanceOf(Date);
+    expect(hydrated.monitoredAt.toISOString()).toBe("2026-08-20T12:00:00.000Z");
+    expect(hydrated.ingestedAt).toBeInstanceOf(Date);
+  });
+
+  test("leaves a real Date alone", () => {
+    const monitoredAt: Date = new Date("2026-08-20T12:00:00.000Z");
+
+    const hydrated: ProbeMonitorResponse = hydrate(
+      storedProbeResponse({ monitoredAt: monitoredAt }),
+    );
+
+    expect(hydrated.monitoredAt).toBe(monitoredAt);
+  });
+
+  test("carries every other field through untouched", () => {
+    const hydrated: ProbeMonitorResponse = hydrate(
+      storedProbeResponse({
+        responseCode: 503,
+        responseTimeInMs: 1234,
+        isOnline: false,
+      }),
+    );
+
+    expect(hydrated.responseCode).toBe(503);
+    expect(hydrated.responseTimeInMs).toBe(1234);
+    expect(hydrated.isOnline).toBe(false);
+  });
+
+  test("does not mutate the stored row", () => {
+    const stored: ProbeMonitorResponse = storedProbeResponse();
+
+    hydrate(stored);
+
+    expect(stored.projectId).not.toBeInstanceOf(ObjectID);
+  });
+
+  test("tolerates missing ids and dates", () => {
+    const sparse: ProbeMonitorResponse = {
+      isOnline: true,
+    } as unknown as ProbeMonitorResponse;
+
+    expect(() => {
+      hydrate(sparse);
+    }).not.toThrow();
+  });
+
+  test("tolerates an unparseable date", () => {
+    const hydrated: ProbeMonitorResponse = hydrate(
+      storedProbeResponse({ monitoredAt: "not-a-date" }),
+    );
+
+    // Left as-is rather than replaced with an Invalid Date.
+    expect(hydrated.monitoredAt).toBe("not-a-date" as unknown as Date);
+  });
+});
+
+describe("MonitorResourceUtil.checkProbeAgreement stored-payload handling", () => {
+  let monitorStep: MonitorStep;
+  let stepId: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    monitorStep = new MonitorStep();
+    stepId = monitorStep.id.toString();
+
+    processMonitorStepMock.mockImplementation(
+      (input: {
+        dataToProcess: DataToProcess;
+        monitor: Monitor;
+      }): Promise<ProbeApiIngestResponse> => {
+        return Promise.resolve({
+          monitorId: input.monitor.id!,
+          criteriaMetId: (input.dataToProcess as any).testCriteriaId,
+          rootCause: (input.dataToProcess as any).testRootCause || null,
+        });
+      },
+    );
+  });
+
+  test("hydrates a stored payload before handing it to the evaluator", async () => {
+    const monitor: Monitor = makeMonitor();
+
+    const otherProbe: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe B",
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-c" }),
+      },
+    });
+
+    await checkProbeAgreement({
+      monitor: monitor,
+      monitorStep: monitorStep,
+      currentCriteriaMetId: "criteria-c",
+      currentRootCause: "root cause C",
+      monitorProbes: [otherProbe],
+    });
+
+    expect(processMonitorStepMock).toHaveBeenCalledTimes(1);
+
+    const handed: ProbeMonitorResponse = (
+      processMonitorStepMock.mock.calls[0]![0] as {
+        dataToProcess: ProbeMonitorResponse;
+      }
+    ).dataToProcess;
+
+    expect(handed.projectId).toBeInstanceOf(ObjectID);
+    expect(handed.projectId.toString()).toBe(PROJECT_ID);
+    expect(handed.monitorId).toBeInstanceOf(ObjectID);
+    expect(handed.monitoredAt).toBeInstanceOf(Date);
+  });
+
+  /*
+   * The caller has already evaluated the probe whose result triggered this
+   * pass, and that evaluation is the one the user sees. Re-running it here
+   * would read a different "over time" window seconds later.
+   */
+  test("reuses the caller's verdict for the probe being handled", async () => {
+    const monitor: Monitor = makeMonitor();
+    const currentProbeId: ObjectID = new ObjectID(PROBE_ID);
+
+    const currentProbe: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe A",
+      probeId: currentProbeId,
+      lastMonitoringLog: {
+        // Deliberately different: it must NOT be what the result reports.
+        [stepId]: storedProbeResponse({ testCriteriaId: "stale-criteria" }),
+      },
+    });
+
+    const result: ProbeAgreementResult = await checkProbeAgreement({
+      monitor: monitor,
+      monitorStep: monitorStep,
+      currentCriteriaMetId: "criteria-live",
+      currentRootCause: "root cause live",
+      currentProbeId: currentProbeId,
+      monitorProbes: [currentProbe],
+    });
+
+    expect(processMonitorStepMock).not.toHaveBeenCalled();
+    expect(result.agreedCriteriaId).toBe("criteria-live");
+    expect(result.agreedRootCause).toBe("root cause live");
+    expect(result.agreementCount).toBe(1);
+  });
+
+  test("still evaluates the other probes", async () => {
+    const monitor: Monitor = makeMonitor();
+    const currentProbeId: ObjectID = new ObjectID(PROBE_ID);
+
+    const currentProbe: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe A",
+      probeId: currentProbeId,
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-live" }),
+      },
+    });
+
+    const otherProbe: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe B",
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-live" }),
+      },
+    });
+
+    const result: ProbeAgreementResult = await checkProbeAgreement({
+      monitor: monitor,
+      monitorStep: monitorStep,
+      currentCriteriaMetId: "criteria-live",
+      currentRootCause: "root cause live",
+      currentProbeId: currentProbeId,
+      monitorProbes: [currentProbe, otherProbe],
+    });
+
+    expect(processMonitorStepMock).toHaveBeenCalledTimes(1);
+    expect(result.agreementCount).toBe(2);
+    expect(result.hasAgreement).toBe(true);
+    expect(result.agreedProbeNames).toEqual(["Probe A", "Probe B"]);
+  });
+
+  /*
+   * The current probe seeing nothing while the others see a breach must
+   * still count as a disagreement, not be quietly folded into the majority.
+   */
+  test("a caller verdict of 'no criteria met' is counted as its own outcome", async () => {
+    const monitor: Monitor = makeMonitor();
+    const currentProbeId: ObjectID = new ObjectID(PROBE_ID);
+
+    const currentProbe: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe A",
+      probeId: currentProbeId,
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-c" }),
+      },
+    });
+
+    const otherProbe: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe B",
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-c" }),
+      },
+    });
+
+    const result: ProbeAgreementResult = await checkProbeAgreement({
+      monitor: monitor,
+      monitorStep: monitorStep,
+      currentCriteriaMetId: null,
+      currentRootCause: null,
+      currentProbeId: currentProbeId,
+      monitorProbes: [currentProbe, otherProbe],
+    });
+
+    // Two probes, both required, but they disagree - no status change.
+    expect(result.hasAgreement).toBe(false);
+    expect(result.agreementCount).toBe(1);
+  });
+
+  /*
+   * Without currentProbeId (the incoming-request caller, for instance) the
+   * behaviour is unchanged: every stored row is evaluated.
+   */
+  test("evaluates every probe when no current probe is named", async () => {
+    const monitor: Monitor = makeMonitor();
+
+    const probeA: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe A",
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-c" }),
+      },
+    });
+    const probeB: MonitorProbe = makeMonitorProbe({
+      probeName: "Probe B",
+      lastMonitoringLog: {
+        [stepId]: storedProbeResponse({ testCriteriaId: "criteria-c" }),
+      },
+    });
+
+    const result: ProbeAgreementResult = await checkProbeAgreement({
+      monitor: monitor,
+      monitorStep: monitorStep,
+      currentCriteriaMetId: "criteria-c",
+      currentRootCause: "root cause C",
+      monitorProbes: [probeA, probeB],
+    });
+
+    expect(processMonitorStepMock).toHaveBeenCalledTimes(2);
+    expect(result.agreementCount).toBe(2);
+  });
+});

--- a/Common/Tests/Server/Services/MonitorResourceProbeAgreementReuse.test.ts
+++ b/Common/Tests/Server/Services/MonitorResourceProbeAgreementReuse.test.ts
@@ -28,6 +28,16 @@
  * Postgres, no Redis, no isolated-vm.
  */
 
+/*
+ * MonitorResource's import chain reaches the native isolated-vm addon
+ * through the sandbox runner. Nothing here touches the sandbox and the
+ * prebuilt binary cannot always dlopen in the test environment, so stub it
+ * out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
 jest.mock("../../../Server/Utils/Monitor/MonitorCriteriaEvaluator", () => {
   return {
     __esModule: true,

--- a/Common/Tests/Server/Utils/CronTab.test.ts
+++ b/Common/Tests/Server/Utils/CronTab.test.ts
@@ -41,4 +41,120 @@ describe("CronTab", () => {
       CronTab.getNextExecutionTime(crontab);
     }).toThrowError(`Invalid cron expression: ${crontab}`);
   });
+
+  /*
+   * getIntervalInSeconds answers "how long can a monitor go between checks",
+   * which is what over-time criteria use to tell a window that is genuinely
+   * all-breaching from one that has simply not filled up yet.
+   */
+  describe("getIntervalInSeconds", () => {
+    // Fixed so the walk over upcoming executions never touches the wall clock.
+    const referenceDate: Date = new Date("2026-08-20T12:00:00.000Z");
+
+    it("returns 60 seconds for an every-minute schedule", () => {
+      expect(CronTab.getIntervalInSeconds("* * * * *", referenceDate)).toBe(60);
+    });
+
+    it("returns 300 seconds for an every-five-minute schedule", () => {
+      expect(CronTab.getIntervalInSeconds("*/5 * * * *", referenceDate)).toBe(
+        300,
+      );
+    });
+
+    it("returns 3600 seconds for an hourly schedule", () => {
+      expect(CronTab.getIntervalInSeconds("0 * * * *", referenceDate)).toBe(
+        3600,
+      );
+    });
+
+    it("returns a day for a daily schedule", () => {
+      expect(CronTab.getIntervalInSeconds("0 0 * * *", referenceDate)).toBe(
+        24 * 60 * 60,
+      );
+    });
+
+    /*
+     * An irregular schedule has both short and long gaps. The longest one is
+     * what callers need: demanding data at the shortest cadence would make
+     * them wait for samples the schedule never produces.
+     */
+    it("reports the longest gap for an irregular schedule", () => {
+      // Fires at :00 :01 :30 - gaps of 1, 29 and 30 minutes.
+      expect(
+        CronTab.getIntervalInSeconds("0,1,30 * * * *", referenceDate),
+      ).toBe(30 * 60);
+    });
+
+    it("is unaffected by which point in the schedule it starts from", () => {
+      const fromMidCycle: number | null = CronTab.getIntervalInSeconds(
+        "*/5 * * * *",
+        new Date("2026-08-20T12:02:37.000Z"),
+      );
+
+      expect(fromMidCycle).toBe(300);
+    });
+
+    it("handles a schedule that wraps the hour", () => {
+      /*
+       * An every-seven-minute schedule fires at :00 :07 ... :56 and then
+       * :00 of the next hour, so the wrap gap is only four minutes - the
+       * seven minute gap still governs.
+       */
+      expect(CronTab.getIntervalInSeconds("*/7 * * * *", referenceDate)).toBe(
+        7 * 60,
+      );
+    });
+
+    /*
+     * Every preset the monitoring-interval picker offers, so a new one added
+     * to the dropdown without a matching gap here shows up as a failure
+     * rather than as silently unknown cadence.
+     */
+    it("resolves every interval the monitor picker offers", () => {
+      const presets: Record<string, number> = {
+        "* * * * *": 60,
+        "*/2 * * * *": 120,
+        "*/5 * * * *": 300,
+        "*/10 * * * *": 600,
+        "*/15 * * * *": 900,
+        "*/30 * * * *": 1800,
+        "0 * * * *": 3600,
+        "0 0 * * *": 24 * 60 * 60,
+        "0 0 * * 0": 7 * 24 * 60 * 60,
+      };
+
+      for (const expression of Object.keys(presets)) {
+        expect(CronTab.getIntervalInSeconds(expression, referenceDate)).toBe(
+          presets[expression],
+        );
+      }
+    });
+
+    /*
+     * monitoringInterval is free text and this repo's own Terraform examples
+     * write the human label, so the label form must degrade to "unknown"
+     * rather than throwing on the criteria hot path.
+     */
+    it("returns null for the human label form", () => {
+      expect(
+        CronTab.getIntervalInSeconds("Every 5 minutes", referenceDate),
+      ).toBeNull();
+    });
+
+    it("returns null for an unparseable expression", () => {
+      expect(
+        CronTab.getIntervalInSeconds("not-a-cron", referenceDate),
+      ).toBeNull();
+    });
+
+    it("returns null when no schedule is configured", () => {
+      expect(CronTab.getIntervalInSeconds(undefined)).toBeNull();
+      expect(CronTab.getIntervalInSeconds(null)).toBeNull();
+      expect(CronTab.getIntervalInSeconds("")).toBeNull();
+    });
+
+    it("falls back to the wall clock when no reference date is given", () => {
+      expect(CronTab.getIntervalInSeconds("*/5 * * * *")).toBe(300);
+    });
+  });
 });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaEvaluateOverTime.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaEvaluateOverTime.test.ts
@@ -1,0 +1,508 @@
+import APIRequestCriteria from "../../../../../Server/Utils/Monitor/Criteria/APIRequestCriteria";
+import MetricService from "../../../../../Server/Services/MetricService";
+import FindBy from "../../../../../Server/Types/AnalyticsDatabase/FindBy";
+import Metric from "../../../../../Models/AnalyticsModels/Metric";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+  NoDataPolicy,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import ProbeMonitorResponse from "../../../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * End-to-end cover for the bug in
+ * https://github.com/OneUptime/oneuptime/issues/2321: a criteria filter set
+ * to look at "All Values over the last N minutes" fired on the first bad
+ * probe instead of waiting for the window.
+ *
+ * These tests drive the real APIRequestCriteria evaluator and stub only the
+ * metric read, so the window arithmetic, the coverage guard, the no-data
+ * policy and the comparison message are all exercised together.
+ */
+
+const NOW: Date = new Date("2026-08-20T12:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+/** Once a minute, oldest first, ending at `now`. */
+function everyMinute(values: Array<number>): Array<Metric> {
+  return values.map((value: number, index: number) => {
+    const metric: Metric = new Metric();
+    metric.value = value;
+    metric.time = new Date(
+      NOW.getTime() - (values.length - 1 - index) * 60 * 1000,
+    );
+    return metric;
+  });
+}
+
+function buildResponse(
+  overrides: Partial<ProbeMonitorResponse> = {},
+): ProbeMonitorResponse {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: "",
+    monitoredAt: NOW,
+    isOnline: true,
+    responseCode: 200,
+    responseTimeInMs: 100,
+    ...overrides,
+  };
+}
+
+let windowSamples: Array<Metric> = [];
+
+function evaluate(input: {
+  criteriaFilter: CriteriaFilter;
+  dataToProcess: ProbeMonitorResponse;
+  monitoringInterval?: string | undefined;
+}): Promise<string | null> {
+  return APIRequestCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess: input.dataToProcess,
+    criteriaFilter: input.criteriaFilter,
+    monitoringInterval: input.monitoringInterval ?? "* * * * *",
+  });
+}
+
+describe("APIRequestCriteria evaluate over time", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+
+    windowSamples = [];
+
+    jest
+      .spyOn(MetricService, "findBy")
+      .mockImplementation((_findBy: FindBy<Metric>): Promise<Array<Metric>> => {
+        return Promise.resolve(windowSamples);
+      });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("the reported scenario: one bad status code in a healthy window", () => {
+    const offlineCriteria: CriteriaFilter = {
+      checkOn: CheckOn.ResponseStatusCode,
+      filterType: FilterType.NotEqualTo,
+      value: 200,
+      evaluateOverTime: true,
+      evaluateOverTimeOptions: {
+        timeValueInMinutes: 5,
+        evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+      },
+    };
+
+    test("does not fire when only the newest sample is bad", async () => {
+      windowSamples = everyMinute([200, 200, 200, 200, 404]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    /*
+     * The heart of the bug. Nothing had been recorded yet, so the evaluator
+     * used to compare the single status code that arrived with this check
+     * and report it as "all values over the last 5 minutes".
+     */
+    test("does not fire when the window is empty", async () => {
+      windowSamples = [];
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("does not fire on a monitor that has only checked once", async () => {
+      windowSamples = everyMinute([404]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("does not fire two minutes into a five minute window", async () => {
+      windowSamples = everyMinute([404, 404]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("fires once the whole window has been bad", async () => {
+      windowSamples = everyMinute([404, 404, 404, 404, 404]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toContain("All values of");
+      expect(result).toContain(CheckOn.ResponseStatusCode as string);
+      expect(result).toContain("over the last 5 minutes");
+      expect(result).toContain("not equal to 200");
+    });
+
+    /*
+     * The recovery direction matters too: a single good sample inside an
+     * otherwise bad window must clear the criteria.
+     */
+    test("stops firing as soon as one sample recovers", async () => {
+      windowSamples = everyMinute([404, 404, 404, 404, 200]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ responseCode: 200 }),
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("the reported scenario: a single latency spike", () => {
+    /*
+     * From the second report on the issue - one 9171 ms tick inside a two
+     * minute window of sub-second responses opened an incident that
+     * auto-resolved 72 seconds later.
+     */
+    const slowCriteria: CriteriaFilter = {
+      checkOn: CheckOn.ResponseTime,
+      filterType: FilterType.GreaterThan,
+      value: 8000,
+      evaluateOverTime: true,
+      evaluateOverTimeOptions: {
+        timeValueInMinutes: 2,
+        evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+      },
+    };
+
+    test("does not fire on a lone spike among healthy samples", async () => {
+      windowSamples = everyMinute([397, 805, 9171]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: slowCriteria,
+        dataToProcess: buildResponse({ responseTimeInMs: 9171 }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("fires when the whole window is slow", async () => {
+      windowSamples = everyMinute([9171, 9002, 8800]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: slowCriteria,
+        dataToProcess: buildResponse({ responseTimeInMs: 8800 }),
+      });
+
+      expect(result).toContain("All values of");
+      expect(result).toContain("greater than 8000");
+    });
+
+    /*
+     * "Any Value" is the setting for "tell me the moment one check
+     * breaches", and it must keep behaving that way.
+     */
+    test("Any Value still fires on the lone spike", async () => {
+      windowSamples = everyMinute([397, 805, 9171]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: {
+          ...slowCriteria,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 2,
+            evaluateOverTimeType: EvaluateOverTimeType.AnyValue,
+          },
+        },
+        dataToProcess: buildResponse({ responseTimeInMs: 9171 }),
+      });
+
+      expect(result).toContain("Any value of");
+    });
+
+    test("Any Value fires off the very first sample", async () => {
+      windowSamples = everyMinute([9171]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: {
+          ...slowCriteria,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 2,
+            evaluateOverTimeType: EvaluateOverTimeType.AnyValue,
+          },
+        },
+        dataToProcess: buildResponse({ responseTimeInMs: 9171 }),
+      });
+
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("Is Online over time", () => {
+    const offlineCriteria: CriteriaFilter = {
+      checkOn: CheckOn.IsOnline,
+      filterType: FilterType.False,
+      value: undefined,
+      evaluateOverTime: true,
+      evaluateOverTimeOptions: {
+        timeValueInMinutes: 5,
+        evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+      },
+    };
+
+    test("fires only after the whole window has been offline", async () => {
+      windowSamples = everyMinute([0, 0, 0, 0, 0]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ isOnline: false }),
+      });
+
+      expect(result).toContain(CheckOn.IsOnline as string);
+    });
+
+    test("does not fire on the first failed check", async () => {
+      windowSamples = everyMinute([1, 1, 1, 1, 0]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ isOnline: false }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("does not fire while the window is still filling", async () => {
+      windowSamples = everyMinute([0]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: offlineCriteria,
+        dataToProcess: buildResponse({ isOnline: false }),
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("no-data policy", () => {
+    const criteriaWith: (policy: NoDataPolicy) => CriteriaFilter = (
+      policy: NoDataPolicy,
+    ): CriteriaFilter => {
+      return {
+        checkOn: CheckOn.ResponseStatusCode,
+        filterType: FilterType.NotEqualTo,
+        value: 200,
+        evaluateOverTime: true,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 5,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          onNoDataPolicy: policy,
+        },
+      };
+    };
+
+    test("Ignore keeps quiet when there is nothing to look at", async () => {
+      windowSamples = [];
+
+      const result: string | null = await evaluate({
+        criteriaFilter: criteriaWith(NoDataPolicy.Ignore),
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toBeNull();
+    });
+
+    /*
+     * For heartbeat-style checks the absence of data is itself the problem,
+     * which is what Trigger is for.
+     */
+    test("Trigger reports the missing data as the root cause", async () => {
+      windowSamples = [];
+
+      const result: string | null = await evaluate({
+        criteriaFilter: criteriaWith(NoDataPolicy.Trigger),
+        dataToProcess: buildResponse({ responseCode: 200 }),
+      });
+
+      expect(result).toContain("no data");
+      expect(result).toContain("5 minutes");
+    });
+
+    test("Treat As Zero compares the window as a single zero", async () => {
+      windowSamples = [];
+
+      const result: string | null = await evaluate({
+        criteriaFilter: criteriaWith(NoDataPolicy.TreatAsZero),
+        dataToProcess: buildResponse({ responseCode: 200 }),
+      });
+
+      // 0 is not equal to 200, so the filter is met.
+      expect(result).toContain("not equal to 200");
+    });
+  });
+
+  describe("monitors that are polled less often than the window", () => {
+    /*
+     * A monitor checked every five minutes can only ever put one sample into
+     * a five minute window, so that sample IS the whole window. Requiring
+     * more would mean it never fires at all.
+     */
+    test("a single sample covers the window at a five minute interval", async () => {
+      windowSamples = everyMinute([404]);
+
+      const result: string | null = await evaluate({
+        criteriaFilter: {
+          checkOn: CheckOn.ResponseStatusCode,
+          filterType: FilterType.NotEqualTo,
+          value: 200,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+        },
+        dataToProcess: buildResponse({ responseCode: 404 }),
+        monitoringInterval: "*/5 * * * *",
+      });
+
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("attribute scoping", () => {
+    /*
+     * Only the disk-usage series carries a diskPath attribute. A stray
+     * serverMonitorOptions left on a non-disk filter used to be harmless
+     * because an empty window fell back to the live value; now it would
+     * silence the filter, so it must not reach the query.
+     */
+    test("does not scope a response-time window by a stray disk path", async () => {
+      windowSamples = everyMinute([9000, 9000, 9000]);
+
+      const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        MetricService,
+        "findBy",
+      );
+
+      const result: string | null = await evaluate({
+        criteriaFilter: {
+          checkOn: CheckOn.ResponseTime,
+          filterType: FilterType.GreaterThan,
+          value: 8000,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 2,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+          serverMonitorOptions: { diskPath: "/" },
+        },
+        dataToProcess: buildResponse({ responseTimeInMs: 9000 }),
+      });
+
+      const query: Record<string, unknown> = (
+        findBySpy.mock.calls[0]![0] as { query: Record<string, unknown> }
+      ).query;
+
+      expect(query["attributes"]).toBeUndefined();
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("filters that do not evaluate over time", () => {
+    test("still compare the value that arrived with this check", async () => {
+      windowSamples = [];
+
+      const result: string | null = await evaluate({
+        criteriaFilter: {
+          checkOn: CheckOn.ResponseStatusCode,
+          filterType: FilterType.NotEqualTo,
+          value: 200,
+          evaluateOverTime: false,
+        },
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(result).toContain("not equal to 200");
+    });
+
+    test("the metric store is never read for them", async () => {
+      const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        MetricService,
+        "findBy",
+      );
+
+      await evaluate({
+        criteriaFilter: {
+          checkOn: CheckOn.ResponseStatusCode,
+          filterType: FilterType.NotEqualTo,
+          value: 200,
+          evaluateOverTime: false,
+        },
+        dataToProcess: buildResponse({ responseCode: 404 }),
+      });
+
+      expect(findBySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("checks with no metric series of their own", () => {
+    /*
+     * Response Body is not recorded as a metric, so an over-time flag on it
+     * cannot be honoured. It falls back to the body from this check rather
+     * than silently never matching.
+     */
+    test("fall back to the value from this check", async () => {
+      windowSamples = [];
+
+      const result: string | null = await evaluate({
+        criteriaFilter: {
+          checkOn: CheckOn.ResponseBody,
+          filterType: FilterType.Contains,
+          value: "healthy",
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+        },
+        dataToProcess: buildResponse({ responseBody: "all healthy here" }),
+      });
+
+      expect(result).toContain("Response body contains healthy");
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaPortTimings.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaPortTimings.test.ts
@@ -1,5 +1,7 @@
 import APIRequestCriteria from "../../../../../Server/Utils/Monitor/Criteria/APIRequestCriteria";
-import EvaluateOverTime from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
+import EvaluateOverTime, {
+  OverTimeCriteriaValue,
+} from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
 import {
   CheckOn,
   CriteriaFilter,
@@ -142,8 +144,11 @@ describe("APIRequestCriteria Port connection phase timings", () => {
 
   test("uses an evaluate-over-time aggregate instead of the current phase", async () => {
     const overTimeSpy: ReturnType<typeof jest.spyOn> = jest
-      .spyOn(EvaluateOverTime, "getValueOverTime")
-      .mockResolvedValue(250);
+      .spyOn(EvaluateOverTime, "getOverTimeValueForCriteriaFilter")
+      .mockResolvedValue({
+        earlyReturn: null,
+        value: 250,
+      } as OverTimeCriteriaValue);
 
     const response: ProbeMonitorResponse = buildResponse({
       dnsLookupInMs: 5,
@@ -164,13 +169,20 @@ describe("APIRequestCriteria Port connection phase timings", () => {
       expect.objectContaining({
         projectId: response.projectId,
         monitorId: response.monitorId,
-        metricType: CheckOn.PortDnsLookupTime,
+        criteriaFilter: expect.objectContaining({
+          checkOn: CheckOn.PortDnsLookupTime,
+        }),
       }),
     );
   });
 
   test("does not replace a zero evaluate-over-time aggregate with the current value", async () => {
-    jest.spyOn(EvaluateOverTime, "getValueOverTime").mockResolvedValue(0);
+    jest
+      .spyOn(EvaluateOverTime, "getOverTimeValueForCriteriaFilter")
+      .mockResolvedValue({
+        earlyReturn: null,
+        value: 0,
+      } as OverTimeCriteriaValue);
 
     const result: string | null = await evaluate(
       buildResponse({
@@ -189,10 +201,19 @@ describe("APIRequestCriteria Port connection phase timings", () => {
     expect(result).not.toBeNull();
   });
 
-  test("falls back to the current phase if the history query fails", async () => {
+  /*
+   * An over-time filter whose history could not be read says nothing about
+   * the last N minutes, so it must not fire. It used to quietly compare the
+   * single phase timing from this one check instead - the same fallback that
+   * let "all values over the last N minutes" fire off one bad probe.
+   */
+  test("does not fire off the current phase if the history query fails", async () => {
     jest
-      .spyOn(EvaluateOverTime, "getValueOverTime")
-      .mockRejectedValue(new Error("history unavailable"));
+      .spyOn(EvaluateOverTime, "getOverTimeValueForCriteriaFilter")
+      .mockResolvedValue({
+        earlyReturn: { result: null },
+        value: undefined,
+      } as OverTimeCriteriaValue);
 
     const result: string | null = await evaluate(
       buildResponse({
@@ -207,6 +228,6 @@ describe("APIRequestCriteria Port connection phase timings", () => {
       }),
     );
 
-    expect(result).not.toBeNull();
+    expect(result).toBeNull();
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/EvaluateOverTime.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/EvaluateOverTime.test.ts
@@ -1,0 +1,987 @@
+import EvaluateOverTime, {
+  OverTimeCriteriaValue,
+  OverTimeEvaluation,
+  OverTimeEvaluationStatus,
+} from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
+import MetricService from "../../../../../Server/Services/MetricService";
+import FindBy from "../../../../../Server/Types/AnalyticsDatabase/FindBy";
+import { JSONObject } from "../../../../../Types/JSON";
+import Metric from "../../../../../Models/AnalyticsModels/Metric";
+import InBetween from "../../../../../Types/BaseDatabase/InBetween";
+import MonitorMetricType from "../../../../../Types/Monitor/MonitorMetricType";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+  NoDataPolicy,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import ObjectID from "../../../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Everything here is anchored to a fixed "now" so the window arithmetic -
+ * which is the whole point of these tests - never depends on the wall clock.
+ */
+const NOW: Date = new Date("2026-08-20T12:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+/** A Metric row as the analytics layer hands it back. */
+function sample(input: { value: number; minutesAgo: number }): Metric {
+  const metric: Metric = new Metric();
+  metric.value = input.value;
+  metric.time = new Date(NOW.getTime() - input.minutesAgo * 60 * 1000);
+  return metric;
+}
+
+/**
+ * A run of samples one per minute ending at `now`, oldest first.
+ * `values[0]` is the oldest.
+ */
+function everyMinute(values: Array<number>): Array<Metric> {
+  return values.map((value: number, index: number) => {
+    return sample({
+      value: value,
+      minutesAgo: values.length - 1 - index,
+    });
+  });
+}
+
+function criteria(overrides: Partial<CriteriaFilter> = {}): CriteriaFilter {
+  return {
+    checkOn: CheckOn.ResponseStatusCode,
+    filterType: FilterType.NotEqualTo,
+    value: 200,
+    evaluateOverTime: true,
+    evaluateOverTimeOptions: {
+      timeValueInMinutes: 5,
+      evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+    },
+    ...overrides,
+  };
+}
+
+/*
+ * The metric read is stubbed in memory rather than through a typed spy so
+ * every query it receives can be asserted on directly.
+ */
+let findByCalls: Array<FindBy<Metric>> = [];
+let findByResult: Array<Metric> = [];
+let findByError: Error | null = null;
+
+function mockSamples(metrics: Array<Metric>): void {
+  findByResult = metrics;
+}
+
+function lastQuery(): JSONObject {
+  return findByCalls[0]!.query as unknown as JSONObject;
+}
+
+function lastSelect(): JSONObject {
+  return findByCalls[0]!.select as unknown as JSONObject;
+}
+
+function evaluate(input: {
+  criteriaFilter: CriteriaFilter;
+  monitoringInterval?: string | undefined;
+  miscData?: JSONObject | undefined;
+}): Promise<OverTimeEvaluation> {
+  return EvaluateOverTime.evaluateOverTime({
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    criteriaFilter: input.criteriaFilter,
+    monitoringInterval: input.monitoringInterval,
+    miscData: input.miscData,
+  });
+}
+
+describe("EvaluateOverTime", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+
+    findByCalls = [];
+    findByResult = [];
+    findByError = null;
+
+    jest
+      .spyOn(MetricService, "findBy")
+      .mockImplementation((findBy: FindBy<Metric>): Promise<Array<Metric>> => {
+        findByCalls.push(findBy);
+
+        if (findByError) {
+          return Promise.reject(findByError);
+        }
+
+        return Promise.resolve(findByResult);
+      });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("when the filter does not evaluate over time", () => {
+    test("reports NotConfigured when evaluateOverTime is false", async () => {
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({ evaluateOverTime: false }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.NotConfigured);
+      expect(findByCalls).toHaveLength(0);
+    });
+
+    test("reports NotConfigured when the options are missing", async () => {
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({ evaluateOverTimeOptions: undefined }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.NotConfigured);
+      expect(findByCalls).toHaveLength(0);
+    });
+  });
+
+  describe("query shape", () => {
+    test("scopes the window, the project, the monitor and the series", async () => {
+      mockSamples(everyMinute([200, 200, 200, 200, 200]));
+
+      await evaluate({ criteriaFilter: criteria() });
+
+      expect(findByCalls).toHaveLength(1);
+
+      const query: JSONObject = lastQuery();
+
+      expect(query["projectId"]).toBe(PROJECT_ID);
+      expect(query["primaryEntityId"]).toBe(MONITOR_ID);
+      expect(query["name"]).toBe(MonitorMetricType.ResponseStatusCode);
+
+      const time: InBetween<Date> = query["time"] as InBetween<Date>;
+      expect(time).toBeInstanceOf(InBetween);
+      expect((time.startValue as Date).toISOString()).toBe(
+        "2026-08-20T11:55:00.000Z",
+      );
+      expect((time.endValue as Date).toISOString()).toBe(NOW.toISOString());
+    });
+
+    test("selects the sample time as well as the value", async () => {
+      mockSamples(everyMinute([200]));
+
+      await evaluate({ criteriaFilter: criteria() });
+
+      const select: JSONObject = lastSelect();
+
+      expect(select["value"]).toBe(true);
+      expect(select["time"]).toBe(true);
+    });
+
+    test("passes misc data through as an attribute filter", async () => {
+      mockSamples(everyMinute([10]));
+
+      await evaluate({
+        criteriaFilter: criteria({ checkOn: CheckOn.DiskUsagePercent }),
+        miscData: { diskPath: "/var" },
+      });
+
+      const query: JSONObject = lastQuery();
+
+      expect(query["attributes"]).toEqual({ diskPath: "/var" });
+    });
+  });
+
+  describe("CheckOns that no series records", () => {
+    /*
+     * These used to throw inside a try/catch that reset the value to
+     * undefined, which sent the evaluator down its instantaneous fallback -
+     * an over-time filter that quietly was not one.
+     */
+    test("reports Unsupported instead of throwing", async () => {
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({ checkOn: CheckOn.ResponseBody }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Unsupported);
+      expect(findByCalls).toHaveLength(0);
+    });
+
+    test("neither do incoming requests or SNMP OID existence", async () => {
+      for (const checkOn of [CheckOn.IncomingRequest, CheckOn.SnmpOidExists]) {
+        const result: OverTimeEvaluation = await evaluate({
+          criteriaFilter: criteria({ checkOn: checkOn }),
+        });
+
+        expect(result.status).toBe(OverTimeEvaluationStatus.Unsupported);
+      }
+
+      expect(findByCalls).toHaveLength(0);
+    });
+
+    test("Is Request Timeout has no series of its own", async () => {
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({ checkOn: CheckOn.IsRequestTimeout }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Unsupported);
+    });
+  });
+
+  describe("CheckOns that share the generic probe series", () => {
+    /*
+     * DNS / SNMP / External Status Page probes write into the shared online
+     * and response-time series. Their CheckOns had no entry in the metric
+     * map at all, so "evaluate over time" was a no-op for every one of them.
+     */
+    const onlineCheckOns: Array<CheckOn> = [
+      CheckOn.DnsIsOnline,
+      CheckOn.SnmpIsOnline,
+      CheckOn.ExternalStatusPageIsOnline,
+    ];
+
+    for (const checkOn of onlineCheckOns) {
+      test(`${checkOn} reads the online series`, async () => {
+        mockSamples(everyMinute([0, 0, 0, 0, 0]));
+
+        const result: OverTimeEvaluation = await evaluate({
+          criteriaFilter: criteria({
+            checkOn: checkOn,
+            filterType: FilterType.False,
+            value: undefined,
+          }),
+        });
+
+        expect(lastQuery()["name"]).toBe(MonitorMetricType.IsOnline);
+        expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+        // 0 maps to false for online-style series.
+        expect(result.value).toEqual([false, false, false, false, false]);
+      });
+    }
+
+    const responseTimeCheckOns: Array<CheckOn> = [
+      CheckOn.DnsResponseTime,
+      CheckOn.SnmpResponseTime,
+      CheckOn.ExternalStatusPageResponseTime,
+    ];
+
+    for (const checkOn of responseTimeCheckOns) {
+      test(`${checkOn} reads the response time series`, async () => {
+        mockSamples(everyMinute([10, 20, 30, 40, 50]));
+
+        const result: OverTimeEvaluation = await evaluate({
+          criteriaFilter: criteria({ checkOn: checkOn }),
+        });
+
+        expect(lastQuery()["name"]).toBe(MonitorMetricType.ResponseTime);
+        expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+        expect(result.value).toEqual([10, 20, 30, 40, 50]);
+      });
+    }
+  });
+
+  describe("empty and unreadable windows", () => {
+    test("an empty window is InsufficientData, not an empty array", async () => {
+      mockSamples([]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+      expect(result.sampleCount).toBe(0);
+      expect(result.isReadError).toBe(false);
+      expect(result.noDataReason).toContain("No data was recorded");
+    });
+
+    test("a failed read is InsufficientData and is flagged as an error", async () => {
+      findByError = new Error("clickhouse unavailable");
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+      expect(result.isReadError).toBe(true);
+    });
+
+    /*
+     * The dashboard persists the window dropdown's STRING value while
+     * Terraform and the API send a number - both must behave the same.
+     */
+    test("accepts a window length that arrives as a string", async () => {
+      mockSamples(everyMinute([404, 404, 404, 404, 404]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: "5" as unknown as number,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+        }),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+
+      const time: InBetween<Date> = lastQuery()["time"] as InBetween<Date>;
+      expect((time.startValue as Date).toISOString()).toBe(
+        "2026-08-20T11:55:00.000Z",
+      );
+    });
+
+    test("an unparseable window length cannot be evaluated", async () => {
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: "not-a-number" as unknown as number,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+        }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+      expect(findByCalls).toHaveLength(0);
+    });
+
+    test("a window of zero minutes cannot be evaluated", async () => {
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 0,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+        }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+      expect(findByCalls).toHaveLength(0);
+    });
+
+    test("rows with no value are dropped", async () => {
+      const withoutValue: Metric = new Metric();
+      withoutValue.time = NOW;
+
+      mockSamples([...everyMinute([200, 200, 200, 200, 200]), withoutValue]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+      });
+
+      expect(result.sampleCount).toBe(5);
+    });
+  });
+
+  describe("All Values needs the window to actually be covered", () => {
+    /*
+     * This is the bug from #2321. Array.every() is trivially true on a
+     * single element, so one bad probe satisfied "all values over the last
+     * five minutes" - on a brand new monitor, or any time the window had not
+     * filled up.
+     */
+    test("a single sample cannot satisfy a five minute window", async () => {
+      mockSamples([sample({ value: 404, minutesAgo: 0 })]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+      expect(result.sampleCount).toBe(1);
+      expect(result.noDataReason).toContain("not enough to cover");
+    });
+
+    test("a partially filled window cannot satisfy it either", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 1 }),
+        sample({ value: 404, minutesAgo: 0 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+    });
+
+    test("a fully covered window evaluates", async () => {
+      mockSamples(everyMinute([404, 404, 404, 404, 404]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+      expect(result.value).toEqual([404, 404, 404, 404, 404]);
+    });
+
+    /*
+     * A monitor polled once every five minutes can only ever put one sample
+     * in a five minute window, so that one sample IS the whole window.
+     */
+    test("one sample covers the window when the monitor polls that slowly", async () => {
+      mockSamples([sample({ value: 404, minutesAgo: 0 })]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "*/5 * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+
+    test("tolerates a probe skipping a beat at the start of the window", async () => {
+      /*
+       * Oldest sample sits 1.5 intervals into the window, which is the
+       * documented jitter allowance - still covered.
+       */
+      mockSamples([
+        sample({ value: 404, minutesAgo: 3.5 }),
+        sample({ value: 404, minutesAgo: 2 }),
+        sample({ value: 404, minutesAgo: 1 }),
+        sample({ value: 404, minutesAgo: 0 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+
+    test("rejects a gap wider than the jitter allowance", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 3.4 }),
+        sample({ value: 404, minutesAgo: 2 }),
+        sample({ value: 404, minutesAgo: 1 }),
+        sample({ value: 404, minutesAgo: 0 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+    });
+
+    /*
+     * Coverage has two edges. Samples that stop part way through the window
+     * say nothing about the minutes since, so they must not satisfy
+     * "all values over the last N minutes" either.
+     */
+    test("rejects a window whose samples stopped part way through", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 4 }),
+        sample({ value: 404, minutesAgo: 3 }),
+        sample({ value: 404, minutesAgo: 2 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+    });
+
+    /*
+     * Metric writes are not synchronous, so the newest sample can lag the
+     * check that produced it. One interval of lag must not stall the filter.
+     */
+    test("tolerates the newest sample lagging by one interval", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 4 }),
+        sample({ value: 404, minutesAgo: 3 }),
+        sample({ value: 404, minutesAgo: 2 }),
+        sample({ value: 404, minutesAgo: 1 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+
+    test("the trailing tolerance is exactly one and a half intervals", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 4 }),
+        sample({ value: 404, minutesAgo: 3 }),
+        sample({ value: 404, minutesAgo: 1.5 }),
+      ]);
+
+      const onTheBoundary: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(onTheBoundary.status).toBe(OverTimeEvaluationStatus.Evaluated);
+
+      mockSamples([
+        sample({ value: 404, minutesAgo: 4 }),
+        sample({ value: 404, minutesAgo: 3 }),
+        sample({ value: 404, minutesAgo: 1.6 }),
+      ]);
+
+      const pastTheBoundary: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(pastTheBoundary.status).toBe(
+        OverTimeEvaluationStatus.InsufficientData,
+      );
+    });
+
+    /*
+     * A probe's clock running slightly ahead of ours dates a sample in the
+     * future. That is still fresh data, not a gap.
+     */
+    test("a sample dated slightly in the future does not break coverage", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 4 }),
+        sample({ value: 404, minutesAgo: 3 }),
+        sample({ value: 404, minutesAgo: 2 }),
+        sample({ value: 404, minutesAgo: 1 }),
+        sample({ value: 404, minutesAgo: -0.5 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+
+    /*
+     * A monitoringInterval that is not a cron (the label form this repo's
+     * own Terraform examples write) must not be trusted as a cadence - the
+     * samples themselves are the only evidence left.
+     */
+    test("an unparseable schedule falls back to the sampled cadence", async () => {
+      mockSamples([sample({ value: 404, minutesAgo: 0 })]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "Every 5 minutes",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+    });
+
+    test("infers the cadence from the samples when no schedule is configured", async () => {
+      mockSamples(everyMinute([404, 404, 404, 404, 404]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+
+    test("a lone sample with no schedule cannot cover the window", async () => {
+      mockSamples([sample({ value: 404, minutesAgo: 0 })]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+    });
+
+    /*
+     * Several probes write into the same series, so samples interleave and
+     * the window holds many more rows than one per interval. That must not
+     * be mistaken for a gap.
+     */
+    test("handles several probes writing into the same series", async () => {
+      const metrics: Array<Metric> = [];
+
+      for (let minutesAgo: number = 4; minutesAgo >= 0; minutesAgo--) {
+        metrics.push(sample({ value: 404, minutesAgo: minutesAgo }));
+        metrics.push(sample({ value: 404, minutesAgo: minutesAgo - 0.1 }));
+        metrics.push(sample({ value: 404, minutesAgo: minutesAgo - 0.2 }));
+      }
+
+      mockSamples(metrics);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+      expect(result.sampleCount).toBe(15);
+    });
+
+    test("rows arriving out of order are still judged correctly", async () => {
+      mockSamples([
+        sample({ value: 404, minutesAgo: 0 }),
+        sample({ value: 404, minutesAgo: 4 }),
+        sample({ value: 404, minutesAgo: 2 }),
+        sample({ value: 404, minutesAgo: 1 }),
+        sample({ value: 404, minutesAgo: 3 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+  });
+
+  describe("evaluation types other than All Values", () => {
+    /*
+     * "Any Value" is documented to fire on a single breaching sample, so the
+     * coverage guard must not touch it.
+     */
+    test("Any Value evaluates off a single sample", async () => {
+      mockSamples([sample({ value: 404, minutesAgo: 0 })]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AnyValue,
+          },
+        }),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+      expect(result.value).toEqual([404]);
+    });
+
+    test("Any Value is not gated on coverage at all", async () => {
+      // Samples cover only the first minute of a five minute window.
+      mockSamples([
+        sample({ value: 404, minutesAgo: 5 }),
+        sample({ value: 404, minutesAgo: 4.5 }),
+      ]);
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AnyValue,
+          },
+        }),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+    });
+
+    test("Average aggregates the window", async () => {
+      mockSamples(everyMinute([10, 20, 30]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.ResponseTime,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.Average,
+          },
+        }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+      expect(result.value).toBe(20);
+    });
+
+    test("Sum aggregates the window", async () => {
+      mockSamples(everyMinute([10, 20, 30]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.ResponseTime,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.Sum,
+          },
+        }),
+      });
+
+      expect(result.value).toBe(60);
+    });
+
+    test("Maximum Value aggregates the window", async () => {
+      mockSamples(everyMinute([10, 90, 30]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.ResponseTime,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.MaximumValue,
+          },
+        }),
+      });
+
+      expect(result.value).toBe(90);
+    });
+
+    test("Minimum Value aggregates the window", async () => {
+      mockSamples(everyMinute([10, 90, 30]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.ResponseTime,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.MunimumValue,
+          },
+        }),
+      });
+
+      expect(result.value).toBe(10);
+    });
+
+    /*
+     * Math.min/max/average over an empty array produce Infinity, -Infinity
+     * and NaN. None of those are arrays, so the old empty-window guard never
+     * saw them and "Minimum Value greater than <anything>" was a guaranteed
+     * false alarm on a monitor with no data. An empty window is now reported
+     * before any aggregate is computed.
+     */
+    test("an empty window never reaches the aggregates", async () => {
+      const aggregateTypes: Array<EvaluateOverTimeType> = [
+        EvaluateOverTimeType.Average,
+        EvaluateOverTimeType.Sum,
+        EvaluateOverTimeType.MaximumValue,
+        EvaluateOverTimeType.MunimumValue,
+      ];
+
+      for (const evaluateOverTimeType of aggregateTypes) {
+        mockSamples([]);
+
+        const result: OverTimeEvaluation = await evaluate({
+          criteriaFilter: criteria({
+            checkOn: CheckOn.ResponseTime,
+            evaluateOverTimeOptions: {
+              timeValueInMinutes: 5,
+              evaluateOverTimeType: evaluateOverTimeType,
+            },
+          }),
+        });
+
+        expect(result.status).toBe(OverTimeEvaluationStatus.InsufficientData);
+        expect(result.value).toBeUndefined();
+      }
+    });
+
+    test("an aggregate of exactly zero is still a real value", async () => {
+      mockSamples(everyMinute([0, 0, 0]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.CPUUsagePercent,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.Average,
+          },
+        }),
+      });
+
+      expect(result.status).toBe(OverTimeEvaluationStatus.Evaluated);
+      expect(result.value).toBe(0);
+    });
+  });
+
+  describe("boolean series", () => {
+    test("1 becomes true and everything else becomes false", async () => {
+      mockSamples(everyMinute([1, 0, 1, 1, 0]));
+
+      const result: OverTimeEvaluation = await evaluate({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        }),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.value).toEqual([true, false, true, true, false]);
+    });
+  });
+
+  describe("getOverTimeValueForCriteriaFilter", () => {
+    function resolve(input: {
+      criteriaFilter: CriteriaFilter;
+      monitoringInterval?: string | undefined;
+    }): Promise<OverTimeCriteriaValue> {
+      return EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: PROJECT_ID,
+        monitorId: MONITOR_ID,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
+    }
+
+    test("hands back the window when it is usable", async () => {
+      mockSamples(everyMinute([404, 404, 404, 404, 404]));
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.earlyReturn).toBeNull();
+      expect(result.value).toEqual([404, 404, 404, 404, 404]);
+    });
+
+    test("lets a filter that does not evaluate over time carry on", async () => {
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({ evaluateOverTime: false }),
+      });
+
+      expect(result.earlyReturn).toBeNull();
+      expect(result.value).toBeUndefined();
+    });
+
+    test("lets a CheckOn with no series carry on with its live value", async () => {
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({ checkOn: CheckOn.ResponseBody }),
+      });
+
+      expect(result.earlyReturn).toBeNull();
+      expect(result.value).toBeUndefined();
+    });
+
+    test("does not fire by default while the window is still filling", async () => {
+      mockSamples([sample({ value: 404, minutesAgo: 0 })]);
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria(),
+        monitoringInterval: "* * * * *",
+      });
+
+      expect(result.earlyReturn).toEqual({ result: null });
+      expect(result.value).toBeUndefined();
+    });
+
+    test("Ignore is the default even when nothing was ever recorded", async () => {
+      mockSamples([]);
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria(),
+      });
+
+      expect(result.earlyReturn).toEqual({ result: null });
+    });
+
+    test("Trigger fires with a no-data root cause", async () => {
+      mockSamples([]);
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+            onNoDataPolicy: NoDataPolicy.Trigger,
+          },
+        }),
+      });
+
+      expect(result.earlyReturn?.result).toContain(
+        CheckOn.ResponseStatusCode as string,
+      );
+      expect(result.earlyReturn?.result).toContain("no data");
+    });
+
+    test("Treat As Zero substitutes zero for a numeric series", async () => {
+      mockSamples([]);
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.ResponseTime,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+            onNoDataPolicy: NoDataPolicy.TreatAsZero,
+          },
+        }),
+      });
+
+      expect(result.earlyReturn).toBeNull();
+      expect(result.value).toEqual([0]);
+    });
+
+    test("Treat As Zero substitutes false for an online series", async () => {
+      mockSamples([]);
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+            onNoDataPolicy: NoDataPolicy.TreatAsZero,
+          },
+        }),
+      });
+
+      expect(result.value).toEqual([false]);
+    });
+
+    /*
+     * A metric store we could not read tells us nothing about the monitor.
+     * Reporting that as a breach would turn every ClickHouse hiccup into an
+     * incident, so Trigger is deliberately not honoured here.
+     */
+    test("a read failure is not substituted with zero either", async () => {
+      findByError = new Error("clickhouse unavailable");
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({
+          checkOn: CheckOn.ResponseTime,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+            onNoDataPolicy: NoDataPolicy.TreatAsZero,
+          },
+        }),
+      });
+
+      expect(result.earlyReturn).toEqual({ result: null });
+      expect(result.value).toBeUndefined();
+    });
+
+    test("a read failure never fires, even under the Trigger policy", async () => {
+      findByError = new Error("clickhouse unavailable");
+
+      const result: OverTimeCriteriaValue = await resolve({
+        criteriaFilter: criteria({
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+            onNoDataPolicy: NoDataPolicy.Trigger,
+          },
+        }),
+      });
+
+      expect(result.earlyReturn).toEqual({ result: null });
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.test.ts
@@ -1,5 +1,7 @@
 import ServerMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/ServerMonitorCriteria";
-import EvaluateOverTime from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
+import EvaluateOverTime, {
+  OverTimeCriteriaValue,
+} from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
 import BasicInfrastructureMetrics, {
   BasicDiskMetrics,
   LoadMetrics,
@@ -893,15 +895,35 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
   });
 
   /*
-   * The evaluate-over-time path replaces the current metric value with a
-   * historical aggregate. The DB-backed EvaluateOverTime.getValueOverTime is
-   * spied so these tests stay deterministic.
+   * The evaluate-over-time path replaces the current metric value with the
+   * window recorded for the monitor. The DB-backed lookup is spied so these
+   * tests stay deterministic.
    */
   describe("evaluate over time", () => {
+    /** The window produced a usable value. */
+    function usable(
+      value: Array<number | boolean> | number | boolean,
+    ): OverTimeCriteriaValue {
+      return { earlyReturn: null, value: value };
+    }
+
+    /** The window could not back the filter, so nothing is compared. */
+    function noUsableWindow(): OverTimeCriteriaValue {
+      return { earlyReturn: { result: null }, value: undefined };
+    }
+
+    function mockOverTime(
+      result: OverTimeCriteriaValue,
+    ): ReturnType<typeof jest.spyOn> {
+      return jest
+        .spyOn(EvaluateOverTime, "getOverTimeValueForCriteriaFilter")
+        .mockResolvedValue(result) as ReturnType<typeof jest.spyOn>;
+    }
+
     test("uses the over-time boolean series for IsOnline while online", async () => {
-      const spy: ReturnType<typeof jest.spyOn> = jest
-        .spyOn(EvaluateOverTime, "getValueOverTime")
-        .mockResolvedValue([true, false]);
+      const spy: ReturnType<typeof jest.spyOn> = mockOverTime(
+        usable([true, false]),
+      );
 
       const response: ServerMonitorResponse = buildServerResponse({
         minutesSinceLastCheck: 5,
@@ -923,7 +945,9 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         expect.objectContaining({
           projectId: response.projectId,
           monitorId: response.monitorId,
-          metricType: CheckOn.IsOnline,
+          criteriaFilter: expect.objectContaining({
+            checkOn: CheckOn.IsOnline,
+          }),
         }),
       );
     });
@@ -934,9 +958,7 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
      * been offline under the default of 3.
      */
     test("timeValueInMinutes overrides the offline threshold", async () => {
-      jest
-        .spyOn(EvaluateOverTime, "getValueOverTime")
-        .mockResolvedValue([false, false]);
+      mockOverTime(usable([false, false]));
 
       const result: string | null = await evaluate(
         buildServerResponse({ minutesSinceLastCheck: 5 }),
@@ -956,11 +978,14 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
     });
 
     /*
-     * An empty history array is reset to undefined, so IsOnline falls back to
-     * the "recent check → online" default rather than an empty series.
+     * "Is Online" is the one filter that keeps its fallback: for a server
+     * monitor the absence of data IS the signal, and the last-check-in
+     * arithmetic above already implements the "wait this long" behaviour. So
+     * an unusable window still falls back to the "recent check -> online"
+     * default rather than declining to evaluate.
      */
     test("empty over-time series falls back to the liveness default", async () => {
-      jest.spyOn(EvaluateOverTime, "getValueOverTime").mockResolvedValue([]);
+      mockOverTime(noUsableWindow());
 
       const result: string | null = await evaluate(
         buildServerResponse({ minutesSinceLastCheck: 1 }),
@@ -984,9 +1009,7 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
      * metric. The array (70, 80) breaches while the live value (10) would not.
      */
     test("over-time numeric series takes precedence over the live CPU metric", async () => {
-      jest
-        .spyOn(EvaluateOverTime, "getValueOverTime")
-        .mockResolvedValue([70, 80]);
+      mockOverTime(usable([70, 80]));
 
       const result: string | null = await evaluate(
         buildServerResponse({ metrics: buildMetrics({ cpuPercentUsed: 10 }) }),
@@ -1007,14 +1030,45 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
     });
 
     /*
-     * A scalar zero aggregate is falsy, so the evaluator falls back to the
-     * live CPU metric rather than treating 0 as the value to compare.
+     * Only the disk-usage series carries a diskPath attribute. Scoping any
+     * other series by it would filter against an attribute no row has, and
+     * an unusable window now means the filter waits rather than comparing
+     * the live value - so the stray option would silence it outright.
      */
-    test("scalar zero aggregate falls back to the live CPU metric", async () => {
-      jest.spyOn(EvaluateOverTime, "getValueOverTime").mockResolvedValue(0);
+    test("scopes the window by disk path only for disk usage", async () => {
+      const spy: ReturnType<typeof jest.spyOn> = mockOverTime(usable([95]));
 
-      const result: string | null = await evaluate(
-        buildServerResponse({ metrics: buildMetrics({ cpuPercentUsed: 90 }) }),
+      await evaluate(
+        buildServerResponse({
+          metrics: buildMetrics({
+            diskMetrics: [
+              buildDiskMetric({ diskPath: "/data", percentUsed: 95 }),
+            ],
+          }),
+        }),
+        {
+          checkOn: CheckOn.DiskUsagePercent,
+          filterType: FilterType.GreaterThan,
+          value: 90,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+          serverMonitorOptions: { diskPath: "/data" },
+        },
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ miscData: { diskPath: "/data" } }),
+      );
+    });
+
+    test("does not scope a CPU window by a stray disk path", async () => {
+      const spy: ReturnType<typeof jest.spyOn> = mockOverTime(usable([70, 80]));
+
+      await evaluate(
+        buildServerResponse({ metrics: buildMetrics({ cpuPercentUsed: 75 }) }),
         {
           checkOn: CheckOn.CPUUsagePercent,
           filterType: FilterType.GreaterThan,
@@ -1022,23 +1076,103 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
           evaluateOverTime: true,
           evaluateOverTimeOptions: {
             timeValueInMinutes: 5,
-            evaluateOverTimeType: EvaluateOverTimeType.Average,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
           },
+          serverMonitorOptions: { diskPath: "/" },
         },
       );
 
-      expect(result).toContain(CheckOn.CPUUsagePercent);
-      expect(result).toContain("90");
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ miscData: undefined }),
+      );
     });
 
     /*
-     * If the history query throws, the error is swallowed and the evaluator
-     * falls back to the live metric instead of failing the criterion.
+     * Disk usage read its over-time window and then threw the result away,
+     * comparing the reading from this check instead - so "evaluate over
+     * time" on a disk filter did nothing at all.
      */
-    test("history query failure falls back to the live CPU metric", async () => {
-      jest
-        .spyOn(EvaluateOverTime, "getValueOverTime")
-        .mockRejectedValue(new Error("history unavailable"));
+    test("disk usage compares the over-time window, not just this check", async () => {
+      mockOverTime(usable([95, 96, 97]));
+
+      const result: string | null = await evaluate(
+        buildServerResponse({
+          metrics: buildMetrics({
+            diskMetrics: [buildDiskMetric({ diskPath: "/", percentUsed: 10 })],
+          }),
+        }),
+        {
+          checkOn: CheckOn.DiskUsagePercent,
+          filterType: FilterType.GreaterThan,
+          value: 90,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+          serverMonitorOptions: { diskPath: "/" },
+        },
+      );
+
+      expect(result).toContain("All values of");
+      expect(result).toContain("95");
+    });
+
+    test("disk usage does not fire while its window is unusable", async () => {
+      mockOverTime(noUsableWindow());
+
+      const result: string | null = await evaluate(
+        buildServerResponse({
+          metrics: buildMetrics({
+            diskMetrics: [buildDiskMetric({ diskPath: "/", percentUsed: 99 })],
+          }),
+        }),
+        {
+          checkOn: CheckOn.DiskUsagePercent,
+          filterType: FilterType.GreaterThan,
+          value: 90,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+          serverMonitorOptions: { diskPath: "/" },
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    /*
+     * A disk filter that does NOT evaluate over time keeps comparing the
+     * reading from this check.
+     */
+    test("disk usage without over-time still compares this check", async () => {
+      const result: string | null = await evaluate(
+        buildServerResponse({
+          metrics: buildMetrics({
+            diskMetrics: [buildDiskMetric({ diskPath: "/", percentUsed: 99 })],
+          }),
+        }),
+        {
+          checkOn: CheckOn.DiskUsagePercent,
+          filterType: FilterType.GreaterThan,
+          value: 90,
+          serverMonitorOptions: { diskPath: "/" },
+        },
+      );
+
+      expect(result).toContain("99");
+    });
+
+    /*
+     * An average of exactly zero is a real measurement, not a missing one.
+     * It used to be swallowed by a truthiness check and replaced with the
+     * live CPU reading, so "average CPU over 5 minutes above 50%" could fire
+     * on a single busy sample while the average itself was 0.
+     */
+    test("a zero aggregate is compared as zero, not replaced by the live metric", async () => {
+      mockOverTime(usable(0));
 
       const result: string | null = await evaluate(
         buildServerResponse({ metrics: buildMetrics({ cpuPercentUsed: 90 }) }),
@@ -1054,8 +1188,32 @@ describe("ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         },
       );
 
-      expect(result).toContain(CheckOn.CPUUsagePercent);
-      expect(result).toContain("90");
+      expect(result).toBeNull();
+    });
+
+    /*
+     * A window that could not be read says nothing about the last five
+     * minutes, so the filter waits rather than firing off the single live
+     * reading that happens to have arrived with this check.
+     */
+    test("an unreadable window does not fire off the live CPU metric", async () => {
+      mockOverTime(noUsableWindow());
+
+      const result: string | null = await evaluate(
+        buildServerResponse({ metrics: buildMetrics({ cpuPercentUsed: 90 }) }),
+        {
+          checkOn: CheckOn.CPUUsagePercent,
+          filterType: FilterType.GreaterThan,
+          value: 50,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.Average,
+          },
+        },
+      );
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/MonitorResourceIngestedStepSelection.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorResourceIngestedStepSelection.test.ts
@@ -33,6 +33,16 @@
  * MonitorResourceProbeAgreementReuse.test.ts. Pure in-memory model instances.
  */
 
+/*
+ * MonitorResource's import chain reaches the native isolated-vm addon
+ * through the sandbox runner. Nothing here touches the sandbox and the
+ * prebuilt binary cannot always dlopen in the test environment, so stub it
+ * out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
 jest.mock("../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator", () => {
   return {
     __esModule: true,
@@ -450,6 +460,82 @@ describe("MonitorResourceUtil.monitorResource ingested monitor step selection", 
       expect(response.ingestedMonitorStepId?.toString()).toBe(
         stepOne.id.toString(),
       );
+    });
+  });
+
+  /*
+   * Over-time criteria size their evaluation window from the monitor's
+   * polling schedule, so the monitor load on this path has to select it.
+   * Without it the cadence is always inferred from the samples, and a
+   * monitor that can only ever produce one sample per window can never
+   * satisfy "All Values" - alerting goes quiet with nothing logged.
+   */
+  describe("monitor load", () => {
+    test("selects the monitoring interval", async () => {
+      const step: MonitorStep = makeStep("Step one criteria");
+      const monitor: Monitor = makeMonitor({
+        monitorType: MonitorType.Website,
+        steps: [step],
+      });
+      monitor.monitoringInterval = "*/5 * * * *";
+
+      const probeId: ObjectID = ObjectID.generate();
+
+      const monitorProbe: MonitorProbe = new MonitorProbe();
+      monitorProbe.id = ObjectID.generate();
+      monitorProbe.probeId = probeId;
+      monitorProbe.isEnabled = true;
+
+      findOneByIdMock.mockResolvedValue(monitor);
+      findByMock.mockResolvedValue([monitorProbe]);
+
+      await MonitorResourceUtil.monitorResource(
+        makeProbeResult({
+          monitor: monitor,
+          probeId: probeId,
+          monitorStepId: step.id,
+        }),
+      );
+
+      const select: Record<string, unknown> = (
+        findOneByIdMock.mock.calls[0]![0] as {
+          select: Record<string, unknown>;
+        }
+      ).select;
+
+      expect(select["monitoringInterval"]).toBe(true);
+    });
+
+    test("hands the monitoring interval to the criteria evaluator", async () => {
+      const step: MonitorStep = makeStep("Step one criteria");
+      const monitor: Monitor = makeMonitor({
+        monitorType: MonitorType.Website,
+        steps: [step],
+      });
+      monitor.monitoringInterval = "*/5 * * * *";
+
+      const probeId: ObjectID = ObjectID.generate();
+
+      const monitorProbe: MonitorProbe = new MonitorProbe();
+      monitorProbe.id = ObjectID.generate();
+      monitorProbe.probeId = probeId;
+      monitorProbe.isEnabled = true;
+
+      findOneByIdMock.mockResolvedValue(monitor);
+      findByMock.mockResolvedValue([monitorProbe]);
+
+      await MonitorResourceUtil.monitorResource(
+        makeProbeResult({
+          monitor: monitor,
+          probeId: probeId,
+          monitorStepId: step.id,
+        }),
+      );
+
+      const evaluatorInput: { monitor: Monitor } = processMonitorStepMock.mock
+        .calls[0]![0] as { monitor: Monitor };
+
+      expect(evaluatorInput.monitor.monitoringInterval).toBe("*/5 * * * *");
     });
   });
 });

--- a/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
@@ -398,3 +398,83 @@ describe("invariant: every probeable monitor type displays some metric", () => {
     expect(typesWithoutMetrics).toEqual([]);
   });
 });
+
+/*
+ * The null-returning variant exists because over-time evaluation asks "is
+ * there a series behind this CheckOn?" for every filter it sees. It used to
+ * ask by calling the throwing variant inside a try/catch that swallowed the
+ * error and quietly compared the instantaneous value instead - so "evaluate
+ * over time" was a silent no-op for every CheckOn missing from the map.
+ */
+describe("getMonitorMetricTypeByCheckOnOrNull", () => {
+  test("returns the same series as the throwing variant for mapped CheckOns", () => {
+    const mapped: Array<CheckOn> = [
+      CheckOn.ResponseTime,
+      CheckOn.ResponseStatusCode,
+      CheckOn.IsOnline,
+      CheckOn.CPUUsagePercent,
+      CheckOn.MemoryUsagePercent,
+      CheckOn.DiskUsagePercent,
+      CheckOn.PacketLossPercent,
+      CheckOn.Jitter,
+      CheckOn.PortDnsLookupTime,
+      CheckOn.PortTcpConnectTime,
+    ];
+
+    for (const checkOn of mapped) {
+      expect(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(checkOn),
+      ).toBe(MonitorMetricTypeUtil.getMonitorMeticTypeByCheckOn(checkOn));
+    }
+  });
+
+  /*
+   * DNS, SNMP and External Status Page probes write into the shared online
+   * and response-time series like every other probe check, and the criteria
+   * UI advertises all six of these as over-time capable - but none of them
+   * had a mapping, so the window could never be read.
+   */
+  test("maps the DNS / SNMP / status page online checks onto the online series", () => {
+    for (const checkOn of [
+      CheckOn.DnsIsOnline,
+      CheckOn.SnmpIsOnline,
+      CheckOn.ExternalStatusPageIsOnline,
+    ]) {
+      expect(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(checkOn),
+      ).toBe(MonitorMetricType.IsOnline);
+    }
+  });
+
+  test("maps their response time checks onto the response time series", () => {
+    for (const checkOn of [
+      CheckOn.DnsResponseTime,
+      CheckOn.SnmpResponseTime,
+      CheckOn.ExternalStatusPageResponseTime,
+    ]) {
+      expect(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(checkOn),
+      ).toBe(MonitorMetricType.ResponseTime);
+    }
+  });
+
+  test("returns null instead of throwing for CheckOns no series records", () => {
+    for (const checkOn of [
+      CheckOn.ResponseBody,
+      CheckOn.ResponseHeader,
+      CheckOn.IsRequestTimeout,
+      CheckOn.JavaScriptExpression,
+      CheckOn.IncomingRequest,
+    ]) {
+      expect(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(checkOn),
+      ).toBeNull();
+    }
+  });
+
+  test("the throwing variant still throws for those CheckOns", () => {
+    expect(() => {
+      MonitorMetricTypeUtil.getMonitorMeticTypeByCheckOn(CheckOn.ResponseBody);
+    }).toThrow();
+  });
+});

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -224,6 +224,14 @@ export enum EvaluateOverTimeMinutes {
 export interface EvaluateOverTimeOptions {
   timeValueInMinutes: number | undefined;
   evaluateOverTimeType: EvaluateOverTimeType | undefined;
+  /*
+   * Governs what happens when the evaluation window cannot back the filter -
+   * either nothing was recorded in it, or the monitor has not been running
+   * long enough to cover it yet. Defaults to Ignore when unset, so a filter
+   * asked to look at the last N minutes waits for N minutes of data instead
+   * of firing off the reading that happens to have just arrived.
+   */
+  onNoDataPolicy?: NoDataPolicy | undefined;
 }
 
 export interface CriteriaFilter {
@@ -449,5 +457,6 @@ export const CriteriaFilterSchema: ZodSchema = Zod.object({
   evaluateOverTimeOptions: Zod.object({
     timeValueInMinutes: Zod.number().optional(),
     evaluateOverTimeType: Zod.string().optional(),
+    onNoDataPolicy: Zod.string().optional(),
   }).optional(),
 });

--- a/Common/Utils/Monitor/MonitorMetricType.ts
+++ b/Common/Utils/Monitor/MonitorMetricType.ts
@@ -95,6 +95,46 @@ class MonitorMetricTypeUtil {
     }
   }
 
+  /**
+   * Metric series that backs this CheckOn, or null when nothing records it.
+   *
+   * The throwing variant below is kept for callers that genuinely cannot
+   * continue without a series. Over-time evaluation needs the null instead:
+   * it used to call the throwing one inside a try/catch that swallowed the
+   * error and quietly compared the instantaneous value, so "evaluate over
+   * time" was a no-op for every CheckOn missing from this map - DNS, SNMP
+   * and External Status Page checks among them.
+   */
+  public static getMonitorMetricTypeByCheckOnOrNull(
+    checkOn: CheckOn,
+  ): MonitorMetricType | null {
+    switch (checkOn) {
+      /*
+       * DNS / SNMP / External Status Page probes write into the shared
+       * online and response-time series like every other probe check, so
+       * their CheckOns map onto those series rather than onto ones of their
+       * own.
+       */
+      case CheckOn.DnsIsOnline:
+      case CheckOn.SnmpIsOnline:
+      case CheckOn.ExternalStatusPageIsOnline:
+        return MonitorMetricType.IsOnline;
+      case CheckOn.DnsResponseTime:
+      case CheckOn.SnmpResponseTime:
+      case CheckOn.ExternalStatusPageResponseTime:
+        return MonitorMetricType.ResponseTime;
+      default:
+        break;
+    }
+
+    try {
+      return this.getMonitorMeticTypeByCheckOn(checkOn);
+    } catch {
+      // No series records this CheckOn.
+      return null;
+    }
+  }
+
   public static getMonitorMeticTypeByCheckOn(
     checkOn: CheckOn,
   ): MonitorMetricType {

--- a/Scripts/TerraformProvider/StaticFiles/monitorsteps.go
+++ b/Scripts/TerraformProvider/StaticFiles/monitorsteps.go
@@ -100,6 +100,15 @@ var monitorStepsEvaluateOverTimeTypeValues = []string{
 	"Any Value",
 }
 
+// NoDataPolicy enum (Common/Types/Monitor/CriteriaFilter.ts). Governs what
+// an over-time filter does while its evaluation window does not hold enough
+// data to judge it.
+var monitorStepsNoDataPolicyValues = []string{
+	"Ignore",
+	"Treat As Zero",
+	"Trigger",
+}
+
 // CheckOn enum (Common/Types/Monitor/CriteriaFilter.ts).
 var monitorStepsCheckOnValues = []string{
 	"Response Time (in ms)",
@@ -220,6 +229,7 @@ var (
 	monitorStepsScreenSizeTypeValidator       = stringvalidator.OneOf(monitorStepsScreenSizeTypeValues...)
 	monitorStepsBrowserTypeValidator          = stringvalidator.OneOf(monitorStepsBrowserTypeValues...)
 	monitorStepsEvaluateOverTimeTypeValidator = stringvalidator.OneOf(monitorStepsEvaluateOverTimeTypeValues...)
+	monitorStepsNoDataPolicyValidator         = stringvalidator.OneOf(monitorStepsNoDataPolicyValues...)
 	monitorStepsCheckOnValidator              = stringvalidator.OneOf(monitorStepsCheckOnValues...)
 	monitorStepsFilterTypeValidator           = stringvalidator.OneOf(monitorStepsFilterTypeValues...)
 )
@@ -269,15 +279,16 @@ var monitorStepsSubConfigs = []monitorStepsSubConfig{
 
 func monitorStepsFilterAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"check_on":                   types.StringType,
-		"filter_type":                types.StringType,
-		"value":                      types.StringType,
-		"evaluate_over_time":         types.BoolType,
-		"evaluate_over_time_minutes": types.Int64Type,
-		"evaluate_over_time_type":    types.StringType,
-		"disk_path":                  types.StringType,
-		"metric_monitor_options":     types.StringType,
-		"snmp_monitor_options":       types.StringType,
+		"check_on":                          types.StringType,
+		"filter_type":                       types.StringType,
+		"value":                             types.StringType,
+		"evaluate_over_time":                types.BoolType,
+		"evaluate_over_time_minutes":        types.Int64Type,
+		"evaluate_over_time_type":           types.StringType,
+		"evaluate_over_time_no_data_policy": types.StringType,
+		"disk_path":                         types.StringType,
+		"metric_monitor_options":            types.StringType,
+		"snmp_monitor_options":              types.StringType,
 	}
 }
 
@@ -570,9 +581,14 @@ func monitorStepsFilterSchema() schema.NestedAttributeObject {
 				Validators:          []validator.Int64{int64validator.AtLeast(1)},
 			},
 			"evaluate_over_time_type": schema.StringAttribute{
-				MarkdownDescription: "Aggregation applied over the evaluation window (e.g. `Average`, `Sum`, `Any Value`).",
+				MarkdownDescription: "Aggregation applied over the evaluation window (e.g. `Average`, `Sum`, `Any Value`). `All Values` only matches once the window is actually covered by data, so give it a window at least twice the monitoring interval.",
 				Optional:            true,
 				Validators:          []validator.String{monitorStepsEvaluateOverTimeTypeValidator},
+			},
+			"evaluate_over_time_no_data_policy": schema.StringAttribute{
+				MarkdownDescription: "What the filter does while the evaluation window does not hold enough data to judge it — for example a monitor that has just been created. `Ignore` (the default) does not match, `Trigger` treats the missing data as the failure, and `Treat As Zero` compares the window as a single zero.",
+				Optional:            true,
+				Validators:          []validator.String{monitorStepsNoDataPolicyValidator},
 			},
 			"disk_path": schema.StringAttribute{
 				MarkdownDescription: "Disk path for `Disk Usage (in %)` filters on Server monitors (e.g. `/` or `C:`).",
@@ -1065,6 +1081,9 @@ func monitorStepsFilterToAPI(attrs map[string]attr.Value, attrPath string, diags
 	if v, ok := monitorStepsAttrString(attrs, "evaluate_over_time_type"); ok {
 		evalOpts["evaluateOverTimeType"] = v
 	}
+	if v, ok := monitorStepsAttrString(attrs, "evaluate_over_time_no_data_policy"); ok {
+		evalOpts["onNoDataPolicy"] = v
+	}
 	if len(evalOpts) > 0 {
 		out["evaluateOverTimeOptions"] = evalOpts
 	}
@@ -1530,6 +1549,9 @@ func monitorStepsFilterFromAPI(v interface{}, diags *diag.Diagnostics) (types.Ob
 		}
 		if s, ok := monitorStepsAPIString(opts["evaluateOverTimeType"]); ok {
 			attrs["evaluate_over_time_type"] = types.StringValue(s)
+		}
+		if s, ok := monitorStepsAPIString(opts["onNoDataPolicy"]); ok {
+			attrs["evaluate_over_time_no_data_policy"] = types.StringValue(s)
 		}
 	}
 	if opts, ok := m["serverMonitorOptions"].(map[string]interface{}); ok {

--- a/Scripts/TerraformProvider/StaticFiles/monitorsteps_test.go
+++ b/Scripts/TerraformProvider/StaticFiles/monitorsteps_test.go
@@ -149,12 +149,13 @@ func monitorStepsFullUserList(t *testing.T) types.List {
 			"filter_type": types.StringValue("True"),
 		}),
 		monitorStepsTestObj(t, monitorStepsFilterAttrTypes(), map[string]attr.Value{
-			"check_on":                   types.StringValue("Response Status Code"),
-			"filter_type":                types.StringValue("Equal To"),
-			"value":                      types.StringValue("200"),
-			"evaluate_over_time":         types.BoolValue(true),
-			"evaluate_over_time_minutes": types.Int64Value(5),
-			"evaluate_over_time_type":    types.StringValue("Average"),
+			"check_on":                          types.StringValue("Response Status Code"),
+			"filter_type":                       types.StringValue("Equal To"),
+			"value":                             types.StringValue("200"),
+			"evaluate_over_time":                types.BoolValue(true),
+			"evaluate_over_time_minutes":        types.Int64Value(5),
+			"evaluate_over_time_type":           types.StringValue("Average"),
+			"evaluate_over_time_no_data_policy": types.StringValue("Trigger"),
 		}),
 	)
 
@@ -380,7 +381,7 @@ func TestMonitorStepsRoundTripFullyPopulated(t *testing.T) {
 	                        "filterType": "Equal To",
 	                        "value": "200",
 	                        "evaluateOverTime": true,
-	                        "evaluateOverTimeOptions": {"timeValueInMinutes": 5, "evaluateOverTimeType": "Average"}
+	                        "evaluateOverTimeOptions": {"timeValueInMinutes": 5, "evaluateOverTimeType": "Average", "onNoDataPolicy": "Trigger"}
 	                      }
 	                    ]
 	                  }
@@ -565,7 +566,7 @@ func TestMonitorStepsRoundTripMinimal(t *testing.T) {
 		}
 	}
 	filterAttrs := criteriaAttrs["filters"].(types.List).Elements()[0].(types.Object).Attributes()
-	for _, name := range []string{"value", "evaluate_over_time", "evaluate_over_time_minutes", "evaluate_over_time_type", "disk_path", "metric_monitor_options", "snmp_monitor_options"} {
+	for _, name := range []string{"value", "evaluate_over_time", "evaluate_over_time_minutes", "evaluate_over_time_type", "evaluate_over_time_no_data_policy", "disk_path", "metric_monitor_options", "snmp_monitor_options"} {
 		v := filterAttrs[name]
 		if !v.IsNull() {
 			t.Fatalf("filter attribute %q should be null after round trip, got %s", name, v)


### PR DESCRIPTION
Fixes #2321.

A criteria filter configured as **"All Values" over the last N minutes** fired on the
first bad check instead of waiting for the window. Three independent defects produced
that, and all three are fixed here.

## What was wrong

**1. An empty window collapsed into the value from this one check.**
Every probe criteria evaluator did `overTimeValue || <value that just arrived>`. When the
metric window came back empty — a monitor that just started, a metric write that failed, a
`CheckOn` with no series at all — the over-time filter silently became an instantaneous
one and matched off a single reading. The surrounding `try/catch` swallowed read errors
into the same fallback.

**2. `.every()` is trivially true on one sample.**
`EvaluateOverTime` returned the raw sample array with no coverage check, so a window
holding a single bad sample satisfied "all values over the last 5 minutes". This is what
made brand-new monitors alert on their very first check.

**3. The decision path evaluated a different window than the summary.**
`MonitorProbe.lastMonitoringLog` is written as `JSON.parse(JSON.stringify(response))`, which
turns every `ObjectID` into a plain `{ _type, value }` object. `checkProbeAgreement` fed
those rows straight back into the evaluator, so the metric query bound a non-`ObjectID` and
matched zero rows — indistinguishable from "no history", which triggered defect 1. That is
why reporters saw an incident whose stored root cause quoted a single sample
(`All values of Response Time over the last 2 minutes is 9171`) sitting next to an
evaluation summary that had read the full window and said the criteria was **not** met.

## The fix

- `EvaluateOverTime.getOverTimeValueForCriteriaFilter()` is now the single entry point for
  every over-time filter. It returns either a usable window value or an already-made
  decision — evaluators never fall back to the instantaneous value for an over-time filter.
- **"All Values" requires the window to be covered.** Coverage is measured in time, not
  sample count, so it tolerates a probe skipping a beat, several probes writing into one
  series, and samples landing a fraction outside the window. The monitor's
  `monitoringInterval` cron sizes the expectation (`CronTab.getIntervalInSeconds`), falling
  back to the cadence the samples themselves demonstrate. A monitor polled every 5 minutes
  correctly treats its single sample as the whole 5-minute window.
- **"Any Value" is untouched** — it fires on the first breaching sample by design.
- **New `evaluateOverTimeOptions.onNoDataPolicy`** (`Ignore` default / `Treat As Zero` /
  `Trigger`), mirroring the existing metric-monitor policy, with a UI control and API-docs
  entry. A metric-store *read failure* never fires, whatever the policy says.
- `checkProbeAgreement` now rehydrates stored payloads (`hydrateStoredProbeResponse`) before
  re-evaluating them, and reuses the caller's verdict for the probe whose result triggered
  the pass instead of recomputing it against a window that has since moved. The summary and
  the decision can no longer disagree.

### Also fixed along the way

- `Dns/Snmp/ExternalStatusPage` `Is Online` and `Response Time` checks had no entry in the
  metric map, so `getMonitorMeticTypeByCheckOn` threw and over-time evaluation was a
  permanent silent no-op for all six — even though the criteria UI advertises them as
  over-time capable. They now map onto the shared online / response-time series they
  actually write to.
- `Disk Usage (in %)` computed its over-time window and then discarded it.
- A scalar aggregate of exactly `0` (average/min CPU, etc.) was falsy and got replaced by
  the live reading. The over-time merges now use `??`.
- `monitoringInterval` is selected on the monitor hot path so the coverage check has it.

## Behaviour changes to be aware of

- "All Values over the last N minutes" now genuinely waits N minutes. Existing criteria that
  were firing on a single sample will wait for the window — that is the point of the issue,
  but it does change when those alerts arrive.
- An over-time filter whose window cannot be read no longer fires off the current value.
  Default policy is `Ignore`, so it stays quiet until data is available.
- Over-time filters on DNS / SNMP / External Status Page checks start actually evaluating
  over time rather than per-check.
- Server monitors' `Is Online` keeps its existing fallback: for an agent-based monitor the
  absence of data *is* the signal, and the last-check-in arithmetic already implements the
  wait.

## Tests

`Common/Tests/Server/Utils/Monitor/Criteria/EvaluateOverTime.test.ts` (new, 43 cases) —
window arithmetic, query shape, coverage guard boundaries (jitter tolerance, interleaved
probes, out-of-order rows, slow-polling monitors), every evaluation type, boolean series,
unsupported CheckOns, and each no-data policy.

`Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaEvaluateOverTime.test.ts`
(new) — drives the real evaluator with only the metric read stubbed, reproducing both
scenarios from the issue thread end to end: one 404 in a healthy window, and one 9171 ms
spike in a 2-minute window of sub-second responses. Neither fires; a fully bad window does.

`Common/Tests/Server/Services/MonitorResourceProbeAgreementHydration.test.ts` (new) —
`hydrateStoredProbeResponse` round-trips, and `checkProbeAgreement` reuses the caller's
verdict for the current probe while hydrating the others.

Plus new `CronTab.getIntervalInSeconds` cases, new `getMonitorMetricTypeByCheckOnOrNull`
cases, disk-usage over-time cases, and updates to the existing `ServerMonitorCriteria` /
`APIRequestCriteriaPortTimings` suites where the fallback behaviour deliberately changed.

## Follow-up worth doing separately

The evaluation summary still just says a filter was "not met" when it is really "waiting for
the window to fill". Surfacing that reason would need the criteria evaluators to return a
reason alongside their match string — a wider refactor than this fix wants to carry.
