### PR TITLE
feat(sso): discover project OIDC on mobile, and make Global SSO revocable

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/Index.tsx
@@ -261,6 +261,16 @@ const Settings: FunctionComponent = (): ReactElement => {
           },
           {
             field: {
+              restrictToAttachedProjects: true,
+            },
+            title: "Restrict to Attached Projects",
+            description:
+              "Off by default. When off, signing in with this provider satisfies SSO enforcement for every project the user is a member of, and the attached projects below only control provisioning. Turn this on to make the attached projects an access boundary too - note that this NARROWS access for people who are already signed in.",
+            fieldType: FormFieldSchemaType.Toggle,
+            stepId: "more",
+          },
+          {
+            field: {
               isEnabled: true,
             },
             description:

--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/View.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/View.tsx
@@ -255,6 +255,15 @@ const GlobalOIDCView: FunctionComponent = (): ReactElement => {
             },
             {
               field: {
+                restrictToAttachedProjects: true,
+              },
+              title: "Restrict to Attached Projects",
+              description:
+                "When on, this provider only satisfies SSO enforcement for the projects attached below. Off by default, where attachments control provisioning only.",
+              fieldType: FormFieldSchemaType.Toggle,
+            },
+            {
+              field: {
                 isEnabled: true,
               },
               title: "Enabled",
@@ -326,6 +335,14 @@ const GlobalOIDCView: FunctionComponent = (): ReactElement => {
                   disableSignUpWithSso: true,
                 },
                 title: "Disable Sign Up with SSO",
+                fieldType: FieldType.Boolean,
+                placeholder: t("common.no"),
+              },
+              {
+                field: {
+                  restrictToAttachedProjects: true,
+                },
+                title: "Restrict to Attached Projects",
                 fieldType: FieldType.Boolean,
                 placeholder: t("common.no"),
               },

--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalSSO/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalSSO/Index.tsx
@@ -239,6 +239,16 @@ const Settings: FunctionComponent = (): ReactElement => {
           },
           {
             field: {
+              restrictToAttachedProjects: true,
+            },
+            title: "Restrict to Attached Projects",
+            description:
+              "Off by default. When off, signing in with this provider satisfies SSO enforcement for every project the user is a member of, and the attached projects below only control provisioning. Turn this on to make the attached projects an access boundary too - note that this NARROWS access for people who are already signed in.",
+            fieldType: FormFieldSchemaType.Toggle,
+            stepId: "more",
+          },
+          {
+            field: {
               isEnabled: true,
             },
             description:

--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalSSO/View.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalSSO/View.tsx
@@ -243,6 +243,15 @@ const GlobalSSOView: FunctionComponent = (): ReactElement => {
             },
             {
               field: {
+                restrictToAttachedProjects: true,
+              },
+              title: "Restrict to Attached Projects",
+              description:
+                "When on, this provider only satisfies SSO enforcement for the projects attached below. Off by default, where attachments control provisioning only.",
+              fieldType: FormFieldSchemaType.Toggle,
+            },
+            {
+              field: {
                 isEnabled: true,
               },
               title: "Enabled",
@@ -300,6 +309,14 @@ const GlobalSSOView: FunctionComponent = (): ReactElement => {
                   disableSignUpWithSso: true,
                 },
                 title: "Disable Sign Up with SSO",
+                fieldType: FieldType.Boolean,
+                placeholder: t("common.no"),
+              },
+              {
+                field: {
+                  restrictToAttachedProjects: true,
+                },
+                title: "Restrict to Attached Projects",
                 fieldType: FieldType.Boolean,
                 placeholder: t("common.no"),
               },

--- a/App/FeatureSet/Identity/API/GlobalOIDC.ts
+++ b/App/FeatureSet/Identity/API/GlobalOIDC.ts
@@ -18,6 +18,7 @@ import BadRequestException from "Common/Types/Exception/BadRequestException";
 import Exception from "Common/Types/Exception/Exception";
 import ServerException from "Common/Types/Exception/ServerException";
 import ObjectID from "Common/Types/ObjectID";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import SsoProviderType from "Common/Types/SSO/SsoProviderType";
 import DatabaseConfig from "Common/Server/DatabaseConfig";
@@ -401,6 +402,7 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
         emailClaimName: true,
         nameClaimName: true,
         disableSignUpWithSso: true,
+        restrictToAttachedProjects: true,
       },
       props: { isRoot: true },
     });
@@ -646,6 +648,55 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
       query: { userId: alreadySavedUser.id! },
       props: { isRoot: true },
     });
+
+    /*
+     * When the admin has restricted this provider to its attached projects,
+     * the session it is about to mint only authorizes those projects. Check
+     * the user actually belongs to one of them BEFORE minting, otherwise the
+     * login reports success and then every request is refused, with
+     * re-authenticating producing an identical token - a dead end with no way
+     * out from inside the product.
+     */
+    if (globalOidc.restrictToAttachedProjects && !isDefaultAllMode) {
+      const governedProjectIds: Array<ObjectID> = attachments
+        .filter((attachment: GlobalOIDCProject) => {
+          return Boolean(attachment.projectId);
+        })
+        .map((attachment: GlobalOIDCProject) => {
+          return attachment.projectId!;
+        });
+
+      const governedMembershipCount: PositiveNumber =
+        governedProjectIds.length === 0
+          ? new PositiveNumber(0)
+          : await TeamMemberService.countBy({
+              query: {
+                userId: alreadySavedUser.id!,
+                projectId: QueryHelper.any(governedProjectIds),
+              },
+              props: { isRoot: true },
+            });
+
+      if (governedMembershipCount.toNumber() === 0) {
+        if (
+          respondToMobileSsoFailure({
+            res,
+            isMobileRequest,
+            error: "no_project_access",
+            errorDescription:
+              "This SSO provider does not grant access to any project you are a member of. Please contact your administrator.",
+          })
+        ) {
+          return;
+        }
+
+        return Response.render(req, res, MESSAGE_VIEW, {
+          title: "No project access.",
+          message:
+            "This SSO provider does not grant access to any project you are a member of. Please contact your administrator.",
+        });
+      }
+    }
 
     if (memberProjectCount.toNumber() === 0) {
       if (

--- a/App/FeatureSet/Identity/API/GlobalSSO.ts
+++ b/App/FeatureSet/Identity/API/GlobalSSO.ts
@@ -19,6 +19,7 @@ import BadRequestException from "Common/Types/Exception/BadRequestException";
 import Exception from "Common/Types/Exception/Exception";
 import ServerException from "Common/Types/Exception/ServerException";
 import ObjectID from "Common/Types/ObjectID";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import SsoProviderType from "Common/Types/SSO/SsoProviderType";
 import DatabaseConfig from "Common/Server/DatabaseConfig";
@@ -314,6 +315,7 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
         issuerURL: true,
         publicCertificate: true,
         disableSignUpWithSso: true,
+        restrictToAttachedProjects: true,
       },
       props: { isRoot: true },
     });
@@ -600,6 +602,55 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
       query: { userId: alreadySavedUser.id! },
       props: { isRoot: true },
     });
+
+    /*
+     * When the admin has restricted this provider to its attached projects,
+     * the session it is about to mint only authorizes those projects. Check
+     * the user actually belongs to one of them BEFORE minting, otherwise the
+     * login reports success and then every request is refused, with
+     * re-authenticating producing an identical token - a dead end with no way
+     * out from inside the product.
+     */
+    if (globalSso.restrictToAttachedProjects && !isDefaultAllMode) {
+      const governedProjectIds: Array<ObjectID> = attachments
+        .filter((attachment: GlobalSSOProject) => {
+          return Boolean(attachment.projectId);
+        })
+        .map((attachment: GlobalSSOProject) => {
+          return attachment.projectId!;
+        });
+
+      const governedMembershipCount: PositiveNumber =
+        governedProjectIds.length === 0
+          ? new PositiveNumber(0)
+          : await TeamMemberService.countBy({
+              query: {
+                userId: alreadySavedUser.id!,
+                projectId: QueryHelper.any(governedProjectIds),
+              },
+              props: { isRoot: true },
+            });
+
+      if (governedMembershipCount.toNumber() === 0) {
+        if (
+          respondToMobileSsoFailure({
+            res,
+            isMobileRequest,
+            error: "no_project_access",
+            errorDescription:
+              "This SSO provider does not grant access to any project you are a member of. Please contact your administrator.",
+          })
+        ) {
+          return;
+        }
+
+        return Response.render(req, res, MESSAGE_VIEW, {
+          title: "No project access.",
+          message:
+            "This SSO provider does not grant access to any project you are a member of. Please contact your administrator.",
+        });
+      }
+    }
 
     if (memberProjectCount.toNumber() === 0) {
       if (

--- a/Common/Models/DatabaseModels/GlobalOidc.ts
+++ b/Common/Models/DatabaseModels/GlobalOidc.ts
@@ -243,6 +243,26 @@ export default class GlobalOIDC extends BaseModel {
   @TableColumn({
     isDefaultValueColumn: true,
     type: TableColumnType.Boolean,
+    title: "Restrict to Attached Projects",
+    description:
+      "When enabled, a login through this provider only satisfies SSO enforcement for the projects attached below. Leave this off (the default) and the provider satisfies SSO enforcement for every project the user is a member of, which is how attachments have always behaved - they are the provisioning allow-list, not an access boundary. Turning this on narrows access for people already signed in.",
+    defaultValue: false,
+    example: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: false,
+  })
+  public restrictToAttachedProjects?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
     title: "Enabled",
     description: "Is this OIDC provider enabled?",
     defaultValue: false,

--- a/Common/Models/DatabaseModels/GlobalSso.ts
+++ b/Common/Models/DatabaseModels/GlobalSso.ts
@@ -204,6 +204,26 @@ export default class GlobalSSO extends BaseModel {
   @TableColumn({
     isDefaultValueColumn: true,
     type: TableColumnType.Boolean,
+    title: "Restrict to Attached Projects",
+    description:
+      "When enabled, a login through this provider only satisfies SSO enforcement for the projects attached below. Leave this off (the default) and the provider satisfies SSO enforcement for every project the user is a member of, which is how attachments have always behaved - they are the provisioning allow-list, not an access boundary. Turning this on narrows access for people already signed in.",
+    defaultValue: false,
+    example: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: false,
+  })
+  public restrictToAttachedProjects?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
     title: "Enabled",
     description: "Is this SSO provider enabled?",
     defaultValue: false,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787900000000-AddRestrictToAttachedProjectsToGlobalSso.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787900000000-AddRestrictToAttachedProjectsToGlobalSso.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Adds the opt-in that decides whether a Global SSO / Global OIDC provider's
+ * project attachments act as an ACCESS boundary as well as a provisioning one.
+ *
+ * Defaults to false, which is the behaviour every existing installation
+ * already has: a global login satisfies SSO enforcement for every project the
+ * user is a member of. Attachments were introduced as the provisioning
+ * allow-list - "a SAML assertion can only ever provision a user into projects
+ * that a master admin has explicitly attached here" - and the login routers
+ * grant a session on membership of ANY project, so silently reinterpreting
+ * them as an access boundary would lock existing users out of projects they
+ * legitimately reach, with nothing in the product to recover with.
+ *
+ * An admin who wants the narrower behaviour turns it on per provider.
+ */
+export class AddRestrictToAttachedProjectsToGlobalSso1787900000000
+  implements MigrationInterface
+{
+  public name = "AddRestrictToAttachedProjectsToGlobalSso1787900000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "GlobalSSO" ADD "restrictToAttachedProjects" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GlobalOIDC" ADD "restrictToAttachedProjects" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "GlobalOIDC" DROP COLUMN "restrictToAttachedProjects"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GlobalSSO" DROP COLUMN "restrictToAttachedProjects"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -532,6 +532,7 @@ import { AddEnableSearchEngineIndexingToStatusPage1787500000000 } from "./178750
 import { AddNetworkDeviceReachabilityColumns1787600000000 } from "./1787600000000-AddNetworkDeviceReachabilityColumns";
 import { FixTotpOtpUrlAlgorithm1787700000000 } from "./1787700000000-FixTotpOtpUrlAlgorithm";
 import { AddScopeToNetworkDeviceLinkRule1787800000000 } from "./1787800000000-AddScopeToNetworkDeviceLinkRule";
+import { AddRestrictToAttachedProjectsToGlobalSso1787900000000 } from "./1787900000000-AddRestrictToAttachedProjectsToGlobalSso";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1072,4 +1073,5 @@ export default [
   AddNetworkDeviceReachabilityColumns1787600000000,
   FixTotpOtpUrlAlgorithm1787700000000,
   AddScopeToNetworkDeviceLinkRule1787800000000,
+  AddRestrictToAttachedProjectsToGlobalSso1787900000000,
 ];

--- a/Common/Server/Middleware/UserAuthorization.ts
+++ b/Common/Server/Middleware/UserAuthorization.ts
@@ -27,6 +27,11 @@ import JSONFunctions from "../../Types/JSONFunctions";
 import JSONWebTokenData from "../../Types/JsonWebTokenData";
 import ObjectID from "../../Types/ObjectID";
 import SsoProviderType from "../../Types/SSO/SsoProviderType";
+import GlobalSsoService from "../Services/GlobalSsoService";
+import { GlobalProviderTrust } from "../Utils/GlobalSsoAuthorization";
+import GlobalOidcService from "../Services/GlobalOidcService";
+import GlobalSsoProjectService from "../Services/GlobalSsoProjectService";
+import GlobalOidcProjectService from "../Services/GlobalOidcProjectService";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import Permission, {
   PermissionHelper,
@@ -234,8 +239,13 @@ export default class UserMiddleware {
     }
   }
 
+  /**
+   * Per-project SSO token check (Project SSO/OIDC login). Bound to one project,
+   * entirely stateless: signature, expiry, project, user, and the optional
+   * pinned-provider discriminator.
+   */
   @CaptureSpan()
-  public static doesSsoTokenForProjectExist(
+  public static doesProjectScopedSsoTokenExist(
     req: ExpressRequest,
     projectId: ObjectID,
     userId: ObjectID,
@@ -243,41 +253,241 @@ export default class UserMiddleware {
   ): boolean {
     const ssoTokens: Dictionary<string> = this.getSsoTokens(req);
 
-    /*
-     * 1) Per-project SSO token (Project SSO/OIDC login). Bound to one project.
-     */
-    if (ssoTokens && ssoTokens[projectId.toString()]) {
+    if (!ssoTokens || !ssoTokens[projectId.toString()]) {
+      return false;
+    }
+
+    try {
       const decodedData: JSONWebTokenData = JSONWebToken.decode(
         ssoTokens[projectId.toString()] as string,
       );
+
+      /*
+       * A Global-typed credential is NEVER accepted here, whichever slot it
+       * arrived in. Before the single-token redesign the Global SSO router
+       * minted one per-project token per project, typed GlobalSSO, signed for
+       * 30 days - and those are still sitting in browsers as `sso-<projectId>`
+       * cookies and in the mobile app's AsyncStorage, replayed on every
+       * request. Accepting them here would let a Global credential short-
+       * circuit past the provider-trust check, so disabling a provider would
+       * still not revoke them. Route every Global token through the stateful
+       * path instead.
+       */
       if (
+        decodedData.ssoProviderType === SsoProviderType.GlobalSSO ||
+        decodedData.ssoProviderType === SsoProviderType.GlobalOIDC
+      ) {
+        return false;
+      }
+
+      return (
         decodedData.projectId?.toString() === projectId.toString() &&
         decodedData.userId.toString() === userId.toString() &&
         this.isSsoProviderSatisfied(decodedData, requiredSsoProviderId)
-      ) {
-        return true;
-      }
+      );
+    } catch {
+      /*
+       * A token that expires between `getSsoTokens` decoding it and this call
+       * throws out of `decode`. Swallowing it here means the request falls
+       * through to the Global SSO token instead of 500-ing, which is what a
+       * user with both kinds would expect.
+       */
+      return false;
     }
+  }
 
-    /*
-     * 2) Global SSO token (Global SSO/OIDC login). Not bound to a project, so a
-     * single token satisfies enforcement for every project this user belongs to
-     * — including projects created after the login. The specific-provider
-     * discriminator still applies (a project pinned to a different provider is
-     * not satisfied by this token).
-     */
+  /**
+   * The Global SSO token, if one is present and stateless-valid for this user.
+   *
+   * "Stateless-valid" means signature, expiry, Global provider type, matching
+   * user, and the project's pinned-provider discriminator. It deliberately
+   * says nothing about whether the provider still exists, is still enabled, or
+   * governs the project in question - those need the database, and live in
+   * `isGlobalSsoTokenAuthorizedForProject`.
+   */
+  @CaptureSpan()
+  public static getStatelessValidGlobalSsoTokenData(
+    req: ExpressRequest,
+    userId: ObjectID,
+    requiredSsoProviderId?: ObjectID | undefined,
+  ): JSONWebTokenData | null {
     const globalSsoTokenData: JSONWebTokenData | null =
       this.getGlobalSsoTokenData(req);
 
+    if (!globalSsoTokenData) {
+      return null;
+    }
+
+    if (globalSsoTokenData.userId.toString() !== userId.toString()) {
+      return null;
+    }
+
     if (
-      globalSsoTokenData &&
-      globalSsoTokenData.userId.toString() === userId.toString() &&
-      this.isSsoProviderSatisfied(globalSsoTokenData, requiredSsoProviderId)
+      !this.isSsoProviderSatisfied(globalSsoTokenData, requiredSsoProviderId)
+    ) {
+      return null;
+    }
+
+    return globalSsoTokenData;
+  }
+
+  /**
+   * The stateless half of the whole decision, kept as one call because it is
+   * the part that can be reasoned about without a database.
+   *
+   * NOTE: this is NOT the enforcement entry point. A Global SSO token that
+   * passes here can still be refused by `isSsoSatisfiedForProject`, which also
+   * asks whether the provider is still trusted and whether it governs this
+   * project. Enforcement must call that.
+   */
+  @CaptureSpan()
+  public static doesSsoTokenForProjectExist(
+    req: ExpressRequest,
+    projectId: ObjectID,
+    userId: ObjectID,
+    requiredSsoProviderId?: ObjectID | undefined,
+  ): boolean {
+    if (
+      this.doesProjectScopedSsoTokenExist(
+        req,
+        projectId,
+        userId,
+        requiredSsoProviderId,
+      )
     ) {
       return true;
     }
 
-    return false;
+    return Boolean(
+      this.getStatelessValidGlobalSsoTokenData(
+        req,
+        userId,
+        requiredSsoProviderId,
+      ),
+    );
+  }
+
+  /**
+   * Whether a stateless-valid Global SSO token is STILL authorized for this
+   * project right now.
+   *
+   * Two questions the token itself cannot answer:
+   *
+   *   1. IS THE PROVIDER STILL TRUSTED? Always checked. A Global SSO token
+   *      lives for 30 days and carries no revocation, so without this an admin
+   *      turning a provider off - or deleting it outright - changes nothing
+   *      for anyone already signed in, for up to a month.
+   *
+   *   2. DOES THE PROVIDER GOVERN THIS PROJECT? Only checked when the admin
+   *      turned on `restrictToAttachedProjects` for that provider. The
+   *      attachment rows are the PROVISIONING allow-list by default, and the
+   *      login routers grant a session on membership of ANY project - so
+   *      treating attachments as an access boundary unasked would deny users
+   *      projects they legitimately reach today, with nothing in the product
+   *      to recover with.
+   *
+   * Answers are cached in-process for 60s and concurrent misses share one
+   * query (Common/Server/Utils/GlobalSsoAuthorization.ts).
+   *
+   * THROWS rather than denying when the lookup itself fails. "This provider is
+   * not allowed here" and "we could not find out" are different answers, and
+   * conflating them lets a database blip look like a permission decision - on
+   * the multi-tenant path that would silently hand back a 200 with no
+   * permissions rather than an error anyone would notice.
+   */
+  @CaptureSpan()
+  public static async isGlobalSsoTokenAuthorizedForProject(data: {
+    globalSsoTokenData: JSONWebTokenData;
+    projectId: ObjectID;
+  }): Promise<boolean> {
+    const { globalSsoTokenData, projectId } = data;
+
+    const providerIdValue: string | undefined =
+      globalSsoTokenData.ssoProviderId?.toString();
+
+    if (!providerIdValue) {
+      /*
+       * A Global-typed token with no provider id cannot be checked against
+       * either question, so it cannot be trusted for a project. This is a
+       * decision, not a failure - do not throw.
+       */
+      return false;
+    }
+
+    const providerId: ObjectID = new ObjectID(providerIdValue);
+
+    const isOidc: boolean =
+      globalSsoTokenData.ssoProviderType === SsoProviderType.GlobalOIDC;
+
+    const trust: GlobalProviderTrust = isOidc
+      ? await GlobalOidcService.getProviderTrust(providerId)
+      : await GlobalSsoService.getProviderTrust(providerId);
+
+    if (!trust.isUsable) {
+      return false;
+    }
+
+    if (!trust.restrictToAttachedProjects) {
+      /*
+       * The default, and what every existing installation gets: a global login
+       * satisfies enforcement for every project the user belongs to.
+       */
+      return true;
+    }
+
+    return isOidc
+      ? GlobalOidcProjectService.doesProviderGovernProject({
+          globalOidcId: providerId,
+          projectId,
+        })
+      : GlobalSsoProjectService.doesProviderGovernProject({
+          globalSsoId: providerId,
+          projectId,
+        });
+  }
+
+  /**
+   * THE enforcement entry point: is this request's SSO requirement satisfied
+   * for this project?
+   *
+   * A per-project token is decided statelessly. A Global SSO token additionally
+   * has to survive the provider-trust and project-governance checks above.
+   */
+  @CaptureSpan()
+  public static async isSsoSatisfiedForProject(data: {
+    req: ExpressRequest;
+    projectId: ObjectID;
+    userId: ObjectID;
+    requiredSsoProviderId?: ObjectID | undefined;
+  }): Promise<boolean> {
+    const { req, projectId, userId, requiredSsoProviderId } = data;
+
+    if (
+      this.doesProjectScopedSsoTokenExist(
+        req,
+        projectId,
+        userId,
+        requiredSsoProviderId,
+      )
+    ) {
+      return true;
+    }
+
+    const globalSsoTokenData: JSONWebTokenData | null =
+      this.getStatelessValidGlobalSsoTokenData(
+        req,
+        userId,
+        requiredSsoProviderId,
+      );
+
+    if (!globalSsoTokenData) {
+      return false;
+    }
+
+    return this.isGlobalSsoTokenAuthorizedForProject({
+      globalSsoTokenData,
+      projectId,
+    });
   }
 
   @CaptureSpan()
@@ -646,12 +856,12 @@ export default class UserMiddleware {
         );
 
       if (
-        !UserMiddleware.doesSsoTokenForProjectExist(
+        !(await UserMiddleware.isSsoSatisfiedForProject({
           req,
-          tenantId,
+          projectId: tenantId,
           userId,
-          requiredSsoProviderId ?? undefined,
-        )
+          requiredSsoProviderId: requiredSsoProviderId ?? undefined,
+        }))
       ) {
         throw new SsoAuthorizationException();
       }
@@ -714,12 +924,12 @@ export default class UserMiddleware {
             });
 
           if (
-            !UserMiddleware.doesSsoTokenForProjectExist(
+            !(await UserMiddleware.isSsoSatisfiedForProject({
               req,
               projectId,
               userId,
-              requiredSsoProviderId ?? undefined,
-            )
+              requiredSsoProviderId: requiredSsoProviderId ?? undefined,
+            }))
           ) {
             return {
               projectId,

--- a/Common/Server/Services/GlobalOidcProjectService.ts
+++ b/Common/Server/Services/GlobalOidcProjectService.ts
@@ -4,16 +4,136 @@ import Team from "../../Models/DatabaseModels/Team";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import ObjectID from "../../Types/ObjectID";
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import validateGlobalProviderProjectTeams, {
   resolveAttachmentProjectId,
 } from "../Utils/ValidateGlobalProviderProjectTeams";
+import {
+  GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+  GlobalProviderAttachments,
+  clearGlobalSsoAuthorizationCaches,
+  doAttachmentsGovernProject,
+  globalProviderCacheKey,
+  globalSsoAttachmentsCache,
+  loadAttachmentsOnce,
+} from "../Utils/GlobalSsoAuthorization";
+import DeleteBy from "../Types/Database/DeleteBy";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /**
+   * Whether this provider's attachments cover `projectId`.
+   *
+   * Only consulted when the provider has `restrictToAttachedProjects` on -
+   * attachments are the PROVISIONING allow-list by default, not an access
+   * boundary, and reading them as one without the admin asking would lock
+   * existing users out of projects they legitimately reach.
+   *
+   * "No attachment rows at all" means instance-wide, matching the login
+   * router's default-all mode. "Rows exist but none are enabled" is a
+   * different answer and denies - otherwise an admin disabling the last
+   * attachment would WIDEN the provider to every project.
+   *
+   * Cached for 60s, with concurrent misses sharing one query.
+   */
+  @CaptureSpan()
+  public async doesProviderGovernProject(data: {
+    globalOidcId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<boolean> {
+    const key: string = globalProviderCacheKey("oidc", data.globalOidcId);
+
+    const cached: GlobalProviderAttachments | undefined =
+      globalSsoAttachmentsCache.get(key);
+
+    if (cached !== undefined) {
+      return doAttachmentsGovernProject(cached, data.projectId);
+    }
+
+    const attachments: GlobalProviderAttachments = await loadAttachmentsOnce(
+      key,
+      async (): Promise<GlobalProviderAttachments> => {
+        /*
+         * Fetched WITHOUT the isEnabled filter so a disabled row still counts
+         * as "this provider has attachments"; the enabled ones are selected
+         * out below.
+         */
+        const rows: Array<Model> = await this.findBy({
+          query: { globalOidcId: data.globalOidcId },
+          select: { _id: true, projectId: true, isEnabled: true },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          props: { isRoot: true },
+        });
+
+        const loaded: GlobalProviderAttachments = {
+          hasAnyAttachmentRows: rows.length > 0,
+          enabledProjectIds: rows
+            .filter((row: Model) => {
+              return Boolean(row.isEnabled) && Boolean(row.projectId);
+            })
+            .map((row: Model) => {
+              return row.projectId!.toString();
+            }),
+        };
+
+        globalSsoAttachmentsCache.set(
+          key,
+          loaded,
+          GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+        );
+
+        return loaded;
+      },
+    );
+
+    return doAttachmentsGovernProject(attachments, data.projectId);
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    // Detaching a project has to take effect now, not in 60s, on this node.
+    clearGlobalSsoAuthorizationCaches();
+    return { deleteBy, carryForward: null };
+  }
+
+  /*
+   * Cleared again AFTER the write commits. A clear that runs before the row
+   * lands can be immediately re-filled with the pre-change answer by a
+   * concurrent request, handing the old attachment set another full TTL.
+   */
+  @CaptureSpan()
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<Model>,
+    _itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onDelete;
+  }
+
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    clearGlobalSsoAuthorizationCaches();
+    return createdItem;
+  }
+
+  @CaptureSpan()
+  protected override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    _updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onUpdate;
   }
 
   @CaptureSpan()
@@ -37,6 +157,9 @@ export class Service extends DatabaseService<Model> {
       teams: createBy.data.teams,
       projectId,
     });
+
+    // A new attachment narrows (or widens) which projects the provider governs.
+    clearGlobalSsoAuthorizationCaches();
 
     return { createBy, carryForward: null };
   }
@@ -77,6 +200,8 @@ export class Service extends DatabaseService<Model> {
         }
       }
     }
+
+    clearGlobalSsoAuthorizationCaches();
 
     return { updateBy, carryForward: null };
   }

--- a/Common/Server/Services/GlobalOidcService.ts
+++ b/Common/Server/Services/GlobalOidcService.ts
@@ -1,9 +1,141 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/GlobalOidc";
+import ObjectID from "../../Types/ObjectID";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import CreateBy from "../Types/Database/CreateBy";
+import DeleteBy from "../Types/Database/DeleteBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
+import {
+  GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+  GlobalProviderTrust,
+  clearGlobalSsoAuthorizationCaches,
+  globalProviderCacheKey,
+  globalSsoProviderTrustCache,
+  loadTrustOnce,
+} from "../Utils/GlobalSsoAuthorization";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /**
+   * What the SSO-enforcement middleware needs to know about this provider:
+   * whether it is still usable at all, and whether the admin opted it into
+   * attachment-scoped access.
+   *
+   * Called on every authenticated request against an SSO-enforced project, so
+   * the answer is cached for 60s and concurrent misses share one query.
+   * Without this lookup, turning a provider off leaves every token it ever
+   * issued working until each one expires - up to thirty days.
+   */
+  @CaptureSpan()
+  public async getProviderTrust(
+    providerId: ObjectID,
+  ): Promise<GlobalProviderTrust> {
+    const key: string = globalProviderCacheKey("oidc", providerId);
+
+    const cached: GlobalProviderTrust | undefined =
+      globalSsoProviderTrustCache.get(key);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    return loadTrustOnce(key, async (): Promise<GlobalProviderTrust> => {
+      const provider: Model | null = await this.findOneBy({
+        query: { _id: providerId.toString() },
+        select: {
+          _id: true,
+          isEnabled: true,
+          restrictToAttachedProjects: true,
+        },
+        props: { isRoot: true },
+      });
+
+      /*
+       * A deleted provider and a disabled one are the same answer: no. Both
+       * are cached, so a revoked provider does not cost a query per request.
+       */
+      const trust: GlobalProviderTrust = {
+        isUsable: Boolean(provider && provider.isEnabled),
+        restrictToAttachedProjects: Boolean(
+          provider && provider.restrictToAttachedProjects,
+        ),
+      };
+
+      globalSsoProviderTrustCache.set(
+        key,
+        trust,
+        GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+      );
+
+      return trust;
+    });
+  }
+
+  /*
+   * Cache invalidation runs in the SUCCESS hooks, not the before-hooks: a
+   * clear that happens before the row is written can be immediately re-filled
+   * with the pre-change answer by a concurrent request, which would hand a
+   * disabled provider another full TTL of life on the very node that served
+   * the disable. Clearing in both is deliberate - the before-hook narrows the
+   * window, the success hook closes it.
+   *
+   * These caches are per-process, so the hooks make a change immediate on the
+   * node that served it and the TTL bounds every other node.
+   */
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return { updateBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    _updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onUpdate;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return { deleteBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<Model>,
+    _itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onDelete;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return { createBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    clearGlobalSsoAuthorizationCaches();
+    return createdItem;
   }
 }
 

--- a/Common/Server/Services/GlobalSsoProjectService.ts
+++ b/Common/Server/Services/GlobalSsoProjectService.ts
@@ -4,16 +4,136 @@ import Team from "../../Models/DatabaseModels/Team";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import ObjectID from "../../Types/ObjectID";
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import validateGlobalProviderProjectTeams, {
   resolveAttachmentProjectId,
 } from "../Utils/ValidateGlobalProviderProjectTeams";
+import {
+  GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+  GlobalProviderAttachments,
+  clearGlobalSsoAuthorizationCaches,
+  doAttachmentsGovernProject,
+  globalProviderCacheKey,
+  globalSsoAttachmentsCache,
+  loadAttachmentsOnce,
+} from "../Utils/GlobalSsoAuthorization";
+import DeleteBy from "../Types/Database/DeleteBy";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /**
+   * Whether this provider's attachments cover `projectId`.
+   *
+   * Only consulted when the provider has `restrictToAttachedProjects` on -
+   * attachments are the PROVISIONING allow-list by default, not an access
+   * boundary, and reading them as one without the admin asking would lock
+   * existing users out of projects they legitimately reach.
+   *
+   * "No attachment rows at all" means instance-wide, matching the login
+   * router's default-all mode. "Rows exist but none are enabled" is a
+   * different answer and denies - otherwise an admin disabling the last
+   * attachment would WIDEN the provider to every project.
+   *
+   * Cached for 60s, with concurrent misses sharing one query.
+   */
+  @CaptureSpan()
+  public async doesProviderGovernProject(data: {
+    globalSsoId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<boolean> {
+    const key: string = globalProviderCacheKey("sso", data.globalSsoId);
+
+    const cached: GlobalProviderAttachments | undefined =
+      globalSsoAttachmentsCache.get(key);
+
+    if (cached !== undefined) {
+      return doAttachmentsGovernProject(cached, data.projectId);
+    }
+
+    const attachments: GlobalProviderAttachments = await loadAttachmentsOnce(
+      key,
+      async (): Promise<GlobalProviderAttachments> => {
+        /*
+         * Fetched WITHOUT the isEnabled filter so a disabled row still counts
+         * as "this provider has attachments"; the enabled ones are selected
+         * out below.
+         */
+        const rows: Array<Model> = await this.findBy({
+          query: { globalSsoId: data.globalSsoId },
+          select: { _id: true, projectId: true, isEnabled: true },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          props: { isRoot: true },
+        });
+
+        const loaded: GlobalProviderAttachments = {
+          hasAnyAttachmentRows: rows.length > 0,
+          enabledProjectIds: rows
+            .filter((row: Model) => {
+              return Boolean(row.isEnabled) && Boolean(row.projectId);
+            })
+            .map((row: Model) => {
+              return row.projectId!.toString();
+            }),
+        };
+
+        globalSsoAttachmentsCache.set(
+          key,
+          loaded,
+          GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+        );
+
+        return loaded;
+      },
+    );
+
+    return doAttachmentsGovernProject(attachments, data.projectId);
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    // Detaching a project has to take effect now, not in 60s, on this node.
+    clearGlobalSsoAuthorizationCaches();
+    return { deleteBy, carryForward: null };
+  }
+
+  /*
+   * Cleared again AFTER the write commits. A clear that runs before the row
+   * lands can be immediately re-filled with the pre-change answer by a
+   * concurrent request, handing the old attachment set another full TTL.
+   */
+  @CaptureSpan()
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<Model>,
+    _itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onDelete;
+  }
+
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    clearGlobalSsoAuthorizationCaches();
+    return createdItem;
+  }
+
+  @CaptureSpan()
+  protected override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    _updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onUpdate;
   }
 
   @CaptureSpan()
@@ -37,6 +157,9 @@ export class Service extends DatabaseService<Model> {
       teams: createBy.data.teams,
       projectId,
     });
+
+    // A new attachment narrows (or widens) which projects the provider governs.
+    clearGlobalSsoAuthorizationCaches();
 
     return { createBy, carryForward: null };
   }
@@ -77,6 +200,8 @@ export class Service extends DatabaseService<Model> {
         }
       }
     }
+
+    clearGlobalSsoAuthorizationCaches();
 
     return { updateBy, carryForward: null };
   }

