### PR TITLE
fix(lint): annotate the probe-state fixtures in the discovery diagnosis test

### DIFF
--- a/Common/Tests/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.test.ts
@@ -1,6 +1,7 @@
 import {
   MAX_SCAN_STATUS_MESSAGE_LENGTH,
   UNCLAIMED_PENDING_MINUTES,
+  UnclaimedScanProbeState,
   buildUnclaimedScanDiagnosis,
 } from "../../../Utils/NetworkDiscovery/UnclaimedScanDiagnosis";
 import OneUptimeDate from "../../../Types/Date";
@@ -21,13 +22,13 @@ import { describe, expect, test } from "@jest/globals";
  * and whether the sentence survives the varchar(500) column it is written to.
  */
 
-const disconnectedProbe = {
+const disconnectedProbe: UnclaimedScanProbeState = {
   probeName: "Datacentre Probe",
   isProbeConnected: false,
   lastAliveAt: OneUptimeDate.getSomeHoursAgo(6),
 };
 
-const connectedProbe = {
+const connectedProbe: UnclaimedScanProbeState = {
   probeName: "Datacentre Probe",
   isProbeConnected: true,
   lastAliveAt: OneUptimeDate.getCurrentDate(),


### PR DESCRIPTION
Follow-up to #3290, which merged before I caught this.

`js-lint` is currently red on master:

```
Common/Tests/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.test.ts
  24:7  error  Expected disconnectedProbe to have a type annotation  @typescript-eslint/typedef
  30:7  error  Expected connectedProbe to have a type annotation     @typescript-eslint/typedef
```

Both fixtures now carry the `UnclaimedScanProbeState` annotation the rule asks for. Test-only change; the suite still passes 18/18, and `npx eslint . --cache` over the whole repo is clean.