### PR TITLE
fix(release): give the release SaaS e2e the verification-code seam

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1512,6 +1512,32 @@ jobs:
           else
             echo "APP_TAG=${SANITIZED_VERSION}" > config.env
           fi
+      - name: Expose notification-channel verification codes to the e2e suite
+        run: |
+          set -euo pipefail
+          # TEST-ONLY, and the same step the master SaaS e2e job runs
+          # (.github/workflows/test-release.yaml). The e2e stack has no mailbox,
+          # so the API is told to hand back the notification-channel
+          # verification code on the create response
+          # (Common/Server/Services/UserEmailService.ts). Without it the create
+          # response carries the stored HASH instead, which is truthy — so the
+          # suite gets past its "did we get a code?" guard and then fails on
+          # POST /api/user-email/verify with 400 "Invalid code", which is
+          # exactly how this job broke 12.0.13 and 12.0.14.
+          #
+          # This is set ONLY here, for the ephemeral CI stack; it is never in a
+          # shipped config, and production leaves it empty so the code stays
+          # emailed.
+          KEY=EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E
+          if [ -f config.env ] && grep -q "^${KEY}=" config.env; then
+            sed -i "s|^${KEY}=.*|${KEY}=true|" config.env
+          else
+            echo "${KEY}=true" >> config.env
+          fi
+          # Also surface it as a real environment variable for every later step,
+          # so `docker compose` interpolates ${KEY} straight from the process
+          # env and does not depend on the config.env round-trip.
+          echo "${KEY}=true" >> "$GITHUB_ENV"
       - name: Start Server with version tag
         run: |
           export $(grep -v '^#' config.env | xargs)
@@ -1520,6 +1546,14 @@ jobs:
           npm run status-check
       - name: Wait for server to start
         run: bash ./Tests/Scripts/status-check.sh http://localhost
+      - name: Diagnose verification-code exposure wiring (non-fatal)
+        run: |
+          set +e
+          echo "config.env flag line:"
+          grep -n "EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E" config.env || echo "  (not in config.env)"
+          echo "runner env flag: [${EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E:-UNSET}]"
+          echo "app container flag:"
+          docker compose -f docker-compose.billing.yml exec -T app sh -lc 'echo "  APP_FLAG=[${EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E:-UNSET}]"' || echo "  (exec into app failed)"
       - name: Pull E2E test image
         run: |
           set -euo pipefail

--- a/Common/Server/Services/UserEmailService.ts
+++ b/Common/Server/Services/UserEmailService.ts
@@ -117,10 +117,10 @@ export class Service extends DatabaseService<Model> {
        * create response for it to confirm the address the way a user would.
        *
        * It is gated on an environment variable that is unset in every shipped
-       * config and set true ONLY in the CI e2e job (docker-compose passes it
-       * through, .github/workflows/test-release.yaml sets it for the SaaS run).
-       * In production the flag is absent, this branch never runs, and the code
-       * never leaves the mail path.
+       * config and set true ONLY in the CI e2e jobs (docker-compose passes it
+       * through; both SaaS e2e jobs set it — test-release.yaml for master and
+       * release.yml for the release branch). In production the flag is absent,
+       * this branch never runs, and the code never leaves the mail path.
        */
       if (
         process.env["EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E"] ===


### PR DESCRIPTION
## Why 12.0.13 and 12.0.14 never shipped

`VERSION` is `12.0.14`, but the latest published GitHub release is **12.0.12**. The last two release runs built and pushed every image, then died before publishing:

- [run 32382003975](https://github.com/OneUptime/oneuptime/actions/runs/32382003975) — `test-e2e-release-saas` ✗, `test-e2e-release-self-hosted` ✗
- [run 32361999475](https://github.com/OneUptime/oneuptime/actions/runs/32361999475) — `test-e2e-release-saas` ✗

`test-e2e-release-saas` failed both times, with the same single hard failure (281 passed, 1 failed):

```
[chromium] › Tests/Dashboard/MonitorIncidentOnCall.spec.ts:393:7 › website monitor ... pages the on-call user when it goes down
    Error: POST /api/user-email/verify failed: 400 {"message":"Invalid code"}
        at ensureUserCanBeNotified (Tests/Dashboard/Helpers/MonitorAlerting.ts:579:7)
```

## Root cause

`test-e2e-release-saas` in [release.yml](.github/workflows/release.yml) never set `EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E`. The equivalent master job, `test-e2e-test-saas` in [test-release.yaml](.github/workflows/test-release.yaml:932), has been setting it all along — which is exactly why this passes on master and fails on release.

The flag is the test-only seam in [UserEmailService.onCreateSuccess](Common/Server/Services/UserEmailService.ts:105): the e2e stack has no mailbox, so with the flag set the API hands the plaintext code back on the create response.

The failure mode is unhelpfully indirect. With the flag unset, the create response still carries `verificationCode` — the **stored hash** written by `ChannelVerification.issueCode`. It is truthy, so the suite's guard

```ts
expect(created["verificationCode"], "creating a UserEmail should return its verification code ...").toBeTruthy();
```

passes, and the run gets all the way to `/api/user-email/verify`, where the server hashes the submitted hash and compares it to the stored hash. Hence `400 Invalid code` rather than a clear "no code was returned".

Note `2d729c2346` ("let the SaaS e2e confirm an email again after the code was hashed") is already on both branches — it fixed the master job. The release job was missed.

## The fix

Add the same step to `test-e2e-release-saas`, in the same position (after `Pin APP_TAG`, before `Start Server`), writing the flag to `config.env` **and** `$GITHUB_ENV` so `docker compose` interpolates it directly rather than depending on the `config.env` round-trip.

Also ported the master job's non-fatal diagnostic step, so if this ever breaks again the log says which of config.env / runner env / app container is missing the flag instead of surfacing as `Invalid code`.

Verified the plumbing reaches the app: `docker-compose.billing.yml`'s `app` extends `docker-compose.base.yml`'s `app`, whose common vars include [`EXPOSE_VERIFICATION_CODE_IN_API_RESPONSE_FOR_E2E`](docker-compose.base.yml:96). The flag is read at runtime, so it works against the prebuilt release image.

## Blast radius

Nothing ships with the flag set. It is written only into the ephemeral CI stack's `config.env`; production leaves it empty, `onCreateSuccess` never takes that branch, and the code stays on the mail path. Updated the now-stale comment in `UserEmailService.ts` that said only `test-release.yaml` sets it.

## Verification

- `.github/workflows/release.yml` parses as valid YAML; step order in `test-e2e-release-saas` confirmed programmatically.
- prettier clean on both changed files.
- Fully verifiable only on a release-branch push — that is the next run.

## Still outstanding (not fixed here)

`test-e2e-release-self-hosted` failed in run 32382003975 on a *different*, intermittent problem — `CreateMonitors.spec.ts:371 › should create a SSL Certificate monitor`, ending in Playwright's `Object with guid response@… was not bound in the connection` after 3 retries, with sibling monitor types flaky in the same block. It passed in run 32361999475, so it is flaky rather than deterministic, and it is a separate issue from this one. Flagging rather than guessing at a fix.