### PR TITLE
feat(logs): surface top errors and time-based correlation on the Logs Insights page

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Logs/ErrorPatternDetail.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/ErrorPatternDetail.tsx
@@ -1,0 +1,538 @@
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+import API from "Common/UI/Utils/API/API";
+import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import Icon from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
+import OneUptimeDate from "Common/Types/Date";
+import Route from "Common/Types/API/Route";
+import Service from "Common/Models/DatabaseModels/Service";
+import SideOver, { SideOverSize } from "Common/UI/Components/SideOver/SideOver";
+import { getSeverityTheme } from "Common/UI/Components/LogsViewer/components/severityTheme";
+import { truncateErrorPattern } from "Common/Utils/Telemetry/LogErrorPattern";
+import AppLink from "../AppLink/AppLink";
+import {
+  ErrorPatternCoOccurrenceRow,
+  ErrorPatternCorrelation,
+  ErrorPatternResourceRow,
+  ErrorPatternSampleRow,
+  ErrorPatternTimelinePoint,
+  ErrorPatternTraceRow,
+  ErrorPatternTrend,
+  LogsInsightsScope,
+  SharedAttribute,
+  TopErrorPatternRow,
+  buildErrorPatternLogsRoute,
+  buildErrorPatternTraceRoute,
+  computeErrorPatternTrend,
+  describeOccurrenceCount,
+  describeTimeRange,
+  summarizeSharedAttributes,
+} from "../../Utils/LogsInsights";
+import { fetchErrorPatternCorrelation } from "./LogsInsightsApi";
+
+/*
+ * The drill-down the issue asked for: pick one error out of the Top Errors
+ * list and see what surrounds it — when it fired, whether it is getting
+ * worse, what its occurrences have in common, which sources and traces
+ * carry it, what else was failing at the same moments, and the raw lines.
+ *
+ * Every section is scoped to the same slice the list was, so nothing here
+ * correlates against logs the user is not looking at.
+ */
+
+export interface ComponentProps {
+  pattern: TopErrorPatternRow;
+  scope: LogsInsightsScope;
+  serviceNameById: Map<string, Service>;
+  onClose: () => void;
+}
+
+/** How many rows each correlation section asks for. */
+const CORRELATION_LIMIT: number = 10;
+
+const TREND_PRESENTATION: Record<
+  ErrorPatternTrend["direction"],
+  { label: string; className: string; icon: IconProp }
+> = {
+  rising: {
+    label: "Rising",
+    className: "bg-red-50 text-red-700",
+    icon: IconProp.ArrowUp,
+  },
+  falling: {
+    label: "Falling",
+    className: "bg-emerald-50 text-emerald-700",
+    icon: IconProp.ArrowDown,
+  },
+  steady: {
+    label: "Steady",
+    className: "bg-gray-100 text-gray-600",
+    icon: IconProp.Minus,
+  },
+  unknown: {
+    label: "Not enough data",
+    className: "bg-gray-100 text-gray-500",
+    icon: IconProp.Help,
+  },
+};
+
+function formatTimestamp(date: Date | null): string {
+  if (!date) {
+    return "unknown";
+  }
+
+  return OneUptimeDate.getDateAsLocalFormattedString(date);
+}
+
+const SectionHeading: FunctionComponent<{
+  title: string;
+  subtitle?: string | undefined;
+}> = (props: {
+  title: string;
+  subtitle?: string | undefined;
+}): ReactElement => {
+  return (
+    <div className="mb-2">
+      <h4 className="text-sm font-semibold text-gray-900">{props.title}</h4>
+      {props.subtitle && (
+        <p className="text-xs text-gray-500">{props.subtitle}</p>
+      )}
+    </div>
+  );
+};
+
+/*
+ * A hand-rolled bar chart rather than a charting component: the timeline is
+ * a single series of counts with no axes, legend or interaction, and the
+ * panel it lives in is narrow. Bars carry a title attribute so the exact
+ * bucket and count are still reachable on hover.
+ */
+const Timeline: FunctionComponent<{
+  points: Array<ErrorPatternTimelinePoint>;
+}> = (props: { points: Array<ErrorPatternTimelinePoint> }): ReactElement => {
+  if (props.points.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">
+        No bucketed occurrences to chart in this window.
+      </p>
+    );
+  }
+
+  const peak: number = Math.max(
+    ...props.points.map((point: ErrorPatternTimelinePoint): number => {
+      return point.count;
+    }),
+    1,
+  );
+
+  return (
+    <div className="flex h-24 items-end gap-0.5">
+      {props.points.map(
+        (point: ErrorPatternTimelinePoint, index: number): ReactElement => {
+          const heightPercent: number = Math.max(
+            2,
+            Math.round((point.count / peak) * 100),
+          );
+
+          return (
+            <div
+              key={`${point.time?.toISOString() || "bucket"}-${index}`}
+              className="flex-1 rounded-sm bg-red-400"
+              style={{ height: `${heightPercent}%` }}
+              title={`${formatTimestamp(point.time)} — ${point.count}`}
+            />
+          );
+        },
+      )}
+    </div>
+  );
+};
+
+const ErrorPatternDetail: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [correlation, setCorrelation] =
+    useState<ErrorPatternCorrelation | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>("");
+
+  const patternText: string = props.pattern.pattern;
+
+  const load: () => Promise<void> = useCallback(async (): Promise<void> => {
+    try {
+      setIsLoading(true);
+      setError("");
+
+      const result: ErrorPatternCorrelation =
+        await fetchErrorPatternCorrelation(
+          props.scope,
+          patternText,
+          CORRELATION_LIMIT,
+        );
+
+      setCorrelation(result);
+    } catch (err) {
+      setError(API.getFriendlyMessage(err as Error));
+    } finally {
+      setIsLoading(false);
+    }
+    /*
+     * Safe to depend on the scope object itself: the host page memoizes it
+     * on the time range and the selected resources, so it is referentially
+     * stable between renders — and when it does change the host closes this
+     * panel rather than leaving it describing a window that moved.
+     */
+  }, [patternText, props.scope]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const logsRoute: Route | null = buildErrorPatternLogsRoute(
+    patternText,
+    props.scope,
+  );
+
+  const resourceLabel: (resourceId: string) => string = (
+    resourceId: string,
+  ): string => {
+    return (
+      props.serviceNameById.get(resourceId)?.name?.toString() || resourceId
+    );
+  };
+
+  const body: ReactElement = ((): ReactElement => {
+    if (isLoading) {
+      return <ComponentLoader />;
+    }
+
+    if (error) {
+      return (
+        <ErrorMessage
+          message={error}
+          onRefreshClick={() => {
+            void load();
+          }}
+        />
+      );
+    }
+
+    if (!correlation) {
+      return (
+        <ErrorMessage message="No correlation data is available for this error." />
+      );
+    }
+
+    const trend: ErrorPatternTrend = computeErrorPatternTrend(
+      correlation.timeline,
+    );
+    const trendStyle: {
+      label: string;
+      className: string;
+      icon: IconProp;
+    } = TREND_PRESENTATION[trend.direction];
+
+    const sharedAttributes: Array<SharedAttribute> = summarizeSharedAttributes(
+      correlation.attributes,
+      props.pattern.count,
+    );
+
+    return (
+      <Fragment>
+        {/* What the error is */}
+        <div className="pb-5">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            {props.pattern.severities.map((severity: string): ReactElement => {
+              return (
+                <span
+                  key={severity}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+                    getSeverityTheme(severity).badgeClass
+                  }`}
+                >
+                  {severity}
+                </span>
+              );
+            })}
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${trendStyle.className}`}
+            >
+              <Icon icon={trendStyle.icon} className="h-3 w-3" />
+              {trendStyle.label}
+              {trend.direction !== "unknown" && (
+                <span className="opacity-70">
+                  {trend.changePercent > 0 ? "+" : ""}
+                  {trend.changePercent}%
+                </span>
+              )}
+            </span>
+          </div>
+
+          <p className="break-words rounded-md bg-gray-50 p-3 font-mono text-sm text-gray-800">
+            {props.pattern.sampleBody || patternText}
+          </p>
+
+          <p className="mt-2 text-sm text-gray-600">
+            {describeOccurrenceCount(
+              props.pattern.count,
+              props.scope.timeRange,
+            )}
+            , across {props.pattern.resourceCount}{" "}
+            {props.pattern.resourceCount === 1 ? "source" : "sources"}. First
+            seen {formatTimestamp(props.pattern.firstSeenAt)}, last seen{" "}
+            {formatTimestamp(props.pattern.lastSeenAt)}.
+          </p>
+
+          {logsRoute && (
+            <AppLink
+              to={logsRoute}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:border-gray-300 hover:bg-gray-50"
+            >
+              <Icon icon={IconProp.List} className="h-3.5 w-3.5" />
+              <span>Open matching logs</span>
+            </AppLink>
+          )}
+        </div>
+
+        {/* When it happened */}
+        <div className="py-5">
+          <SectionHeading
+            title="When it happened"
+            subtitle={`Occurrences per ${correlation.bucketSizeInMinutes} min bucket over ${describeTimeRange(props.scope.timeRange)}.`}
+          />
+          <Timeline points={correlation.timeline} />
+        </div>
+
+        {/* What the occurrences have in common */}
+        <div className="py-5">
+          <SectionHeading
+            title="What these occurrences share"
+            subtitle="Attributes carried by the matching logs, most widespread first."
+          />
+          {sharedAttributes.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              These logs carry no attributes in common.
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {sharedAttributes.map(
+                (attribute: SharedAttribute): ReactElement => {
+                  return (
+                    <li
+                      key={`${attribute.key}=${attribute.value}`}
+                      className="flex items-center justify-between gap-3 rounded-md border border-gray-100 px-3 py-2"
+                    >
+                      <span className="min-w-0 break-words font-mono text-xs text-gray-700">
+                        <span className="text-gray-500">{attribute.key}</span>
+                        {" = "}
+                        <span className="font-medium text-gray-900">
+                          {attribute.value}
+                        </span>
+                      </span>
+                      <span
+                        className={`flex-shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                          attribute.isUniversal
+                            ? "bg-amber-50 text-amber-700"
+                            : "bg-gray-100 text-gray-600"
+                        }`}
+                      >
+                        {attribute.isUniversal
+                          ? "every occurrence"
+                          : `${attribute.coveragePercent}%`}
+                      </span>
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          )}
+        </div>
+
+        {/* Where it happens */}
+        <div className="py-5">
+          <SectionHeading
+            title="Where it happens"
+            subtitle="Services, hosts and clusters reporting this error."
+          />
+          {correlation.resources.length === 0 ? (
+            <p className="text-sm text-gray-500">No sources to report.</p>
+          ) : (
+            <ul className="space-y-1.5">
+              {correlation.resources.map(
+                (resource: ErrorPatternResourceRow): ReactElement => {
+                  return (
+                    <li
+                      key={resource.resourceId}
+                      className="flex items-center justify-between gap-3 rounded-md border border-gray-100 px-3 py-2"
+                    >
+                      <span className="min-w-0 break-words text-sm text-gray-800">
+                        {resourceLabel(resource.resourceId)}
+                        {resource.resourceType && (
+                          <span className="ml-2 text-xs text-gray-400">
+                            {resource.resourceType}
+                          </span>
+                        )}
+                      </span>
+                      <span className="flex-shrink-0 text-xs font-medium text-gray-600">
+                        {resource.count}
+                      </span>
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          )}
+        </div>
+
+        {/* What else was failing at the same time */}
+        <div className="py-5">
+          <SectionHeading
+            title="What else was failing at the same time"
+            subtitle={`Other errors that fired in the same ${correlation.bucketSizeInMinutes} min buckets as this one.`}
+          />
+          {correlation.coOccurringPatterns.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Nothing else was failing in the same buckets.
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {correlation.coOccurringPatterns.map(
+                (row: ErrorPatternCoOccurrenceRow): ReactElement => {
+                  return (
+                    <li
+                      key={row.pattern}
+                      className="rounded-md border border-gray-100 px-3 py-2"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <span className="min-w-0 break-words font-mono text-xs text-gray-800">
+                          {truncateErrorPattern(
+                            row.sampleBody || row.pattern,
+                            140,
+                          )}
+                        </span>
+                        <span className="flex-shrink-0 text-xs font-medium text-gray-600">
+                          {row.count}
+                        </span>
+                      </div>
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          )}
+        </div>
+
+        {/* Traces */}
+        <div className="py-5">
+          <SectionHeading
+            title="Traces carrying this error"
+            subtitle="Open a trace to see the request the error happened inside."
+          />
+          {correlation.traces.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              None of these logs carry a trace id.
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {correlation.traces.map(
+                (trace: ErrorPatternTraceRow): ReactElement => {
+                  const traceRoute: Route | null = buildErrorPatternTraceRoute(
+                    trace.traceId,
+                  );
+
+                  return (
+                    <li
+                      key={trace.traceId}
+                      className="flex items-center justify-between gap-3 rounded-md border border-gray-100 px-3 py-2"
+                    >
+                      {traceRoute ? (
+                        <AppLink
+                          to={traceRoute}
+                          className="min-w-0 truncate font-mono text-xs text-indigo-600 hover:underline"
+                        >
+                          {trace.traceId}
+                        </AppLink>
+                      ) : (
+                        <span className="min-w-0 truncate font-mono text-xs text-gray-700">
+                          {trace.traceId}
+                        </span>
+                      )}
+                      <span className="flex-shrink-0 text-xs text-gray-500">
+                        {trace.count}
+                      </span>
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          )}
+        </div>
+
+        {/* Raw lines */}
+        <div className="py-5">
+          <SectionHeading
+            title="Recent occurrences"
+            subtitle="The most recent raw log lines behind this error."
+          />
+          {correlation.samples.length === 0 ? (
+            <p className="text-sm text-gray-500">No sample lines available.</p>
+          ) : (
+            <ul className="space-y-2">
+              {correlation.samples.map(
+                (
+                  sample: ErrorPatternSampleRow,
+                  index: number,
+                ): ReactElement => {
+                  return (
+                    <li
+                      key={sample.logId || `sample-${index}`}
+                      className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2"
+                    >
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                        <span>{formatTimestamp(sample.time)}</span>
+                        {sample.severityText && (
+                          <span
+                            className={`rounded-full px-1.5 py-0.5 font-medium ring-1 ring-inset ${
+                              getSeverityTheme(sample.severityText).badgeClass
+                            }`}
+                          >
+                            {sample.severityText}
+                          </span>
+                        )}
+                        <span>{resourceLabel(sample.resourceId)}</span>
+                      </div>
+                      <p className="mt-1 break-words font-mono text-xs text-gray-800">
+                        {sample.body}
+                      </p>
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          )}
+        </div>
+      </Fragment>
+    );
+  })();
+
+  return (
+    <SideOver
+      title="Error details"
+      description={truncateErrorPattern(patternText, 120)}
+      size={SideOverSize.Large}
+      onClose={props.onClose}
+    >
+      {body}
+    </SideOver>
+  );
+};
+
+export default ErrorPatternDetail;

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsDashboard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsDashboard.tsx
@@ -7,295 +7,316 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import Service from "Common/Models/DatabaseModels/Service";
-import Log from "Common/Models/AnalyticsModels/Log";
-import LogSeverity from "Common/Types/Log/LogSeverity";
-import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
-import AnalyticsModelAPI, {
-  ListResult as AnalyticsListResult,
-} from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
-import ProjectUtil from "Common/UI/Utils/Project";
 import API from "Common/UI/Utils/API/API";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import Dictionary from "Common/Types/Dictionary";
+import Dropdown, {
+  DropdownOption,
+  DropdownOptionGroup,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
-import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import Query from "Common/Types/BaseDatabase/Query";
-import Select from "Common/Types/BaseDatabase/Select";
-import InBetween from "Common/Types/BaseDatabase/InBetween";
-import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
-import ObjectID from "Common/Types/ObjectID";
-import RangeStartAndEndDateTime, {
-  RangeStartAndEndDateTimeUtil,
-} from "Common/Types/Time/RangeStartAndEndDateTime";
-import TimeRange from "Common/Types/Time/TimeRange";
-import TelemetryTimeRangePicker from "Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker";
 import Icon from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
-import ServiceElement from "../Service/ServiceElement";
-import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
-import PageMap from "../../Utils/PageMap";
+import { JSONObject } from "Common/Types/JSON";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ObjectID from "Common/Types/ObjectID";
+import ProjectUtil from "Common/UI/Utils/Project";
+import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
 import Route from "Common/Types/API/Route";
+import Service from "Common/Models/DatabaseModels/Service";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import TelemetryTimeRangePicker from "Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker";
+import TimeRange from "Common/Types/Time/TimeRange";
+import { getSeverityTheme } from "Common/UI/Components/LogsViewer/components/severityTheme";
 import AppLink from "../AppLink/AppLink";
+import ErrorPatternDetail from "./ErrorPatternDetail";
+import PageMap from "../../Utils/PageMap";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import ServiceElement from "../Service/ServiceElement";
+import TopErrorsPanel from "./TopErrorsPanel";
+import {
+  fetchInsightsHistogram,
+  fetchResourceBreakdown,
+  fetchScopeFacets,
+  fetchTopErrorPatterns,
+} from "./LogsInsightsApi";
+import {
+  INSIGHTS_SCOPE_FACET_KEYS,
+  INSIGHTS_SCOPE_FACET_LABELS,
+  LogVolumeSummary,
+  LogsInsightsScope,
+  ParsedScopeSelections,
+  ResourceLogBreakdown,
+  ScopeFacetValue,
+  SeverityShare,
+  TopErrorPatternRow,
+  describeTimeRange,
+  encodeScopeSelection,
+  parseScopeSelections,
+  summarizeSeverityBuckets,
+} from "../../Utils/LogsInsights";
 
-interface SeverityBucket {
-  severity: LogSeverity;
-  count: number;
-  color: string;
-  bgColor: string;
-  barColor: string;
-}
+/*
+ * The Logs Insights page.
+ *
+ * Two things distinguish it from a wall of counters. First, every number is
+ * aggregated in ClickHouse over the whole window: the page previously
+ * fetched a capped page of raw log rows and counted those in the browser,
+ * so on any busy project its totals silently described the fetch rather
+ * than the project. Second, it names the errors — the distinct messages,
+ * how often each happened, and, one click in, what surrounded it.
+ */
 
-interface ServiceSummary {
-  service: Service;
-  logCount: number;
-  errorCount: number;
-  warnCount: number;
-}
+/** How many error patterns the list asks for. */
+const TOP_ERROR_LIMIT: number = 12;
 
-const SEVERITY_STYLES: Record<
-  string,
-  { color: string; bgColor: string; barColor: string; order: number }
-> = {
-  Fatal: {
-    color: "text-rose-700",
-    bgColor: "bg-rose-50",
-    barColor: "bg-rose-500",
-    order: 0,
-  },
-  Error: {
-    color: "text-red-700",
-    bgColor: "bg-red-50",
-    barColor: "bg-red-400",
-    order: 1,
-  },
-  Warning: {
-    color: "text-amber-700",
-    bgColor: "bg-amber-50",
-    barColor: "bg-amber-400",
-    order: 2,
-  },
-  Information: {
-    color: "text-sky-700",
-    bgColor: "bg-sky-50",
-    barColor: "bg-sky-400",
-    order: 3,
-  },
-  Debug: {
-    color: "text-violet-700",
-    bgColor: "bg-violet-50",
-    barColor: "bg-violet-400",
-    order: 4,
-  },
-  Trace: {
-    color: "text-emerald-700",
-    bgColor: "bg-emerald-50",
-    barColor: "bg-emerald-400",
-    order: 5,
-  },
-  Unspecified: {
-    color: "text-gray-700",
-    bgColor: "bg-gray-100",
-    barColor: "bg-gray-300",
-    order: 6,
-  },
-};
-
-function timeRangeLabel(range: RangeStartAndEndDateTime): string {
-  if (range.range === TimeRange.CUSTOM) {
-    return "the selected time range";
-  }
-  return `the ${(range.range as string).toLowerCase()}`;
-}
+/** How many resources the per-service section renders before cutting off. */
+const RESOURCE_CARD_LIMIT: number = 12;
 
 const LogsDashboard: FunctionComponent = (): ReactElement => {
   const [timeRange, setTimeRange] = useState<RangeStartAndEndDateTime>({
-    range: TimeRange.PAST_ONE_HOUR,
+    range: TimeRange.PAST_ONE_DAY,
   });
+  /*
+   * Encoded "<facetKey>:<id>" values — one flat multi-select over Services
+   * AND the resources that log under their own id (hosts, docker hosts,
+   * Kubernetes clusters). Decoded into the two scope fields the API takes
+   * by parseScopeSelections.
+   */
+  const [selectedScopeValues, setSelectedScopeValues] = useState<Array<string>>(
+    [],
+  );
 
   const [services, setServices] = useState<Array<Service>>([]);
-  const [logs, setLogs] = useState<Array<Log>>([]);
+  const [scopeFacets, setScopeFacets] = useState<
+    Dictionary<Array<ScopeFacetValue>>
+  >({});
+  const [volume, setVolume] = useState<LogVolumeSummary | null>(null);
+  const [errorPatterns, setErrorPatterns] = useState<Array<TopErrorPatternRow>>(
+    [],
+  );
+  const [resourceBreakdown, setResourceBreakdown] = useState<
+    Array<ResourceLogBreakdown>
+  >([]);
+  const [selectedPattern, setSelectedPattern] =
+    useState<TopErrorPatternRow | null>(null);
+
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>("");
 
-  const loadDashboard: () => Promise<void> = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      setError("");
+  /*
+   * One scope object, shared by every panel and by the detail drawer, so a
+   * correlation the page draws is always a correlation inside the slice the
+   * user selected.
+   */
+  const scope: LogsInsightsScope = useMemo(() => {
+    const selections: ParsedScopeSelections =
+      parseScopeSelections(selectedScopeValues);
 
+    return { timeRange, ...selections };
+  }, [timeRange, selectedScopeValues]);
+
+  const loadServices: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
       const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+
       if (!projectId) {
-        setIsLoading(false);
         return;
       }
 
-      const dateRange: InBetween<Date> =
-        RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+      const result: { data: Array<Service> } = await ModelAPI.getList({
+        modelType: Service,
+        query: { projectId },
+        select: { name: true, serviceColor: true },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        sort: { name: SortOrder.Ascending },
+      });
 
-      const [servicesResult, logsResult] = await Promise.all([
-        ModelAPI.getList({
-          modelType: Service,
-          query: { projectId },
-          select: { name: true, serviceColor: true },
-          limit: LIMIT_PER_PROJECT,
-          skip: 0,
-          sort: { name: SortOrder.Ascending },
-        }),
-        AnalyticsModelAPI.getList<Log>({
-          modelType: Log,
-          query: {
-            projectId,
-            time: new InBetween<Date>(dateRange.startValue, dateRange.endValue),
-          } as Query<Log>,
-          limit: 5000,
-          skip: 0,
-          select: {
-            primaryEntityId: true,
-            severityText: true,
-            time: true,
-          } as Select<Log>,
-          sort: { time: SortOrder.Descending } as Record<string, SortOrder>,
-          requestOptions: {},
-        }),
-      ]);
+      setServices(result.data || []);
+    }, []);
 
-      setServices(servicesResult.data || []);
-      setLogs(
-        ((logsResult as AnalyticsListResult<Log>).data || []) as Array<Log>,
-      );
-    } catch (err) {
-      setError(API.getFriendlyMessage(err as Error));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [timeRange]);
+  const loadInsights: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      try {
+        setIsLoading(true);
+        setError("");
+
+        const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+
+        if (!projectId) {
+          setIsLoading(false);
+          return;
+        }
+
+        const [buckets, patterns, breakdown, facets] = await Promise.all([
+          fetchInsightsHistogram(scope),
+          fetchTopErrorPatterns(scope, TOP_ERROR_LIMIT),
+          fetchResourceBreakdown(scope),
+          /*
+           * Non-critical: without it the picker just falls back to the
+           * Services the project has, which is still a usable page.
+           */
+          fetchScopeFacets(scope).catch(
+            (): Dictionary<Array<ScopeFacetValue>> => {
+              return {};
+            },
+          ),
+        ]);
+
+        setVolume(summarizeSeverityBuckets(buckets as Array<JSONObject>));
+        setErrorPatterns(patterns);
+        setResourceBreakdown(breakdown);
+        setScopeFacets(facets);
+      } catch (err) {
+        setError(API.getFriendlyMessage(err as Error));
+      } finally {
+        setIsLoading(false);
+      }
+    }, [scope]);
 
   useEffect(() => {
-    void loadDashboard();
-  }, [loadDashboard]);
+    void loadServices();
+  }, [loadServices]);
 
-  const stats: {
-    severityCounts: Map<string, number>;
-    logsByService: Map<string, { total: number; error: number; warn: number }>;
-    total: number;
-    errorCount: number;
-    warnCount: number;
-  } = useMemo(() => {
-    const severityCounts: Map<string, number> = new Map();
-    const logsByService: Map<
-      string,
-      { total: number; error: number; warn: number }
-    > = new Map();
-    let errorCount: number = 0;
-    let warnCount: number = 0;
+  useEffect(() => {
+    void loadInsights();
+  }, [loadInsights]);
 
-    for (const log of logs) {
-      const sev: LogSeverity | undefined = log.severityText;
-      const sevKey: string = (sev as string) || "Unspecified";
-      severityCounts.set(sevKey, (severityCounts.get(sevKey) || 0) + 1);
+  /*
+   * A drawer opened against the previous scope would keep describing a
+   * window the page has moved on from, so close it when the scope changes.
+   */
+  useEffect(() => {
+    setSelectedPattern(null);
+  }, [scope]);
 
-      const isError: boolean =
-        sev === LogSeverity.Error || sev === LogSeverity.Fatal;
-      const isWarn: boolean = sev === LogSeverity.Warning;
-      if (isError) {
-        errorCount++;
-      }
-      if (isWarn) {
-        warnCount++;
-      }
+  const serviceById: Map<string, Service> = useMemo(() => {
+    const map: Map<string, Service> = new Map();
 
-      const primaryEntityId: ObjectID | undefined = log.primaryEntityId;
-      if (primaryEntityId) {
-        const sid: string = primaryEntityId.toString();
-        const existing: { total: number; error: number; warn: number } =
-          logsByService.get(sid) || { total: 0, error: 0, warn: 0 };
-        existing.total++;
-        if (isError) {
-          existing.error++;
-        }
-        if (isWarn) {
-          existing.warn++;
-        }
-        logsByService.set(sid, existing);
+    for (const service of services) {
+      const id: string | undefined =
+        service.id?.toString() || (service._id as string | undefined);
+
+      if (id) {
+        map.set(id, service);
       }
     }
 
-    return {
-      severityCounts,
-      logsByService,
-      total: logs.length,
-      errorCount,
-      warnCount,
-    };
-  }, [logs]);
+    return map;
+  }, [services]);
 
-  const severityBuckets: Array<SeverityBucket> = useMemo(() => {
-    return Array.from(stats.severityCounts.entries())
-      .map(([name, count]: [string, number]): SeverityBucket => {
-        const style: {
-          color: string;
-          bgColor: string;
-          barColor: string;
-          order: number;
-        } = SEVERITY_STYLES[name] || SEVERITY_STYLES["Unspecified"]!;
-        return {
-          severity: name as LogSeverity,
-          count,
-          color: style.color,
-          bgColor: style.bgColor,
-          barColor: style.barColor,
-        };
-      })
-      .sort((a: SeverityBucket, b: SeverityBucket): number => {
-        const oa: number = SEVERITY_STYLES[a.severity as string]?.order ?? 99;
-        const ob: number = SEVERITY_STYLES[b.severity as string]?.order ?? 99;
-        return oa - ob;
-      });
-  }, [stats.severityCounts]);
+  /*
+   * One option group per resource kind. Built from the facet response
+   * rather than from the project's Service list so the picker offers
+   * exactly what has telemetry in the window — including hosts and
+   * clusters, which have no Service row at all.
+   */
+  const scopeOptionGroups: Array<DropdownOptionGroup> = useMemo(() => {
+    const groups: Array<DropdownOptionGroup> = [];
 
-  const serviceSummaries: Array<ServiceSummary> = useMemo(() => {
-    const serviceById: Map<string, Service> = new Map();
-    for (const s of services) {
-      if (s.id) {
-        serviceById.set(s.id.toString(), s);
-      }
-    }
+    for (const facetKey of INSIGHTS_SCOPE_FACET_KEYS) {
+      const values: Array<ScopeFacetValue> = scopeFacets[facetKey] || [];
 
-    const out: Array<ServiceSummary> = [];
-    for (const [sid, counts] of stats.logsByService.entries()) {
-      const service: Service | undefined = serviceById.get(sid);
-      if (!service) {
+      if (values.length === 0) {
         continue;
       }
-      out.push({
-        service,
-        logCount: counts.total,
-        errorCount: counts.error,
-        warnCount: counts.warn,
+
+      groups.push({
+        label: INSIGHTS_SCOPE_FACET_LABELS[facetKey] || facetKey,
+        options: values.map((value: ScopeFacetValue): DropdownOption => {
+          return {
+            value: encodeScopeSelection(facetKey, value.value),
+            label:
+              serviceById.get(value.value)?.name?.toString() ||
+              value.displayName,
+          };
+        }),
       });
     }
-    return out.sort((a: ServiceSummary, b: ServiceSummary): number => {
-      return b.logCount - a.logCount;
-    });
-  }, [services, stats.logsByService]);
 
-  const reportingServices: number = serviceSummaries.length;
-  const quietServices: number = Math.max(
-    0,
-    services.length - reportingServices,
-  );
-  const errorRate: number =
-    stats.total > 0 ? Math.round((stats.errorCount / stats.total) * 100) : 0;
-  const rangeLabel: string = timeRangeLabel(timeRange);
+    return groups;
+  }, [scopeFacets, serviceById]);
+
+  const scopeOptionByValue: Map<string, DropdownOption> = useMemo(() => {
+    const map: Map<string, DropdownOption> = new Map();
+
+    for (const group of scopeOptionGroups) {
+      for (const option of group.options) {
+        map.set(option.value as string, option);
+      }
+    }
+
+    return map;
+  }, [scopeOptionGroups]);
+
+  const selectedScopeOptions: Array<DropdownOption> = useMemo(() => {
+    return selectedScopeValues
+      .map((value: string): DropdownOption | undefined => {
+        /*
+         * A selection whose option has left the facet list (the window
+         * moved and that host stopped logging) still has to render, or the
+         * user would have a filter they cannot see or remove.
+         */
+        return (
+          scopeOptionByValue.get(value) || {
+            value,
+            label: value.split(":")[1] || value,
+          }
+        );
+      })
+      .filter(
+        (option: DropdownOption | undefined): option is DropdownOption => {
+          return option !== undefined;
+        },
+      );
+  }, [selectedScopeValues, scopeOptionByValue]);
+
+  const rangeLabel: string = describeTimeRange(timeRange);
 
   const headerBar: ReactElement = (
     <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
       <div>
         <h2 className="text-base font-semibold text-gray-900">Insights</h2>
         <p className="text-xs text-gray-500">
-          Log activity across your services in {rangeLabel}.
+          What your services are logging in {rangeLabel} — and what is going
+          wrong.
         </p>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-[16rem]">
+          <Dropdown
+            options={scopeOptionGroups}
+            value={selectedScopeOptions}
+            isMultiSelect={true}
+            placeholder="All services and hosts"
+            ariaLabel="Scope insights to a service, host or cluster"
+            onChange={(
+              value: DropdownValue | Array<DropdownValue> | null,
+            ): void => {
+              if (!value) {
+                setSelectedScopeValues([]);
+                return;
+              }
+
+              const values: Array<DropdownValue> = Array.isArray(value)
+                ? value
+                : [value];
+
+              setSelectedScopeValues(
+                values
+                  .map((item: DropdownValue): string => {
+                    return String(item);
+                  })
+                  .filter((item: string): boolean => {
+                    return item.length > 0;
+                  }),
+              );
+            }}
+          />
+        </div>
         <TelemetryTimeRangePicker
           value={timeRange}
           onChange={(value: RangeStartAndEndDateTime): void => {
@@ -305,7 +326,7 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
         <button
           type="button"
           onClick={() => {
-            void loadDashboard();
+            void loadInsights();
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50"
           title="Refresh"
@@ -317,7 +338,7 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
     </div>
   );
 
-  if (isLoading) {
+  if (isLoading && !volume) {
     return (
       <Fragment>
         {headerBar}
@@ -335,14 +356,16 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
         <ErrorMessage
           message={error}
           onRefreshClick={() => {
-            void loadDashboard();
+            void loadInsights();
           }}
         />
       </Fragment>
     );
   }
 
-  if (stats.total === 0) {
+  const total: number = volume?.total || 0;
+
+  if (total === 0) {
     return (
       <Fragment>
         {headerBar}
@@ -355,8 +378,8 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
           </h3>
           <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-gray-500">
             Once your services start shipping logs via OpenTelemetry,
-            you&apos;ll see severity distribution, error rate, and per-service
-            volume here.
+            you&apos;ll see your top errors, severity distribution and
+            per-service volume here.
           </p>
           <div className="mt-6 flex items-center justify-center gap-2">
             <AppLink
@@ -383,9 +406,25 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
     );
   }
 
-  const maxLogs: number = Math.max(
-    ...serviceSummaries.map((s: ServiceSummary): number => {
-      return s.logCount;
+  const reportingResources: number = resourceBreakdown.length;
+  /*
+   * Counted against the resources that ARE Services, not against every
+   * reporting resource: hosts and clusters log under their own ids too, and
+   * including them would make "quiet services" go negative on any project
+   * running the infrastructure agent.
+   */
+  const reportingServices: number = resourceBreakdown.filter(
+    (row: ResourceLogBreakdown): boolean => {
+      return serviceById.has(row.resourceId);
+    },
+  ).length;
+  const quietServices: number = Math.max(
+    0,
+    services.length - reportingServices,
+  );
+  const maxResourceVolume: number = Math.max(
+    ...resourceBreakdown.map((row: ResourceLogBreakdown): number => {
+      return row.total;
     }),
     1,
   );
@@ -398,28 +437,32 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
       <div className="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           label="Total logs"
-          value={stats.total}
+          value={total}
           subtext={`ingested in ${rangeLabel}`}
           icon={IconProp.List}
           tone="indigo"
         />
         <StatCard
           label="Errors"
-          value={stats.errorCount}
-          subtext={`${errorRate}% of total volume`}
+          value={volume?.errorCount || 0}
+          subtext={`${volume?.errorRatePercent || 0}% of total volume`}
           icon={IconProp.Alert}
-          tone={stats.errorCount > 0 ? "amber" : "emerald"}
+          tone={(volume?.errorCount || 0) > 0 ? "amber" : "emerald"}
         />
         <StatCard
-          label="Warnings"
-          value={stats.warnCount}
-          subtext="warning-level logs"
-          icon={IconProp.Alert}
-          tone="amber"
+          label="Distinct errors"
+          value={errorPatterns.length}
+          subtext={
+            errorPatterns.length > 0
+              ? "unique messages, listed below"
+              : "nothing failing"
+          }
+          icon={IconProp.Search}
+          tone={errorPatterns.length > 0 ? "amber" : "emerald"}
         />
         <StatCard
-          label={quietServices > 0 ? "Quiet services" : "Reporting services"}
-          value={quietServices > 0 ? quietServices : reportingServices}
+          label={quietServices > 0 ? "Quiet services" : "Reporting sources"}
+          value={quietServices > 0 ? quietServices : reportingResources}
           subtext={
             quietServices > 0
               ? "no logs in range"
@@ -433,48 +476,49 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
       </div>
 
       {/* Severity distribution */}
-      {severityBuckets.length > 0 && (
+      {volume && volume.severities.length > 0 && (
         <div className="mb-5 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="mb-3 flex items-center justify-between">
-            <div>
-              <h3 className="text-sm font-semibold text-gray-900">
-                Severity distribution
-              </h3>
-              <p className="text-xs text-gray-500">
-                How {stats.total} log{stats.total === 1 ? "" : "s"} break down
-                by severity
-              </p>
-            </div>
+          <div className="mb-3">
+            <h3 className="text-sm font-semibold text-gray-900">
+              Severity distribution
+            </h3>
+            <p className="text-xs text-gray-500">
+              How {total.toLocaleString()} log{total === 1 ? "" : "s"} break
+              down by severity
+            </p>
           </div>
           <div className="flex h-2 overflow-hidden rounded-full bg-gray-100">
-            {severityBuckets.map((b: SeverityBucket): ReactElement => {
-              const pct: number =
-                stats.total > 0 ? (b.count / stats.total) * 100 : 0;
+            {volume.severities.map((share: SeverityShare): ReactElement => {
+              const widthPercent: number =
+                total > 0 ? (share.count / total) * 100 : 0;
+
               return (
                 <div
-                  key={b.severity as string}
-                  className={b.barColor}
-                  style={{ width: `${Math.max(pct, 1)}%` }}
-                  title={`${b.severity as string}: ${b.count}`}
+                  key={share.severity}
+                  className={getSeverityTheme(share.severity).dotClass}
+                  style={{ width: `${Math.max(widthPercent, 1)}%` }}
+                  title={`${share.severity}: ${share.count}`}
                 />
               );
             })}
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
-            {severityBuckets.map((b: SeverityBucket): ReactElement => {
-              const pct: number =
-                stats.total > 0 ? Math.round((b.count / stats.total) * 100) : 0;
+            {volume.severities.map((share: SeverityShare): ReactElement => {
               return (
                 <div
-                  key={b.severity as string}
-                  className={`inline-flex items-center gap-2 rounded-md px-2.5 py-1 ${b.bgColor}`}
+                  key={share.severity}
+                  className={`inline-flex items-center gap-2 rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${
+                    getSeverityTheme(share.severity).badgeClass
+                  }`}
                 >
-                  <span className={`h-2 w-2 rounded-full ${b.barColor}`} />
-                  <span className={`text-xs font-medium ${b.color}`}>
-                    {b.severity as string}
-                  </span>
-                  <span className={`text-xs ${b.color} opacity-70`}>
-                    {b.count} · {pct}%
+                  <span
+                    className={`h-2 w-2 rounded-full ${
+                      getSeverityTheme(share.severity).dotClass
+                    }`}
+                  />
+                  <span>{share.severity}</span>
+                  <span className="opacity-70">
+                    {share.count.toLocaleString()} · {share.percent}%
                   </span>
                 </div>
               );
@@ -483,11 +527,22 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
         </div>
       )}
 
-      {/* Per-service cards */}
+      <TopErrorsPanel
+        patterns={errorPatterns}
+        timeRange={timeRange}
+        isLoading={isLoading}
+        serviceNameById={serviceById}
+        selectedPattern={selectedPattern?.pattern}
+        onSelect={(row: TopErrorPatternRow): void => {
+          setSelectedPattern(row);
+        }}
+      />
+
+      {/* Per-resource volume */}
       <div className="mb-3 flex items-center justify-between">
         <div>
           <h3 className="text-base font-semibold text-gray-900">
-            Services reporting logs
+            Sources reporting logs
           </h3>
           <p className="text-xs text-gray-500">
             Volume and error signal per service in {rangeLabel}
@@ -502,36 +557,42 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
         </AppLink>
       </div>
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-        {serviceSummaries.map((summary: ServiceSummary): ReactElement => {
-          const coverage: number = Math.round(
-            (summary.logCount / maxLogs) * 100,
-          );
-          const sid: string =
-            summary.service.id?.toString() ||
-            (summary.service._id as string) ||
-            "";
-          return (
-            <AppLink
-              key={sid}
-              className="block"
-              to={RouteUtil.populateRouteParams(
-                RouteMap[PageMap.SERVICE_VIEW_LOGS] as Route,
-                { modelId: new ObjectID(sid) },
-              )}
-            >
-              <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md">
-                <div className="mb-4 flex items-start justify-between">
-                  <ServiceElement service={summary.service} />
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    {summary.errorCount > 0 && (
+        {resourceBreakdown
+          .slice(0, RESOURCE_CARD_LIMIT)
+          .map((row: ResourceLogBreakdown): ReactElement => {
+            const service: Service | undefined = serviceById.get(
+              row.resourceId,
+            );
+            const coverage: number = Math.round(
+              (row.total / maxResourceVolume) * 100,
+            );
+
+            const card: ReactElement = (
+              <div className="h-full rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md">
+                <div className="mb-4 flex items-start justify-between gap-2">
+                  {service ? (
+                    <ServiceElement service={service} />
+                  ) : (
+                    /*
+                     * Logs primary-keyed on a host, cluster or other
+                     * non-Service resource have no Service row to name them.
+                     * Showing the raw id beats dropping the row: it is still
+                     * volume the user is paying for and can search on.
+                     */
+                    <span className="truncate font-mono text-xs text-gray-500">
+                      {row.resourceId}
+                    </span>
+                  )}
+                  <div className="flex flex-wrap items-center justify-end gap-1.5">
+                    {row.errorCount > 0 && (
                       <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">
-                        {summary.errorCount} error
-                        {summary.errorCount === 1 ? "" : "s"}
+                        {row.errorCount.toLocaleString()} error
+                        {row.errorCount === 1 ? "" : "s"}
                       </span>
                     )}
-                    {summary.warnCount > 0 && (
+                    {row.warnCount > 0 && (
                       <span className="rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
-                        {summary.warnCount} warn
+                        {row.warnCount.toLocaleString()} warn
                       </span>
                     )}
                   </div>
@@ -540,10 +601,10 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
                 <div className="mb-1">
                   <div className="mb-1.5 flex items-end justify-between">
                     <span className="text-2xl font-bold text-gray-900">
-                      {summary.logCount}
+                      {row.total.toLocaleString()}
                     </span>
                     <span className="mb-1 text-xs text-gray-400">
-                      log{summary.logCount === 1 ? "" : "s"}
+                      log{row.total === 1 ? "" : "s"}
                     </span>
                   </div>
                   <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
@@ -554,10 +615,37 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
                   </div>
                 </div>
               </div>
-            </AppLink>
-          );
-        })}
+            );
+
+            if (!service) {
+              return <div key={row.resourceId}>{card}</div>;
+            }
+
+            return (
+              <AppLink
+                key={row.resourceId}
+                className="block"
+                to={RouteUtil.populateRouteParams(
+                  RouteMap[PageMap.SERVICE_VIEW_LOGS] as Route,
+                  { modelId: new ObjectID(row.resourceId) },
+                )}
+              >
+                {card}
+              </AppLink>
+            );
+          })}
       </div>
+
+      {selectedPattern && (
+        <ErrorPatternDetail
+          pattern={selectedPattern}
+          scope={scope}
+          serviceNameById={serviceById}
+          onClose={() => {
+            setSelectedPattern(null);
+          }}
+        />
+      )}
     </Fragment>
   );
 };
@@ -601,6 +689,7 @@ const StatCard: FunctionComponent<StatCardProps> = (
 ): ReactElement => {
   const tone: { bg: string; text: string; valueText: string } =
     TONE_STYLES[props.tone];
+
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
       <div className="flex items-center justify-between">
@@ -612,7 +701,7 @@ const StatCard: FunctionComponent<StatCardProps> = (
         </div>
       </div>
       <p className={`mt-2 text-3xl font-bold ${tone.valueText}`}>
-        {props.value}
+        {props.value.toLocaleString()}
       </p>
       <p className="mt-1 text-xs text-gray-400">{props.subtext}</p>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts
@@ -120,6 +120,24 @@ export function buildLogsHistogramRequest(
     requestData["spanIds"] = Array.from(spanFilterValues);
   }
 
+  /*
+   * A body chip is a contains-match on the message (the logs list compiles
+   * it to a Search predicate). The histogram has to receive it as
+   * bodySearchText or the chart would keep counting rows the list no longer
+   * shows — which is exactly what a deep link from Insights' Top Errors
+   * produces.
+   */
+  const bodyValues: Set<string> | undefined =
+    params.appliedFacetFilters.get("body");
+
+  if (bodyValues && bodyValues.size > 0) {
+    const bodySearchText: string = Array.from(bodyValues)[0]!;
+
+    if (bodySearchText.trim().length > 0) {
+      requestData["bodySearchText"] = bodySearchText;
+    }
+  }
+
   if (params.attributes) {
     requestData["attributes"] = params.attributes;
   }

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsInsightsApi.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsInsightsApi.ts
@@ -1,0 +1,122 @@
+import API from "Common/UI/Utils/API/API";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import URL from "Common/Types/API/URL";
+import { APP_API_URL } from "Common/UI/Config";
+import Dictionary from "Common/Types/Dictionary";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  ErrorPatternCorrelation,
+  LogsInsightsScope,
+  ResourceLogBreakdown,
+  ScopeFacetValue,
+  TopErrorPatternRow,
+  buildErrorPatternCorrelationRequest,
+  buildInsightsHistogramRequest,
+  buildScopeFacetsRequest,
+  buildServiceBreakdownRequest,
+  buildTopErrorPatternsRequest,
+  parseErrorPatternCorrelation,
+  parseScopeFacets,
+  parseTopErrorPatterns,
+  summarizeResourceBreakdown,
+} from "../../Utils/LogsInsights";
+
+/*
+ * The network half of the Logs Insights page. Kept apart from
+ * Utils/LogsInsights so that module — the request bodies, the parsing and
+ * every derived number — stays free of the API client and can be exercised
+ * in plain Node.
+ */
+
+function getApiUrl(path: string): URL {
+  return URL.fromString(APP_API_URL.toString()).addRoute(path);
+}
+
+async function postApi(
+  path: string,
+  data: JSONObject,
+): Promise<HTTPResponse<JSONObject>> {
+  const response: HTTPResponse<JSONObject> | HTTPErrorResponse = await API.post(
+    {
+      url: getApiUrl(path),
+      data,
+      headers: ModelAPI.getCommonHeaders(),
+    },
+  );
+
+  if (response instanceof HTTPErrorResponse) {
+    throw response;
+  }
+
+  return response;
+}
+
+/** Severity-bucketed volume for the whole window, aggregated server-side. */
+export async function fetchInsightsHistogram(
+  scope: LogsInsightsScope,
+): Promise<Array<JSONObject>> {
+  const response: HTTPResponse<JSONObject> = await postApi(
+    "/telemetry/logs/histogram",
+    buildInsightsHistogramRequest(scope),
+  );
+
+  const buckets: unknown = response.data["buckets"];
+
+  return Array.isArray(buckets) ? (buckets as Array<JSONObject>) : [];
+}
+
+/** The distinct error messages in the window, most frequent first. */
+export async function fetchTopErrorPatterns(
+  scope: LogsInsightsScope,
+  limit: number,
+): Promise<Array<TopErrorPatternRow>> {
+  const response: HTTPResponse<JSONObject> = await postApi(
+    "/telemetry/logs/error-patterns",
+    buildTopErrorPatternsRequest(scope, limit),
+  );
+
+  return parseTopErrorPatterns(response.data);
+}
+
+/** Everything the detail panel needs about one pattern, in one round trip. */
+export async function fetchErrorPatternCorrelation(
+  scope: LogsInsightsScope,
+  pattern: string,
+  limit: number,
+): Promise<ErrorPatternCorrelation> {
+  const response: HTTPResponse<JSONObject> = await postApi(
+    "/telemetry/logs/error-pattern-correlation",
+    buildErrorPatternCorrelationRequest(scope, pattern, limit),
+  );
+
+  return parseErrorPatternCorrelation(response.data);
+}
+
+/** Per-resource log volume and error counts, aggregated server-side. */
+export async function fetchResourceBreakdown(
+  scope: LogsInsightsScope,
+): Promise<Array<ResourceLogBreakdown>> {
+  const response: HTTPResponse<JSONObject> = await postApi(
+    "/telemetry/logs/analytics",
+    buildServiceBreakdownRequest(scope),
+  );
+
+  return summarizeResourceBreakdown(response.data);
+}
+
+/**
+ * The services, hosts and clusters that logged anything in the window —
+ * the options the scope picker offers.
+ */
+export async function fetchScopeFacets(
+  scope: LogsInsightsScope,
+): Promise<Dictionary<Array<ScopeFacetValue>>> {
+  const response: HTTPResponse<JSONObject> = await postApi(
+    "/telemetry/logs/facets",
+    buildScopeFacetsRequest(scope.timeRange),
+  );
+
+  return parseScopeFacets(response.data);
+}

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -1946,6 +1946,12 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
       kubernetesClusterId: "Kubernetes Cluster",
       traceId: "Trace",
       spanId: "Span",
+      /*
+       * The one chip whose value is a substring rather than an exact id —
+       * "Message contains" says so, since "body: connection refused" reads
+       * like an equality the filter is not.
+       */
+      body: "Message contains",
     };
 
     /*

--- a/App/FeatureSet/Dashboard/src/Components/Logs/TopErrorsPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/TopErrorsPanel.tsx
@@ -1,0 +1,264 @@
+import React, { FunctionComponent, ReactElement } from "react";
+import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import Icon from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
+import OneUptimeDate from "Common/Types/Date";
+import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import Service from "Common/Models/DatabaseModels/Service";
+import { getSeverityTheme } from "Common/UI/Components/LogsViewer/components/severityTheme";
+import { truncateErrorPattern } from "Common/Utils/Telemetry/LogErrorPattern";
+import {
+  TopErrorPatternRow,
+  describeOccurrenceCount,
+  describeTimeRange,
+} from "../../Utils/LogsInsights";
+
+/*
+ * "Top Errors": the distinct error messages in the window, each with how
+ * often it happened, when it started, when it last happened and how far it
+ * has spread. This is the panel the Insights page exists for — the previous
+ * page could tell you that 4% of your logs were errors but not which errors
+ * those were.
+ */
+
+export interface ComponentProps {
+  patterns: Array<TopErrorPatternRow>;
+  timeRange: RangeStartAndEndDateTime;
+  isLoading: boolean;
+  /** Resolved names for the resource ids a pattern was seen on. */
+  serviceNameById: Map<string, Service>;
+  selectedPattern?: string | undefined;
+  onSelect: (pattern: TopErrorPatternRow) => void;
+}
+
+function formatTimestamp(date: Date | null): string {
+  if (!date) {
+    return "unknown";
+  }
+
+  return OneUptimeDate.getDateAsLocalFormattedString(date);
+}
+
+/*
+ * How long the error has been happening. A pattern that started three
+ * seconds before it last fired is a burst; one spanning the whole window is
+ * chronic — and the two want very different responses.
+ */
+function formatSpan(row: TopErrorPatternRow): string | null {
+  if (!row.firstSeenAt || !row.lastSeenAt) {
+    return null;
+  }
+
+  const spanMs: number = row.lastSeenAt.getTime() - row.firstSeenAt.getTime();
+
+  if (spanMs < 60 * 1000) {
+    return "within a minute";
+  }
+
+  const minutes: number = Math.round(spanMs / (60 * 1000));
+
+  if (minutes < 60) {
+    return `over ${minutes} min`;
+  }
+
+  const hours: number = Math.round(minutes / 60);
+
+  if (hours < 48) {
+    return `over ${hours} hr`;
+  }
+
+  return `over ${Math.round(hours / 24)} days`;
+}
+
+const TopErrorsPanel: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const header: ReactElement = (
+    <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
+      <div>
+        <h3 className="text-base font-semibold text-gray-900">Top errors</h3>
+        <p className="text-xs text-gray-500">
+          Distinct error messages in {describeTimeRange(props.timeRange)}.
+          Select one to see what else was happening around it.
+        </p>
+      </div>
+    </div>
+  );
+
+  if (props.isLoading) {
+    return (
+      <div className="mb-5">
+        {header}
+        <div className="rounded-xl border border-gray-200 bg-white p-10">
+          <ComponentLoader />
+        </div>
+      </div>
+    );
+  }
+
+  if (props.patterns.length === 0) {
+    return (
+      <div className="mb-5">
+        {header}
+        <div className="rounded-xl border border-dashed border-gray-300 bg-white p-10 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50">
+            <Icon
+              icon={IconProp.CheckCircle}
+              className="h-5 w-5 text-emerald-500"
+            />
+          </div>
+          <h4 className="mt-4 text-sm font-semibold text-gray-900">
+            No errors in {describeTimeRange(props.timeRange)}
+          </h4>
+          <p className="mx-auto mt-1 max-w-md text-sm text-gray-500">
+            Nothing at Error or Fatal severity was logged in this window. Widen
+            the time range or clear the service filter to look further.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const topCount: number = Math.max(
+    ...props.patterns.map((row: TopErrorPatternRow): number => {
+      return row.count;
+    }),
+    1,
+  );
+
+  return (
+    <div className="mb-5">
+      {header}
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <ul className="divide-y divide-gray-100">
+          {props.patterns.map(
+            (row: TopErrorPatternRow, index: number): ReactElement => {
+              const isSelected: boolean = props.selectedPattern === row.pattern;
+              const sharePercent: number = Math.max(
+                2,
+                Math.round((row.count / topCount) * 100),
+              );
+              const span: string | null = formatSpan(row);
+
+              /*
+               * The raw body reads far better than the normalized pattern,
+               * so it is the headline; the pattern itself sits underneath as
+               * the thing that actually did the grouping.
+               */
+              const headline: string = truncateErrorPattern(
+                row.sampleBody || row.pattern,
+                180,
+              );
+
+              const resourceNames: Array<string> = row.resourceIds.map(
+                (resourceId: string): string => {
+                  return (
+                    props.serviceNameById.get(resourceId)?.name?.toString() ||
+                    resourceId
+                  );
+                },
+              );
+
+              return (
+                <li key={row.pattern}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      props.onSelect(row);
+                    }}
+                    className={`w-full px-5 py-4 text-left transition-colors ${
+                      isSelected ? "bg-indigo-50/60" : "hover:bg-gray-50"
+                    }`}
+                  >
+                    <div className="flex items-start gap-4">
+                      <span className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-gray-100 text-xs font-semibold text-gray-500">
+                        {index + 1}
+                      </span>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          {row.severities.map(
+                            (severity: string): ReactElement => {
+                              return (
+                                <span
+                                  key={severity}
+                                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+                                    getSeverityTheme(severity).badgeClass
+                                  }`}
+                                >
+                                  {severity}
+                                </span>
+                              );
+                            },
+                          )}
+                          <span className="text-sm font-semibold text-gray-900">
+                            {describeOccurrenceCount(
+                              row.count,
+                              props.timeRange,
+                            )}
+                          </span>
+                          {span && (
+                            <span className="text-xs text-gray-400">
+                              {span}
+                            </span>
+                          )}
+                        </div>
+
+                        <p className="mt-1 break-words font-mono text-sm text-gray-800">
+                          {headline}
+                        </p>
+
+                        <p
+                          className="mt-1 break-words font-mono text-xs text-gray-400"
+                          title={row.pattern}
+                        >
+                          {truncateErrorPattern(row.pattern, 160)}
+                        </p>
+
+                        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500">
+                          <span>
+                            {row.resourceCount}{" "}
+                            {row.resourceCount === 1 ? "source" : "sources"}
+                            {resourceNames.length > 0
+                              ? ` · ${resourceNames.slice(0, 2).join(", ")}`
+                              : ""}
+                          </span>
+                          {row.traceCount > 0 && (
+                            <span>
+                              {row.traceCount}{" "}
+                              {row.traceCount === 1 ? "trace" : "traces"}
+                            </span>
+                          )}
+                          <span>
+                            last seen {formatTimestamp(row.lastSeenAt)}
+                          </span>
+                          <span>
+                            first seen {formatTimestamp(row.firstSeenAt)}
+                          </span>
+                        </div>
+
+                        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                          <div
+                            className="h-full rounded-full bg-gradient-to-r from-rose-400 to-red-500"
+                            style={{ width: `${sharePercent}%` }}
+                          />
+                        </div>
+                      </div>
+
+                      <Icon
+                        icon={IconProp.ChevronRight}
+                        className="mt-1 h-4 w-4 flex-shrink-0 text-gray-300"
+                      />
+                    </div>
+                  </button>
+                </li>
+              );
+            },
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default TopErrorsPanel;

--- a/App/FeatureSet/Dashboard/src/Utils/LogsCrossSignalPivot.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/LogsCrossSignalPivot.ts
@@ -1,5 +1,6 @@
 import Includes from "Common/Types/BaseDatabase/Includes";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Search from "Common/Types/BaseDatabase/Search";
 import Query from "Common/Types/BaseDatabase/Query";
 import Dictionary from "Common/Types/Dictionary";
 import Log from "Common/Models/AnalyticsModels/Log";
@@ -79,6 +80,13 @@ export interface LogsPivotScopeResult {
 }
 
 const ATTRIBUTE_FACET_PREFIX: string = "attributes.";
+
+/*
+ * The one top-level column whose facet chip is a contains-match rather than
+ * an equality. Shared with CrossSignalScope's logs serializer, which emits
+ * chips under this key for a `bodyContains` scope.
+ */
+export const BODY_FACET_KEY: string = "body";
 
 function mergeUnique(
   base: Array<string> | undefined,
@@ -342,6 +350,11 @@ type ApplyLogsFacetFiltersToQueryFunction = (
  *    primary entity at all. Each facet is its own AND group, so a cluster
  *    and a service intersect;
  *  - `attributes.<key>` facets land under `query.attributes[<key>]`;
+ *  - a `body` facet compiles to a CONTAINS match, not equality — a message
+ *    filter is only ever a substring of the line, and equality on a body
+ *    carrying a timestamp or a request id matches nothing. This is what
+ *    lets an Insights "Top Errors" row deep-link to the raw occurrences it
+ *    counted;
  *  - every other facet key is a top-level column predicate;
  *  - single values compile to equality, multiple to Includes.
  */
@@ -371,6 +384,17 @@ export const applyLogsFacetFiltersToQuery: ApplyLogsFacetFiltersToQueryFunction 
 
       // Both resource groups are compiled above.
       if (isResourceFacetKey(key)) {
+        continue;
+      }
+
+      /*
+       * Body is a free-text predicate, so multiple values cannot be an
+       * Includes (that is an exact-set match). The first value wins — the
+       * chip UI only ever sets one, and a second would silently widen the
+       * result rather than narrow it.
+       */
+      if (key === BODY_FACET_KEY) {
+        (query as any).body = new Search(Array.from(values)[0]!);
         continue;
       }
 

--- a/App/FeatureSet/Dashboard/src/Utils/LogsInsights.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/LogsInsights.ts
@@ -1,0 +1,1036 @@
+import Route from "Common/Types/API/Route";
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import LogSeverity from "Common/Types/Log/LogSeverity";
+import OneUptimeDate from "Common/Types/Date";
+import RangeStartAndEndDateTime, {
+  RangeStartAndEndDateTimeUtil,
+} from "Common/Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "Common/Types/Time/TimeRange";
+import {
+  RESOURCE_ENTITY_FACET_KEYS,
+  ResourceEntityFacetSelections,
+  isResourceEntityFacetKey,
+  isServiceFacetKey,
+} from "Common/Types/Telemetry/ResourceEntityFacet";
+import {
+  CrossSignalQueryParams,
+  TelemetryCrossSignalScope,
+  toLogsExplorerQueryParams,
+} from "Common/Utils/Telemetry/CrossSignalScope";
+import { getErrorPatternSearchText } from "Common/Utils/Telemetry/LogErrorPattern";
+import RouteMap, { RouteUtil } from "./RouteMap";
+import PageMap from "./PageMap";
+
+/*
+ * The logic behind the Logs Insights page, kept free of React and of the
+ * network so App/Tests/Dashboard can exercise every branch in plain Node.
+ *
+ * The page asks the server three questions — how much is being logged and
+ * at what severity, which distinct errors are happening, and what surrounds
+ * one of those errors — and this module owns the request bodies for those
+ * questions, the parsing of their answers (every field of which arrives as
+ * untyped JSON), the derived numbers the UI renders, and the deep links out
+ * to the Logs viewer and the trace detail page.
+ */
+
+// --- Request building ---
+
+/**
+ * The one scope the whole page shares. Every panel is built from this, so a
+ * correlation the page draws is always a correlation within the slice the
+ * user is looking at.
+ */
+export interface LogsInsightsScope {
+  timeRange: RangeStartAndEndDateTime;
+  /** Service ObjectID strings. Empty/absent means "the whole project". */
+  serviceIds?: Array<string> | undefined;
+  /** Host / docker host / podman host / Kubernetes cluster selections. */
+  resourceFilters?: ResourceEntityFacetSelections | undefined;
+  /** Absent means the server's default of Error + Fatal. */
+  severityTexts?: Array<string> | undefined;
+}
+
+/*
+ * Preset ranges resolve against "now" on every call rather than being
+ * captured once, so a refresh on "past 24 hours" genuinely re-asks for the
+ * last 24 hours instead of replaying the window the page loaded with.
+ */
+function resolveWindow(timeRange: RangeStartAndEndDateTime): InBetween<Date> {
+  return RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+}
+
+function appendScope(requestData: JSONObject, scope: LogsInsightsScope): void {
+  const window: InBetween<Date> = resolveWindow(scope.timeRange);
+
+  requestData["startTime"] = window.startValue.toISOString();
+  requestData["endTime"] = window.endValue.toISOString();
+
+  if (scope.serviceIds && scope.serviceIds.length > 0) {
+    requestData["serviceIds"] = scope.serviceIds;
+  }
+
+  if (scope.resourceFilters && Object.keys(scope.resourceFilters).length > 0) {
+    requestData["resourceFilters"] = scope.resourceFilters;
+  }
+
+  if (scope.severityTexts && scope.severityTexts.length > 0) {
+    requestData["severityTexts"] = scope.severityTexts;
+  }
+}
+
+/** POST body for `/telemetry/logs/error-patterns`. */
+export function buildTopErrorPatternsRequest(
+  scope: LogsInsightsScope,
+  limit?: number | undefined,
+): JSONObject {
+  const requestData: JSONObject = {};
+
+  appendScope(requestData, scope);
+
+  if (typeof limit === "number" && Number.isFinite(limit)) {
+    requestData["limit"] = limit;
+  }
+
+  return requestData;
+}
+
+/** POST body for `/telemetry/logs/histogram`, scoped like the rest of the page. */
+export function buildInsightsHistogramRequest(
+  scope: LogsInsightsScope,
+): JSONObject {
+  const requestData: JSONObject = {};
+
+  /*
+   * Severity is deliberately NOT forwarded: the histogram is what draws the
+   * severity breakdown, so filtering it to the error severities would leave
+   * the page unable to say what share of the volume the errors are.
+   */
+  appendScope(requestData, { ...scope, severityTexts: undefined });
+
+  return requestData;
+}
+
+/**
+ * POST body for `/telemetry/logs/analytics` asking for per-resource,
+ * per-severity counts.
+ *
+ * The page used to derive its per-service numbers by counting a capped page
+ * of raw log rows in the browser, which made every figure a property of the
+ * fetch size rather than of the project. This asks the database the actual
+ * question instead.
+ */
+export function buildServiceBreakdownRequest(
+  scope: LogsInsightsScope,
+  /*
+   * One row per (resource, severity) pair, so the cap is roughly
+   * resources x severities. 500 covers ~70 reporting resources at every
+   * severity; past that the smallest pairs are cut, which can only ever
+   * understate a badge, never invent one.
+   */
+  limit: number = 500,
+): JSONObject {
+  const requestData: JSONObject = {
+    chartType: "table",
+    aggregation: "count",
+    groupBy: ["primaryEntityId", "severityText"],
+    limit,
+  };
+
+  // Severity is what the breakdown splits by, so it must not also filter it.
+  appendScope(requestData, { ...scope, severityTexts: undefined });
+
+  return requestData;
+}
+
+/** POST body for `/telemetry/logs/error-pattern-correlation`. */
+export function buildErrorPatternCorrelationRequest(
+  scope: LogsInsightsScope,
+  pattern: string,
+  limit?: number | undefined,
+): JSONObject {
+  const requestData: JSONObject = { pattern };
+
+  appendScope(requestData, scope);
+
+  if (typeof limit === "number" && Number.isFinite(limit)) {
+    requestData["limit"] = limit;
+  }
+
+  return requestData;
+}
+
+// --- Scope picker ---
+
+/**
+ * The facets the scope picker offers, in the order their groups render.
+ *
+ * Services first because most projects think in services, then the
+ * resources that log under their own id (agent-ingested host / container /
+ * cluster telemetry). The issue this page answers asks for "top errors per
+ * host/service", so both kinds have to be selectable — not just the one the
+ * page happened to start with.
+ */
+export const INSIGHTS_SCOPE_FACET_KEYS: Array<string> = [
+  "primaryEntityId",
+  ...RESOURCE_ENTITY_FACET_KEYS,
+];
+
+/** Human-readable group label per facet key. */
+export const INSIGHTS_SCOPE_FACET_LABELS: Dictionary<string> = {
+  primaryEntityId: "Services",
+  hostId: "Hosts",
+  dockerHostId: "Docker hosts",
+  podmanHostId: "Podman hosts",
+  kubernetesClusterId: "Kubernetes clusters",
+};
+
+export interface ScopeFacetValue {
+  facetKey: string;
+  value: string;
+  displayName: string;
+  count: number;
+}
+
+/**
+ * POST body for `/telemetry/logs/facets`, asking only for the resource
+ * facets the picker offers.
+ *
+ * Unlike every other request here this one is NOT scoped by the current
+ * selection: the picker has to keep offering the options the user has not
+ * chosen yet, and narrowing it by its own output would let a selection
+ * erase the way back out of itself.
+ */
+export function buildScopeFacetsRequest(
+  timeRange: RangeStartAndEndDateTime,
+  limit: number = 200,
+): JSONObject {
+  const window: InBetween<Date> = resolveWindow(timeRange);
+
+  return {
+    startTime: window.startValue.toISOString(),
+    endTime: window.endValue.toISOString(),
+    facetKeys: INSIGHTS_SCOPE_FACET_KEYS,
+    limit,
+  };
+}
+
+/**
+ * Parse the `facets` map of a `/telemetry/logs/facets` response into one
+ * flat list per facet key, dropping values with no id.
+ *
+ * The server resolves resource facets against Postgres, so a row usually
+ * carries a `displayName`; the raw id is the fallback, because an
+ * unnameable resource still has telemetry worth scoping to.
+ */
+export function parseScopeFacets(
+  response: JSONObject | undefined,
+): Dictionary<Array<ScopeFacetValue>> {
+  const facets: JSONObject =
+    (response?.["facets"] as JSONObject | undefined) || {};
+
+  const parsed: Dictionary<Array<ScopeFacetValue>> = {};
+
+  for (const facetKey of INSIGHTS_SCOPE_FACET_KEYS) {
+    parsed[facetKey] = asArray(facets[facetKey])
+      .map((row: JSONObject): ScopeFacetValue => {
+        const value: string = asString(row["value"]);
+
+        return {
+          facetKey,
+          value,
+          displayName: asString(row["displayName"]) || value,
+          count: asCount(row["count"]),
+        };
+      })
+      .filter((row: ScopeFacetValue): boolean => {
+        return row.value.length > 0;
+      });
+  }
+
+  return parsed;
+}
+
+/*
+ * The picker is one flat multi-select over several facets, so each option
+ * value has to say which facet it came from. A colon is safe as the
+ * separator: facet keys are fixed identifiers and the values are Postgres
+ * ids, neither of which contains one — and the parser splits on the FIRST
+ * colon regardless, so an id that somehow did would still round-trip.
+ */
+export function encodeScopeSelection(facetKey: string, value: string): string {
+  return `${facetKey}:${value}`;
+}
+
+export interface ParsedScopeSelections {
+  serviceIds?: Array<string> | undefined;
+  resourceFilters?: ResourceEntityFacetSelections | undefined;
+}
+
+/**
+ * Turn the picker's selected option values back into the two scope fields
+ * the API takes.
+ *
+ * Services and non-Service resources cannot share a field: a Service id
+ * belongs in `primaryEntityId`, while a host or cluster id has to be
+ * resolved to that resource's entity key server-side, because OTLP
+ * telemetry carrying a `service.name` is primary-keyed on the Service and
+ * only records the host it ran on in `entityKeys`.
+ */
+export function parseScopeSelections(
+  values: Array<string>,
+): ParsedScopeSelections {
+  const serviceIds: Array<string> = [];
+  const resourceFilters: ResourceEntityFacetSelections = {};
+
+  for (const encoded of values) {
+    if (typeof encoded !== "string") {
+      continue;
+    }
+
+    const separatorIndex: number = encoded.indexOf(":");
+
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const facetKey: string = encoded.substring(0, separatorIndex);
+    const value: string = encoded.substring(separatorIndex + 1);
+
+    if (value.length === 0) {
+      continue;
+    }
+
+    if (isServiceFacetKey(facetKey)) {
+      if (!serviceIds.includes(value)) {
+        serviceIds.push(value);
+      }
+      continue;
+    }
+
+    if (!isResourceEntityFacetKey(facetKey)) {
+      // An unknown facet would compile to a predicate no explorer can read.
+      continue;
+    }
+
+    const existing: Array<string> =
+      (resourceFilters as Dictionary<Array<string>>)[facetKey] || [];
+
+    if (!existing.includes(value)) {
+      existing.push(value);
+    }
+
+    (resourceFilters as Dictionary<Array<string>>)[facetKey] = existing;
+  }
+
+  return {
+    serviceIds: serviceIds.length > 0 ? serviceIds : undefined,
+    resourceFilters:
+      Object.keys(resourceFilters).length > 0 ? resourceFilters : undefined,
+  };
+}
+
+// --- Response parsing ---
+
+export interface TopErrorPatternRow {
+  pattern: string;
+  sampleBody: string;
+  count: number;
+  firstSeenAt: Date | null;
+  lastSeenAt: Date | null;
+  resourceCount: number;
+  resourceIds: Array<string>;
+  severities: Array<string>;
+  traceCount: number;
+  sampleTraceIds: Array<string>;
+}
+
+export interface ErrorPatternTimelinePoint {
+  time: Date | null;
+  count: number;
+}
+
+export interface ErrorPatternCoOccurrenceRow {
+  pattern: string;
+  sampleBody: string;
+  count: number;
+}
+
+export interface ErrorPatternAttributeRow {
+  key: string;
+  value: string;
+  count: number;
+}
+
+export interface ErrorPatternResourceRow {
+  resourceId: string;
+  resourceType: string;
+  count: number;
+  lastSeenAt: Date | null;
+}
+
+export interface ErrorPatternTraceRow {
+  traceId: string;
+  count: number;
+  lastSeenAt: Date | null;
+  resourceId: string;
+}
+
+export interface ErrorPatternSampleRow {
+  logId: string;
+  time: Date | null;
+  body: string;
+  severityText: string;
+  resourceId: string;
+  traceId: string;
+  spanId: string;
+}
+
+export interface ErrorPatternCorrelation {
+  pattern: string;
+  bucketSizeInMinutes: number;
+  timeline: Array<ErrorPatternTimelinePoint>;
+  coOccurringPatterns: Array<ErrorPatternCoOccurrenceRow>;
+  attributes: Array<ErrorPatternAttributeRow>;
+  resources: Array<ErrorPatternResourceRow>;
+  traces: Array<ErrorPatternTraceRow>;
+  samples: Array<ErrorPatternSampleRow>;
+}
+
+function asArray(value: unknown): Array<JSONObject> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return (value as JSONArray).filter((item: unknown): item is JSONObject => {
+    return Boolean(item) && typeof item === "object" && !Array.isArray(item);
+  });
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asCount(value: unknown): number {
+  const parsed: number = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function asStringArray(value: unknown): Array<string> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return (value as Array<unknown>)
+    .filter((item: unknown): item is string => {
+      return typeof item === "string";
+    })
+    .filter((item: string): boolean => {
+      return item.length > 0;
+    });
+}
+
+/*
+ * ClickHouse hands datetimes back as "YYYY-MM-DD HH:mm:ss.fffffffff", which
+ * OneUptimeDate reads as UTC. A row that reached us any other way (or an
+ * empty aggregate over no rows) yields null rather than an Invalid Date the
+ * renderer would print as "Invalid Date".
+ */
+function asDate(value: unknown): Date | null {
+  const raw: string = asString(value);
+
+  if (raw.length === 0) {
+    return null;
+  }
+
+  const parsed: Date = OneUptimeDate.fromString(raw);
+
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** Parse the `patterns` array of an `/error-patterns` response. */
+export function parseTopErrorPatterns(
+  response: JSONObject | undefined,
+): Array<TopErrorPatternRow> {
+  return asArray(response?.["patterns"])
+    .map((row: JSONObject): TopErrorPatternRow => {
+      return {
+        pattern: asString(row["pattern"]),
+        sampleBody: asString(row["sampleBody"]),
+        count: asCount(row["count"]),
+        firstSeenAt: asDate(row["firstSeenAt"]),
+        lastSeenAt: asDate(row["lastSeenAt"]),
+        resourceCount: asCount(row["resourceCount"]),
+        resourceIds: asStringArray(row["resourceIds"]),
+        severities: asStringArray(row["severities"]),
+        traceCount: asCount(row["traceCount"]),
+        sampleTraceIds: asStringArray(row["sampleTraceIds"]),
+      };
+    })
+    .filter((row: TopErrorPatternRow): boolean => {
+      return row.pattern.length > 0;
+    });
+}
+
+/** Parse an `/error-pattern-correlation` response. */
+export function parseErrorPatternCorrelation(
+  response: JSONObject | undefined,
+): ErrorPatternCorrelation {
+  return {
+    pattern: asString(response?.["pattern"]),
+    bucketSizeInMinutes: asCount(response?.["bucketSizeInMinutes"]),
+    timeline: asArray(response?.["timeline"]).map(
+      (row: JSONObject): ErrorPatternTimelinePoint => {
+        return { time: asDate(row["time"]), count: asCount(row["count"]) };
+      },
+    ),
+    coOccurringPatterns: asArray(response?.["coOccurringPatterns"])
+      .map((row: JSONObject): ErrorPatternCoOccurrenceRow => {
+        return {
+          pattern: asString(row["pattern"]),
+          sampleBody: asString(row["sampleBody"]),
+          count: asCount(row["count"]),
+        };
+      })
+      .filter((row: ErrorPatternCoOccurrenceRow): boolean => {
+        return row.pattern.length > 0;
+      }),
+    attributes: asArray(response?.["attributes"])
+      .map((row: JSONObject): ErrorPatternAttributeRow => {
+        return {
+          key: asString(row["key"]),
+          value: asString(row["value"]),
+          count: asCount(row["count"]),
+        };
+      })
+      .filter((row: ErrorPatternAttributeRow): boolean => {
+        return row.key.length > 0;
+      }),
+    resources: asArray(response?.["resources"])
+      .map((row: JSONObject): ErrorPatternResourceRow => {
+        return {
+          resourceId: asString(row["resourceId"]),
+          resourceType: asString(row["resourceType"]),
+          count: asCount(row["count"]),
+          lastSeenAt: asDate(row["lastSeenAt"]),
+        };
+      })
+      .filter((row: ErrorPatternResourceRow): boolean => {
+        return row.resourceId.length > 0;
+      }),
+    traces: asArray(response?.["traces"])
+      .map((row: JSONObject): ErrorPatternTraceRow => {
+        return {
+          traceId: asString(row["traceId"]),
+          count: asCount(row["count"]),
+          lastSeenAt: asDate(row["lastSeenAt"]),
+          resourceId: asString(row["resourceId"]),
+        };
+      })
+      .filter((row: ErrorPatternTraceRow): boolean => {
+        return row.traceId.length > 0;
+      }),
+    samples: asArray(response?.["samples"]).map(
+      (row: JSONObject): ErrorPatternSampleRow => {
+        return {
+          logId: asString(row["logId"]),
+          time: asDate(row["time"]),
+          body: asString(row["body"]),
+          severityText: asString(row["severityText"]),
+          resourceId: asString(row["resourceId"]),
+          traceId: asString(row["traceId"]),
+          spanId: asString(row["spanId"]),
+        };
+      },
+    ),
+  };
+}
+
+/*
+ * The severities that count as "an error" everywhere on this page, matching
+ * LogAggregationService.DEFAULT_ERROR_LOG_SEVERITIES on the server. If the
+ * two ever disagree, the headline error count and the Top Errors list stop
+ * describing the same set of logs.
+ */
+const ERROR_SEVERITIES: Array<string> = [LogSeverity.Error, LogSeverity.Fatal];
+
+export interface ResourceLogBreakdown {
+  resourceId: string;
+  total: number;
+  errorCount: number;
+  warnCount: number;
+}
+
+/**
+ * Fold `/telemetry/logs/analytics` table rows — one per
+ * (resource, severity) pair — into one row per resource.
+ *
+ * Sorted by volume, because "which of my services is loudest" is the
+ * question the panel is answering; ties break on id so the order is stable
+ * across refreshes rather than following the database's row order.
+ */
+export function summarizeResourceBreakdown(
+  response: JSONObject | undefined,
+): Array<ResourceLogBreakdown> {
+  const byResource: Map<string, ResourceLogBreakdown> = new Map();
+
+  for (const row of asArray(response?.["data"])) {
+    const groupValues: JSONObject =
+      (row["groupValues"] as JSONObject | undefined) || {};
+
+    const resourceId: string = asString(groupValues["primaryEntityId"]);
+
+    if (resourceId.length === 0) {
+      continue;
+    }
+
+    const severity: string = asString(groupValues["severityText"]);
+    const count: number = asCount(row["count"]);
+
+    const existing: ResourceLogBreakdown = byResource.get(resourceId) || {
+      resourceId,
+      total: 0,
+      errorCount: 0,
+      warnCount: 0,
+    };
+
+    existing.total += count;
+
+    if (ERROR_SEVERITIES.includes(severity)) {
+      existing.errorCount += count;
+    }
+
+    if (severity === LogSeverity.Warning) {
+      existing.warnCount += count;
+    }
+
+    byResource.set(resourceId, existing);
+  }
+
+  return Array.from(byResource.values()).sort(
+    (a: ResourceLogBreakdown, b: ResourceLogBreakdown): number => {
+      if (b.total !== a.total) {
+        return b.total - a.total;
+      }
+
+      return a.resourceId.localeCompare(b.resourceId);
+    },
+  );
+}
+
+// --- Derived numbers ---
+
+export interface SeverityShare {
+  severity: string;
+  count: number;
+  percent: number;
+}
+
+export interface LogVolumeSummary {
+  total: number;
+  errorCount: number;
+  warnCount: number;
+  errorRatePercent: number;
+  severities: Array<SeverityShare>;
+  /** Total volume per bucket, ascending by time — the page's volume chart. */
+  series: Array<{ time: string; count: number }>;
+}
+
+/*
+ * Display order for the severity breakdown. Anything the database returns
+ * that is not on this list (a custom severity from a pipeline rule) sorts
+ * after the known ones rather than being dropped.
+ */
+const SEVERITY_ORDER: Array<string> = [
+  LogSeverity.Fatal,
+  LogSeverity.Error,
+  LogSeverity.Warning,
+  LogSeverity.Information,
+  LogSeverity.Debug,
+  LogSeverity.Trace,
+];
+
+/**
+ * Fold `/telemetry/logs/histogram` buckets into the page's headline numbers.
+ *
+ * The histogram is aggregated server-side over the whole window, which is
+ * the point: the previous Insights page counted a capped page of raw rows,
+ * so on any busy project its "total logs" was really "the 5000 rows we
+ * fetched" and its error rate was the error rate of that sample.
+ */
+export function summarizeSeverityBuckets(
+  buckets: Array<JSONObject> | undefined,
+): LogVolumeSummary {
+  const bySeverity: Map<string, number> = new Map();
+  const byBucket: Map<string, number> = new Map();
+  let total: number = 0;
+
+  for (const bucket of asArray(buckets)) {
+    const count: number = asCount(bucket["count"]);
+
+    if (count === 0) {
+      /*
+       * Still record the bucket so the chart keeps its empty slots — a gap
+       * in a volume chart is information ("nothing was logged"), and
+       * dropping it would silently compress the time axis.
+       */
+      const time: string = asString(bucket["time"]);
+
+      if (time.length > 0 && !byBucket.has(time)) {
+        byBucket.set(time, 0);
+      }
+      continue;
+    }
+
+    const severity: string = asString(bucket["severity"]) || "Unspecified";
+
+    bySeverity.set(severity, (bySeverity.get(severity) || 0) + count);
+    total += count;
+
+    const time: string = asString(bucket["time"]);
+
+    if (time.length > 0) {
+      byBucket.set(time, (byBucket.get(time) || 0) + count);
+    }
+  }
+
+  const severities: Array<SeverityShare> = Array.from(bySeverity.entries())
+    .map(([severity, count]: [string, number]): SeverityShare => {
+      return {
+        severity,
+        count,
+        percent: total > 0 ? Math.round((count / total) * 100) : 0,
+      };
+    })
+    .sort((a: SeverityShare, b: SeverityShare): number => {
+      const orderA: number = SEVERITY_ORDER.indexOf(a.severity);
+      const orderB: number = SEVERITY_ORDER.indexOf(b.severity);
+
+      return (
+        (orderA === -1 ? SEVERITY_ORDER.length : orderA) -
+        (orderB === -1 ? SEVERITY_ORDER.length : orderB)
+      );
+    });
+
+  let errorCount: number = 0;
+  let warnCount: number = 0;
+
+  for (const [severity, count] of bySeverity.entries()) {
+    if (ERROR_SEVERITIES.includes(severity)) {
+      errorCount += count;
+    }
+
+    if (severity === LogSeverity.Warning) {
+      warnCount += count;
+    }
+  }
+
+  const series: Array<{ time: string; count: number }> = Array.from(
+    byBucket.entries(),
+  )
+    .map(([time, count]: [string, number]): { time: string; count: number } => {
+      return { time, count };
+    })
+    .sort(
+      (
+        a: { time: string; count: number },
+        b: { time: string; count: number },
+      ): number => {
+        return a.time.localeCompare(b.time);
+      },
+    );
+
+  return {
+    total,
+    errorCount,
+    warnCount,
+    errorRatePercent: total > 0 ? Math.round((errorCount / total) * 100) : 0,
+    severities,
+    series,
+  };
+}
+
+export type ErrorPatternTrendDirection =
+  | "rising"
+  | "falling"
+  | "steady"
+  | "unknown";
+
+export interface ErrorPatternTrend {
+  direction: ErrorPatternTrendDirection;
+  /** Signed percentage change from the older half to the newer half. */
+  changePercent: number;
+  recentCount: number;
+  previousCount: number;
+}
+
+/*
+ * A change smaller than this is noise, not a trend. Ten percent is small
+ * enough to catch a real drift and large enough that a single extra
+ * occurrence in a low-volume pattern does not read as an escalation.
+ */
+const TREND_THRESHOLD_PERCENT: number = 10;
+
+/**
+ * Is this error getting worse? Compares the newer half of the pattern's
+ * timeline against the older half.
+ *
+ * Deliberately halves the window rather than comparing against a fixed
+ * lookback: the timeline is whatever window the user picked, so the honest
+ * comparison is "the second half of what you are looking at against the
+ * first half of it".
+ */
+export function computeErrorPatternTrend(
+  timeline: Array<ErrorPatternTimelinePoint>,
+): ErrorPatternTrend {
+  if (!Array.isArray(timeline) || timeline.length < 2) {
+    return {
+      direction: "unknown",
+      changePercent: 0,
+      recentCount: 0,
+      previousCount: 0,
+    };
+  }
+
+  const midpoint: number = Math.floor(timeline.length / 2);
+
+  let previousCount: number = 0;
+  let recentCount: number = 0;
+
+  timeline.forEach((point: ErrorPatternTimelinePoint, index: number): void => {
+    if (index < midpoint) {
+      previousCount += point.count;
+    } else {
+      recentCount += point.count;
+    }
+  });
+
+  if (previousCount === 0 && recentCount === 0) {
+    return {
+      direction: "unknown",
+      changePercent: 0,
+      recentCount,
+      previousCount,
+    };
+  }
+
+  if (previousCount === 0) {
+    // Brand new: everything happened in the newer half.
+    return {
+      direction: "rising",
+      changePercent: 100,
+      recentCount,
+      previousCount,
+    };
+  }
+
+  const changePercent: number = Math.round(
+    ((recentCount - previousCount) / previousCount) * 100,
+  );
+
+  let direction: ErrorPatternTrendDirection = "steady";
+
+  if (changePercent >= TREND_THRESHOLD_PERCENT) {
+    direction = "rising";
+  } else if (changePercent <= -TREND_THRESHOLD_PERCENT) {
+    direction = "falling";
+  }
+
+  return { direction, changePercent, recentCount, previousCount };
+}
+
+export interface SharedAttribute extends ErrorPatternAttributeRow {
+  /** Share of the pattern's occurrences carrying this exact key=value. */
+  coveragePercent: number;
+  /** True when every occurrence carries it — the strongest kind of clue. */
+  isUniversal: boolean;
+}
+
+/**
+ * Rank the attributes of a pattern's occurrences by how much they explain.
+ *
+ * An attribute present on every occurrence ("host.name = web-3", 30 of 30)
+ * localizes the error; one present on a third of them does not. Ranking by
+ * coverage puts the localizing ones first, which is the whole reason the
+ * panel exists.
+ *
+ * Keys whose value is different on nearly every occurrence (request ids,
+ * timestamps) are dropped: they are what makes a pattern a pattern, and
+ * listing them would bury the useful rows.
+ */
+export function summarizeSharedAttributes(
+  attributes: Array<ErrorPatternAttributeRow>,
+  totalOccurrences: number,
+  limit: number = 8,
+): Array<SharedAttribute> {
+  if (!Array.isArray(attributes) || totalOccurrences <= 0) {
+    return [];
+  }
+
+  return attributes
+    .map((attribute: ErrorPatternAttributeRow): SharedAttribute => {
+      const coveragePercent: number = Math.min(
+        100,
+        Math.round((attribute.count / totalOccurrences) * 100),
+      );
+
+      return {
+        ...attribute,
+        coveragePercent,
+        isUniversal: attribute.count >= totalOccurrences,
+      };
+    })
+    .filter((attribute: SharedAttribute): boolean => {
+      /*
+       * Below 5% an attribute value is per-occurrence noise. Kept as a
+       * share rather than a count so it behaves the same on a pattern seen
+       * 20 times and one seen 20,000 times.
+       */
+      return attribute.coveragePercent >= 5;
+    })
+    .sort((a: SharedAttribute, b: SharedAttribute): number => {
+      if (b.count !== a.count) {
+        return b.count - a.count;
+      }
+
+      return a.key.localeCompare(b.key);
+    })
+    .slice(0, Math.max(0, limit));
+}
+
+// --- Human-readable summaries ---
+
+/**
+ * The window as a phrase that can follow "in" — "in the past 2 days".
+ *
+ * The TimeRange enum's values are already human-readable ("Past 2 Days"),
+ * so lowercasing one is both the shortest correct rendering and one that
+ * cannot fall out of date when a range is added. Custom windows have no
+ * name worth printing, so they get a neutral phrase.
+ */
+export function describeTimeRange(timeRange: RangeStartAndEndDateTime): string {
+  const range: TimeRange | undefined = timeRange?.range;
+
+  if (!range || range === TimeRange.CUSTOM) {
+    return "the selected time range";
+  }
+
+  return `the ${(range as string).toLowerCase()}`;
+}
+
+/**
+ * "30 times in the last 2 days" — the sentence the issue asked for, built
+ * from a count and the window it was counted over.
+ */
+export function describeOccurrenceCount(
+  count: number,
+  timeRange: RangeStartAndEndDateTime,
+): string {
+  const safeCount: number = Number.isFinite(count) ? Math.max(0, count) : 0;
+  const noun: string = safeCount === 1 ? "time" : "times";
+
+  return `${safeCount.toLocaleString()} ${noun} in ${describeTimeRange(timeRange)}`;
+}
+
+// --- Deep links ---
+
+/*
+ * Route-safe single encoding for one query-param value. encodeURIComponent
+ * leaves "~" bare and Route's setter rejects it, so escape that one by
+ * hand; every target explorer reads its params back through
+ * URLSearchParams, which is a single decode.
+ */
+function encodeRouteQueryParamValue(value: string): string {
+  return encodeURIComponent(value).replace(/~/g, "%7E");
+}
+
+function withQueryParams(
+  route: Route,
+  params: Dictionary<string>,
+): Route | null {
+  const keys: Array<string> = Object.keys(params);
+
+  if (keys.length === 0) {
+    return route;
+  }
+
+  const encoded: Dictionary<string> = {};
+
+  for (const key of keys) {
+    encoded[key] = encodeRouteQueryParamValue(params[key] as string);
+  }
+
+  try {
+    const result: Route = new Route(route.toString());
+    result.addQueryParams(encoded);
+
+    return result;
+  } catch {
+    /*
+     * These builders run inside row renderers: a value Route rejects must
+     * mean "no link", never an exception out of render.
+     */
+    return null;
+  }
+}
+
+/**
+ * A Logs viewer link showing the raw occurrences behind one error pattern.
+ *
+ * The body filter is the pattern's longest literal run, not the pattern
+ * itself — the pattern contains placeholders (`<num>`, `<ip>`) that no real
+ * log body contains, so filtering on it would land the user on an empty
+ * list. That makes the link slightly wider than the pattern (other errors
+ * sharing that phrase come along), which is the right way to be wrong here:
+ * the user sees their error plus context rather than nothing.
+ *
+ * Returns null only when Route rejects a value.
+ */
+export function buildErrorPatternLogsRoute(
+  pattern: string,
+  scope: LogsInsightsScope,
+): Route | null {
+  const window: InBetween<Date> = resolveWindow(scope.timeRange);
+
+  const crossSignalScope: TelemetryCrossSignalScope = {
+    serviceIds: scope.serviceIds,
+    resourceFacetSelections: scope.resourceFilters,
+    severityTexts:
+      scope.severityTexts && scope.severityTexts.length > 0
+        ? scope.severityTexts
+        : ERROR_SEVERITIES,
+    bodyContains: getErrorPatternSearchText(pattern),
+    startTime: window.startValue,
+    endTime: window.endValue,
+  };
+
+  const serialized: CrossSignalQueryParams =
+    toLogsExplorerQueryParams(crossSignalScope);
+
+  return withQueryParams(
+    RouteUtil.populateRouteParams(RouteMap[PageMap.LOGS] as Route),
+    serialized.params,
+  );
+}
+
+/** The trace detail route for one of a pattern's related traces. */
+export function buildErrorPatternTraceRoute(traceId: string): Route | null {
+  const trimmed: string = typeof traceId === "string" ? traceId.trim() : "";
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    return RouteUtil.populateRouteParams(
+      RouteMap[PageMap.TRACE_VIEW] as Route,
+      {
+        modelId: trimmed,
+      },
+    );
+  } catch {
+    return null;
+  }
+}

--- a/App/Tests/Dashboard/LogsCrossSignalPivot.test.ts
+++ b/App/Tests/Dashboard/LogsCrossSignalPivot.test.ts
@@ -20,6 +20,7 @@ import type {
 type PivotModule =
   typeof import("../../FeatureSet/Dashboard/src/Utils/LogsCrossSignalPivot");
 type IncludesModule = typeof import("Common/Types/BaseDatabase/Includes");
+type SearchModule = typeof import("Common/Types/BaseDatabase/Search");
 type InBetweenModule = typeof import("Common/Types/BaseDatabase/InBetween");
 type ObjectIDModule = typeof import("Common/Types/ObjectID");
 type SpanModule = typeof import("Common/Models/AnalyticsModels/Span");
@@ -28,6 +29,7 @@ type RumSessionModule =
 
 let Pivot: PivotModule;
 let Includes: IncludesModule["default"];
+let Search: SearchModule["default"];
 let InBetween: InBetweenModule["default"];
 let ObjectID: ObjectIDModule["default"];
 let Span: SpanModule["default"];
@@ -157,6 +159,7 @@ beforeAll(async () => {
   ] as SerializeScopeFunction;
 
   Includes = (await import("Common/Types/BaseDatabase/Includes")).default;
+  Search = (await import("Common/Types/BaseDatabase/Search")).default;
   InBetween = (await import("Common/Types/BaseDatabase/InBetween")).default;
   ObjectID = (await import("Common/Types/ObjectID")).default;
   Span = (await import("Common/Models/AnalyticsModels/Span")).default;
@@ -638,6 +641,61 @@ describe("applyLogsFacetFiltersToQuery", () => {
       hostId: ["host-1"],
       dockerHostId: ["docker-1"],
     });
+  });
+
+  test("a body chip compiles to a contains-match, not an equality", () => {
+    const query: Record<string, unknown> = {};
+
+    Pivot.applyLogsFacetFiltersToQuery(
+      query as Parameters<typeof Pivot.applyLogsFacetFiltersToQuery>[0],
+      facets({ body: ["connection refused"] }),
+    );
+
+    /*
+     * A message filter is only ever a substring of the line. Equality on a
+     * body carrying a timestamp or a request id matches nothing, which is
+     * exactly what an Insights "Top Errors" deep link would have produced.
+     */
+    expect(query["body"]).toBeInstanceOf(Search);
+    expect((query["body"] as InstanceType<typeof Search>).toString()).toBe(
+      "connection refused",
+    );
+  });
+
+  test("a body chip never becomes an Includes set", () => {
+    const query: Record<string, unknown> = {};
+
+    Pivot.applyLogsFacetFiltersToQuery(
+      query as Parameters<typeof Pivot.applyLogsFacetFiltersToQuery>[0],
+      facets({ body: ["first", "second"] }),
+    );
+
+    /*
+     * Includes is an exact-set match, so a two-valued body chip would
+     * silently stop matching anything. The first value wins instead.
+     */
+    expect(query["body"]).toBeInstanceOf(Search);
+    expect(query["body"]).not.toBeInstanceOf(Includes);
+    expect((query["body"] as InstanceType<typeof Search>).toString()).toBe(
+      "first",
+    );
+  });
+
+  test("a body chip combines with severity and service chips", () => {
+    const query: Record<string, unknown> = {};
+
+    Pivot.applyLogsFacetFiltersToQuery(
+      query as Parameters<typeof Pivot.applyLogsFacetFiltersToQuery>[0],
+      facets({
+        body: ["connection refused"],
+        severityText: ["Error", "Fatal"],
+        primaryEntityId: ["svc-1"],
+      }),
+    );
+
+    expect(query["body"]).toBeInstanceOf(Search);
+    expect(query["severityText"]).toBeInstanceOf(Includes);
+    expect(query["primaryEntityId"]).toBe("svc-1");
   });
 
   test("a cluster chip alone leaves primaryEntityId unconstrained", () => {

--- a/App/Tests/Dashboard/LogsHistogramRequest.test.ts
+++ b/App/Tests/Dashboard/LogsHistogramRequest.test.ts
@@ -380,3 +380,45 @@ describe("buildLogsHistogramRequest", () => {
     expect(second).toEqual(first);
   });
 });
+
+/*
+ * The body chip is the one facet whose predicate is a contains-match. The
+ * histogram receives it under its own request field, or the chart would
+ * keep counting rows the list no longer shows — which is exactly what a
+ * deep link from Insights' Top Errors produces.
+ */
+describe("buildLogsHistogramRequest — body chips", () => {
+  test("forwards a body chip as bodySearchText", () => {
+    const request: JSONObject = build({
+      appliedFacetFilters: facets({ body: ["connection refused"] }),
+    });
+
+    expect(request["bodySearchText"]).toBe("connection refused");
+  });
+
+  test("omits the field for an absent, empty or blank chip", () => {
+    expect(build()["bodySearchText"]).toBeUndefined();
+    expect(
+      build({ appliedFacetFilters: facets({ body: [] }) })["bodySearchText"],
+    ).toBeUndefined();
+    expect(
+      build({ appliedFacetFilters: facets({ body: ["   "] }) })[
+        "bodySearchText"
+      ],
+    ).toBeUndefined();
+  });
+
+  test("a body chip does not disturb the other facet fields", () => {
+    const request: JSONObject = build({
+      appliedFacetFilters: facets({
+        body: ["timeout"],
+        severityText: ["Error"],
+        primaryEntityId: ["svc-1"],
+      }),
+    });
+
+    expect(request["bodySearchText"]).toBe("timeout");
+    expect(request["severityTexts"]).toEqual(["Error"]);
+    expect(request["serviceIds"]).toEqual(["svc-1"]);
+  });
+});

--- a/App/Tests/Dashboard/LogsInsights.test.ts
+++ b/App/Tests/Dashboard/LogsInsights.test.ts
@@ -1,0 +1,1028 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { JSONObject } from "Common/Types/JSON";
+import LogSeverity from "Common/Types/Log/LogSeverity";
+import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import TimeRange from "Common/Types/Time/TimeRange";
+import type {
+  ErrorPatternCorrelation,
+  ErrorPatternTrend,
+  LogVolumeSummary,
+  LogsInsightsScope,
+  ResourceLogBreakdown,
+  SharedAttribute,
+  TopErrorPatternRow,
+} from "../../FeatureSet/Dashboard/src/Utils/LogsInsights";
+
+/*
+ * The logic behind the Logs Insights page: what it asks the server, how it
+ * reads the answers, the numbers it derives from them, and the deep links
+ * it builds out of them.
+ *
+ * Two themes run through the suite. Every response field arrives as untyped
+ * JSON, so each parser is exercised on malformed and absent input as well
+ * as its happy path — a dashboard must degrade, never throw out of render.
+ * And every request builder is checked for scope fidelity: a panel that
+ * quietly widened or narrowed its own window would show the user a
+ * correlation that is not real.
+ */
+
+type InsightsModule =
+  typeof import("../../FeatureSet/Dashboard/src/Utils/LogsInsights");
+
+let Insights: InsightsModule;
+
+const NOW: Date = new Date("2026-08-21T12:00:00.000Z");
+const SERVICE_ID: string = "0195d6c1-0000-7000-8000-000000000001";
+
+/*
+ * Common/UI/Config reads `window` the moment it loads, and this module
+ * pulls it in transitively via RouteMap -> ProjectUtil, so the browser stub
+ * has to exist before the deferred import runs. Same approach as
+ * AIInsightExplorerLinks.test.ts.
+ */
+beforeAll(async () => {
+  (globalThis as Record<string, unknown>)["window"] = {
+    location: { pathname: "/", search: "", hash: "" },
+    history: {
+      state: null,
+      replaceState: (): void => {
+        // no-op; these tests never navigate.
+      },
+    },
+  };
+
+  for (const storageName of ["sessionStorage", "localStorage"]) {
+    Object.defineProperty(globalThis, storageName, {
+      value: {
+        getItem: (): null => {
+          return null;
+        },
+        setItem: (): void => {
+          // no-op
+        },
+        removeItem: (): void => {
+          // no-op
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  Insights = await import("../../FeatureSet/Dashboard/src/Utils/LogsInsights");
+});
+
+const PAST_TWO_DAYS: RangeStartAndEndDateTime = {
+  range: TimeRange.PAST_TWO_DAYS,
+};
+
+function scope(overrides: Partial<LogsInsightsScope> = {}): LogsInsightsScope {
+  return { timeRange: PAST_TWO_DAYS, ...overrides };
+}
+
+function queryOf(route: { toString(): string }): URLSearchParams {
+  const routeString: string = route.toString();
+  const queryIndex: number = routeString.indexOf("?");
+
+  return new URLSearchParams(
+    queryIndex >= 0 ? routeString.substring(queryIndex + 1) : "",
+  );
+}
+
+describe("request builders", () => {
+  beforeEach(() => {
+    /*
+     * Only Date needs faking; the sinon backend jest 28 uses cannot hijack
+     * the read-only `performance` global on current Node, so leave the
+     * timer/callback APIs alone.
+     */
+    jest.useFakeTimers({
+      doNotFake: [
+        "performance",
+        "hrtime",
+        "queueMicrotask",
+        "requestAnimationFrame",
+        "cancelAnimationFrame",
+        "requestIdleCallback",
+        "cancelIdleCallback",
+        "setImmediate",
+        "clearImmediate",
+        "setInterval",
+        "clearInterval",
+        "setTimeout",
+        "clearTimeout",
+      ],
+    });
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("resolves a preset range against the current clock on every call", () => {
+    const first: JSONObject = Insights.buildTopErrorPatternsRequest(scope());
+
+    expect(first["startTime"]).toBe("2026-08-19T12:00:00.000Z");
+    expect(first["endTime"]).toBe("2026-08-21T12:00:00.000Z");
+
+    /*
+     * "Past 2 days" means the last 48 hours, not the 48 hours the page
+     * happened to load with — a refresh an hour later must slide forward.
+     */
+    jest.setSystemTime(new Date("2026-08-21T13:00:00.000Z"));
+
+    const second: JSONObject = Insights.buildTopErrorPatternsRequest(scope());
+
+    expect(second["startTime"]).toBe("2026-08-19T13:00:00.000Z");
+    expect(second["endTime"]).toBe("2026-08-21T13:00:00.000Z");
+  });
+
+  test("a custom range pins both edges verbatim", () => {
+    const request: JSONObject = Insights.buildTopErrorPatternsRequest(
+      scope({
+        timeRange: {
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2026-08-01T00:00:00.000Z"),
+            new Date("2026-08-02T00:00:00.000Z"),
+          ),
+        },
+      }),
+    );
+
+    expect(request["startTime"]).toBe("2026-08-01T00:00:00.000Z");
+    expect(request["endTime"]).toBe("2026-08-02T00:00:00.000Z");
+  });
+
+  test("forwards a service selection and omits it when empty", () => {
+    expect(
+      Insights.buildTopErrorPatternsRequest(
+        scope({ serviceIds: [SERVICE_ID] }),
+      )["serviceIds"],
+    ).toEqual([SERVICE_ID]);
+
+    /*
+     * An empty array is "no filter", not "match no service" — sending it
+     * would scope the page to nothing.
+     */
+    expect(
+      Insights.buildTopErrorPatternsRequest(scope({ serviceIds: [] }))[
+        "serviceIds"
+      ],
+    ).toBeUndefined();
+  });
+
+  test("forwards resource facet selections and omits an empty map", () => {
+    expect(
+      Insights.buildTopErrorPatternsRequest(
+        scope({ resourceFilters: { hostId: ["host-1"] } }),
+      )["resourceFilters"],
+    ).toEqual({ hostId: ["host-1"] });
+
+    expect(
+      Insights.buildTopErrorPatternsRequest(scope({ resourceFilters: {} }))[
+        "resourceFilters"
+      ],
+    ).toBeUndefined();
+  });
+
+  test("forwards a limit only when it is a usable number", () => {
+    expect(Insights.buildTopErrorPatternsRequest(scope(), 12)["limit"]).toBe(
+      12,
+    );
+    expect(
+      Insights.buildTopErrorPatternsRequest(scope(), Number.NaN)["limit"],
+    ).toBeUndefined();
+    expect(
+      Insights.buildTopErrorPatternsRequest(scope())["limit"],
+    ).toBeUndefined();
+  });
+
+  test("the histogram request never filters by severity", () => {
+    /*
+     * The histogram is what draws the severity breakdown. Filtering it to
+     * the error severities would leave the page unable to say what share of
+     * the volume the errors are — the denominator would equal the
+     * numerator.
+     */
+    const request: JSONObject = Insights.buildInsightsHistogramRequest(
+      scope({ severityTexts: [LogSeverity.Error], serviceIds: [SERVICE_ID] }),
+    );
+
+    expect(request["severityTexts"]).toBeUndefined();
+    // ...but the rest of the scope still applies.
+    expect(request["serviceIds"]).toEqual([SERVICE_ID]);
+  });
+
+  test("the service breakdown groups by resource and severity, unfiltered by severity", () => {
+    const request: JSONObject = Insights.buildServiceBreakdownRequest(
+      scope({ severityTexts: [LogSeverity.Error] }),
+    );
+
+    expect(request["chartType"]).toBe("table");
+    expect(request["aggregation"]).toBe("count");
+    expect(request["groupBy"]).toEqual(["primaryEntityId", "severityText"]);
+    expect(request["severityTexts"]).toBeUndefined();
+    expect(request["limit"]).toBe(500);
+  });
+
+  test("the correlation request carries the pattern alongside the page's scope", () => {
+    const request: JSONObject = Insights.buildErrorPatternCorrelationRequest(
+      scope({ serviceIds: [SERVICE_ID], severityTexts: [LogSeverity.Fatal] }),
+      "connection refused to <ip>",
+      5,
+    );
+
+    expect(request["pattern"]).toBe("connection refused to <ip>");
+    expect(request["serviceIds"]).toEqual([SERVICE_ID]);
+    expect(request["severityTexts"]).toEqual([LogSeverity.Fatal]);
+    expect(request["limit"]).toBe(5);
+    expect(request["startTime"]).toBe("2026-08-19T12:00:00.000Z");
+  });
+
+  test("the list and its drill-down ask for the same window and scope", () => {
+    /*
+     * The whole point of the correlation panel is that it describes the
+     * same logs the list counted. If the two requests could disagree on
+     * window or scope, the panel would be correlating against a different
+     * population than the one the user clicked.
+     */
+    const pageScope: LogsInsightsScope = scope({ serviceIds: [SERVICE_ID] });
+
+    const list: JSONObject = Insights.buildTopErrorPatternsRequest(pageScope);
+    const detail: JSONObject = Insights.buildErrorPatternCorrelationRequest(
+      pageScope,
+      "boom",
+    );
+
+    expect(detail["startTime"]).toBe(list["startTime"]);
+    expect(detail["endTime"]).toBe(list["endTime"]);
+    expect(detail["serviceIds"]).toEqual(list["serviceIds"]);
+  });
+});
+
+describe("parseTopErrorPatterns", () => {
+  test("maps a well-formed row, parsing ClickHouse datetimes as UTC", () => {
+    const rows: Array<TopErrorPatternRow> = Insights.parseTopErrorPatterns({
+      patterns: [
+        {
+          pattern: "connection refused to <ip>:<num>",
+          sampleBody: "connection refused to 10.0.0.4:5432",
+          count: 30,
+          firstSeenAt: "2026-08-19 03:00:00.000000000",
+          lastSeenAt: "2026-08-20 22:14:02.000000000",
+          resourceCount: 2,
+          resourceIds: ["svc-a", "svc-b"],
+          severities: ["Error"],
+          traceCount: 4,
+          sampleTraceIds: ["t1"],
+        },
+      ],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.count).toBe(30);
+    expect(rows[0]!.firstSeenAt!.toISOString()).toBe(
+      "2026-08-19T03:00:00.000Z",
+    );
+    expect(rows[0]!.lastSeenAt!.toISOString()).toBe("2026-08-20T22:14:02.000Z");
+    expect(rows[0]!.resourceIds).toEqual(["svc-a", "svc-b"]);
+  });
+
+  test("drops rows with no pattern and coerces malformed fields", () => {
+    const rows: Array<TopErrorPatternRow> = Insights.parseTopErrorPatterns({
+      patterns: [
+        { pattern: "", count: 9 },
+        {
+          pattern: "boom",
+          count: "17",
+          firstSeenAt: null,
+          /*
+           * Datetime-SHAPED but not a real instant. Deliberately not free
+           * text: moment's non-ISO fallback logs a deprecation warning,
+           * which would make every run of this suite noisy for a branch
+           * that is about the result, not the parser's chattiness.
+           */
+          lastSeenAt: "0000-99-99 99:99:99",
+          resourceIds: "nope",
+          severities: ["Error", 42, ""],
+          traceCount: undefined,
+        },
+      ],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.count).toBe(17);
+    expect(rows[0]!.firstSeenAt).toBeNull();
+    expect(rows[0]!.lastSeenAt).toBeNull();
+    expect(rows[0]!.resourceIds).toEqual([]);
+    expect(rows[0]!.severities).toEqual(["Error"]);
+    expect(rows[0]!.traceCount).toBe(0);
+  });
+
+  test("degrades to an empty list on absent or non-array payloads", () => {
+    expect(Insights.parseTopErrorPatterns(undefined)).toEqual([]);
+    expect(Insights.parseTopErrorPatterns({})).toEqual([]);
+    expect(Insights.parseTopErrorPatterns({ patterns: "nope" })).toEqual([]);
+    expect(Insights.parseTopErrorPatterns({ patterns: [null, 7] })).toEqual([]);
+  });
+});
+
+describe("parseErrorPatternCorrelation", () => {
+  const response: JSONObject = {
+    pattern: "boom <num>",
+    bucketSizeInMinutes: 15,
+    timeline: [
+      { time: "2026-08-20 10:00:00.000000000", count: 3 },
+      { time: "2026-08-20 10:15:00.000000000", count: 0 },
+    ],
+    coOccurringPatterns: [
+      {
+        pattern: "upstream timed out",
+        sampleBody: "upstream timed out",
+        count: 7,
+      },
+      { pattern: "", count: 3 },
+    ],
+    attributes: [
+      { key: "host.name", value: "web-3", count: 30 },
+      { key: "", value: "orphan", count: 1 },
+    ],
+    resources: [
+      {
+        resourceId: "svc-1",
+        resourceType: "Host",
+        count: 21,
+        lastSeenAt: "2026-08-20 22:00:00.000000000",
+      },
+      { resourceId: "", count: 5 },
+    ],
+    traces: [
+      {
+        traceId: "abc",
+        count: 3,
+        lastSeenAt: "2026-08-20 22:00:00.000000000",
+        resourceId: "svc-1",
+      },
+      { traceId: "", count: 9 },
+    ],
+    samples: [
+      {
+        logId: "log-1",
+        time: "2026-08-20 22:00:00.000000000",
+        body: "boom 42",
+        severityText: "Error",
+        resourceId: "svc-1",
+        traceId: "abc",
+        spanId: "def",
+      },
+    ],
+  };
+
+  test("maps every section and drops rows missing their identifying field", () => {
+    const parsed: ErrorPatternCorrelation =
+      Insights.parseErrorPatternCorrelation(response);
+
+    expect(parsed.pattern).toBe("boom <num>");
+    expect(parsed.bucketSizeInMinutes).toBe(15);
+    expect(parsed.timeline).toHaveLength(2);
+    expect(parsed.timeline[0]!.time!.toISOString()).toBe(
+      "2026-08-20T10:00:00.000Z",
+    );
+    /*
+     * An empty bucket is data — "the error stopped" — so a zero count must
+     * survive parsing rather than being filtered out as falsy.
+     */
+    expect(parsed.timeline[1]!.count).toBe(0);
+
+    expect(parsed.coOccurringPatterns).toHaveLength(1);
+    expect(parsed.attributes).toEqual([
+      { key: "host.name", value: "web-3", count: 30 },
+    ]);
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.traces).toHaveLength(1);
+    expect(parsed.samples[0]!.body).toBe("boom 42");
+  });
+
+  test("returns an empty shape rather than throwing on an absent payload", () => {
+    const parsed: ErrorPatternCorrelation =
+      Insights.parseErrorPatternCorrelation(undefined);
+
+    expect(parsed.pattern).toBe("");
+    expect(parsed.bucketSizeInMinutes).toBe(0);
+    expect(parsed.timeline).toEqual([]);
+    expect(parsed.coOccurringPatterns).toEqual([]);
+    expect(parsed.attributes).toEqual([]);
+    expect(parsed.resources).toEqual([]);
+    expect(parsed.traces).toEqual([]);
+    expect(parsed.samples).toEqual([]);
+  });
+});
+
+describe("summarizeSeverityBuckets", () => {
+  const buckets: Array<JSONObject> = [
+    { time: "2026-08-20 10:00:00.000000000", severity: "Error", count: 6 },
+    {
+      time: "2026-08-20 10:00:00.000000000",
+      severity: "Information",
+      count: 90,
+    },
+    { time: "2026-08-20 11:00:00.000000000", severity: "Fatal", count: 2 },
+    { time: "2026-08-20 11:00:00.000000000", severity: "Warning", count: 2 },
+  ];
+
+  test("totals volume, error count and error rate across the whole window", () => {
+    const summary: LogVolumeSummary =
+      Insights.summarizeSeverityBuckets(buckets);
+
+    expect(summary.total).toBe(100);
+    // Error + Fatal, matching the server's default error severities.
+    expect(summary.errorCount).toBe(8);
+    expect(summary.warnCount).toBe(2);
+    expect(summary.errorRatePercent).toBe(8);
+  });
+
+  test("orders the severity breakdown by seriousness, not by volume", () => {
+    const summary: LogVolumeSummary =
+      Insights.summarizeSeverityBuckets(buckets);
+
+    expect(
+      summary.severities.map((share: { severity: string }): string => {
+        return share.severity;
+      }),
+    ).toEqual(["Fatal", "Error", "Warning", "Information"]);
+    expect(summary.severities[3]!.percent).toBe(90);
+  });
+
+  test("keeps an unknown severity instead of dropping its volume", () => {
+    const summary: LogVolumeSummary = Insights.summarizeSeverityBuckets([
+      { time: "t1", severity: "Audit", count: 4 },
+      { time: "t1", severity: "Error", count: 1 },
+    ]);
+
+    expect(summary.total).toBe(5);
+    // Unknown severities sort after every known one rather than vanishing.
+    expect(summary.severities[1]!.severity).toBe("Audit");
+  });
+
+  test("a severity-less bucket is counted under Unspecified", () => {
+    const summary: LogVolumeSummary = Insights.summarizeSeverityBuckets([
+      { time: "t1", count: 3 },
+    ]);
+
+    expect(summary.total).toBe(3);
+    expect(summary.severities[0]!.severity).toBe("Unspecified");
+  });
+
+  test("sums the per-bucket series and keeps empty buckets as gaps", () => {
+    const summary: LogVolumeSummary = Insights.summarizeSeverityBuckets([
+      ...buckets,
+      { time: "2026-08-20 12:00:00.000000000", severity: "Error", count: 0 },
+    ]);
+
+    expect(summary.series).toEqual([
+      { time: "2026-08-20 10:00:00.000000000", count: 96 },
+      { time: "2026-08-20 11:00:00.000000000", count: 4 },
+      { time: "2026-08-20 12:00:00.000000000", count: 0 },
+    ]);
+  });
+
+  test("an empty window reports zeroes rather than dividing by zero", () => {
+    const summary: LogVolumeSummary = Insights.summarizeSeverityBuckets([]);
+
+    expect(summary.total).toBe(0);
+    expect(summary.errorRatePercent).toBe(0);
+    expect(summary.severities).toEqual([]);
+    expect(Insights.summarizeSeverityBuckets(undefined).total).toBe(0);
+  });
+});
+
+describe("summarizeResourceBreakdown", () => {
+  test("folds per-severity rows into one row per resource, busiest first", () => {
+    const rows: Array<ResourceLogBreakdown> =
+      Insights.summarizeResourceBreakdown({
+        data: [
+          {
+            groupValues: { primaryEntityId: "svc-a", severityText: "Error" },
+            count: 5,
+          },
+          {
+            groupValues: {
+              primaryEntityId: "svc-a",
+              severityText: "Information",
+            },
+            count: 20,
+          },
+          {
+            groupValues: { primaryEntityId: "svc-b", severityText: "Fatal" },
+            count: 2,
+          },
+          {
+            groupValues: { primaryEntityId: "svc-b", severityText: "Warning" },
+            count: 40,
+          },
+        ],
+      });
+
+    expect(rows).toEqual([
+      { resourceId: "svc-b", total: 42, errorCount: 2, warnCount: 40 },
+      { resourceId: "svc-a", total: 25, errorCount: 5, warnCount: 0 },
+    ]);
+  });
+
+  test("breaks volume ties on id so the order is stable across refreshes", () => {
+    const rows: Array<ResourceLogBreakdown> =
+      Insights.summarizeResourceBreakdown({
+        data: [
+          { groupValues: { primaryEntityId: "zeta" }, count: 5 },
+          { groupValues: { primaryEntityId: "alpha" }, count: 5 },
+        ],
+      });
+
+    expect(
+      rows.map((row: ResourceLogBreakdown): string => {
+        return row.resourceId;
+      }),
+    ).toEqual(["alpha", "zeta"]);
+  });
+
+  test("skips rows with no resource id and degrades on malformed payloads", () => {
+    expect(
+      Insights.summarizeResourceBreakdown({
+        data: [{ groupValues: {}, count: 9 }, { count: 4 }],
+      }),
+    ).toEqual([]);
+    expect(Insights.summarizeResourceBreakdown(undefined)).toEqual([]);
+    expect(Insights.summarizeResourceBreakdown({ data: "nope" })).toEqual([]);
+  });
+});
+
+describe("computeErrorPatternTrend", () => {
+  function timeline(counts: Array<number>): Array<{
+    time: Date | null;
+    count: number;
+  }> {
+    return counts.map((count: number): { time: Date | null; count: number } => {
+      return { time: null, count };
+    });
+  }
+
+  test("calls a doubling rising, with the percentage change", () => {
+    const trend: ErrorPatternTrend = Insights.computeErrorPatternTrend(
+      timeline([1, 1, 2, 2]),
+    );
+
+    expect(trend.direction).toBe("rising");
+    expect(trend.previousCount).toBe(2);
+    expect(trend.recentCount).toBe(4);
+    expect(trend.changePercent).toBe(100);
+  });
+
+  test("calls a halving falling", () => {
+    const trend: ErrorPatternTrend = Insights.computeErrorPatternTrend(
+      timeline([10, 10, 5, 5]),
+    );
+
+    expect(trend.direction).toBe("falling");
+    expect(trend.changePercent).toBe(-50);
+  });
+
+  test("a small wobble is steady, not a trend", () => {
+    /*
+     * 100 -> 105 is five percent. Calling that an escalation would make the
+     * badge meaningless on any pattern with normal variance.
+     */
+    expect(
+      Insights.computeErrorPatternTrend(timeline([100, 105])).direction,
+    ).toBe("steady");
+  });
+
+  test("a pattern that only started in the newer half is rising", () => {
+    const trend: ErrorPatternTrend = Insights.computeErrorPatternTrend(
+      timeline([0, 0, 4, 6]),
+    );
+
+    expect(trend.direction).toBe("rising");
+    expect(trend.changePercent).toBe(100);
+    expect(trend.recentCount).toBe(10);
+  });
+
+  test("reports unknown rather than guessing on too little data", () => {
+    expect(Insights.computeErrorPatternTrend([]).direction).toBe("unknown");
+    expect(Insights.computeErrorPatternTrend(timeline([5])).direction).toBe(
+      "unknown",
+    );
+    // All-empty buckets are not a falling trend, they are no data.
+    expect(Insights.computeErrorPatternTrend(timeline([0, 0])).direction).toBe(
+      "unknown",
+    );
+  });
+
+  test("splits an odd-length timeline with the extra bucket in the newer half", () => {
+    const trend: ErrorPatternTrend = Insights.computeErrorPatternTrend(
+      timeline([2, 1, 1, 1, 1]),
+    );
+
+    expect(trend.previousCount).toBe(3);
+    expect(trend.recentCount).toBe(3);
+  });
+});
+
+describe("summarizeSharedAttributes", () => {
+  test("ranks by coverage and flags the ones on every occurrence", () => {
+    const shared: Array<SharedAttribute> = Insights.summarizeSharedAttributes(
+      [
+        { key: "http.route", value: "/checkout", count: 12 },
+        { key: "host.name", value: "web-3", count: 30 },
+      ],
+      30,
+    );
+
+    expect(shared[0]!.key).toBe("host.name");
+    expect(shared[0]!.isUniversal).toBe(true);
+    expect(shared[0]!.coveragePercent).toBe(100);
+    expect(shared[1]!.isUniversal).toBe(false);
+    expect(shared[1]!.coveragePercent).toBe(40);
+  });
+
+  test("drops per-occurrence noise like request ids", () => {
+    /*
+     * A value that appears once in thirty occurrences is what MAKES this a
+     * pattern rather than one log line. Listing every such value would bury
+     * the attributes that actually localize the error.
+     */
+    const shared: Array<SharedAttribute> = Insights.summarizeSharedAttributes(
+      [
+        { key: "request.id", value: "req-1", count: 1 },
+        { key: "host.name", value: "web-3", count: 30 },
+      ],
+      30,
+    );
+
+    expect(shared).toHaveLength(1);
+    expect(shared[0]!.key).toBe("host.name");
+  });
+
+  test("clamps coverage at 100% when a log carries the attribute more than once", () => {
+    const shared: Array<SharedAttribute> = Insights.summarizeSharedAttributes(
+      [{ key: "k8s.pod.name", value: "checkout-7d9", count: 45 }],
+      30,
+    );
+
+    expect(shared[0]!.coveragePercent).toBe(100);
+    expect(shared[0]!.isUniversal).toBe(true);
+  });
+
+  test("breaks count ties on key so the order is stable", () => {
+    const shared: Array<SharedAttribute> = Insights.summarizeSharedAttributes(
+      [
+        { key: "zeta", value: "1", count: 10 },
+        { key: "alpha", value: "1", count: 10 },
+      ],
+      10,
+    );
+
+    expect(
+      shared.map((attribute: SharedAttribute): string => {
+        return attribute.key;
+      }),
+    ).toEqual(["alpha", "zeta"]);
+  });
+
+  test("honours the limit and degrades on unusable inputs", () => {
+    const many: Array<{ key: string; value: string; count: number }> =
+      Array.from({ length: 20 }, (_unused: unknown, index: number) => {
+        return { key: `k${index}`, value: "v", count: 10 };
+      });
+
+    expect(Insights.summarizeSharedAttributes(many, 10, 3)).toHaveLength(3);
+    expect(Insights.summarizeSharedAttributes(many, 0)).toEqual([]);
+    expect(Insights.summarizeSharedAttributes([], 10)).toEqual([]);
+  });
+});
+
+describe("describeTimeRange / describeOccurrenceCount", () => {
+  test("renders the window as a phrase that can follow 'in'", () => {
+    expect(Insights.describeTimeRange(PAST_TWO_DAYS)).toBe("the past 2 days");
+    expect(Insights.describeTimeRange({ range: TimeRange.PAST_ONE_HOUR })).toBe(
+      "the past 1 hour",
+    );
+  });
+
+  test("a custom window gets a neutral phrase, not an enum value", () => {
+    expect(Insights.describeTimeRange({ range: TimeRange.CUSTOM })).toBe(
+      "the selected time range",
+    );
+  });
+
+  test("builds the sentence the issue asked for", () => {
+    expect(Insights.describeOccurrenceCount(30, PAST_TWO_DAYS)).toBe(
+      "30 times in the past 2 days",
+    );
+  });
+
+  test("singularizes one occurrence and floors nonsense counts", () => {
+    expect(Insights.describeOccurrenceCount(1, PAST_TWO_DAYS)).toBe(
+      "1 time in the past 2 days",
+    );
+    expect(Insights.describeOccurrenceCount(-4, PAST_TWO_DAYS)).toContain(
+      "0 times",
+    );
+    expect(
+      Insights.describeOccurrenceCount(Number.NaN, PAST_TWO_DAYS),
+    ).toContain("0 times");
+  });
+});
+
+describe("buildErrorPatternLogsRoute", () => {
+  test("filters the viewer on the pattern's literal text, not its placeholders", () => {
+    const route: { toString(): string } | null =
+      Insights.buildErrorPatternLogsRoute(
+        "connection refused to <ip>:<num>",
+        scope(),
+      );
+
+    expect(route).not.toBeNull();
+
+    const filters: Array<[string, Array<string>]> = JSON.parse(
+      queryOf(route!).get("filters") as string,
+    );
+
+    /*
+     * The pattern itself contains <ip>/<num>, which no real body contains —
+     * filtering on it would land the user on an empty list. The link
+     * carries the longest literal run instead.
+     */
+    expect(filters).toContainEqual(["body", ["connection refused to"]]);
+  });
+
+  test("carries severity, service scope and the window", () => {
+    const route: { toString(): string } | null =
+      Insights.buildErrorPatternLogsRoute(
+        "connection refused",
+        scope({ serviceIds: [SERVICE_ID] }),
+      );
+
+    const params: URLSearchParams = queryOf(route!);
+    const filters: Array<[string, Array<string>]> = JSON.parse(
+      params.get("filters") as string,
+    );
+
+    expect(filters).toContainEqual(["severityText", ["Error", "Fatal"]]);
+    expect(filters).toContainEqual(["primaryEntityId", [SERVICE_ID]]);
+    expect(params.get("range")).toBe(TimeRange.CUSTOM);
+    expect(params.get("start")).toBeTruthy();
+    expect(params.get("end")).toBeTruthy();
+  });
+
+  test("an explicit severity selection overrides the error default", () => {
+    const route: { toString(): string } | null =
+      Insights.buildErrorPatternLogsRoute(
+        "slow query",
+        scope({ severityTexts: [LogSeverity.Warning] }),
+      );
+
+    const filters: Array<[string, Array<string>]> = JSON.parse(
+      queryOf(route!).get("filters") as string,
+    );
+
+    expect(filters).toContainEqual(["severityText", ["Warning"]]);
+  });
+
+  test("omits the body filter when the pattern has no selective literal run", () => {
+    const route: { toString(): string } | null =
+      Insights.buildErrorPatternLogsRoute("<timestamp> <uuid>", scope());
+
+    const filters: Array<[string, Array<string>]> = JSON.parse(
+      queryOf(route!).get("filters") as string,
+    );
+
+    /*
+     * An empty body filter would match everything while telling the user
+     * their view is filtered — worse than no filter at all.
+     */
+    for (const [key] of filters) {
+      expect(key).not.toBe("body");
+    }
+  });
+
+  test("survives the characters a real log body can contain", () => {
+    /*
+     * Log bodies are free-form. encodeURIComponent leaves "~" bare and
+     * Route's character whitelist rejects it, which is exactly how a link
+     * builder throws out of a row renderer.
+     */
+    const hostile: Array<string> = [
+      "svc~canary refused",
+      'quoted "eu west" failed',
+      "spaces and 100% failure",
+      "{braces}<angle>|pipe error",
+      "plus+amp&eq=q?hash# failed",
+      "emoji 🚀 café unavailable",
+    ];
+
+    for (const pattern of hostile) {
+      const route: { toString(): string } | null =
+        Insights.buildErrorPatternLogsRoute(pattern, scope());
+
+      expect(route).not.toBeNull();
+
+      // One decode, exactly as LogsViewer.readInitialUrlState applies.
+      const filters: Array<[string, Array<string>]> = JSON.parse(
+        queryOf(route!).get("filters") as string,
+      );
+
+      const bodyFilter: [string, Array<string>] | undefined = filters.find(
+        ([key]: [string, Array<string>]): boolean => {
+          return key === "body";
+        },
+      );
+
+      expect(bodyFilter).toBeDefined();
+      expect(pattern).toContain(bodyFilter![1][0] as string);
+    }
+  });
+});
+
+describe("buildErrorPatternTraceRoute", () => {
+  test("points at the trace detail page for the id", () => {
+    const route: { toString(): string } | null =
+      Insights.buildErrorPatternTraceRoute("4bf92f3577b34da6a3ce929d0e0e4736");
+
+    expect(route!.toString()).toContain("4bf92f3577b34da6a3ce929d0e0e4736");
+  });
+
+  test("returns null for an absent or blank trace id", () => {
+    expect(Insights.buildErrorPatternTraceRoute("")).toBeNull();
+    expect(Insights.buildErrorPatternTraceRoute("   ")).toBeNull();
+    expect(
+      Insights.buildErrorPatternTraceRoute(undefined as unknown as string),
+    ).toBeNull();
+  });
+});
+
+/*
+ * The scope picker is one flat multi-select over two very different kinds
+ * of id. A Service id belongs in `primaryEntityId`; a host or cluster id has
+ * to reach the server as its own facet, because OTLP telemetry carrying a
+ * `service.name` is primary-keyed on the Service and only records the host
+ * it ran on in `entityKeys`. Conflating them is what made an earlier
+ * cluster filter match nothing at all.
+ */
+describe("scope picker", () => {
+  test("asks for every resource facet the picker offers", () => {
+    const request: JSONObject = Insights.buildScopeFacetsRequest(PAST_TWO_DAYS);
+
+    expect(request["facetKeys"]).toEqual([
+      "primaryEntityId",
+      "hostId",
+      "dockerHostId",
+      "podmanHostId",
+      "kubernetesClusterId",
+    ]);
+    expect(request["startTime"]).toBeTruthy();
+    expect(request["endTime"]).toBeTruthy();
+    expect(request["limit"]).toBe(200);
+  });
+
+  test("the facet request carries no selection of its own", () => {
+    /*
+     * Narrowing the picker by its own output would let a selection erase
+     * the way back out of itself — pick one host and the others vanish.
+     */
+    const request: JSONObject = Insights.buildScopeFacetsRequest(PAST_TWO_DAYS);
+
+    expect(request["serviceIds"]).toBeUndefined();
+    expect(request["resourceFilters"]).toBeUndefined();
+    expect(request["severityTexts"]).toBeUndefined();
+  });
+
+  test("parses each facet's values, preferring the resolved display name", () => {
+    const parsed: Record<
+      string,
+      Array<{ displayName: string }>
+    > = Insights.parseScopeFacets({
+      facets: {
+        primaryEntityId: [
+          { value: "svc-1", displayName: "checkout", count: 40 },
+        ],
+        hostId: [{ value: "host-1", count: 12 }],
+      },
+    }) as unknown as Record<string, Array<{ displayName: string }>>;
+
+    expect(parsed["primaryEntityId"]![0]!.displayName).toBe("checkout");
+    // No resolved name — the raw id still identifies a scopeable resource.
+    expect(parsed["hostId"]![0]!.displayName).toBe("host-1");
+  });
+
+  test("drops values with no id and degrades on missing payloads", () => {
+    const parsed: Record<string, Array<unknown>> = Insights.parseScopeFacets({
+      facets: { hostId: [{ value: "", count: 9 }, { count: 4 }] },
+    }) as unknown as Record<string, Array<unknown>>;
+
+    expect(parsed["hostId"]).toEqual([]);
+    // Every offered facet key is present, even when the response omitted it.
+    expect(Object.keys(Insights.parseScopeFacets(undefined)).sort()).toEqual(
+      [...Insights.INSIGHTS_SCOPE_FACET_KEYS].sort(),
+    );
+  });
+
+  test("round-trips a selection through its encoded option value", () => {
+    const encoded: string = Insights.encodeScopeSelection(
+      "hostId",
+      "0195d6c1-0000-7000-8000-0000000000aa",
+    );
+
+    expect(encoded).toBe("hostId:0195d6c1-0000-7000-8000-0000000000aa");
+    expect(Insights.parseScopeSelections([encoded]).resourceFilters).toEqual({
+      hostId: ["0195d6c1-0000-7000-8000-0000000000aa"],
+    });
+  });
+
+  test("routes services and non-service resources into different scope fields", () => {
+    const selections: {
+      serviceIds?: Array<string> | undefined;
+      resourceFilters?: Record<string, Array<string>> | undefined;
+    } = Insights.parseScopeSelections([
+      Insights.encodeScopeSelection("primaryEntityId", "svc-1"),
+      Insights.encodeScopeSelection("hostId", "host-1"),
+      Insights.encodeScopeSelection("kubernetesClusterId", "k8s-1"),
+    ]);
+
+    expect(selections.serviceIds).toEqual(["svc-1"]);
+    expect(selections.resourceFilters).toEqual({
+      hostId: ["host-1"],
+      kubernetesClusterId: ["k8s-1"],
+    });
+  });
+
+  test("groups several ids under one facet and deduplicates them", () => {
+    const selections: {
+      resourceFilters?: Record<string, Array<string>> | undefined;
+    } = Insights.parseScopeSelections([
+      "hostId:host-1",
+      "hostId:host-2",
+      "hostId:host-1",
+    ]);
+
+    expect(selections.resourceFilters).toEqual({
+      hostId: ["host-1", "host-2"],
+    });
+  });
+
+  test("an unknown facet key is dropped rather than sent as an unreadable filter", () => {
+    const selections: {
+      serviceIds?: Array<string> | undefined;
+      resourceFilters?: Record<string, Array<string>> | undefined;
+    } = Insights.parseScopeSelections(["madeUpFacet:x", "primaryEntityId:ok"]);
+
+    expect(selections.serviceIds).toEqual(["ok"]);
+    expect(selections.resourceFilters).toBeUndefined();
+  });
+
+  test("malformed entries and an empty selection carry no scope", () => {
+    for (const values of [
+      [],
+      ["no-separator"],
+      [":leading-colon"],
+      ["hostId:"],
+      [undefined as unknown as string],
+    ]) {
+      const selections: {
+        serviceIds?: Array<string> | undefined;
+        resourceFilters?: Record<string, Array<string>> | undefined;
+      } = Insights.parseScopeSelections(values);
+
+      expect(selections.serviceIds).toBeUndefined();
+      expect(selections.resourceFilters).toBeUndefined();
+    }
+  });
+
+  test("a selection reaches the API request bodies it was decoded for", () => {
+    const selections: {
+      serviceIds?: Array<string> | undefined;
+      resourceFilters?: Record<string, Array<string>> | undefined;
+    } = Insights.parseScopeSelections([
+      "primaryEntityId:svc-1",
+      "hostId:host-1",
+    ]);
+
+    const request: JSONObject = Insights.buildTopErrorPatternsRequest({
+      timeRange: PAST_TWO_DAYS,
+      ...selections,
+    } as LogsInsightsScope);
+
+    expect(request["serviceIds"]).toEqual(["svc-1"]);
+    expect(request["resourceFilters"]).toEqual({ hostId: ["host-1"] });
+  });
+});

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -24,6 +24,10 @@ import LogAggregationService, {
   AnalyticsTimeseriesRow,
   AnalyticsTopItem,
   AnalyticsTableRow,
+  ErrorPatternFilters,
+  ErrorPatternTimelineRequest,
+  TopErrorPattern,
+  TopErrorPatternsRequest,
 } from "../Services/LogAggregationService";
 import TraceAggregationService, {
   HistogramBucket as TraceHistogramBucket,
@@ -1911,6 +1915,248 @@ router.post(
 
       return Response.sendJsonObjectResponse(req, res, {
         data: data as unknown as JSONObject,
+      });
+    } catch (err: unknown) {
+      next(err);
+    }
+  },
+);
+
+// --- Log Error Pattern Endpoints ---
+
+/*
+ * Shared body parsing for the two error-pattern endpoints. Both take the
+ * same filter shape as the histogram/facet endpoints so the Insights page
+ * can hand its one scope (time range, service selection, severities) to
+ * every panel it draws; the detail endpoint adds the pattern itself.
+ *
+ * Defensive about shapes throughout: these bodies come from the browser,
+ * and a stringly-typed or null field must mean "no filter" rather than
+ * becoming an active predicate that silently narrows the result.
+ */
+function parseErrorPatternFilterBody(
+  body: JSONObject,
+  projectId: ObjectID,
+): Omit<ErrorPatternFilters, "startTime" | "endTime"> {
+  const stringArray: (value: unknown) => Array<string> | undefined = (
+    value: unknown,
+  ): Array<string> | undefined => {
+    if (!Array.isArray(value)) {
+      return undefined;
+    }
+
+    const values: Array<string> = (value as Array<unknown>).filter(
+      (item: unknown): item is string => {
+        return typeof item === "string" && item.length > 0;
+      },
+    );
+
+    return values.length > 0 ? values : undefined;
+  };
+
+  const serviceIdStrings: Array<string> | undefined = stringArray(
+    body["serviceIds"],
+  );
+
+  return {
+    projectId,
+    serviceIds: serviceIdStrings
+      ? serviceIdStrings.map((id: string): ObjectID => {
+          return new ObjectID(id);
+        })
+      : undefined,
+    entityKeys: stringArray(body["entityKeys"]),
+    severityTexts: stringArray(body["severityTexts"]),
+    bodySearchText:
+      typeof body["bodySearchText"] === "string" &&
+      body["bodySearchText"].trim().length > 0
+        ? (body["bodySearchText"] as string)
+        : undefined,
+    traceIds: stringArray(body["traceIds"]),
+    spanIds: stringArray(body["spanIds"]),
+    sessionIds: stringArray(body["sessionIds"]),
+    attributes:
+      body["attributes"] && typeof body["attributes"] === "object"
+        ? (body["attributes"] as Record<string, string | Array<string>>)
+        : undefined,
+  };
+}
+
+/*
+ * Default window for the error-pattern endpoints: 24 hours rather than the
+ * one hour the histogram defaults to. "Top errors" is a question about a
+ * period long enough for a pattern to establish itself; an hour of a quiet
+ * service routinely has nothing in it.
+ */
+function parseErrorPatternWindow(body: JSONObject): {
+  startTime: Date;
+  endTime: Date;
+} {
+  const endTime: Date = body["endTime"]
+    ? OneUptimeDate.fromString(body["endTime"] as string)
+    : OneUptimeDate.getCurrentDate();
+
+  const startTime: Date = body["startTime"]
+    ? OneUptimeDate.fromString(body["startTime"] as string)
+    : OneUptimeDate.addRemoveHours(endTime, -24);
+
+  return { startTime, endTime };
+}
+
+router.post(
+  "/telemetry/logs/error-patterns",
+  ...requireLogReadAccess,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const databaseProps: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      if (!databaseProps?.tenantId) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("Invalid Project ID"),
+        );
+      }
+
+      const body: JSONObject = req.body as JSONObject;
+      const window: { startTime: Date; endTime: Date } =
+        parseErrorPatternWindow(body);
+
+      const request: TopErrorPatternsRequest = {
+        ...parseErrorPatternFilterBody(body, databaseProps.tenantId),
+        ...window,
+        resourceScopes: await resolveResourceScopesFromBody(
+          body,
+          databaseProps.tenantId,
+        ),
+        limit: typeof body["limit"] === "number" ? body["limit"] : undefined,
+      };
+
+      const patterns: Array<TopErrorPattern> =
+        await LogAggregationService.getTopErrorPatterns(request);
+
+      return Response.sendJsonObjectResponse(req, res, {
+        patterns: patterns as unknown as JSONObject,
+      });
+    } catch (err: unknown) {
+      next(err);
+    }
+  },
+);
+
+/*
+ * Everything the UI needs to explain ONE error pattern, in a single round
+ * trip: when it fired, what else fired alongside it, what the occurrences
+ * have in common, which resources and traces carry it, and a handful of
+ * raw lines.
+ *
+ * The six aggregations run concurrently and each degrades to an empty
+ * result on its own failure. A correlation panel is supplementary
+ * information — one slow or unlucky sub-query should cost the user that
+ * section, not the whole page.
+ */
+router.post(
+  "/telemetry/logs/error-pattern-correlation",
+  ...requireLogReadAccess,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const databaseProps: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      if (!databaseProps?.tenantId) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("Invalid Project ID"),
+        );
+      }
+
+      const body: JSONObject = req.body as JSONObject;
+
+      const pattern: string =
+        typeof body["pattern"] === "string" ? (body["pattern"] as string) : "";
+
+      if (pattern.trim().length === 0) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("pattern is required"),
+        );
+      }
+
+      const window: { startTime: Date; endTime: Date } =
+        parseErrorPatternWindow(body);
+
+      const bucketSizeInMinutes: number =
+        typeof body["bucketSizeInMinutes"] === "number" &&
+        body["bucketSizeInMinutes"] > 0
+          ? (body["bucketSizeInMinutes"] as number)
+          : computeDefaultBucketSize(window.startTime, window.endTime);
+
+      const detailRequest: ErrorPatternTimelineRequest = {
+        ...parseErrorPatternFilterBody(body, databaseProps.tenantId),
+        ...window,
+        resourceScopes: await resolveResourceScopesFromBody(
+          body,
+          databaseProps.tenantId,
+        ),
+        pattern,
+        bucketSizeInMinutes,
+        limit: typeof body["limit"] === "number" ? body["limit"] : undefined,
+      };
+
+      const degradeToEmpty: <T>(
+        promise: Promise<Array<T>>,
+      ) => Promise<Array<T>> = async <T>(
+        promise: Promise<Array<T>>,
+      ): Promise<Array<T>> => {
+        try {
+          return await promise;
+        } catch {
+          return [];
+        }
+      };
+
+      const [timeline, coOccurring, attributes, resources, traces, samples] =
+        await Promise.all([
+          degradeToEmpty(
+            LogAggregationService.getErrorPatternTimeline(detailRequest),
+          ),
+          degradeToEmpty(
+            LogAggregationService.getErrorPatternCoOccurrences(detailRequest),
+          ),
+          degradeToEmpty(
+            LogAggregationService.getErrorPatternAttributes(detailRequest),
+          ),
+          degradeToEmpty(
+            LogAggregationService.getErrorPatternResources(detailRequest),
+          ),
+          degradeToEmpty(
+            LogAggregationService.getErrorPatternTraces(detailRequest),
+          ),
+          degradeToEmpty(
+            LogAggregationService.getErrorPatternSamples(detailRequest),
+          ),
+        ]);
+
+      return Response.sendJsonObjectResponse(req, res, {
+        pattern,
+        bucketSizeInMinutes,
+        timeline: timeline as unknown as JSONObject,
+        coOccurringPatterns: coOccurring as unknown as JSONObject,
+        attributes: attributes as unknown as JSONObject,
+        resources: resources as unknown as JSONObject,
+        traces: traces as unknown as JSONObject,
+        samples: samples as unknown as JSONObject,
       });
     } catch (err: unknown) {
       next(err);

--- a/Common/Server/Services/LogAggregationService.ts
+++ b/Common/Server/Services/LogAggregationService.ts
@@ -14,6 +14,10 @@ import {
   appendResourceScopeFilters,
   ResourceEntityScope,
 } from "../Utils/Telemetry/ResourceEntityFilter";
+import {
+  buildLogErrorPatternExpression,
+  clampLogErrorPattern,
+} from "../Utils/Telemetry/LogErrorPatternSql";
 
 export interface HistogramBucket {
   time: string;
@@ -123,6 +127,111 @@ export interface AnalyticsTopItem {
 export interface AnalyticsTableRow {
   groupValues: Record<string, string>;
   count: number;
+}
+
+/*
+ * ---------------------------------------------------------------------
+ * Error-pattern insights
+ * ---------------------------------------------------------------------
+ *
+ * The Logs Insights page answers "what is actually going wrong, and where"
+ * by clustering error bodies into patterns (see
+ * Common/Utils/Telemetry/LogErrorPattern) and counting the clusters in the
+ * database. Everything below shares one filter shape so the top-list and
+ * every drill-down run against exactly the same slice of logs — a
+ * correlation panel that silently widened its own scope would be worse
+ * than no panel at all.
+ */
+
+/** Severities treated as "an error" when the caller does not say. */
+export const DEFAULT_ERROR_LOG_SEVERITIES: Array<string> = ["Error", "Fatal"];
+
+export interface ErrorPatternFilters {
+  projectId: ObjectID;
+  startTime: Date;
+  endTime: Date;
+  serviceIds?: Array<ObjectID> | undefined;
+  entityKeys?: Array<string> | undefined;
+  resourceScopes?: Array<ResourceEntityScope> | undefined;
+  /** Defaults to DEFAULT_ERROR_LOG_SEVERITIES when absent or empty. */
+  severityTexts?: Array<string> | undefined;
+  bodySearchText?: string | undefined;
+  traceIds?: Array<string> | undefined;
+  spanIds?: Array<string> | undefined;
+  sessionIds?: Array<string> | undefined;
+  attributes?: LogAttributeFilters | undefined;
+}
+
+export interface TopErrorPatternsRequest extends ErrorPatternFilters {
+  limit?: number | undefined;
+}
+
+export interface TopErrorPattern {
+  /** The normalized message every occurrence in this group shares. */
+  pattern: string;
+  /** The most recent raw body in the group, for display. */
+  sampleBody: string;
+  count: number;
+  /** ClickHouse datetime strings — parse with OneUptimeDate.fromString. */
+  firstSeenAt: string;
+  lastSeenAt: string;
+  /** Distinct services / hosts / clusters this pattern was seen on. */
+  resourceCount: number;
+  resourceIds: Array<string>;
+  severities: Array<string>;
+  /** Distinct traces carrying at least one occurrence. */
+  traceCount: number;
+  sampleTraceIds: Array<string>;
+}
+
+export interface ErrorPatternDetailRequest extends ErrorPatternFilters {
+  pattern: string;
+  limit?: number | undefined;
+}
+
+export interface ErrorPatternTimelineRequest extends ErrorPatternDetailRequest {
+  bucketSizeInMinutes: number;
+}
+
+export interface ErrorPatternTimelinePoint {
+  time: string;
+  count: number;
+}
+
+export interface ErrorPatternCoOccurrence {
+  pattern: string;
+  sampleBody: string;
+  count: number;
+}
+
+export interface ErrorPatternAttribute {
+  key: string;
+  value: string;
+  count: number;
+}
+
+export interface ErrorPatternResource {
+  resourceId: string;
+  resourceType: string;
+  count: number;
+  lastSeenAt: string;
+}
+
+export interface ErrorPatternTrace {
+  traceId: string;
+  count: number;
+  lastSeenAt: string;
+  resourceId: string;
+}
+
+export interface ErrorPatternSample {
+  logId: string;
+  time: string;
+  body: string;
+  severityText: string;
+  resourceId: string;
+  traceId: string;
+  spanId: string;
 }
 
 export class LogAggregationService {
@@ -1217,6 +1326,639 @@ export class LogAggregationService {
       totalLogs > 0 ? Math.round((matchingLogs / totalLogs) * 100) : 0;
 
     return { totalLogs, matchingLogs, estimatedReductionPercent };
+  }
+
+  // --- Error pattern insights ---
+
+  private static readonly DEFAULT_ERROR_PATTERN_LIMIT: number = 10;
+  private static readonly MAX_ERROR_PATTERN_LIMIT: number = 50;
+  private static readonly ERROR_PATTERN_SAMPLE_ARRAY_LIMIT: number = 5;
+  /* Every severity a pattern can carry fits comfortably in eight slots. */
+  private static readonly ERROR_PATTERN_SEVERITY_ARRAY_LIMIT: number = 8;
+  /*
+   * Bodies that are empty or nothing but whitespace normalize to the empty
+   * pattern, which would otherwise become a single meaningless "" group
+   * sitting at the top of the list. Excluded at the source instead of via
+   * HAVING so the rows never enter the aggregation at all.
+   */
+  private static readonly NON_EMPTY_BODY_FILTER: string =
+    " AND notEmpty(trimBoth(ifNull(body, '')))";
+
+  /**
+   * The distinct error messages in the window, most frequent first.
+   *
+   * This is the "Top Errors" list: one row per pattern with its occurrence
+   * count, when it started and last happened, how many resources it spans,
+   * and enough sample material (a real body, some trace ids) for the UI to
+   * render the row without a second round trip.
+   */
+  @CaptureSpan()
+  public static async getTopErrorPatterns(
+    request: TopErrorPatternsRequest,
+  ): Promise<Array<TopErrorPattern>> {
+    const statement: Statement =
+      LogAggregationService.buildTopErrorPatternsStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows
+      .map((row: JSONObject): TopErrorPattern => {
+        return {
+          pattern: String(row["pattern"] || ""),
+          sampleBody: String(row["sampleBody"] || ""),
+          count: Number(row["cnt"] || 0),
+          firstSeenAt: String(row["firstSeen"] || ""),
+          lastSeenAt: String(row["lastSeen"] || ""),
+          resourceCount: Number(row["resourceCount"] || 0),
+          resourceIds: LogAggregationService.toStringArray(row["resourceIds"]),
+          severities: LogAggregationService.toStringArray(row["severities"]),
+          traceCount: Number(row["traceCount"] || 0),
+          sampleTraceIds: LogAggregationService.toStringArray(
+            row["sampleTraceIds"],
+          ),
+        };
+      })
+      .filter((item: TopErrorPattern): boolean => {
+        return item.pattern.length > 0;
+      });
+  }
+
+  /**
+   * When one pattern happened, bucketed over the window — the "is this a
+   * steady drip or a spike at 14:05" question.
+   */
+  @CaptureSpan()
+  public static async getErrorPatternTimeline(
+    request: ErrorPatternTimelineRequest,
+  ): Promise<Array<ErrorPatternTimelinePoint>> {
+    const statement: Statement =
+      LogAggregationService.buildErrorPatternTimelineStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows.map((row: JSONObject): ErrorPatternTimelinePoint => {
+      return {
+        time: String(row["bucket"] || ""),
+        count: Number(row["cnt"] || 0),
+      };
+    });
+  }
+
+  /**
+   * Other error patterns that fired in the same time buckets as this one.
+   *
+   * This is the correlation the Insights page exists for: rather than
+   * eyeballing two log lists side by side, the panel names the errors that
+   * keep company with the one under investigation. "Same bucket" is a
+   * deliberately coarse notion of simultaneity — it inherits whatever
+   * bucket size the timeline is drawn at, so a wide window correlates
+   * loosely and a narrow one tightly.
+   */
+  @CaptureSpan()
+  public static async getErrorPatternCoOccurrences(
+    request: ErrorPatternTimelineRequest,
+  ): Promise<Array<ErrorPatternCoOccurrence>> {
+    const statement: Statement =
+      LogAggregationService.buildErrorPatternCoOccurrenceStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows
+      .map((row: JSONObject): ErrorPatternCoOccurrence => {
+        return {
+          pattern: String(row["pattern"] || ""),
+          sampleBody: String(row["sampleBody"] || ""),
+          count: Number(row["cnt"] || 0),
+        };
+      })
+      .filter((item: ErrorPatternCoOccurrence): boolean => {
+        return item.pattern.length > 0;
+      });
+  }
+
+  /**
+   * The attribute key/value pairs carried by this pattern's occurrences,
+   * most common first — how the page answers "which host is this?" without
+   * the user having to open a log line and read its attributes.
+   */
+  @CaptureSpan()
+  public static async getErrorPatternAttributes(
+    request: ErrorPatternDetailRequest,
+  ): Promise<Array<ErrorPatternAttribute>> {
+    const statement: Statement =
+      LogAggregationService.buildErrorPatternAttributesStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows
+      .map((row: JSONObject): ErrorPatternAttribute => {
+        return {
+          key: String(row["attrKey"] || ""),
+          value: String(row["attrValue"] || ""),
+          count: Number(row["cnt"] || 0),
+        };
+      })
+      .filter((item: ErrorPatternAttribute): boolean => {
+        return item.key.length > 0;
+      });
+  }
+
+  /** Which services / hosts / clusters this pattern is happening on. */
+  @CaptureSpan()
+  public static async getErrorPatternResources(
+    request: ErrorPatternDetailRequest,
+  ): Promise<Array<ErrorPatternResource>> {
+    const statement: Statement =
+      LogAggregationService.buildErrorPatternResourcesStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows
+      .map((row: JSONObject): ErrorPatternResource => {
+        return {
+          resourceId: String(row["resourceId"] || ""),
+          resourceType: String(row["resourceType"] || ""),
+          count: Number(row["cnt"] || 0),
+          lastSeenAt: String(row["lastSeen"] || ""),
+        };
+      })
+      .filter((item: ErrorPatternResource): boolean => {
+        return item.resourceId.length > 0;
+      });
+  }
+
+  /**
+   * Traces that carry at least one occurrence — the jump from "this error
+   * happened" to the request it happened inside.
+   */
+  @CaptureSpan()
+  public static async getErrorPatternTraces(
+    request: ErrorPatternDetailRequest,
+  ): Promise<Array<ErrorPatternTrace>> {
+    const statement: Statement =
+      LogAggregationService.buildErrorPatternTracesStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows
+      .map((row: JSONObject): ErrorPatternTrace => {
+        return {
+          traceId: String(row["traceId"] || ""),
+          count: Number(row["cnt"] || 0),
+          lastSeenAt: String(row["lastSeen"] || ""),
+          resourceId: String(row["resourceId"] || ""),
+        };
+      })
+      .filter((item: ErrorPatternTrace): boolean => {
+        return item.traceId.length > 0;
+      });
+  }
+
+  /** The most recent raw log lines behind the pattern. */
+  @CaptureSpan()
+  public static async getErrorPatternSamples(
+    request: ErrorPatternDetailRequest,
+  ): Promise<Array<ErrorPatternSample>> {
+    const statement: Statement =
+      LogAggregationService.buildErrorPatternSamplesStatement(request);
+
+    const rows: Array<JSONObject> =
+      await LogAggregationService.runQuery(statement);
+
+    return rows.map((row: JSONObject): ErrorPatternSample => {
+      return {
+        logId: String(row["_id"] || ""),
+        time: String(row["time"] || ""),
+        body: String(row["body"] || ""),
+        severityText: String(row["severityText"] || ""),
+        resourceId: String(row["resourceId"] || ""),
+        traceId: String(row["traceId"] || ""),
+        spanId: String(row["spanId"] || ""),
+      };
+    });
+  }
+
+  private static async runQuery(
+    statement: Statement,
+  ): Promise<Array<JSONObject>> {
+    const dbResult: Results = await LogDatabaseService.executeQuery(statement);
+    const response: DbJSONResponse = await dbResult.json<{
+      data?: Array<JSONObject>;
+    }>();
+
+    return response.data || [];
+  }
+
+  /*
+   * ClickHouse returns array-valued aggregates (groupUniqArray) as JSON
+   * arrays, but a row that reached us through a different serializer could
+   * carry anything — coerce defensively rather than trusting the shape.
+   */
+  private static toStringArray(value: unknown): Array<string> {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .map((item: unknown): string => {
+        return String(item ?? "");
+      })
+      .filter((item: string): boolean => {
+        return item.length > 0;
+      });
+  }
+
+  private static clampErrorPatternLimit(limit: number | undefined): number {
+    if (typeof limit !== "number" || !Number.isFinite(limit)) {
+      return LogAggregationService.DEFAULT_ERROR_PATTERN_LIMIT;
+    }
+
+    return Math.min(
+      Math.max(1, Math.floor(limit)),
+      LogAggregationService.MAX_ERROR_PATTERN_LIMIT,
+    );
+  }
+
+  /*
+   * Error-pattern reads share one WHERE clause so a drill-down can never
+   * see rows the top-list did not. The only thing this adds over
+   * appendCommonFilters is the severity default: a request that names no
+   * severities means "errors", not "every log in the project".
+   */
+  private static appendErrorPatternScope(
+    statement: Statement,
+    request: ErrorPatternFilters,
+  ): void {
+    statement.append(
+      SQL` WHERE projectId = ${{
+        type: TableColumnType.ObjectID,
+        value: request.projectId,
+      }} AND time >= ${{
+        type: TableColumnType.Date,
+        value: request.startTime,
+      }} AND time <= ${{
+        type: TableColumnType.Date,
+        value: request.endTime,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.RETENTION_FILTER);
+    statement.append(LogAggregationService.NON_EMPTY_BODY_FILTER);
+
+    LogAggregationService.appendCommonFilters(statement, {
+      ...request,
+      severityTexts:
+        request.severityTexts && request.severityTexts.length > 0
+          ? request.severityTexts
+          : DEFAULT_ERROR_LOG_SEVERITIES,
+    });
+  }
+
+  /*
+   * ` AND <pattern expression> = '<the pattern>'` — the predicate every
+   * drill-down uses to reduce the window to one cluster. The pattern value
+   * is clamped to the same maximum length the expression truncates to, so
+   * an oversized parameter cannot be used to push a huge constant into the
+   * query (it could only ever match nothing anyway).
+   */
+  private static appendErrorPatternEquality(
+    statement: Statement,
+    pattern: string,
+  ): void {
+    statement.append(" AND ");
+    statement.append(buildLogErrorPatternExpression());
+    statement.append(
+      SQL` = ${{
+        type: TableColumnType.Text,
+        value: clampLogErrorPattern(pattern),
+      }}`,
+    );
+  }
+
+  private static errorPatternQuerySettings(): string {
+    /*
+     * Same ceiling as every other aggregation here: below the client's 58s
+     * request timeout, 'break' so a wide window degrades to partial counts
+     * instead of an error page, and the scan-memory bound because these
+     * queries read the fat `attributes` map alongside `body`.
+     */
+    return getQuerySettings({
+      maxExecutionTimeInSeconds: 45,
+      timeoutOverflowMode: "break",
+      boundScanMemory: true,
+    });
+  }
+
+  private static buildTopErrorPatternsStatement(
+    request: TopErrorPatternsRequest,
+  ): Statement {
+    const limit: number = LogAggregationService.clampErrorPatternLimit(
+      request.limit,
+    );
+    /*
+     * Inlined rather than bound as a parameter: these are the parameters of
+     * a PARAMETRIC aggregate function, which ClickHouse requires to be
+     * constants, and they are trusted class constants rather than anything
+     * a caller supplies.
+     */
+    const sampleLimit: number =
+      LogAggregationService.ERROR_PATTERN_SAMPLE_ARRAY_LIMIT;
+    const severityLimit: number =
+      LogAggregationService.ERROR_PATTERN_SEVERITY_ARRAY_LIMIT;
+
+    const statement: Statement = new Statement();
+
+    statement.append("SELECT ");
+    statement.append(buildLogErrorPatternExpression());
+    statement.append(" AS pattern");
+    statement.append(", count() AS cnt");
+    /*
+     * The newest real body in the group. Showing a raw example alongside
+     * the normalized pattern is what makes a row readable — `<num>` reads
+     * very differently next to the line it came from.
+     */
+    statement.append(", argMax(ifNull(body, ''), time) AS sampleBody");
+    statement.append(", min(time) AS firstSeen");
+    statement.append(", max(time) AS lastSeen");
+    statement.append(", uniqExact(primaryEntityId) AS resourceCount");
+    statement.append(
+      `, groupUniqArray(${sampleLimit})(toString(primaryEntityId)) AS resourceIds`,
+    );
+    statement.append(
+      `, groupUniqArray(${severityLimit})(toString(severityText)) AS severities`,
+    );
+    statement.append(
+      ", uniqExactIf(traceId, ifNull(traceId, '') != '') AS traceCount",
+    );
+    statement.append(
+      `, groupUniqArrayIf(${sampleLimit})(ifNull(traceId, ''), ifNull(traceId, '') != '') AS sampleTraceIds`,
+    );
+    statement.append(` FROM ${LogAggregationService.TABLE_NAME}`);
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+
+    statement.append(
+      SQL` GROUP BY pattern ORDER BY cnt DESC LIMIT ${{
+        type: TableColumnType.Number,
+        value: limit,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  private static buildErrorPatternTimelineStatement(
+    request: ErrorPatternTimelineRequest,
+  ): Statement {
+    const intervalSeconds: number =
+      LogAggregationService.resolveBucketSeconds(request);
+
+    const statement: Statement = SQL`SELECT toStartOfInterval(time, INTERVAL ${{
+      type: TableColumnType.Number,
+      value: intervalSeconds,
+    }} SECOND) AS bucket, count() AS cnt`;
+
+    statement.append(` FROM ${LogAggregationService.TABLE_NAME}`);
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+    LogAggregationService.appendErrorPatternEquality(
+      statement,
+      request.pattern,
+    );
+
+    statement.append(" GROUP BY bucket ORDER BY bucket ASC");
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  private static buildErrorPatternCoOccurrenceStatement(
+    request: ErrorPatternTimelineRequest,
+  ): Statement {
+    const intervalSeconds: number =
+      LogAggregationService.resolveBucketSeconds(request);
+    const limit: number = LogAggregationService.clampErrorPatternLimit(
+      request.limit,
+    );
+
+    const statement: Statement = new Statement();
+
+    statement.append("SELECT ");
+    statement.append(buildLogErrorPatternExpression());
+    statement.append(" AS pattern");
+    statement.append(", count() AS cnt");
+    statement.append(", argMax(ifNull(body, ''), time) AS sampleBody");
+    statement.append(` FROM ${LogAggregationService.TABLE_NAME}`);
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+
+    /*
+     * Everything EXCEPT the pattern under investigation. Written as the
+     * full expression rather than the `pattern` alias: ClickHouse
+     * substitutes same-level SELECT aliases into WHERE, and an alias that
+     * shadows nothing today can start shadowing a real column tomorrow.
+     */
+    statement.append(" AND ");
+    statement.append(buildLogErrorPatternExpression());
+    statement.append(
+      SQL` != ${{
+        type: TableColumnType.Text,
+        value: clampLogErrorPattern(request.pattern),
+      }}`,
+    );
+
+    // ...restricted to the buckets the investigated pattern itself landed in.
+    statement.append(
+      SQL` AND toStartOfInterval(time, INTERVAL ${{
+        type: TableColumnType.Number,
+        value: intervalSeconds,
+      }} SECOND) IN (SELECT DISTINCT toStartOfInterval(time, INTERVAL ${{
+        type: TableColumnType.Number,
+        value: intervalSeconds,
+      }} SECOND)`,
+    );
+
+    statement.append(` FROM ${LogAggregationService.TABLE_NAME}`);
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+    LogAggregationService.appendErrorPatternEquality(
+      statement,
+      request.pattern,
+    );
+
+    statement.append(")");
+
+    statement.append(
+      SQL` GROUP BY pattern ORDER BY cnt DESC LIMIT ${{
+        type: TableColumnType.Number,
+        value: limit,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  private static buildErrorPatternAttributesStatement(
+    request: ErrorPatternDetailRequest,
+  ): Statement {
+    const limit: number = LogAggregationService.clampErrorPatternLimit(
+      request.limit,
+    );
+
+    /*
+     * The ARRAY JOIN runs over a pre-filtered subquery on purpose. Written
+     * flat, the join explodes every row in the window into one row per
+     * attribute BEFORE the WHERE narrows to a single pattern — on a service
+     * carrying twenty resource attributes that is a twentyfold scan for a
+     * result the size of a tooltip.
+     */
+    const statement: Statement = new Statement();
+
+    statement.append(
+      `SELECT attrKey, attrValue, count() AS cnt FROM (SELECT attributes FROM ${LogAggregationService.TABLE_NAME}`,
+    );
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+    LogAggregationService.appendErrorPatternEquality(
+      statement,
+      request.pattern,
+    );
+
+    statement.append(
+      ") ARRAY JOIN mapKeys(attributes) AS attrKey, mapValues(attributes) AS attrValue",
+    );
+    statement.append(
+      SQL` GROUP BY attrKey, attrValue ORDER BY cnt DESC LIMIT ${{
+        type: TableColumnType.Number,
+        value: limit,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  private static buildErrorPatternResourcesStatement(
+    request: ErrorPatternDetailRequest,
+  ): Statement {
+    const limit: number = LogAggregationService.clampErrorPatternLimit(
+      request.limit,
+    );
+
+    const statement: Statement = new Statement();
+
+    statement.append(
+      `SELECT toString(primaryEntityId) AS resourceId, any(ifNull(primaryEntityType, '')) AS resourceType, count() AS cnt, max(time) AS lastSeen FROM ${LogAggregationService.TABLE_NAME}`,
+    );
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+    LogAggregationService.appendErrorPatternEquality(
+      statement,
+      request.pattern,
+    );
+
+    statement.append(
+      SQL` GROUP BY resourceId ORDER BY cnt DESC LIMIT ${{
+        type: TableColumnType.Number,
+        value: limit,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  private static buildErrorPatternTracesStatement(
+    request: ErrorPatternDetailRequest,
+  ): Statement {
+    const limit: number = LogAggregationService.clampErrorPatternLimit(
+      request.limit,
+    );
+
+    const statement: Statement = new Statement();
+
+    statement.append(
+      `SELECT ifNull(traceId, '') AS traceId, count() AS cnt, max(time) AS lastSeen, any(toString(primaryEntityId)) AS resourceId FROM ${LogAggregationService.TABLE_NAME}`,
+    );
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+    LogAggregationService.appendErrorPatternEquality(
+      statement,
+      request.pattern,
+    );
+
+    statement.append(" AND ifNull(traceId, '') != ''");
+
+    statement.append(
+      SQL` GROUP BY traceId ORDER BY cnt DESC LIMIT ${{
+        type: TableColumnType.Number,
+        value: limit,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  private static buildErrorPatternSamplesStatement(
+    request: ErrorPatternDetailRequest,
+  ): Statement {
+    const limit: number = LogAggregationService.clampErrorPatternLimit(
+      request.limit,
+    );
+
+    const statement: Statement = new Statement();
+
+    statement.append(
+      `SELECT _id, time, ifNull(body, '') AS body, toString(severityText) AS severityText, toString(primaryEntityId) AS resourceId, ifNull(traceId, '') AS traceId, ifNull(spanId, '') AS spanId FROM ${LogAggregationService.TABLE_NAME}`,
+    );
+
+    LogAggregationService.appendErrorPatternScope(statement, request);
+    LogAggregationService.appendErrorPatternEquality(
+      statement,
+      request.pattern,
+    );
+
+    statement.append(
+      SQL` ORDER BY time DESC LIMIT ${{
+        type: TableColumnType.Number,
+        value: limit,
+      }}`,
+    );
+
+    statement.append(LogAggregationService.errorPatternQuerySettings());
+
+    return statement;
+  }
+
+  /*
+   * Bucket size in seconds, clamped to a minute floor. A zero or negative
+   * bucket would compile to `INTERVAL 0 SECOND`, which ClickHouse rejects —
+   * and the correlation query's "same bucket" join would lose all meaning.
+   */
+  private static resolveBucketSeconds(
+    request: ErrorPatternTimelineRequest,
+  ): number {
+    const minutes: number = request.bucketSizeInMinutes;
+
+    if (typeof minutes !== "number" || !Number.isFinite(minutes)) {
+      return 60;
+    }
+
+    return Math.max(1, Math.floor(minutes)) * 60;
   }
 
   private static isTopLevelColumn(key: string): boolean {

--- a/Common/Server/Utils/Telemetry/LogErrorPatternSql.ts
+++ b/Common/Server/Utils/Telemetry/LogErrorPatternSql.ts
@@ -1,0 +1,117 @@
+import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
+import { SQL, Statement } from "../AnalyticsDatabase/Statement";
+import {
+  LOG_ERROR_PATTERN_MAX_LENGTH,
+  LOG_ERROR_PATTERN_RULES,
+  LogErrorPatternRule,
+} from "../../../Utils/Telemetry/LogErrorPattern";
+
+/*
+ * Compiles the shared error-pattern rules (Common/Utils/Telemetry/
+ * LogErrorPattern) into the ClickHouse expression that does the grouping.
+ *
+ * The grouping has to happen in the database. Normalizing client-side would
+ * mean shipping a page of raw bodies to the browser and counting those,
+ * which answers "what are the top errors in the 5000 rows I happened to
+ * fetch" — a different, and much less useful, question than "what are the
+ * top errors in this window".
+ *
+ * Shape of the emitted expression, for rules r0..rN in order:
+ *
+ *   trimBoth(substring(trimBoth(
+ *     replaceRegexpAll(...replaceRegexpAll(ifNull(body,''), p0, x0)..., pN, xN)
+ *   ), 1, 300))
+ *
+ * The innermost call is the FIRST rule, matching the sequential application
+ * order `normalizeLogBodyToErrorPattern` uses, and the trim/truncate/trim
+ * tail mirrors its `.trim()` -> `.slice()` -> `.trim()`. Parity between the
+ * two is pinned by Common/Tests/Utils/Telemetry/LogErrorPatternSql.test.ts.
+ *
+ * Patterns and replacements ride as bound query parameters rather than
+ * being interpolated. ClickHouse substitutes parameters into the AST as
+ * constant literals during parsing, so `replaceRegexpAll` still sees the
+ * constant regexp argument it requires (the same shape the Sigma compiler
+ * already relies on for `match(expr, {p:String})`), and no rule text ever
+ * reaches the SQL text itself.
+ */
+
+/**
+ * The column expression the pattern is computed from.
+ *
+ * `body` is Nullable(String) on the Log table, and `replaceRegexpAll(NULL,
+ * ...)` is NULL — which would collapse every body-less row into one NULL
+ * group. Coalescing first turns those into the empty pattern, which the
+ * callers exclude with a `!= ''` predicate.
+ */
+export const LOG_ERROR_PATTERN_SOURCE_EXPRESSION: string = "ifNull(body, '')";
+
+/**
+ * Build the pattern expression over `sourceExpression`.
+ *
+ * `sourceExpression` is appended to the statement as trusted SQL — it must
+ * be a literal owned by this codebase (in practice always
+ * LOG_ERROR_PATTERN_SOURCE_EXPRESSION), never anything derived from a
+ * request.
+ */
+export function buildLogErrorPatternExpression(
+  sourceExpression: string = LOG_ERROR_PATTERN_SOURCE_EXPRESSION,
+): Statement {
+  const statement: Statement = new Statement();
+
+  statement.append("trimBoth(substring(trimBoth(");
+
+  // One open paren per rule; the arguments below close them inside-out.
+  statement.append("replaceRegexpAll(".repeat(LOG_ERROR_PATTERN_RULES.length));
+
+  statement.append(sourceExpression);
+
+  /*
+   * Ascending order: rule 0's arguments close the innermost call, so it is
+   * applied first — exactly as the JavaScript normalizer iterates.
+   */
+  for (const rule of LOG_ERROR_PATTERN_RULES) {
+    statement.append(
+      SQL`, ${{
+        type: TableColumnType.Text,
+        value: rule.pattern,
+      }}, ${{
+        type: TableColumnType.Text,
+        value: rule.replacement,
+      }})`,
+    );
+  }
+
+  statement.append(
+    SQL`), 1, ${{
+      type: TableColumnType.Number,
+      value: LOG_ERROR_PATTERN_MAX_LENGTH,
+    }}))`,
+  );
+
+  return statement;
+}
+
+/**
+ * How many bound parameters `buildLogErrorPatternExpression` contributes.
+ * Exported so callers reasoning about parameter budgets (and the tests that
+ * pin statement shapes) do not have to count rules by hand.
+ */
+export function getLogErrorPatternParameterCount(): number {
+  return LOG_ERROR_PATTERN_RULES.length * 2 + 1;
+}
+
+/**
+ * Guard for a caller-supplied pattern value (the detail endpoints echo one
+ * back to scope their queries). Patterns are compared with `=` against the
+ * expression above, so an over-long value can only ever match nothing —
+ * clamping keeps the parameter bounded without changing any result.
+ */
+export function clampLogErrorPattern(pattern: string): string {
+  if (pattern.length <= LOG_ERROR_PATTERN_MAX_LENGTH) {
+    return pattern;
+  }
+
+  return pattern.slice(0, LOG_ERROR_PATTERN_MAX_LENGTH);
+}
+
+export type { LogErrorPatternRule };

--- a/Common/Tests/Server/API/LogErrorPatternAPI.test.ts
+++ b/Common/Tests/Server/API/LogErrorPatternAPI.test.ts
@@ -1,0 +1,811 @@
+import CommonAPI from "../../../Server/API/CommonAPI";
+import LogAggregationService, {
+  ErrorPatternTimelineRequest,
+  TopErrorPatternsRequest,
+} from "../../../Server/Services/LogAggregationService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "../../../Types/Dictionary";
+import Exception from "../../../Types/Exception/Exception";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import UserType from "../../../Types/UserType";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The two endpoints behind the Logs Insights page: the Top Errors list and
+ * the correlation drill-down for one of its rows.
+ *
+ * What is worth pinning at this layer, rather than in the aggregation
+ * suite, is everything that happens between an untrusted request body and
+ * the service call: the read guard, the window defaults, the shapes a
+ * browser can send for each field, and the promise that a correlation panel
+ * degrades section by section instead of failing whole.
+ */
+
+type RouterFunction = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+type RecordedRoute = {
+  method: string;
+  uri: string;
+  handlers: Array<RouterFunction>;
+};
+
+const recordedRoutes: Array<RecordedRoute> = [];
+
+type RecordRouteFunction = (
+  method: string,
+) => (uri: string, ...handlers: Array<RouterFunction>) => void;
+
+const recordRoute: RecordRouteFunction = (method: string) => {
+  return (uri: string, ...handlers: Array<RouterFunction>): void => {
+    recordedRoutes.push({
+      method: method.toUpperCase(),
+      uri: uri,
+      handlers: handlers,
+    });
+  };
+};
+
+const telemetryRouter: JSONObject = {
+  get: recordRoute("get"),
+  post: recordRoute("post"),
+  put: recordRoute("put"),
+  delete: recordRoute("delete"),
+} as unknown as JSONObject;
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return telemetryRouter;
+    },
+    getClientIp: () => {
+      return "203.0.113.7";
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+  };
+});
+
+const PATTERNS_ROUTE: string = "/telemetry/logs/error-patterns";
+const CORRELATION_ROUTE: string = "/telemetry/logs/error-pattern-correlation";
+
+function findRoute(uri: string): RecordedRoute {
+  const route: RecordedRoute | undefined = recordedRoutes.find(
+    (candidate: RecordedRoute): boolean => {
+      return candidate.method === "POST" && candidate.uri === uri;
+    },
+  );
+
+  if (!route) {
+    throw new Error(`Route not registered: ${uri}`);
+  }
+
+  return route;
+}
+
+type CallResult = {
+  /** Exception handed to Response.sendErrorResponse by a guard or handler. */
+  deniedWith: Exception | undefined;
+  /** Exception thrown out of the handler into express' error path. */
+  thrownToNext: unknown;
+  /** True when the final route handler was actually entered. */
+  reachedHandler: boolean;
+  jsonBody: JSONObject | undefined;
+};
+
+/*
+ * Runs a recorded route's middleware chain for real, starting at
+ * requireUserAuthentication. Index 0 is getUserMiddleware, whose only job
+ * is to populate the session fields these fixtures set directly — running
+ * it would need a live session store and prove nothing about
+ * authorization.
+ */
+async function callRoute(data: {
+  uri: string;
+  request: JSONObject;
+  body: JSONObject;
+}): Promise<CallResult> {
+  const route: RecordedRoute = findRoute(data.uri);
+
+  const req: ExpressRequest = {
+    ...data.request,
+    body: data.body,
+    params: {},
+    query: {},
+    headers: { "user-agent": "jest-agent" },
+  } as unknown as ExpressRequest;
+
+  const res: ExpressResponse = {
+    setHeader: (): void => {
+      // no-op
+    },
+    send: (): void => {
+      // no-op
+    },
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as ExpressResponse;
+
+  /*
+   * Held in a const container rather than in loop-scoped `let`s so the
+   * per-iteration `next` closures never capture a mutable outer binding.
+   */
+  const outcome: { thrownToNext: unknown; reachedHandler: boolean } = {
+    thrownToNext: undefined,
+    reachedHandler: false,
+  };
+
+  for (let index: number = 1; index < route.handlers.length; index++) {
+    const handler: RouterFunction | undefined = route.handlers[index];
+
+    if (!handler) {
+      break;
+    }
+
+    if (index === route.handlers.length - 1) {
+      outcome.reachedHandler = true;
+    }
+
+    const step: { calledNext: boolean } = { calledNext: false };
+
+    const next: NextFunction = ((error?: unknown): void => {
+      step.calledNext = true;
+
+      if (error) {
+        outcome.thrownToNext = error;
+      }
+    }) as unknown as NextFunction;
+
+    await handler(req, res, next);
+
+    // A guard that answered the request itself never calls next.
+    if (!step.calledNext) {
+      break;
+    }
+  }
+
+  const sendErrorResponse: jest.Mock =
+    Response.sendErrorResponse as unknown as jest.Mock;
+  const sendJsonObjectResponse: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+
+  const errorCall: Array<unknown> | undefined = sendErrorResponse.mock
+    .calls[0] as Array<unknown> | undefined;
+  const jsonCall: Array<unknown> | undefined = sendJsonObjectResponse.mock
+    .calls[0] as Array<unknown> | undefined;
+
+  return {
+    deniedWith: errorCall ? (errorCall[2] as Exception) : undefined,
+    thrownToNext: outcome.thrownToNext,
+    reachedHandler: outcome.reachedHandler,
+    jsonBody: jsonCall ? (jsonCall[2] as JSONObject) : undefined,
+  };
+}
+
+function buildPrincipal(data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+  permissions: Array<Permission>;
+}): {
+  request: JSONObject;
+  databaseProps: DatabaseCommonInteractionProps;
+} {
+  /*
+   * isBlockPermission must be an explicit false:
+   * DatabaseCommonInteractionPropsUtil.getUserPermissions filters tenant
+   * permissions with a strict `=== false`, so an undefined would silently
+   * drop every permission the fixture grants.
+   */
+  const userPermissions: Array<UserPermission> = data.permissions.map(
+    (permission: Permission): UserPermission => {
+      return {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+        isBlockPermission: false,
+      };
+    },
+  );
+
+  const tenantPermission: UserTenantAccessPermission = {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: userPermissions,
+  };
+
+  const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+  permissionMap[data.projectId.toString()] = tenantPermission;
+
+  return {
+    request: {
+      userType: UserType.User,
+      tenantId: data.projectId,
+      userTenantAccessPermission: permissionMap,
+      userAuthorization: { userId: data.userId },
+    } as unknown as JSONObject,
+    databaseProps: {
+      tenantId: data.projectId,
+      userId: data.userId,
+      userType: UserType.User,
+      userTenantAccessPermission: permissionMap,
+    },
+  };
+}
+
+describe("Log error pattern API", () => {
+  let projectId: ObjectID;
+  let userId: ObjectID;
+
+  /*
+   * A structural view of the spies rather than jest's own SpyInstance
+   * alias. spyOn returns a type carrying the spied method's exact
+   * signature, which neither assigns to the bare alias nor survives an
+   * explicit generic instantiation across jest type versions — and every
+   * assertion below only needs the three members named here.
+   */
+  interface AggregationSpy {
+    mock: { calls: Array<Array<unknown>> };
+    mockResolvedValue: (value: Array<unknown>) => unknown;
+    mockRejectedValue: (value: unknown) => unknown;
+  }
+
+  function spyOnAggregation(
+    method: keyof typeof LogAggregationService,
+  ): AggregationSpy {
+    const spy: AggregationSpy = jest.spyOn(
+      LogAggregationService,
+      method as never,
+    ) as unknown as AggregationSpy;
+
+    // Default every read to "no rows"; individual tests override.
+    spy.mockResolvedValue([]);
+
+    return spy;
+  }
+
+  function firstRequest(spy: AggregationSpy): JSONObject {
+    return spy.mock.calls[0]?.[0] as JSONObject;
+  }
+
+  interface AggregationSpies {
+    topErrors: AggregationSpy;
+    timeline: AggregationSpy;
+    coOccurrence: AggregationSpy;
+    attributes: AggregationSpy;
+    resources: AggregationSpy;
+    traces: AggregationSpy;
+    samples: AggregationSpy;
+  }
+
+  let spies: AggregationSpies;
+
+  beforeAll(() => {
+    recordedRoutes.length = 0;
+    /*
+     * Loaded lazily rather than with a top-level import: TelemetryAPI calls
+     * Express.getRouter() at module scope, so a static import would run the
+     * mock factory before `telemetryRouter` is initialised and die in the
+     * temporal dead zone.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../../../Server/API/TelemetryAPI");
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    projectId = ObjectID.generate();
+    userId = ObjectID.generate();
+
+    spies = {
+      topErrors: spyOnAggregation("getTopErrorPatterns"),
+      timeline: spyOnAggregation("getErrorPatternTimeline"),
+      coOccurrence: spyOnAggregation("getErrorPatternCoOccurrences"),
+      attributes: spyOnAggregation("getErrorPatternAttributes"),
+      resources: spyOnAggregation("getErrorPatternResources"),
+      traces: spyOnAggregation("getErrorPatternTraces"),
+      samples: spyOnAggregation("getErrorPatternSamples"),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockProps(props: DatabaseCommonInteractionProps): void {
+    jest
+      .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+      .mockResolvedValue(props);
+  }
+
+  function asViewer(): JSONObject {
+    const principal: {
+      request: JSONObject;
+      databaseProps: DatabaseCommonInteractionProps;
+    } = buildPrincipal({
+      projectId,
+      userId,
+      permissions: [Permission.ProjectMember, Permission.TelemetryViewer],
+    });
+
+    mockProps(principal.databaseProps);
+
+    return principal.request;
+  }
+
+  describe("route registration and access control", () => {
+    test("both routes are registered as POST", () => {
+      expect(findRoute(PATTERNS_ROUTE)).toBeDefined();
+      expect(findRoute(CORRELATION_ROUTE)).toBeDefined();
+    });
+
+    test("both routes sit behind the same guard chain as the other log reads", () => {
+      const patterns: RecordedRoute = findRoute(PATTERNS_ROUTE);
+      const correlation: RecordedRoute = findRoute(CORRELATION_ROUTE);
+      const histogram: RecordedRoute = findRoute("/telemetry/logs/histogram");
+
+      /*
+       * Compared against the existing histogram route rather than a
+       * hardcoded count: these endpoints read the same table, so they must
+       * be guarded by the same middleware, whatever that chain becomes.
+       */
+      expect(patterns.handlers.length).toBe(histogram.handlers.length);
+      expect(correlation.handlers.length).toBe(histogram.handlers.length);
+
+      for (
+        let index: number = 0;
+        index < histogram.handlers.length - 1;
+        index++
+      ) {
+        expect(patterns.handlers[index]).toBe(histogram.handlers[index]);
+        expect(correlation.handlers[index]).toBe(histogram.handlers[index]);
+      }
+    });
+
+    test.each([PATTERNS_ROUTE, CORRELATION_ROUTE])(
+      "%s denies a principal with no telemetry read permission",
+      async (uri: string) => {
+        const principal: {
+          request: JSONObject;
+          databaseProps: DatabaseCommonInteractionProps;
+        } = buildPrincipal({
+          projectId,
+          userId,
+          permissions: [Permission.CreateProjectApiKey],
+        });
+
+        mockProps(principal.databaseProps);
+
+        const result: CallResult = await callRoute({
+          uri,
+          request: principal.request,
+          body: { pattern: "boom" },
+        });
+
+        expect(result.reachedHandler).toBe(false);
+        expect(result.deniedWith).toBeDefined();
+        expect(spies.topErrors.mock.calls.length).toBe(0);
+        expect(spies.timeline.mock.calls.length).toBe(0);
+      },
+    );
+
+    test.each([PATTERNS_ROUTE, CORRELATION_ROUTE])(
+      "%s refuses a session with no project",
+      async (uri: string) => {
+        const principal: {
+          request: JSONObject;
+          databaseProps: DatabaseCommonInteractionProps;
+        } = buildPrincipal({
+          projectId,
+          userId,
+          permissions: [Permission.ProjectMember, Permission.TelemetryViewer],
+        });
+
+        mockProps({
+          ...principal.databaseProps,
+          tenantId: undefined,
+        } as DatabaseCommonInteractionProps);
+
+        const result: CallResult = await callRoute({
+          uri,
+          request: principal.request,
+          body: { pattern: "boom" },
+        });
+
+        expect(result.deniedWith?.message).toBe("Invalid Project ID");
+        expect(spies.topErrors.mock.calls.length).toBe(0);
+      },
+    );
+  });
+
+  describe("POST /telemetry/logs/error-patterns", () => {
+    test("defaults to a 24 hour window ending now", async () => {
+      const before: number = Date.now();
+
+      await callRoute({ uri: PATTERNS_ROUTE, request: asViewer(), body: {} });
+
+      const request: TopErrorPatternsRequest = firstRequest(
+        spies.topErrors,
+      ) as unknown as TopErrorPatternsRequest;
+
+      /*
+       * A day, not the histogram's hour: "top errors" is a question about a
+       * period long enough for a pattern to establish itself, and an hour
+       * of a quiet service routinely has nothing in it.
+       */
+      const spanMs: number =
+        request.endTime.getTime() - request.startTime.getTime();
+
+      expect(spanMs).toBe(24 * 60 * 60 * 1000);
+      expect(request.endTime.getTime()).toBeGreaterThanOrEqual(before);
+      expect(request.projectId.toString()).toBe(projectId.toString());
+    });
+
+    test("an explicit window is used verbatim", async () => {
+      await callRoute({
+        uri: PATTERNS_ROUTE,
+        request: asViewer(),
+        body: {
+          startTime: "2026-08-01T00:00:00.000Z",
+          endTime: "2026-08-02T00:00:00.000Z",
+        },
+      });
+
+      const request: TopErrorPatternsRequest = firstRequest(
+        spies.topErrors,
+      ) as unknown as TopErrorPatternsRequest;
+
+      expect(request.startTime.toISOString()).toBe("2026-08-01T00:00:00.000Z");
+      expect(request.endTime.toISOString()).toBe("2026-08-02T00:00:00.000Z");
+    });
+
+    test("a start time alone anchors its 24 hours to now", async () => {
+      await callRoute({
+        uri: PATTERNS_ROUTE,
+        request: asViewer(),
+        body: { startTime: "2026-08-01T00:00:00.000Z" },
+      });
+
+      const request: TopErrorPatternsRequest = firstRequest(
+        spies.topErrors,
+      ) as unknown as TopErrorPatternsRequest;
+
+      expect(request.startTime.toISOString()).toBe("2026-08-01T00:00:00.000Z");
+      expect(request.endTime.getTime()).toBeGreaterThan(
+        new Date("2026-08-01T00:00:00.000Z").getTime(),
+      );
+    });
+
+    test("threads scope fields through and maps service ids to ObjectIDs", async () => {
+      const serviceId: ObjectID = ObjectID.generate();
+
+      await callRoute({
+        uri: PATTERNS_ROUTE,
+        request: asViewer(),
+        body: {
+          serviceIds: [serviceId.toString()],
+          severityTexts: ["Warning"],
+          entityKeys: ["host-key-1"],
+          traceIds: ["trace-1"],
+          spanIds: ["span-1"],
+          sessionIds: ["sess-1"],
+          bodySearchText: "refused",
+          attributes: { "host.name": "web-3" },
+          limit: 7,
+        },
+      });
+
+      const request: TopErrorPatternsRequest = firstRequest(
+        spies.topErrors,
+      ) as unknown as TopErrorPatternsRequest;
+
+      expect(
+        request.serviceIds?.map((id: ObjectID): string => {
+          return id.toString();
+        }),
+      ).toEqual([serviceId.toString()]);
+      expect(request.severityTexts).toEqual(["Warning"]);
+      expect(request.entityKeys).toEqual(["host-key-1"]);
+      expect(request.traceIds).toEqual(["trace-1"]);
+      expect(request.spanIds).toEqual(["span-1"]);
+      expect(request.sessionIds).toEqual(["sess-1"]);
+      expect(request.bodySearchText).toBe("refused");
+      expect(request.attributes).toEqual({ "host.name": "web-3" });
+      expect(request.limit).toBe(7);
+    });
+
+    test("empty and malformed array fields become 'no filter', never an empty predicate", async () => {
+      await callRoute({
+        uri: PATTERNS_ROUTE,
+        request: asViewer(),
+        body: {
+          serviceIds: [],
+          severityTexts: [""],
+          traceIds: "trace-1",
+          spanIds: [42, null],
+          sessionIds: null,
+          bodySearchText: "   ",
+          limit: "10",
+        },
+      });
+
+      const request: TopErrorPatternsRequest = firstRequest(
+        spies.topErrors,
+      ) as unknown as TopErrorPatternsRequest;
+
+      /*
+       * Every one of these must be undefined. An empty array reaching
+       * `IN ()` or a blank string reaching `ILIKE '%%'` would silently
+       * change which logs the page describes.
+       */
+      expect(request.serviceIds).toBeUndefined();
+      expect(request.severityTexts).toBeUndefined();
+      expect(request.traceIds).toBeUndefined();
+      expect(request.spanIds).toBeUndefined();
+      expect(request.sessionIds).toBeUndefined();
+      expect(request.bodySearchText).toBeUndefined();
+      // A stringly-typed limit is not a limit.
+      expect(request.limit).toBeUndefined();
+    });
+
+    test("returns the service's patterns under `patterns`", async () => {
+      spies.topErrors.mockResolvedValue([
+        {
+          pattern: "connection refused to <ip>",
+          sampleBody: "connection refused to 10.0.0.4",
+          count: 30,
+          firstSeenAt: "2026-08-19 03:00:00.000000000",
+          lastSeenAt: "2026-08-20 22:14:02.000000000",
+          resourceCount: 1,
+          resourceIds: ["svc-a"],
+          severities: ["Error"],
+          traceCount: 2,
+          sampleTraceIds: ["t1"],
+        },
+      ]);
+
+      const result: CallResult = await callRoute({
+        uri: PATTERNS_ROUTE,
+        request: asViewer(),
+        body: {},
+      });
+
+      expect(result.reachedHandler).toBe(true);
+      expect(
+        (result.jsonBody?.["patterns"] as Array<JSONObject>)[0]?.["count"],
+      ).toBe(30);
+    });
+
+    test("a failing aggregation reaches the error handler rather than a half-empty page", async () => {
+      spies.topErrors.mockRejectedValue(new Error("clickhouse is down"));
+
+      const result: CallResult = await callRoute({
+        uri: PATTERNS_ROUTE,
+        request: asViewer(),
+        body: {},
+      });
+
+      /*
+       * Unlike the correlation panel's sections, the list IS the page —
+       * showing "no errors" when the query failed would be a lie.
+       */
+      expect(result.thrownToNext).toBeInstanceOf(Error);
+      expect(result.jsonBody).toBeUndefined();
+    });
+  });
+
+  describe("POST /telemetry/logs/error-pattern-correlation", () => {
+    test("requires a pattern", async () => {
+      for (const body of [
+        {},
+        { pattern: "" },
+        { pattern: "   " },
+        { pattern: 7 },
+      ]) {
+        jest.clearAllMocks();
+
+        const result: CallResult = await callRoute({
+          uri: CORRELATION_ROUTE,
+          request: asViewer(),
+          body: body as JSONObject,
+        });
+
+        expect(result.deniedWith?.message).toBe("pattern is required");
+        expect(spies.timeline.mock.calls.length).toBe(0);
+      }
+    });
+
+    test("runs all six correlation reads against one identical request", async () => {
+      const serviceId: ObjectID = ObjectID.generate();
+
+      await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: {
+          pattern: "boom <num>",
+          serviceIds: [serviceId.toString()],
+          startTime: "2026-08-01T00:00:00.000Z",
+          endTime: "2026-08-02T00:00:00.000Z",
+        },
+      });
+
+      const detailSpies: Array<AggregationSpy> = [
+        spies.timeline,
+        spies.coOccurrence,
+        spies.attributes,
+        spies.resources,
+        spies.traces,
+        spies.samples,
+      ];
+
+      const requests: Array<ErrorPatternTimelineRequest> = detailSpies.map(
+        (spy: AggregationSpy): ErrorPatternTimelineRequest => {
+          expect(spy.mock.calls.length).toBe(1);
+          return firstRequest(spy) as unknown as ErrorPatternTimelineRequest;
+        },
+      );
+
+      /*
+       * Every section must describe the same population. A drill-down that
+       * saw a different window or a different service scope than its
+       * siblings would draw correlations that do not exist.
+       */
+      for (const request of requests) {
+        expect(request).toBe(requests[0]);
+      }
+
+      expect(requests[0]!.pattern).toBe("boom <num>");
+      expect(requests[0]!.startTime.toISOString()).toBe(
+        "2026-08-01T00:00:00.000Z",
+      );
+      expect(
+        requests[0]!.serviceIds?.map((id: ObjectID): string => {
+          return id.toString();
+        }),
+      ).toEqual([serviceId.toString()]);
+    });
+
+    test("derives a bucket size from the window when the client does not name one", async () => {
+      await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: {
+          pattern: "boom",
+          startTime: "2026-08-01T00:00:00.000Z",
+          endTime: "2026-08-01T01:00:00.000Z",
+        },
+      });
+
+      const request: ErrorPatternTimelineRequest = firstRequest(
+        spies.timeline,
+      ) as unknown as ErrorPatternTimelineRequest;
+
+      // One hour of window buckets by the minute, as the histogram does.
+      expect(request.bucketSizeInMinutes).toBe(1);
+    });
+
+    test("honours an explicit bucket size and rejects an unusable one", async () => {
+      await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: { pattern: "boom", bucketSizeInMinutes: 30 },
+      });
+
+      expect(
+        (firstRequest(spies.timeline) as unknown as ErrorPatternTimelineRequest)
+          .bucketSizeInMinutes,
+      ).toBe(30);
+
+      jest.clearAllMocks();
+
+      await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: { pattern: "boom", bucketSizeInMinutes: 0 },
+      });
+
+      /*
+       * Zero would compile to `INTERVAL 0 SECOND`, which ClickHouse
+       * rejects — fall back to the window-derived size instead.
+       */
+      expect(
+        (firstRequest(spies.timeline) as unknown as ErrorPatternTimelineRequest)
+          .bucketSizeInMinutes,
+      ).toBeGreaterThan(0);
+    });
+
+    test("returns every section plus the pattern and bucket size it used", async () => {
+      spies.timeline.mockResolvedValue([{ time: "t", count: 3 }]);
+      spies.coOccurrence.mockResolvedValue([
+        { pattern: "other", sampleBody: "other", count: 2 },
+      ]);
+      spies.attributes.mockResolvedValue([
+        { key: "host.name", value: "web-3", count: 30 },
+      ]);
+
+      const result: CallResult = await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: { pattern: "boom", bucketSizeInMinutes: 15 },
+      });
+
+      expect(result.jsonBody?.["pattern"]).toBe("boom");
+      expect(result.jsonBody?.["bucketSizeInMinutes"]).toBe(15);
+      expect(result.jsonBody?.["timeline"]).toHaveLength(1);
+      expect(result.jsonBody?.["coOccurringPatterns"]).toHaveLength(1);
+      expect(result.jsonBody?.["attributes"]).toHaveLength(1);
+      expect(result.jsonBody?.["resources"]).toEqual([]);
+      expect(result.jsonBody?.["traces"]).toEqual([]);
+      expect(result.jsonBody?.["samples"]).toEqual([]);
+    });
+
+    test("one failing section degrades to empty without taking the panel down", async () => {
+      /*
+       * The correlation panel is supplementary information. A slow or
+       * unlucky sub-query should cost the user that one section, not the
+       * whole drill-down.
+       */
+      spies.coOccurrence.mockRejectedValue(new Error("timed out"));
+      spies.timeline.mockResolvedValue([{ time: "t", count: 3 }]);
+
+      const result: CallResult = await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: { pattern: "boom" },
+      });
+
+      expect(result.thrownToNext).toBeUndefined();
+      expect(result.jsonBody?.["coOccurringPatterns"]).toEqual([]);
+      expect(result.jsonBody?.["timeline"]).toHaveLength(1);
+    });
+
+    test("every section failing still answers, with empty sections", async () => {
+      spies.timeline.mockRejectedValue(new Error("clickhouse is down"));
+      spies.coOccurrence.mockRejectedValue(new Error("clickhouse is down"));
+      spies.attributes.mockRejectedValue(new Error("clickhouse is down"));
+      spies.resources.mockRejectedValue(new Error("clickhouse is down"));
+      spies.traces.mockRejectedValue(new Error("clickhouse is down"));
+      spies.samples.mockRejectedValue(new Error("clickhouse is down"));
+
+      const result: CallResult = await callRoute({
+        uri: CORRELATION_ROUTE,
+        request: asViewer(),
+        body: { pattern: "boom" },
+      });
+
+      expect(result.thrownToNext).toBeUndefined();
+      expect(result.jsonBody?.["timeline"]).toEqual([]);
+      expect(result.jsonBody?.["samples"]).toEqual([]);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts
+++ b/Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts
@@ -1,0 +1,718 @@
+import LogAggregationService, {
+  DEFAULT_ERROR_LOG_SEVERITIES,
+  ErrorPatternAttribute,
+  ErrorPatternCoOccurrence,
+  ErrorPatternResource,
+  ErrorPatternSample,
+  ErrorPatternTimelinePoint,
+  ErrorPatternTrace,
+  TopErrorPattern,
+} from "../../../Server/Services/LogAggregationService";
+import LogDatabaseService from "../../../Server/Services/LogService";
+import { Results } from "../../../Server/Services/AnalyticsDatabaseService";
+import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import { LOG_ERROR_PATTERN_MAX_LENGTH } from "../../../Utils/Telemetry/LogErrorPattern";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The error-pattern reads are what turn the Logs Insights page from a pile
+ * of counters into an answer. Every one of them has to satisfy the same
+ * three properties, which is what this suite pins:
+ *
+ *   1. the clustering happens in ClickHouse, over the whole window;
+ *   2. every drill-down sees EXACTLY the slice the top-list saw (same
+ *      window, same severities, same resource scope) — a panel that
+ *      quietly widened its own scope would show correlations that are not
+ *      real;
+ *   3. nothing a caller supplies reaches the SQL text.
+ */
+
+const projectId: ObjectID = ObjectID.generate();
+const startTime: Date = new Date("2026-08-19T00:00:00.000Z");
+const endTime: Date = new Date("2026-08-21T00:00:00.000Z");
+const pattern: string = "connection refused to <ip>:<num>";
+
+/*
+ * Stub the ClickHouse boundary and capture the Statements handed to it, so
+ * the public (async) read methods can be exercised without a database —
+ * the same pattern the sibling LogAggregationService suite uses.
+ */
+function stubAndCapture(rows: Array<JSONObject>): Array<Statement> {
+  const captured: Array<Statement> = [];
+  const fakeResult: Results = {
+    json: () => {
+      return Promise.resolve({ data: rows });
+    },
+  } as unknown as Results;
+
+  jest
+    .spyOn(LogDatabaseService, "executeQuery")
+    .mockImplementation((statement: Statement | string): Promise<Results> => {
+      captured.push(statement as Statement);
+      return Promise.resolve(fakeResult);
+    });
+
+  return captured;
+}
+
+function baseFilters(): {
+  projectId: ObjectID;
+  startTime: Date;
+  endTime: Date;
+} {
+  return { projectId, startTime, endTime };
+}
+
+function detailRequest(overrides: Record<string, unknown> = {}): any {
+  return {
+    ...baseFilters(),
+    pattern,
+    bucketSizeInMinutes: 60,
+    ...overrides,
+  };
+}
+
+/** Every async error-pattern read, so shared invariants can be swept. */
+const DETAIL_READS: Array<{
+  name: string;
+  run: (request: any) => Promise<unknown>;
+}> = [
+  {
+    name: "timeline",
+    run: (request: any) => {
+      return LogAggregationService.getErrorPatternTimeline(request);
+    },
+  },
+  {
+    name: "co-occurrences",
+    run: (request: any) => {
+      return LogAggregationService.getErrorPatternCoOccurrences(request);
+    },
+  },
+  {
+    name: "attributes",
+    run: (request: any) => {
+      return LogAggregationService.getErrorPatternAttributes(request);
+    },
+  },
+  {
+    name: "resources",
+    run: (request: any) => {
+      return LogAggregationService.getErrorPatternResources(request);
+    },
+  },
+  {
+    name: "traces",
+    run: (request: any) => {
+      return LogAggregationService.getErrorPatternTraces(request);
+    },
+  },
+  {
+    name: "samples",
+    run: (request: any) => {
+      return LogAggregationService.getErrorPatternSamples(request);
+    },
+  },
+];
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("getTopErrorPatterns", () => {
+  test("groups in the database and returns one row per pattern", async () => {
+    const captured: Array<Statement> = stubAndCapture([
+      {
+        pattern,
+        cnt: 30,
+        sampleBody: "connection refused to 10.0.0.4:5432",
+        firstSeen: "2026-08-19 03:00:00.000000000",
+        lastSeen: "2026-08-20 22:14:02.000000000",
+        resourceCount: 2,
+        resourceIds: ["svc-a", "svc-b"],
+        severities: ["Error"],
+        traceCount: 4,
+        sampleTraceIds: ["t1", "t2"],
+      },
+    ]);
+
+    const patterns: Array<TopErrorPattern> =
+      await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.query).toContain("GROUP BY pattern");
+    expect(captured[0]!.query).toContain("ORDER BY cnt DESC");
+    expect(captured[0]!.query).toContain("replaceRegexpAll(");
+
+    expect(patterns).toEqual([
+      {
+        pattern,
+        sampleBody: "connection refused to 10.0.0.4:5432",
+        count: 30,
+        firstSeenAt: "2026-08-19 03:00:00.000000000",
+        lastSeenAt: "2026-08-20 22:14:02.000000000",
+        resourceCount: 2,
+        resourceIds: ["svc-a", "svc-b"],
+        severities: ["Error"],
+        traceCount: 4,
+        sampleTraceIds: ["t1", "t2"],
+      },
+    ]);
+  });
+
+  test("selects the first-seen, last-seen and reach columns the list needs", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    const query: string = captured[0]!.query;
+
+    expect(query).toContain("min(time) AS firstSeen");
+    expect(query).toContain("max(time) AS lastSeen");
+    expect(query).toContain("uniqExact(primaryEntityId) AS resourceCount");
+    expect(query).toContain("argMax(ifNull(body, ''), time) AS sampleBody");
+    /*
+     * Trace reach must ignore the Nullable column's NULLs explicitly:
+     * `traceId != ''` alone is NULL for a log with no trace, and a NULL
+     * condition is not a counted one.
+     */
+    expect(query).toContain(
+      "uniqExactIf(traceId, ifNull(traceId, '') != '') AS traceCount",
+    );
+  });
+
+  test("defaults to Error and Fatal when the caller names no severities", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    expect(captured[0]!.query).toContain("AND severityText IN (");
+    expect(Object.values(captured[0]!.query_params)).toContainEqual(
+      DEFAULT_ERROR_LOG_SEVERITIES,
+    );
+  });
+
+  test("an explicit severity selection replaces the default", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      severityTexts: ["Warning"],
+    });
+
+    expect(Object.values(captured[0]!.query_params)).toContainEqual([
+      "Warning",
+    ]);
+    expect(Object.values(captured[0]!.query_params)).not.toContainEqual(
+      DEFAULT_ERROR_LOG_SEVERITIES,
+    );
+  });
+
+  test("an empty severity array is treated as 'not specified', not as 'match nothing'", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      severityTexts: [],
+    });
+
+    expect(Object.values(captured[0]!.query_params)).toContainEqual(
+      DEFAULT_ERROR_LOG_SEVERITIES,
+    );
+  });
+
+  test("excludes empty and whitespace-only bodies from the aggregation", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    expect(captured[0]!.query).toContain(
+      "AND notEmpty(trimBoth(ifNull(body, '')))",
+    );
+  });
+
+  test("applies the read-side retention filter", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    expect(captured[0]!.query).toContain("AND retentionDate >= now()");
+  });
+
+  test("threads the service scope into the read", async () => {
+    const serviceId: ObjectID = ObjectID.generate();
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      serviceIds: [serviceId],
+    });
+
+    expect(captured[0]!.query).toMatch(
+      /AND primaryEntityId IN \(\{p\d+:Array\(String\)\}\)/,
+    );
+    expect(Object.values(captured[0]!.query_params)).toContainEqual([
+      serviceId.toString(),
+    ]);
+  });
+
+  test("threads entity keys, trace/span/session scope and attribute filters", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      entityKeys: ["host-key-1"],
+      traceIds: ["trace-1"],
+      spanIds: ["span-1"],
+      sessionIds: ["sess-1"],
+      attributes: { "k8s.pod.name": "checkout-7d9" },
+    });
+
+    const query: string = captured[0]!.query;
+    const values: Array<unknown> = Object.values(captured[0]!.query_params);
+
+    expect(query).toContain("hasAny(entityKeys,");
+    expect(query).toMatch(/AND traceId IN \(\{p\d+:Array\(String\)\}\)/);
+    expect(query).toMatch(/AND spanId IN \(\{p\d+:Array\(String\)\}\)/);
+    expect(query).toMatch(/AND sessionId IN \(\{p\d+:Array\(String\)\}\)/);
+    expect(query).toContain("arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(");
+    expect(values).toContainEqual(["host-key-1"]);
+    expect(values).toContain("checkout-7d9");
+  });
+
+  test("clamps the limit into range and defaults when it is absent or nonsense", async () => {
+    const limitOf: (statement: Statement) => number = (
+      statement: Statement,
+    ): number => {
+      const numbers: Array<number> = Object.values(
+        statement.query_params,
+      ).filter((value: unknown): value is number => {
+        return typeof value === "number";
+      });
+
+      // The trailing LIMIT is the last bound number in the statement.
+      return numbers[numbers.length - 1]!;
+    };
+
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns(baseFilters());
+    expect(limitOf(captured[0]!)).toBe(10);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      limit: 5000,
+    });
+    expect(limitOf(captured[1]!)).toBe(50);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      limit: 0,
+    });
+    expect(limitOf(captured[2]!)).toBe(1);
+
+    await LogAggregationService.getTopErrorPatterns({
+      ...baseFilters(),
+      limit: Number.NaN,
+    });
+    expect(limitOf(captured[3]!)).toBe(10);
+  });
+
+  test("drops rows whose pattern came back empty", async () => {
+    stubAndCapture([
+      { pattern: "", cnt: 9 },
+      { pattern, cnt: 3 },
+    ]);
+
+    const patterns: Array<TopErrorPattern> =
+      await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    expect(
+      patterns.map((p: TopErrorPattern) => {
+        return p.pattern;
+      }),
+    ).toEqual([pattern]);
+  });
+
+  test("coerces malformed array aggregates instead of throwing", async () => {
+    stubAndCapture([
+      {
+        pattern,
+        cnt: "12",
+        resourceIds: "not-an-array",
+        severities: ["Error", null, ""],
+        sampleTraceIds: null,
+      },
+    ]);
+
+    const patterns: Array<TopErrorPattern> =
+      await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    expect(patterns[0]!.count).toBe(12);
+    expect(patterns[0]!.resourceIds).toEqual([]);
+    expect(patterns[0]!.severities).toEqual(["Error"]);
+    expect(patterns[0]!.sampleTraceIds).toEqual([]);
+  });
+
+  test("caps the sampled id arrays so a hot pattern cannot return a huge row", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getTopErrorPatterns(baseFilters());
+
+    /*
+     * Inlined constants, not bound parameters: these are the parameters of
+     * a parametric aggregate function, which ClickHouse requires to be
+     * constants.
+     */
+    expect(captured[0]!.query).toContain(
+      "groupUniqArray(5)(toString(primaryEntityId)) AS resourceIds",
+    );
+    expect(captured[0]!.query).toContain(
+      "groupUniqArray(8)(toString(severityText)) AS severities",
+    );
+    expect(captured[0]!.query).toContain(
+      "groupUniqArrayIf(5)(ifNull(traceId, ''), ifNull(traceId, '') != '') AS sampleTraceIds",
+    );
+  });
+});
+
+describe("error-pattern drill-downs share the top list's scope", () => {
+  test.each(DETAIL_READS)(
+    "$name scopes to the pattern, the window and the default severities",
+    async ({ run }: { run: (request: any) => Promise<unknown> }) => {
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await run(detailRequest());
+
+      const statement: Statement = captured[0]!;
+      const values: Array<unknown> = Object.values(statement.query_params);
+
+      expect(statement.query).toContain("replaceRegexpAll(");
+      expect(values).toContain(pattern);
+      expect(values).toContainEqual(DEFAULT_ERROR_LOG_SEVERITIES);
+      expect(statement.query).toContain("AND retentionDate >= now()");
+      expect(statement.query).toContain(
+        "AND notEmpty(trimBoth(ifNull(body, '')))",
+      );
+    },
+  );
+
+  test.each(DETAIL_READS)(
+    "$name carries the caller's service scope",
+    async ({ run }: { run: (request: any) => Promise<unknown> }) => {
+      const serviceId: ObjectID = ObjectID.generate();
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await run(detailRequest({ serviceIds: [serviceId] }));
+
+      expect(Object.values(captured[0]!.query_params)).toContainEqual([
+        serviceId.toString(),
+      ]);
+    },
+  );
+
+  test.each(DETAIL_READS)(
+    "$name never puts the caller's pattern into the query text",
+    async ({ run }: { run: (request: any) => Promise<unknown> }) => {
+      const injection: string =
+        "x' OR 1=1 UNION ALL SELECT version() FROM system.one -- ";
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await run(detailRequest({ pattern: injection }));
+
+      expect(captured[0]!.query).not.toContain("UNION");
+      expect(captured[0]!.query).not.toContain(injection);
+      expect(Object.values(captured[0]!.query_params)).toContain(injection);
+    },
+  );
+
+  test.each(DETAIL_READS)(
+    "$name clamps an oversized pattern to the expression's own maximum",
+    async ({ run }: { run: (request: any) => Promise<unknown> }) => {
+      const oversized: string = "y".repeat(LOG_ERROR_PATTERN_MAX_LENGTH * 4);
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await run(detailRequest({ pattern: oversized }));
+
+      const echoed: Array<string> = Object.values(
+        captured[0]!.query_params,
+      ).filter((value: unknown): value is string => {
+        return typeof value === "string" && value.startsWith("yyy");
+      });
+
+      expect(echoed.length).toBeGreaterThan(0);
+      for (const value of echoed) {
+        expect(value.length).toBe(LOG_ERROR_PATTERN_MAX_LENGTH);
+      }
+    },
+  );
+
+  test.each(DETAIL_READS)(
+    "$name bounds its runtime below the client request timeout",
+    async ({ run }: { run: (request: any) => Promise<unknown> }) => {
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await run(detailRequest());
+
+      expect(captured[0]!.query).toContain("max_execution_time = 45");
+      expect(captured[0]!.query).toContain("timeout_overflow_mode = 'break'");
+      expect(captured[0]!.query).toContain("max_memory_usage =");
+    },
+  );
+});
+
+describe("getErrorPatternTimeline", () => {
+  test("buckets by the requested interval, in seconds", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getErrorPatternTimeline(
+      detailRequest({ bucketSizeInMinutes: 15 }),
+    );
+
+    expect(captured[0]!.query).toMatch(
+      /toStartOfInterval\(time, INTERVAL \{p\d+:Int32\} SECOND\) AS bucket/,
+    );
+    expect(Object.values(captured[0]!.query_params)).toContain(15 * 60);
+    expect(captured[0]!.query).toContain("ORDER BY bucket ASC");
+  });
+
+  test.each([0, -5, Number.NaN, undefined])(
+    "an unusable bucket size (%s) never compiles to INTERVAL 0",
+    async (bucketSizeInMinutes: number | undefined) => {
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await LogAggregationService.getErrorPatternTimeline(
+        detailRequest({ bucketSizeInMinutes }),
+      );
+
+      const seconds: Array<number> = Object.values(
+        captured[0]!.query_params,
+      ).filter((value: unknown): value is number => {
+        return typeof value === "number";
+      });
+
+      for (const value of seconds) {
+        expect(value).toBeGreaterThan(0);
+      }
+    },
+  );
+
+  test("maps rows to time/count points", async () => {
+    stubAndCapture([
+      { bucket: "2026-08-20 10:00:00.000000000", cnt: 4 },
+      { bucket: "2026-08-20 11:00:00.000000000", cnt: 0 },
+    ]);
+
+    const points: Array<ErrorPatternTimelinePoint> =
+      await LogAggregationService.getErrorPatternTimeline(detailRequest());
+
+    expect(points).toEqual([
+      { time: "2026-08-20 10:00:00.000000000", count: 4 },
+      { time: "2026-08-20 11:00:00.000000000", count: 0 },
+    ]);
+  });
+});
+
+describe("getErrorPatternCoOccurrences", () => {
+  test("restricts to the buckets the investigated pattern landed in, and excludes itself", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getErrorPatternCoOccurrences(detailRequest());
+
+    const query: string = captured[0]!.query;
+
+    // The self-exclusion...
+    expect(query).toMatch(/!= \{p\d+:String\}/);
+    // ...and the temporal join onto the investigated pattern's own buckets.
+    expect(query).toContain("IN (SELECT DISTINCT toStartOfInterval(time,");
+    expect(query).toContain("GROUP BY pattern");
+  });
+
+  test("the inner bucket subquery is scoped identically to the outer read", async () => {
+    const serviceId: ObjectID = ObjectID.generate();
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getErrorPatternCoOccurrences(
+      detailRequest({ serviceIds: [serviceId] }),
+    );
+
+    const query: string = captured[0]!.query;
+
+    /*
+     * Two WHERE clauses (outer + subquery), two retention filters, two
+     * severity predicates, two service predicates. A subquery that skipped
+     * any of them would collect buckets from logs the outer query cannot
+     * see, and every "co-occurring" error would be correlated against the
+     * wrong timeline.
+     */
+    expect((query.match(/ WHERE projectId = /g) || []).length).toBe(2);
+    expect((query.match(/AND retentionDate >= now\(\)/g) || []).length).toBe(2);
+    expect((query.match(/AND severityText IN \(/g) || []).length).toBe(2);
+    expect((query.match(/AND primaryEntityId IN \(/g) || []).length).toBe(2);
+  });
+
+  test("maps rows and drops empty patterns", async () => {
+    stubAndCapture([
+      { pattern: "upstream timed out", cnt: 7, sampleBody: "upstream timed" },
+      { pattern: "", cnt: 3 },
+    ]);
+
+    const rows: Array<ErrorPatternCoOccurrence> =
+      await LogAggregationService.getErrorPatternCoOccurrences(detailRequest());
+
+    expect(rows).toEqual([
+      { pattern: "upstream timed out", count: 7, sampleBody: "upstream timed" },
+    ]);
+  });
+});
+
+describe("getErrorPatternAttributes", () => {
+  test("array-joins over a pre-filtered subquery, not the raw table", async () => {
+    const captured: Array<Statement> = stubAndCapture([]);
+
+    await LogAggregationService.getErrorPatternAttributes(detailRequest());
+
+    const query: string = captured[0]!.query;
+
+    /*
+     * Written flat, the ARRAY JOIN explodes the whole window into one row
+     * per attribute before the pattern predicate narrows it. The subquery
+     * is what keeps a tooltip-sized answer from costing a twentyfold scan.
+     */
+    expect(query).toContain("FROM (SELECT attributes FROM");
+    expect(query).toContain(
+      ") ARRAY JOIN mapKeys(attributes) AS attrKey, mapValues(attributes) AS attrValue",
+    );
+    expect(query.indexOf("ARRAY JOIN")).toBeGreaterThan(
+      query.indexOf("WHERE projectId"),
+    );
+    expect(query).toContain("GROUP BY attrKey, attrValue");
+  });
+
+  test("maps key/value/count rows and drops keyless ones", async () => {
+    stubAndCapture([
+      { attrKey: "host.name", attrValue: "web-3", cnt: 30 },
+      { attrKey: "", attrValue: "orphan", cnt: 1 },
+    ]);
+
+    const rows: Array<ErrorPatternAttribute> =
+      await LogAggregationService.getErrorPatternAttributes(detailRequest());
+
+    expect(rows).toEqual([{ key: "host.name", value: "web-3", count: 30 }]);
+  });
+});
+
+describe("getErrorPatternResources", () => {
+  test("groups by the resource the log belongs to and keeps its type", async () => {
+    const captured: Array<Statement> = stubAndCapture([
+      {
+        resourceId: "svc-1",
+        resourceType: "Host",
+        cnt: 21,
+        lastSeen: "2026-08-20 22:00:00.000000000",
+      },
+    ]);
+
+    const rows: Array<ErrorPatternResource> =
+      await LogAggregationService.getErrorPatternResources(detailRequest());
+
+    expect(captured[0]!.query).toContain("GROUP BY resourceId");
+    /*
+     * primaryEntityType is Nullable — a row written before the
+     * discriminator existed would otherwise surface as a null resource
+     * type and break the UI's dispatch to the right detail page.
+     */
+    expect(captured[0]!.query).toContain(
+      "any(ifNull(primaryEntityType, '')) AS resourceType",
+    );
+
+    expect(rows).toEqual([
+      {
+        resourceId: "svc-1",
+        resourceType: "Host",
+        count: 21,
+        lastSeenAt: "2026-08-20 22:00:00.000000000",
+      },
+    ]);
+  });
+});
+
+describe("getErrorPatternTraces", () => {
+  test("excludes logs with no trace instead of returning an empty trace id", async () => {
+    const captured: Array<Statement> = stubAndCapture([
+      {
+        traceId: "abc",
+        cnt: 3,
+        lastSeen: "2026-08-20 22:00:00.000000000",
+        resourceId: "svc-1",
+      },
+      { traceId: "", cnt: 99 },
+    ]);
+
+    const rows: Array<ErrorPatternTrace> =
+      await LogAggregationService.getErrorPatternTraces(detailRequest());
+
+    expect(captured[0]!.query).toContain("AND ifNull(traceId, '') != ''");
+    expect(rows).toEqual([
+      {
+        traceId: "abc",
+        count: 3,
+        lastSeenAt: "2026-08-20 22:00:00.000000000",
+        resourceId: "svc-1",
+      },
+    ]);
+  });
+});
+
+describe("getErrorPatternSamples", () => {
+  test("returns the newest raw lines with their correlation ids", async () => {
+    const captured: Array<Statement> = stubAndCapture([
+      {
+        _id: "log-1",
+        time: "2026-08-20 22:00:00.000000000",
+        body: "connection refused to 10.0.0.4:5432",
+        severityText: "Error",
+        resourceId: "svc-1",
+        traceId: "abc",
+        spanId: "def",
+      },
+    ]);
+
+    const rows: Array<ErrorPatternSample> =
+      await LogAggregationService.getErrorPatternSamples(detailRequest());
+
+    expect(captured[0]!.query).toContain("ORDER BY time DESC");
+    expect(rows).toEqual([
+      {
+        logId: "log-1",
+        time: "2026-08-20 22:00:00.000000000",
+        body: "connection refused to 10.0.0.4:5432",
+        severityText: "Error",
+        resourceId: "svc-1",
+        traceId: "abc",
+        spanId: "def",
+      },
+    ]);
+  });
+
+  test("a row missing every optional field maps to empty strings, not undefined", async () => {
+    stubAndCapture([{}]);
+
+    const rows: Array<ErrorPatternSample> =
+      await LogAggregationService.getErrorPatternSamples(detailRequest());
+
+    expect(rows).toEqual([
+      {
+        logId: "",
+        time: "",
+        body: "",
+        severityText: "",
+        resourceId: "",
+        traceId: "",
+        spanId: "",
+      },
+    ]);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts
@@ -1,0 +1,130 @@
+import {
+  LOG_ERROR_PATTERN_SOURCE_EXPRESSION,
+  buildLogErrorPatternExpression,
+  clampLogErrorPattern,
+  getLogErrorPatternParameterCount,
+} from "../../../../Server/Utils/Telemetry/LogErrorPatternSql";
+import { Statement } from "../../../../Server/Utils/AnalyticsDatabase/Statement";
+import {
+  LOG_ERROR_PATTERN_MAX_LENGTH,
+  LOG_ERROR_PATTERN_RULES,
+  LogErrorPatternRule,
+} from "../../../../Utils/Telemetry/LogErrorPattern";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The SQL compiler and the JavaScript normalizer must stay two views of one
+ * rule table. If they drift, the Insights page groups errors one way in the
+ * database and describes them another way in the browser — a discrepancy
+ * that is invisible until someone notices the counts do not add up.
+ */
+
+describe("buildLogErrorPatternExpression", () => {
+  test("nests one replaceRegexpAll per rule around the body expression", () => {
+    const statement: Statement = buildLogErrorPatternExpression();
+
+    const openCount: number = (
+      statement.query.match(/replaceRegexpAll\(/g) || []
+    ).length;
+
+    expect(openCount).toBe(LOG_ERROR_PATTERN_RULES.length);
+    expect(statement.query).toContain(LOG_ERROR_PATTERN_SOURCE_EXPRESSION);
+  });
+
+  test("coalesces the Nullable body column before rewriting it", () => {
+    /*
+     * `replaceRegexpAll(NULL, ...)` is NULL, which would collapse every
+     * body-less row into one meaningless NULL group at the top of the list.
+     */
+    expect(LOG_ERROR_PATTERN_SOURCE_EXPRESSION).toBe("ifNull(body, '')");
+    expect(buildLogErrorPatternExpression().query).toContain(
+      "replaceRegexpAll(ifNull(body, '')",
+    );
+  });
+
+  test("binds every rule pattern and replacement as a parameter, never as SQL text", () => {
+    const statement: Statement = buildLogErrorPatternExpression();
+    const values: Array<unknown> = Object.values(statement.query_params);
+
+    for (const rule of LOG_ERROR_PATTERN_RULES) {
+      expect(values).toContain(rule.pattern);
+      expect(values).toContain(rule.replacement);
+      /*
+       * A regex spliced into the query text would be both an injection
+       * surface and a quoting nightmare (every rule contains backslashes).
+       */
+      expect(statement.query).not.toContain(rule.pattern);
+    }
+  });
+
+  test("applies rules innermost-first, matching the normalizer's iteration order", () => {
+    const statement: Statement = buildLogErrorPatternExpression();
+    const params: Record<string, unknown> = statement.query_params;
+
+    LOG_ERROR_PATTERN_RULES.forEach(
+      (rule: LogErrorPatternRule, index: number): void => {
+        expect(params[`p${index * 2}`]).toBe(rule.pattern);
+        expect(params[`p${index * 2 + 1}`]).toBe(rule.replacement);
+      },
+    );
+  });
+
+  test("truncates to the same maximum length the normalizer slices at", () => {
+    const statement: Statement = buildLogErrorPatternExpression();
+
+    expect(statement.query).toContain("substring(");
+    expect(Object.values(statement.query_params)).toContain(
+      LOG_ERROR_PATTERN_MAX_LENGTH,
+    );
+  });
+
+  test("trims on both sides of the truncation, as the normalizer does", () => {
+    /*
+     * trim -> slice -> trim. Without the outer trim a cut landing mid-space
+     * would yield a pattern with a trailing space, which is a different
+     * GROUP BY key from the same pattern trimmed.
+     */
+    const query: string = buildLogErrorPatternExpression().query;
+
+    expect(query.startsWith("trimBoth(substring(trimBoth(")).toBe(true);
+    expect(query.endsWith("))")).toBe(true);
+  });
+
+  test("reports its own parameter count", () => {
+    const statement: Statement = buildLogErrorPatternExpression();
+
+    expect(getLogErrorPatternParameterCount()).toBe(
+      Object.keys(statement.query_params).length,
+    );
+  });
+
+  test("accepts an alternate trusted source expression", () => {
+    const statement: Statement = buildLogErrorPatternExpression(
+      "ifNull(attributes['message'], '')",
+    );
+
+    expect(statement.query).toContain(
+      "replaceRegexpAll(ifNull(attributes['message'], '')",
+    );
+  });
+});
+
+describe("clampLogErrorPattern", () => {
+  test("leaves a pattern within the limit untouched", () => {
+    expect(clampLogErrorPattern("connection refused to <ip>")).toBe(
+      "connection refused to <ip>",
+    );
+  });
+
+  test("clamps an oversized pattern to the expression's own maximum", () => {
+    const oversized: string = "x".repeat(LOG_ERROR_PATTERN_MAX_LENGTH * 3);
+
+    expect(clampLogErrorPattern(oversized).length).toBe(
+      LOG_ERROR_PATTERN_MAX_LENGTH,
+    );
+  });
+
+  test("an empty pattern clamps to itself", () => {
+    expect(clampLogErrorPattern("")).toBe("");
+  });
+});

--- a/Common/Tests/Utils/Telemetry/CrossSignalScope.test.ts
+++ b/Common/Tests/Utils/Telemetry/CrossSignalScope.test.ts
@@ -696,3 +696,85 @@ describe("toMetricsExplorerQueryParams", () => {
     });
   });
 });
+
+/*
+ * `bodyContains` exists so a Logs Insights "Top Errors" row can deep-link to
+ * the raw occurrences it counted. Only the logs grammar has a message
+ * dimension, so the other two targets must report it rather than dropping it
+ * in silence.
+ */
+describe("bodyContains", () => {
+  test("logs: becomes a body filter chip", () => {
+    const result: CrossSignalQueryParams = toLogsExplorerQueryParams({
+      bodyContains: "connection refused",
+    });
+
+    expect(JSON.parse(result.params["filters"] as string)).toContainEqual([
+      "body",
+      ["connection refused"],
+    ]);
+    expect(result.dropped).toEqual([]);
+  });
+
+  test("logs: rides alongside severity, service and window scope", () => {
+    const result: CrossSignalQueryParams = toLogsExplorerQueryParams({
+      ...fullScope(),
+      bodyContains: "connection refused",
+    });
+
+    const filters: Array<[string, Array<string>]> = JSON.parse(
+      result.params["filters"] as string,
+    );
+
+    expect(filters).toContainEqual(["body", ["connection refused"]]);
+    expect(filters).toContainEqual(["severityText", ["Error", "Warning"]]);
+    expect(result.params["range"]).toBe(TimeRange.CUSTOM);
+  });
+
+  test("logs: a blank or whitespace-only value carries no scope", () => {
+    /*
+     * An empty body chip would match every row while telling the user their
+     * view is filtered — worse than no chip at all.
+     */
+    for (const bodyContains of ["", "   ", undefined]) {
+      const result: CrossSignalQueryParams = toLogsExplorerQueryParams({
+        bodyContains,
+      });
+
+      expect(result.params["filters"]).toBeUndefined();
+      expect(result.dropped).toEqual([]);
+    }
+  });
+
+  test("logs: surrounding whitespace is trimmed off the chip value", () => {
+    const result: CrossSignalQueryParams = toLogsExplorerQueryParams({
+      bodyContains: "  timed out  ",
+    });
+
+    expect(JSON.parse(result.params["filters"] as string)).toContainEqual([
+      "body",
+      ["timed out"],
+    ]);
+  });
+
+  test("traces and metrics report it as dropped rather than ignoring it", () => {
+    expect(
+      toTracesExplorerQueryParams({ bodyContains: "connection refused" })
+        .dropped,
+    ).toContain("bodyContains");
+
+    expect(
+      toMetricsExplorerQueryParams({ bodyContains: "connection refused" })
+        .dropped,
+    ).toContain("bodyContains");
+  });
+
+  test("traces and metrics stay silent about a blank value", () => {
+    expect(toTracesExplorerQueryParams({ bodyContains: "  " }).dropped).toEqual(
+      [],
+    );
+    expect(
+      toMetricsExplorerQueryParams({ bodyContains: "  " }).dropped,
+    ).toEqual([]);
+  });
+});

--- a/Common/Tests/Utils/Telemetry/LogErrorPattern.test.ts
+++ b/Common/Tests/Utils/Telemetry/LogErrorPattern.test.ts
@@ -1,0 +1,295 @@
+import {
+  LOG_ERROR_PATTERN_MAX_LENGTH,
+  LOG_ERROR_PATTERN_PLACEHOLDERS,
+  LOG_ERROR_PATTERN_RULES,
+  LogErrorPatternRule,
+  getErrorPatternSearchText,
+  normalizeLogBodyToErrorPattern,
+  truncateErrorPattern,
+} from "../../../Utils/Telemetry/LogErrorPattern";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * These rules decide which log lines count as "the same error" on the
+ * Insights page. Grouping too aggressively merges unrelated failures under
+ * one headline; grouping too little scatters one incident across dozens of
+ * one-count rows. Each test below pins one of those two failure directions.
+ */
+
+describe("normalizeLogBodyToErrorPattern — variable spans collapse", () => {
+  test("collapses occurrences that differ only in their variable parts", () => {
+    const first: string = normalizeLogBodyToErrorPattern(
+      "connection refused to 10.0.0.14:5432 after 1200ms (attempt 3)",
+    );
+    const second: string = normalizeLogBodyToErrorPattern(
+      "connection refused to 10.0.2.99:6543 after 87ms (attempt 11)",
+    );
+
+    expect(first).toBe(second);
+    expect(first).toBe(
+      "connection refused to <ip>:<num> after <num>ms (attempt <num>)",
+    );
+  });
+
+  test("masks ISO timestamps before the numeric rule can shred them", () => {
+    expect(
+      normalizeLogBodyToErrorPattern("2026-08-21T10:15:30.123Z job failed"),
+    ).toBe("<timestamp> job failed");
+
+    // Space-separated and offset-suffixed forms are the same shape.
+    expect(
+      normalizeLogBodyToErrorPattern("2026-08-21 10:15:30+05:30 job failed"),
+    ).toBe("<timestamp> job failed");
+  });
+
+  test("masks uuids, emails and long hex ids", () => {
+    expect(
+      normalizeLogBodyToErrorPattern(
+        "user 3f2504e0-4f89-41d3-9a0c-0305e82c3301 not found",
+      ),
+    ).toBe("user <uuid> not found");
+
+    expect(
+      normalizeLogBodyToErrorPattern("bounce for alice.smith@example.co.uk"),
+    ).toBe("bounce for <email>");
+
+    expect(
+      normalizeLogBodyToErrorPattern("trace 4bf92f3577b34da6a3ce929d0e0e4736"),
+    ).toBe("trace <hex>");
+  });
+
+  test("masks whole URLs rather than their pieces", () => {
+    /*
+     * URL before email/ip matters: a URL carrying credentials and a host
+     * would otherwise be rewritten into a mix of placeholders that no
+     * longer reads as "a URL".
+     */
+    expect(
+      normalizeLogBodyToErrorPattern(
+        "GET https://user@10.0.0.1:8080/api/v2/items?id=9 failed",
+      ),
+    ).toBe("GET <url> failed");
+  });
+
+  test("masks double-quoted values but leaves apostrophes alone", () => {
+    expect(
+      normalizeLogBodyToErrorPattern('unknown field "customerRef" in payload'),
+    ).toBe('unknown field "<str>" in payload');
+
+    /*
+     * A single-quote rule would pair the apostrophe in "can't" with the
+     * quote before db and destroy the stable half of the message. Pinned so
+     * nobody adds one back.
+     */
+    expect(normalizeLogBodyToErrorPattern("can't reach 'db-primary'")).toBe(
+      "can't reach 'db-primary'",
+    );
+  });
+
+  test("flattens a multi-line stack trace onto one groupable line", () => {
+    const stack: string = [
+      "TypeError: Cannot read properties of undefined",
+      "    at handler (/srv/app/routes/order.js:42:17)",
+      "    at process (/srv/app/lib/queue.js:118:9)",
+    ].join("\n");
+
+    expect(normalizeLogBodyToErrorPattern(stack)).toBe(
+      "TypeError: Cannot read properties of undefined at handler (/srv/app/routes/order.js:<num>:<num>) at process (/srv/app/lib/queue.js:<num>:<num>)",
+    );
+  });
+
+  test("truncates to the maximum pattern length and trims the cut edge", () => {
+    const long: string = `boom ${"x".repeat(LOG_ERROR_PATTERN_MAX_LENGTH * 2)}`;
+
+    const pattern: string = normalizeLogBodyToErrorPattern(long);
+
+    expect(pattern.length).toBe(LOG_ERROR_PATTERN_MAX_LENGTH);
+    expect(pattern.startsWith("boom ")).toBe(true);
+  });
+
+  test("two stack traces sharing a prefix but differing deep down still group", () => {
+    const prefix: string = `${"NullPointerException at com.example.Very.Long.Frame.Name.method ".repeat(
+      6,
+    )}`;
+
+    const a: string = normalizeLogBodyToErrorPattern(
+      `${prefix} at first.frame`,
+    );
+    const b: string = normalizeLogBodyToErrorPattern(
+      `${prefix} at second.frame`,
+    );
+
+    // The differing tail lies past the truncation point.
+    expect(a).toBe(b);
+  });
+});
+
+describe("normalizeLogBodyToErrorPattern — things that must NOT collapse", () => {
+  test("keeps genuinely different messages apart", () => {
+    expect(normalizeLogBodyToErrorPattern("connection refused")).not.toBe(
+      normalizeLogBodyToErrorPattern("connection reset by peer"),
+    );
+  });
+
+  test("short hex-looking words survive as themselves", () => {
+    // 8 chars — below the 16-char floor the hex rule fires at.
+    expect(normalizeLogBodyToErrorPattern("cache key deadbeef missed")).toBe(
+      "cache key deadbeef missed",
+    );
+  });
+
+  test("returns the empty pattern for absent, empty or whitespace bodies", () => {
+    expect(normalizeLogBodyToErrorPattern(undefined)).toBe("");
+    expect(normalizeLogBodyToErrorPattern(null)).toBe("");
+    expect(normalizeLogBodyToErrorPattern("")).toBe("");
+    expect(normalizeLogBodyToErrorPattern("   \n\t  ")).toBe("");
+  });
+
+  test("a body that is entirely a dollar-sign replacement pattern is inserted verbatim", () => {
+    /*
+     * String.replace treats `$&` in a replacement string specially. The
+     * normalizer uses a replacer function so ClickHouse and JavaScript
+     * insert identical text; this pins that the source text's own `$&`
+     * survives untouched.
+     */
+    expect(normalizeLogBodyToErrorPattern("cost $& 42 usd")).toBe(
+      "cost $& <num> usd",
+    );
+  });
+
+  test("is idempotent — normalizing a pattern again changes nothing", () => {
+    const pattern: string = normalizeLogBodyToErrorPattern(
+      "timeout talking to 10.0.0.1:5432 after 30s",
+    );
+
+    expect(normalizeLogBodyToErrorPattern(pattern)).toBe(pattern);
+  });
+});
+
+describe("LOG_ERROR_PATTERN_RULES — cross-engine constraints", () => {
+  test("every rule compiles as a JavaScript regular expression", () => {
+    for (const rule of LOG_ERROR_PATTERN_RULES) {
+      expect(() => {
+        return new RegExp(rule.pattern, "g");
+      }).not.toThrow();
+    }
+  });
+
+  test("no rule uses syntax RE2 cannot parse", () => {
+    /*
+     * ClickHouse's replaceRegexpAll runs on RE2, which has no lookaround
+     * and no backreferences. A rule using either would work in the test
+     * suite and throw in production, so the constraint is pinned here
+     * rather than discovered on a dashboard.
+     */
+    for (const rule of LOG_ERROR_PATTERN_RULES) {
+      expect(rule.pattern).not.toMatch(/\(\?=/);
+      expect(rule.pattern).not.toMatch(/\(\?!/);
+      expect(rule.pattern).not.toMatch(/\(\?<[=!]/);
+      expect(rule.pattern).not.toMatch(/\\[1-9]/);
+    }
+  });
+
+  test("no replacement contains a character either engine treats specially", () => {
+    for (const rule of LOG_ERROR_PATTERN_RULES) {
+      expect(rule.replacement).not.toContain("$");
+      expect(rule.replacement).not.toContain("\\");
+    }
+  });
+
+  test("rule names are unique", () => {
+    const names: Array<string> = LOG_ERROR_PATTERN_RULES.map(
+      (rule: LogErrorPatternRule): string => {
+        return rule.name;
+      },
+    );
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("whitespace collapse is last, so it flattens every earlier rewrite", () => {
+    const last: LogErrorPatternRule =
+      LOG_ERROR_PATTERN_RULES[LOG_ERROR_PATTERN_RULES.length - 1]!;
+
+    expect(last.name).toBe("whitespace");
+  });
+
+  test("the url rule precedes the email and ip rules", () => {
+    const indexOf: (name: string) => number = (name: string): number => {
+      return LOG_ERROR_PATTERN_RULES.findIndex(
+        (rule: LogErrorPatternRule): boolean => {
+          return rule.name === name;
+        },
+      );
+    };
+
+    expect(indexOf("url")).toBeLessThan(indexOf("email"));
+    expect(indexOf("url")).toBeLessThan(indexOf("ip"));
+    expect(indexOf("timestamp")).toBeLessThan(indexOf("number"));
+    expect(indexOf("hex")).toBeLessThan(indexOf("number"));
+  });
+
+  test("the exported placeholder list matches the rules that emit one", () => {
+    expect(LOG_ERROR_PATTERN_PLACEHOLDERS).toEqual([
+      "<timestamp>",
+      "<uuid>",
+      "<url>",
+      "<email>",
+      "<ip>",
+      "<hex>",
+      "<num>",
+    ]);
+  });
+});
+
+describe("getErrorPatternSearchText", () => {
+  test("returns the longest literal run, which is what a body search can match", () => {
+    expect(
+      getErrorPatternSearchText(
+        "connection refused to <ip>:<num> after <num>ms",
+      ),
+    ).toBe("connection refused to");
+  });
+
+  test("strips the punctuation a placeholder leaves behind", () => {
+    expect(getErrorPatternSearchText("<timestamp>: upstream timed out")).toBe(
+      "upstream timed out",
+    );
+  });
+
+  test("returns empty when nothing selective survives", () => {
+    // All placeholders — every literal run is punctuation.
+    expect(getErrorPatternSearchText("<timestamp> <uuid> <num>")).toBe("");
+    // Literal runs shorter than the minimum are not selective enough.
+    expect(getErrorPatternSearchText("<num> ms <num>")).toBe("");
+    expect(getErrorPatternSearchText("")).toBe("");
+    expect(getErrorPatternSearchText(undefined)).toBe("");
+  });
+
+  test("honours a caller-supplied minimum length", () => {
+    expect(getErrorPatternSearchText("<num> ms <num>", 2)).toBe("ms");
+  });
+
+  test("a pattern with no placeholders is its own search text", () => {
+    expect(getErrorPatternSearchText("connection reset by peer")).toBe(
+      "connection reset by peer",
+    );
+  });
+});
+
+describe("truncateErrorPattern", () => {
+  test("collapses whitespace and appends an ellipsis past the limit", () => {
+    expect(truncateErrorPattern("a very  long\nmessage here", 12)).toBe(
+      "a very long...",
+    );
+  });
+
+  test("leaves a short pattern untouched", () => {
+    expect(truncateErrorPattern("short", 12)).toBe("short");
+  });
+
+  test("degrades safely on non-string input and non-positive limits", () => {
+    expect(truncateErrorPattern(undefined, 10)).toBe("");
+    expect(truncateErrorPattern("keep me", 0)).toBe("keep me");
+  });
+});

--- a/Common/Utils/Telemetry/CrossSignalScope.ts
+++ b/Common/Utils/Telemetry/CrossSignalScope.ts
@@ -32,9 +32,11 @@ const WHITESPACE: RegExp = /\s/;
  *  - Logs explorer (App/FeatureSet/Dashboard/src/Components/Logs/
  *    LogsViewer.tsx, readInitialUrlState): `filters` is a JSON array of
  *    [facetKey, values[]] tuples. Supported facet keys are the top-level
- *    columns severityText / primaryEntityId / traceId / spanId plus
+ *    columns severityText / primaryEntityId / traceId / spanId / body plus
  *    `attributes.<key>` for telemetry attributes (dots in <key> are kept —
- *    only the first "attributes." prefix is stripped). `range` is a
+ *    only the first "attributes." prefix is stripped). A `body` chip is the
+ *    one whose value compiles to a CONTAINS match rather than an equality
+ *    (LogsCrossSignalPivot.applyLogsFacetFiltersToQuery). `range` is a
  *    TimeRange enum value; a Custom range additionally needs `start` and
  *    `end` (parsed with `new Date(...)`). There is no `search` param.
  *
@@ -88,6 +90,13 @@ export interface TelemetryCrossSignalScope {
    * carry the exact stored casing.
    */
   severityTexts?: Array<string> | undefined;
+  /**
+   * Free-text the log body must CONTAIN. Only the logs explorer has a
+   * body dimension, and only as a substring match — an exact-equality
+   * filter on a body carrying a timestamp or a request id matches
+   * nothing. Traces and metrics report it as dropped.
+   */
+  bodyContains?: string | undefined;
   startTime?: Date | undefined;
   endTime?: Date | undefined;
 }
@@ -210,6 +219,18 @@ function sanitizeResourceFacetSelections(
   return entries;
 }
 
+/*
+ * A blank body filter carries no scope: emitting it would add a chip that
+ * matches every row while telling the user their view is filtered.
+ */
+function sanitizeBodyContains(value: string | undefined): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
 function isValidDate(value: Date | undefined): value is Date {
   return value instanceof Date && !isNaN(value.getTime());
 }
@@ -258,9 +279,10 @@ function resolveTimeWindow(
  *
  * Field support: serviceIds -> `primaryEntityId` filter tuple, severityTexts
  * -> `severityText` (canonicalized casing), traceIds -> `traceId`, spanIds
- * -> `spanId`, attributes -> `attributes.<key>` tuples, startTime+endTime ->
- * `range=Custom` + `start`/`end`. Every scope field is expressible in the
- * logs grammar, so `dropped` only ever reports a lone time endpoint.
+ * -> `spanId`, attributes -> `attributes.<key>` tuples, bodyContains ->
+ * `body` (a contains-match chip), startTime+endTime -> `range=Custom` +
+ * `start`/`end`. Every scope field is expressible in the logs grammar, so
+ * `dropped` only ever reports a lone time endpoint.
  */
 export function toLogsExplorerQueryParams(
   scope: TelemetryCrossSignalScope,
@@ -315,6 +337,12 @@ export function toLogsExplorerQueryParams(
 
   for (const [key, value] of sanitizeAttributeEntries(scope.attributes)) {
     tuples.push([`attributes.${key}`, [value]]);
+  }
+
+  const bodyContains: string = sanitizeBodyContains(scope.bodyContains);
+
+  if (bodyContains.length > 0) {
+    tuples.push(["body", [bodyContains]]);
   }
 
   if (tuples.length > 0) {
@@ -406,7 +434,8 @@ function buildTraceSearchTokenValue(value: string): string | null {
  * valueDisplayMap, where a `service:` token would show the raw ObjectID),
  * startTime+endTime -> `range=Custom` + `start`/`end`.
  *
- * Dropped: severityTexts — spans have no severity dimension.
+ * Dropped: severityTexts and bodyContains — spans have neither a severity
+ * nor a message-body dimension.
  */
 export function toTracesExplorerQueryParams(
   scope: TelemetryCrossSignalScope,
@@ -488,6 +517,10 @@ export function toTracesExplorerQueryParams(
     dropped.push("severityTexts");
   }
 
+  if (sanitizeBodyContains(scope.bodyContains).length > 0) {
+    dropped.push("bodyContains");
+  }
+
   dropped.push(...window.dropped);
 
   return { params, dropped };
@@ -503,9 +536,9 @@ export function toTracesExplorerQueryParams(
  * optional `metricName` argument names the query.
  *
  * Dropped: serviceIds, resourceFacetSelections, traceIds, spanIds,
- * severityTexts — the metric explorer's URL grammar has no service /
- * resource / trace / span / severity dimension (metrics carry a
- * primaryEntityId column, but the explorer only parses metricName +
+ * severityTexts, bodyContains — the metric explorer's URL grammar has no
+ * service / resource / trace / span / severity / message dimension (metrics
+ * carry a primaryEntityId column, but the explorer only parses metricName +
  * attributes out of `metricQueries`).
  */
 export function toMetricsExplorerQueryParams(
@@ -565,6 +598,10 @@ export function toMetricsExplorerQueryParams(
 
   if (sanitizeValues(scope.severityTexts).length > 0) {
     dropped.push("severityTexts");
+  }
+
+  if (sanitizeBodyContains(scope.bodyContains).length > 0) {
+    dropped.push("bodyContains");
   }
 
   dropped.push(...window.dropped);

--- a/Common/Utils/Telemetry/LogErrorPattern.ts
+++ b/Common/Utils/Telemetry/LogErrorPattern.ts
@@ -1,0 +1,263 @@
+/*
+ * Error-message clustering for the Logs Insights surface.
+ *
+ * "30 x connection refused" is only a useful headline if the thirty raw
+ * bodies — each carrying its own timestamp, request id, port and latency —
+ * collapse onto one row. That collapse is a normalization: every span of
+ * text that varies per occurrence is rewritten to a placeholder, and what
+ * remains is the pattern the occurrences share.
+ *
+ * The rule table below is the single source of truth for that rewrite. It
+ * is consumed twice:
+ *
+ *   - by `normalizeLogBodyToErrorPattern` here, in plain JavaScript, for
+ *     client-side previews and for the test suite; and
+ *   - by Common/Server/Utils/Telemetry/LogErrorPatternSql, which compiles
+ *     the same rules into a nest of ClickHouse `replaceRegexpAll` calls so
+ *     the GROUP BY happens in the database over the whole window rather
+ *     than over a sampled page of rows.
+ *
+ * Because both readers share this table they cannot drift apart, and every
+ * pattern here is therefore restricted to the syntax BOTH engines accept:
+ * RE2 (ClickHouse) has no lookaround and no backreferences, so rules use
+ * only character classes, quantifiers, alternation and `\b`.
+ *
+ * Rule ORDER is part of the contract — rules apply in sequence, each over
+ * the output of the last:
+ *
+ *   1. timestamps first, because their digits and dashes would otherwise be
+ *      shredded by the numeric rule into an unrecognizable shape;
+ *   2. URLs before emails and IPs, so `https://user@10.0.0.1/x` collapses
+ *      to one `<url>` instead of three overlapping placeholders;
+ *   3. long hex runs before numbers, so a trace id stays one token;
+ *   4. numbers last of the value rules, as the catch-all;
+ *   5. whitespace collapse at the end, which is also what flattens a
+ *      multi-line stack trace into a single groupable line.
+ */
+
+export interface LogErrorPatternRule {
+  /** Stable identifier — used by tests and by the SQL compiler's comments. */
+  name: string;
+  /**
+   * Regular expression source accepted by BOTH the JavaScript engine and
+   * RE2. Applied globally (every match is replaced).
+   */
+  pattern: string;
+  /** Literal replacement text. Never contains `$` or `\` — see below. */
+  replacement: string;
+}
+
+/**
+ * The normalization rules, in application order. See the file header for
+ * why the order matters.
+ *
+ * Replacements are deliberately plain literals: `String.replace` treats
+ * `$&`/`$1` in a replacement specially and ClickHouse treats `\1`
+ * specially, so keeping them free of both characters means the two engines
+ * substitute identical text.
+ */
+export const LOG_ERROR_PATTERN_RULES: Array<LogErrorPatternRule> = [
+  {
+    name: "timestamp",
+    pattern:
+      "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:?\\d{2})?",
+    replacement: "<timestamp>",
+  },
+  {
+    name: "uuid",
+    pattern:
+      "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+    replacement: "<uuid>",
+  },
+  {
+    /*
+     * Before `email` and `ip`: a URL can contain both, and the whole URL is
+     * the varying part.
+     */
+    name: "url",
+    pattern: "[a-zA-Z][a-zA-Z0-9+.-]*://[^\\s\"'<>]+",
+    replacement: "<url>",
+  },
+  {
+    name: "email",
+    pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}",
+    replacement: "<email>",
+  },
+  {
+    name: "ip",
+    pattern: "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+    replacement: "<ip>",
+  },
+  {
+    /*
+     * Trace ids, span ids, content hashes, object ids. 16 is the shortest
+     * run this fires on so ordinary hex-looking words ("deadbeef", "cafe")
+     * survive as themselves.
+     */
+    name: "hex",
+    pattern: "\\b[0-9a-fA-F]{16,}\\b",
+    replacement: "<hex>",
+  },
+  {
+    /*
+     * Double quotes only. A single-quote rule would eat English
+     * apostrophes: in `can't reach 'db'` the first `'` pairs with the one
+     * before `db`, mangling the stable half of the message.
+     */
+    name: "quoted",
+    pattern: '"[^"]*"',
+    replacement: '"<str>"',
+  },
+  {
+    name: "number",
+    pattern: "\\d+(\\.\\d+)?",
+    replacement: "<num>",
+  },
+  {
+    /*
+     * Last: collapses the newlines and indentation of a stack trace onto
+     * one line so the truncation below keeps the exception type and the
+     * top frames — the part that identifies the error.
+     */
+    name: "whitespace",
+    pattern: "\\s+",
+    replacement: " ",
+  },
+];
+
+/**
+ * Longest pattern kept, in characters.
+ *
+ * A stack trace normalizes to a very long single line; grouping on the
+ * whole thing would split occurrences whose tails differ (different frame
+ * counts, different truncation by the emitting library) while adding
+ * nothing to what identifies the error. 300 characters comfortably covers
+ * an exception type plus its first frames.
+ */
+export const LOG_ERROR_PATTERN_MAX_LENGTH: number = 300;
+
+/**
+ * The placeholders the rules can emit. Exported so consumers (the deep-link
+ * builder below, the UI's pattern renderer) can recognize the variable
+ * spans without re-deriving them from the rule table.
+ */
+export const LOG_ERROR_PATTERN_PLACEHOLDERS: Array<string> =
+  LOG_ERROR_PATTERN_RULES.filter((rule: LogErrorPatternRule): boolean => {
+    return rule.replacement.startsWith("<") && rule.replacement.endsWith(">");
+  }).map((rule: LogErrorPatternRule): string => {
+    return rule.replacement;
+  });
+
+/*
+ * Any placeholder token, for splitting a pattern back into its literal
+ * spans. Built from the rule table rather than hardcoded so a new rule's
+ * placeholder is understood here automatically. `<str>` is included even
+ * though its rule's replacement is `"<str>"` — the surrounding quotes are
+ * literal text that belongs to the stable half of the message.
+ */
+const PLACEHOLDER_TOKEN: RegExp = /<[a-z]+>/g;
+
+/**
+ * Collapse one raw log body to its error pattern.
+ *
+ * Non-string input (a log row can arrive with a null/absent body) yields
+ * the empty string rather than throwing, because this runs over rows the
+ * caller did not construct.
+ */
+export function normalizeLogBodyToErrorPattern(
+  body: string | undefined | null,
+): string {
+  if (typeof body !== "string" || body.length === 0) {
+    return "";
+  }
+
+  let normalized: string = body;
+
+  for (const rule of LOG_ERROR_PATTERN_RULES) {
+    /*
+     * A replacer function rather than the literal string: it makes the `$`
+     * substitution rules of String.replace unreachable, so the replacement
+     * text is inserted verbatim exactly as ClickHouse inserts it.
+     */
+    normalized = normalized.replace(
+      new RegExp(rule.pattern, "g"),
+      (): string => {
+        return rule.replacement;
+      },
+    );
+  }
+
+  normalized = normalized.trim();
+
+  if (normalized.length > LOG_ERROR_PATTERN_MAX_LENGTH) {
+    normalized = normalized.slice(0, LOG_ERROR_PATTERN_MAX_LENGTH).trim();
+  }
+
+  return normalized;
+}
+
+/**
+ * The longest placeholder-free run inside a pattern — the part of the
+ * message that is identical in every occurrence, and therefore the only
+ * part that can be handed to a substring search.
+ *
+ * Used to turn "Insights says this error happened 30 times" into a Logs
+ * viewer deep link that actually lists those 30 rows: the viewer filters
+ * `body` with a contains-match, which a pattern containing `<num>` would
+ * never satisfy.
+ *
+ * Returns "" when nothing usable survives (an all-placeholder pattern, or
+ * literal runs too short to be selective), which callers read as "no body
+ * filter" rather than as a filter matching everything.
+ */
+export function getErrorPatternSearchText(
+  pattern: string | undefined | null,
+  minimumLength: number = 4,
+): string {
+  if (typeof pattern !== "string" || pattern.length === 0) {
+    return "";
+  }
+
+  let longest: string = "";
+
+  for (const segment of pattern.split(PLACEHOLDER_TOKEN)) {
+    /*
+     * Trim the punctuation a placeholder leaves behind — `to <ip>:<num>`
+     * splits into `to ` and `:` — so the search text is words, not the
+     * glue between them.
+     */
+    const candidate: string = segment.replace(/^[\s"':,;=([{]+/, "").trim();
+
+    if (candidate.length > longest.length) {
+      longest = candidate;
+    }
+  }
+
+  if (longest.length < minimumLength) {
+    return "";
+  }
+
+  return longest;
+}
+
+/**
+ * A short, single-line label for a pattern, for list rows and chips.
+ * Truncation is by characters with an ellipsis; the full pattern stays
+ * available for tooltips and for the detail panel.
+ */
+export function truncateErrorPattern(
+  pattern: string | undefined | null,
+  maxLength: number,
+): string {
+  if (typeof pattern !== "string") {
+    return "";
+  }
+
+  const collapsed: string = pattern.replace(/\s+/g, " ").trim();
+
+  if (maxLength <= 0 || collapsed.length <= maxLength) {
+    return collapsed;
+  }
+
+  return `${collapsed.slice(0, maxLength).trim()}...`;
+}


### PR DESCRIPTION
### Title of this pull request?

feat(logs): surface top errors and time-based correlation on the Logs Insights page

### Small Description?

The Insights tab could tell you that 4% of your logs were errors, but not **which** errors. Finding that out still meant searching the raw log list and eyeballing patterns by hand, then cross-referencing timestamps against Traces. This PR makes the page name the errors and explain them.

It also fixes something quieter: every number on the old page came from fetching up to 5,000 raw log rows and counting them in the browser. On any busy project "Total logs" really meant "the rows we happened to fetch", and the error rate was the error rate of that sample. All of it is now aggregated in ClickHouse over the whole window.

**Clustering.** `Common/Utils/Telemetry/LogErrorPattern` owns a single rule table that rewrites the per-occurrence parts of a log body — timestamps, uuids, urls, emails, ips, long hex ids, quoted values, numbers — to placeholders, so thirty lines differing only in a port and a latency collapse onto one pattern. That table is read twice: by the JavaScript normalizer (previews, tests) and by `LogErrorPatternSql`, which compiles it into a nest of ClickHouse `replaceRegexpAll` calls so the `GROUP BY` happens in the database rather than over a sampled page. Rules are restricted to the syntax **both** engines accept (RE2 has no lookaround or backreferences) and the two implementations are pinned against each other by tests.

**Reads.** `LogAggregationService` gains `getTopErrorPatterns` plus five drill-downs — timeline, co-occurring patterns, shared attributes, resources, traces, samples. All of them share one WHERE clause builder, so a correlation panel can never describe logs the list did not count. Two endpoints expose them; the correlation endpoint runs its six reads concurrently and degrades **section by section** rather than failing the whole panel.

**The page.**

- **Top errors** — each distinct message with "30 times in the past 2 days", how long it has been happening, how many sources it spans, and how many traces carry it.
- **Click into one** and you get: when it fired (bucketed timeline), whether it is rising or falling, *what its occurrences share* (`host.name = web-3` on every one — this is the "which host?" answer), which services/hosts report it, **what else was failing in the same time buckets**, the traces carrying it, and the raw log lines.
- **Scope picker** — filter the whole page to a service, host, docker/podman host or Kubernetes cluster. Services and non-Service resources are routed into different scope fields, because a host id has to be resolved to that resource's entity key server-side (OTLP telemetry carrying a `service.name` is primary-keyed on the Service and only records the host in `entityKeys`).
- **"Open matching logs"** — a `body` facet chip now compiles to a contains-match instead of an equality, and `CrossSignalScope` carries it as `bodyContains`, so the deep link actually lands on the occurrences the row counted. The link filters on the pattern's longest literal run, not the pattern itself — `connection refused to <ip>` matches no real body.

**Not included:** the issue mentions correlating against deploys. OneUptime has no deployment/release model to correlate against, so that part is not implemented; the correlation panel covers traces, co-occurring errors, shared attributes and affected resources.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Verification run locally:**

| Check | Result |
| --- | --- |
| `Common` tsc | clean |
| `App` tsc | clean |
| `App/FeatureSet/Dashboard` tsc | clean |
| eslint (all changed files) | clean |
| `Common/Tests/Utils/Telemetry/LogErrorPattern.test.ts` | 28 passed |
| `Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts` | 11 passed |
| `Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts` | 58 passed |
| `Common/Tests/Server/API/LogErrorPatternAPI.test.ts` | 20 passed |
| `Common/Tests/Utils/Telemetry/CrossSignalScope.test.ts` | 49 passed |
| `Common/Tests/Server/Services/LogAggregationService.test.ts` | passed (unchanged) |
| `App/Tests/Dashboard/LogsInsights.test.ts` | 55 passed |
| `App/Tests/Dashboard/LogsCrossSignalPivot.test.ts` + `LogsHistogramRequest.test.ts` | 78 passed |

New coverage worth calling out:

- **Clustering behaviour in both directions** — occurrences that must collapse (ip/port/latency, stack traces past the truncation point) and things that must *not* (different messages, short hex-looking words, apostrophes, a body containing `$&`).
- **Cross-engine constraints** — every rule compiles in JS, uses no RE2-illegal syntax, and emits a replacement neither engine treats specially; rule ordering is pinned.
- **Scope fidelity** — a parameterised sweep asserts all six drill-downs scope to the same window, severities and resources as the top list, never put the caller's pattern into SQL text, clamp an oversized pattern, and bound their runtime.
- **Correlation query shape** — the inner bucket subquery is asserted to be scoped *identically* to the outer read (two WHEREs, two retention filters, two severity predicates, two service predicates); a subquery that skipped any would correlate against the wrong timeline.
- **Degradation** — every response field arrives as untyped JSON, so each parser is exercised on malformed and absent input; the correlation endpoint is tested with one section failing and with all six failing.

### Related Issue?

Closes #3318

### Screenshots (if appropriate):

Not attached — running the page needs the full docker-compose stack (Postgres + ClickHouse) with ingested telemetry, which I did not stand up. Verification here is typecheck, lint and the unit suites above; the UI itself has not been exercised against live data.
