### PR TITLE
fix(identity): bound guessing on the anonymous credential routes

### DIFF
--- a/App/FeatureSet/Identity/API/Authentication.ts
+++ b/App/FeatureSet/Identity/API/Authentication.ts
@@ -58,9 +58,53 @@ import UserWebAuthn from "Common/Models/DatabaseModels/UserWebAuthn";
 import UserWebAuthnService from "Common/Server/Services/UserWebAuthnService";
 import NotAuthenticatedException from "Common/Types/Exception/NotAuthenticatedException";
 import TeamMemberService from "Common/Server/Services/TeamMemberService";
+import IdentityRateLimit, {
+  IdentityRateLimitBucket,
+} from "Common/Server/Middleware/IdentityRateLimit";
 import TeamMember from "Common/Models/DatabaseModels/TeamMember";
 
 const router: ExpressRouter = Express.getRouter();
+
+/*
+ * The credential routes below are anonymous by definition -- they are how a
+ * session is obtained -- so nothing upstream of them counts attempts. Both
+ * limiters are registered as the FIRST handler on their routes, ahead of the
+ * user lookup and the bcrypt verify, so a flood is refused before it costs us
+ * anything. See Common/Server/Middleware/IdentityRateLimit.ts for the budgets
+ * and for why these fail closed when Redis is unreachable.
+ */
+const loginRateLimit: (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => Promise<void> = IdentityRateLimit.getMiddleware(
+  IdentityRateLimitBucket.Login,
+);
+
+/*
+ * The second step gets its own bucket, shared by all three routes that reach
+ * `login()` with verifyTotpAuth, verifyWebAuthn or verifyTotpEnrolment set.
+ *
+ * For /verify-totp-auth it is the sharper of the two limiters: the password
+ * has already been accepted by the time it is reached, so all that stands
+ * between the caller and the account is a six digit code, and TotpAuth accepts
+ * fourteen of the 10^6 of them at any instant.
+ *
+ * /verify-webauthn-auth and /verify-totp-enrolment are here for a second
+ * reason that applies whatever their own factor is worth. All three re-submit
+ * the email and password and run the same `verifyHashedColumnValue` before
+ * they reach their factor, so each one is a password oracle in its own right
+ * -- and an unlimited one is a hole in the fence, not merely an unguarded
+ * route: an attacker refused at /login simply points the same guesses here.
+ * Whatever bounds /login has to bound these too.
+ */
+const twoFactorRateLimit: (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => Promise<void> = IdentityRateLimit.getMiddleware(
+  IdentityRateLimitBucket.TwoFactor,
+);
 
 const ACCESS_TOKEN_EXPIRY_SECONDS: number = 15 * 60;
 
@@ -944,6 +988,7 @@ router.post(
 
 router.post(
   "/verify-totp-auth",
+  twoFactorRateLimit,
   async (
     req: ExpressRequest,
     res: ExpressResponse,
@@ -962,6 +1007,7 @@ router.post(
 
 router.post(
   "/verify-webauthn-auth",
+  twoFactorRateLimit,
   async (
     req: ExpressRequest,
     res: ExpressResponse,
@@ -1003,6 +1049,7 @@ router.post(
  */
 router.post(
   "/verify-totp-enrolment",
+  twoFactorRateLimit,
   async (
     req: ExpressRequest,
     res: ExpressResponse,
@@ -1021,6 +1068,7 @@ router.post(
 
 router.post(
   "/login",
+  loginRateLimit,
   async (
     req: ExpressRequest,
     res: ExpressResponse,

--- a/App/Tests/FeatureSet/Identity/IdentityRateLimit.test.ts
+++ b/App/Tests/FeatureSet/Identity/IdentityRateLimit.test.ts
@@ -1,0 +1,1037 @@
+import {
+  buildRequest,
+  buildResponse,
+  createMockIdentityRouter,
+  MockIdentityRouter,
+  RouteHandler,
+} from "./IdentityRouterTestUtil";
+import {
+  buildOtpauthUri,
+  conformingAppCode,
+} from "Common/Tests/Server/TestingUtils/AuthenticatorApp";
+import UserService from "Common/Server/Services/UserService";
+import PasswordHash from "Common/Server/Utils/PasswordHash";
+import TotpAuth from "Common/Server/Utils/TotpAuth";
+import User from "Common/Models/DatabaseModels/User";
+import UserTotpAuth from "Common/Models/DatabaseModels/UserTotpAuth";
+import Email from "Common/Types/Email";
+import Exception from "Common/Types/Exception/Exception";
+import ExceptionCode from "Common/Types/Exception/ExceptionCode";
+import HashedString from "Common/Types/HashedString";
+import ObjectID from "Common/Types/ObjectID";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+const mockRouter: MockIdentityRouter = createMockIdentityRouter();
+
+/*
+ * ---------------------------------------------------------------------------
+ * Attempt limiting on the anonymous credential routes — POST /login,
+ * POST /verify-totp-auth, POST /verify-webauthn-auth and
+ * POST /verify-totp-enrolment — exercised through the real routers with the
+ * real middleware in front of the real handler.
+ *
+ * WHAT THESE TESTS ARE ACTUALLY PINNING
+ *
+ * Not "does a counter count". The properties that decide whether the limit
+ * can be walked around at all, each of which is a way the limiter could look
+ * present in a diff and be worth nothing:
+ *
+ *   - it runs BEFORE the handler, so a refused attempt never reaches the user
+ *     lookup or the bcrypt verify;
+ *   - rotating the email address in the body does not buy a fresh bucket;
+ *   - changing the CASE of the email address does not either;
+ *   - nor does switching between the two wire SHAPES an email arrives in,
+ *     and -- the other half of that same coin -- two different accounts are
+ *     not silently collapsed onto one shared counter;
+ *   - a caller-supplied X-Forwarded-For entry does not buy a fresh bucket;
+ *   - the window does not slide forward under sustained load, which would
+ *     turn a fifteen minute pause into a permanent lockout;
+ *   - it fails CLOSED, so a Redis outage does not quietly restore the
+ *     unlimited guessing oracle it exists to close.
+ *
+ * The /verify-totp-auth case is the one that matters most. It is reached with
+ * a valid password already accepted, so the only thing left is a six digit
+ * code, and TotpAuth accepts fourteen of the 10^6 of them at any instant
+ * (TotpValidationWindow = 3 steps either side of now, across both entries in
+ * SupportedTotpAlgorithms). Unbounded, that is a second factor bypassed in
+ * minutes.
+ *
+ * Redis is faked rather than mocked per-assertion: INCR really increments and
+ * EXPIRE really records a TTL, so the window and reset tests exercise the
+ * limiter's arithmetic instead of restating it. Everything else the handlers
+ * reach (sessions, cookies, mail, tokens) is mocked, because none of it is
+ * what is under test.
+ * ---------------------------------------------------------------------------
+ */
+
+interface RecordedExpire {
+  key: string;
+  ttlSeconds: number;
+}
+
+class FakeRedisClient {
+  public counters: Map<string, number> = new Map();
+  public expires: Array<RecordedExpire> = [];
+
+  /* Set to make the next exec() reject, for the error-path test. */
+  public failNextExec: Error | null = null;
+
+  public pipeline(): FakePipeline {
+    return new FakePipeline(this);
+  }
+
+  public reset(): void {
+    this.counters.clear();
+    this.expires = [];
+    this.failNextExec = null;
+  }
+}
+
+type QueuedCommand = () => [Error | null, unknown];
+
+class FakePipeline {
+  private commands: Array<QueuedCommand> = [];
+
+  public constructor(private client: FakeRedisClient) {}
+
+  public incr(key: string): FakePipeline {
+    this.commands.push((): [Error | null, unknown] => {
+      const next: number = (this.client.counters.get(key) || 0) + 1;
+      this.client.counters.set(key, next);
+      return [null, next];
+    });
+
+    return this;
+  }
+
+  public expire(key: string, ttlSeconds: number): FakePipeline {
+    this.commands.push((): [Error | null, unknown] => {
+      this.client.expires.push({ key, ttlSeconds });
+      return [null, 1];
+    });
+
+    return this;
+  }
+
+  public async exec(): Promise<unknown> {
+    if (this.client.failNextExec) {
+      const error: Error = this.client.failNextExec;
+      this.client.failNextExec = null;
+      throw error;
+    }
+
+    return this.commands.map((command: QueuedCommand) => {
+      return command();
+    });
+  }
+}
+
+const redisClient: FakeRedisClient = new FakeRedisClient();
+let isRedisConnected: boolean = true;
+
+jest.mock("Common/Server/Infrastructure/Redis", () => {
+  return {
+    __esModule: true,
+    default: {
+      getClient: (): unknown => {
+        return isRedisConnected ? redisClient : null;
+      },
+      isConnected: (): boolean => {
+        return isRedisConnected;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      getRouter: (): MockIdentityRouter => {
+        return mockRouter;
+      },
+    },
+    getClientIp: (): string => {
+      return "127.0.0.1";
+    },
+    extractDeviceInfo: (): Record<string, unknown> => {
+      return {};
+    },
+    headerValueToString: (): string => {
+      return "";
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/EmailVerificationTokenService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn(), create: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/TeamMemberService", () => {
+  return { __esModule: true, default: { findOneBy: jest.fn() } };
+});
+
+jest.mock("Common/Server/Services/AccessTokenService", () => {
+  return {
+    __esModule: true,
+    default: { refreshUserAllPermissions: jest.fn() },
+  };
+});
+
+const totpFindBy: jest.Mock = jest.fn();
+const totpFindOneBy: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserTotpAuthService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (...args: Array<unknown>): unknown => {
+        return totpFindBy(...args);
+      },
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return totpFindOneBy(...args);
+      },
+    },
+  };
+});
+
+const verifyWebAuthnAuthentication: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserWebAuthnService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      verifyAuthentication: (...args: Array<unknown>): unknown => {
+        return verifyWebAuthnAuthentication(...args);
+      },
+    },
+  };
+});
+
+const createSession: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserSessionService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createSession: (...args: Array<unknown>): unknown => {
+        return createSession(...args);
+      },
+      revokeAllSessionsByUserId: (): Promise<void> => {
+        return Promise.resolve();
+      },
+      findActiveSessionByRefreshToken: jest.fn(),
+      revokeSessionById: jest.fn(),
+      revokeSessionByRefreshToken: jest.fn(),
+      renewSessionWithNewRefreshToken: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: (): Promise<void> => {
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/DatabaseConfig", () => {
+  return {
+    __esModule: true,
+    default: {
+      shouldDisableSignup: (): Promise<boolean> => {
+        return Promise.resolve(false);
+      },
+      getHost: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "localhost";
+          },
+        });
+      },
+      getHttpProtocol: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "http://";
+          },
+        });
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Cookie", () => {
+  return {
+    __esModule: true,
+    default: {
+      setUserCookie: jest.fn(),
+      removeAllCookies: jest.fn(),
+      removeCookie: jest.fn(),
+      getRefreshTokenFromExpressRequest: jest.fn(),
+      getUserTokenKey: jest.fn(),
+      getRefreshTokenKey: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Captcha", () => {
+  return {
+    __esModule: true,
+    default: {
+      verifyCaptcha: (): Promise<void> => {
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/JsonWebToken", () => {
+  return {
+    __esModule: true,
+    default: {
+      sign: (): string => {
+        return "signed-token";
+      },
+      signUserLoginToken: (): string => {
+        return "signed-user-token";
+      },
+    },
+  };
+});
+
+jest.mock("../../../FeatureSet/Identity/Utils/AuthenticationEmail", () => {
+  return {
+    __esModule: true,
+    default: { sendVerificationEmail: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+    getLogAttributesFromRequest: (): Record<string, unknown> => {
+      return {};
+    },
+  };
+});
+
+const sendErrorResponse: jest.Mock = jest.fn();
+const sendEntityResponse: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: (...args: Array<unknown>): unknown => {
+        return sendErrorResponse(...args);
+      },
+      sendEmptySuccessResponse: jest.fn(),
+      sendEntityResponse: (...args: Array<unknown>): unknown => {
+        return sendEntityResponse(...args);
+      },
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+// Importing the router registers every handler, and every middleware, above.
+import "../../../FeatureSet/Identity/API/Authentication";
+
+/* The shipped defaults, restated so a change to either has to be deliberate. */
+const WINDOW_SECONDS: number = 15 * 60;
+const PER_ACCOUNT_LIMIT: number = 10;
+const PER_IP_LIMIT: number = 150;
+
+const PASSWORD: string = "correct horse battery staple";
+const USER_EMAIL: string = "totp.user@example.com";
+const TOTP_ID: ObjectID = new ObjectID("66666666-6666-4666-8666-666666666666");
+
+/* The address our own Nginx appends. Everything below is billed to it. */
+const REAL_CLIENT_IP: string = "203.0.113.9";
+
+type AttemptOptions = {
+  uri?: string;
+  email?: string;
+
+  /*
+   * Which wire shape to send `email` in. Both are first-party and both reach
+   * the routes limited here: the dashboard's /login serializes the User model
+   * through ModelAPI, and the mobile app hand-builds the same envelope, so
+   * "object" is what POST /login actually receives in production -- hence the
+   * default. The dashboard's second-step calls spread raw form values instead,
+   * so those send "string". See resolveAccountKey for the full account.
+   */
+  emailShape?: "string" | "object";
+  code?: string;
+  headers?: Record<string, string | Array<string>>;
+  socketAddress?: string;
+};
+
+type AttemptResult = {
+  reachedHandler: boolean;
+  errorCode: ExceptionCode | undefined;
+  errorMessage: string | undefined;
+  retryAfter: string | undefined;
+};
+
+/*
+ * One request through the WHOLE registered chain — limiter first, handler
+ * last — which is the only arrangement that can tell a wired-up limiter from
+ * an unwired one. `next` is what Express would call between handlers, so a
+ * limiter that refuses simply never calls it and the handler never runs.
+ */
+type AttemptFunction = (options?: AttemptOptions) => Promise<AttemptResult>;
+
+const attempt: AttemptFunction = async (
+  options: AttemptOptions = {},
+): Promise<AttemptResult> => {
+  const uri: string = options.uri || "/verify-totp-auth";
+
+  const handlers: Array<RouteHandler> = mockRouter.matchAll("post", uri);
+
+  const emailValue: string =
+    options.email === undefined ? USER_EMAIL : options.email;
+
+  const emailField: unknown =
+    options.emailShape === "string"
+      ? emailValue
+      : { _type: "Email", value: emailValue };
+
+  const req: ExpressRequest = buildRequest(
+    {
+      data: {
+        email: emailField,
+        password: { _type: "HashedString", value: PASSWORD },
+        code: options.code === undefined ? "000000" : options.code,
+        twoFactorAuthId: TOTP_ID.toString(),
+      },
+    },
+    {
+      headers: options.headers || { "x-forwarded-for": REAL_CLIENT_IP },
+      socketAddress: options.socketAddress || REAL_CLIENT_IP,
+    },
+  );
+
+  const headers: Record<string, string> = {};
+
+  const res: ExpressResponse = {
+    ...buildResponse(),
+    setHeader: (name: string, value: string): void => {
+      headers[name] = value;
+    },
+  } as unknown as ExpressResponse;
+
+  let reachedHandler: boolean = false;
+
+  for (let index: number = 0; index < handlers.length; index++) {
+    const handler: RouteHandler = handlers[index] as RouteHandler;
+
+    let continued: boolean = false;
+
+    const next: NextFunction = ((): void => {
+      continued = true;
+    }) as unknown as NextFunction;
+
+    if (index === handlers.length - 1) {
+      reachedHandler = true;
+    }
+
+    await handler(req, res, next);
+
+    if (!continued) {
+      break;
+    }
+  }
+
+  const call: Array<unknown> | undefined = sendErrorResponse.mock.calls[
+    sendErrorResponse.mock.calls.length - 1
+  ] as Array<unknown> | undefined;
+
+  const error: Exception | undefined = call?.[2] as Exception | undefined;
+
+  return {
+    reachedHandler,
+    errorCode: error?.code,
+    errorMessage: error?.message,
+    retryAfter: headers["Retry-After"],
+  };
+};
+
+/*
+ * An account with 2FA switched on, stored the way Postgres would hand it back.
+ */
+type StoredUserFunction = () => Promise<User>;
+
+const storedUser: StoredUserFunction = async (): Promise<User> => {
+  const salt: string = PasswordHash.generateSalt();
+
+  const user: User = new User();
+  user._id = ObjectID.generate().toString();
+  user.email = new Email(USER_EMAIL);
+  user.isEmailVerified = true;
+  user.isMasterAdmin = false;
+  user.enableTwoFactorAuth = true;
+  user.passwordSalt = salt;
+  user.password = new HashedString(
+    await PasswordHash.hash({ plainValue: PASSWORD, salt: salt }),
+    true,
+  );
+
+  return user;
+};
+
+type EnrolmentFunction = () => { row: UserTotpAuth; code: () => string };
+
+const enrolment: EnrolmentFunction = () => {
+  const secret: string = TotpAuth.generateSecret();
+
+  const otpUrl: string = buildOtpauthUri({
+    secret: secret,
+    label: USER_EMAIL,
+    algorithm: "SHA1",
+  });
+
+  const row: UserTotpAuth = new UserTotpAuth();
+  row.id = TOTP_ID;
+  row.twoFactorSecret = secret;
+  row.twoFactorOtpUrl = otpUrl;
+  row.isVerified = true;
+
+  return {
+    row: row,
+    code: (): string => {
+      return conformingAppCode(otpUrl);
+    },
+  };
+};
+
+let findOneBy: jest.SpiedFunction<typeof UserService.findOneBy>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  redisClient.reset();
+  isRedisConnected = true;
+
+  createSession.mockResolvedValue({
+    session: { id: ObjectID.generate() },
+    refreshToken: "refresh-token",
+    refreshTokenExpiresAt: new Date(),
+  } as never);
+
+  totpFindBy.mockResolvedValue([] as never);
+  totpFindOneBy.mockResolvedValue(null as never);
+
+  /*
+   * The handler's first database read. Whether this ran is how every test
+   * below decides if the request got past the limiter.
+   */
+  findOneBy = jest
+    .spyOn(UserService, "findOneBy")
+    .mockResolvedValue(null as never);
+
+  jest.spyOn(UserService, "updateOneById").mockResolvedValue(1 as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("the credential routes have a limiter in front of the handler", () => {
+  /*
+   * Registration order is the whole point. A limiter behind the handler would
+   * count attempts it had already served, which is not a limit.
+   */
+  it.each([
+    ["/login"],
+    ["/verify-totp-auth"],
+    ["/verify-webauthn-auth"],
+    ["/verify-totp-enrolment"],
+  ])("%s runs middleware before its handler", (uri: string) => {
+    expect(mockRouter.matchAll("post", uri).length).toBeGreaterThan(1);
+  });
+
+  /*
+   * The list above is the whole point of this block, so it must not be
+   * possible to add a fifth credential route and have it quietly go
+   * uncounted. Every route that reaches `login()` re-submits the email and
+   * password and runs the same verifyHashedColumnValue, so every one of them
+   * is a password oracle and every one of them needs a limiter -- an
+   * unguarded sibling is a hole in the fence, not merely an unguarded route.
+   */
+  it("covers every route that reaches the shared login() function", () => {
+    const credentialRoutes: Array<string> = mockRouter.routes
+      .filter(
+        (route: { method: string; uri: string; handlers: Array<unknown> }) => {
+          return (
+            route.method === "POST" &&
+            [
+              "/login",
+              "/verify-totp-auth",
+              "/verify-webauthn-auth",
+              "/verify-totp-enrolment",
+            ].includes(route.uri)
+          );
+        },
+      )
+      .map((route: { uri: string }) => {
+        return route.uri;
+      });
+
+    expect(credentialRoutes.sort()).toEqual([
+      "/login",
+      "/verify-totp-auth",
+      "/verify-totp-enrolment",
+      "/verify-webauthn-auth",
+    ]);
+  });
+});
+
+describe("POST /verify-totp-auth — bounding the guesses", () => {
+  it("lets an honest user through while they are inside the budget", async () => {
+    const user: User = await storedUser();
+    const totp: ReturnType<EnrolmentFunction> = enrolment();
+
+    findOneBy.mockResolvedValue(user as never);
+    totpFindOneBy.mockResolvedValue(totp.row as never);
+
+    const result: AttemptResult = await attempt({ code: totp.code() });
+
+    expect(result.reachedHandler).toBe(true);
+    expect(sendEntityResponse).toHaveBeenCalled();
+    expect(sendErrorResponse).not.toHaveBeenCalled();
+  });
+
+  it("refuses the attempt after the per-account budget is spent", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      const allowed: AttemptResult = await attempt();
+      expect(allowed.reachedHandler).toBe(true);
+    }
+
+    findOneBy.mockClear();
+
+    const refused: AttemptResult = await attempt();
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  /*
+   * The refusal has to land before the user lookup and the bcrypt verify.
+   * A limiter that answers 429 only after paying for the guess still lets an
+   * attacker spend our CPU, and — worse — still tells them, by timing, that
+   * the address they tried exists.
+   */
+  it("refuses before the handler touches the database", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt();
+    }
+
+    findOneBy.mockClear();
+
+    await attempt();
+
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  it("tells the caller when the window rolls", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt();
+    }
+
+    const refused: AttemptResult = await attempt();
+
+    expect(Number(refused.retryAfter)).toBeGreaterThan(0);
+    expect(Number(refused.retryAfter)).toBeLessThanOrEqual(WINDOW_SECONDS);
+  });
+
+  /*
+   * The 429 says nothing the 400 above it would not have said. A limiter that
+   * refused a real address sooner than an invented one would hand back the
+   * account enumeration the handlers are careful to withhold.
+   */
+  it("says the same thing whether or not the account exists", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt();
+    }
+
+    const missingAccount: AttemptResult = await attempt();
+
+    redisClient.reset();
+    findOneBy.mockResolvedValue((await storedUser()) as never);
+
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt();
+    }
+
+    const realAccount: AttemptResult = await attempt();
+
+    expect(realAccount.errorMessage).toBe(missingAccount.errorMessage);
+  });
+});
+
+describe("the ways a caller might try to buy a fresh bucket", () => {
+  /*
+   * The email address is a field in the request body, so it costs nothing to
+   * change. If it were the only key, an attacker guessing TOTP codes would
+   * simply cycle addresses and never meet a limit at all — and against the
+   * second factor that works, because a code guessed for ANY account is a
+   * bypass. The per-address counter is what survives this.
+   */
+  it("rotating the email address still runs into the per-address ceiling", async () => {
+    for (let i: number = 0; i < PER_IP_LIMIT; i++) {
+      const allowed: AttemptResult = await attempt({
+        email: `victim-${i}@example.com`,
+      });
+
+      expect(allowed.reachedHandler).toBe(true);
+    }
+
+    const refused: AttemptResult = await attempt({
+      email: "victim-fresh@example.com",
+    });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  /*
+   * Postgres matches the address case-insensitively, so BOB@ and bob@ are one
+   * account. If the counter disagreed, holding shift would double the budget.
+   */
+  it("changing the case of the email address does not reset the count", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ email: USER_EMAIL });
+    }
+
+    const refused: AttemptResult = await attempt({
+      email: USER_EMAIL.toUpperCase(),
+    });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  /*
+   * `email` reaches these routes in two shapes, and both are first-party.
+   * POST /login gets the serialized envelope { _type: "Email", value } --
+   * from the dashboard via ModelAPI's JSONFunctions.serialize, and from the
+   * mobile app which hand-builds it. The dashboard's second-step calls spread
+   * raw form values instead, so those send a bare string. The handler treats
+   * them identically because BaseModel.fromJSON resolves both to one address,
+   * so the counter has to as well -- otherwise alternating the two shapes
+   * takes the per-account budget twice.
+   */
+  it("counts the two wire shapes of one address as one account", async () => {
+    const half: number = PER_ACCOUNT_LIMIT / 2;
+
+    for (let i: number = 0; i < half; i++) {
+      await attempt({ emailShape: "string" });
+    }
+
+    for (let i: number = 0; i < half; i++) {
+      await attempt({ emailShape: "object" });
+    }
+
+    const refused: AttemptResult = await attempt({ emailShape: "object" });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  /*
+   * The other half of the same coin, and the more damaging one.
+   *
+   * If the limiter cannot read the shape the shipped clients actually send,
+   * every account collapses onto the single shared "none" key. That is not a
+   * weaker limit, it is a much TIGHTER one applied to the wrong thing: one
+   * office behind one NAT would be refused after ten sign-ins between all of
+   * them, rather than the hundred and fifty the per-address ceiling exists to
+   * allow. This test fails against exactly that mistake.
+   */
+  it("gives two different accounts on one address their own budgets", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ email: "first.colleague@example.com" });
+    }
+
+    const spent: AttemptResult = await attempt({
+      email: "first.colleague@example.com",
+    });
+    expect(spent.reachedHandler).toBe(false);
+
+    const colleague: AttemptResult = await attempt({
+      email: "second.colleague@example.com",
+    });
+
+    expect(colleague.reachedHandler).toBe(true);
+  });
+
+  /*
+   * X-Forwarded-For is a list that every proxy APPENDS to, so its leftmost
+   * entries are whatever the caller chose to send. A limiter that read the
+   * left-hand end would hand out a fresh bucket for every forged value — no
+   * limit at all. The address is taken from the hop our own Nginx wrote.
+   */
+  it("a forged X-Forwarded-For entry does not reset the count", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ headers: { "x-forwarded-for": REAL_CLIENT_IP } });
+    }
+
+    const refused: AttemptResult = await attempt({
+      headers: {
+        "x-forwarded-for": `198.51.100.${PER_ACCOUNT_LIMIT}, ${REAL_CLIENT_IP}`,
+      },
+    });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  /*
+   * The flip side: a genuinely different client must not inherit somebody
+   * else's spent budget. One noisy office does not lock out the internet.
+   */
+  it("a different client still gets its own budget", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt();
+    }
+
+    const other: AttemptResult = await attempt({
+      headers: { "x-forwarded-for": "198.51.100.4" },
+      socketAddress: "198.51.100.4",
+    });
+
+    expect(other.reachedHandler).toBe(true);
+  });
+
+  /*
+   * Separate buckets, so spending the password budget cannot lock a user out
+   * of finishing a two-factor login they had already started — and so an
+   * attacker cannot use cheap /login noise to mask their code guessing.
+   */
+  it("the password bucket and the second-factor bucket are independent", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ uri: "/login" });
+    }
+
+    const refusedLogin: AttemptResult = await attempt({ uri: "/login" });
+    expect(refusedLogin.reachedHandler).toBe(false);
+
+    const totpVerify: AttemptResult = await attempt({
+      uri: "/verify-totp-auth",
+    });
+    expect(totpVerify.reachedHandler).toBe(true);
+  });
+
+  it("/verify-webauthn-auth shares the second-step budget", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ uri: "/verify-totp-auth" });
+    }
+
+    const refused: AttemptResult = await attempt({
+      uri: "/verify-webauthn-auth",
+    });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  it("/verify-totp-enrolment shares the second-step budget", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ uri: "/verify-totp-auth" });
+    }
+
+    const refused: AttemptResult = await attempt({
+      uri: "/verify-totp-enrolment",
+    });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+});
+
+/*
+ * The mandated-enrolment route, added with the admin MFA work, is the one it
+ * would be easiest to leave out — guessing its CODE is pointless, because
+ * /login hands the user the very secret the code is derived from, so it reads
+ * like a route with nothing to guess.
+ *
+ * It is a password oracle all the same. It reaches the same login() function
+ * and runs the same verifyHashedColumnValue before it ever looks at the
+ * enrolment, so leaving it unlimited would not be one unguarded route, it
+ * would be a hole in the fence around the other three: an attacker refused at
+ * /login simply re-points the same password guesses here.
+ */
+describe("POST /verify-totp-enrolment", () => {
+  it("bounds password guessing aimed at it directly", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      const allowed: AttemptResult = await attempt({
+        uri: "/verify-totp-enrolment",
+      });
+
+      expect(allowed.reachedHandler).toBe(true);
+    }
+
+    const refused: AttemptResult = await attempt({
+      uri: "/verify-totp-enrolment",
+    });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+
+  it("refuses before the handler touches the database", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt({ uri: "/verify-totp-enrolment" });
+    }
+
+    findOneBy.mockClear();
+
+    await attempt({ uri: "/verify-totp-enrolment" });
+
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  it("refuses rather than running unthrottled when Redis is gone", async () => {
+    isRedisConnected = false;
+
+    const result: AttemptResult = await attempt({
+      uri: "/verify-totp-enrolment",
+    });
+
+    expect(result.reachedHandler).toBe(false);
+    expect(result.errorCode).toBe(ExceptionCode.ServiceUnavailableException);
+  });
+});
+
+describe("the window", () => {
+  /*
+   * The expiry is set once, on the write that created the key. Re-issuing it
+   * on every increment would push the reset further out for as long as the
+   * attempts kept coming — so a caller who tripped the limit and then kept
+   * retrying, which is exactly what a locked-out human does, would never get
+   * back in. That is a permanent lockout dressed up as a rate limit.
+   */
+  it("does not slide forward while attempts keep arriving", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT + 5; i++) {
+      await attempt();
+    }
+
+    const accountExpires: Array<RecordedExpire> = redisClient.expires.filter(
+      (recorded: RecordedExpire) => {
+        return recorded.key.includes(":a:");
+      },
+    );
+
+    expect(accountExpires).toHaveLength(1);
+    expect(accountExpires[0]?.ttlSeconds).toBe(WINDOW_SECONDS * 2);
+  });
+
+  /*
+   * The clock is moved rather than waited on. Only Date.now is replaced --
+   * jest.useFakeTimers cannot install here, and the limiter reads nothing
+   * else to decide which window a request lands in.
+   */
+  it("lets the caller back in once the window has rolled", async () => {
+    let now: number = Date.parse("2026-01-01T00:00:00.000Z");
+
+    jest.spyOn(Date, "now").mockImplementation((): number => {
+      return now;
+    });
+
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      await attempt();
+    }
+
+    expect((await attempt()).reachedHandler).toBe(false);
+
+    now += (WINDOW_SECONDS + 30) * 1000;
+
+    expect((await attempt()).reachedHandler).toBe(true);
+  });
+});
+
+describe("when Redis is unreachable", () => {
+  /*
+   * Fails CLOSED, which is the opposite of what a load-shedding limiter does
+   * and the right answer here: nothing in Postgres counts login attempts, so
+   * serving these routes without the counter is serving the unlimited
+   * guessing oracle the middleware exists to close.
+   *
+   * It costs no availability that was not already lost — a successful login
+   * writes the user's permissions to the same Redis through GlobalCache, and
+   * that throws when it is down. The difference is a 503 that says to come
+   * back shortly instead of a 500.
+   */
+  it("refuses the attempt rather than serving it unthrottled", async () => {
+    isRedisConnected = false;
+
+    const result: AttemptResult = await attempt();
+
+    expect(result.reachedHandler).toBe(false);
+    expect(result.errorCode).toBe(ExceptionCode.ServiceUnavailableException);
+  });
+
+  it("refuses when the counter errors mid-pipeline too", async () => {
+    redisClient.failNextExec = new Error("READONLY: cannot write to replica");
+
+    const result: AttemptResult = await attempt();
+
+    expect(result.reachedHandler).toBe(false);
+    expect(result.errorCode).toBe(ExceptionCode.ServiceUnavailableException);
+  });
+
+  it("resumes serving once Redis comes back", async () => {
+    isRedisConnected = false;
+    expect((await attempt()).reachedHandler).toBe(false);
+
+    isRedisConnected = true;
+    expect((await attempt()).reachedHandler).toBe(true);
+  });
+});
+
+describe("a request that does not name an account", () => {
+  /*
+   * `email` is whatever JSON the caller sent. A missing one, or one that is
+   * an object rather than a string, must land in a bucket rather than throw
+   * out of the limiter and surface as a 500 — and it must be a SHARED bucket,
+   * so a caller cannot get a private allowance by omitting the field.
+   */
+  it("counts a missing email address against one shared bucket", async () => {
+    for (let i: number = 0; i < PER_ACCOUNT_LIMIT; i++) {
+      const allowed: AttemptResult = await attempt({ email: "" });
+      expect(allowed.reachedHandler).toBe(true);
+    }
+
+    const refused: AttemptResult = await attempt({ email: "" });
+
+    expect(refused.reachedHandler).toBe(false);
+    expect(refused.errorCode).toBe(ExceptionCode.TooManyRequestsException);
+  });
+});

