### PR TITLE
fix(permissions): lock create/update/delete buttons instead of hiding them

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
@@ -48,6 +48,7 @@ import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
 import { CardButtonSchema } from "Common/UI/Components/Card/Card";
 import Route from "Common/Types/API/Route";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import Navigation from "Common/UI/Utils/Navigation";
 import AffectedResourcesCell from "../AffectedResources/AffectedResourcesCell";
 import {
@@ -551,20 +552,32 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
   let cardbuttons: Array<CardButtonSchema> = [];
 
   if (!props.disableCreate) {
+    /*
+     * These route to a dedicated create page instead of the table's built in
+     * create modal, so ModelTable's own permission gate never sees them. Gate
+     * them here or a viewer walks the whole flow and is refused at the end
+     * (issue #3306).
+     */
     cardbuttons = [
-      {
-        title: "Create Alert",
-        onClick: () => {
-          Navigation.navigate(
-            RouteUtil.populateRouteParams(
-              RouteMap[PageMap.ALERT_CREATE] as Route,
-            ),
-          );
+      PermissionGate.gateCardButton(
+        {
+          title: "Create Alert",
+          onClick: () => {
+            Navigation.navigate(
+              RouteUtil.populateRouteParams(
+                RouteMap[PageMap.ALERT_CREATE] as Route,
+              ),
+            );
+          },
+          buttonStyle: ButtonStyleType.NORMAL,
+          icon: IconProp.Add,
         },
-        buttonStyle: ButtonStyleType.NORMAL,
-        icon: IconProp.Add,
-      },
-    ];
+        new Alert(),
+        ModelAction.Create,
+      ),
+    ].filter((button: CardButtonSchema | null): boolean => {
+      return button !== null;
+    }) as Array<CardButtonSchema>;
   }
 
   return (

--- a/App/FeatureSet/Dashboard/src/Components/AlertEpisode/AlertEpisodesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AlertEpisode/AlertEpisodesTable.tsx
@@ -27,6 +27,7 @@ import React, {
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
 import Route from "Common/Types/API/Route";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import Navigation from "Common/UI/Utils/Navigation";
 import {
   BulkActionButtonSchema,
@@ -34,6 +35,7 @@ import {
   BulkActionOnClickProps,
 } from "Common/UI/Components/BulkUpdate/BulkUpdateForm";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import { CardButtonSchema } from "Common/UI/Components/Card/Card";
 import IconProp from "Common/Types/Icon/IconProp";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
@@ -267,19 +269,30 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
           description:
             props.description ||
             "Here is a list of alert episodes for this project.",
+          /*
+           * Routes to the episode create page rather than the table's built in
+           * create modal, so ModelTable's own permission gate never sees this
+           * button - it has to be gated here (issue #3306).
+           */
           buttons: [
-            {
-              title: "Create Episode",
-              onClick: () => {
-                Navigation.navigate(
-                  RouteUtil.populateRouteParams(
-                    RouteMap[PageMap.ALERT_EPISODE_CREATE] as Route,
-                  ),
-                );
+            PermissionGate.gateCardButton(
+              {
+                title: "Create Episode",
+                onClick: () => {
+                  Navigation.navigate(
+                    RouteUtil.populateRouteParams(
+                      RouteMap[PageMap.ALERT_EPISODE_CREATE] as Route,
+                    ),
+                  );
+                },
+                icon: IconProp.Add,
               },
-              icon: IconProp.Add,
-            },
-          ],
+              new AlertEpisode(),
+              ModelAction.Create,
+            ),
+          ].filter((button: CardButtonSchema | null): boolean => {
+            return button !== null;
+          }) as Array<CardButtonSchema>,
         }}
         noItemsMessage={props.noItemsMessage || "No episodes found."}
         showRefreshButton={true}

--- a/App/FeatureSet/Dashboard/src/Components/Announcement/AnnouncementsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Announcement/AnnouncementsTable.tsx
@@ -11,6 +11,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import API from "Common/UI/Utils/API/API";
 import DropdownUtil from "Common/UI/Utils/Dropdown";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPageAnnouncement from "Common/Models/DatabaseModels/StatusPageAnnouncement";
 import StatusPageAnnouncementTemplate from "Common/Models/DatabaseModels/StatusPageAnnouncementTemplate";
@@ -80,30 +81,45 @@ const AnnouncementTable: FunctionComponent<ComponentProps> = (
   let cardbuttons: Array<CardButtonSchema> = [];
 
   if (!props.disableCreate) {
-    // add card buttons for creating announcements
+    /*
+     * These route to a dedicated create page instead of the table's built in
+     * create modal, so ModelTable's own permission gate never sees them. Gate
+     * them here or a viewer walks the whole flow and is refused at the end
+     * (issue #3306).
+     */
     cardbuttons = [
-      {
-        title: "Create from Template",
-        icon: IconProp.Template,
-        buttonStyle: ButtonStyleType.OUTLINE,
-        onClick: async (): Promise<void> => {
-          setShowAnnouncementTemplateModal(true);
-          await fetchAnnouncementTemplates();
+      PermissionGate.gateCardButton(
+        {
+          title: "Create from Template",
+          icon: IconProp.Template,
+          buttonStyle: ButtonStyleType.OUTLINE,
+          onClick: async (): Promise<void> => {
+            setShowAnnouncementTemplateModal(true);
+            await fetchAnnouncementTemplates();
+          },
         },
-      },
-      {
-        title: "Create Announcement",
-        onClick: () => {
-          Navigation.navigate(
-            RouteUtil.populateRouteParams(
-              RouteMap[PageMap.ANNOUNCEMENT_CREATE] as Route,
-            ),
-          );
+        new StatusPageAnnouncement(),
+        ModelAction.Create,
+      ),
+      PermissionGate.gateCardButton(
+        {
+          title: "Create Announcement",
+          onClick: () => {
+            Navigation.navigate(
+              RouteUtil.populateRouteParams(
+                RouteMap[PageMap.ANNOUNCEMENT_CREATE] as Route,
+              ),
+            );
+          },
+          buttonStyle: ButtonStyleType.NORMAL,
+          icon: IconProp.Add,
         },
-        buttonStyle: ButtonStyleType.NORMAL,
-        icon: IconProp.Add,
-      },
-    ];
+        new StatusPageAnnouncement(),
+        ModelAction.Create,
+      ),
+    ].filter((button: CardButtonSchema | null): boolean => {
+      return button !== null;
+    }) as Array<CardButtonSchema>;
   }
   return (
     <Fragment>

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
@@ -57,6 +57,7 @@ import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
 import { CardButtonSchema } from "Common/UI/Components/Card/Card";
 import Route from "Common/Types/API/Route";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import Navigation from "Common/UI/Utils/Navigation";
 import {
   BulkActionButtonSchema,
@@ -516,30 +517,45 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
   let cardbuttons: Array<CardButtonSchema> = [];
 
   if (!props.disableCreate) {
-    // then add a card button that takes to monitor create page
+    /*
+     * Both buttons route to the incident create page instead of the table's
+     * built in create modal, so ModelTable's permission gate never sees them.
+     * Gate them here or a viewer walks the whole flow and is refused at the
+     * end (issue #3306).
+     */
     cardbuttons = [
-      {
-        title: "Create from Template",
-        icon: IconProp.Template,
-        buttonStyle: ButtonStyleType.OUTLINE,
-        onClick: async (): Promise<void> => {
-          setShowIncidentTemplateModal(true);
-          await fetchIncidentTemplates();
+      PermissionGate.gateCardButton(
+        {
+          title: "Create from Template",
+          icon: IconProp.Template,
+          buttonStyle: ButtonStyleType.OUTLINE,
+          onClick: async (): Promise<void> => {
+            setShowIncidentTemplateModal(true);
+            await fetchIncidentTemplates();
+          },
         },
-      },
-      {
-        title: "Declare Incident",
-        onClick: () => {
-          Navigation.navigate(
-            RouteUtil.populateRouteParams(
-              RouteMap[PageMap.INCIDENT_CREATE] as Route,
-            ),
-          );
+        new Incident(),
+        ModelAction.Create,
+      ),
+      PermissionGate.gateCardButton(
+        {
+          title: "Declare Incident",
+          onClick: () => {
+            Navigation.navigate(
+              RouteUtil.populateRouteParams(
+                RouteMap[PageMap.INCIDENT_CREATE] as Route,
+              ),
+            );
+          },
+          buttonStyle: ButtonStyleType.NORMAL,
+          icon: IconProp.Add,
         },
-        buttonStyle: ButtonStyleType.NORMAL,
-        icon: IconProp.Add,
-      },
-    ];
+        new Incident(),
+        ModelAction.Create,
+      ),
+    ].filter((button: CardButtonSchema | null): boolean => {
+      return button !== null;
+    }) as Array<CardButtonSchema>;
   }
 
   return (

--- a/App/FeatureSet/Dashboard/src/Components/IncidentEpisode/IncidentEpisodesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/IncidentEpisode/IncidentEpisodesTable.tsx
@@ -34,6 +34,7 @@ import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import { CardButtonSchema } from "Common/UI/Components/Card/Card";
 import IconProp from "Common/Types/Icon/IconProp";
 import Route from "Common/Types/API/Route";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import Navigation from "Common/UI/Utils/Navigation";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
@@ -248,20 +249,32 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
   let cardbuttons: Array<CardButtonSchema> = [];
 
   if (!props.disableCreate) {
+    /*
+     * These route to a dedicated create page instead of the table's built in
+     * create modal, so ModelTable's own permission gate never sees them. Gate
+     * them here or a viewer walks the whole flow and is refused at the end
+     * (issue #3306).
+     */
     cardbuttons = [
-      {
-        title: "Create Episode",
-        onClick: () => {
-          Navigation.navigate(
-            RouteUtil.populateRouteParams(
-              RouteMap[PageMap.INCIDENT_EPISODE_CREATE] as Route,
-            ),
-          );
+      PermissionGate.gateCardButton(
+        {
+          title: "Create Episode",
+          onClick: () => {
+            Navigation.navigate(
+              RouteUtil.populateRouteParams(
+                RouteMap[PageMap.INCIDENT_EPISODE_CREATE] as Route,
+              ),
+            );
+          },
+          buttonStyle: ButtonStyleType.NORMAL,
+          icon: IconProp.Add,
         },
-        buttonStyle: ButtonStyleType.NORMAL,
-        icon: IconProp.Add,
-      },
-    ];
+        new IncidentEpisode(),
+        ModelAction.Create,
+      ),
+    ].filter((button: CardButtonSchema | null): boolean => {
+      return button !== null;
+    }) as Array<CardButtonSchema>;
   }
 
   return (

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
@@ -66,6 +66,7 @@ import URL from "Common/Types/API/URL";
 import BasicFormModal from "Common/UI/Components/FormModal/BasicFormModal";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ObjectID from "Common/Types/ObjectID";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import ProbeUtil from "../../Utils/Probe";
 
 export interface ComponentProps {
@@ -474,21 +475,34 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
     : [];
 
   if (!props.disableCreate) {
-    // then add a card button that takes to monitor create page
+    /*
+     * A card button that routes to the monitor create page rather than the
+     * table's built in create modal - which means ModelTable's own permission
+     * gate never sees it. Without this check a viewer could open the whole
+     * wizard and only find out at submit, via a validation error about a field
+     * they were never shown (issue #3306).
+     */
+    const createMonitorButton: CardButtonSchema | null =
+      PermissionGate.gateCardButton(
+        {
+          title: "Create Monitor",
+          onClick: () => {
+            Navigation.navigate(
+              RouteUtil.populateRouteParams(
+                RouteMap[PageMap.MONITOR_CREATE] as Route,
+              ),
+            );
+          },
+          buttonStyle: ButtonStyleType.NORMAL,
+          icon: IconProp.Add,
+        },
+        new Monitor(),
+        ModelAction.Create,
+      );
+
     cardbuttons = [
       ...(props.cardButtons || []),
-      {
-        title: "Create Monitor",
-        onClick: () => {
-          Navigation.navigate(
-            RouteUtil.populateRouteParams(
-              RouteMap[PageMap.MONITOR_CREATE] as Route,
-            ),
-          );
-        },
-        buttonStyle: ButtonStyleType.NORMAL,
-        icon: IconProp.Add,
-      },
+      ...(createMonitorButton ? [createMonitorButton] : []),
     ];
   }
 

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
@@ -54,6 +54,7 @@ import {
   ModalTableBulkDefaultActions,
   SaveFilterProps,
 } from "Common/UI/Components/ModelTable/BaseModelTable";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import Navigation from "Common/UI/Utils/Navigation";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
@@ -435,30 +436,45 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
     };
 
   if (!props.disableCreate) {
-    // then add a card button that takes to monitor create page
+    /*
+     * These route to a dedicated create page instead of the table's built in
+     * create modal, so ModelTable's own permission gate never sees them. Gate
+     * them here or a viewer walks the whole flow and is refused at the end
+     * (issue #3306).
+     */
     cardbuttons = [
-      {
-        title: "Create from Template",
-        icon: IconProp.Template,
-        buttonStyle: ButtonStyleType.OUTLINE,
-        onClick: async (): Promise<void> => {
-          setShowScheduledMaintenanceTemplateModal(true);
-          await fetchScheduledMaintenanceTemplates();
+      PermissionGate.gateCardButton(
+        {
+          title: "Create from Template",
+          icon: IconProp.Template,
+          buttonStyle: ButtonStyleType.OUTLINE,
+          onClick: async (): Promise<void> => {
+            setShowScheduledMaintenanceTemplateModal(true);
+            await fetchScheduledMaintenanceTemplates();
+          },
         },
-      },
-      {
-        title: "Create Scheduled Maintenance Event",
-        onClick: () => {
-          Navigation.navigate(
-            RouteUtil.populateRouteParams(
-              RouteMap[PageMap.SCHEDULED_MAINTENANCE_EVENT_CREATE] as Route,
-            ),
-          );
+        new ScheduledMaintenance(),
+        ModelAction.Create,
+      ),
+      PermissionGate.gateCardButton(
+        {
+          title: "Create Scheduled Maintenance Event",
+          onClick: () => {
+            Navigation.navigate(
+              RouteUtil.populateRouteParams(
+                RouteMap[PageMap.SCHEDULED_MAINTENANCE_EVENT_CREATE] as Route,
+              ),
+            );
+          },
+          buttonStyle: ButtonStyleType.NORMAL,
+          icon: IconProp.Add,
         },
-        buttonStyle: ButtonStyleType.NORMAL,
-        icon: IconProp.Add,
-      },
-    ];
+        new ScheduledMaintenance(),
+        ModelAction.Create,
+      ),
+    ].filter((button: CardButtonSchema | null): boolean => {
+      return button !== null;
+    }) as Array<CardButtonSchema>;
   }
 
   return (

--- a/App/FeatureSet/Dashboard/src/Components/TelemetryResource/ArchiveResourceCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TelemetryResource/ArchiveResourceCard.tsx
@@ -10,6 +10,10 @@ import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "Common/UI/Utils/PermissionGate";
 import React, { Fragment, ReactElement, useEffect, useState } from "react";
 
 export interface ComponentProps<TBaseModel extends BaseModel> {
@@ -41,6 +45,17 @@ const ArchiveResourceCard: <TBaseModel extends BaseModel>(
   const model: TBaseModel = new props.modelType();
   const singularName: string =
     props.singularName || model.singularName || "resource";
+
+  /*
+   * Archiving flips a column on the record, so it needs update permission.
+   * Without it the button stays put and says which permission is missing,
+   * rather than opening a confirmation the API will refuse.
+   */
+  const updateGate: PermissionGateResult = PermissionGate.check(
+    model,
+    ModelAction.Update,
+    { singularName: props.singularName },
+  );
 
   const loadState: () => Promise<void> = async (): Promise<void> => {
     setIsLoading(true);
@@ -126,7 +141,13 @@ const ArchiveResourceCard: <TBaseModel extends BaseModel>(
             title: isArchived ? "Unarchive" : "Archive",
             icon: isArchived ? IconProp.Unarchive : IconProp.Archive,
             buttonStyle: ButtonStyleType.NORMAL,
+            disabled: !updateGate.isAllowed,
+            tooltip: updateGate.disabledReason,
             onClick: () => {
+              if (!updateGate.isAllowed) {
+                return;
+              }
+
               setShowConfirm(true);
             },
           },

--- a/App/Tests/Dashboard/CreateEntryPointPermissionInvariants.test.ts
+++ b/App/Tests/Dashboard/CreateEntryPointPermissionInvariants.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Seven tables opt out of ModelTable's built-in create modal - they set
+ * isCreateable={false} and substitute a card button that navigates to a full
+ * create page instead. That substitution also opts them out of ModelTable's
+ * permission gate, which is what issue #3306 reported: a Viewer-only user
+ * could open the entire "Create New Monitor" wizard and only be refused at
+ * submit, with a form-validation error about a field they were never shown.
+ *
+ * They are copy-paste siblings of one another, so a new one is far more likely
+ * to be written by copying an existing file than by reading the gate's
+ * documentation - and the omission is invisible to the type checker and to any
+ * test that does not happen to render that particular table as a Viewer.
+ *
+ * The Monitors table is rendered for real, as a Viewer and as an admin, in
+ * Common/Tests/App/Dashboard/CreatePageEntryPointPermissions.test.tsx. That is
+ * the behavioural test. This file is the cheap net under the other six, and
+ * under the seventh if somebody ever removes the gate from it: the App suite
+ * runs in a plain Node environment with no renderer, so the wiring is pinned by
+ * reading the source, the same way StatusPageResourcesPageInvariants does.
+ *
+ * Sources are whitespace-squashed first so prettier re-wrapping a line cannot
+ * turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+type CreateEntryPoint = {
+  /* Path segments below App/FeatureSet/Dashboard/src. */
+  file: Array<string>;
+  /* The model whose create permission the button must be gated on. */
+  model: string;
+  /* The button labels that route to the dedicated create page. */
+  buttons: Array<string>;
+};
+
+const ENTRY_POINTS: Array<CreateEntryPoint> = [
+  {
+    file: ["Components", "Monitor", "MonitorTable.tsx"],
+    model: "Monitor",
+    buttons: ["Create Monitor"],
+  },
+  {
+    file: ["Components", "Incident", "IncidentsTable.tsx"],
+    model: "Incident",
+    buttons: ["Declare Incident", "Create from Template"],
+  },
+  {
+    file: ["Components", "IncidentEpisode", "IncidentEpisodesTable.tsx"],
+    model: "IncidentEpisode",
+    buttons: ["Create Episode"],
+  },
+  {
+    file: ["Components", "Alert", "AlertsTable.tsx"],
+    model: "Alert",
+    buttons: ["Create Alert"],
+  },
+  {
+    file: ["Components", "AlertEpisode", "AlertEpisodesTable.tsx"],
+    model: "AlertEpisode",
+    buttons: ["Create Episode"],
+  },
+  {
+    file: [
+      "Components",
+      "ScheduledMaintenance",
+      "ScheduledMaintenanceTable.tsx",
+    ],
+    model: "ScheduledMaintenance",
+    buttons: ["Create Scheduled Maintenance Event", "Create from Template"],
+  },
+  {
+    file: ["Components", "Announcement", "AnnouncementsTable.tsx"],
+    model: "StatusPageAnnouncement",
+    buttons: ["Create Announcement", "Create from Template"],
+  },
+];
+
+type ReadSourceFunction = (segments: Array<string>) => string;
+
+const readSource: ReadSourceFunction = (segments: Array<string>): string => {
+  return fs
+    .readFileSync(path.join(DASHBOARD_SRC, ...segments), "utf-8")
+    .replace(/\s+/g, " ");
+};
+
+describe("dedicated create-page entry points are permission gated", () => {
+  for (const entryPoint of ENTRY_POINTS) {
+    const name: string = entryPoint.file[entryPoint.file.length - 1] as string;
+
+    describe(name, () => {
+      const source: string = readSource(entryPoint.file);
+
+      test("routes its create button through the permission gate", () => {
+        expect(source).toContain("PermissionGate.gateCardButton");
+      });
+
+      test("gates on the create permission of its own model", () => {
+        expect(source).toContain(
+          `new ${entryPoint.model}(), ModelAction.Create`,
+        );
+      });
+
+      /*
+       * A button that survives outside the gate is exactly the regression this
+       * file exists to catch: the label is still on screen, still navigates,
+       * and refuses the user two pages later.
+       */
+      for (const button of entryPoint.buttons) {
+        test(`"${button}" is inside a gateCardButton call`, () => {
+          const declaration: string = `title: "${button}"`;
+
+          expect(source).toContain(declaration);
+
+          const gateIndex: number = source.lastIndexOf(
+            "PermissionGate.gateCardButton",
+            source.indexOf(declaration),
+          );
+
+          expect(gateIndex).toBeGreaterThan(-1);
+
+          /*
+           * The nearest preceding gate call has to be close by - a button
+           * declared hundreds of characters after the last gate is a sibling
+           * that was left ungated, not one the gate wraps.
+           */
+          expect(source.indexOf(declaration) - gateIndex).toBeLessThan(200);
+        });
+      }
+    });
+  }
+});

--- a/Common/Tests/App/Dashboard/CreatePageEntryPointPermissions.test.tsx
+++ b/Common/Tests/App/Dashboard/CreatePageEntryPointPermissions.test.tsx
@@ -1,0 +1,306 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Issue #3306, at its point of origin.
+ *
+ * A handful of tables do not use ModelTable's built-in create modal. They set
+ * isCreateable={false} and substitute their own card button that navigates to
+ * a full create page instead - Monitors, Incidents, Alerts, both kinds of
+ * episode, Scheduled Maintenance, Announcements. Doing that also opts them out
+ * of ModelTable's permission gate, which is why a Viewer-only user could click
+ * "Create Monitor", walk all three steps of the wizard, press Create, and be
+ * told "Monitor type required to create monitor" - a form-validation error, for
+ * a permissions problem, naming a field they had never been shown.
+ *
+ * Each of those buttons now carries its own gate. The two things that matter
+ * are asserted for every one of them: the button says why it is locked, and
+ * clicking it does not navigate anybody into a flow that will refuse them.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+let navigateCalls: number = 0;
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<unknown> } => {
+        return { globalPermissions: [...permissionsForTest] };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: async (): Promise<{
+        data: Array<unknown>;
+        count: number;
+        skip: number;
+        limit: number;
+      }> => {
+        return { data: [], count: 0, skip: 0, limit: 10 };
+      },
+      getItem: async (): Promise<null> => {
+        return null;
+      },
+      count: async (): Promise<number> => {
+        return 0;
+      },
+      deleteItem: async (): Promise<void> => {
+        return undefined;
+      },
+      updateById: async (): Promise<void> => {
+        return undefined;
+      },
+      createOrUpdate: async (): Promise<null> => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: (): { toString: () => string } => {
+        return {
+          toString: (): string => {
+            return "00000000-0000-4000-8000-000000000001";
+          },
+        };
+      },
+      getCurrentProject: (): null => {
+        return null;
+      },
+      getCurrentPlan: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+import MonitorTable from "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable";
+import Navigation from "../../../UI/Utils/Navigation";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import TableFilterUrlState from "../../../UI/Utils/TableFilterUrlState";
+import Permission from "../../../Types/Permission";
+import { getJestSpyOn } from "../../Spy";
+
+type FindButtonFunction = (label: string) => HTMLButtonElement | null;
+
+const findButton: FindButtonFunction = (
+  label: string,
+): HTMLButtonElement | null => {
+  return (
+    Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button: HTMLButtonElement) => {
+        return (button.textContent || "").trim().startsWith(label);
+      },
+    ) || null
+  );
+};
+
+describe("dedicated create-page entry points", () => {
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [];
+    navigateCalls = 0;
+    PermissionGate.clearPermissionPropsCache();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/dashboard/monitors",
+    );
+    TableFilterUrlState.resetClaimedKeys();
+    window.localStorage.clear();
+
+    /*
+     * Spied rather than stubbed wholesale: the table's own URL-state helpers
+     * call several other Navigation methods on mount, and only the page
+     * transition is interesting here.
+     */
+    getJestSpyOn(Navigation, "navigate").mockImplementation((): void => {
+      navigateCalls++;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("Monitors table", () => {
+    test("offers a working Create Monitor button to somebody who may create", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      render(<MonitorTable />);
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      const button: HTMLButtonElement = findButton("Create Monitor")!;
+
+      expect(button).not.toBeDisabled();
+
+      fireEvent.click(button);
+
+      expect(navigateCalls).toBe(1);
+    });
+
+    /*
+     * The reported scenario, exactly: a Viewer-only user on Monitors.
+     */
+    test("locks Create Monitor for a Viewer instead of letting them into the wizard", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(<MonitorTable />);
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      expect(findButton("Create Monitor")).toBeDisabled();
+    });
+
+    test("tells the Viewer which permission they are missing", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(<MonitorTable />);
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      fireEvent.mouseEnter(
+        findButton("Create Monitor")!.parentElement as HTMLElement,
+      );
+
+      const tooltip: HTMLElement = screen.getByRole("tooltip");
+
+      expect(tooltip).toHaveTextContent(
+        "You do not have permission to create this Monitor.",
+      );
+      expect(tooltip).toHaveTextContent("Create Monitor");
+      expect(tooltip).toHaveTextContent("Monitor Admin");
+    });
+
+    /*
+     * "Block on click of Create", in the words of the bug report - rather than
+     * letting the user through and failing at submission.
+     */
+    test("does not navigate to the create page when the locked button is clicked", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(<MonitorTable />);
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      fireEvent.click(findButton("Create Monitor")!);
+
+      expect(navigateCalls).toBe(0);
+    });
+
+    /*
+     * disableCreate is a layout flag - the disabled-monitors and
+     * probe-disconnected pages set it because those lists are not a place to
+     * create anything, which has nothing to do with permissions. Turning it
+     * into a permanently locked button would be its own bug.
+     */
+    test("keeps the button absent when the caller disabled create for layout reasons", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      render(<MonitorTable disableCreate={true} />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Monitors").length).toBeGreaterThan(0);
+      });
+
+      expect(findButton("Create Monitor")).toBeNull();
+    });
+
+    test("keeps the button absent while the permission snapshot has not loaded", async () => {
+      permissionsForTest = [];
+
+      render(<MonitorTable />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Monitors").length).toBeGreaterThan(0);
+      });
+
+      expect(findButton("Create Monitor")).toBeNull();
+    });
+
+    test("works for a master admin", async () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      render(<MonitorTable />);
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      expect(findButton("Create Monitor")).not.toBeDisabled();
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/DangerZone.test.tsx
+++ b/Common/Tests/App/Dashboard/DangerZone.test.tsx
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it } from "@jest/globals";
 import API from "../../../UI/Utils/API/API";
 import ProjectUtil from "../../../UI/Utils/Project";
 import PermissionUtil from "../../../UI/Utils/Permission";
+import Permission from "../../../Types/Permission";
 import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../../Types/API/HTTPResponse";
 import Route from "../../../Types/API/Route";
@@ -171,6 +172,16 @@ describe("Settings > Danger Zone", () => {
     getJestSpyOn(PermissionUtil, "clearProjectPermissions").mockImplementation(
       () => {},
     );
+
+    /*
+     * The delete button is gated on the viewer's permissions now, and without a
+     * permission snapshot the card cannot tell "not allowed" from "not loaded
+     * yet" and offers no button at all. Deleting a project is the owner's to
+     * do, so that is who these tests are.
+     */
+    getJestSpyOn(PermissionUtil, "getAllPermissions").mockReturnValue([
+      Permission.ProjectOwner,
+    ]);
 
     getJestSpyOn(API, "post").mockImplementation((data: any) => {
       postCalls.push({

--- a/Common/Tests/App/Dashboard/OverviewCustomFields.test.tsx
+++ b/Common/Tests/App/Dashboard/OverviewCustomFields.test.tsx
@@ -23,6 +23,30 @@ const getCurrentProjectIdMock: MockFunction = getJestMockFunction();
  * requires, so naming the mocks directly would capture them before their
  * initializers have run.
  */
+/*
+ * The Edit Fields button is gated on the viewer's permissions now - custom
+ * field values live on the record, so editing them is an update of it. Without
+ * a permission snapshot the card cannot tell "not allowed" from "not loaded
+ * yet" and offers no button at all, which is correct and covered in the
+ * permission gating suites.
+ */
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<string> => {
+        return ["ProjectOwner"];
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<string> } => {
+        return { globalPermissions: ["ProjectOwner"] };
+      },
+    },
+  };
+});
+
 jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
   return {
     __esModule: true,

--- a/Common/Tests/UI/Components/BulkActionPermissionGating.test.tsx
+++ b/Common/Tests/UI/Components/BulkActionPermissionGating.test.tsx
@@ -1,0 +1,296 @@
+import "@testing-library/jest-dom";
+import { renderHook } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The bulk-action hooks were the widest hole left in the table gating.
+ *
+ * BaseModelTable checks delete permission before it auto-injects the bulk
+ * Delete, but it spreads whatever the caller passed in `bulkActions.buttons`
+ * straight through untouched - and these three hooks are what nearly every
+ * table passes. So a viewer could select every row on a table that correctly
+ * refused them a per-row Edit, and still relabel, reassign or archive the lot
+ * from the action bar.
+ *
+ * Labels and archive state live on the record, so those are updates.
+ * Ownership lives in a junction table, so adding an owner is a create there
+ * and removing one is a delete - which is why the owner hook checks two
+ * different permissions rather than one.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<unknown> } => {
+        return { globalPermissions: [...permissionsForTest] };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: async (): Promise<{
+        data: Array<unknown>;
+        count: number;
+        skip: number;
+        limit: number;
+      }> => {
+        return { data: [], count: 0, skip: 0, limit: 10 };
+      },
+      getItem: async (): Promise<null> => {
+        return null;
+      },
+      updateById: async (): Promise<void> => {
+        return undefined;
+      },
+      deleteItem: async (): Promise<void> => {
+        return undefined;
+      },
+      create: async (): Promise<null> => {
+        return null;
+      },
+    },
+  };
+});
+
+import useBulkLabelActions, {
+  BulkLabelActionsResult,
+} from "../../../UI/Components/BulkUpdate/BulkLabelActions";
+import useBulkArchiveActions, {
+  BulkArchiveActionsResult,
+} from "../../../UI/Components/BulkUpdate/BulkArchiveActions";
+import useBulkOwnerActions, {
+  BulkOwnerActionsResult,
+} from "../../../UI/Components/BulkUpdate/BulkOwnerActions";
+import { BulkActionButtonSchema } from "../../../UI/Components/BulkUpdate/BulkUpdateForm";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorOwnerUser from "../../../Models/DatabaseModels/MonitorOwnerUser";
+import MonitorOwnerTeam from "../../../Models/DatabaseModels/MonitorOwnerTeam";
+import PodmanHost from "../../../Models/DatabaseModels/PodmanHost";
+import Permission from "../../../Types/Permission";
+
+type FindActionFunction = (
+  actions: Array<BulkActionButtonSchema<never>>,
+  title: string,
+) => BulkActionButtonSchema<never> | undefined;
+
+const findAction: FindActionFunction = (
+  actions: Array<BulkActionButtonSchema<never>>,
+  title: string,
+): BulkActionButtonSchema<never> | undefined => {
+  return actions.find((action: BulkActionButtonSchema<never>) => {
+    return action.title === title;
+  });
+};
+
+describe("bulk action permission gating", () => {
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [];
+    PermissionGate.clearPermissionPropsCache();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("useBulkLabelActions", () => {
+    type RenderFunction = () => BulkLabelActionsResult<Monitor>;
+
+    const renderActions: RenderFunction =
+      (): BulkLabelActionsResult<Monitor> => {
+        return renderHook(() => {
+          return useBulkLabelActions<Monitor>({ modelType: Monitor });
+        }).result.current;
+      };
+
+    test("leaves the label actions working for someone who may update", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      const actions: Array<BulkActionButtonSchema<never>> = renderActions()
+        .bulkActions as unknown as Array<BulkActionButtonSchema<never>>;
+
+      expect(findAction(actions, "Add Labels")?.disabled).toBeFalsy();
+      expect(findAction(actions, "Remove Labels")?.disabled).toBeFalsy();
+    });
+
+    test("locks both label actions for a viewer, with a reason", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const actions: Array<BulkActionButtonSchema<never>> = renderActions()
+        .bulkActions as unknown as Array<BulkActionButtonSchema<never>>;
+
+      for (const title of ["Add Labels", "Remove Labels"]) {
+        const action: BulkActionButtonSchema<never> | undefined = findAction(
+          actions,
+          title,
+        );
+
+        expect(action?.disabled).toBe(true);
+        expect(action?.tooltip).toContain(
+          "You do not have permission to update this Monitor.",
+        );
+      }
+    });
+
+    /*
+     * The actions still have to be handed to the table - Table derives the row
+     * checkboxes from this array being non-empty, and a viewer losing the
+     * selection column would be a layout change nobody asked for.
+     */
+    test("keeps the actions in the array rather than dropping them", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      expect(renderActions().bulkActions.length).toBe(2);
+    });
+
+    test("leaves them working for a master admin", () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      const actions: Array<BulkActionButtonSchema<never>> = renderActions()
+        .bulkActions as unknown as Array<BulkActionButtonSchema<never>>;
+
+      expect(findAction(actions, "Add Labels")?.disabled).toBeFalsy();
+    });
+  });
+
+  describe("useBulkArchiveActions", () => {
+    type RenderFunction = () => BulkArchiveActionsResult<PodmanHost>;
+
+    const renderActions: RenderFunction =
+      (): BulkArchiveActionsResult<PodmanHost> => {
+        return renderHook(() => {
+          return useBulkArchiveActions<PodmanHost>({
+            modelType: PodmanHost,
+          });
+        }).result.current;
+      };
+
+    test("locks Archive and Unarchive for a viewer", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const result: BulkArchiveActionsResult<PodmanHost> = renderActions();
+
+      expect(result.archiveBulkActions[0]?.disabled).toBe(true);
+      expect(result.archiveBulkActions[0]?.tooltip).toContain(
+        "You do not have permission to update",
+      );
+      expect(result.unarchiveBulkActions[0]?.disabled).toBe(true);
+    });
+
+    test("leaves them working for someone who may update", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      const result: BulkArchiveActionsResult<PodmanHost> = renderActions();
+
+      expect(result.archiveBulkActions[0]?.disabled).toBeFalsy();
+      expect(result.unarchiveBulkActions[0]?.disabled).toBeFalsy();
+    });
+  });
+
+  describe("useBulkOwnerActions", () => {
+    type RenderFunction = () => BulkOwnerActionsResult<Monitor>;
+
+    const renderActions: RenderFunction =
+      (): BulkOwnerActionsResult<Monitor> => {
+        return renderHook(() => {
+          return useBulkOwnerActions<Monitor>({
+            ownerUserModelType: MonitorOwnerUser,
+            ownerTeamModelType: MonitorOwnerTeam,
+            resourceIdField: "monitorId",
+          });
+        }).result.current;
+      };
+
+    test("locks adding and removing owners for a viewer", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const actions: Array<BulkActionButtonSchema<never>> = renderActions()
+        .bulkActions as unknown as Array<BulkActionButtonSchema<never>>;
+
+      expect(findAction(actions, "Add Owner")?.disabled).toBe(true);
+      expect(findAction(actions, "Remove Owner")?.disabled).toBe(true);
+    });
+
+    /*
+     * Add and Remove are checked against different permissions on the junction
+     * table, so a grant that covers one need not cover the other.
+     */
+    test("checks Add against create and Remove against delete", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const actions: Array<BulkActionButtonSchema<never>> = renderActions()
+        .bulkActions as unknown as Array<BulkActionButtonSchema<never>>;
+
+      expect(findAction(actions, "Add Owner")?.tooltip).toContain(
+        "permission to create",
+      );
+      expect(findAction(actions, "Remove Owner")?.tooltip).toContain(
+        "permission to delete",
+      );
+    });
+
+    test("leaves them working for someone who may manage owners", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      const actions: Array<BulkActionButtonSchema<never>> = renderActions()
+        .bulkActions as unknown as Array<BulkActionButtonSchema<never>>;
+
+      expect(findAction(actions, "Add Owner")?.disabled).toBeFalsy();
+      expect(findAction(actions, "Remove Owner")?.disabled).toBeFalsy();
+    });
+  });
+});

