### PR TITLE
feat(network): ask link rules' "exactly one parent" question per site

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
@@ -39,6 +39,7 @@ import Label from "Common/Models/DatabaseModels/Label";
 import NetworkDeviceLinkRuleUtil, {
   LinkRuleDeviceInput,
   LinkRuleOutcome,
+  LinkRuleWarning,
 } from "Common/Utils/Monitor/NetworkDeviceLinkRuleUtil";
 import NetworkTopologySuppressionService from "Common/Server/Services/NetworkTopologySuppressionService";
 
@@ -163,6 +164,19 @@ export default class NetworkDeviceTopologyAPI {
                  */
                 labels: {
                   _id: true,
+                },
+                /*
+                 * Not rendered either — read only by site-scoped uplink rules,
+                 * which ask "exactly one parent" once per site rather than
+                 * once per project. The name rides along so a rule that fails
+                 * in one site can name it; NetworkSite.name is
+                 * canReadOnRelationQuery, so this needs no ReadNetworkSite
+                 * permission and a separate site query (which would 403 a
+                 * device-only role and take the whole map down) is avoided.
+                 */
+                siteId: true,
+                site: {
+                  name: true,
                 },
                 /*
                  * The LLDP and CDP walks ride along with the interface walk,
@@ -463,6 +477,7 @@ export default class NetworkDeviceTopologyAPI {
                 _id: true,
                 name: true,
                 isEnabled: true,
+                scope: true,
                 childDeviceLabels: {
                   _id: true,
                 },
@@ -494,6 +509,14 @@ export default class NetworkDeviceTopologyAPI {
               return {
                 id: device.id!.toString(),
                 labelIds: labelIdsOf(device.labels),
+                /*
+                 * .toString() is load-bearing: the resolver keys a Map on this
+                 * to group devices by site, and an ObjectID instance would
+                 * compare by identity — putting every device in a site of its
+                 * own and silently reducing site scope to nothing.
+                 */
+                siteId: device.siteId?.toString(),
+                siteName: device.site?.name,
               };
             },
           );
@@ -507,6 +530,7 @@ export default class NetworkDeviceTopologyAPI {
                   isEnabled: rule.isEnabled,
                   childLabelIds: labelIdsOf(rule.childDeviceLabels),
                   parentLabelIds: labelIdsOf(rule.parentDeviceLabels),
+                  scope: rule.scope,
                 };
               }),
               ruleDeviceInput,
@@ -589,7 +613,9 @@ export default class NetworkDeviceTopologyAPI {
            * present, only their state is missing) and search cannot fix it,
            * so it gets its own flag rather than lying in this one.
            */
-          topology.isTruncated = devices.length >= LIMIT_PER_PROJECT;
+          const isDeviceListTruncated: boolean =
+            devices.length >= LIMIT_PER_PROJECT;
+          topology.isTruncated = isDeviceListTruncated;
 
           /*
            * The builder reports endpoints it dropped internally; OR in
@@ -607,22 +633,42 @@ export default class NetworkDeviceTopologyAPI {
             ...(topology as unknown as JSONObject),
             interfacesTruncated: interfaceRows.length >= LIMIT_PER_PROJECT,
             /*
-             * Only the rules that drew nothing. A rule doing its job needs no
-             * explanation, but one that silently produces no edges is
-             * indistinguishable from one that is working — which is the
-             * failure mode this whole feature is supposed to remove, not add.
+             * Only the rules with something to explain — at most one line
+             * each. A rule doing its job needs no explanation, but one that
+             * silently produces no edges is indistinguishable from one that is
+             * working, which is the failure mode this whole feature exists to
+             * remove rather than add.
+             *
+             * NOT `links.length === 0` any more, and that is the point of
+             * issue #3260: a site-scoped rule can draw in thirteen sites and
+             * still owe the operator an account of the fourteenth, so the
+             * resolver decides what is worth saying and this only asks.
              */
             linkRuleWarnings: ruleOutcomes
-              .filter((outcome: LinkRuleOutcome) => {
-                return outcome.links.length === 0;
-              })
               .map((outcome: LinkRuleOutcome) => {
-                return {
-                  ruleId: outcome.ruleId,
-                  ruleName: outcome.ruleName,
-                  reason: outcome.skipReason,
-                  message: NetworkDeviceLinkRuleUtil.describeOutcome(outcome),
-                };
+                return NetworkDeviceLinkRuleUtil.getWarning(outcome);
+              })
+              .filter(
+                (
+                  warning: LinkRuleWarning | null,
+                ): warning is LinkRuleWarning => {
+                  return warning !== null;
+                },
+              )
+              .map((warning: LinkRuleWarning) => {
+                /*
+                 * Truncation is a fact about the query, not about the rule, so
+                 * it is admitted here rather than inside the resolver. It
+                 * matters more under site scoping: a cut-off device list can
+                 * strand whole sites whose router simply was not in the first
+                 * page of rows.
+                 */
+                return isDeviceListTruncated
+                  ? {
+                      ...warning,
+                      message: `${warning.message} ${NetworkDeviceLinkRuleUtil.TRUNCATED_DEVICE_LIST_NOTE}`,
+                    }
+                  : warning;
               }) as unknown as JSONObject[],
           };
 

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyLiveView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyLiveView.tsx
@@ -104,7 +104,13 @@ interface TopologyViewData extends NetworkTopology {
   droppedEndpointCount?: number | undefined;
   // Nodes the project has hidden; drives the "N hidden — show them" note.
   suppressedNodeCount?: number | undefined;
-  // Link rules that resolved to nothing, with the reason each one gave.
+  /*
+   * Link rules with something to explain, at most one line each: a rule that
+   * drew nothing at all, or a site-scoped one that drew in some sites and
+   * could not in others. Not "rules that resolved to nothing" — a site-scoped
+   * rule can draw thirteen sites' uplinks and still owe an account of the
+   * fourteenth.
+   */
   linkRuleWarnings?: Array<TopologyLinkRuleWarning> | undefined;
 }
 
@@ -943,10 +949,12 @@ const NetworkTopologyLiveView: FunctionComponent<ComponentProps> = (
       )}
 
       {/*
-       * The rules that drew nothing. Surfaced on the map rather than only on
-       * the rule page: an ambiguous parent is invisible from the rule list,
-       * which is exactly where somebody would go looking and find a rule
-       * that appears perfectly configured.
+       * The rules with something to explain — including a site-scoped rule
+       * that drew in most of its sites and failed in the rest, so a listed
+       * rule has not necessarily drawn nothing. Surfaced on the map rather
+       * than only on the rule page: an ambiguous parent is invisible from the
+       * rule list, which is exactly where somebody would go looking and find
+       * a rule that appears perfectly configured.
        */}
       {topology.linkRuleWarnings && topology.linkRuleWarnings.length > 0 ? (
         <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800">

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LinkRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LinkRules.tsx
@@ -8,8 +8,12 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import NetworkDeviceLinkRule from "Common/Models/DatabaseModels/NetworkDeviceLinkRule";
 import React, { FunctionComponent, ReactElement } from "react";
-import { Green, Red } from "Common/Types/BrandColors";
+import { Blue, Green, Grey, Red } from "Common/Types/BrandColors";
 import Label from "Common/Models/DatabaseModels/Label";
+import NetworkDeviceLinkRuleScope, {
+  NetworkDeviceLinkRuleScopeUtil,
+} from "Common/Types/NetworkDevice/NetworkDeviceLinkRuleScope";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 
 const networkDeviceLinkRuleDocumentation: string = `
 ### How Network Device Link Rules Work
@@ -29,6 +33,19 @@ This is deliberately not "link devices that share a label". Forty devices sharin
 
 Either way the topology map tells you, rather than leaving you with an empty result and no explanation. Narrow the parent labels until they name one device.
 
+### One rule, or one rule per site
+
+**Parent Scope** decides how wide the "exactly one device" question is asked.
+
+- **Project** (the default, and what every rule written before this option existed does) looks for one parent device across the whole project.
+- **Site** asks the same question once per site. If every one of your buildings has a router labelled the same way, one rule draws the uplinks in all of them — instead of reporting every router as a candidate and drawing nothing anywhere.
+
+A site-scoped rule only looks inside each device's **own** site. A device assigned to no site is skipped, and the map tells you how many. If your parent device sits on a parent site while its children sit on the sites beneath it, a site-scoped rule will not find it — put the parent on the same site as the devices that uplink to it, or use Project scope.
+
+### What the map tells you
+
+A site-scoped rule is not all-or-nothing. If it resolves in thirteen sites and fails in the fourteenth, it draws the thirteen and names the one that failed. Sites where nothing carries the child labels are not failures — the rule simply does not apply there, and the map stays quiet about them.
+
 ### Rules are live, not stored
 
 Links are worked out each time the map loads. Relabel a device and the map follows on the next refresh; delete a rule and its links simply stop being drawn. Nothing is left behind to clean up.
@@ -37,6 +54,17 @@ Links are worked out each time the map loads. Relabel a device and the map follo
 
 A link you drew by hand under **Device Links** wins over a rule covering the same pair — it keeps its own name and port labels. A rule link that discovery later confirms merges into the discovered link rather than doubling it.
 `;
+
+const LINK_RULE_SCOPE_OPTIONS: Array<DropdownOption> = [
+  {
+    value: NetworkDeviceLinkRuleScope.Project,
+    label: "Project — one parent device for the whole project",
+  },
+  {
+    value: NetworkDeviceLinkRuleScope.Site,
+    label: "Site — one parent device in each site",
+  },
+];
 
 const NetworkDeviceLinkRulesPage: FunctionComponent<
   PageComponentProps
@@ -67,7 +95,7 @@ const NetworkDeviceLinkRulesPage: FunctionComponent<
       }}
       sortBy="name"
       sortOrder={SortOrder.Ascending}
-      selectMoreFields={{ isEnabled: true }}
+      selectMoreFields={{ isEnabled: true, scope: true }}
       filters={[
         { field: { name: true }, title: "Name", type: FieldType.Text },
         {
@@ -92,6 +120,18 @@ const NetworkDeviceLinkRulesPage: FunctionComponent<
               <Pill color={Green} text="Enabled" />
             ) : (
               <Pill color={Red} text="Disabled" />
+            );
+          },
+        },
+        {
+          field: { scope: true },
+          title: "Parent Scope",
+          type: FieldType.Text,
+          getElement: (item: NetworkDeviceLinkRule): ReactElement => {
+            return NetworkDeviceLinkRuleScopeUtil.isSiteScoped(item.scope) ? (
+              <Pill color={Blue} text="Per site" />
+            ) : (
+              <Pill color={Grey} text="Project" />
             );
           },
         },
@@ -158,6 +198,18 @@ const NetworkDeviceLinkRulesPage: FunctionComponent<
           },
           required: true,
           placeholder: "Select Labels",
+        },
+        {
+          field: { scope: true },
+          title: "Parent Scope",
+          stepId: "devices",
+          fieldType: FormFieldSchemaType.Dropdown,
+          dropdownOptions: LINK_RULE_SCOPE_OPTIONS,
+          required: false,
+          defaultValue: NetworkDeviceLinkRuleScope.Project,
+          placeholder: "Project",
+          description:
+            "Project: the parent labels must name exactly one device across the whole project. Site: they must name exactly one device inside each site, and the rule is applied once per site. Devices that are not assigned to a site are skipped by a site-scoped rule.",
         },
       ]}
       showRefreshButton={true}

--- a/App/Tests/BaseAPI/NetworkDeviceTopologyAPI.test.ts
+++ b/App/Tests/BaseAPI/NetworkDeviceTopologyAPI.test.ts
@@ -297,3 +297,538 @@ describe("POST /network-device/topology", () => {
     expect(body["interfacesTruncated"]).toBe(false);
   });
 });