--- a/App/Tests/FeatureSet/Identity/IdentityRouterTestUtil.ts
+++ b/App/Tests/FeatureSet/Identity/IdentityRouterTestUtil.ts
@@ -13,7 +13,17 @@ export type RouteHandler = (
 export type CapturedRoute = {
   method: string;
   uri: string;
+
+  /* The route handler proper -- the last function passed to router.post. */
   handler: RouteHandler;
+
+  /*
+   * Everything passed to router.post, middleware first, handler last. `match`
+   * returns only the handler so that a test written against the handler keeps
+   * working when middleware is added in front of it; `matchAll` is for the
+   * tests that are about the middleware BEING there.
+   */
+  handlers: Array<RouteHandler>;
 };
 
 /*
@@ -29,6 +39,7 @@ export type MockIdentityRouter = {
   delete: jest.Mock;
   routes: Array<CapturedRoute>;
   match: (method: string, uri: string) => RouteHandler;
+  matchAll: (method: string, uri: string) => Array<RouteHandler>;
 };
 
 type RegisterForMethod = (
@@ -36,6 +47,36 @@ type RegisterForMethod = (
 ) => (uri: string, ...handlers: Array<RouteHandler>) => void;
 
 export type CreateMockIdentityRouterFunction = () => MockIdentityRouter;
+
+type FindRouteFunction = (
+  routes: Array<CapturedRoute>,
+  method: string,
+  uri: string,
+) => CapturedRoute;
+
+const findRoute: FindRouteFunction = (
+  routes: Array<CapturedRoute>,
+  method: string,
+  uri: string,
+): CapturedRoute => {
+  const route: CapturedRoute | undefined = routes.find(
+    (route: CapturedRoute) => {
+      return route.method === method.toUpperCase() && route.uri === uri;
+    },
+  );
+
+  if (!route) {
+    throw new Error(
+      `Route ${method} ${uri} not registered. Registered: ${routes
+        .map((r: CapturedRoute) => {
+          return `${r.method} ${r.uri}`;
+        })
+        .join(", ")}`,
+    );
+  }
+
+  return route;
+};
 
 export const createMockIdentityRouter: CreateMockIdentityRouterFunction =
   (): MockIdentityRouter => {
@@ -49,7 +90,12 @@ export const createMockIdentityRouter: CreateMockIdentityRouterFunction =
           throw new Error(`No handler registered for ${method} ${uri}`);
         }
 
-        routes.push({ method: method.toUpperCase(), uri, handler });
+        routes.push({
+          method: method.toUpperCase(),
+          uri,
+          handler,
+          handlers: handlers,
+        });
       };
     };
 
@@ -60,37 +106,39 @@ export const createMockIdentityRouter: CreateMockIdentityRouterFunction =
       delete: jest.fn(registerForMethod("delete")),
       routes,
       match: (method: string, uri: string): RouteHandler => {
-        const route: CapturedRoute | undefined = routes.find(
-          (route: CapturedRoute) => {
-            return route.method === method.toUpperCase() && route.uri === uri;
-          },
-        );
-
-        if (!route) {
-          throw new Error(
-            `Route ${method} ${uri} not registered. Registered: ${routes
-              .map((r: CapturedRoute) => {
-                return `${r.method} ${r.uri}`;
-              })
-              .join(", ")}`,
-          );
-        }
-
-        return route.handler;
+        return findRoute(routes, method, uri).handler;
+      },
+      matchAll: (method: string, uri: string): Array<RouteHandler> => {
+        return findRoute(routes, method, uri).handlers;
       },
     };
   };
 
-export type BuildRequestFunction = (body: unknown) => ExpressRequest;
+/*
+ * Anything a test needs to vary about the request beyond its body. `headers`
+ * and `socketAddress` are what the rate limiter reads to decide which client
+ * an attempt is billed to.
+ */
+export type BuildRequestOverrides = {
+  headers?: Record<string, string | Array<string>> | undefined;
+  socketAddress?: string | undefined;
+};
+
+export type BuildRequestFunction = (
+  body: unknown,
+  overrides?: BuildRequestOverrides,
+) => ExpressRequest;
 
 export const buildRequest: BuildRequestFunction = (
   body: unknown,
+  overrides?: BuildRequestOverrides,
 ): ExpressRequest => {
   return {
     body: body,
     params: {},
     query: {},
-    headers: {},
+    headers: overrides?.headers || {},
+    socket: { remoteAddress: overrides?.socketAddress },
     get: (): undefined => {
       return undefined;
     },

--- a/Common/Server/Middleware/IdentityRateLimit.ts
+++ b/Common/Server/Middleware/IdentityRateLimit.ts
@@ -1,0 +1,672 @@
+import Redis, { ClientType } from "../Infrastructure/Redis";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../Utils/Express";
+import logger from "../Utils/Logger";
+import resolveTrustedClientIp, { ClientIpRequestLike } from "../Utils/ClientIp";
+import Response from "../Utils/Response";
+import ServiceUnavailableException from "../../Types/Exception/ServiceUnavailableException";
+import TooManyRequestsException from "../../Types/Exception/TooManyRequestsException";
+
+/*
+ * Attempt limiting for the anonymous identity routes that accept a
+ * credential: POST /login, POST /verify-totp-auth, POST /verify-webauthn-auth
+ * and POST /verify-totp-enrolment
+ * (App/FeatureSet/Identity/API/Authentication.ts).
+ *
+ * WHY THESE ROUTES NEED IT
+ *
+ * All three are unauthenticated by definition -- they are how a session is
+ * obtained -- so nothing upstream of them counts anything. Until this
+ * middleware existed a caller could submit credentials to them as fast as the
+ * process would answer.
+ *
+ * /verify-totp-auth is the sharpest case. It is reached with a valid password
+ * already in hand, and the only thing left to produce is a six digit code, so
+ * unthrottled it is an online guessing oracle against a 10^6 space. The space
+ * is not even 10^6 wide at any given instant: Common/Server/Utils/TotpAuth.ts
+ * accepts TotpValidationWindow = 3 steps either side of now (seven 30 second
+ * steps, +/- 90 seconds) across both entries in SupportedTotpAlgorithms, so
+ * fourteen distinct six digit strings are live at once and a single guess
+ * lands with probability ~1.4e-5. At a few thousand requests a second that is
+ * a bypassed second factor in minutes. Bounded to the budgets below it is
+ * years, and the account owner sees the failures.
+ *
+ * /login is the same shape one step earlier, against a password rather than a
+ * code.
+ *
+ * /verify-webauthn-auth and /verify-totp-enrolment are covered for a reason
+ * that holds whatever their own factor is worth. All four routes share one
+ * `login()` function and all of them run the same `verifyHashedColumnValue`
+ * before they reach their factor, so each is a password oracle in its own
+ * right. Leaving any one of them unlimited would not be an unguarded route so
+ * much as a hole in the fence: an attacker refused at /login points the same
+ * guesses at whichever sibling still answers. The enrolment route makes that
+ * concrete -- guessing its CODE is pointless, because /login hands the user
+ * the secret it is derived from, but guessing the PASSWORD it demands first is
+ * exactly as useful there as anywhere else.
+ *
+ * CAPTCHA IS NOT THIS
+ *
+ * /login already calls CaptchaUtil.verifyCaptcha, but that is not a
+ * substitute on either axis. CAPTCHA_ENABLED is off by default, so a
+ * self-hosted instance has nothing there at all; and an hCaptcha token is
+ * single use, which is exactly why the second step of a login cannot demand
+ * one -- /verify-totp-auth deliberately does not, and could not.
+ *
+ * THIS FAILS CLOSED
+ *
+ * With Redis unreachable these routes answer 503 rather than running
+ * unthrottled. That is the choice PublicDashboardRateLimit makes for
+ * /master-password and the opposite of the one VerificationCodeRateLimit
+ * makes, and the deciding question is the same in all three: is there another
+ * control still standing? Here there is not. Nothing in Postgres counts login
+ * attempts, so serving the route without the counter means serving the
+ * unlimited guessing oracle this middleware exists to close.
+ *
+ * It also costs nothing in availability that was not already lost. A
+ * successful login goes through AccessTokenService.refreshUserAllPermissions,
+ * which writes the user's permissions to GlobalCache, which throws
+ * DatabaseNotConnectedException when Redis is down. Logging in is already
+ * impossible in that state; the difference this makes is a 503 that says to
+ * come back shortly instead of a 500.
+ */
+
+/*
+ * Every request consumes TWO counters, and either one can reject it:
+ *
+ *  - the account counter, keyed on the submitted email address AND the client
+ *    address. This is the budget one person gets for one account.
+ *
+ *  - the address counter, keyed on the client address alone. Without it the
+ *    account counter is trivially bypassed: the email address is a field in
+ *    the request body, so a caller who changes it on every request lands in a
+ *    fresh bucket every time. Against /verify-totp-auth that matters
+ *    enormously -- a code guessed against ANY account is a bypassed second
+ *    factor, the attacker does not care whose. The address counter is the
+ *    ceiling that survives email rotation.
+ *
+ * Deliberately NOT keyed on the email address alone. A bare per-account
+ * counter is a lockout weapon: anyone who knows a victim's email address
+ * could burn that account's whole budget from anywhere and keep the real
+ * owner out for as long as they cared to keep sending. Pairing the address
+ * in means an attacker can only spend their own bucket.
+ *
+ * The cost of that pairing, stated plainly: an attacker with many source
+ * addresses gets a fresh per-account budget from each one, so a distributed
+ * attack on a single account is bounded only by how many addresses they have.
+ * That is the standard trade and it is the right way round -- the alternative
+ * hands every user a remote lockout button, and the distributed case is what
+ * the account owner's own failed-login visibility and the network layer are
+ * for.
+ *
+ * Both counters are incremented on every request including a rejected one.
+ * That is standard fixed-window behaviour and it is deliberate: a caller who
+ * keeps hammering keeps their window pinned rather than being handed a fresh
+ * allowance for free.
+ */
+export enum IdentityRateLimitBucket {
+  /* POST /login. Password guessing. */
+  Login = "login",
+
+  /*
+   * POST /verify-totp-auth, POST /verify-webauthn-auth and
+   * POST /verify-totp-enrolment -- the second step, reached with a valid
+   * password already accepted.
+   */
+  TwoFactor = "two-factor",
+}
+
+export enum IdentityRateLimitScope {
+  /* One email address, from one client address. */
+  Account = "account",
+
+  /* One client address, across every account. Survives email rotation. */
+  Ip = "ip",
+}
+
+export enum IdentityRateLimitOutcome {
+  Allowed = "allowed",
+  RateLimited = "rate-limited",
+
+  /* Redis is unreachable, so no limit can be honoured either way. */
+  CounterUnavailable = "counter-unavailable",
+}
+
+export interface IdentityRateLimitDecision {
+  outcome: IdentityRateLimitOutcome;
+  retryAfterSeconds?: number | undefined;
+
+  /* Which counter rejected, for logs. Unset unless rejected. */
+  scope?: IdentityRateLimitScope | undefined;
+
+  /*
+   * True only on the request that first crossed the line in this window.
+   *
+   * The point of a limiter is that the caller keeps knocking, so logging
+   * every refusal turns a flood into a second flood in the log pipeline --
+   * the tool an operator needs to see the first one. Logging only the
+   * crossing gives exactly one line per key per window.
+   */
+  isFirstRejectionInWindow?: boolean | undefined;
+}
+
+const parsePositiveIntFromEnv: (envKey: string, fallback: number) => number = (
+  envKey: string,
+  fallback: number,
+): number => {
+  const rawValue: string | undefined = process.env[envKey];
+
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsedValue: number = parseInt(rawValue, 10);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    return fallback;
+  }
+
+  return parsedValue;
+};
+
+interface BucketConfig {
+  windowSeconds: number;
+  perAccountLimit: number;
+  perIpLimit: number;
+}
+
+/*
+ * Password budget.
+ *
+ * Ten attempts per quarter hour for one account from one address. A person
+ * who has forgotten which of their passwords this is tries three or four and
+ * then uses the reset link; ten is comfortably past that and still turns
+ * "as fast as the process answers" into forty an hour.
+ *
+ * The per-address ceiling is set for the honest worst case rather than the
+ * typical one, because a corporate NAT puts a whole office behind a single
+ * address and a morning sign-in surge must not be refused. 150 a quarter hour
+ * covers that while still bounding a caller who rotates email addresses to
+ * fifteen accounts' worth of attempts -- and it is the number an operator
+ * most likely wants to lower, which is what the environment variable is for.
+ * A limiter that fires on real users gets switched off, and a switched-off
+ * limiter bounds nothing.
+ */
+const LOGIN_BUCKET: BucketConfig = {
+  windowSeconds: parsePositiveIntFromEnv(
+    "IDENTITY_LOGIN_RATE_LIMIT_WINDOW_SECONDS",
+    15 * 60,
+  ),
+  perAccountLimit: parsePositiveIntFromEnv(
+    "IDENTITY_LOGIN_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW",
+    10,
+  ),
+  perIpLimit: parsePositiveIntFromEnv(
+    "IDENTITY_LOGIN_RATE_LIMIT_PER_IP_PER_WINDOW",
+    150,
+  ),
+};
+
+/*
+ * Second step budget.
+ *
+ * Same shape as the password bucket, and the same numbers, for a different
+ * reason: the code is read off a screen rather than recalled, so ten wrong
+ * ones in a quarter hour is already well past anything a real user does --
+ * a phone whose clock has drifted past the +/- 90 second window fails every
+ * time, and no number of retries fixes that.
+ *
+ * Kept as a SEPARATE bucket from the password one rather than a shared pool,
+ * which does mean a caller gets both budgets in a window. That is the price of
+ * the property that matters more: a burst of /login noise must not be able to
+ * refuse a user who is midway through finishing a two factor login, and a user
+ * being marched through a mandated enrolment must not be locked out of it by
+ * the /login attempt that sent them there.
+ *
+ * What ten buys against guessing: fourteen of the 10^6 codes are live at any
+ * instant, so forty guesses an hour is a ~0.06% chance of landing one in a
+ * day and about a year to reach even odds -- against an attacker who holds
+ * the account's password for that entire year and generates a visible failed
+ * attempt every ninety seconds throughout.
+ */
+const TWO_FACTOR_BUCKET: BucketConfig = {
+  windowSeconds: parsePositiveIntFromEnv(
+    "IDENTITY_TWO_FACTOR_RATE_LIMIT_WINDOW_SECONDS",
+    15 * 60,
+  ),
+  perAccountLimit: parsePositiveIntFromEnv(
+    "IDENTITY_TWO_FACTOR_RATE_LIMIT_PER_ACCOUNT_PER_WINDOW",
+    10,
+  ),
+  perIpLimit: parsePositiveIntFromEnv(
+    "IDENTITY_TWO_FACTOR_RATE_LIMIT_PER_IP_PER_WINDOW",
+    150,
+  ),
+};
+
+const KEY_PREFIX: string = "identity:rl:";
+
+/*
+ * Counter keys outlive their window by one full window, so a request landing
+ * on a boundary cannot read a key that was reclaimed mid-window.
+ */
+const TTL_MULTIPLIER: number = 2;
+
+/* Bounds a Redis key built from caller-supplied values. */
+const MAX_KEY_SEGMENT_LENGTH: number = 64;
+
+/* How often the "counter unavailable" condition may be logged, per bucket. */
+const COUNTER_UNAVAILABLE_LOG_INTERVAL_MS: number = 60 * 1000;
+
+export default class IdentityRateLimit {
+  /*
+   * The client address to bill this request to.
+   *
+   * Delegates to the shared ClientIp helper, which reads X-Forwarded-For from
+   * the trusted (right-hand) end under the instance-wide TRUSTED_PROXY_HOPS
+   * setting. Deliberately NOT Express.getClientIp: that one takes the LEFTMOST
+   * entry, which any caller can set by sending its own X-Forwarded-For header,
+   * and for a rate limiter that is fatal -- a fresh spoofed value per request
+   * is a fresh bucket per request and therefore no limit at all.
+   *
+   * The helper also normalizes ports, brackets and IPv4-mapped IPv6, so one
+   * caller cannot land in two different buckets depending on the form their
+   * address arrives in.
+   */
+  public static resolveClientIp(req: ExpressRequest): string {
+    const clientIp: string | undefined = resolveTrustedClientIp(
+      req as unknown as ClientIpRequestLike,
+    );
+
+    if (clientIp) {
+      return IdentityRateLimit.sanitizeKeySegment(clientIp);
+    }
+
+    /*
+     * Everything with no resolvable address shares one bucket. That is the
+     * conservative direction: an unidentifiable caller should not be handed a
+     * private allowance.
+     */
+    return "unknown";
+  }
+
+  /*
+   * The account this request is trying to authenticate as, as a key segment.
+   *
+   * The login page posts everything nested under `data` (see
+   * App/FeatureSet/Accounts/src/Pages/Login.tsx), which is where all four
+   * routes read the credentials from; the top level is checked too so that a
+   * caller posting the flatter shape is still counted rather than silently
+   * sharing the "none" bucket with everybody else.
+   *
+   * `email` ARRIVES IN TWO SHAPES, AND BOTH ARE FIRST-PARTY
+   *
+   * A bare string, and the serialized SerializableObject envelope
+   * `{ _type: "Email", value: "..." }` that Email.toJSON produces. Which one
+   * turns up depends on how the caller was written, and the shipped clients
+   * disagree with each other on the very routes limited here:
+   *
+   *   - POST /login from the dashboard goes through ModelForm, which hands the
+   *     model to ModelAPI.createOrUpdate, which sends
+   *     JSONFunctions.serialize(BaseModel.toJSON(...)) -- the ENVELOPE.
+   *   - POST /login from the mobile app hand-builds the same envelope
+   *     (MobileApp/src/api/auth.ts).
+   *   - POST /verify-totp-auth, /verify-totp-enrolment and
+   *     /verify-webauthn-auth from the dashboard spread the raw form values
+   *     (`...initialValues`), so there `email` is a bare STRING.
+   *
+   * The handler does not care, because BaseModel.fromJSON resolves both to the
+   * same address -- so this must not care either. Reading only the string form
+   * would put every /login from every shipped client into the shared "none"
+   * bucket, which is not a small mistake in either direction: the per-account
+   * counter would degenerate into a SECOND per-address counter at the much
+   * tighter per-account limit, refusing a whole office (or a carrier NAT) after
+   * ten sign-ins rather than the hundred and fifty the per-address ceiling is
+   * deliberately sized for; and, because the two shapes would key differently,
+   * an attacker could take the per-account budget twice by alternating them.
+   *
+   * The unwrap is deliberately not gated on `_type` being exactly Email. Any
+   * object carrying a string `value` is keyed by that value, which is the safe
+   * direction: the worst case is counting a request the handler will reject
+   * anyway against the bucket it names, whereas gating narrowly leaves another
+   * shape sitting in "none" for someone to spend.
+   *
+   * Lower-cased, because otherwise Bob@example.com and bob@example.com are
+   * two buckets for one account and case alone buys a fresh allowance. No
+   * attempt is made to validate the address: a well-formed one that belongs
+   * to nobody is worth exactly as much to an attacker as a malformed one, so
+   * there is nothing for a format check to separate. Normalizing is the part
+   * that matters.
+   */
+  public static resolveAccountKey(req: ExpressRequest): string {
+    const body: Record<string, unknown> | undefined = req.body as
+      | Record<string, unknown>
+      | undefined;
+
+    const data: Record<string, unknown> | undefined =
+      body && typeof body["data"] === "object" && body["data"] !== null
+        ? (body["data"] as Record<string, unknown>)
+        : undefined;
+
+    const field: unknown = data?.["email"] ?? body?.["email"];
+
+    /*
+     * Arrays are typeof "object" too, and indexing one by "value" is
+     * undefined rather than a throw -- but excluding them keeps the intent
+     * legible and stops a caller smuggling anything odd through.
+     */
+    const raw: unknown =
+      field && typeof field === "object" && !Array.isArray(field)
+        ? (field as Record<string, unknown>)["value"]
+        : field;
+
+    /*
+     * `email` is whatever JSON the caller sent, so it is only a string
+     * because they chose to make it one. A number, a nested object or a
+     * missing field must land in a bucket rather than throw.
+     */
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+      return "none";
+    }
+
+    return IdentityRateLimit.sanitizeKeySegment(raw.trim().toLowerCase());
+  }
+
+  private static sanitizeKeySegment(value: string): string {
+    return (
+      value
+        .slice(0, MAX_KEY_SEGMENT_LENGTH)
+        /*
+         * Redis keys are binary safe, but a predictable charset keeps
+         * operational tooling (SCAN patterns, dashboards) sane.
+         */
+        .replace(/[^a-zA-Z0-9._:%\-[\]@]/g, "_")
+    );
+  }
+
+  public static getBucketConfig(bucket: IdentityRateLimitBucket): BucketConfig {
+    return bucket === IdentityRateLimitBucket.TwoFactor
+      ? TWO_FACTOR_BUCKET
+      : LOGIN_BUCKET;
+  }
+
+  /*
+   * Increment both counters for this request and decide.
+   *
+   * Both INCRs go out in one pipeline so the common path costs a single round
+   * trip; the EXPIRE follow-ups only happen on the request that created a key.
+   */
+  public static async consume(data: {
+    accountKey: string;
+    clientIp: string;
+    bucket: IdentityRateLimitBucket;
+  }): Promise<IdentityRateLimitDecision> {
+    const client: ClientType | null = Redis.getClient();
+
+    if (!client || !Redis.isConnected()) {
+      return { outcome: IdentityRateLimitOutcome.CounterUnavailable };
+    }
+
+    const config: BucketConfig = IdentityRateLimit.getBucketConfig(data.bucket);
+
+    const windowMs: number = config.windowSeconds * 1000;
+    const windowIndex: number = Math.floor(Date.now() / windowMs);
+
+    const accountCounterKey: string = `${KEY_PREFIX}${data.bucket}:a:${data.accountKey}:${data.clientIp}:${windowIndex}`;
+    const ipCounterKey: string = `${KEY_PREFIX}${data.bucket}:i:${data.clientIp}:${windowIndex}`;
+
+    try {
+      const pipelineResults: Array<[Error | null, unknown]> | null =
+        (await client
+          .pipeline()
+          .incr(accountCounterKey)
+          .incr(ipCounterKey)
+          .exec()) as Array<[Error | null, unknown]> | null;
+
+      if (!pipelineResults || pipelineResults.length < 2) {
+        throw new Error("Rate limit pipeline returned no result");
+      }
+
+      const accountCount: number = IdentityRateLimit.readCounterResult(
+        pipelineResults[0],
+      );
+      const ipCount: number = IdentityRateLimit.readCounterResult(
+        pipelineResults[1],
+      );
+
+      /*
+       * Set the expiry only on the write that created the key. Re-issuing
+       * EXPIRE on every increment would slide the window forward for as long
+       * as the attempts continue, so the counter would never reset and a
+       * caller who tripped the limit once could never recover -- which on a
+       * login route is a permanent lockout, not a slowdown.
+       */
+      const ttlSeconds: number = config.windowSeconds * TTL_MULTIPLIER;
+      const keysToExpire: Array<string> = [];
+
+      if (accountCount === 1) {
+        keysToExpire.push(accountCounterKey);
+      }
+
+      if (ipCount === 1) {
+        keysToExpire.push(ipCounterKey);
+      }
+
+      if (keysToExpire.length > 0) {
+        const expirePipeline: ReturnType<ClientType["pipeline"]> =
+          client.pipeline();
+
+        for (const key of keysToExpire) {
+          expirePipeline.expire(key, ttlSeconds);
+        }
+
+        await expirePipeline.exec();
+      }
+
+      const retryAfterSeconds: number =
+        IdentityRateLimit.getSecondsUntilWindowEnd(config.windowSeconds);
+
+      /*
+       * The account counter is reported first when both are over, because it
+       * is the more specific of the two and the more useful thing to see in a
+       * log line.
+       */
+      if (accountCount > config.perAccountLimit) {
+        return {
+          outcome: IdentityRateLimitOutcome.RateLimited,
+          retryAfterSeconds,
+          scope: IdentityRateLimitScope.Account,
+          isFirstRejectionInWindow: accountCount === config.perAccountLimit + 1,
+        };
+      }
+
+      if (ipCount > config.perIpLimit) {
+        return {
+          outcome: IdentityRateLimitOutcome.RateLimited,
+          retryAfterSeconds,
+          scope: IdentityRateLimitScope.Ip,
+          isFirstRejectionInWindow: ipCount === config.perIpLimit + 1,
+        };
+      }
+
+      return { outcome: IdentityRateLimitOutcome.Allowed };
+    } catch (err) {
+      /*
+       * Throttled: whatever broke Redis is unlikely to have broken it for one
+       * request only, and a per-request log line buries the incident it is
+       * reporting.
+       */
+      if (IdentityRateLimit.shouldLogCounterUnavailable(data.bucket)) {
+        logger.warn(
+          `IdentityRateLimit: counter failed for ${data.bucket} request from ${data.clientIp}`,
+        );
+        logger.warn(err);
+      }
+
+      return { outcome: IdentityRateLimitOutcome.CounterUnavailable };
+    }
+  }
+
+  private static readCounterResult(
+    result: [Error | null, unknown] | undefined,
+  ): number {
+    if (!result) {
+      throw new Error("Rate limit counter returned no result");
+    }
+
+    const [error, value] = result;
+
+    if (error) {
+      throw error;
+    }
+
+    if (typeof value !== "number") {
+      throw new Error("Rate limit counter returned a non-numeric value");
+    }
+
+    return value;
+  }
+
+  /*
+   * Remaining seconds in the current fixed window, so every rejected caller
+   * is told to come back when the window actually rolls rather than all
+   * backing off by the same constant and re-colliding.
+   */
+  private static getSecondsUntilWindowEnd(windowSeconds: number): number {
+    const windowMs: number = windowSeconds * 1000;
+    const msIntoWindow: number = Date.now() % windowMs;
+
+    return Math.max(1, Math.ceil((windowMs - msIntoWindow) / 1000));
+  }
+
+  /*
+   * Express middleware. Registered as the first handler on each credential
+   * route, so a flood is refused before it costs a user lookup -- and, on the
+   * password routes, before it costs the bcrypt verify that makes each guess
+   * expensive for us as well as for the attacker.
+   */
+  public static getMiddleware(
+    bucket: IdentityRateLimitBucket,
+  ): (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ) => Promise<void> {
+    return async (
+      req: ExpressRequest,
+      res: ExpressResponse,
+      next: NextFunction,
+    ): Promise<void> => {
+      const accountKey: string = IdentityRateLimit.resolveAccountKey(req);
+      const clientIp: string = IdentityRateLimit.resolveClientIp(req);
+
+      const decision: IdentityRateLimitDecision =
+        await IdentityRateLimit.consume({
+          accountKey,
+          clientIp,
+          bucket,
+        });
+
+      if (decision.outcome === IdentityRateLimitOutcome.RateLimited) {
+        if (decision.retryAfterSeconds) {
+          IdentityRateLimit.setRetryAfterHeader(
+            res,
+            decision.retryAfterSeconds,
+          );
+        }
+
+        if (decision.isFirstRejectionInWindow) {
+          logger.warn(
+            `IdentityRateLimit: rejected ${bucket} attempt for ${accountKey} from ${clientIp} (${decision.scope} limit)`,
+          );
+        }
+
+        /*
+         * The same message whichever counter fired, and whether or not the
+         * account exists. These routes are careful not to say which half of a
+         * credential was wrong; a limiter that answered differently for a real
+         * address than for an invented one would hand back the account
+         * enumeration the handlers withhold.
+         */
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new TooManyRequestsException(
+            "Too many sign-in attempts. Please try again later.",
+          ),
+        );
+      }
+
+      if (decision.outcome === IdentityRateLimitOutcome.CounterUnavailable) {
+        /*
+         * Fails closed. See the note at the top of this file: the counter is
+         * the only thing bounding guesses on these routes, and a login cannot
+         * complete without Redis anyway.
+         */
+        if (IdentityRateLimit.shouldLogCounterUnavailable(bucket)) {
+          logger.error(
+            `IdentityRateLimit: rate limit counter unavailable, refusing ${bucket} attempts`,
+          );
+        }
+
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new ServiceUnavailableException(
+            "Unable to sign you in right now. Please try again shortly.",
+          ),
+        );
+      }
+
+      return next();
+    };
+  }
+
+  /*
+   * A Redis outage means EVERY request takes the unavailable path, so an
+   * unguarded log line there is one per request for as long as the outage
+   * lasts -- the same log-flooding problem the crossing-only rejection log
+   * avoids, but continuous. One line per bucket per interval is enough to
+   * make the condition visible without burying everything else.
+   */
+  private static shouldLogCounterUnavailable(
+    bucket: IdentityRateLimitBucket,
+  ): boolean {
+    const now: number = Date.now();
+    const lastLoggedAt: number =
+      IdentityRateLimit.counterUnavailableLastLoggedAt.get(bucket) || 0;
+
+    if (now - lastLoggedAt < COUNTER_UNAVAILABLE_LOG_INTERVAL_MS) {
+      return false;
+    }
+
+    IdentityRateLimit.counterUnavailableLastLoggedAt.set(bucket, now);
+
+    return true;
+  }
+
+  private static counterUnavailableLastLoggedAt: Map<
+    IdentityRateLimitBucket,
+    number
+  > = new Map();
+
+  private static setRetryAfterHeader(
+    res: ExpressResponse,
+    retryAfterSeconds: number,
+  ): void {
+    const setHeader: unknown = (res as unknown as Record<string, unknown>)[
+      "setHeader"
+    ];
+
+    if (typeof setHeader === "function") {
+      (setHeader as (name: string, value: string) => void).call(
+        res,
+        "Retry-After",
+        String(retryAfterSeconds),
+      );
+    }
+  }
+}


