### PR TITLE
fix(workers): sweep the legacy AIAgentTask cron definitions from Redis

### DIFF
--- a/App/FeatureSet/Workers/StartupMigrations/Index.ts
+++ b/App/FeatureSet/Workers/StartupMigrations/Index.ts
@@ -1,3 +1,4 @@
+import RemoveLegacyAIAgentTaskCrons from "./RemoveLegacyAIAgentTaskCrons";
 import RemoveLegacySentinelInsightCron from "./RemoveLegacySentinelInsightCron";
 import SeedGlobalLlmProviderFromEnv from "./SeedGlobalLlmProviderFromEnv";
 import StartupMigrationBase from "./StartupMigrationBase";
@@ -9,6 +10,7 @@ import StartupMigrationBase from "./StartupMigrationBase";
 const StartupMigrations: Array<StartupMigrationBase> = [
   new SeedGlobalLlmProviderFromEnv(),
   new RemoveLegacySentinelInsightCron(),
+  new RemoveLegacyAIAgentTaskCrons(),
 ];
 
 export default StartupMigrations;

--- a/App/FeatureSet/Workers/StartupMigrations/RemoveLegacyAIAgentTaskCrons.ts
+++ b/App/FeatureSet/Workers/StartupMigrations/RemoveLegacyAIAgentTaskCrons.ts
@@ -1,0 +1,71 @@
+import StartupMigrationBase from "./StartupMigrationBase";
+import Queue, { QueueName } from "Common/Server/Infrastructure/Queue";
+import logger from "Common/Server/Utils/Logger";
+
+/*
+ * The legacy AIAgentTask sweepers "AIAgent:TimeoutStuckTasks" and
+ * "AIAgent:FailOrphanedScheduledTasks" were deleted along with the AIAgentTask
+ * tables (#2675). Their work is now done by
+ * "AIAgent:FailOrphanedQueuedCodeFixRuns" (Jobs/AIAgent) and
+ * "AIChat:TimeoutStuckRuns" (Jobs/AIChat). This removes the old names'
+ * leftover repeatables from Redis.
+ *
+ * WHY THE REMOVAL NEEDS A CLEANUP AT ALL:
+ * RunCron -> Queue.addJob registers a BullMQ REPEATABLE keyed by job name, and
+ * addJob only clears a pre-existing repeatable whose name matches the name
+ * being registered. A name that is never registered again is never cleared, so
+ * both definitions survive in Redis and keep firing every minute forever. Each
+ * fire enqueues a job by a name that is no longer in JobDictionary, so the
+ * worker's JobDictionary.getJobFunction() throws BadDataException("No job found
+ * with name: ...") -> ~1440 failed jobs a day, forever, pinning the Failed
+ * count on the admin Health page at its removeOnFail cap. It never self-heals.
+ *
+ * WHY THIS RUNS ON EVERY BOOT RATHER THAN ONCE:
+ * during a rolling deploy an OLD worker pod is still alive and still holds the
+ * old names in its in-memory Queue.repeatableJobs dict. That pod RE-ADDS every
+ * repeatable it holds on any Redis "ready" event (the reconnect listener in
+ * Common/Server/Infrastructure/Queue.ts). So a Redis blip while the old pod is
+ * draining can re-create an orphan AFTER a one-shot cleanup has already run,
+ * and the one-shot would never fire again. Sweeping on every boot means the
+ * next worker start — the next replica in the same rollout, or any later
+ * restart — removes a late re-add.
+ *
+ * SAFE TO DELETE once every environment has cycled onto a build that no longer
+ * knows the old names (so no pod anywhere can re-add them). Until then it costs
+ * one getRepeatableJobs() read per name per worker boot, and is a no-op after
+ * the first successful sweep.
+ */
+
+const LEGACY_JOB_NAMES: Array<string> = [
+  "AIAgent:TimeoutStuckTasks",
+  "AIAgent:FailOrphanedScheduledTasks",
+];
+
+export default class RemoveLegacyAIAgentTaskCrons extends StartupMigrationBase {
+  public constructor() {
+    super("RemoveLegacyAIAgentTaskCrons");
+  }
+
+  public override async migrate(): Promise<void> {
+    for (const legacyJobName of LEGACY_JOB_NAMES) {
+      /*
+       * Must match on the job NAME. Queue.removeJob() cannot do this: BullMQ
+       * keys a repeatable by an opaque md5 (the member of the
+       * bull:<queue>:repeat zset), and removeRepeatableByKey() ZREMs that exact
+       * member — handing it a job name matches nothing and silently no-ops.
+       * removeRepeatableByName() enumerates getRepeatableJobs() and removes by
+       * .key, which also drops the already-materialized next delayed iteration.
+       */
+      const removedCount: number = await Queue.removeRepeatableByName(
+        QueueName.Worker,
+        legacyJobName,
+      );
+
+      if (removedCount > 0) {
+        logger.info(
+          `Removed ${removedCount} orphaned repeatable job definition(s) named "${legacyJobName}" from the ${QueueName.Worker} queue. These legacy AIAgentTask sweepers were deleted with the AIAgentTask tables; the old definitions would otherwise have kept firing every minute and failing, because no job is registered under these names.`,
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What's broken

#2675 dropped the AIAgentTask tables and with them the two sweeper jobs `AIAgent:TimeoutStuckTasks` and `AIAgent:FailOrphanedScheduledTasks`. Their BullMQ **repeatable definitions stay in Redis**: `Queue.addJob` only clears a repeatable whose name matches the name being registered, so a name that is never registered again is never cleared.

On any installation whose Redis predates #2675 the definition keeps firing on its `* * * * *` pattern, the enqueued job is no longer in `JobDictionary`, and the worker throws:

```
BadDataException [Error]: No job found with name: AIAgent:TimeoutStuckTasks
    at JobDictionary.getJobFunction (/usr/src/app/FeatureSet/Workers/Utils/JobDictionary.ts:16:11)
    at QueueWorker_1.default.getWorker.concurrency (/usr/src/app/FeatureSet/Workers/Index.ts:420:29)
```

That is ~1440 failed jobs a day, forever, and it never self-heals. Since 12.x it is also highly visible: the new admin **Health → Background Queues** page shows the Worker queue red, `Failed` pinned at the `removeOnFail` cap of 100 and the queue labelled "100 failing" — with a stack trace that points at `JobDictionary` rather than at the real cause in Redis.

## Fix

A startup migration that removes both legacy repeatables by name, mirroring the existing `RemoveLegacySentinelInsightCron` — same failure mode, there after a rename rather than a removal.

It runs on every boot for the reason documented in that file: during a rolling deploy an old worker pod still holds the name in its in-memory `repeatableJobs` dict and re-adds every repeatable it holds on any Redis `ready` event, so a one-shot sweep can be undone mid-rollout. After the first successful sweep it costs one `getRepeatableJobs()` read per name per worker boot and is a no-op.

## Verified on a real installation

Self-hosted 12.0.12, upgraded from 11.6.1:

- `AIAgent:TimeoutStuckTasks` was still present in Redis with pattern `* * * * *` and `repeat.count` 54875 (~38 days), failing once a minute on all four worker replicas.
- Of the **128** repeatable definitions on the Worker queue it was the **only** name with no counterpart in the deployed code (every name checked against the tree).
- `Queue.removeRepeatableByName(QueueName.Worker, "AIAgent:TimeoutStuckTasks")` returned `1`, and the error disappeared from all worker logs from the next tick onwards.

## Notes

- This supersedes the closed draft #2686, which proposed the same migration. This is that change on current master, with the comment updated to name the current replacements (`AIAgent:FailOrphanedQueuedCodeFixRuns`, `AIChat:TimeoutStuckRuns`).
- Possible follow-up, deliberately not in this PR: sweep *any* repeatable whose name is absent from `JobDictionary` after job registration, which would cover future renames without a per-name migration. It needs care around the rolling-deploy re-add race above, so it seemed better kept separate.
- No test added: `RemoveLegacySentinelInsightCron` has none either, and the runner itself is covered by `App/Tests/Workers/Utils/MigrationRunnerConcurrency.test.ts`.