+
+/*
+ * --- Site-scoped link rules (issue #3260) ---
+ *
+ * A link rule links every device carrying ALL the child labels to the SINGLE
+ * device carrying ALL the parent labels. "Single" needs a universe to be
+ * single in, and until the `scope` column existed that universe was whatever
+ * the topology query happened to return. On the global map — every site at
+ * once — fourteen units' routers all carried `SubCategory:Router`, the rule
+ * reported `ambiguousParent`, and EVERY rule-derived uplink disappeared,
+ * including the thirteen that were never ambiguous.
+ *
+ * These tests exercise the whole endpoint rather than the resolver, because
+ * the parts that actually broke live at this seam: the columns the device
+ * query asks for, and the fact that rule links reach the client as edges of
+ * the built topology rather than as a list of their own.
+ */
+
+import Label from "Common/Models/DatabaseModels/Label";
+import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
+import NetworkDeviceLinkRule from "Common/Models/DatabaseModels/NetworkDeviceLinkRule";
+import NetworkDeviceLinkRuleUtil from "Common/Utils/Monitor/NetworkDeviceLinkRuleUtil";
+
+function makeLabel(): Label {
+  return new Label(ObjectID.generate());
+}
+
+function makeSite(name: string): NetworkSite {
+  const site: NetworkSite = new NetworkSite(ObjectID.generate());
+  site.name = name;
+  return site;
+}
+
+/*
+ * A device that knows where it lives. Both halves matter and they come from
+ * the same row: siteId is what the resolver groups on, and site.name is the
+ * only thing a warning has to call a site by — reading the name off the
+ * device row rather than a separate site query is what keeps a viewer from
+ * being told the name of a site they cannot read.
+ *
+ * Passing `null` for the site leaves siteId genuinely undefined, which is the
+ * state a device has before anyone has assigned it.
+ */
+function makeSitedDevice(
+  name: string,
+  site: NetworkSite | null,
+  labels: Array<Label>,
+): NetworkDevice {
+  const device: NetworkDevice = makeDevice(name);
+  if (site) {
+    device.siteId = site.id!;
+    device.site = site;
+  }
+  device.labels = labels;
+  return device;
+}
+
+function makeLinkRule(
+  name: string,
+  childLabels: Array<Label>,
+  parentLabels: Array<Label>,
+  scope: string | undefined,
+): NetworkDeviceLinkRule {
+  const rule: NetworkDeviceLinkRule = new NetworkDeviceLinkRule(
+    ObjectID.generate(),
+  );
+  rule.name = name;
+  rule.isEnabled = true;
+  rule.childDeviceLabels = childLabels;
+  rule.parentDeviceLabels = parentLabels;
+  /*
+   * Left unset rather than set to "Project" for the project-scope cases: an
+   * absent column is what every rule written before #3260 actually holds, and
+   * that NULL reading as Project is the compatibility promise being pinned.
+   */
+  if (scope !== undefined) {
+    rule.scope = scope;
+  }
+  return rule;
+}
+
+interface SiteStar {
+  site: NetworkSite;
+  router: NetworkDevice;
+  switches: Array<NetworkDevice>;
+}
+
+/*
+ * One site's worth of the shape the issue is about: a single router carrying
+ * the parent label and some switches carrying the child label, all in the
+ * same site.
+ */
+function makeSiteStar(
+  siteName: string,
+  switchCount: number,
+  routerLabel: Label,
+  switchLabel: Label,
+): SiteStar {
+  const site: NetworkSite = makeSite(siteName);
+  const switches: Array<NetworkDevice> = [];
+  for (let index: number = 0; index < switchCount; index++) {
+    switches.push(
+      makeSitedDevice(`${siteName}-sw${index}`, site, [switchLabel]),
+    );
+  }
+  return {
+    site: site,
+    router: makeSitedDevice(`${siteName}-rtr`, site, [routerLabel]),
+    switches: switches,
+  };
+}
+
+function devicesOf(stars: Array<SiteStar>): Array<NetworkDevice> {
+  const devices: Array<NetworkDevice> = [];
+  for (const star of stars) {
+    devices.push(star.router);
+    devices.push(...star.switches);
+  }
+  return devices;
+}
+
+interface Issue3260Fixture {
+  devices: Array<NetworkDevice>;
+  // The thirteen units whose router is unmistakable.
+  healthy: Array<SiteStar>;
+  // Unit 14, the one with two routers.
+  broken: SiteStar;
+}
+
+/*
+ * The reported topology, rebuilt: fourteen units, each with one router
+ * carrying `SubCategory:Router` and one switch carrying the child label —
+ * except Unit 14, which has a second router. Thirteen of the fourteen
+ * questions this rule asks have a single obvious answer; only the fourteenth
+ * does not.
+ */
+function makeIssue3260Fixture(
+  routerLabel: Label,
+  switchLabel: Label,
+): Issue3260Fixture {
+  const stars: Array<SiteStar> = [];
+  for (let unit: number = 1; unit <= 14; unit++) {
+    stars.push(makeSiteStar(`Unit ${unit}`, 1, routerLabel, switchLabel));
+  }
+  const broken: SiteStar = stars[13]!;
+  const secondRouter: NetworkDevice = makeSitedDevice(
+    "Unit 14-rtr-b",
+    broken.site,
+    [routerLabel],
+  );
+  return {
+    devices: [...devicesOf(stars), secondRouter],
+    healthy: stars.slice(0, 13),
+    broken: broken,
+  };
+}
+
+/*
+ * Rule links do not travel as a list of their own: the handler pushes them
+ * into manualLinkInput and NetworkTopologyUtil.buildTopology merges them into
+ * the edge map, so what the client sees is edges whose node ids are the
+ * device ids themselves. Every assertion about what a rule drew therefore has
+ * to read the built graph.
+ */
+function edgePairs(body: JSONObject): Array<string> {
+  return (body["edges"] as Array<JSONObject>)
+    .map((edge: JSONObject) => {
+      return `${edge["fromNodeId"] as string}->${edge["toNodeId"] as string}`;
+    })
+    .sort();
+}
+
+function uplinkPair(child: NetworkDevice, parent: NetworkDevice): string {
+  return `${child.id!.toString()}->${parent.id!.toString()}`;
+}
+
+function warningsIn(body: JSONObject): Array<JSONObject> {
+  return body["linkRuleWarnings"] as Array<JSONObject>;
+}
+
+function resetTopologyMocks(): void {
+  jest.clearAllMocks();
+  commonAPI.getDatabaseCommonInteractionProps.mockResolvedValue({
+    tenantId: projectId,
+  } as never);
+  deviceService.findBy.mockResolvedValue([] as never);
+  interfaceService.findBy.mockResolvedValue([] as never);
+  endpointService.findBy.mockResolvedValue([] as never);
+  deviceLinkService.findBy.mockResolvedValue([] as never);
+  monitorStatusService.findBy.mockResolvedValue([] as never);
+  linkRuleService.findBy.mockResolvedValue([] as never);
+  suppressionService.getSuppressedNodeKeys.mockResolvedValue(
+    new Set<string>() as never,
+  );
+}
+
+describe("POST /network-device/topology — site-scoped link rules", () => {
+  beforeEach(() => {
+    resetTopologyMocks();
+  });
+
+  /*
+   * Site scoping is only as good as the columns it reads. An unselected
+   * siteId comes back undefined on every row, which normalises to "no site" —
+   * so a site-scoped rule would skip the entire fleet and report it as
+   * unassigned devices. site.name is what lets a failing site be NAMED
+   * instead of appearing as "an unnamed site"; it rides on the device row
+   * because NetworkSite.name is readable on a relation query, so no separate
+   * site query (which would 403 a device-only role and take the whole map
+   * down with it) is needed.
+   */
+  test("asks the device query for the site columns site scoping depends on", async () => {
+    await callTopology({});
+
+    const select: JSONObject = (
+      deviceService.findBy.mock.calls[0]![0] as JSONObject
+    )["select"] as JSONObject;
+    expect(select["siteId"]).toBe(true);
+    expect(select["site"]).toEqual({ name: true });
+    // The labels the rules match on still have to come back too.
+    expect(select["labels"]).toEqual({ _id: true });
+  });
+
+  /*
+   * An unselected scope column arrives as undefined, and undefined parses to
+   * Project by design — so forgetting it here would not throw or warn, it
+   * would quietly resolve every Site rule the operator saved at project
+   * scope and put the map straight back to the #3260 behaviour.
+   */
+  test("asks the rule query for the scope column", async () => {
+    await callTopology({});
+
+    const select: JSONObject = (
+      linkRuleService.findBy.mock.calls[0]![0] as JSONObject
+    )["select"] as JSONObject;
+    expect(select["scope"]).toBe(true);
+  });
+
+  /*
+   * The core of site scoping: the same "exactly one parent" question asked
+   * once per site. Two sites, each with its own router, must produce two
+   * separate stars — and crucially no edge between a switch in one site and
+   * the router in the other, which is the cable nobody has.
+   */
+  test("a site-scoped rule draws one star per site and never across sites", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const unitA: SiteStar = makeSiteStar("Unit A", 2, routerLabel, switchLabel);
+    const unitB: SiteStar = makeSiteStar("Unit B", 2, routerLabel, switchLabel);
+
+    deviceService.findBy.mockResolvedValue(devicesOf([unitA, unitB]) as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink to router", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+
+    /*
+     * Exactly these four edges — the equality is what rules out a cross-site
+     * pair, since any extra edge would fail it.
+     */
+    expect(edgePairs(body)).toEqual(
+      [
+        uplinkPair(unitA.switches[0]!, unitA.router),
+        uplinkPair(unitA.switches[1]!, unitA.router),
+        uplinkPair(unitB.switches[0]!, unitB.router),
+        uplinkPair(unitB.switches[1]!, unitB.router),
+      ].sort(),
+    );
+
+    /*
+     * A rule is stated in child and parent labels, so unlike a hand-drawn
+     * cable it knows which end is up without anyone saying — the edge has to
+     * carry that as parentNodeId or the layout draws a bag of peers.
+     */
+    for (const edge of body["edges"] as Array<JSONObject>) {
+      expect(edge["protocols"]).toEqual(["manual"]);
+      expect(edge["name"]).toBe("Uplink to router");
+      expect(edge["parentNodeId"]).toBe(edge["toNodeId"]);
+    }
+
+    // Nothing failed anywhere, so the rule owes the operator no explanation.
+    expect(warningsIn(body)).toEqual([]);
+  });
+
+  /*
+   * ISSUE #3260, THE BROKEN HALF — now the documented meaning of Project
+   * scope rather than a bug. One ambiguity in Unit 14 makes the single
+   * project-wide question unanswerable, and all fourteen stars vanish. Pinned
+   * so that "Project" keeps meaning exactly what every rule saved before the
+   * column existed already meant.
+   */
+  test("issue #3260: a Project-scoped rule over fourteen units' routers draws nothing at all", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const fixture: Issue3260Fixture = makeIssue3260Fixture(
+      routerLabel,
+      switchLabel,
+    );
+
+    deviceService.findBy.mockResolvedValue(fixture.devices as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule(
+        "Uplink to router",
+        [switchLabel],
+        [routerLabel],
+        // No scope column at all: the state of every pre-#3260 rule row.
+        undefined,
+      ),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+
+    // Not "most of the map" — none of it, including the thirteen good sites.
+    expect(edgePairs(body)).toEqual([]);
+
+    const warnings: Array<JSONObject> = warningsIn(body);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["reason"]).toBe("ambiguousParent");
+    // Fifteen routers across fourteen units, counted project-wide.
+    expect(warnings[0]!["message"]).toBe(
+      "15 devices carry the parent labels. Exactly one must, or there is no way to tell which is the uplink.",
+    );
+  });
+
+  /*
+   * ISSUE #3260, THE FIXED HALF — the same devices and the same labels, with
+   * the scope column set. Thirteen sites draw, the fourteenth is named, and
+   * the account of it is ONE warning row: the banner's length is bounded by
+   * the number of rules the operator wrote, not by the number of sites in
+   * their project.
+   */
+  test("issue #3260: the same rule at Site scope draws the thirteen good units and names the fourteenth", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const fixture: Issue3260Fixture = makeIssue3260Fixture(
+      routerLabel,
+      switchLabel,
+    );
+
+    deviceService.findBy.mockResolvedValue(fixture.devices as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink to router", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+
+    expect(edgePairs(body)).toEqual(
+      fixture.healthy
+        .map((star: SiteStar) => {
+          return uplinkPair(star.switches[0]!, star.router);
+        })
+        .sort(),
+    );
+
+    /*
+     * Unit 14's switch is still floating — site scoping does not guess a
+     * parent, it just stops one site's ambiguity from erasing the others.
+     */
+    const brokenChildId: string = fixture.broken.switches[0]!.id!.toString();
+    expect(
+      edgePairs(body).some((pair: string) => {
+        return pair.includes(brokenChildId);
+      }),
+    ).toBe(false);
+
+    /*
+     * One row, not fourteen: getWarning summarises the whole rule, and the
+     * coverage fraction is what tells the operator the map is mostly working
+     * rather than mostly broken.
+     */
+    const warnings: Array<JSONObject> = warningsIn(body);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["reason"]).toBe("ambiguousParent");
+    expect(warnings[0]!["message"]).toBe(
+      "Drawing in 13 of 14 sites. 2 devices carry the parent labels in Unit 14. Exactly one must, or there is no way to tell which is the uplink.",
+    );
+  });
+
+  /*
+   * The silence case, and it is the one that decides whether the banner is
+   * read at all. A parent label like `SubCategory:Router` exists in nearly
+   * every site by construction, so a rule that reported every site it touched
+   * would produce a wall of text on a perfectly healthy map and be ignored
+   * inside a week.
+   */
+  test("a fully healthy fourteen-site rule returns no warnings whatsoever", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const stars: Array<SiteStar> = [];
+    for (let unit: number = 1; unit <= 14; unit++) {
+      stars.push(makeSiteStar(`Unit ${unit}`, 2, routerLabel, switchLabel));
+    }
+
+    deviceService.findBy.mockResolvedValue(devicesOf(stars) as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink to router", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+    expect(edgePairs(body).length).toBe(28);
+    expect(warningsIn(body)).toEqual([]);
+  });
+
+  /*
+   * Truncation is a fact about the QUERY, not about the rule, so it is
+   * admitted by the endpoint rather than baked into the resolver's sentences.
+   * It matters most under site scoping: a cut-off device list can strand a
+   * whole site whose router simply was not in the first page of rows, and
+   * without this note the operator would go looking for a labelling mistake
+   * that does not exist.
+   */
+  test("every warning admits it when the device list was truncated", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+
+    const devices: Array<NetworkDevice> = [];
+    for (let index: number = 0; index < LIMIT_PER_PROJECT; index++) {
+      devices.push(
+        makeSitedDevice(`sw-${index}`, null, index === 0 ? [switchLabel] : []),
+      );
+    }
+    deviceService.findBy.mockResolvedValue(devices as never);
+    // Nobody carries the parent label — possibly only because of the cap.
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink to router", [switchLabel], [routerLabel], undefined),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+    expect(body["isTruncated"]).toBe(true);
+
+    const warnings: Array<JSONObject> = warningsIn(body);
+    expect(warnings.length).toBe(1);
+    for (const warning of warnings) {
+      expect(
+        (warning["message"] as string).endsWith(
+          NetworkDeviceLinkRuleUtil.TRUNCATED_DEVICE_LIST_NOTE,
+        ),
+      ).toBe(true);
+    }
+    // The resolver's own sentence survives in front of the caveat.
+    expect(warnings[0]!["message"]).toBe(
+      `No device carries the parent labels, so there is nothing to uplink to. ${NetworkDeviceLinkRuleUtil.TRUNCATED_DEVICE_LIST_NOTE}`,
+    );
+  });
+
+  /*
+   * The other side of the same coin: when the whole fleet was returned there
+   * is nothing to hedge about, and hedging anyway would teach the operator to
+   * discount every warning they ever read.
+   */
+  test("a complete device list leaves the truncation caveat off the warning", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+
+    deviceService.findBy.mockResolvedValue([
+      makeSitedDevice("sw1", null, [switchLabel]),
+      makeSitedDevice("sw2", null, []),
+    ] as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink to router", [switchLabel], [routerLabel], undefined),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+    expect(body["isTruncated"]).toBe(false);
+
+    const warnings: Array<JSONObject> = warningsIn(body);
+    expect(warnings.length).toBe(1);
+    for (const warning of warnings) {
+      expect(warning["message"]).not.toContain(
+        NetworkDeviceLinkRuleUtil.TRUNCATED_DEVICE_LIST_NOTE,
+      );
+    }
+  });
+
+  /*
+   * A device with no site is EXCLUDED from a site-scoped rule — not pooled
+   * with the other unassigned devices (which would ask "exactly one parent
+   * among everything nobody has filed yet", a question no operator posed) and
+   * not given a singleton site. It must not break the sites that do resolve,
+   * and it must be said out loud, because the fix here is "assign this device
+   * to a site" and nothing else on the map would ever suggest that.
+   */
+  test("a device with no siteId is skipped by a site-scoped rule and reported, not silently dropped", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const unit: SiteStar = makeSiteStar("Unit A", 1, routerLabel, switchLabel);
+    const unassigned: NetworkDevice = makeSitedDevice("spare-sw", null, [
+      switchLabel,
+    ]);
+
+    // The state of a device nobody has filed yet: no column, not an empty one.
+    expect(unassigned.siteId).toBeUndefined();
+
+    deviceService.findBy.mockResolvedValue([
+      ...devicesOf([unit]),
+      unassigned,
+    ] as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink to router", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+
+    // Unit A still draws, and the unassigned switch is on no edge at all.
+    expect(edgePairs(body)).toEqual([
+      uplinkPair(unit.switches[0]!, unit.router),
+    ]);
+
+    const warnings: Array<JSONObject> = warningsIn(body);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["reason"]).toBe("devicesWithoutSite");
+    /*
+     * No "Drawing in 1 of 1 sites." preamble: a coverage fraction over a
+     * single applicable site says nothing the sentence after it does not.
+     */
+    expect(warnings[0]!["message"]).toBe(
+      "1 device carrying the child labels is not assigned to a site, so this site-scoped rule skips it.",
+    );
+  });
+});