### PR DESCRIPTION
### Title of this pull request?

fix(identity): bound guessing on the anonymous credential routes

### Small Description?

`App/FeatureSet/Identity` mounted its routers with **no attempt limiting of any kind**, so `POST /login`, `POST /verify-totp-auth`, `POST /verify-webauthn-auth` and `POST /verify-totp-enrolment` accepted credentials as fast as the process would answer them.

**`/verify-totp-auth` is the sharp one.** It is reached with a valid password already in hand, and the only thing left to produce is a six digit code — so unthrottled it is an online guessing oracle against a 10^6 space. The space is not even 10^6 wide at any instant: `TotpAuth` accepts `TotpValidationWindow = 3` steps either side of now (seven 30-second steps, ±90 seconds) across **both** entries in `SupportedTotpAlgorithms`, so fourteen distinct six-digit strings are live at once and a single guess lands with probability ~1.4e-5. At a few thousand requests a second that is a bypassed second factor in minutes.

This is a **second-factor bypass rather than a full takeover** — the password is still required first — but it is the kind of thing that should not be missing.

`/login` is the same shape one step earlier, against a password.

`/verify-webauthn-auth` and `/verify-totp-enrolment` are covered for a reason that holds whatever their own factor is worth. All four routes share one `login()` function and **every one of them runs the same `verifyHashedColumnValue` before it reaches its factor**, so each is a password oracle in its own right. Leaving any one unlimited would not be an unguarded route so much as a hole in the fence: an attacker refused at `/login` points the same guesses at whichever sibling still answers. The enrolment route makes that concrete — guessing its *code* is pointless, because `/login` hands the user the very secret it is derived from, but guessing the *password* it demands first is exactly as useful there.

