### PR TITLE
test: cover QueryHelper operators, LocalCache, and infra monitor-step utils

### DIFF
--- a/Common/Tests/Server/Infrastructure/LocalCache.test.ts
+++ b/Common/Tests/Server/Infrastructure/LocalCache.test.ts
@@ -1,0 +1,149 @@
+import LocalCache from "../../../Server/Infrastructure/LocalCache";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * LocalCache is a process-local, namespaced key/value store used for cheap
+ * in-memory memoization (feature flags, small config lookups) where a
+ * round-trip to Redis would be wasteful. It is a single shared static map,
+ * so:
+ *
+ *   - the namespace has to actually isolate keys — two callers using the
+ *     same key in different namespaces must not read each other's values;
+ *   - `hasValue` is a Boolean() coercion, so a stored falsy value (0, "")
+ *     reads as absent. That is a real edge every caller of getOrSet-style
+ *     logic inherits, so it is pinned here rather than left implicit.
+ *
+ * Every test below uses a unique namespace so the shared map cannot leak
+ * state between cases.
+ */
+
+describe("LocalCache string/number/JSON round-trips", () => {
+  it("stores and returns a string", () => {
+    LocalCache.setString("ns-str", "k", "hello");
+    expect(LocalCache.getString("ns-str", "k")).toBe("hello");
+  });
+
+  it("stores and returns a number, including zero", () => {
+    LocalCache.setNumber("ns-num", "k", 42);
+    expect(LocalCache.getNumber("ns-num", "k")).toBe(42);
+
+    LocalCache.setNumber("ns-num-zero", "k", 0);
+    expect(LocalCache.getNumber("ns-num-zero", "k")).toBe(0);
+  });
+
+  it("stores and returns a JSON object", () => {
+    const value: JSONObject = { a: 1, b: ["x", "y"] };
+    LocalCache.setJSON("ns-json", "k", value);
+    expect(LocalCache.getJSON("ns-json", "k")).toEqual(value);
+  });
+
+  it("overwrites an existing value on a repeated set", () => {
+    LocalCache.setString("ns-overwrite", "k", "first");
+    LocalCache.setString("ns-overwrite", "k", "second");
+    expect(LocalCache.getString("ns-overwrite", "k")).toBe("second");
+  });
+});
+
+describe("LocalCache namespacing", () => {
+  it("isolates the same key across different namespaces", () => {
+    LocalCache.setString("ns-a", "shared-key", "from-a");
+    LocalCache.setString("ns-b", "shared-key", "from-b");
+
+    expect(LocalCache.getString("ns-a", "shared-key")).toBe("from-a");
+    expect(LocalCache.getString("ns-b", "shared-key")).toBe("from-b");
+  });
+
+  it("collides when namespace/key pairs concatenate to the same string", () => {
+    /*
+     * Known limitation, pinned deliberately: the map key is
+     * `namespace + "." + key` with no escaping, so ("team", "member.count")
+     * and ("team.member", "count") both resolve to "team.member.count" and
+     * share one slot. Callers must not choose namespaces/keys whose dotted
+     * concatenation can coincide. If this is ever hardened (e.g. an escaped
+     * delimiter), this test is the tripwire that will flag the change.
+     */
+    LocalCache.setString("team", "member.count", "written-first");
+    expect(LocalCache.getString("team.member", "count")).toBe("written-first");
+  });
+});
+
+describe("LocalCache.hasValue", () => {
+  it("is false for a key that was never set", () => {
+    expect(LocalCache.hasValue("ns-missing", "nope")).toBe(false);
+  });
+
+  it("is true after a truthy value is set", () => {
+    LocalCache.setString("ns-has", "k", "present");
+    expect(LocalCache.hasValue("ns-has", "k")).toBe(true);
+  });
+
+  it("reads a stored falsy value as absent (Boolean coercion)", () => {
+    // Documented edge: 0 and "" are stored but hasValue coerces to false.
+    LocalCache.setNumber("ns-falsy", "zero", 0);
+    LocalCache.setString("ns-falsy", "empty", "");
+    expect(LocalCache.hasValue("ns-falsy", "zero")).toBe(false);
+    expect(LocalCache.hasValue("ns-falsy", "empty")).toBe(false);
+  });
+});
+
+describe("LocalCache.getOrSetString", () => {
+  it("invokes the producer and caches its result when absent", async () => {
+    let calls: number = 0;
+    const produce: () => Promise<string> = async (): Promise<string> => {
+      calls++;
+      return "computed";
+    };
+
+    const first: string = await LocalCache.getOrSetString(
+      "ns-getset",
+      "k",
+      produce,
+    );
+    expect(first).toBe("computed");
+    expect(calls).toBe(1);
+    // The value is now in the cache.
+    expect(LocalCache.getString("ns-getset", "k")).toBe("computed");
+  });
+
+  it("does not invoke the producer again once a value is cached", async () => {
+    let calls: number = 0;
+    const produce: () => Promise<string> = async (): Promise<string> => {
+      calls++;
+      return `value-${calls}`;
+    };
+
+    const first: string = await LocalCache.getOrSetString(
+      "ns-getset-2",
+      "k",
+      produce,
+    );
+    const second: string = await LocalCache.getOrSetString(
+      "ns-getset-2",
+      "k",
+      produce,
+    );
+
+    expect(first).toBe("value-1");
+    // Second call short-circuits on the cached value; producer not re-run.
+    expect(second).toBe("value-1");
+    expect(calls).toBe(1);
+  });
+
+  it("re-invokes the producer when the previously produced value was empty", async () => {
+    /*
+     * getOrSetString gates on getString() being falsy, so an empty-string
+     * result is treated as "not cached" and the producer runs every time.
+     * This mirrors the hasValue Boolean-coercion edge above.
+     */
+    let calls: number = 0;
+    const produce: () => Promise<string> = async (): Promise<string> => {
+      calls++;
+      return "";
+    };
+
+    await LocalCache.getOrSetString("ns-getset-empty", "k", produce);
+    await LocalCache.getOrSetString("ns-getset-empty", "k", produce);
+    expect(calls).toBe(2);
+  });
+});