--- a/Common/Tests/UI/Components/CardModelDetailPermissionGating.test.tsx
+++ b/Common/Tests/UI/Components/CardModelDetailPermissionGating.test.tsx
@@ -1,0 +1,305 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * CardModelDetail's Edit button was the only model-level permission check in
+ * the app outside of tables, and it got three things wrong at once:
+ *
+ *   1. it HID the button, so a viewer saw a detail card that looked like it
+ *      was simply not editable by anybody;
+ *   2. it consulted project permissions only, so a permission granted
+ *      globally - which is where master-admin-adjacent grants live - did not
+ *      count;
+ *   3. it computed the answer inside a mount-only effect, so a card that
+ *      rendered before the permission snapshot arrived kept the wrong answer
+ *      for as long as the page stayed open.
+ *
+ * Each of those is pinned below.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      /*
+       * Deliberately empty. The old implementation read ONLY this, so if the
+       * component ever goes back to it every test below that grants a
+       * permission starts failing.
+       */
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (): Promise<null> => {
+        return null;
+      },
+      getList: async (): Promise<{
+        data: Array<unknown>;
+        count: number;
+        skip: number;
+        limit: number;
+      }> => {
+        return { data: [], count: 0, skip: 0, limit: 10 };
+      },
+    },
+  };
+});
+
+import CardModelDetail from "../../../UI/Components/ModelDetail/CardModelDetail";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+import FieldType from "../../../UI/Components/Types/FieldType";
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+type FindEditButtonFunction = () => HTMLButtonElement | null;
+
+const findEditButton: FindEditButtonFunction = (): HTMLButtonElement | null => {
+  return (
+    Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button: HTMLButtonElement) => {
+        return (button.textContent || "").trim().startsWith("Edit Monitor");
+      },
+    ) || null
+  );
+};
+
+type RenderCardFunction = (refresher?: boolean) => ReturnType<typeof render>;
+
+const renderCard: RenderCardFunction = (
+  refresher: boolean = false,
+): ReturnType<typeof render> => {
+  return render(
+    <CardModelDetail<Monitor>
+      name="Monitor Details"
+      cardProps={{ title: "Monitor Details", description: "About it" }}
+      isEditable={true}
+      refresher={refresher}
+      formFields={[
+        {
+          field: { name: true },
+          title: "Name",
+          fieldType: "Text" as never,
+          required: true,
+        },
+      ]}
+      modelDetailProps={{
+        modelType: Monitor,
+        id: "monitor-detail",
+        modelId: MONITOR_ID,
+        fields: [
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FieldType.Text,
+          },
+        ],
+      }}
+    />,
+  );
+};
+
+describe("CardModelDetail permission gating", () => {
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [];
+    PermissionGate.clearPermissionPropsCache();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("offers a working Edit button when the viewer may update", async () => {
+    permissionsForTest = [Permission.ProjectAdmin];
+
+    renderCard();
+
+    await waitFor(() => {
+      expect(findEditButton()).not.toBeNull();
+    });
+
+    expect(findEditButton()).not.toBeDisabled();
+  });
+
+  test("locks the Edit button rather than removing it", async () => {
+    permissionsForTest = [Permission.Viewer];
+
+    renderCard();
+
+    await waitFor(() => {
+      expect(findEditButton()).not.toBeNull();
+    });
+
+    expect(findEditButton()).toBeDisabled();
+  });
+
+  test("explains the locked Edit on hover", async () => {
+    permissionsForTest = [Permission.Viewer];
+
+    renderCard();
+
+    await waitFor(() => {
+      expect(findEditButton()).not.toBeNull();
+    });
+
+    fireEvent.mouseEnter(findEditButton()!.parentElement as HTMLElement);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "You do not have permission to update this Monitor.",
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Edit Monitor");
+  });
+
+  /*
+   * The check used to run against getProjectPermissions() alone. This grant
+   * arrives through getAllPermissions(), which merges global and project - so
+   * it only passes if the component is reading the merged view.
+   */
+  test("honours a permission that is not in the project snapshot", async () => {
+    permissionsForTest = [Permission.ProjectOwner];
+
+    renderCard();
+
+    await waitFor(() => {
+      expect(findEditButton()).not.toBeNull();
+    });
+
+    expect(findEditButton()).not.toBeDisabled();
+  });
+
+  /*
+   * The snapshot lands on an API response header, which can easily be after
+   * the card's first paint. A mount-only effect froze the button in whatever
+   * state that first paint implied.
+   */
+  test("re-evaluates when the permission snapshot arrives after first paint", async () => {
+    permissionsForTest = [];
+
+    const { rerender } = renderCard(false);
+
+    await waitFor(() => {
+      expect(screen.getByText("Monitor Details")).toBeInTheDocument();
+    });
+
+    // Nothing honest to say yet, so no button at all.
+    expect(findEditButton()).toBeNull();
+
+    permissionsForTest = [Permission.ProjectAdmin];
+
+    rerender(
+      <CardModelDetail<Monitor>
+        name="Monitor Details"
+        cardProps={{ title: "Monitor Details", description: "About it" }}
+        isEditable={true}
+        refresher={true}
+        formFields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: "Text" as never,
+            required: true,
+          },
+        ]}
+        modelDetailProps={{
+          modelType: Monitor,
+          id: "monitor-detail",
+          modelId: MONITOR_ID,
+          fields: [
+            {
+              field: { name: true },
+              title: "Name",
+              fieldType: FieldType.Text,
+            },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(findEditButton()).not.toBeNull();
+    });
+
+    expect(findEditButton()).not.toBeDisabled();
+  });
+
+  test("works for a master admin", async () => {
+    isMasterAdminForTest = true;
+    permissionsForTest = [];
+
+    renderCard();
+
+    await waitFor(() => {
+      expect(findEditButton()).not.toBeNull();
+    });
+
+    expect(findEditButton()).not.toBeDisabled();
+  });
+});