Captcha was never a substitute. `CAPTCHA_ENABLED` is off by default, so a self-hosted instance has nothing there at all; and an hCaptcha token is single-use, which is exactly why the second step of a login cannot demand one — `/verify-totp-auth` deliberately does not, and could not.

---

## What this adds

`Common/Server/Middleware/IdentityRateLimit.ts`, modelled on the two limiters the codebase already ships (`PublicDashboardRateLimit`, `VerificationCodeRateLimit`) and following their structure deliberately, so the next person to read all three finds one pattern rather than three.

**Two buckets, separately tunable.** `Login` for the password step, `TwoFactor` for the three second-step routes. Both default to a 15-minute window, **10 attempts per account** and **150 per client address**, with six environment variables to move them. They are kept separate rather than pooled so a burst of `/login` noise cannot refuse a user midway through finishing a two-factor login, and so a user being marched through a mandated enrolment is not locked out of it by the `/login` attempt that sent them there.

**Two counters per request, either of which can reject it.** The account counter is keyed on the submitted email address **and** the client address; the address counter is keyed on the address alone. The second is what survives email rotation — the address is a field in the request body, so without it a caller changing it on every request lands in a fresh bucket every time, and against the second factor that works, because a code guessed for *any* account is a bypass.

Deliberately **not** keyed on the email address alone. A bare per-account counter is a lockout weapon: anyone who knows a victim's address could burn that account's budget from anywhere and keep the real owner out. The cost of pairing the address in, stated plainly in the file, is that an attacker with many source addresses gets a fresh per-account budget from each one.

