### PR TITLE
fix(topology): judge site-scoped link rules on the whole fleet, not the map's page

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
@@ -57,6 +57,153 @@ import NetworkTopologySuppressionService from "Common/Server/Services/NetworkTop
 // Hard cap on endpoint rows fed to the builder — beyond this the map is noise.
 const MAX_TOPOLOGY_ENDPOINTS: number = 2000;
 
+/*
+ * Bounds on the link-rule device sweep.
+ *
+ * The map itself is capped at LIMIT_PER_PROJECT devices because beyond that
+ * there is nothing a human can read. The link RULES are a different question:
+ * "is there exactly one router in this site" is answered wrongly, not
+ * partially, when the router happens to sit outside the first page of rows.
+ * That is issue #3321 — 949 sites, a fleet past the 10,000-row cap, and a
+ * banner reporting 697 sites as having no parent device when their routers
+ * were simply never fetched.
+ *
+ * So the rules get their own pass over the fleet, in pages, reading only the
+ * four columns they need. It is skipped entirely unless the map's own page
+ * came back full, which is the only circumstance in which the two device sets
+ * can differ — an ordinary project pays for nothing.
+ */
+const LINK_RULE_DEVICE_PAGE_SIZE: number = LIMIT_PER_PROJECT;
+const MAX_LINK_RULE_DEVICES: number = LIMIT_PER_PROJECT * 10;
+
+interface LinkRuleDeviceSweep {
+  devices: Array<LinkRuleDeviceInput>;
+  /*
+   * The sweep stopped at MAX_LINK_RULE_DEVICES with rows still unread, so its
+   * verdicts really might be about devices it never saw. Distinct from the
+   * map's own truncation, which says nothing about the rules either way.
+   */
+  isTruncated: boolean;
+}
+
+/*
+ * Every device a link rule could match, in pages. A fresh query object per
+ * page on purpose: the query layer rewrites what it is handed (relation
+ * filters are deleted and re-expressed against _id), so handing the same
+ * object round a loop would compile a different statement each time.
+ */
+async function sweepLinkRuleDevices(data: {
+  projectId: ObjectID;
+  siteId: string | null;
+  props: DatabaseCommonInteractionProps;
+}): Promise<LinkRuleDeviceSweep> {
+  const collected: Array<LinkRuleDeviceInput> = [];
+  let skip: number = 0;
+
+  for (;;) {
+    const query: Query<NetworkDevice> = {
+      projectId: data.projectId,
+      isArchived: false,
+    };
+    if (data.siteId) {
+      query.siteId = new ObjectID(data.siteId);
+    }
+
+    const page: Array<NetworkDevice> = await NetworkDeviceService.findBy({
+      query: query,
+      /*
+       * The resolver reads labels, a site and that site's name. Nothing on
+       * this pass is rendered, so none of the map's forty columns are read —
+       * which is what makes a full-fleet sweep affordable at all.
+       */
+      select: {
+        _id: true,
+        siteId: true,
+        site: {
+          name: true,
+        },
+        labels: {
+          _id: true,
+        },
+      },
+      /*
+       * By id, not by the default createdAt: a discovery import stamps
+       * thousands of devices with the same createdAt, and rows tied on the
+       * sort key can shift between pages and be read twice or skipped —
+       * which would put back exactly the phantom "no parent in this site"
+       * this sweep exists to remove.
+       */
+      sort: {
+        _id: SortOrder.Ascending,
+      },
+      limit: LINK_RULE_DEVICE_PAGE_SIZE,
+      skip: skip,
+      props: data.props,
+    });
+
+    for (const device of page) {
+      if (!device.id) {
+        continue;
+      }
+      collected.push({
+        id: device.id.toString(),
+        labelIds: (device.labels || [])
+          .map((label: Label) => {
+            return label._id ? label._id.toString() : "";
+          })
+          .filter((id: string) => {
+            return id.length > 0;
+          }),
+        /*
+         * .toString() is load-bearing: the resolver keys a Map on this to
+         * group devices by site, and an ObjectID instance would compare by
+         * identity — putting every device in a site of its own and silently
+         * reducing site scope to nothing.
+         */
+        siteId: device.siteId?.toString(),
+        siteName: device.site?.name,
+      });
+    }
+
+    skip += page.length;
+
+    // A short page is the end of the fleet, with nothing left unread.
+    if (page.length < LINK_RULE_DEVICE_PAGE_SIZE) {
+      return { devices: collected, isTruncated: false };
+    }
+
+    if (skip >= MAX_LINK_RULE_DEVICES) {
+      /*
+       * A full last page is not proof that more devices exist — a fleet of
+       * exactly the cap would confess to a truncation that never happened,
+       * and every warning would then carry a caveat it does not need. One
+       * row settles it.
+       */
+      const nextDevice: Array<NetworkDevice> =
+        await NetworkDeviceService.findBy({
+          query: data.siteId
+            ? {
+                projectId: data.projectId,
+                isArchived: false,
+                siteId: new ObjectID(data.siteId),
+              }
+            : { projectId: data.projectId, isArchived: false },
+          select: {
+            _id: true,
+          },
+          sort: {
+            _id: SortOrder.Ascending,
+          },
+          limit: 1,
+          skip: skip,
+          props: data.props,
+        });
+
+      return { devices: collected, isTruncated: nextDevice.length > 0 };
+    }
+  }
+}
+
 export default class NetworkDeviceTopologyAPI {
   public getRouter(): ExpressRouter {
     const router: ExpressRouter = Express.getRouter();
@@ -198,6 +345,14 @@ export default class NetworkDeviceTopologyAPI {
               return device.id!.toString();
             }),
           );
