### PR TITLE
feat(discovery): filter discovered hosts by SNMP / No SNMP before import

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter.ts
@@ -1,0 +1,402 @@
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import NetworkDeviceMonitoringMethod from "Common/Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import {
+  isImportableDiscoveredHost,
+  monitoringMethodForDiscoveredHost,
+} from "./DiscoveryImportEligibility";
+
+/*
+ * Splitting one scan's results into the two groups an operator actually
+ * reviews separately: hosts that answered SNMP, and hosts that only answered
+ * ping.
+ *
+ * The Review Discovered Devices dialog used to render every responding host in
+ * one list with everything pre-checked. That is fine for a lab /24 and
+ * unusable at the size real sweeps come back at — issue #3322 reports 2,890
+ * ICMP-only hosts and 2,866 SNMP hosts in a single scan, mixed together, with
+ * no way to import one group without scrolling the other and unchecking it by
+ * hand. The two groups are also not interchangeable: an SNMP host imports as a
+ * polled device carrying the scan's credentials, a ping-only host imports as a
+ * monitor-backed device with no polling at all (see DiscoveryImportEligibility)
+ * — so "import the switches now, deal with the endpoints later" is the normal
+ * thing to want, not an edge case.
+ *
+ * Kept react-free and out of the page component for the usual reason: the App
+ * test suite runs in a plain Node environment with no renderer, so rules left
+ * inside a `.tsx` are effectively untestable — and every failure mode here
+ * (a filter that shows the wrong group, a count badge that disagrees with the
+ * list under it, an import that quietly includes hosts the operator filtered
+ * away) renders perfectly while being wrong.
+ */
+
+export enum DiscoveredHostFilter {
+  // Everything the sweep found alive — the pre-#3322 behaviour, still default.
+  All = "All",
+  // Answered SNMP: imports as a polled device with the scan's credentials.
+  Snmp = "Snmp",
+  // Answered ping only: imports as a monitor-backed device, no polling.
+  NoSnmp = "NoSnmp",
+}
+
+/** Group sizes for the filter badges. */
+export interface DiscoveredHostCounts {
+  all: number;
+  snmp: number;
+  noSnmp: number;
+}
+
+/** One button in the dialog's filter row. */
+export interface DiscoveredHostFilterOption {
+  // Already carries the group size, e.g. "SNMP (2,866)".
+  label: string;
+  value: DiscoveredHostFilter;
+  count: number;
+}
+
+/**
+ * True when the host answered ping but not SNMP — the "No SNMP" badge group.
+ *
+ * Phrased through `monitoringMethodForDiscoveredHost` rather than by reading
+ * `snmpReachable` again so the filter can never disagree with the import: the
+ * group a host is shown under and the monitoring method it is imported with
+ * are the same decision, made once.
+ */
+export function isPingOnlyDiscoveredHost(
+  host: DiscoveredNetworkDevice,
+): boolean {
+  return (
+    monitoringMethodForDiscoveredHost(host) ===
+    NetworkDeviceMonitoringMethod.Monitor
+  );
+}
+
+export function matchesDiscoveredHostFilter(data: {
+  host: DiscoveredNetworkDevice;
+  filter: DiscoveredHostFilter;
+}): boolean {
+  if (data.filter === DiscoveredHostFilter.All) {
+    return true;
+  }
+
+  const isPingOnly: boolean = isPingOnlyDiscoveredHost(data.host);
+
+  return data.filter === DiscoveredHostFilter.NoSnmp ? isPingOnly : !isPingOnly;
+}
+
+/**
+ * The hosts the dialog should render, in scan order.
+ *
+ * Order is preserved deliberately: the probe reports hosts in address order,
+ * and re-sorting would move rows under the operator's cursor every time the
+ * filter changed.
+ */
+export function filterDiscoveredHosts(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+}): Array<DiscoveredNetworkDevice> {
+  return data.hosts.filter((host: DiscoveredNetworkDevice) => {
+    return matchesDiscoveredHostFilter({ host: host, filter: data.filter });
+  });
+}
+
+/**
+ * Group sizes, computed from the UNFILTERED list.
+ *
+ * Same reasoning as the recommendations tiles: the badges are what the
+ * operator clicks to change the filter, so deriving them from the filtered
+ * list would make every badge except the active one read zero.
+ *
+ * Already-registered hosts are counted. The badge answers "how big is this
+ * group", which is how the number is checked against the probe's own ICMP/SNMP
+ * tallies; excluding rows for a reason the badge cannot show would just make
+ * the two disagree.
+ */
+export function countDiscoveredHosts(
+  hosts: Array<DiscoveredNetworkDevice>,
+): DiscoveredHostCounts {
+  const counts: DiscoveredHostCounts = {
+    all: hosts.length,
+    snmp: 0,
+    noSnmp: 0,
+  };
+
+  for (const host of hosts) {
+    if (isPingOnlyDiscoveredHost(host)) {
+      counts.noSnmp = counts.noSnmp + 1;
+    } else {
+      counts.snmp = counts.snmp + 1;
+    }
+  }
+
+  return counts;
+}
+
+/**
+ * How a group is named in prose — and, critically, on the row badge.
+ *
+ * "No SNMP" is the exact wording already on the per-row pill, so the filter
+ * button and the thing it filters for read as the same word rather than as two
+ * near-synonyms the operator has to connect.
+ */
+export function getDiscoveredHostFilterLabel(
+  filter: DiscoveredHostFilter,
+): string {
+  if (filter === DiscoveredHostFilter.Snmp) {
+    return "SNMP";
+  }
+
+  if (filter === DiscoveredHostFilter.NoSnmp) {
+    return "No SNMP";
+  }
+
+  return "All";
+}
+
+/**
+ * The filter row, counts included.
+ *
+ * The count is in the label rather than in a badge because a group of zero has
+ * to render its zero: "SNMP (0)" is the answer to "did this sweep find any
+ * switches at all", and a badge that hides zeroes would leave that button
+ * looking identical to one with results behind it.
+ *
+ * Thousands separators for the reason #3322 exists — at four digits, 2866 and
+ * 2,866 are not equally easy to check against the probe's own tally.
+ */
+export function getDiscoveredHostFilterOptions(
+  hosts: Array<DiscoveredNetworkDevice>,
+): Array<DiscoveredHostFilterOption> {
+  const counts: DiscoveredHostCounts = countDiscoveredHosts(hosts);
+
+  const countByFilter: Record<DiscoveredHostFilter, number> = {
+    [DiscoveredHostFilter.All]: counts.all,
+    [DiscoveredHostFilter.Snmp]: counts.snmp,
+    [DiscoveredHostFilter.NoSnmp]: counts.noSnmp,
+  };
+
+  return [
+    DiscoveredHostFilter.All,
+    DiscoveredHostFilter.Snmp,
+    DiscoveredHostFilter.NoSnmp,
+  ].map((filter: DiscoveredHostFilter) => {
+    const count: number = countByFilter[filter];
+
+    return {
+      label: `${getDiscoveredHostFilterLabel(filter)} (${count.toLocaleString(
+        "en-US",
+      )})`,
+      value: filter,
+      count: count,
+    };
+  });
+}
+
+/**
+ * True when this row's checkbox can be ticked at all.
+ *
+ * A host with no address cannot be imported (the address is the device's
+ * hostname AND the selection key), and one already registered has nothing left
+ * to import.
+ */
+export function isSelectableDiscoveredHost(
+  host: DiscoveredNetworkDevice,
+): boolean {
+  return (
+    Boolean(host.ipAddress) &&
+    !host.isAlreadyRegistered &&
+    isImportableDiscoveredHost(host)
+  );
+}
+
+/**
+ * The scan's hosts with the ones imported during this sitting flipped to
+ * already-registered.
+ *
+ * `isAlreadyRegistered` is computed server-side when the probe uploads its
+ * results and then frozen into the jsonb column — nothing recomputes it on
+ * read. So a host imported a moment ago still reports false, and the dialog
+ * would happily offer it again, pre-checked, creating a second Network Device
+ * for the same address.
+ *
+ * That was survivable when one press imported everything and closed the
+ * dialog. Importing group by group is now the intended flow (#3322), which
+ * means coming back to a list that still contains what you just imported is
+ * the normal case rather than the odd one, so the page overlays what it knows.
+ *
+ * Returns copies; the scan's own array is left alone so nothing depends on
+ * mutation order.
+ */
+export function markDiscoveredHostsAsRegistered(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  importedIpAddresses: Set<string>;
+}): Array<DiscoveredNetworkDevice> {
+  if (data.importedIpAddresses.size === 0) {
+    return data.hosts;
+  }
+
+  return data.hosts.map((host: DiscoveredNetworkDevice) => {
+    if (!data.importedIpAddresses.has(host.ipAddress)) {
+      return host;
+    }
+
+    return { ...host, isAlreadyRegistered: true };
+  });
+}
+
+/**
+ * The dialog's opening selection: every selectable host, pre-checked.
+ *
+ * Computed over the whole scan rather than the active filter because the
+ * dialog always opens on `All` — and because a filter is a view, not a
+ * selection: switching to SNMP and back must not lose the ticks.
+ */
+export function getInitialSelection(
+  hosts: Array<DiscoveredNetworkDevice>,
+): Record<string, boolean> {
+  const selection: Record<string, boolean> = {};
+
+  for (const host of hosts) {
+    if (isSelectableDiscoveredHost(host)) {
+      selection[host.ipAddress] = true;
+    }
+  }
+
+  return selection;
+}
+
+/**
+ * Exactly what pressing Import imports: selected AND currently shown.
+ *
+ * Scoping the import to the active filter is the whole point of #3322. The
+ * alternative — importing everything ticked, including hosts the filter has
+ * hidden — would make "filter to SNMP, press Import Selected" quietly create
+ * the 2,890 ping-only devices the operator just filtered away, which is the
+ * exact outcome the issue is asking to avoid. Nothing is lost by it either:
+ * ticks on hidden hosts survive in state and come back with the filter, and
+ * the submit button's count is computed from this same list, so the number on
+ * the button always matches what the press will do.
+ *
+ * Duplicate addresses collapse to one device. A single checkbox is keyed by
+ * address and governs every row carrying it, so importing each row would
+ * create N devices from one tick. `discoveredDevices` is jsonb written from
+ * the probe's payload, so duplicates are a thing the page has to survive
+ * rather than a thing it can assume away.
+ */
+export function getDiscoveredHostsToImport(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+  selectedIpAddresses: Record<string, boolean>;
+}): Array<DiscoveredNetworkDevice> {
+  const seenIpAddresses: Set<string> = new Set<string>();
+
+  return filterDiscoveredHosts({
+    hosts: data.hosts,
+    filter: data.filter,
+  }).filter((host: DiscoveredNetworkDevice) => {
+    if (!isSelectableDiscoveredHost(host)) {
+      return false;
+    }
+
+    if (!data.selectedIpAddresses[host.ipAddress]) {
+      return false;
+    }
+
+    if (seenIpAddresses.has(host.ipAddress)) {
+      return false;
+    }
+
+    seenIpAddresses.add(host.ipAddress);
+
+    return true;
+  });
+}
+
+/**
+ * How many hosts the active filter offers a checkbox for.
+ *
+ * Deduplicated for the same reason as the import list: one address is one
+ * checkbox, so counting it twice would make "Select all" claim to tick more
+ * boxes than exist.
+ */
+export function countSelectableShownHosts(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+}): number {
+  const seenIpAddresses: Set<string> = new Set<string>();
+
+  for (const host of filterDiscoveredHosts({
+    hosts: data.hosts,
+    filter: data.filter,
+  })) {
+    if (isSelectableDiscoveredHost(host)) {
+      seenIpAddresses.add(host.ipAddress);
+    }
+  }
+
+  return seenIpAddresses.size;
+}
+
+/**
+ * True when every tickable host in the current view is already ticked.
+ *
+ * False for an empty view rather than vacuously true, so the bulk control
+ * reads "Select all" (and stays disabled) on a group with nothing to select,
+ * instead of offering to clear a selection that does not exist.
+ */
+export function areAllShownHostsSelected(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+  selectedIpAddresses: Record<string, boolean>;
+}): boolean {
+  const selectableCount: number = countSelectableShownHosts({
+    hosts: data.hosts,
+    filter: data.filter,
+  });
+
+  if (selectableCount === 0) {
+    return false;
+  }
+
+  return (
+    getDiscoveredHostsToImport({
+      hosts: data.hosts,
+      filter: data.filter,
+      selectedIpAddresses: data.selectedIpAddresses,
+    }).length === selectableCount
+  );
+}
+
+/**
+ * Selection after ticking (or clearing) every tickable host in the current
+ * view — the bulk control next to the filter.
+ *
+ * Scoped to the view and additive across views, following
+ * `RecommendationFilterUtil.toggleSelectionForGroup`: selecting all while the
+ * SNMP filter is active must not disturb ticks on ping-only hosts, because the
+ * operator's next move is usually to switch filters and import the other group
+ * too. Only a fully-selected view toggles off.
+ *
+ * This is what replaces "scroll 2,890 rows and uncheck them one at a time".
+ */
+export function toggleSelectionForShownHosts(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+  selectedIpAddresses: Record<string, boolean>;
+}): Record<string, boolean> {
+  const shouldClear: boolean = areAllShownHostsSelected(data);
+
+  const selection: Record<string, boolean> = { ...data.selectedIpAddresses };
+
+  for (const host of filterDiscoveredHosts({
+    hosts: data.hosts,
+    filter: data.filter,
+  })) {
+    if (!isSelectableDiscoveredHost(host)) {
+      continue;
+    }
+
+    selection[host.ipAddress] = !shouldClear;
+  }
+
+  return selection;
+}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -11,9 +11,15 @@ import Probe from "Common/Models/DatabaseModels/Probe";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import IconProp from "Common/Types/Icon/IconProp";
 import ObjectID from "Common/Types/ObjectID";