--- a/Common/Models/DatabaseModels/NetworkDeviceLinkRule.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceLinkRule.ts
@@ -1,6 +1,7 @@
 import Label from "./Label";
 import Project from "./Project";
 import User from "./User";
+import NetworkDeviceLinkRuleScope from "../../Types/NetworkDevice/NetworkDeviceLinkRuleScope";
 import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
 import Route from "../../Types/API/Route";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
@@ -41,6 +42,15 @@ import {
  * nothing, because picking one of them would be a guess about somebody's
  * cabling. Both cases are reported rather than silently producing an empty
  * map — see NetworkDeviceLinkRuleUtil.
+ *
+ * "Exactly one" needs a universe, and `scope` names it. By default the
+ * question is asked across the whole project, which is what every rule
+ * written before that column existed means. Setting it to Site asks the same
+ * question once per site instead, so one rule draws the same router-to-switch
+ * star in every building rather than reporting fourteen candidate routers and
+ * drawing nothing anywhere. A site-scoped rule looks only inside each device's
+ * OWN site — it never reaches up to a parent site — and skips devices that
+ * have no site at all, reporting how many it walked past.
  *
  * Rules are evaluated when the topology is built, not materialised into
  * NetworkDeviceLink rows: relabelling a device then shows up on the next
@@ -341,6 +351,42 @@ export default class NetworkDeviceLinkRule extends BaseModel {
     },
   })
   public parentDeviceLabels?: Array<Label> = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateNetworkDeviceLinkRule,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadNetworkDeviceLinkRule,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditNetworkDeviceLinkRule,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "Parent Scope",
+    description:
+      "How wide the 'exactly one parent device' question is asked. Project (the default) looks for one parent across the whole project. Site asks once per site, so the same rule can draw an uplink in every building. Rules created before this existed are Project.",
+    example: "Project",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    default: NetworkDeviceLinkRuleScope.Project,
+  })
+  public scope?: string = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787800000000-AddScopeToNetworkDeviceLinkRule.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787800000000-AddScopeToNetworkDeviceLinkRule.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddScopeToNetworkDeviceLinkRule1787800000000
+  implements MigrationInterface
+{
+  public name: string = "AddScopeToNetworkDeviceLinkRule1787800000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceLinkRule" ADD "scope" character varying(100) DEFAULT 'Project'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceLinkRule" DROP COLUMN "scope"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -531,6 +531,7 @@ import { AddDeviceRoleAndDeclaredLinkParent1787400000000 } from "./1787400000000
 import { AddEnableSearchEngineIndexingToStatusPage1787500000000 } from "./1787500000000-AddEnableSearchEngineIndexingToStatusPage";
 import { AddNetworkDeviceReachabilityColumns1787600000000 } from "./1787600000000-AddNetworkDeviceReachabilityColumns";
 import { FixTotpOtpUrlAlgorithm1787700000000 } from "./1787700000000-FixTotpOtpUrlAlgorithm";
+import { AddScopeToNetworkDeviceLinkRule1787800000000 } from "./1787800000000-AddScopeToNetworkDeviceLinkRule";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1070,4 +1071,5 @@ export default [
   AddEnableSearchEngineIndexingToStatusPage1787500000000,
   AddNetworkDeviceReachabilityColumns1787600000000,
   FixTotpOtpUrlAlgorithm1787700000000,
+  AddScopeToNetworkDeviceLinkRule1787800000000,
 ];

--- a/Common/Tests/Types/NetworkDevice/NetworkDeviceLinkRuleScope.test.ts
+++ b/Common/Tests/Types/NetworkDevice/NetworkDeviceLinkRuleScope.test.ts
@@ -1,0 +1,215 @@
+import NetworkDeviceLinkRuleScope, {
+  NetworkDeviceLinkRuleScopeUtil,
+} from "../../../Types/NetworkDevice/NetworkDeviceLinkRuleScope";
+
+/*
+ * `scope` was added to a table that already had rules in it, so every rule
+ * written before the column existed holds NULL — and each of those rules is
+ * currently drawing a topology somebody has already looked at and trusted.
+ * NULL therefore has to read as Project, because Project is exactly what
+ * those rules have always meant: one parent across whatever device set the
+ * query handed the resolver. Read NULL as Site instead and every legacy rule
+ * quietly starts asking a different question, re-pointing cables on maps
+ * nobody re-opened. That is why the default lives in `parse` rather than in a
+ * `=== "Site"` comparison scattered over the call sites: one place to be
+ * right, and it is pinned here.
+ *
+ * The mirror of the same worry is the unrecognised value. The column is free
+ * text (the NetworkDeviceMonitoringMethod precedent), so a typo, an older
+ * client, or a future scope name that this build has never heard of can all
+ * land in it. Every one of them has to fall back to the behaviour that was
+ * already on screen rather than to the new one.
+ */
+describe("NetworkDeviceLinkRuleScope enum", () => {
+  /*
+   * These strings are persisted values, not display labels. Renaming one is
+   * a silent data migration: every row already holding the old spelling stops
+   * being recognised and — by the fallback above — quietly reverts to
+   * Project, with no error anywhere to say so. Change these only alongside a
+   * migration that rewrites the column.
+   */
+  test("Project is persisted as the string Project", () => {
+    expect(NetworkDeviceLinkRuleScope.Project).toBe("Project");
+  });
+
+  test("Site is persisted as the string Site", () => {
+    expect(NetworkDeviceLinkRuleScope.Site).toBe("Site");
+  });
+
+  test("has exactly the two known scopes", () => {
+    expect(Object.values(NetworkDeviceLinkRuleScope).sort()).toEqual([
+      "Project",
+      "Site",
+    ]);
+  });
+});
+
+/*
+ * One table, two consumers. `parse` and `isSiteScoped` are asserted against
+ * the same rows further down so the pair cannot drift apart: a caller that
+ * branches on `isSiteScoped` and a caller that switches on `parse` must never
+ * disagree about the same stored string.
+ */
+const PROJECT_INPUTS: Array<string | null | undefined> = [
+  // The pre-column rows, and the shapes an empty form field arrives as.
+  undefined,
+  null,
+  "",
+  "  ",
+  // The value written by anything that does set the column explicitly.
+  "Project",
+  "project",
+  "PROJECT",
+  " Project ",
+  /*
+   * Near-misses that must NOT be read as site scope. "Sites" and
+   * "site-scoped" are the plausible typo and the plausible rename; matching
+   * them loosely would turn a mistyped rule into one that silently redraws.
+   */
+  "Sites",
+  "site-scoped",
+  "anything",
+  // Falsy-looking text is still just unrecognised text, not a flag.
+  "0",
+  "false",
+];
+
+const SITE_INPUTS: Array<string> = [
+  "Site",
+  "site",
+  "SITE",
+  " site ",
+  "  SiTe  ",
+];
+
+interface ScopeCase {
+  value: string | null | undefined;
+  expected: NetworkDeviceLinkRuleScope;
+}
+
+const ALL_CASES: Array<ScopeCase> = [
+  ...PROJECT_INPUTS.map((value: string | null | undefined): ScopeCase => {
+    return { value: value, expected: NetworkDeviceLinkRuleScope.Project };
+  }),
+  ...SITE_INPUTS.map((value: string): ScopeCase => {
+    return { value: value, expected: NetworkDeviceLinkRuleScope.Site };
+  }),
+];
+
+describe("NetworkDeviceLinkRuleScopeUtil.parse", () => {
+  test.each(PROJECT_INPUTS)(
+    "reads %p as Project",
+    (value: string | null | undefined) => {
+      expect(NetworkDeviceLinkRuleScopeUtil.parse(value)).toBe(
+        NetworkDeviceLinkRuleScope.Project,
+      );
+    },
+  );
+
+  test.each(SITE_INPUTS)(
+    "reads %p as Site, case- and whitespace-insensitively",
+    (value: string) => {
+      expect(NetworkDeviceLinkRuleScopeUtil.parse(value)).toBe(
+        NetworkDeviceLinkRuleScope.Site,
+      );
+    },
+  );
+
+  /*
+   * Only an exact (trimmed, lowercased) "site" opts in. Substring matching
+   * would make "not site" or "site (deprecated)" flip the rule's meaning,
+   * which is the one direction of mistake this type refuses to make.
+   */
+  test("does not treat a string merely containing 'site' as site-scoped", () => {
+    expect(NetworkDeviceLinkRuleScopeUtil.parse("per site")).toBe(
+      NetworkDeviceLinkRuleScope.Project,
+    );
+    expect(NetworkDeviceLinkRuleScopeUtil.parse("not site")).toBe(
+      NetworkDeviceLinkRuleScope.Project,
+    );
+  });
+
+  /*
+   * The return value is always one of the two enum members — never the raw
+   * column text passed straight back. Callers switch on it, and a passthrough
+   * would send an unrecognised spelling into a branch that does not exist.
+   */
+  test("returns an enum member for every case in the table, never the raw input", () => {
+    for (const testCase of ALL_CASES) {
+      const parsed: NetworkDeviceLinkRuleScope =
+        NetworkDeviceLinkRuleScopeUtil.parse(testCase.value);
+
+      expect(Object.values(NetworkDeviceLinkRuleScope)).toContain(parsed);
+    }
+  });
+
+  /*
+   * The parser sits in the middle of rendering a topology map: throwing here
+   * would take out the whole map over one bad cell, when the safe answer
+   * (Project, what the rule drew yesterday) is right there. So nothing in the
+   * declared signature may throw — and neither may the falsy non-string
+   * shapes a loosely typed caller or a hand-rolled JSON body can smuggle past
+   * TypeScript, which the `|| ""` guard absorbs.
+   */
+  test("never throws for any value in or near its declared signature", () => {
+    const inputs: Array<string | null | undefined> = [
+      ...ALL_CASES.map((testCase: ScopeCase): string | null | undefined => {
+        return testCase.value;
+      }),
+      "\tSITE\n",
+      "\n  project  \t",
+      "Site\u0000",
+      "🙂",
+    ];
+
+    for (const input of inputs) {
+      expect((): NetworkDeviceLinkRuleScope => {
+        return NetworkDeviceLinkRuleScopeUtil.parse(input);
+      }).not.toThrow();
+    }
+
+    /*
+     * Not strings at all. 0/false/NaN are what a JSON body or a permissive
+     * ORM can hand over in place of "no scope set", and they have to land on
+     * the same safe default rather than blow up.
+     */
+    const nonStrings: Array<unknown> = [0, false, NaN];
+
+    for (const input of nonStrings) {
+      expect(
+        NetworkDeviceLinkRuleScopeUtil.parse(input as unknown as string),
+      ).toBe(NetworkDeviceLinkRuleScope.Project);
+    }
+  });
+});
+
+describe("NetworkDeviceLinkRuleScopeUtil.isSiteScoped", () => {
+  test.each(SITE_INPUTS)("is true for %p", (value: string) => {
+    expect(NetworkDeviceLinkRuleScopeUtil.isSiteScoped(value)).toBe(true);
+  });
+
+  test.each(PROJECT_INPUTS)(
+    "is false for %p",
+    (value: string | null | undefined) => {
+      expect(NetworkDeviceLinkRuleScopeUtil.isSiteScoped(value)).toBe(false);
+    },
+  );
+
+  /*
+   * The two entry points are asserted against the same table in the same
+   * loop, so neither can be extended (a new alias, a new scope) without the
+   * other. `NetworkDeviceLinkRuleUtil` branches on `isSiteScoped` while the
+   * dashboard's rule list renders off it too — if they ever disagreed, a rule
+   * would be labelled one way and resolved the other.
+   */
+  test("agrees with parse on every case in the table", () => {
+    for (const testCase of ALL_CASES) {
+      expect(NetworkDeviceLinkRuleScopeUtil.parse(testCase.value)).toBe(
+        testCase.expected,
+      );
+      expect(NetworkDeviceLinkRuleScopeUtil.isSiteScoped(testCase.value)).toBe(
+        testCase.expected === NetworkDeviceLinkRuleScope.Site,
+      );
+    }
+  });
+});

--- a/Common/Tests/Utils/Monitor/NetworkDeviceLinkRuleUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkDeviceLinkRuleUtil.test.ts
@@ -196,3 +196,1294 @@ describe("NetworkDeviceLinkRuleUtil.resolveRule", () => {
     ]);
   });
 });