+
+          /*
+           * A full page means devices are missing from the GRAPH. Decided here
+           * rather than at the response, because it is also what decides
+           * whether the link rules need a fleet sweep of their own below.
+           */
+          const isDeviceListTruncated: boolean =
+            devices.length >= LIMIT_PER_PROJECT;
 
           /*
            * Interface rows for the devices in THIS graph in ONE query; the
@@ -504,8 +659,44 @@ export default class NetworkDeviceTopologyAPI {
               });
           };
 
-          const ruleDeviceInput: Array<LinkRuleDeviceInput> = devices.map(
-            (device: NetworkDevice) => {
+          /*
+           * A rule with an empty label set on either side resolves the same
+           * way whatever devices exist, so it is not worth a fleet sweep.
+           */
+          const hasResolvableRule: boolean = linkRuleRows.some(
+            (rule: NetworkDeviceLinkRule) => {
+              return (
+                labelIdsOf(rule.childDeviceLabels).length > 0 &&
+                labelIdsOf(rule.parentDeviceLabels).length > 0
+              );
+            },
+          );
+
+          /*
+           * ISSUE #3321. The rules are resolved over the whole fleet, not over
+           * the page the map is drawn from.
+           *
+           * When the map's page is complete it IS the whole fleet, so it is
+           * reused and no second query is issued — which is every project
+           * under the row cap. Past the cap the two device sets genuinely
+           * differ, and judging "exactly one parent in this site" on a partial
+           * fleet does not degrade gracefully: it reports sites as having no
+           * router when their router simply sat outside the page. The sweep is
+           * the only way to tell the two apart.
+           */
+          let isLinkRuleDeviceListTruncated: boolean = false;
+          let ruleDeviceInput: Array<LinkRuleDeviceInput>;
+
+          if (isDeviceListTruncated && hasResolvableRule) {
+            const sweep: LinkRuleDeviceSweep = await sweepLinkRuleDevices({
+              projectId: props.tenantId,
+              siteId: siteId,
+              props: props,
+            });
+            ruleDeviceInput = sweep.devices;
+            isLinkRuleDeviceListTruncated = sweep.isTruncated;
+          } else {
+            ruleDeviceInput = devices.map((device: NetworkDevice) => {
               return {
                 id: device.id!.toString(),
                 labelIds: labelIdsOf(device.labels),
@@ -518,8 +709,8 @@ export default class NetworkDeviceTopologyAPI {
                 siteId: device.siteId?.toString(),
                 siteName: device.site?.name,
               };
-            },
-          );
+            });
+          }
 
           const ruleOutcomes: Array<LinkRuleOutcome> =
             NetworkDeviceLinkRuleUtil.resolveRules(
@@ -613,8 +804,6 @@ export default class NetworkDeviceTopologyAPI {
            * present, only their state is missing) and search cannot fix it,
            * so it gets its own flag rather than lying in this one.
            */
-          const isDeviceListTruncated: boolean =
-            devices.length >= LIMIT_PER_PROJECT;
           topology.isTruncated = isDeviceListTruncated;
 
           /*
@@ -658,12 +847,18 @@ export default class NetworkDeviceTopologyAPI {
               .map((warning: LinkRuleWarning) => {
                 /*
                  * Truncation is a fact about the query, not about the rule, so
-                 * it is admitted here rather than inside the resolver. It
-                 * matters more under site scoping: a cut-off device list can
-                 * strand whole sites whose router simply was not in the first
-                 * page of rows.
+                 * it is admitted here rather than inside the resolver.
+                 *
+                 * The flag read here is the SWEEP's, not the map's. Hedging on
+                 * the map's cap was the old behaviour and it was wrong in both
+                 * directions after #3321: the sweep normally reads the whole
+                 * fleet, so the caveat would be a lie on a truncated map, and
+                 * it would go missing on a fleet larger than the sweep's own
+                 * cap where the doubt is real. A caveat attached to warnings
+                 * that do not need it teaches operators to discount the ones
+                 * that do.
                  */
-                return isDeviceListTruncated
+                return isLinkRuleDeviceListTruncated
                   ? {
                       ...warning,
                       message: `${warning.message} ${NetworkDeviceLinkRuleUtil.TRUNCATED_DEVICE_LIST_NOTE}`,

--- a/App/FeatureSet/Dashboard/src/Components/Topology/LinkRuleWarningUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/LinkRuleWarningUtil.ts
@@ -1,0 +1,219 @@
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+
+/*
+ * The topology map's link-rule banner, computed without react.
+ *
+ * A warning arrives as untrusted JSON — the map is drawn from whatever the
+ * endpoint sent, and a row missing its id or its message must be dropped
+ * rather than rendered as an empty bullet. Parsing and phrasing live here so
+ * both are assertions in the test suite instead of hopes: App/Tests cannot
+ * render a component.
+ *
+ * The site list is the point of issue #3321. The sentence a rule produces
+ * names three sites and then says "and 694 more", which is a blast radius and
+ * not something anybody can act on. These rows are what turn that number back
+ * into a list of buildings to go and look at.
+ */
+
+/** Why one site could not be resolved. Mirrors LinkRuleGroupSkipReason. */
+export type LinkRuleWarningSiteReason = "noParentMatched" | "ambiguousParent";
+
+export interface TopologyLinkRuleWarningSite {
+  siteId: string;
+  siteName?: string | undefined;
+  reason: LinkRuleWarningSiteReason;
+  // Devices in this site the rule wanted to place and could not.
+  strandedDeviceCount: number;
+  // Devices in this site carrying the parent labels: 0, or >= 2 when ambiguous.
+  matchedParentCount: number;
+}
+
+export interface TopologyLinkRuleWarning {
+  ruleId: string;
+  ruleName?: string | undefined;
+  message: string;
+  /*
+   * The failing sites, capped by the endpoint. Never assume this is all of
+   * them — `siteCount` is the true total and can be larger.
+   */
+  sites?: Array<TopologyLinkRuleWarningSite> | undefined;
+  siteCount?: number | undefined;
+}
+
+/*
+ * What a site with no name is called. A site can be read through a device's
+ * relation without its name coming back, so this is a real state rather than
+ * a defensive one.
+ */
+export const UNNAMED_SITE_LABEL: string = "Unnamed site";
+
+const isFiniteNumber: (value: unknown) => value is number = (
+  value: unknown,
+): value is number => {
+  return typeof value === "number" && Number.isFinite(value);
+};
+
+/*
+ * A site row is only worth rendering if it can be named and counted. A row
+ * with no id cannot be pointed at, and a reason outside the two the resolver
+ * produces would render as a sentence nobody wrote.
+ */
+const parseWarningSite: (row: unknown) => TopologyLinkRuleWarningSite | null = (
+  row: unknown,
+): TopologyLinkRuleWarningSite | null => {
+  const site: JSONObject = (row || {}) as JSONObject;
+  const siteId: unknown = site["siteId"];
+  const reason: unknown = site["reason"];
+
+  if (typeof siteId !== "string" || !siteId) {
+    return null;
+  }
+  if (reason !== "noParentMatched" && reason !== "ambiguousParent") {
+    return null;
+  }
+
+  const siteName: unknown = site["siteName"];
+  const stranded: unknown = site["strandedDeviceCount"];
+  const parents: unknown = site["matchedParentCount"];
+
+  return {
+    siteId: siteId,
+    siteName:
+      typeof siteName === "string" && siteName.trim() ? siteName : undefined,
+    reason: reason,
+    /*
+     * Counts are clamped rather than trusted: a negative or missing count
+     * would render as "-1 devices", which reads as a bug in the map rather
+     * than as the malformed payload it is.
+     */
+    strandedDeviceCount:
+      isFiniteNumber(stranded) && stranded > 0 ? stranded : 0,
+    matchedParentCount: isFiniteNumber(parents) && parents > 0 ? parents : 0,
+  };
+};
+
+/** Narrow the endpoint's `linkRuleWarnings` array, dropping malformed rows. */
+export const parseLinkRuleWarnings: (
+  raw: unknown,
+) => Array<TopologyLinkRuleWarning> = (
+  raw: unknown,
+): Array<TopologyLinkRuleWarning> => {
+  const rows: JSONArray = Array.isArray(raw) ? (raw as JSONArray) : [];
+
+  return rows
+    .map((row: unknown): TopologyLinkRuleWarning | null => {
+      const warning: JSONObject = (row || {}) as JSONObject;
+      const ruleId: unknown = warning["ruleId"];
+      const message: unknown = warning["message"];
+
+      if (typeof ruleId !== "string" || !ruleId) {
+        return null;
+      }
+      if (typeof message !== "string" || !message) {
+        return null;
+      }
+
+      const ruleName: unknown = warning["ruleName"];
+      const sites: Array<TopologyLinkRuleWarningSite> = (
+        Array.isArray(warning["sites"])
+          ? (warning["sites"] as JSONArray)
+          : ([] as JSONArray)
+      )
+        .map(parseWarningSite)
+        .filter(
+          (
+            site: TopologyLinkRuleWarningSite | null,
+          ): site is TopologyLinkRuleWarningSite => {
+            return site !== null;
+          },
+        );
+
+      const siteCountRaw: unknown = warning["siteCount"];
+      /*
+       * The endpoint's count wins when it is at least as large as the rows it
+       * sent — that is the whole point of sending both, since the rows are
+       * capped and the count is not. A count SMALLER than the rows is a
+       * payload contradicting itself, so the rows are believed instead.
+       */
+      const siteCount: number = isFiniteNumber(siteCountRaw)
+        ? Math.max(siteCountRaw, sites.length)
+        : sites.length;
+
+      return {
+        ruleId: ruleId,
+        ruleName:
+          typeof ruleName === "string" && ruleName.trim()
+            ? ruleName
+            : undefined,
+        message: message,
+        sites: sites.length > 0 ? sites : undefined,
+        siteCount: siteCount > 0 ? siteCount : undefined,
+      };
+    })
+    .filter(
+      (
+        warning: TopologyLinkRuleWarning | null,
+      ): warning is TopologyLinkRuleWarning => {
+        return warning !== null;
+      },
+    );
+};
+
+/** "3 devices" / "1 device" — the count and its noun, nothing else. */
+const devicePhrase: (count: number) => string = (count: number): string => {
+  return `${count} ${count === 1 ? "device" : "devices"}`;
+};
+
+/**
+ * One row of the site list: the site, what is wrong there, and the damage.
+ *
+ * Phrased as a fix rather than as a diagnosis. "No device carries the parent
+ * labels" tells an operator standing in front of 697 rows exactly which of
+ * the two things to go and do, which "unresolved" would not.
+ */
+export const describeWarningSite: (
+  site: TopologyLinkRuleWarningSite,
+) => string = (site: TopologyLinkRuleWarningSite): string => {
+  const fault: string =
+    site.reason === "ambiguousParent"
+      ? `${devicePhrase(site.matchedParentCount)} carry the parent labels`
+      : "no device carries the parent labels";
+
+  return `${site.siteName || UNNAMED_SITE_LABEL} — ${fault}, so ${devicePhrase(
+    site.strandedDeviceCount,
+  )} ${site.strandedDeviceCount === 1 ? "has" : "have"} no uplink`;
+};
+
+/**
+ * The label on the control that opens the site list.
+ *
+ * Counts the sites the RULE failed in, not the rows that fit in the payload:
+ * an operator who opens "Show the 100 sites" and finds 697 has been misled by
+ * the one number they were given before deciding to look.
+ */
+export const describeSiteListToggle: (
+  warning: TopologyLinkRuleWarning,
+) => string = (warning: TopologyLinkRuleWarning): string => {
+  const total: number = Math.max(
+    warning.siteCount || 0,
+    (warning.sites || []).length,
+  );
+
+  return total === 1
+    ? "Show the 1 site that needs attention"
+    : `Show the ${total} sites that need attention`;
+};
+
+/**
+ * Failing sites the endpoint counted but did not send rows for.
+ *
+ * Shown rather than swallowed: a list that silently stops at its cap reads as
+ * the complete set of broken sites, which at this scale is exactly the wrong
+ * thing to believe.
+ */
+export const hiddenSiteCount: (warning: TopologyLinkRuleWarning) => number = (
+  warning: TopologyLinkRuleWarning,
+): number => {
+  const listed: number = (warning.sites || []).length;
+  return Math.max((warning.siteCount || 0) - listed, 0);
+};

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyLiveView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyLiveView.tsx
@@ -31,6 +31,14 @@ import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
 import IconProp from "Common/Types/Icon/IconProp";
 import { JSONArray, JSONObject } from "Common/Types/JSON";
+import {
+  TopologyLinkRuleWarning,
+  TopologyLinkRuleWarningSite,
+  describeSiteListToggle,
+  describeWarningSite,
+  hiddenSiteCount,
+  parseLinkRuleWarnings,
+} from "./LinkRuleWarningUtil";
 import NetworkTopology, {
   NetworkTopologyEdge,
   NetworkTopologyNode,
@@ -93,12 +101,6 @@ export interface ComponentProps {
  * NetworkTopology plus the endpoint-loss indicators the topology endpoint
  * reports alongside the graph.
  */
-interface TopologyLinkRuleWarning {
-  ruleId: string;
-  ruleName?: string | undefined;
-  message: string;
-}
-
 interface TopologyViewData extends NetworkTopology {
   endpointsTruncated?: boolean | undefined;
   droppedEndpointCount?: number | undefined;
@@ -159,23 +161,8 @@ const parseTopologyResponse: (
   const droppedEndpointCountRaw: unknown = data?.["droppedEndpointCount"];
   const suppressedNodeCountRaw: unknown = data?.["suppressedNodeCount"];
 
-  const linkRuleWarnings: Array<TopologyLinkRuleWarning> = (
-    Array.isArray(data?.["linkRuleWarnings"])
-      ? (data!["linkRuleWarnings"] as JSONArray)
-      : []
-  )
-    .map((row: unknown): TopologyLinkRuleWarning | null => {
-      const warning: JSONObject = (row || {}) as JSONObject;
-      if (!warning["ruleId"] || !warning["message"]) {
-        return null;
-      }
-      return warning as unknown as TopologyLinkRuleWarning;
-    })
-    .filter(
-      (w: TopologyLinkRuleWarning | null): w is TopologyLinkRuleWarning => {
-        return w !== null;
-      },
-    );
+  const linkRuleWarnings: Array<TopologyLinkRuleWarning> =
+    parseLinkRuleWarnings(data?.["linkRuleWarnings"]);
 
   return {
     nodes,
@@ -961,15 +948,55 @@ const NetworkTopologyLiveView: FunctionComponent<ComponentProps> = (
           <ul className="list-disc space-y-1 pl-4">
             {topology.linkRuleWarnings.map(
               (
-                warning: { ruleName?: string | undefined; message: string },
+                warning: TopologyLinkRuleWarning,
                 index: number,
               ): ReactElement => {
+                const hidden: number = hiddenSiteCount(warning);
+
                 return (
                   <li key={index}>
                     <span className="font-medium">
                       {warning.ruleName || "Link rule"}
                     </span>
                     {`: ${warning.message}`}
+                    {/*
+                     * The sentence above names three sites and then a number.
+                     * Collapsed rather than inline because the number can be
+                     * in the hundreds — but present, because "694 more sites"
+                     * is a blast radius and not a list of buildings anybody
+                     * can go and fix (issue #3321).
+                     */}
+                    {warning.sites && warning.sites.length > 0 ? (
+                      <details className="mt-1">
+                        <summary className="cursor-pointer select-none text-amber-900 underline">
+                          {describeSiteListToggle(warning)}
+                        </summary>
+                        <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                          {warning.sites.map(
+                            (
+                              site: TopologyLinkRuleWarningSite,
+                            ): ReactElement => {
+                              return (
+                                <li key={site.siteId}>
+                                  {describeWarningSite(site)}
+                                </li>
+                              );
+                            },
+                          )}
+                        </ul>
+                        {hidden > 0 ? (
+                          <div className="mt-1 italic">
+                            {`${hidden} more site${
+                              hidden === 1 ? "" : "s"
+                            } not listed here.`}
+                          </div>
+                        ) : (
+                          <></>
+                        )}
+                      </details>
+                    ) : (
+                      <></>
+                    )}
                   </li>
                 );
               },

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LinkRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LinkRules.tsx
@@ -46,6 +46,8 @@ A site-scoped rule only looks inside each device's **own** site. A device assign
 
 A site-scoped rule is not all-or-nothing. If it resolves in thirteen sites and fails in the fourteenth, it draws the thirteen and names the one that failed. Sites where nothing carries the child labels are not failures — the rule simply does not apply there, and the map stays quiet about them.
 
+Across hundreds of sites the map's one-line summary names the first few and counts the rest. Expand **Show the N sites that need attention** underneath it for the full list: each site, whether it has no parent device or several, and how many devices are left with no uplink there.
+
 ### Rules are live, not stored
 
 Links are worked out each time the map loads. Relabel a device and the map follows on the next refresh; delete a rule and its links simply stop being drawn. Nothing is left behind to clean up.

--- a/App/Tests/BaseAPI/NetworkDeviceTopologyAPI.test.ts
+++ b/App/Tests/BaseAPI/NetworkDeviceTopologyAPI.test.ts
@@ -317,6 +317,7 @@ describe("POST /network-device/topology", () => {
 
 import Label from "Common/Models/DatabaseModels/Label";
 import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import NetworkDeviceLinkRule from "Common/Models/DatabaseModels/NetworkDeviceLinkRule";
 import NetworkDeviceLinkRuleUtil from "Common/Utils/Monitor/NetworkDeviceLinkRuleUtil";
 
@@ -712,12 +713,15 @@ describe("POST /network-device/topology — site-scoped link rules", () => {
   /*
    * Truncation is a fact about the QUERY, not about the rule, so it is
    * admitted by the endpoint rather than baked into the resolver's sentences.
-   * It matters most under site scoping: a cut-off device list can strand a
-   * whole site whose router simply was not in the first page of rows, and
-   * without this note the operator would go looking for a labelling mistake
-   * that does not exist.
+   *
+   * The query that has to be complete is the link-rule SWEEP, not the map's
+   * own page — see the #3321 block at the end of this file. This is the case
+   * where even the sweep gave up: a fleet past its ten-page cap, where "no
+   * device carries the parent labels" really might be about devices nobody
+   * looked at, and the operator would otherwise go hunting for a labelling
+   * mistake that does not exist.
    */
-  test("every warning admits it when the device list was truncated", async () => {
+  test("every warning admits it when even the link-rule sweep was truncated", async () => {
     const routerLabel: Label = makeLabel();
     const switchLabel: Label = makeLabel();
 
@@ -727,6 +731,11 @@ describe("POST /network-device/topology — site-scoped link rules", () => {
         makeSitedDevice(`sw-${index}`, null, index === 0 ? [switchLabel] : []),
       );
     }
+    /*
+     * Every page comes back full, including the one-row probe past the cap:
+     * a fleet with no end in sight, which is the only state that earns the
+     * caveat.
+     */
     deviceService.findBy.mockResolvedValue(devices as never);
     // Nobody carries the parent label — possibly only because of the cap.
     linkRuleService.findBy.mockResolvedValue([
@@ -830,5 +839,548 @@ describe("POST /network-device/topology — site-scoped link rules", () => {
     expect(warnings[0]!["message"]).toBe(
       "1 device carrying the child labels is not assigned to a site, so this site-scoped rule skips it.",
     );
+  });
+});
+
+/*
+ * ISSUE #3321 — link rules past the device row cap.
+ *
+ * The map is capped at LIMIT_PER_PROJECT devices because past that there is
+ * nothing a human can read. Resolving the link RULES on that same page does
+ * not degrade in the same way: "is there exactly one router in this site" is
+ * answered WRONGLY, not partially, when the router sat outside the page. The
+ * reporter's 949-site estate came back as "Drawing in 252 of 949 sites… no
+ * device carries the parent labels in … 694 more sites", on a fleet whose
+ * routers were all present and correctly labelled.
+ *
+ * So the rules read the fleet themselves, in pages, and only when the map's
+ * page came back full — the one circumstance in which the two device sets can
+ * differ at all.
+ */
+describe("POST /network-device/topology — link rules past the device row cap", () => {
+  beforeEach(() => {
+    resetTopologyMocks();
+  });
+
+  /*
+   * The handler asks the device service two different questions and the tests
+   * have to tell the answers apart the way the reader does: by the columns.
+   * The map's page reads `name`; the sweep reads four columns and no name;
+   * the past-the-cap probe reads nothing but `_id`.
+   */
+  type DeviceCall = {
+    query: JSONObject;
+    select: JSONObject;
+    sort: JSONObject | undefined;
+    limit: number;
+    skip: number;
+  };
+
+  function deviceCalls(): Array<DeviceCall> {
+    return deviceService.findBy.mock.calls.map((call: Array<unknown>) => {
+      const findBy: JSONObject = call[0] as JSONObject;
+      return {
+        query: findBy["query"] as JSONObject,
+        select: findBy["select"] as JSONObject,
+        sort: findBy["sort"] as JSONObject | undefined,
+        limit: findBy["limit"] as number,
+        skip: findBy["skip"] as number,
+      };
+    });
+  }
+
+  function isSweepCall(call: DeviceCall): boolean {
+    return call.select["name"] === undefined;
+  }
+
+  function sweepCalls(): Array<DeviceCall> {
+    return deviceCalls().filter(isSweepCall);
+  }
+
+  /*
+   * The map gets `renderPage` whatever it asks for; the sweep gets a real
+   * slice of `fleet`, so a test that mis-pages shows up as missing devices
+   * rather than as an infinite loop.
+   */
+  function serveDevices(data: {
+    renderPage: Array<NetworkDevice>;
+    fleet?: Array<NetworkDevice> | undefined;
+  }): void {
+    deviceService.findBy.mockImplementation(((
+      findBy: JSONObject,
+    ): Promise<Array<NetworkDevice>> => {
+      const select: JSONObject = findBy["select"] as JSONObject;
+      if (select["name"] !== undefined) {
+        return Promise.resolve(data.renderPage);
+      }
+      const fleet: Array<NetworkDevice> = data.fleet || data.renderPage;
+      const skip: number = findBy["skip"] as number;
+      const limit: number = findBy["limit"] as number;
+      return Promise.resolve(fleet.slice(skip, skip + limit));
+    }) as never);
+  }
+
+  /** `count` labelless devices, purely to push the page over the row cap. */
+  function filler(count: number): Array<NetworkDevice> {
+    const devices: Array<NetworkDevice> = [];
+    for (let index: number = 0; index < count; index++) {
+      devices.push(makeSitedDevice(`filler-${index}`, null, []));
+    }
+    return devices;
+  }
+
+  interface FranchiseFleet {
+    // Every device in the project, routers included.
+    fleet: Array<NetworkDevice>;
+    // What the map's capped query can actually return — no routers in it.
+    renderPage: Array<NetworkDevice>;
+    stars: Array<SiteStar>;
+  }
+
+  /*
+   * The reporter's estate: 949 units, each with one router carrying the
+   * parent label and eleven switches carrying the child label. Eleven,
+   * because the switches alone have to overflow the row cap — that overflow
+   * is the bug, and a fixture that fits under the cap would pass either way.
+   */
+  function makeIssue3321Fleet(
+    routerLabel: Label,
+    switchLabel: Label,
+  ): FranchiseFleet {
+    const stars: Array<SiteStar> = [];
+    for (let unit: number = 1; unit <= 949; unit++) {
+      stars.push(
+        makeSiteStar(
+          `WB Franchise Unit ${`${unit}`.padStart(4, "0")}`,
+          11,
+          routerLabel,
+          switchLabel,
+        ),
+      );
+    }
+
+    const switches: Array<NetworkDevice> = [];
+    for (const star of stars) {
+      switches.push(...star.switches);
+    }
+
+    return {
+      fleet: devicesOf(stars),
+      renderPage: switches.slice(0, LIMIT_PER_PROJECT),
+      stars: stars,
+    };
+  }
+
+  /*
+   * THE REPORTED BUG. Same devices, same labels, same rule — the only thing
+   * that changed is which device list the rule was judged on.
+   */
+  test("issue #3321: 949 correctly labelled sites produce no warning at all", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const fixture: FranchiseFleet = makeIssue3321Fleet(
+      routerLabel,
+      switchLabel,
+    );
+
+    serveDevices({ renderPage: fixture.renderPage, fleet: fixture.fleet });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule(
+        "Router link with Switch",
+        [switchLabel],
+        [routerLabel],
+        "Site",
+      ),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+
+    // The MAP is still truncated — that part of the report was never wrong.
+    expect(body["isTruncated"]).toBe(true);
+    // The rules are not. Not one of the 949 sites is misconfigured.
+    expect(warningsIn(body)).toEqual([]);
+  });
+
+  /*
+   * The same fixture read the old way, kept as the counter-example: without
+   * the sweep the endpoint reports 949 broken sites and 10,439 stranded
+   * devices, which is the banner in the issue. If a change ever puts rule
+   * resolution back on the map's page, this is what it will read like.
+   */
+  test("issue #3321: the map's own page alone would report every site as broken", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const fixture: FranchiseFleet = makeIssue3321Fleet(
+      routerLabel,
+      switchLabel,
+    );
+
+    // No fleet behind it: the sweep sees exactly what the map sees.
+    serveDevices({ renderPage: fixture.renderPage });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule(
+        "Router link with Switch",
+        [switchLabel],
+        [routerLabel],
+        "Site",
+      ),
+    ] as never);
+
+    await callTopology({});
+
+    const warnings: Array<JSONObject> = warningsIn(lastResponseBody());
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["reason"]).toBe("noParentMatched");
+    expect(warnings[0]!["message"]).toContain("No site resolved this rule.");
+  });
+
+  test("a complete map page is reused, so an ordinary project runs one device query", async () => {
+    /*
+     * The sweep is a second pass over the fleet. Paying for it on every map
+     * load — including a project with forty devices — would be a real cost
+     * for a difference that cannot exist below the cap.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const unit: SiteStar = makeSiteStar("Unit A", 2, routerLabel, switchLabel);
+
+    serveDevices({ renderPage: devicesOf([unit]) });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    expect(sweepCalls()).toEqual([]);
+    expect(deviceService.findBy).toHaveBeenCalledTimes(1);
+
+    // And the rule still resolves off the page it reused.
+    const body: JSONObject = lastResponseBody();
+    expect(edgePairs(body)).toEqual(
+      [
+        uplinkPair(unit.switches[0]!, unit.router),
+        uplinkPair(unit.switches[1]!, unit.router),
+      ].sort(),
+    );
+  });
+
+  test("a truncated map with no link rules at all still runs one device query", async () => {
+    serveDevices({ renderPage: filler(LIMIT_PER_PROJECT) });
+    linkRuleService.findBy.mockResolvedValue([] as never);
+
+    await callTopology({});
+
+    expect(sweepCalls()).toEqual([]);
+    expect(warningsIn(lastResponseBody())).toEqual([]);
+  });
+
+  test("a rule with an empty label set is not worth a fleet sweep", async () => {
+    /*
+     * It resolves to noChildLabels whatever devices exist, so reading ten
+     * pages to confirm that would be ten queries spent on a foregone
+     * conclusion — and the warning it produces is identical either way.
+     */
+    const routerLabel: Label = makeLabel();
+
+    serveDevices({ renderPage: filler(LIMIT_PER_PROJECT) });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Half-written rule", [], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    expect(sweepCalls()).toEqual([]);
+    const warnings: Array<JSONObject> = warningsIn(lastResponseBody());
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["reason"]).toBe("noChildLabels");
+  });
+
+  test("the sweep reads only the four columns the resolver needs", async () => {
+    /*
+     * The map's page carries forty columns per device. Reading those again
+     * across ten pages is what would make a full-fleet pass unaffordable —
+     * and none of them is rendered on this path, so none is read.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+
+    serveDevices({ renderPage: filler(LIMIT_PER_PROJECT) });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const sweep: DeviceCall = sweepCalls()[0]!;
+    expect(Object.keys(sweep.select).sort()).toEqual([
+      "_id",
+      "labels",
+      "site",
+      "siteId",
+    ]);
+    expect(sweep.select["labels"]).toEqual({ _id: true });
+    expect(sweep.select["site"]).toEqual({ name: true });
+    // Archived devices are ghosts on the map and must not vote on a parent.
+    expect(sweep.query["isArchived"]).toBe(false);
+    expect((sweep.query["projectId"] as ObjectID).toString()).toBe(
+      projectId.toString(),
+    );
+    expect(sweep.limit).toBe(LIMIT_PER_PROJECT);
+  });
+
+  test("the sweep pages by id, not by the default createdAt", async () => {
+    /*
+     * A discovery import stamps thousands of devices with one createdAt, and
+     * rows tied on the sort key can shift between pages — read twice or
+     * skipped. A skipped router is exactly the phantom "no parent in this
+     * site" the sweep exists to remove, so an unstable sort would reintroduce
+     * the bug in a form that only shows up at scale.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+
+    serveDevices({ renderPage: filler(LIMIT_PER_PROJECT) });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    for (const sweep of sweepCalls()) {
+      expect(sweep.sort).toEqual({ _id: SortOrder.Ascending });
+    }
+  });
+
+  test("the sweep walks page after page until one comes back short", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const unit: SiteStar = makeSiteStar("Unit A", 1, routerLabel, switchLabel);
+
+    const renderPage: Array<NetworkDevice> = filler(LIMIT_PER_PROJECT);
+    serveDevices({
+      renderPage: renderPage,
+      // The unit's router and switch sit on the far side of the cap.
+      fleet: [...renderPage, ...devicesOf([unit])],
+    });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    expect(
+      sweepCalls().map((call: DeviceCall) => {
+        return call.skip;
+      }),
+    ).toEqual([0, LIMIT_PER_PROJECT]);
+    // Unit A resolved, so it says nothing about it.
+    expect(warningsIn(lastResponseBody())).toEqual([]);
+  });
+
+  test("a fleet of exactly the sweep's cap does not confess to a truncation", async () => {
+    /*
+     * A full last page is not proof that more devices exist. Hedging anyway
+     * would put "some of these may be false alarms" on a warning that is
+     * certain, and a caveat attached to warnings that do not need it teaches
+     * operators to discount the ones that do.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const page: Array<NetworkDevice> = filler(LIMIT_PER_PROJECT);
+    page[0] = makeSitedDevice("lonely-switch", null, [switchLabel]);
+
+    // Ten full pages and then genuinely nothing.
+    deviceService.findBy.mockImplementation(((
+      findBy: JSONObject,
+    ): Promise<Array<NetworkDevice>> => {
+      const select: JSONObject = findBy["select"] as JSONObject;
+      if (select["name"] !== undefined || (findBy["skip"] as number) === 0) {
+        return Promise.resolve(page);
+      }
+      if ((findBy["skip"] as number) >= LIMIT_PER_PROJECT * 10) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(page);
+    }) as never);
+
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], undefined),
+    ] as never);
+
+    await callTopology({});
+
+    const probe: DeviceCall = sweepCalls()[sweepCalls().length - 1]!;
+    expect(probe.limit).toBe(1);
+    expect(probe.skip).toBe(LIMIT_PER_PROJECT * 10);
+    expect(probe.select).toEqual({ _id: true });
+
+    const warnings: Array<JSONObject> = warningsIn(lastResponseBody());
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["message"]).not.toContain(
+      NetworkDeviceLinkRuleUtil.TRUNCATED_DEVICE_LIST_NOTE,
+    );
+  });
+
+  test("a truncated map with a complete sweep leaves the caveat off a real failure", async () => {
+    /*
+     * The behaviour change that matters most day to day. The old endpoint
+     * hedged on the MAP's cap, so on a large estate every warning — right or
+     * wrong — ended in "some of these may be false alarms". Here the sweep
+     * read the whole fleet and the failure is real, so it is stated plainly.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const good: SiteStar = makeSiteStar("Unit A", 1, routerLabel, switchLabel);
+    const site: NetworkSite = makeSite("Unit B");
+    const orphan: NetworkDevice = makeSitedDevice("unit-b-sw1", site, [
+      switchLabel,
+    ]);
+
+    const renderPage: Array<NetworkDevice> = filler(LIMIT_PER_PROJECT);
+    serveDevices({
+      renderPage: renderPage,
+      fleet: [...renderPage, ...devicesOf([good]), orphan],
+    });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const body: JSONObject = lastResponseBody();
+    expect(body["isTruncated"]).toBe(true);
+
+    const warnings: Array<JSONObject> = warningsIn(body);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["message"]).toBe(
+      "Drawing in 1 of 2 sites. No device carries the parent labels in Unit B, so 1 device there has no uplink.",
+    );
+  });
+
+  test("the sweep follows a site-scoped request rather than reading the project", async () => {
+    /*
+     * A request for one site's map must not have its rules judged against
+     * every device in the project: a second router in another building would
+     * report this site as ambiguous, which is the failure this whole feature
+     * was built to stop.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const siteId: ObjectID = ObjectID.generate();
+
+    serveDevices({ renderPage: filler(LIMIT_PER_PROJECT) });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({ siteId: siteId.toString() });
+
+    for (const sweep of sweepCalls()) {
+      expect((sweep.query["siteId"] as ObjectID).toString()).toBe(
+        siteId.toString(),
+      );
+    }
+  });
+
+  test("the sweep carries the caller's permission props, never root", async () => {
+    /*
+     * The map is permission-scoped: a viewer only sees devices they can read,
+     * and a warning may only name a site whose devices they can read. A sweep
+     * running as root would leak both — the existence of devices and the
+     * names of the sites holding them.
+     */
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const userId: ObjectID = ObjectID.generate();
+    commonAPI.getDatabaseCommonInteractionProps.mockResolvedValue({
+      tenantId: projectId,
+      userId: userId,
+    } as never);
+
+    serveDevices({ renderPage: filler(LIMIT_PER_PROJECT) });
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    for (const call of deviceService.findBy.mock.calls) {
+      const props: JSONObject = (call[0] as JSONObject)["props"] as JSONObject;
+      expect(props["isRoot"]).toBeUndefined();
+      expect((props["userId"] as ObjectID).toString()).toBe(userId.toString());
+    }
+  });
+
+  /*
+   * The audit list. "and 694 more sites" is a blast radius; the operator
+   * still has to be told which buildings to walk into.
+   */
+  test("the payload names every failing site, not just the three in the sentence", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+    const good: SiteStar = makeSiteStar("Unit A", 1, routerLabel, switchLabel);
+
+    const broken: Array<NetworkDevice> = [];
+    for (const name of ["Unit B", "Unit C", "Unit D", "Unit E"]) {
+      const site: NetworkSite = makeSite(name);
+      broken.push(makeSitedDevice(`${name}-sw1`, site, [switchLabel]));
+      broken.push(makeSitedDevice(`${name}-sw2`, site, [switchLabel]));
+    }
+
+    deviceService.findBy.mockResolvedValue([
+      ...devicesOf([good]),
+      ...broken,
+    ] as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], "Site"),
+    ] as never);
+
+    await callTopology({});
+
+    const warnings: Array<JSONObject> = warningsIn(lastResponseBody());
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["siteCount"]).toBe(4);
+
+    const sites: Array<JSONObject> = warnings[0]!["sites"] as Array<JSONObject>;
+    expect(
+      sites.map((site: JSONObject) => {
+        return [
+          site["siteName"],
+          site["reason"],
+          site["strandedDeviceCount"],
+          site["matchedParentCount"],
+        ];
+      }),
+    ).toEqual([
+      ["Unit B", "noParentMatched", 2, 0],
+      ["Unit C", "noParentMatched", 2, 0],
+      ["Unit D", "noParentMatched", 2, 0],
+      ["Unit E", "noParentMatched", 2, 0],
+    ]);
+    // The sentence itself only ever names three of them.
+    expect(warnings[0]!["message"]).toContain(
+      "Unit B, Unit C, Unit D and 1 more site",
+    );
+  });
+
+  test("a project-scoped warning carries no site list to expand", async () => {
+    const routerLabel: Label = makeLabel();
+    const switchLabel: Label = makeLabel();
+
+    deviceService.findBy.mockResolvedValue([
+      makeSitedDevice("sw1", makeSite("Unit A"), [switchLabel]),
+    ] as never);
+    linkRuleService.findBy.mockResolvedValue([
+      makeLinkRule("Uplink", [switchLabel], [routerLabel], undefined),
+    ] as never);
+
+    await callTopology({});
+
+    const warnings: Array<JSONObject> = warningsIn(lastResponseBody());
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!["sites"]).toBeUndefined();
+    expect(warnings[0]!["siteCount"]).toBeUndefined();
   });
 });

--- a/App/Tests/Dashboard/LinkRuleWarningUtil.test.ts
+++ b/App/Tests/Dashboard/LinkRuleWarningUtil.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  TopologyLinkRuleWarning,
+  TopologyLinkRuleWarningSite,
+  UNNAMED_SITE_LABEL,
+  describeSiteListToggle,
+  describeWarningSite,
+  hiddenSiteCount,
+  parseLinkRuleWarnings,
+} from "../../FeatureSet/Dashboard/src/Components/Topology/LinkRuleWarningUtil";
+
+/*
+ * The banner is drawn from whatever the topology endpoint sent, so every row
+ * here is untrusted input. A malformed one has to disappear rather than
+ * render as an empty bullet on an amber panel — the panel's whole job is to
+ * be believed.
+ *
+ * The site rows are issue #3321: a rule failing in 697 sites can only say
+ * "and 694 more sites" in one line of prose, and an operator cannot walk into
+ * a number. These are the rows that line expands into.
+ */
+
+function warningRow(overrides?: JSONObject): JSONObject {
+  return {
+    ruleId: "rule-1",
+    ruleName: "Router link with Switch",
+    message: "Drawing in 252 of 949 sites.",
+    ...(overrides || {}),
+  };
+}
+
+function siteRow(overrides?: JSONObject): JSONObject {
+  return {
+    siteId: "site-1",
+    siteName: "WB Franchise Unit 0005",
+    reason: "noParentMatched",
+    strandedDeviceCount: 3,
+    matchedParentCount: 0,
+    ...(overrides || {}),
+  };
+}
+
+function firstSite(
+  warning: TopologyLinkRuleWarning,
+): TopologyLinkRuleWarningSite {
+  const sites: Array<TopologyLinkRuleWarningSite> = warning.sites || [];
+  expect(sites.length).toBeGreaterThan(0);
+  return sites[0]!;
+}
+
+describe("parseLinkRuleWarnings", () => {
+  test("keeps a well-formed warning intact", () => {
+    const warnings: Array<TopologyLinkRuleWarning> = parseLinkRuleWarnings([
+      warningRow({ sites: [siteRow()], siteCount: 1 }),
+    ]);
+
+    expect(warnings).toEqual([
+      {
+        ruleId: "rule-1",
+        ruleName: "Router link with Switch",
+        message: "Drawing in 252 of 949 sites.",
+        sites: [
+          {
+            siteId: "site-1",
+            siteName: "WB Franchise Unit 0005",
+            reason: "noParentMatched",
+            strandedDeviceCount: 3,
+            matchedParentCount: 0,
+          },
+        ],
+        siteCount: 1,
+      },
+    ]);
+  });
+
+  test("returns nothing at all for a payload that is not a list", () => {
+    expect(parseLinkRuleWarnings(undefined)).toEqual([]);
+    expect(parseLinkRuleWarnings(null)).toEqual([]);
+    expect(parseLinkRuleWarnings("linkRuleWarnings")).toEqual([]);
+    expect(parseLinkRuleWarnings({ ruleId: "rule-1" })).toEqual([]);
+  });
+
+  test("drops a warning with nothing to say or nothing to say it about", () => {
+    /*
+     * A row with no message renders as a rule name and a colon; a row with no
+     * ruleId cannot be keyed. Both are silence dressed up as a warning.
+     */
+    expect(
+      parseLinkRuleWarnings([
+        warningRow({ message: "" }),
+        warningRow({ ruleId: "" }),
+        warningRow({ ruleId: 7 }),
+        warningRow({ message: { text: "nested" } }),
+        null,
+        "a string",
+      ]),
+    ).toEqual([]);
+  });
+
+  test("a rule with no name is left unnamed rather than named the empty string", () => {
+    // The component falls back to "Link rule", which a "" would defeat.
+    expect(
+      parseLinkRuleWarnings([warningRow({ ruleName: "   " })])[0]!.ruleName,
+    ).toBeUndefined();
+    expect(
+      parseLinkRuleWarnings([warningRow({ ruleName: 42 })])[0]!.ruleName,
+    ).toBeUndefined();
+  });
+
+  test("keeps every well-formed row and drops only the broken ones", () => {
+    const warnings: Array<TopologyLinkRuleWarning> = parseLinkRuleWarnings([
+      warningRow({ ruleId: "rule-1" }),
+      warningRow({ ruleId: "" }),
+      warningRow({ ruleId: "rule-2" }),
+    ]);
+
+    expect(
+      warnings.map((warning: TopologyLinkRuleWarning) => {
+        return warning.ruleId;
+      }),
+    ).toEqual(["rule-1", "rule-2"]);
+  });
+
+  test("omits the site list rather than sending an empty one", () => {
+    /*
+     * The component keys the expander off `sites` being present, so an empty
+     * array would put a "Show the 0 sites that need attention" control under
+     * a project-scoped warning that has no sites at all.
+     */
+    const noSites: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow(),
+    ])[0]!;
+    expect(noSites.sites).toBeUndefined();
+    expect(noSites.siteCount).toBeUndefined();
+
+    const emptySites: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow({ sites: [], siteCount: 0 }),
+    ])[0]!;
+    expect(emptySites.sites).toBeUndefined();
+    expect(emptySites.siteCount).toBeUndefined();
+  });
+
+  test("drops a site row that cannot be identified or explained", () => {
+    const warning: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow({
+        sites: [
+          siteRow({ siteId: "" }),
+          siteRow({ siteId: 12 }),
+          // Not one of the two reasons the resolver produces.
+          siteRow({ siteId: "site-x", reason: "ambiguous" }),
+          siteRow({ siteId: "site-x", reason: undefined }),
+          null,
+          siteRow({ siteId: "site-good" }),
+        ],
+      }),
+    ])[0]!;
+
+    expect(
+      (warning.sites || []).map((site: TopologyLinkRuleWarningSite) => {
+        return site.siteId;
+      }),
+    ).toEqual(["site-good"]);
+  });
+
+  test("clamps a count that would render as nonsense", () => {
+    /*
+     * "-1 devices have no uplink" reads as a bug in the map rather than as
+     * the malformed payload it is.
+     */
+    const warning: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow({
+        sites: [
+          siteRow({
+            strandedDeviceCount: -4,
+            matchedParentCount: Number.NaN,
+          }),
+        ],
+      }),
+    ])[0]!;
+
+    expect(firstSite(warning).strandedDeviceCount).toBe(0);
+    expect(firstSite(warning).matchedParentCount).toBe(0);
+  });
+
+  test("a site with no name keeps its id, which is what it is found by", () => {
+    const warning: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow({ sites: [siteRow({ siteName: "  " })] }),
+    ])[0]!;
+
+    expect(firstSite(warning).siteId).toBe("site-1");
+    expect(firstSite(warning).siteName).toBeUndefined();
+  });
+
+  test("believes the endpoint's total over the rows it actually sent", () => {
+    /*
+     * The rows are capped and the total is not — that is the whole reason
+     * both are sent. Reading the total off the rows would tell an operator
+     * with 697 broken sites that they have 100.
+     */
+    const warning: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow({
+        sites: [siteRow(), siteRow({ siteId: "site-2" })],
+        siteCount: 697,
+      }),
+    ])[0]!;
+
+    expect(warning.sites).toHaveLength(2);
+    expect(warning.siteCount).toBe(697);
+  });
+
+  test("believes the rows when the total contradicts them", () => {
+    // A payload disagreeing with itself must not hide rows it did send.
+    const warning: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+      warningRow({
+        sites: [siteRow(), siteRow({ siteId: "site-2" })],
+        siteCount: 1,
+      }),
+    ])[0]!;
+
+    expect(warning.siteCount).toBe(2);
+  });
+
+  test("falls back to the row count when the total is missing or unusable", () => {
+    for (const bogus of [
+      undefined,
+      "many",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      const warning: TopologyLinkRuleWarning = parseLinkRuleWarnings([
+        warningRow({ sites: [siteRow()], siteCount: bogus as never }),
+      ])[0]!;
+      expect(warning.siteCount).toBe(1);
+    }
+  });
+});
+
+describe("describeWarningSite", () => {
+  function describe_(overrides?: Partial<TopologyLinkRuleWarningSite>): string {
+    return describeWarningSite({
+      siteId: "site-1",
+      siteName: "WB Franchise Unit 0005",
+      reason: "noParentMatched",
+      strandedDeviceCount: 3,
+      matchedParentCount: 0,
+      ...(overrides || {}),
+    });
+  }
+
+  test("names the site, the fault and the damage", () => {
+    expect(describe_()).toBe(
+      "WB Franchise Unit 0005 — no device carries the parent labels, so 3 devices have no uplink",
+    );
+  });
+
+  test("an ambiguous site is told how many parents it has, not that it has none", () => {
+    /*
+     * The two faults need opposite fixes — remove a label, or add one — so a
+     * row that got them backwards would be worse than no row.
+     */
+    expect(
+      describe_({ reason: "ambiguousParent", matchedParentCount: 2 }),
+    ).toBe(
+      "WB Franchise Unit 0005 — 2 devices carry the parent labels, so 3 devices have no uplink",
+    );
+  });
+
+  test("reads as English for a single device", () => {
+    expect(describe_({ strandedDeviceCount: 1 })).toBe(
+      "WB Franchise Unit 0005 — no device carries the parent labels, so 1 device has no uplink",
+    );
+  });
+
+  test("calls an unnamed site what it is", () => {
+    expect(describe_({ siteName: undefined })).toBe(
+      `${UNNAMED_SITE_LABEL} — no device carries the parent labels, so 3 devices have no uplink`,
+    );
+  });
+
+  test("prints a long site name in full, because this is the list not the sentence", () => {
+    /*
+     * The one-line summary truncates names at 40 characters to stay readable.
+     * The list is where the operator goes to find the actual building, so a
+     * clipped name here would defeat the point of expanding it.
+     */
+    const longName: string = "WB Franchise Unit 0005 Distribution Annexe East";
+    expect(describe_({ siteName: longName })).toContain(longName);
+  });
+});
+
+describe("describeSiteListToggle", () => {
+  function warning(
+    listed: number,
+    siteCount: number | undefined,
+  ): TopologyLinkRuleWarning {
+    const sites: Array<TopologyLinkRuleWarningSite> = [];
+    for (let index: number = 0; index < listed; index++) {
+      sites.push({
+        siteId: `site-${index}`,
+        reason: "noParentMatched",
+        strandedDeviceCount: 1,
+        matchedParentCount: 0,
+      });
+    }
+    return {
+      ruleId: "rule-1",
+      message: "…",
+      sites: sites,
+      siteCount: siteCount,
+    };
+  }
+
+  test("counts the sites the rule failed in, not the rows that fit", () => {
+    /*
+     * The operator decides whether to open the list from this number. "Show
+     * the 100 sites" on a rule that failed in 697 would understate the
+     * problem at the exact moment they are deciding how seriously to take it.
+     */
+    expect(describeSiteListToggle(warning(100, 697))).toBe(
+      "Show the 697 sites that need attention",
+    );
+  });
+
+  test("reads as English for a single site", () => {
+    expect(describeSiteListToggle(warning(1, 1))).toBe(
+      "Show the 1 site that needs attention",
+    );
+  });
+
+  test("falls back to the rows when the total is missing or too small", () => {
+    expect(describeSiteListToggle(warning(4, undefined))).toBe(
+      "Show the 4 sites that need attention",
+    );
+    expect(describeSiteListToggle(warning(4, 1))).toBe(
+      "Show the 4 sites that need attention",
+    );
+  });
+});
+
+describe("hiddenSiteCount", () => {
+  function warning(
+    listed: number,
+    siteCount: number | undefined,
+  ): TopologyLinkRuleWarning {
+    const sites: Array<TopologyLinkRuleWarningSite> = [];
+    for (let index: number = 0; index < listed; index++) {
+      sites.push({
+        siteId: `site-${index}`,
+        reason: "noParentMatched",
+        strandedDeviceCount: 1,
+        matchedParentCount: 0,
+      });
+    }
+    return {
+      ruleId: "rule-1",
+      message: "…",
+      sites: sites,
+      siteCount: siteCount,
+    };
+  }
+
+  test("counts the sites the endpoint capped away", () => {
+    /*
+     * A list that silently stops at its cap reads as the complete set of
+     * broken sites, which at this scale is exactly the wrong thing to
+     * believe.
+     */
+    expect(hiddenSiteCount(warning(100, 697))).toBe(597);
+  });
+
+  test("hides nothing when every failing site was sent", () => {
+    expect(hiddenSiteCount(warning(4, 4))).toBe(0);
+  });
+
+  test("never goes negative on a payload that disagrees with itself", () => {
+    expect(hiddenSiteCount(warning(4, 1))).toBe(0);
+    expect(hiddenSiteCount(warning(4, undefined))).toBe(0);
+  });
+
+  test("hides nothing for a warning with no site list at all", () => {
+    expect(
+      hiddenSiteCount({
+        ruleId: "rule-1",
+        message: "Disabled — draws no links.",
+      }),
+    ).toBe(0);
+  });
+});

