### PR TITLE
perf(ci): run App Test as one job again, the shards cost more than they save

### DIFF
--- a/.github/workflows/test.app.yaml
+++ b/.github/workflows/test.app.yaml
@@ -15,27 +15,23 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # This job used to run every App suite in one serial pass and stopped
-    # finishing at all: it ran into the 6h runner ceiling and was killed, so
-    # master had no App test signal. Three things bound it now.
+    # This job stopped finishing altogether: it ran into the 6h runner ceiling
+    # and was killed there, so master had no App test signal at all. The suite
+    # is ~340 files, two thirds of them under Tests/Dashboard, and each one was
+    # dragging the Dashboard's React import graph through ts-jest's per-file
+    # type check -- in a single process, because --detectOpenHandles implies
+    # --runInBand. It now transpiles instead of type-checking
+    # (App/jest.config.json sets isolatedModules) and runs on jest's worker
+    # pool, which took the whole suite to under three minutes of test time.
     #
-    # 1. jest --shard splits the ~340 suites across these runners. The split is
-    #    by hash of the test path, so the Dashboard suites -- two thirds of the
-    #    total, and the expensive ones -- spread evenly instead of landing in
-    #    one shard.
-    # 2. The suite no longer runs serially, and ts-jest no longer type-checks
-    #    every file it loads (App/jest.config.json sets isolatedModules). The
-    #    types are still checked, once and in about a minute, by the compile-app
-    #    job in the Compile workflow: App's tsconfig has every test file as a
-    #    program root, so nothing here goes unchecked.
-    # 3. This cap is the tripwire. If the suite creeps back towards hours the
-    #    job fails here rather than quietly blocking the queue for a workday.
+    # Nothing goes unchecked: the compile-app job in the Compile workflow has
+    # every App test file as a tsc program root, and checks the whole program
+    # once in about a minute rather than 338 times over.
+    #
+    # This cap is the tripwire. The suite has room to grow several times over
+    # before it comes close, so if the job ever hits it something has regressed
+    # and it should fail here rather than quietly block the queue for a workday.
     timeout-minutes: 30
-    strategy:
-      # One slow or broken shard should not hide the results of the others.
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
     env:
       CI_PIPELINE_ID: ${{github.run_number}}
       BILLING_PRIVATE_KEY: ${{secrets.TEST_BILLING_PRIVATE_KEY}}
@@ -48,4 +44,4 @@ jobs:
       # App tests import Common sources directly (jest maps Common/* to
       # ../Common), so Common's own dependencies must be installed too.
       - run: cd Common && npm install
-      - run: cd App && npm install && npm run test -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+      - run: cd App && npm install && npm run test


### PR DESCRIPTION
### Title of this pull request?

perf(ci): run App Test as one job again, the shards cost more than they save

### Small Description?

Follow-up to #3292. That PR did two things at once: it fixed the App Test job (which had stopped finishing at all, hitting the 6h runner ceiling), and it sharded the job 4 ways. With the job green it is now possible to measure the sharding on its own — and it is a net loss on both axes.

**Total work is higher.** One job runs the whole suite in **95.0s** of jest time ([32391268212](https://github.com/OneUptime/oneuptime/actions/runs/32391268212): 338 suites, 8981 tests, 2m47s end-to-end, one runner). Four shards spend **170.1s** across four runners for the same work ([32393792645](https://github.com/OneUptime/oneuptime/actions/runs/32393792645) on master: 46.6 + 35.7 + 46.9 + 40.9). The extra ~75s is cold start paid four times: a single run amortizes the ts-jest transform cache across all 338 suites, while each shard separately recompiles the Common and Dashboard modules they all share.

**Wall clock is worse whenever the queue is busy.** A sharded run isn't green until its slowest-to-*start* shard finishes, and each shard queues for its own runner. Run 32393792645 was created 16:45:30Z and finished 17:32:51Z — **47 minutes**, with shards starting at 17:17, 17:26, 17:28 and 17:30. The single-job run went from created to green in **2m47s**. On an idle queue the two are comparable; on a busy one, four queue waits compound.

| | 4 shards | 1 job |
|---|---|---|
| jest time | 170.1s across 4 runners | **95.0s** on 1 |
| end-to-end, busy queue | 47m (32393792645) | **2m47s** (32391268212) |
| runners | 4 checkouts, 8 npm installs | 1 checkout, 2 npm installs |
| check name | `test (1..4)` | `test` |

This also drops the `strategy.job-total` plumbing and puts the check name back to `test`.

**What actually fixed the job is untouched**: `isolatedModules` in `App/jest.config.json` and the worker pool in `App/package.json`. This PR only removes the matrix. Sharding stays an easy lever to re-add if the suite ever outgrows a single runner, and `timeout-minutes: 30` remains as the tripwire.

### Verification

The exact file in this PR ran green as [32391268212](https://github.com/OneUptime/oneuptime/actions/runs/32391268212) — `Test Suites: 338 passed, 338 total`, `Tests: 8981 passed, 8981 total`, `Time: 95.024s`, job total 2m47s. Every other workflow on that commit was green too, including `compile-app` (2m09s), which is the type-check that `isolatedModules` relies on.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate? (Workflow-only change; no behaviour to test.)

### Related Issue?

Follow-up to #3292.
