### PR TITLE
fix: "Block Permissions" on a Team do not prevent members from deleting the p...

### DIFF
--- a/Common/UI/Utils/Permission.ts
+++ b/Common/UI/Utils/Permission.ts
@@ -41,12 +41,15 @@ export default class PermissionUtil {
     if (projectPermissions) {
       permissions = [
         ...permissions,
-        ...projectPermissions.permissions.map((i: UserPermission) => {
-          return i.permission;
-        }),
+        ...projectPermissions.permissions
+          .filter((i: UserPermission) => {
+            return !i.isBlockPermission;
+          })
+          .map((i: UserPermission) => {
+            return i.permission;
+          }),
       ];
     }
-
     return permissions;
   }
 


### PR DESCRIPTION
Fixes #3253

## Root cause

Client permission snapshot counts "Block Permissions" rows as grants

## Changes

- PermissionUtil.getAllPermissions() now drops UserPermission rows with isBlockPermission set, mirroring the server's PermissionType.Allow filtering (DatabaseCommonInteractionPropsUtil.getUserPermissions) used by every table/column/row permission check. With the snapshot honest, the existing PermissionGate in ModelDelete renders "Delete Project" disabled with the missing-permission tooltip instead of letting a blocked member walk to the confirmation dialog. Added a focused regression test for the block/grant distinction.