--- a/Common/Tests/Utils/Monitor/NetworkDeviceLinkRuleUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkDeviceLinkRuleUtil.test.ts
@@ -1487,3 +1487,288 @@ describe("NetworkDeviceLinkRuleUtil.getWarning", () => {
     expect(warning.message.length).toBeLessThanOrEqual(700);
   });
 });
+
+/*
+ * ISSUE #3321 — the audit list.
+ *
+ * The sentence a failing site-scoped rule produces names three sites and then
+ * a number: "…in WB Franchise Unit 0005, WB Franchise Unit 0047, WB Franchise
+ * Unit 0069 and 694 more sites". At fourteen sites that is a summary. At 949
+ * it is a dead end — the operator has been told the size of the problem and
+ * nothing about where it is. These rows are what the banner expands into.
+ */
+describe("NetworkDeviceLinkRuleUtil.getWarning — the failing-site list", () => {
+  type ResolvedWarningSite = NonNullable<ResolvedWarning["sites"]>[number];
+
+  /** Zero padded past three digits so 949 sites still sort as text. */
+  const fourDigit: (value: number) => string = (value: number): string => {
+    return `${value}`.padStart(4, "0");
+  };
+
+  /**
+   * `franchise(index, routers, switches)` — one WB-style unit, named the way
+   * the reporter's are so the sort order under test is the one they see.
+   */
+  const franchise: (
+    index: number,
+    routerCount: number,
+    switchCount: number,
+  ) => Array<LinkRuleDeviceInput> = (
+    index: number,
+    routerCount: number,
+    switchCount: number,
+  ): Array<LinkRuleDeviceInput> => {
+    const siteId: string = `wb-${fourDigit(index)}`;
+    const siteName: string = `WB Franchise Unit ${fourDigit(index)}`;
+    const devices: Array<LinkRuleDeviceInput> = [];
+    for (let router: number = 1; router <= routerCount; router++) {
+      devices.push(routerAt(`wb-router-${index}-${router}`, siteId, siteName));
+    }
+    for (let leaf: number = 1; leaf <= switchCount; leaf++) {
+      devices.push(switchAt(`wb-switch-${index}-${leaf}`, siteId, siteName));
+    }
+    return devices;
+  };
+
+  const sitesOf: (outcome: LinkRuleOutcome) => Array<ResolvedWarningSite> = (
+    outcome: LinkRuleOutcome,
+  ): Array<ResolvedWarningSite> => {
+    return warningOf(outcome).sites || [];
+  };
+
+  it("lists the sites the sentence could only count", () => {
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        ...franchise(5, 1, 2),
+        // No router: three switches with nowhere to go.
+        ...franchise(47, 0, 3),
+        ...franchise(69, 0, 1),
+      ],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.siteCount).toBe(2);
+    expect(warning.sites).toEqual([
+      {
+        siteId: "wb-0047",
+        siteName: "WB Franchise Unit 0047",
+        reason: "noParentMatched",
+        strandedDeviceCount: 3,
+        matchedParentCount: 0,
+      },
+      {
+        siteId: "wb-0069",
+        siteName: "WB Franchise Unit 0069",
+        reason: "noParentMatched",
+        strandedDeviceCount: 1,
+        matchedParentCount: 0,
+      },
+    ]);
+  });
+
+  it("carries each site's own reason, not the rule's headline one", () => {
+    /*
+     * The rule's `reason` is the highest-ranked condition present, so a mixed
+     * failure reads "ambiguousParent" — which is wrong about every one of the
+     * parentless sites. Per-site reasons are the whole reason the list is
+     * worth sending: the two faults need opposite fixes (delete a label vs.
+     * add one), and a list that got them backwards would be worse than none.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        ...franchise(1, 1, 1),
+        // Two routers in one unit.
+        ...franchise(2, 2, 1),
+        // None in the other.
+        ...franchise(3, 0, 2),
+      ],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.reason).toBe("ambiguousParent");
+    expect(
+      (warning.sites || []).map((site: ResolvedWarningSite) => {
+        return [site.siteName, site.reason, site.matchedParentCount];
+      }),
+    ).toEqual([
+      ["WB Franchise Unit 0002", "ambiguousParent", 2],
+      ["WB Franchise Unit 0003", "noParentMatched", 0],
+    ]);
+  });
+
+  it("orders the list exactly as the sentence names them", () => {
+    /*
+     * The first rows of the list must be the sites the sentence already
+     * named, or the two read as different sets of buildings. Both go through
+     * one sort for that reason.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [
+        ...franchise(1, 1, 1),
+        ...franchise(69, 0, 1),
+        ...franchise(5, 0, 1),
+        ...franchise(47, 0, 1),
+        ...franchise(12, 0, 1),
+      ],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.message).toContain(
+      "WB Franchise Unit 0005, WB Franchise Unit 0012, WB Franchise Unit 0047 and 1 more site",
+    );
+    expect(
+      (warning.sites || []).map((site: ResolvedWarningSite) => {
+        return site.siteName;
+      }),
+    ).toEqual([
+      "WB Franchise Unit 0005",
+      "WB Franchise Unit 0012",
+      "WB Franchise Unit 0047",
+      "WB Franchise Unit 0069",
+    ]);
+  });
+
+  it("stays byte-identical however the device query ordered its rows", () => {
+    /*
+     * The live view refetches every sixty seconds; a reshuffling list reads
+     * as a change that did not happen.
+     */
+    const forwards: Array<LinkRuleDeviceInput> = [
+      ...franchise(3, 0, 1),
+      ...franchise(1, 0, 1),
+      ...franchise(2, 0, 1),
+    ];
+    const backwards: Array<LinkRuleDeviceInput> = [
+      ...franchise(2, 0, 1),
+      ...franchise(3, 0, 1),
+      ...franchise(1, 0, 1),
+    ];
+
+    expect(
+      sitesOf(NetworkDeviceLinkRuleUtil.resolveRule(scopedRule(), forwards)),
+    ).toEqual(
+      sitesOf(NetworkDeviceLinkRuleUtil.resolveRule(scopedRule(), backwards)),
+    );
+  });
+
+  it("names a site with no name nothing at all rather than guessing one", () => {
+    /*
+     * A device can carry a siteId whose name never came back — the name rides
+     * on a relation read. The row still has to be sent: its id is what the
+     * operator navigates by.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...franchise(1, 1, 1), switchAt("nameless-switch", "site-nameless")],
+    );
+
+    expect(sitesOf(outcome)).toEqual([
+      {
+        siteId: "site-nameless",
+        siteName: undefined,
+        reason: "noParentMatched",
+        strandedDeviceCount: 1,
+        matchedParentCount: 0,
+      },
+    ]);
+  });
+
+  it("caps the list but never the count", () => {
+    /*
+     * The cap is what keeps a 60-second poll from carrying a megabyte of site
+     * names. Reporting sites.length as the number of broken sites is then a
+     * bug waiting to happen, so the exact total rides alongside.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [...franchise(1, 1, 1)];
+    for (let index: number = 2; index <= 400; index++) {
+      devices.push(...franchise(index, 0, 1));
+    }
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.siteCount).toBe(399);
+    expect(warning.sites).toHaveLength(
+      NetworkDeviceLinkRuleUtil.MAX_LISTED_SITES,
+    );
+    // The cap keeps the sentence's own three sites, which are the first rows.
+    expect((warning.sites || [])[0]!.siteName).toBe("WB Franchise Unit 0002");
+  });
+
+  it("says nothing about sites when the rule is project scoped", () => {
+    /*
+     * A project-scoped outcome has no site dimension at all, and inventing an
+     * empty list for it would put a "0 sites need attention" control on a
+     * banner that is not about sites.
+     */
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule({ scope: "Project" }),
+      [...franchise(1, 1, 1), ...franchise(2, 1, 1)],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.reason).toBe("ambiguousParent");
+    expect(warning.sites).toBeUndefined();
+    expect(warning.siteCount).toBeUndefined();
+  });
+
+  it("says nothing about sites when only unsited devices are wrong", () => {
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      [...franchise(1, 1, 1), switchAt("spare-switch")],
+    );
+
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(warning.reason).toBe("devicesWithoutSite");
+    expect(warning.sites).toBeUndefined();
+    expect(warning.siteCount).toBeUndefined();
+  });
+
+  it("keeps the list and the sentence telling the same story at 949 sites", () => {
+    /*
+     * The reporter's estate, with the truncation removed: 949 units, of which
+     * 697 have no router. The two numbers an operator reads — the coverage
+     * fraction and the stranded device total — have to be reproducible from
+     * the rows, or the list is a second opinion rather than a breakdown.
+     */
+    const devices: Array<LinkRuleDeviceInput> = [];
+    for (let index: number = 1; index <= 252; index++) {
+      devices.push(...franchise(index, 1, 3));
+    }
+    for (let index: number = 253; index <= 949; index++) {
+      devices.push(...franchise(index, 0, 3));
+    }
+
+    const outcome: LinkRuleOutcome = NetworkDeviceLinkRuleUtil.resolveRule(
+      scopedRule(),
+      devices,
+    );
+    const warning: ResolvedWarning = warningOf(outcome);
+
+    expect(outcome.links).toHaveLength(252 * 3);
+    expect(outcome.applicableSiteCount).toBe(949);
+    expect(warning.message).toContain("Drawing in 252 of 949 sites.");
+    expect(warning.message).toContain("so 2091 devices there have no uplink.");
+
+    expect(warning.siteCount).toBe(697);
+    expect(warning.sites).toHaveLength(
+      NetworkDeviceLinkRuleUtil.MAX_LISTED_SITES,
+    );
+    for (const site of warning.sites || []) {
+      expect(site.reason).toBe("noParentMatched");
+      expect(site.strandedDeviceCount).toBe(3);
+      expect(site.matchedParentCount).toBe(0);
+    }
+  });
+});

