### PR TITLE
fix(accounts): read the login misc bag under its wire key

### DIFF
--- a/App/FeatureSet/Accounts/src/Pages/Login.tsx
+++ b/App/FeatureSet/Accounts/src/Pages/Login.tsx
@@ -41,6 +41,20 @@ import Base64 from "Common/Utils/Base64";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
 
+/*
+ * The misc bag travels on the wire under `_miscData` — the key
+ * Response.sendEntityResponse sets. ModelAPI renames it to `miscData` while
+ * parsing a response, but the two factor verify calls below post through API
+ * directly and bypass that rename, so they read the wire key themselves.
+ */
+type GetMiscDataFunction = (response: HTTPResponse<JSONObject>) => JSONObject;
+
+const getMiscData: GetMiscDataFunction = (
+  response: HTTPResponse<JSONObject>,
+): JSONObject => {
+  return ((response.data as JSONObject)["_miscData"] as JSONObject) || {};
+};
+
 const LoginPage: () => JSX.Element = () => {
   const { t } = useTranslation();
   const apiUrl: URL = LOGIN_API_URL;
@@ -249,7 +263,7 @@ const LoginPage: () => JSX.Element = () => {
           verifyResult.data as JSONObject,
           User,
         ) as User;
-        const miscData: JSONObject = {};
+        const miscData: JSONObject = getMiscData(verifyResult);
 
         login(user as User, miscData);
       } catch (error) {
@@ -485,11 +499,9 @@ const LoginPage: () => JSX.Element = () => {
                     result["data"] as JSONObject,
                     User,
                   ) as User;
-                  const miscData: JSONObject = (result["data"] as JSONObject)[
-                    "miscData"
-                  ] as JSONObject;
+                  const miscData: JSONObject = getMiscData(result);
 
-                  login(user as User, miscData as JSONObject);
+                  login(user as User, miscData);
                 } catch (error) {
                   setTwoFactorAuthError(
                     API.getFriendlyErrorMessage(error as Error),


### PR DESCRIPTION
### Title of this pull request?

fix(accounts): read the login misc bag under its wire key

### Small Description?

The two factor verify handlers on the accounts login page read the response envelope under the wrong key, so the misc bag was never actually reaching them.

`Response.sendEntityResponse` puts the bag on the wire as `_miscData` (`Common/Server/Utils/Response.ts:324`). The rename to `miscData` happens only inside `ModelAPI` (`Common/UI/Utils/ModelAPI/ModelAPI.ts:188-191`). Both 2FA verify calls in `Login.tsx` post through `API.post` directly and bypass that rename, so they have to read the wire key themselves — and neither did:

- **TOTP branch** read `result["data"]["miscData"]`, which is always `undefined`.
- **WebAuthn branch** did not read the response at all — it passed a hardcoded `{}`.

Both now go through a single documented helper, `getMiscData`, that reads `_miscData`.

#### Why this was invisible

Nothing is broken today, for two independent reasons: the only field read off the bag is `token`, and `LoginUtil.login` (`Common/UI/Utils/Login.ts`) ignores `token` entirely — the dashboard session comes from the cookie the server sets. The dashboard bag does not even contain a `token` key; it carries `accessToken` / `refreshToken` / `refreshTokenExpiresAt`.

So **this is not a behavior change.** `miscData["token"]` is still `undefined` afterwards. What it fixes is that the *read* is now correct, so the next field added to that bag actually arrives instead of silently coming back `undefined`.

#### Scope of the sweep

I checked every other client-side read of the response envelope. The other two are already correct:

- `Common/UI/Components/Forms/ModelForm.tsx` — goes through ModelAPI, which does the rename.
- `MobileApp/src/api/auth.ts` — already reads `_miscData` directly.

Most other `miscData` hits in the repo are the unrelated `WorkspaceProjectAuthToken.miscData` database column. `Login.tsx` was the only site with the mismatch.

#### One thing deliberately left alone

The `token: miscData ? miscData["token"] : undefined` plumbing looks dead here, and in this flow it is. But the identically shaped call in the status page (`App/FeatureSet/StatusPage/src/Utils/Login.ts:21-27`) genuinely consumes it — `StatusPageAuthentication.ts:429` sends `miscData: { token: accessToken }` and the status page stores it as a cookie. Removing it from the dashboard side would break the symmetry between two files that should keep matching, so I left it. Happy to prune it separately if preferred.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

**The last two boxes are unchecked deliberately — please read:**

**Lint / typecheck:** I could not run these. This worktree has no `node_modules`, and `tsc` fails on missing `@types/jest` and `@types/node` before it reaches any source file. What I did verify: the standalone TypeScript compiler (5.9.3) parses the edited file with zero syntax errors, and the new block comment conforms to the `multiline-comment-style: starred-block` rule at `eslint.config.js:65`. A real `npm ci && npx tsc` in `App/` still needs to happen in CI or by a reviewer.

**Tests:** none added. The App package sets `testEnvironment: "node"` with no jsdom and no testing-library, and there are no `.test.tsx` files anywhere under `App/Tests`. Covering a React submit handler would mean adding component-test infrastructure to the package, which is well outside the scope of this fix. A server-side test would not help either — the server contract is already correct; the client was the wrong half.

### Related Issue?

None.

### Screenshots (if appropriate):

Not applicable — no user-visible change.
