### PR TITLE
fix(test): guard migration registry ordering globally, not per-migration

### DIFF
--- a/Common/Tests/Server/Infrastructure/Postgres/FixTotpOtpUrlAlgorithmMigration.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/FixTotpOtpUrlAlgorithmMigration.test.ts
@@ -31,14 +31,12 @@ import { beforeEach, describe, expect, test } from "@jest/globals";
  * without a database, and what can go wrong here is the WHERE clause, not
  * Postgres' REPLACE().
  *
- * This file also carries the ORDERING guard, handed on from
- * AddNetworkDeviceReachabilityColumnsMigration.test.ts: this is the newest
- * registered migration, so its timestamp must sort above every other one.
- * `generate-postgres-migration` stamps a WALL-CLOCK timestamp, while the
- * recent migrations here use hand-picked round numbers that already run ahead
- * of it — so a generated file lands BELOW several registered migrations
- * unless somebody renumbers it, and runs out of order without anything saying
- * so. Whoever adds the next migration should move this block to theirs.
+ * The ordering of this migration against the others is no longer asserted
+ * here. It used to be — as a guard hand-carried from one migration's test to
+ * the next, which broke the moment a migration was added without moving it.
+ * It now lives in SchemaMigrationsOrdering.test.ts, written against the
+ * registry as a whole so that it covers whichever migration is newest without
+ * anybody having to remember it.
  */
 
 const MIGRATION_TIMESTAMP: string = "1787700000000";
@@ -47,15 +45,6 @@ const MIGRATION_DIRECTORY: string = path.join(
   __dirname,
   "../../../../Server/Infrastructure/Postgres/SchemaMigrations",
 );
