### PR TITLE
fix(analytics): stop form submits reporting "FORM SUBMIT: undefined"

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/InternalNote.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/InternalNote.tsx
@@ -365,6 +365,7 @@ const AlertDelete: FunctionComponent<PageComponentProps> = (
       {showAlertNoteTemplateModal && alertNoteTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Create Note from Template"
+          name="Alert > Internal Note from Template"
           isLoading={isLoading}
           submitButtonText="Create from Template"
           onClose={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/EpisodeView/Postmortem.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/EpisodeView/Postmortem.tsx
@@ -288,6 +288,7 @@ const EpisodePostmortem: FunctionComponent<
       {showTemplateModal && incidentPostmortemTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Apply Postmortem Template"
+          name="Incident Episode > Apply Postmortem Template"
           isLoading={isLoading}
           submitButtonText="Apply Template"
           onClose={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/InternalNote.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/InternalNote.tsx
@@ -366,6 +366,7 @@ const IncidentDelete: FunctionComponent<PageComponentProps> = (
       {showIncidentNoteTemplateModal && incidentNoteTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Create Note from Template"
+          name="Incident > Internal Note from Template"
           isLoading={isLoading}
           submitButtonText="Create from Template"
           onClose={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Postmortem.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Postmortem.tsx
@@ -456,6 +456,7 @@ const IncidentPostmortem: FunctionComponent<
       {showTemplateModal && incidentPostmortemTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Apply Postmortem Template"
+          name="Incident > Apply Postmortem Template"
           isLoading={isLoading}
           submitButtonText="Apply Template"
           onClose={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/PublicNote.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/PublicNote.tsx
@@ -442,6 +442,7 @@ const PublicNote: FunctionComponent<PageComponentProps> = (
       {showIncidentNoteTemplateModal && incidentNoteTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Create Note from Template"
+          name="Incident > Public Note from Template"
           isLoading={isLoading}
           submitButtonText="Create from Template"
           onClose={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorSecrets.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorSecrets.tsx
@@ -192,6 +192,7 @@ const MonitorSecrets: FunctionComponent<
       {currentlyEditingItem && (
         <BasicFormModal
           title={"Update Secret Value"}
+          name="Monitor > Update Secret Value"
           isLoading={isLoading}
           onClose={() => {
             setIsLoading(false);

--- a/App/FeatureSet/Dashboard/src/Pages/Runbook/Secrets.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Runbook/Secrets.tsx
@@ -191,6 +191,7 @@ const RunbookSecrets: FunctionComponent<
       {currentlyEditingItem && (
         <BasicFormModal
           title={"Update Secret Value"}
+          name="Runbook > Update Secret Value"
           isLoading={isLoading}
           onClose={() => {
             setIsLoading(false);

--- a/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/InternalNote.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/InternalNote.tsx
@@ -383,6 +383,7 @@ const ScheduledMaintenanceDelete: FunctionComponent<PageComponentProps> = (
       scheduledMaintenanceNoteTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Create Note from Template"
+          name="Scheduled Maintenance > Internal Note from Template"
           isLoading={isLoading}
           submitButtonText="Create from Template"
           onClose={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/PublicNote.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/PublicNote.tsx
@@ -461,6 +461,7 @@ const PublicNote: FunctionComponent<PageComponentProps> = (
       scheduledMaintenanceNoteTemplates.length > 0 ? (
         <BasicFormModal<JSONObject>
           title="Create Note from Template"
+          name="Scheduled Maintenance > Public Note from Template"
           isLoading={isLoading}
           submitButtonText="Create from Template"
           onClose={() => {

--- a/Common/Tests/UI/Components/Forms/FormSubmitAnalytics.test.tsx
+++ b/Common/Tests/UI/Components/Forms/FormSubmitAnalytics.test.tsx
@@ -1,0 +1,206 @@
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+/*
+ * The "FORM SUBMIT" event is what names a conversion in PostHog and in the GTM
+ * dataLayer. Every wrapper around BasicForm has to hand it something
+ * meaningful, and BasicForm has to stay silent when nothing meaningful exists.
+ * An event named after a missing prop reads as "FORM SUBMIT: undefined" and
+ * collapses every form in the product into one indistinguishable conversion.
+ */
+
+const captureMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../../UI/Utils/Analytics", () => {
+  return {
+    __esModule: true,
+    default: {
+      capture: (...args: Array<any>) => {
+        return captureMock(...args);
+      },
+    },
+  };
+});
+
+import BasicForm from "../../../../UI/Components/Forms/BasicForm";
+import BasicFormModal from "../../../../UI/Components/FormModal/BasicFormModal";
+import Fields from "../../../../UI/Components/Forms/Types/Fields";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import FormAnalyticsName from "../../../../UI/Components/Forms/Utils/FormAnalyticsName";
+
+const fields: Fields<FormValues<any>> = [
+  {
+    field: {
+      label: true,
+    },
+    title: "Label",
+    fieldType: FormFieldSchemaType.Text,
+    dataTestId: "label",
+  },
+];
+
+function setupUser(): UserEvent {
+  return userEvent.setup({ delay: null });
+}
+
+type CapturedEventNamesFunction = () => Array<string>;
+
+const capturedEventNames: CapturedEventNamesFunction = (): Array<string> => {
+  return captureMock.mock.calls.map((call: Array<any>) => {
+    return call[0] as string;
+  });
+};
+
+describe("FORM SUBMIT analytics naming", () => {
+  beforeEach(() => {
+    captureMock.mockClear();
+  });
+
+  describe("FormAnalyticsName.resolve", () => {
+    test("takes the first usable candidate", () => {
+      expect(FormAnalyticsName.resolve("Create Monitor", "Fallback")).toBe(
+        "Create Monitor",
+      );
+      expect(FormAnalyticsName.resolve(undefined, "Fallback")).toBe("Fallback");
+      expect(FormAnalyticsName.resolve(null, "  Trimmed  ")).toBe("Trimmed");
+    });
+
+    test("rejects candidates that are, or embed, a stringified empty value", () => {
+      expect(FormAnalyticsName.resolve("undefined")).toBeUndefined();
+      expect(FormAnalyticsName.resolve("null")).toBeUndefined();
+      expect(FormAnalyticsName.resolve("Duplicate undefined")).toBeUndefined();
+      expect(FormAnalyticsName.resolve("Edit null")).toBeUndefined();
+
+      // A rejected candidate falls through to the next one.
+      expect(
+        FormAnalyticsName.resolve("Duplicate undefined", "Duplicate Monitor"),
+      ).toBe("Duplicate Monitor");
+    });
+
+    test("returns undefined when no candidate is usable", () => {
+      expect(FormAnalyticsName.resolve()).toBeUndefined();
+      expect(
+        FormAnalyticsName.resolve(undefined, null, "", "   "),
+      ).toBeUndefined();
+    });
+
+    test("leaves real words that merely look like empty values alone", () => {
+      expect(FormAnalyticsName.resolve("Set Nullable Columns")).toBe(
+        "Set Nullable Columns",
+      );
+    });
+  });
+
+  describe("BasicForm", () => {
+    test("captures the form name on submit", async () => {
+      const onSubmit: MockFunction = getJestMockFunction();
+
+      render(
+        <BasicForm
+          fields={fields}
+          id="named-form"
+          name="Create Widget"
+          initialValues={{ label: "" }}
+          onSubmit={onSubmit}
+          submitButtonText="Submit"
+        />,
+      );
+
+      const user: UserEvent = setupUser();
+      await user.click(screen.getByTestId("Submit"));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+
+      expect(capturedEventNames()).toEqual(["FORM SUBMIT: Create Widget"]);
+    }, 30000);
+
+    test("stays silent when the form has no name", async () => {
+      const onSubmit: MockFunction = getJestMockFunction();
+
+      render(
+        <BasicForm
+          fields={fields}
+          id="unnamed-form"
+          initialValues={{ label: "" }}
+          onSubmit={onSubmit}
+          submitButtonText="Submit"
+        />,
+      );
+
+      const user: UserEvent = setupUser();
+      await user.click(screen.getByTestId("Submit"));
+
+      // The form still submits -- only the analytics event is skipped.
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+
+      expect(captureMock).not.toHaveBeenCalled();
+    }, 30000);
+  });
+
+  describe("BasicFormModal", () => {
+    test("falls back to the modal title when the caller passes no name", async () => {
+      const onSubmit: MockFunction = getJestMockFunction();
+
+      render(
+        <BasicFormModal<FormValues<any>>
+          title="Add Probe to Monitors"
+          submitButtonText="Save"
+          onSubmit={onSubmit}
+          formProps={{
+            fields: fields,
+            initialValues: { label: "" },
+          }}
+        />,
+      );
+
+      const user: UserEvent = setupUser();
+      await user.click(screen.getByTestId("modal-footer-submit-button"));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+
+      expect(capturedEventNames()).toEqual([
+        "FORM SUBMIT: Add Probe to Monitors",
+      ]);
+    }, 30000);
+
+    test("prefers a name the caller supplied over the modal title", async () => {
+      const onSubmit: MockFunction = getJestMockFunction();
+
+      render(
+        <BasicFormModal<FormValues<any>>
+          title="Add Probe to Monitors"
+          name="Monitor > Bulk Add Probe"
+          submitButtonText="Save"
+          onSubmit={onSubmit}
+          formProps={{
+            fields: fields,
+            initialValues: { label: "" },
+          }}
+        />,
+      );
+
+      const user: UserEvent = setupUser();
+      await user.click(screen.getByTestId("modal-footer-submit-button"));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+
+      expect(capturedEventNames()).toEqual([
+        "FORM SUBMIT: Monitor > Bulk Add Probe",
+      ]);
+    }, 30000);
+  });
+});

--- a/Common/UI/Components/FormModal/BasicFormModal.tsx
+++ b/Common/UI/Components/FormModal/BasicFormModal.tsx
@@ -5,12 +5,19 @@ import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import BasicForm, {
   BaseComponentProps as BasicFormComponentProps,
 } from "../Forms/BasicForm";
+import FormAnalyticsName from "../Forms/Utils/FormAnalyticsName";
 import Modal, { ModalWidth } from "../Modal/Modal";
 import GenericObject from "../../../Types/GenericObject";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 
 export interface ComponentProps<T extends GenericObject> {
   title: string;
+  /*
+   * Identifies this form in the "FORM SUBMIT" analytics event. Falls back to
+   * formProps.name and then to the modal title, so every modal reports a
+   * distinguishable conversion without each caller having to name it.
+   */
+  name?: string | undefined;
   isLoading?: boolean | undefined;
   error?: string | undefined;
   onClose?: undefined | (() => void);
@@ -51,6 +58,11 @@ const BasicFormModal: <T extends GenericObject>(
         {!isLoading && (
           <BasicForm
             {...props.formProps}
+            name={FormAnalyticsName.resolve(
+              props.name,
+              props.formProps.name,
+              props.title,
+            )}
             hideSubmitButton={true}
             ref={formRef}
             onLoadingChange={(isFormLoading: boolean) => {

--- a/Common/UI/Components/Forms/BasicForm.tsx
+++ b/Common/UI/Components/Forms/BasicForm.tsx
@@ -20,6 +20,7 @@ import FormFieldSchemaType from "./Types/FormFieldSchemaType";
 import { FormStep } from "./Types/FormStep";
 import FormValues from "./Types/FormValues";
 import Validation from "./Validation";
+import FormAnalyticsName from "./Utils/FormAnalyticsName";
 import OneUptimeDate from "../../../Types/Date";
 import Dictionary from "../../../Types/Dictionary";
 import { VoidFunction } from "../../../Types/FunctionTypes";
@@ -447,7 +448,18 @@ const BasicForm: ForwardRefExoticComponent<any> = forwardRef(
           }
         }
 
-        UiAnalytics.capture("FORM SUBMIT: " + props.name);
+        const analyticsName: string | undefined = FormAnalyticsName.resolve(
+          props.name,
+        );
+
+        /*
+         * Unnamed forms are embedded sub-forms (filter builders, argument
+         * editors) rather than conversions. Skip them instead of reporting an
+         * event named after a missing prop.
+         */
+        if (analyticsName) {
+          UiAnalytics.capture("FORM SUBMIT: " + analyticsName);
+        }
 
         props.onSubmit(values, () => {
           setDidSomethingChange(false);

--- a/Common/UI/Components/Forms/BasicModelForm.tsx
+++ b/Common/UI/Components/Forms/BasicModelForm.tsx
@@ -8,6 +8,7 @@ import BasicForm, {
 import Fields from "./Types/Fields";
 import { FormStep } from "./Types/FormStep";
 import FormValues from "./Types/FormValues";
+import FormAnalyticsName from "./Utils/FormAnalyticsName";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import React, {
   MutableRefObject,
@@ -113,7 +114,7 @@ const BasicModelForm: <TBaseModel extends BaseModel>(
       onValidate={props.onValidate ? props.onValidate : DefaultValidateFunction}
       disableAutofocus={props.disableAutofocus}
       steps={props.steps}
-      name={props.name}
+      name={FormAnalyticsName.resolve(props.name, props.title)}
       onFormStepChange={props.onFormStepChange}
       submitButtonStyleType={props.submitButtonStyleType}
       onSubmit={props.onSubmit}

--- a/Common/UI/Components/Forms/ModelForm.tsx
+++ b/Common/UI/Components/Forms/ModelForm.tsx
@@ -21,6 +21,7 @@ import Field from "./Types/Field";
 import Fields from "./Types/Fields";
 import { FormStep } from "./Types/FormStep";
 import FormValues from "./Types/FormValues";
+import FormAnalyticsName from "./Utils/FormAnalyticsName";
 import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
 import AccessControlModel from "../../../Models/DatabaseModels/DatabaseBaseModel/AccessControlModel";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
@@ -854,7 +855,15 @@ const ModelForm: <TBaseModel extends BaseModel>(
         disableAutofocus={props.disableAutofocus}
         model={model}
         id={props.id}
-        name={props.name}
+        name={FormAnalyticsName.resolve(
+          props.name,
+          props.title,
+          model.singularName
+            ? `${
+                props.formType === FormType.Create ? "Create" : "Update"
+              } ${model.singularName}`
+            : undefined,
+        )}
         onFormStepChange={props.onFormStepChange}
         onIsLastFormStep={props.onIsLastFormStep}
         fields={fields}

--- a/Common/UI/Components/Forms/Utils/FormAnalyticsName.ts
+++ b/Common/UI/Components/Forms/Utils/FormAnalyticsName.ts
@@ -1,0 +1,39 @@
+/*
+ * Matches "undefined" / "null" as a whole word, which is what a missing value
+ * turns into once it is interpolated into a title (`Duplicate ${undefined}`).
+ * Case sensitive on purpose: titles are written in Title Case, so a real word
+ * like "Null" in a form title is left alone.
+ */
+const STRINGIFIED_EMPTY_VALUE: RegExp = /\b(undefined|null)\b/;
+
+/*
+ * Resolves the human readable name that identifies a form in the
+ * "FORM SUBMIT" analytics event.
+ *
+ * Wrappers around BasicForm pass a chain of candidates - the explicit name
+ * first, then whatever title they already render - and the first usable one
+ * wins. When no candidate is usable the caller is expected to skip the capture
+ * altogether, because an event named after a missing value collapses distinct
+ * conversions into one indistinguishable event.
+ */
+export default class FormAnalyticsName {
+  public static resolve(
+    ...candidates: Array<string | undefined | null>
+  ): string | undefined {
+    for (const candidate of candidates) {
+      if (typeof candidate !== "string") {
+        continue;
+      }
+
+      const name: string = candidate.trim();
+
+      if (!name || STRINGIFIED_EMPTY_VALUE.test(name)) {
+        continue;
+      }
+
+      return name;
+    }
+
+    return undefined;
+  }
+}

--- a/Common/UI/Components/ModelFormModal/ModelFormModal.tsx
+++ b/Common/UI/Components/ModelFormModal/ModelFormModal.tsx
@@ -7,6 +7,7 @@ import ModelForm, {
   ComponentProps as ModelFormComponentProps,
 } from "../Forms/ModelForm";
 import FormValues from "../Forms/Types/FormValues";
+import FormAnalyticsName from "../Forms/Utils/FormAnalyticsName";
 import Modal, { ModalWidth } from "../Modal/Modal";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import { JSONObject } from "../../../Types/JSON";
@@ -77,7 +78,11 @@ const ModelFormModal: <TBaseModel extends BaseModel>(
         <>
           <ModelForm<TBaseModel>
             {...props.formProps}
-            name={props.name}
+            name={FormAnalyticsName.resolve(
+              props.name,
+              props.formProps.name,
+              props.title,
+            )}
             modelAPI={props.modelAPI}
             modelType={props.modelType}
             onIsLastFormStep={(isLastFormStep: boolean) => {


### PR DESCRIPTION
### Title of this pull request?

fix(analytics): stop form submits reporting "FORM SUBMIT: undefined"

### Small Description?

`BasicForm` named its submit event off `props.name` with no fallback and no guard:

```ts
UiAnalytics.capture("FORM SUBMIT: " + props.name);
```

`name` is optional, so any form reaching it without one emitted the literal event **`FORM SUBMIT: undefined`** to PostHog and the GTM dataLayer — collapsing distinct conversions into a single indistinguishable event.

**Where it actually came from.** I parsed every JSX call site (tracking brace/generic depth, comments stripped) rather than grepping, because the counts matter here:

| Path | Call sites | Passing `name` |
|---|---:|---:|
| `<ModelForm` | 27 | **27** |
| `<ModelFormModal` | 51 | **51** |
| `<BasicFormModal` | 45 | **15** (via `formProps.name`) |
| `<BasicForm` direct | 22 | 13 |

So `BasicFormModal` was the real source — it submits through a ref but declared no `name` prop at all, leaving 30 call sites with no way to supply one. `ModelForm` and `ModelFormModal` were already fine.

The 9 unnamed direct `<BasicForm>` sites turned out to be change-tracking sub-forms (filter builders, argument editors): no `onSubmit`, `hideSubmitButton={true}`, and the three holding a `ref` never call `submitForm()`. For those, *skipping* the capture is correct — inventing a name would manufacture conversions that don't exist.

**The fix.** New `FormAnalyticsName.resolve` picks the first usable candidate from a chain; the single capture site is guarded on it. Each wrapper feeds it one:

| Wrapper | Chain |
|---|---|
| `BasicFormModal` | `name` → `formProps.name` → `title` (`name` prop is new) |
| `ModelFormModal` | `name` → `formProps.name` → `title` |
| `ModelForm` | `name` → `title` → `"Create/Update {singularName}"` |
| `BasicModelForm` | `name` → `title` |

`ModelFormModal` also had a latent bug: it wrote `name={props.name}` *after* spreading `formProps`, clobbering `formProps.name` with `undefined` whenever `name` was omitted. No current caller hits it, but it's fixed.

The resolver rejects `undefined`/`null` as **whole words**, not just as the entire string — three fallback titles interpolate nullable values (`` `Duplicate ${model.singularName}` ``, `"Edit " + singularName`, `` `Verify ${totp.name}` ``) and would otherwise have reported `"Edit undefined"`. Word-boundary and case-sensitive, so a real title like "Set Nullable Columns" is left alone.

### Reviewer notes

**Slightly beyond the literal ask:** deriving from titles left 9 sites sharing 3 names (`Create Note from Template` ×5, `Apply Postmortem Template` ×2, `Update Secret Value` ×2). Those are genuinely distinct conversions, so they get explicit names via the new prop (`Incident > Public Note from Template`, `Runbook > Update Secret Value`, …), following the existing `X > Y` convention.

**Left alone deliberately:** ten duplicate event names predate this change and come from explicit `name` props already in the codebase — `Create Ingestion Key` ×10 (one per DocumentationCard), `execute-on-call-policy` ×4, `Login` ×2, and others. Renaming them would break existing analytics series, so that's a separate call.

**Analytics impact:** ~30 forms that reported `FORM SUBMIT: undefined` now report distinct names. Any dashboard keyed on the `undefined` event will go quiet.

### Verification

Re-ran the call-site parser across all **137 submitting paths**:

- **0** can produce a literal `undefined`/`null` in an event name
- 3 resolve to nothing → capture skipped (the workflow/dashboard argument editors, which never submit)
- 5 have dynamic names, all protected by the resolver at the single choke point
- `grep "FORM SUBMIT"` confirms exactly one emitter, guarded

`tsc --noEmit` clean on `Common` and `App`; 222 tests pass, including 8 new ones covering the resolver, the silent-when-unnamed path, and the modal title fallback. Prettier and ESLint clean on all changed files.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

N/A

### Screenshots (if appropriate):

N/A — no visual change; this affects analytics event names only.