**The client address** comes from `resolveTrustedClientIp`, which reads `X-Forwarded-For` from the trusted right-hand end — **not** `Express.getClientIp`, which takes the leftmost entry, the one any caller can set. For a rate limiter that distinction is the whole thing: a fresh spoofed value per request is a fresh bucket per request, and therefore no limit at all.

## The email address arrives in two shapes, and both are first-party

Worth calling out for review, because reading only one of them is a bug that looks like working code — and it is the defect this change's own review caught.

`email` reaches these routes either as a bare string or as the serialized `SerializableObject` envelope `{ _type: "Email", value }` that `Email.toJSON` produces, and **the shipped clients disagree on the very routes limited here**:

| caller | route | shape |
| --- | --- | --- |
| Dashboard (`ModelForm` → `ModelAPI.createOrUpdate` → `JSONFunctions.serialize`) | `/login` | envelope |
| Mobile app (`MobileApp/src/api/auth.ts`, hand-built) | `/login` | envelope |
| Dashboard (spreads raw `initialValues`) | the three second-step routes | bare string |

`BaseModel.fromJSON` resolves both to the same address, so the counter has to as well. Keying only the string form would have put **every `/login` from every shipped client** into the shared `"none"` bucket — which is not a weaker limit but a much *tighter* one applied to the wrong thing: one office behind one NAT refused after ten sign-ins between all of them, rather than the hundred and fifty the per-address ceiling exists to allow. It would also have let an attacker take the per-account budget twice by alternating the two shapes.