--- a/Common/Utils/Monitor/NetworkDeviceLinkRuleUtil.ts
+++ b/Common/Utils/Monitor/NetworkDeviceLinkRuleUtil.ts
@@ -156,12 +156,47 @@ export interface LinkRuleOutcome {
   unsitedChildDeviceCount?: number | undefined;
 }
 
+/*
+ * One failing site, as the banner lists it rather than as the resolver
+ * computed it. Deliberately not LinkRuleGroupFailure itself: this crosses the
+ * wire to the browser, so it carries the two numbers an operator acts on and
+ * nothing else.
+ */
+export interface LinkRuleWarningSite {
+  siteId: string;
+  siteName?: string | undefined;
+  reason: LinkRuleGroupSkipReason;
+  /*
+   * Devices in THIS site the rule wanted to place and could not — the damage
+   * count for one line of the list, which sums to the sentence's total.
+   */
+  strandedDeviceCount: number;
+  // Devices in this site carrying the parent labels: 0, or >= 2 when ambiguous.
+  matchedParentCount: number;
+}
+
 /** One bullet in the topology map's warning banner. At most one per rule. */
 export interface LinkRuleWarning {
   ruleId: string;
   ruleName?: string | undefined;
   reason: LinkRuleWarningReason;
   message: string;
+  /*
+   * The failing sites themselves, in the same order the sentence names them,
+   * capped at MAX_LISTED_SITES. Present only for a site-scoped rule that
+   * failed somewhere.
+   *
+   * The sentence names three sites and then says "and 694 more", which is a
+   * blast radius and not something anybody can act on — issue #3321, where an
+   * operator with 949 sites had no way to find out WHICH of them were broken.
+   * The list is what turns that number back into work.
+   */
+  sites?: Array<LinkRuleWarningSite> | undefined;
+  /*
+   * Exact number of failing sites, still exact when `sites` was capped. Always
+   * >= sites.length, so the UI can say how many it is not showing.
+   */
+  siteCount?: number | undefined;
 }
 
 /*
@@ -204,6 +239,13 @@ export default class NetworkDeviceLinkRuleUtil {
 
   // Three names is enough to recognise a pattern; fourteen is a wall of text.
   private static readonly MAX_NAMED_SITES: number = 3;
+  /*
+   * How many failing sites ride back on the warning for the operator to work
+   * through. Far more than the sentence names, because this is a list nobody
+   * reads until they open it — but still capped: a project with 949 broken
+   * sites must not turn a 60-second map poll into a megabyte of site names.
+   */
+  public static readonly MAX_LISTED_SITES: number = 100;
   // Site names are ShortText and can run to 100 characters.
   private static readonly MAX_SITE_NAME_LENGTH: number = 40;
   private static readonly UNNAMED_SITE: string = "an unnamed site";