+
+/*
+ * ---------------------------------------------------------------------------
+ * Site scope — GitHub issue #3260.
+ *
+ * The suite above is the project-scope contract and has to keep passing
+ * exactly as written: site scope is opt-in, so every rule saved before the
+ * column existed still means "one parent for the whole project".
+ *
+ * The fixtures below speak the reporter's vocabulary — routers and switches
+ * in numbered units — because the bug is only legible at that shape: fourteen
+ * units, fourteen routers all carrying the same label, and a global map that
+ * answered "which one is THE router?" with silence in all fourteen.
+ * ---------------------------------------------------------------------------
+ */
+
+const SWITCH_LABEL: string = "label-subcategory-switch";
+const ROUTER_LABEL: string = "label-subcategory-router";
+const MANAGED_LABEL: string = "label-managed";
+
+/*
+ * The `device` helper from the suite above, extended rather than replaced: id
+ * and labels first, the two site fields optional, so an unsited device is
+ * still written `deviceAt("sw1", [...])` and reads the way it always did.
+ */
+const deviceAt: (
+  id: string,
+  labelIds: Array<string>,
+  siteId?: string | null | undefined,
+  siteName?: string | undefined,
+) => LinkRuleDeviceInput = (
+  id: string,
+  labelIds: Array<string>,
+  siteId?: string | null | undefined,
+  siteName?: string | undefined,
+): LinkRuleDeviceInput => {
+  return { id, labelIds, siteId, siteName };
+};
+
+const routerAt: (
+  id: string,
+  siteId?: string | null | undefined,
+  siteName?: string | undefined,
+) => LinkRuleDeviceInput = (
+  id: string,
+  siteId?: string | null | undefined,
+  siteName?: string | undefined,
+): LinkRuleDeviceInput => {
+  return deviceAt(id, [ROUTER_LABEL, MANAGED_LABEL], siteId, siteName);
+};
+
+const switchAt: (
+  id: string,
+  siteId?: string | null | undefined,
+  siteName?: string | undefined,
+) => LinkRuleDeviceInput = (
+  id: string,
+  siteId?: string | null | undefined,
+  siteName?: string | undefined,
+): LinkRuleDeviceInput => {
+  return deviceAt(id, [SWITCH_LABEL, MANAGED_LABEL], siteId, siteName);
+};
+
+// Site-scoped by default; `scopedRule({ scope: "Project" })` for the other one.
+const scopedRule: (overrides?: Partial<LinkRuleInput>) => LinkRuleInput = (
+  overrides?: Partial<LinkRuleInput>,
+): LinkRuleInput => {
+  return {
+    id: "rule-uplink",
+    name: "Switch uplinks",
+    isEnabled: true,
+    childLabelIds: [SWITCH_LABEL, MANAGED_LABEL],
+    parentLabelIds: [ROUTER_LABEL, MANAGED_LABEL],
+    scope: "Site",
+    ...overrides,
+  };
+};
+
+/*
+ * Site names sort into the warning text, so they are zero padded: "Unit 9"
+ * would sort after "Unit 14" and make an assertion about which three sites got
+ * named depend on how many units the test happened to build.
+ */
+const twoDigit: (value: number) => string = (value: number): string => {
+  return value < 10 ? `0${value}` : `${value}`;
+};
+
+/** One unit's devices, in the order a device query would hand them over. */
+const unit: (
+  index: number,
+  routerCount: number,
+  switchCount: number,
+) => Array<LinkRuleDeviceInput> = (
+  index: number,
+  routerCount: number,
+  switchCount: number,
+): Array<LinkRuleDeviceInput> => {
+  const siteId: string = `site-${twoDigit(index)}`;
+  const siteName: string = `Unit ${twoDigit(index)}`;
+  const devices: Array<LinkRuleDeviceInput> = [];
+  for (let router: number = 1; router <= routerCount; router++) {
+    devices.push(
+      routerAt(`router-${twoDigit(index)}-${router}`, siteId, siteName),
+    );
+  }
+  for (let leaf: number = 1; leaf <= switchCount; leaf++) {
+    devices.push(
+      switchAt(`switch-${twoDigit(index)}-${leaf}`, siteId, siteName),
+    );
+  }
+  return devices;
+};
+
+/** `unit()` over a run of consecutive units, flattened. */
+const units: (
+  from: number,
+  to: number,
+  routerCount: number,
+  switchCount: number,
+) => Array<LinkRuleDeviceInput> = (
+  from: number,
+  to: number,
+  routerCount: number,
+  switchCount: number,
+): Array<LinkRuleDeviceInput> => {
+  const devices: Array<LinkRuleDeviceInput> = [];
+  for (let index: number = from; index <= to; index++) {
+    devices.push(...unit(index, routerCount, switchCount));
+  }
+  return devices;
+};
+
+/*
+ * Device id -> normalised site key, so a test can ask which site a link's two
+ * ends live in without hard-coding the id-to-site mapping a second time.
+ */
+const siteIndexOf: (
+  devices: Array<LinkRuleDeviceInput>,
+) => Map<string, string> = (
+  devices: Array<LinkRuleDeviceInput>,
+): Map<string, string> => {
+  const index: Map<string, string> = new Map<string, string>();
+  for (const entry of devices) {
+    index.set(entry.id, (entry.siteId || "").toString().trim());
+  }
+  return index;
+};
+
+/*
+ * The util's warning and group-failure types, reached through its own
+ * signatures. A second `import` from the same module would trip
+ * `no-duplicate-imports`, and this file is only ever meant to grow downwards.
+ */
+type ResolvedWarning = NonNullable<
+  ReturnType<typeof NetworkDeviceLinkRuleUtil.getWarning>
+>;
+
+type ResolvedGroupFailure = NonNullable<
+  LinkRuleOutcome["groupFailures"]
+>[number];
+
+const warningOf: (outcome: LinkRuleOutcome) => ResolvedWarning = (
+  outcome: LinkRuleOutcome,
+): ResolvedWarning => {
+  const warning: ResolvedWarning | null =
+    NetworkDeviceLinkRuleUtil.getWarning(outcome);
+  expect(warning).not.toBeNull();
+  return warning!;
+};
+
+const failuresOf: (outcome: LinkRuleOutcome) => Array<ResolvedGroupFailure> = (
+  outcome: LinkRuleOutcome,
+): Array<ResolvedGroupFailure> => {
+  return outcome.groupFailures || [];
+};
+
+interface ScopeScenario {
+  label: string;
+  rule: LinkRuleInput;
+  devices: Array<LinkRuleDeviceInput>;
+}
+
+/*
+ * One table, swept by the invariant tests below. The point of sweeping rather
+ * than asserting case by case is that the two invariants — matchedChildCount
+ * tracks links, and "empty" and "skipped" are the same fact — are what every
+ * caller reads the outcome through, so they must hold on the paths nobody
+ * thought about as much as on the ones they did.
+ */
+const SCOPE_SCENARIOS: Array<ScopeScenario> = [
+  {
+    label: "project scope, one router and two switches",
+    rule: scopedRule({ scope: "Project" }),
+    devices: unit(1, 1, 2),
+  },
+  {
+    label: "project scope, a router in each of two units",
+    rule: scopedRule({ scope: "Project" }),
+    devices: units(1, 2, 1, 2),
+  },
+  {
+    label: "project scope, no router anywhere",
+    rule: scopedRule({ scope: "Project" }),
+    devices: unit(1, 0, 2),
+  },
+  {
+    label: "project scope, a router and nothing to place",
+    rule: scopedRule({ scope: "Project" }),
+    devices: unit(1, 1, 0),
+  },
+  {
+    label: "project scope, disabled",
+    rule: scopedRule({ scope: "Project", isEnabled: false }),
+    devices: unit(1, 1, 2),
+  },
+  {
+    label: "project scope, no child labels",
+    rule: scopedRule({ scope: "Project", childLabelIds: [] }),
+    devices: unit(1, 1, 2),
+  },
+  {
+    label: "project scope, no parent labels",
+    rule: scopedRule({ scope: "Project", parentLabelIds: [] }),
+    devices: unit(1, 1, 2),
+  },
+  {
+    label: "site scope, fourteen healthy units",
+    rule: scopedRule(),
+    devices: units(1, 14, 1, 3),
+  },
+  {
+    label: "site scope, thirteen healthy units and one with two routers",
+    rule: scopedRule(),
+    devices: [...units(1, 13, 1, 3), ...unit(14, 2, 3)],
+  },
+  {
+    label: "site scope, every unit parentless",
+    rule: scopedRule(),
+    devices: units(1, 3, 0, 2),
+  },
+  {
+    label: "site scope, nothing is assigned to a site",
+    rule: scopedRule(),
+    devices: [
+      switchAt("floater-1"),
+      switchAt("floater-2"),
+      routerAt("floater-3"),
+    ],
+  },
+  {
+    label: "site scope, no devices at all",
+    rule: scopedRule(),
+    devices: [],
+  },
+  {
+    label: "site scope, the only child match is the router itself",
+    rule: scopedRule(),
+    devices: [
+      deviceAt(
+        "core-01",
+        [ROUTER_LABEL, SWITCH_LABEL, MANAGED_LABEL],
+        "site-01",
+        "Unit 01",
+      ),
+    ],
+  },
+  {
+    label: "site scope, nothing carries the child labels",
+    rule: scopedRule(),
+    devices: units(1, 3, 1, 0),
+  },
+  {
+    label: "site scope, disabled",
+    rule: scopedRule({ isEnabled: false }),
+    devices: units(1, 3, 1, 2),
+  },
+];
+
+describe("NetworkDeviceLinkRuleUtil.resolveRule — site scope", () => {
+  it("leaves the project-scope outcome byte for byte what it always was", () => {
+    /*
+     * The migration adds a nullable column, so every rule in every existing
+     * project arrives here with scope undefined. If that path grew even one
+     * new key, a rule nobody touched would start reporting site coverage for
+     * a project that has never been divided into sites — which is why the
+     * absence of the keys is asserted with `in`, not with `toBeUndefined`.
+     */
+    const devices: Array<LinkRuleDeviceInput> = unit(1, 1, 2);
+
+    const implicit: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule({ scope: undefined }),
+      devices,
+    );
+    const explicit: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule({ scope: "Project" }),
+      devices,
+    );
+    // An unrecognised column value is a project-scoped rule too, never a guess.
+    const garbage: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule({ scope: "Region" }),
+      devices,
+    );
+
+    expect(implicit).toEqual(explicit);
+    expect(garbage).toEqual(explicit);
+
+    expect(Object.keys(implicit).sort()).toEqual([
+      "links",
+      "matchedChildCount",
+      "matchedParentCount",
+      "ruleId",
+      "ruleName",
+    ]);
+    expect("groupFailures" in implicit).toBe(false);
+    expect("applicableSiteCount" in implicit).toBe(false);
+    expect("unsitedChildDeviceCount" in implicit).toBe(false);
+
+    // The skipping path carries exactly one more key, and still no site keys.
+    const skipped: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule({ scope: "Project" }),
+      unit(1, 0, 2),
+    );
+
+    expect(Object.keys(skipped).sort()).toEqual([
+      "links",
+      "matchedChildCount",
+      "matchedParentCount",
+      "ruleId",
+      "ruleName",
+      "skipReason",
+    ]);
+    expect("groupFailures" in skipped).toBe(false);
+    expect("applicableSiteCount" in skipped).toBe(false);
+    expect("unsitedChildDeviceCount" in skipped).toBe(false);
+  });
+
+  it("asks the parent question once per site, so two units draw four uplinks", () => {
+    /*
+     * Under project scope this exact device set is `ambiguousParent` — two
+     * routers carry the parent labels — and draws nothing. Partitioning by
+     * site turns the same labels into the star each unit was meant to have.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [
+      ...unit(1, 1, 2),
+      ...unit(2, 1, 2),
+    ];
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+
+    expect(outcome.links).toHaveLength(4);
+    expect(outcome.skipReason).toBeUndefined();
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.applicableSiteCount).toBe(2);
+
+    // No uplink may cross a site boundary: that would be a cable nobody has.
+    const siteOf: Map<string, string> = siteIndexOf(devices);
+    for (const link of outcome.links) {
+      expect(siteOf.get(link.fromDeviceId)).toBe(siteOf.get(link.toDeviceId));
+    }
+  });
+
+  it("draws all fourteen units instead of reporting fourteen candidate routers", () => {
+    /*
+     * The reporter's exact scenario from issue #3260: fourteen units, each
+     * with one router carrying `SubCategory:Router` and three switches. On
+     * the global map the old resolver saw fourteen parent candidates, called
+     * the rule ambiguous, and drew NOTHING — not even the thirteen units that
+     * were never ambiguous in the first place.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 14, 1, 3),
+    );
+
+    expect(outcome.links).toHaveLength(42);
+    expect(outcome.skipReason).toBeUndefined();
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.applicableSiteCount).toBe(14);
+    expect(outcome.matchedParentCount).toBe(14);
+    // A rule doing its job owes the operator no explanation.
+    expect(NetworkDeviceLinkRuleUtil.getWarning(outcome)).toBeNull();
+  });
+
+  it("puts a null site and a missing site in the same excluded bucket", () => {
+    /*
+     * `null` and `undefined` are the same fact — "nobody has assigned this
+     * device to a site" — and the resolver keys its groups on a string, so if
+     * they normalised differently they would become two sites, each with one
+     * router, each drawing uplinks between devices whose only relationship is
+     * that neither has been filed yet.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        routerAt("router-null", null),
+        switchAt("switch-null", null),
+        routerAt("router-undefined"),
+        switchAt("switch-undefined"),
+        switchAt("switch-empty", ""),
+        switchAt("switch-blank", "   "),
+      ],
+    );
+
+    expect(outcome.links).toEqual([]);
+    expect(outcome.applicableSiteCount).toBe(0);
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.unsitedChildDeviceCount).toBe(4);
+  });
+
+  it("trims and stringifies the site key, so '  s1  ' and 's1' are one site", () => {
+    /*
+     * The caller stringifies an ObjectID into this field, and a stray space in
+     * an imported site id would otherwise split one building into two — each
+     * half then reporting that it has no router.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        routerAt("router-1", "  s1  ", "Unit 01"),
+        switchAt("switch-1", "s1", "Unit 01"),
+        switchAt("switch-2", "s1 ", "Unit 01"),
+      ],
+    );
+
+    expect(outcome.links).toEqual([
+      { fromDeviceId: "switch-1", toDeviceId: "router-1" },
+      { fromDeviceId: "switch-2", toDeviceId: "router-1" },
+    ]);
+    expect(outcome.applicableSiteCount).toBe(1);
+    expect(outcome.groupFailures).toBeUndefined();
+  });
+
+  it("counts unsited children rather than linking them to each other", () => {
+    /*
+     * Two switches and a router with no site is not a site with three devices
+     * in it. Linking them would assert a cabling fact from the absence of
+     * data, so they are walked past — and counted, because "the rule skipped
+     * four of your devices" is the whole reason the operator can act on it.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [switchAt("switch-1"), switchAt("switch-2"), routerAt("router-1")],
+    );
+
+    expect(outcome.links).toEqual([]);
+    expect(outcome.unsitedChildDeviceCount).toBe(2);
+    expect(outcome.applicableSiteCount).toBe(0);
+    expect(warningOf(outcome).message).toContain("not assigned to a site");
+  });
+
+  it("does not count an unsited device that only carries the parent labels", () => {
+    /*
+     * The count is a damage assessment — "these are the nodes floating on your
+     * map" — and an unsited router is not a node the rule wanted to place. It
+     * would inflate the number the operator is being asked to act on.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [routerAt("router-unsited"), ...unit(1, 1, 1)],
+    );
+
+    expect(outcome.unsitedChildDeviceCount).toBeUndefined();
+    expect(outcome.links).toEqual([
+      { fromDeviceId: "switch-01-1", toDeviceId: "router-01-1" },
+    ]);
+  });
+
+  it("says nothing about a site holding neither a parent nor a child", () => {
+    /*
+     * The rule simply does not apply in that building. Reporting it would
+     * trade one loud failure for one quiet one per site in the project, and a
+     * banner that lists two hundred irrelevant sites is a banner nobody reads.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [
+      ...unit(1, 1, 2),
+      deviceAt("camera-1", ["label-camera"], "site-02", "Unit 02"),
+      deviceAt("camera-2", ["label-camera"], "site-02", "Unit 02"),
+    ];
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+
+    expect(outcome.links).toHaveLength(2);
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.applicableSiteCount).toBe(1);
+  });
+
+  it("says nothing about a site with a router and nothing to place", () => {
+    /*
+     * A parent label like `SubCategory:Router` is present in nearly every
+     * site by construction, so a site that has one and no switches is the
+     * normal case, not a misconfiguration.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...unit(1, 1, 2), ...unit(2, 1, 0), ...unit(3, 3, 0)],
+    );
+
+    expect(outcome.links).toHaveLength(2);
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.applicableSiteCount).toBe(1);
+  });
+
+  it("says nothing about a site whose only child match is its own router", () => {
+    /*
+     * A collapsed core carrying both label sets is one box: after the
+     * self-link exclusion the site has nothing left to place, which is the
+     * same silence as having no switches at all rather than a failure to
+     * report. The pre-exclusion child count is 1 here, so this pins that the
+     * gate looks at what is left AFTER the parent is removed.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        ...unit(1, 1, 2),
+        deviceAt(
+          "core-02",
+          [ROUTER_LABEL, SWITCH_LABEL, MANAGED_LABEL],
+          "site-02",
+          "Unit 02",
+        ),
+      ],
+    );
+
+    expect(outcome.links).toHaveLength(2);
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.applicableSiteCount).toBe(1);
+  });
+
+  it("reports a site with switches and no router once, with its own damage count", () => {
+    const devices: Array<LinkRuleDeviceInput> = [
+      ...unit(1, 1, 2),
+      ...unit(2, 0, 3),
+    ];
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+
+    expect(outcome.links).toHaveLength(2);
+    expect(failuresOf(outcome)).toEqual([
+      {
+        siteId: "site-02",
+        siteName: "Unit 02",
+        reason: "noParentMatched",
+        matchedParentCount: 0,
+        // The three switches stranded in Unit 02, not the five in the project.
+        matchedChildCount: 3,
+      },
+    ]);
+    expect(outcome.applicableSiteCount).toBe(2);
+  });
+
+  it("reports an ambiguous site's own parent count, never the project-wide one", () => {
+    /*
+     * The old failure mode in one number. Project-wide there are four routers
+     * here; the operator's actual problem is the two sitting in Unit 03, and
+     * telling them "4 devices carry the parent labels" would send them looking
+     * at the three units that are fine.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [
+      ...unit(1, 1, 2),
+      ...unit(2, 1, 2),
+      ...unit(3, 2, 2),
+    ];
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+
+    expect(outcome.links).toHaveLength(4);
+    expect(failuresOf(outcome)).toHaveLength(1);
+    expect(failuresOf(outcome)[0]!.reason).toBe("ambiguousParent");
+    expect(failuresOf(outcome)[0]!.matchedParentCount).toBe(2);
+    expect(failuresOf(outcome)[0]!.siteId).toBe("site-03");
+    expect(failuresOf(outcome)[0]!.matchedChildCount).toBe(2);
+  });
+
+  it("keeps matchedChildCount equal to links.length in every scope and outcome", () => {
+    /*
+     * The rule list renders "Draws N uplinks" from matchedChildCount while the
+     * map renders links, so the moment those two disagree the product tells
+     * the operator two different stories about the same rule.
+     */
+    for (const scenario of SCOPE_SCENARIOS) {
+      const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+        scenario.rule,
+        scenario.devices,
+      );
+
+      expect({
+        label: scenario.label,
+        matchedChildCount: outcome.matchedChildCount,
+      }).toEqual({
+        label: scenario.label,
+        matchedChildCount: outcome.links.length,
+      });
+    }
+  });
+
+  it("treats an empty links array and a skipReason as the same fact, both scopes", () => {
+    /*
+     * describeOutcome switches on skipReason and falls through to "Draws N
+     * uplinks", so a gap in either direction produces a rule that either
+     * claims to draw nothing while drawing, or claims to draw nothing while
+     * offering no reason at all.
+     */
+    for (const scenario of SCOPE_SCENARIOS) {
+      const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+        scenario.rule,
+        scenario.devices,
+      );
+
+      expect({
+        label: scenario.label,
+        empty: outcome.links.length === 0,
+      }).toEqual({
+        label: scenario.label,
+        empty: outcome.skipReason !== undefined,
+      });
+    }
+  });
+
+  it("never claims to draw anything for an outcome that drew nothing", () => {
+    for (const scenario of SCOPE_SCENARIOS) {
+      const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+        scenario.rule,
+        scenario.devices,
+      );
+      const sentence: string =
+        NetworkDeviceLinkRuleUtil.describeOutcome(outcome);
+
+      expect({
+        label: scenario.label,
+        draws: sentence.startsWith("Draws"),
+      }).toEqual({
+        label: scenario.label,
+        draws: outcome.links.length > 0,
+      });
+    }
+  });
+
+  it("reports an empty device list as nothing to place, not as a resolved rule", () => {
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [],
+    );
+
+    expect(outcome.links).toEqual([]);
+    expect(outcome.skipReason).toBe("noChildrenMatched");
+    expect(outcome.groupFailures).toBeUndefined();
+    expect(outcome.unsitedChildDeviceCount).toBeUndefined();
+    expect(outcome.applicableSiteCount).toBe(0);
+  });
+
+  it("never links a device to itself, and a dual-labelled core is its site's parent", () => {
+    /*
+     * A collapsed core carrying both label sets is still one box. In Unit 01
+     * it is the only parent candidate, so it becomes the parent and is
+     * excluded from its own children; Unit 02 resolves its own star in
+     * parallel and the two never touch.
+     */
+    const dualIsTheOnlyParent: LinkRuleOutcome =
+      NetworkDeviceLinkRuleUtil.resolveRule(scopedRule(), [
+        deviceAt(
+          "core-01",
+          [ROUTER_LABEL, SWITCH_LABEL, MANAGED_LABEL],
+          "site-01",
+          "Unit 01",
+        ),
+        switchAt("switch-01-1", "site-01", "Unit 01"),
+        routerAt("router-02-1", "site-02", "Unit 02"),
+        switchAt("switch-02-1", "site-02", "Unit 02"),
+      ]);
+
+    expect(dualIsTheOnlyParent.links).toEqual([
+      { fromDeviceId: "switch-01-1", toDeviceId: "core-01" },
+      { fromDeviceId: "switch-02-1", toDeviceId: "router-02-1" },
+    ]);
+    for (const link of dualIsTheOnlyParent.links) {
+      expect(link.fromDeviceId).not.toBe(link.toDeviceId);
+    }
+
+    /*
+     * And the other half of the same rule: a device carrying the parent labels
+     * is always a parent CANDIDATE, so it is never quietly demoted to child
+     * just because its site already has a router. Unit 02 below has two boxes
+     * answering to `SubCategory:Router` and the honest answer is that nobody
+     * said which one is the uplink — so Unit 02 draws nothing and says why,
+     * while Unit 01 is untouched by its neighbour's problem.
+     */
+    const dualCompetesWithARouter: LinkRuleOutcome =
+      NetworkDeviceLinkRuleUtil.resolveRule(scopedRule(), [
+        deviceAt(
+          "core-01",
+          [ROUTER_LABEL, SWITCH_LABEL, MANAGED_LABEL],
+          "site-01",
+          "Unit 01",
+        ),
+        switchAt("switch-01-1", "site-01", "Unit 01"),
+        deviceAt(
+          "core-02",
+          [ROUTER_LABEL, SWITCH_LABEL, MANAGED_LABEL],
+          "site-02",
+          "Unit 02",
+        ),
+        routerAt("router-02-1", "site-02", "Unit 02"),
+        switchAt("switch-02-1", "site-02", "Unit 02"),
+      ]);
+
+    expect(dualCompetesWithARouter.links).toEqual([
+      { fromDeviceId: "switch-01-1", toDeviceId: "core-01" },
+    ]);
+    expect(failuresOf(dualCompetesWithARouter)).toEqual([
+      {
+        siteId: "site-02",
+        siteName: "Unit 02",
+        reason: "ambiguousParent",
+        matchedParentCount: 2,
+        matchedChildCount: 2,
+      },
+    ]);
+  });
+
+  it("never draws the same pair twice under site scope", () => {
+    /*
+     * Sites are disjoint buckets and the builder merges by pair, so a repeated
+     * pair would silently become one edge on the map while inflating every
+     * count the rule list shows.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 4, 1, 3),
+    );
+
+    const pairs: Set<string> = new Set<string>(
+      outcome.links.map(
+        (link: { fromDeviceId: string; toDeviceId: string }) => {
+          return `${link.fromDeviceId}->${link.toDeviceId}`;
+        },
+      ),
+    );
+
+    expect(outcome.links).toHaveLength(12);
+    expect(pairs.size).toBe(outcome.links.length);
+  });
+
+  it("is exactly project scope when every device is in one site", () => {
+    /*
+     * One site is one universe, so the partition is the identity and the two
+     * scopes cannot disagree. This is what makes the column safe to flip on a
+     * single-site project: the map does not move.
+     */
+    const devices: Array<LinkRuleDeviceInput> = unit(1, 1, 3);
+
+    const siteScoped: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+    const projectScoped: LinkRuleOutcome =
+      NetworkDeviceLinkRuleUtil.resolveRule(
+        scopedRule({ scope: "Project" }),
+        devices,
+      );
+
+    expect(siteScoped.links).toEqual(projectScoped.links);
+    expect(siteScoped.matchedChildCount).toBe(projectScoped.matchedChildCount);
+    expect(siteScoped.matchedParentCount).toBe(
+      projectScoped.matchedParentCount,
+    );
+    expect(siteScoped.skipReason).toBe(projectScoped.skipReason);
+  });
+
+  it("reports noSiteResolved rather than borrowing one site's reason", () => {
+    /*
+     * Unit 01 has no router and Unit 02 has two. Reporting either reason for
+     * the rule as a whole would be a false statement about the other site, and
+     * the mixture is exactly why this reason exists.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...unit(1, 0, 2), ...unit(2, 2, 1)],
+    );
+
+    expect(outcome.links).toEqual([]);
+    expect(outcome.skipReason).toBe("noSiteResolved");
+    expect(NetworkDeviceLinkRuleUtil.describeOutcome(outcome)).toBe(
+      "No site resolved this rule.",
+    );
+    expect(failuresOf(outcome)).toHaveLength(2);
+    expect(outcome.applicableSiteCount).toBe(2);
+  });
+
+  it("counts every site that drew in the coverage fraction's numerator", () => {
+    /*
+     * "Drawing in X of Y sites" is subtraction, so it is only true if the
+     * sites that failed and the sites that drew partition the applicable set
+     * with nothing double-counted and nothing missing. Checked against the
+     * links themselves rather than against the counters.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [
+      ...unit(1, 1, 2),
+      ...unit(2, 1, 1),
+      ...unit(3, 0, 2),
+      ...unit(4, 2, 1),
+      ...unit(5, 1, 0),
+      deviceAt("camera-1", ["label-camera"], "site-06", "Unit 06"),
+    ];
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+
+    const siteOf: Map<string, string> = siteIndexOf(devices);
+    const sitesThatDrew: Set<string> = new Set<string>();
+    for (const link of outcome.links) {
+      sitesThatDrew.add(siteOf.get(link.fromDeviceId)!);
+      sitesThatDrew.add(siteOf.get(link.toDeviceId)!);
+    }
+
+    expect(outcome.applicableSiteCount).toBe(4);
+    expect(failuresOf(outcome)).toHaveLength(2);
+    expect(sitesThatDrew.size).toBe(
+      (outcome.applicableSiteCount || 0) - failuresOf(outcome).length,
+    );
+  });
+
+  it("does not touch the device array it was handed", () => {
+    /*
+     * resolveRules hands the SAME array instance to every rule in turn, so a
+     * resolver that sorted or bucketed in place would make rule two see a
+     * different project from rule one — and the bug would only show up in
+     * projects with more than one rule.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [
+      ...units(1, 3, 1, 2),
+      switchAt("floater-1"),
+    ];
+    const before: string = JSON.stringify(devices);
+
+    const alone: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+
+    const outcomes: Array<LinkRuleOutcome> =
+      NetworkDeviceLinkRuleUtil.resolveRules(
+        [
+          scopedRule({ id: "rule-first", scope: "Project" }),
+          scopedRule({ id: "rule-second", childLabelIds: ["label-camera"] }),
+          scopedRule(),
+        ],
+        devices,
+      );
+
+    expect(JSON.stringify(devices)).toBe(before);
+    // Third in a queue, and still the outcome it produces on its own.
+    expect(outcomes[2]).toEqual(alone);
+  });
+
+  it("does not reach across the site tree from an ancestor site", () => {
+    /*
+     * DELIBERATE, not a gap: sites are matched exactly, so a router filed
+     * under the campus does not parent the switches filed under each building
+     * inside it. Resolving up the tree would mean the map silently depends on
+     * a hierarchy the operator can restructure at any time, and every building
+     * would suddenly share one uplink. The rule refuses and names the
+     * buildings instead, which is a fix the operator can actually make.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        routerAt("campus-core", "site-campus", "Campus"),
+        switchAt("switch-a-1", "site-bldg-a", "Building A"),
+        switchAt("switch-a-2", "site-bldg-a", "Building A"),
+        switchAt("switch-b-1", "site-bldg-b", "Building B"),
+      ],
+    );
+
+    expect(outcome.links).toEqual([]);
+    expect(outcome.skipReason).toBe("noSiteResolved");
+    expect(failuresOf(outcome)).toEqual([
+      {
+        siteId: "site-bldg-a",
+        siteName: "Building A",
+        reason: "noParentMatched",
+        matchedParentCount: 0,
+        matchedChildCount: 2,
+      },
+      {
+        siteId: "site-bldg-b",
+        siteName: "Building B",
+        reason: "noParentMatched",
+        matchedParentCount: 0,
+        matchedChildCount: 1,
+      },
+    ]);
+    // The campus itself had nothing to place, so it is not counted against.
+    expect(outcome.applicableSiteCount).toBe(2);
+  });
+});
+
+describe("NetworkDeviceLinkRuleUtil.getWarning", () => {
+  it("stays silent for a rule that is doing its job, in either scope", () => {
+    const projectScoped: LinkRuleOutcome =
+      NetworkDeviceLinkRuleUtil.resolveRule(
+        scopedRule({ scope: "Project" }),
+        unit(1, 1, 3),
+      );
+    const siteScoped: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 6, 1, 2),
+    );
+
+    expect(NetworkDeviceLinkRuleUtil.getWarning(projectScoped)).toBeNull();
+    expect(NetworkDeviceLinkRuleUtil.getWarning(siteScoped)).toBeNull();
+  });
+
+  it("echoes describeOutcome verbatim for every project-scoped skip", () => {
+    /*
+     * The project path is what the topology API used to compute inline, and
+     * the banner and the rule list render the same rule side by side. Asserted
+     * against describeOutcome's OWN return value rather than against copies of
+     * its sentences, so the two can never be edited apart.
+     */
+    const skips: Array<ScopeScenario> = [
+      {
+        label: "disabled",
+        rule: scopedRule({ scope: "Project", isEnabled: false }),
+        devices: unit(1, 1, 2),
+      },
+      {
+        label: "noChildLabels",
+        rule: scopedRule({ scope: "Project", childLabelIds: [] }),
+        devices: unit(1, 1, 2),
+      },
+      {
+        label: "noParentLabels",
+        rule: scopedRule({ scope: "Project", parentLabelIds: [] }),
+        devices: unit(1, 1, 2),
+      },
+      {
+        label: "noParentMatched",
+        rule: scopedRule({ scope: "Project" }),
+        devices: unit(1, 0, 2),
+      },
+      {
+        label: "ambiguousParent",
+        rule: scopedRule({ scope: "Project" }),
+        devices: units(1, 2, 1, 2),
+      },
+      {
+        label: "noChildrenMatched",
+        rule: scopedRule({ scope: "Project" }),
+        devices: unit(1, 1, 0),
+      },
+    ];
+
+    for (const scenario of skips) {
+      const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+        scenario.rule,
+        scenario.devices,
+      );
+      const warning: ResolvedWarning = warningOf(outcome);
+
+      expect({ label: scenario.label, reason: warning.reason }).toEqual({
+        label: scenario.label,
+        reason: outcome.skipReason,
+      });
+      expect({ label: scenario.label, message: warning.message }).toEqual({
+        label: scenario.label,
+        message: NetworkDeviceLinkRuleUtil.describeOutcome(outcome),
+      });
+      expect(warning.ruleId).toBe("rule-uplink");
+      expect(warning.ruleName).toBe("Switch uplinks");
+    }
+  });
+
+  it("warns about the fourteenth unit while the other thirteen keep drawing", () => {
+    /*
+     * The regression this whole change is for. The warning predicate used to
+     * be `links.length === 0`, which this outcome passes — 39 links — while
+     * the operator's fourteenth building is genuinely broken. Silence here
+     * means a site that has been quietly missing its uplinks since somebody
+     * racked a second router in it.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...units(1, 13, 1, 3), ...unit(14, 2, 3)],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(outcome.links.length).toBeGreaterThan(0);
+    expect(outcome.links).toHaveLength(39);
+    expect(warning.reason).toBe("ambiguousParent");
+    expect(warning.message).toContain("Drawing in 13 of 14 sites.");
+    expect(warning.message).toContain("Unit 14");
+    expect(warning.message).toContain("2 devices carry the parent labels");
+  });
+
+  it("folds mixed failures into one bullet, ambiguity before missing parents", () => {
+    /*
+     * One bullet per rule, never one per site: the banner's length has to be
+     * bounded by the number of rules the operator wrote, not by the number of
+     * sites they own. Ambiguity leads because it is the more specific
+     * complaint — "you have two of these" is a five-second fix, "you have
+     * none" may be a truck roll.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...unit(1, 2, 2), ...unit(2, 0, 1), ...unit(3, 0, 2), ...unit(4, 1, 1)],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(failuresOf(outcome)).toHaveLength(3);
+    expect(warning.reason).toBe("ambiguousParent");
+
+    const ambiguity: number = warning.message.indexOf(
+      "2 devices carry the parent labels in Unit 01.",
+    );
+    const missing: number = warning.message.indexOf(
+      "No device carries the parent labels in Unit 02 and Unit 03,",
+    );
+
+    expect(ambiguity).toBeGreaterThan(-1);
+    expect(missing).toBeGreaterThan(-1);
+    expect(ambiguity).toBeLessThan(missing);
+    expect(warning.message).toContain("3 devices there have no uplink.");
+  });
+
+  it("uses the project's own sentence when nothing carries the child labels", () => {
+    /*
+     * No site failed and nothing was stranded, so there is nothing site-shaped
+     * to say — and inventing a site-scoped phrasing here would give the
+     * operator two different sentences for the same situation depending on a
+     * column they may not know they set.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 3, 1, 0),
+    );
+
+    expect(outcome.skipReason).toBe("noChildrenMatched");
+    expect(warningOf(outcome).message).toBe(
+      "No device carries the child labels yet.",
+    );
+  });
+
+  it("opens with the headline that matches whether anything drew at all", () => {
+    const nothingDrew: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 2, 0, 1),
+    );
+    const somethingDrew: LinkRuleOutcome =
+      NetworkDeviceLinkRuleUtil.resolveRule(scopedRule(), [
+        ...unit(1, 1, 2),
+        ...unit(2, 0, 1),
+      ]);
+
+    expect(
+      warningOf(nothingDrew).message.startsWith("No site resolved this rule."),
+    ).toBe(true);
+    expect(warningOf(somethingDrew).message.startsWith("Drawing in")).toBe(
+      true,
+    );
+    expect(warningOf(somethingDrew).message).toContain(
+      "Drawing in 1 of 2 sites.",
+    );
+  });
+
+  it("omits the coverage fraction when only one site applies", () => {
+    /*
+     * "Drawing in 1 of 1 sites" is a sentence that costs the reader time and
+     * tells them nothing. The unsited clause still has to be emitted, so this
+     * pins that the two are independent rather than one gating the other.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...unit(1, 1, 2), switchAt("floater-1"), switchAt("floater-2")],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(outcome.applicableSiteCount).toBe(1);
+    expect(outcome.links).toHaveLength(2);
+    expect(warning.reason).toBe("devicesWithoutSite");
+    expect(warning.message).toBe(
+      "2 devices carrying the child labels are not assigned to a site, so this site-scoped rule skips them.",
+    );
+    expect(warning.message).not.toContain("Drawing in");
+    expect(warning.message).not.toContain("of 1 sites");
+  });
+
+  it("names three sites and counts the rest exactly", () => {
+    /*
+     * Three names is enough to recognise a pattern; fifteen is a wall of text
+     * in a banner. The COUNT stays exact even though the names are elided, so
+     * the operator still knows the true blast radius.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 15, 0, 1),
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+    const allNames: Array<string> = [];
+    for (let index: number = 1; index <= 15; index++) {
+      allNames.push(`Unit ${twoDigit(index)}`);
+    }
+    const named: Array<string> = allNames.filter((name: string): boolean => {
+      return warning.message.includes(name);
+    });
+
+    expect(failuresOf(outcome)).toHaveLength(15);
+    expect(named).toEqual(["Unit 01", "Unit 02", "Unit 03"]);
+    expect(warning.message).toContain("and 12 more sites");
+    expect(warning.message).toContain("15 devices there have no uplink.");
+  });
+
+  it("says 'and 1 more site' rather than 'and 1 more sites'", () => {
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      units(1, 4, 0, 1),
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.message).toContain(
+      "Unit 01, Unit 02, Unit 03 and 1 more site,",
+    );
+    expect(warning.message).not.toContain("more sites");
+  });
+
+  it("describes a site with no name instead of printing its id", () => {
+    /*
+     * The id is a database key: it means nothing to the reader and, printed in
+     * a banner, it is the one part of the sentence they might paste into a
+     * ticket. A site with no name is missing a name, which is a different
+     * problem from the one this warning is about.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [switchAt("switch-x", "site-9f3c-never-printed")],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.message).toBe(
+      "No site resolved this rule. No device carries the parent labels in an unnamed site, so 1 device there has no uplink.",
+    );
+    expect(warning.message).not.toContain("site-9f3c-never-printed");
+  });
+
+  it("truncates a site name past 40 characters to 39 and an ellipsis", () => {
+    /*
+     * Site names are ShortText and run to 100 characters. Three of them
+     * unabridged would be a 300-character site list inside a one-line banner.
+     */
+    const longName: string = "Manufacturing Plant Seven East Annex Riser Room";
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [switchAt("switch-x", "site-long", longName)],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(longName.length).toBeGreaterThan(40);
+    expect(warning.message).toContain(
+      "Manufacturing Plant Seven East Annex Ri…",
+    );
+    expect(warning.message).not.toContain(longName);
+  });
+
+  it("produces a byte-identical message however the devices are ordered", () => {
+    /*
+     * The live view refetches every sixty seconds and the device query has no
+     * ORDER BY, so an unsorted site list would reshuffle the banner on every
+     * poll and read as a change that did not happen. Links keep following
+     * first appearance in the array — that is the map's stable draw order, not
+     * the banner's.
+     */
+    const inOrder: Array<LinkRuleDeviceInput> = [
+      ...unit(5, 1, 1),
+      ...unit(3, 0, 1),
+      ...unit(1, 1, 1),
+      ...unit(4, 2, 1),
+      ...unit(2, 0, 1),
+    ];
+    const shuffled: Array<LinkRuleDeviceInput> = [
+      ...unit(1, 1, 1),
+      ...unit(2, 0, 1),
+      ...unit(4, 2, 1),
+      ...unit(5, 1, 1),
+      ...unit(3, 0, 1),
+    ];
+
+    const first: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      inOrder,
+    );
+    const second: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      shuffled,
+    );
+
+    expect(warningOf(first).message).toBe(warningOf(second).message);
+    expect(warningOf(first).message).toContain(
+      "Unit 02 and Unit 03, so 2 devices there have no uplink.",
+    );
+
+    expect(first.links).toEqual([
+      { fromDeviceId: "switch-05-1", toDeviceId: "router-05-1" },
+      { fromDeviceId: "switch-01-1", toDeviceId: "router-01-1" },
+    ]);
+    expect(second.links).toEqual([
+      { fromDeviceId: "switch-01-1", toDeviceId: "router-01-1" },
+      { fromDeviceId: "switch-05-1", toDeviceId: "router-05-1" },
+    ]);
+  });
+
+  it("reads 'has' for one stranded device and 'have' for several", () => {
+    const one: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...unit(1, 1, 1), ...unit(2, 0, 1)],
+    );
+    const several: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...unit(1, 1, 1), ...unit(2, 0, 4)],
+    );
+
+    expect(warningOf(one).message).toContain(
+      "so 1 device there has no uplink.",
+    );
+    expect(warningOf(several).message).toContain(
+      "so 4 devices there have no uplink.",
+    );
+  });
+
+  it("keeps even the worst case short enough to read", () => {
+    /*
+     * The banner is one line per rule. Thirty failing sites of both kinds,
+     * hundred-character names and stranded unsited devices is the loudest a
+     * single rule can be, and it still has to fit somewhere a human will read
+     * it rather than scroll past.
+     */
+    const hundredCharName: (index: number) => string = (
+      index: number,
+    ): string => {
+      const base: string = `Unit ${twoDigit(index)} Distribution Annex `;
+      return (base + "0123456789".repeat(10)).slice(0, 100);
+    };
+
+    const devices: Array<LinkRuleDeviceInput> = [];
+    for (let index: number = 1; index <= 15; index++) {
+      const siteId: string = `ambiguous-${twoDigit(index)}`;
+      const siteName: string = hundredCharName(index);
+      devices.push(routerAt(`amb-router-a-${index}`, siteId, siteName));
+      devices.push(routerAt(`amb-router-b-${index}`, siteId, siteName));
+      devices.push(switchAt(`amb-switch-${index}`, siteId, siteName));
+    }
+    for (let index: number = 16; index <= 30; index++) {
+      const siteId: string = `parentless-${twoDigit(index)}`;
+      const siteName: string = hundredCharName(index);
+      devices.push(switchAt(`orphan-switch-${index}`, siteId, siteName));
+    }
+    devices.push(switchAt("floater-1"));
+    devices.push(switchAt("floater-2"));
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(hundredCharName(1)).toHaveLength(100);
+    expect(failuresOf(outcome)).toHaveLength(30);
+    expect(outcome.unsitedChildDeviceCount).toBe(2);
+    expect(warning.message.length).toBeLessThanOrEqual(700);
+  });
+});