## Why it fails closed

With Redis unreachable these routes answer **503** rather than running unthrottled. That is the choice `PublicDashboardRateLimit` makes for `/master-password` and the opposite of `VerificationCodeRateLimit`'s, and the deciding question is the same in all three: **is another control still standing?** Here there is not — nothing in Postgres counts login attempts, so serving the route without the counter is serving the unlimited oracle this exists to close.

It also costs no availability that was not already lost. A successful login goes through `AccessTokenService.refreshUserAllPermissions` → `GlobalCache.setJSON`, which throws `DatabaseNotConnectedException` when Redis is down. Logging in is already impossible in that state; the difference is a 503 that says to come back shortly instead of a 500.

## Reviewer notes

- **Registration order matters and is tested.** Both limiters are the *first* handler on their routes, ahead of the user lookup and the bcrypt verify, so a flood is refused before it costs anything — and before timing can leak whether an address exists.
- **No double counting.** `Index.ts` mounts the same router instance at two paths (`['/api/identity', '/']`); Express registers that as one layer with two paths, so a request is dispatched once.
- **The window does not slide.** `EXPIRE` is issued only on the write that created a key. Re-issuing it per increment would push the reset out for as long as attempts kept arriving — which on a login route is a permanent lockout dressed up as a rate limit, since retrying is exactly what a locked-out human does.