--- a/Common/Server/Services/GlobalSsoService.ts
+++ b/Common/Server/Services/GlobalSsoService.ts
@@ -1,9 +1,141 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/GlobalSso";
+import ObjectID from "../../Types/ObjectID";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import CreateBy from "../Types/Database/CreateBy";
+import DeleteBy from "../Types/Database/DeleteBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
+import {
+  GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+  GlobalProviderTrust,
+  clearGlobalSsoAuthorizationCaches,
+  globalProviderCacheKey,
+  globalSsoProviderTrustCache,
+  loadTrustOnce,
+} from "../Utils/GlobalSsoAuthorization";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /**
+   * What the SSO-enforcement middleware needs to know about this provider:
+   * whether it is still usable at all, and whether the admin opted it into
+   * attachment-scoped access.
+   *
+   * Called on every authenticated request against an SSO-enforced project, so
+   * the answer is cached for 60s and concurrent misses share one query.
+   * Without this lookup, turning a provider off leaves every token it ever
+   * issued working until each one expires - up to thirty days.
+   */
+  @CaptureSpan()
+  public async getProviderTrust(
+    providerId: ObjectID,
+  ): Promise<GlobalProviderTrust> {
+    const key: string = globalProviderCacheKey("sso", providerId);
+
+    const cached: GlobalProviderTrust | undefined =
+      globalSsoProviderTrustCache.get(key);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    return loadTrustOnce(key, async (): Promise<GlobalProviderTrust> => {
+      const provider: Model | null = await this.findOneBy({
+        query: { _id: providerId.toString() },
+        select: {
+          _id: true,
+          isEnabled: true,
+          restrictToAttachedProjects: true,
+        },
+        props: { isRoot: true },
+      });
+
+      /*
+       * A deleted provider and a disabled one are the same answer: no. Both
+       * are cached, so a revoked provider does not cost a query per request.
+       */
+      const trust: GlobalProviderTrust = {
+        isUsable: Boolean(provider && provider.isEnabled),
+        restrictToAttachedProjects: Boolean(
+          provider && provider.restrictToAttachedProjects,
+        ),
+      };
+
+      globalSsoProviderTrustCache.set(
+        key,
+        trust,
+        GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+      );
+
+      return trust;
+    });
+  }
+
+  /*
+   * Cache invalidation runs in the SUCCESS hooks, not the before-hooks: a
+   * clear that happens before the row is written can be immediately re-filled
+   * with the pre-change answer by a concurrent request, which would hand a
+   * disabled provider another full TTL of life on the very node that served
+   * the disable. Clearing in both is deliberate - the before-hook narrows the
+   * window, the success hook closes it.
+   *
+   * These caches are per-process, so the hooks make a change immediate on the
+   * node that served it and the TTL bounds every other node.
+   */
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return { updateBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    _updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onUpdate;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return { deleteBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<Model>,
+    _itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return onDelete;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    clearGlobalSsoAuthorizationCaches();
+    return { createBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    clearGlobalSsoAuthorizationCaches();
+    return createdItem;
   }
 }
 

--- a/Common/Server/Utils/GlobalSsoAuthorization.ts
+++ b/Common/Server/Utils/GlobalSsoAuthorization.ts
@@ -1,0 +1,175 @@
+import ObjectID from "../../Types/ObjectID";
+import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+
+/*
+ * The stateful half of Global SSO enforcement.
+ *
+ * A Global SSO/OIDC token is a 30-day, self-contained JWT with no project
+ * binding, so on its own it answers only "this person authenticated against
+ * SOME instance-wide identity provider at some point in the last month". Two
+ * questions it cannot answer:
+ *
+ *   1. IS THE PROVIDER STILL TRUSTED? Turning a provider off, or deleting it,
+ *      has to actually cut off access. Without a check at request time the
+ *      "Enabled" toggle does nothing to anyone already signed in, for up to
+ *      thirty days. This check is UNCONDITIONAL - "disabled" has only one
+ *      possible meaning.
+ *
+ *   2. DOES THE PROVIDER GOVERN THIS PROJECT? Deliberately OPT-IN, per
+ *      provider, via `restrictToAttachedProjects`. The attachment rows
+ *      (GlobalSsoProject / GlobalOidcProject) were introduced as the
+ *      PROVISIONING allow-list - "a SAML assertion can only ever provision a
+ *      user into projects that a master admin has explicitly attached here",
+ *      per the model's own docstring - and the login routers gate a session on
+ *      membership of ANY project, not of an attached one. Reading attachments
+ *      as an access boundary by default would therefore lock existing users
+ *      out of projects they legitimately reach today, immediately on upgrade,
+ *      with no way to recover from inside the product. So it stays off unless
+ *      an admin asks for it.
+ *
+ * Both answers come from Postgres and run on every authenticated request
+ * against an SSO-enforced project, so both are cached in-process for 60
+ * seconds, and concurrent misses share one query.
+ */
+
+export const GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS: number = 60_000;
+
+/** What the enforcement path needs to know about a global provider. */
+export interface GlobalProviderTrust {
+  // The provider row exists and its "Enabled" toggle is on.
+  isUsable: boolean;
+  // The admin opted this provider into attachment-scoped access.
+  restrictToAttachedProjects: boolean;
+}
+
+/*
+ * Absence of an entry means "not yet looked up", which is why these are read
+ * with an explicit `undefined` check rather than a truthiness test: a cached
+ * "this provider is disabled" must not be mistaken for a cache miss and
+ * re-queried on every single request.
+ */
+export const globalSsoProviderTrustCache: InMemoryTTLCache<GlobalProviderTrust> =
+  new InMemoryTTLCache(10_000);
+
+/**
+ * A provider's attachment rows.
+ *
+ * `hasAnyAttachmentRows` distinguishes "this provider has no attachments at
+ * all" from "it has attachments but every one of them is disabled". Collapsing
+ * those two would mean an admin disabling the last attachment WIDENS the
+ * provider to every project - the exact opposite of the intent.
+ */
+export interface GlobalProviderAttachments {
+  hasAnyAttachmentRows: boolean;
+  enabledProjectIds: Array<string>;
+}
+
+export const globalSsoAttachmentsCache: InMemoryTTLCache<GlobalProviderAttachments> =
+  new InMemoryTTLCache(10_000);
+
+export type GlobalProviderKind = "sso" | "oidc";
+
+/*
+ * Namespaced by kind. A Global SSO provider and a Global OIDC provider are
+ * different rows in different tables and could in principle share an id;
+ * collapsing the keys would let one vouch for the other.
+ */
+export function globalProviderCacheKey(
+  providerKind: GlobalProviderKind,
+  providerId: ObjectID,
+): string {
+  return `${providerKind}:${providerId.toString()}`;
+}
+
+/**
+ * Decides whether a provider's attachments cover `projectId`, for a provider
+ * that has opted into attachment-scoped access.
+ *
+ * A provider with no attachment rows at all is instance-wide, matching the
+ * "default-all" reading the login routers use. A provider that HAS attachment
+ * rows governs exactly the enabled ones - so disabling them all denies rather
+ * than widens.
+ */
+export function doAttachmentsGovernProject(
+  attachments: GlobalProviderAttachments,
+  projectId: ObjectID,
+): boolean {
+  if (!attachments.hasAnyAttachmentRows) {
+    return true;
+  }
+
+  return attachments.enabledProjectIds.includes(projectId.toString());
+}
+
+/** Drops every cached answer. Used by the write hooks and by tests. */
+export function clearGlobalSsoAuthorizationCaches(): void {
+  globalSsoProviderTrustCache.clear();
+  globalSsoAttachmentsCache.clear();
+  inFlightTrustLookups.clear();
+  inFlightAttachmentLookups.clear();
+}
+
+/*
+ * In-flight de-duplication.
+ *
+ * The multi-tenant permission path fans out over every project the user
+ * belongs to CONCURRENTLY. Without this, a cold cache means N simultaneous
+ * copies of the same two queries - for a user in fifty projects, a hundred
+ * queries where two would do. Worse, failures are never cached, so a database
+ * that is already struggling gets the full fan-out again on every request.
+ *
+ * Sharing the promise collapses all of that to one query per provider, and a
+ * rejection is shared too rather than being retried N times in the same tick.
+ */
+const inFlightTrustLookups: Map<
+  string,
+  Promise<GlobalProviderTrust>
+> = new Map();
+const inFlightAttachmentLookups: Map<
+  string,
+  Promise<GlobalProviderAttachments>
+> = new Map();
+
+async function loadOnce<T>(
+  inFlight: Map<string, Promise<T>>,
+  key: string,
+  load: () => Promise<T>,
+): Promise<T> {
+  const existing: Promise<T> | undefined = inFlight.get(key);
+
+  if (existing) {
+    return existing;
+  }
+
+  const pending: Promise<T> = load().finally((): void => {
+    /*
+     * Only clear the slot if it is still OURS. A cache clear between the two
+     * (every write to a Global SSO/OIDC service does exactly that, twice) lets
+     * a NEWER lookup take the key while this one is still on the wire; a blind
+     * delete would evict that newer entry when this one settles, and the fan-
+     * out that follows would stop de-duplicating - the one situation this
+     * exists for.
+     */
+    if (inFlight.get(key) === pending) {
+      inFlight.delete(key);
+    }
+  });
+
+  inFlight.set(key, pending);
+
+  return pending;
+}
+
+export function loadTrustOnce(
+  key: string,
+  load: () => Promise<GlobalProviderTrust>,
+): Promise<GlobalProviderTrust> {
+  return loadOnce(inFlightTrustLookups, key, load);
+}
+
+export function loadAttachmentsOnce(
+  key: string,
+  load: () => Promise<GlobalProviderAttachments>,
+): Promise<GlobalProviderAttachments> {
+  return loadOnce(inFlightAttachmentLookups, key, load);
+}

--- a/Common/Tests/Server/Middleware/UserAuthorization.test.ts
+++ b/Common/Tests/Server/Middleware/UserAuthorization.test.ts
@@ -677,9 +677,16 @@ describe("UserMiddleware", () => {
       ProjectService,
       "getRequireSsoWithSsoProviderId",
     );
-    const spyDoesSsoTokenForProjectExist: jest.SpyInstance = getJestSpyOn(
+    /*
+     * The enforcement entry point is `isSsoSatisfiedForProject`, not the
+     * stateless `doesSsoTokenForProjectExist`: a Global SSO token also has to
+     * clear the provider-trust and project-governance checks, which need the
+     * database. Spying here keeps these tests about the middleware's control
+     * flow rather than about SSO token internals.
+     */
+    const spyIsSsoSatisfiedForProject: jest.SpyInstance = getJestSpyOn(
       UserMiddleware,
-      "doesSsoTokenForProjectExist",
+      "isSsoSatisfiedForProject",
     );
     const spyGetGlobalRequireSsoForLogin: jest.SpyInstance = getJestSpyOn(
       GlobalConfigService,
@@ -717,7 +724,7 @@ describe("UserMiddleware", () => {
     test("should throw SsoAuthorizationException error, when sso login is required but sso token for the projectId does not exist", async () => {
       spyGetRequireSsoForLogin.mockResolvedValueOnce(true);
 
-      spyDoesSsoTokenForProjectExist.mockReturnValueOnce(false);
+      spyIsSsoSatisfiedForProject.mockResolvedValueOnce(false);
 
       await expect(
         UserMiddleware.getUserTenantAccessPermissionWithTenantId({
@@ -726,12 +733,12 @@ describe("UserMiddleware", () => {
           userId,
         }),
       ).rejects.toThrowError(new SsoAuthorizationException());
-      expect(spyDoesSsoTokenForProjectExist).toHaveBeenCalledWith(
+      expect(spyIsSsoSatisfiedForProject).toHaveBeenCalledWith({
         req,
         projectId,
         userId,
-        undefined,
-      );
+        requiredSsoProviderId: undefined,
+      });
     });
 
     test("should return null when getUserTenantAccessPermission returns null", async () => {
@@ -797,9 +804,16 @@ describe("UserMiddleware", () => {
       ProjectService,
       "getRequireSsoWithSsoProviderId",
     );
-    const spyDoesSsoTokenForProjectExist: jest.SpyInstance = getJestSpyOn(
+    /*
+     * The enforcement entry point is `isSsoSatisfiedForProject`, not the
+     * stateless `doesSsoTokenForProjectExist`: a Global SSO token also has to
+     * clear the provider-trust and project-governance checks, which need the
+     * database. Spying here keeps these tests about the middleware's control
+     * flow rather than about SSO token internals.
+     */
+    const spyIsSsoSatisfiedForProject: jest.SpyInstance = getJestSpyOn(
       UserMiddleware,
-      "doesSsoTokenForProjectExist",
+      "isSsoSatisfiedForProject",
     );
     const spyGetGlobalRequireSsoForLogin: jest.SpyInstance = getJestSpyOn(
       GlobalConfigService,
@@ -833,7 +847,7 @@ describe("UserMiddleware", () => {
     });
 
     test("should return default tenant access permission, when project for a projectId is found, sso is required for login, but sso token does not exist for that projectId", async () => {
-      spyDoesSsoTokenForProjectExist.mockReturnValueOnce(false);
+      spyIsSsoSatisfiedForProject.mockResolvedValueOnce(false);
       spyGetProjectRequireSsoForLogin.mockResolvedValueOnce(true);
 
       const spyGetDefaultUserTenantAccessPermission: jest.SpyInstance =
@@ -852,12 +866,12 @@ describe("UserMiddleware", () => {
       expect(result).toEqual({
         [projectId.toString()]: mockedUserTenantAccessPermission,
       });
-      expect(spyDoesSsoTokenForProjectExist).toHaveBeenCalledWith(
+      expect(spyIsSsoSatisfiedForProject).toHaveBeenCalledWith({
         req,
         projectId,
         userId,
-        undefined,
-      );
+        requiredSsoProviderId: undefined,
+      });
       expect(spyGetDefaultUserTenantAccessPermission).toHaveBeenCalledWith(
         projectId,
       );
@@ -879,7 +893,7 @@ describe("UserMiddleware", () => {
       expect(result).toEqual({
         [projectId.toString()]: mockedUserTenantAccessPermission,
       });
-      expect(spyDoesSsoTokenForProjectExist).not.toBeCalled();
+      expect(spyIsSsoSatisfiedForProject).not.toBeCalled();
       expect(spyGetUserTenantAccessPermission).toHaveBeenCalledWith(
         userId,
         projectId,

--- a/Common/Tests/Server/Middleware/UserAuthorizationGlobalSsoGovernance.test.ts
+++ b/Common/Tests/Server/Middleware/UserAuthorizationGlobalSsoGovernance.test.ts
@@ -1,0 +1,1455 @@
+import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import GlobalOidcProjectService from "../../../Server/Services/GlobalOidcProjectService";
+import GlobalOidcService from "../../../Server/Services/GlobalOidcService";
+import GlobalSsoProjectService from "../../../Server/Services/GlobalSsoProjectService";
+import GlobalSsoService from "../../../Server/Services/GlobalSsoService";
+import CookieUtil from "../../../Server/Utils/Cookie";
+import { ExpressRequest } from "../../../Server/Utils/Express";
+import { GlobalProviderTrust } from "../../../Server/Utils/GlobalSsoAuthorization";
+import JSONWebToken from "../../../Server/Utils/JsonWebToken";
+import Email from "../../../Types/Email";
+import JSONWebTokenData from "../../../Types/JsonWebTokenData";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+import SsoProviderType from "../../../Types/SSO/SsoProviderType";
+import User from "../../../Models/DatabaseModels/User";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import type { SpyInstance } from "jest-mock";
+
+jest.mock("../../../Server/Utils/Logger");
+
+/*
+ * A Global SSO/OIDC token is a 30-day JWT with NO project binding, so by
+ * itself it only proves "this person authenticated against SOME instance-wide
+ * identity provider at some point in the last month". Enforcement therefore
+ * has two halves:
+ *
+ *   STATELESS  - signature, expiry, Global provider type, matching user, and
+ *                the project's pinned-provider discriminator.
+ *   STATEFUL   - is the provider still trusted (exists AND enabled), and -
+ *                only when the admin opted in - does it govern this project.
+ *
+ * `UserMiddleware.isSsoSatisfiedForProject` is THE enforcement entry point and
+ * runs both. `UserMiddleware.doesSsoTokenForProjectExist` is the stateless
+ * half only, and is deliberately NOT enforcement (see the final describe).
+ *
+ * These tests mint REAL tokens through CookieUtil (real signing, real
+ * verification) and stub ONLY the four service methods that reach Postgres,
+ * so the middleware's own routing, ordering and AND-ing logic runs for real.
+ *
+ * Deliberately NOT repeated here, because it is already covered:
+ *   - Common/Tests/Server/Middleware/UserAuthorizationSSOProvider.test.ts -
+ *     the full `requiredSsoProviderId` discriminator matrix, the cookie vs
+ *     `x-global-sso-token` header transports, and the sync-level refusal of
+ *     Global-typed tokens in the per-project slot.
+ *   - Common/Tests/Server/Utils/GlobalSSOToken.test.ts - the global token's
+ *     payload/TTL contract, wrong-secret and syntactic tampering, and
+ *     project-typed tokens sitting in the global slot.
+ *   - Common/Tests/Server/Utils/GlobalSsoAuthorization.test.ts - the
+ *     attachment/cache primitives underneath the services.
+ * What this file adds is the DATABASE-backed half of the decision, and proof
+ * that every stateless rejection happens BEFORE the database is consulted.
+ *
+ * Every "refused" assertion below is paired with an "allowed" assertion over
+ * the SAME setup with only the single thing under test corrected. An
+ * implementation that simply returned false everywhere would fail this file.
+ */
+
+const THIRTY_DAYS_IN_SECONDS: number = 30 * 24 * 60 * 60;
+
+const TRUSTED_AND_UNRESTRICTED: GlobalProviderTrust = {
+  isUsable: true,
+  restrictToAttachedProjects: false,
+};
+
+const TRUSTED_AND_RESTRICTED: GlobalProviderTrust = {
+  isUsable: true,
+  restrictToAttachedProjects: true,
+};
+
+const REVOKED: GlobalProviderTrust = {
+  isUsable: false,
+  restrictToAttachedProjects: false,
+};
+
+type TrustSpy = SpyInstance<
+  (providerId: ObjectID) => Promise<GlobalProviderTrust>
+>;
+
+type SsoGovernSpy = SpyInstance<
+  (data: { globalSsoId: ObjectID; projectId: ObjectID }) => Promise<boolean>
+>;
+
+type OidcGovernSpy = SpyInstance<
+  (data: { globalOidcId: ObjectID; projectId: ObjectID }) => Promise<boolean>
+>;
+
+let ssoTrustSpy: TrustSpy;
+let oidcTrustSpy: TrustSpy;
+let ssoGovernsSpy: SsoGovernSpy;
+let oidcGovernsSpy: OidcGovernSpy;
+
+const buildUser: (userId: ObjectID) => User = (userId: ObjectID): User => {
+  const user: User = new User();
+  user.id = userId;
+  user.name = new Name("Global SSO User");
+  user.email = new Email("global-sso@oneuptime.com");
+  return user;
+};
+
+/** A real Global SSO/OIDC token, exactly as a global login mints it. */
+const mintGlobalToken: (data: {
+  userId: ObjectID;
+  providerId: ObjectID;
+  providerType: SsoProviderType;
+}) => string = (data: {
+  userId: ObjectID;
+  providerId: ObjectID;
+  providerType: SsoProviderType;
+}): string => {
+  return CookieUtil.getGlobalSSOToken({
+    user: buildUser(data.userId),
+    ssoProviderId: data.providerId,
+    ssoProviderType: data.providerType,
+  });
+};
+
+/** A real per-project `sso-<projectId>` token. */
+const mintProjectToken: (data: {
+  userId: ObjectID;
+  projectId: ObjectID;
+  providerId: ObjectID;
+  providerType: SsoProviderType;
+}) => string = (data: {
+  userId: ObjectID;
+  projectId: ObjectID;
+  providerId: ObjectID;
+  providerType: SsoProviderType;
+}): string => {
+  return CookieUtil.getSSOToken({
+    user: buildUser(data.userId),
+    projectId: data.projectId,
+    ssoProviderId: data.providerId,
+    ssoProviderType: data.providerType,
+  });
+};
+
+const decodeToken: (token: string) => JSONWebTokenData = (
+  token: string,
+): JSONWebTokenData => {
+  return JSONWebToken.decode(token);
+};
+
+interface RequestParts {
+  globalToken?: string | undefined;
+  projectTokens?: Array<{ projectId: ObjectID; token: string }> | undefined;
+}
+
+const buildRequest: (parts: RequestParts) => ExpressRequest = (
+  parts: RequestParts,
+): ExpressRequest => {
+  const cookies: Record<string, string> = {};
+
+  if (parts.globalToken) {
+    cookies[CookieUtil.getGlobalSSOKey()] = parts.globalToken;
+  }
+
+  for (const entry of parts.projectTokens || []) {
+    cookies[CookieUtil.getUserSSOKey(entry.projectId)] = entry.token;
+  }
+
+  return {
+    cookies: cookies,
+    headers: {},
+  } as unknown as ExpressRequest;
+};
+
+/*
+ * "The database was never asked." Used by every test that claims a decision
+ * was reached statelessly - a stateless gate that silently started issuing
+ * queries would be a performance regression on the hottest path in the
+ * product, and a gate that ran AFTER the lookup would leak provider existence.
+ */
+const expectNoDatabaseLookups: () => void = (): void => {
+  expect(ssoTrustSpy).not.toHaveBeenCalled();
+  expect(oidcTrustSpy).not.toHaveBeenCalled();
+  expect(ssoGovernsSpy).not.toHaveBeenCalled();
+  expect(oidcGovernsSpy).not.toHaveBeenCalled();
+};
+
+beforeEach(() => {
+  ssoTrustSpy = jest.spyOn(GlobalSsoService, "getProviderTrust");
+  oidcTrustSpy = jest.spyOn(GlobalOidcService, "getProviderTrust");
+  ssoGovernsSpy = jest.spyOn(
+    GlobalSsoProjectService,
+    "doesProviderGovernProject",
+  );
+  oidcGovernsSpy = jest.spyOn(
+    GlobalOidcProjectService,
+    "doesProviderGovernProject",
+  );
+
+  /*
+   * Default: a healthy, enabled, unrestricted provider that governs
+   * everything - i.e. what an existing installation looks like on upgrade.
+   * Each test narrows only the answer it is about.
+   */
+  ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+  oidcTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+  ssoGovernsSpy.mockResolvedValue(true);
+  oidcGovernsSpy.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/*
+ * The provider-trust check is what makes the admin "Enabled" toggle mean
+ * something. A Global SSO token carries no revocation and lives for 30 days,
+ * so if this check were conditional - skipped for unrestricted providers, or
+ * short-circuited when governance already said yes - turning a provider off
+ * (or deleting it) would change nothing for anyone already signed in, for up
+ * to a month.
+ */
+describe("isGlobalSsoTokenAuthorizedForProject - provider trust is unconditional", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  const samlTokenData: () => JSONWebTokenData = (): JSONWebTokenData => {
+    return decodeToken(
+      mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    );
+  };
+
+  const oidcTokenData: () => JSONWebTokenData = (): JSONWebTokenData => {
+    return decodeToken(
+      mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalOIDC,
+      }),
+    );
+  };
+
+  test("SAML: a disabled or deleted provider refuses an otherwise perfect token", async () => {
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    // Trust said no, so there is nothing left to ask.
+    expect(ssoGovernsSpy).not.toHaveBeenCalled();
+  });
+
+  test("SAML: the SAME token is allowed the moment the provider is enabled again", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("OIDC: a disabled or deleted provider refuses an otherwise perfect token", async () => {
+    oidcTrustSpy.mockResolvedValue(REVOKED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: oidcTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    expect(oidcGovernsSpy).not.toHaveBeenCalled();
+  });
+
+  test("OIDC: the SAME token is allowed the moment the provider is enabled again", async () => {
+    oidcTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: oidcTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("a disabled provider is refused EVEN when it governs the project - trust is not skippable", async () => {
+    // Restriction on, attachment present: governance would happily say yes.
+    ssoTrustSpy.mockResolvedValue({
+      isUsable: false,
+      restrictToAttachedProjects: true,
+    });
+    ssoGovernsSpy.mockResolvedValue(true);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    // Same setup, only `isUsable` flipped -> allowed.
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("the whole enforcement entry point refuses a request once the provider is disabled", async () => {
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+  });
+});
+
+/*
+ * THE HEADLINE BEHAVIOUR.
+ *
+ * The attachment rows (GlobalSsoProject / GlobalOidcProject) were introduced
+ * as the PROVISIONING allow-list, and the login routers grant a session on
+ * membership of ANY project. Reading them as an access boundary by default
+ * would deny existing users the projects they legitimately reach today, the
+ * instant they upgraded, with nothing inside the product to recover with. So
+ * the boundary is OPT-IN per provider, via `restrictToAttachedProjects`, and
+ * with it off the attachment table is not even consulted.
+ */
+describe("isGlobalSsoTokenAuthorizedForProject - project governance is opt-in", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  const samlTokenData: () => JSONWebTokenData = (): JSONWebTokenData => {
+    return decodeToken(
+      mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    );
+  };
+
+  test("restrictToAttachedProjects FALSE -> allowed WITHOUT ever asking the attachment table", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+    /*
+     * Rigged to deny. If the implementation consulted it anyway, the result
+     * would be false and this test would fail - which is exactly the
+     * upgrade-day lockout being guarded against.
+     */
+    ssoGovernsSpy.mockResolvedValue(false);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(ssoGovernsSpy).not.toHaveBeenCalled();
+    expect(oidcGovernsSpy).not.toHaveBeenCalled();
+  });
+
+  test("restrictToAttachedProjects FALSE -> every project the user reaches is satisfied, not just one", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(false);
+
+    const otherProjectId: ObjectID = ObjectID.generate();
+    const thirdProjectId: ObjectID = ObjectID.generate();
+
+    for (const candidateProjectId of [
+      projectId,
+      otherProjectId,
+      thirdProjectId,
+    ]) {
+      await expect(
+        UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+          globalSsoTokenData: samlTokenData(),
+          projectId: candidateProjectId,
+        }),
+      ).resolves.toBe(true);
+    }
+
+    expect(ssoGovernsSpy).not.toHaveBeenCalled();
+  });
+
+  test("restrictToAttachedProjects TRUE + provider governs the project -> allowed", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(true);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(ssoGovernsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("restrictToAttachedProjects TRUE + provider does NOT govern the project -> refused", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(false);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    expect(ssoGovernsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("flipping ONLY restrictToAttachedProjects turns a non-governed project from allowed to refused", async () => {
+    ssoGovernsSpy.mockResolvedValue(false);
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test("governance flows through the enforcement entry point too, both ways", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    });
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+
+    ssoGovernsSpy.mockResolvedValue(false);
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+
+    ssoGovernsSpy.mockResolvedValue(true);
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+  });
+});
+
+/*
+ * Global SAML and Global OIDC are different tables, different services, and
+ * different provider-id namespaces - an id from one must never be resolved
+ * against the other, or a disabled SAML provider could be vouched for by an
+ * unrelated OIDC row that happens to share its id.
+ */
+describe("isGlobalSsoTokenAuthorizedForProject - SAML vs OIDC routing", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  test("a GlobalSSO token consults the SSO service and NOT the OIDC one", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(true);
+    // Rigged the other way, so any cross-talk changes the answer.
+    oidcTrustSpy.mockResolvedValue(REVOKED);
+    oidcGovernsSpy.mockResolvedValue(false);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalSSO,
+          }),
+        ),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+    expect(ssoGovernsSpy).toHaveBeenCalledTimes(1);
+    expect(oidcTrustSpy).not.toHaveBeenCalled();
+    expect(oidcGovernsSpy).not.toHaveBeenCalled();
+  });
+
+  test("a GlobalOIDC token consults the OIDC service and NOT the SSO one", async () => {
+    oidcTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    oidcGovernsSpy.mockResolvedValue(true);
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+    ssoGovernsSpy.mockResolvedValue(false);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalOIDC,
+          }),
+        ),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(oidcTrustSpy).toHaveBeenCalledTimes(1);
+    expect(oidcGovernsSpy).toHaveBeenCalledTimes(1);
+    expect(ssoTrustSpy).not.toHaveBeenCalled();
+    expect(ssoGovernsSpy).not.toHaveBeenCalled();
+  });
+
+  test("a disabled SAML provider is NOT rescued by an enabled OIDC row of the same id", async () => {
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+    oidcTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalSSO,
+          }),
+        ),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    expect(oidcTrustSpy).not.toHaveBeenCalled();
+  });
+
+  test("a disabled OIDC provider is NOT rescued by an enabled SAML row of the same id", async () => {
+    oidcTrustSpy.mockResolvedValue(REVOKED);
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalOIDC,
+          }),
+        ),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    expect(ssoTrustSpy).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * The decision has to be made about the provider named by THIS token and the
+ * project named by THIS request. Passing the wrong id - a hard-coded one, the
+ * required-provider id, the user id - would produce answers that look right in
+ * a single-provider install and are wrong everywhere else.
+ */
+describe("isGlobalSsoTokenAuthorizedForProject - the ids handed to the services", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  test("SAML: the token's provider id and the request's project id are the ones queried", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(true);
+
+    await UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+      globalSsoTokenData: decodeToken(
+        mintGlobalToken({
+          userId,
+          providerId,
+          providerType: SsoProviderType.GlobalSSO,
+        }),
+      ),
+      projectId,
+    });
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+    expect(ssoTrustSpy.mock.calls[0]?.[0]?.toString()).toBe(
+      providerId.toString(),
+    );
+
+    expect(ssoGovernsSpy).toHaveBeenCalledTimes(1);
+    expect(ssoGovernsSpy.mock.calls[0]?.[0]?.globalSsoId.toString()).toBe(
+      providerId.toString(),
+    );
+    expect(ssoGovernsSpy.mock.calls[0]?.[0]?.projectId.toString()).toBe(
+      projectId.toString(),
+    );
+  });
+
+  test("OIDC: the token's provider id and the request's project id are the ones queried", async () => {
+    oidcTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    oidcGovernsSpy.mockResolvedValue(true);
+
+    await UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+      globalSsoTokenData: decodeToken(
+        mintGlobalToken({
+          userId,
+          providerId,
+          providerType: SsoProviderType.GlobalOIDC,
+        }),
+      ),
+      projectId,
+    });
+
+    expect(oidcTrustSpy.mock.calls[0]?.[0]?.toString()).toBe(
+      providerId.toString(),
+    );
+    expect(oidcGovernsSpy.mock.calls[0]?.[0]?.globalOidcId.toString()).toBe(
+      providerId.toString(),
+    );
+    expect(oidcGovernsSpy.mock.calls[0]?.[0]?.projectId.toString()).toBe(
+      projectId.toString(),
+    );
+  });
+
+  test("each project in a multi-project fan-out is queried with its OWN id", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(true);
+
+    const projectA: ObjectID = ObjectID.generate();
+    const projectB: ObjectID = ObjectID.generate();
+
+    const tokenData: JSONWebTokenData = decodeToken(
+      mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    );
+
+    await UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+      globalSsoTokenData: tokenData,
+      projectId: projectA,
+    });
+    await UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+      globalSsoTokenData: tokenData,
+      projectId: projectB,
+    });
+
+    expect(ssoGovernsSpy.mock.calls[0]?.[0]?.projectId.toString()).toBe(
+      projectA.toString(),
+    );
+    expect(ssoGovernsSpy.mock.calls[1]?.[0]?.projectId.toString()).toBe(
+      projectB.toString(),
+    );
+  });
+});
+
+/*
+ * "This provider is not allowed here" and "we could not find out" are
+ * different answers, and the code must not conflate them.
+ *
+ * If a failed lookup were caught and turned into `false`, a database blip - a
+ * dropped connection, a statement timeout, a failover - would look exactly
+ * like a deliberate permission decision. On the multi-tenant permission path
+ * that means the request still succeeds, with 200 and an empty permission
+ * set: the UI silently loses every button instead of showing an error, and
+ * nothing in the logs distinguishes it from a correctly-revoked user. Letting
+ * it throw turns an infrastructure fault into an infrastructure-shaped
+ * failure that alerts, retries, and gets fixed.
+ */
+describe("isGlobalSsoTokenAuthorizedForProject - a failed lookup THROWS, it does not deny", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  const samlTokenData: () => JSONWebTokenData = (): JSONWebTokenData => {
+    return decodeToken(
+      mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    );
+  };
+
+  const buildGlobalRequest: (
+    providerType: SsoProviderType,
+  ) => ExpressRequest = (providerType: SsoProviderType): ExpressRequest => {
+    return buildRequest({
+      globalToken: mintGlobalToken({ userId, providerId, providerType }),
+    });
+  };
+
+  test("SAML trust lookup rejects -> the decision rejects rather than resolving false", async () => {
+    ssoTrustSpy.mockRejectedValue(new Error("connection terminated"));
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).rejects.toThrow("connection terminated");
+
+    /*
+     * And the same lookup succeeding is a plain "allowed" - so the rejection
+     * above is about the failure and nothing else.
+     */
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("OIDC trust lookup rejects -> the decision rejects rather than resolving false", async () => {
+    oidcTrustSpy.mockRejectedValue(new Error("statement timeout"));
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalOIDC,
+          }),
+        ),
+        projectId,
+      }),
+    ).rejects.toThrow("statement timeout");
+  });
+
+  test("governance lookup rejects under restrict-on -> the decision rejects", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockRejectedValue(new Error("attachment read failed"));
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).rejects.toThrow("attachment read failed");
+
+    // Same restrict-on setup, lookup healthy -> allowed.
+    ssoGovernsSpy.mockResolvedValue(true);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: samlTokenData(),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("OIDC governance lookup rejects under restrict-on -> the decision rejects", async () => {
+    oidcTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    oidcGovernsSpy.mockRejectedValue(new Error("oidc attachment read failed"));
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalOIDC,
+          }),
+        ),
+        projectId,
+      }),
+    ).rejects.toThrow("oidc attachment read failed");
+  });
+
+  test("the enforcement entry point propagates the failure instead of denying", async () => {
+    const req: ExpressRequest = buildGlobalRequest(SsoProviderType.GlobalSSO);
+
+    ssoTrustSpy.mockRejectedValue(new Error("connection terminated"));
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).rejects.toThrow("connection terminated");
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+  });
+
+  test("the enforcement entry point propagates a failed governance lookup too", async () => {
+    const req: ExpressRequest = buildGlobalRequest(SsoProviderType.GlobalSSO);
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockRejectedValue(new Error("attachment read failed"));
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).rejects.toThrow("attachment read failed");
+  });
+});
+
+/*
+ * A Global-typed token with no `ssoProviderId` cannot be checked against
+ * either question, so it cannot be trusted for a project. That is a DECISION -
+ * `false` - not a failure. It must not throw, and it must not spend a query
+ * finding out, because the answer is fully determined by the token.
+ */
+describe("isGlobalSsoTokenAuthorizedForProject - a token with no provider id", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  const mintProviderlessGlobalToken: () => string = (): string => {
+    return JSONWebToken.sign({
+      data: {
+        userId: userId,
+        name: new Name("Global SSO User"),
+        email: new Email("global-sso@oneuptime.com"),
+        isMasterAdmin: false,
+        isGeneralLogin: false,
+        // No ssoProviderId at all - the shape a pre-discriminator token had.
+        ssoProviderType: SsoProviderType.GlobalSSO.toString(),
+      },
+      expiresInSeconds: THIRTY_DAYS_IN_SECONDS,
+    });
+  };
+
+  test("the fixture really is a Global token with no provider id", () => {
+    const decoded: JSONWebTokenData = decodeToken(
+      mintProviderlessGlobalToken(),
+    );
+
+    expect(decoded.ssoProviderType).toBe(SsoProviderType.GlobalSSO);
+    expect(decoded.ssoProviderId).toBeUndefined();
+  });
+
+  test("resolves false, and never touches the database", async () => {
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(mintProviderlessGlobalToken()),
+        projectId,
+      }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+  });
+
+  test("the same token WITH a provider id is allowed - the refusal is about the missing id", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isGlobalSsoTokenAuthorizedForProject({
+        globalSsoTokenData: decodeToken(
+          mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalSSO,
+          }),
+        ),
+        projectId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("through the enforcement entry point: refused, with no database lookups", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintProviderlessGlobalToken(),
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+  });
+});
+
+/*
+ * A per-project SSO token is bound to one project by a login that already
+ * proved the project's own provider trusts this user. It is decided
+ * statelessly and short-circuits the whole stateful path - which is what
+ * keeps a project-SSO-only installation from paying for Global SSO queries it
+ * has no use for.
+ */
+describe("isSsoSatisfiedForProject - the per-project token short-circuits", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const otherProjectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  test("a valid ProjectSSO token for THIS project -> true, with no global lookups", async () => {
+    // Rigged so any fall-through to the global path would refuse.
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+    oidcTrustSpy.mockResolvedValue(REVOKED);
+
+    const req: ExpressRequest = buildRequest({
+      projectTokens: [
+        {
+          projectId,
+          token: mintProjectToken({
+            userId,
+            projectId,
+            providerId,
+            providerType: SsoProviderType.ProjectSSO,
+          }),
+        },
+      ],
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+
+    expectNoDatabaseLookups();
+  });
+
+  test("a valid ProjectOIDC token for THIS project -> true, with no global lookups", async () => {
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+    oidcTrustSpy.mockResolvedValue(REVOKED);
+
+    const req: ExpressRequest = buildRequest({
+      projectTokens: [
+        {
+          projectId,
+          token: mintProjectToken({
+            userId,
+            projectId,
+            providerId,
+            providerType: SsoProviderType.ProjectOIDC,
+          }),
+        },
+      ],
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+
+    expectNoDatabaseLookups();
+  });
+
+  test("a per-project token for a DIFFERENT project does not short-circuit - the global path decides", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+      projectTokens: [
+        {
+          projectId: otherProjectId,
+          token: mintProjectToken({
+            userId,
+            projectId: otherProjectId,
+            providerId,
+            providerType: SsoProviderType.ProjectSSO,
+          }),
+        },
+      ],
+    });
+
+    /*
+     * The global provider is disabled, so the unrelated project token must
+     * not carry this request.
+     */
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+
+    // The project the token IS for still short-circuits, disabled or not.
+    ssoTrustSpy.mockClear();
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req,
+        projectId: otherProjectId,
+        userId,
+      }),
+    ).resolves.toBe(true);
+
+    expectNoDatabaseLookups();
+  });
+
+  test("with the global provider healthy, the other project is satisfied by the global token", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+      projectTokens: [
+        {
+          projectId: otherProjectId,
+          token: mintProjectToken({
+            userId,
+            projectId: otherProjectId,
+            providerId,
+            providerType: SsoProviderType.ProjectSSO,
+          }),
+        },
+      ],
+    });
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * THE UPGRADE HAZARD.
+ *
+ * Before the single-token redesign the Global SSO router minted one
+ * per-project token PER PROJECT, typed GlobalSSO/GlobalOIDC and signed for 30
+ * days. Those are still sitting in browsers as `sso-<projectId>` cookies and
+ * in the mobile app's AsyncStorage, replayed on every request. If the
+ * per-project slot accepted them they would short-circuit past the
+ * provider-trust check - so an admin disabling a provider would still not
+ * revoke them, for up to a month. The slot refuses them by TYPE, which sends
+ * the user through a fresh global login that mints a properly-typed token.
+ */
+describe("isSsoSatisfiedForProject - a legacy Global-typed token in the per-project slot", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  const buildLegacyRequest: (data: {
+    projectSlotType: SsoProviderType;
+    alsoInGlobalSlot: boolean;
+  }) => ExpressRequest = (data: {
+    projectSlotType: SsoProviderType;
+    alsoInGlobalSlot: boolean;
+  }): ExpressRequest => {
+    return buildRequest({
+      globalToken: data.alsoInGlobalSlot
+        ? mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalSSO,
+          })
+        : undefined,
+      projectTokens: [
+        {
+          projectId,
+          token: mintProjectToken({
+            userId,
+            projectId,
+            providerId,
+            providerType: data.projectSlotType,
+          }),
+        },
+      ],
+    });
+  };
+
+  test("with the provider disabled, the legacy GlobalSSO-typed token no longer buys 30 days of access", async () => {
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildLegacyRequest({
+          projectSlotType: SsoProviderType.GlobalSSO,
+          alsoInGlobalSlot: true,
+        }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(false);
+
+    // It really did go through the stateful path rather than being dropped.
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("the SAME request with the project-slot token typed ProjectSSO short-circuits and is allowed", async () => {
+    /*
+     * The pairing that keeps the test above honest: a blanket-deny
+     * implementation would fail here. A properly project-typed token is a
+     * project login, decided statelessly, so the disabled GLOBAL provider is
+     * irrelevant to it.
+     */
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildLegacyRequest({
+          projectSlotType: SsoProviderType.ProjectSSO,
+          alsoInGlobalSlot: true,
+        }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(true);
+
+    expectNoDatabaseLookups();
+  });
+
+  test("a legacy GlobalOIDC-typed token in the project slot is refused the same way", async () => {
+    oidcTrustSpy.mockResolvedValue(REVOKED);
+
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalOIDC,
+      }),
+      projectTokens: [
+        {
+          projectId,
+          token: mintProjectToken({
+            userId,
+            projectId,
+            providerId,
+            providerType: SsoProviderType.GlobalOIDC,
+          }),
+        },
+      ],
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+
+    expect(oidcTrustSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a legacy Global-typed token ALONE in the project slot is not a credential at all", async () => {
+    // Provider perfectly healthy - the refusal is about the slot and type.
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildLegacyRequest({
+          projectSlotType: SsoProviderType.GlobalSSO,
+          alsoInGlobalSlot: false,
+        }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(false);
+
+    // There was no global token to check, so nothing was looked up.
+    expectNoDatabaseLookups();
+  });
+
+  test("moving that same credential into the global slot makes it work again", async () => {
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildRequest({
+          globalToken: mintGlobalToken({
+            userId,
+            providerId,
+            providerType: SsoProviderType.GlobalSSO,
+          }),
+        }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * Every stateless gate must be decided BEFORE the database is consulted. Two
+ * reasons: a forged or expired token should never cost a query (this path runs
+ * on every authenticated request), and a lookup that ran first would make the
+ * request's fate depend on database health for tokens that were never valid
+ * in the first place.
+ */
+describe("isSsoSatisfiedForProject - stateless gates run before the database", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  const validGlobalToken: () => string = (): string => {
+    return mintGlobalToken({
+      userId,
+      providerId,
+      providerType: SsoProviderType.GlobalSSO,
+    });
+  };
+
+  test("no token at all -> false, no lookups", async () => {
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildRequest({}),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+  });
+
+  test("a token belonging to a DIFFERENT user -> false, no lookups", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: validGlobalToken(),
+    });
+    const otherUserId: ObjectID = ObjectID.generate();
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req,
+        projectId,
+        userId: otherUserId,
+      }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+
+    // The user it was minted for still gets in, via the stateful path.
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("an expired token -> false, no lookups", async () => {
+    const expiredToken: string = JSONWebToken.sign({
+      data: {
+        userId: userId,
+        name: new Name("Global SSO User"),
+        email: new Email("global-sso@oneuptime.com"),
+        isMasterAdmin: false,
+        isGeneralLogin: false,
+        ssoProviderId: providerId.toString(),
+        ssoProviderType: SsoProviderType.GlobalSSO.toString(),
+      },
+      expiresInSeconds: -60,
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildRequest({ globalToken: expiredToken }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+
+    // The identical payload, unexpired, is allowed.
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildRequest({ globalToken: validGlobalToken() }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("a token whose payload was edited after signing -> false, no lookups", async () => {
+    const genuine: string = validGlobalToken();
+    const parts: Array<string> = genuine.split(".");
+
+    const payload: Record<string, unknown> = JSON.parse(
+      Buffer.from(parts[1] as string, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+
+    // Re-point the token at a provider the attacker would rather use.
+    payload["ssoProviderId"] = ObjectID.generate().toString();
+
+    const forged: string = `${parts[0]}.${Buffer.from(
+      JSON.stringify(payload),
+      "utf8",
+    ).toString("base64url")}.${parts[2]}`;
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildRequest({ globalToken: forged }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+
+    // The untampered token is allowed, so the refusal is about the edit.
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req: buildRequest({ globalToken: genuine }),
+        projectId,
+        userId,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("a project pinned to a DIFFERENT provider -> false, no lookups", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: validGlobalToken(),
+    });
+    const requiredProviderId: ObjectID = ObjectID.generate();
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req,
+        projectId,
+        userId,
+        requiredSsoProviderId: requiredProviderId,
+      }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+
+    // Pinned to the provider the token actually carries -> allowed.
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({
+        req,
+        projectId,
+        userId,
+        requiredSsoProviderId: providerId,
+      }),
+    ).resolves.toBe(true);
+
+    expect(ssoTrustSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a project-typed token sitting in the global slot -> false, no lookups", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintProjectToken({
+        userId,
+        projectId,
+        providerId,
+        providerType: SsoProviderType.ProjectSSO,
+      }),
+    });
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+
+    expectNoDatabaseLookups();
+  });
+});
+
+/*
+ * `doesSsoTokenForProjectExist` is the STATELESS half only. It is kept for the
+ * existing suites and for callers that just want to know whether a credential
+ * is present and well-formed - it is NOT enforcement, and this test exists so
+ * that anyone tempted to wire a middleware back to it sees the divergence
+ * spelled out: it answers "yes" for a token whose provider an admin revoked
+ * an hour ago.
+ */
+describe("doesSsoTokenForProjectExist is NOT the enforcement entry point", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const providerId: ObjectID = ObjectID.generate();
+
+  test("the sync check says yes where the enforcement check refuses (disabled provider)", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    });
+
+    ssoTrustSpy.mockResolvedValue(REVOKED);
+
+    // Stateless: the token is genuine, unexpired, and for this user.
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, userId),
+    ).toBe(true);
+
+    // Stateful: the provider behind it is gone, so the request is refused.
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+  });
+
+  test("the sync check says yes where the enforcement check refuses (restrict-on, unattached project)", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    });
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_RESTRICTED);
+    ssoGovernsSpy.mockResolvedValue(false);
+
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, userId),
+    ).toBe(true);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(false);
+  });
+
+  test("the two agree whenever the provider is healthy - the divergence is only about revocation", async () => {
+    const req: ExpressRequest = buildRequest({
+      globalToken: mintGlobalToken({
+        userId,
+        providerId,
+        providerType: SsoProviderType.GlobalSSO,
+      }),
+    });
+
+    ssoTrustSpy.mockResolvedValue(TRUSTED_AND_UNRESTRICTED);
+
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, userId),
+    ).toBe(true);
+
+    await expect(
+      UserMiddleware.isSsoSatisfiedForProject({ req, projectId, userId }),
+    ).resolves.toBe(true);
+  });
+});