--- a/Common/Tests/UI/Components/CustomFields/CustomFieldsDetail.test.tsx
+++ b/Common/Tests/UI/Components/CustomFields/CustomFieldsDetail.test.tsx
@@ -34,6 +34,29 @@ const updateByIdMock: MockFunction = getJestMockFunction();
  * requires, so naming the mocks directly would capture them before their
  * initializers have run.
  */
+/*
+ * The button is now gated on the viewer's permissions, so the tests have to
+ * say who is looking at the card. Without a permission snapshot the component
+ * cannot tell "not allowed" from "not loaded yet" and offers no button at all
+ * - which is correct, and is covered in the permission gating suites.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<string> => {
+        return ["ProjectOwner"];
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<string> } => {
+        return { globalPermissions: ["ProjectOwner"] };
+      },
+    },
+  };
+});
+
 jest.mock("../../../../UI/Utils/ModelAPI/ModelAPI", () => {
   return {
     __esModule: true,

--- a/Common/Tests/UI/Components/DisabledButtonTooltip.test.tsx
+++ b/Common/Tests/UI/Components/DisabledButtonTooltip.test.tsx
@@ -1,0 +1,267 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import Button from "../../../UI/Components/Button/Button";
+import MoreMenuItem from "../../../UI/Components/MoreMenu/MoreMenuItem";
+import IconProp from "../../../Types/Icon/IconProp";
+
+/*
+ * Button and MoreMenuItem have both accepted a `tooltip` for a long time, and
+ * on a disabled control it did nothing at all. That is the one case where the
+ * tooltip carries the whole message: a locked button with no explanation is
+ * indistinguishable from a broken one.
+ *
+ * Two separate mechanisms conspired against it. A disabled form control
+ * dispatches no pointer events and cannot be focused, so neither of tippy's
+ * triggers ever fires; and tippy's own show() bails out early when its
+ * reference element carries a `disabled` attribute. The fix needs both halves:
+ * a hoverable, focusable wrapper to act as the reference, and
+ * `pointer-events-none` on the button so hit-testing lands on that wrapper
+ * instead of on the control that swallows events.
+ *
+ * These tests are the regression guard for both halves. Deleting either one
+ * makes the "renders the tooltip" cases fail.
+ *
+ * Notes on asserting tippy under jsdom, learned the hard way:
+ *   - the tooltip is portalled to document.body, so query with `screen`,
+ *     never the render container;
+ *   - the box stays data-state="hidden" because the animation never completes
+ *     under jsdom - assert presence, not that attribute;
+ *   - aria-describedby is not yet on the trigger immediately after mouseenter.
+ */
+
+describe("tooltips on disabled controls", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("Button", () => {
+    test("shows its tooltip on hover when enabled", () => {
+      render(
+        <Button
+          dataTestId="btn"
+          title="Create Monitor"
+          tooltip="Some reason"
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByTestId("btn"));
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Some reason");
+    });
+
+    /*
+     * The core assertion of the whole change. Before the fix this found no
+     * tooltip at all: hovering a disabled button produced nothing, not even a
+     * tippy root element.
+     */
+    test("shows its tooltip on hover when DISABLED", () => {
+      render(
+        <Button
+          dataTestId="btn"
+          title="Create Monitor"
+          disabled={true}
+          tooltip="You do not have permission to create this Monitor."
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByTestId("btn-disabled-wrapper"));
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to create this Monitor.",
+      );
+    });
+
+    /*
+     * Half two of the fix. Without pointer-events-none the wrapper is never
+     * hovered in a real browser, because the button on top of it eats the
+     * pointer without dispatching anything. jsdom does not hit-test, so this
+     * has to be asserted on the class directly.
+     */
+    test("takes a disabled button out of hit-testing so the wrapper can be hovered", () => {
+      render(
+        <Button
+          dataTestId="btn"
+          title="Create Monitor"
+          disabled={true}
+          tooltip="You do not have permission to create this Monitor."
+        />,
+      );
+
+      expect(screen.getByTestId("btn")).toHaveClass("pointer-events-none");
+    });
+
+    test("keeps a disabled button reachable by keyboard for the tooltip", () => {
+      render(
+        <Button
+          dataTestId="btn"
+          title="Create Monitor"
+          disabled={true}
+          tooltip="You do not have permission to create this Monitor."
+        />,
+      );
+
+      // A disabled button is out of the tab order; the wrapper stands in.
+      expect(screen.getByTestId("btn-disabled-wrapper")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+
+      fireEvent.focus(screen.getByTestId("btn-disabled-wrapper"));
+
+      expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
+
+    test("still marks the button disabled to assistive technology", () => {
+      render(
+        <Button
+          dataTestId="btn"
+          title="Create Monitor"
+          disabled={true}
+          tooltip="Nope"
+        />,
+      );
+
+      const button: HTMLElement = screen.getByTestId("btn");
+
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute("aria-disabled", "true");
+    });
+
+    test("does not fire onClick while disabled", () => {
+      let clicked: boolean = false;
+
+      render(
+        <Button
+          dataTestId="btn"
+          title="Create Monitor"
+          disabled={true}
+          tooltip="Nope"
+          onClick={() => {
+            clicked = true;
+          }}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("btn"));
+
+      expect(clicked).toBe(false);
+    });
+
+    /*
+     * isLoading hard-disables the button too, so it hits exactly the same
+     * dead-tooltip path.
+     */
+    test("shows its tooltip while loading", () => {
+      render(
+        <Button
+          dataTestId="btn"
+          title="Saving"
+          isLoading={true}
+          tooltip="Working on it"
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByTestId("btn-disabled-wrapper"));
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Working on it");
+    });
+
+    /*
+     * The enabled path is by far the most common one - 200-odd call sites - and
+     * must keep rendering the bare button with no extra wrapper around it,
+     * because layout in several places depends on the button being the direct
+     * child of its flex container.
+     */
+    test("does not wrap an enabled button", () => {
+      render(<Button dataTestId="btn" title="Create" tooltip="Hello" />);
+
+      expect(screen.queryByTestId("btn-disabled-wrapper")).toBeNull();
+    });
+
+    test("does not wrap a disabled button that has nothing to say", () => {
+      render(<Button dataTestId="btn" title="Create" disabled={true} />);
+
+      expect(screen.queryByTestId("btn-disabled-wrapper")).toBeNull();
+      expect(screen.getByTestId("btn")).not.toHaveClass("pointer-events-none");
+    });
+  });
+
+  describe("MoreMenuItem", () => {
+    /*
+     * Header buttons that do not fit spill into a More menu, and bulk actions
+     * live there permanently - so a locked Delete is just as likely to be seen
+     * as a MoreMenuItem as it is as a Button.
+     */
+    test("shows its tooltip on hover when disabled", () => {
+      render(
+        <MoreMenuItem
+          text="Delete"
+          icon={IconProp.Trash}
+          isDisabled={true}
+          tooltip="You do not have permission to delete this Monitor."
+          onClick={() => {}}
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole("menuitem").parentElement!);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to delete this Monitor.",
+      );
+    });
+
+    test("takes a disabled item out of hit-testing", () => {
+      render(
+        <MoreMenuItem
+          text="Delete"
+          isDisabled={true}
+          tooltip="Nope"
+          onClick={() => {}}
+        />,
+      );
+
+      expect(screen.getByRole("menuitem")).toHaveClass("pointer-events-none");
+    });
+
+    test("does not fire onClick while disabled", () => {
+      let clicked: boolean = false;
+
+      render(
+        <MoreMenuItem
+          text="Delete"
+          isDisabled={true}
+          tooltip="Nope"
+          onClick={() => {
+            clicked = true;
+          }}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("menuitem"));
+
+      expect(clicked).toBe(false);
+    });
+
+    test("renders an enabled item unwrapped and clickable", () => {
+      let clicked: boolean = false;
+
+      render(
+        <MoreMenuItem
+          text="Delete"
+          onClick={() => {
+            clicked = true;
+          }}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("menuitem"));
+
+      expect(clicked).toBe(true);
+      expect(screen.getByRole("menuitem")).not.toHaveClass(
+        "pointer-events-none",
+      );
+    });
+  });
+});

--- a/Common/Tests/UI/Components/DuplicateModel.test.tsx
+++ b/Common/Tests/UI/Components/DuplicateModel.test.tsx
@@ -17,6 +17,31 @@ import ObjectID from "../../../Types/ObjectID";
 import React from "react";
 import { act } from "react-test-renderer";
 import Select from "../../../Types/BaseDatabase/Select";
+import TableAccessControl from "../../../Types/Database/AccessControl/TableAccessControl";
+import Permission from "../../../Types/Permission";
+/*
+ * The button is now gated on the viewer's permissions, so the tests have to
+ * say who is looking at the card. Without a permission snapshot the component
+ * cannot tell "not allowed" from "not loaded yet" and offers no button at all
+ * - which is correct, and is covered in the permission gating suites.
+ */
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<string> => {
+        return ["ProjectOwner"];
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<string> } => {
+        return { globalPermissions: ["ProjectOwner"] };
+      },
+    },
+  };
+});
+
 jest.mock("../../../UI/Utils/Navigation", () => {
   return {
     __esModule: true,
@@ -64,6 +89,18 @@ jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
   };
 });
 
+/*
+ * Access control is not decoration here: Duplicate writes a new record, so the
+ * button is gated on create permission, and a model that declares none is one
+ * nobody can create - the button is correctly withheld. Every real model
+ * declares its own, so this one does too.
+ */
+@TableAccessControl({
+  create: [Permission.ProjectOwner],
+  read: [Permission.ProjectOwner],
+  update: [Permission.ProjectOwner],
+  delete: [Permission.ProjectOwner],
+})
 @TableMetaData({
   tableName: "Foo",
   singularName: "Foo",

--- a/Common/Tests/UI/Components/ModelCardPermissionGating.test.tsx
+++ b/Common/Tests/UI/Components/ModelCardPermissionGating.test.tsx
@@ -1,0 +1,348 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The cards on a resource's own pages - Delete, Edit, Duplicate, Reset Key -
+ * are where a viewer meets the same problem the tables had, in a sharper form.
+ *
+ * ModelDelete had no permission logic at all: 60 pages rendered a live, red
+ * "Delete <X>" button for everybody, with a confirmation dialog behind it, and
+ * the refusal only arrived from the API after the user had confirmed they
+ * wanted to destroy something. CardModelDetail did check, but hid the Edit
+ * button - and checked only project permissions, so a permission granted
+ * globally did not count, and it read the answer once at mount and never
+ * again.
+ *
+ * All of them now behave the same way: the button stays, locked, and names the
+ * permission it wants.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      deleteItem: async (): Promise<void> => {
+        deleteItemCalls++;
+      },
+      getItem: async (): Promise<null> => {
+        return null;
+      },
+      getList: async (): Promise<{
+        data: Array<unknown>;
+        count: number;
+        skip: number;
+        limit: number;
+      }> => {
+        return { data: [], count: 0, skip: 0, limit: 10 };
+      },
+    },
+  };
+});
+
+let deleteItemCalls: number = 0;
+
+import ModelDelete from "../../../UI/Components/ModelDelete/ModelDelete";
+import DuplicateModel from "../../../UI/Components/DuplicateModel/DuplicateModel";
+import ResetObjectID from "../../../UI/Components/ResetObjectID/ResetObjectID";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+type FindButtonFunction = (label: string) => HTMLButtonElement | null;
+
+const findButton: FindButtonFunction = (
+  label: string,
+): HTMLButtonElement | null => {
+  return (
+    Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button: HTMLButtonElement) => {
+        return (button.textContent || "").trim().startsWith(label);
+      },
+    ) || null
+  );
+};
+
+describe("resource card permission gating", () => {
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [];
+    deleteItemCalls = 0;
+    PermissionGate.clearPermissionPropsCache();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("ModelDelete", () => {
+    test("offers a working Delete button when the viewer may delete", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      render(
+        <ModelDelete<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          onDeleteSuccess={() => {}}
+        />,
+      );
+
+      const button: HTMLButtonElement = findButton("Delete Monitor")!;
+
+      expect(button).not.toBeDisabled();
+
+      fireEvent.click(button);
+
+      // The confirmation dialog restates the question before anything happens.
+      expect(
+        screen.getAllByText("Are you sure you want to delete this monitor?")
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    /*
+     * The worst version of the old behaviour: a red Delete button, a
+     * confirmation the user has to actively agree to, and only then a refusal
+     * from the server.
+     */
+    test("locks the Delete button when the viewer may not delete", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(
+        <ModelDelete<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          onDeleteSuccess={() => {}}
+        />,
+      );
+
+      expect(findButton("Delete Monitor")).toBeDisabled();
+    });
+
+    test("explains the locked Delete on hover", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(
+        <ModelDelete<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          onDeleteSuccess={() => {}}
+        />,
+      );
+
+      fireEvent.mouseEnter(
+        findButton("Delete Monitor")!.parentElement as HTMLElement,
+      );
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to delete this Monitor.",
+      );
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Delete Monitor");
+    });
+
+    test("a locked Delete opens no confirmation and deletes nothing", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(
+        <ModelDelete<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          onDeleteSuccess={() => {}}
+        />,
+      );
+
+      fireEvent.click(findButton("Delete Monitor")!);
+
+      expect(
+        screen.queryAllByText("Are you sure you want to delete this monitor?")
+          .length,
+      ).toBe(1); // only the card's own description, never the dialog's copy
+      expect(deleteItemCalls).toBe(0);
+    });
+
+    test("works for a master admin", () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      render(
+        <ModelDelete<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          onDeleteSuccess={() => {}}
+        />,
+      );
+
+      expect(findButton("Delete Monitor")).not.toBeDisabled();
+    });
+  });
+
+  describe("DuplicateModel", () => {
+    /*
+     * Duplicating writes a new record, so it is a create - not, as the button's
+     * position on an existing record might suggest, an update.
+     */
+    test("locks Duplicate behind create permission", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(
+        <DuplicateModel<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          fieldsToDuplicate={{}}
+          navigateToOnSuccess={undefined as never}
+          fieldsToChange={[]}
+          onDuplicateSuccess={() => {}}
+        />,
+      );
+
+      const button: HTMLButtonElement = findButton("Duplicate Monitor")!;
+
+      expect(button).toBeDisabled();
+
+      fireEvent.mouseEnter(button.parentElement as HTMLElement);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to create this Monitor.",
+      );
+    });
+
+    test("leaves Duplicate working for someone who may create", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      render(
+        <DuplicateModel<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          fieldsToDuplicate={{}}
+          navigateToOnSuccess={undefined as never}
+          fieldsToChange={[]}
+          onDuplicateSuccess={() => {}}
+        />,
+      );
+
+      expect(findButton("Duplicate Monitor")).not.toBeDisabled();
+    });
+  });
+
+  describe("ResetObjectID", () => {
+    /*
+     * Resetting a secret key rewrites a column on the record, so it needs
+     * update permission - and it is exactly the kind of destructive action
+     * that should say so rather than silently vanish.
+     */
+    test("locks the reset behind update permission", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      render(
+        <ResetObjectID<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          fieldName={"_id" as keyof Monitor}
+          title="Reset Key"
+          description="Reset the key for this monitor."
+          onUpdateComplete={() => {}}
+        />,
+      );
+
+      const button: HTMLButtonElement = findButton("Reset Key")!;
+
+      expect(button).toBeDisabled();
+
+      fireEvent.mouseEnter(button.parentElement as HTMLElement);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to update this Monitor.",
+      );
+    });
+
+    test("leaves the reset working for someone who may update", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      render(
+        <ResetObjectID<Monitor>
+          modelType={Monitor}
+          modelId={MONITOR_ID}
+          fieldName={"_id" as keyof Monitor}
+          title="Reset Key"
+          description="Reset the key for this monitor."
+          onUpdateComplete={() => {}}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(findButton("Reset Key")).not.toBeDisabled();
+      });
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModelDelete.test.tsx
+++ b/Common/Tests/UI/Components/ModelDelete.test.tsx
@@ -1,8 +1,32 @@
+/*
+ * The delete button is now gated on the viewer's permissions, so the tests
+ * have to say who is looking at the card. Without a permission snapshot the
+ * component cannot tell "not allowed" from "not loaded yet" and offers no
+ * button at all - which is correct, and is covered in
+ * ModelCardPermissionGating.test.tsx.
+ */
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<string> => {
+        return ["ProjectOwner"];
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<string> } => {
+        return { globalPermissions: ["ProjectOwner"] };
+      },
+    },
+  };
+});
+
 import ModelDelete from "../../../UI/Components/ModelDelete/ModelDelete";
 import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
 import Project from "../../../Models/DatabaseModels/Project";
 import ObjectID from "../../../Types/ObjectID";
-import { describe, expect, it, beforeEach } from "@jest/globals";
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
 import { getJestSpyOn } from "../../Spy";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";