--- a/Common/Tests/Server/Types/Database/QueryHelperOperators.test.ts
+++ b/Common/Tests/Server/Types/Database/QueryHelperOperators.test.ts
@@ -168,9 +168,7 @@ describe("QueryHelper comparison operators — exact rendered SQL", () => {
     });
 
     it("lessThanEqualToOrNull emits an INCLUSIVE `<=` OR IS NULL", () => {
-      const operator: RawOperator = asRaw(
-        QueryHelper.lessThanEqualToOrNull(5),
-      );
+      const operator: RawOperator = asRaw(QueryHelper.lessThanEqualToOrNull(5));
 
       const param: string = soleParamName(operator);
       expect(operator.getSql(ALIAS)).toBe(
@@ -199,9 +197,7 @@ describe("QueryHelper comparison operators — exact rendered SQL", () => {
     it("inBetween is an inclusive `>=` … `<=` band binding both bounds", () => {
       const operator: RawOperator = asRaw(QueryHelper.inBetween(1, 9));
 
-      const keys: Array<string> = Object.keys(
-        operator.objectLiteralParameters,
-      );
+      const keys: Array<string> = Object.keys(operator.objectLiteralParameters);
       expect(keys).toHaveLength(2);
       const [lo, hi] = keys as [string, string];
 

--- a/Common/Tests/Server/Types/Database/QueryHelperOperators.test.ts
+++ b/Common/Tests/Server/Types/Database/QueryHelperOperators.test.ts
@@ -1,0 +1,332 @@
+import QueryHelper from "../../../../Server/Types/Database/QueryHelper";
+import BaseModel from "../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import ObjectID from "../../../../Types/ObjectID";
+import { FindOperator } from "typeorm";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * QueryHelper turns a browser-built filter into the WHERE clause the
+ * database layer runs. Two properties are load-bearing for every operator
+ * here and neither is visible from the FindOperator's JSON — the SQL is
+ * produced by a function on `.value`, given the column alias:
+ *
+ *   1. VALUES ARE BOUND, NEVER INTERPOLATED. The comparands come from
+ *      user-editable filters, so an interpolated value would be an
+ *      injection vector. Every test that inspects the parameter bag rather
+ *      than the SQL text is guarding that.
+ *
+ *   2. THE OPERATOR IS THE ONE THE NAME PROMISES. `lessThan` must emit `<`,
+ *      not `<=`; `inBetween` must be inclusive on both ends; the `*OrNull`
+ *      variants must add an `IS NULL` branch. A wrong operator produces a
+ *      query that runs, returns rows, and is silently wrong.
+ *
+ * These operators were previously exercised only indirectly (or not at
+ * all); this file pins them directly. It complements
+ * QueryHelperManyToManyAndEmptyValues.test.ts (the many-to-many + empty-
+ * list operators) and QueryHelperFindWithSameTextAnyOf.test.ts.
+ */
+
+interface RawOperator {
+  type: string;
+  objectLiteralParameters: Record<string, unknown>;
+  // TypeORM builds the SQL through this, given the column alias.
+  getSql: (aliasPath: string) => string;
+}
+
+function asRaw(operator: unknown): RawOperator {
+  return operator as unknown as RawOperator;
+}
+
+// A stable alias to render every operator against.
+const ALIAS: string = '"Monitor"."responseTimeInMs"';
+
+function paramValues(operator: RawOperator): Array<unknown> {
+  return Object.values(operator.objectLiteralParameters);
+}
+
+describe("QueryHelper comparison operators", () => {
+  it("greaterThan emits a strict `>` and binds the value", () => {
+    const op: RawOperator = asRaw(QueryHelper.greaterThan(100));
+    expect(op).toBeInstanceOf(FindOperator);
+    expect(op.type).toBe("raw");
+
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} >`);
+    // Strict: must not be `>=`.
+    expect(sql).not.toContain(">=");
+    // The value is bound, not interpolated.
+    expect(sql).not.toContain("100");
+    expect(paramValues(op)).toEqual([100]);
+  });
+
+  it("lessThan emits a strict `<` and binds the value", () => {
+    const op: RawOperator = asRaw(QueryHelper.lessThan(50));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} <`);
+    expect(sql).not.toContain("<=");
+    expect(sql).not.toContain("50");
+    expect(paramValues(op)).toEqual([50]);
+  });
+
+  it("lessThanEqualTo emits `<=`", () => {
+    const op: RawOperator = asRaw(QueryHelper.lessThanEqualTo(50));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} <=`);
+    expect(paramValues(op)).toEqual([50]);
+  });
+
+  it("greaterThanEqualToOrNull emits `>=` with an IS NULL branch", () => {
+    const op: RawOperator = asRaw(QueryHelper.greaterThanEqualToOrNull(10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} >=`);
+    expect(sql.toUpperCase()).toContain("IS NULL");
+    expect(paramValues(op)).toEqual([10]);
+  });
+
+  it("lessThanOrNull emits a strict `<` with an IS NULL branch", () => {
+    const op: RawOperator = asRaw(QueryHelper.lessThanOrNull(10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} <`);
+    expect(sql).not.toContain("<=");
+    expect(sql.toUpperCase()).toContain("IS NULL");
+    expect(paramValues(op)).toEqual([10]);
+  });
+
+  it("lessThanEqualToOrNull emits `<=` with an IS NULL branch", () => {
+    const op: RawOperator = asRaw(QueryHelper.lessThanEqualToOrNull(10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} <=`);
+    expect(sql.toUpperCase()).toContain("IS NULL");
+    expect(paramValues(op)).toEqual([10]);
+  });
+
+  it("greaterThanOrNull adds an IS NULL branch and binds the value", () => {
+    /*
+     * NOTE: greaterThanOrNull currently renders `>=` (identical to
+     * greaterThanEqualToOrNull), which reads as inconsistent with its
+     * name. This test pins the two properties that are unambiguously
+     * required — the value is bound and a NULL row is included — rather
+     * than blessing the `>=`/`>` choice, so it will not have to change if
+     * that inconsistency is later corrected.
+     */
+    const op: RawOperator = asRaw(QueryHelper.greaterThanOrNull(10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(ALIAS);
+    expect(sql).toContain(">");
+    expect(sql.toUpperCase()).toContain("IS NULL");
+    expect(sql).not.toContain("10");
+    expect(paramValues(op)).toEqual([10]);
+  });
+
+  it("preserves Date comparands as Date objects in the parameter bag", () => {
+    /*
+     * Callers pass Date for time-column comparisons; the value must reach
+     * the driver as a Date, not a pre-stringified timestamp.
+     */
+    const when: Date = new Date("2026-01-01T00:00:00.000Z");
+    const op: RawOperator = asRaw(QueryHelper.greaterThan(when));
+    expect(paramValues(op)).toEqual([when]);
+    expect(paramValues(op)[0]).toBeInstanceOf(Date);
+  });
+});
+
+describe("QueryHelper range operators", () => {
+  it("inBetween is inclusive on both ends and binds both bounds", () => {
+    const op: RawOperator = asRaw(QueryHelper.inBetween(5, 10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} >=`);
+    expect(sql).toContain(`${ALIAS} <=`);
+    expect(sql.toLowerCase()).toContain("and");
+    // Both bounds bound as parameters, in order.
+    expect(paramValues(op)).toEqual([5, 10]);
+    // Two distinct parameter names so the bounds cannot alias each other.
+    expect(Object.keys(op.objectLiteralParameters)).toHaveLength(2);
+    expect(Object.keys(op.objectLiteralParameters)[0]).not.toBe(
+      Object.keys(op.objectLiteralParameters)[1],
+    );
+  });
+
+  it("inBetweenOrNull is the inclusive range OR NULL", () => {
+    const op: RawOperator = asRaw(QueryHelper.inBetweenOrNull(5, 10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} >=`);
+    expect(sql).toContain(`${ALIAS} <=`);
+    expect(sql.toUpperCase()).toContain("IS NULL");
+    expect(sql.toLowerCase()).toContain(" or ");
+    expect(paramValues(op)).toEqual([5, 10]);
+  });
+
+  it("notInBetween is the complement — strict `<` start OR strict `>` end", () => {
+    const op: RawOperator = asRaw(QueryHelper.notInBetween(5, 10));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} <`);
+    expect(sql).toContain(`${ALIAS} >`);
+    // Complement of an inclusive range uses strict comparisons.
+    expect(sql).not.toContain("<=");
+    expect(sql).not.toContain(">=");
+    expect(sql.toLowerCase()).toContain(" or ");
+    expect(paramValues(op)).toEqual([5, 10]);
+  });
+});
+
+describe("QueryHelper text operators", () => {
+  it("startsWith / endsWith anchor the ILIKE pattern on the correct side", () => {
+    const starts: RawOperator = asRaw(QueryHelper.startsWith("Prod"));
+    const ends: RawOperator = asRaw(QueryHelper.endsWith("Prod"));
+
+    expect(starts.getSql(ALIAS).toUpperCase()).toContain("ILIKE");
+    expect(ends.getSql(ALIAS).toUpperCase()).toContain("ILIKE");
+
+    // Pattern lives only in the parameter bag, lower-cased and anchored.
+    expect(paramValues(starts)).toEqual(["prod%"]);
+    expect(paramValues(ends)).toEqual(["%prod"]);
+  });
+
+  it("notContains excludes the substring but keeps NULL rows", () => {
+    const op: RawOperator = asRaw(QueryHelper.notContains("Down"));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql.toUpperCase()).toContain("NOT ILIKE");
+    // A row with no value should not be excluded by a "does not contain".
+    expect(sql.toUpperCase()).toContain("IS NULL");
+    expect(paramValues(op)).toEqual(["%down%"]);
+  });
+
+  it("notContains lower-cases and trims the needle", () => {
+    const op: RawOperator = asRaw(QueryHelper.notContains("  DOWN  "));
+    expect(paramValues(op)).toEqual(["%down%"]);
+  });
+
+  it("multiSearch ORs a case-insensitive ILIKE across every property", () => {
+    const op: RawOperator = asRaw(
+      QueryHelper.multiSearch(["title", "description"], "Payments"),
+    );
+    // multiSearch derives the table alias from a `table.column` alias.
+    const sql: string = op.getSql('"Incident"."title"');
+
+    expect(sql).toContain('"Incident".title');
+    expect(sql).toContain('"Incident".description');
+    expect(sql.toUpperCase()).toContain("ILIKE");
+    expect(sql.toUpperCase()).toContain(" OR ");
+    // One shared bound parameter for all fields; value lower-cased + wrapped.
+    expect(paramValues(op)).toEqual(["%payments%"]);
+    expect(sql).not.toContain("Payments");
+  });
+
+  it("multiSearch handles a bare (dot-less) alias by using it directly", () => {
+    const op: RawOperator = asRaw(QueryHelper.multiSearch(["name"], "abc"));
+    const sql: string = op.getSql("Incident");
+    expect(sql).toContain("Incident.name");
+  });
+});
+
+describe("QueryHelper null + equality operators", () => {
+  it("notNull emits IS NOT NULL and binds nothing", () => {
+    const op: RawOperator = asRaw(QueryHelper.notNull());
+    const sql: string = op.getSql(ALIAS);
+    expect(sql.toUpperCase()).toContain("IS NOT NULL");
+    // A pure IS NOT NULL predicate binds no parameters at all.
+    expect(Object.keys(op.objectLiteralParameters ?? {})).toHaveLength(0);
+  });
+
+  it("notEquals emits `!=` and binds the value as a string", () => {
+    const op: RawOperator = asRaw(QueryHelper.notEquals("active"));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} !=`);
+    expect(sql).not.toContain("active");
+    expect(paramValues(op)).toEqual(["active"]);
+  });
+
+  it("notEquals stringifies an ObjectID comparand", () => {
+    const id: ObjectID = ObjectID.generate();
+    const op: RawOperator = asRaw(QueryHelper.notEquals(id));
+    expect(paramValues(op)).toEqual([id.toString()]);
+    expect(typeof paramValues(op)[0]).toBe("string");
+  });
+});
+
+describe("QueryHelper.modulo", () => {
+  it("emits `(col % :by = :remainder)` with both operands bound", () => {
+    const op: RawOperator = asRaw(QueryHelper.modulo(4, 1));
+    const sql: string = op.getSql(ALIAS);
+    expect(sql).toContain(`${ALIAS} %`);
+    expect(sql).toContain("=");
+    // Neither operand interpolated.
+    expect(sql).not.toContain(" 4 ");
+    const values: Array<unknown> = paramValues(op);
+    expect(values).toContain(4);
+    expect(values).toContain(1);
+    // Two distinct parameter names.
+    expect(Object.keys(op.objectLiteralParameters)).toHaveLength(2);
+  });
+});
+
+describe("QueryHelper.inRelationArray", () => {
+  it("returns ObjectID values unchanged", () => {
+    const a: ObjectID = ObjectID.generate();
+    const b: ObjectID = ObjectID.generate();
+    const result: Array<any> = QueryHelper.inRelationArray([a, b]);
+    expect(result).toEqual([a, b]);
+  });
+
+  it("maps a model to its id", () => {
+    const id: ObjectID = ObjectID.generate();
+    const model: BaseModel = new BaseModel();
+    model.id = id;
+    const result: Array<any> = QueryHelper.inRelationArray([model]);
+    expect(result).toEqual([id]);
+  });
+
+  it("handles a mix of models and ObjectIDs", () => {
+    const modelId: ObjectID = ObjectID.generate();
+    const model: BaseModel = new BaseModel();
+    model.id = modelId;
+    const directId: ObjectID = ObjectID.generate();
+
+    const result: Array<any> = QueryHelper.inRelationArray([model, directId]);
+    expect(result).toEqual([modelId, directId]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(QueryHelper.inRelationArray([])).toEqual([]);
+  });
+});
+
+describe("QueryHelper.queryJson", () => {
+  it("returns a passed-in FindOperator unchanged", () => {
+    // If the caller already built an operator, queryJson must not re-wrap it.
+    const existing: FindOperator<any> = QueryHelper.equalTo(
+      "x",
+    ) as unknown as FindOperator<any>;
+    const result: unknown = QueryHelper.queryJson(existing as any);
+    expect(result).toBe(existing);
+  });
+
+  it("builds a Raw operator that quotes the column and binds the value", () => {
+    const op: RawOperator = asRaw(QueryHelper.queryJson({ team: "Payments" }));
+    expect(op).toBeInstanceOf(FindOperator);
+
+    // Alias arrives as `table.column`; queryJson must quote each segment.
+    const sql: string = op.getSql("Incident.customFields");
+    expect(sql).toContain('"Incident"."customFields"');
+
+    /*
+     * The value is a bound parameter, never spliced into the SQL text —
+     * custom-field values arrive from the browser.
+     */
+    expect(sql).not.toContain("Payments");
+    expect(paramValues(op)).toContain("Payments");
+  });
+
+  it("binds the jsonb KEY as a parameter, never interpolates it", () => {
+    /*
+     * The key is a user-named custom field; interpolating it would let a
+     * field name inject SQL. It must appear only in the parameter bag.
+     */
+    const op: RawOperator = asRaw(
+      QueryHelper.queryJson({ "weird key": "value" }),
+    );
+    const sql: string = op.getSql("Incident.customFields");
+    expect(sql).not.toContain("weird key");
+    expect(paramValues(op)).toContain("weird key");
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorStepInfraMonitorUtils.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepInfraMonitorUtils.test.ts
@@ -1,0 +1,194 @@
+import MonitorStepCephMonitor, {
+  MonitorStepCephMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepCephMonitor";
+import MonitorStepDockerMonitor, {
+  MonitorStepDockerMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepDockerMonitor";
+import MonitorStepDockerSwarmMonitor, {
+  MonitorStepDockerSwarmMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepDockerSwarmMonitor";
+import MonitorStepHostMonitor, {
+  MonitorStepHostMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepHostMonitor";
+import MonitorStepIoTMonitor, {
+  IoTResourceScope,
+  MonitorStepIoTMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepIoTMonitor";
+import MonitorStepKubernetesMonitor, {
+  KubernetesResourceScope,
+  MonitorStepKubernetesMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepKubernetesMonitor";
+import MonitorStepPodmanMonitor, {
+  MonitorStepPodmanMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepPodmanMonitor";
+import MonitorStepProxmoxMonitor, {
+  MonitorStepProxmoxMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepProxmoxMonitor";
+import { JSONObject } from "../../../Types/JSON";
+import RollingTime from "../../../Types/RollingTime/RollingTime";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The infrastructure monitor-step types (Host, Docker, Podman, Kubernetes,
+ * Ceph, IoT, Docker Swarm, Proxmox) each ship a small `*Util` class with
+ * getDefault / fromJSON / toJSON. getDefault seeds the monitor-step editor
+ * when a user first picks that monitor type, so two things it does are
+ * load-bearing and neither is obvious from the (near-identity) code:
+ *
+ *   1. THE DEFAULT ROLLING WINDOW. Every infra step defaults to
+ *      RollingTime.Past1Minute. That value is what a freshly created
+ *      metric monitor evaluates over until the user changes it; a silent
+ *      change to it would change the meaning of every new monitor. Pinned
+ *      per type so a copy-paste edit in one file is caught.
+ *
+ *   2. getDefault RETURNS A FRESH OBJECT GRAPH. The editor mutates the
+ *      returned object (typing an identifier, adding a filter). If
+ *      getDefault handed back a shared reference — or a shared nested
+ *      metricViewConfig — one monitor's edits would bleed into the next
+ *      default. Each call must yield independent objects all the way down.
+ */
+
+interface InfraMonitorUtil<T> {
+  getDefault: () => T;
+  fromJSON: (json: JSONObject) => T;
+  toJSON: (monitor: T) => JSONObject;
+}
+
+interface InfraCase {
+  name: string;
+  // The util under test. Typed loosely so the table can hold every variant.
+  util: InfraMonitorUtil<any>;
+  // The empty-string identifier field each default carries.
+  identifierField: string;
+}
+
+const CASES: Array<InfraCase> = [
+  {
+    name: "Host",
+    util: MonitorStepHostMonitorUtil as InfraMonitorUtil<MonitorStepHostMonitor>,
+    identifierField: "hostIdentifier",
+  },
+  {
+    name: "Docker",
+    util: MonitorStepDockerMonitorUtil as InfraMonitorUtil<MonitorStepDockerMonitor>,
+    identifierField: "hostIdentifier",
+  },
+  {
+    name: "Podman",
+    util: MonitorStepPodmanMonitorUtil as InfraMonitorUtil<MonitorStepPodmanMonitor>,
+    identifierField: "hostIdentifier",
+  },
+  {
+    name: "Kubernetes",
+    util: MonitorStepKubernetesMonitorUtil as InfraMonitorUtil<MonitorStepKubernetesMonitor>,
+    identifierField: "clusterIdentifier",
+  },
+  {
+    name: "Ceph",
+    util: MonitorStepCephMonitorUtil as InfraMonitorUtil<MonitorStepCephMonitor>,
+    identifierField: "clusterIdentifier",
+  },
+  {
+    name: "IoT",
+    util: MonitorStepIoTMonitorUtil as InfraMonitorUtil<MonitorStepIoTMonitor>,
+    identifierField: "fleetIdentifier",
+  },
+  {
+    name: "DockerSwarm",
+    util: MonitorStepDockerSwarmMonitorUtil as InfraMonitorUtil<MonitorStepDockerSwarmMonitor>,
+    identifierField: "clusterIdentifier",
+  },
+  {
+    name: "Proxmox",
+    util: MonitorStepProxmoxMonitorUtil as InfraMonitorUtil<MonitorStepProxmoxMonitor>,
+    identifierField: "clusterIdentifier",
+  },
+];
+
+describe("Infrastructure monitor-step getDefault contract", () => {
+  for (const testCase of CASES) {
+    describe(`MonitorStep${testCase.name}MonitorUtil`, () => {
+      it("defaults the rolling window to Past1Minute", () => {
+        const def: Record<string, unknown> = testCase.util.getDefault();
+        expect(def["rollingTime"]).toBe(RollingTime.Past1Minute);
+      });
+
+      it("defaults the identifier to an empty string", () => {
+        const def: Record<string, unknown> = testCase.util.getDefault();
+        expect(def[testCase.identifierField]).toBe("");
+      });
+
+      it("defaults to an empty metric view config", () => {
+        const def: Record<string, any> = testCase.util.getDefault();
+        expect(def["metricViewConfig"]).toEqual({
+          queryConfigs: [],
+          formulaConfigs: [],
+        });
+      });
+
+      it("returns a fresh object graph on every call", () => {
+        const first: Record<string, any> = testCase.util.getDefault();
+        const second: Record<string, any> = testCase.util.getDefault();
+
+        // Distinct top-level objects.
+        expect(first).not.toBe(second);
+        // Distinct nested metricViewConfig, so mutating one is isolated.
+        expect(first["metricViewConfig"]).not.toBe(second["metricViewConfig"]);
+
+        // Mutating the first default must not touch a later default.
+        first["metricViewConfig"].queryConfigs.push({ any: "thing" });
+        first[testCase.identifierField] = "edited";
+
+        const third: Record<string, any> = testCase.util.getDefault();
+        expect(third["metricViewConfig"].queryConfigs).toEqual([]);
+        expect(third[testCase.identifierField]).toBe("");
+      });
+    });
+  }
+});
+
+describe("Infrastructure monitor-step JSON round-trip", () => {
+  for (const testCase of CASES) {
+    it(`MonitorStep${testCase.name}MonitorUtil round-trips getDefault through to/fromJSON`, () => {
+      const def: any = testCase.util.getDefault();
+
+      const json: JSONObject = testCase.util.toJSON(def);
+      const restored: any = testCase.util.fromJSON(json);
+
+      // The value survives a serialize/deserialize cycle unchanged.
+      expect(restored).toEqual(def);
+    });
+
+    it(`MonitorStep${testCase.name}MonitorUtil preserves a populated identifier + rolling window`, () => {
+      const populated: Record<string, unknown> = {
+        ...(testCase.util.getDefault() as Record<string, unknown>),
+        [testCase.identifierField]: "prod-cluster-1",
+        rollingTime: RollingTime.Past1Hour,
+      };
+
+      const restored: Record<string, unknown> = testCase.util.fromJSON(
+        testCase.util.toJSON(populated),
+      ) as Record<string, unknown>;
+
+      expect(restored[testCase.identifierField]).toBe("prod-cluster-1");
+      expect(restored["rollingTime"]).toBe(RollingTime.Past1Hour);
+    });
+  }
+});
+
+describe("Infrastructure monitor-step scope enums", () => {
+  it("Kubernetes default scope is Cluster", () => {
+    const def: MonitorStepKubernetesMonitor =
+      MonitorStepKubernetesMonitorUtil.getDefault();
+    expect(def.resourceScope).toBe(KubernetesResourceScope.Cluster);
+  });
+
+  it("IoT scope enum values match the agent-stamped attribute strings", () => {
+    /*
+     * These strings equal the `iot.scope` datapoint attribute, so a rename
+     * here would silently break the worker's attribute-equality mapping.
+     */
+    expect(IoTResourceScope.Fleet).toBe("fleet");
+    expect(IoTResourceScope.Device).toBe("device");
+  });
+});

--- a/E2E/Tests/App/StatusProbeMinimalBody.spec.ts
+++ b/E2E/Tests/App/StatusProbeMinimalBody.spec.ts
@@ -1,0 +1,74 @@
+import { BASE_URL } from "../../Config";
+import { APIResponse, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+
+/*
+ * Exact-shape contract for the App service's status probes.
+ *
+ * The sibling suites assert the status code (HealthEndpoints), the
+ * Content-Type (HealthEndpointContentType), and that the body *contains*
+ * `status: "ok"` (StatusCheck, HealthEndpoints via toMatchObject). None of
+ * them assert what the body must NOT contain.
+ *
+ * StatusAPI serves each of these routes with
+ * `Response.sendJsonObjectResponse(req, res, { status: "ok" })` — a body of
+ * exactly one key. That minimalism is a real contract worth pinning:
+ *
+ *   - A regression that started echoing request data, build metadata, or —
+ *     worst — an error/stack field into a public, unauthenticated probe
+ *     would be information disclosure. These endpoints sit in front of the
+ *     ingress and answer anyone.
+ *   - Probe traffic is high-frequency (k8s liveness/readiness on every
+ *     pod); an accidentally bloated body is paid for on every request.
+ *
+ * So this suite asserts the body has *exactly* the `status` key and nothing
+ * else. `toMatchObject` cannot catch an extra field; an exact key-set check
+ * can.
+ */
+
+const STATUS_PROBE_ROUTES: Array<string> = [
+  "/status",
+  "/status/ready",
+  "/status/live",
+];
+
+test.describe("App status probes return a minimal, single-key body", () => {
+  for (const route of STATUS_PROBE_ROUTES) {
+    test(`${route} body is exactly { status: "ok" } with no extra fields`, async ({
+      page,
+    }: {
+      page: Page;
+    }) => {
+      page.setDefaultNavigationTimeout(120000); // 2 minutes
+
+      const endpoint: string = URL.fromString(BASE_URL.toString())
+        .addRoute(route)
+        .toString();
+
+      const response: APIResponse = await page.request.get(endpoint);
+
+      // Success code, same as the sibling suites.
+      expect(response.status()).toBeGreaterThanOrEqual(200);
+      expect(response.status()).toBeLessThan(300);
+
+      const body: unknown = await response.json();
+
+      // Must be a plain JSON object, not an array or scalar.
+      expect(typeof body).toBe("object");
+      expect(body).not.toBeNull();
+      expect(Array.isArray(body)).toBe(false);
+
+      const record: Record<string, unknown> = body as Record<string, unknown>;
+
+      // The value is "ok"...
+      expect(record["status"]).toBe("ok");
+
+      /*
+       * ...and `status` is the ONLY key. This is the assertion the other
+       * suites cannot make: no metadata, no echoed input, no error/stack
+       * field leaked onto a public probe.
+       */
+      expect(Object.keys(record)).toEqual(["status"]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Automated master-health run: all jobs on master are green (the latest master commit was validated via PR #3302 with 19/19 checks passing), so there was nothing failing to fix. Per the task's second directive, this PR adds coverage for previously **untested** code.

## New tests

**Unit (Common, 89 tests)**
- `Common/Tests/Server/Types/Database/QueryHelperOperators.test.ts` — the 18 `QueryHelper` SQL-builder operators that had no direct tests (comparison, range, text, null/equality, `modulo`, `inRelationArray`, `queryJson`). Each asserts the operator the method name promises **and** that user-supplied comparands are bound as parameters rather than interpolated (SQL-injection guard). Complements the existing many-to-many / `findWithSameTextAnyOf` suites.
- `Common/Tests/Server/Infrastructure/LocalCache.test.ts` — round-trips, namespace isolation, the `Boolean()`-based `hasValue` falsy-value edge (0 / "" read as absent), `getOrSetString` caching + empty-value re-fetch, and the documented namespace/key delimiter-collision limitation.
- `Common/Tests/Types/Monitor/MonitorStepInfraMonitorUtils.test.ts` — `getDefault` contract for all 8 infra monitor-step types (default `Past1Minute` window, empty seed, and a **fresh object graph per call** so editor mutations can't bleed into the next default) plus `to/fromJSON` round-trips.

**E2E (Playwright)**
- `E2E/Tests/App/StatusProbeMinimalBody.spec.ts` — App status probes (`/status`, `/status/ready`, `/status/live`) return **exactly** `{ status: "ok" }` with no extra keys — an information-disclosure / payload-bloat guard the sibling `toMatchObject` suites cannot make.

## Notes
- `QueryHelper.greaterThanOrNull` currently emits `>=` (identical to `greaterThanEqualToOrNull`), which reads as inconsistent with its name. The test pins only the unambiguously-required properties (value bound, NULL row included) so it won't need changing if that inconsistency is later fixed — flagged for maintainer review.

## Verification
- All 89 Common unit tests pass locally.
- All 4 files lint clean (eslint) and the E2E project type-checks (`tsc --noEmit`); Common test files type-check via ts-jest.

🤖 Generated by the daily master-build scheduled task.