--- a/Common/Types/NetworkDevice/NetworkDeviceLinkRuleScope.ts
+++ b/Common/Types/NetworkDevice/NetworkDeviceLinkRuleScope.ts
@@ -1,0 +1,51 @@
+/*
+ * How wide a link rule's "exactly one parent" question is asked.
+ *
+ * A rule says every device carrying ALL the child labels gets one uplink to
+ * the SINGLE device carrying ALL the parent labels. "Single" needs a universe,
+ * and until now that universe was whatever device set the topology query
+ * happened to hand the resolver. The same rule therefore resolved fine on a
+ * site-filtered map and collapsed to `ambiguousParent` on the global one —
+ * issue #3260, where fourteen units each have a router carrying
+ * `SubCategory:Router` and the global map drew NO rule uplinks at all, not
+ * even the thirteen unambiguous ones.
+ *
+ * Site asks the same question once per site instead. Opt-in, never inferred:
+ * inferring it would silently change what an already-saved rule draws, and a
+ * rule that quietly re-points cables is worse than one that refuses to draw.
+ *
+ * Stored as free text on the column (the NetworkDeviceMonitoringMethod
+ * precedent), so read it through `parse` rather than comparing the raw column:
+ * rows written before this existed hold NULL and must read as Project, which
+ * is what they are.
+ */
+export enum NetworkDeviceLinkRuleScope {
+  // One parent for the whole project. What every rule written so far means.
+  Project = "Project",
+  // One parent per site. Devices with no site are skipped, and said so.
+  Site = "Site",
+}
+
+export class NetworkDeviceLinkRuleScopeUtil {
+  /*
+   * NULL, empty, whitespace and anything unrecognised read as Project.
+   * Defaulting the other way would silently redraw somebody's map.
+   */
+  public static parse(
+    value: string | undefined | null,
+  ): NetworkDeviceLinkRuleScope {
+    if ((value || "").trim().toLowerCase() === "site") {
+      return NetworkDeviceLinkRuleScope.Site;
+    }
+    return NetworkDeviceLinkRuleScope.Project;
+  }
+
+  public static isSiteScoped(value: string | undefined | null): boolean {
+    return (
+      NetworkDeviceLinkRuleScopeUtil.parse(value) ===
+      NetworkDeviceLinkRuleScope.Site
+    );
+  }
+}
+
+export default NetworkDeviceLinkRuleScope;