--- a/Common/Tests/UI/Components/ModelFormCreatePermission.test.tsx
+++ b/Common/Tests/UI/Components/ModelFormCreatePermission.test.tsx
@@ -1,0 +1,342 @@
+import "@testing-library/jest-dom";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The second half of issue #3306, and the part that made the bug so confusing
+ * to the person who filed it.
+ *
+ * A Viewer who reached the "Create New Monitor" page got a form that looked
+ * complete: three steps, every one of them showing as done, and an active
+ * Create button. That is because ModelForm's per-FIELD access control had
+ * quietly stripped every column the viewer could not write - which is all of
+ * them - leaving a wizard of empty steps with nothing left to fail validation.
+ * Submitting posted an empty body, and the API answered with whichever field
+ * it validated first: "Monitor type required to create monitor". A permissions
+ * problem, reported as a form-validation problem, about a field the user was
+ * never shown.
+ *
+ * A create form the viewer cannot submit now says so instead of rendering.
+ *
+ * The scope of that rule matters. It applies to CREATE only, and never to a
+ * model that Public may create - the status page's own subscribe forms are
+ * public creates rendered for visitors who may also happen to be signed in to
+ * a project in the same browser, and blocking those would break sign-up flows
+ * for a permission that has nothing to do with them.
+ */
+
+let permissionsForTest: Array<unknown> = [];
+
+/*
+ * ModelForm reads the merged list for the model-level gate but still reads the
+ * global/project snapshots directly for its per-column checks, so all three
+ * have to agree or the field-level path fails for reasons that have nothing to
+ * do with what is being tested here.
+ */
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<unknown> } => {
+        return { globalPermissions: permissionsForTest };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return false;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (): Promise<null> => {
+        return null;
+      },
+      getList: async (): Promise<{
+        data: Array<unknown>;
+        count: number;
+        skip: number;
+        limit: number;
+      }> => {
+        return { data: [], count: 0, skip: 0, limit: 10 };
+      },
+      createOrUpdate: async (): Promise<null> => {
+        return null;
+      },
+    },
+  };
+});
+
+import ModelForm, { FormType } from "../../../UI/Components/Forms/ModelForm";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import StatusPageSubscriber from "../../../Models/DatabaseModels/StatusPageSubscriber";
+import StatusPagePrivateUser from "../../../Models/DatabaseModels/StatusPagePrivateUser";
+import URL from "../../../Types/API/URL";
+import Permission from "../../../Types/Permission";
+
+describe("ModelForm model-level create permission", () => {
+  beforeEach(() => {
+    permissionsForTest = [];
+    PermissionGate.clearPermissionPropsCache();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("renders the create form for someone who may create", async () => {
+    permissionsForTest = [Permission.ProjectAdmin];
+
+    render(
+      <ModelForm<Monitor>
+        modelType={Monitor}
+        name="Create New Monitor"
+        id="create-monitor-form"
+        formType={FormType.Create}
+        submitButtonText="Create Monitor"
+        onSuccess={() => {}}
+        fields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Name")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/You do not have permission to create/),
+    ).toBeNull();
+  });
+
+  /*
+   * The heart of the reported bug. Before, this rendered an empty but
+   * apparently-complete form; now it renders one sentence saying why.
+   */
+  test("replaces the create form with the reason when the viewer may not create", async () => {
+    permissionsForTest = [Permission.Viewer];
+
+    render(
+      <ModelForm<Monitor>
+        modelType={Monitor}
+        name="Create New Monitor"
+        id="create-monitor-form"
+        formType={FormType.Create}
+        submitButtonText="Create Monitor"
+        onSuccess={() => {}}
+        fields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You do not have permission to create this Monitor/),
+      ).toBeInTheDocument();
+    });
+
+    // And no submit button to press, so there is no wrong error to reach.
+    expect(screen.queryByText("Create Monitor")).toBeNull();
+  });
+
+  test("names the permissions that would let them create", async () => {
+    permissionsForTest = [Permission.Viewer];
+
+    render(
+      <ModelForm<Monitor>
+        modelType={Monitor}
+        name="Create New Monitor"
+        id="create-monitor-form"
+        formType={FormType.Create}
+        onSuccess={() => {}}
+        fields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You need one of these permissions/),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Create Monitor/)).toBeInTheDocument();
+  });
+
+  /*
+   * Before the snapshot arrives the honest answer is "we do not know yet", and
+   * blanking a create page over it would be a worse bug than the one being
+   * fixed - the page would flash an accusation and then work.
+   */
+  test("renders the form while the permission snapshot has not loaded", async () => {
+    permissionsForTest = [];
+
+    render(
+      <ModelForm<Monitor>
+        modelType={Monitor}
+        name="Create New Monitor"
+        id="create-monitor-form"
+        formType={FormType.Create}
+        onSuccess={() => {}}
+        fields={[
+          {
+            field: { name: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+            showEvenIfPermissionDoesNotExist: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Name")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/You do not have permission to create/),
+    ).toBeNull();
+  });
+
+  /*
+   * A status page visitor signing in. The form is a ModelForm over
+   * StatusPagePrivateUser with formType Create, but it posts to the login
+   * endpoint - the model's create permission has nothing to do with whether
+   * this visitor may sign in. A signed-in project Viewer opening a status page
+   * in the same browser must not be locked out of its login form.
+   */
+  test("never blocks a form that posts somewhere other than the model endpoint", async () => {
+    permissionsForTest = [Permission.Viewer];
+
+    render(
+      <ModelForm<StatusPagePrivateUser>
+        modelType={StatusPagePrivateUser}
+        name="Login"
+        id="login-form"
+        formType={FormType.Create}
+        createOrUpdateApiUrl={URL.fromString("http://localhost/api/login")}
+        onSuccess={() => {}}
+        fields={[
+          {
+            field: { email: true },
+            title: "Email",
+            fieldType: FormFieldSchemaType.Email,
+            required: true,
+            showEvenIfPermissionDoesNotExist: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Email")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/You do not have permission to create/),
+    ).toBeNull();
+  });
+
+  /*
+   * A status page visitor subscribing to updates. StatusPageSubscriber lists
+   * Public among its create permissions, which is the marker for "anybody may
+   * do this" - the gate must not touch it, no matter what unrelated project
+   * permissions happen to be sitting in the same browser's storage.
+   */
+  test("never blocks a create that Public is allowed to perform", async () => {
+    permissionsForTest = [Permission.Viewer];
+
+    render(
+      <ModelForm<StatusPageSubscriber>
+        modelType={StatusPageSubscriber}
+        name="Subscribe"
+        id="subscribe-form"
+        formType={FormType.Create}
+        onSuccess={() => {}}
+        fields={[
+          {
+            field: { subscriberEmail: true },
+            title: "Email",
+            fieldType: FormFieldSchemaType.Email,
+            required: true,
+            showEvenIfPermissionDoesNotExist: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Email")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/You do not have permission to create/),
+    ).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTablePermissionGating.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTablePermissionGating.test.tsx
@@ -1,0 +1,680 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * What a table offers a viewer who is not allowed to change anything.
+ *
+ * It used to offer nothing: no Create button in the header, no Edit or Delete
+ * in the rows, and - because the whole Actions column was dropped when no row
+ * action survived - not even a column where those buttons would have been. To
+ * the person looking at the screen that is indistinguishable from a product
+ * that cannot do those things at all, which is why the bug report that
+ * prompted this said the permissions problem "only surfaces after clicking
+ * Create" (issue #3306).
+ *
+ * Now every one of those affordances stays where it is, locked, and says which
+ * permission is missing. Three things have to hold for that to be true and all
+ * three are asserted here:
+ *
+ *   1. the button is rendered rather than removed;
+ *   2. it does not act when clicked;
+ *   3. hovering it produces the sentence naming the permission.
+ *
+ * The exceptions matter as much as the rule. `isCreateable` / `isEditable` /
+ * `isDeleteable` are the table author saying "this surface has no such action"
+ * - nothing to do with permission - and must still hide. View still hides
+ * without read permission, because a locked "View X" on a row confirms a
+ * record the viewer is not allowed to know exists.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import PermissionGate from "../../../../UI/Utils/PermissionGate";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import { ButtonStyleType } from "../../../../UI/Components/Button/Button";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Permission from "../../../../Types/Permission";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+type Row = {
+  _id: string;
+  name: string;
+  description: string;
+};
+
+const ROWS: Array<Row> = [
+  { _id: "monitor-1", name: "Checkout API", description: "Payments" },
+  { _id: "monitor-2", name: "Billing Worker", description: "Invoices" },
+];
+
+const COLUMNS: Array<unknown> = [
+  { field: { name: true }, title: "Name", type: FieldType.Text },
+  {
+    field: { description: true },
+    title: "Description",
+    type: FieldType.LongText,
+  },
+];
+
+/*
+ * Restated rather than imported from the component, so that a change to the
+ * wording has to be made deliberately here too. This sentence is the entire
+ * user-facing payload of the feature.
+ */
+const CREATE_DENIED_MESSAGE: string =
+  "You do not have permission to create this Monitor.";
+const UPDATE_DENIED_MESSAGE: string =
+  "You do not have permission to update this Monitor.";
+const DELETE_DENIED_MESSAGE: string =
+  "You do not have permission to delete this Monitor.";
+
+type TableOptions = {
+  isCreateable?: boolean | undefined;
+  isEditable?: boolean | undefined;
+  isDeleteable?: boolean | undefined;
+  isViewable?: boolean | undefined;
+  bulkActionButtons?: Array<unknown> | undefined;
+};
+
+describe("BaseModelTable permission gating", () => {
+  let showCreateEditModalCalls: number = 0;
+
+  type MakePropsFunction = (
+    options: TableOptions,
+  ) => BaseModelTableProps<Monitor>;
+
+  const makeProps: MakePropsFunction = (
+    options: TableOptions,
+  ): BaseModelTableProps<Monitor> => {
+    const callbacks: BaseTableCallbacks<Monitor> = {
+      deleteItem: async (): Promise<void> => {
+        return undefined;
+      },
+      getModelFromJSON: (item: JSONObject): Monitor => {
+        return item as unknown as Monitor;
+      },
+      getJSONFromModel: (item: Monitor): JSONObject => {
+        return item as unknown as JSONObject;
+      },
+      addSlugToSelect: (select: unknown): unknown => {
+        return select;
+      },
+      getList: async (data: {
+        skip: number;
+        limit: number;
+      }): Promise<ListResult<Monitor>> => {
+        return {
+          data: ROWS as unknown as Array<Monitor>,
+          count: ROWS.length,
+          skip: data.skip,
+          limit: data.limit,
+        };
+      },
+      toJSONArray: (): Array<JSONObject> => {
+        return [];
+      },
+      updateById: async (): Promise<void> => {
+        return undefined;
+      },
+      showCreateEditModal: (): React.ReactElement => {
+        showCreateEditModalCalls++;
+        return <div data-testid="create-edit-modal" />;
+      },
+    } as unknown as BaseTableCallbacks<Monitor>;
+
+    return {
+      modelType: Monitor,
+      id: "monitors-table",
+      name: "Monitors",
+      singularName: "Monitor",
+      pluralName: "Monitors",
+      userPreferencesKey: "monitors-permission-table",
+      urlStateKey: "monitors-permission-table",
+      columns: COLUMNS,
+      filters: [],
+      cardProps: { title: "Monitors", description: "All monitors" },
+      isCreateable: options.isCreateable ?? true,
+      isEditable: options.isEditable ?? true,
+      isDeleteable: options.isDeleteable ?? true,
+      isViewable: options.isViewable ?? false,
+      callbacks: callbacks,
+      ...(options.bulkActionButtons
+        ? { bulkActions: { buttons: options.bulkActionButtons } }
+        : {}),
+    } as unknown as BaseModelTableProps<Monitor>;
+  };
+
+  type RenderTableFunction = (
+    options?: TableOptions | undefined,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    options?: TableOptions | undefined,
+  ): ReturnType<typeof render> => {
+    return render(<BaseModelTable<Monitor> {...makeProps(options || {})} />);
+  };
+
+  type FindButtonFunction = (label: string) => HTMLButtonElement | null;
+
+  /*
+   * The rendered label carries the model noun ("Create Monitor"), and row
+   * actions render as plain buttons, so one prefix match covers both.
+   */
+  const findButton: FindButtonFunction = (
+    label: string,
+  ): HTMLButtonElement | null => {
+    const buttons: Array<HTMLButtonElement> = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    );
+
+    return (
+      buttons.find((button: HTMLButtonElement) => {
+        return (button.textContent || "").trim().startsWith(label);
+      }) || null
+    );
+  };
+
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [];
+    showCreateEditModalCalls = 0;
+    PermissionGate.clearPermissionPropsCache();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/dashboard/monitors",
+    );
+    TableFilterUrlState.resetClaimedKeys();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("the header Create button", () => {
+    test("works when the viewer may create", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      const button: HTMLButtonElement = findButton("Create Monitor")!;
+
+      expect(button).not.toBeDisabled();
+
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(showCreateEditModalCalls).toBeGreaterThan(0);
+      });
+    });
+
+    /*
+     * The report that prompted all of this: a Viewer-only user. Viewer grants
+     * read on Monitor and nothing else, so the snapshot is unambiguously
+     * loaded and unambiguously insufficient.
+     */
+    test("is shown LOCKED, not removed, when the viewer may not create", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      expect(findButton("Create Monitor")).toBeDisabled();
+    });
+
+    test("explains itself on hover", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      /*
+       * A disabled button dispatches no pointer events, so the hoverable
+       * element is the wrapper Button puts around it.
+       */
+      const wrapper: HTMLElement = findButton("Create Monitor")!
+        .parentElement as HTMLElement;
+
+      fireEvent.mouseEnter(wrapper);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        CREATE_DENIED_MESSAGE,
+      );
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Create Monitor");
+      expect(container).toBeTruthy();
+    });
+
+    test("does not open the create modal when clicked while locked", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      fireEvent.click(findButton("Create Monitor")!);
+
+      expect(showCreateEditModalCalls).toBe(0);
+    });
+
+    /*
+     * isCreateable is the table author saying this surface does not create
+     * anything - several tables set it precisely because they route to a
+     * dedicated create page instead. Flipping those to a permanently locked
+     * button would be a worse bug than the one being fixed.
+     */
+    test("stays hidden when the table itself is not creatable", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      renderTable({ isCreateable: false });
+
+      await waitFor(() => {
+        expect(screen.getByText("Monitors")).toBeInTheDocument();
+      });
+
+      expect(findButton("Create Monitor")).toBeNull();
+    });
+
+    /*
+     * The snapshot arrives on an API response header. Until it does, telling
+     * a project owner they need permissions they own would be worse than the
+     * button briefly not being there.
+     */
+    test("stays hidden while the permission snapshot has not loaded", async () => {
+      permissionsForTest = [];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(screen.getByText("Monitors")).toBeInTheDocument();
+      });
+
+      expect(findButton("Create Monitor")).toBeNull();
+    });
+
+    test("works for a master admin regardless of the snapshot", async () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Create Monitor")).not.toBeNull();
+      });
+
+      expect(findButton("Create Monitor")).not.toBeDisabled();
+    });
+  });
+
+  describe("row Edit and Delete", () => {
+    test("both work when the viewer may edit and delete", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Edit")).not.toBeNull();
+      });
+
+      expect(findButton("Edit")).not.toBeDisabled();
+      expect(findButton("Delete")).not.toBeDisabled();
+    });
+
+    /*
+     * The Actions column used to be dropped entirely when no row action
+     * survived its permission check - so there was not even a cell for a
+     * locked button to live in. It now follows the table author's intent.
+     */
+    test("keeps the Actions column so the locked buttons have somewhere to render", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(screen.getByText("Actions")).toBeInTheDocument();
+      });
+    });
+
+    test("are shown LOCKED when the viewer may not edit or delete", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Edit")).not.toBeNull();
+      });
+
+      expect(findButton("Edit")).toBeDisabled();
+      expect(findButton("Delete")).toBeDisabled();
+    });
+
+    test("the locked Edit explains itself on hover", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Edit")).not.toBeNull();
+      });
+
+      fireEvent.mouseEnter(findButton("Edit")!.parentElement as HTMLElement);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        UPDATE_DENIED_MESSAGE,
+      );
+    });
+
+    test("the locked Delete explains itself on hover", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Delete")).not.toBeNull();
+      });
+
+      fireEvent.mouseEnter(findButton("Delete")!.parentElement as HTMLElement);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        DELETE_DENIED_MESSAGE,
+      );
+    });
+
+    test("a locked Delete does not open the confirmation dialog", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(findButton("Delete")).not.toBeNull();
+      });
+
+      fireEvent.click(findButton("Delete")!);
+
+      /*
+       * The confirm dialog restates the action in its own heading, so its
+       * absence is what proves the click did nothing.
+       */
+      expect(screen.queryByText("Confirm Delete")).toBeNull();
+    });
+
+    test("stay hidden when the table itself is not editable or deleteable", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      renderTable({ isEditable: false, isDeleteable: false });
+
+      await waitFor(() => {
+        expect(screen.getByText("Monitors")).toBeInTheDocument();
+      });
+
+      expect(findButton("Edit")).toBeNull();
+      expect(findButton("Delete")).toBeNull();
+    });
+
+    /*
+     * Read is the one operation that keeps hiding. A locked "View Monitor" on
+     * a row is itself a disclosure: it confirms a record exists to somebody
+     * who is not allowed to see it.
+     */
+    test("View is hidden, not locked, without read permission", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      /*
+       * ProjectAdmin can read monitors, so the button is present here - the
+       * point of the pairing below is that it disappears entirely rather than
+       * turning into a locked button when read is missing.
+       */
+      renderTable({
+        isViewable: true,
+        isEditable: false,
+        isDeleteable: false,
+      });
+
+      await waitFor(() => {
+        expect(findButton("View Monitor")).not.toBeNull();
+      });
+
+      cleanup();
+
+      permissionsForTest = [Permission.User];
+
+      renderTable({
+        isViewable: true,
+        isEditable: false,
+        isDeleteable: false,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Monitors")).toBeInTheDocument();
+      });
+
+      expect(findButton("View Monitor")).toBeNull();
+    });
+  });
+
+  describe("the bulk Delete action", () => {
+    const ARCHIVE_ACTION: unknown = {
+      title: "Archive",
+      buttonStyleType: ButtonStyleType.NORMAL,
+      onClick: async (): Promise<void> => {
+        return Promise.resolve();
+      },
+    };
+
+    type OpenBulkMenuFunction = (container: HTMLElement) => Promise<void>;
+
+    /*
+     * Selecting a row reveals the bulk bar, whose actions live behind a "Bulk
+     * Actions" dropdown - so getting to the Delete item takes both steps.
+     */
+    const openBulkMenu: OpenBulkMenuFunction = async (
+      container: HTMLElement,
+    ): Promise<void> => {
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('input[type="checkbox"]:not([disabled])')
+            .length,
+        ).toBeGreaterThan(0);
+      });
+
+      const checkboxes: NodeListOf<HTMLInputElement> =
+        container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+      fireEvent.click(checkboxes[0]!);
+
+      await waitFor(() => {
+        expect(screen.getByText("Bulk Actions")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("Bulk Actions"));
+
+      await waitFor(() => {
+        expect(
+          document.querySelectorAll('[role="menuitem"]').length,
+        ).toBeGreaterThan(0);
+      });
+    };
+
+    type FindMenuItemFunction = (label: string) => HTMLElement | undefined;
+
+    const findMenuItem: FindMenuItemFunction = (
+      label: string,
+    ): HTMLElement | undefined => {
+      return Array.from(
+        document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      ).find((item: HTMLElement) => {
+        return (item.textContent || "").trim() === label;
+      });
+    };
+
+    test("is offered as a locked menu item when the viewer may not delete", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable({
+        bulkActionButtons: [ARCHIVE_ACTION],
+      });
+
+      await openBulkMenu(container);
+
+      const deleteItem: HTMLElement | undefined = findMenuItem("Delete");
+
+      expect(deleteItem).toBeDefined();
+      expect(deleteItem).toBeDisabled();
+    });
+
+    test("the locked bulk Delete explains itself on hover", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable({
+        bulkActionButtons: [ARCHIVE_ACTION],
+      });
+
+      await openBulkMenu(container);
+
+      fireEvent.mouseEnter(
+        findMenuItem("Delete")!.parentElement as HTMLElement,
+      );
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        DELETE_DENIED_MESSAGE,
+      );
+    });
+
+    /*
+     * The row checkboxes only exist because the table has bulk actions at all.
+     * Auto-injecting a locked Delete into a table that has none would grow a
+     * selection column onto screens that have never had one.
+     */
+    test("is not auto-injected into a table that has no other bulk actions", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable();
+
+      await waitFor(() => {
+        expect(screen.getByText("Monitors")).toBeInTheDocument();
+      });
+
+      expect(container.querySelectorAll('input[type="checkbox"]').length).toBe(
+        0,
+      );
+    });
+
+    /*
+     * When the gate refused, the default Delete used to be left in the array
+     * as its raw enum string and handed to the bulk bar as if it were a button
+     * schema - which renders as a menu item with no label at all.
+     */
+    test("never leaks the raw default-action enum into the menu", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable({
+        bulkActionButtons: [ARCHIVE_ACTION],
+      });
+
+      await openBulkMenu(container);
+
+      for (const item of Array.from(
+        document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      )) {
+        expect((item.textContent || "").trim()).not.toBe("");
+      }
+    });
+
+    test("works when the viewer may delete", async () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      const { container } = renderTable({
+        bulkActionButtons: [ARCHIVE_ACTION],
+      });
+
+      await openBulkMenu(container);
+
+      const deleteItem: HTMLElement | undefined = findMenuItem("Delete");
+
+      expect(deleteItem).toBeDefined();
+      expect(deleteItem).not.toBeDisabled();
+    });
+  });
+});