--- a/Common/Tests/Server/Middleware/UserAuthorizationSSOProvider.test.ts
+++ b/Common/Tests/Server/Middleware/UserAuthorizationSSOProvider.test.ts
@@ -33,20 +33,29 @@ describe("UserMiddleware.doesSsoTokenForProjectExist - requiredSsoProviderId", (
     return u;
   };
 
-  // Build a request whose cookies carry a real `sso-<projectId>` token.
+  /*
+   * Build a request whose cookies carry a real `sso-<projectId>` token.
+   *
+   * The type defaults to ProjectSSO because that is what a PROJECT SSO login
+   * actually mints, and the project-scoped slot now refuses Global-typed
+   * credentials outright - see the "legacy Global-typed token" block below for
+   * why, and for the tests that pin it.
+   */
   const buildRequestWithSsoToken: (data: {
     tokenProjectId: ObjectID;
     discriminatorProviderId?: ObjectID | undefined;
+    ssoProviderType?: SsoProviderType | undefined;
   }) => ExpressRequest = (data: {
     tokenProjectId: ObjectID;
     discriminatorProviderId?: ObjectID | undefined;
+    ssoProviderType?: SsoProviderType | undefined;
   }): ExpressRequest => {
     const token: string = CookieUtil.getSSOToken({
       user: buildUser(),
       projectId: data.tokenProjectId,
       ssoProviderId: data.discriminatorProviderId,
       ssoProviderType: data.discriminatorProviderId
-        ? SsoProviderType.GlobalSSO
+        ? data.ssoProviderType || SsoProviderType.ProjectSSO
         : undefined,
     });
 
@@ -170,6 +179,86 @@ describe("UserMiddleware.doesSsoTokenForProjectExist - requiredSsoProviderId", (
  * a matching token. The token is sourced from the `global-sso-token` cookie
  * (web) or the `x-global-sso-token` header (mobile).
  */
+/*
+ * A Global-typed credential must never be accepted from the per-project slot.
+ *
+ * Before the single-token redesign, the Global SSO router fanned out one
+ * per-project `sso-<projectId>` cookie per project the user belonged to, typed
+ * GlobalSSO and signed for 30 days. Those are still in browsers, and the
+ * mobile app still replays every non-expired stored token as `x-sso-tokens`.
+ * If the project slot accepted them, they would short-circuit past the
+ * provider-trust check - so disabling a provider would still not revoke them,
+ * for up to a month. They are refused here instead, which sends the user
+ * through a fresh global login that mints a properly-typed token.
+ */
+describe("UserMiddleware.doesSsoTokenForProjectExist - legacy Global-typed token in the project slot", () => {
+  const legacyProjectId: ObjectID = ObjectID.generate();
+  const legacyUserId: ObjectID = ObjectID.generate();
+  const legacyProviderId: ObjectID = ObjectID.generate();
+
+  const buildLegacyRequest: (
+    ssoProviderType: SsoProviderType,
+  ) => ExpressRequest = (ssoProviderType: SsoProviderType): ExpressRequest => {
+    const user: User = new User();
+    user.id = legacyUserId;
+    user.email = new Email("legacy-sso-user@oneuptime.com");
+
+    const token: string = CookieUtil.getSSOToken({
+      user,
+      projectId: legacyProjectId,
+      ssoProviderId: legacyProviderId,
+      ssoProviderType,
+    });
+
+    return {
+      cookies: {
+        [CookieUtil.getUserSSOKey(legacyProjectId)]: token,
+      },
+      headers: {},
+    } as unknown as ExpressRequest;
+  };
+
+  test("a GlobalSSO-typed token in the project slot is refused", () => {
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildLegacyRequest(SsoProviderType.GlobalSSO),
+        legacyProjectId,
+        legacyUserId,
+      ),
+    ).toBe(false);
+  });
+
+  test("a GlobalOIDC-typed token in the project slot is refused", () => {
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildLegacyRequest(SsoProviderType.GlobalOIDC),
+        legacyProjectId,
+        legacyUserId,
+      ),
+    ).toBe(false);
+  });
+
+  test("the SAME token typed ProjectSSO is accepted, so the refusal is about the type and nothing else", () => {
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildLegacyRequest(SsoProviderType.ProjectSSO),
+        legacyProjectId,
+        legacyUserId,
+      ),
+    ).toBe(true);
+  });
+
+  test("a ProjectOIDC-typed token in the project slot is accepted", () => {
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildLegacyRequest(SsoProviderType.ProjectOIDC),
+        legacyProjectId,
+        legacyUserId,
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("UserMiddleware.doesSsoTokenForProjectExist - global SSO token", () => {
   const projectId: ObjectID = ObjectID.generate();
   const otherProjectId: ObjectID = ObjectID.generate();

--- a/Common/Tests/Server/Services/GlobalSsoProviderAuthorization.test.ts
+++ b/Common/Tests/Server/Services/GlobalSsoProviderAuthorization.test.ts
@@ -1,0 +1,1242 @@
+import GlobalOidcProjectService from "../../../Server/Services/GlobalOidcProjectService";
+import GlobalOidcService from "../../../Server/Services/GlobalOidcService";
+import GlobalSsoProjectService from "../../../Server/Services/GlobalSsoProjectService";
+import GlobalSsoService from "../../../Server/Services/GlobalSsoService";
+import GlobalOidc from "../../../Models/DatabaseModels/GlobalOidc";
+import GlobalOidcProject from "../../../Models/DatabaseModels/GlobalOidcProject";
+import GlobalSso from "../../../Models/DatabaseModels/GlobalSso";
+import GlobalSsoProject from "../../../Models/DatabaseModels/GlobalSsoProject";
+import {
+  GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+  GlobalProviderTrust,
+  clearGlobalSsoAuthorizationCaches,
+} from "../../../Server/Utils/GlobalSsoAuthorization";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The STATEFUL half of Global SSO / Global OIDC enforcement.
+ *
+ * A Global SSO/OIDC token is a self-contained 30-day JWT with no project
+ * binding. Its signature, expiry, type, user and pinned-provider checks are
+ * pinned elsewhere (Common/Tests/Server/Utils/GlobalSSOToken.test.ts and
+ * Common/Tests/Server/Middleware/UserAuthorizationSSOProvider.test.ts) and
+ * together they can only ever answer "this person authenticated against SOME
+ * instance-wide provider within the last month". This file pins the two
+ * questions the token itself cannot answer, and which therefore have to be
+ * asked of Postgres on every request:
+ *
+ *   1. IS THE PROVIDER STILL TRUSTED? getProviderTrust().isUsable - the admin
+ *      "Enabled" toggle, and a delete, must cut access off now rather than in
+ *      thirty days.
+ *   2. DOES THE PROVIDER GOVERN THIS PROJECT? doesProviderGovernProject() -
+ *      consulted only for a provider whose admin opted into
+ *      `restrictToAttachedProjects`, because attachments are the PROVISIONING
+ *      allow-list by default and reading them as an access boundary for
+ *      everyone would lock existing users out on upgrade.
+ *
+ * Because both run per-request they are backed by 60s in-process caches, so
+ * the caching is part of the contract and not an implementation detail:
+ *
+ *   - a cached `false` that is dropped (the classic truthiness-cache bug) is a
+ *     query per request for exactly the providers an attacker is hammering;
+ *   - a cache that is not invalidated on write turns an admin's "Disable"
+ *     click into a no-op for a minute;
+ *   - and the invalidation has to run in the SUCCESS hook, not only the
+ *     before-hook: a clear that lands before the row is written can be
+ *     re-filled with the PRE-change answer by a concurrent request on the same
+ *     node, handing the disabled provider another full TTL of life.
+ *
+ * Nothing here touches a database. findOneBy/findBy are spied on each service
+ * so the test both controls the rows AND counts the round trips.
+ *
+ * Deliberately NOT covered here (they belong to the middleware suites):
+ * isGlobalSsoTokenAuthorizedForProject, isSsoSatisfiedForProject, and the
+ * token-shaped checks in UserAuthorization.
+ */
+
+const PROVIDER_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_PROVIDER_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+/*
+ * One id used against BOTH the SSO service and the OIDC service. The two live
+ * in different tables and could genuinely collide, so the cache keys are
+ * namespaced; these tests are what stops that namespacing from regressing.
+ */
+const SHARED_PROVIDER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const PROJECT_A: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const PROJECT_B: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+const PROJECT_C: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+
+// The shape the services pass to findOneBy / findBy.
+interface DatabaseCallArgs {
+  query: Record<string, unknown>;
+  select: Record<string, unknown>;
+  props: Record<string, unknown>;
+  limit?: number | undefined;
+  skip?: number | undefined;
+}
+
+function spyOnQuery(service: any, methodName: string): jest.SpyInstance {
+  return jest.spyOn(service, methodName) as unknown as jest.SpyInstance;
+}
+
+function callArgs(spy: jest.SpyInstance, callIndex: number): DatabaseCallArgs {
+  const calls: Array<Array<unknown>> = spy.mock.calls as Array<Array<unknown>>;
+  const call: Array<unknown> | undefined = calls[callIndex];
+
+  expect(call).toBeDefined();
+
+  return (call as Array<unknown>)[0] as DatabaseCallArgs;
+}
+
+// Calls a protected hook without widening the service's public surface.
+function callHook(
+  service: any,
+  hookName: string,
+  args: Array<unknown>,
+): Promise<unknown> {
+  const hooks: Record<string, (...a: Array<unknown>) => Promise<unknown>> =
+    service as unknown as Record<
+      string,
+      (...a: Array<unknown>) => Promise<unknown>
+    >;
+
+  const hook: ((...a: Array<unknown>) => Promise<unknown>) | undefined =
+    hooks[hookName];
+
+  if (!hook) {
+    throw new Error(`Hook ${hookName} is not defined on the service`);
+  }
+
+  return hook.apply(service, args);
+}
+
+/*
+ * `isEnabled` / `restrictToAttachedProjects` are written through an untyped
+ * view of the row on purpose: the point of several tests below is what happens
+ * when Postgres hands back null, or the column is missing entirely (an old row
+ * read by a new binary), which the model's `boolean | undefined` type cannot
+ * express.
+ */
+function setRawColumns(
+  row: unknown,
+  columns: Record<string, unknown>,
+): unknown {
+  const mutable: Record<string, unknown> = row as Record<string, unknown>;
+
+  for (const columnName of Object.keys(columns)) {
+    mutable[columnName] = columns[columnName];
+  }
+
+  return row;
+}
+
+interface AttachmentRowSpec {
+  projectId: ObjectID | undefined;
+  isEnabled: unknown;
+}
+
+beforeEach(() => {
+  /*
+   * The caches live at module scope, so without this a `true` cached by one
+   * test would answer the next test's question before its stub ever ran.
+   */
+  clearGlobalSsoAuthorizationCaches();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  clearGlobalSsoAuthorizationCaches();
+});
+
+/*
+ * -------------------------------------------------------------------------
+ * getProviderTrust
+ * ----------------------------------------------------------------------
+ */
+
+interface TrustSuite {
+  name: string;
+  service: any;
+  getTrust: (providerId: ObjectID) => Promise<GlobalProviderTrust>;
+  buildRow: (isEnabled: unknown, restrict: unknown) => unknown;
+}
+
+const TRUST_SUITES: Array<TrustSuite> = [
+  {
+    name: "GlobalSsoService",
+    service: GlobalSsoService,
+    getTrust: (providerId: ObjectID): Promise<GlobalProviderTrust> => {
+      return GlobalSsoService.getProviderTrust(providerId);
+    },
+    buildRow: (isEnabled: unknown, restrict: unknown): unknown => {
+      const row: GlobalSso = new GlobalSso();
+      row.id = PROVIDER_ID;
+      return setRawColumns(row, {
+        isEnabled: isEnabled,
+        restrictToAttachedProjects: restrict,
+      });
+    },
+  },
+  {
+    name: "GlobalOidcService",
+    service: GlobalOidcService,
+    getTrust: (providerId: ObjectID): Promise<GlobalProviderTrust> => {
+      return GlobalOidcService.getProviderTrust(providerId);
+    },
+    buildRow: (isEnabled: unknown, restrict: unknown): unknown => {
+      const row: GlobalOidc = new GlobalOidc();
+      row.id = PROVIDER_ID;
+      return setRawColumns(row, {
+        isEnabled: isEnabled,
+        restrictToAttachedProjects: restrict,
+      });
+    },
+  },
+];
+
+describe.each(TRUST_SUITES)(
+  "$name.getProviderTrust",
+  (suite: TrustSuite): void => {
+    function stubRow(row: unknown): jest.SpyInstance {
+      const spy: jest.SpyInstance = spyOnQuery(suite.service, "findOneBy");
+      spy.mockResolvedValue(row);
+      return spy;
+    }
+
+    test("enabled, not restricted -> usable and instance-wide", async () => {
+      stubRow(suite.buildRow(true, false));
+
+      const trust: GlobalProviderTrust = await suite.getTrust(PROVIDER_ID);
+
+      expect(trust).toEqual({
+        isUsable: true,
+        restrictToAttachedProjects: false,
+      });
+    });
+
+    test("enabled and restricted -> usable, and the opt-in is reported", async () => {
+      stubRow(suite.buildRow(true, true));
+
+      const trust: GlobalProviderTrust = await suite.getTrust(PROVIDER_ID);
+
+      expect(trust).toEqual({
+        isUsable: true,
+        restrictToAttachedProjects: true,
+      });
+    });
+
+    test("disabled -> NOT usable, whether or not it is restricted", async () => {
+      /*
+       * "Disabled" has exactly one meaning. This is the check that makes the
+       * admin toggle revoke the 30-day tokens the provider already minted, so
+       * the restrict flag must not be able to soften it in either direction.
+       */
+      const unrestricted: jest.SpyInstance = stubRow(
+        suite.buildRow(false, false),
+      );
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+
+      unrestricted.mockRestore();
+      clearGlobalSsoAuthorizationCaches();
+
+      stubRow(suite.buildRow(false, true));
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+    });
+
+    test("the SAME row is usable once isEnabled is flipped back on", async () => {
+      /*
+       * The pair for the two denials above: identical setup, one field
+       * changed. Without this an implementation that always answered `false`
+       * would satisfy the disabled cases.
+       */
+      stubRow(suite.buildRow(true, true));
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+    });
+
+    test("a deleted provider (no row) -> not usable, not restricted", async () => {
+      stubRow(null);
+
+      expect(await suite.getTrust(PROVIDER_ID)).toEqual({
+        isUsable: false,
+        restrictToAttachedProjects: false,
+      });
+    });
+
+    test.each([
+      ["undefined", undefined],
+      ["null", null],
+    ])(
+      "isEnabled %s fails CLOSED, and the same row with true is open",
+      async (_label: string, missingValue: unknown) => {
+        stubRow(suite.buildRow(missingValue, true));
+
+        expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+
+        jest.restoreAllMocks();
+        clearGlobalSsoAuthorizationCaches();
+
+        stubRow(suite.buildRow(true, true));
+
+        expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+      },
+    );
+
+    test.each([
+      ["undefined", undefined],
+      ["null", null],
+    ])(
+      "restrictToAttachedProjects %s fails CLOSED to the safe DEFAULT, and true opts in",
+      async (_label: string, missingValue: unknown) => {
+        stubRow(suite.buildRow(true, missingValue));
+
+        /*
+         * "Closed" for THIS flag means `false` - the default every existing
+         * installation gets, where a global login satisfies every project the
+         * user belongs to. A null read as `true` would silently start denying
+         * projects nobody attached.
+         */
+        expect(
+          (await suite.getTrust(PROVIDER_ID)).restrictToAttachedProjects,
+        ).toBe(false);
+
+        jest.restoreAllMocks();
+        clearGlobalSsoAuthorizationCaches();
+
+        stubRow(suite.buildRow(true, true));
+
+        expect(
+          (await suite.getTrust(PROVIDER_ID)).restrictToAttachedProjects,
+        ).toBe(true);
+      },
+    );
+
+    test("the SELECT asks for restrictToAttachedProjects", async () => {
+      /*
+       * If the column is not selected, the hydrated row carries `undefined`,
+       * `Boolean(undefined)` is false, and the admin's opt-in silently never
+       * takes effect - a bug no behavioural assertion above would catch,
+       * because "not restricted" is also the legitimate default.
+       */
+      const spy: jest.SpyInstance = stubRow(suite.buildRow(true, true));
+
+      await suite.getTrust(PROVIDER_ID);
+
+      const args: DatabaseCallArgs = callArgs(spy, 0);
+
+      expect(args.select["restrictToAttachedProjects"]).toBe(true);
+      expect(args.select["isEnabled"]).toBe(true);
+      expect(args.query["_id"]).toBe(PROVIDER_ID.toString());
+      expect(args.props["isRoot"]).toBe(true);
+    });
+
+    test("a repeat question does NOT hit the database", async () => {
+      const spy: jest.SpyInstance = stubRow(suite.buildRow(true, false));
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("a DISABLED provider is cached too - it must not re-query per request", async () => {
+      /*
+       * The truthiness-cache bug: a cached `{ isUsable: false }` that reads as
+       * a miss means every single request against a revoked provider pays a
+       * query, which is precisely the traffic an attacker with a stale token
+       * generates.
+       */
+      const spy: jest.SpyInstance = stubRow(suite.buildRow(false, false));
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("a 'row not found' answer is cached too", async () => {
+      const spy: jest.SpyInstance = stubRow(null);
+
+      await suite.getTrust(PROVIDER_ID);
+      await suite.getTrust(PROVIDER_ID);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("different provider ids are cached independently", async () => {
+      const spy: jest.SpyInstance = spyOnQuery(suite.service, "findOneBy");
+
+      spy.mockImplementation((async (
+        findBy: DatabaseCallArgs,
+      ): Promise<unknown> => {
+        return findBy.query["_id"] === PROVIDER_ID.toString()
+          ? suite.buildRow(true, false)
+          : suite.buildRow(false, false);
+      }) as never);
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+      expect((await suite.getTrust(OTHER_PROVIDER_ID)).isUsable).toBe(false);
+
+      // Two distinct ids, two queries - one answer did not stand in for the other.
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      // And both are now cached, each under its own key.
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+      expect((await suite.getTrust(OTHER_PROVIDER_ID)).isUsable).toBe(false);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    test("concurrent misses for one provider share a single query", async () => {
+      /*
+       * The multi-tenant permission path fans out over every project the user
+       * belongs to at once. Without in-flight de-duplication a cold cache
+       * means one query per project for the same provider.
+       */
+      const spy: jest.SpyInstance = stubRow(suite.buildRow(true, false));
+
+      const answers: Array<GlobalProviderTrust> = await Promise.all([
+        suite.getTrust(PROVIDER_ID),
+        suite.getTrust(PROVIDER_ID),
+        suite.getTrust(PROVIDER_ID),
+        suite.getTrust(PROVIDER_ID),
+        suite.getTrust(PROVIDER_ID),
+      ]);
+
+      expect(
+        answers.every((trust: GlobalProviderTrust): boolean => {
+          return trust.isUsable;
+        }),
+      ).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("the cached answer expires after the TTL, so re-enabling takes effect", async () => {
+      const nowSpy: jest.SpyInstance = jest.spyOn(Date, "now");
+      let clock: number = 1_700_000_000_000;
+      nowSpy.mockImplementation((): number => {
+        return clock;
+      });
+
+      const spy: jest.SpyInstance = spyOnQuery(suite.service, "findOneBy");
+      spy.mockResolvedValue(suite.buildRow(false, false));
+
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+
+      // Still inside the window: served from cache, the new row is not seen.
+      spy.mockResolvedValue(suite.buildRow(true, false));
+      clock += GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS - 1;
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // Past the window: re-read, and the provider is live again.
+      clock += 2;
+      expect((await suite.getTrust(PROVIDER_ID)).isUsable).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  },
+);
+
+describe("getProviderTrust - the SSO and OIDC caches are separate namespaces", () => {
+  test("one id, enabled as SSO and disabled as OIDC, keeps two answers", async () => {
+    const ssoSpy: jest.SpyInstance = spyOnQuery(GlobalSsoService, "findOneBy");
+    const ssoRow: GlobalSso = new GlobalSso();
+    ssoRow.id = SHARED_PROVIDER_ID;
+    ssoSpy.mockResolvedValue(
+      setRawColumns(ssoRow, {
+        isEnabled: true,
+        restrictToAttachedProjects: false,
+      }),
+    );
+
+    const oidcSpy: jest.SpyInstance = spyOnQuery(
+      GlobalOidcService,
+      "findOneBy",
+    );
+    const oidcRow: GlobalOidc = new GlobalOidc();
+    oidcRow.id = SHARED_PROVIDER_ID;
+    oidcSpy.mockResolvedValue(
+      setRawColumns(oidcRow, {
+        isEnabled: false,
+        restrictToAttachedProjects: true,
+      }),
+    );
+
+    const ssoTrust: GlobalProviderTrust =
+      await GlobalSsoService.getProviderTrust(SHARED_PROVIDER_ID);
+    const oidcTrust: GlobalProviderTrust =
+      await GlobalOidcService.getProviderTrust(SHARED_PROVIDER_ID);
+
+    expect(ssoTrust.isUsable).toBe(true);
+    expect(oidcTrust.isUsable).toBe(false);
+    expect(oidcTrust.restrictToAttachedProjects).toBe(true);
+
+    // Neither table vouched for the other: each answered from its own query.
+    expect(ssoSpy).toHaveBeenCalledTimes(1);
+    expect(oidcSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("the reverse pairing holds too - disabled as SSO, enabled as OIDC", async () => {
+    /*
+     * The mirror of the case above. A cache that collapsed the two would
+     * happen to give the right answer for one ordering and the wrong one for
+     * the other, so both orderings are pinned.
+     */
+    const ssoSpy: jest.SpyInstance = spyOnQuery(GlobalSsoService, "findOneBy");
+    const ssoRow: GlobalSso = new GlobalSso();
+    ssoRow.id = SHARED_PROVIDER_ID;
+    ssoSpy.mockResolvedValue(
+      setRawColumns(ssoRow, {
+        isEnabled: false,
+        restrictToAttachedProjects: false,
+      }),
+    );
+
+    const oidcSpy: jest.SpyInstance = spyOnQuery(
+      GlobalOidcService,
+      "findOneBy",
+    );
+    const oidcRow: GlobalOidc = new GlobalOidc();
+    oidcRow.id = SHARED_PROVIDER_ID;
+    oidcSpy.mockResolvedValue(
+      setRawColumns(oidcRow, {
+        isEnabled: true,
+        restrictToAttachedProjects: false,
+      }),
+    );
+
+    expect(
+      (await GlobalOidcService.getProviderTrust(SHARED_PROVIDER_ID)).isUsable,
+    ).toBe(true);
+    expect(
+      (await GlobalSsoService.getProviderTrust(SHARED_PROVIDER_ID)).isUsable,
+    ).toBe(false);
+  });
+});
+
+/*
+ * -------------------------------------------------------------------------
+ * doesProviderGovernProject
+ * ----------------------------------------------------------------------
+ */
+
+interface GovernSuite {
+  name: string;
+  service: any;
+  foreignKey: string;
+  buildRows: (specs: Array<AttachmentRowSpec>) => Array<unknown>;
+  govern: (providerId: ObjectID, projectId: ObjectID) => Promise<boolean>;
+}
+
+const GOVERN_SUITES: Array<GovernSuite> = [
+  {
+    name: "GlobalSsoProjectService",
+    service: GlobalSsoProjectService,
+    foreignKey: "globalSsoId",
+    buildRows: (specs: Array<AttachmentRowSpec>): Array<unknown> => {
+      return specs.map((spec: AttachmentRowSpec): unknown => {
+        const row: GlobalSsoProject = new GlobalSsoProject();
+        row.globalSsoId = PROVIDER_ID;
+        return setRawColumns(row, {
+          projectId: spec.projectId,
+          isEnabled: spec.isEnabled,
+        });
+      });
+    },
+    govern: (providerId: ObjectID, projectId: ObjectID): Promise<boolean> => {
+      return GlobalSsoProjectService.doesProviderGovernProject({
+        globalSsoId: providerId,
+        projectId: projectId,
+      });
+    },
+  },
+  {
+    name: "GlobalOidcProjectService",
+    service: GlobalOidcProjectService,
+    foreignKey: "globalOidcId",
+    buildRows: (specs: Array<AttachmentRowSpec>): Array<unknown> => {
+      return specs.map((spec: AttachmentRowSpec): unknown => {
+        const row: GlobalOidcProject = new GlobalOidcProject();
+        row.globalOidcId = PROVIDER_ID;
+        return setRawColumns(row, {
+          projectId: spec.projectId,
+          isEnabled: spec.isEnabled,
+        });
+      });
+    },
+    govern: (providerId: ObjectID, projectId: ObjectID): Promise<boolean> => {
+      return GlobalOidcProjectService.doesProviderGovernProject({
+        globalOidcId: providerId,
+        projectId: projectId,
+      });
+    },
+  },
+];
+
+describe.each(GOVERN_SUITES)(
+  "$name.doesProviderGovernProject",
+  (suite: GovernSuite): void => {
+    function stubAttachments(
+      specs: Array<AttachmentRowSpec>,
+    ): jest.SpyInstance {
+      const spy: jest.SpyInstance = spyOnQuery(suite.service, "findBy");
+      spy.mockResolvedValue(suite.buildRows(specs));
+      return spy;
+    }
+
+    test("NO attachment rows at all -> instance-wide, every project governed", async () => {
+      /*
+       * This is the shape every existing installation is in, and it is what
+       * the login routers already treat an unattached provider as. Denying
+       * here would lock people out the moment an admin ticked the opt-in.
+       */
+      stubAttachments([]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_C)).toBe(true);
+    });
+
+    test("an attached, enabled project is governed; one outside the set is not", async () => {
+      stubAttachments([
+        { projectId: PROJECT_A, isEnabled: true },
+        { projectId: PROJECT_B, isEnabled: true },
+      ]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_B)).toBe(true);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_C)).toBe(false);
+    });
+
+    test("rows exist but ALL are disabled -> denied, NOT widened", async () => {
+      /*
+       * The widening bug. If "no ENABLED rows" collapsed into "no rows", an
+       * admin disabling the last attachment would hand the provider every
+       * project on the instance instead of none.
+       */
+      stubAttachments([
+        { projectId: PROJECT_A, isEnabled: false },
+        { projectId: PROJECT_B, isEnabled: false },
+      ]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(false);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_C)).toBe(false);
+    });
+
+    test("the same rows govern again as soon as one is re-enabled", async () => {
+      /*
+       * The pair for the all-disabled denial: identical rows, one flag
+       * flipped. A blanket `false` would pass the test above and fail here.
+       */
+      stubAttachments([
+        { projectId: PROJECT_A, isEnabled: true },
+        { projectId: PROJECT_B, isEnabled: false },
+      ]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+    });
+
+    test("a DISABLED row for our project does not borrow another project's enabled row", async () => {
+      stubAttachments([
+        { projectId: PROJECT_A, isEnabled: false },
+        { projectId: PROJECT_B, isEnabled: true },
+      ]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(false);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_B)).toBe(true);
+    });
+
+    test.each([
+      ["undefined", undefined],
+      ["null", null],
+    ])(
+      "isEnabled %s on the row fails CLOSED, and true on the same row opens it",
+      async (_label: string, missingValue: unknown) => {
+        stubAttachments([{ projectId: PROJECT_A, isEnabled: missingValue }]);
+
+        expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(false);
+
+        jest.restoreAllMocks();
+        clearGlobalSsoAuthorizationCaches();
+
+        stubAttachments([{ projectId: PROJECT_A, isEnabled: true }]);
+
+        expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      },
+    );
+
+    test("a row with no projectId is ignored, not treated as a wildcard", async () => {
+      /*
+       * `projectId` is NOT NULL in the schema, but the enforcement path must
+       * not crash on - or be widened by - a row that arrives without one.
+       */
+      stubAttachments([
+        { projectId: undefined, isEnabled: true },
+        { projectId: PROJECT_A, isEnabled: true },
+      ]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_C)).toBe(false);
+    });
+
+    test("a projectId-less row still counts as 'this provider has attachments'", async () => {
+      /*
+       * On its own such a row governs nothing, but it must not fall back to
+       * the instance-wide reading either - that would be the widening bug
+       * arriving through a different door.
+       */
+      stubAttachments([{ projectId: undefined, isEnabled: true }]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(false);
+    });
+
+    test("the query does NOT filter on isEnabled, but the SELECT asks for it", async () => {
+      /*
+       * Filtering in SQL would make "no rows" ambiguous: a provider with two
+       * disabled attachments would come back empty and be read as
+       * instance-wide. All rows are fetched and the enabled ones picked out in
+       * memory precisely so the two cases stay distinguishable.
+       */
+      const spy: jest.SpyInstance = stubAttachments([
+        { projectId: PROJECT_A, isEnabled: false },
+      ]);
+
+      await suite.govern(PROVIDER_ID, PROJECT_A);
+
+      const args: DatabaseCallArgs = callArgs(spy, 0);
+
+      expect(args.query).not.toHaveProperty("isEnabled");
+      expect(args.select["isEnabled"]).toBe(true);
+      expect(args.select["projectId"]).toBe(true);
+      expect(String(args.query[suite.foreignKey])).toBe(PROVIDER_ID.toString());
+      expect(args.props["isRoot"]).toBe(true);
+      expect(args.skip).toBe(0);
+      expect(typeof args.limit).toBe("number");
+    });
+
+    test("ONE query serves several projects - the attachment SET is what is cached", async () => {
+      const spy: jest.SpyInstance = stubAttachments([
+        { projectId: PROJECT_A, isEnabled: true },
+      ]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_C)).toBe(false);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_B)).toBe(false);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+
+      // One round trip answered both a granted and a denied question.
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("an EMPTY attachment set is cached too", async () => {
+      const spy: jest.SpyInstance = stubAttachments([]);
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      expect(await suite.govern(PROVIDER_ID, PROJECT_B)).toBe(true);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("concurrent misses for one provider share a single query", async () => {
+      const spy: jest.SpyInstance = stubAttachments([
+        { projectId: PROJECT_A, isEnabled: true },
+      ]);
+
+      const answers: Array<boolean> = await Promise.all([
+        suite.govern(PROVIDER_ID, PROJECT_A),
+        suite.govern(PROVIDER_ID, PROJECT_B),
+        suite.govern(PROVIDER_ID, PROJECT_C),
+        suite.govern(PROVIDER_ID, PROJECT_A),
+      ]);
+
+      expect(answers).toEqual([true, false, false, true]);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test("the cached attachment set expires after the TTL", async () => {
+      const nowSpy: jest.SpyInstance = jest.spyOn(Date, "now");
+      let clock: number = 1_700_000_000_000;
+      nowSpy.mockImplementation((): number => {
+        return clock;
+      });
+
+      const spy: jest.SpyInstance = spyOnQuery(suite.service, "findBy");
+      spy.mockResolvedValue(
+        suite.buildRows([{ projectId: PROJECT_A, isEnabled: true }]),
+      );
+
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+
+      spy.mockResolvedValue(
+        suite.buildRows([{ projectId: PROJECT_A, isEnabled: false }]),
+      );
+
+      clock += GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS - 1;
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      clock += 2;
+      expect(await suite.govern(PROVIDER_ID, PROJECT_A)).toBe(false);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  },
+);
+
+describe("doesProviderGovernProject - the SSO and OIDC caches are separate namespaces", () => {
+  test("one id governs different project sets under each provider type", async () => {
+    const ssoSpy: jest.SpyInstance = spyOnQuery(
+      GlobalSsoProjectService,
+      "findBy",
+    );
+    const ssoRow: GlobalSsoProject = new GlobalSsoProject();
+    ssoRow.globalSsoId = SHARED_PROVIDER_ID;
+    ssoSpy.mockResolvedValue([
+      setRawColumns(ssoRow, { projectId: PROJECT_A, isEnabled: true }),
+    ]);
+
+    const oidcSpy: jest.SpyInstance = spyOnQuery(
+      GlobalOidcProjectService,
+      "findBy",
+    );
+    const oidcRow: GlobalOidcProject = new GlobalOidcProject();
+    oidcRow.globalOidcId = SHARED_PROVIDER_ID;
+    oidcSpy.mockResolvedValue([
+      setRawColumns(oidcRow, { projectId: PROJECT_B, isEnabled: true }),
+    ]);
+
+    const ssoGovernsA: boolean =
+      await GlobalSsoProjectService.doesProviderGovernProject({
+        globalSsoId: SHARED_PROVIDER_ID,
+        projectId: PROJECT_A,
+      });
+    const ssoGovernsB: boolean =
+      await GlobalSsoProjectService.doesProviderGovernProject({
+        globalSsoId: SHARED_PROVIDER_ID,
+        projectId: PROJECT_B,
+      });
+    const oidcGovernsA: boolean =
+      await GlobalOidcProjectService.doesProviderGovernProject({
+        globalOidcId: SHARED_PROVIDER_ID,
+        projectId: PROJECT_A,
+      });
+    const oidcGovernsB: boolean =
+      await GlobalOidcProjectService.doesProviderGovernProject({
+        globalOidcId: SHARED_PROVIDER_ID,
+        projectId: PROJECT_B,
+      });
+
+    expect(ssoGovernsA).toBe(true);
+    expect(ssoGovernsB).toBe(false);
+    expect(oidcGovernsA).toBe(false);
+    expect(oidcGovernsB).toBe(true);
+
+    expect(ssoSpy).toHaveBeenCalledTimes(1);
+    expect(oidcSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * -------------------------------------------------------------------------
+ * Cache invalidation on write
+ * ----------------------------------------------------------------------
+ */
+
+interface CacheProbes {
+  ssoTrust: jest.SpyInstance;
+  oidcTrust: jest.SpyInstance;
+  ssoAttachments: jest.SpyInstance;
+  oidcAttachments: jest.SpyInstance;
+}
+
+function installProbes(): CacheProbes {
+  const ssoTrust: jest.SpyInstance = spyOnQuery(GlobalSsoService, "findOneBy");
+  const ssoRow: GlobalSso = new GlobalSso();
+  ssoRow.id = PROVIDER_ID;
+  ssoTrust.mockResolvedValue(
+    setRawColumns(ssoRow, {
+      isEnabled: true,
+      restrictToAttachedProjects: true,
+    }),
+  );
+
+  const oidcTrust: jest.SpyInstance = spyOnQuery(
+    GlobalOidcService,
+    "findOneBy",
+  );
+  const oidcRow: GlobalOidc = new GlobalOidc();
+  oidcRow.id = PROVIDER_ID;
+  oidcTrust.mockResolvedValue(
+    setRawColumns(oidcRow, {
+      isEnabled: true,
+      restrictToAttachedProjects: true,
+    }),
+  );
+
+  const ssoAttachments: jest.SpyInstance = spyOnQuery(
+    GlobalSsoProjectService,
+    "findBy",
+  );
+  const ssoAttachmentRow: GlobalSsoProject = new GlobalSsoProject();
+  ssoAttachmentRow.globalSsoId = PROVIDER_ID;
+  ssoAttachments.mockResolvedValue([
+    setRawColumns(ssoAttachmentRow, {
+      projectId: PROJECT_A,
+      isEnabled: true,
+    }),
+  ]);
+
+  const oidcAttachments: jest.SpyInstance = spyOnQuery(
+    GlobalOidcProjectService,
+    "findBy",
+  );
+  const oidcAttachmentRow: GlobalOidcProject = new GlobalOidcProject();
+  oidcAttachmentRow.globalOidcId = PROVIDER_ID;
+  oidcAttachments.mockResolvedValue([
+    setRawColumns(oidcAttachmentRow, {
+      projectId: PROJECT_A,
+      isEnabled: true,
+    }),
+  ]);
+
+  return {
+    ssoTrust: ssoTrust,
+    oidcTrust: oidcTrust,
+    ssoAttachments: ssoAttachments,
+    oidcAttachments: oidcAttachments,
+  };
+}
+
+// Asks all four cached questions, so one hook call can be checked against all.
+async function askEverything(): Promise<void> {
+  await GlobalSsoService.getProviderTrust(PROVIDER_ID);
+  await GlobalOidcService.getProviderTrust(PROVIDER_ID);
+  await GlobalSsoProjectService.doesProviderGovernProject({
+    globalSsoId: PROVIDER_ID,
+    projectId: PROJECT_A,
+  });
+  await GlobalOidcProjectService.doesProviderGovernProject({
+    globalOidcId: PROVIDER_ID,
+    projectId: PROJECT_A,
+  });
+}
+
+function expectQueryCounts(probes: CacheProbes, expected: number): void {
+  expect(probes.ssoTrust).toHaveBeenCalledTimes(expected);
+  expect(probes.oidcTrust).toHaveBeenCalledTimes(expected);
+  expect(probes.ssoAttachments).toHaveBeenCalledTimes(expected);
+  expect(probes.oidcAttachments).toHaveBeenCalledTimes(expected);
+}
+
+interface HookCase {
+  hookName: string;
+  buildArgs: () => Array<unknown>;
+}
+
+interface HookSuite {
+  name: string;
+  service: any;
+  hookCases: Array<HookCase>;
+}
+
+function buildProviderHookCases(buildRow: () => unknown): Array<HookCase> {
+  const createBy: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return { data: buildRow(), props: { isRoot: true } };
+  };
+
+  const updateBy: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return {
+      query: { _id: PROVIDER_ID.toString() },
+      data: { isEnabled: false },
+      props: { isRoot: true },
+    };
+  };
+
+  const deleteBy: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return { query: { _id: PROVIDER_ID.toString() }, props: { isRoot: true } };
+  };
+
+  return [
+    {
+      hookName: "onBeforeCreate",
+      buildArgs: (): Array<unknown> => {
+        return [createBy()];
+      },
+    },
+    {
+      hookName: "onCreateSuccess",
+      buildArgs: (): Array<unknown> => {
+        return [{ createBy: createBy(), carryForward: null }, buildRow()];
+      },
+    },
+    {
+      hookName: "onBeforeUpdate",
+      buildArgs: (): Array<unknown> => {
+        return [updateBy()];
+      },
+    },
+    {
+      hookName: "onUpdateSuccess",
+      buildArgs: (): Array<unknown> => {
+        return [{ updateBy: updateBy(), carryForward: null }, [PROVIDER_ID]];
+      },
+    },
+    {
+      hookName: "onBeforeDelete",
+      buildArgs: (): Array<unknown> => {
+        return [deleteBy()];
+      },
+    },
+    {
+      hookName: "onDeleteSuccess",
+      buildArgs: (): Array<unknown> => {
+        return [{ deleteBy: deleteBy(), carryForward: null }, [PROVIDER_ID]];
+      },
+    },
+  ];
+}
+
+function buildAttachmentHookCases(
+  foreignKey: string,
+  buildRow: () => unknown,
+): Array<HookCase> {
+  const createBy: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    // No `teams`, so the create hook's team validation is a no-op here.
+    return { data: buildRow(), props: { isRoot: true } };
+  };
+
+  const updateBy: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return {
+      query: { [foreignKey]: PROVIDER_ID },
+      data: { isEnabled: false },
+      props: { isRoot: true },
+    };
+  };
+
+  const deleteBy: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return { query: { [foreignKey]: PROVIDER_ID }, props: { isRoot: true } };
+  };
+
+  return [
+    {
+      hookName: "onBeforeCreate",
+      buildArgs: (): Array<unknown> => {
+        return [createBy()];
+      },
+    },
+    {
+      hookName: "onCreateSuccess",
+      buildArgs: (): Array<unknown> => {
+        return [{ createBy: createBy(), carryForward: null }, buildRow()];
+      },
+    },
+    {
+      hookName: "onBeforeUpdate",
+      buildArgs: (): Array<unknown> => {
+        return [updateBy()];
+      },
+    },
+    {
+      hookName: "onUpdateSuccess",
+      buildArgs: (): Array<unknown> => {
+        return [{ updateBy: updateBy(), carryForward: null }, [PROVIDER_ID]];
+      },
+    },
+    {
+      hookName: "onBeforeDelete",
+      buildArgs: (): Array<unknown> => {
+        return [deleteBy()];
+      },
+    },
+    {
+      hookName: "onDeleteSuccess",
+      buildArgs: (): Array<unknown> => {
+        return [{ deleteBy: deleteBy(), carryForward: null }, [PROVIDER_ID]];
+      },
+    },
+  ];
+}
+
+const HOOK_SUITES: Array<HookSuite> = [
+  {
+    name: "GlobalSsoService",
+    service: GlobalSsoService,
+    hookCases: buildProviderHookCases((): unknown => {
+      const row: GlobalSso = new GlobalSso();
+      row.id = PROVIDER_ID;
+      return row;
+    }),
+  },
+  {
+    name: "GlobalOidcService",
+    service: GlobalOidcService,
+    hookCases: buildProviderHookCases((): unknown => {
+      const row: GlobalOidc = new GlobalOidc();
+      row.id = PROVIDER_ID;
+      return row;
+    }),
+  },
+  {
+    name: "GlobalSsoProjectService",
+    service: GlobalSsoProjectService,
+    hookCases: buildAttachmentHookCases("globalSsoId", (): unknown => {
+      const row: GlobalSsoProject = new GlobalSsoProject();
+      row.globalSsoId = PROVIDER_ID;
+      row.projectId = PROJECT_A;
+      return row;
+    }),
+  },
+  {
+    name: "GlobalOidcProjectService",
+    service: GlobalOidcProjectService,
+    hookCases: buildAttachmentHookCases("globalOidcId", (): unknown => {
+      const row: GlobalOidcProject = new GlobalOidcProject();
+      row.globalOidcId = PROVIDER_ID;
+      row.projectId = PROJECT_A;
+      return row;
+    }),
+  },
+];
+
+describe("cache invalidation - the control case", () => {
+  test("with no write at all, the cached answers keep serving", async () => {
+    /*
+     * The counterpart to every invalidation test below. Without it, an
+     * implementation that simply never cached would pass the whole
+     * invalidation suite.
+     */
+    const probes: CacheProbes = installProbes();
+
+    await askEverything();
+    await askEverything();
+    await askEverything();
+
+    expectQueryCounts(probes, 1);
+  });
+});
+
+describe.each(HOOK_SUITES)(
+  "$name write hooks drop the authorization caches",
+  (suite: HookSuite): void => {
+    test.each(suite.hookCases)(
+      "$hookName re-arms every cached answer",
+      async (hookCase: HookCase) => {
+        const probes: CacheProbes = installProbes();
+
+        await askEverything();
+        await askEverything();
+        expectQueryCounts(probes, 1);
+
+        await callHook(suite.service, hookCase.hookName, hookCase.buildArgs());
+
+        await askEverything();
+        expectQueryCounts(probes, 2);
+      },
+    );
+
+    test("the SUCCESS hooks clear independently of the before-hooks", async () => {
+      /*
+       * Why both matter. The before-hook clear happens while the row still
+       * holds its OLD value, so a concurrent request on the same node can
+       * re-fill the cache with the pre-change answer between the clear and the
+       * commit - handing a provider that was just disabled another full TTL of
+       * life. The success hook is what closes that window, so it is checked on
+       * its own here rather than only as one entry in the list above.
+       */
+      const successHooks: Array<HookCase> = suite.hookCases.filter(
+        (hookCase: HookCase): boolean => {
+          return hookCase.hookName.endsWith("Success");
+        },
+      );
+
+      expect(successHooks.length).toBe(3);
+
+      for (const hookCase of successHooks) {
+        const probes: CacheProbes = installProbes();
+
+        await askEverything();
+        await askEverything();
+        expectQueryCounts(probes, 1);
+
+        // Simulates the concurrent re-fill: the cache is warm at commit time.
+        await callHook(suite.service, hookCase.hookName, hookCase.buildArgs());
+
+        await askEverything();
+        expectQueryCounts(probes, 2);
+
+        jest.restoreAllMocks();
+        clearGlobalSsoAuthorizationCaches();
+      }
+    });
+
+    test("the before-hooks pass their payload straight through", async () => {
+      installProbes();
+
+      const updateCase: HookCase | undefined = suite.hookCases.find(
+        (hookCase: HookCase): boolean => {
+          return hookCase.hookName === "onBeforeUpdate";
+        },
+      );
+      const deleteCase: HookCase | undefined = suite.hookCases.find(
+        (hookCase: HookCase): boolean => {
+          return hookCase.hookName === "onBeforeDelete";
+        },
+      );
+
+      expect(updateCase).toBeDefined();
+      expect(deleteCase).toBeDefined();
+
+      const updateArgs: Array<unknown> = (updateCase as HookCase).buildArgs();
+      const deleteArgs: Array<unknown> = (deleteCase as HookCase).buildArgs();
+
+      const onUpdate: Record<string, unknown> = (await callHook(
+        suite.service,
+        "onBeforeUpdate",
+        updateArgs,
+      )) as Record<string, unknown>;
+      const onDelete: Record<string, unknown> = (await callHook(
+        suite.service,
+        "onBeforeDelete",
+        deleteArgs,
+      )) as Record<string, unknown>;
+
+      expect(onUpdate["updateBy"]).toBe(updateArgs[0]);
+      expect(onUpdate["carryForward"]).toBeNull();
+      expect(onDelete["deleteBy"]).toBe(deleteArgs[0]);
+      expect(onDelete["carryForward"]).toBeNull();
+    });
+  },
+);

--- a/Common/Tests/Server/Utils/GlobalSsoAuthorization.test.ts
+++ b/Common/Tests/Server/Utils/GlobalSsoAuthorization.test.ts
@@ -1,0 +1,1401 @@
+import {
+  GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+  GlobalProviderAttachments,
+  GlobalProviderTrust,
+  clearGlobalSsoAuthorizationCaches,
+  doAttachmentsGovernProject,
+  globalProviderCacheKey,
+  globalSsoAttachmentsCache,
+  globalSsoProviderTrustCache,
+  loadAttachmentsOnce,
+  loadTrustOnce,
+} from "../../../Server/Utils/GlobalSsoAuthorization";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The stateful half of Global SSO enforcement, at the level of the pure
+ * helpers the two provider services are built out of.
+ *
+ * A Global SSO/OIDC token is a 30-day JWT with NO project binding. The
+ * stateless checks it can answer on its own (signature / expiry / Global type /
+ * user / pinned provider) belong to
+ * Common/Tests/Server/Utils/GlobalSSOToken.test.ts and
+ * Common/Tests/Server/Middleware/UserAuthorizationSSOProvider.test.ts, and the
+ * service-level wiring (getProviderTrust / doesProviderGovernProject actually
+ * querying Postgres, and the write hooks invalidating) belongs to
+ * Common/Tests/Server/Services/GlobalSsoProviderAuthorization.test.ts. None of
+ * that is repeated here.
+ *
+ * What this file pins down is everything those layers stand on:
+ *
+ *   - doAttachmentsGovernProject, the policy decision itself. The dangerous
+ *     case is not "attached project is allowed"; it is "rows exist but every
+ *     one of them is disabled", which must DENY. Reading that as "no
+ *     attachments, therefore instance-wide" would mean an admin disabling the
+ *     last attachment WIDENS the provider to every project on the instance.
+ *   - globalProviderCacheKey, where the dangerous case is a Global SSO row
+ *     vouching for a Global OIDC row that happens to share its id.
+ *   - the two caches, where the dangerous case is a cached negative
+ *     (isUsable:false, or an empty attachment set) being mistaken for a cache
+ *     miss - the reason the services read with an explicit `undefined` check.
+ *   - loadTrustOnce / loadAttachmentsOnce, the in-flight de-duplication that
+ *     collapses the multi-tenant permission fan-out (N projects, concurrently)
+ *     from N copies of the same query down to one.
+ */
+
+/*
+ * Minimal structural view of a jest spy - the @jest/globals and @types/jest spy
+ * types disagree in this repo, so annotate with just the surface used here.
+ * (Same workaround as Common/Tests/Server/Infrastructure/InMemoryTTLCache.test.ts.)
+ */
+type NowSpyLike = {
+  mockReturnValue: (value: number) => unknown;
+  mockRestore: () => void;
+};
+
+function spyNow(value: number): NowSpyLike {
+  const spy: NowSpyLike = jest.spyOn(Date, "now") as unknown as NowSpyLike;
+  spy.mockReturnValue(value);
+  return spy;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveFn!: (value: T) => void;
+  let rejectFn!: (error: Error) => void;
+
+  const promise: Promise<T> = new Promise<T>(
+    (resolve: (value: T) => void, reject: (error: Error) => void): void => {
+      resolveFn = resolve;
+      rejectFn = reject;
+    },
+  );
+
+  return { promise: promise, resolve: resolveFn, reject: rejectFn };
+}
+
+function attachments(data: {
+  hasAnyAttachmentRows: boolean;
+  enabledProjectIds: Array<string>;
+}): GlobalProviderAttachments {
+  return {
+    hasAnyAttachmentRows: data.hasAnyAttachmentRows,
+    enabledProjectIds: data.enabledProjectIds,
+  };
+}
+
+const USABLE_UNRESTRICTED: GlobalProviderTrust = {
+  isUsable: true,
+  restrictToAttachedProjects: false,
+};
+
+const DISABLED_PROVIDER: GlobalProviderTrust = {
+  isUsable: false,
+  restrictToAttachedProjects: false,
+};
+
+/*
+ * The caches and the in-flight maps are module-level singletons shared by every
+ * service, so each test starts and ends from a clean slate.
+ */
+beforeEach(() => {
+  clearGlobalSsoAuthorizationCaches();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  clearGlobalSsoAuthorizationCaches();
+});
+
+describe("doAttachmentsGovernProject - no attachment rows at all is instance-wide", () => {
+  test("a provider with no attachment rows governs ANY project", () => {
+    const noRows: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: false,
+      enabledProjectIds: [],
+    });
+
+    const projects: Array<ObjectID> = [
+      ObjectID.generate(),
+      ObjectID.generate(),
+      ObjectID.generate(),
+    ];
+
+    for (const projectId of projects) {
+      expect(doAttachmentsGovernProject(noRows, projectId)).toBe(true);
+    }
+  });
+
+  test("`hasAnyAttachmentRows` is the gate, not the length of the enabled list", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    /*
+     * The flag - not the emptiness of `enabledProjectIds` - decides whether the
+     * provider is in instance-wide mode. Both directions are asserted so that
+     * neither a blanket true nor a blanket false would satisfy this test.
+     */
+    expect(
+      doAttachmentsGovernProject(
+        attachments({ hasAnyAttachmentRows: false, enabledProjectIds: [] }),
+        projectId,
+      ),
+    ).toBe(true);
+
+    expect(
+      doAttachmentsGovernProject(
+        attachments({ hasAnyAttachmentRows: true, enabledProjectIds: [] }),
+        projectId,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("doAttachmentsGovernProject - explicit attachment mode", () => {
+  test("a project inside the enabled set is governed", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: [projectId.toString()],
+        }),
+        projectId,
+      ),
+    ).toBe(true);
+  });
+
+  test("a project OUTSIDE the enabled set is NOT governed", () => {
+    const attachedProject: ObjectID = ObjectID.generate();
+    const otherProject: ObjectID = ObjectID.generate();
+
+    const oneAttachment: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: [attachedProject.toString()],
+    });
+
+    // Denied for the project that is not attached...
+    expect(doAttachmentsGovernProject(oneAttachment, otherProject)).toBe(false);
+
+    // ...and granted for the one that is, from the very same attachment set.
+    expect(doAttachmentsGovernProject(oneAttachment, attachedProject)).toBe(
+      true,
+    );
+
+    // Attaching the other project as well is all it takes to flip the deny.
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: [
+            attachedProject.toString(),
+            otherProject.toString(),
+          ],
+        }),
+        otherProject,
+      ),
+    ).toBe(true);
+  });
+
+  test("THE ONE THAT MATTERS: rows exist but every one is disabled DENIES, it does not widen", () => {
+    /*
+     * An admin who disables the last remaining attachment is NARROWING the
+     * provider. If "rows exist, none enabled" collapsed into the same answer as
+     * "no rows at all", that click would instead WIDEN the provider from one
+     * project to every project on the instance - the exact opposite of the
+     * intent, and silently. Disabling an attachment must never grant access.
+     */
+    const projectId: ObjectID = ObjectID.generate();
+
+    const allAttachmentsDisabled: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: [],
+    });
+
+    expect(doAttachmentsGovernProject(allAttachmentsDisabled, projectId)).toBe(
+      false,
+    );
+
+    // The same provider, same project, with that one attachment re-enabled.
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: [projectId.toString()],
+        }),
+        projectId,
+      ),
+    ).toBe(true);
+
+    /*
+     * And deleting the rows outright (rather than disabling them) is the
+     * genuinely instance-wide state, which does grant. The two states are
+     * reached by different admin actions and must not be conflated.
+     */
+    expect(
+      doAttachmentsGovernProject(
+        attachments({ hasAnyAttachmentRows: false, enabledProjectIds: [] }),
+        projectId,
+      ),
+    ).toBe(true);
+  });
+
+  test("a large attachment set is matched at the start, middle and end", () => {
+    const target: ObjectID = ObjectID.generate();
+
+    const filler: Array<string> = [];
+    for (let index: number = 0; index < 50; index++) {
+      filler.push(ObjectID.generate().toString());
+    }
+
+    const atStart: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: [target.toString(), ...filler],
+    });
+    const atMiddle: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: [
+        ...filler.slice(0, 25),
+        target.toString(),
+        ...filler.slice(25),
+      ],
+    });
+    const atEnd: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: [...filler, target.toString()],
+    });
+
+    expect(doAttachmentsGovernProject(atStart, target)).toBe(true);
+    expect(doAttachmentsGovernProject(atMiddle, target)).toBe(true);
+    expect(doAttachmentsGovernProject(atEnd, target)).toBe(true);
+
+    // A set of the same size that simply does not contain the target denies.
+    expect(
+      doAttachmentsGovernProject(
+        attachments({ hasAnyAttachmentRows: true, enabledProjectIds: filler }),
+        target,
+      ),
+    ).toBe(false);
+  });
+
+  test("ids are compared exactly - prefixes, suffixes and case variants do not match", () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const id: string = projectId.toString();
+
+    const nearMisses: Array<string> = [
+      id.slice(0, -1), // one character short
+      `${id}0`, // one character too long
+      id.toUpperCase(), // same uuid, different case
+      ` ${id}`, // leading whitespace
+      `${id} `, // trailing whitespace
+      id.replace(/-/g, ""), // dashes stripped
+    ];
+
+    for (const nearMiss of nearMisses) {
+      expect(
+        doAttachmentsGovernProject(
+          attachments({
+            hasAnyAttachmentRows: true,
+            enabledProjectIds: [nearMiss],
+          }),
+          projectId,
+        ),
+      ).toBe(false);
+    }
+
+    // All of the near misses together still deny...
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: nearMisses,
+        }),
+        projectId,
+      ),
+    ).toBe(false);
+
+    // ...and adding the exact id to that same list grants.
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: [...nearMisses, id],
+        }),
+        projectId,
+      ),
+    ).toBe(true);
+  });
+
+  test("substring relationships between short ids never match", () => {
+    const projectId: ObjectID = new ObjectID("abc");
+
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: ["abcd"],
+        }),
+        projectId,
+      ),
+    ).toBe(false);
+    expect(
+      doAttachmentsGovernProject(
+        attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: ["zabc"],
+        }),
+        projectId,
+      ),
+    ).toBe(false);
+    expect(
+      doAttachmentsGovernProject(
+        attachments({ hasAnyAttachmentRows: true, enabledProjectIds: ["abc"] }),
+        projectId,
+      ),
+    ).toBe(true);
+  });
+
+  test("the decision does not mutate the attachment set it was handed", () => {
+    /*
+     * The cached GlobalProviderAttachments object is shared by every concurrent
+     * request for that provider, so a decision that sorted or spliced the array
+     * in place would corrupt the answer for everyone else.
+     */
+    const target: ObjectID = ObjectID.generate();
+    const enabledProjectIds: Array<string> = [
+      ObjectID.generate().toString(),
+      target.toString(),
+      ObjectID.generate().toString(),
+    ];
+    const snapshot: Array<string> = [...enabledProjectIds];
+
+    const shared: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: enabledProjectIds,
+    });
+
+    expect(doAttachmentsGovernProject(shared, target)).toBe(true);
+    expect(doAttachmentsGovernProject(shared, ObjectID.generate())).toBe(false);
+    expect(doAttachmentsGovernProject(shared, target)).toBe(true);
+
+    expect(shared.enabledProjectIds).toEqual(snapshot);
+    expect(shared.hasAnyAttachmentRows).toBe(true);
+  });
+});
+
+describe("doAttachmentsGovernProject - agreement with the login router's isDefaultAllMode", () => {
+  /*
+   * App/FeatureSet/Identity/API/GlobalSSO.ts loads the attachments with
+   * `findBy({ globalSsoId, isEnabled: true })` and then computes
+   * `const isDefaultAllMode: boolean = attachments.length === 0;`.
+   *
+   * These helpers reproduce both readings from the same raw rows so the two can
+   * be compared directly.
+   */
+  interface AttachmentRow {
+    projectId: string;
+    isEnabled: boolean;
+  }
+
+  function routerIsDefaultAllMode(rows: Array<AttachmentRow>): boolean {
+    return (
+      rows.filter((row: AttachmentRow) => {
+        return row.isEnabled;
+      }).length === 0
+    );
+  }
+
+  function toAttachments(
+    rows: Array<AttachmentRow>,
+  ): GlobalProviderAttachments {
+    // Mirrors GlobalSsoProjectService.doesProviderGovernProject's loader.
+    return {
+      hasAnyAttachmentRows: rows.length > 0,
+      enabledProjectIds: rows
+        .filter((row: AttachmentRow) => {
+          return row.isEnabled;
+        })
+        .map((row: AttachmentRow) => {
+          return row.projectId;
+        }),
+    };
+  }
+
+  test("no rows at all: both layers read it as instance-wide", () => {
+    const rows: Array<AttachmentRow> = [];
+
+    expect(routerIsDefaultAllMode(rows)).toBe(true);
+    expect(
+      doAttachmentsGovernProject(toAttachments(rows), ObjectID.generate()),
+    ).toBe(true);
+  });
+
+  test("an enabled row: both layers leave instance-wide mode", () => {
+    const attachedProject: ObjectID = ObjectID.generate();
+    const rows: Array<AttachmentRow> = [
+      { projectId: attachedProject.toString(), isEnabled: true },
+    ];
+
+    expect(routerIsDefaultAllMode(rows)).toBe(false);
+    expect(
+      doAttachmentsGovernProject(toAttachments(rows), attachedProject),
+    ).toBe(true);
+    expect(
+      doAttachmentsGovernProject(toAttachments(rows), ObjectID.generate()),
+    ).toBe(false);
+  });
+
+  test("rows that exist but are all disabled: the router widens, enforcement narrows - deliberately", () => {
+    /*
+     * The one place the two readings diverge, and it is intentional.
+     *
+     * The router's `isDefaultAllMode` only ever REMOVES capability: in
+     * default-all mode it disables SSO sign-up and skips auto-provisioning,
+     * because there is no attachment telling it which project or team to place
+     * a new user in. It never grants project access. This module's answer IS an
+     * access decision, so the same state has to deny - otherwise disabling the
+     * last attachment would hand the provider every project on the instance.
+     */
+    const attachedProject: ObjectID = ObjectID.generate();
+    const rows: Array<AttachmentRow> = [
+      { projectId: attachedProject.toString(), isEnabled: false },
+    ];
+
+    expect(routerIsDefaultAllMode(rows)).toBe(true);
+    expect(
+      doAttachmentsGovernProject(toAttachments(rows), attachedProject),
+    ).toBe(false);
+
+    // Re-enabling that same row is what grants access back.
+    expect(
+      doAttachmentsGovernProject(
+        toAttachments([
+          { projectId: attachedProject.toString(), isEnabled: true },
+        ]),
+        attachedProject,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("globalProviderCacheKey", () => {
+  test("the same provider id under 'sso' and 'oidc' produces DIFFERENT keys", () => {
+    const providerId: ObjectID = ObjectID.generate();
+
+    const ssoKey: string = globalProviderCacheKey("sso", providerId);
+    const oidcKey: string = globalProviderCacheKey("oidc", providerId);
+
+    expect(ssoKey).not.toBe(oidcKey);
+    expect(ssoKey.startsWith("sso:")).toBe(true);
+    expect(oidcKey.startsWith("oidc:")).toBe(true);
+    expect(ssoKey).toContain(providerId.toString());
+    expect(oidcKey).toContain(providerId.toString());
+  });
+
+  test("the key is stable for the same kind and id", () => {
+    const id: string = ObjectID.generate().toString();
+
+    // Two distinct ObjectID instances carrying the same id must agree.
+    expect(globalProviderCacheKey("sso", new ObjectID(id))).toBe(
+      globalProviderCacheKey("sso", new ObjectID(id)),
+    );
+    expect(globalProviderCacheKey("oidc", new ObjectID(id))).toBe(
+      globalProviderCacheKey("oidc", new ObjectID(id)),
+    );
+  });
+
+  test("different provider ids of the same kind produce different keys", () => {
+    const first: ObjectID = ObjectID.generate();
+    const second: ObjectID = ObjectID.generate();
+
+    expect(globalProviderCacheKey("sso", first)).not.toBe(
+      globalProviderCacheKey("sso", second),
+    );
+    expect(globalProviderCacheKey("oidc", first)).not.toBe(
+      globalProviderCacheKey("oidc", second),
+    );
+  });
+
+  test("no crafted id can make an OIDC key collide with an SSO key", () => {
+    /*
+     * The namespace prefix is what stops a Global OIDC row from vouching for a
+     * Global SSO row. Ids that look like a namespace of their own must not be
+     * able to forge the other side's key.
+     */
+    const crafted: Array<string> = [
+      "oidc:11111111-1111-1111-1111-111111111111",
+      "sso:11111111-1111-1111-1111-111111111111",
+      ":",
+      "",
+    ];
+
+    const ssoKeys: Array<string> = crafted.map((id: string) => {
+      return globalProviderCacheKey("sso", new ObjectID(id));
+    });
+    const oidcKeys: Array<string> = crafted.map((id: string) => {
+      return globalProviderCacheKey("oidc", new ObjectID(id));
+    });
+
+    for (const ssoKey of ssoKeys) {
+      expect(oidcKeys).not.toContain(ssoKey);
+    }
+  });
+
+  test("a trust answer stored under one namespace is invisible to the other", () => {
+    const providerId: ObjectID = ObjectID.generate();
+    const ssoKey: string = globalProviderCacheKey("sso", providerId);
+    const oidcKey: string = globalProviderCacheKey("oidc", providerId);
+
+    globalSsoProviderTrustCache.set(
+      ssoKey,
+      USABLE_UNRESTRICTED,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    // The enabled SAML provider does not make an OIDC provider of the same id usable.
+    expect(globalSsoProviderTrustCache.get(oidcKey)).toBeUndefined();
+    expect(globalSsoProviderTrustCache.get(ssoKey)).toEqual(
+      USABLE_UNRESTRICTED,
+    );
+
+    // And the OIDC side can hold the opposite answer at the same time.
+    globalSsoProviderTrustCache.set(
+      oidcKey,
+      DISABLED_PROVIDER,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.get(ssoKey)?.isUsable).toBe(true);
+    expect(globalSsoProviderTrustCache.get(oidcKey)?.isUsable).toBe(false);
+  });
+
+  test("an attachment set stored under one namespace is invisible to the other", () => {
+    const providerId: ObjectID = ObjectID.generate();
+    const projectId: ObjectID = ObjectID.generate();
+    const ssoKey: string = globalProviderCacheKey("sso", providerId);
+    const oidcKey: string = globalProviderCacheKey("oidc", providerId);
+
+    globalSsoAttachmentsCache.set(
+      ssoKey,
+      attachments({
+        hasAnyAttachmentRows: true,
+        enabledProjectIds: [projectId.toString()],
+      }),
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoAttachmentsCache.get(oidcKey)).toBeUndefined();
+
+    const cached: GlobalProviderAttachments | undefined =
+      globalSsoAttachmentsCache.get(ssoKey);
+    expect(cached).toBeDefined();
+    expect(doAttachmentsGovernProject(cached!, projectId)).toBe(true);
+  });
+});
+
+describe("the caches - round trip", () => {
+  test("the trust cache round-trips a value", () => {
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const trust: GlobalProviderTrust = {
+      isUsable: true,
+      restrictToAttachedProjects: true,
+    };
+
+    expect(globalSsoProviderTrustCache.get(key)).toBeUndefined();
+
+    globalSsoProviderTrustCache.set(
+      key,
+      trust,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(trust);
+    expect(
+      globalSsoProviderTrustCache.get(key)?.restrictToAttachedProjects,
+    ).toBe(true);
+  });
+
+  test("the attachments cache round-trips a value", () => {
+    const key: string = globalProviderCacheKey("oidc", ObjectID.generate());
+    const attached: ObjectID = ObjectID.generate();
+    const value: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: true,
+      enabledProjectIds: [attached.toString()],
+    });
+
+    expect(globalSsoAttachmentsCache.get(key)).toBeUndefined();
+
+    globalSsoAttachmentsCache.set(
+      key,
+      value,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    const cached: GlobalProviderAttachments | undefined =
+      globalSsoAttachmentsCache.get(key);
+
+    expect(cached).toEqual(value);
+    expect(doAttachmentsGovernProject(cached!, attached)).toBe(true);
+    expect(doAttachmentsGovernProject(cached!, ObjectID.generate())).toBe(
+      false,
+    );
+  });
+
+  test("the two caches are separate stores - the same key in each holds its own value", () => {
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+
+    globalSsoProviderTrustCache.set(
+      key,
+      USABLE_UNRESTRICTED,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoAttachmentsCache.get(key)).toBeUndefined();
+
+    globalSsoAttachmentsCache.set(
+      key,
+      attachments({ hasAnyAttachmentRows: false, enabledProjectIds: [] }),
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(USABLE_UNRESTRICTED);
+    expect(globalSsoAttachmentsCache.get(key)?.hasAnyAttachmentRows).toBe(
+      false,
+    );
+  });
+});
+
+describe("the caches - a cached negative is a HIT, not a miss", () => {
+  test("a cached isUsable:false is served from cache rather than re-queried", () => {
+    /*
+     * The services read with `if (cached !== undefined) { return cached; }`.
+     * A truthiness read of the interesting FIELD - `if (cached?.isUsable)` -
+     * would treat a cached "this provider is disabled" as a cache miss and send
+     * a query to Postgres on every single request from every still-signed-in
+     * holder of that provider's 30-day tokens. Exactly the population that is
+     * largest right after an admin disables a provider.
+     */
+    const disabledKey: string = globalProviderCacheKey(
+      "sso",
+      ObjectID.generate(),
+    );
+    const neverLookedUpKey: string = globalProviderCacheKey(
+      "sso",
+      ObjectID.generate(),
+    );
+
+    globalSsoProviderTrustCache.set(
+      disabledKey,
+      DISABLED_PROVIDER,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    const cachedNegative: GlobalProviderTrust | undefined =
+      globalSsoProviderTrustCache.get(disabledKey);
+
+    // The cached negative is present and says "no".
+    expect(cachedNegative).toBeDefined();
+    expect(cachedNegative).not.toBeUndefined();
+    expect(cachedNegative?.isUsable).toBe(false);
+    expect(globalSsoProviderTrustCache.has(disabledKey)).toBe(true);
+
+    // A key that was genuinely never looked up is the other answer entirely.
+    expect(globalSsoProviderTrustCache.get(neverLookedUpKey)).toBeUndefined();
+    expect(globalSsoProviderTrustCache.has(neverLookedUpKey)).toBe(false);
+
+    /*
+     * The distinction the explicit undefined check preserves, spelled out: the
+     * correct read sees a hit for the disabled provider, the truthiness-on-the-
+     * field read does not.
+     */
+    const correctReadIsAHit: boolean = cachedNegative !== undefined;
+    const truthinessOnFieldIsAHit: boolean = Boolean(cachedNegative?.isUsable);
+
+    expect(correctReadIsAHit).toBe(true);
+    expect(truthinessOnFieldIsAHit).toBe(false);
+  });
+
+  test("a cached EMPTY attachment set is a hit too - default-all does not re-query", () => {
+    const key: string = globalProviderCacheKey("oidc", ObjectID.generate());
+
+    const instanceWide: GlobalProviderAttachments = attachments({
+      hasAnyAttachmentRows: false,
+      enabledProjectIds: [],
+    });
+
+    globalSsoAttachmentsCache.set(
+      key,
+      instanceWide,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    const cached: GlobalProviderAttachments | undefined =
+      globalSsoAttachmentsCache.get(key);
+
+    expect(cached).toBeDefined();
+    expect(cached?.enabledProjectIds).toEqual([]);
+    expect(globalSsoAttachmentsCache.has(key)).toBe(true);
+
+    // An empty list is falsy-adjacent but must still count as an answer.
+    const correctReadIsAHit: boolean = cached !== undefined;
+    const truthinessOnLengthIsAHit: boolean = Boolean(
+      cached?.enabledProjectIds.length,
+    );
+
+    expect(correctReadIsAHit).toBe(true);
+    expect(truthinessOnLengthIsAHit).toBe(false);
+  });
+});
+
+describe("the caches - TTL", () => {
+  test("a trust entry survives to its TTL boundary and is gone after it", () => {
+    const t0: number = 1_700_000_000_000;
+    const nowSpy: NowSpyLike = spyNow(t0);
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+
+    globalSsoProviderTrustCache.set(
+      key,
+      USABLE_UNRESTRICTED,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(USABLE_UNRESTRICTED);
+
+    nowSpy.mockReturnValue(t0 + GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS - 1);
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(USABLE_UNRESTRICTED);
+
+    nowSpy.mockReturnValue(t0 + GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS);
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(USABLE_UNRESTRICTED);
+
+    nowSpy.mockReturnValue(t0 + GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS + 1);
+    expect(globalSsoProviderTrustCache.get(key)).toBeUndefined();
+  });
+
+  test("an expired trust entry is a miss, not a stale negative or a stale positive", () => {
+    const t0: number = 1_700_000_000_000;
+    const nowSpy: NowSpyLike = spyNow(t0);
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+
+    globalSsoProviderTrustCache.set(
+      key,
+      DISABLED_PROVIDER,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.has(key)).toBe(true);
+
+    nowSpy.mockReturnValue(t0 + GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS + 1);
+
+    expect(globalSsoProviderTrustCache.get(key)).toBeUndefined();
+    expect(globalSsoProviderTrustCache.has(key)).toBe(false);
+
+    // Re-populating at the later clock gives the entry a fresh full TTL.
+    globalSsoProviderTrustCache.set(
+      key,
+      USABLE_UNRESTRICTED,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(USABLE_UNRESTRICTED);
+  });
+
+  test("an attachment entry expires on the same 60s TTL", () => {
+    const t0: number = 1_700_000_000_000;
+    const nowSpy: NowSpyLike = spyNow(t0);
+    const key: string = globalProviderCacheKey("oidc", ObjectID.generate());
+    const projectId: ObjectID = ObjectID.generate();
+
+    globalSsoAttachmentsCache.set(
+      key,
+      attachments({
+        hasAnyAttachmentRows: true,
+        enabledProjectIds: [projectId.toString()],
+      }),
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoAttachmentsCache.get(key)).toBeDefined();
+
+    nowSpy.mockReturnValue(t0 + GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS);
+    expect(globalSsoAttachmentsCache.get(key)).toBeDefined();
+
+    nowSpy.mockReturnValue(t0 + GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS + 1);
+    expect(globalSsoAttachmentsCache.get(key)).toBeUndefined();
+  });
+});
+
+describe("clearGlobalSsoAuthorizationCaches", () => {
+  test("it empties BOTH caches", () => {
+    const ssoKey: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const oidcKey: string = globalProviderCacheKey("oidc", ObjectID.generate());
+
+    globalSsoProviderTrustCache.set(
+      ssoKey,
+      USABLE_UNRESTRICTED,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+    globalSsoProviderTrustCache.set(
+      oidcKey,
+      DISABLED_PROVIDER,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+    globalSsoAttachmentsCache.set(
+      ssoKey,
+      attachments({ hasAnyAttachmentRows: false, enabledProjectIds: [] }),
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+    globalSsoAttachmentsCache.set(
+      oidcKey,
+      attachments({ hasAnyAttachmentRows: true, enabledProjectIds: [] }),
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.size()).toBe(2);
+    expect(globalSsoAttachmentsCache.size()).toBe(2);
+
+    clearGlobalSsoAuthorizationCaches();
+
+    expect(globalSsoProviderTrustCache.size()).toBe(0);
+    expect(globalSsoAttachmentsCache.size()).toBe(0);
+    expect(globalSsoProviderTrustCache.get(ssoKey)).toBeUndefined();
+    expect(globalSsoProviderTrustCache.get(oidcKey)).toBeUndefined();
+    expect(globalSsoAttachmentsCache.get(ssoKey)).toBeUndefined();
+    expect(globalSsoAttachmentsCache.get(oidcKey)).toBeUndefined();
+  });
+
+  test("clearing twice is harmless, and the caches are usable again afterwards", () => {
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+
+    clearGlobalSsoAuthorizationCaches();
+    clearGlobalSsoAuthorizationCaches();
+
+    globalSsoProviderTrustCache.set(
+      key,
+      USABLE_UNRESTRICTED,
+      GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS,
+    );
+
+    expect(globalSsoProviderTrustCache.get(key)).toEqual(USABLE_UNRESTRICTED);
+  });
+});
+
+describe("loadTrustOnce / loadAttachmentsOnce - in-flight de-duplication", () => {
+  test("N concurrent callers for the SAME key run the loader ONCE and all get the same value", async () => {
+    /*
+     * This is the multi-tenant fan-out: the permission path asks about every
+     * project the user belongs to concurrently, and on a cold cache each of
+     * those asks would otherwise issue its own copy of the same provider query.
+     */
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const gate: Deferred<GlobalProviderTrust> =
+      createDeferred<GlobalProviderTrust>();
+
+    let loaderCalls: number = 0;
+
+    const load: () => Promise<GlobalProviderTrust> =
+      (): Promise<GlobalProviderTrust> => {
+        loaderCalls++;
+        return gate.promise;
+      };
+
+    const pending: Array<Promise<GlobalProviderTrust>> = [];
+    for (let index: number = 0; index < 50; index++) {
+      pending.push(loadTrustOnce(key, load));
+    }
+
+    // Fifty callers, one query.
+    expect(pending).toHaveLength(50);
+    expect(loaderCalls).toBe(1);
+
+    gate.resolve(USABLE_UNRESTRICTED);
+
+    const results: Array<GlobalProviderTrust> = await Promise.all(pending);
+
+    /*
+     * Every caller resolves with the very same object, not merely an equal one:
+     * they are all reading the single shared load rather than fifty of their
+     * own.
+     */
+    expect(results).toHaveLength(50);
+    for (const result of results) {
+      expect(result).toBe(USABLE_UNRESTRICTED);
+    }
+    expect(loaderCalls).toBe(1);
+  });
+
+  test("without the de-duplication the same fan-out would issue one load per caller", () => {
+    /*
+     * The control for the test above: the counting harness itself is capable of
+     * seeing N loads, so "loaderCalls === 1" there is a real observation and not
+     * an artefact of how the loader is written.
+     */
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const gate: Deferred<GlobalProviderTrust> =
+      createDeferred<GlobalProviderTrust>();
+
+    let loaderCalls: number = 0;
+
+    const load: () => Promise<GlobalProviderTrust> =
+      (): Promise<GlobalProviderTrust> => {
+        loaderCalls++;
+        return gate.promise;
+      };
+
+    for (let index: number = 0; index < 50; index++) {
+      // Calling the loader directly - i.e. skipping loadTrustOnce entirely.
+      void load();
+    }
+
+    expect(loaderCalls).toBe(50);
+
+    // And through loadTrustOnce, the same fifty asks cost one load.
+    loaderCalls = 0;
+    for (let index: number = 0; index < 50; index++) {
+      void loadTrustOnce(key, load);
+    }
+
+    expect(loaderCalls).toBe(1);
+
+    gate.resolve(USABLE_UNRESTRICTED);
+  });
+
+  test("concurrent callers for DIFFERENT keys each run their own loader", async () => {
+    const firstKey: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const secondKey: string = globalProviderCacheKey(
+      "sso",
+      ObjectID.generate(),
+    );
+    // Same provider id, other namespace: still a different key, still its own loader.
+    const sharedId: ObjectID = ObjectID.generate();
+    const ssoKey: string = globalProviderCacheKey("sso", sharedId);
+    const oidcKey: string = globalProviderCacheKey("oidc", sharedId);
+
+    const calls: Array<string> = [];
+
+    function loaderFor(
+      key: string,
+      value: GlobalProviderTrust,
+    ): () => Promise<GlobalProviderTrust> {
+      return async (): Promise<GlobalProviderTrust> => {
+        calls.push(key);
+        return value;
+      };
+    }
+
+    const results: Array<GlobalProviderTrust> = await Promise.all([
+      loadTrustOnce(firstKey, loaderFor(firstKey, USABLE_UNRESTRICTED)),
+      loadTrustOnce(secondKey, loaderFor(secondKey, DISABLED_PROVIDER)),
+      loadTrustOnce(ssoKey, loaderFor(ssoKey, USABLE_UNRESTRICTED)),
+      loadTrustOnce(oidcKey, loaderFor(oidcKey, DISABLED_PROVIDER)),
+    ]);
+
+    expect(calls.sort()).toEqual([firstKey, secondKey, ssoKey, oidcKey].sort());
+    expect(results[0]).toBe(USABLE_UNRESTRICTED);
+    expect(results[1]).toBe(DISABLED_PROVIDER);
+    expect(results[2]).toBe(USABLE_UNRESTRICTED);
+    expect(results[3]).toBe(DISABLED_PROVIDER);
+  });
+
+  test("the trust and attachment lookups are de-duplicated independently", async () => {
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+
+    let trustCalls: number = 0;
+    let attachmentCalls: number = 0;
+
+    const trust: Promise<GlobalProviderTrust> = loadTrustOnce(
+      key,
+      async (): Promise<GlobalProviderTrust> => {
+        trustCalls++;
+        return USABLE_UNRESTRICTED;
+      },
+    );
+    const attached: Promise<GlobalProviderAttachments> = loadAttachmentsOnce(
+      key,
+      async (): Promise<GlobalProviderAttachments> => {
+        attachmentCalls++;
+        return attachments({
+          hasAnyAttachmentRows: false,
+          enabledProjectIds: [],
+        });
+      },
+    );
+
+    // The same key string in the two maps must not shadow one another.
+    expect(await trust).toBe(USABLE_UNRESTRICTED);
+    expect((await attached).hasAnyAttachmentRows).toBe(false);
+    expect(trustCalls).toBe(1);
+    expect(attachmentCalls).toBe(1);
+  });
+
+  test("the in-flight entry is released once it settles, so a later caller loads again", async () => {
+    const key: string = globalProviderCacheKey("oidc", ObjectID.generate());
+
+    const values: Array<GlobalProviderAttachments> = [
+      attachments({ hasAnyAttachmentRows: false, enabledProjectIds: [] }),
+      attachments({ hasAnyAttachmentRows: true, enabledProjectIds: [] }),
+    ];
+
+    let loaderCalls: number = 0;
+
+    const load: () => Promise<GlobalProviderAttachments> =
+      async (): Promise<GlobalProviderAttachments> => {
+        const value: GlobalProviderAttachments | undefined =
+          values[loaderCalls];
+        loaderCalls++;
+        return value!;
+      };
+
+    const first: GlobalProviderAttachments = await loadAttachmentsOnce(
+      key,
+      load,
+    );
+    expect(first).toBe(values[0]);
+    expect(loaderCalls).toBe(1);
+
+    /*
+     * The de-dup window is one settle, not one process lifetime - otherwise a
+     * provider's very first answer would be pinned forever and the 60s TTL
+     * would never take effect.
+     */
+    const second: GlobalProviderAttachments = await loadAttachmentsOnce(
+      key,
+      load,
+    );
+    expect(second).toBe(values[1]);
+    expect(loaderCalls).toBe(2);
+  });
+
+  test("a REJECTING loader is shared by every concurrent caller and is then released for a retry", async () => {
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const gate: Deferred<GlobalProviderTrust> =
+      createDeferred<GlobalProviderTrust>();
+    const failure: Error = new Error("connection terminated unexpectedly");
+
+    let loaderCalls: number = 0;
+
+    const failingLoad: () => Promise<GlobalProviderTrust> =
+      (): Promise<GlobalProviderTrust> => {
+        loaderCalls++;
+        return gate.promise;
+      };
+
+    const pending: Array<Promise<GlobalProviderTrust>> = [
+      loadTrustOnce(key, failingLoad),
+      loadTrustOnce(key, failingLoad),
+      loadTrustOnce(key, failingLoad),
+    ];
+
+    expect(loaderCalls).toBe(1);
+
+    gate.reject(failure);
+
+    /*
+     * All three see the failure. A lookup failure must surface as a failure -
+     * the enforcement path THROWS rather than turning "could not find out" into
+     * "not allowed here" - so a shared rejection has to reach every caller.
+     */
+    const outcomes: Array<unknown> = await Promise.all(
+      pending.map((promise: Promise<GlobalProviderTrust>) => {
+        return promise.then(
+          (): unknown => {
+            return "resolved";
+          },
+          (error: unknown): unknown => {
+            return error;
+          },
+        );
+      }),
+    );
+
+    for (const outcome of outcomes) {
+      expect(outcome).toBe(failure);
+    }
+    expect(loaderCalls).toBe(1);
+
+    /*
+     * ...and the key is NOT poisoned. A transient database blip must not pin a
+     * rejected promise in the map, which would fail every later request for
+     * that provider for the life of the process.
+     */
+    const retried: GlobalProviderTrust = await loadTrustOnce(
+      key,
+      async (): Promise<GlobalProviderTrust> => {
+        loaderCalls++;
+        return USABLE_UNRESTRICTED;
+      },
+    );
+
+    expect(retried).toBe(USABLE_UNRESTRICTED);
+    expect(loaderCalls).toBe(2);
+  });
+
+  test("a rejecting attachment loader behaves the same way", async () => {
+    const key: string = globalProviderCacheKey("oidc", ObjectID.generate());
+    const failure: Error = new Error("attachment lookup failed");
+
+    let loaderCalls: number = 0;
+
+    await expect(
+      loadAttachmentsOnce(key, async (): Promise<GlobalProviderAttachments> => {
+        loaderCalls++;
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+
+    const retried: GlobalProviderAttachments = await loadAttachmentsOnce(
+      key,
+      async (): Promise<GlobalProviderAttachments> => {
+        loaderCalls++;
+        return attachments({
+          hasAnyAttachmentRows: true,
+          enabledProjectIds: [],
+        });
+      },
+    );
+
+    expect(retried.hasAnyAttachmentRows).toBe(true);
+    expect(loaderCalls).toBe(2);
+  });
+
+  test("clearGlobalSsoAuthorizationCaches drops IN-FLIGHT entries as well as cached ones", async () => {
+    /*
+     * A write hook fires while a lookup is already in flight. The in-flight
+     * promise is carrying the pre-change answer, so a caller arriving after the
+     * clear must start its own lookup instead of joining it.
+     */
+    const trustKey: string = globalProviderCacheKey("sso", ObjectID.generate());
+    const attachmentKey: string = globalProviderCacheKey(
+      "sso",
+      ObjectID.generate(),
+    );
+
+    const trustGate: Deferred<GlobalProviderTrust> =
+      createDeferred<GlobalProviderTrust>();
+    const attachmentGate: Deferred<GlobalProviderAttachments> =
+      createDeferred<GlobalProviderAttachments>();
+
+    let trustCalls: number = 0;
+    let attachmentCalls: number = 0;
+
+    const staleTrust: () => Promise<GlobalProviderTrust> =
+      (): Promise<GlobalProviderTrust> => {
+        trustCalls++;
+        return trustGate.promise;
+      };
+    const staleAttachments: () => Promise<GlobalProviderAttachments> =
+      (): Promise<GlobalProviderAttachments> => {
+        attachmentCalls++;
+        return attachmentGate.promise;
+      };
+
+    const inFlightTrust: Promise<GlobalProviderTrust> = loadTrustOnce(
+      trustKey,
+      staleTrust,
+    );
+    const inFlightAttachments: Promise<GlobalProviderAttachments> =
+      loadAttachmentsOnce(attachmentKey, staleAttachments);
+
+    expect(trustCalls).toBe(1);
+    expect(attachmentCalls).toBe(1);
+
+    /*
+     * Without a clear, a second caller joins the in-flight lookup: no new load,
+     * and it will be handed the pre-change answer.
+     */
+    const joinedTrust: Promise<GlobalProviderTrust> = loadTrustOnce(
+      trustKey,
+      staleTrust,
+    );
+    const joinedAttachments: Promise<GlobalProviderAttachments> =
+      loadAttachmentsOnce(attachmentKey, staleAttachments);
+
+    expect(trustCalls).toBe(1);
+    expect(attachmentCalls).toBe(1);
+
+    clearGlobalSsoAuthorizationCaches();
+
+    const freshTrust: Promise<GlobalProviderTrust> = loadTrustOnce(
+      trustKey,
+      async (): Promise<GlobalProviderTrust> => {
+        trustCalls++;
+        return DISABLED_PROVIDER;
+      },
+    );
+    const freshAttachments: Promise<GlobalProviderAttachments> =
+      loadAttachmentsOnce(
+        attachmentKey,
+        async (): Promise<GlobalProviderAttachments> => {
+          attachmentCalls++;
+          return attachments({
+            hasAnyAttachmentRows: true,
+            enabledProjectIds: [],
+          });
+        },
+      );
+
+    /*
+     * The clear is what forces the new load. Compare with the two calls above,
+     * which added nothing to these counters.
+     */
+    expect(trustCalls).toBe(2);
+    expect(attachmentCalls).toBe(2);
+
+    // The post-clear lookup is the one that sees the admin's change.
+    expect(await freshTrust).toBe(DISABLED_PROVIDER);
+    expect((await freshAttachments).hasAnyAttachmentRows).toBe(true);
+
+    // Let the pre-clear lookups finish so nothing is left dangling.
+    trustGate.resolve(USABLE_UNRESTRICTED);
+    attachmentGate.resolve(
+      attachments({ hasAnyAttachmentRows: false, enabledProjectIds: [] }),
+    );
+
+    /*
+     * The callers that joined before the clear still get the pre-change answer -
+     * their query was already on the wire. That staleness is bounded by the
+     * request in flight, which is why the write hooks clear in the success hook
+     * as well as the before-hook.
+     */
+    expect(await inFlightTrust).toBe(USABLE_UNRESTRICTED);
+    expect(await joinedTrust).toBe(USABLE_UNRESTRICTED);
+    expect((await inFlightAttachments).hasAnyAttachmentRows).toBe(false);
+    expect((await joinedAttachments).hasAnyAttachmentRows).toBe(false);
+  });
+
+  test("de-duplication does not populate the cache by itself", () => {
+    /*
+     * loadOnce only shares the promise; writing the answer into the 60s cache
+     * is the loader's job. If sharing implied caching, a loader that threw
+     * would still leave something behind.
+     */
+    const key: string = globalProviderCacheKey("sso", ObjectID.generate());
+
+    const pending: Promise<GlobalProviderTrust> = loadTrustOnce(
+      key,
+      async (): Promise<GlobalProviderTrust> => {
+        return USABLE_UNRESTRICTED;
+      },
+    );
+
+    expect(globalSsoProviderTrustCache.get(key)).toBeUndefined();
+    expect(globalSsoProviderTrustCache.size()).toBe(0);
+
+    return pending.then((): void => {
+      expect(globalSsoProviderTrustCache.get(key)).toBeUndefined();
+    });
+  });
+});
+
+/*
+ * The in-flight slot is released only by the lookup that owns it.
+ *
+ * A cache clear can happen WHILE a lookup is on the wire - every write to any
+ * of the four Global SSO/OIDC services calls clearGlobalSsoAuthorizationCaches
+ * twice, and the multi-tenant permission path fans out immediately afterwards.
+ * If the older lookup deleted the key blindly when it finally settled, it
+ * would evict the NEWER lookup that had since taken the slot, and every
+ * caller arriving after that would start its own query - de-duplication
+ * silently off in exactly the situation it exists for.
+ */
+describe("loadTrustOnce - a settling lookup does not evict a newer one", () => {
+  const evictionProviderId: ObjectID = ObjectID.generate();
+
+  test("a caller arriving after a clear joins the second lookup rather than starting a third", async () => {
+    const key: string = globalProviderCacheKey("sso", evictionProviderId);
+
+    let loadCount: number = 0;
+    const releases: Array<(trust: GlobalProviderTrust) => void> = [];
+
+    const blockingLoader: () => Promise<GlobalProviderTrust> =
+      (): Promise<GlobalProviderTrust> => {
+        loadCount += 1;
+
+        return new Promise((resolve: (trust: GlobalProviderTrust) => void) => {
+          releases.push(resolve);
+        });
+      };
+
+    // Lookup #1 starts and is still in flight.
+    const first: Promise<GlobalProviderTrust> = loadTrustOnce(
+      key,
+      blockingLoader,
+    );
+
+    // A write happens: the caches, and the in-flight slot, are dropped.
+    clearGlobalSsoAuthorizationCaches();
+
+    // Lookup #2 takes the slot and is also still in flight.
+    const second: Promise<GlobalProviderTrust> = loadTrustOnce(
+      key,
+      blockingLoader,
+    );
+
+    expect(loadCount).toBe(2);
+
+    // Lookup #1 now settles. It must NOT take lookup #2's slot with it.
+    releases[0]!({ isUsable: true, restrictToAttachedProjects: false });
+    await first;
+
+    // A third caller arrives while lookup #2 is STILL in flight.
+    const third: Promise<GlobalProviderTrust> = loadTrustOnce(
+      key,
+      blockingLoader,
+    );
+
+    expect(loadCount).toBe(2);
+
+    releases[1]!({ isUsable: false, restrictToAttachedProjects: true });
+
+    await expect(second).resolves.toEqual({
+      isUsable: false,
+      restrictToAttachedProjects: true,
+    });
+    await expect(third).resolves.toEqual({
+      isUsable: false,
+      restrictToAttachedProjects: true,
+    });
+  });
+
+  test("the owning lookup still releases its own slot, so a later call re-loads", async () => {
+    // The guard must not turn into "never release".
+    const key: string = globalProviderCacheKey("oidc", evictionProviderId);
+
+    let loadCount: number = 0;
+    const loader: () => Promise<GlobalProviderTrust> =
+      async (): Promise<GlobalProviderTrust> => {
+        loadCount += 1;
+        return { isUsable: true, restrictToAttachedProjects: false };
+      };
+
+    await loadTrustOnce(key, loader);
+    await loadTrustOnce(key, loader);
+
+    expect(loadCount).toBe(2);
+  });
+});
+
+describe("GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS", () => {
+  test("is 60 seconds", () => {
+    /*
+     * This number is the blast radius of a revoked provider: the caches are
+     * per-process with no cross-process invalidation, so on any node that did
+     * NOT serve the disable, a provider that an admin turned off keeps
+     * satisfying SSO enforcement for up to this long. Changing it changes that
+     * exposure window.
+     */
+    expect(GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS).toBe(60_000);
+    expect(GLOBAL_SSO_AUTHORIZATION_CACHE_TTL_MS).toBe(60 * 1000);
+  });
+});

--- a/MobileApp/src/api/client.ts
+++ b/MobileApp/src/api/client.ts
@@ -16,6 +16,7 @@ import {
   getCachedGlobalSsoToken,
   getCachedSsoTokens,
 } from "../storage/ssoTokens";
+import { clearProjectSsoDenial, markProjectSsoDenied } from "../sso/ssoDenials";
 
 /**
  * Recursively normalizes OneUptime API serialized types in response data.
@@ -107,10 +108,59 @@ apiClient.interceptors.request.use(
   },
 );
 
+/*
+ * Axios stores a header under whatever casing the caller wrote, so a raw index
+ * read only finds `tenantid` and would silently miss a `tenantId` written in
+ * the natural camelCase - turning a 406 into a recorded-nothing dead end, the
+ * exact state this feature exists to remove. AxiosHeaders.get() is
+ * case-insensitive; fall back to a manual scan for a plain object.
+ */
+function readTenantId(config: InternalAxiosRequestConfig | undefined): string {
+  const headers: unknown = config?.headers;
+
+  if (!headers || typeof headers !== "object") {
+    return "";
+  }
+
+  const getter: unknown = (headers as { get?: unknown }).get;
+
+  if (typeof getter === "function") {
+    const value: unknown = (getter as (name: string) => unknown).call(
+      headers,
+      "tenantid",
+    );
+
+    return typeof value === "string" ? value : "";
+  }
+
+  for (const key of Object.keys(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === "tenantid") {
+      const value: unknown = (headers as Record<string, unknown>)[key];
+      return typeof value === "string" ? value : "";
+    }
+  }
+
+  return "";
+}
+
 // Response interceptor: normalize OneUptime serialized types then handle 401
 apiClient.interceptors.response.use(
   (response: AxiosResponse) => {
     response.data = normalizeResponseData(response.data);
+
+    /*
+     * A successful response is the server's LATER word about this project, so
+     * it retires any earlier SSO refusal. Without this, a denial recorded
+     * before an admin re-enabled the provider would keep the project showing
+     * "Authenticate with SSO" for the rest of the session even though its
+     * requests are now succeeding.
+     */
+    const tenantId: string = readTenantId(response.config);
+
+    if (tenantId) {
+      clearProjectSsoDenial(tenantId);
+    }
+
     return response;
   },
   async (error: AxiosError) => {
@@ -119,6 +169,21 @@ apiClient.interceptors.response.use(
     } = error.config as InternalAxiosRequestConfig & {
       _retry?: boolean;
     };
+
+    /*
+     * 406 is ExceptionCode.SsoAuthorizationException - the server saying this
+     * project needs an SSO login the caller has not completed (or no longer
+     * has: the token expired, or the provider was disabled). Record it against
+     * the project so the UI can offer the fix, instead of every screen
+     * separately rendering "SSO Authorization Required" with nothing to press.
+     */
+    if (error.response?.status === 406) {
+      const tenantId: string = readTenantId(originalRequest);
+
+      if (tenantId) {
+        markProjectSsoDenied(tenantId);
+      }
+    }
 
     if (error.response?.status !== 401 || originalRequest._retry) {
       return Promise.reject(error);

--- a/MobileApp/src/api/clientSsoDenial.test.ts
+++ b/MobileApp/src/api/clientSsoDenial.test.ts
@@ -1,0 +1,762 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { clearTokens } from "../storage/keychain";
+import { setServerUrl } from "../storage/serverUrl";
+import { clearAllSsoTokens } from "../storage/ssoTokens";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "../sso/session";
+import {
+  clearAllSsoDenials,
+  getSsoDeniedProjectIds,
+  isProjectSsoDenied,
+  subscribeToSsoDenials,
+} from "../sso/ssoDenials";
+import apiClient from "./client";
+import {
+  AxiosError,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from "axios";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The 406 half of the API client's response interceptor.
+ *
+ * 406 is ExceptionCode.SsoAuthorizationException
+ * (Common/Types/Exception/ExceptionCode.ts): the server saying "this project
+ * requires an SSO login you have not completed". Before this handling existed
+ * the app had no idea which projects were refused - it inferred SSO status
+ * from what was in storage ("a global token exists, therefore every project is
+ * fine"), which is wrong the moment the token lapses, the provider is
+ * disabled, or an admin restricts the provider to its attached projects. Every
+ * screen then rendered its own dead-end error string.
+ *
+ * So this file drives the REAL interceptor in src/api/client.ts, the same way
+ * clientSsoHeaders.test.ts does - by handing axios a custom `config.adapter`,
+ * which receives the fully assembled request after every request interceptor
+ * has run, and gets to decide what the "server" answers. Nothing is
+ * re-implemented and no socket is opened.
+ *
+ * Two contracts are pinned here rather than imported, because both are shared
+ * with code that ships separately:
+ *
+ *   406        - the numeric status the server uses for SSO refusal.
+ *   `tenantid` - the request header every project-scoped call in src/api/*.ts
+ *                sets, and the ONLY thing that tells the interceptor which
+ *                project was refused.
+ *
+ * Every negative assertion below ("nothing was recorded") is paired, in the
+ * same test, with the positive control that differs by exactly the one thing
+ * under test - otherwise an interceptor that recorded nothing at all would
+ * satisfy the whole file.
+ */
+
+const SSO_AUTHORIZATION_STATUS: number = 406;
+const TENANT_HEADER: string = "tenantid";
+
+const PROJECT_A: string = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PROJECT_B: string = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+const BASE64_ALPHABET: string =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/** ASCII -> base64url (JWT flavour: no padding, `-`/`_` for `+`/`/`). */
+function toBase64Url(value: string): string {
+  let output: string = "";
+  let buffer: number = 0;
+  let bitsInBuffer: number = 0;
+
+  for (let index: number = 0; index < value.length; index++) {
+    buffer = (buffer << 8) | (value.charCodeAt(index) & 0xff);
+    bitsInBuffer += 8;
+
+    while (bitsInBuffer >= 6) {
+      bitsInBuffer -= 6;
+      output += BASE64_ALPHABET[(buffer >> bitsInBuffer) & 0x3f];
+    }
+  }
+
+  if (bitsInBuffer > 0) {
+    output += BASE64_ALPHABET[(buffer << (6 - bitsInBuffer)) & 0x3f];
+  }
+
+  return output.replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/*
+ * A real three-segment JWT, valid for 30 days - the lifetime the server signs
+ * SSO tokens for. The storage layer evicts anything `isJwtExpired` rejects,
+ * which includes anything that is not a well-formed JWT, so a fixture string
+ * like "token-1" would vanish for reasons unrelated to what is being tested.
+ */
+function freshJwt(subject: string): string {
+  const header: string = toBase64Url(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  );
+  const payload: string = toBase64Url(
+    JSON.stringify({
+      sub: subject,
+      exp: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+    }),
+  );
+
+  return `${header}.${payload}.not-verified-by-the-app`;
+}
+
+function buildCallbackUrl(params: Record<string, string>): string {
+  const query: string = Object.keys(params)
+    .map((key: string): string => {
+      return `${encodeURIComponent(key)}=${encodeURIComponent(params[key]!)}`;
+    })
+    .join("&");
+
+  return `oneuptime://sso-callback?${query}`;
+}
+
+/** The auth tokens every SSO callback carries, whatever its flavour. */
+function authParams(): Record<string, string> {
+  return {
+    accessToken: freshJwt("access"),
+    refreshToken: freshJwt("refresh"),
+    refreshTokenExpiresAt: new Date(Date.now() + 86400000).toISOString(),
+  };
+}
+
+let sentConfigs: Array<InternalAxiosRequestConfig> = [];
+
+/*
+ * The exact error object the fake server rejected with. Held so a test can
+ * assert the caller received THAT object rather than merely "some rejection" -
+ * an interceptor that caught the error, recorded the denial and then threw
+ * something of its own would still reject, and would still be a bug.
+ */
+let lastAdapterError: AxiosError | null = null;
+
+function adapterFor(
+  status: number,
+): (config: InternalAxiosRequestConfig) => Promise<AxiosResponse> {
+  return (config: InternalAxiosRequestConfig): Promise<AxiosResponse> => {
+    sentConfigs.push(config);
+
+    const response: AxiosResponse = {
+      data: { message: `server said ${status}` },
+      status,
+      statusText: String(status),
+      headers: {},
+      config,
+    } as AxiosResponse;
+
+    if (status >= 200 && status < 300) {
+      return Promise.resolve(response);
+    }
+
+    const error: AxiosError = new AxiosError(
+      `Request failed with status code ${status}`,
+      String(status),
+      config,
+      undefined,
+      response,
+    );
+
+    lastAdapterError = error;
+
+    return Promise.reject(error);
+  };
+}
+
+type Settled =
+  | { outcome: "resolved"; response: AxiosResponse }
+  | { outcome: "rejected"; error: unknown };
+
+interface CallOptions {
+  status: number;
+  /*
+   * Omitted entirely = the request carries no tenantid at all (an
+   * instance-level call such as /api/project or the SSO status endpoints).
+   * Passing "" = the header is present but empty.
+   */
+  tenantId?: string;
+  /*
+   * Header name to send the project id under. Defaults to the lowercase
+   * `tenantid` every src/api module uses today; overridden by the casing
+   * tests below.
+   */
+  tenantHeaderName?: string;
+  /*
+   * Marks the request as one the 401 refresh path has already retried, which
+   * is how the interceptor short-circuits without going near the network.
+   */
+  alreadyRetried?: boolean;
+  url?: string;
+}
+
+/**
+ * Issues one request through the real client and reports how it settled.
+ *
+ * Deliberately does not rethrow: several tests need to assert both "the caller
+ * saw the rejection" and "the denial was recorded", and swallowing the error
+ * here would make the first of those untestable.
+ */
+async function call(options: CallOptions): Promise<Settled> {
+  const config: AxiosRequestConfig & { _retry?: boolean } = {
+    adapter: adapterFor(options.status),
+  };
+
+  if (options.tenantId !== undefined) {
+    config.headers = {
+      [options.tenantHeaderName || TENANT_HEADER]: options.tenantId,
+    };
+  }
+
+  if (options.alreadyRetried) {
+    config._retry = true;
+  }
+
+  try {
+    const response: AxiosResponse = await apiClient.get(
+      options.url || "/api/monitor",
+      config,
+    );
+
+    return { outcome: "resolved", response };
+  } catch (error) {
+    return { outcome: "rejected", error };
+  }
+}
+
+function lastRequest(): InternalAxiosRequestConfig {
+  return sentConfigs[sentConfigs.length - 1]!;
+}
+
+/**
+ * Reads a header off a captured request the way an HTTP server does -
+ * case-insensitively - so a test can tell "absent" from "present and empty".
+ */
+function headerOf(config: InternalAxiosRequestConfig, name: string): unknown {
+  const headers: Record<string, unknown> = config.headers as unknown as Record<
+    string,
+    unknown
+  >;
+
+  const key: string | undefined = Object.keys(headers).find(
+    (candidate: string): boolean => {
+      return candidate.toLowerCase() === name.toLowerCase();
+    },
+  );
+
+  return key === undefined ? undefined : headers[key];
+}
+
+function deniedIds(): Array<string> {
+  return [...getSsoDeniedProjectIds()].sort();
+}
+
+/*
+ * The denial set, the AsyncStorage fake and both storage caches are all
+ * module-level and survive between tests. All of them are reset, or a test
+ * inherits the previous one's denials and passes for the wrong reason.
+ *
+ * Clearing the keychain matters for a second reason: a 401 that has NOT
+ * already been retried drives the real refresh path, and that path only stays
+ * offline because getTokens() finds no refresh token and fails immediately.
+ */
+beforeEach(async () => {
+  sentConfigs = [];
+  lastAdapterError = null;
+  clearAllSsoDenials();
+  await AsyncStorage.clear();
+  await clearAllSsoTokens();
+  await clearTokens();
+  await setServerUrl("https://test.oneuptime.local");
+});
+
+afterEach(() => {
+  clearAllSsoDenials();
+});
+
+describe("a 406 marks the project it names", () => {
+  test("records the project from the tenantid header", async () => {
+    const settled: Settled = await call({
+      status: SSO_AUTHORIZATION_STATUS,
+      tenantId: PROJECT_A,
+    });
+
+    expect(settled.outcome).toBe("rejected");
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(deniedIds()).toEqual([PROJECT_A]);
+
+    // The refusal is about one project, not the whole session.
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(false);
+  });
+
+  test("reads the same header name the API modules actually send", async () => {
+    /*
+     * client.ts indexes `originalRequest.headers["tenantid"]` directly. Every
+     * project-scoped call in src/api/*.ts sends exactly that spelling. If
+     * either side drifted, the interceptor would quietly record nothing and
+     * the user would be back to an unexplained error on every screen.
+     */
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(headerOf(lastRequest(), TENANT_HEADER)).toBe(PROJECT_A);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+  });
+
+  test("still rejects with the server's own error", async () => {
+    /*
+     * Recording a denial must not swallow the failure. A caller that got a
+     * resolved promise here would render an empty list as if the project had
+     * no incidents, instead of showing the SSO prompt.
+     */
+    const settled: Settled = await call({
+      status: SSO_AUTHORIZATION_STATUS,
+      tenantId: PROJECT_A,
+    });
+
+    expect(settled.outcome).toBe("rejected");
+
+    const error: unknown = (settled as { error: unknown }).error;
+
+    expect(error).toBe(lastAdapterError);
+    expect((error as AxiosError).response?.status).toBe(
+      SSO_AUTHORIZATION_STATUS,
+    );
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+  });
+
+  test("marks the project before the caller is told", async () => {
+    /*
+     * The screens read isProjectSsoDenied() in the same catch block that
+     * receives this rejection. If the recording were deferred (a floating
+     * promise, a setTimeout), the first render after the failure would still
+     * show the old state and the prompt would appear only on the next one.
+     */
+    let deniedWhenCallerSawIt: boolean = false;
+
+    await apiClient
+      .get("/api/monitor", {
+        adapter: adapterFor(SSO_AUTHORIZATION_STATUS),
+        headers: { [TENANT_HEADER]: PROJECT_A },
+      })
+      .catch((): void => {
+        deniedWhenCallerSawIt = isProjectSsoDenied(PROJECT_A);
+      });
+
+    expect(deniedWhenCallerSawIt).toBe(true);
+  });
+});
+
+describe("a 406 with no project to blame records nothing", () => {
+  test("a request with no tenantid header records nothing and does not throw", async () => {
+    /*
+     * Instance-level endpoints (project list, SSO status) carry no tenantid.
+     * A 406 from one of those names no project, and inventing one - or
+     * blowing up reading an absent header - would be worse than recording
+     * nothing.
+     */
+    const settled: Settled = await call({ status: SSO_AUTHORIZATION_STATUS });
+
+    expect(headerOf(lastRequest(), TENANT_HEADER)).toBeUndefined();
+    expect(deniedIds()).toEqual([]);
+
+    // The 406 itself is still surfaced - it is the server's error, not ours.
+    expect(settled.outcome).toBe("rejected");
+    expect((settled as { error: unknown }).error).toBe(lastAdapterError);
+
+    // Positive control: the identical call WITH a tenantid does record.
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(deniedIds()).toEqual([PROJECT_A]);
+  });
+
+  test("an empty-string tenantid records nothing", async () => {
+    /*
+     * An empty tenantid is what a screen sends when its selected project has
+     * not loaded yet. Recording "" would put a project id of "" in the denial
+     * set, which no screen can ever clear because no screen has that id.
+     */
+    const settled: Settled = await call({
+      status: SSO_AUTHORIZATION_STATUS,
+      tenantId: "",
+    });
+
+    /*
+     * Asserted, not assumed: axios keeps an empty header rather than dropping
+     * it, so the interceptor really does see `""` and really does have to
+     * reject it on its own. If a future axios stopped sending it, this test
+     * would silently become a duplicate of the no-header one.
+     */
+    expect(headerOf(lastRequest(), TENANT_HEADER)).toBe("");
+
+    expect(deniedIds()).toEqual([]);
+    expect(isProjectSsoDenied("")).toBe(false);
+    expect(settled.outcome).toBe("rejected");
+
+    // Positive control: same request, same status, a real tenant id.
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(deniedIds()).toEqual([PROJECT_A]);
+  });
+});
+
+describe("only 406 records a denial", () => {
+  test("a successful response records nothing", async () => {
+    const settled: Settled = await call({ status: 200, tenantId: PROJECT_A });
+
+    expect(settled.outcome).toBe("resolved");
+    expect(deniedIds()).toEqual([]);
+
+    // Positive control: the same project, the same request, status 406.
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(deniedIds()).toEqual([PROJECT_A]);
+  });
+
+  test("400, 403 and 500 record nothing", async () => {
+    /*
+     * A denial is a durable claim about the project: the UI stops offering the
+     * data and starts offering an SSO button. A validation error, an ordinary
+     * permission failure or a server crash must not produce that - the user
+     * would be sent off to re-authenticate against a provider that was never
+     * the problem, and the denial would survive the login that could not fix
+     * it.
+     */
+    for (const status of [400, 403, 500]) {
+      const settled: Settled = await call({ status, tenantId: PROJECT_A });
+
+      expect(settled.outcome).toBe("rejected");
+      expect(deniedIds()).toEqual([]);
+    }
+
+    // Positive control: the one status that does mean "SSO required".
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(deniedIds()).toEqual([PROJECT_A]);
+  });
+
+  test("a 401 that has already been retried records nothing", async () => {
+    /*
+     * `_retry` is the flag the refresh path sets before replaying a request,
+     * so this is the shape a 401 has after the refresh already happened. It
+     * short-circuits before the refresh block, which keeps this test off the
+     * network entirely.
+     */
+    const settled: Settled = await call({
+      status: 401,
+      tenantId: PROJECT_A,
+      alreadyRetried: true,
+    });
+
+    expect(settled.outcome).toBe("rejected");
+    expect(deniedIds()).toEqual([]);
+
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(deniedIds()).toEqual([PROJECT_A]);
+  });
+
+  test("a 401 that drives the refresh path records nothing", async () => {
+    /*
+     * The un-retried 401 is the interesting one: it runs the real refresh
+     * block. There is no refresh token stored (beforeEach clears the
+     * keychain), so getTokens() returns null, the block throws before it can
+     * reach out to /identity/refresh-token, and the original 401 is rejected.
+     * No socket, no hang - and still no denial, because 401 means "your
+     * session lapsed", not "this project needs SSO".
+     */
+    const settled: Settled = await call({ status: 401, tenantId: PROJECT_A });
+
+    expect(settled.outcome).toBe("rejected");
+    expect((settled as { error: unknown }).error).toBe(lastAdapterError);
+    expect(deniedIds()).toEqual([]);
+
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(deniedIds()).toEqual([PROJECT_A]);
+  });
+});
+
+describe("denials accumulate per project", () => {
+  test("two projects both refused are both recorded", async () => {
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_B });
+
+    expect(deniedIds()).toEqual([PROJECT_A, PROJECT_B]);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(true);
+  });
+
+  test("the same project refused repeatedly is recorded once and announced once", async () => {
+    /*
+     * A screen with three panels produces three 406s for one project. Each
+     * one re-entering the denial set would be harmless, but each one
+     * re-notifying subscribers would re-render every subscribed screen for no
+     * change - which is exactly the kind of thing that turns an error state
+     * into a render loop.
+     */
+    let notifications: number = 0;
+
+    const unsubscribe: () => void = subscribeToSsoDenials((): void => {
+      notifications++;
+    });
+
+    try {
+      await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+      await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+      await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+      expect(deniedIds()).toEqual([PROJECT_A]);
+      expect(notifications).toBe(1);
+
+      /*
+       * Positive control for the notification count: the de-duplication is
+       * per project, not a subscriber that stopped listening after one event.
+       */
+      await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_B });
+
+      expect(deniedIds()).toEqual([PROJECT_A, PROJECT_B]);
+      expect(notifications).toBe(2);
+    } finally {
+      unsubscribe();
+    }
+  });
+});
+
+describe("an SSO login turns a denial back into a working project", () => {
+  test("a global token callback clears every denial", async () => {
+    /*
+     * A Global SSO/OIDC token is not bound to a project and the app cannot
+     * tell from the token which projects it satisfies - so the only correct
+     * move is to drop every denial and let the server answer again. Clearing
+     * just one would leave the other projects showing an SSO prompt the user
+     * has already satisfied.
+     */
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_B });
+
+    expect(deniedIds()).toEqual([PROJECT_A, PROJECT_B]);
+
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        globalSsoToken: freshJwt("global-sso"),
+      }),
+    );
+
+    expect(outcome.status).toBe("success");
+    expect(outcome).toMatchObject({ isGlobal: true, projectId: null });
+    expect(deniedIds()).toEqual([]);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(false);
+  });
+
+  test("a project token callback clears only that project", async () => {
+    /*
+     * The mirror image: a project-scoped login proves nothing about any other
+     * project. Clearing all of them here would hide a genuine denial until the
+     * next request re-earned it, and the user would see a project flip from
+     * "ready" to "SSO required" for no visible reason.
+     */
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_B });
+
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        projectId: PROJECT_A,
+        ssoToken: freshJwt("project-sso"),
+      }),
+    );
+
+    expect(outcome).toMatchObject({
+      status: "success",
+      isGlobal: false,
+      projectId: PROJECT_A,
+    });
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(true);
+    expect(deniedIds()).toEqual([PROJECT_B]);
+  });
+
+  test("a callback the server rejected clears nothing", async () => {
+    /*
+     * A failed login has fixed nothing. Clearing on the way out would make the
+     * app forget the refusal and go straight back to showing the project as
+     * usable - until the next request 406'd again.
+     */
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_B });
+
+    const failed: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        error: "sso_failed",
+        errorDescription: "IdP refused the assertion",
+      }),
+    );
+
+    expect(failed.status).toBe("error");
+    expect(deniedIds()).toEqual([PROJECT_A, PROJECT_B]);
+
+    /*
+     * Positive control: the denials were clearable the whole time - it is the
+     * failure, not the state, that stopped them being cleared.
+     */
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        globalSsoToken: freshJwt("global-sso"),
+      }),
+    );
+
+    expect(deniedIds()).toEqual([]);
+  });
+
+  test("a callback with nothing usable in it clears nothing", async () => {
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    const missingTokens: CompleteSsoLoginOutcome =
+      await completeSsoLoginFromUrl(
+        buildCallbackUrl({ globalSsoToken: freshJwt("global-sso") }),
+      );
+
+    expect(missingTokens.status).toBe("error");
+    expect(deniedIds()).toEqual([PROJECT_A]);
+
+    const notACallback: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      "https://example.com/not-a-callback",
+    );
+
+    expect(notACallback.status).toBe("error");
+    expect(deniedIds()).toEqual([PROJECT_A]);
+
+    // Positive control: a well-formed global callback does clear it.
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        globalSsoToken: freshJwt("global-sso"),
+      }),
+    );
+
+    expect(deniedIds()).toEqual([]);
+  });
+
+  test("a project refused again after a login is recorded again", async () => {
+    /*
+     * The whole loop, in one test: refused -> logged in -> cleared -> refused
+     * again. Clearing on login is optimistic ("this login may have fixed it"),
+     * so the server has to be able to say no a second time. A one-shot denial
+     * set would leave the app permanently believing the project was fine.
+     */
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        globalSsoToken: freshJwt("global-sso"),
+      }),
+    );
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+  });
+});
+
+/*
+ * Axios keeps a header under exactly the casing the caller wrote it in, so a
+ * raw `headers["tenantid"]` index only ever finds the lowercase spelling. Every
+ * src/api module happens to use lowercase today, which is precisely what makes
+ * this a trap: the next one written as `tenantId` - the natural spelling in a
+ * TypeScript codebase - would 406 and record nothing, leaving the user back at
+ * the dead end this whole feature exists to remove.
+ */
+describe("the project id is found whatever casing the caller used", () => {
+  test.each([
+    ["tenantid"],
+    ["tenantId"],
+    ["TenantId"],
+    ["TENANTID"],
+    ["Tenantid"],
+  ])(
+    "a 406 on a request sending %s records the denial",
+    async (headerName: string) => {
+      const settled: Settled = await call({
+        status: SSO_AUTHORIZATION_STATUS,
+        tenantId: PROJECT_A,
+        tenantHeaderName: headerName,
+      });
+
+      expect(settled.outcome).toBe("rejected");
+      expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    },
+  );
+
+  test("a header whose name merely contains 'tenantid' is not treated as one", async () => {
+    // Guards the fallback scan against matching `x-tenantid-hint` and friends.
+    const settled: Settled = await call({
+      status: SSO_AUTHORIZATION_STATUS,
+      tenantId: PROJECT_A,
+      tenantHeaderName: "x-tenantid-hint",
+    });
+
+    expect(settled.outcome).toBe("rejected");
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+  });
+});
+
+/*
+ * A denial is the server's word, but so is a success. If an admin re-enables a
+ * provider (or drops restrictToAttachedProjects) while the user's 30-day token
+ * is still valid, requests start succeeding - and without this the project
+ * would keep showing "Authenticate with SSO" until the app was relaunched.
+ */
+describe("a successful response retires an earlier denial", () => {
+  test("a 2xx for a denied project clears it", async () => {
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+
+    const settled: Settled = await call({ status: 200, tenantId: PROJECT_A });
+
+    expect(settled.outcome).toBe("resolved");
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+  });
+
+  test("it clears only the project it names", async () => {
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_B });
+
+    await call({ status: 200, tenantId: PROJECT_A });
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(true);
+  });
+
+  test("a 2xx with no tenantid leaves every denial alone", async () => {
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    await call({ status: 200 });
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+  });
+
+  test("a 2xx for a project that was never denied is a no-op", async () => {
+    const settled: Settled = await call({ status: 200, tenantId: PROJECT_B });
+
+    expect(settled.outcome).toBe("resolved");
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(false);
+  });
+
+  test("a denial recorded after a success is still recorded", async () => {
+    // The two directions must not fight: last word wins, in order.
+    await call({ status: 200, tenantId: PROJECT_A });
+    await call({ status: SSO_AUTHORIZATION_STATUS, tenantId: PROJECT_A });
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+  });
+});