-
-interface MigrationClass {
-  name: string;
-}
-
-function timestampOf(migrationClass: MigrationClass): number | null {
-  const match: RegExpMatchArray | null = migrationClass.name.match(/(\d+)$/);
-  return match ? Number(match[1]) : null;
-}
 
 type CapturedQueryRunner = {
   runner: QueryRunner;
@@ -104,46 +93,7 @@ describe("FixTotpOtpUrlAlgorithm migration", () => {
     expect(SchemaMigrations).toContain(FixTotpOtpUrlAlgorithm1787700000000);
   });
 
-  // The guard described in the header. Hand it to the next migration.
-  describe("ordering", () => {
-    test("its timestamp sorts after every other registered migration", () => {
-      const ourTimestamp: number | null = timestampOf(
-        FixTotpOtpUrlAlgorithm1787700000000,
-      );
-
-      expect(ourTimestamp).not.toBeNull();
-
-      const otherTimestamps: Array<number> = [];
-
-      for (const migrationClass of SchemaMigrations) {
-        if (migrationClass === FixTotpOtpUrlAlgorithm1787700000000) {
-          continue;
-        }
-
-        const timestamp: number | null = timestampOf(
-          migrationClass as MigrationClass,
-        );
-
-        if (timestamp !== null) {
-          otherTimestamps.push(timestamp);
-        }
-      }
-
-      /*
-       * Math.max() of an empty list is -Infinity, which every timestamp beats.
-       * Prove the list was actually enumerated before leaning on the maximum.
-       */
-      expect(otherTimestamps.length).toBeGreaterThan(100);
-
-      expect(ourTimestamp).toBeGreaterThan(Math.max(...otherTimestamps));
-    });
-
-    test("it is registered last, matching that timestamp", () => {
-      expect(SchemaMigrations[SchemaMigrations.length - 1]).toBe(
-        FixTotpOtpUrlAlgorithm1787700000000,
-      );
-    });
-
+  describe("registration", () => {
     test("it is registered exactly once", () => {
       const occurrences: number = SchemaMigrations.filter(
         (migration: new () => MigrationInterface): boolean => {
@@ -157,8 +107,8 @@ describe("FixTotpOtpUrlAlgorithm migration", () => {
     /*
      * ...and the timestamp in the class name is the one on disk. A class
      * renamed without renaming its file (or two migrations landing on the
-     * same timestamp) leaves the ordering above asserting something that is
-     * not what actually runs.
+     * same timestamp) leaves the registry pointing at a different file from
+     * the one this test read.
      */
     test("exactly one file on disk carries its timestamp, and it is this one", () => {
       const matching: Array<string> = fs

--- a/Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts
@@ -1,0 +1,227 @@
+import SchemaMigrations from "../../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import { MigrationInterface } from "typeorm";
+import fs from "fs";
+import path from "path";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The ordering guard for the migration registry.
+ *
+ * TypeORM runs migrations in the order this array lists them, and records each
+ * one by class name. Two things can go wrong when a migration is added, and
+ * neither one announces itself — the schema simply diverges on some
+ * installations and not others:
+ *
+ *   1. the new migration runs BEFORE one that is already deployed. Existing
+ *      installations have already recorded the older migration, so the new one
+ *      still runs last for them, while a fresh install runs it in the listed
+ *      position. The two databases end up different.
+ *   2. two migrations share a timestamp, so the file a class belongs to is
+ *      ambiguous and the pairing between name and file can silently swap.
+ *
+ * `generate-postgres-migration` stamps a WALL-CLOCK timestamp, while the
+ * recent migrations here use hand-picked round numbers that already run ahead
+ * of wall clock — so a freshly generated file lands BELOW several registered
+ * migrations unless somebody renumbers it. That is case 1, and it is the
+ * likely one.
+ *
+ * This guard is deliberately written against the registry as a whole rather
+ * than against whichever migration happens to be newest, so that adding a
+ * migration never requires editing (or hand-carrying) the guard itself.
+ *
+ * Note it does NOT assert the whole array is sorted. It is not: a handful of
+ * historical entries were registered out of timestamp order years ago and have
+ * long since run everywhere, so renumbering them now would re-run them. What
+ * is asserted is the part that is still live — the newest entry must sort
+ * above everything already registered.
+ */
+
+const MIGRATION_DIRECTORY: string = path.join(
+  __dirname,
+  "../../../../Server/Infrastructure/Postgres/SchemaMigrations",
+);
+
+/*
+ * The very first migration predates the convention and carries no timestamp in
+ * its class name. It is first in the array and can never be last, so it is
+ * simply excluded rather than special-cased in every assertion below.
+ */
+const UNTIMESTAMPED_MIGRATION_NAME: string = "InitialMigration";
+
+const INITIAL_MIGRATION_TIMESTAMP: number = 1717605043663;
+
+const TIMESTAMPED_FILE: RegExp = new RegExp("^\\d+-");
+
+type MigrationClass = new () => MigrationInterface;
+
+type TimestampOfFunction = (migrationClass: MigrationClass) => number | null;
+
+const timestampOf: TimestampOfFunction = (
+  migrationClass: MigrationClass,
+): number | null => {
+  const match: RegExpMatchArray | null = migrationClass.name.match(/(\d+)$/);
+  return match ? Number(match[1]) : null;
+};
+
+const registered: Array<MigrationClass> =
+  SchemaMigrations as Array<MigrationClass>;
+
+describe("the migration registry", () => {
+  /*
+   * Math.max() of an empty list is -Infinity and every assertion below would
+   * pass vacuously against one. Prove the import actually produced a registry
+   * before leaning on anything derived from it.
+   */
+  test("is actually populated, so nothing below passes vacuously", () => {
+    expect(registered.length).toBeGreaterThan(100);
+  });
+
+  test("names every migration after its timestamp, bar the first one", () => {
+    const untimestamped: Array<string> = registered
+      .filter((migrationClass: MigrationClass): boolean => {
+        return timestampOf(migrationClass) === null;
+      })
+      .map((migrationClass: MigrationClass): string => {
+        return migrationClass.name;
+      });
+
+    expect(untimestamped).toEqual([UNTIMESTAMPED_MIGRATION_NAME]);
+  });
+
+  describe("ordering", () => {
+    /*
+     * The guard that used to be hand-carried from one migration's test to the
+     * next. Whoever adds a migration adds it to the end of the array, and this
+     * is what says the timestamp has to match that position.
+     */
+    test("gives the last-registered migration the highest timestamp", () => {
+      const last: MigrationClass = registered[registered.length - 1]!;
+      const lastTimestamp: number | null = timestampOf(last);
+
+      expect(lastTimestamp).not.toBeNull();
+
+      const earlierTimestamps: Array<number> = registered
+        .slice(0, -1)
+        .map(timestampOf)
+        .filter((timestamp: number | null): timestamp is number => {
+          return timestamp !== null;
+        });
+
+      expect(earlierTimestamps.length).toBe(registered.length - 2);
+
+      /*
+       * If this fails, the migration at the end of SchemaMigrations/Index.ts
+       * carries a timestamp that sorts below one already registered — rename
+       * the new migration's file and class to a timestamp above the current
+       * maximum, rather than moving it up the array.
+       */
+      expect(lastTimestamp).toBeGreaterThan(Math.max(...earlierTimestamps));
+    });
+
+    test("never registers the same timestamp twice", () => {
+      const timestamps: Array<number> = registered
+        .map(timestampOf)
+        .filter((timestamp: number | null): timestamp is number => {
+          return timestamp !== null;
+        });
+
+      const duplicates: Array<number> = timestamps.filter(
+        (timestamp: number, index: number): boolean => {
+          return timestamps.indexOf(timestamp) !== index;
+        },
+      );
+
+      expect(duplicates).toEqual([]);
+    });
+
+    test("never registers the same migration class twice", () => {
+      const names: Array<string> = registered.map(
+        (migrationClass: MigrationClass): string => {
+          return migrationClass.name;
+        },
+      );
+
+      const duplicates: Array<string> = names.filter(
+        (name: string, index: number): boolean => {
+          return names.indexOf(name) !== index;
+        },
+      );
+
+      expect(duplicates).toEqual([]);
+    });
+  });
+
+  /*
+   * ...and the timestamps in the class names are the ones on disk. A class
+   * renamed without renaming its file — or two files landing on the same
+   * timestamp — leaves the ordering above asserting something that is not what
+   * actually runs.
+   */
+  test("backs every registered migration with exactly one file on disk", () => {
+    const files: Array<string> = fs.readdirSync(MIGRATION_DIRECTORY);
+
+    const unbacked: Array<string> = registered
+      .filter((migrationClass: MigrationClass): boolean => {
+        const timestamp: number | null = timestampOf(migrationClass);
+
+        if (timestamp === null) {
+          return false;
+        }
+
+        return (
+          files.filter((file: string): boolean => {
+            return file.startsWith(`${timestamp}-`);
+          }).length !== 1
+        );
+      })
+      .map((migrationClass: MigrationClass): string => {
+        return migrationClass.name;
+      });
+
+    expect(unbacked).toEqual([]);
+  });
+
+  /*
+   * The other direction: a migration file that nobody registered never runs at
+   * all. That is the failure mode with no symptom until a query hits a column
+   * that was never created.
+   *
+   * The registered side is read out of the exported array rather than out of
+   * Index.ts, so a file that is imported but never added to the array — which
+   * is exactly as inert as one that is not imported at all — still fails here.
+   */
+  test("registers every migration file that exists on disk", () => {
+    const registeredTimestamps: Set<number> = new Set(
+      registered
+        .map(timestampOf)
+        .filter((timestamp: number | null): timestamp is number => {
+          return timestamp !== null;
+        }),
+    );
+
+    /*
+     * The one file whose class name carries no timestamp, so it cannot be
+     * matched by the timestamps above.
+     */
+    registeredTimestamps.add(INITIAL_MIGRATION_TIMESTAMP);
+
+    const timestampsOnDisk: Array<string> = fs
+      .readdirSync(MIGRATION_DIRECTORY)
+      .filter((file: string): boolean => {
+        return file.endsWith(".ts") && TIMESTAMPED_FILE.test(file);
+      })
+      .map((file: string): string => {
+        return file.split("-")[0]!;
+      });
+
+    expect(timestampsOnDisk.length).toBeGreaterThan(100);
+
+    const unregistered: Array<string> = timestampsOnDisk.filter(
+      (timestamp: string): boolean => {
+        return !registeredTimestamps.has(Number(timestamp));
+      },
+    );
+
+    expect(unregistered).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The failure

`Common Test` is red on master ([run 32393792603](https://github.com/OneUptime/oneuptime/actions/runs/32393792603)) — 2 failures out of 31,482:

```
● FixTotpOtpUrlAlgorithm migration › ordering › its timestamp sorts after every other registered migration
    Expected: > 1787800000000
    Received:   1787700000000

● FixTotpOtpUrlAlgorithm migration › ordering › it is registered last, matching that timestamp
    Expected: [Function FixTotpOtpUrlAlgorithm1787700000000]
    Received: [Function AddScopeToNetworkDeviceLinkRule1787800000000]
```

The migration under test is fine, and so is the new one. The *test* was the problem: it asserted "I am the newest migration", and carried a comment asking whoever added the next migration to move the block into their own test file. `AddScopeToNetworkDeviceLinkRule1787800000000` landed without that move — correctly numbered above everything else — and the stale guard failed.

That guard has now broken twice by design; it was previously hand-carried from `AddNetworkDeviceReachabilityColumnsMigration.test.ts`.

## The fix

Delete the two per-migration ordering assertions and replace them with `Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts`, written against the registry as a whole so it covers whichever migration is newest without anybody having to remember it:

- the **last-registered migration carries the highest timestamp** — the real invariant, and the one that catches a `generate-postgres-migration` wall-clock stamp landing below the hand-picked round numbers currently in use;
- no timestamp and no class is registered twice;
- every registered migration is backed by **exactly one** file on disk;
- every migration file on disk is **actually registered** — read out of the exported array, not out of `Index.ts`, so a file that is imported but never appended still fails.

The array is deliberately **not** asserted to be fully sorted. It isn't: 9 adjacent pairs are out of timestamp order from years ago and have long since run everywhere, so renumbering them now would re-run them. What is asserted is the part that is still live.

The migration-specific tests in `FixTotpOtpUrlAlgorithmMigration.test.ts` (registered, registered once, named consistently, backed by its file, and all the SQL/TOTP behaviour) are untouched.

## Verification

- `SchemaMigrationsOrdering.test.ts` — 7 passed.
- Whole `Tests/Server/Infrastructure/Postgres/` directory — **6 suites, 129 tests, all passing**.
- **Negative test**: swapped the last two entries in `Index.ts` and confirmed the new guard fails with `Expected: > 1787800000000 / Received: 1787700000000`, then reverted. `Index.ts` is unchanged in this PR.
- `npm run compile` in `Common` clean; eslint + prettier clean on both files.

Every other job on master's head is green — `Common Test` was the only red one.