-import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
 import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import FilterButtons, {
+  FilterButtonOption,
+} from "Common/UI/Components/FilterButtons/FilterButtons";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import OneUptimeDate from "Common/Types/Date";
@@ -35,8 +41,23 @@ import {
 import NetworkDeviceMonitoringMethod from "Common/Types/NetworkDevice/NetworkDeviceMonitoringMethod";
 import {
   DiscoveryScanOutcome,
+  getDiscoveredHosts,
   summarizeDiscoveryScan,
 } from "../../Components/NetworkDevice/DiscoveryScanOutcome";
+import {
+  DiscoveredHostFilter,
+  DiscoveredHostFilterOption,
+  areAllShownHostsSelected,
+  countSelectableShownHosts,
+  filterDiscoveredHosts,
+  getDiscoveredHostFilterLabel,
+  getDiscoveredHostFilterOptions,
+  getDiscoveredHostsToImport,
+  getInitialSelection,
+  isPingOnlyDiscoveredHost,
+  markDiscoveredHostsAsRegistered,
+  toggleSelectionForShownHosts,
+} from "../../Components/NetworkDevice/DiscoveredHostFilter";
 import React, {
   Fragment,
   FunctionComponent,
@@ -46,20 +67,6 @@ import React, {
 } from "react";
 
 type DiscoveredDeviceEntry = DiscoveredNetworkDevice;
-
-type GetDiscoveredDevicesFunction = (
-  scan: NetworkDeviceDiscoveryScan | null,
-) => Array<DiscoveredDeviceEntry>;
-
-const getDiscoveredDevices: GetDiscoveredDevicesFunction = (
-  scan: NetworkDeviceDiscoveryScan | null,
-): Array<DiscoveredDeviceEntry> => {
-  const raw: unknown = scan?.discoveredDevices;
-  if (!raw || !Array.isArray(raw)) {
-    return [];
-  }
-  return raw as Array<DiscoveredDeviceEntry>;
-};
 
 const NetworkDeviceDiscovery: FunctionComponent<
   PageComponentProps
@@ -75,8 +82,25 @@ const NetworkDeviceDiscovery: FunctionComponent<
   const [scanToReview, setScanToReview] =
     useState<NetworkDeviceDiscoveryScan | null>(null);
   const [selectedIps, setSelectedIps] = useState<Record<string, boolean>>({});
+  /*
+   * Which group of hosts the dialog is showing — and, because Import is scoped
+   * to the view, which group Import brings in. See DiscoveredHostFilter.
+   */
+  const [hostFilter, setHostFilter] = useState<DiscoveredHostFilter>(
+    DiscoveredHostFilter.All,
+  );
   const [isImporting, setIsImporting] = useState<boolean>(false);
   const [importError, setImportError] = useState<string>("");
+  /*
+   * Addresses imported during this sitting. The scan's own
+   * `isAlreadyRegistered` flags were frozen when the probe uploaded its
+   * results, so without this the dialog would re-offer what it just imported
+   * — which now matters, because importing one group and then the other is
+   * the intended flow rather than an unusual one.
+   */
+  const [importedIpAddresses, setImportedIpAddresses] = useState<Set<string>>(
+    new Set<string>(),
+  );
 
   const fetchProbes: PromiseVoidFunction = async (): Promise<void> => {
     setIsLoading(true);
@@ -97,29 +121,40 @@ const NetworkDeviceDiscovery: FunctionComponent<
 
   type OpenReviewModalFunction = (scan: NetworkDeviceDiscoveryScan) => void;
 
+  type GetReviewHostsFunction = (
+    scan: NetworkDeviceDiscoveryScan | null,
+    imported?: Set<string>,
+  ) => Array<DiscoveredDeviceEntry>;
+
+  /*
+   * The list the dialog reasons about: what the probe found, with anything
+   * imported since the dialog opened flipped to already-registered. Every
+   * count, filter and import path goes through this so they cannot disagree
+   * about what is still importable.
+   */
+  const getReviewHosts: GetReviewHostsFunction = (
+    scan: NetworkDeviceDiscoveryScan | null,
+    imported?: Set<string>,
+  ): Array<DiscoveredDeviceEntry> => {
+    return markDiscoveredHostsAsRegistered({
+      hosts: getDiscoveredHosts(scan),
+      importedIpAddresses: imported || importedIpAddresses,
+    });
+  };
+
   const openReviewModal: OpenReviewModalFunction = (
     scan: NetworkDeviceDiscoveryScan,
   ): void => {
-    const entries: Array<DiscoveredDeviceEntry> = getDiscoveredDevices(scan);
-
+    setScanToReview(scan);
     /*
      * Preselect every host that is not already registered. Ping-only hosts
      * are included: they import as monitor-backed devices rather than as
      * SNMP-credentialed ones that could never be polled.
      */
-    const initialSelection: Record<string, boolean> = {};
-    for (const entry of entries) {
-      if (
-        entry.ipAddress &&
-        !entry.isAlreadyRegistered &&
-        isImportableDiscoveredHost(entry)
-      ) {
-        initialSelection[entry.ipAddress] = true;
-      }
-    }
-
-    setScanToReview(scan);
-    setSelectedIps(initialSelection);
+    setSelectedIps(getInitialSelection(getDiscoveredHosts(scan)));
+    // Every scan opens on the whole list; narrowing is the operator's move.
+    setHostFilter(DiscoveredHostFilter.All);
+    setImportedIpAddresses(new Set<string>());
     setImportError("");
     setShowReviewModal(true);
   };
@@ -128,6 +163,8 @@ const NetworkDeviceDiscovery: FunctionComponent<
     setShowReviewModal(false);
     setScanToReview(null);
     setSelectedIps({});
+    setHostFilter(DiscoveredHostFilter.All);
+    setImportedIpAddresses(new Set<string>());
     setImportError("");
   };
 
@@ -137,17 +174,17 @@ const NetworkDeviceDiscovery: FunctionComponent<
         return;
       }
 
+      /*
+       * Selected AND currently shown. Scoping to the active filter is what
+       * makes "show only SNMP, press Import" import only the SNMP devices
+       * instead of every ticked host in the scan (issue #3322).
+       */
       const entriesToImport: Array<DiscoveredDeviceEntry> =
-        getDiscoveredDevices(scanToReview).filter(
-          (entry: DiscoveredDeviceEntry) => {
-            return (
-              Boolean(entry.ipAddress) &&
-              !entry.isAlreadyRegistered &&
-              isImportableDiscoveredHost(entry) &&
-              Boolean(selectedIps[entry.ipAddress])
-            );
-          },
-        );
+        getDiscoveredHostsToImport({
+          hosts: getReviewHosts(scanToReview),
+          filter: hostFilter,
+          selectedIpAddresses: selectedIps,
+        });
 
       if (entriesToImport.length === 0) {
         return;
@@ -156,7 +193,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
       setIsImporting(true);
       setImportError("");
 
-      let successCount: number = 0;
+      const importedNow: Array<string> = [];
       const failures: Array<string> = [];
 
       for (const entry of entriesToImport) {
@@ -188,7 +225,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
               modelType: NetworkDevice,
             });
 
-            successCount++;
+            importedNow.push(entry.ipAddress);
             continue;
           }
 
