### PR TITLE
test(measurements): pin the backfill column contract the casts cannot type

### DIFF
--- a/App/Tests/Workers/Jobs/Measurement/BackfillMeasurements.test.ts
+++ b/App/Tests/Workers/Jobs/Measurement/BackfillMeasurements.test.ts
@@ -1,0 +1,674 @@
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * Regression tests for the Measurement:Backfill cron, which fills in
+ * measurement values for entities that already existed when a measurement was
+ * defined.
+ *
+ * The job reaches every service through `as unknown as` casts -- the model
+ * graph is too deep to instantiate Partial<Model> over -- so the compiler
+ * checks almost nothing about the values it writes. These tests stand in for
+ * the types that cannot be applied:
+ *
+ *   1. THE COLUMN CONTRACT. All three backfill columns are TIMESTAMPs. The
+ *      progress patch must carry Dates into backfillCursorCreatedAt /
+ *      backfillCompletedAt and the measurement id must travel as `id`, never
+ *      into a date column: an ObjectID landing in the cursor is a write error
+ *      that takes down the whole backfill for that project.
+ *   2. THE RESUME SEMANTICS. Completed-at-or-after-requested is what stops a
+ *      finished backfill from being redone every five minutes, and the cursor
+ *      is what stops a restart from starting the project over.
+ *   3. THE TWO NON-TERMINATION GUARDS: the same-timestamp stall bail-out and
+ *      the per-run page cap, plus the isolation that keeps one unreadable
+ *      entity, or one broken domain, from stalling everything behind it.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+function mockMeasurementService(): {
+  __esModule: true;
+  default: { findBy: jest.Mock; updateOneById: jest.Mock };
+} {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+}
+
+jest.mock("Common/Server/Services/IncidentMeasurementService", () => {
+  return mockMeasurementService();
+});
+jest.mock("Common/Server/Services/AlertMeasurementService", () => {
+  return mockMeasurementService();
+});
+jest.mock(
+  "Common/Server/Services/ScheduledMaintenanceMeasurementService",
+  () => {
+    return mockMeasurementService();
+  },
+);
+
+jest.mock("Common/Server/Services/IncidentMeasurementValueService", () => {
+  return {
+    __esModule: true,
+    default: { recomputeForIncident: jest.fn() },
+  };
+});
+jest.mock("Common/Server/Services/AlertMeasurementValueService", () => {
+  return {
+    __esModule: true,
+    default: { recomputeForAlert: jest.fn() },
+  };
+});
+jest.mock(
+  "Common/Server/Services/ScheduledMaintenanceMeasurementValueService",
+  () => {
+    return {
+      __esModule: true,
+      default: { recomputeForScheduledMaintenance: jest.fn() },
+    };
+  },
+);
+
+jest.mock("Common/Server/Services/IncidentService", () => {
+  return { __esModule: true, default: { findBy: jest.fn() } };
+});
+jest.mock("Common/Server/Services/AlertService", () => {
+  return { __esModule: true, default: { findBy: jest.fn() } };
+});
+jest.mock("Common/Server/Services/ScheduledMaintenanceService", () => {
+  return { __esModule: true, default: { findBy: jest.fn() } };
+});
+
+import IncidentMeasurementService from "Common/Server/Services/IncidentMeasurementService";
+import AlertMeasurementService from "Common/Server/Services/AlertMeasurementService";
+import ScheduledMaintenanceMeasurementService from "Common/Server/Services/ScheduledMaintenanceMeasurementService";
+import IncidentMeasurementValueService from "Common/Server/Services/IncidentMeasurementValueService";
+import AlertMeasurementValueService from "Common/Server/Services/AlertMeasurementValueService";
+import ScheduledMaintenanceMeasurementValueService from "Common/Server/Services/ScheduledMaintenanceMeasurementValueService";
+import IncidentService from "Common/Server/Services/IncidentService";
+import AlertService from "Common/Server/Services/AlertService";
+import ScheduledMaintenanceService from "Common/Server/Services/ScheduledMaintenanceService";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/Measurement/BackfillMeasurements";
+
+interface MeasurementServiceMock {
+  findBy: jest.Mock;
+  updateOneById: jest.Mock;
+}
+
+interface EntityServiceMock {
+  findBy: jest.Mock;
+}
+
+const incidentMeasurements: MeasurementServiceMock =
+  IncidentMeasurementService as unknown as MeasurementServiceMock;
+const alertMeasurements: MeasurementServiceMock =
+  AlertMeasurementService as unknown as MeasurementServiceMock;
+const maintenanceMeasurements: MeasurementServiceMock =
+  ScheduledMaintenanceMeasurementService as unknown as MeasurementServiceMock;
+
+const incidents: EntityServiceMock =
+  IncidentService as unknown as EntityServiceMock;
+const alerts: EntityServiceMock = AlertService as unknown as EntityServiceMock;
+const maintenanceEvents: EntityServiceMock =
+  ScheduledMaintenanceService as unknown as EntityServiceMock;
+
+const incidentValues: { recomputeForIncident: jest.Mock } =
+  IncidentMeasurementValueService as unknown as {
+    recomputeForIncident: jest.Mock;
+  };
+const alertValues: { recomputeForAlert: jest.Mock } =
+  AlertMeasurementValueService as unknown as { recomputeForAlert: jest.Mock };
+const maintenanceValues: { recomputeForScheduledMaintenance: jest.Mock } =
+  ScheduledMaintenanceMeasurementValueService as unknown as {
+    recomputeForScheduledMaintenance: jest.Mock;
+  };
+
+const mockedLogger: { error: jest.Mock; warn: jest.Mock } =
+  logger as unknown as {
+    error: jest.Mock;
+    warn: jest.Mock;
+  };
+
+// Mirrors the constants in the job. A page shorter than this ends the run.
+const PAGE_SIZE: number = 500;
+const MAX_PAGES_PER_RUN: number = 10;
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MEASUREMENT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+interface MeasurementRow {
+  _id?: ObjectID | undefined;
+  projectId?: ObjectID | undefined;
+  backfillRequestedAt?: Date | undefined;
+  backfillCompletedAt?: Date | undefined;
+  backfillCursorCreatedAt?: Date | undefined;
+}
+
+interface EntityRow {
+  _id?: ObjectID | undefined;
+  createdAt?: Date | undefined;
+}
+
+function measurementRow(input: {
+  id?: ObjectID;
+  projectId?: ObjectID | undefined;
+  requestedAt?: Date | undefined;
+  completedAt?: Date | undefined;
+  cursorCreatedAt?: Date | undefined;
+}): MeasurementRow {
+  return {
+    _id: input.id ?? MEASUREMENT_ID,
+    projectId: input.projectId ?? PROJECT_ID,
+    backfillRequestedAt:
+      input.requestedAt ?? new Date("2026-07-01T00:00:00.000Z"),
+    backfillCompletedAt: input.completedAt,
+    backfillCursorCreatedAt: input.cursorCreatedAt,
+  };
+}
+
+// A page of entities one second apart, oldest first, as the job sorts them.
+function entityPage(input: {
+  count: number;
+  firstCreatedAt: Date;
+  prefix?: string;
+  sameTimestamp?: boolean;
+}): Array<EntityRow> {
+  const rows: Array<EntityRow> = [];
+
+  for (let index: number = 0; index < input.count; index++) {
+    rows.push({
+      _id: new ObjectID(`${input.prefix || "entity"}-${index}`),
+      createdAt: input.sameTimestamp
+        ? input.firstCreatedAt
+        : new Date(input.firstCreatedAt.getTime() + index * 1000),
+    });
+  }
+
+  return rows;
+}
+
+/*
+ * Reads the single value bound into one of QueryHelper's Raw predicates
+ * (typeorm keeps the bound parameters on the FindOperator).
+ */
+function boundValueOf(predicate: unknown): unknown {
+  if (!predicate) {
+    return undefined;
+  }
+
+  const parameters: Record<string, unknown> | undefined = (
+    predicate as {
+      objectLiteralParameters?: Record<string, unknown> | undefined;
+    }
+  ).objectLiteralParameters;
+
+  return Object.values(parameters || {})[0];
+}
+
+function entityQueryOf(call: Array<unknown>): Record<string, unknown> {
+  return (call[0] as { query: Record<string, unknown> }).query;
+}
+
+function patchOf(call: Array<unknown>): Record<string, unknown> {
+  return (call[0] as { data: Record<string, unknown> }).data;
+}
+
+function idOf(call: Array<unknown>): ObjectID {
+  return (call[0] as { id: ObjectID }).id;
+}
+
+async function runTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["Measurement:Backfill"];
+
+  if (!handler) {
+    throw new Error("Measurement:Backfill did not register a cron handler");
+  }
+
+  await handler();
+}
+
+describe("Measurement:Backfill", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Nothing to backfill in any domain unless a test says otherwise.
+    for (const service of [
+      incidentMeasurements,
+      alertMeasurements,
+      maintenanceMeasurements,
+    ]) {
+      service.findBy.mockResolvedValue([] as Array<MeasurementRow>);
+      service.updateOneById.mockResolvedValue(undefined);
+    }
+
+    for (const service of [incidents, alerts, maintenanceEvents]) {
+      service.findBy.mockResolvedValue([] as Array<EntityRow>);
+    }
+
+    incidentValues.recomputeForIncident.mockResolvedValue(undefined);
+    alertValues.recomputeForAlert.mockResolvedValue(undefined);
+    maintenanceValues.recomputeForScheduledMaintenance.mockResolvedValue(
+      undefined,
+    );
+  });
+
+  test("registers itself, so the tick under test is the one that ships", () => {
+    expect(mockCapturedJobs["Measurement:Backfill"]).toBeDefined();
+  });
+
+  test("walks every domain on one tick, so a measurement is never left to a later run", async () => {
+    await runTick();
+
+    expect(incidentMeasurements.findBy).toHaveBeenCalledTimes(1);
+    expect(alertMeasurements.findBy).toHaveBeenCalledTimes(1);
+    expect(maintenanceMeasurements.findBy).toHaveBeenCalledTimes(1);
+  });
+
+  describe("deciding what still needs a backfill", () => {
+    test("skips a measurement that finished after it was requested, so a done backfill is not redone every five minutes", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([
+        measurementRow({
+          requestedAt: new Date("2026-07-01T00:00:00.000Z"),
+          completedAt: new Date("2026-07-01T00:05:00.000Z"),
+        }),
+      ]);
+
+      await runTick();
+
+      expect(incidents.findBy).not.toHaveBeenCalled();
+      expect(incidentMeasurements.updateOneById).not.toHaveBeenCalled();
+    });
+
+    test("runs again when the definition was edited after the last completion, because its history has to be rewritten", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([
+        measurementRow({
+          completedAt: new Date("2026-07-01T00:05:00.000Z"),
+          requestedAt: new Date("2026-07-02T00:00:00.000Z"),
+        }),
+      ]);
+
+      await runTick();
+
+      expect(incidents.findBy).toHaveBeenCalledTimes(1);
+    });
+
+    test("runs a measurement that has never completed", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([
+        measurementRow({ completedAt: undefined }),
+      ]);
+
+      await runTick();
+
+      expect(incidents.findBy).toHaveBeenCalledTimes(1);
+    });
+
+    test("skips a row with no id or no project, which has nothing to scope a walk to", async () => {
+      const requestedAt: Date = new Date("2026-07-01T00:00:00.000Z");
+
+      incidentMeasurements.findBy.mockResolvedValue([
+        { projectId: PROJECT_ID, backfillRequestedAt: requestedAt },
+        { _id: MEASUREMENT_ID, backfillRequestedAt: requestedAt },
+      ] as Array<MeasurementRow>);
+
+      await runTick();
+
+      expect(incidents.findBy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the progress patch", () => {
+    test("writes timestamps into the backfill columns and carries the measurement id as the row id", async () => {
+      /*
+       * THE regression this suite exists for. Both columns are TIMESTAMPs, and
+       * the only ObjectID in play addresses the row -- it must never be one of
+       * the values.
+       */
+      const created: Date = new Date("2026-06-01T09:00:00.000Z");
+
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy.mockResolvedValue(
+        entityPage({ count: 3, firstCreatedAt: created }),
+      );
+
+      await runTick();
+
+      expect(incidentMeasurements.updateOneById).toHaveBeenCalledTimes(1);
+
+      const call: Array<unknown> =
+        incidentMeasurements.updateOneById.mock.calls[0]!;
+
+      expect(idOf(call).toString()).toBe(MEASUREMENT_ID.toString());
+
+      const patch: Record<string, unknown> = patchOf(call);
+
+      expect(Object.keys(patch).sort()).toEqual([
+        "backfillCompletedAt",
+        "backfillCursorCreatedAt",
+      ]);
+
+      for (const column of Object.keys(patch)) {
+        expect(patch[column]).toBeInstanceOf(Date);
+        expect(patch[column]).not.toBeInstanceOf(ObjectID);
+      }
+
+      // The cursor is the last row of the page, not the first and not "now".
+      expect((patch["backfillCursorCreatedAt"] as Date).toISOString()).toBe(
+        new Date(created.getTime() + 2000).toISOString(),
+      );
+    });
+
+    test("stamps completion on a short page, because a page under the limit is the end of the project", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy.mockResolvedValue(
+        entityPage({
+          count: PAGE_SIZE - 1,
+          firstCreatedAt: new Date("2026-06-01T09:00:00.000Z"),
+        }),
+      );
+
+      await runTick();
+
+      expect(incidents.findBy).toHaveBeenCalledTimes(1);
+      expect(
+        patchOf(incidentMeasurements.updateOneById.mock.calls[0]!)[
+          "backfillCompletedAt"
+        ],
+      ).toBeInstanceOf(Date);
+    });
+
+    test("stamps completion for a project with no entities at all, so an empty project stops being rescanned", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy.mockResolvedValue([]);
+
+      await runTick();
+
+      const patch: Record<string, unknown> = patchOf(
+        incidentMeasurements.updateOneById.mock.calls[0]!,
+      );
+
+      expect(patch["backfillCompletedAt"]).toBeInstanceOf(Date);
+      // No rows, so there is no cursor to write -- and null would clear it.
+      expect(patch["backfillCursorCreatedAt"]).toBeUndefined();
+    });
+
+    test("saves the cursor without a completion stamp mid-walk, so an interrupted run resumes instead of finishing early", async () => {
+      const created: Date = new Date("2026-06-01T09:00:00.000Z");
+
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy
+        .mockResolvedValueOnce(
+          entityPage({ count: PAGE_SIZE, firstCreatedAt: created }),
+        )
+        .mockResolvedValue([]);
+
+      await runTick();
+
+      const firstPatch: Record<string, unknown> = patchOf(
+        incidentMeasurements.updateOneById.mock.calls[0]!,
+      );
+
+      expect(firstPatch["backfillCursorCreatedAt"]).toBeInstanceOf(Date);
+      expect(firstPatch["backfillCompletedAt"]).toBeUndefined();
+    });
+  });
+
+  describe("paging", () => {
+    test("scopes the first page to the project with no cursor predicate", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([
+        measurementRow({ cursorCreatedAt: undefined }),
+      ]);
+
+      await runTick();
+
+      const query: Record<string, unknown> = entityQueryOf(
+        incidents.findBy.mock.calls[0]!,
+      );
+
+      expect((query["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(query["createdAt"]).toBeUndefined();
+    });
+
+    test("resumes from the stored cursor rather than walking the project again", async () => {
+      const cursor: Date = new Date("2026-06-15T12:00:00.000Z");
+
+      incidentMeasurements.findBy.mockResolvedValue([
+        measurementRow({ cursorCreatedAt: cursor }),
+      ]);
+
+      await runTick();
+
+      const query: Record<string, unknown> = entityQueryOf(
+        incidents.findBy.mock.calls[0]!,
+      );
+
+      /*
+       * Inclusive on purpose: rows sharing the boundary timestamp are
+       * recomputed again rather than risking a skip, and the recompute is a
+       * total function of current data.
+       */
+      expect(boundValueOf(query["createdAt"])).toEqual(cursor);
+    });
+
+    test("advances the cursor page by page until a short page ends the walk", async () => {
+      const created: Date = new Date("2026-06-01T09:00:00.000Z");
+      const secondPageStart: Date = new Date("2026-06-02T09:00:00.000Z");
+
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy
+        .mockResolvedValueOnce(
+          entityPage({ count: PAGE_SIZE, firstCreatedAt: created }),
+        )
+        .mockResolvedValueOnce(
+          entityPage({ count: 2, firstCreatedAt: secondPageStart }),
+        );
+
+      await runTick();
+
+      expect(incidents.findBy).toHaveBeenCalledTimes(2);
+
+      // The second page starts at the last row of the first.
+      expect(
+        boundValueOf(
+          entityQueryOf(incidents.findBy.mock.calls[1]!)["createdAt"],
+        ),
+      ).toEqual(new Date(created.getTime() + (PAGE_SIZE - 1) * 1000));
+
+      expect(incidentMeasurements.updateOneById).toHaveBeenCalledTimes(2);
+      expect(
+        patchOf(incidentMeasurements.updateOneById.mock.calls[1]!)[
+          "backfillCompletedAt"
+        ],
+      ).toBeInstanceOf(Date);
+    });
+
+    test("stops after the per-run page cap, so one large project cannot starve the others", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy.mockImplementation(
+        (data: unknown): Promise<Array<EntityRow>> => {
+          /*
+           * Every page is full and strictly newer than the last, so only the
+           * cap can end this walk.
+           */
+          const after: Date =
+            (boundValueOf(
+              (data as { query: Record<string, unknown> }).query["createdAt"],
+            ) as Date) || new Date("2026-06-01T09:00:00.000Z");
+
+          return Promise.resolve(
+            entityPage({
+              count: PAGE_SIZE,
+              firstCreatedAt: new Date(after.getTime() + 1000),
+            }),
+          );
+        },
+      );
+
+      await runTick();
+
+      expect(incidents.findBy).toHaveBeenCalledTimes(MAX_PAGES_PER_RUN);
+      // Nothing is marked complete: the next tick picks the walk back up.
+      for (const call of incidentMeasurements.updateOneById.mock.calls) {
+        expect(patchOf(call)["backfillCompletedAt"]).toBeUndefined();
+      }
+    });
+
+    test("bails out with a warning when a full page shares one timestamp, instead of paging the same rows for ever", async () => {
+      const stuck: Date = new Date("2026-06-01T09:00:00.000Z");
+
+      incidentMeasurements.findBy.mockResolvedValue([
+        measurementRow({ cursorCreatedAt: stuck }),
+      ]);
+      incidents.findBy.mockResolvedValue(
+        entityPage({
+          count: PAGE_SIZE,
+          firstCreatedAt: stuck,
+          sameTimestamp: true,
+        }),
+      );
+
+      await runTick();
+
+      expect(incidents.findBy).toHaveBeenCalledTimes(1);
+      expect(mockedLogger.warn).toHaveBeenCalledTimes(1);
+      expect(String(mockedLogger.warn.mock.calls[0]![0])).toContain(
+        MEASUREMENT_ID.toString(),
+      );
+      // Neither the cursor nor completion moves, so the next tick can retry.
+      expect(incidentMeasurements.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recomputing", () => {
+    test("recomputes every entity on the page, which is what actually fills the measurement in", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy.mockResolvedValue(
+        entityPage({
+          count: 3,
+          firstCreatedAt: new Date("2026-06-01T09:00:00.000Z"),
+        }),
+      );
+
+      await runTick();
+
+      expect(incidentValues.recomputeForIncident).toHaveBeenCalledTimes(3);
+      expect(incidentValues.recomputeForIncident).toHaveBeenCalledWith({
+        incidentId: expect.any(ObjectID),
+      });
+    });
+
+    test("keeps going when one entity fails, so a single bad row cannot stall the cursor behind it", async () => {
+      incidentMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      incidents.findBy.mockResolvedValue(
+        entityPage({
+          count: 3,
+          firstCreatedAt: new Date("2026-06-01T09:00:00.000Z"),
+        }),
+      );
+      incidentValues.recomputeForIncident
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("unreadable incident"))
+        .mockResolvedValueOnce(undefined);
+
+      await runTick();
+
+      expect(incidentValues.recomputeForIncident).toHaveBeenCalledTimes(3);
+      expect(mockedLogger.error).toHaveBeenCalled();
+      // The page still completes, so the walk moves past the bad row.
+      expect(incidentMeasurements.updateOneById).toHaveBeenCalledTimes(1);
+    });
+
+    test("routes each domain to its own value service and entity table", async () => {
+      const created: Date = new Date("2026-06-01T09:00:00.000Z");
+
+      alertMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      alerts.findBy.mockResolvedValue(
+        entityPage({ count: 1, firstCreatedAt: created }),
+      );
+      maintenanceMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+      maintenanceEvents.findBy.mockResolvedValue(
+        entityPage({ count: 1, firstCreatedAt: created }),
+      );
+
+      await runTick();
+
+      expect(alertValues.recomputeForAlert).toHaveBeenCalledWith({
+        alertId: expect.any(ObjectID),
+      });
+      expect(
+        maintenanceValues.recomputeForScheduledMaintenance,
+      ).toHaveBeenCalledWith({
+        scheduledMaintenanceId: expect.any(ObjectID),
+      });
+
+      expect(incidentValues.recomputeForIncident).not.toHaveBeenCalled();
+      expect(alertMeasurements.updateOneById).toHaveBeenCalledTimes(1);
+      expect(maintenanceMeasurements.updateOneById).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("logs and moves on when a whole domain fails, so one broken table does not block the rest", async () => {
+    incidentMeasurements.findBy.mockRejectedValue(
+      new Error("incident measurements unavailable"),
+    );
+    alertMeasurements.findBy.mockResolvedValue([measurementRow({})]);
+    alerts.findBy.mockResolvedValue(
+      entityPage({
+        count: 1,
+        firstCreatedAt: new Date("2026-06-01T09:00:00.000Z"),
+      }),
+    );
+
+    await runTick();
+
+    expect(mockedLogger.error).toHaveBeenCalled();
+    expect(alertValues.recomputeForAlert).toHaveBeenCalledTimes(1);
+    expect(maintenanceMeasurements.findBy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Services/AlertMeasurementService.test.ts
+++ b/Common/Tests/Server/Services/AlertMeasurementService.test.ts
@@ -1,0 +1,665 @@
+import AlertMeasurement from "../../../Models/DatabaseModels/AlertMeasurement";
+import AlertState from "../../../Models/DatabaseModels/AlertState";
+import AlertMeasurementService from "../../../Server/Services/AlertMeasurementService";
+import AlertStateService from "../../../Server/Services/AlertStateService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import DeleteBy from "../../../Server/Types/Database/DeleteBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import {
+  OnCreate,
+  OnDelete,
+  OnUpdate,
+} from "../../../Server/Types/Database/Hooks";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import AlertMeasurementAnchorType from "../../../Types/Alerts/AlertMeasurementAnchorType";
+import AlertStateRole from "../../../Types/Alerts/AlertStateRole";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The alert twin of Tests/Server/Services/IncidentMeasurementService.test.ts --
+ * keep the two suites symmetric, the services are line-for-line equivalents
+ * over a different set of state columns.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MEASUREMENT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const CREATED_STATE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const RESOLVED_STATE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+/*
+ * The hooks are protected, as they are on every DatabaseService. Reaching them
+ * through a cast is how the rest of this suite exercises them -- see
+ * Tests/Server/Types/Database/Permissions/TenantPermission.test.ts.
+ */
+interface MeasurementHooks {
+  onBeforeCreate(
+    createBy: CreateBy<AlertMeasurement>,
+  ): Promise<OnCreate<AlertMeasurement>>;
+  onBeforeUpdate(
+    updateBy: UpdateBy<AlertMeasurement>,
+  ): Promise<OnUpdate<AlertMeasurement>>;
+  onBeforeDelete(
+    deleteBy: DeleteBy<AlertMeasurement>,
+  ): Promise<OnDelete<AlertMeasurement>>;
+}
+
+const hooks: MeasurementHooks =
+  AlertMeasurementService as unknown as MeasurementHooks;
+
+function buildCreateBy(input: {
+  key?: string;
+  name?: string;
+  order?: number;
+  startAnchorType?: AlertMeasurementAnchorType;
+  endAnchorType?: AlertMeasurementAnchorType;
+  startStateId?: ObjectID;
+  endStateId?: ObjectID;
+  startStateRole?: AlertStateRole;
+  endStateRole?: AlertStateRole;
+}): CreateBy<AlertMeasurement> {
+  const measurement: AlertMeasurement = new AlertMeasurement();
+
+  measurement.projectId = PROJECT_ID;
+  measurement.name = input.name ?? "Time to Acknowledge";
+  measurement.key = input.key ?? "time-to-acknowledge";
+  measurement.startAnchorType =
+    input.startAnchorType ?? AlertMeasurementAnchorType.CreatedAt;
+  measurement.endAnchorType =
+    input.endAnchorType ?? AlertMeasurementAnchorType.StateRoleEntered;
+
+  if (input.order !== undefined) {
+    measurement.order = input.order;
+  }
+
+  if (input.startStateId) {
+    measurement.startAlertStateId = input.startStateId;
+  }
+
+  if (input.endStateId) {
+    measurement.endAlertStateId = input.endStateId;
+  }
+
+  if (input.startStateRole) {
+    measurement.startAlertStateRole = input.startStateRole;
+  }
+
+  if (
+    measurement.endAnchorType === AlertMeasurementAnchorType.StateRoleEntered
+  ) {
+    measurement.endAlertStateRole =
+      input.endStateRole ?? AlertStateRole.Acknowledged;
+  } else if (input.endStateRole) {
+    measurement.endAlertStateRole = input.endStateRole;
+  }
+
+  return {
+    data: measurement,
+    props: { isRoot: true },
+  };
+}
+
+function buildExistingMeasurement(input: {
+  isSystemDefined?: boolean;
+  name?: string;
+  metricName?: string;
+  isEnabled?: boolean;
+}): AlertMeasurement {
+  const measurement: AlertMeasurement = new AlertMeasurement();
+
+  measurement._id = MEASUREMENT_ID.toString();
+  measurement.id = MEASUREMENT_ID;
+  measurement.projectId = PROJECT_ID;
+  measurement.name = input.name ?? "Time to Acknowledge";
+  measurement.isSystemDefined = input.isSystemDefined ?? false;
+  measurement.isEnabled = input.isEnabled ?? true;
+  measurement.startAnchorType = AlertMeasurementAnchorType.CreatedAt;
+  measurement.endAnchorType = AlertMeasurementAnchorType.StateRoleEntered;
+  measurement.endAlertStateRole = AlertStateRole.Acknowledged;
+
+  if (input.metricName) {
+    measurement.metricName = input.metricName;
+  }
+
+  return measurement;
+}
+
+function buildAlertState(input: {
+  id: ObjectID;
+  name: string;
+  order: number;
+}): AlertState {
+  const state: AlertState = new AlertState();
+
+  state._id = input.id.toString();
+  state.id = input.id;
+  state.name = input.name;
+  state.order = input.order;
+
+  return state;
+}
+
+function buildUpdateBy(
+  data: Record<string, unknown>,
+): UpdateBy<AlertMeasurement> {
+  return {
+    id: MEASUREMENT_ID,
+    query: { _id: MEASUREMENT_ID.toString() },
+    data: data,
+    props: { isRoot: true },
+    limit: 1,
+    skip: 0,
+  } as unknown as UpdateBy<AlertMeasurement>;
+}
+
+function dataOf(updateBy: UpdateBy<AlertMeasurement>): Record<string, unknown> {
+  return updateBy.data as unknown as Record<string, unknown>;
+}
+
+describe("AlertMeasurementService", () => {
+  beforeEach(() => {
+    // No existing definitions unless a test says otherwise.
+    jest
+      .spyOn(AlertMeasurementService, "findOneBy")
+      .mockResolvedValue(null as never);
+    jest
+      .spyOn(AlertMeasurementService, "findBy")
+      .mockResolvedValue([] as Array<AlertMeasurement> as never);
+    jest
+      .spyOn(AlertStateService, "findBy")
+      .mockResolvedValue([] as Array<AlertState> as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("onBeforeCreate", () => {
+    test("rejects a key that could not survive as part of a metric name", async () => {
+      /*
+       * The key lands in the metric name, in ClickHouse and in the API, and is
+       * immutable afterwards. This is the only moment it can still be fixed.
+       */
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "Time To Acknowledge" })),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "" })),
+      ).rejects.toThrow(BadDataException);
+
+      // Leading hyphen, and one character past the 50 the column allows.
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "-time-to-acknowledge" })),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "a".repeat(51) })),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("accepts a lowercase hyphenated key", async () => {
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({
+        key: "time-to-first-response",
+      });
+
+      await expect(hooks.onBeforeCreate(createBy)).resolves.toBeDefined();
+    });
+
+    test("derives the metric name from the key, so a new definition is chartable with no dashboard change", async () => {
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({
+        key: "time-to-acknowledge",
+      });
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.metricName).toBe(
+        "oneuptime.alert.measurement.time-to-acknowledge",
+      );
+    });
+
+    test("puts a new definition after the project's last one, so the settings list has a stable order", async () => {
+      const highest: AlertMeasurement = new AlertMeasurement();
+      highest.order = 4;
+
+      jest
+        .spyOn(AlertMeasurementService, "findOneBy")
+        .mockResolvedValue(highest as never);
+
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({});
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.order).toBe(5);
+    });
+
+    test("gives the first definition in a project order 1", async () => {
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({});
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.order).toBe(1);
+    });
+
+    test("keeps an order the caller supplied, so a reordered list is not overwritten on save", async () => {
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({ order: 2 });
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.order).toBe(2);
+      expect(AlertMeasurementService.findOneBy).not.toHaveBeenCalled();
+    });
+
+    test("requests a backfill, or the definition would be blank on every alert that already happened", async () => {
+      const before: number = Date.now();
+
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({});
+
+      await hooks.onBeforeCreate(createBy);
+
+      const requestedAt: Date | undefined = createBy.data.backfillRequestedAt;
+
+      expect(requestedAt).toBeInstanceOf(Date);
+      expect(requestedAt!.getTime()).toBeGreaterThanOrEqual(before - 1000);
+      expect(requestedAt!.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+
+    test("leaves the backfill cursor and completion stamp unset on create, so the worker starts from the beginning", async () => {
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({});
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.backfillCursorCreatedAt).toBeUndefined();
+      expect(createBy.data.backfillCompletedAt).toBeUndefined();
+    });
+
+    test("rejects a definition with no start or no end, which has nothing to measure between", async () => {
+      const missingStart: CreateBy<AlertMeasurement> = buildCreateBy({});
+      delete missingStart.data.startAnchorType;
+
+      await expect(hooks.onBeforeCreate(missingStart)).rejects.toThrow(
+        BadDataException,
+      );
+
+      const missingEnd: CreateBy<AlertMeasurement> = buildCreateBy({});
+      delete missingEnd.data.endAnchorType;
+
+      await expect(hooks.onBeforeCreate(missingEnd)).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    test("rejects a state anchor with no state picked, which would never resolve to a timestamp", async () => {
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.StateEntered,
+            endAnchorType: AlertMeasurementAnchorType.CreatedAt,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.CreatedAt,
+            endAnchorType: AlertMeasurementAnchorType.StateEntered,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("rejects a state-role anchor with no role picked", async () => {
+      const createBy: CreateBy<AlertMeasurement> = buildCreateBy({
+        startAnchorType: AlertMeasurementAnchorType.StateRoleEntered,
+        endAnchorType: AlertMeasurementAnchorType.StateRoleEntered,
+        endStateRole: AlertStateRole.Resolved,
+      });
+
+      // No start role, so the start of the duration has no timestamp to read.
+      delete createBy.data.startAlertStateRole;
+
+      await expect(hooks.onBeforeCreate(createBy)).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    test("rejects two anchors that read the same column, which would chart a constant zero", async () => {
+      /*
+       * Different enum values, one column: both Timeline Start and Created At
+       * resolve to the alert's createdAt.
+       */
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.TimelineStart,
+            endAnchorType: AlertMeasurementAnchorType.CreatedAt,
+          }),
+        ),
+      ).rejects.toThrow(/always be zero/);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.CreatedAt,
+            endAnchorType: AlertMeasurementAnchorType.CreatedAt,
+          }),
+        ),
+      ).rejects.toThrow(/always be zero/);
+    });
+
+    test("rejects the same state at both ends, and allows two different ones", async () => {
+      jest.spyOn(AlertStateService, "findBy").mockResolvedValue([
+        buildAlertState({
+          id: CREATED_STATE_ID,
+          name: "Created",
+          order: 1,
+        }),
+        buildAlertState({
+          id: RESOLVED_STATE_ID,
+          name: "Resolved",
+          order: 3,
+        }),
+      ] as never);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.StateEntered,
+            endAnchorType: AlertMeasurementAnchorType.StateEntered,
+            startStateId: CREATED_STATE_ID,
+            endStateId: CREATED_STATE_ID,
+          }),
+        ),
+      ).rejects.toThrow(/always be zero/);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.StateEntered,
+            endAnchorType: AlertMeasurementAnchorType.StateEntered,
+            startStateId: CREATED_STATE_ID,
+            endStateId: RESOLVED_STATE_ID,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    test("rejects a definition that ends at a state the alert reaches before it starts, which could never complete", async () => {
+      jest.spyOn(AlertStateService, "findBy").mockResolvedValue([
+        buildAlertState({
+          id: CREATED_STATE_ID,
+          name: "Created",
+          order: 1,
+        }),
+        buildAlertState({
+          id: RESOLVED_STATE_ID,
+          name: "Resolved",
+          order: 3,
+        }),
+      ] as never);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType: AlertMeasurementAnchorType.StateEntered,
+            endAnchorType: AlertMeasurementAnchorType.StateEntered,
+            startStateId: RESOLVED_STATE_ID,
+            endStateId: CREATED_STATE_ID,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+  });
+
+  describe("onBeforeUpdate", () => {
+    test("restarts the backfill when the definition's meaning changes, so its stored history is rewritten", async () => {
+      jest
+        .spyOn(AlertMeasurementService, "findBy")
+        .mockResolvedValue([buildExistingMeasurement({})] as never);
+
+      const updateBy: UpdateBy<AlertMeasurement> = buildUpdateBy({
+        endStateOccurrence: "Last",
+      });
+
+      await hooks.onBeforeUpdate(updateBy);
+
+      const data: Record<string, unknown> = dataOf(updateBy);
+
+      expect(data["backfillRequestedAt"]).toBeInstanceOf(Date);
+      // Cleared, or the restarted backfill would resume mid-way through.
+      expect(data["backfillCursorCreatedAt"]).toBeNull();
+      expect(data["backfillCompletedAt"]).toBeNull();
+    });
+
+    test("restarts the backfill for every column that changes what the number means", async () => {
+      const definitionKeys: Array<string> = [
+        "startAnchorType",
+        "endAnchorType",
+        "startAlertStateId",
+        "endAlertStateId",
+        "startAlertStateRole",
+        "endAlertStateRole",
+        "startStateOccurrence",
+        "endStateOccurrence",
+        "isEnabled",
+      ];
+
+      for (const key of definitionKeys) {
+        jest
+          .spyOn(AlertMeasurementService, "findBy")
+          .mockResolvedValue([] as Array<AlertMeasurement> as never);
+
+        const updateBy: UpdateBy<AlertMeasurement> = buildUpdateBy({
+          [key]: undefined,
+        });
+
+        await hooks.onBeforeUpdate(updateBy);
+
+        expect(dataOf(updateBy)["backfillRequestedAt"]).toBeInstanceOf(Date);
+      }
+    });
+
+    test("writes only timestamps into the backfill columns, never an id", async () => {
+      /*
+       * The hook reaches updateBy.data through a cast, so the compiler cannot
+       * catch a measurement or state id assigned into one of these three
+       * columns. Every one of them is a TIMESTAMP in Postgres: an ObjectID
+       * landing here is a write error at runtime, and the cursor column would
+       * take the whole backfill down with it.
+       */
+      jest
+        .spyOn(AlertMeasurementService, "findBy")
+        .mockResolvedValue([buildExistingMeasurement({})] as never);
+
+      const updateBy: UpdateBy<AlertMeasurement> = buildUpdateBy({
+        isEnabled: false,
+      });
+
+      await hooks.onBeforeUpdate(updateBy);
+
+      const data: Record<string, unknown> = dataOf(updateBy);
+
+      for (const column of [
+        "backfillRequestedAt",
+        "backfillCursorCreatedAt",
+        "backfillCompletedAt",
+      ]) {
+        expect(data[column]).not.toBeInstanceOf(ObjectID);
+        expect(typeof data[column]).not.toBe("string");
+      }
+
+      expect(data["backfillRequestedAt"]).toBeInstanceOf(Date);
+    });
+
+    test("leaves the backfill alone for a rename, so renaming a measurement does not recompute every alert", async () => {
+      const updateBy: UpdateBy<AlertMeasurement> = buildUpdateBy({
+        name: "Time to Acknowledge (v2)",
+      });
+
+      await hooks.onBeforeUpdate(updateBy);
+
+      const data: Record<string, unknown> = dataOf(updateBy);
+
+      expect(data["backfillRequestedAt"]).toBeUndefined();
+      expect(AlertMeasurementService.findBy).not.toHaveBeenCalled();
+    });
+
+    test("leaves the backfill alone for the presentation-only columns", async () => {
+      for (const key of [
+        "description",
+        "showOnAlertView",
+        "order",
+        "unit",
+        "aggregationType",
+      ]) {
+        const updateBy: UpdateBy<AlertMeasurement> = buildUpdateBy({
+          [key]: undefined,
+        });
+
+        await hooks.onBeforeUpdate(updateBy);
+
+        expect(dataOf(updateBy)["backfillRequestedAt"]).toBeUndefined();
+      }
+
+      expect(AlertMeasurementService.findBy).not.toHaveBeenCalled();
+    });
+
+    test("validates the edit against the stored definition, so a half-specified change cannot become an unmeasurable one", async () => {
+      /*
+       * The update carries only the end anchor. Merged onto the stored row it
+       * becomes "created at -> created at", which the create path would have
+       * rejected outright.
+       */
+      const existing: AlertMeasurement = buildExistingMeasurement({});
+      existing.startAnchorType = AlertMeasurementAnchorType.CreatedAt;
+
+      jest
+        .spyOn(AlertMeasurementService, "findBy")
+        .mockResolvedValue([existing] as never);
+
+      const updateBy: UpdateBy<AlertMeasurement> = buildUpdateBy({
+        endAnchorType: AlertMeasurementAnchorType.CreatedAt,
+      });
+
+      await expect(hooks.onBeforeUpdate(updateBy)).rejects.toThrow(
+        /always be zero/,
+      );
+    });
+  });
+
+  describe("onBeforeDelete", () => {
+    function deleteBy(): DeleteBy<AlertMeasurement> {
+      return {
+        query: { _id: MEASUREMENT_ID.toString() },
+        props: { isRoot: true },
+        limit: 1,
+        skip: 0,
+      } as unknown as DeleteBy<AlertMeasurement>;
+    }
+
+    test("refuses to delete a built-in measurement and names it, because its metric series is referenced elsewhere", async () => {
+      jest.spyOn(AlertMeasurementService, "findBy").mockResolvedValue([
+        buildExistingMeasurement({
+          isSystemDefined: true,
+          name: "Time to Acknowledge",
+        }),
+      ] as never);
+
+      await expect(hooks.onBeforeDelete(deleteBy())).rejects.toThrow(
+        /Time to Acknowledge/,
+      );
+      await expect(hooks.onBeforeDelete(deleteBy())).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    test("allows a measurement the project defined itself to be deleted", async () => {
+      jest
+        .spyOn(AlertMeasurementService, "findBy")
+        .mockResolvedValue([
+          buildExistingMeasurement({ isSystemDefined: false }),
+        ] as never);
+
+      await expect(hooks.onBeforeDelete(deleteBy())).resolves.toBeDefined();
+    });
+
+    test("refuses a bulk delete that would sweep up a built-in measurement alongside custom ones", async () => {
+      jest.spyOn(AlertMeasurementService, "findBy").mockResolvedValue([
+        buildExistingMeasurement({
+          isSystemDefined: false,
+          name: "Time to Page",
+        }),
+        buildExistingMeasurement({
+          isSystemDefined: true,
+          name: "Time to Resolve",
+        }),
+      ] as never);
+
+      await expect(hooks.onBeforeDelete(deleteBy())).rejects.toThrow(
+        /Time to Resolve/,
+      );
+    });
+  });
+
+  describe("getMetricNamesForProject", () => {
+    test("includes disabled definitions, so disabling one tombstones its points instead of stranding them", async () => {
+      jest.spyOn(AlertMeasurementService, "findBy").mockResolvedValue([
+        buildExistingMeasurement({
+          isEnabled: true,
+          metricName: "oneuptime.alert.measurement.time-to-acknowledge",
+        }),
+        buildExistingMeasurement({
+          isEnabled: false,
+          metricName: "oneuptime.alert.measurement.time-to-resolve",
+        }),
+      ] as never);
+
+      const names: Array<string> =
+        await AlertMeasurementService.getMetricNamesForProject(PROJECT_ID);
+
+      expect(names).toEqual([
+        "oneuptime.alert.measurement.time-to-acknowledge",
+        "oneuptime.alert.measurement.time-to-resolve",
+      ]);
+    });
+
+    test("drops a row with no metric name rather than returning a hole the writer would compare against", async () => {
+      jest.spyOn(AlertMeasurementService, "findBy").mockResolvedValue([
+        buildExistingMeasurement({
+          metricName: "oneuptime.alert.measurement.time-to-acknowledge",
+        }),
+        buildExistingMeasurement({}),
+      ] as never);
+
+      const names: Array<string> =
+        await AlertMeasurementService.getMetricNamesForProject(PROJECT_ID);
+
+      expect(names).toEqual([
+        "oneuptime.alert.measurement.time-to-acknowledge",
+      ]);
+    });
+
+    test("returns an empty list for a project with no measurements, which stops the writer touching ClickHouse at all", async () => {
+      const names: Array<string> =
+        await AlertMeasurementService.getMetricNamesForProject(PROJECT_ID);
+
+      expect(names).toEqual([]);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/ScheduledMaintenanceMeasurementService.test.ts
+++ b/Common/Tests/Server/Services/ScheduledMaintenanceMeasurementService.test.ts
@@ -1,0 +1,750 @@
+import ScheduledMaintenanceMeasurement from "../../../Models/DatabaseModels/ScheduledMaintenanceMeasurement";
+import ScheduledMaintenanceState from "../../../Models/DatabaseModels/ScheduledMaintenanceState";
+import ScheduledMaintenanceMeasurementService from "../../../Server/Services/ScheduledMaintenanceMeasurementService";
+import ScheduledMaintenanceStateService from "../../../Server/Services/ScheduledMaintenanceStateService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import DeleteBy from "../../../Server/Types/Database/DeleteBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import {
+  OnCreate,
+  OnDelete,
+  OnUpdate,
+} from "../../../Server/Types/Database/Hooks";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ScheduledMaintenanceMeasurementAnchorType from "../../../Types/ScheduledMaintenance/ScheduledMaintenanceMeasurementAnchorType";
+import ScheduledMaintenanceStateRole from "../../../Types/ScheduledMaintenance/ScheduledMaintenanceStateRole";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The scheduled maintenance twin of
+ * Tests/Server/Services/IncidentMeasurementService.test.ts -- keep the three
+ * suites symmetric, the services are line-for-line equivalents over a
+ * different set of state columns and anchors.
+ *
+ * Maintenance is the domain that carries a PLANNED window, so this suite also
+ * pins the anchors incidents and alerts do not have: scheduled starts / ends
+ * against what actually happened.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MEASUREMENT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SCHEDULED_STATE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const COMPLETED_STATE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+/*
+ * The hooks are protected, as they are on every DatabaseService. Reaching them
+ * through a cast is how the rest of this suite exercises them -- see
+ * Tests/Server/Types/Database/Permissions/TenantPermission.test.ts.
+ */
+interface MeasurementHooks {
+  onBeforeCreate(
+    createBy: CreateBy<ScheduledMaintenanceMeasurement>,
+  ): Promise<OnCreate<ScheduledMaintenanceMeasurement>>;
+  onBeforeUpdate(
+    updateBy: UpdateBy<ScheduledMaintenanceMeasurement>,
+  ): Promise<OnUpdate<ScheduledMaintenanceMeasurement>>;
+  onBeforeDelete(
+    deleteBy: DeleteBy<ScheduledMaintenanceMeasurement>,
+  ): Promise<OnDelete<ScheduledMaintenanceMeasurement>>;
+}
+
+const hooks: MeasurementHooks =
+  ScheduledMaintenanceMeasurementService as unknown as MeasurementHooks;
+
+function buildCreateBy(input: {
+  key?: string;
+  name?: string;
+  order?: number;
+  startAnchorType?: ScheduledMaintenanceMeasurementAnchorType;
+  endAnchorType?: ScheduledMaintenanceMeasurementAnchorType;
+  startStateId?: ObjectID;
+  endStateId?: ObjectID;
+  startStateRole?: ScheduledMaintenanceStateRole;
+  endStateRole?: ScheduledMaintenanceStateRole;
+}): CreateBy<ScheduledMaintenanceMeasurement> {
+  const measurement: ScheduledMaintenanceMeasurement =
+    new ScheduledMaintenanceMeasurement();
+
+  measurement.projectId = PROJECT_ID;
+  measurement.name = input.name ?? "Start Delay";
+  measurement.key = input.key ?? "start-delay";
+  measurement.startAnchorType =
+    input.startAnchorType ??
+    ScheduledMaintenanceMeasurementAnchorType.ScheduledStartsAt;
+  measurement.endAnchorType =
+    input.endAnchorType ??
+    ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered;
+
+  if (input.order !== undefined) {
+    measurement.order = input.order;
+  }
+
+  if (input.startStateId) {
+    measurement.startScheduledMaintenanceStateId = input.startStateId;
+  }
+
+  if (input.endStateId) {
+    measurement.endScheduledMaintenanceStateId = input.endStateId;
+  }
+
+  if (input.startStateRole) {
+    measurement.startScheduledMaintenanceStateRole = input.startStateRole;
+  }
+
+  if (
+    measurement.endAnchorType ===
+    ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered
+  ) {
+    measurement.endScheduledMaintenanceStateRole =
+      input.endStateRole ?? ScheduledMaintenanceStateRole.Ongoing;
+  } else if (input.endStateRole) {
+    measurement.endScheduledMaintenanceStateRole = input.endStateRole;
+  }
+
+  return {
+    data: measurement,
+    props: { isRoot: true },
+  };
+}
+
+function buildExistingMeasurement(input: {
+  isSystemDefined?: boolean;
+  name?: string;
+  metricName?: string;
+  isEnabled?: boolean;
+}): ScheduledMaintenanceMeasurement {
+  const measurement: ScheduledMaintenanceMeasurement =
+    new ScheduledMaintenanceMeasurement();
+
+  measurement._id = MEASUREMENT_ID.toString();
+  measurement.id = MEASUREMENT_ID;
+  measurement.projectId = PROJECT_ID;
+  measurement.name = input.name ?? "Start Delay";
+  measurement.isSystemDefined = input.isSystemDefined ?? false;
+  measurement.isEnabled = input.isEnabled ?? true;
+  measurement.startAnchorType =
+    ScheduledMaintenanceMeasurementAnchorType.ScheduledStartsAt;
+  measurement.endAnchorType =
+    ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered;
+  measurement.endScheduledMaintenanceStateRole =
+    ScheduledMaintenanceStateRole.Ongoing;
+
+  if (input.metricName) {
+    measurement.metricName = input.metricName;
+  }
+
+  return measurement;
+}
+
+function buildScheduledMaintenanceState(input: {
+  id: ObjectID;
+  name: string;
+  order: number;
+}): ScheduledMaintenanceState {
+  const state: ScheduledMaintenanceState = new ScheduledMaintenanceState();
+
+  state._id = input.id.toString();
+  state.id = input.id;
+  state.name = input.name;
+  state.order = input.order;
+
+  return state;
+}
+
+function buildUpdateBy(
+  data: Record<string, unknown>,
+): UpdateBy<ScheduledMaintenanceMeasurement> {
+  return {
+    id: MEASUREMENT_ID,
+    query: { _id: MEASUREMENT_ID.toString() },
+    data: data,
+    props: { isRoot: true },
+    limit: 1,
+    skip: 0,
+  } as unknown as UpdateBy<ScheduledMaintenanceMeasurement>;
+}
+
+function dataOf(
+  updateBy: UpdateBy<ScheduledMaintenanceMeasurement>,
+): Record<string, unknown> {
+  return updateBy.data as unknown as Record<string, unknown>;
+}
+
+describe("ScheduledMaintenanceMeasurementService", () => {
+  beforeEach(() => {
+    // No existing definitions unless a test says otherwise.
+    jest
+      .spyOn(ScheduledMaintenanceMeasurementService, "findOneBy")
+      .mockResolvedValue(null as never);
+    jest
+      .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+      .mockResolvedValue([] as Array<ScheduledMaintenanceMeasurement> as never);
+    jest
+      .spyOn(ScheduledMaintenanceStateService, "findBy")
+      .mockResolvedValue([] as Array<ScheduledMaintenanceState> as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("onBeforeCreate", () => {
+    test("rejects a key that could not survive as part of a metric name", async () => {
+      /*
+       * The key lands in the metric name, in ClickHouse and in the API, and is
+       * immutable afterwards. This is the only moment it can still be fixed.
+       */
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "Start Delay" })),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "" })),
+      ).rejects.toThrow(BadDataException);
+
+      // Leading hyphen, and one character past the 50 the column allows.
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "-start-delay" })),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        hooks.onBeforeCreate(buildCreateBy({ key: "a".repeat(51) })),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("accepts a lowercase hyphenated key", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        { key: "maintenance-overrun" },
+      );
+
+      await expect(hooks.onBeforeCreate(createBy)).resolves.toBeDefined();
+    });
+
+    test("derives the metric name from the key, so a new definition is chartable with no dashboard change", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        { key: "start-delay" },
+      );
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.metricName).toBe(
+        "oneuptime.scheduled-maintenance.measurement.start-delay",
+      );
+    });
+
+    test("puts a new definition after the project's last one, so the settings list has a stable order", async () => {
+      const highest: ScheduledMaintenanceMeasurement =
+        new ScheduledMaintenanceMeasurement();
+      highest.order = 2;
+
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findOneBy")
+        .mockResolvedValue(highest as never);
+
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        {},
+      );
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.order).toBe(3);
+    });
+
+    test("gives the first definition in a project order 1", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        {},
+      );
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.order).toBe(1);
+    });
+
+    test("keeps an order the caller supplied, so a reordered list is not overwritten on save", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        { order: 6 },
+      );
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.order).toBe(6);
+      expect(
+        ScheduledMaintenanceMeasurementService.findOneBy,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("requests a backfill, or the definition would be blank on every maintenance event that already ran", async () => {
+      const before: number = Date.now();
+
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        {},
+      );
+
+      await hooks.onBeforeCreate(createBy);
+
+      const requestedAt: Date | undefined = createBy.data.backfillRequestedAt;
+
+      expect(requestedAt).toBeInstanceOf(Date);
+      expect(requestedAt!.getTime()).toBeGreaterThanOrEqual(before - 1000);
+      expect(requestedAt!.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+
+    test("leaves the backfill cursor and completion stamp unset on create, so the worker starts from the beginning", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        {},
+      );
+
+      await hooks.onBeforeCreate(createBy);
+
+      expect(createBy.data.backfillCursorCreatedAt).toBeUndefined();
+      expect(createBy.data.backfillCompletedAt).toBeUndefined();
+    });
+
+    test("accepts the planned window as a measurement, which is the anchor pair only maintenance has", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        {
+          key: "planned-window-length",
+          startAnchorType:
+            ScheduledMaintenanceMeasurementAnchorType.ScheduledStartsAt,
+          endAnchorType:
+            ScheduledMaintenanceMeasurementAnchorType.ScheduledEndsAt,
+        },
+      );
+
+      await expect(hooks.onBeforeCreate(createBy)).resolves.toBeDefined();
+    });
+
+    test("rejects a definition with no start or no end, which has nothing to measure between", async () => {
+      const missingStart: CreateBy<ScheduledMaintenanceMeasurement> =
+        buildCreateBy({});
+      delete missingStart.data.startAnchorType;
+
+      await expect(hooks.onBeforeCreate(missingStart)).rejects.toThrow(
+        BadDataException,
+      );
+
+      const missingEnd: CreateBy<ScheduledMaintenanceMeasurement> =
+        buildCreateBy({});
+      delete missingEnd.data.endAnchorType;
+
+      await expect(hooks.onBeforeCreate(missingEnd)).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    test("rejects a state anchor with no state picked, which would never resolve to a timestamp", async () => {
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateEntered,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.ScheduledEndsAt,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.ScheduledStartsAt,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateEntered,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("rejects a state-role anchor with no role picked", async () => {
+      const createBy: CreateBy<ScheduledMaintenanceMeasurement> = buildCreateBy(
+        {
+          startAnchorType:
+            ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered,
+          endAnchorType:
+            ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered,
+          endStateRole: ScheduledMaintenanceStateRole.Ended,
+        },
+      );
+
+      // No start role, so the start of the duration has no timestamp to read.
+      delete createBy.data.startScheduledMaintenanceStateRole;
+
+      await expect(hooks.onBeforeCreate(createBy)).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    test("rejects two anchors that read the same column, which would chart a constant zero", async () => {
+      /*
+       * Different enum values, one column: both Timeline Start and Created At
+       * resolve to the event's createdAt.
+       */
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.TimelineStart,
+            endAnchorType: ScheduledMaintenanceMeasurementAnchorType.CreatedAt,
+          }),
+        ),
+      ).rejects.toThrow(/always be zero/);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.ScheduledEndsAt,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.ScheduledEndsAt,
+          }),
+        ),
+      ).rejects.toThrow(/always be zero/);
+    });
+
+    test("rejects the same state role at both ends, and allows two different ones", async () => {
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered,
+            startStateRole: ScheduledMaintenanceStateRole.Ongoing,
+            endStateRole: ScheduledMaintenanceStateRole.Ongoing,
+          }),
+        ),
+      ).rejects.toThrow(/always be zero/);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateRoleEntered,
+            startStateRole: ScheduledMaintenanceStateRole.Ongoing,
+            endStateRole: ScheduledMaintenanceStateRole.Ended,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    test("rejects a definition that ends at a state the event reaches before it starts, which could never complete", async () => {
+      jest.spyOn(ScheduledMaintenanceStateService, "findBy").mockResolvedValue([
+        buildScheduledMaintenanceState({
+          id: SCHEDULED_STATE_ID,
+          name: "Scheduled",
+          order: 1,
+        }),
+        buildScheduledMaintenanceState({
+          id: COMPLETED_STATE_ID,
+          name: "Completed",
+          order: 3,
+        }),
+      ] as never);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateEntered,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateEntered,
+            startStateId: COMPLETED_STATE_ID,
+            endStateId: SCHEDULED_STATE_ID,
+          }),
+        ),
+      ).rejects.toThrow(/Completed/);
+
+      await expect(
+        hooks.onBeforeCreate(
+          buildCreateBy({
+            startAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateEntered,
+            endAnchorType:
+              ScheduledMaintenanceMeasurementAnchorType.StateEntered,
+            startStateId: SCHEDULED_STATE_ID,
+            endStateId: COMPLETED_STATE_ID,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("onBeforeUpdate", () => {
+    test("restarts the backfill when the definition's meaning changes, so its stored history is rewritten", async () => {
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([buildExistingMeasurement({})] as never);
+
+      const updateBy: UpdateBy<ScheduledMaintenanceMeasurement> = buildUpdateBy(
+        { endStateOccurrence: "Last" },
+      );
+
+      await hooks.onBeforeUpdate(updateBy);
+
+      const data: Record<string, unknown> = dataOf(updateBy);
+
+      expect(data["backfillRequestedAt"]).toBeInstanceOf(Date);
+      // Cleared, or the restarted backfill would resume mid-way through.
+      expect(data["backfillCursorCreatedAt"]).toBeNull();
+      expect(data["backfillCompletedAt"]).toBeNull();
+    });
+
+    test("restarts the backfill for every column that changes what the number means", async () => {
+      const definitionKeys: Array<string> = [
+        "startAnchorType",
+        "endAnchorType",
+        "startScheduledMaintenanceStateId",
+        "endScheduledMaintenanceStateId",
+        "startScheduledMaintenanceStateRole",
+        "endScheduledMaintenanceStateRole",
+        "startStateOccurrence",
+        "endStateOccurrence",
+        "isEnabled",
+      ];
+
+      for (const key of definitionKeys) {
+        jest
+          .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+          .mockResolvedValue(
+            [] as Array<ScheduledMaintenanceMeasurement> as never,
+          );
+
+        const updateBy: UpdateBy<ScheduledMaintenanceMeasurement> =
+          buildUpdateBy({ [key]: undefined });
+
+        await hooks.onBeforeUpdate(updateBy);
+
+        expect(dataOf(updateBy)["backfillRequestedAt"]).toBeInstanceOf(Date);
+      }
+    });
+
+    test("writes only timestamps into the backfill columns, never an id", async () => {
+      /*
+       * The hook reaches updateBy.data through a cast, so the compiler cannot
+       * catch a measurement or state id assigned into one of these three
+       * columns. Every one of them is a TIMESTAMP in Postgres: an ObjectID
+       * landing here is a write error at runtime, and the cursor column would
+       * take the whole backfill down with it.
+       */
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([buildExistingMeasurement({})] as never);
+
+      const updateBy: UpdateBy<ScheduledMaintenanceMeasurement> = buildUpdateBy(
+        { isEnabled: false },
+      );
+
+      await hooks.onBeforeUpdate(updateBy);
+
+      const data: Record<string, unknown> = dataOf(updateBy);
+
+      for (const column of [
+        "backfillRequestedAt",
+        "backfillCursorCreatedAt",
+        "backfillCompletedAt",
+      ]) {
+        expect(data[column]).not.toBeInstanceOf(ObjectID);
+        expect(typeof data[column]).not.toBe("string");
+      }
+
+      expect(data["backfillRequestedAt"]).toBeInstanceOf(Date);
+    });
+
+    test("leaves the backfill alone for a rename, so renaming a measurement does not recompute every event", async () => {
+      const updateBy: UpdateBy<ScheduledMaintenanceMeasurement> = buildUpdateBy(
+        { name: "Start Delay (v2)" },
+      );
+
+      await hooks.onBeforeUpdate(updateBy);
+
+      const data: Record<string, unknown> = dataOf(updateBy);
+
+      expect(data["backfillRequestedAt"]).toBeUndefined();
+      expect(
+        ScheduledMaintenanceMeasurementService.findBy,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("leaves the backfill alone for the presentation-only columns", async () => {
+      for (const key of [
+        "description",
+        "showOnScheduledMaintenanceView",
+        "order",
+        "unit",
+        "aggregationType",
+      ]) {
+        const updateBy: UpdateBy<ScheduledMaintenanceMeasurement> =
+          buildUpdateBy({ [key]: undefined });
+
+        await hooks.onBeforeUpdate(updateBy);
+
+        expect(dataOf(updateBy)["backfillRequestedAt"]).toBeUndefined();
+      }
+
+      expect(
+        ScheduledMaintenanceMeasurementService.findBy,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("validates the edit against the stored definition, so a half-specified change cannot become an unmeasurable one", async () => {
+      /*
+       * The update carries only the end anchor. Merged onto the stored row it
+       * becomes "scheduled starts at -> scheduled starts at", which the create
+       * path would have rejected outright.
+       */
+      const existing: ScheduledMaintenanceMeasurement =
+        buildExistingMeasurement({});
+
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([existing] as never);
+
+      const updateBy: UpdateBy<ScheduledMaintenanceMeasurement> = buildUpdateBy(
+        {
+          endAnchorType:
+            ScheduledMaintenanceMeasurementAnchorType.ScheduledStartsAt,
+        },
+      );
+
+      await expect(hooks.onBeforeUpdate(updateBy)).rejects.toThrow(
+        /always be zero/,
+      );
+    });
+  });
+
+  describe("onBeforeDelete", () => {
+    function deleteBy(): DeleteBy<ScheduledMaintenanceMeasurement> {
+      return {
+        query: { _id: MEASUREMENT_ID.toString() },
+        props: { isRoot: true },
+        limit: 1,
+        skip: 0,
+      } as unknown as DeleteBy<ScheduledMaintenanceMeasurement>;
+    }
+
+    test("refuses to delete a built-in measurement and names it, because its metric series is referenced elsewhere", async () => {
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([
+          buildExistingMeasurement({
+            isSystemDefined: true,
+            name: "Start Delay",
+          }),
+        ] as never);
+
+      await expect(hooks.onBeforeDelete(deleteBy())).rejects.toThrow(
+        /Start Delay/,
+      );
+      await expect(hooks.onBeforeDelete(deleteBy())).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    test("allows a measurement the project defined itself to be deleted", async () => {
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([
+          buildExistingMeasurement({ isSystemDefined: false }),
+        ] as never);
+
+      await expect(hooks.onBeforeDelete(deleteBy())).resolves.toBeDefined();
+    });
+
+    test("refuses a bulk delete that would sweep up a built-in measurement alongside custom ones", async () => {
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([
+          buildExistingMeasurement({
+            isSystemDefined: false,
+            name: "Approval Lead Time",
+          }),
+          buildExistingMeasurement({
+            isSystemDefined: true,
+            name: "Maintenance Duration",
+          }),
+        ] as never);
+
+      await expect(hooks.onBeforeDelete(deleteBy())).rejects.toThrow(
+        /Maintenance Duration/,
+      );
+    });
+  });
+
+  describe("getMetricNamesForProject", () => {
+    test("includes disabled definitions, so disabling one tombstones its points instead of stranding them", async () => {
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([
+          buildExistingMeasurement({
+            isEnabled: true,
+            metricName:
+              "oneuptime.scheduled-maintenance.measurement.start-delay",
+          }),
+          buildExistingMeasurement({
+            isEnabled: false,
+            metricName:
+              "oneuptime.scheduled-maintenance.measurement.maintenance-duration",
+          }),
+        ] as never);
+
+      const names: Array<string> =
+        await ScheduledMaintenanceMeasurementService.getMetricNamesForProject(
+          PROJECT_ID,
+        );
+
+      expect(names).toEqual([
+        "oneuptime.scheduled-maintenance.measurement.start-delay",
+        "oneuptime.scheduled-maintenance.measurement.maintenance-duration",
+      ]);
+    });
+
+    test("drops a row with no metric name rather than returning a hole the writer would compare against", async () => {
+      jest
+        .spyOn(ScheduledMaintenanceMeasurementService, "findBy")
+        .mockResolvedValue([
+          buildExistingMeasurement({
+            metricName:
+              "oneuptime.scheduled-maintenance.measurement.start-delay",
+          }),
+          buildExistingMeasurement({}),
+        ] as never);
+
+      const names: Array<string> =
+        await ScheduledMaintenanceMeasurementService.getMetricNamesForProject(
+          PROJECT_ID,
+        );
+
+      expect(names).toEqual([
+        "oneuptime.scheduled-maintenance.measurement.start-delay",
+      ]);
+    });
+
+    test("returns an empty list for a project with no measurements, which stops the writer touching ClickHouse at all", async () => {
+      const names: Array<string> =
+        await ScheduledMaintenanceMeasurementService.getMetricNamesForProject(
+          PROJECT_ID,
+        );
+
+      expect(names).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What this is

The reported `TS2740: Type 'ObjectID' is missing the following properties from type 'Date'` at `Common/Server/Services/ScheduledMaintenanceMeasurementService.ts:172` **does not exist**. Line 172 is the closing brace of the `for (const existing of existingItems)` loop, and the file is byte-identical to the copy on `master`. It typechecks clean under `Common/tsconfig.json` and under `App/tsconfig.json` with `Common/*` pointed at the branch's own `Common`. The `AlertMeasurementService.ts(77,34)` `TS2589` does not reproduce either — `App/FeatureSet/Dashboard` compiles clean.

Both were artifacts of a build that had **two copies of `Common` in one program**. `App/node_modules/Common` is a symlink to `../../Common`, so when `App/node_modules` is itself a symlink into the main checkout, `Common/*` imports resolve to the main repo's `Common` while relative imports resolve to the worktree's. Reproduced here on an untouched tree: that setup reports `TS2322 ... Types have separate declarations of a private property '_id'` in `Tests/Dashboard/RecommendationFilterUtil.test.ts`, and every one of those errors disappears once `paths` maps `Common/*` back to the worktree. Same shape, same cause.

So there is nothing to fix in the services — but the reported failure mode is real and the type system genuinely cannot catch it, which is what this PR addresses instead.

## Why tests rather than a fix

Every write in this area goes through an `as unknown as` cast, because the measurement models carry enough relations that instantiating `Partial<Model>` over them trips the compiler's recursion limit:

```ts
const backfillFields: BackfillFields = updateBy.data as unknown as BackfillFields;
```

```ts
patch["backfillCursorCreatedAt"] = data.cursorCreatedAt;   // Record<string, unknown>
```

`backfillRequestedAt`, `backfillCursorCreatedAt` and `backfillCompletedAt` are all `TIMESTAMP WITH TIME ZONE`. An `ObjectID` reaching one of them is a runtime write error that takes down the whole backfill for that project, and the compiler would not say a word. These tests are the guard the types cannot be.

## What is covered

Only `IncidentMeasurementService` had a hook suite. This adds the two missing twins and a first suite for the cron.

**`Common/Tests/Server/Services/AlertMeasurementService.test.ts` (26 tests)** and **`.../ScheduledMaintenanceMeasurementService.test.ts` (27 tests)** — key validation, metric-name derivation, ordering, the anchor rules (missing endpoints, state/role anchors with nothing picked, two anchors that read one column, state order), the definition-vs-presentation split that decides whether an update restarts the backfill, and the delete guard on built-ins. Both assert the update hook writes only `Date`s and `null`s into the three backfill columns, never an id or a string. The maintenance suite also pins the planned-window anchors that only that domain has.

**`App/Tests/Workers/Jobs/Measurement/BackfillMeasurements.test.ts` (19 tests)** — completed-at-or-after-requested skipping, the cursor resume and its deliberately inclusive boundary, the progress patch shape (`Date`s in the columns, the measurement id travelling as the row `id`), completion stamped on a short page and on an empty project, the same-timestamp stall bail-out, the per-run page cap, and the isolation that keeps one unreadable entity — or one broken domain — from stalling everything behind it. The job registers itself via `RunCron` at import time, so the Cron util is mocked to capture the handler, matching the other `App/Tests/Workers/Jobs` suites.

## Verification

- `Common`: 67 tests pass across the three measurement service suites (14 existing incident + 53 new).
- `App`: 19 tests pass in the new backfill suite.
- `App/tsconfig.json` with `Common/*` mapped to this branch's `Common`: clean, apart from a pre-existing `js-yaml` `TS7016` caused by `@types/js-yaml` not being installed in the shared `node_modules` — present on `master` too and unrelated to this change.
- `prettier --check` and `eslint` clean on all three files.

No source files are touched.