--- a/MobileApp/src/api/sso.test.ts
+++ b/MobileApp/src/api/sso.test.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { getServerUrl } from "../storage/serverUrl";
+import { buildSsoLoginUrl } from "../sso/providerUrl";
 import {
   GlobalSSOProvider,
   SSOProvider,
@@ -7,7 +8,9 @@ import {
   fetchAllGlobalProviders,
   fetchGlobalOIDCProviders,
   fetchGlobalSSOProviders,
+  fetchProjectOIDCProviders,
   fetchProjectProvidersForEmail,
+  fetchSSOProviders,
   fetchSSOProvidersForProject,
 } from "./sso";
 import { beforeEach, describe, expect, test } from "@jest/globals";
@@ -581,6 +584,13 @@ describe("fetchProjectProvidersForEmail separates 'none' from 'unreachable'", ()
       description: "Acme staff",
       projectId: "project-1",
       project: { name: "Acme" },
+      /*
+       * Stamped by the endpoint that answered, not by the payload. The
+       * discovery response carries no type field, so this is the only thing
+       * telling the app to start the login at /identity/sso rather than
+       * /identity/oidc.
+       */
+      kind: "project",
     });
   });
 
@@ -686,5 +696,614 @@ describe("fetchSSOProvidersForProject", () => {
     await expect(fetchSSOProvidersForProject("project-1")).rejects.toThrow(
       "Network Error",
     );
+  });
+});
+
+/*
+ * The two project-scoped discovery routes, as registered by the server:
+ * App/FeatureSet/Identity/API/SSO.ts  -> router.get("/service-provider-login")
+ * App/FeatureSet/Identity/API/OIDC.ts -> router.get("/service-provider-login-oidc")
+ *
+ * Note the first is a strict PREFIX of the second. Any routing done with
+ * `includes()` sends both requests down the same branch.
+ */
+const PROJECT_SAML_URL: string = `${SERVER_URL}/identity/service-provider-login`;
+const PROJECT_OIDC_URL: string = `${SERVER_URL}/identity/service-provider-login-oidc`;
+
+/**
+ * An axios-shaped rejection carrying an HTTP status, the way axios rejects on
+ * a 4xx/5xx response.
+ */
+function httpStatus(status: number): Error {
+  const error: Error & { response?: { status: number } } = new Error(
+    `Request failed with status code ${status}`,
+  );
+  error.response = { status };
+  return error;
+}
+
+/*
+ * Route the two PROJECT discovery calls independently, as stubGlobalEndpoints
+ * does for the instance-wide pair. fetchProjectProvidersForEmail fires both in
+ * parallel, so "SAML answered, OIDC did not" is only expressible by keying off
+ * the URL.
+ *
+ * The match is exact and longest-first on purpose: "/service-provider-login"
+ * is a prefix of "/service-provider-login-oidc", so a naive
+ * `url.includes("/service-provider-login")` would hand BOTH requests the SAML
+ * outcome and every assertion below would pass for the wrong reason. Any URL
+ * that is neither route is rejected as a transport error, so a route the
+ * module gets wrong shows up as an outage rather than as a silent pass.
+ */
+function stubProjectEndpoints(saml: Outcome, oidc: Outcome): void {
+  getSpy().mockImplementation((url: string): Promise<unknown> => {
+    let outcome: Outcome;
+
+    if (url === PROJECT_OIDC_URL) {
+      outcome = oidc;
+    } else if (url === PROJECT_SAML_URL) {
+      outcome = saml;
+    } else {
+      outcome = new Error(`unexpected discovery URL: ${url}`);
+    }
+
+    if (outcome instanceof Error) {
+      return Promise.reject(outcome);
+    }
+
+    return Promise.resolve(outcome);
+  });
+}
+
+/** A project discovery response body: `{ data: { data: [...] } }`. */
+function projectResponse(items: Array<unknown>): { data: unknown } {
+  return { data: wrapped(items) };
+}
+
+/** Every URL axios.get was asked for, in call order. */
+function getUrls(): Array<string> {
+  return getSpy().mock.calls.map((call: Array<unknown>) => {
+    return call[0] as string;
+  });
+}
+
+/** The config object passed alongside `url`. */
+function configForUrl(url: string): Record<string, unknown> {
+  const call: Array<unknown> | undefined = getSpy().mock.calls.find(
+    (candidate: Array<unknown>) => {
+      return candidate[0] === url;
+    },
+  );
+
+  return (call?.[1] as Record<string, unknown>) || {};
+}
+
+describe("fetchProjectOIDCProviders asks the route the server actually registers", () => {
+  /*
+   * This endpoint existed on the server the whole time and the app never
+   * called it: discovery offered project SAML and both global kinds, so a
+   * project whose only identity provider was OIDC did not appear on the SSO
+   * login screen at all. The literal below is the contract with
+   * App/FeatureSet/Identity/API/OIDC.ts, `router.get("/service-provider-login-oidc")`.
+   * A typo does not fail to compile and does not throw - the request 404s,
+   * which discovery reads as "the server answered", and the screen quietly
+   * goes back to offering nothing.
+   */
+  test("GETs /identity/service-provider-login-oidc with the email as a query param", async () => {
+    respondWith({ data: [] });
+
+    await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(firstGetUrl()).toBe(PROJECT_OIDC_URL);
+    expect(firstGetConfig()["params"]).toEqual({ email: "responder@acme.com" });
+  });
+
+  test("is a different URL from the SAML route, not a suffix-less near miss", async () => {
+    /*
+     * Guards the prefix trap from the other side: if this ever became the SAML
+     * URL, fetchProjectProvidersForEmail would ask the same endpoint twice and
+     * list every SAML provider twice, half of them mis-stamped as OIDC.
+     */
+    respondWith({ data: [] });
+
+    await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(firstGetUrl()).not.toBe(PROJECT_SAML_URL);
+    expect(firstGetUrl().endsWith("-oidc")).toBe(true);
+  });
+
+  test("carries the same 15s timeout as the rest of discovery", async () => {
+    respondWith({ data: [] });
+
+    await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(firstGetConfig()["timeout"]).toBe(15000);
+  });
+
+  test("builds the URL from the stored server, not a hard-coded host", async () => {
+    serverUrlSpy().mockResolvedValue("https://status.acme.internal" as never);
+    respondWith({ data: [] });
+
+    await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(firstGetUrl()).toBe(
+      "https://status.acme.internal/identity/service-provider-login-oidc",
+    );
+  });
+
+  test("a rejection is surfaced to the caller - the raw fetcher does not settle", async () => {
+    /*
+     * Only fetchProjectProvidersForEmail is allowed to swallow a failure into
+     * `failed`. If this one started resolving to [] on its own, an outage
+     * would become "this email has no OIDC" one level too early.
+     */
+    getSpy().mockRejectedValue(httpStatus(503) as never);
+
+    await expect(
+      fetchProjectOIDCProviders("responder@acme.com"),
+    ).rejects.toThrow("Request failed with status code 503");
+  });
+});
+
+describe("The project kind is stamped by the endpoint that answered", () => {
+  /*
+   * The whole point of the `kind` field. Neither project discovery payload
+   * carries a type, so the endpoint asked is the only thing that can say
+   * whether a provider's login starts at /identity/sso/:projectId/:id or
+   * /identity/oidc/:projectId/:id. Sending one to the other 400s from a router
+   * that has never heard of that id.
+   */
+  test("every provider from the OIDC endpoint is stamped project-oidc", async () => {
+    respondWith(wrapped([{ _id: "a", name: "Entra" }, { _id: "b" }]));
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(
+      providers.map((provider: SSOProvider) => {
+        return provider.kind;
+      }),
+    ).toEqual(["project-oidc", "project-oidc"]);
+  });
+
+  test("every provider from the SAML endpoint is stamped project", async () => {
+    respondWith(wrapped([{ _id: "a", name: "Okta" }, { _id: "b" }]));
+
+    const providers: Array<SSOProvider> =
+      await fetchSSOProviders("responder@acme.com");
+
+    expect(
+      providers.map((provider: SSOProvider) => {
+        return provider.kind;
+      }),
+    ).toEqual(["project", "project"]);
+  });
+
+  test("a kind field in the payload never overrides the endpoint", async () => {
+    /*
+     * Nothing on the server sends this today. If something ever starts - or a
+     * stale cached body carries one - the endpoint still has to win.
+     */
+    respondWith(wrapped([{ _id: "a", name: "Entra", kind: "project" }]));
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]!.kind).toBe("project-oidc");
+  });
+
+  test("the stamped kind routes the login to the OIDC router, not the SAML one", async () => {
+    /*
+     * Ties the stamp to the thing it exists for: the discovered provider fed
+     * to buildSsoLoginUrl has to come out on /identity/oidc/:projectId/:id,
+     * which is what App/FeatureSet/Identity/API/OIDC.ts registers.
+     */
+    respondWith(
+      wrapped([
+        {
+          _id: { _type: "ObjectID", value: "oidc-1" },
+          name: "Entra",
+          projectId: { _type: "ObjectID", value: "project-1" },
+        },
+      ]),
+    );
+
+    const provider: SSOProvider = (
+      await fetchProjectOIDCProviders("responder@acme.com")
+    )[0]!;
+
+    expect(
+      buildSsoLoginUrl(SERVER_URL, {
+        kind: provider.kind,
+        providerId: provider._id,
+        projectId: provider.projectId,
+      }),
+    ).toBe(`${SERVER_URL}/identity/oidc/project-1/oidc-1?mobile=true`);
+  });
+});
+
+describe("fetchProjectOIDCProviders de-serialises the payload like the SAML one", () => {
+  test("unwraps the ObjectID envelopes and the project relation", async () => {
+    respondWith({
+      data: [
+        {
+          _id: { _type: "ObjectID", value: "oidc-1" },
+          name: "Acme Entra",
+          description: "Acme staff",
+          projectId: { _type: "ObjectID", value: "project-1" },
+          project: { name: "Acme" },
+        },
+      ],
+    });
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]).toEqual({
+      _id: "oidc-1",
+      name: "Acme Entra",
+      description: "Acme staff",
+      projectId: "project-1",
+      project: { name: "Acme" },
+      kind: "project-oidc",
+    });
+  });
+
+  test("ids that are already plain strings are left alone", async () => {
+    respondWith(
+      wrapped([{ _id: "oidc-1", name: "Entra", projectId: "project-1" }]),
+    );
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]!._id).toBe("oidc-1");
+    expect(providers[0]!.projectId).toBe("project-1");
+  });
+
+  test("a missing projectId becomes an empty string, never undefined", async () => {
+    /*
+     * The projectId is a path segment of the login URL. undefined would be
+     * pasted in literally as "/identity/oidc/undefined/<id>"; the empty string
+     * is what buildSsoLoginUrl checks for before it throws.
+     */
+    respondWith(wrapped([{ _id: "oidc-1", name: "Entra" }]));
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]!.projectId).toBe("");
+    expect(providers[0]!._id).toBe("oidc-1");
+  });
+
+  test("a missing name becomes an empty string so the row still renders", async () => {
+    respondWith(wrapped([{ _id: "oidc-1" }]));
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]!.name).toBe("");
+  });
+
+  test("an empty project name carries no project object", async () => {
+    /*
+     * The select screen prints "<provider> - <project>" only when there is a
+     * project to print; an empty name would render a dangling separator.
+     */
+    respondWith(
+      wrapped([{ _id: "oidc-1", name: "Entra", project: { name: "" } }]),
+    );
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]!.project).toBeUndefined();
+  });
+
+  test("a missing project relation leaves project undefined", async () => {
+    respondWith(wrapped([{ _id: "oidc-1", name: "Entra" }]));
+
+    const providers: Array<SSOProvider> =
+      await fetchProjectOIDCProviders("responder@acme.com");
+
+    expect(providers[0]!.project).toBeUndefined();
+  });
+
+  test("a null body yields an empty list instead of throwing", async () => {
+    respondWith(null);
+
+    await expect(
+      fetchProjectOIDCProviders("responder@acme.com"),
+    ).resolves.toEqual([]);
+  });
+
+  test("a body with no data key yields an empty list", async () => {
+    respondWith({});
+
+    await expect(
+      fetchProjectOIDCProviders("responder@acme.com"),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("fetchProjectProvidersForEmail asks BOTH project endpoints", () => {
+  test("fires two GETs, one per route, each carrying the email", async () => {
+    stubProjectEndpoints(projectResponse([]), projectResponse([]));
+
+    await fetchProjectProvidersForEmail("responder@acme.com");
+
+    const urls: Array<string> = getUrls();
+
+    expect(urls).toHaveLength(2);
+    expect(urls).toContain(PROJECT_SAML_URL);
+    expect(urls).toContain(PROJECT_OIDC_URL);
+    expect(configForUrl(PROJECT_SAML_URL)["params"]).toEqual({
+      email: "responder@acme.com",
+    });
+    expect(configForUrl(PROJECT_OIDC_URL)["params"]).toEqual({
+      email: "responder@acme.com",
+    });
+  });
+
+  test("concatenates SAML first, then OIDC, with the right kind on each half", async () => {
+    stubProjectEndpoints(
+      projectResponse([
+        {
+          _id: "saml-1",
+          name: "Acme Okta",
+          projectId: { _type: "ObjectID", value: "project-1" },
+          project: { name: "Acme" },
+        },
+      ]),
+      projectResponse([
+        {
+          _id: "oidc-1",
+          name: "Acme Entra",
+          projectId: { _type: "ObjectID", value: "project-2" },
+          project: { name: "Beta" },
+        },
+      ]),
+    );
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(
+      result.providers.map((provider: SSOProvider) => {
+        return [provider._id, provider.projectId, provider.kind];
+      }),
+    ).toEqual([
+      ["saml-1", "project-1", "project"],
+      ["oidc-1", "project-2", "project-oidc"],
+    ]);
+  });
+
+  test("the order is the request order, not the order the endpoints answer in", async () => {
+    /*
+     * Promise.all preserves the input order, so a slow SAML endpoint must not
+     * push its providers below the OIDC ones - the select screen lists them in
+     * this order and an unstable list would reshuffle under the user's finger.
+     */
+    getSpy().mockImplementation((url: string): Promise<unknown> => {
+      if (url === PROJECT_OIDC_URL) {
+        return Promise.resolve(projectResponse([{ _id: "oidc-1" }]));
+      }
+
+      return new Promise((resolve: (value: unknown) => void): void => {
+        setTimeout(() => {
+          resolve(projectResponse([{ _id: "saml-1" }]));
+        }, 20);
+      });
+    });
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(
+      result.providers.map((provider: SSOProvider) => {
+        return provider._id;
+      }),
+    ).toEqual(["saml-1", "oidc-1"]);
+  });
+
+  test("two identically named providers keep the kind of the endpoint they came from", async () => {
+    /*
+     * A tenant that runs both SAML and OIDC against the same IdP names them
+     * the same thing. Nothing in the merged list distinguishes them except
+     * `kind`, and that is what picks the router.
+     */
+    stubProjectEndpoints(
+      projectResponse([{ _id: "same-name-1", name: "Corp IdP" }]),
+      projectResponse([{ _id: "same-name-2", name: "Corp IdP" }]),
+    );
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(
+      result.providers.map((provider: SSOProvider) => {
+        return [provider.name, provider.kind];
+      }),
+    ).toEqual([
+      ["Corp IdP", "project"],
+      ["Corp IdP", "project-oidc"],
+    ]);
+  });
+});
+
+describe("fetchProjectProvidersForEmail reports failure only when BOTH routes are down", () => {
+  const samlOnly: { data: unknown } = projectResponse([
+    { _id: "saml-1", name: "Okta" },
+  ]);
+  const oidcOnly: { data: unknown } = projectResponse([
+    { _id: "oidc-1", name: "Entra" },
+  ]);
+
+  test("both endpoints answering is not failed", async () => {
+    stubProjectEndpoints(samlOnly, oidcOnly);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(2);
+  });
+
+  test("only SAML failing still returns a usable OIDC list, and is not failed", async () => {
+    /*
+     * This is the regression the whole change exists for, in its harshest
+     * form: the project's SAML endpoint is down and its ONLY identity provider
+     * is OIDC. Reporting failure here would hide a login that works perfectly
+     * behind a retry prompt.
+     */
+    stubProjectEndpoints(httpStatus(503), oidcOnly);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!._id).toBe("oidc-1");
+    expect(result.providers[0]!.kind).toBe("project-oidc");
+  });
+
+  test("only OIDC failing still returns the SAML list, and is not failed", async () => {
+    stubProjectEndpoints(samlOnly, new Error("Network Error"));
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!._id).toBe("saml-1");
+    expect(result.providers[0]!.kind).toBe("project");
+  });
+
+  test("both endpoints unreachable is the only case reported as failed", async () => {
+    stubProjectEndpoints(
+      new Error("Network Error"),
+      new Error("Network Error"),
+    );
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(true);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("both endpoints answering 5xx is failed too", async () => {
+    stubProjectEndpoints(httpStatus(502), httpStatus(500));
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(true);
+    expect(result.providers).toEqual([]);
+  });
+
+  /*
+   * The 4xx distinction, applied to the pair. Both routes answer the ordinary
+   * "nothing configured for this address" case with HTTP 400 - SSO.ts says
+   * "No SSO config found for this user", OIDC.ts says "No OIDC config found
+   * for this user" - and axios rejects on 4xx. A 400 from one endpoint while
+   * the other hands back providers is the single most common real-world
+   * outcome, and calling it an outage would tell a user whose network is fine
+   * to go and check their network.
+   */
+  test("a 400 from OIDC alongside SAML providers is not an outage", async () => {
+    stubProjectEndpoints(samlOnly, httpStatus(400));
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.kind).toBe("project");
+  });
+
+  test("a 400 from SAML alongside OIDC providers is not an outage", async () => {
+    stubProjectEndpoints(httpStatus(400), oidcOnly);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.kind).toBe("project-oidc");
+  });
+
+  test("both endpoints answering 400 is empty and NOT failed", async () => {
+    stubProjectEndpoints(httpStatus(400), httpStatus(400));
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("both endpoints answering an empty list is empty and NOT failed", async () => {
+    /*
+     * "No project on this instance federates that address" and "we could not
+     * reach your server" are the same empty list; only the second is worth a
+     * retry button.
+     */
+    stubProjectEndpoints(projectResponse([]), projectResponse([]));
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("one endpoint empty and the other populated is not failed", async () => {
+    stubProjectEndpoints(projectResponse([]), oidcOnly);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.kind).toBe("project-oidc");
+  });
+
+  test("a 400 from one route and a 5xx from the other is still not reported as failed", async () => {
+    /*
+     * The documented rule taken to its edge: `failed` means BOTH endpoints
+     * were unreachable, and a 400 counts as reached. So SAML answering "no
+     * config for this user" while OIDC is genuinely down produces an empty
+     * list with failed=false - the user is told they have no project SSO
+     * without a retry button, even though the OIDC half was never heard from.
+     */
+    stubProjectEndpoints(httpStatus(400), httpStatus(503));
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("a malformed 200 from one route does not throw out of the merge", async () => {
+    /*
+     * `response.data.data` being an object rather than an array makes .map
+     * throw inside the fetcher. That happens while the user is typing their
+     * email, so it must land in `failed` rather than escape as an unhandled
+     * rejection - and the other route's providers must survive it.
+     */
+    stubProjectEndpoints(
+      { data: { data: { message: "unauthorized" } } },
+      oidcOnly,
+    );
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.kind).toBe("project-oidc");
   });
 });

--- a/MobileApp/src/api/sso.ts
+++ b/MobileApp/src/api/sso.ts
@@ -10,6 +10,13 @@ export interface SSOProvider {
   project?: {
     name: string;
   };
+  /*
+   * Which project-scoped router starts this login. The discovery payload does
+   * not carry it - the endpoint that answered is what determines it - so it is
+   * stamped on at parse time. Without it the app cannot tell a project SAML
+   * provider from a project OIDC one, and would send both to /identity/sso.
+   */
+  kind: Extract<SsoProviderKind, "project" | "project-oidc">;
 }
 
 /*
@@ -45,16 +52,23 @@ interface RawSSOItem {
   };
 }
 
-function parseSSOProvider(raw: RawSSOItem): SSOProvider {
+function parseSSOProvider(
+  raw: RawSSOItem,
+  kind: SSOProvider["kind"],
+): SSOProvider {
   return {
     _id: resolveId(raw._id),
     name: raw.name || "",
     description: raw.description,
     projectId: resolveId(raw.projectId),
     project: raw.project?.name ? { name: raw.project.name } : undefined,
+    kind,
   };
 }
 
+/**
+ * Project SAML providers configured for `email`.
+ */
 export async function fetchSSOProviders(
   email: string,
 ): Promise<Array<SSOProvider>> {
@@ -70,7 +84,36 @@ export async function fetchSSOProviders(
 
   const items: Array<RawSSOItem> = response.data?.data || [];
 
-  return items.map(parseSSOProvider);
+  return items.map((item: RawSSOItem) => {
+    return parseSSOProvider(item, "project");
+  });
+}
+
+/**
+ * Project OIDC providers configured for `email`.
+ *
+ * A separate endpoint from the SAML one, and it was never called: the app
+ * offered project SAML and both global kinds, so a project whose only identity
+ * provider was OIDC simply did not appear on the SSO login screen at all.
+ */
+export async function fetchProjectOIDCProviders(
+  email: string,
+): Promise<Array<SSOProvider>> {
+  const serverUrl: string = await getServerUrl();
+
+  const response: AxiosResponse = await axios.get(
+    `${serverUrl}/identity/service-provider-login-oidc`,
+    {
+      params: { email },
+      timeout: 15000,
+    },
+  );
+
+  const items: Array<RawSSOItem> = response.data?.data || [];
+
+  return items.map((item: RawSSOItem) => {
+    return parseSSOProvider(item, "project-oidc");
+  });
 }
 
 /**
@@ -245,9 +288,26 @@ export async function fetchAllGlobalProviders(): Promise<
 export async function fetchProjectProvidersForEmail(
   email: string,
 ): Promise<SsoDiscoveryResult<SSOProvider>> {
-  return settle(() => {
-    return fetchSSOProviders(email);
-  });
+  const [saml, oidc]: [
+    SsoDiscoveryResult<SSOProvider>,
+    SsoDiscoveryResult<SSOProvider>,
+  ] = await Promise.all([
+    settle(() => {
+      return fetchSSOProviders(email);
+    }),
+    settle(() => {
+      return fetchProjectOIDCProviders(email);
+    }),
+  ]);
+
+  return {
+    providers: [...saml.providers, ...oidc.providers],
+    /*
+     * Only an outage on BOTH endpoints is an outage worth telling the user
+     * about. One of the two being down still leaves a login screen that works.
+     */
+    failed: saml.failed && oidc.failed,
+  };
 }
 
 export async function fetchSSOProvidersForProject(
@@ -266,7 +326,7 @@ export async function fetchSSOProvidersForProject(
   const items: Array<RawSSOItem> = response.data?.data || [];
 
   return items.map((item: RawSSOItem) => {
-    const parsed: SSOProvider = parseSSOProvider(item);
+    const parsed: SSOProvider = parseSSOProvider(item, "project");
     // For project-specific endpoint, use the passed-in projectId
     parsed.projectId = projectId;
     return parsed;

--- a/MobileApp/src/hooks/useAuth.tsx
+++ b/MobileApp/src/hooks/useAuth.tsx
@@ -29,6 +29,7 @@ import {
   completeSsoLoginFromUrl,
   type CompleteSsoLoginOutcome,
 } from "../sso/session";
+import { clearAllSsoDenials } from "../sso/ssoDenials";
 
 interface AuthContextValue {
   isAuthenticated: boolean;
@@ -145,6 +146,12 @@ export function AuthProvider({
     await unregisterPushToken();
     await apiLogout();
     await clearAllSsoTokens();
+    /*
+     * The denial set is module-scope and in-memory, so without this a project
+     * the previous user was refused would still read as "needs SSO" for
+     * whoever signs in next on the same handset.
+     */
+    clearAllSsoDenials();
     setIsAuthenticated(false);
     setUser(null);
   }, []);

--- a/MobileApp/src/hooks/useAuthSsoColdStart.test.tsx
+++ b/MobileApp/src/hooks/useAuthSsoColdStart.test.tsx
@@ -18,6 +18,11 @@ import {
 } from "../storage/ssoTokens";
 import { logout as apiLogout } from "../api/auth";
 import { unregisterPushToken } from "./pushTokenUtils";
+/*
+ * Deliberately NOT mocked: the assertion below is about real denial state
+ * surviving (or not) a sign-out, which a spy would not tell us.
+ */
+import { isProjectSsoDenied, markProjectSsoDenied } from "../sso/ssoDenials";
 
 /*
  * AuthProvider is the only thing running when the app cold-starts, so it is
@@ -548,6 +553,26 @@ describe("AuthProvider logout", () => {
     });
 
     expect(unregisterPushTokenSpy()).toHaveBeenCalled();
+  });
+
+  test("clears the recorded SSO denials, so they do not follow the next user", async () => {
+    /*
+     * The denial set is module-scope and in-memory, cleared only by a
+     * successful SSO callback or by the process restarting. Without a clear on
+     * sign-out, a project the PREVIOUS user was refused would still read as
+     * "needs SSO" for whoever signs in next on the same handset - and that
+     * user may need no SSO at all.
+     */
+    markProjectSsoDenied("project-from-the-previous-user");
+    expect(isProjectSsoDenied("project-from-the-previous-user")).toBe(true);
+
+    await renderAuthProvider();
+
+    await act(async () => {
+      await currentAuth().logout();
+    });
+
+    expect(isProjectSsoDenied("project-from-the-previous-user")).toBe(false);
   });
 
   test("the context reports the user as signed out afterwards", async () => {

--- a/MobileApp/src/navigation/types.ts
+++ b/MobileApp/src/navigation/types.ts
@@ -23,7 +23,7 @@ export interface SelectableSsoProvider {
   _id: string;
   name: string;
   description?: string;
-  kind: "project" | "global-sso" | "global-oidc";
+  kind: "project" | "project-oidc" | "global-sso" | "global-oidc";
 }
 
 export type SettingsStackParamList = {

--- a/MobileApp/src/screens/HomeScreen.tsx
+++ b/MobileApp/src/screens/HomeScreen.tsx
@@ -22,6 +22,7 @@ import Logo from "../components/Logo";
 import GradientButton from "../components/GradientButton";
 import { useAllProjectOnCallPolicies } from "../hooks/useAllProjectOnCallPolicies";
 import { getGlobalSsoToken, getSsoTokens } from "../storage/ssoTokens";
+import { isProjectSsoDenied } from "../sso/ssoDenials";
 
 type HomeNavProp = BottomTabNavigationProp<MainTabParamList, "Home">;
 
@@ -193,7 +194,21 @@ export default function HomeScreen(): React.JSX.Element {
       const globalSsoToken: string | null = await getGlobalSsoToken();
       const unauthenticated: ProjectItem[] = projectList.filter(
         (p: ProjectItem) => {
-          return p.requireSsoForLogin && !ssoTokens[p._id] && !globalSsoToken;
+          if (!p.requireSsoForLogin) {
+            return false;
+          }
+
+          /*
+           * A denial recorded by the API client outranks anything in storage:
+           * the server has already refused this project, so a stored token
+           * (expired, or issued by a provider that has since been disabled or
+           * restricted) does not make it authenticated.
+           */
+          if (isProjectSsoDenied(p._id)) {
+            return true;
+          }
+
+          return !ssoTokens[p._id] && !globalSsoToken;
         },
       );
       setUnauthenticatedSsoProjects(unauthenticated);

--- a/MobileApp/src/screens/auth/SSOLoginScreen.test.tsx
+++ b/MobileApp/src/screens/auth/SSOLoginScreen.test.tsx
@@ -144,6 +144,8 @@ function projectProvider(overrides: Partial<SSOProvider> = {}): SSOProvider {
     name: "Acme Okta",
     projectId: "project-1",
     project: { name: "Acme Production" },
+    // Project SAML by default; pass kind: "project-oidc" for the OIDC router.
+    kind: "project",
     ...overrides,
   };
 }
@@ -773,6 +775,261 @@ describe("Choosing a project provider", () => {
     await waitFor(() => {
       expect(mockAuth.setIsAuthenticated).toHaveBeenCalledWith(true);
     });
+  });
+});
+
+/*
+ * Project OIDC is served by a SECOND discovery endpoint
+ * (/identity/service-provider-login-oidc) that this screen never asked. It
+ * knew about project SAML and the two global kinds only, so a project whose
+ * only identity provider was OIDC did not appear here at all - and because
+ * project discovery is email-scoped, there was no address a user could type
+ * that would ever reveal it. They were told their email had no SSO config.
+ *
+ * Neither project payload carries a type field, so the `kind` stamped on by
+ * whichever endpoint answered is the only thing separating the two - and it
+ * picks the router: project SAML is /identity/sso/:projectId/:providerId,
+ * project OIDC is /identity/oidc/:projectId/:providerId. Each router 400s on
+ * the other's ids, so a mis-routed row is a login that cannot complete.
+ */
+function projectOidcProvider(
+  overrides: Partial<SSOProvider> = {},
+): SSOProvider {
+  return projectProvider({
+    _id: "provider-oidc-1",
+    name: "Acme Entra ID",
+    kind: "project-oidc",
+    ...overrides,
+  });
+}
+
+describe("A project whose identity provider is OIDC", () => {
+  test("is offered on the provider list like any other", async () => {
+    projectDiscovery().mockResolvedValue(found([projectOidcProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Select your SSO provider")).toBeTruthy();
+    expect(screen.getByText("Acme Entra ID")).toBeTruthy();
+    expect(screen.getByText("Acme Production")).toBeTruthy();
+  });
+
+  test("tapping it opens the project OIDC route for that project", async () => {
+    projectDiscovery().mockResolvedValue(found([projectOidcProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/oidc/project-1/provider-oidc-1?mobile=true",
+      );
+    });
+  });
+
+  test("and never the SAML route, which has never heard of its id", async () => {
+    /*
+     * The kind is the only thing standing between an OIDC provider and
+     * /identity/sso/..., where the id belongs to no SAML config and the login
+     * dies on a 400 inside the auth browser - after the user has already been
+     * sent away from the app.
+     */
+    projectDiscovery().mockResolvedValue(found([projectOidcProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledTimes(1);
+    });
+
+    const requestedUrl: string = authSession().mock.calls[0][0] as string;
+
+    expect(requestedUrl).toContain("/identity/oidc/");
+    expect(requestedUrl).not.toContain("/identity/sso/");
+  });
+
+  test("a completed OIDC login signs the user in", async () => {
+    projectDiscovery().mockResolvedValue(found([projectOidcProvider()]));
+    authSession().mockResolvedValue({
+      status: "callback",
+      url: "oneuptime://sso-callback?sso-token=abc&project-id=project-1",
+    });
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(completeLogin()).toHaveBeenCalledWith(
+        "oneuptime://sso-callback?sso-token=abc&project-id=project-1",
+      );
+    });
+
+    expect(mockAuth.setIsAuthenticated).toHaveBeenCalledWith(true);
+  });
+
+  test("one with no project id is reported as misconfigured, not routed", async () => {
+    /*
+     * The project-scoped guard has to cover BOTH project kinds. If it only
+     * knew about SAML, an OIDC row from a sparse payload would build
+     * /identity/oidc//provider-oidc-1 and fail somewhere the user cannot see.
+     */
+    projectDiscovery().mockResolvedValue(
+      found([projectOidcProvider({ projectId: "" })]),
+    );
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    expect(
+      await screen.findByText(
+        "This SSO provider is misconfigured and cannot be used. Please contact your admin.",
+      ),
+    ).toBeTruthy();
+    expect(authSession()).not.toHaveBeenCalled();
+    expect(mockAuth.setIsAuthenticated).not.toHaveBeenCalled();
+  });
+});
+
+describe("A project that has both a SAML and an OIDC provider", () => {
+  function bothKinds(): Array<SSOProvider> {
+    return [projectProvider(), projectOidcProvider()];
+  }
+
+  test("offers both of them, under the one project heading", async () => {
+    /*
+     * They belong to the same project, so grouping by project id has to put
+     * them together - a second "Acme Production" heading would read as a
+     * second project the user has to choose between.
+     */
+    projectDiscovery().mockResolvedValue(found(bothKinds()));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Acme Okta")).toBeTruthy();
+    expect(screen.getByText("Acme Entra ID")).toBeTruthy();
+    expect(screen.getAllByText("Acme Production")).toHaveLength(1);
+  });
+
+  test("and each row starts its own router", async () => {
+    projectDiscovery().mockResolvedValue(found(bothKinds()));
+    authSession().mockResolvedValue({ status: "cancelled" });
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/sso/project-1/provider-1?mobile=true",
+      );
+    });
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/oidc/project-1/provider-oidc-1?mobile=true",
+      );
+    });
+
+    expect(authSession()).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Two projects that federate the same address differently", () => {
+  function oneOfEach(): Array<SSOProvider> {
+    return [
+      projectProvider(),
+      projectOidcProvider({
+        projectId: "project-2",
+        project: { name: "Acme Staging" },
+      }),
+    ];
+  }
+
+  test("are listed under their own project names", async () => {
+    projectDiscovery().mockResolvedValue(found(oneOfEach()));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Acme Production")).toBeTruthy();
+    expect(screen.getByText("Acme Staging")).toBeTruthy();
+    expect(screen.getByText("Acme Okta")).toBeTruthy();
+    expect(screen.getByText("Acme Entra ID")).toBeTruthy();
+  });
+
+  test("and the OIDC one carries its own project into the URL", async () => {
+    /*
+     * Both ids come out of the path, so an OIDC row that borrowed the SAML
+     * project's id would start a login for the wrong project.
+     */
+    projectDiscovery().mockResolvedValue(found(oneOfEach()));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/oidc/project-2/provider-oidc-1?mobile=true",
+      );
+    });
+  });
+});
+
+describe("An instance whose only SSO is project OIDC", () => {
+  test("has a working login screen rather than nothing at all", async () => {
+    /*
+     * The regression in one test: no global providers, no project SAML, one
+     * project OIDC provider. This used to land on "No SSO configuration found
+     * for the email", because the only endpoint the app asked was the SAML
+     * one and it correctly answered that there was no SAML.
+     */
+    globalDiscovery().mockResolvedValue(found<GlobalSSOProvider>([]));
+    projectDiscovery().mockResolvedValue(found([projectOidcProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Acme Entra ID")).toBeTruthy();
+    expect(screen.queryByText(/No SSO configuration found/i)).toBeNull();
+    expectNoErrorShown();
+  });
+
+  test("and the login it starts is one that can complete", async () => {
+    globalDiscovery().mockResolvedValue(found<GlobalSSOProvider>([]));
+    projectDiscovery().mockResolvedValue(found([projectOidcProvider()]));
+    authSession().mockResolvedValue({
+      status: "callback",
+      url: "oneuptime://sso-callback?sso-token=abc&project-id=project-1",
+    });
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/oidc/project-1/provider-oidc-1?mobile=true",
+      );
+    });
+
+    expect(mockAuth.setIsAuthenticated).toHaveBeenCalledWith(true);
   });
 });
 

--- a/MobileApp/src/screens/auth/SSOLoginScreen.tsx
+++ b/MobileApp/src/screens/auth/SSOLoginScreen.tsx
@@ -198,7 +198,8 @@ export default function SSOLoginScreen(): React.JSX.Element {
       const serverUrl: string = await getServerUrl();
 
       return buildSsoLoginUrl(serverUrl, {
-        kind: "project",
+        // SAML and OIDC project providers are served by different routers.
+        kind: provider.kind,
         providerId: provider._id,
         projectId: provider.projectId,
       });

--- a/MobileApp/src/screens/settings/ProjectsScreen.tsx
+++ b/MobileApp/src/screens/settings/ProjectsScreen.tsx
@@ -20,6 +20,10 @@ import {
 } from "../../api/sso";
 import { getServerUrl } from "../../storage/serverUrl";
 import { getSsoTokens, getGlobalSsoToken } from "../../storage/ssoTokens";
+import {
+  getSsoDeniedProjectIds,
+  subscribeToSsoDenials,
+} from "../../sso/ssoDenials";
 import { buildSsoLoginUrl } from "../../sso/providerUrl";
 import {
   openSsoAuthSession,
@@ -50,6 +54,16 @@ export default function ProjectsScreen({
     string | null
   >(null);
   const [error, setError] = useState<string | null>(null);
+  const [deniedProjectIds, setDeniedProjectIds] = useState<Array<string>>(
+    getSsoDeniedProjectIds(),
+  );
+
+  // The API client records denials as requests fail; mirror them into state.
+  useEffect(() => {
+    return subscribeToSsoDenials((): void => {
+      setDeniedProjectIds(getSsoDeniedProjectIds());
+    });
+  }, []);
 
   const loadData: () => Promise<void> = useCallback(async (): Promise<void> => {
     try {
@@ -186,7 +200,8 @@ export default function ProjectsScreen({
             _id: provider._id,
             name: provider.name,
             description: provider.description,
-            kind: "project" as const,
+            // "project" (SAML) or "project-oidc" - different routers.
+            kind: provider.kind,
           };
         }),
       ];
@@ -218,7 +233,18 @@ export default function ProjectsScreen({
   const isProjectAuthenticated: (projectId: string) => boolean = (
     projectId: string,
   ): boolean => {
-    // A global SSO token satisfies enforcement for every project.
+    /*
+     * The server has the last word. A stored token - global or per-project -
+     * is only evidence; if the server has actually refused this project on SSO
+     * grounds (expired token, disabled provider, a provider restricted to
+     * other projects) then it is not authenticated no matter what is in
+     * storage, and the user needs the button rather than a green badge.
+     */
+    if (deniedProjectIds.includes(projectId)) {
+      return false;
+    }
+
+    // Otherwise a global SSO token satisfies enforcement for every project.
     return Boolean(ssoTokens[projectId] || globalSsoToken);
   };
 

--- a/MobileApp/src/screens/settings/SSOProviderSelectScreen.test.tsx
+++ b/MobileApp/src/screens/settings/SSOProviderSelectScreen.test.tsx
@@ -5,8 +5,10 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react-native";
 import SSOProviderSelectScreen from "./SSOProviderSelectScreen";
+import type { SsoProviderKind } from "../../sso/providerUrl";
 import {
   openSsoAuthSession,
   type SsoAuthSessionOutcome,
@@ -105,6 +107,20 @@ const projectSamlProvider: SelectableSsoProvider = {
 };
 
 /*
+ * The fourth kind, and the last one the app learned to discover. It is the
+ * only one that is BOTH project-scoped and OIDC, so it is the one a routing
+ * shortcut gets wrong: treated as project SAML it goes to `/identity/sso/...`,
+ * treated as OIDC-therefore-global it loses the project id, and both land on a
+ * router that has never heard of the id.
+ */
+const projectOidcProvider: SelectableSsoProvider = {
+  _id: "bbbbbbbbbbbbbbbbbbbbbbb2",
+  name: "Production Keycloak",
+  description: "OIDC configured in this project's settings",
+  kind: "project-oidc",
+};
+
+/*
  * Every message this screen is capable of showing contains one of these words.
  * Used to assert the ABSENCE of an error, which a `queryByText` of one specific
  * string would not really establish.
@@ -185,6 +201,30 @@ function lastOpenedUrl(): string {
   return urls[urls.length - 1] as string;
 }
 
+// The element type RNTL's queries hand back; it has no exported name.
+type QueriedElement = ReturnType<typeof screen.getByText>;
+
+/**
+ * Queries scoped to the section a heading introduces.
+ *
+ * Each heading and the card of rows it labels are the two children of one
+ * wrapper View, so the heading's parent IS the section. Scoping to it is what
+ * turns "the row is on the screen somewhere" into "the row is on the side of
+ * the global/project line it belongs on" - and grouping is the whole point of
+ * the two headings, since picking a provider from the wrong group is a
+ * rejection the server explains to nobody.
+ */
+function withinSection(heading: string): ReturnType<typeof within> {
+  const headingNode: QueriedElement = screen.getByText(heading);
+  const section: QueriedElement | null = headingNode.parent;
+
+  if (!section) {
+    throw new Error(`The "${heading}" heading is not inside a section.`);
+  }
+
+  return within(section);
+}
+
 function isRowDisabled(name: string): boolean {
   const row: { props: { accessibilityState?: { disabled?: boolean } } } =
     screen.getByLabelText(name) as unknown as {
@@ -262,6 +302,50 @@ describe("The row sends the user to the router that owns the provider", () => {
       `${SERVER_URL}/identity/global-oidc/${globalOidcProvider._id}?mobile=true`,
     );
     expect(lastOpenedUrl()).not.toContain(PROJECT_ID);
+  });
+
+  test("a project OIDC provider goes to the project OIDC router, keeping the project id", async () => {
+    /*
+     * The other half of the same regression, from the other direction: a
+     * project whose only identity provider is OIDC was invisible to the app
+     * until discovery learned to ask `/identity/service-provider-login-oidc`,
+     * and a row for it is only useful if it opens
+     * `/identity/oidc/<projectId>/<id>`. Both neighbouring routes are wrong in
+     * a way the user cannot see - `/identity/sso/...` is project SAML and
+     * would 400 on an id it does not own, and `/identity/global-oidc/...` is
+     * the instance-wide OIDC router, which takes no project at all.
+     */
+    await renderScreen([projectOidcProvider]);
+
+    await pressProvider(projectOidcProvider.name);
+    await settleAuthFlow();
+
+    expect(lastOpenedUrl()).toBe(
+      `${SERVER_URL}/identity/oidc/${PROJECT_ID}/${projectOidcProvider._id}?mobile=true`,
+    );
+    expect(lastOpenedUrl()).not.toContain("/identity/sso/");
+    expect(lastOpenedUrl()).not.toContain("/identity/global-oidc/");
+  });
+
+  test("the two project kinds do not share a route", async () => {
+    /*
+     * Nothing in the discovery payload says which of the two a provider is -
+     * only the endpoint that answered does - so if `kind` were dropped
+     * anywhere between discovery and this row, both would open the same URL
+     * and one of them would be silently broken.
+     */
+    await renderScreen([projectSamlProvider, projectOidcProvider]);
+
+    await pressProvider(projectSamlProvider.name);
+    await settleAuthFlow();
+    await pressProvider(projectOidcProvider.name);
+    await settleAuthFlow();
+
+    const [samlUrl, oidcUrl]: Array<string> = openedUrls();
+
+    expect(samlUrl).toContain(`/identity/sso/${PROJECT_ID}/`);
+    expect(oidcUrl).toContain(`/identity/oidc/${PROJECT_ID}/`);
+    expect(samlUrl).not.toBe(oidcUrl);
   });
 
   test("every login is flagged as a mobile login", async () => {
@@ -346,6 +430,23 @@ describe("A completed login is persisted before the sheet closes", () => {
 
     expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledWith(CALLBACK_URL);
     expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("a project OIDC login is stored and the sheet closes", async () => {
+    /*
+     * A project OIDC login comes back with a project-bound token, exactly like
+     * project SAML - the newest kind must not be the one that reaches the
+     * hand-off differently.
+     */
+    const rendered: RenderedScreen = await renderScreen([projectOidcProvider]);
+
+    await pressProvider(projectOidcProvider.name);
+    await settleAuthFlow();
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledTimes(1);
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(ANY_ERROR_MESSAGE)).toBeNull();
   });
 
   test("the url handed over is the browser's callback, not the login url", async () => {
@@ -467,6 +568,28 @@ describe("Nothing is claimed when the login did not complete", () => {
     );
 
     await pressProvider(projectSamlProvider.name);
+
+    await waitFor((): void => {
+      expect(screen.getByText(/SSO authentication failed/i)).toBeTruthy();
+    });
+
+    expect(mockOpenSsoAuthSession).not.toHaveBeenCalled();
+    expect(rendered.goBack).not.toHaveBeenCalled();
+  });
+
+  test("a project OIDC row with no project id is refused too", async () => {
+    /*
+     * `isProjectScopedKind` is what decides whether a project id is demanded.
+     * If project OIDC had been left out of it, this would open
+     * `/identity/global-oidc/<projectOidcId>` - a URL that is well-formed, so
+     * the browser opens happily and the failure only surfaces at the IdP.
+     */
+    const rendered: RenderedScreen = await renderScreen(
+      [projectOidcProvider],
+      "",
+    );
+
+    await pressProvider(projectOidcProvider.name);
 
     await waitFor((): void => {
       expect(screen.getByText(/SSO authentication failed/i)).toBeTruthy();
@@ -637,6 +760,68 @@ describe("Grouping the providers a user can choose from", () => {
     expect(screen.queryByText("Available providers")).toBeNull();
   });
 
+  test("a project OIDC provider is listed under the project heading, not the organization one", async () => {
+    /*
+     * "OIDC" is not a synonym for "global": project OIDC belongs to this one
+     * project, and filing it with the organization's providers would both
+     * mislabel it and - since the grouping and the routing are the same
+     * `isProjectScopedKind` call - mean its login url had lost the project id.
+     */
+    await renderScreen([globalOidcProvider, projectOidcProvider]);
+
+    expect(
+      withinSection("This project").getByLabelText(projectOidcProvider.name),
+    ).toBeTruthy();
+    expect(
+      withinSection("Your organization").queryByLabelText(
+        projectOidcProvider.name,
+      ),
+    ).toBeNull();
+    expect(
+      withinSection("Your organization").getByLabelText(
+        globalOidcProvider.name,
+      ),
+    ).toBeTruthy();
+  });
+
+  test("both project kinds share the one project heading", async () => {
+    await renderScreen([
+      globalSamlProvider,
+      projectSamlProvider,
+      projectOidcProvider,
+    ]);
+
+    const projectSection: ReturnType<typeof within> =
+      withinSection("This project");
+
+    expect(
+      projectSection.getByLabelText(projectSamlProvider.name),
+    ).toBeTruthy();
+    expect(
+      projectSection.getByLabelText(projectOidcProvider.name),
+    ).toBeTruthy();
+    expect(projectSection.queryByLabelText(globalSamlProvider.name)).toBeNull();
+
+    // One project card, not one per kind.
+    expect(screen.queryAllByText("This project")).toHaveLength(1);
+    expect(screen.queryByText("Available providers")).toBeNull();
+  });
+
+  test("a sheet of only project OIDC providers gets the project-only heading", async () => {
+    /*
+     * The case that motivated the discovery fix: a project whose sole identity
+     * provider is OIDC. There is no organization group to contrast with, so
+     * the heading is the neutral one - and "Your organization" appearing here
+     * would tell the user this signs them into the whole instance.
+     */
+    await renderScreen([projectOidcProvider]);
+
+    expect(screen.getByText("Available providers")).toBeTruthy();
+    expect(screen.getByLabelText(projectOidcProvider.name)).toBeTruthy();
+    expect(screen.queryByText("Your organization")).toBeNull();
+    expect(screen.queryByText("This project")).toBeNull();
+  });
+
   test("project-only instances get no organization heading", async () => {
     // Nothing to contrast with, so the heading would be noise.
     await renderScreen([projectSamlProvider]);
@@ -658,5 +843,164 @@ describe("Grouping the providers a user can choose from", () => {
     expect(
       screen.getByText(globalSamlProvider.description as string),
     ).toBeTruthy();
+  });
+});
+
+/*
+ * What every kind of provider is supposed to do, keyed by the kind itself.
+ *
+ * `Record<SsoProviderKind, ...>` is the point: a fifth kind added to the union
+ * does not compile until it has a row here, and every test below is driven off
+ * `Object.keys`, so a new kind arrives with its route, its project binding and
+ * its grouping already asserted instead of quietly untested. Project OIDC is
+ * exactly the kind that was missing for a while, on the screen before this one.
+ */
+interface KindExpectation {
+  provider: SelectableSsoProvider;
+  expectedUrl: string;
+  isProjectScoped: boolean;
+  heading: string;
+}
+
+const expectationByKind: Record<SsoProviderKind, KindExpectation> = {
+  "global-sso": {
+    provider: globalSamlProvider,
+    expectedUrl: `${SERVER_URL}/identity/global-sso/${globalSamlProvider._id}?mobile=true`,
+    isProjectScoped: false,
+    heading: "Your organization",
+  },
+  "global-oidc": {
+    provider: globalOidcProvider,
+    expectedUrl: `${SERVER_URL}/identity/global-oidc/${globalOidcProvider._id}?mobile=true`,
+    isProjectScoped: false,
+    heading: "Your organization",
+  },
+  project: {
+    provider: projectSamlProvider,
+    expectedUrl: `${SERVER_URL}/identity/sso/${PROJECT_ID}/${projectSamlProvider._id}?mobile=true`,
+    isProjectScoped: true,
+    heading: "This project",
+  },
+  "project-oidc": {
+    provider: projectOidcProvider,
+    expectedUrl: `${SERVER_URL}/identity/oidc/${PROJECT_ID}/${projectOidcProvider._id}?mobile=true`,
+    isProjectScoped: true,
+    heading: "This project",
+  },
+};
+
+const allKinds: Array<SsoProviderKind> = Object.keys(
+  expectationByKind,
+) as Array<SsoProviderKind>;
+
+const allExpectations: Array<KindExpectation> = allKinds.map(
+  (kind: SsoProviderKind): KindExpectation => {
+    return expectationByKind[kind];
+  },
+);
+
+const everyKindOfProvider: Array<SelectableSsoProvider> = allExpectations.map(
+  (expectation: KindExpectation): SelectableSsoProvider => {
+    return expectation.provider;
+  },
+);
+
+describe("A sheet carrying every kind at once", () => {
+  test("the table covers each kind exactly once", async () => {
+    /*
+     * Guards the tests below rather than the screen: a table with a duplicated
+     * or mismatched provider would make them pass while covering three kinds.
+     */
+    for (const kind of allKinds) {
+      expect(expectationByKind[kind].provider.kind).toBe(kind);
+    }
+
+    const ids: Array<string> = everyKindOfProvider.map(
+      (provider: SelectableSsoProvider): string => {
+        return provider._id;
+      },
+    );
+
+    expect(new Set<string>(ids).size).toBe(allKinds.length);
+  });
+
+  test("a row is rendered for every kind", async () => {
+    /*
+     * A mixed instance - global SSO on the admin dashboard plus a project that
+     * configured its own - is the normal case, not a contrived one, and a kind
+     * the screen cannot render is a kind the user cannot sign in with.
+     */
+    await renderScreen(everyKindOfProvider);
+
+    for (const expectation of allExpectations) {
+      expect(screen.getByLabelText(expectation.provider.name)).toBeTruthy();
+    }
+  });
+
+  test("each row opens the route its own kind is served by", async () => {
+    await renderScreen(everyKindOfProvider);
+
+    for (const expectation of allExpectations) {
+      await pressProvider(expectation.provider.name);
+      await settleAuthFlow();
+
+      expect(lastOpenedUrl()).toBe(expectation.expectedUrl);
+    }
+
+    // Nothing was skipped, and no row started two sessions.
+    expect(openedUrls()).toHaveLength(allExpectations.length);
+    expect(new Set<string>(openedUrls()).size).toBe(allExpectations.length);
+  });
+
+  test("only the project-scoped kinds carry the project id", async () => {
+    /*
+     * Both mistakes are invisible on the device and fatal on the server: a
+     * project id in a global login is a 400, and a missing one in a project
+     * login is `/identity/oidc/undefined/<id>`.
+     */
+    await renderScreen(everyKindOfProvider);
+
+    for (const expectation of allExpectations) {
+      await pressProvider(expectation.provider.name);
+      await settleAuthFlow();
+
+      if (expectation.isProjectScoped) {
+        expect(lastOpenedUrl()).toContain(`/${PROJECT_ID}/`);
+      } else {
+        expect(lastOpenedUrl()).not.toContain(PROJECT_ID);
+      }
+    }
+  });
+
+  test("each row is filed under the heading its kind belongs to", async () => {
+    await renderScreen(everyKindOfProvider);
+
+    for (const expectation of allExpectations) {
+      expect(
+        withinSection(expectation.heading).getByLabelText(
+          expectation.provider.name,
+        ),
+      ).toBeTruthy();
+    }
+  });
+
+  test("a completed login is handed over and closes the sheet for every kind", async () => {
+    const rendered: RenderedScreen = await renderScreen(everyKindOfProvider);
+
+    for (const expectation of allExpectations) {
+      await pressProvider(expectation.provider.name);
+      await settleAuthFlow();
+    }
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledTimes(
+      allExpectations.length,
+    );
+
+    for (const call of mockCompleteSsoLoginFromUrl.mock.calls) {
+      expect(call[0]).toBe(CALLBACK_URL);
+    }
+
+    expect(rendered.goBack).toHaveBeenCalledTimes(allExpectations.length);
+    expect(screen.queryByText(ANY_ERROR_MESSAGE)).toBeNull();
   });
 });

--- a/MobileApp/src/screens/settings/SSOProviderSelectScreen.tsx
+++ b/MobileApp/src/screens/settings/SSOProviderSelectScreen.tsx
@@ -10,7 +10,7 @@ import { Ionicons } from "@expo/vector-icons";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useTheme } from "../../theme";
 import { getServerUrl } from "../../storage/serverUrl";
-import { buildSsoLoginUrl } from "../../sso/providerUrl";
+import { buildSsoLoginUrl, isProjectScopedKind } from "../../sso/providerUrl";
 import {
   openSsoAuthSession,
   type SsoAuthSessionOutcome,
@@ -52,7 +52,7 @@ export default function SSOProviderSelectScreen({
       const ssoUrl: string = buildSsoLoginUrl(serverUrl, {
         kind: provider.kind,
         providerId: provider._id,
-        projectId: provider.kind === "project" ? projectId : undefined,
+        projectId: isProjectScopedKind(provider.kind) ? projectId : undefined,
       });
 
       const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(ssoUrl);
@@ -92,12 +92,12 @@ export default function SSOProviderSelectScreen({
 
   const globalProviders: Array<SelectableSsoProvider> = providers.filter(
     (provider: SelectableSsoProvider) => {
-      return provider.kind !== "project";
+      return !isProjectScopedKind(provider.kind);
     },
   );
   const projectProviders: Array<SelectableSsoProvider> = providers.filter(
     (provider: SelectableSsoProvider) => {
-      return provider.kind === "project";
+      return isProjectScopedKind(provider.kind);
     },
   );
 
@@ -161,7 +161,7 @@ export default function SSOProviderSelectScreen({
                 >
                   <Ionicons
                     name={
-                      provider.kind === "project"
+                      isProjectScopedKind(provider.kind)
                         ? "shield-checkmark-outline"
                         : "globe-outline"
                     }

--- a/MobileApp/src/sso/providerUrl.test.ts
+++ b/MobileApp/src/sso/providerUrl.test.ts
@@ -1,5 +1,6 @@
 import {
   buildSsoLoginUrl,
+  isProjectScopedKind,
   SsoProviderKind,
   SsoProviderTarget,
 } from "./providerUrl";
@@ -431,6 +432,430 @@ describe("The server URL is normalised before the path is appended", () => {
       }),
     ).toBe(
       `https://https-example.https/identity/global-sso/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Project OIDC.
+ *
+ * The fourth kind arrived last. Discovery for it is a SECOND endpoint
+ * (/identity/service-provider-login-oidc) whose payload is shaped exactly like
+ * the SAML one and carries no type field, so `kind` is stamped from whichever
+ * endpoint answered and is the ONLY thing that decides which router the login
+ * is sent to:
+ *
+ *   /identity/sso/:projectId/:projectSsoId    - App/FeatureSet/Identity/API/SSO.ts
+ *   /identity/oidc/:projectId/:projectOidcId  - App/FeatureSet/Identity/API/OIDC.ts
+ *
+ * Two routers, two id columns, one URL shape. A provider id sent to the wrong
+ * one is not a 404 the app can distinguish - it is a "Project ID not found" /
+ * unknown-provider BadRequest rendered inside the auth browser, minutes into a
+ * login, with nothing in the app to explain it.
+ * ---------------------------------------------------------------------------
+ */
+
+interface KindExpectation {
+  target: SsoProviderTarget;
+  isProjectScoped: boolean;
+  expectedUrl: string;
+}
+
+/*
+ * Every value of SsoProviderKind, as a Record so the compiler REQUIRES an
+ * entry per kind: adding a fifth kind to the union without describing it here
+ * fails type-checking, and the runtime assertions below then pin what the
+ * helper and the builder must do with it. That is the point of driving these
+ * tests off one table instead of listing kinds by hand in each test.
+ *
+ * `projectId` is supplied for every kind on purpose, including the global
+ * ones - it is what lets a single table assert both "the project kinds put it
+ * in the path" and "the global kinds drop it on the floor".
+ */
+const EVERY_KIND: Record<SsoProviderKind, KindExpectation> = {
+  project: {
+    target: {
+      kind: "project",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    },
+    isProjectScoped: true,
+    expectedUrl: `${SERVER}/identity/sso/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`,
+  },
+  "project-oidc": {
+    target: {
+      kind: "project-oidc",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    },
+    isProjectScoped: true,
+    expectedUrl: `${SERVER}/identity/oidc/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`,
+  },
+  "global-sso": {
+    target: {
+      kind: "global-sso",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    },
+    isProjectScoped: false,
+    expectedUrl: `${SERVER}/identity/global-sso/${PROVIDER_ID}?mobile=true`,
+  },
+  "global-oidc": {
+    target: {
+      kind: "global-oidc",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    },
+    isProjectScoped: false,
+    expectedUrl: `${SERVER}/identity/global-oidc/${PROVIDER_ID}?mobile=true`,
+  },
+};
+
+const EVERY_KIND_CASE: Array<[SsoProviderKind, KindExpectation]> =
+  Object.entries(EVERY_KIND) as Array<[SsoProviderKind, KindExpectation]>;
+
+describe("A project OIDC login goes to the OIDC router", () => {
+  test("hits /identity/oidc/<projectId>/<providerId>", () => {
+    /*
+     * Pinned as a whole literal against the route registered in
+     * App/FeatureSet/Identity/API/OIDC.ts:
+     *   router.get("/oidc/:projectId/:projectOidcId", ...)
+     * mounted under /identity, and reading `req.query["mobile"] === "true"`
+     * inside that same handler.
+     */
+    expect(
+      buildSsoLoginUrl(SERVER, {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).toBe(`${SERVER}/identity/oidc/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`);
+  });
+
+  test("puts the project id before the provider id, not after", () => {
+    /*
+     * Same positional trap as the SAML route: :projectId then :projectOidcId,
+     * two opaque uuids, and a swap produces a URL that looks fine.
+     */
+    expect(
+      pathSegmentsOf(
+        buildSsoLoginUrl(SERVER, {
+          kind: "project-oidc",
+          providerId: PROVIDER_ID,
+          projectId: PROJECT_ID,
+        }),
+      ),
+    ).toEqual(["identity", "oidc", PROJECT_ID, PROVIDER_ID]);
+  });
+
+  test("passes both ids through verbatim", () => {
+    expect(
+      buildSsoLoginUrl(SERVER, {
+        kind: "project-oidc",
+        providerId: "AAAA-bbbb-CCCC",
+        projectId: "DDDD-eeee-FFFF",
+      }),
+    ).toBe(`${SERVER}/identity/oidc/DDDD-eeee-FFFF/AAAA-bbbb-CCCC?mobile=true`);
+  });
+
+  test("does not route a project OIDC login through a global router", () => {
+    const url: string = buildSsoLoginUrl(SERVER, {
+      kind: "project-oidc",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(url).not.toContain("global-sso");
+    expect(url).not.toContain("global-oidc");
+  });
+
+  test("the two project kinds are not interchangeable", () => {
+    /*
+     * THE failure this kind exists to prevent. Before `project-oidc` there was
+     * one project kind, so a project OIDC provider - if it had been discovered
+     * at all - would have been handed to /identity/sso/:projectId/:projectSsoId
+     * with an id that router has never heard of. Identical ids here, so only
+     * the path can tell the two URLs apart.
+     */
+    const samlUrl: string = buildSsoLoginUrl(SERVER, {
+      kind: "project",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    });
+    const oidcUrl: string = buildSsoLoginUrl(SERVER, {
+      kind: "project-oidc",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(samlUrl).not.toBe(oidcUrl);
+    expect(samlUrl).toContain("/identity/sso/");
+    expect(oidcUrl).toContain("/identity/oidc/");
+    expect(samlUrl).not.toContain("/identity/oidc/");
+    expect(oidcUrl).not.toContain("/identity/sso/");
+  });
+
+  test("the SAML segment is not a prefix match of the OIDC one", () => {
+    /*
+     * `/oidc/` ends in the same three letters as nothing else here, but
+     * `/identity/oidc/...` does contain "identity/o..." - assert on the
+     * segment list so a builder that emitted "/identity/sso-oidc/" or
+     * "/identity/oidc-callback/" (a real route, for the IdP's return leg)
+     * cannot pass on a substring technicality.
+     */
+    const segments: Array<string> = pathSegmentsOf(
+      buildSsoLoginUrl(SERVER, EVERY_KIND["project-oidc"].target),
+    );
+
+    expect(segments[1]).toBe("oidc");
+    expect(segments).toHaveLength(4);
+  });
+});
+
+describe("A project OIDC login without a project id fails loudly", () => {
+  /*
+   * Identical rule to project SAML, and it has to be asserted separately: the
+   * guard is written against `isProjectScopedKind`, so a helper that forgot
+   * the new kind would let `/identity/oidc/undefined/<id>` out of the door
+   * while every project-SAML test above stayed green.
+   */
+  test("throws when projectId is missing entirely", () => {
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+      });
+    }).toThrow(/projectId/);
+  });
+
+  test("throws when projectId is explicitly undefined", () => {
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+        projectId: undefined,
+      });
+    }).toThrow(/projectId/);
+  });
+
+  test("throws on an empty-string projectId", () => {
+    /*
+     * `/identity/oidc//<providerId>` would collapse to a three-segment path
+     * and miss the two-parameter route entirely.
+     */
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+        projectId: "",
+      });
+    }).toThrow(/projectId/);
+  });
+
+  test("throws an Error, so a caller's catch block sees a message", () => {
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+        projectId: "",
+      });
+    }).toThrow(Error);
+  });
+});
+
+describe("All four kinds build their own router's URL", () => {
+  test("the kind table covers the whole union", () => {
+    /*
+     * Guards the tables below: they are only exhaustive while this is. The
+     * Record type already forces an entry per kind at compile time; this is
+     * the runtime half, so a fifth kind cannot slip through a test run that
+     * never type-checked.
+     */
+    expect(
+      EVERY_KIND_CASE.map(
+        ([kind]: [SsoProviderKind, KindExpectation]): SsoProviderKind => {
+          return kind;
+        },
+      ),
+    ).toEqual(["project", "project-oidc", "global-sso", "global-oidc"]);
+  });
+
+  test.each(EVERY_KIND_CASE)(
+    "a %s login builds exactly its own path",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      expect(buildSsoLoginUrl(SERVER, expectation.target)).toBe(
+        expectation.expectedUrl,
+      );
+    },
+  );
+
+  test("no two kinds produce the same URL for the same ids", () => {
+    /*
+     * Every kind is discovered with the same payload shape and the same id
+     * field. If any two collapsed onto one URL, the app would be silently
+     * sending one provider's id to the other's router.
+     */
+    const urls: Array<string> = EVERY_KIND_CASE.map(
+      ([, expectation]: [SsoProviderKind, KindExpectation]): string => {
+        return buildSsoLoginUrl(SERVER, expectation.target);
+      },
+    );
+
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  test.each(EVERY_KIND_CASE)(
+    "a %s login sets mobile=true",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      /*
+       * Parsed, not substring-matched: the server compares
+       * `req.query["mobile"] === "true"` exactly - OIDC.ts does it in the
+       * /oidc/:projectId/:projectOidcId handler itself.
+       */
+      expect(
+        queryParamsOf(buildSsoLoginUrl(SERVER, expectation.target))["mobile"],
+      ).toBe("true");
+    },
+  );
+
+  test.each(EVERY_KIND_CASE)(
+    "a %s login sends mobile as its only query param",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      expect(queryStringOf(buildSsoLoginUrl(SERVER, expectation.target))).toBe(
+        "mobile=true",
+      );
+    },
+  );
+
+  test.each(EVERY_KIND_CASE)(
+    "a %s login ends on the lower-case flag",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      expect(
+        buildSsoLoginUrl(SERVER, expectation.target).endsWith("?mobile=true"),
+      ).toBe(true);
+    },
+  );
+
+  test.each(EVERY_KIND_CASE)(
+    "a %s login carries a project segment only when it is project scoped",
+    (kind: SsoProviderKind, expectation: KindExpectation): void => {
+      /*
+       * Every target in the table carries a projectId, including the global
+       * ones. A global login that let it through would mint a token for the
+       * wrong scope through a router that does not expect a project at all;
+       * a project login that dropped it would 404.
+       */
+      const url: string = buildSsoLoginUrl(SERVER, expectation.target);
+
+      expect(url.includes(PROJECT_ID)).toBe(expectation.isProjectScoped);
+      expect(pathSegmentsOf(url)).toHaveLength(
+        isProjectScopedKind(kind) ? 4 : 3,
+      );
+    },
+  );
+});
+
+describe("isProjectScopedKind knows about every kind", () => {
+  test.each(EVERY_KIND_CASE)(
+    "%s",
+    (kind: SsoProviderKind, expectation: KindExpectation): void => {
+      expect(isProjectScopedKind(kind)).toBe(expectation.isProjectScoped);
+    },
+  );
+
+  test("exactly the two project kinds are project scoped", () => {
+    expect(
+      EVERY_KIND_CASE.filter(
+        ([kind]: [SsoProviderKind, KindExpectation]): boolean => {
+          return isProjectScopedKind(kind);
+        },
+      ).map(([kind]: [SsoProviderKind, KindExpectation]): SsoProviderKind => {
+        return kind;
+      }),
+    ).toEqual(["project", "project-oidc"]);
+  });
+
+  test.each(EVERY_KIND_CASE)(
+    "%s: the helper agrees with what the builder actually requires",
+    (kind: SsoProviderKind): void => {
+      /*
+       * The invariant that survives a fifth kind: SSOProviderSelectScreen asks
+       * `isProjectScopedKind` whether to pass a projectId, and
+       * `buildSsoLoginUrl` throws when a kind it considers project scoped did
+       * not get one. If those two ever disagree, the screen either omits an id
+       * the builder demands (a hard throw where a login should have started)
+       * or passes one the builder ignores (a scope leak). Derived rather than
+       * hard-coded, so no expectation has to be updated for a new kind - only
+       * the source has to stay consistent.
+       */
+      let threwWithoutProjectId: boolean = false;
+
+      try {
+        buildSsoLoginUrl(SERVER, { kind: kind, providerId: PROVIDER_ID });
+      } catch {
+        threwWithoutProjectId = true;
+      }
+
+      expect(threwWithoutProjectId).toBe(isProjectScopedKind(kind));
+    },
+  );
+});
+
+describe("Server URL normalisation applies to every kind", () => {
+  test.each(EVERY_KIND_CASE)(
+    "a single trailing slash does not double up for a %s login",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      expect(buildSsoLoginUrl(`${SERVER}/`, expectation.target)).toBe(
+        expectation.expectedUrl,
+      );
+    },
+  );
+
+  test.each(EVERY_KIND_CASE)(
+    "several trailing slashes are all removed for a %s login",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      expect(buildSsoLoginUrl(`${SERVER}///`, expectation.target)).toBe(
+        expectation.expectedUrl,
+      );
+    },
+  );
+
+  test.each(EVERY_KIND_CASE)(
+    "a normalised %s URL contains no empty path segment",
+    (_kind: SsoProviderKind, expectation: KindExpectation): void => {
+      const url: string = buildSsoLoginUrl(`${SERVER}//`, expectation.target);
+
+      expect(url.replace(/^[a-z]+:\/\//, "")).not.toContain("//");
+      expect(pathSegmentsOf(url)).not.toContain("");
+    },
+  );
+
+  test("a self-hosted host with a port AND a trailing slash keeps the OIDC path", () => {
+    /*
+     * The shape a self-hosted user actually types on the server URL screen,
+     * against the newest of the four routes.
+     */
+    expect(
+      buildSsoLoginUrl("http://192.168.1.10:3002/", {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).toBe(
+      `http://192.168.1.10:3002/identity/oidc/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+
+  test("a server hosted under a sub-path keeps that prefix on the OIDC path", () => {
+    expect(
+      buildSsoLoginUrl("https://intranet.example.com/oneuptime/", {
+        kind: "project-oidc",
+        providerId: PROVIDER_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).toBe(
+      `https://intranet.example.com/oneuptime/identity/oidc/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`,
     );
   });
 });

--- a/MobileApp/src/sso/providerUrl.ts
+++ b/MobileApp/src/sso/providerUrl.ts
@@ -13,20 +13,32 @@
  *
  * - `project` - SAML configured inside one project's settings. Grants access
  *   to that project only.
+ * - `project-oidc` - OIDC configured inside one project's settings.
  * - `global-sso` - instance-wide SAML configured on the admin dashboard.
  * - `global-oidc` - instance-wide OIDC configured on the admin dashboard.
  *
- * The two global kinds are separate because they are served by two different
- * routers (`/identity/global-sso/...` and `/identity/global-oidc/...`), and
- * the discovery endpoints do not return a type field to tell them apart.
+ * Every kind is a separate value because each is served by a different router
+ * (`/identity/sso/...`, `/identity/oidc/...`, `/identity/global-sso/...`,
+ * `/identity/global-oidc/...`), and none of the discovery endpoints returns a
+ * type field to tell them apart - the endpoint you asked is the only thing
+ * that says which kind came back.
  */
-export type SsoProviderKind = "project" | "global-sso" | "global-oidc";
+export type SsoProviderKind =
+  | "project"
+  | "project-oidc"
+  | "global-sso"
+  | "global-oidc";
 
 export interface SsoProviderTarget {
   kind: SsoProviderKind;
   providerId: string;
-  // Required for `project`, ignored for the global kinds.
+  // Required for the project kinds, ignored for the global ones.
   projectId?: string | undefined;
+}
+
+/** True for the kinds whose login URL needs a project id in the path. */
+export function isProjectScopedKind(kind: SsoProviderKind): boolean {
+  return kind === "project" || kind === "project-oidc";
 }
 
 /*
@@ -51,12 +63,20 @@ export function buildSsoLoginUrl(
 ): string {
   const base: string = normalizeServerUrl(serverUrl);
 
-  if (target.kind === "project") {
+  if (isProjectScopedKind(target.kind)) {
     if (!target.projectId) {
       throw new Error("projectId is required to start a project SSO login.");
     }
 
-    return `${base}/identity/sso/${target.projectId}/${target.providerId}?mobile=true`;
+    /*
+     * Project SAML and project OIDC are different routers:
+     * `/identity/sso/:projectId/:projectSsoId` versus
+     * `/identity/oidc/:projectId/:projectOidcId`. Sending one to the other
+     * produces a 400 from a router that has never heard of the id.
+     */
+    const segment: string = target.kind === "project-oidc" ? "oidc" : "sso";
+
+    return `${base}/identity/${segment}/${target.projectId}/${target.providerId}?mobile=true`;
   }
 
   return `${base}/identity/${target.kind}/${target.providerId}?mobile=true`;

--- a/MobileApp/src/sso/session.ts
+++ b/MobileApp/src/sso/session.ts
@@ -12,6 +12,7 @@
 import { storeTokens } from "../storage/keychain";
 import { storeGlobalSsoToken, storeSsoToken } from "../storage/ssoTokens";
 import { parseSsoCallbackUrl, type SsoCallbackResult } from "./callbackUrl";
+import { clearAllSsoDenials, clearProjectSsoDenial } from "./ssoDenials";
 
 export type CompleteSsoLoginOutcome =
   | {
@@ -56,6 +57,17 @@ export async function completeSsoLoginFromUrl(
       parsed.projectSsoToken.projectId,
       parsed.projectSsoToken.ssoToken,
     );
+
+    clearProjectSsoDenial(parsed.projectSsoToken.projectId);
+  }
+
+  /*
+   * A global login can satisfy any number of projects at once and the token
+   * does not say which, so every recorded denial is dropped and the server
+   * gets to answer again.
+   */
+  if (parsed.globalSsoToken) {
+    clearAllSsoDenials();
   }
 
   return {

--- a/MobileApp/src/sso/ssoDenials.test.ts
+++ b/MobileApp/src/sso/ssoDenials.test.ts
@@ -1,0 +1,625 @@
+import {
+  clearAllSsoDenials,
+  clearProjectSsoDenial,
+  getSsoDeniedProjectIds,
+  isProjectSsoDenied,
+  markProjectSsoDenied,
+  subscribeToSsoDenials,
+} from "./ssoDenials";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * This module is the app's record of what the SERVER refused, and the screens
+ * treat it as authoritative over anything in storage. That inversion is the
+ * whole point: the app used to reason "a global SSO token exists, therefore
+ * every project is satisfied", which is wrong for an expired token, wrong for a
+ * disabled provider, and wrong when an admin has opted a provider into
+ * restrictToAttachedProjects. The visible symptom was a project rendering a
+ * green "Authenticated" badge with no re-authenticate button while every single
+ * request to it came back 406.
+ *
+ * So the failure mode this file guards is not a crash. It is a denial that is
+ * recorded but never announced (src/screens/settings/ProjectsScreen.tsx mirrors
+ * this set into React state through subscribeToSsoDenials, so a missing
+ * notification is a button that never appears), or a denial that outlives the
+ * login that fixed it (src/sso/session.ts clears on a successful callback, so a
+ * missed clear is a button demanding SSO the user has just completed).
+ *
+ * Both of those look identical to "working" from inside the module, which is
+ * why almost every test below pairs a "nothing should happen" case with the
+ * same setup where one detail is changed and something must happen. A
+ * do-nothing implementation of markProjectSsoDenied, or a notify() wired to
+ * fire on every call, has to fail one half of each pair.
+ *
+ * Nothing here is platform-specific - it is a Set and an array of callbacks -
+ * so every assertion is expected to hold under both the "ios" and the "android"
+ * Jest project.
+ */
+
+const PROJECT_A: string = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PROJECT_B: string = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const PROJECT_C: string = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+/*
+ * A listener that records the state it was able to OBSERVE at the moment it
+ * ran, not merely that it ran. notify() firing before the Set is mutated would
+ * be invisible to a call counter, and would make ProjectsScreen re-read stale
+ * ids and paint the previous frame's badges.
+ */
+interface Recorder {
+  listener: () => void;
+  snapshots: Array<Array<string>>;
+}
+
+function recorder(): Recorder {
+  const snapshots: Array<Array<string>> = [];
+
+  return {
+    snapshots,
+    listener: (): void => {
+      snapshots.push(getSsoDeniedProjectIds());
+    },
+  };
+}
+
+function callCount(subject: Recorder): number {
+  return subject.snapshots.length;
+}
+
+function lastSnapshot(subject: Recorder): Array<string> {
+  return subject.snapshots[subject.snapshots.length - 1]!;
+}
+
+/*
+ * The listener list lives at module scope and nothing in the module's public
+ * surface clears it, so a subscription leaked by one test would still be
+ * attached during every test that follows. Registering through this helper
+ * means afterEach can guarantee each test starts with no subscribers at all.
+ */
+let activeUnsubscribes: Array<() => void> = [];
+
+function subscribe(subject: Recorder): () => void {
+  const unsubscribe: () => void = subscribeToSsoDenials(subject.listener);
+
+  activeUnsubscribes.push(unsubscribe);
+
+  return unsubscribe;
+}
+
+/*
+ * The denial Set is module scope too, and it is deliberately in-memory rather
+ * than persisted - so importing the module twice in one process is the same
+ * state. Reset it before every test, or a test inherits the previous one's
+ * denials and passes for the wrong reason.
+ */
+beforeEach(() => {
+  clearAllSsoDenials();
+});
+
+afterEach(() => {
+  for (const unsubscribe of activeUnsubscribes) {
+    unsubscribe();
+  }
+
+  activeUnsubscribes = [];
+});
+
+describe("recording a denial", () => {
+  test("a marked project reads back as denied, and its neighbours do not", () => {
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(false);
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+  });
+
+  test("several projects are tracked independently", () => {
+    /*
+     * A user can be refused by more than one project in the same session - the
+     * dashboard polls several at once - and each has to keep its own answer.
+     */
+    markProjectSsoDenied(PROJECT_A);
+    markProjectSsoDenied(PROJECT_B);
+    markProjectSsoDenied(PROJECT_C);
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(true);
+    expect(isProjectSsoDenied(PROJECT_C)).toBe(true);
+
+    const ids: Array<string> = getSsoDeniedProjectIds();
+
+    expect(ids).toHaveLength(3);
+    expect(ids).toEqual(
+      expect.arrayContaining([PROJECT_A, PROJECT_B, PROJECT_C]),
+    );
+  });
+
+  test("a project nobody has been refused for is not denied", () => {
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(isProjectSsoDenied(PROJECT_C)).toBe(false);
+    expect(getSsoDeniedProjectIds()).not.toContain(PROJECT_C);
+  });
+
+  test("marking the same project twice neither duplicates it nor notifies twice", () => {
+    /*
+     * Every failing request to a denied project marks it again, so this is the
+     * common case, not an edge case: a dashboard refreshing on a timer would
+     * otherwise re-render the whole project list on a fixed interval forever.
+     *
+     * The paired assertion is the point - a DIFFERENT id under the same
+     * subscription must still get through, so "notified once" cannot be
+     * satisfied by a notify() that has simply stopped working.
+     */
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_A);
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+    expect(callCount(subject)).toBe(1);
+
+    markProjectSsoDenied(PROJECT_B);
+
+    expect(callCount(subject)).toBe(2);
+    expect(getSsoDeniedProjectIds()).toHaveLength(2);
+  });
+
+  test("an empty project id is ignored, while a real one alongside it is not", () => {
+    /*
+     * The API client reads the id off the outgoing `tenantid` header
+     * (src/api/client.ts), which is absent on instance-level calls. Recording
+     * "" would put a denial in the set that no project can ever clear, because
+     * no project is keyed by it.
+     */
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied("");
+
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+    expect(isProjectSsoDenied("")).toBe(false);
+    expect(callCount(subject)).toBe(0);
+
+    // Same call, same subscription - only the id is different.
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+    expect(callCount(subject)).toBe(1);
+  });
+});
+
+describe("clearing a denial", () => {
+  test("clearing one project leaves the others denied", () => {
+    /*
+     * A per-project SSO login satisfies exactly one project. Dropping the
+     * others' denials here would hide the re-authenticate button on projects
+     * the server is still refusing.
+     */
+    markProjectSsoDenied(PROJECT_A);
+    markProjectSsoDenied(PROJECT_B);
+    markProjectSsoDenied(PROJECT_C);
+
+    clearProjectSsoDenial(PROJECT_B);
+
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(false);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(isProjectSsoDenied(PROJECT_C)).toBe(true);
+
+    const ids: Array<string> = getSsoDeniedProjectIds();
+
+    expect(ids).toHaveLength(2);
+    expect(ids).toEqual(expect.arrayContaining([PROJECT_A, PROJECT_C]));
+    expect(ids).not.toContain(PROJECT_B);
+  });
+
+  test("clearing a project that was never denied does not notify, but clearing a denied one does", () => {
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(callCount(subject)).toBe(1);
+
+    clearProjectSsoDenial(PROJECT_B);
+
+    expect(callCount(subject)).toBe(1);
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+
+    // Same call, same subscription - only the id is different.
+    clearProjectSsoDenial(PROJECT_A);
+
+    expect(callCount(subject)).toBe(2);
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+  });
+
+  test("clearing an empty id does not notify and does not disturb the set", () => {
+    const subject: Recorder = recorder();
+
+    markProjectSsoDenied(PROJECT_A);
+    subscribe(subject);
+
+    clearProjectSsoDenial("");
+
+    expect(callCount(subject)).toBe(0);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+
+    clearProjectSsoDenial(PROJECT_A);
+
+    expect(callCount(subject)).toBe(1);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+  });
+
+  test("clearing the same project twice notifies only for the first", () => {
+    const subject: Recorder = recorder();
+
+    markProjectSsoDenied(PROJECT_A);
+    markProjectSsoDenied(PROJECT_B);
+    subscribe(subject);
+
+    clearProjectSsoDenial(PROJECT_A);
+    clearProjectSsoDenial(PROJECT_A);
+
+    expect(callCount(subject)).toBe(1);
+
+    // The second clear was a no-op, not a failure of clearing in general.
+    clearProjectSsoDenial(PROJECT_B);
+
+    expect(callCount(subject)).toBe(2);
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+  });
+
+  test("a project can be denied again after being cleared", () => {
+    /*
+     * Clearing is optimistic - it happens after a login that COULD have fixed
+     * the denial, and lets the server answer again. If the server refuses once
+     * more, that refusal has to stick.
+     */
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_A);
+    clearProjectSsoDenial(PROJECT_A);
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+    expect(callCount(subject)).toBe(3);
+  });
+});
+
+describe("clearing every denial at once", () => {
+  test("a global login drops every project's denial", () => {
+    /*
+     * A Global SSO/OIDC login can satisfy any number of projects and the token
+     * does not say which, so src/sso/session.ts drops them all and lets the
+     * server re-answer per project.
+     */
+    markProjectSsoDenied(PROJECT_A);
+    markProjectSsoDenied(PROJECT_B);
+    markProjectSsoDenied(PROJECT_C);
+
+    clearAllSsoDenials();
+
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+    expect(isProjectSsoDenied(PROJECT_B)).toBe(false);
+    expect(isProjectSsoDenied(PROJECT_C)).toBe(false);
+  });
+
+  test("clearing an already-empty set does not notify, but clearing a populated one does", () => {
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    clearAllSsoDenials();
+
+    expect(callCount(subject)).toBe(0);
+
+    // Same call, same subscription - only the set is non-empty now.
+    markProjectSsoDenied(PROJECT_A);
+    clearAllSsoDenials();
+
+    expect(callCount(subject)).toBe(2);
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+  });
+
+  test("clearing everything twice notifies only for the first", () => {
+    const subject: Recorder = recorder();
+
+    markProjectSsoDenied(PROJECT_A);
+    subscribe(subject);
+
+    clearAllSsoDenials();
+    clearAllSsoDenials();
+
+    expect(callCount(subject)).toBe(1);
+
+    // Still functional: re-populating and clearing again does notify.
+    markProjectSsoDenied(PROJECT_B);
+    clearAllSsoDenials();
+
+    expect(callCount(subject)).toBe(3);
+  });
+});
+
+describe("subscribers", () => {
+  test("a listener is notified on a mark, on a clear, and on a clear-all", () => {
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(callCount(subject)).toBe(1);
+
+    clearProjectSsoDenial(PROJECT_A);
+
+    expect(callCount(subject)).toBe(2);
+
+    markProjectSsoDenied(PROJECT_B);
+    clearAllSsoDenials();
+
+    expect(callCount(subject)).toBe(4);
+  });
+
+  test("a listener sees the new state, not the state before the change", () => {
+    /*
+     * ProjectsScreen's listener does not receive the change - it re-reads
+     * getSsoDeniedProjectIds(). Notifying before the mutation would hand it the
+     * previous frame's ids and leave the UI exactly one event behind forever.
+     */
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(lastSnapshot(subject)).toEqual([PROJECT_A]);
+
+    markProjectSsoDenied(PROJECT_B);
+
+    expect(lastSnapshot(subject)).toHaveLength(2);
+    expect(lastSnapshot(subject)).toEqual(
+      expect.arrayContaining([PROJECT_A, PROJECT_B]),
+    );
+
+    clearProjectSsoDenial(PROJECT_A);
+
+    expect(lastSnapshot(subject)).toEqual([PROJECT_B]);
+
+    clearAllSsoDenials();
+
+    expect(lastSnapshot(subject)).toEqual([]);
+  });
+
+  test("every subscriber is notified, not just the first", () => {
+    /*
+     * The projects list and the home screen can both be mounted at once, and
+     * whichever subscribed second must not be the one left rendering a stale
+     * badge.
+     */
+    const first: Recorder = recorder();
+    const second: Recorder = recorder();
+    const third: Recorder = recorder();
+
+    subscribe(first);
+    subscribe(second);
+    subscribe(third);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(callCount(first)).toBe(1);
+    expect(callCount(second)).toBe(1);
+    expect(callCount(third)).toBe(1);
+    expect(lastSnapshot(third)).toEqual([PROJECT_A]);
+  });
+
+  test("the same listener subscribed twice is notified once per subscription", () => {
+    /*
+     * Subscriptions are not de-duplicated by callback identity. Worth pinning
+     * because the alternative - silently collapsing them - would mean a screen
+     * that remounts and re-subscribes before the old effect's cleanup runs ends
+     * up with no subscription at all once that cleanup does run.
+     */
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(callCount(subject)).toBe(2);
+  });
+
+  test("unsubscribing stops that listener and leaves the others alone", () => {
+    /*
+     * The screens unsubscribe on unmount. A leak here is not a crash: it is a
+     * setState on an unmounted screen for the rest of the process's life.
+     */
+    const staying: Recorder = recorder();
+    const leaving: Recorder = recorder();
+    const alsoStaying: Recorder = recorder();
+
+    subscribe(staying);
+    const unsubscribe: () => void = subscribe(leaving);
+    subscribe(alsoStaying);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(callCount(staying)).toBe(1);
+    expect(callCount(leaving)).toBe(1);
+    expect(callCount(alsoStaying)).toBe(1);
+
+    unsubscribe();
+
+    markProjectSsoDenied(PROJECT_B);
+
+    expect(callCount(leaving)).toBe(1);
+    expect(callCount(staying)).toBe(2);
+    expect(callCount(alsoStaying)).toBe(2);
+  });
+
+  test("unsubscribing twice is harmless and does not take a second listener with it", () => {
+    /*
+     * React can invoke an effect's cleanup more than once across a Strict Mode
+     * remount, so the second call has to be a no-op rather than popping
+     * whatever is at that index now.
+     */
+    const leaving: Recorder = recorder();
+    const staying: Recorder = recorder();
+
+    const unsubscribe: () => void = subscribe(leaving);
+
+    subscribe(staying);
+
+    unsubscribe();
+
+    expect((): void => {
+      unsubscribe();
+    }).not.toThrow();
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(callCount(leaving)).toBe(0);
+    expect(callCount(staying)).toBe(1);
+  });
+
+  test("a listener subscribed after a denial is not replayed the ones it missed", () => {
+    /*
+     * Subscribers read the current set at mount (ProjectsScreen seeds its state
+     * from getSsoDeniedProjectIds()), so the subscription is for CHANGES only.
+     */
+    const late: Recorder = recorder();
+
+    markProjectSsoDenied(PROJECT_A);
+    subscribe(late);
+
+    expect(callCount(late)).toBe(0);
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+
+    markProjectSsoDenied(PROJECT_B);
+
+    expect(callCount(late)).toBe(1);
+  });
+
+  test("a mark with no subscribers at all is still recorded", () => {
+    /*
+     * The API client marks denials whether or not a screen is mounted; the
+     * denial has to be waiting in the set when one finally is.
+     */
+    markProjectSsoDenied(PROJECT_A);
+
+    const late: Recorder = recorder();
+
+    subscribe(late);
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+    expect(callCount(late)).toBe(0);
+  });
+});
+
+describe("getSsoDeniedProjectIds returns a copy", () => {
+  test("mutating the returned array does not change module state", () => {
+    /*
+     * ProjectsScreen puts this array straight into React state, where it is
+     * filtered and sorted by render code that has no idea it might be the
+     * module's own storage. Handing out the live collection would let a screen
+     * silently erase the app's record of what the server refused.
+     */
+    markProjectSsoDenied(PROJECT_A);
+    markProjectSsoDenied(PROJECT_B);
+
+    const ids: Array<string> = getSsoDeniedProjectIds();
+
+    ids.push("injected-project-id");
+    ids.splice(0, 1);
+
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(true);
+    expect(isProjectSsoDenied("injected-project-id")).toBe(false);
+
+    const fresh: Array<string> = getSsoDeniedProjectIds();
+
+    expect(fresh).toHaveLength(2);
+    expect(fresh).toEqual(expect.arrayContaining([PROJECT_A, PROJECT_B]));
+    expect(fresh).not.toContain("injected-project-id");
+  });
+
+  test("emptying the returned array does not empty the module", () => {
+    markProjectSsoDenied(PROJECT_A);
+
+    const ids: Array<string> = getSsoDeniedProjectIds();
+
+    ids.length = 0;
+
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+  });
+
+  test("two calls hand back two different arrays", () => {
+    markProjectSsoDenied(PROJECT_A);
+
+    const first: Array<string> = getSsoDeniedProjectIds();
+    const second: Array<string> = getSsoDeniedProjectIds();
+
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+  });
+
+  test("an already-returned array does not grow when a new denial arrives", () => {
+    // The snapshot is a value, not a live view - React relies on that to diff.
+    markProjectSsoDenied(PROJECT_A);
+
+    const snapshot: Array<string> = getSsoDeniedProjectIds();
+
+    markProjectSsoDenied(PROJECT_B);
+
+    expect(snapshot).toEqual([PROJECT_A]);
+    expect(getSsoDeniedProjectIds()).toHaveLength(2);
+  });
+});
+
+describe("the module state does not leak between tests", () => {
+  /*
+   * These two are deliberately a matched pair: each denies a different project
+   * and asserts the set was empty on entry. Run in either order, one of them
+   * would see the other's project if beforeEach were not resetting the module.
+   */
+  test("first test starts from an empty set", () => {
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+
+    markProjectSsoDenied(PROJECT_A);
+
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_A]);
+  });
+
+  test("second test starts from an empty set too", () => {
+    expect(getSsoDeniedProjectIds()).toEqual([]);
+    expect(isProjectSsoDenied(PROJECT_A)).toBe(false);
+
+    markProjectSsoDenied(PROJECT_B);
+
+    expect(getSsoDeniedProjectIds()).toEqual([PROJECT_B]);
+  });
+
+  test("a subscription taken out here is not visible to the next test", () => {
+    /*
+     * Nothing in the module's surface empties the listener list, so this file
+     * unsubscribes in afterEach. Without that, every "notified once" assertion
+     * elsewhere would be measuring a listener list that grows with the suite.
+     */
+    const subject: Recorder = recorder();
+
+    subscribe(subject);
+
+    markProjectSsoDenied(PROJECT_C);
+
+    expect(callCount(subject)).toBe(1);
+    expect(lastSnapshot(subject)).toEqual([PROJECT_C]);
+  });
+});

--- a/MobileApp/src/sso/ssoDenials.ts
+++ b/MobileApp/src/sso/ssoDenials.ts
@@ -1,0 +1,84 @@
+/*
+ * Projects the SERVER has refused on SSO grounds.
+ *
+ * The app used to infer per-project SSO status entirely from what it had in
+ * storage: "a global SSO token exists, therefore every project is satisfied".
+ * That was true when a global token unconditionally satisfied every project.
+ * It is no longer guaranteed - a provider can be disabled, or (when an admin
+ * opts in) restricted to the projects it is attached to - and it was never
+ * true for an expired token, which the app would happily keep presenting as
+ * "Authenticated" while every request came back 406.
+ *
+ * The server is the only thing that actually knows. So rather than guessing
+ * harder, the API client records which projects it has been refused for, and
+ * the screens treat that as authoritative over what is in storage. The result
+ * is that a denial turns into a visible "Authenticate with SSO" button instead
+ * of an error string on every individual screen.
+ *
+ * Deliberately in-memory: it is a cache of the server's last word, not state
+ * worth persisting across launches, and a fresh launch should ask again.
+ */
+
+const deniedProjectIds: Set<string> = new Set<string>();
+
+type Listener = () => void;
+let listeners: Array<Listener> = [];
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Records that the server refused this project for SSO reasons. */
+export function markProjectSsoDenied(projectId: string): void {
+  if (!projectId || deniedProjectIds.has(projectId)) {
+    return;
+  }
+
+  deniedProjectIds.add(projectId);
+  notify();
+}
+
+/**
+ * Clears a project's denial - call after an SSO login that could plausibly
+ * have fixed it, so the UI stops demanding SSO the user has just completed.
+ */
+export function clearProjectSsoDenial(projectId: string): void {
+  if (deniedProjectIds.delete(projectId)) {
+    notify();
+  }
+}
+
+/**
+ * Clears every denial. A GLOBAL SSO login can satisfy any number of projects
+ * at once, and the app cannot tell which from the token alone - so it drops
+ * every denial and lets the server say again.
+ */
+export function clearAllSsoDenials(): void {
+  if (deniedProjectIds.size === 0) {
+    return;
+  }
+
+  deniedProjectIds.clear();
+  notify();
+}
+
+export function isProjectSsoDenied(projectId: string): boolean {
+  return deniedProjectIds.has(projectId);
+}
+
+export function getSsoDeniedProjectIds(): Array<string> {
+  return [...deniedProjectIds];
+}
+
+/** Subscribe to changes. Returns an unsubscribe function. */
+export function subscribeToSsoDenials(listener: Listener): () => void {
+  listeners.push(listener);
+
+  return (): void => {
+    listeners = listeners.filter((candidate: Listener): boolean => {
+      return candidate !== listener;
+    });
+  };
+}


### PR DESCRIPTION
Follow-up to #3289, which is now merged. Two things I flagged there as out of scope, implemented properly.

The first was a straightforward gap. The second turned out to be **two questions wearing one hat**, and only one of them has an unambiguous answer — so this PR ships one unconditionally and puts the other behind an explicit opt-in. That distinction is the main thing worth reviewing.

## 1. Project OIDC discovery on mobile

The app called `/identity/service-provider-login` and both global discovery endpoints, but never `/identity/service-provider-login-oidc`. A project whose only identity provider was OIDC did not appear on the SSO screen at all — the user got *"No SSO configuration found for the email."*

Discovery now runs both project endpoints in parallel, and every provider carries the `kind` that decides which router starts its login. The payload doesn't say which it is — the endpoint that answered is the only signal — and sending a project-OIDC id to `/identity/sso` gets a 400 from a router that has never heard of it.

## 2. Global SSO revocation — unconditional

A Global SSO token is a 30-day JWT with no revocation, so an admin turning a provider off changed nothing for anyone already signed in, for up to a month. The **Enabled** toggle has exactly one possible meaning, so this check is unconditional: enforcement now verifies the provider still exists and is still enabled, cached 60s per process, with concurrent misses sharing one query and write hooks clearing it on the node that served the change.

This also closes a **real bypass**. Before the single-token redesign, the Global SSO router minted one per-project token *per project*, typed `GlobalSSO`, signed for 30 days. Those are still sitting in browsers as `sso-<projectId>` cookies and in the mobile app's AsyncStorage, replayed on every request. The per-project slot accepted them, which would have let them skip the new check entirely — so it now refuses any Global-typed token and routes it through the stateful path instead. Affected users get one SSO prompt and a properly-typed token.

## 3. Project scope — deliberately opt-in, and this is the part to review

My first attempt enforced `GlobalSsoProject` attachments unconditionally. **That was wrong**, and an adversarial review caught it before it shipped:

- The attachment rows are the **provisioning** allow-list. The model's own docstring: *"a SAML assertion can only ever provision a user into projects that a master admin has explicitly attached here"*, and *"If a GlobalSSO has NO attached projects, it applies to all projects the user is already a member of."*
- The login routers gate a session on `memberProjectCount > 0` across **all** projects, not attached ones.

So reinterpreting attachments as an access boundary would have locked existing users out of projects they legitimately reach, immediately on upgrade. Worse: a login could succeed, mint a 30-day token, and authorize *nothing* — with re-authenticating producing a byte-identical token, and the SSO-denied page listing only project providers, which is empty on a global-SSO-only instance. A dead end with no way out from inside the product.

It is therefore a per-provider opt-in, **`restrictToAttachedProjects`, default false**, with a migration and an admin toggle whose copy says what it does and that it narrows access for people already signed in. When it is on, the login gate also counts membership of *governed* projects and refuses with a specific message rather than minting a token that authorizes nothing.

Two related corrections in the same area:
- **"Rows exist but all disabled" now denies** rather than widening. Previously it collapsed into "no attachments" → instance-wide, so an admin disabling the last attachment would have *widened* the provider to every project.
- **A failed lookup throws rather than denying.** On the multi-tenant path, conflating "could not find out" with "not allowed" would silently return `200` with an empty permission set — no error, no re-auth prompt, just every project rendering empty.

## 4. Mobile: the server has the last word

The app inferred per-project SSO status from storage alone — *"a global token exists, therefore every project is satisfied"*. That could show a green **Authenticated** badge with the re-auth button hidden while every request to that project came back 406. True for an expired token long before any of this.

The API client now records what the server actually refused, screens treat that as authoritative over storage, a later success retires it, and logout clears the set so it cannot follow the next user onto the same handset.

## Tests

| Suite | Result |
| --- | --- |
| `MobileApp` (iOS + Android) | 1527 tests, 45 suites, green |
| `Common` middleware / utils / services | 565 tests, 19 suites, green |
| `App/Tests/Identity` | 286 tests, green |
| `npm run check-postgres-schema-drift` | no drift |

`tsc --noEmit` and `eslint` clean across all 39 changed files. The three new `Common` suites were mutation-tested by their authors — source temporarily mutated, run, restored, and verified byte-identical — so the assertions are known not to be vacuous.

**Five defects in this change were caught by its own tests and review, each now pinned by a test:**

1. An in-flight lookup evicting a *newer* one after a cache clear, silently disabling de-duplication for the fan-out it exists for.
2. Denials leaking across users on logout.
3. A case-sensitive `tenantid` header read that would silently miss a `tenantId` written in the natural camelCase — a 406 recording nothing, which is the dead end this feature removes.
4. A denial that never self-healed after the server started answering again.
5. The attachment-as-access-boundary lockout described above.

## Reviewing this

The behaviour change to look hardest at is item 2: after this, a **disabled or deleted** Global SSO provider stops satisfying enforcement immediately (within the 60s cache window on other nodes), and legacy Global-typed per-project tokens stop being accepted. Both are intended, and both mean some users will see one SSO prompt they would not have seen before. Item 3 changes nothing for anyone until an admin turns it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