@@ -238,13 +275,26 @@ const NetworkDeviceDiscovery: FunctionComponent<
             modelType: NetworkDevice,
           });
 
-          successCount++;
+          importedNow.push(entry.ipAddress);
         } catch (err) {
           failures.push(`${entry.ipAddress}: ${API.getFriendlyMessage(err)}`);
         }
       }
 
       setIsImporting(false);
+
+      const successCount: number = importedNow.length;
+
+      /*
+       * Retire what was imported so it cannot be imported a second time, and
+       * so the row shows "Already added" like any other registered host.
+       */
+      const importedAfterThisRun: Set<string> = new Set<string>([
+        ...importedIpAddresses,
+        ...importedNow,
+      ]);
+
+      setImportedIpAddresses(importedAfterThisRun);
 
       if (successCount > 0) {
         ShowToastNotification({
@@ -265,7 +315,19 @@ const NetworkDeviceDiscovery: FunctionComponent<
           type: ToastType.DANGER,
         });
         setImportError(failures.join(" "));
-      } else {
+      } else if (
+        /*
+         * Closing on success is right only when there is nothing left to do.
+         * Importing group by group means the usual case is now "the SNMP
+         * devices are in, the ping-only ones are still waiting" — closing
+         * there would throw away the review and make the operator reopen the
+         * scan to finish the job.
+         */
+        countSelectableShownHosts({
+          hosts: getReviewHosts(scanToReview, importedAfterThisRun),
+          filter: DiscoveredHostFilter.All,
+        }) === 0
+      ) {
         closeReviewModal();
       }
 
@@ -282,18 +344,44 @@ const NetworkDeviceDiscovery: FunctionComponent<
   }
 
   const reviewEntries: Array<DiscoveredDeviceEntry> =
-    getDiscoveredDevices(scanToReview);
+    getReviewHosts(scanToReview);
 