--- a/Common/Tests/UI/Components/OrderedStatesListCreateGate.test.tsx
+++ b/Common/Tests/UI/Components/OrderedStatesListCreateGate.test.tsx
@@ -1,0 +1,174 @@
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+import OrderedStatesList from "../../../UI/Components/OrderedStatesList/OrderedStatesList";
+
+/*
+ * Ordered lists - monitor statuses, incident states, on-call escalation order -
+ * put their "Add New" affordance inside the list rather than in the card
+ * header, so it never went through the header button's permission check. It
+ * had no check of its own either: a viewer could open the create modal for a
+ * monitor status from any of these pages.
+ *
+ * The affordance is a clickable <div>, not a button, so being disabled is not
+ * something the platform does for it. All three of those behaviours have to be
+ * built by hand and are asserted here: it stops responding, it stops looking
+ * clickable, and it explains itself.
+ */
+
+type Row = {
+  _id: string;
+  name: string;
+  order: number;
+};
+
+const ROWS: Array<Row> = [
+  { _id: "state-1", name: "Operational", order: 1 },
+  { _id: "state-2", name: "Degraded", order: 2 },
+];
+
+const DENIED_REASON: string =
+  "You do not have permission to create this Monitor Status.";
+
+type RenderListFunction = (options: {
+  data: Array<Row>;
+  createDisabledReason?: string | undefined;
+  onCreateNewItem?: ((order: number) => void) | undefined;
+}) => ReturnType<typeof render>;
+
+const renderList: RenderListFunction = (options: {
+  data: Array<Row>;
+  createDisabledReason?: string | undefined;
+  onCreateNewItem?: ((order: number) => void) | undefined;
+}): ReturnType<typeof render> => {
+  return render(
+    <OrderedStatesList<Row>
+      data={options.data}
+      titleField="name"
+      orderField="order"
+      singularLabel="Monitor Status"
+      shouldAddItemInTheBeginning={true}
+      shouldAddItemInTheEnd={true}
+      onCreateNewItem={options.onCreateNewItem}
+      createDisabledReason={options.createDisabledReason}
+    />,
+  );
+};
+
+type FindAddAffordanceFunction = () => HTMLElement | null;
+
+const findAddAffordance: FindAddAffordanceFunction = (): HTMLElement | null => {
+  return (
+    Array.from(document.querySelectorAll<HTMLElement>("div")).find(
+      (element: HTMLElement) => {
+        return (
+          Boolean(element.getAttribute("aria-disabled")) &&
+          (element.textContent || "").includes("Add New")
+        );
+      },
+    ) || null
+  );
+};
+
+describe("OrderedStatesList create gate", () => {
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("creates when the viewer is allowed", () => {
+    let createdOrder: number | null = null;
+
+    renderList({
+      data: ROWS,
+      onCreateNewItem: (order: number) => {
+        createdOrder = order;
+      },
+    });
+
+    const addAffordance: HTMLElement = findAddAffordance()!;
+
+    fireEvent.click(addAffordance);
+
+    expect(createdOrder).not.toBeNull();
+  });
+
+  test("keeps the affordance on screen when the viewer is not allowed", () => {
+    renderList({
+      data: ROWS,
+      createDisabledReason: DENIED_REASON,
+      onCreateNewItem: () => {},
+    });
+
+    expect(findAddAffordance()).not.toBeNull();
+    expect(findAddAffordance()).toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("does not create when the locked affordance is clicked", () => {
+    let created: boolean = false;
+
+    renderList({
+      data: ROWS,
+      createDisabledReason: DENIED_REASON,
+      onCreateNewItem: () => {
+        created = true;
+      },
+    });
+
+    fireEvent.click(findAddAffordance()!);
+
+    expect(created).toBe(false);
+  });
+
+  test("explains itself on hover", () => {
+    renderList({
+      data: ROWS,
+      createDisabledReason: DENIED_REASON,
+      onCreateNewItem: () => {},
+    });
+
+    /*
+     * Unlike a disabled <button>, a div still dispatches its own pointer
+     * events - so the tooltip hangs directly off the affordance here.
+     */
+    fireEvent.mouseEnter(findAddAffordance()!);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(DENIED_REASON);
+  });
+
+  test("stops looking clickable when locked", () => {
+    renderList({
+      data: ROWS,
+      createDisabledReason: DENIED_REASON,
+      onCreateNewItem: () => {},
+    });
+
+    const addAffordance: HTMLElement = findAddAffordance()!;
+
+    expect(addAffordance).toHaveClass("cursor-not-allowed");
+    expect(addAffordance).not.toHaveClass("cursor-pointer");
+  });
+
+  /*
+   * The empty state is the one place the affordance is the only thing on
+   * screen, so a viewer opening an empty list sees the reason rather than a
+   * blank page.
+   */
+  test("locks the empty-state affordance too", () => {
+    renderList({
+      data: [],
+      createDisabledReason: DENIED_REASON,
+      onCreateNewItem: () => {},
+    });
+
+    const addAffordance: HTMLElement = findAddAffordance()!;
+
+    expect(addAffordance).toHaveTextContent("Add New Monitor Status");
+
+    fireEvent.mouseEnter(addAffordance);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(DENIED_REASON);
+  });
+});

--- a/Common/Tests/UI/Utils/PermissionGate.test.ts
+++ b/Common/Tests/UI/Utils/PermissionGate.test.ts
@@ -1,0 +1,467 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Before this gate existed, "you cannot do this" was rendered as "this button
+ * does not exist". A viewer looking at a monitor list simply had no Create
+ * button, no Edit and no Delete, with nothing to say why - and on the flows
+ * that route to a dedicated create page there was no gate at all, so the whole
+ * wizard opened and only failed at submit, with a validation error about a
+ * field the user had never been shown (issue #3306).
+ *
+ * The gate turns a boolean into an answer with a reason attached, and these
+ * tests pin the three-way distinction the rest of the UI depends on:
+ *
+ *   allowed                       -> render the button, working
+ *   denied, WITH a reason         -> render it locked, tooltip explains
+ *   denied, WITHOUT a reason      -> render nothing at all
+ *
+ * That third case is the one worth being careful about. It covers the moments
+ * where the UI genuinely does not know: the permission snapshot arrives on an
+ * API response header, so it is empty on the first paint after a login and for
+ * a beat after a project switch. Accusing somebody of lacking a permission
+ * they actually hold is worse than briefly not offering the button.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+import PermissionGate, {
+  ModelAction,
+  PermissionCheckableModel,
+  PermissionGateResult,
+} from "../../../UI/Utils/PermissionGate";
+import { CardButtonSchema } from "../../../UI/Components/Card/Card";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Log from "../../../Models/AnalyticsModels/Log";
+import IconProp from "../../../Types/Icon/IconProp";
+import Permission from "../../../Types/Permission";
+
+/*
+ * A model that supports create but genuinely does not support delete - the
+ * shape an analytics model takes when it declares no access control for an
+ * operation. Nobody can ever be granted delete on it, so the UI has nothing to
+ * tell the user and must render nothing rather than a locked button.
+ */
+const modelWithNoDeletePermissions: PermissionCheckableModel = {
+  singularName: "Widget",
+  hasCreatePermissions: (): boolean => {
+    return true;
+  },
+  hasReadPermissions: (): boolean => {
+    return true;
+  },
+  hasUpdatePermissions: (): boolean => {
+    return true;
+  },
+  hasDeletePermissions: (): boolean => {
+    return false;
+  },
+  getCreatePermissions: (): Array<Permission> => {
+    return [Permission.ProjectOwner];
+  },
+  getReadPermissions: (): Array<Permission> => {
+    return [Permission.ProjectOwner];
+  },
+  getUpdatePermissions: (): Array<Permission> => {
+    return [Permission.ProjectOwner];
+  },
+  getDeletePermissions: (): Array<Permission> => {
+    return [];
+  },
+};
+
+describe("PermissionGate", () => {
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [];
+    PermissionGate.clearPermissionPropsCache();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("check", () => {
+    test("allows an operation the user holds a permission for", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      expect(result.isAllowed).toBe(true);
+      expect(result.disabledReason).toBeUndefined();
+    });
+
+    /*
+     * The exact case from issue #3306: a Viewer opening the monitors list. The
+     * snapshot IS loaded - Viewer is a real permission - it just does not carry
+     * create. This must produce a reason, because that reason is the whole
+     * point of the change.
+     */
+    test("denies with a reason when the snapshot is loaded but insufficient", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      expect(result.isAllowed).toBe(false);
+      expect(result.disabledReason).toBeTruthy();
+      expect(result.disabledReason).toContain(
+        "You do not have permission to create this Monitor.",
+      );
+    });
+
+    test("names the permissions that would grant the operation", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      /*
+       * Human titles, not raw enum values. A user told they need
+       * "CreateProjectMonitor" has been handed an internal identifier.
+       */
+      expect(result.disabledReason).toContain("Create Monitor");
+      expect(result.disabledReason).toContain("Project Admin");
+      expect(result.disabledReason).not.toContain("CreateProjectMonitor");
+    });
+
+    /*
+     * The snapshot lands on a response header. Until the first response with
+     * one arrives, every permission check would come back false - and would
+     * tell a project owner they need permissions they own.
+     */
+    test("denies WITHOUT a reason when the permission snapshot has not loaded", () => {
+      permissionsForTest = [];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      expect(result.isAllowed).toBe(false);
+      expect(result.disabledReason).toBeUndefined();
+    });
+
+    /*
+     * An analytics model with no declared access control for an operation
+     * reports false for every user. There is no permission anybody could be
+     * granted, so there is nothing to say - and certainly not
+     * "You need one of these permissions: " with an empty list.
+     */
+    test("denies WITHOUT a reason when the model declares no permissions for the operation", () => {
+      permissionsForTest = [Permission.ProjectOwner];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        modelWithNoDeletePermissions,
+        ModelAction.Delete,
+      );
+
+      expect(result.isAllowed).toBe(false);
+      expect(result.disabledReason).toBeUndefined();
+    });
+
+    test("short-circuits for a master admin, even with an empty snapshot", () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      for (const action of [
+        ModelAction.Create,
+        ModelAction.Read,
+        ModelAction.Update,
+        ModelAction.Delete,
+      ]) {
+        const result: PermissionGateResult = PermissionGate.check(
+          new Monitor(),
+          action,
+        );
+
+        expect(result.isAllowed).toBe(true);
+        expect(result.disabledReason).toBeUndefined();
+      }
+    });
+
+    test("checks each operation against its own permission list", () => {
+      /*
+       * Monitor's read list includes Viewer; create, update and delete do not.
+       * One permission therefore has to produce four different answers.
+       */
+      permissionsForTest = [Permission.Viewer];
+
+      const monitor: Monitor = new Monitor();
+
+      expect(PermissionGate.check(monitor, ModelAction.Read).isAllowed).toBe(
+        true,
+      );
+      expect(PermissionGate.check(monitor, ModelAction.Create).isAllowed).toBe(
+        false,
+      );
+      expect(PermissionGate.check(monitor, ModelAction.Update).isAllowed).toBe(
+        false,
+      );
+      expect(PermissionGate.check(monitor, ModelAction.Delete).isAllowed).toBe(
+        false,
+      );
+    });
+
+    test("accepts an explicit permission list instead of reading storage", () => {
+      permissionsForTest = [];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Create,
+        { permissions: [Permission.ProjectOwner] },
+      );
+
+      expect(result.isAllowed).toBe(true);
+    });
+
+    test("uses the caller's noun for the resource when one is supplied", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Create,
+        { singularName: "Monitor Template" },
+      );
+
+      expect(result.disabledReason).toContain("this Monitor Template");
+    });
+
+    /*
+     * Both model hierarchies are unrelated classes that happen to expose the
+     * same permission API, and the gate is structurally typed so one
+     * implementation covers both. If AnalyticsBaseModel ever drifts, this is
+     * where it shows up.
+     */
+    test("works for analytics models as well as database models", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      expect(PermissionGate.check(new Log(), ModelAction.Read).isAllowed).toBe(
+        true,
+      );
+
+      permissionsForTest = [Permission.Viewer];
+
+      const denied: PermissionGateResult = PermissionGate.check(
+        new Log(),
+        ModelAction.Create,
+      );
+
+      expect(denied.isAllowed).toBe(false);
+      expect(denied.disabledReason).toBeTruthy();
+    });
+  });
+
+  describe("getPermissionTitles", () => {
+    test("maps permissions to their human titles", () => {
+      expect(
+        PermissionGate.getPermissionTitles([
+          Permission.ProjectOwner,
+          Permission.ProjectAdmin,
+        ]),
+      ).toEqual(["Project Owner", "Project Admin"]);
+    });
+
+    /*
+     * PermissionHelper.getTitle throws on a permission with no props entry.
+     * Called in a loop while building a tooltip, one stale enum value would
+     * take down the whole table it was rendering in.
+     */
+    test("skips unknown permissions instead of throwing", () => {
+      const titles: Array<string> = PermissionGate.getPermissionTitles([
+        Permission.ProjectOwner,
+        "SomePermissionThatDoesNotExist" as Permission,
+      ]);
+
+      expect(titles).toEqual(["Project Owner"]);
+    });
+
+    test("returns an empty list rather than throwing for an empty input", () => {
+      expect(PermissionGate.getPermissionTitles([])).toEqual([]);
+    });
+
+    test("does not repeat a title", () => {
+      const titles: Array<string> = PermissionGate.getPermissionTitles([
+        Permission.ProjectOwner,
+        Permission.ProjectOwner,
+      ]);
+
+      expect(titles).toEqual(["Project Owner"]);
+    });
+  });
+
+  describe("getMissingPermissionMessage", () => {
+    test("falls back to a bare sentence when no permission has a title", () => {
+      /*
+       * Never "You need one of these permissions: " trailing into nothing.
+       */
+      const model: PermissionCheckableModel = {
+        singularName: "Widget",
+        hasCreatePermissions: (): boolean => {
+          return false;
+        },
+        hasReadPermissions: (): boolean => {
+          return false;
+        },
+        hasUpdatePermissions: (): boolean => {
+          return false;
+        },
+        hasDeletePermissions: (): boolean => {
+          return false;
+        },
+        getCreatePermissions: (): Array<Permission> => {
+          return ["NotARealPermission" as Permission];
+        },
+        getReadPermissions: (): Array<Permission> => {
+          return [];
+        },
+        getUpdatePermissions: (): Array<Permission> => {
+          return [];
+        },
+        getDeletePermissions: (): Array<Permission> => {
+          return [];
+        },
+      };
+
+      const message: string = PermissionGate.getMissingPermissionMessage(
+        model,
+        ModelAction.Create,
+      );
+
+      expect(message).toBe("You do not have permission to create this Widget.");
+      expect(message).not.toContain("permissions:");
+    });
+
+    test("uses the operation verb the user performed", () => {
+      const monitor: Monitor = new Monitor();
+
+      expect(
+        PermissionGate.getMissingPermissionMessage(monitor, ModelAction.Delete),
+      ).toContain("permission to delete this Monitor");
+      expect(
+        PermissionGate.getMissingPermissionMessage(monitor, ModelAction.Update),
+      ).toContain("permission to update this Monitor");
+    });
+  });
+
+  describe("gateCardButton", () => {
+    const button: CardButtonSchema = {
+      title: "Create Monitor",
+      icon: IconProp.Add,
+      onClick: (): void => {
+        clicked = true;
+      },
+    };
+
+    let clicked: boolean = false;
+
+    beforeEach(() => {
+      clicked = false;
+    });
+
+    test("returns the button untouched when the user is allowed", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      const gated: CardButtonSchema | null = PermissionGate.gateCardButton(
+        button,
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      expect(gated).toBe(button);
+    });
+
+    test("returns a locked button with a tooltip when the user is denied", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const gated: CardButtonSchema | null = PermissionGate.gateCardButton(
+        button,
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      expect(gated).not.toBeNull();
+      expect(gated!.title).toBe("Create Monitor");
+      expect(gated!.disabled).toBe(true);
+      expect(gated!.tooltip).toContain(
+        "You do not have permission to create this Monitor.",
+      );
+    });
+
+    /*
+     * Disabling a button is a rendering hint; a schema handed to something that
+     * ignores it must still not navigate the user into a flow they will be
+     * thrown out of.
+     */
+    test("neuters the click handler of a locked button", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const gated: CardButtonSchema | null = PermissionGate.gateCardButton(
+        button,
+        new Monitor(),
+        ModelAction.Create,
+      );
+
+      gated!.onClick();
+
+      expect(clicked).toBe(false);
+    });
+
+    test("returns null when there is no reason to show - snapshot not loaded", () => {
+      permissionsForTest = [];
+
+      expect(
+        PermissionGate.gateCardButton(
+          button,
+          new Monitor(),
+          ModelAction.Create,
+        ),
+      ).toBeNull();
+    });
+  });
+});