## Testing

**28 new tests** in `App/Tests/FeatureSet/Identity/IdentityRateLimit.test.ts`, driving the **whole registered chain** — limiter first, handler last — because that is the only arrangement that can tell a wired-up limiter from an unwired one. Redis is faked rather than mocked per assertion: `INCR` really increments and `EXPIRE` really records a TTL, so the window tests exercise the arithmetic instead of restating it.

They pin the properties that decide whether the limit can be walked around at all — each of which is a way this could look present in a diff and be worth nothing:

- it runs before the handler touches the database;
- rotating the email address runs into the address ceiling;
- neither changing its **case** nor switching between its two wire **shapes** resets the count;
- two different accounts behind one address are **not** collapsed onto one counter;
- a forged `X-Forwarded-For` entry buys nothing;
- the window does not slide forward under sustained load;
- the two buckets are independent, and all three second-step routes share one;
- both counter-unavailable paths refuse rather than serve.

The two wire-shape tests were **mutation-checked**: reverting the unwrap in `resolveAccountKey` fails three of them.

`IdentityRouterTestUtil` gains `matchAll`, which returns every handler registered on a route. `match` still returns the last one, so the seven existing Identity suites needed no changes.

**218 tests pass** across `App/Tests/FeatureSet/Identity` (11 suites). eslint and prettier clean; `Common` and `App` both type-check.

## Not covered here

- The status page has its own anonymous `POST /login` (`App/FeatureSet/Identity/API/StatusPageAuthentication.ts`) — the same bcrypt password oracle, still unlimited. So are `/signup`, `/forgot-password` and `/reset-password` on both routers. Those are a different abuse shape (mail flooding, reset-token guessing) and want their own bucket sizing.
- The per-address counter keys on the **full** IPv6 address, so an attacker with a routed /64 gets a fresh address ceiling per host. Keying IPv6 to its /64 prefix would close that — but it is equally true of the two limiters already shipped, and is better done across all three at once than diverged here.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). — no issue filed for this
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None. Adjacent to the admin-MFA work in #3313 / #3314, which added `/verify-totp-enrolment` — that route is covered here.

### Screenshots (if appropriate):

Not applicable — server-side middleware, no UI change.