-  const selectedCount: number = reviewEntries.filter(
-    (entry: DiscoveredDeviceEntry) => {
-      return (
-        Boolean(entry.ipAddress) &&
-        !entry.isAlreadyRegistered &&
-        isImportableDiscoveredHost(entry) &&
-        Boolean(selectedIps[entry.ipAddress])
-      );
-    },
-  ).length;
+  // Group sizes come off the whole scan, so every button keeps its own count.
+  const hostFilterOptions: Array<FilterButtonOption> =
+    getDiscoveredHostFilterOptions(reviewEntries).map(
+      (option: DiscoveredHostFilterOption) => {
+        return {
+          label: option.label,
+          value: option.value,
+        };
+      },
+    );
+
+  const shownEntries: Array<DiscoveredDeviceEntry> = filterDiscoveredHosts({
+    hosts: reviewEntries,
+    filter: hostFilter,
+  });
+
+  /*
+   * What Import will actually create — selected AND shown — so the number on
+   * the button can never promise something other than what the press does.
+   */
+  const selectedCount: number = getDiscoveredHostsToImport({
+    hosts: reviewEntries,
+    filter: hostFilter,
+    selectedIpAddresses: selectedIps,
+  }).length;
+
+  const selectableShownCount: number = countSelectableShownHosts({
+    hosts: reviewEntries,
+    filter: hostFilter,
+  });
+
+  const areAllShownSelected: boolean = areAllShownHostsSelected({
+    hosts: reviewEntries,
+    filter: hostFilter,
+    selectedIpAddresses: selectedIps,
+  });
 
   return (
     <Fragment>
@@ -639,9 +727,15 @@ const NetworkDeviceDiscovery: FunctionComponent<
       {showReviewModal && scanToReview && (
         <Modal
           title="Review Discovered Devices"
+          /*
+           * This used to end "hosts without SNMP cannot be imported", which
+           * stopped being true when ping-only hosts started importing as
+           * monitor-backed devices — and reads as a flat contradiction next to
+           * a No SNMP filter that exists precisely to import them as a batch.
+           */
           description={`Hosts that responded in ${
             scanToReview.cidr || "the scanned address range"
-          }. Select the ones you want to import as Network Devices — hosts without SNMP cannot be imported.${
+          }. Filter to a group, pick the hosts you want, and import — SNMP hosts arrive as polled devices, hosts without SNMP as monitor-backed ones.${
             /*
              * The probe's summary of the sweep. Most valuable precisely when
              * this list is empty, which is the one case where the operator
@@ -663,12 +757,68 @@ const NetworkDeviceDiscovery: FunctionComponent<
           }}
         >
           <div>
+            {reviewEntries.length > 0 && (
+              <div className="mb-3 border-b border-gray-200 pb-3">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <FilterButtons
+                    options={hostFilterOptions}
+                    selectedValue={hostFilter}
+                    onSelect={(value: string) => {
+                      setHostFilter(value as DiscoveredHostFilter);
+                    }}
+                  />
+                  {/*
+                   * The answer to "2,890 hosts are pre-checked and I only want
+                   * the switches": clear this group, or take all of it, in one
+                   * press. Scoped to the group on screen, so using it on one
+                   * filter never disturbs the other.
+                   */}
+                  <Button
+                    title={
+                      areAllShownSelected
+                        ? `Clear all (${selectableShownCount.toLocaleString("en-US")})`
+                        : `Select all (${selectableShownCount.toLocaleString("en-US")})`
+                    }
+                    dataTestId="discovered-device-select-all"
+                    buttonStyle={ButtonStyleType.SECONDARY_LINK}
+                    buttonSize={ButtonSize.Small}
+                    disabled={selectableShownCount === 0 || isImporting}
+                    onClick={() => {
+                      setSelectedIps((current: Record<string, boolean>) => {
+                        return toggleSelectionForShownHosts({
+                          hosts: reviewEntries,
+                          filter: hostFilter,
+                          selectedIpAddresses: current,
+                        });
+                      });
+                    }}
+                  />
+                </div>
+                {/*
+                 * Import is scoped to the group on screen, and that has to be
+                 * said out loud: an operator who filters to SNMP and presses
+                 * Import needs to know both that the ping-only hosts are not
+                 * coming along, and that their ticks are still there when they
+                 * switch back.
+                 */}
+                <p className="mt-2 text-xs text-gray-500">
+                  {hostFilter === DiscoveredHostFilter.All
+                    ? `${selectedCount.toLocaleString("en-US")} of ${selectableShownCount.toLocaleString("en-US")} importable hosts selected.`
+                    : `${selectedCount.toLocaleString("en-US")} of ${selectableShownCount.toLocaleString("en-US")} importable ${getDiscoveredHostFilterLabel(hostFilter)} hosts selected. Import brings in this group only — selections in the other group are kept, so you can switch and import it too.`}
+                </p>
+              </div>
+            )}
             {reviewEntries.length === 0 && (
               <p className="text-sm text-gray-500">
-                This scan did not find any SNMP devices.
+                This scan did not find any responding hosts.
               </p>
             )}
-            {reviewEntries.map(
+            {reviewEntries.length > 0 && shownEntries.length === 0 && (
+              <p className="text-sm text-gray-500">
+                {`No ${getDiscoveredHostFilterLabel(hostFilter)} hosts in this scan.`}
+              </p>
+            )}
+            {shownEntries.map(
               (entry: DiscoveredDeviceEntry, index: number): ReactElement => {
                 /*
                  * Ping-only hosts (snmpReachable === false) import too, as
@@ -678,9 +828,11 @@ const NetworkDeviceDiscovery: FunctionComponent<
                  * (snmpReachable undefined) import as SNMP, as before.
                  */
                 const isImportable: boolean = isImportableDiscoveredHost(entry);
-                const isPingOnly: boolean =
-                  monitoringMethodForDiscoveredHost(entry) ===
-                  NetworkDeviceMonitoringMethod.Monitor;
+                /*
+                 * Same predicate the No SNMP filter groups by, so a badged row
+                 * and a filtered row can never be different sets.
+                 */
+                const isPingOnly: boolean = isPingOnlyDiscoveredHost(entry);
                 return (
                   <div
                     key={`${entry.ipAddress}-${index}`}

--- a/App/Tests/Dashboard/DiscoveredHostFilter.test.ts
+++ b/App/Tests/Dashboard/DiscoveredHostFilter.test.ts
@@ -1,0 +1,1260 @@
+import { describe, expect, test } from "@jest/globals";
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import {
+  DiscoveredHostCounts,
+  DiscoveredHostFilter,
+  DiscoveredHostFilterOption,
+  areAllShownHostsSelected,
+  countDiscoveredHosts,
+  countSelectableShownHosts,
+  filterDiscoveredHosts,
+  getDiscoveredHostFilterLabel,
+  getDiscoveredHostFilterOptions,
+  getDiscoveredHostsToImport,
+  getInitialSelection,
+  isPingOnlyDiscoveredHost,
+  isSelectableDiscoveredHost,
+  markDiscoveredHostsAsRegistered,
+  matchesDiscoveredHostFilter,
+  toggleSelectionForShownHosts,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
+
+/*
+ * The rules behind the SNMP / No SNMP filter in the Review Discovered Devices
+ * dialog (issue #3322).
+ *
+ * Everything here fails silently in production if it is wrong: a filter that
+ * puts a host in the wrong group, a count badge that disagrees with the list
+ * under it, a "Select all" that reaches outside the group on screen, or — the
+ * expensive one — an Import that creates the 2,890 ping-only devices the
+ * operator just filtered away. All of those render perfectly.
+ */
+
+/** An SNMP responder: answered the walk, so it imports as a polled device. */
+function snmpHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    sysName: `switch-${ipAddress}`,
+    snmpReachable: true,
+    ...overrides,
+  };
+}
+
+/** Answered ping, not SNMP — the "No SNMP" badge group. */
+function pingOnlyHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    snmpReachable: false,
+    ...overrides,
+  };
+}
+
+/*
+ * A row from a scan stored before `snmpReachable` existed. Every host on those
+ * scans answered SNMP — ping-only sweeps did not exist yet — so `undefined`
+ * has to read as SNMP everywhere, not as ping-only.
+ */
+function legacyHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    sysName: `legacy-${ipAddress}`,
+    ...overrides,
+  };
+}
+
+function ipAddressesOf(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+  return hosts.map((host: DiscoveredNetworkDevice) => {
+    return host.ipAddress;
+  });
+}
+
+/** Everything selected — the state the dialog opens in. */
+function selectAll(
+  hosts: Array<DiscoveredNetworkDevice>,
+): Record<string, boolean> {
+  return getInitialSelection(hosts);
+}
+
+describe("isPingOnlyDiscoveredHost", () => {
+  test("explicit snmpReachable false is ping-only", () => {
+    expect(isPingOnlyDiscoveredHost(pingOnlyHost("10.0.0.42"))).toBe(true);
+  });
+
+  test("an SNMP responder is not ping-only", () => {
+    expect(isPingOnlyDiscoveredHost(snmpHost("10.0.0.5"))).toBe(false);
+  });
+
+  test("a legacy row with no snmpReachable is not ping-only", () => {
+    expect(isPingOnlyDiscoveredHost(legacyHost("10.0.0.9"))).toBe(false);
+    expect(
+      isPingOnlyDiscoveredHost({
+        ipAddress: "10.0.0.10",
+        snmpReachable: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  test("already-registered hosts still belong to a group", () => {
+    /*
+     * Registration is orthogonal to which group a host is in. Reading it as
+     * "not in either group" would drop rows out of the counts they are
+     * rendered under.
+     */
+    expect(
+      isPingOnlyDiscoveredHost(
+        pingOnlyHost("10.0.0.42", { isAlreadyRegistered: true }),
+      ),
+    ).toBe(true);
+    expect(
+      isPingOnlyDiscoveredHost(
+        snmpHost("10.0.0.5", { isAlreadyRegistered: true }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("matchesDiscoveredHostFilter", () => {
+  test("All keeps every host, whatever it answered", () => {
+    for (const host of [
+      snmpHost("10.0.0.5"),
+      pingOnlyHost("10.0.0.42"),
+      legacyHost("10.0.0.9"),
+    ]) {
+      expect(
+        matchesDiscoveredHostFilter({
+          host: host,
+          filter: DiscoveredHostFilter.All,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("Snmp keeps SNMP responders and legacy rows, drops ping-only", () => {
+    expect(
+      matchesDiscoveredHostFilter({
+        host: snmpHost("10.0.0.5"),
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(true);
+    expect(
+      matchesDiscoveredHostFilter({
+        host: legacyHost("10.0.0.9"),
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(true);
+    expect(
+      matchesDiscoveredHostFilter({
+        host: pingOnlyHost("10.0.0.42"),
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(false);
+  });
+
+  test("NoSnmp keeps only explicit ping-only hosts", () => {
+    expect(
+      matchesDiscoveredHostFilter({
+        host: pingOnlyHost("10.0.0.42"),
+        filter: DiscoveredHostFilter.NoSnmp,
+      }),
+    ).toBe(true);
+    expect(
+      matchesDiscoveredHostFilter({
+        host: snmpHost("10.0.0.5"),
+        filter: DiscoveredHostFilter.NoSnmp,
+      }),
+    ).toBe(false);
+    expect(
+      matchesDiscoveredHostFilter({
+        host: legacyHost("10.0.0.9"),
+        filter: DiscoveredHostFilter.NoSnmp,
+      }),
+    ).toBe(false);
+  });
+
+  test("the two groups partition the list — never both, never neither", () => {
+    for (const host of [
+      snmpHost("10.0.0.5"),
+      pingOnlyHost("10.0.0.42"),
+      legacyHost("10.0.0.9"),
+      { ipAddress: "10.0.0.11" },
+    ]) {
+      const inSnmp: boolean = matchesDiscoveredHostFilter({
+        host: host,
+        filter: DiscoveredHostFilter.Snmp,
+      });
+      const inNoSnmp: boolean = matchesDiscoveredHostFilter({
+        host: host,
+        filter: DiscoveredHostFilter.NoSnmp,
+      });
+
+      expect(inSnmp).toBe(!inNoSnmp);
+    }
+  });
+});
+
+describe("filterDiscoveredHosts", () => {
+  const hosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    legacyHost("10.0.0.3"),
+    pingOnlyHost("10.0.0.4"),
+    snmpHost("10.0.0.5"),
+  ];
+
+  test("All returns the whole list", () => {
+    expect(
+      ipAddressesOf(
+        filterDiscoveredHosts({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.All,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"]);
+  });
+
+  test("Snmp returns responders and legacy rows in scan order", () => {
+    /*
+     * Order is the probe's address order. Re-sorting would move rows under the
+     * operator's cursor every time the filter changed.
+     */
+    expect(
+      ipAddressesOf(
+        filterDiscoveredHosts({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.Snmp,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.3", "10.0.0.5"]);
+  });
+
+  test("NoSnmp returns ping-only hosts in scan order", () => {
+    expect(
+      ipAddressesOf(
+        filterDiscoveredHosts({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.NoSnmp,
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.4"]);
+  });
+
+  test("an empty scan filters to nothing under every filter", () => {
+    for (const filter of [
+      DiscoveredHostFilter.All,
+      DiscoveredHostFilter.Snmp,
+      DiscoveredHostFilter.NoSnmp,
+    ]) {
+      expect(filterDiscoveredHosts({ hosts: [], filter: filter })).toEqual([]);
+    }
+  });
+
+  test("the scan's own array is never mutated", () => {
+    const original: Array<DiscoveredNetworkDevice> = [...hosts];
+
+    filterDiscoveredHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.NoSnmp,
+    });
+
+    expect(hosts).toEqual(original);
+  });
+});
+
+describe("countDiscoveredHosts", () => {
+  test("counts each group, legacy rows counted as SNMP", () => {
+    const counts: DiscoveredHostCounts = countDiscoveredHosts([
+      snmpHost("10.0.0.1"),
+      snmpHost("10.0.0.2"),
+      legacyHost("10.0.0.3"),
+      pingOnlyHost("10.0.0.4"),
+    ]);
+
+    expect(counts).toEqual({ all: 4, snmp: 3, noSnmp: 1 });
+  });
+
+  test("already-registered hosts are counted — the badge is a group size", () => {
+    /*
+     * The badge is checked against the probe's own ICMP/SNMP tallies. Hiding
+     * rows for a reason the badge cannot show would make the two disagree.
+     */
+    const counts: DiscoveredHostCounts = countDiscoveredHosts([
+      snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+      pingOnlyHost("10.0.0.2", { isAlreadyRegistered: true }),
+    ]);
+
+    expect(counts).toEqual({ all: 2, snmp: 1, noSnmp: 1 });
+  });
+
+  test("an empty scan counts zero everywhere", () => {
+    expect(countDiscoveredHosts([])).toEqual({ all: 0, snmp: 0, noSnmp: 0 });
+  });
+
+  test("the two groups always add up to the total", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      legacyHost("10.0.0.3"),
+      { ipAddress: "10.0.0.4", snmpReachable: undefined },
+      pingOnlyHost("10.0.0.5", { isAlreadyRegistered: true }),
+    ];
+
+    const counts: DiscoveredHostCounts = countDiscoveredHosts(hosts);
+
+    expect(counts.snmp + counts.noSnmp).toBe(counts.all);
+    expect(counts.all).toBe(hosts.length);
+  });
+
+  test("counts agree with what the filter actually shows", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      legacyHost("10.0.0.3"),
+    ];
+
+    const counts: DiscoveredHostCounts = countDiscoveredHosts(hosts);
+
+    expect(
+      filterDiscoveredHosts({ hosts: hosts, filter: DiscoveredHostFilter.Snmp })
+        .length,
+    ).toBe(counts.snmp);
+    expect(
+      filterDiscoveredHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.NoSnmp,
+      }).length,
+    ).toBe(counts.noSnmp);
+  });
+});
+
+describe("getDiscoveredHostFilterLabel", () => {
+  test("groups are named the way the row badge names them", () => {
+    // "No SNMP" is the exact wording on the per-row pill.
+    expect(getDiscoveredHostFilterLabel(DiscoveredHostFilter.All)).toBe("All");
+    expect(getDiscoveredHostFilterLabel(DiscoveredHostFilter.Snmp)).toBe(
+      "SNMP",
+    );
+    expect(getDiscoveredHostFilterLabel(DiscoveredHostFilter.NoSnmp)).toBe(
+      "No SNMP",
+    );
+  });
+});
+
+describe("getDiscoveredHostFilterOptions", () => {
+  test("three buttons, All first, each carrying its group size", () => {
+    const options: Array<DiscoveredHostFilterOption> =
+      getDiscoveredHostFilterOptions([
+        snmpHost("10.0.0.1"),
+        snmpHost("10.0.0.2"),
+        pingOnlyHost("10.0.0.3"),
+      ]);
+
+    expect(
+      options.map((option: DiscoveredHostFilterOption) => {
+        return option.value;
+      }),
+    ).toEqual([
+      DiscoveredHostFilter.All,
+      DiscoveredHostFilter.Snmp,
+      DiscoveredHostFilter.NoSnmp,
+    ]);
+
+    expect(
+      options.map((option: DiscoveredHostFilterOption) => {
+        return option.label;
+      }),
+    ).toEqual(["All (3)", "SNMP (2)", "No SNMP (1)"]);
+
+    expect(
+      options.map((option: DiscoveredHostFilterOption) => {
+        return option.count;
+      }),
+    ).toEqual([3, 2, 1]);
+  });
+
+  test("an empty group still renders its zero", () => {
+    /*
+     * "SNMP (0)" is the answer to "did this sweep find any switches at all".
+     * A button that hid its zero would look identical to one with results
+     * behind it.
+     */
+    const options: Array<DiscoveredHostFilterOption> =
+      getDiscoveredHostFilterOptions([pingOnlyHost("10.0.0.3")]);
+
+    expect(
+      options.map((option: DiscoveredHostFilterOption) => {
+        return option.label;
+      }),
+    ).toEqual(["All (1)", "SNMP (0)", "No SNMP (1)"]);
+  });
+
+  test("an empty scan reads zero on all three", () => {
+    expect(
+      getDiscoveredHostFilterOptions([]).map(
+        (option: DiscoveredHostFilterOption) => {
+          return option.label;
+        },
+      ),
+    ).toEqual(["All (0)", "SNMP (0)", "No SNMP (0)"]);
+  });
+
+  test("four-digit counts are grouped, which is the whole point at scan scale", () => {
+    /*
+     * The numbers from issue #3322: a sweep of 17,850 addresses that came back
+     * with 2,866 SNMP hosts and 2,890 ping-only ones. At that size 2866 and
+     * 2,866 are not equally easy to check against the probe's own tally.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [];
+
+    for (let index: number = 0; index < 2866; index++) {
+      hosts.push(snmpHost(`10.1.${Math.floor(index / 256)}.${index % 256}`));
+    }
+
+    for (let index: number = 0; index < 2890; index++) {
+      hosts.push(
+        pingOnlyHost(`10.2.${Math.floor(index / 256)}.${index % 256}`),
+      );
+    }
+
+    expect(
+      getDiscoveredHostFilterOptions(hosts).map(
+        (option: DiscoveredHostFilterOption) => {
+          return option.label;
+        },
+      ),
+    ).toEqual(["All (5,756)", "SNMP (2,866)", "No SNMP (2,890)"]);
+  });
+});
+
+describe("isSelectableDiscoveredHost", () => {
+  test("a fresh SNMP host is selectable", () => {
+    expect(isSelectableDiscoveredHost(snmpHost("10.0.0.5"))).toBe(true);
+  });
+
+  test("a fresh ping-only host is selectable — it imports as monitor-backed", () => {
+    expect(isSelectableDiscoveredHost(pingOnlyHost("10.0.0.42"))).toBe(true);
+  });
+
+  test("an already-registered host is not selectable", () => {
+    expect(
+      isSelectableDiscoveredHost(
+        snmpHost("10.0.0.5", { isAlreadyRegistered: true }),
+      ),
+    ).toBe(false);
+    expect(
+      isSelectableDiscoveredHost(
+        pingOnlyHost("10.0.0.42", { isAlreadyRegistered: true }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a host with no address is not selectable", () => {
+    /*
+     * The address is both the device's hostname and the selection key, so a
+     * blank one has nothing to tick and nothing to import.
+     */
+    expect(
+      isSelectableDiscoveredHost({ ipAddress: "", snmpReachable: true }),
+    ).toBe(false);
+  });
+});
+
+describe("markDiscoveredHostsAsRegistered", () => {
+  const hosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    snmpHost("10.0.0.3"),
+  ];
+
+  test("nothing imported yet leaves the list exactly as it was", () => {
+    expect(
+      markDiscoveredHostsAsRegistered({
+        hosts: hosts,
+        importedIpAddresses: new Set<string>(),
+      }),
+    ).toBe(hosts);
+  });
+
+  test("imported addresses come back already-registered", () => {
+    const marked: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: hosts,
+        importedIpAddresses: new Set<string>(["10.0.0.1", "10.0.0.3"]),
+      });
+
+    expect(marked[0]!.isAlreadyRegistered).toBe(true);
+    expect(marked[1]!.isAlreadyRegistered).toBeUndefined();
+    expect(marked[2]!.isAlreadyRegistered).toBe(true);
+  });
+
+  test("the scan's own objects are not mutated", () => {
+    markDiscoveredHostsAsRegistered({
+      hosts: hosts,
+      importedIpAddresses: new Set<string>(["10.0.0.1"]),
+    });
+
+    expect(hosts[0]!.isAlreadyRegistered).toBeUndefined();
+  });
+
+  test("an address that is not in the scan changes nothing", () => {
+    const marked: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: hosts,
+        importedIpAddresses: new Set<string>(["192.168.99.99"]),
+      });
+
+    expect(
+      marked.filter((host: DiscoveredNetworkDevice) => {
+        return host.isAlreadyRegistered;
+      }),
+    ).toEqual([]);
+  });
+
+  test("marking retires the host from selection and import", () => {
+    const marked: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: hosts,
+        importedIpAddresses: new Set<string>(["10.0.0.1"]),
+      });
+
+    expect(isSelectableDiscoveredHost(marked[0]!)).toBe(false);
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: marked,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: selectAll(hosts),
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.3"]);
+  });
+
+  test("group membership survives being marked", () => {
+    const marked: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: hosts,
+        importedIpAddresses: new Set<string>(["10.0.0.1", "10.0.0.2"]),
+      });
+
+    expect(countDiscoveredHosts(marked)).toEqual({
+      all: 3,
+      snmp: 2,
+      noSnmp: 1,
+    });
+  });
+});
+
+describe("getInitialSelection", () => {
+  test("everything importable opens pre-checked, both groups", () => {
+    expect(
+      getInitialSelection([snmpHost("10.0.0.1"), pingOnlyHost("10.0.0.2")]),
+    ).toEqual({ "10.0.0.1": true, "10.0.0.2": true });
+  });
+
+  test("already-registered hosts are not pre-checked", () => {
+    expect(
+      getInitialSelection([
+        snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+        snmpHost("10.0.0.2"),
+      ]),
+    ).toEqual({ "10.0.0.2": true });
+  });
+
+  test("a blank address never becomes a selection key", () => {
+    expect(
+      getInitialSelection([
+        { ipAddress: "", snmpReachable: true },
+        snmpHost("10.0.0.2"),
+      ]),
+    ).toEqual({ "10.0.0.2": true });
+  });
+
+  test("an empty scan selects nothing", () => {
+    expect(getInitialSelection([])).toEqual({});
+  });
+});
+
+describe("getDiscoveredHostsToImport", () => {
+  const hosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    legacyHost("10.0.0.3"),
+    pingOnlyHost("10.0.0.4"),
+  ];
+
+  test("All imports every selected host", () => {
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: selectAll(hosts),
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"]);
+  });
+
+  test("filtering to SNMP imports only the SNMP group, even with everything ticked", () => {
+    /*
+     * This is issue #3322 in one assertion. The dialog opens with every host
+     * pre-checked; if Import ignored the filter, narrowing to SNMP and pressing
+     * it would still create the ping-only devices the operator just filtered
+     * away — at scan scale, thousands of them.
+     */
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.Snmp,
+          selectedIpAddresses: selectAll(hosts),
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.3"]);
+  });
+
+  test("filtering to No SNMP imports only the ping-only group", () => {
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: selectAll(hosts),
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.4"]);
+  });
+
+  test("a host hidden by the filter keeps its tick for later", () => {
+    // Filtering is a view, not a deselection — the ticks survive the round trip.
+    const selection: Record<string, boolean> = selectAll(hosts);
+
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.Snmp,
+          selectedIpAddresses: selection,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.3"]);
+
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: selection,
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.4"]);
+  });
+
+  test("unticked hosts are left behind", () => {
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: { "10.0.0.1": true, "10.0.0.4": false },
+        }),
+      ),
+    ).toEqual(["10.0.0.1"]);
+  });
+
+  test("an empty selection imports nothing", () => {
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual([]);
+  });
+
+  test("already-registered hosts are never imported, ticked or not", () => {
+    const withRegistered: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+      snmpHost("10.0.0.2"),
+    ];
+
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: withRegistered,
+          filter: DiscoveredHostFilter.All,
+          // A stale tick, e.g. from an import that happened in another tab.
+          selectedIpAddresses: { "10.0.0.1": true, "10.0.0.2": true },
+        }),
+      ),
+    ).toEqual(["10.0.0.2"]);
+  });
+
+  test("a blank address is never imported", () => {
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: [{ ipAddress: "", snmpReachable: true }],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: { "": true },
+      }),
+    ).toEqual([]);
+  });
+
+  test("a duplicated address imports once, not once per row", () => {
+    /*
+     * `discoveredDevices` is jsonb written from the probe's payload, and one
+     * checkbox is keyed by address — so two rows sharing an address share a
+     * tick. Importing both would create two devices from one tick.
+     */
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: [
+            snmpHost("10.0.0.1"),
+            snmpHost("10.0.0.1", { sysName: "same-box-again" }),
+            snmpHost("10.0.0.2"),
+          ],
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: { "10.0.0.1": true, "10.0.0.2": true },
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.2"]);
+  });
+
+  test("the first row of a duplicated address is the one imported", () => {
+    const imported: Array<DiscoveredNetworkDevice> = getDiscoveredHostsToImport(
+      {
+        hosts: [
+          snmpHost("10.0.0.1", { sysName: "first" }),
+          snmpHost("10.0.0.1", { sysName: "second" }),
+        ],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: { "10.0.0.1": true },
+      },
+    );
+
+    expect(imported).toHaveLength(1);
+    expect(imported[0]!.sysName).toBe("first");
+  });
+
+  test("import order follows the scan, not the selection", () => {
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: {
+            "10.0.0.4": true,
+            "10.0.0.1": true,
+            "10.0.0.3": true,
+          },
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.3", "10.0.0.4"]);
+  });
+
+  test("the button's count is the import list's length, by construction", () => {
+    for (const filter of [
+      DiscoveredHostFilter.All,
+      DiscoveredHostFilter.Snmp,
+      DiscoveredHostFilter.NoSnmp,
+    ]) {
+      const selection: Record<string, boolean> = selectAll(hosts);
+
+      expect(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: filter,
+          selectedIpAddresses: selection,
+        }).length,
+      ).toBe(
+        filterDiscoveredHosts({ hosts: hosts, filter: filter }).filter(
+          (host: DiscoveredNetworkDevice) => {
+            return isSelectableDiscoveredHost(host);
+          },
+        ).length,
+      );
+    }
+  });
+});
+
+describe("countSelectableShownHosts", () => {
+  test("counts only what the current filter shows", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      pingOnlyHost("10.0.0.3"),
+    ];
+
+    expect(
+      countSelectableShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(3);
+    expect(
+      countSelectableShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(1);
+    expect(
+      countSelectableShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.NoSnmp,
+      }),
+    ).toBe(2);
+  });
+
+  test("already-registered and blank-address hosts do not count", () => {
+    expect(
+      countSelectableShownHosts({
+        hosts: [
+          snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+          { ipAddress: "", snmpReachable: true },
+          snmpHost("10.0.0.2"),
+        ],
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(1);
+  });
+
+  test("a duplicated address counts once — one address is one checkbox", () => {
+    expect(
+      countSelectableShownHosts({
+        hosts: [snmpHost("10.0.0.1"), snmpHost("10.0.0.1")],
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(1);
+  });
+
+  test("an empty group counts zero", () => {
+    expect(
+      countSelectableShownHosts({
+        hosts: [pingOnlyHost("10.0.0.2")],
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("areAllShownHostsSelected", () => {
+  const hosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+  ];
+
+  test("true when every tickable host on screen is ticked", () => {
+    expect(
+      areAllShownHostsSelected({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: selectAll(hosts),
+      }),
+    ).toBe(true);
+  });
+
+  test("false when one is missing", () => {
+    expect(
+      areAllShownHostsSelected({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: { "10.0.0.1": true },
+      }),
+    ).toBe(false);
+  });
+
+  test("judged per group, so a filtered view can be full while the scan is not", () => {
+    expect(
+      areAllShownHostsSelected({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: { "10.0.0.1": true },
+      }),
+    ).toBe(true);
+    expect(
+      areAllShownHostsSelected({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: { "10.0.0.1": true },
+      }),
+    ).toBe(false);
+  });
+
+  test("false for a group with nothing to select, not vacuously true", () => {
+    /*
+     * Otherwise the bulk control would read "Clear all" over an empty group and
+     * offer to clear a selection that does not exist.
+     */
+    expect(
+      areAllShownHostsSelected({
+        hosts: [pingOnlyHost("10.0.0.2")],
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: {},
+      }),
+    ).toBe(false);
+    expect(
+      areAllShownHostsSelected({
+        hosts: [],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toBe(false);
+  });
+
+  test("a group of nothing-but-registered hosts is not 'all selected'", () => {
+    expect(
+      areAllShownHostsSelected({
+        hosts: [snmpHost("10.0.0.1", { isAlreadyRegistered: true })],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: { "10.0.0.1": true },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("toggleSelectionForShownHosts", () => {
+  const hosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    snmpHost("10.0.0.2"),
+    pingOnlyHost("10.0.0.3"),
+    pingOnlyHost("10.0.0.4"),
+  ];
+
+  test("a partly-selected group fills up rather than clearing", () => {
+    expect(
+      toggleSelectionForShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: { "10.0.0.1": true },
+      }),
+    ).toEqual({ "10.0.0.1": true, "10.0.0.2": true });
+  });
+
+  test("a full group clears", () => {
+    expect(
+      toggleSelectionForShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: { "10.0.0.1": true, "10.0.0.2": true },
+      }),
+    ).toEqual({ "10.0.0.1": false, "10.0.0.2": false });
+  });
+
+  test("clearing the SNMP group leaves the ping-only ticks alone", () => {
+    /*
+     * The scenario from the issue: 2,890 pre-checked ping-only hosts you do
+     * want and 2,866 SNMP ones you do not (or the other way round). Clearing
+     * one group has to be exactly that — clearing one group.
+     */
+    expect(
+      toggleSelectionForShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selectAll(hosts),
+      }),
+    ).toEqual({
+      "10.0.0.1": false,
+      "10.0.0.2": false,
+      "10.0.0.3": true,
+      "10.0.0.4": true,
+    });
+  });
+
+  test("selecting all is additive across groups", () => {
+    const afterSnmp: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.Snmp,
+      selectedIpAddresses: {},
+    });
+
+    const afterBoth: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.NoSnmp,
+      selectedIpAddresses: afterSnmp,
+    });
+
+    expect(afterBoth).toEqual({
+      "10.0.0.1": true,
+      "10.0.0.2": true,
+      "10.0.0.3": true,
+      "10.0.0.4": true,
+    });
+  });
+
+  test("All selects everything, then clears everything", () => {
+    const selected: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.All,
+      selectedIpAddresses: {},
+    });
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: selected,
+      }),
+    ).toHaveLength(4);
+
+    const cleared: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.All,
+      selectedIpAddresses: selected,
+    });
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: cleared,
+      }),
+    ).toEqual([]);
+  });
+
+  test("hosts that cannot be ticked are not given a key", () => {
+    expect(
+      toggleSelectionForShownHosts({
+        hosts: [
+          snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+          { ipAddress: "", snmpReachable: true },
+          snmpHost("10.0.0.2"),
+        ],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual({ "10.0.0.2": true });
+  });
+
+  test("a group with nothing to select is left untouched", () => {
+    expect(
+      toggleSelectionForShownHosts({
+        hosts: [pingOnlyHost("10.0.0.3")],
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: { "10.0.0.3": true },
+      }),
+    ).toEqual({ "10.0.0.3": true });
+  });
+
+  test("the caller's selection object is not mutated", () => {
+    const selection: Record<string, boolean> = { "10.0.0.1": true };
+
+    toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.All,
+      selectedIpAddresses: selection,
+    });
+
+    expect(selection).toEqual({ "10.0.0.1": true });
+  });
+});
+
+describe("the review-and-import flow the filter exists for", () => {
+  /*
+   * Issue #3322's scan, scaled down but shaped the same: a mixed list, all
+   * pre-checked, where the operator wants the switches first and the
+   * ICMP-only hosts later — without unchecking anything by hand.
+   */
+  const scan: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    snmpHost("10.0.0.3", { isAlreadyRegistered: true }),
+    pingOnlyHost("10.0.0.4"),
+    legacyHost("10.0.0.5"),
+  ];
+
+  test("import the SNMP group, then the rest, with no manual unchecking", () => {
+    const selection: Record<string, boolean> = getInitialSelection(scan);
+
+    // Narrow to SNMP: the ping-only hosts are out of scope for this press.
+    const snmpImport: Array<DiscoveredNetworkDevice> =
+      getDiscoveredHostsToImport({
+        hosts: scan,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selection,
+      });
+
+    expect(ipAddressesOf(snmpImport)).toEqual(["10.0.0.1", "10.0.0.5"]);
+
+    // Those are in now, so they retire from the dialog.
+    const afterSnmpImport: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: scan,
+        importedIpAddresses: new Set<string>(ipAddressesOf(snmpImport)),
+      });
+
+    expect(
+      countSelectableShownHosts({
+        hosts: afterSnmpImport,
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(0);
+
+    // Pressing Import again on the same group would create nothing.
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: afterSnmpImport,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selection,
+      }),
+    ).toEqual([]);
+
+    // The other group is untouched and still ticked.
+    const noSnmpImport: Array<DiscoveredNetworkDevice> =
+      getDiscoveredHostsToImport({
+        hosts: afterSnmpImport,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: selection,
+      });
+
+    expect(ipAddressesOf(noSnmpImport)).toEqual(["10.0.0.2", "10.0.0.4"]);
+
+    // And once it goes in too, there is nothing importable left anywhere.
+    const afterBoth: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: scan,
+        importedIpAddresses: new Set<string>([
+          ...ipAddressesOf(snmpImport),
+          ...ipAddressesOf(noSnmpImport),
+        ]),
+      });
+
+    expect(
+      countSelectableShownHosts({
+        hosts: afterBoth,
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(0);
+  });
+
+  test("take only the ping-only group and drop the switches in one press", () => {
+    const cleared: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: scan,
+      filter: DiscoveredHostFilter.Snmp,
+      selectedIpAddresses: getInitialSelection(scan),
+    });
+
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: cleared,
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.4"]);
+  });
+
+  test("a host already in the inventory is offered by neither group", () => {
+    for (const filter of [
+      DiscoveredHostFilter.All,
+      DiscoveredHostFilter.Snmp,
+      DiscoveredHostFilter.NoSnmp,
+    ]) {
+      expect(
+        ipAddressesOf(
+          getDiscoveredHostsToImport({
+            hosts: scan,
+            filter: filter,
+            selectedIpAddresses: { "10.0.0.3": true },
+          }),
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  test("group sizes stay put no matter what gets imported or selected", () => {
+    /*
+     * The badges describe the sweep, not the operator's progress through it.
+     * A count that shrank as things were imported would stop matching the
+     * probe's own ICMP/SNMP tallies, which is what they get checked against.
+     */
+    const afterImport: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: scan,
+        importedIpAddresses: new Set<string>(["10.0.0.1", "10.0.0.2"]),
+      });
+
+    expect(countDiscoveredHosts(afterImport)).toEqual(
+      countDiscoveredHosts(scan),
+    );
+  });
+});
+
+describe("hosts at scan scale", () => {
+  /*
+   * The dialog's job at the size #3322 reports. Nothing here is a performance
+   * assertion — it is a correctness one: the arithmetic has to survive four
+   * digits, and "select all" has to mean the group, not the scan.
+   */
+  const snmpCount: number = 2866;
+  const pingOnlyCount: number = 2890;
+
+  function bigScan(): Array<DiscoveredNetworkDevice> {
+    const hosts: Array<DiscoveredNetworkDevice> = [];
+
+    for (let index: number = 0; index < snmpCount; index++) {
+      hosts.push(snmpHost(`10.1.${Math.floor(index / 256)}.${index % 256}`));
+    }
+
+    for (let index: number = 0; index < pingOnlyCount; index++) {
+      hosts.push(
+        pingOnlyHost(`10.2.${Math.floor(index / 256)}.${index % 256}`),
+      );
+    }
+
+    return hosts;
+  }
+
+  test("both groups are counted independently and add up", () => {
+    expect(countDiscoveredHosts(bigScan())).toEqual({
+      all: snmpCount + pingOnlyCount,
+      snmp: snmpCount,
+      noSnmp: pingOnlyCount,
+    });
+  });
+
+  test("importing the SNMP group leaves every ping-only host behind", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = bigScan();
+
+    const toImport: Array<DiscoveredNetworkDevice> = getDiscoveredHostsToImport(
+      {
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: getInitialSelection(hosts),
+      },
+    );
+
+    expect(toImport).toHaveLength(snmpCount);
+    expect(
+      toImport.filter((host: DiscoveredNetworkDevice) => {
+        return isPingOnlyDiscoveredHost(host);
+      }),
+    ).toEqual([]);
+  });
+
+  test("one press clears all 2,866 pre-checked SNMP hosts", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = bigScan();
+
+    const cleared: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.Snmp,
+      selectedIpAddresses: getInitialSelection(hosts),
+    });
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: cleared,
+      }),
+    ).toHaveLength(pingOnlyCount);
+  });
+});

--- a/App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * The SNMP / No SNMP filter added for issue #3322 is only half a feature in
+ * DiscoveredHostFilter.ts. The other half is the wiring in Discovery.tsx, and
+ * that half has one failure mode that costs real money:
+ *
+ *   Import must be scoped to the group on screen. The dialog opens with every
+ *   host pre-checked, so if the Import path stops going through
+ *   `getDiscoveredHostsToImport` with the ACTIVE filter — if someone
+ *   "simplifies" it back to filtering `selectedIps` inline, as it did before —
+ *   then narrowing to SNMP and pressing Import silently creates the thousands
+ *   of ping-only devices the operator just filtered away. Nothing throws. The
+ *   toast even says it succeeded.
+ *
+ * Its twin: the count on the submit button has to be computed the same way, or
+ * the button promises one number and the press does another.
+ *
+ * The App suite runs in a plain Node environment with no React renderer (see
+ * jest.config.json), so the dialog cannot be mounted and clicked. This pins
+ * the JSX wiring at source level instead, the same fs/path approach
+ * InventoryTableInvariants.test.ts and NetworkFormStepsInvariants.test.ts use.
+ * Whitespace is squashed so Prettier can reflow props without making the test
+ * brittle, and comments are stripped so that describing a rule in prose never
+ * counts as implementing it.
+ */
+
+const DISCOVERY_PAGE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "NetworkDevice",
+  "Discovery.tsx",
+);
+
+function readSource(): string {
+  return fs.readFileSync(DISCOVERY_PAGE, "utf8");
+}
+
+function squash(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/** The page with comments removed and whitespace squashed to single spaces. */
+function readCode(): string {
+  return squash(stripComments(readSource()));
+}
+
+/** The body of `importSelectedDevices`, up to the render return. */
+function importSection(): string {
+  const code: string = readCode();
+
+  return code.slice(
+    code.indexOf("const importSelectedDevices"),
+    code.indexOf("if (isLoading)"),
+  );
+}
+
+/** Everything the Review Discovered Devices modal renders. */
+function modalSection(): string {
+  const code: string = readCode();
+
+  return code.slice(code.indexOf('title="Review Discovered Devices"'));
+}
+
+describe("the Review Discovered Devices dialog imports only what it is showing", () => {
+  test("the import path goes through the filter-scoped helper", () => {
+    const section: string = importSection();
+
+    expect(section).toContain("getDiscoveredHostsToImport({");
+    expect(section).toContain("filter: hostFilter");
+  });
+
+  test("import does not re-implement the selection rule inline", () => {
+    /*
+     * The predicate this replaced — `entry.ipAddress && !isAlreadyRegistered
+     * && isImportableDiscoveredHost(entry) && selectedIps[entry.ipAddress]` —
+     * had no idea a filter existed. Re-growing it anywhere in the import path
+     * is exactly how the scoping silently comes undone.
+     */
+    expect(importSection()).not.toContain("selectedIps[entry.ipAddress]");
+  });
+
+  test("the button's count is computed the same way the import is", () => {
+    const code: string = readCode();
+
+    const selectedCountDeclaration: string = code.slice(
+      code.indexOf("const selectedCount: number ="),
+      code.indexOf("const selectableShownCount"),
+    );
+
+    expect(selectedCountDeclaration).toContain("getDiscoveredHostsToImport({");
+    expect(selectedCountDeclaration).toContain("filter: hostFilter");
+    expect(modalSection()).toContain(
+      "submitButtonText={`Import Selected (${selectedCount})`}",
+    );
+    expect(modalSection()).toContain(
+      "disableSubmitButton={selectedCount === 0}",
+    );
+  });
+
+  test("hosts imported in this sitting are retired from the dialog", () => {
+    /*
+     * `isAlreadyRegistered` is frozen into the scan's jsonb when the probe
+     * uploads. Importing group by group means returning to a list that still
+     * contains what you just imported, pre-checked — so the page overlays what
+     * it knows through markDiscoveredHostsAsRegistered.
+     */
+    const code: string = readCode();
+
+    expect(code).toContain("markDiscoveredHostsAsRegistered({");
+    expect(importSection()).toContain("setImportedIpAddresses(");
+  });
+});
+
+describe("the filter row", () => {
+  test("the dialog renders FilterButtons bound to the filter state", () => {
+    const section: string = modalSection();
+
+    expect(section).toContain("<FilterButtons");
+    expect(section).toContain("selectedValue={hostFilter}");
+    expect(section).toContain("setHostFilter(value as DiscoveredHostFilter)");
+  });
+
+  test("the buttons and their counts come from the tested helper", () => {
+    // Not hand-built in JSX, where the counts could drift from the groups.
+    expect(readCode()).toContain(
+      "getDiscoveredHostFilterOptions(reviewEntries)",
+    );
+    expect(modalSection()).toContain("options={hostFilterOptions}");
+  });
+
+  test("the list renders the filtered hosts, not the whole scan", () => {
+    const section: string = modalSection();
+
+    expect(section).toContain("{shownEntries.map(");
+    expect(section).not.toContain("{reviewEntries.map(");
+  });
+
+  test("shownEntries is the filter applied to the scan", () => {
+    const code: string = readCode();
+
+    const declaration: string = code.slice(
+      code.indexOf("const shownEntries"),
+      code.indexOf("const selectedCount"),
+    );
+
+    expect(declaration).toContain("filterDiscoveredHosts({");
+    expect(declaration).toContain("hosts: reviewEntries");
+    expect(declaration).toContain("filter: hostFilter");
+  });
+
+  test("a scan opens on All, and closing resets to All", () => {
+    /*
+     * A filter that persisted across scans would mean opening a review and
+     * being shown a subset with no memory of having asked for it.
+     */
+    const code: string = readCode();
+
+    const openBody: string = code.slice(
+      code.indexOf("const openReviewModal"),
+      code.indexOf("const closeReviewModal"),
+    );
+
+    const closeBody: string = code.slice(
+      code.indexOf("const closeReviewModal"),
+      code.indexOf("const importSelectedDevices"),
+    );
+
+    expect(openBody).toContain("setHostFilter(DiscoveredHostFilter.All)");
+    expect(closeBody).toContain("setHostFilter(DiscoveredHostFilter.All)");
+    expect(openBody).toContain("setImportedIpAddresses(new Set<string>())");
+    expect(closeBody).toContain("setImportedIpAddresses(new Set<string>())");
+  });
+});
+
+describe("the bulk selection control", () => {
+  test("it exists, is addressable, and toggles only the shown group", () => {
+    const section: string = modalSection();
+
+    expect(section).toContain('dataTestId="discovered-device-select-all"');
+    expect(section).toContain("toggleSelectionForShownHosts({");
+    expect(section).toContain("filter: hostFilter");
+  });
+
+  test("it is disabled when the shown group has nothing to select", () => {
+    expect(modalSection()).toContain(
+      "disabled={selectableShownCount === 0 || isImporting}",
+    );
+  });
+
+  test("its label follows whether the shown group is already full", () => {
+    expect(modalSection()).toContain("areAllShownSelected");
+  });
+
+  test("it updates selection functionally, not from a captured value", () => {
+    /*
+     * Two presses in the same tick against a stale `selectedIps` would drop
+     * the first one's work.
+     */
+    expect(modalSection()).toContain(
+      "setSelectedIps((current: Record<string, boolean>) =>",
+    );
+  });
+});
+
+describe("what the dialog tells the operator", () => {
+  test("it no longer claims hosts without SNMP cannot be imported", () => {
+    /*
+     * That stopped being true when ping-only hosts started importing as
+     * monitor-backed devices, and it reads as a flat contradiction next to a
+     * No SNMP filter whose entire purpose is importing them as a batch.
+     */
+    expect(readSource()).not.toContain(
+      "Select the ones you want to import as Network Devices — hosts without SNMP cannot be imported.",
+    );
+  });
+
+  test("an empty scan is not described as having found no SNMP devices", () => {
+    // Ping-only hosts are listed too, so "no SNMP devices" is the wrong claim.
+    expect(readSource()).not.toContain(
+      "This scan did not find any SNMP devices.",
+    );
+    expect(modalSection()).toContain(
+      "This scan did not find any responding hosts.",
+    );
+  });
+
+  test("a group that filters to nothing says so instead of rendering blank", () => {
+    const section: string = modalSection();
+
+    expect(section).toContain("shownEntries.length === 0");
+    expect(section).toContain("hosts in this scan.");
+  });
+
+  test("the row badge and the filter button use the same words", () => {
+    /*
+     * The pill on a ping-only row reads "No SNMP". The button that filters to
+     * those rows is labelled from getDiscoveredHostFilterLabel, which returns
+     * the same string — the two must not drift into near-synonyms the operator
+     * has to connect.
+     */
+    expect(modalSection()).toContain("No SNMP");
+    expect(readCode()).toContain("getDiscoveredHostFilterLabel(hostFilter)");
+  });
+
+  test("the row badge is decided by the same predicate the filter groups by", () => {
+    /*
+     * A row can carry the No SNMP pill and a filter can collect No SNMP rows;
+     * if those are two separate expressions they can drift, and the dialog
+     * ends up showing a badged host that the No SNMP filter hides.
+     */
+    expect(modalSection()).toContain("isPingOnlyDiscoveredHost(entry)");
+    expect(modalSection()).not.toContain(
+      "NetworkDeviceMonitoringMethod.Monitor",
+    );
+  });
+});
+
+describe("the page reads the scan through the shared, tested helper", () => {
+  test("discoveredDevices is not re-parsed inline", () => {
+    /*
+     * Discovery.tsx used to carry its own copy of the jsonb guard. Two copies
+     * of "what counts as a result array" is one copy too many; the page now
+     * uses DiscoveryScanOutcome.getDiscoveredHosts, which has tests covering
+     * junk values.
+     */
+    const code: string = readCode();
+
+    expect(code).toContain("getDiscoveredHosts(");
+    expect(code).not.toContain("const getDiscoveredDevices:");
+  });
+});


### PR DESCRIPTION
Closes #3322.

## The problem

The **Review Discovered Devices** dialog listed every responding host in one pre-checked list — SNMP-identified switches and bare `No SNMP` ICMP-only hosts mixed together. At the size real sweeps come back at (the issue reports a scan of 17,850 addresses returning 2,890 ICMP-only and 2,866 SNMP hosts) that is all-or-nothing: importing one group meant scrolling the other and unchecking it by hand.

The two groups are not interchangeable either — an SNMP host imports as a polled device carrying the scan's credentials, a ping-only host imports as a monitor-backed device with no polling — so "import the switches now, deal with the endpoints later" is the normal thing to want.

## What changed

**A filter row in the dialog**, each button carrying its group's size: `All (5,756)` / `SNMP (2,866)` / `No SNMP (2,890)`. A group of zero still renders its zero — "did this sweep find any switches at all" is a real question.

**Import is scoped to the group on screen.** This is the part that makes the filter a feature rather than a view. The dialog opens with everything pre-checked, so an Import that ignored the filter would let "show only SNMP, press Import" quietly create the thousands of ping-only devices the operator just filtered away. The submit button's count is computed from the same list the press acts on, so the number can never promise something different. Ticks on hidden hosts survive — switch the filter and they come back.

**A `Select all` / `Clear all` scoped to the group on screen**, additive across groups: clearing the SNMP group never disturbs ping-only ticks. This is what replaces "scroll 2,890 rows and uncheck them one at a time".

**Hosts imported during a sitting are retired from the list.** `isAlreadyRegistered` is computed server-side when the probe uploads and then frozen into the jsonb column — nothing recomputes it on read. That was survivable when one press imported everything and closed the dialog; importing group by group makes "come back to a list that still contains what you just imported, pre-checked" the normal case, and importing it again would create a second Network Device for the same address. For the same reason the dialog now **stays open after a partial import** and closes only when nothing importable is left anywhere.

### Two smaller things in the same code

- The dialog's description ended *"hosts without SNMP cannot be imported"*. That stopped being true when ping-only hosts started importing as monitor-backed devices, and it reads as a flat contradiction next to a `No SNMP` filter whose purpose is importing them as a batch. Same for the empty state's "This scan did not find any SNMP devices."
- `Discovery.tsx` carried its own copy of the `discoveredDevices` jsonb guard, duplicating `DiscoveryScanOutcome.getDiscoveredHosts`. The page now uses the tested one.

## Tests

91 new tests, all passing, plus the existing 6,018 in `App/Tests/Dashboard` still green.

- **`App/Tests/Dashboard/DiscoveredHostFilter.test.ts`** (73) — the rules themselves. Group membership including legacy rows where `snmpReachable` is `undefined` (those must read as SNMP, not ping-only); the two groups partitioning the list; counts computed from the unfiltered scan and agreeing with what the filter shows; thousands separators at four digits; selection eligibility; duplicate-address collapse on both import and the selectable count; scoped/additive toggling; the retire-after-import overlay; and end-to-end scenarios for the workflow the issue asks for, including one at the issue's own 2,866 / 2,890 scale.
- **`App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts`** (18) — the JSX wiring, at source level. The App suite runs in a plain Node environment with no React renderer, so this follows the pattern already used by `InventoryTableInvariants.test.ts` and `NetworkFormStepsInvariants.test.ts`. It pins the expensive regression specifically: that the import path and the button's count both go through the filter-scoped helper with the active filter, and that the old inline `selectedIps[entry.ipAddress]` predicate — which had no idea a filter existed — does not grow back.

The rules live in a react-free `DiscoveredHostFilter` module rather than inside the `.tsx`, for the same reason `DiscoveryImportEligibility` and `DiscoveryScanOutcome` do: every failure mode here renders perfectly while being wrong.

## Verification

`npm test` for the Dashboard suite (170 suites / 6,018 tests) and `eslint --fix` are clean. `tsc` reports no new errors — the one error it does report (`js-yaml` types in `Common/Utils/SecurityEvent/Sigma/SigmaRuleParser.ts`) reproduces on a clean tree and is unrelated.

Not verified in a running browser: exercising this needs a probe that has actually swept a subnet and a completed scan with results, which isn't reproducible locally here. The behaviour under it is covered by the unit tests; the JSX arrangement is not.