--- a/Common/Utils/Monitor/NetworkDeviceLinkRuleUtil.ts
+++ b/Common/Utils/Monitor/NetworkDeviceLinkRuleUtil.ts
@@ -1,3 +1,5 @@
+import { NetworkDeviceLinkRuleScopeUtil } from "../../Types/NetworkDevice/NetworkDeviceLinkRuleScope";
+
 /*
  * Turning label rules into uplinks.
  *
@@ -9,12 +11,35 @@
  * edge to the single device carrying all the parent labels. Matching "devices
  * that share a label" symmetrically, which is what was originally asked for,
  * would turn one forty-device site label into 780 edges.
+ *
+ * "The single device" needs a universe to be single IN, and the rule's scope
+ * is what names it. Project scope asks across everything the caller passed;
+ * Site scope asks once per site, which is what lets one rule draw the same
+ * router-to-switch star in fourteen buildings instead of reporting fourteen
+ * candidate routers and drawing nothing anywhere.
  */
 
 export interface LinkRuleDeviceInput {
   id: string;
   // Normalised label ids the device carries.
   labelIds: Array<string>;
+  /*
+   * Which site the device belongs to. ALWAYS a string, never an ObjectID —
+   * grouping keys a Map on it, and an ObjectID instance would compare by
+   * identity and put every device in a group of its own. null, undefined, ""
+   * and whitespace all normalise to the same "no site" key.
+   *
+   * Read only when the rule is site-scoped, so a caller that never populates
+   * it leaves project-scoped rules resolving exactly as before.
+   */
+  siteId?: string | null | undefined;
+  /*
+   * Display name of that site, for the warning text. Carried on the device
+   * rather than looked up by the caller so the name comes from the same
+   * permission-filtered rows the map itself is drawn from — a viewer can
+   * never be told the name of a site none of whose devices they can read.
+   */
+  siteName?: string | undefined;
 }
 
 export interface LinkRuleInput {
@@ -23,6 +48,19 @@ export interface LinkRuleInput {
   isEnabled?: boolean | undefined;
   childLabelIds: Array<string>;
   parentLabelIds: Array<string>;
+  /*
+   * Raw column value. Always read through NetworkDeviceLinkRuleScopeUtil.parse
+   * so undefined and NULL read as Project — every rule written before the
+   * column existed means "one parent for the whole project", and defaulting
+   * the other way would silently redraw somebody's map.
+   */
+  scope?: string | undefined;
+}
+
+// Structurally identical to the inline type it replaces.
+export interface LinkRuleLink {
+  fromDeviceId: string;
+  toDeviceId: string;
 }
 
 /*
@@ -36,34 +74,231 @@ export type LinkRuleSkipReason =
   | "noParentLabels"
   | "noParentMatched"
   | "ambiguousParent"
-  | "noChildrenMatched";
+  | "noChildrenMatched"
+  /*
+   * Site scope only: sites were in play and not one of them resolved. Its own
+   * reason because the per-site failures can be MIXED — one site with no
+   * parent, another with two — which none of the reasons above states.
+   */
+  | "noSiteResolved";
+
+/*
+ * The only two ways ONE site can fail in a way worth reporting. Deliberately
+ * narrower than LinkRuleSkipReason: `noChildrenMatched` is unreachable here
+ * (a site with nothing to place is never considered at all), and the three
+ * rule-level reasons are settled before any device is looked at.
+ */
+export type LinkRuleGroupSkipReason = "noParentMatched" | "ambiguousParent";
+
+/*
+ * Warnings have a slightly wider vocabulary than skips: "some matching devices
+ * have no site" is not a reason the RULE drew nothing, so it has no business
+ * in LinkRuleSkipReason, which describeOutcome switches over.
+ */
+export type LinkRuleWarningReason = LinkRuleSkipReason | "devicesWithoutSite";
+
+/*
+ * One site this rule was clearly meant to cover and could not. Independent of
+ * outcome.links.length — thirteen sites can draw while the fourteenth is
+ * listed here.
+ */
+export interface LinkRuleGroupFailure {
+  siteId: string;
+  siteName?: string | undefined;
+  reason: LinkRuleGroupSkipReason;
+  // Devices in THIS site carrying all the parent labels. 0 or >= 2.
+  matchedParentCount: number;
+  /*
+   * Devices in THIS site carrying all the child labels — the damage count,
+   * "how many nodes are floating on the map right now". No parent exclusion
+   * is applied because there is no resolved parent to exclude.
+   */
+  matchedChildCount: number;
+}
 
 export interface LinkRuleOutcome {
   ruleId: string;
   ruleName?: string | undefined;
   // Device pairs this rule contributes, parent second.
-  links: Array<{ fromDeviceId: string; toDeviceId: string }>;
-  // Set when links is empty and the rule had something to say about why.
+  links: Array<LinkRuleLink>;
+  /*
+   * Set when links is empty and the rule had something to say about why.
+   * INVARIANT, both scopes: links.length === 0 <=> skipReason !== undefined.
+   * A site-scoped rule that drew in thirteen of fourteen sites has NOT been
+   * skipped; the fourteenth lives in groupFailures.
+   */
   skipReason?: LinkRuleSkipReason | undefined;
-  // How many devices the parent labels matched — the ambiguity evidence.
+  /*
+   * How many devices the parent labels matched — the ambiguity evidence.
+   * Project scope: unchanged. Site scope: summed over the sites the rule
+   * actually applies to.
+   */
   matchedParentCount: number;
+  // INVARIANT, both scopes: matchedChildCount === links.length.
   matchedChildCount: number;
+
+  /*
+   * The three fields below are SITE SCOPE ONLY. On the project path the keys
+   * are not written at all, so a project-scoped outcome is the exact object
+   * it has always been, key for key.
+   */
+
+  // Sites the rule was meant to cover and could not. Omitted when empty.
+  groupFailures?: Array<LinkRuleGroupFailure> | undefined;
+  /*
+   * Sites this rule applies to: the ones holding at least one device it wanted
+   * to place. The coverage denominator, and deliberately not "every site in
+   * the project" — a healthy rule reading "drawing in 12 of 74 sites" would
+   * make the coverage sentence itself the noise.
+   */
+  applicableSiteCount?: number | undefined;
+  // Devices carrying ALL the child labels that have no site. Omitted when 0.
+  unsitedChildDeviceCount?: number | undefined;
+}
+
+/** One bullet in the topology map's warning banner. At most one per rule. */
+export interface LinkRuleWarning {
+  ruleId: string;
+  ruleName?: string | undefined;
+  reason: LinkRuleWarningReason;
+  message: string;
+}
+
+/*
+ * Devices are normalised once per resolveRule call: the label Set is built
+ * here rather than allocated afresh inside every match, and the group key is
+ * stringified and trimmed here so null, undefined, "" and "  " cannot become
+ * four different sites. Nothing here mutates the caller's array, which matters
+ * because resolveRules hands the same array to every rule in turn.
+ */
+interface NormalizedDevice {
+  device: LinkRuleDeviceInput;
+  labelSet: Set<string>;
+  // "" means the device has no site.
+  siteKey: string;
+}
+
+/*
+ * One site's verdict — the same decision matrix as always, asked inside a
+ * narrower device set. Used by both scopes, so the parent/child matching
+ * exists exactly once.
+ */
+interface LinkRuleGroupResult {
+  // Empty on every failure path.
+  links: Array<LinkRuleLink>;
+  // 0, 1, or >= 2.
+  parentMatchCount: number;
+  // Devices carrying all the child labels, BEFORE the unique-parent exclusion.
+  childMatchCount: number;
+  // null when links is non-empty.
+  failure: "noParentMatched" | "ambiguousParent" | "noChildrenMatched" | null;
 }
 
 export default class NetworkDeviceLinkRuleUtil {
+  /*
+   * Appended by the caller when the device list hit its row cap. Lives here so
+   * every operator-facing string this feature produces stays in one file.
+   */
+  public static readonly TRUNCATED_DEVICE_LIST_NOTE: string =
+    "The device list was truncated, so some of these may be false alarms.";
+
+  // Three names is enough to recognise a pattern; fourteen is a wall of text.
+  private static readonly MAX_NAMED_SITES: number = 3;
+  // Site names are ShortText and can run to 100 characters.
+  private static readonly MAX_SITE_NAME_LENGTH: number = 40;
+  private static readonly UNNAMED_SITE: string = "an unnamed site";
+
   /*
    * ALL of the rule's labels must be present on the device, not any. "Devices
    * that are both an access point AND on floor 1" is the question an operator
    * is asking; any-of would sweep in every access point in the building.
    */
-  private static deviceMatches(
-    device: LinkRuleDeviceInput,
+  private static matches(
+    labelSet: Set<string>,
     requiredLabelIds: Array<string>,
   ): boolean {
-    const owned: Set<string> = new Set<string>(device.labelIds);
     return requiredLabelIds.every((labelId: string) => {
-      return owned.has(labelId);
+      return labelSet.has(labelId);
     });
+  }
+
+  private static resolveGroup(
+    rule: LinkRuleInput,
+    group: Array<NormalizedDevice>,
+  ): LinkRuleGroupResult {
+    const parents: Array<NormalizedDevice> = group.filter(
+      (entry: NormalizedDevice) => {
+        return NetworkDeviceLinkRuleUtil.matches(
+          entry.labelSet,
+          rule.parentLabelIds,
+        );
+      },
+    );
+
+    /*
+     * Counted before the parent branch, not after: a site that failed to
+     * resolve still has to report how many devices are floating there, and
+     * that number is the operator's damage assessment.
+     */
+    const childCandidates: Array<NormalizedDevice> = group.filter(
+      (entry: NormalizedDevice) => {
+        return NetworkDeviceLinkRuleUtil.matches(
+          entry.labelSet,
+          rule.childLabelIds,
+        );
+      },
+    );
+    const childMatchCount: number = childCandidates.length;
+
+    if (parents.length === 0) {
+      return {
+        links: [],
+        parentMatchCount: 0,
+        childMatchCount: childMatchCount,
+        failure: "noParentMatched",
+      };
+    }
+
+    /*
+     * Two candidate parents is not a tie to break — it is a question the
+     * labels do not answer. Drawing to either one would assert a cabling
+     * fact nobody stated.
+     */
+    if (parents.length > 1) {
+      return {
+        links: [],
+        parentMatchCount: parents.length,
+        childMatchCount: childMatchCount,
+        failure: "ambiguousParent",
+      };
+    }
+
+    const parent: NormalizedDevice = parents[0]!;
+
+    // The parent is excluded even when it matches both sets: no self-links.
+    const children: Array<NormalizedDevice> = childCandidates.filter(
+      (entry: NormalizedDevice) => {
+        return entry.device.id !== parent.device.id;
+      },
+    );
+
+    if (children.length === 0) {
+      return {
+        links: [],
+        parentMatchCount: 1,
+        childMatchCount: childMatchCount,
+        failure: "noChildrenMatched",
+      };
+    }
+
+    return {
+      links: children.map((child: NormalizedDevice) => {
+        return { fromDeviceId: child.device.id, toDeviceId: parent.device.id };
+      }),
+      parentMatchCount: 1,
+      childMatchCount: childMatchCount,
+      failure: null,
+    };
   }
 
   public static resolveRule(
@@ -89,6 +324,13 @@ export default class NetworkDeviceLinkRuleUtil {
       };
     };
 
+    /*
+     * The three checks below are properties of the rule's TEXT, true in every
+     * site, so they are settled before scope is even read. A disabled rule is
+     * not "disabled in Unit 7", and partitioning a rule with an empty parent
+     * label set would make every site in the project ambiguous at once — the
+     * worst noise outcome available.
+     */
     if (rule.isEnabled === false) {
       return empty("disabled");
     }
@@ -105,53 +347,233 @@ export default class NetworkDeviceLinkRuleUtil {
       return empty("noParentLabels");
     }
 
-    const parents: Array<LinkRuleDeviceInput> = devices.filter(
+    const normalized: Array<NormalizedDevice> = devices.map(
       (device: LinkRuleDeviceInput) => {
-        return NetworkDeviceLinkRuleUtil.deviceMatches(
-          device,
-          rule.parentLabelIds,
-        );
+        return {
+          device: device,
+          labelSet: new Set<string>(device.labelIds),
+          siteKey: (device.siteId || "").toString().trim(),
+        };
       },
     );
 
-    if (parents.length === 0) {
+    if (NetworkDeviceLinkRuleScopeUtil.isSiteScoped(rule.scope)) {
+      return NetworkDeviceLinkRuleUtil.resolvePerSite(rule, normalized);
+    }
+
+    return NetworkDeviceLinkRuleUtil.resolveProject(rule, normalized, empty);
+  }
+
+  private static resolveProject(
+    rule: LinkRuleInput,
+    normalized: Array<NormalizedDevice>,
+    empty: (
+      reason: LinkRuleSkipReason,
+      parents?: number,
+      children?: number,
+    ) => LinkRuleOutcome,
+  ): LinkRuleOutcome {
+    const result: LinkRuleGroupResult = NetworkDeviceLinkRuleUtil.resolveGroup(
+      rule,
+      normalized,
+    );
+
+    if (result.failure === "noParentMatched") {
       return empty("noParentMatched", 0);
     }
-
-    /*
-     * Two candidate parents is not a tie to break — it is a question the
-     * labels do not answer. Drawing to either one would assert a cabling
-     * fact nobody stated.
-     */
-    if (parents.length > 1) {
-      return empty("ambiguousParent", parents.length);
+    if (result.failure === "ambiguousParent") {
+      return empty("ambiguousParent", result.parentMatchCount);
     }
-
-    const parent: LinkRuleDeviceInput = parents[0]!;
-
-    const children: Array<LinkRuleDeviceInput> = devices.filter(
-      (device: LinkRuleDeviceInput) => {
-        // The parent is excluded even when it matches both sets: no self-links.
-        return (
-          device.id !== parent.id &&
-          NetworkDeviceLinkRuleUtil.deviceMatches(device, rule.childLabelIds)
-        );
-      },
-    );
-
-    if (children.length === 0) {
+    if (result.failure === "noChildrenMatched") {
       return empty("noChildrenMatched", 1);
     }
 
     return {
       ruleId: rule.id,
       ruleName: rule.name,
-      links: children.map((child: LinkRuleDeviceInput) => {
-        return { fromDeviceId: child.id, toDeviceId: parent.id };
-      }),
+      links: result.links,
       matchedParentCount: 1,
-      matchedChildCount: children.length,
+      matchedChildCount: result.links.length,
     };
+  }
+
+  private static resolvePerSite(
+    rule: LinkRuleInput,
+    normalized: Array<NormalizedDevice>,
+  ): LinkRuleOutcome {
+    /*
+     * Bucketed in ONE pass in first-appearance order. Never
+     * `devices.filter(...)` inside a loop over sites: that is O(devices x
+     * sites) per rule, and this endpoint runs at ten thousand devices.
+     */
+    const buckets: Map<string, Array<NormalizedDevice>> = new Map<
+      string,
+      Array<NormalizedDevice>
+    >();
+    let unsitedChildDeviceCount: number = 0;
+
+    for (const entry of normalized) {
+      /*
+       * A device with no site is EXCLUDED, not pooled with the other unsited
+       * ones and not given a group of its own. Pooling would ask "exactly one
+       * parent among all the unsited devices", a question nobody posed, and
+       * would draw an edge between two boxes whose only relationship is that
+       * neither has been assigned a site yet. Counted instead, so the map can
+       * say how many the rule walked past.
+       */
+      if (entry.siteKey === "") {
+        if (
+          NetworkDeviceLinkRuleUtil.matches(entry.labelSet, rule.childLabelIds)
+        ) {
+          unsitedChildDeviceCount++;
+        }
+        continue;
+      }
+
+      const bucket: Array<NormalizedDevice> | undefined = buckets.get(
+        entry.siteKey,
+      );
+      if (bucket) {
+        bucket.push(entry);
+      } else {
+        buckets.set(entry.siteKey, [entry]);
+      }
+    }
+
+    const links: Array<LinkRuleLink> = [];
+    const groupFailures: Array<LinkRuleGroupFailure> = [];
+    let applicableSiteCount: number = 0;
+    let matchedParentCount: number = 0;
+
+    for (const [siteId, group] of buckets) {
+      const result: LinkRuleGroupResult =
+        NetworkDeviceLinkRuleUtil.resolveGroup(rule, group);
+
+      if (result.links.length > 0) {
+        applicableSiteCount++;
+        matchedParentCount += result.parentMatchCount;
+        links.push(...result.links);
+        continue;
+      }
+
+      /*
+       * A site speaks only when it holds devices this rule wanted to place.
+       * Sites with nothing to place are not misconfigured — the rule simply
+       * does not apply there, and a parent label like `SubCategory:Router` is
+       * present in nearly every site by construction. Without this gate, site
+       * scoping would trade one loud failure for two hundred quiet ones and
+       * the banner would be ignored inside a week.
+       *
+       * `noChildrenMatched` lands here too: the only child candidate was the
+       * parent itself, so after the self-link exclusion there is nothing to
+       * place and nothing to report.
+       */
+      if (
+        result.childMatchCount === 0 ||
+        result.failure === null ||
+        result.failure === "noChildrenMatched"
+      ) {
+        continue;
+      }
+
+      applicableSiteCount++;
+      matchedParentCount += result.parentMatchCount;
+      groupFailures.push({
+        siteId: siteId,
+        siteName: NetworkDeviceLinkRuleUtil.siteNameOf(group),
+        reason: result.failure,
+        matchedParentCount: result.parentMatchCount,
+        matchedChildCount: result.childMatchCount,
+      });
+    }
+
+    const outcome: LinkRuleOutcome = {
+      ruleId: rule.id,
+      ruleName: rule.name,
+      links: links,
+      matchedParentCount: matchedParentCount,
+      matchedChildCount: links.length,
+      applicableSiteCount: applicableSiteCount,
+    };
+
+    /*
+     * Keeps `links.length === 0 <=> skipReason defined` true with no gaps, so
+     * describeOutcome can never fall through to "Draws 0 uplinks" on an empty
+     * outcome. The second arm covers both an empty device list and a rule
+     * whose labels match nothing anywhere.
+     */
+    if (links.length === 0) {
+      outcome.skipReason =
+        groupFailures.length > 0 ? "noSiteResolved" : "noChildrenMatched";
+    }
+
+    if (groupFailures.length > 0) {
+      outcome.groupFailures = groupFailures;
+    }
+    if (unsitedChildDeviceCount > 0) {
+      outcome.unsitedChildDeviceCount = unsitedChildDeviceCount;
+    }
+
+    return outcome;
+  }
+
+  /** First non-empty site name among a site's devices, if any of them carry one. */
+  private static siteNameOf(
+    group: Array<NormalizedDevice>,
+  ): string | undefined {
+    for (const entry of group) {
+      if (entry.device.siteName) {
+        return entry.device.siteName;
+      }
+    }
+    return undefined;
+  }
+
+  /*
+   * "Unit 4, Unit 9 and 2 more sites".
+   *
+   * Sorted before naming, and that is load-bearing rather than cosmetic: the
+   * live view refetches every sixty seconds and the device query has no ORDER
+   * BY, so an unsorted list would reshuffle the banner on every poll and read
+   * as a change that did not happen. The count stays exact even when the names
+   * are elided, so the operator always knows the true blast radius.
+   */
+  private static describeSiteList(
+    failures: Array<LinkRuleGroupFailure>,
+  ): string {
+    const sorted: Array<LinkRuleGroupFailure> = [...failures].sort(
+      (a: LinkRuleGroupFailure, b: LinkRuleGroupFailure) => {
+        return (
+          (a.siteName || "").localeCompare(b.siteName || "") ||
+          a.siteId.localeCompare(b.siteId)
+        );
+      },
+    );
+
+    const names: Array<string> = sorted
+      .slice(0, NetworkDeviceLinkRuleUtil.MAX_NAMED_SITES)
+      .map((failure: LinkRuleGroupFailure) => {
+        const name: string =
+          failure.siteName || NetworkDeviceLinkRuleUtil.UNNAMED_SITE;
+        return name.length > NetworkDeviceLinkRuleUtil.MAX_SITE_NAME_LENGTH
+          ? `${name.slice(
+              0,
+              NetworkDeviceLinkRuleUtil.MAX_SITE_NAME_LENGTH - 1,
+            )}…`
+          : name;
+      });
+
+    const remaining: number = sorted.length - names.length;
+
+    if (remaining > 0) {
+      return `${names.join(", ")} and ${remaining} more site${
+        remaining === 1 ? "" : "s"
+      }`;
+    }
+    if (names.length === 1) {
+      return names[0]!;
+    }
+    return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]!}`;
   }
 
   public static resolveRules(
@@ -178,10 +600,138 @@ export default class NetworkDeviceLinkRuleUtil {
         return `${outcome.matchedParentCount} devices carry the parent labels. Exactly one must, or there is no way to tell which is the uplink.`;
       case "noChildrenMatched":
         return "No device carries the child labels yet.";
+      case "noSiteResolved":
+        return "No site resolved this rule.";
       default:
         return `Draws ${outcome.matchedChildCount} uplink${
           outcome.matchedChildCount === 1 ? "" : "s"
         }.`;
     }
+  }
+
+  /**
+   * The operator-facing warning, or null when the rule needs no explanation.
+   *
+   * Singular on purpose: ONE bullet per rule, never one per site. The banner's
+   * length is then bounded by the number of rules the operator wrote — a small
+   * number they control — rather than by the number of sites in their project.
+   *
+   * This is also the only sanctioned "did this rule fail" predicate. A caller
+   * must not go back to testing `outcome.links.length === 0`, which a rule
+   * drawing thirteen of fourteen sites passes while genuinely failing.
+   */
+  public static getWarning(outcome: LinkRuleOutcome): LinkRuleWarning | null {
+    const failures: Array<LinkRuleGroupFailure> = outcome.groupFailures || [];
+    const unsited: number = outcome.unsitedChildDeviceCount || 0;
+
+    /*
+     * Project scope always lands here, and this branch is what the topology
+     * API used to compute inline: warn iff the rule drew nothing, using
+     * describeOutcome's own words. The `!skipReason` guard makes the old
+     * code's implicit assumption explicit rather than emitting a warning with
+     * an undefined reason.
+     */
+    if (failures.length === 0 && unsited === 0) {
+      if (outcome.links.length > 0 || !outcome.skipReason) {
+        return null;
+      }
+      return {
+        ruleId: outcome.ruleId,
+        ruleName: outcome.ruleName,
+        reason: outcome.skipReason,
+        message: NetworkDeviceLinkRuleUtil.describeOutcome(outcome),
+      };
+    }
+
+    const parts: Array<string> = [];
+    const applicableSiteCount: number = outcome.applicableSiteCount || 0;
+
+    if (outcome.links.length === 0) {
+      parts.push("No site resolved this rule.");
+    } else if (applicableSiteCount > 1) {
+      // A single applicable site needs no coverage fraction.
+      parts.push(
+        `Drawing in ${
+          applicableSiteCount - failures.length
+        } of ${applicableSiteCount} sites.`,
+      );
+    }
+
+    const ambiguous: Array<LinkRuleGroupFailure> = failures.filter(
+      (failure: LinkRuleGroupFailure) => {
+        return failure.reason === "ambiguousParent";
+      },
+    );
+    const parentless: Array<LinkRuleGroupFailure> = failures.filter(
+      (failure: LinkRuleGroupFailure) => {
+        return failure.reason === "noParentMatched";
+      },
+    );
+
+    if (ambiguous.length === 1) {
+      /*
+       * The trailing sentence deliberately echoes the project-scope wording so
+       * an operator's vocabulary does not fork between the two scopes.
+       */
+      parts.push(
+        `${
+          ambiguous[0]!.matchedParentCount
+        } devices carry the parent labels in ${NetworkDeviceLinkRuleUtil.describeSiteList(
+          ambiguous,
+        )}. Exactly one must, or there is no way to tell which is the uplink.`,
+      );
+    } else if (ambiguous.length > 1) {
+      parts.push(
+        `Several devices carry the parent labels in ${NetworkDeviceLinkRuleUtil.describeSiteList(
+          ambiguous,
+        )}. Exactly one per site must, or there is no way to tell which is the uplink.`,
+      );
+    }
+
+    if (parentless.length > 0) {
+      const stranded: number = parentless.reduce(
+        (sum: number, failure: LinkRuleGroupFailure) => {
+          return sum + failure.matchedChildCount;
+        },
+        0,
+      );
+      parts.push(
+        `No device carries the parent labels in ${NetworkDeviceLinkRuleUtil.describeSiteList(
+          parentless,
+        )}, so ${stranded} ${stranded === 1 ? "device" : "devices"} there ${
+          stranded === 1 ? "has" : "have"
+        } no uplink.`,
+      );
+    }
+
+    /*
+     * Always last and always its own sentence: the fix here is "assign these
+     * devices to a site", not "fix your labels", so they are never folded into
+     * a site-name list.
+     */
+    if (unsited > 0) {
+      parts.push(
+        `${unsited} ${
+          unsited === 1 ? "device" : "devices"
+        } carrying the child labels ${
+          unsited === 1 ? "is" : "are"
+        } not assigned to a site, so this site-scoped rule skips ${
+          unsited === 1 ? "it" : "them"
+        }.`,
+      );
+    }
+
+    return {
+      ruleId: outcome.ruleId,
+      ruleName: outcome.ruleName,
+      // Highest-ranked condition present. Ambiguity outranks a missing parent.
+      reason:
+        ambiguous.length > 0
+          ? "ambiguousParent"
+          : parentless.length > 0
+            ? "noParentMatched"
+            : "devicesWithoutSite",
+      message: parts.join(" "),
+    };
   }
 }


### PR DESCRIPTION
Fixes #3260.

## The bug is worse than the warning suggests

A link rule links every device carrying **all** the child labels to the **single** device carrying **all** the parent labels. That "exactly one" question was asked across whatever device set the caller handed the resolver — and the topology API narrows its device query by site only when a single site is being viewed.

So the invariant was being satisfied by the *query*, not by the rule. On a per-site map it resolved fine. On the global map, all fourteen units' routers carried `SubCategory:Router`, `parents.length === 14`, and the rule returned `links: []` with `ambiguousParent`.

The API pushed only `outcome.links` into the graph, so **every rule-derived uplink vanished from the global map** — the thirteen unambiguous ones along with the ambiguous one. The reporter saw an amber banner and a topology missing its entire label-driven hierarchy.

## The fix

Rules gain an opt-in `scope` column (nullable ShortText, following the `NetworkDeviceMonitoringMethod` precedent):

- **Project** — NULL, unrecognised text, and every rule that exists in every database today. Asks across the whole project, byte for byte as before.
- **Site** — asks the same question once per site and unions the results, so one rule draws the same router-to-switch star in all fourteen buildings.

Opt-in rather than inferred. Inferring per-site behaviour would need no configuration and would have fixed the reporter without them touching anything — but it silently changes what an already-saved rule draws, and a rule that was *correctly* reporting ambiguity would start asserting cabling nobody stated. The model's own comments make a point of refusing to guess about cabling.

## Two consequences worth reviewing carefully

**Warnings are no longer all-or-nothing.** A site-scoped rule can draw in thirteen sites and still owe an account of the fourteenth, so the API stops deciding "this rule failed" with `links.length === 0` and asks `getWarning` instead. That returns at most one clause-composed line per rule, so the banner's length is bounded by the number of rules the operator wrote rather than by the number of sites in their project:

> Drawing in 13 of 14 sites. 2 devices carry the parent labels in Unit 07. Exactly one must, or there is no way to tell which is the uplink.

**A site speaks only when it holds devices the rule wanted to place.** This is the load-bearing noise decision. Parent labels like `SubCategory:Router` are present in nearly every site by construction, so warning about every parentless site would trade one loud failure for two hundred quiet ones and the banner would be ignored inside a week.

The cost is real and is stated in the code rather than hidden: a site whose child labels all went missing goes unmentioned, and only the coverage denominator moves. The invariant kept instead is narrower — a rule may be quiet about one site, but it can never be quiet while drawing nothing at all (`links.length === 0` always yields a defined `skipReason`, so it always yields a warning).

## Deliberate limits

- **Unsited devices are skipped, not pooled.** Asking "exactly one parent among all the unsited devices" would draw an edge between two boxes whose only relationship is that nobody has assigned them a site yet. They are counted and reported instead: *"2 devices carrying the child labels are not assigned to a site, so this site-scoped rule skips them."*
- **Grouping is by the device's own exact site, never an ancestor.** `NetworkSite` has `parentSiteId`, so a parent router on a parent site with switches beneath it will not resolve. Subtree scoping needs a semantics decision nobody has made (does a parent site's router serve its children's devices?), so the leaf behaviour is documented in the form field, in the operator help, and pinned by a test rather than left emergent.
- **Site names ride in on the device rows** (`site: { name: true }`, which is `canReadOnRelationQuery`) rather than a separate `NetworkSiteService` query, which would throw `NotAuthorizedException` for a role holding only `ReadNetworkDevice` and take the whole map down for the sake of a string.

## Verification

- `Common` and `App` `tsc --noEmit`: clean. eslint + prettier on all changed files: clean.
- **`Common/Tests/Utils/Monitor/NetworkDeviceLinkRuleUtil.test.ts` — 47 pass.** Append-only: all 10 pre-existing cases pass with zero edits, which is the regression guard on the Project path. 37 new cases cover per-site grouping, the silence rules, unsited devices, both invariants (`matchedChildCount === links.length`; `links.length === 0 ⟺ skipReason` defined) swept over a scenario table, message composition, the name cap and truncation, determinism of the message under input reordering, and non-mutation of the caller's device array.
- **`Common/Tests/Types/NetworkDevice/NetworkDeviceLinkRuleScope.test.ts` — 43 pass.** Table-driven; pins that NULL and unrecognised text read as Project, which is what protects existing rules.
- **`App/Tests/BaseAPI/NetworkDeviceTopologyAPI.test.ts` — 15 pass.** 6 pre-existing untouched. The centrepiece is an adjacent pair over the same 14-site fixture: the Project-scoped rule draws nothing at all, and the same rule at Site scope draws the thirteen and names the fourteenth.
- 515 tests / 17 suites across the affected `Common` area, including the schema-wide `PermissionCatalogueCoverage` and `ColumnTransformerInvariants` checks.
- Migration generated with `typeorm migration:generate` (not hand-written) and registered in `SchemaMigrations/Index.ts`. It applies to a fully-migrated database, and `migration:generate --check` afterwards reports **"No changes in database schema were found"** — zero drift.

**Not verified:** the dashboard was not run. Docker was unavailable on this machine, so the app could not be started; the UI change is a declarative `ModelTable` form field and column following the existing `monitoringMethod` dropdown, type-checked and lint-clean, but nobody has clicked it.