--- a/Common/UI/Components/ActionButton/ActionButtonSchema.ts
+++ b/Common/UI/Components/ActionButton/ActionButtonSchema.ts
@@ -10,6 +10,13 @@ interface ActionButtonSchema<T extends GenericObject> {
   isLoading?: boolean | undefined;
   isVisible?: (item: T) => boolean | undefined;
   hideOnMobile?: boolean | undefined;
+  /*
+   * A row action the viewer is not allowed to perform stays on screen, locked,
+   * so the row does not silently look different from everybody else's. The
+   * tooltip is what turns a dead button into an explanation.
+   */
+  disabled?: boolean | undefined;
+  tooltip?: string | undefined;
   onClick: (
     item: T,
     onCompleteAction: VoidFunction,

--- a/Common/UI/Components/BulkUpdate/BulkArchiveActions.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkArchiveActions.tsx
@@ -4,6 +4,10 @@ import IconProp from "../../../Types/Icon/IconProp";
 import ObjectID from "../../../Types/ObjectID";
 import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import { ButtonStyleType } from "../Button/Button";
 import {
   BulkActionButtonSchema,
@@ -103,6 +107,35 @@ function useBulkArchiveActions<T extends BaseModel>(
     onBulkActionEnd();
   };
 
+  /*
+   * Bulk actions are handed straight to the table's action bar, which never
+   * looks at permissions - so a viewer on an otherwise gated table could still
+   * relabel, reassign or archive every row they had selected. Each of these
+   * actions is an update of the records it touches.
+   */
+  const updateGate: PermissionGateResult = PermissionGate.check(
+    new config.modelType(),
+    ModelAction.Update,
+  );
+
+  type GateActionFunction = (
+    action: BulkActionButtonSchema<T>,
+  ) => BulkActionButtonSchema<T>;
+
+  const gateAction: GateActionFunction = (
+    action: BulkActionButtonSchema<T>,
+  ): BulkActionButtonSchema<T> => {
+    if (updateGate.isAllowed || !updateGate.disabledReason) {
+      return action;
+    }
+
+    return {
+      ...action,
+      disabled: true,
+      tooltip: updateGate.disabledReason,
+    };
+  };
+
   const archiveAction: BulkActionButtonSchema<T> = {
     title: "Archive",
     icon: IconProp.Archive,
@@ -142,8 +175,8 @@ function useBulkArchiveActions<T extends BaseModel>(
   };
 
   return {
-    archiveBulkActions: [archiveAction],
-    unarchiveBulkActions: [unarchiveAction],
+    archiveBulkActions: [gateAction(archiveAction)],
+    unarchiveBulkActions: [gateAction(unarchiveAction)],
   };
 }
 

--- a/Common/UI/Components/BulkUpdate/BulkLabelActions.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkLabelActions.tsx
@@ -18,6 +18,10 @@ import ObjectID from "../../../Types/ObjectID";
 import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "../../Utils/Project";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import { ButtonStyleType } from "../Button/Button";
 import BasicFormModal from "../FormModal/BasicFormModal";
 import Modal from "../Modal/Modal";
@@ -381,6 +385,35 @@ function useBulkLabelActions<T extends BaseModel>(
     },
   );
 
+  /*
+   * Bulk actions are handed straight to the table's action bar, which never
+   * looks at permissions - so a viewer on an otherwise gated table could still
+   * relabel, reassign or archive every row they had selected. Each of these
+   * actions is an update of the records it touches.
+   */
+  const updateGate: PermissionGateResult = PermissionGate.check(
+    new config.modelType(),
+    ModelAction.Update,
+  );
+
+  type GateActionFunction = (
+    action: BulkActionButtonSchema<T>,
+  ) => BulkActionButtonSchema<T>;
+
+  const gateAction: GateActionFunction = (
+    action: BulkActionButtonSchema<T>,
+  ): BulkActionButtonSchema<T> => {
+    if (updateGate.isAllowed || !updateGate.disabledReason) {
+      return action;
+    }
+
+    return {
+      ...action,
+      disabled: true,
+      tooltip: updateGate.disabledReason,
+    };
+  };
+
   const addLabelsAction: BulkActionButtonSchema<T> = {
     title: "Add Labels",
     buttonStyleType: ButtonStyleType.NORMAL,
@@ -496,7 +529,7 @@ function useBulkLabelActions<T extends BaseModel>(
   );
 
   return {
-    bulkActions: [addLabelsAction, removeLabelsAction],
+    bulkActions: [gateAction(addLabelsAction), gateAction(removeLabelsAction)],
     modals: modals,
   };
 }

--- a/Common/UI/Components/BulkUpdate/BulkOwnerActions.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkOwnerActions.tsx
@@ -14,6 +14,10 @@ import ObjectID from "../../../Types/ObjectID";
 import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "../../Utils/Project";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import { ButtonStyleType } from "../Button/Button";
 import { DropdownOption, DropdownOptionGroup } from "../Dropdown/Dropdown";
 import BasicFormModal from "../FormModal/BasicFormModal";
@@ -411,6 +415,43 @@ function useBulkOwnerActions<T extends BaseModel>(
       return groups;
     }, [userOptions, teamOptions]);
 
+  /*
+   * Bulk actions are handed straight to the table's action bar, which never
+   * looks at permissions - so a viewer on an otherwise gated table could still
+   * reassign every row they had selected. Ownership is stored as rows in the
+   * owner junction tables, so adding an owner is a create there and removing
+   * one is a delete.
+   */
+  const addGate: PermissionGateResult = PermissionGate.check(
+    new config.ownerUserModelType(),
+    ModelAction.Create,
+  );
+
+  const removeGate: PermissionGateResult = PermissionGate.check(
+    new config.ownerUserModelType(),
+    ModelAction.Delete,
+  );
+
+  type GateActionFunction = (
+    action: BulkActionButtonSchema<T>,
+    gate: PermissionGateResult,
+  ) => BulkActionButtonSchema<T>;
+
+  const gateAction: GateActionFunction = (
+    action: BulkActionButtonSchema<T>,
+    gate: PermissionGateResult,
+  ): BulkActionButtonSchema<T> => {
+    if (gate.isAllowed || !gate.disabledReason) {
+      return action;
+    }
+
+    return {
+      ...action,
+      disabled: true,
+      tooltip: gate.disabledReason,
+    };
+  };
+
   const addOwnerAction: BulkActionButtonSchema<T> = {
     title: "Add Owner",
     buttonStyleType: ButtonStyleType.NORMAL,
@@ -507,7 +548,10 @@ function useBulkOwnerActions<T extends BaseModel>(
   );
 
   return {
-    bulkActions: [addOwnerAction, removeOwnerAction],
+    bulkActions: [
+      gateAction(addOwnerAction, addGate),
+      gateAction(removeOwnerAction, removeGate),
+    ],
     modals: modals,
   };
 }

--- a/Common/UI/Components/BulkUpdate/BulkUpdateForm.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkUpdateForm.tsx
@@ -50,6 +50,8 @@ export interface BulkActionButtonSchema<T extends GenericObject> {
   className?: string | undefined;
   onClick: (props: BulkActionOnClickProps<T>) => Promise<void>;
   disabled?: boolean | undefined;
+  /* Why the action is unavailable - shown on hover of the locked menu item. */
+  tooltip?: string | undefined;
   shortcutKey?: undefined | ShortcutKey;
   confirmMessage?: ((items: Array<T>) => string) | undefined;
   confirmTitle?: ((items: Array<T>) => string) | undefined;
@@ -214,6 +216,7 @@ const BulkUpdateForm: <T extends GenericObject>(
         className={itemClassName}
         iconClassName={iconClassName}
         isDisabled={isDisabled}
+        tooltip={button.tooltip}
         onClick={() => {
           triggerButtonClick(button);
         }}

--- a/Common/UI/Components/Button/Button.tsx
+++ b/Common/UI/Components/Button/Button.tsx
@@ -254,6 +254,18 @@ const Button: FunctionComponent<ComponentProps> = ({
 
   buttonStyleCssClass += ` ` + buttonSize;
 
+  const isDisabled: boolean = Boolean(disabled || isLoading);
+
+  /*
+   * A disabled <button> swallows the pointer without dispatching anything, so
+   * the hover never reaches the wrapper that carries the tooltip. Taking the
+   * button out of hit-testing hands the pointer to that wrapper instead. Only
+   * applied when there is a tooltip to show, so nothing else changes.
+   */
+  if (isDisabled && translatedTooltip) {
+    buttonStyleCssClass += ` pointer-events-none`;
+  }
+
   if (className) {
     buttonStyleCssClass += ` ` + className;
   }
@@ -278,10 +290,10 @@ const Button: FunctionComponent<ComponentProps> = ({
         }}
         data-testid={dataTestId}
         type={type}
-        disabled={disabled || isLoading}
+        disabled={isDisabled}
         className={buttonStyleCssClass}
         aria-label={computedAriaLabel}
-        aria-disabled={disabled || isLoading}
+        aria-disabled={isDisabled}
         aria-expanded={ariaExpanded}
         aria-haspopup={ariaHaspopup}
         aria-controls={ariaControls}
@@ -314,6 +326,29 @@ const Button: FunctionComponent<ComponentProps> = ({
   };
 
   if (translatedTooltip) {
+    /*
+     * Tippy makes its child the trigger element, and a disabled control is
+     * both unhoverable and unfocusable - tippy.js even bails out of show()
+     * when the trigger has a `disabled` attribute. Explaining WHY a button is
+     * disabled is exactly when the tooltip matters most, so wrap the disabled
+     * button in an element that can still be hovered and tabbed to.
+     */
+    if (isDisabled) {
+      return (
+        <Tooltip text={translatedTooltip}>
+          <span
+            className="inline-flex"
+            tabIndex={0}
+            data-testid={
+              dataTestId ? `${dataTestId}-disabled-wrapper` : undefined
+            }
+          >
+            {getButton()}
+          </span>
+        </Tooltip>
+      );
+    }
+
     return <Tooltip text={translatedTooltip}>{getButton()}</Tooltip>;
   }
   return getButton();

--- a/Common/UI/Components/Card/Card.tsx
+++ b/Common/UI/Components/Card/Card.tsx
@@ -9,6 +9,11 @@ export interface CardButtonSchema {
   buttonStyle?: ButtonStyleType | undefined;
   onClick: () => void;
   disabled?: boolean | undefined;
+  /*
+   * Shown on hover. The reason a disabled button is disabled belongs here -
+   * Button keeps a disabled button hoverable precisely so this can be read.
+   */
+  tooltip?: string | undefined;
   icon: IconProp;
   isLoading?: undefined | boolean;
   className?: string | undefined;
@@ -104,6 +109,7 @@ const Card: FunctionComponent<ComponentProps> = (
                                   disabled={
                                     (button as CardButtonSchema).disabled
                                   }
+                                  tooltip={(button as CardButtonSchema).tooltip}
                                   icon={(button as CardButtonSchema).icon}
                                   shortcutKey={
                                     (button as CardButtonSchema).shortcutKey

--- a/Common/UI/Components/CustomFields/CustomFieldsDetail.tsx
+++ b/Common/UI/Components/CustomFields/CustomFieldsDetail.tsx
@@ -1,5 +1,9 @@
 import API from "../../Utils/API/API";
 import ModelAPI, { ListResult } from "../../Utils/ModelAPI/ModelAPI";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import { ButtonStyleType } from "../Button/Button";
 import Card from "../Card/Card";
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
@@ -194,17 +198,36 @@ const CustomFieldsDetail: FunctionComponent<ComponentProps> = (
   const canEdit: boolean =
     isEditable && !isLoading && schemaList.length > 0 && Boolean(model);
 
+  /*
+   * Custom field values live on the record itself, so editing them is an
+   * update of that record. Without the permission the button stays put and
+   * explains itself instead of disappearing.
+   */
+  const updateGate: PermissionGateResult = PermissionGate.check(
+    new props.modelType(),
+    ModelAction.Update,
+  );
+
+  const showEditButton: boolean =
+    canEdit && (updateGate.isAllowed || Boolean(updateGate.disabledReason));
+
   return (
     <Card
       title={props.title}
       description={props.description}
       buttons={
-        canEdit
+        showEditButton
           ? [
               {
                 title: "Edit Fields",
                 buttonStyle: ButtonStyleType.NORMAL,
+                disabled: !updateGate.isAllowed,
+                tooltip: updateGate.disabledReason,
                 onClick: () => {
+                  if (!updateGate.isAllowed) {
+                    return;
+                  }
+
                   setShowModelForm(true);
                 },
                 icon: IconProp.Edit,

--- a/Common/UI/Components/DuplicateModel/DuplicateModel.tsx
+++ b/Common/UI/Components/DuplicateModel/DuplicateModel.tsx
@@ -2,6 +2,10 @@ import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
 import Navigation from "../../Utils/Navigation";
 import { ButtonStyleType } from "../Button/Button";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import Card from "../Card/Card";
 import BasicFormModal from "../FormModal/BasicFormModal";
 import { ModelField } from "../Forms/ModelForm";
@@ -29,6 +33,12 @@ const DuplicateModel: <TBaseModel extends BaseModel>(
   props: ComponentProps<TBaseModel>,
 ): ReactElement => {
   const model: TBaseModel = new props.modelType();
+
+  /* Duplicating writes a brand new record, so it needs create permission. */
+  const createGate: PermissionGateResult = PermissionGate.check(
+    model,
+    ModelAction.Create,
+  );
   const [showModal, setShowModal] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
@@ -109,7 +119,13 @@ const DuplicateModel: <TBaseModel extends BaseModel>(
           {
             title: `Duplicate ${model.singularName}`,
             buttonStyle: ButtonStyleType.NORMAL,
+            disabled: !createGate.isAllowed,
+            tooltip: createGate.disabledReason,
             onClick: () => {
+              if (!createGate.isAllowed) {
+                return;
+              }
+
               setShowModal(true);
             },
             isLoading: isLoading,

--- a/Common/UI/Components/Forms/ModelForm.tsx
+++ b/Common/UI/Components/Forms/ModelForm.tsx
@@ -5,7 +5,12 @@ import ModelAPI, {
   ModelAPIHttpResponse,
   RequestOptions,
 } from "../../Utils/ModelAPI/ModelAPI";
+import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import PermissionUtil from "../../Utils/Permission";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import User from "../../Utils/User";
 import { ButtonStyleType } from "../Button/Button";
 import {
@@ -180,8 +185,14 @@ const ModelForm: <TBaseModel extends BaseModel>(
       return true; // master admin can do anything.
     }
 
-    let userPermissions: Array<Permission> =
-      PermissionUtil.getGlobalPermissions()?.globalPermissions || [];
+    /*
+     * A copy. The Public permission is appended below, and pushing into the
+     * array the util handed back mutates the snapshot every other permission
+     * check on the page reads from.
+     */
+    let userPermissions: Array<Permission> = [
+      ...(PermissionUtil.getGlobalPermissions()?.globalPermissions || []),
+    ];
     if (
       PermissionUtil.getProjectPermissions() &&
       PermissionUtil.getProjectPermissions()?.permissions &&
@@ -844,6 +855,47 @@ const ModelForm: <TBaseModel extends BaseModel>(
         <Loader loaderType={LoaderType.Bar} color={VeryLightGray} size={200} />
       </div>
     );
+  }
+
+  /*
+   * A create form for a model the viewer cannot create is worse than no form:
+   * the per-field access control above strips every column, so the wizard
+   * renders empty steps that all read as complete, and the submit fails with
+   * whatever the server happens to validate first - which is how creating a
+   * monitor as a Viewer produced "Monitor type required to create monitor"
+   * with not a word about permissions (issue #3306). Say the real reason.
+   *
+   * Deliberately narrow, because a false positive here blanks a page:
+   *
+   *  - create only. An update form is reached through an Edit button that is
+   *    gated already, and gating the form as well only risks a dead end.
+   *  - only when the form posts to the model's own CRUD endpoint. Sign-in,
+   *    sign-up, password reset and status page subscribe are all ModelForms
+   *    with formType Create that submit somewhere else entirely; the model's
+   *    create permission has nothing to do with whether the visitor may use
+   *    them, and a signed-in user opening a status page in the same browser
+   *    would otherwise be locked out of its login form by an unrelated
+   *    project permission.
+   *  - never for a model Public may create, which is the marker for "anybody
+   *    may do this".
+   */
+  const isModelCrudCreate: boolean =
+    props.formType === FormType.Create && !props.createOrUpdateApiUrl;
+
+  const isPublicCreate: boolean = PermissionGate.getModelPermissions(
+    model,
+    ModelAction.Create,
+  ).includes(Permission.Public);
+
+  if (isModelCrudCreate && !isPublicCreate) {
+    const createGate: PermissionGateResult = PermissionGate.check(
+      model,
+      ModelAction.Create,
+    );
+
+    if (!createGate.isAllowed && createGate.disabledReason) {
+      return <ErrorMessage message={createGate.disabledReason} />;
+    }
   }
 
   return (

--- a/Common/UI/Components/List/ListRow.tsx
+++ b/Common/UI/Components/List/ListRow.tsx
@@ -120,7 +120,13 @@ const ListRow: ListRowFunction = <T extends GenericObject>(
                     icon={button.icon}
                     buttonStyle={button.buttonStyleType}
                     isLoading={isButtonLoading[i]}
+                    disabled={button.disabled}
+                    tooltip={button.tooltip}
                     onClick={() => {
+                      if (button.disabled) {
+                        return;
+                      }
+
                       if (button.onClick) {
                         isButtonLoading[i] = true;
                         setIsButtonLoading(isButtonLoading);

--- a/Common/UI/Components/ModelDelete/ModelDelete.tsx
+++ b/Common/UI/Components/ModelDelete/ModelDelete.tsx
@@ -1,5 +1,9 @@
 import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import { ButtonStyleType } from "../Button/Button";
 import Card from "../Card/Card";
 import ConfirmModal from "../Modal/ConfirmModal";
@@ -33,6 +37,16 @@ const ModelDelete: <TBaseModel extends BaseModel>(
   props: ComponentProps<TBaseModel>,
 ): ReactElement => {
   const model: TBaseModel = new props.modelType();
+  /*
+   * The delete card used to be rendered for everybody: a viewer got a live
+   * "Delete <X>" button, a confirmation dialog, and then a refusal from the
+   * API. It now stays visible but locked, and says which permission is
+   * missing.
+   */
+  const deleteGate: PermissionGateResult = PermissionGate.check(
+    model,
+    ModelAction.Delete,
+  );
   const [showModal, setShowModal] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
@@ -69,7 +83,13 @@ const ModelDelete: <TBaseModel extends BaseModel>(
           {
             title: `Delete ${model.singularName}`,
             buttonStyle: ButtonStyleType.DANGER,
+            disabled: !deleteGate.isAllowed,
+            tooltip: deleteGate.disabledReason,
             onClick: () => {
+              if (!deleteGate.isAllowed) {
+                return;
+              }
+
               setShowModal(true);
             },
             isLoading: isLoading,

--- a/Common/UI/Components/ModelDetail/CardModelDetail.tsx
+++ b/Common/UI/Components/ModelDetail/CardModelDetail.tsx
@@ -1,6 +1,8 @@
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
-import PermissionUtil from "../../Utils/Permission";
-import User from "../../Utils/User";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import Navigation from "../../Utils/Navigation";
 import { ButtonStyleType } from "../Button/Button";
 import Card, {
@@ -17,11 +19,6 @@ import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/Database
 import IconProp from "../../../Types/Icon/IconProp";
 import Route from "../../../Types/API/Route";
 import URL from "../../../Types/API/URL";
-import {
-  PermissionHelper,
-  UserPermission,
-  UserTenantAccessPermission,
-} from "../../../Types/Permission";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 
 export interface ComponentProps<TBaseModel extends BaseModel> {
@@ -67,20 +64,15 @@ const CardModelDetail: <TBaseModel extends BaseModel>(
   }, [props.refresher]);
 
   useEffect(() => {
-    const userProjectPermissions: UserTenantAccessPermission | null =
-      PermissionUtil.getProjectPermissions();
-
-    const hasPermissionToEdit: boolean =
-      Boolean(
-        userProjectPermissions &&
-          userProjectPermissions.permissions &&
-          PermissionHelper.doesPermissionsIntersect(
-            model.updateRecordPermissions,
-            userProjectPermissions.permissions.map((item: UserPermission) => {
-              return item.permission;
-            }),
-          ),
-      ) || User.isMasterAdmin();
+    /*
+     * This used to look at project permissions only, so a permission granted
+     * globally did not count, and it read the raw updateRecordPermissions
+     * field rather than going through the model's own accessor.
+     */
+    const updateGate: PermissionGateResult = PermissionGate.check(
+      model,
+      ModelAction.Update,
+    );
 
     let cardButtons: Array<CardButtonSchema | ReactElement> = [];
 
@@ -114,11 +106,27 @@ const CardModelDetail: <TBaseModel extends BaseModel>(
       });
     }
 
-    if (props.isEditable && hasPermissionToEdit) {
+    /*
+     * Without update permission the button stays where it is, locked, and the
+     * tooltip names the permission that is missing. Removing it made the page
+     * look like editing was not a thing rather than not allowed. It is only
+     * dropped entirely when there is nothing honest to say - the permission
+     * snapshot has not loaded, or the model declares no update permissions.
+     */
+    if (
+      props.isEditable &&
+      (updateGate.isAllowed || updateGate.disabledReason)
+    ) {
       cardButtons.push({
         title: props.editButtonText || `Edit ${model.singularName}`,
         buttonStyle: ButtonStyleType.NORMAL,
+        disabled: !updateGate.isAllowed,
+        tooltip: updateGate.disabledReason,
         onClick: () => {
+          if (!updateGate.isAllowed) {
+            return;
+          }
+
           if (onBeforeEditRef.current && onBeforeEditRef.current() === false) {
             return;
           }
@@ -133,7 +141,12 @@ const CardModelDetail: <TBaseModel extends BaseModel>(
     }
 
     setCardButtons(cardButtons);
-  }, []);
+    /*
+     * props.refresher is the card's existing "something changed, look again"
+     * signal. The permission snapshot arrives on an API response header, so a
+     * one-shot read at mount could permanently show the wrong state.
+     */
+  }, [props.refresher, props.isEditable, props.editButtonText]);
 
   return (
     <>

--- a/Common/UI/Components/ModelList/ModelList.tsx
+++ b/Common/UI/Components/ModelList/ModelList.tsx
@@ -1,5 +1,9 @@
 import API from "../../Utils/API/API";
 import Query from "../../../Types/BaseDatabase/Query";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import ModelAPI, {
   ListResult,
   RequestOptions,
@@ -51,6 +55,16 @@ const ModelList: <TBaseModel extends BaseModel>(
 ) => ReactElement = <TBaseModel extends BaseModel>(
   props: ComponentProps<TBaseModel>,
 ): ReactElement => {
+  /*
+   * The row Delete button used to appear for anybody the caller marked the
+   * list deleteable for, permission or not. It now stays visible but locked
+   * when the viewer cannot delete the model.
+   */
+  const deleteGate: PermissionGateResult = PermissionGate.check(
+    new props.modelType(),
+    ModelAction.Delete,
+  );
+
   const [selectedList, setSelectedList] = useState<Array<TBaseModel>>([]);
   const [modelList, setModalList] = useState<Array<TBaseModel>>([]);
   const [error, setError] = useState<string>("");
@@ -262,12 +276,17 @@ const ModelList: <TBaseModel extends BaseModel>(
             }}
             titleField={props.titleField}
             onDelete={
-              props.isDeleteable
+              props.isDeleteable && deleteGate.isAllowed
                 ? async (item: TBaseModel) => {
                     await deleteItem(item);
                   }
-                : undefined
+                : props.isDeleteable && deleteGate.disabledReason
+                  ? () => {
+                      // Locked - the tooltip below explains why.
+                    }
+                  : undefined
             }
+            deleteDisabledReason={deleteGate.disabledReason}
             selectedItems={selectedList}
             onClick={(model: TBaseModel) => {
               if (props.selectMultiple) {

--- a/Common/UI/Components/ModelList/StaticModelList.tsx
+++ b/Common/UI/Components/ModelList/StaticModelList.tsx
@@ -22,6 +22,11 @@ export interface ComponentProps<TBaseModel extends BaseModel> {
   onClick: (item: TBaseModel) => void;
   titleField: string;
   onDelete?: ((item: TBaseModel) => void) | undefined;
+  /*
+   * When set, the row Delete buttons stay on screen but are locked, and say
+   * this on hover.
+   */
+  deleteDisabledReason?: string | undefined;
   customElement?: ((item: TBaseModel) => ReactElement) | undefined;
   enableDragAndDrop?: boolean | undefined;
   dragAndDropScope?: string | undefined;
@@ -103,7 +108,13 @@ const StaticModelList: <TBaseModel extends BaseModel>(
               icon={IconProp.Trash}
               buttonStyle={ButtonStyleType.OUTLINE}
               title="Delete"
+              disabled={Boolean(props.deleteDisabledReason)}
+              tooltip={props.deleteDisabledReason}
               onClick={() => {
+                if (props.deleteDisabledReason) {
+                  return;
+                }
+
                 props.onDelete?.(model);
               }}
             />

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -19,6 +19,10 @@ import buildQueryFromFilterData, {
   sanitizeFilterData,
 } from "./FilterDataToQuery";
 import PermissionUtil from "../../Utils/Permission";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import ProjectUtil from "../../Utils/Project";
 import User from "../../Utils/User";
 import ActionButtonSchema from "../ActionButton/ActionButtonSchema";
@@ -388,6 +392,45 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     props.bulkActions?.matchBulkSelectedItemByField || "_id";
 
   const model: TBaseModel = new props.modelType();
+
+  /*
+   * How a create / update / delete affordance should be rendered for this
+   * viewer. A user without the permission used to simply not see the button,
+   * which reads as "this feature does not exist" - and on the flows that route
+   * to a dedicated create page it did not even do that: the page opened, the
+   * form submitted, and the API refused it with a validation error about a
+   * field the user was never shown (issue #3306). The button now stays put and
+   * says which permission is missing.
+   *
+   * `show: false` is reserved for the two cases where there is nothing honest
+   * to say - the permission snapshot has not arrived yet, or the model has no
+   * permissions declared for the operation at all.
+   */
+  interface ActionGate {
+    show: boolean;
+    disabled: boolean;
+    tooltip: string | undefined;
+  }
+
+  type GetActionGateFunction = (action: ModelAction) => ActionGate;
+
+  const getActionGate: GetActionGateFunction = (
+    action: ModelAction,
+  ): ActionGate => {
+    const result: PermissionGateResult = PermissionGate.check(model, action, {
+      singularName: props.singularName || model.singularName || undefined,
+    });
+
+    if (result.isAllowed) {
+      return { show: true, disabled: false, tooltip: undefined };
+    }
+
+    if (result.disabledReason) {
+      return { show: true, disabled: true, tooltip: result.disabledReason };
+    }
+
+    return { show: false, disabled: false, tooltip: undefined };
+  };
 
   const [bulkSelectedItems, setBulkSelectedItems] = useState<Array<TBaseModel>>(
     [],
@@ -1247,29 +1290,21 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       }
     }
 
-    const permissions: Array<Permission> | null =
-      PermissionUtil.getAllPermissions();
-
-    let showActionsColumn: boolean = Boolean(
-      (permissions &&
-        ((props.isDeleteable && model.hasDeletePermissions(permissions)) ||
-          (props.isEditable && model.hasUpdatePermissions(permissions)) ||
-          (props.isViewable && model.hasReadPermissions(permissions)))) ||
+    /*
+     * The column has to exist for a locked Edit / Delete button to have
+     * somewhere to live, so it follows what the table author asked for rather
+     * than what this particular viewer is allowed to do. View is the exception
+     * - a disabled "View X" on a row would confirm a record the viewer is not
+     * allowed to know about - so it still disappears without read permission.
+     */
+    const showActionsColumn: boolean = Boolean(
+      (props.isDeleteable && getActionGate(ModelAction.Delete).show) ||
+        (props.isEditable && getActionGate(ModelAction.Update).show) ||
+        (props.isViewable &&
+          PermissionGate.check(model, ModelAction.Read).isAllowed) ||
         (props.actionButtons && props.actionButtons.length > 0) ||
         props.showViewIdButton,
     );
-
-    if (User.isMasterAdmin()) {
-      if (
-        (props.actionButtons && props.actionButtons.length > 0) ||
-        props.showViewIdButton ||
-        props.isDeleteable ||
-        props.isEditable ||
-        props.isViewable
-      ) {
-        showActionsColumn = true;
-      }
-    }
 
     if (showActionsColumn) {
       columns.push({
@@ -2126,22 +2161,19 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       headerbuttons = [...headerbuttons, ...props.cardProps.buttons];
     }
 
-    const permissions: Array<Permission> | null =
-      PermissionUtil.getAllPermissions();
-
-    let hasPermissionToCreate: boolean = false;
-
-    if (permissions) {
-      hasPermissionToCreate =
-        model.hasCreatePermissions(permissions) || User.isMasterAdmin();
-    }
+    const createGate: ActionGate = getActionGate(ModelAction.Create);
 
     const showFilterButton: boolean = props.filters.length > 0;
 
-    // because ordered list add button is inside the table and not on the card header.
+    /*
+     * because ordered list add button is inside the table and not on the card
+     * header. Without create permission the button is shown locked rather than
+     * removed, so the user can see the action exists and read why it is not
+     * available to them.
+     */
     if (
       props.isCreateable &&
-      hasPermissionToCreate &&
+      createGate.show &&
       showAs !== ShowAs.OrderedStatesList
     ) {
       headerbuttons.push({
@@ -2151,7 +2183,13 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         buttonStyle: ButtonStyleType.NORMAL,
         buttonSize: ButtonSize.Normal,
         className: "",
+        disabled: createGate.disabled,
+        tooltip: createGate.tooltip,
         onClick: () => {
+          if (createGate.disabled) {
+            return;
+          }
+
           if (props.onCreateClick) {
             props.onCreateClick();
             return;
@@ -2346,8 +2384,14 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
   const getUserPermissions: GetUserPermissionsFunction =
     (): Array<Permission> => {
-      let userPermissions: Array<Permission> =
-        PermissionUtil.getGlobalPermissions()?.globalPermissions || [];
+      /*
+       * A copy - Public is appended below, and pushing into the array the util
+       * handed back mutates the snapshot every other permission check on the
+       * page reads from.
+       */
+      let userPermissions: Array<Permission> = [
+        ...(PermissionUtil.getGlobalPermissions()?.globalPermissions || []),
+      ];
       if (
         PermissionUtil.getProjectPermissions() &&
         PermissionUtil.getProjectPermissions()?.permissions &&
@@ -2490,13 +2534,14 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         });
       }
 
-      if (
-        props.isEditable &&
-        (model.hasUpdatePermissions(permissions) || User.isMasterAdmin())
-      ) {
+      const updateGate: ActionGate = getActionGate(ModelAction.Update);
+
+      if (props.isEditable && updateGate.show) {
         actionsSchema.push({
           title: tx(props.editButtonText || "Edit"),
           buttonStyleType: ButtonStyleType.OUTLINE,
+          disabled: updateGate.disabled,
+          tooltip: updateGate.tooltip,
           onClick: async (
             item: TBaseModel,
             onCompleteAction: VoidFunction,
@@ -2519,14 +2564,15 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         });
       }
 
-      if (
-        props.isDeleteable &&
-        (model.hasDeletePermissions(permissions) || User.isMasterAdmin())
-      ) {
+      const deleteGate: ActionGate = getActionGate(ModelAction.Delete);
+
+      if (props.isDeleteable && deleteGate.show) {
         actionsSchema.push({
           title: tx(props.deleteButtonText || "Delete"),
           icon: IconProp.Trash,
           buttonStyleType: ButtonStyleType.DANGER_OUTLINE,
+          disabled: deleteGate.disabled,
+          tooltip: deleteGate.tooltip,
           onClick: async (
             item: TBaseModel,
             onCompleteAction: VoidFunction,
@@ -2723,10 +2769,20 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           await getFilterDropdownItems();
         }}
         bulkActions={(() => {
-          const permissions: Array<Permission> =
-            PermissionUtil.getAllPermissions();
-          const userCanDelete: boolean =
-            model.hasDeletePermissions(permissions);
+          const bulkDeleteGate: ActionGate = getActionGate(ModelAction.Delete);
+
+          /*
+           * Whether to auto-add the default Delete still follows the model
+           * check alone, exactly as it did before. Folding the master-admin
+           * short circuit in here would grow a row-selection column onto every
+           * table a master admin opens without project permissions - Table
+           * derives those checkboxes from this array being non-empty - which is
+           * a layout change nobody asked for. The gate above still decides
+           * whether the action, once present, is locked and what it says.
+           */
+          const userCanDelete: boolean = model.hasDeletePermissions(
+            PermissionUtil.getAllPermissions(),
+          );
 
           const sourceButtons: Array<
             BulkActionButtonSchema<TBaseModel> | ModalTableBulkDefaultActions
@@ -2740,6 +2796,11 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
            * per-row Delete button in the Actions column, not bulk operations.
            * The confirmation modal is wired up via the schema's confirmMessage
            * / confirmTitle below. Skip if the table author already added it.
+           *
+           * Only auto-inject it when the table already offers bulk actions.
+           * Table derives the row checkboxes from this array being non-empty,
+           * so injecting a locked Delete into an otherwise empty array would
+           * grow a selection column onto tables that have never had one.
            */
           const alreadyHasDeleteAction: boolean = sourceButtons.some(
             (
@@ -2762,26 +2823,64 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               return false;
             },
           );
-          if (userCanDelete && !alreadyHasDeleteAction) {
+
+          const canAutoInjectDelete: boolean =
+            userCanDelete ||
+            (bulkDeleteGate.disabled && sourceButtons.length > 0);
+
+          if (canAutoInjectDelete && !alreadyHasDeleteAction) {
             sourceButtons.push(ModalTableBulkDefaultActions.Delete);
           }
 
           return {
-            buttons: sourceButtons.map(
-              (
-                action:
+            buttons: sourceButtons
+              .map(
+                (
+                  action:
+                    | BulkActionButtonSchema<TBaseModel>
+                    | ModalTableBulkDefaultActions,
+                ):
                   | BulkActionButtonSchema<TBaseModel>
-                  | ModalTableBulkDefaultActions,
-              ) => {
-                if (
-                  action === ModalTableBulkDefaultActions.Delete &&
-                  userCanDelete
-                ) {
-                  return getDeleteBulkAction();
-                }
-                return action;
-              },
-            ) as Array<BulkActionButtonSchema<TBaseModel>>,
+                  | ModalTableBulkDefaultActions
+                  | null => {
+                  if (action !== ModalTableBulkDefaultActions.Delete) {
+                    return action;
+                  }
+
+                  /*
+                   * A table author who asked for the default Delete but whose
+                   * viewer cannot delete used to leave the raw enum string in
+                   * the array, which then reached BulkUpdateForm as if it were
+                   * a button schema. Resolve it here, in every branch.
+                   */
+                  if (!bulkDeleteGate.show) {
+                    return null;
+                  }
+
+                  const deleteAction: BulkActionButtonSchema<TBaseModel> =
+                    getDeleteBulkAction();
+
+                  if (bulkDeleteGate.disabled) {
+                    return {
+                      ...deleteAction,
+                      disabled: true,
+                      tooltip: bulkDeleteGate.tooltip,
+                    };
+                  }
+
+                  return deleteAction;
+                },
+              )
+              .filter(
+                (
+                  action:
+                    | BulkActionButtonSchema<TBaseModel>
+                    | ModalTableBulkDefaultActions
+                    | null,
+                ): boolean => {
+                  return action !== null;
+                },
+              ) as Array<BulkActionButtonSchema<TBaseModel>>,
           };
         })()}
         onBulkActionEnd={async () => {
@@ -2976,7 +3075,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           await fetchItems();
         }}
         onCreateNewItem={
-          props.isCreateable
+          props.isCreateable && getActionGate(ModelAction.Create).show
             ? (order: number) => {
                 setOrderedStatesListNewItemOrder(order);
                 setModalType(ModalType.Create);
@@ -2984,6 +3083,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               }
             : undefined
         }
+        createDisabledReason={getActionGate(ModelAction.Create).tooltip}
         singularLabel={props.singularName || model.singularName || "Item"}
         actionButtons={actionButtonSchema}
         getTitleElement={getTitleElement}
@@ -3637,9 +3737,14 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         buttonSize={b.buttonSize}
         className={b.className}
         onClick={() => {
+          if (b.disabled) {
+            return;
+          }
+
           b.onClick?.();
         }}
         disabled={b.disabled}
+        tooltip={b.tooltip}
         icon={b.icon}
         shortcutKey={b.shortcutKey}
         dataTestId="card-button"
@@ -3708,6 +3813,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               }
             }}
             isDisabled={b.disabled}
+            tooltip={b.tooltip}
           />
         );
       },
@@ -4033,7 +4139,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
                */}
               {tableColumns.length === 0 && allColumns.length > 0 ? (
                 <ErrorMessage
-                  message={`You are not authorized to view this table. You need any one of these permissions: ${PermissionHelper.getPermissionTitles(
+                  message={`You are not authorized to view this table. You need any one of these permissions: ${PermissionGate.getPermissionTitles(
                     model.getReadPermissions(),
                   ).join(", ")}`}
                 />

--- a/Common/UI/Components/ModelTable/ModelTable.tsx
+++ b/Common/UI/Components/ModelTable/ModelTable.tsx
@@ -3,8 +3,10 @@ import API from "../../Utils/API/API";
 import ModelImportExportUtil, {
   ImportResult,
 } from "../../Utils/ModelImportExport";
-import PermissionUtil from "../../Utils/Permission";
-import User from "../../Utils/User";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import { FormType, ModelField } from "../Forms/ModelForm";
 import ModelFormModal from "../ModelFormModal/ModelFormModal";
 import BaseModelTable, {
@@ -28,7 +30,6 @@ import Dictionary from "../../../Types/Dictionary";
 import IconProp from "../../../Types/Icon/IconProp";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
-import Permission from "../../../Types/Permission";
 import React, { ReactElement, useState } from "react";
 import Query from "../../../Types/BaseDatabase/Query";
 import GroupBy from "../../../Types/BaseDatabase/GroupBy";
@@ -129,14 +130,13 @@ const ModelTable: <TBaseModel extends BaseModel>(
       buttons: [...(props.bulkActions?.buttons || []), getExportBulkAction()],
     };
 
-    const permissions: Array<Permission> | null =
-      PermissionUtil.getAllPermissions();
+    /* Importing writes new records, so it is gated on create permission. */
+    const createGate: PermissionGateResult = PermissionGate.check(
+      model,
+      ModelAction.Create,
+    );
 
-    const hasPermissionToCreate: boolean = permissions
-      ? model.hasCreatePermissions(permissions) || User.isMasterAdmin()
-      : false;
-
-    if (hasPermissionToCreate) {
+    if (createGate.isAllowed || createGate.disabledReason) {
       cardProps = {
         ...(props.cardProps || {}),
         buttons: [
@@ -145,7 +145,13 @@ const ModelTable: <TBaseModel extends BaseModel>(
             title: "Import JSON",
             buttonStyle: ButtonStyleType.OUTLINE,
             icon: IconProp.Upload,
+            disabled: !createGate.isAllowed,
+            tooltip: createGate.disabledReason,
             onClick: () => {
+              if (!createGate.isAllowed) {
+                return;
+              }
+
               setShowImportModal(true);
             },
           },

--- a/Common/UI/Components/MoreMenu/MoreMenuItem.tsx
+++ b/Common/UI/Components/MoreMenu/MoreMenuItem.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, ReactElement } from "react";
 import IconProp from "../../../Types/Icon/IconProp";
 import Icon from "../Icon/Icon";
+import Tooltip from "../Tooltip/Tooltip";
 
 export interface ComponentProps {
   icon?: IconProp | undefined;
@@ -10,12 +11,18 @@ export interface ComponentProps {
   className?: string | undefined;
   iconClassName?: string | undefined;
   isDisabled?: boolean | undefined;
+  /*
+   * Shown on hover - the place a locked menu item says why it is locked.
+   */
+  tooltip?: string | undefined;
 }
 
 const MoreMenuItem: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  return (
+  const isDisabled: boolean = Boolean(props.isDisabled);
+
+  const menuItem: ReactElement = (
     /*
      * A button shrink-wraps its content whatever its display type, so the width
      * has to be set explicitly or the hover background stops at the end of the
@@ -23,11 +30,13 @@ const MoreMenuItem: FunctionComponent<ComponentProps> = (
      */
     <button
       type="button"
-      className={`group mx-1 flex w-[calc(100%-0.5rem)] items-center rounded-md px-3 py-2 text-left text-sm text-gray-700 transition-colors duration-100 enabled:cursor-pointer enabled:hover:bg-indigo-50 enabled:hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 ${props.className || ""}`}
+      className={`group mx-1 flex w-[calc(100%-0.5rem)] items-center rounded-md px-3 py-2 text-left text-sm text-gray-700 transition-colors duration-100 enabled:cursor-pointer enabled:hover:bg-indigo-50 enabled:hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 ${
+        isDisabled && props.tooltip ? "pointer-events-none " : ""
+      }${props.className || ""}`}
       role="menuitem"
       tabIndex={-1}
-      disabled={props.isDisabled}
-      aria-disabled={Boolean(props.isDisabled)}
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
       onClick={() => {
         props.onClick();
       }}
@@ -44,6 +53,29 @@ const MoreMenuItem: FunctionComponent<ComponentProps> = (
       </div>
     </button>
   );
+
+  if (!props.tooltip) {
+    return menuItem;
+  }
+
+  /*
+   * A disabled control dispatches no pointer events, so the tooltip has to
+   * hang off a wrapper that still receives them. Matches what Button does for
+   * the same reason - but tabIndex stays -1 here, because MoreMenu drives
+   * focus itself with a roving tabindex and a tabbable wrapper would add a
+   * stop it does not know about.
+   */
+  if (isDisabled) {
+    return (
+      <Tooltip text={props.tooltip}>
+        <span className="flex w-full" tabIndex={-1}>
+          {menuItem}
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return <Tooltip text={props.tooltip}>{menuItem}</Tooltip>;
 };
 
 export default MoreMenuItem;

--- a/Common/UI/Components/OrderedStatesList/Item.tsx
+++ b/Common/UI/Components/OrderedStatesList/Item.tsx
@@ -103,7 +103,13 @@ const Item: ItemFunction = <T extends GenericObject>(
                   icon={button.icon}
                   buttonStyle={button.buttonStyleType}
                   isLoading={isButtonLoading[i]}
+                  disabled={button.disabled}
+                  tooltip={button.tooltip}
                   onClick={() => {
+                    if (button.disabled) {
+                      return;
+                    }
+
                     if (button.onClick) {
                       isButtonLoading[i] = true;
                       setIsButtonLoading(isButtonLoading);

--- a/Common/UI/Components/OrderedStatesList/OrderedStatesList.tsx
+++ b/Common/UI/Components/OrderedStatesList/OrderedStatesList.tsx
@@ -2,6 +2,7 @@ import ActionButtonSchema from "../ActionButton/ActionButtonSchema";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import Icon, { SizeProp } from "../Icon/Icon";
 import Item from "./Item";
+import Tooltip from "../Tooltip/Tooltip";
 import Skeleton from "../Skeleton/Skeleton";
 import GenericObject from "../../../Types/GenericObject";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -10,6 +11,12 @@ import React, { ReactElement } from "react";
 export interface ComponentProps<T extends GenericObject> {
   data: Array<T>;
   onCreateNewItem?: ((order: number) => void) | undefined;
+  /*
+   * When set, the "Add New" affordances stay on screen but do nothing, and
+   * hovering one explains why - the same treatment a locked Create button
+   * gets on every other table.
+   */
+  createDisabledReason?: string | undefined;
   noItemsMessage?: string | ReactElement | undefined;
   error?: string | undefined;
   isLoading?: boolean | undefined;
@@ -39,6 +46,58 @@ const OrderedStatesList: OrderedStatesListFunction = <T extends GenericObject>(
    */
   const isRefetchingWithData: boolean =
     Boolean(props.isLoading) && props.data.length > 0;
+
+  const isCreateDisabled: boolean = Boolean(props.createDisabledReason);
+
+  type RenderAddNewFunction = (
+    label: string,
+    order: number,
+    className: string,
+    contentClassName: string,
+  ) => ReactElement;
+
+  /*
+   * These are clickable <div>s rather than buttons, so "disabled" has to be
+   * built by hand: drop the pointer cursor and the hover colours, ignore the
+   * click, and hang the reason off a tooltip wrapper.
+   */
+  const renderAddNew: RenderAddNewFunction = (
+    label: string,
+    order: number,
+    className: string,
+    contentClassName: string,
+  ): ReactElement => {
+    const affordance: ReactElement = (
+      <div
+        className={`${className} ${
+          isCreateDisabled
+            ? "cursor-not-allowed opacity-50"
+            : "cursor-pointer hover:bg-gray-50 hover:text-gray-600"
+        }`}
+        aria-disabled={isCreateDisabled}
+        onClick={() => {
+          if (isCreateDisabled) {
+            return;
+          }
+
+          if (props.onCreateNewItem) {
+            props.onCreateNewItem(order);
+          }
+        }}
+      >
+        <div className={contentClassName}>
+          <Icon icon={IconProp.Add} className="m-auto h-5 w-5" />
+          <span className="text-sm ml-2">{label}</span>
+        </div>
+      </div>
+    );
+
+    if (!props.createDisabledReason) {
+      return affordance;
+    }
+
+    return <Tooltip text={props.createDisabledReason}>{affordance}</Tooltip>;
+  };
 
   if (props.isLoading && props.data.length === 0) {
     /*
@@ -100,19 +159,12 @@ const OrderedStatesList: OrderedStatesListFunction = <T extends GenericObject>(
         )}
         {props.onCreateNewItem && (
           <div className="my-10">
-            <div
-              className="m-auto inline-flex items-center cursor-pointer text-gray-400 hover:bg-gray-50 border hover:text-gray-600 rounded-full border-gray-300 p-5"
-              onClick={() => {
-                if (props.onCreateNewItem) {
-                  props.onCreateNewItem(1);
-                }
-              }}
-            >
-              <Icon icon={IconProp.Add} className="h-5 w-5" />
-              <span className="text-sm ml-2">
-                Add New {props.singularLabel}
-              </span>
-            </div>
+            {renderAddNew(
+              `Add New ${props.singularLabel}`,
+              1,
+              "m-auto inline-flex items-center text-gray-400 border rounded-full border-gray-300 p-5",
+              "flex items-center",
+            )}
           </div>
         )}
       </div>
@@ -142,23 +194,14 @@ const OrderedStatesList: OrderedStatesListFunction = <T extends GenericObject>(
                 isBeginning &&
                 props.shouldAddItemInTheBeginning && (
                   <div className="text-center">
-                    <div
-                      className="m-auto rounded-full items-center cursor-pointer text-gray-400 hover:bg-gray-50 hover:text-gray-600 items-center border border-gray-300 p-5 w-fit"
-                      onClick={() => {
-                        if (props.onCreateNewItem) {
-                          props.onCreateNewItem(
-                            item[props.orderField]
-                              ? (item[props.orderField] as number) + 1
-                              : 0,
-                          );
-                        }
-                      }}
-                    >
-                      <div className="flex text-center">
-                        <Icon icon={IconProp.Add} className="m-auto h-5 w-5" />{" "}
-                        <span className="text-sm ml-2">Add New Item</span>
-                      </div>
-                    </div>
+                    {renderAddNew(
+                      "Add New Item",
+                      item[props.orderField]
+                        ? (item[props.orderField] as number) + 1
+                        : 0,
+                      "m-auto rounded-full items-center text-gray-400 border border-gray-300 p-5 w-fit",
+                      "flex text-center",
+                    )}
 
                     <div className="items-center m-10 ">
                       <Icon
@@ -189,23 +232,14 @@ const OrderedStatesList: OrderedStatesListFunction = <T extends GenericObject>(
               {props.onCreateNewItem &&
                 ((isEnd && props.shouldAddItemInTheEnd) || !isEnd) && (
                   <div className="text-center">
-                    <div
-                      className="m-auto items-center cursor-pointer text-gray-400 hover:bg-gray-50 border hover:text-gray-600 rounded-full border-gray-300 p-5 w-fit"
-                      onClick={() => {
-                        if (props.onCreateNewItem) {
-                          props.onCreateNewItem(
-                            item[props.orderField]
-                              ? (item[props.orderField] as number) + 1
-                              : 0,
-                          );
-                        }
-                      }}
-                    >
-                      <div className="flex items-center ">
-                        <Icon icon={IconProp.Add} className="m-auto h-5 w-5" />{" "}
-                        <span className="text-sm ml-2">Add New Item</span>
-                      </div>
-                    </div>
+                    {renderAddNew(
+                      "Add New Item",
+                      item[props.orderField]
+                        ? (item[props.orderField] as number) + 1
+                        : 0,
+                      "m-auto items-center text-gray-400 border rounded-full border-gray-300 p-5 w-fit",
+                      "flex items-center",
+                    )}
                     {!isEnd && (
                       <div className="items-center m-10">
                         <Icon

--- a/Common/UI/Components/ResetObjectID/ResetObjectID.tsx
+++ b/Common/UI/Components/ResetObjectID/ResetObjectID.tsx
@@ -1,6 +1,10 @@
 import API from "../../Utils/API/API";
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
 import { ButtonStyleType } from "../Button/Button";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "../../Utils/PermissionGate";
 import Card from "../Card/Card";
 import ConfirmModal from "../Modal/ConfirmModal";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
@@ -62,6 +66,12 @@ const ResetObjectID: <TBaseModel extends BaseModel>(
   const tableColumnName: string =
     tableColumn?.title || (props.fieldName as string);
 
+  /* Resetting the id writes to the record, so it is an update. */
+  const updateGate: PermissionGateResult = PermissionGate.check(
+    model,
+    ModelAction.Update,
+  );
+
   return (
     <>
       <Card
@@ -71,7 +81,13 @@ const ResetObjectID: <TBaseModel extends BaseModel>(
           {
             title: `${props.title}`,
             buttonStyle: ButtonStyleType.NORMAL,
+            disabled: !updateGate.isAllowed,
+            tooltip: updateGate.disabledReason,
             onClick: () => {
+              if (!updateGate.isAllowed) {
+                return;
+              }
+
               setShowModal(true);
             },
             isLoading: isLoading,

--- a/Common/UI/Components/Table/TableRow.tsx
+++ b/Common/UI/Components/Table/TableRow.tsx
@@ -213,7 +213,13 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
                               icon={button.icon}
                               buttonStyle={button.buttonStyleType}
                               isLoading={isButtonLoading[actionIndex]}
+                              disabled={button.disabled}
+                              tooltip={button.tooltip}
                               onClick={() => {
+                                if (button.disabled) {
+                                  return;
+                                }
+
                                 if (button.onClick) {
                                   isButtonLoading[actionIndex] = true;
                                   setIsButtonLoading(isButtonLoading);
@@ -526,7 +532,13 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
                                 icon={button.icon}
                                 buttonStyle={button.buttonStyleType}
                                 isLoading={isButtonLoading[i]}
+                                disabled={button.disabled}
+                                tooltip={button.tooltip}
                                 onClick={() => {
+                                  if (button.disabled) {
+                                    return;
+                                  }
+
                                   if (button.onClick) {
                                     isButtonLoading[i] = true;
                                     setIsButtonLoading(isButtonLoading);

--- a/Common/UI/Utils/PermissionGate.ts
+++ b/Common/UI/Utils/PermissionGate.ts
@@ -1,0 +1,277 @@
+import { CardButtonSchema } from "../Components/Card/Card";
+import Dictionary from "../../Types/Dictionary";
+import Permission, {
+  PermissionHelper,
+  PermissionProps,
+} from "../../Types/Permission";
+import PermissionUtil from "./Permission";
+import User from "./User";
+
+/*
+ * The four record-level operations a user can be gated on. Deliberately not the
+ * column-level equivalents: field access control stays hidden rather than
+ * disabled, because selecting an unreadable column makes the whole list request
+ * fail (see the comment on isPickableColumn in BaseModelTable).
+ */
+export enum ModelAction {
+  Create = "create",
+  Read = "read",
+  Update = "update",
+  Delete = "delete",
+}
+
+export interface PermissionGateResult {
+  /* Whether the user may perform the operation. */
+  isAllowed: boolean;
+  /*
+   * Why the button is disabled, ready to be shown in a tooltip - or undefined
+   * when there is nothing useful to say. `undefined` with `isAllowed: false` is
+   * the "do not accuse the user" case: the permission snapshot has not loaded
+   * yet, or the model declares no permissions for this operation at all. The
+   * caller must HIDE the affordance in that case rather than show a disabled
+   * button with an empty reason.
+   */
+  disabledReason?: string | undefined;
+}
+
+/*
+ * Structurally typed so that both DatabaseBaseModel and AnalyticsBaseModel
+ * satisfy it without a union - the two class hierarchies are unrelated but
+ * expose an identical permission API. (Same trick as canCreate in
+ * DashboardCommandPaletteHelpers.)
+ */
+export interface PermissionCheckableModel {
+  singularName: string | null;
+  hasCreatePermissions: (permissions: Array<Permission>) => boolean;
+  hasReadPermissions: (permissions: Array<Permission>) => boolean;
+  hasUpdatePermissions: (permissions: Array<Permission>) => boolean;
+  hasDeletePermissions: (permissions: Array<Permission>) => boolean;
+  getCreatePermissions: () => Array<Permission>;
+  getReadPermissions: () => Array<Permission>;
+  getUpdatePermissions: () => Array<Permission>;
+  getDeletePermissions: () => Array<Permission>;
+}
+
+export interface PermissionGateOptions {
+  /*
+   * Overrides the permissions read from storage. Only used by tests and by
+   * callers that already hold a snapshot they want every gate on the screen to
+   * agree with.
+   */
+  permissions?: Array<Permission> | undefined;
+  /*
+   * The noun to use in the message when the model's own singularName is not
+   * what the user sees on screen ("Monitor" vs "Monitor Template").
+   */
+  singularName?: string | undefined;
+}
+
+/*
+ * PermissionHelper.getAllPermissionProps() rebuilds a ~2000 entry array literal
+ * on every call, and a gate runs once per action button per render of every
+ * table. Build the lookup once per page load instead.
+ */
+let permissionPropsCache: Dictionary<PermissionProps> | null = null;
+
+type GetPermissionPropsFunction = () => Dictionary<PermissionProps>;
+
+const getPermissionProps: GetPermissionPropsFunction =
+  (): Dictionary<PermissionProps> => {
+    if (!permissionPropsCache) {
+      permissionPropsCache =
+        PermissionHelper.getAllPermissionPropsAsDictionary();
+    }
+
+    return permissionPropsCache;
+  };
+
+/*
+ * Decides whether a create / update / delete affordance should be offered, and
+ * when it should not, produces the sentence that explains why.
+ *
+ * Before this existed, every gate in the UI was `if (allowed) { render() }`, so
+ * a user without permission saw the button simply not be there - or, worse,
+ * saw a fully working create page that only failed at submit with a validation
+ * error about a field they never got to fill in (issue #3306). The button now
+ * stays on screen, disabled, and says which permission is missing.
+ */
+export default class PermissionGate {
+  public static check(
+    model: PermissionCheckableModel,
+    action: ModelAction,
+    options?: PermissionGateOptions | undefined,
+  ): PermissionGateResult {
+    /*
+     * A master admin is allowed everything, everywhere. Every gate in the UI
+     * already ORs this in - except the bulk delete one, which is why that gate
+     * used to disagree with the per-row Delete button next to it.
+     */
+    if (User.isMasterAdmin()) {
+      return { isAllowed: true };
+    }
+
+    const userPermissions: Array<Permission> =
+      options?.permissions ?? PermissionUtil.getAllPermissions();
+
+    const modelPermissions: Array<Permission> = this.getModelPermissions(
+      model,
+      action,
+    );
+
+    /*
+     * The model does not support this operation at all (an analytics model with
+     * no declared access control reports exactly this). There is no permission
+     * the user could be granted to make the button work, so there is nothing
+     * worth showing them - hide it, as before.
+     */
+    if (modelPermissions.length === 0) {
+      return { isAllowed: false };
+    }
+
+    /*
+     * The permission snapshot arrives on a response header, so it is empty for
+     * the first paint after a fresh login and for a moment after the project is
+     * switched. Telling somebody they need a permission they actually hold is
+     * worse than briefly not offering the button, so this case stays hidden.
+     */
+    if (userPermissions.length === 0) {
+      return { isAllowed: false };
+    }
+
+    if (this.hasPermission(model, action, userPermissions)) {
+      return { isAllowed: true };
+    }
+
+    return {
+      isAllowed: false,
+      disabledReason: this.getMissingPermissionMessage(model, action, options),
+    };
+  }
+
+  /*
+   * The sentence shown in the tooltip. Deliberately the same phrasing the API
+   * returns when it refuses the same operation (see TablePermission on the
+   * server) so that the two do not read like different products.
+   */
+  public static getMissingPermissionMessage(
+    model: PermissionCheckableModel,
+    action: ModelAction,
+    options?: PermissionGateOptions | undefined,
+  ): string {
+    const singularName: string =
+      options?.singularName || model.singularName || "item";
+
+    const titles: Array<string> = this.getPermissionTitles(
+      this.getModelPermissions(model, action),
+    );
+
+    if (titles.length === 0) {
+      return `You do not have permission to ${action} this ${singularName}.`;
+    }
+
+    return `You do not have permission to ${action} this ${singularName}. You need one of these permissions: ${titles.join(
+      ", ",
+    )}.`;
+  }
+
+  public static getModelPermissions(
+    model: PermissionCheckableModel,
+    action: ModelAction,
+  ): Array<Permission> {
+    switch (action) {
+      case ModelAction.Create:
+        return model.getCreatePermissions() || [];
+      case ModelAction.Read:
+        return model.getReadPermissions() || [];
+      case ModelAction.Update:
+        return model.getUpdatePermissions() || [];
+      case ModelAction.Delete:
+        return model.getDeletePermissions() || [];
+      default:
+        return [];
+    }
+  }
+
+  /*
+   * Human titles for a permission list, skipping anything the props table does
+   * not know about. PermissionHelper.getTitle throws on an unknown permission,
+   * which would take down the whole table for one stale enum value.
+   */
+  public static getPermissionTitles(
+    permissions: Array<Permission>,
+  ): Array<string> {
+    const props: Dictionary<PermissionProps> = getPermissionProps();
+    const titles: Array<string> = [];
+
+    for (const permission of permissions) {
+      const permissionProp: PermissionProps | undefined = props[permission];
+
+      if (permissionProp && !titles.includes(permissionProp.title)) {
+        titles.push(permissionProp.title);
+      }
+    }
+
+    return titles;
+  }
+
+  private static hasPermission(
+    model: PermissionCheckableModel,
+    action: ModelAction,
+    userPermissions: Array<Permission>,
+  ): boolean {
+    switch (action) {
+      case ModelAction.Create:
+        return model.hasCreatePermissions(userPermissions);
+      case ModelAction.Read:
+        return model.hasReadPermissions(userPermissions);
+      case ModelAction.Update:
+        return model.hasUpdatePermissions(userPermissions);
+      case ModelAction.Delete:
+        return model.hasDeletePermissions(userPermissions);
+      default:
+        return false;
+    }
+  }
+
+  /*
+   * Applies a gate to a card button in one line. Several tables replace the
+   * built in create modal with a button that routes to a dedicated create
+   * page - those bypass ModelTable's own gate entirely, which is how a viewer
+   * ended up walking through the whole "Create New Monitor" wizard before
+   * being refused (issue #3306).
+   *
+   * Returns null when the button should not be rendered at all, which is only
+   * the "nothing honest to say" case: the permission snapshot has not landed,
+   * or the model declares no permissions for the operation.
+   */
+  public static gateCardButton(
+    button: CardButtonSchema,
+    model: PermissionCheckableModel,
+    action: ModelAction,
+    options?: PermissionGateOptions | undefined,
+  ): CardButtonSchema | null {
+    const result: PermissionGateResult = this.check(model, action, options);
+
+    if (result.isAllowed) {
+      return button;
+    }
+
+    if (!result.disabledReason) {
+      return null;
+    }
+
+    return {
+      ...button,
+      disabled: true,
+      tooltip: result.disabledReason,
+      onClick: () => {
+        // Locked. The tooltip says which permission is missing.
+      },
+    };
+  }
+
+  /* Test seam - the props lookup is memoized for the lifetime of the page. */
+  public static clearPermissionPropsCache(): void {
+    permissionPropsCache = null;
+  }
+}


### PR DESCRIPTION
Fixes #3306.

## The problem

A Viewer-only user could open **Monitors → Create New Monitor**, walk all three
steps of the wizard — every one of them showing as complete — press **Create
Monitor**, and be told *"Monitor type required to create monitor"*. A
permissions problem, reported as a form-validation error, naming a field they
were never shown.

Two separate gaps caused that:

1. **The entry point had no permission check at all.** Seven tables replace
   `ModelTable`'s built-in create modal with a card button that navigates to a
   dedicated create page. Doing so opts them out of `ModelTable`'s permission
   gate, so the button was live for everybody.
2. **The create page could not tell the user why.** `ModelForm`'s per-column
   access control silently stripped every field the Viewer could not write,
   leaving a wizard of empty steps with nothing left to fail validation. The
   submit posted an empty body and the API answered with whichever field it
   validated first.

More broadly, every permission gate in the UI was `if (allowed) { render() }` —
so "you are not allowed to do this" was drawn as "this feature does not exist".

## What this changes

When a user lacks create / update / delete permission, the button now **stays
on screen, disabled, and says on hover which permission is missing**:

> You do not have permission to create this Monitor. You need one of these
> permissions: Project Owner, Project Admin, Project Member, Monitor Admin,
> Monitor Member, Create Monitor.

### The tooltip bug underneath it

`Button` and `MoreMenuItem` have both accepted a `tooltip` prop for a long time,
and **on a disabled control it did nothing at all** — which is exactly when it
matters most. A disabled form control dispatches no pointer events and cannot be
focused, so neither of tippy's triggers ever fires, and `tippy.js` additionally
bails out of `show()` when its reference element carries a `disabled` attribute.

Both components now wrap a disabled-with-tooltip control in a hoverable,
focusable span and take the control itself out of hit-testing. The enabled path
is untouched, so none of the ~250 existing tooltip call sites change.

### Where the gate is applied

A new `Common/UI/Utils/PermissionGate.ts` answers one question — *should this
affordance be offered, and if not, why not* — and returns three outcomes rather
than a boolean:

| outcome | rendering |
|---|---|
| allowed | button, working |
| denied, with a reason | button, locked, tooltip explains |
| denied, no reason to give | nothing at all |

That third case is deliberate. `PermissionUtil.getAllPermissions()` is empty
until the first API response carrying the permission headers lands, and telling
a project owner they need permissions they own is worse than briefly not
offering the button. It also covers a model that declares no permissions for an
operation at all, where no grant could ever make the button work.

Shared components now routed through it:

- `BaseModelTable` — header Create, row Edit / Delete, the bulk Delete, and the
  Actions column itself (which used to disappear entirely, leaving nowhere for a
  locked button to render)
- `ModelDelete` — 60 "Delete &lt;X&gt;" cards that previously had **no permission
  logic whatsoever**: a live red button, a confirmation dialog, and a refusal
  from the API only after the user had agreed to destroy something
- `CardModelDetail` — the Edit button (223 call sites)
- `ModelForm` — a create form the viewer cannot submit now says why instead of
  rendering an empty wizard
- `ModelTable` Import JSON, `DuplicateModel`, `ResetObjectID`,
  `CustomFieldsDetail`, `ModelList`, `OrderedStatesList`
- the three bulk-action hooks (`useBulkLabelActions`, `useBulkOwnerActions`,
  `useBulkArchiveActions`) — ~79 call sites that bypassed the table's gate
  entirely, so a viewer could still relabel, reassign or archive every row they
  had selected
- the seven dedicated create-page entry points (Monitors, Incidents, Alerts,
  both episode kinds, Scheduled Maintenance, Announcements) and
  `ArchiveResourceCard`

### Deliberately left hiding

- **Read.** A locked "View X" on a row confirms a record the viewer is not
  allowed to know exists. Row View and the "not authorized to view this table"
  message keep hiding.
- **Column-level access control.** Selecting an unreadable column makes the
  whole list request fail, and a locked cell still leaks the column's existence.
- **`isCreateable` / `isEditable` / `isDeleteable`.** These are the table author
  saying the surface has no such action — nothing to do with permissions — and
  still hide. Same for `MonitorTable`'s `disableCreate`, which is a layout flag.
- **Forms that post somewhere other than the model's own CRUD endpoint.** Sign
  in, sign up, password reset and status page subscribe are all `ModelForm`s
  with `formType={FormType.Create}` that submit elsewhere; the model's create
  permission has nothing to do with whether the visitor may use them. Without
  this a signed-in project Viewer opening a status page in the same browser
  would have been locked out of its login form.

## Bugs found and fixed along the way

- **The permission snapshot was being mutated.** `ModelForm` and
  `BaseModelTable` both did `getGlobalPermissions().globalPermissions.push(Public)`,
  writing straight into the array every other permission check on the page reads
  from. Benign today only because the util re-parses from storage on each call.
- **The bulk Delete leaked a raw enum.** When a table author put
  `ModalTableBulkDefaultActions.Delete` in `bulkActions.buttons` and the gate
  refused, the enum string was left in the array and handed to the action bar as
  if it were a button schema.
- **`CardModelDetail` ignored global permissions** (it read only the project
  snapshot) and computed the answer in a mount-only effect, so it went stale if
  permissions arrived after first paint.

## Tests

10 new suites, 120 tests, plus permission stubs added to 3 existing suites that
previously rendered these components with no viewer identity at all.

- `PermissionGate.test.ts` — the three-way outcome, master-admin short circuit,
  unloaded snapshot, models declaring no permissions, human titles rather than
  raw enum values, and both `DatabaseBaseModel` and `AnalyticsBaseModel`
- `DisabledButtonTooltip.test.tsx` — the core regression guard. **Reverting the
  `Button` fix fails 4 of these.**
- `BaseModelTablePermissionGating.test.tsx` — locked create / edit / delete /
  bulk delete, the tooltips, that clicking does nothing, the Actions column
  surviving, and the exceptions that must keep hiding
- `CreatePageEntryPointPermissions.test.tsx` — the reported scenario end to end:
  a Viewer on the Monitors table, and `Navigation.navigate` never called
- `CreateEntryPointPermissionInvariants.test.ts` — a source-level net under all
  seven copy-paste sibling tables
- `ModelCardPermissionGating.test.tsx`, `CardModelDetailPermissionGating.test.tsx`,
  `ModelFormCreatePermission.test.tsx`, `BulkActionPermissionGating.test.tsx`,
  `OrderedStatesListCreateGate.test.tsx`

`npx tsc --noEmit`, prettier and eslint are clean.

`App`: **9097 tests pass, 0 failures.** `Common`: full suite green apart from
failures that reproduce on `master` and are untouched by this change — four
`SecurityEvent` suites that cannot compile without `@types/js-yaml`, and (in
App) seven Workflow/Runbook/Telemetry suites whose `isolated-vm` native module
does not load on this machine's Node build. Both are suite *load* failures, not
test failures.

Three existing suites — `ModelDelete`, `DuplicateModel`, `CustomFieldsDetail` —
rendered these components with no viewer identity at all, which now correctly
withholds the button. They gained a permission stub saying who is looking, and
`DuplicateModel`'s synthetic test model gained the `@TableAccessControl` every
real model declares.