@@ -530,18 +572,17 @@ export default class NetworkDeviceLinkRuleUtil {
   }
 
   /*
-   * "Unit 4, Unit 9 and 2 more sites".
-   *
-   * Sorted before naming, and that is load-bearing rather than cosmetic: the
-   * live view refetches every sixty seconds and the device query has no ORDER
-   * BY, so an unsorted list would reshuffle the banner on every poll and read
-   * as a change that did not happen. The count stays exact even when the names
-   * are elided, so the operator always knows the true blast radius.
+   * By site name, then by id so equally-named (and unnamed) sites still have
+   * ONE order. Load-bearing rather than cosmetic: the live view refetches
+   * every sixty seconds and the device query has no ORDER BY, so an unsorted
+   * list would reshuffle the banner on every poll and read as a change that
+   * did not happen. The sentence and the site list share it so the three names
+   * the sentence gives are the first three rows of the list.
    */
-  private static describeSiteList(
+  private static sortSiteFailures(
     failures: Array<LinkRuleGroupFailure>,
-  ): string {
-    const sorted: Array<LinkRuleGroupFailure> = [...failures].sort(
+  ): Array<LinkRuleGroupFailure> {
+    return [...failures].sort(
       (a: LinkRuleGroupFailure, b: LinkRuleGroupFailure) => {
         return (
           (a.siteName || "").localeCompare(b.siteName || "") ||
@@ -549,6 +590,21 @@ export default class NetworkDeviceLinkRuleUtil {
         );
       },
     );
+  }
+
+  /*
+   * "Unit 4, Unit 9 and 2 more sites".
+   *
+   * Named in sortSiteFailures order, for the reasons given there. The count
+   * stays exact even when the names are elided, so the operator always knows
+   * the true blast radius — and `getWarning` sends the sites themselves
+   * alongside, because a blast radius is not a list of buildings.
+   */
+  private static describeSiteList(
+    failures: Array<LinkRuleGroupFailure>,
+  ): string {
+    const sorted: Array<LinkRuleGroupFailure> =
+      NetworkDeviceLinkRuleUtil.sortSiteFailures(failures);
 
     const names: Array<string> = sorted
       .slice(0, NetworkDeviceLinkRuleUtil.MAX_NAMED_SITES)
@@ -721,7 +777,7 @@ export default class NetworkDeviceLinkRuleUtil {
       );
     }
 
-    return {
+    const warning: LinkRuleWarning = {
       ruleId: outcome.ruleId,
       ruleName: outcome.ruleName,
       // Highest-ranked condition present. Ambiguity outranks a missing parent.
@@ -733,5 +789,31 @@ export default class NetworkDeviceLinkRuleUtil {
             : "devicesWithoutSite",
       message: parts.join(" "),
     };
+
+    /*
+     * The list, for the sentence the operator cannot act on. Written only when
+     * there are failing sites, so a warning that is purely about unsited
+     * devices — which names no site at all — keeps the exact shape it had.
+     *
+     * `siteCount` is the true total and `sites` may be shorter; a caller that
+     * reads sites.length as the number of broken sites is wrong at the cap,
+     * which is precisely the scale this exists for.
+     */
+    if (failures.length > 0) {
+      warning.siteCount = failures.length;
+      warning.sites = NetworkDeviceLinkRuleUtil.sortSiteFailures(failures)
+        .slice(0, NetworkDeviceLinkRuleUtil.MAX_LISTED_SITES)
+        .map((failure: LinkRuleGroupFailure) => {
+          return {
+            siteId: failure.siteId,
+            siteName: failure.siteName,
+            reason: failure.reason,
+            strandedDeviceCount: failure.matchedChildCount,
+            matchedParentCount: failure.matchedParentCount,
+          };
+        });
+    }
+
+    return warning;
   }
 }


### PR DESCRIPTION
### Title of this pull request?

fix(topology): judge site-scoped link rules on the whole fleet, not the map's page

### Small Description?

A site-scoped link rule asks *"which single device in this site carries the parent labels"*. The topology endpoint answered that from the same device page it draws the map with, which is capped at `LIMIT_PER_PROJECT` (10,000) rows. On a fleet past the cap, a site whose router simply fell outside the page came back as **a site with no router at all**.

That is the report in #3321: 949 correctly labelled sites, every unit with its router, and a banner reading

> Drawing in 252 of 949 sites. No device carries the parent labels in WB Franchise Unit 0005, WB Franchise Unit 0047, WB Franchise Unit 0069 and 694 more sites, so 2031 devices there have no uplink. … The device list was truncated, so some of these may be false alarms.

Unlike the map itself, this failure does not degrade gracefully — the rule is answered **wrongly**, not partially.

**The fix.** The rules now read the fleet themselves, in pages, instead of borrowing the map's page:

- Paged at `LIMIT_PER_PROJECT`, sorted by `_id` — not the default `createdAt`, because a discovery import stamps thousands of devices with the same timestamp and rows tied on the sort key can shift between pages. A skipped router is exactly the phantom this sweep exists to remove.
- Four columns (`_id`, `siteId`, `site.name`, `labels`) instead of the map's forty, which is what makes a full-fleet pass affordable.
- **Runs only when the map's own page came back full** and at least one enabled rule has labels on both sides. Below the cap the map's page *is* the whole fleet, so it is reused and an ordinary project still issues exactly one device query.
- Bounded at ten pages, and a one-row probe past the cap so a fleet of exactly 100,000 devices does not confess to a truncation that never happened.
- Runs on the caller's props, never root: a viewer must not be shown devices, or site names, they cannot read.

**The truncation caveat now tracks the sweep, not the map.** It was wrong in both directions before — a lie on any truncated map, and silent on a fleet past the sweep's own cap, where the doubt is real. A caveat attached to warnings that do not need it teaches operators to discount the ones that do.

**The second half of the report** — *"we need better tooling to audit gaps once applied across hundreds of sites"*. One line of prose can only ever say "and 694 more sites", which is a blast radius, not a list of buildings. Each warning now carries the failing sites themselves — capped at 100 rows with the **exact** total alongside — each with its own reason (no parent vs. several, which need opposite fixes) and its stranded device count. The map's banner expands into them:

> **Show the 697 sites that need attention**
> - WB Franchise Unit 0005 — no device carries the parent labels, so 3 devices have no uplink
> - WB Franchise Unit 0047 — 2 devices carry the parent labels, so 3 devices have no uplink
> - …
> - 597 more sites not listed here.

Behaviour below the row cap is unchanged, project scope is untouched, and no migration is involved — link rules are resolved live, never stored.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

`npm run compile` passes in `App` and `Common`; `eslint --fix` is clean on every touched file.

**Tests — 60 new, and every existing suite in `App/Tests/Dashboard`, `App/Tests/BaseAPI` (6,095) and `Common/Tests/Utils/Monitor` (441) still green.**

`App/Tests/BaseAPI/NetworkDeviceTopologyAPI.test.ts` — the reporter's estate end to end, 949 units of one router and eleven switches, with the map's page holding the switches and nothing else:

- the 949 sites now produce **no warning at all**, while `isTruncated` still reports the map as partial — that half of the report was never wrong
- the counter-example: the same fixture judged on the map's page alone, kept so a regression reads like the issue rather than like a diff
- a complete map page is reused — one device query, no sweep
- no sweep for a truncated map with no rules, or with a rule missing labels on one side
- the sweep's query shape: four columns, `isArchived: false`, project scope, page size
- paging by `_id`, page after page until one comes back short
- a fleet of exactly the cap does not confess to a truncation (the one-row probe)
- a truncated map with a complete sweep states a real failure plainly, with no caveat
- the sweep follows a site-scoped request instead of reading the project
- the sweep carries the caller's permission props, never root
- the per-site payload, and its absence on a project-scoped warning

`Common/Tests/Utils/Monitor/NetworkDeviceLinkRuleUtil.test.ts` — the resolver's side of the list: per-site reasons on a mixed failure (the rule's headline reason is wrong about half of them), the list ordered exactly as the sentence names them, byte-stability across device orderings, unnamed sites, the cap with an exact total, silence for project scope and for unsited-devices-only, and the 949-site case where the coverage fraction and the stranded total are reproducible from the rows.

`App/Tests/Dashboard/LinkRuleWarningUtil.test.ts` — the banner reads untrusted JSON: malformed warnings and site rows dropped rather than rendered as empty bullets, negative counts clamped, the endpoint's total believed over the rows it sent (and the rows believed when the payload contradicts itself), and the phrasing of each row and of the toggle.

### Related Issue?

closes #3321

### Screenshots (if appropriate):

n/a — the change is the absence of a false banner, plus an expander under the existing one.
