### PR TITLE
fix(discovery): harden the SNMP / No SNMP review filter, and test it properly

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter.ts
@@ -74,13 +74,134 @@ export function matchesDiscoveredHostFilter(data: {
   host: DiscoveredNetworkDevice;
   filter: DiscoveredHostFilter;
 }): boolean {
-  if (data.filter === DiscoveredHostFilter.All) {
-    return true;
-  }
-
   const isPingOnly: boolean = isPingOnlyDiscoveredHost(data.host);
 
-  return data.filter === DiscoveredHostFilter.NoSnmp ? isPingOnly : !isPingOnly;
+  if (data.filter === DiscoveredHostFilter.NoSnmp) {
+    return isPingOnly;
+  }
+
+  if (data.filter === DiscoveredHostFilter.Snmp) {
+    return !isPingOnly;
+  }
+
+  /*
+   * All, and anything unrecognised. The page casts into the enum
+   * (`value as DiscoveredHostFilter`), so nothing at runtime rejects a value
+   * outside the three — a persisted preference or a URL parameter is one
+   * change away from supplying one. Falling through to "show everything" is
+   * the only safe default: the label and empty-message helpers already fall
+   * through to the All wording, so any other fall-through would produce a
+   * dialog headed "All" that had silently hidden a whole group, which is the
+   * exact confusion #3322 was filed about.
+   */
+  return true;
+}
+
+/*
+ * What a nullish or non-object entry in the jsonb reads as: nothing. Written
+ * as a type guard so the normalisation below narrows properly.
+ */
+function isDiscoveredHostObject(
+  host: unknown,
+): host is DiscoveredNetworkDevice {
+  return Boolean(host) && typeof host === "object";
+}
+
+/**
+ * The scan's rows, cleaned up so every rule downstream sees the same thing.
+ *
+ * `discoveredDevices` is jsonb written verbatim from the probe's payload, and
+ * the only guard on it checks that the VALUE is an array — never that its
+ * elements are shaped like hosts. Everything the dialog does keys off
+ * `ipAddress`, so three payload shapes that a probe should never send, but
+ * that nothing stops it sending, each broke something:
+ *
+ *   - A `null` element. Every predicate dereferences the host, so one null row
+ *     threw a TypeError the moment the operator clicked a filter button —
+ *     inside the modal body, during render.
+ *   - A non-string address. `10` is written into the selection record as the
+ *     key "10" (object keys are strings) but matched out of the imported-set
+ *     with `Set.has(10)`, which does not coerce — so the host imported and
+ *     then could never be retired, and pressing Import again duplicated it.
+ *   - The same address on two rows with different frozen `isAlreadyRegistered`
+ *     values. One checkbox governs both rows, but only one of them refused to
+ *     import, so whether a device already in the inventory got created a
+ *     second time depended on which order the probe happened to list them in.
+ *
+ * All three are fixed here rather than at each call site, so the row the
+ * operator sees, the badge above it and the list Import walks can never be
+ * working from three different readings of the same payload.
+ */
+export function normalizeDiscoveredHosts(
+  hosts: Array<DiscoveredNetworkDevice>,
+): Array<DiscoveredNetworkDevice> {
+  const cleaned: Array<DiscoveredNetworkDevice> = [];
+
+  for (const host of hosts) {
+    if (!isDiscoveredHostObject(host)) {
+      continue;
+    }
+
+    /*
+     * Trimmed as well as stringified: " " is not an address, but it is
+     * truthy, so it used to pass selectability and import as a Network Device
+     * whose hostname was a single space.
+     */
+    cleaned.push({
+      ...host,
+      ipAddress:
+        host.ipAddress === undefined || host.ipAddress === null
+          ? ""
+          : String(host.ipAddress).trim(),
+    });
+  }
+
+  // An address the scan reports as registered is registered on every row.
+  const registeredIpAddresses: Set<string> = new Set<string>();
+
+  for (const host of cleaned) {
+    if (host.ipAddress && host.isAlreadyRegistered) {
+      registeredIpAddresses.add(host.ipAddress);
+    }
+  }
+
+  if (registeredIpAddresses.size === 0) {
+    return cleaned;
+  }
+
+  return cleaned.map((host: DiscoveredNetworkDevice) => {
+    if (
+      host.isAlreadyRegistered ||
+      !registeredIpAddresses.has(host.ipAddress)
+    ) {
+      return host;
+    }
+
+    return { ...host, isAlreadyRegistered: true };
+  });
+}
+
+/**
+ * True when this address carries a tick of its own.
+ *
+ * `hasOwnProperty` rather than a bare index, because the address is a
+ * probe-supplied string used verbatim as an object key: a host reporting its
+ * address as "constructor" or "toString" finds a truthy function on
+ * `Object.prototype` and imports itself without anyone ever ticking it. A host
+ * whose address spells "__proto__" cannot be ticked at all — assigning that
+ * key on an object literal runs the prototype setter and stores nothing — so
+ * it now stays out of the import instead of walking into it.
+ */
+export function isSelectedIpAddress(data: {
+  selectedIpAddresses: Record<string, boolean>;
+  ipAddress: string;
+}): boolean {
+  return (
+    Object.prototype.hasOwnProperty.call(
+      data.selectedIpAddresses,
+      data.ipAddress,
+    ) && Boolean(data.selectedIpAddresses[data.ipAddress])
+  );
 }
 
 /**
@@ -97,6 +218,46 @@ export function filterDiscoveredHosts(data: {
   return data.hosts.filter((host: DiscoveredNetworkDevice) => {
     return matchesDiscoveredHostFilter({ host: host, filter: data.filter });
   });
+}
+
+/**
+ * A host paired with where it sits in the UNFILTERED scan.
+ *
+ * The dialog keys its rows by address plus position. Taking that position from
+ * the filtered array moves it every time the filter changes, which changes the
+ * key, which makes React unmount and remount the row — and `CheckboxElement`
+ * seeds its checked state from `initialValue` and only reconciles `value` in a
+ * passive effect, so a remounted row paints UNCHECKED for a frame. On a
+ * thousands-of-hosts scan the whole selection appears to blank out and snap
+ * back on every filter click, in a dialog whose entire job is deciding what is
+ * ticked. Scan position does not move when the filter changes, so it is what
+ * the key has to be built from.
+ */
+export interface ShownDiscoveredHost {
+  host: DiscoveredNetworkDevice;
+  /** Index in the unfiltered scan — stable across filter changes. */
+  scanIndex: number;
+}
+
+/**
+ * The rows to render, each carrying its stable identity.
+ *
+ * Same order and same membership as `filterDiscoveredHosts`; this is that
+ * function plus the position the caller needs for a React key.
+ */
+export function getShownDiscoveredHosts(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+}): Array<ShownDiscoveredHost> {
+  const shown: Array<ShownDiscoveredHost> = [];
+
+  data.hosts.forEach((host: DiscoveredNetworkDevice, scanIndex: number) => {
+    if (matchesDiscoveredHostFilter({ host: host, filter: data.filter })) {
+      shown.push({ host: host, scanIndex: scanIndex });
+    }
+  });
+
+  return shown;
 }
 
 /**
@@ -153,6 +314,33 @@ export function getDiscoveredHostFilterLabel(
 }
 
 /**
+ * What to say when a group has nothing in it.
+ *
+ * A separate function rather than `No ${getDiscoveredHostFilterLabel(f)} hosts`
+ * because that label is a noun phrase built for a button — and for the No SNMP
+ * group it already starts with "No", so the sentence frame's own "No " collided
+ * with it and the dialog read "No No SNMP hosts in this scan." A group of zero
+ * is one click away on any all-SNMP sweep, so that sentence is not a rare path.
+ *
+ * The two group messages are phrased positively for the same reason: "every
+ * host answered SNMP" tells the operator what the sweep found, where "no
+ * ping-only hosts" only tells them what it did not.
+ */
+export function getDiscoveredHostFilterEmptyMessage(
+  filter: DiscoveredHostFilter,
+): string {
+  if (filter === DiscoveredHostFilter.Snmp) {
+    return "No host in this scan answered SNMP.";
+  }
+
+  if (filter === DiscoveredHostFilter.NoSnmp) {
+    return "Every host in this scan answered SNMP.";
+  }
+
+  return "This scan did not find any responding hosts.";
+}
+
+/**
  * The filter row, counts included.
  *
  * The count is in the label rather than in a badge because a group of zero has
@@ -199,10 +387,21 @@ export function getDiscoveredHostFilterOptions(
  * to import.
  */
 export function isSelectableDiscoveredHost(
-  host: DiscoveredNetworkDevice,
+  host: DiscoveredNetworkDevice | null | undefined,
 ): boolean {
+  if (!host) {
+    return false;
+  }
+
+  /*
+   * Trimmed, so a whitespace-only address is refused the same way an empty
+   * one is. normalizeDiscoveredHosts already trims, but this predicate is
+   * exported and called on raw rows too, and "selectable" disagreeing with
+   * itself depending on which list you came through is the class of bug the
+   * whole module is arranged to avoid.
+   */
   return (
-    Boolean(host.ipAddress) &&
+    Boolean(String(host.ipAddress ?? "").trim()) &&
     !host.isAlreadyRegistered &&
     isImportableDiscoveredHost(host)
   );
@@ -235,12 +434,91 @@ export function markDiscoveredHostsAsRegistered(data: {
   }
 
   return data.hosts.map((host: DiscoveredNetworkDevice) => {
-    if (!data.importedIpAddresses.has(host.ipAddress)) {
+    /*
+     * Stringified: object keys are strings, so a numeric address is recorded
+     * as "10" on the way in and would never match `has(10)` on the way out —
+     * leaving an imported host looking importable for ever.
+     */
+    if (!data.importedIpAddresses.has(String(host?.ipAddress ?? ""))) {
       return host;
     }
 
     return { ...host, isAlreadyRegistered: true };
   });
+}
+
+/*
+ * Where the page remembers what it has imported, keyed by scan.
+ *
+ * Keyed rather than a bare set for two reasons, both of which are real:
+ *
+ *   - An import of 2,866 hosts is thousands of sequential creates and runs for
+ *     minutes. Nothing stops the operator closing the dialog and opening a
+ *     different scan meanwhile, and a bare set written when that run finally
+ *     lands would mark the OTHER scan's same-addressed hosts "Already added" —
+ *     disabled, unticked, silently skipped by Import.
+ *   - Keeping the record per scan lets it outlive the dialog, so closing and
+ *     reopening the same scan does not resurrect what was just imported.
+ *     `isAlreadyRegistered` is frozen into the jsonb at probe-upload time and
+ *     never recomputed, so without that the reopened dialog offers imported
+ *     hosts again, pre-checked, and Import creates duplicates.
+ *
+ * A plain Record of arrays rather than a Map of Sets so the value stays
+ * JSON-shaped: it is React state, it gets compared and asserted on, and
+ * neither of those is pleasant with nested Maps.
+ */
+export type ImportedIpAddressesByScanId = Record<string, Array<string>>;
+
+/** What has been imported for one scan, ready for the overlay. */
+export function getImportedIpAddressesForScan(data: {
+  importedByScanId: ImportedIpAddressesByScanId;
+  scanId: string | null | undefined;
+}): Set<string> {
+  if (!data.scanId) {
+    return new Set<string>();
+  }
+
+  /*
+   * hasOwnProperty for the same reason the selection lookup uses it: a bare
+   * index into a plain object finds inherited members, and `new Set(fn)` on
+   * an inherited function throws rather than falling back to the `|| []`.
+   */
+  if (
+    !Object.prototype.hasOwnProperty.call(data.importedByScanId, data.scanId)
+  ) {
+    return new Set<string>();
+  }
+
+  return new Set<string>(data.importedByScanId[data.scanId] || []);
+}
+
+/**
+ * The store with more addresses recorded against one scan.
+ *
+ * Additive and duplicate-free, so two imports in one sitting accumulate rather
+ * than the second replacing the first.
+ */
+export function withImportedIpAddresses(data: {
+  importedByScanId: ImportedIpAddressesByScanId;
+  scanId: string | null | undefined;
+  ipAddresses: Array<string>;
+}): ImportedIpAddressesByScanId {
+  if (!data.scanId || data.ipAddresses.length === 0) {
+    return data.importedByScanId;
+  }
+
+  const merged: Set<string> = new Set<string>([
+    ...getImportedIpAddressesForScan({
+      importedByScanId: data.importedByScanId,
+      scanId: data.scanId,
+    }),
+    ...data.ipAddresses,
+  ]);
+
+  return {
+    ...data.importedByScanId,
+    [data.scanId]: Array.from(merged),
+  };
 }
 
 /**
@@ -297,7 +575,12 @@ export function getDiscoveredHostsToImport(data: {
       return false;
     }
 
-    if (!data.selectedIpAddresses[host.ipAddress]) {
+    if (
+      !isSelectedIpAddress({
+        selectedIpAddresses: data.selectedIpAddresses,
+        ipAddress: host.ipAddress,
+      })
+    ) {
       return false;
     }
 

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryImportEligibility.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryImportEligibility.ts
@@ -30,9 +30,19 @@ import NetworkDeviceMonitoringMethod from "Common/Types/NetworkDevice/NetworkDev
  * importing as SNMP devices.
  */
 export function monitoringMethodForDiscoveredHost(
-  host: DiscoveredNetworkDevice,
+  host: DiscoveredNetworkDevice | null | undefined,
 ): NetworkDeviceMonitoringMethod {
-  return host.snmpReachable === false
+  /*
+   * Nullish hosts read as SNMP rather than throwing. `discoveredDevices` is
+   * jsonb written verbatim from the probe's payload and the only guard on it
+   * (DiscoveryScanOutcome.getDiscoveredHosts) checks that the VALUE is an
+   * array — never that its elements are objects. A single null element used
+   * to take the whole page down from inside a table cell or a modal body,
+   * where a thrown TypeError has nowhere useful to go. Every other kind of
+   * junk element (a number, a string, {}) already read as SNMP; null is now
+   * simply consistent with them.
+   */
+  return host?.snmpReachable === false
     ? NetworkDeviceMonitoringMethod.Monitor
     : NetworkDeviceMonitoringMethod.Snmp;
 }

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome.ts
@@ -1,6 +1,7 @@
 import NetworkDeviceDiscoveryScan, {
   DiscoveredNetworkDevice,
 } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { isPingOnlyDiscoveredHost } from "./DiscoveredHostFilter";
 
 /*
  * Pure, react-free reading of "what did this discovery scan actually find".
@@ -66,16 +67,26 @@ export function getDiscoveredHosts(
 /**
  * Hosts that answered ICMP but not SNMP.
  *
- * Only an EXPLICIT snmpReachable === false counts, matching
- * isImportableDiscoveredHost: scans stored before the field existed carry
- * undefined and every host on them answered SNMP, so legacy rows must not be
- * retroactively reported as ping-only.
+ * Only an EXPLICIT snmpReachable === false counts: scans stored before the
+ * field existed carry undefined and every host on them answered SNMP, so
+ * legacy rows must not be retroactively reported as ping-only.
+ *
+ * Asked through `isPingOnlyDiscoveredHost` rather than by reading
+ * `snmpReachable` here as well, because this number and the dialog's
+ * "No SNMP (N)" badge describe the same set of hosts on two screens the
+ * operator moves between in one click — the scans table says "+N alive
+ * without SNMP", they press Review Results, and the badge had better say N.
+ * Two copies of the rule is how those two numbers come to disagree.
+ *
+ * It also stops a junk jsonb element taking the table down: the predicate is
+ * nullish-safe, where the bare `host.snmpReachable` this replaced threw a
+ * TypeError from inside a table cell.
  */
 export function countPingOnlyHosts(
   scan: NetworkDeviceDiscoveryScan | null | undefined,
 ): number {
   return getDiscoveredHosts(scan).filter((host: DiscoveredNetworkDevice) => {
-    return host.snmpReachable === false;
+    return isPingOnlyDiscoveredHost(host);
   }).length;
 }
 

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -34,10 +34,7 @@ import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
 import { getSnmpConfigFormFields } from "./SnmpConfigFormFields";
-import {
-  isImportableDiscoveredHost,
-  monitoringMethodForDiscoveredHost,
-} from "../../Components/NetworkDevice/DiscoveryImportEligibility";
+import { monitoringMethodForDiscoveredHost } from "../../Components/NetworkDevice/DiscoveryImportEligibility";
 import NetworkDeviceMonitoringMethod from "Common/Types/NetworkDevice/NetworkDeviceMonitoringMethod";
 import {
   DiscoveryScanOutcome,
@@ -47,22 +44,30 @@ import {
 import {
   DiscoveredHostFilter,
   DiscoveredHostFilterOption,
+  ImportedIpAddressesByScanId,
+  ShownDiscoveredHost,
   areAllShownHostsSelected,
   countSelectableShownHosts,
-  filterDiscoveredHosts,
+  getDiscoveredHostFilterEmptyMessage,
   getDiscoveredHostFilterLabel,
   getDiscoveredHostFilterOptions,
   getDiscoveredHostsToImport,
+  getImportedIpAddressesForScan,
   getInitialSelection,
+  getShownDiscoveredHosts,
   isPingOnlyDiscoveredHost,
+  isSelectableDiscoveredHost,
   markDiscoveredHostsAsRegistered,
+  normalizeDiscoveredHosts,
   toggleSelectionForShownHosts,
+  withImportedIpAddresses,
 } from "../../Components/NetworkDevice/DiscoveredHostFilter";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -92,15 +97,26 @@ const NetworkDeviceDiscovery: FunctionComponent<
   const [isImporting, setIsImporting] = useState<boolean>(false);
   const [importError, setImportError] = useState<string>("");
   /*
-   * Addresses imported during this sitting. The scan's own
+   * Addresses imported from each scan, per scan id. The scan's own
    * `isAlreadyRegistered` flags were frozen when the probe uploaded its
    * results, so without this the dialog would re-offer what it just imported
    * — which now matters, because importing one group and then the other is
    * the intended flow rather than an unusual one.
+   *
+   * Kept for the life of the page rather than the life of the dialog, so
+   * closing and reopening the same scan does not resurrect imported hosts;
+   * and keyed by scan so a long import that lands after the operator has
+   * moved to a different scan cannot mark that scan's hosts.
    */
-  const [importedIpAddresses, setImportedIpAddresses] = useState<Set<string>>(
-    new Set<string>(),
-  );
+  const [importedIpAddressesByScanId, setImportedIpAddressesByScanId] =
+    useState<ImportedIpAddressesByScanId>({});
+  /*
+   * The scan the dialog is showing right now, readable from inside an import
+   * that started minutes ago. State would be the value captured when the run
+   * began, which is exactly the value that cannot answer "is this still the
+   * dialog I was importing for".
+   */
+  const reviewedScanIdRef: React.MutableRefObject<string> = useRef<string>("");
 
   const fetchProbes: PromiseVoidFunction = async (): Promise<void> => {
     setIsLoading(true);
@@ -123,22 +139,30 @@ const NetworkDeviceDiscovery: FunctionComponent<
 
   type GetReviewHostsFunction = (
     scan: NetworkDeviceDiscoveryScan | null,
-    imported?: Set<string>,
+    importedByScanId?: ImportedIpAddressesByScanId,
   ) => Array<DiscoveredDeviceEntry>;
 
   /*
    * The list the dialog reasons about: what the probe found, with anything
-   * imported since the dialog opened flipped to already-registered. Every
+   * already imported from this scan flipped to already-registered. Every
    * count, filter and import path goes through this so they cannot disagree
    * about what is still importable.
    */
   const getReviewHosts: GetReviewHostsFunction = (
     scan: NetworkDeviceDiscoveryScan | null,
-    imported?: Set<string>,
+    importedByScanId?: ImportedIpAddressesByScanId,
   ): Array<DiscoveredDeviceEntry> => {
     return markDiscoveredHostsAsRegistered({
-      hosts: getDiscoveredHosts(scan),
-      importedIpAddresses: imported || importedIpAddresses,
+      /*
+       * Normalised first: the jsonb comes verbatim off the probe, and a null
+       * row or a numeric address used to break a different rule at each call
+       * site. See normalizeDiscoveredHosts.
+       */
+      hosts: normalizeDiscoveredHosts(getDiscoveredHosts(scan)),
+      importedIpAddresses: getImportedIpAddressesForScan({
+        importedByScanId: importedByScanId || importedIpAddressesByScanId,
+        scanId: scan?._id,
+      }),
     });
   };
 
@@ -146,15 +170,18 @@ const NetworkDeviceDiscovery: FunctionComponent<
     scan: NetworkDeviceDiscoveryScan,
   ): void => {
     setScanToReview(scan);
+    // Answers "is this still the dialog I am importing for" from a stale run.
+    reviewedScanIdRef.current = scan._id || "";
     /*
      * Preselect every host that is not already registered. Ping-only hosts
      * are included: they import as monitor-backed devices rather than as
-     * SNMP-credentialed ones that could never be polled.
+     * SNMP-credentialed ones that could never be polled. Read through the
+     * overlay so reopening a scan does not re-tick what was already imported
+     * from it.
      */
-    setSelectedIps(getInitialSelection(getDiscoveredHosts(scan)));
+    setSelectedIps(getInitialSelection(getReviewHosts(scan)));
     // Every scan opens on the whole list; narrowing is the operator's move.
     setHostFilter(DiscoveredHostFilter.All);
-    setImportedIpAddresses(new Set<string>());
     setImportError("");
     setShowReviewModal(true);
   };
@@ -162,10 +189,15 @@ const NetworkDeviceDiscovery: FunctionComponent<
   const closeReviewModal: VoidFunction = (): void => {
     setShowReviewModal(false);
     setScanToReview(null);
+    reviewedScanIdRef.current = "";
     setSelectedIps({});
     setHostFilter(DiscoveredHostFilter.All);
-    setImportedIpAddresses(new Set<string>());
     setImportError("");
+    /*
+     * importedIpAddressesByScanId is deliberately NOT cleared. It is what
+     * stops a reopened scan offering hosts that are already in the inventory,
+     * and the scan row it describes does not change when the dialog closes.
+     */
   };
 
   const importSelectedDevices: PromiseVoidFunction =
@@ -173,6 +205,15 @@ const NetworkDeviceDiscovery: FunctionComponent<
       if (!scanToReview) {
         return;
       }
+
+      /*
+       * The scan this run belongs to. Importing a large group is thousands of
+       * sequential creates and takes minutes, during which the dialog can be
+       * closed and another scan opened — so everything this run does when it
+       * finally lands has to be attributed to the scan it started on, not to
+       * whatever is on screen by then.
+       */
+      const runScanId: string = scanToReview._id || "";
 
       /*
        * Selected AND currently shown. Scoping to the active filter is what
@@ -288,13 +329,34 @@ const NetworkDeviceDiscovery: FunctionComponent<
       /*
        * Retire what was imported so it cannot be imported a second time, and
        * so the row shows "Already added" like any other registered host.
+       *
+       * Recorded against this run's own scan, and merged functionally, so it
+       * is correct whether or not the operator has moved on and whether or
+       * not another import already wrote to the store.
        */
-      const importedAfterThisRun: Set<string> = new Set<string>([
-        ...importedIpAddresses,
-        ...importedNow,
-      ]);
+      const importedAfterThisRun: ImportedIpAddressesByScanId =
+        withImportedIpAddresses({
+          importedByScanId: importedIpAddressesByScanId,
+          scanId: runScanId,
+          ipAddresses: importedNow,
+        });
 
-      setImportedIpAddresses(importedAfterThisRun);
+      setImportedIpAddressesByScanId((current: ImportedIpAddressesByScanId) => {
+        return withImportedIpAddresses({
+          importedByScanId: current,
+          scanId: runScanId,
+          ipAddresses: importedNow,
+        });
+      });
+
+      /*
+       * Whether the dialog still belongs to this run. A run that outlived its
+       * dialog must not push its errors onto whatever is open now, and must
+       * not close it — but its toasts still fire, because the devices really
+       * were created and the operator needs to know.
+       */
+      const isStillTheSameReview: boolean =
+        reviewedScanIdRef.current === runScanId;
 
       if (successCount > 0) {
         ShowToastNotification({
@@ -314,19 +376,30 @@ const NetworkDeviceDiscovery: FunctionComponent<
           } failed to import.`,
           type: ToastType.DANGER,
         });
-        setImportError(failures.join(" "));
+
+        if (isStillTheSameReview) {
+          setImportError(failures.join(" "));
+        }
       } else if (
+        isStillTheSameReview &&
         /*
          * Closing on success is right only when there is nothing left to do.
          * Importing group by group means the usual case is now "the SNMP
          * devices are in, the ping-only ones are still waiting" — closing
          * there would throw away the review and make the operator reopen the
          * scan to finish the job.
+         *
+         * The test is on what is still SELECTED, not on what is still
+         * selectable. Gating on selectable would keep the dialog open after a
+         * complete import whenever the operator had deliberately unticked a
+         * host — showing them a dialog whose only button reads "Import
+         * Selected (0)" and is disabled, with nothing left to do in it.
          */
-        countSelectableShownHosts({
+        getDiscoveredHostsToImport({
           hosts: getReviewHosts(scanToReview, importedAfterThisRun),
           filter: DiscoveredHostFilter.All,
-        }) === 0
+          selectedIpAddresses: selectedIps,
+        }).length === 0
       ) {
         closeReviewModal();
       }
@@ -357,7 +430,11 @@ const NetworkDeviceDiscovery: FunctionComponent<
       },
     );
 
-  const shownEntries: Array<DiscoveredDeviceEntry> = filterDiscoveredHosts({
+  /*
+   * Each row carries its position in the UNFILTERED scan, so its React key
+   * does not change when the filter does — see ShownDiscoveredHost.
+   */
+  const shownEntries: Array<ShownDiscoveredHost> = getShownDiscoveredHosts({
     hosts: reviewEntries,
     filter: hostFilter,
   });
@@ -810,16 +887,17 @@ const NetworkDeviceDiscovery: FunctionComponent<
             )}
             {reviewEntries.length === 0 && (
               <p className="text-sm text-gray-500">
-                This scan did not find any responding hosts.
+                {getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.All)}
               </p>
             )}
             {reviewEntries.length > 0 && shownEntries.length === 0 && (
               <p className="text-sm text-gray-500">
-                {`No ${getDiscoveredHostFilterLabel(hostFilter)} hosts in this scan.`}
+                {getDiscoveredHostFilterEmptyMessage(hostFilter)}
               </p>
             )}
             {shownEntries.map(
-              (entry: DiscoveredDeviceEntry, index: number): ReactElement => {
+              (shownEntry: ShownDiscoveredHost): ReactElement => {
+                const entry: DiscoveredDeviceEntry = shownEntry.host;
                 /*
                  * Ping-only hosts (snmpReachable === false) import too, as
                  * monitor-backed devices rather than SNMP-credentialed ones
@@ -827,29 +905,52 @@ const NetworkDeviceDiscovery: FunctionComponent<
                  * operator knows what they are agreeing to. Legacy rows
                  * (snmpReachable undefined) import as SNMP, as before.
                  */
-                const isImportable: boolean = isImportableDiscoveredHost(entry);
-                /*
-                 * Same predicate the No SNMP filter groups by, so a badged row
-                 * and a filtered row can never be different sets.
-                 */
                 const isPingOnly: boolean = isPingOnlyDiscoveredHost(entry);
+                /*
+                 * The SAME predicate every count, the bulk toggle and the
+                 * import path use. The row used to spell out its own version
+                 * of it, which left a host with a blank address rendering an
+                 * enabled checkbox that no count would ever agree existed.
+                 */
+                const isSelectable: boolean = isSelectableDiscoveredHost(entry);
+                const isChecked: boolean =
+                  isSelectable && Boolean(selectedIps[entry.ipAddress]);
                 return (
                   <div
-                    key={`${entry.ipAddress}-${index}`}
+                    /*
+                     * Scan position, not position in the filtered list — see
+                     * ShownDiscoveredHost. A key that moved with the filter
+                     * would remount every row on every filter click, and a
+                     * remounted CheckboxElement paints unticked for a frame.
+                     */
+                    key={`${entry.ipAddress}-${shownEntry.scanIndex}`}
                     className="flex items-start justify-between gap-3 border-b border-gray-100 py-3"
                   >
                     <div className="flex min-w-0 items-start gap-3">
                       <CheckboxElement
                         dataTestId={`discovered-device-checkbox-${entry.ipAddress}`}
-                        value={
-                          entry.isAlreadyRegistered || !isImportable
-                            ? false
-                            : Boolean(selectedIps[entry.ipAddress])
-                        }
-                        disabled={
-                          Boolean(entry.isAlreadyRegistered) ||
-                          !isImportable ||
-                          isImporting
+                        /*
+                         * initialValue as well as value: CheckboxElement seeds
+                         * its own state from initialValue and only reconciles
+                         * value in a passive effect, so without this a row
+                         * mounts unticked and corrects itself a frame later.
+                         */
+                        initialValue={isChecked}
+                        value={isChecked}
+                        disabled={!isSelectable || isImporting}
+                        /*
+                         * A bare checkbox in a list is announced as
+                         * "checkbox" and nothing else; a disabled one that
+                         * does not say why reads as broken rather than as
+                         * deliberate.
+                         */
+                        ariaLabel={`Import ${entry.sysName || entry.ipAddress} (${entry.ipAddress || "no address"})`}
+                        hoverText={
+                          entry.isAlreadyRegistered
+                            ? "Already added as a Network Device."
+                            : entry.ipAddress
+                              ? undefined
+                              : "This host reported no address, so it cannot be imported."
                         }
                         onChange={(value: boolean) => {
                           setSelectedIps((current: Record<string, boolean>) => {

--- a/App/Tests/Dashboard/DiscoveredHostFilter.test.ts
+++ b/App/Tests/Dashboard/DiscoveredHostFilter.test.ts
@@ -14,8 +14,10 @@ import {
   getInitialSelection,
   isPingOnlyDiscoveredHost,
   isSelectableDiscoveredHost,
+  isSelectedIpAddress,
   markDiscoveredHostsAsRegistered,
   matchesDiscoveredHostFilter,
+  normalizeDiscoveredHosts,
   toggleSelectionForShownHosts,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
 
@@ -1256,5 +1258,194 @@ describe("hosts at scan scale", () => {
         selectedIpAddresses: cleared,
       }),
     ).toHaveLength(pingOnlyCount);
+  });
+});
+
+describe("normalizeDiscoveredHosts", () => {
+  /*
+   * The gate every scan passes through before the dialog reads it. Its whole
+   * job is to make sure the row on screen, the badge above it and the list
+   * Import walks are all reading the same payload the same way — see the
+   * function's own comment for the three jsonb shapes that used to make them
+   * disagree.
+   */
+
+  test("an ordinary scan comes through unchanged in content and order", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      legacyHost("10.0.0.3"),
+    ];
+
+    expect(normalizeDiscoveredHosts(hosts)).toEqual(hosts);
+  });
+
+  test("nullish and non-object rows are dropped", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      null,
+      snmpHost("10.0.0.1"),
+      undefined,
+      42,
+      "10.0.0.9",
+      pingOnlyHost("10.0.0.2"),
+    ] as unknown as Array<DiscoveredNetworkDevice>;
+
+    expect(ipAddressesOf(normalizeDiscoveredHosts(hosts))).toEqual([
+      "10.0.0.1",
+      "10.0.0.2",
+    ]);
+  });
+
+  test("an address is stringified and trimmed", () => {
+    /*
+     * A numeric address is written into the selection record as a string key
+     * and was matched out of the imported set as a number, so an imported host
+     * could never be retired. A whitespace-only address is truthy, so it used
+     * to import as a device whose hostname was a space.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      { ipAddress: 10 } as unknown as DiscoveredNetworkDevice,
+      { ipAddress: "  10.0.0.2  " },
+      { ipAddress: " " },
+      { ipAddress: undefined } as unknown as DiscoveredNetworkDevice,
+    ];
+
+    expect(ipAddressesOf(normalizeDiscoveredHosts(hosts))).toEqual([
+      "10",
+      "10.0.0.2",
+      "",
+      "",
+    ]);
+  });
+
+  test("registration is a fact about an address, not about a row", () => {
+    /*
+     * The jsonb can carry one address twice with different frozen
+     * isAlreadyRegistered values. One checkbox governs both rows, so leaving
+     * them disagreeing meant whether a device already in the inventory got
+     * created a second time depended on which order the probe listed them in.
+     */
+    const registeredFirst: Array<DiscoveredNetworkDevice> =
+      normalizeDiscoveredHosts([
+        snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+        snmpHost("10.0.0.1"),
+        snmpHost("10.0.0.2"),
+      ]);
+
+    expect(
+      registeredFirst.map((host: DiscoveredNetworkDevice) => {
+        return Boolean(host.isAlreadyRegistered);
+      }),
+    ).toEqual([true, true, false]);
+
+    const registeredSecond: Array<DiscoveredNetworkDevice> =
+      normalizeDiscoveredHosts([
+        snmpHost("10.0.0.1"),
+        snmpHost("10.0.0.1", { isAlreadyRegistered: true }),
+      ]);
+
+    expect(
+      registeredSecond.map((host: DiscoveredNetworkDevice) => {
+        return Boolean(host.isAlreadyRegistered);
+      }),
+    ).toEqual([true, true]);
+  });
+
+  test("a blank address never spreads registration to another blank row", () => {
+    // Two address-less rows are not "the same host"; they are two non-hosts.
+    const normalized: Array<DiscoveredNetworkDevice> = normalizeDiscoveredHosts(
+      [{ ipAddress: "", isAlreadyRegistered: true }, { ipAddress: "" }],
+    );
+
+    expect(Boolean(normalized[1]!.isAlreadyRegistered)).toBe(false);
+  });
+
+  test("group membership is untouched — only identity and registration are", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      legacyHost("10.0.0.3"),
+    ];
+
+    expect(countDiscoveredHosts(normalizeDiscoveredHosts(hosts))).toEqual(
+      countDiscoveredHosts(hosts),
+    );
+  });
+
+  test("the caller's rows are never mutated", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      { ipAddress: "  10.0.0.1  " },
+      snmpHost("10.0.0.2", { isAlreadyRegistered: true }),
+      snmpHost("10.0.0.2"),
+    ];
+
+    normalizeDiscoveredHosts(hosts);
+
+    expect(hosts[0]!.ipAddress).toBe("  10.0.0.1  ");
+    expect(hosts[2]!.isAlreadyRegistered).toBeUndefined();
+  });
+
+  test("an empty scan normalises to an empty scan", () => {
+    expect(normalizeDiscoveredHosts([])).toEqual([]);
+  });
+});
+
+describe("isSelectedIpAddress", () => {
+  test("an own truthy key is a tick; an own falsy key is not", () => {
+    expect(
+      isSelectedIpAddress({
+        selectedIpAddresses: { "10.0.0.1": true },
+        ipAddress: "10.0.0.1",
+      }),
+    ).toBe(true);
+    expect(
+      isSelectedIpAddress({
+        selectedIpAddresses: { "10.0.0.1": false },
+        ipAddress: "10.0.0.1",
+      }),
+    ).toBe(false);
+  });
+
+  test("an absent key is not a tick", () => {
+    expect(
+      isSelectedIpAddress({ selectedIpAddresses: {}, ipAddress: "10.0.0.1" }),
+    ).toBe(false);
+  });
+
+  test("an inherited member is not a tick", () => {
+    /*
+     * The address is a probe-supplied string used verbatim as an object key.
+     * A bare index would find a truthy function on Object.prototype and report
+     * a host as ticked that nobody ticked — and then import it.
+     */
+    for (const inherited of [
+      "toString",
+      "constructor",
+      "valueOf",
+      "hasOwnProperty",
+      "__proto__",
+    ]) {
+      expect(
+        isSelectedIpAddress({
+          selectedIpAddresses: {},
+          ipAddress: inherited,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("an own key wins over the inherited member it shadows", () => {
+    expect(
+      isSelectedIpAddress({
+        selectedIpAddresses: { toString: true },
+        ipAddress: "toString",
+      }),
+    ).toBe(true);
+    expect(
+      isSelectedIpAddress({
+        selectedIpAddresses: { toString: false },
+        ipAddress: "toString",
+      }),
+    ).toBe(false);
   });
 });

--- a/App/Tests/Dashboard/DiscoveredHostFilterEdgeCases.test.ts
+++ b/App/Tests/Dashboard/DiscoveredHostFilterEdgeCases.test.ts
@@ -1,0 +1,1031 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import {
+  DiscoveredHostCounts,
+  DiscoveredHostFilter,
+  DiscoveredHostFilterOption,
+  ImportedIpAddressesByScanId,
+  ShownDiscoveredHost,
+  areAllShownHostsSelected,
+  countDiscoveredHosts,
+  countSelectableShownHosts,
+  filterDiscoveredHosts,
+  getDiscoveredHostFilterEmptyMessage,
+  getDiscoveredHostFilterLabel,
+  getDiscoveredHostFilterOptions,
+  getDiscoveredHostsToImport,
+  getImportedIpAddressesForScan,
+  getInitialSelection,
+  getShownDiscoveredHosts,
+  isPingOnlyDiscoveredHost,
+  isSelectableDiscoveredHost,
+  markDiscoveredHostsAsRegistered,
+  matchesDiscoveredHostFilter,
+  normalizeDiscoveredHosts,
+  toggleSelectionForShownHosts,
+  withImportedIpAddresses,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * DiscoveredHostFilter.test.ts covers the rules with rows that look like the
+ * interface says they will. This file is the other half: what the same rules
+ * do when the rows do NOT.
+ *
+ * They often will not. `discoveredDevices` is a jsonb column written verbatim
+ * from whatever a probe uploaded — no column type checks the shape of an
+ * element, no migration has ever rewritten one, and rows written by probes of
+ * every vintage sit in the same array. `DiscoveredNetworkDevice` is a
+ * compile-time story about that array, not a runtime guarantee, and every
+ * function here is handed the array with a cast. So `null` elements, a
+ * `snmpReachable` that arrived as the STRING "false", an `ipAddress` that is a
+ * number, and an address that happens to spell "constructor" are all inputs
+ * the dialog can actually receive.
+ *
+ * The point of pinning them is that the two ways this feature fails are both
+ * silent. Either the modal body throws while rendering (a dialog that opens
+ * blank, with the scan still listed as having results), or the wrong hosts
+ * import — and an import is thousands of sequential creates that no one is
+ * going to undo by hand.
+ *
+ * Every expectation below is the CURRENT behaviour, verified against the
+ * implementation, not the behaviour anyone would have designed. Where the
+ * current behaviour is wrong, the test still asserts it and the comment says
+ * so in the words "SUSPECTED DEFECT" — a red test left behind for a bug the
+ * author of this file cannot fix is worth nothing to the next person.
+ */
+
+const FILTER_SOURCE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "NetworkDevice",
+  "DiscoveredHostFilter.ts",
+);
+
+/*
+ * A row the jsonb can hold but the interface says it cannot. Written as one
+ * named helper rather than a cast at every call site so that "this value is
+ * deliberately the wrong shape" is visible in the test, instead of reading as
+ * a type error someone silenced.
+ */
+function junkRow(value: unknown): DiscoveredNetworkDevice {
+  return value as DiscoveredNetworkDevice;
+}
+
+/** Junk rows as a scan array. */
+function junkScan(values: Array<unknown>): Array<DiscoveredNetworkDevice> {
+  return values.map((value: unknown) => {
+    return junkRow(value);
+  });
+}
+
+function snmpHost(ipAddress: string): DiscoveredNetworkDevice {
+  return { ipAddress: ipAddress, snmpReachable: true };
+}
+
+function pingOnlyHost(ipAddress: string): DiscoveredNetworkDevice {
+  return { ipAddress: ipAddress, snmpReachable: false };
+}
+
+function ipAddressesOf(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+  return hosts.map((host: DiscoveredNetworkDevice) => {
+    return host.ipAddress;
+  });
+}
+
+/** Every filter, for the assertions that have to hold under all three. */
+const ALL_FILTERS: Array<DiscoveredHostFilter> = [
+  DiscoveredHostFilter.All,
+  DiscoveredHostFilter.Snmp,
+  DiscoveredHostFilter.NoSnmp,
+];
+
+describe("scan rows that are not objects at all", () => {
+  test("a number, a string or an empty object is grouped as SNMP rather than skipped", () => {
+    /*
+     * `monitoringMethodForDiscoveredHost` asks only whether `snmpReachable` is
+     * exactly `false`. On a primitive or a shapeless object that property is
+     * undefined, which is the legacy answer, which means SNMP. Nothing skips
+     * the row: it stays in the list, it is counted, and the badge under it
+     * says SNMP. That is the tolerable outcome of the two available — the
+     * alternative, dropping rows the operator can see in the scan's own host
+     * count, would make the dialog disagree with the page that opened it.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = junkScan([
+      42,
+      "10.0.0.1",
+      {},
+      { sysName: "no-address-at-all" },
+    ]);
+
+    for (const row of rows) {
+      expect(isPingOnlyDiscoveredHost(row)).toBe(false);
+    }
+
+    expect(countDiscoveredHosts(rows)).toEqual({ all: 4, snmp: 4, noSnmp: 0 });
+  });
+
+  test("a null or undefined row reads as SNMP instead of taking the page down", () => {
+    /*
+     * `null` is a legal jsonb array element and nothing on the read path used
+     * to filter one out — `DiscoveryScanOutcome.getDiscoveredHosts` guards the
+     * ARRAY, not its elements. Every grouping call then dereferenced the row
+     * and died with a TypeError, and not the survivable kind: it happened
+     * inside the modal body during render, on the operator's first click of a
+     * filter button, on a scan the page had already advertised as having
+     * results.
+     *
+     * A nullish row now answers the same way every other kind of junk element
+     * already did — "no explicit snmpReachable, therefore SNMP" — so one bad
+     * row costs one wrong-looking row rather than the whole dialog.
+     */
+    for (const row of junkScan([null, undefined])) {
+      expect(isPingOnlyDiscoveredHost(row)).toBe(false);
+
+      expect(countDiscoveredHosts([row])).toEqual({
+        all: 1,
+        snmp: 1,
+        noSnmp: 0,
+      });
+
+      expect(
+        filterDiscoveredHosts({
+          hosts: [row],
+          filter: DiscoveredHostFilter.Snmp,
+        }),
+      ).toHaveLength(1);
+
+      expect(
+        getShownDiscoveredHosts({
+          hosts: [row],
+          filter: DiscoveredHostFilter.NoSnmp,
+        }),
+      ).toHaveLength(0);
+    }
+  });
+
+  test("normalising drops nullish rows entirely, so the dialog never renders one", () => {
+    /*
+     * The predicates surviving a null row is the safety net; this is the
+     * actual fix. Discovery.tsx runs every scan through
+     * normalizeDiscoveredHosts before anything else reads it, so a nullish
+     * row never reaches a badge, a checkbox or the import list at all.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = junkScan([
+      null,
+      undefined,
+      { ipAddress: "10.0.0.1", snmpReachable: true },
+    ]);
+
+    const normalized: Array<DiscoveredNetworkDevice> =
+      normalizeDiscoveredHosts(rows);
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]!.ipAddress).toBe("10.0.0.1");
+    expect(countDiscoveredHosts(normalized)).toEqual({
+      all: 1,
+      snmp: 1,
+      noSnmp: 0,
+    });
+  });
+
+  test("the All filter never reads a row, so junk reaches the list intact", () => {
+    /*
+     * `matchesDiscoveredHostFilter` returns true for All before touching the
+     * host, so the default view of a scan carrying a null row renders it and
+     * only blows up when the operator clicks SNMP or No SNMP. Worth pinning
+     * precisely because it makes the crash above look like a filter bug: the
+     * dialog opened fine, one click killed it.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = junkScan([null, undefined, 7]);
+
+    for (const row of rows) {
+      expect(
+        matchesDiscoveredHostFilter({
+          host: row,
+          filter: DiscoveredHostFilter.All,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      filterDiscoveredHosts({ hosts: rows, filter: DiscoveredHostFilter.All }),
+    ).toHaveLength(3);
+  });
+
+  test("selection and import refuse a null row instead of dying on it", () => {
+    /*
+     * These three read `ipAddress`, so unlike the filter they never had the
+     * All short-circuit: a scan with one null row could not compute its
+     * opening selection at all, which is the dialog's initial render path —
+     * the modal did not open wrong, it did not open.
+     *
+     * A nullish row is now simply not selectable, which is the honest answer:
+     * there is no address to import it under.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = junkScan([null]);
+
+    expect(isSelectableDiscoveredHost(rows[0]!)).toBe(false);
+    expect(getInitialSelection(rows)).toEqual({});
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: rows,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual([]);
+    expect(
+      markDiscoveredHostsAsRegistered({
+        hosts: rows,
+        importedIpAddresses: new Set<string>(["10.0.0.1"]),
+      }),
+    ).toEqual(rows);
+  });
+  test("a shown row carries its unfiltered scan position, junk rows included", () => {
+    /*
+     * `scanIndex` is what the dialog builds its React key from, and it has to
+     * be the position in the WHOLE scan: taking it from the filtered array
+     * would move it on every filter click, remounting rows whose checkbox
+     * seeds from `initialValue` and repainting them unchecked for a frame.
+     * Junk rows do not get to opt out of that — they occupy a scan position
+     * like anything else, and the rows after them must not shift up.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = junkScan([
+      42,
+      pingOnlyHost("10.0.0.2"),
+      {},
+      snmpHost("10.0.0.4"),
+    ]);
+
+    const shown: Array<ShownDiscoveredHost> = getShownDiscoveredHosts({
+      hosts: rows,
+      filter: DiscoveredHostFilter.Snmp,
+    });
+
+    expect(
+      shown.map((entry: ShownDiscoveredHost) => {
+        return entry.scanIndex;
+      }),
+    ).toEqual([0, 2, 3]);
+
+    expect(shown[0]!.host).toBe(rows[0]);
+  });
+});
+
+describe("fields that are not the type the interface promises", () => {
+  test("snmpReachable arriving as the string 'false' reads as SNMP", () => {
+    /*
+     * SUSPECTED DEFECT (wire format, reported).
+     *
+     * The comparison is `=== false`, so any non-boolean falls through to the
+     * legacy branch and means SNMP. A probe (or a proxy, or a hand-edited row)
+     * that serialised the flag as the string "false" therefore puts a
+     * ping-only host in the SNMP group — where it is hidden from the No SNMP
+     * filter, counted on the SNMP badge, and imported as a POLLED device
+     * carrying the scan's credentials against a box that never answered a
+     * walk. The device then sits permanently unreachable in the inventory.
+     *
+     * "false" is singled out because it is the one junk value that is both
+     * plausible on the wire and truthy in JavaScript, so the usual
+     * `!host.snmpReachable` reflex would not have caught it either.
+     */
+    const host: DiscoveredNetworkDevice = junkRow({
+      ipAddress: "10.0.0.7",
+      snmpReachable: "false",
+    });
+
+    expect(isPingOnlyDiscoveredHost(host)).toBe(false);
+    expect(
+      matchesDiscoveredHostFilter({
+        host: host,
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(true);
+    expect(countDiscoveredHosts([host])).toEqual({
+      all: 1,
+      snmp: 1,
+      noSnmp: 0,
+    });
+  });
+
+  test("isAlreadyRegistered is judged by truthiness, not by being exactly true", () => {
+    /*
+     * `!host.isAlreadyRegistered` means a falsy non-boolean (0, "") reads as
+     * "not registered yet" and the row stays tickable, while a truthy
+     * non-boolean (1, or the string "no", which is truthy however it reads to
+     * a human) retires the row.
+     *
+     * The 0 / "" direction is harmless-to-useful: those are what "not
+     * registered" serialises to. The "no" direction is the dangerous one — it
+     * disables a host the operator can see and wants, with a row that says
+     * "Already added" about a device that is not.
+     */
+    expect(
+      isSelectableDiscoveredHost(
+        junkRow({ ipAddress: "10.0.0.1", isAlreadyRegistered: 0 }),
+      ),
+    ).toBe(true);
+    expect(
+      isSelectableDiscoveredHost(
+        junkRow({ ipAddress: "10.0.0.2", isAlreadyRegistered: "" }),
+      ),
+    ).toBe(true);
+    expect(
+      isSelectableDiscoveredHost(
+        junkRow({ ipAddress: "10.0.0.3", isAlreadyRegistered: 1 }),
+      ),
+    ).toBe(false);
+    expect(
+      isSelectableDiscoveredHost(
+        junkRow({ ipAddress: "10.0.0.4", isAlreadyRegistered: "no" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a numeric ipAddress is selectable and keys the selection as a string", () => {
+    /*
+     * `Boolean(10)` is true, so a numeric address passes the "has an address"
+     * gate, and `selection[host.ipAddress] = true` stringifies the key on the
+     * way in. Reading it back out stringifies too, so selection and import
+     * agree with each other and the host is importable under a "10" key.
+     *
+     * Pinned rather than left implicit because the consistency here is what
+     * makes the mismatch in the next test surprising.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = junkScan([{ ipAddress: 10 }]);
+
+    expect(isSelectableDiscoveredHost(hosts[0]!)).toBe(true);
+    expect(getInitialSelection(hosts)).toEqual({ "10": true });
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: { "10": true },
+      }),
+    ).toHaveLength(1);
+  });
+
+  test("a numeric ipAddress is retired like any other, so it cannot import twice", () => {
+    /*
+     * Everything else on this path goes through object-key stringification;
+     * `markDiscoveredHostsAsRegistered` goes through `Set.has`, which uses
+     * SameValueZero and does not. So the address the page recorded after an
+     * import — the string it read out of the selection — never matched the
+     * number on the row, and the host came back still tickable and still
+     * pre-checked.
+     *
+     * That was the exact duplicate-creation loop the overlay exists to close:
+     * `isAlreadyRegistered` is frozen into the jsonb at probe-upload time, so
+     * the overlay is the only thing standing between "import, come back to the
+     * group, press again" and a second Network Device for the same host. The
+     * lookup is stringified now, and normalisation stringifies the row itself
+     * before the dialog ever sees it.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = junkScan([{ ipAddress: 10 }]);
+
+    const marked: Array<DiscoveredNetworkDevice> =
+      markDiscoveredHostsAsRegistered({
+        hosts: hosts,
+        importedIpAddresses: new Set<string>(["10"]),
+      });
+
+    expect(marked[0]!.isAlreadyRegistered).toBe(true);
+    expect(isSelectableDiscoveredHost(marked[0]!)).toBe(false);
+
+    // And the row reaches the dialog as a string in the first place.
+    expect(normalizeDiscoveredHosts(hosts)[0]!.ipAddress).toBe("10");
+  });
+  test("neither an empty address nor a whitespace-only one is selectable", () => {
+    /*
+     * The gate used to be `Boolean(host.ipAddress)`, and " " is a perfectly
+     * truthy string — so a row whose address was a single space was tickable,
+     * pre-checked and importable, and because the address is also the imported
+     * device's hostname it created a Network Device called " ".
+     */
+    expect(isSelectableDiscoveredHost(junkRow({ ipAddress: "" }))).toBe(false);
+    expect(isSelectableDiscoveredHost(junkRow({ ipAddress: " " }))).toBe(false);
+    expect(isSelectableDiscoveredHost(junkRow({ ipAddress: "\t\n " }))).toBe(
+      false,
+    );
+
+    const hosts: Array<DiscoveredNetworkDevice> = junkScan([
+      { ipAddress: " " },
+    ]);
+
+    expect(getInitialSelection(hosts)).toEqual({});
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: { " ": true },
+      }),
+    ).toEqual([]);
+
+    // Normalisation collapses it to the empty address it actually is.
+    expect(normalizeDiscoveredHosts(hosts)[0]!.ipAddress).toBe("");
+  });
+  test("addresses are compared raw — no normalisation, no case folding, no length cap", () => {
+    /*
+     * A reader coming to this file may assume the dedup in
+     * `getDiscoveredHostsToImport` understands addresses. It does not: the key
+     * is the literal string. "10.0.0.1" and "010.0.0.1" name the same host to
+     * every resolver on earth and are two independent checkboxes here; so are
+     * the two casings of an IPv6 address, which is worse, because RFC 5952
+     * lower-cases and plenty of gear does not.
+     *
+     * The consequence is duplicate devices for one host, from one press, with
+     * both boxes ticked by default. Pinned as current behaviour so that adding
+     * canonicalisation later is a deliberate change with a test to update,
+     * rather than something someone assumes is already there.
+     */
+    const longAddress: string = "9".repeat(300);
+
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      snmpHost("010.0.0.1"),
+      snmpHost("FE80::1"),
+      snmpHost("fe80::1"),
+      snmpHost(longAddress),
+    ];
+
+    expect(Object.keys(getInitialSelection(hosts))).toEqual([
+      "10.0.0.1",
+      "010.0.0.1",
+      "FE80::1",
+      "fe80::1",
+      longAddress,
+    ]);
+
+    expect(
+      countSelectableShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(5);
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: getInitialSelection(hosts),
+      }),
+    ).toHaveLength(5);
+  });
+});
+
+describe("addresses that collide with Object.prototype", () => {
+  test("an UNTICKED host named toString or constructor stays out of the import", () => {
+    /*
+     * The selection is a plain object literal, and the tick test used to be a
+     * bare `data.selectedIpAddresses[host.ipAddress]`. For an address that
+     * spells an inherited key, that lookup walks the prototype chain and finds
+     * a truthy function, so the host read as ticked no matter what the
+     * operator did — below, the selection is `{}`, nothing has ever been
+     * ticked, and every one of these hosts used to import.
+     *
+     * `ipAddress` is a probe-supplied string used as an object key with no
+     * validation anywhere on the path, so this was reachable by a malformed or
+     * hostile payload rather than only by a typo, and it made the one
+     * invariant the whole feature rests on — "Import imports what is ticked" —
+     * simply false for these names. `isSelectedIpAddress` now asks for an OWN
+     * property.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("toString"),
+      snmpHost("constructor"),
+      snmpHost("valueOf"),
+      snmpHost("hasOwnProperty"),
+    ];
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual([]);
+
+    // And a real tick on such a name still works.
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: { toString: true },
+        }),
+      ),
+    ).toEqual(["toString"]);
+  });
+  test("a host named __proto__ cannot be ticked, and is therefore not imported", () => {
+    /*
+     * The same root cause with the opposite symptom, which is why it is a
+     * separate test. Assigning `selection["__proto__"] = true` on a plain
+     * object does not create a property; it invokes the prototype setter,
+     * which ignores a primitive. So `getInitialSelection` and
+     * `toggleSelectionForShownHosts` both come back with no key for this host
+     * — it cannot be recorded as ticked by any means the dialog offers.
+     *
+     * Reading it back used to yield `Object.prototype`, which is truthy, so it
+     * imported anyway: a host impossible to select, impossible to deselect,
+     * and imported regardless. With an own-property check the two halves agree
+     * — it cannot be ticked, so it is not imported, which is the safe
+     * direction for a host nobody can express an opinion about.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [snmpHost("__proto__")];
+
+    expect(Object.keys(getInitialSelection(hosts))).toEqual([]);
+    expect(
+      Object.keys(
+        toggleSelectionForShownHosts({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: {},
+        }),
+      ),
+    ).toEqual([]);
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual([]);
+  });
+  test("a prototype-named host does not make the bulk control claim the view is full", () => {
+    /*
+     * The third distinct symptom. `areAllShownHostsSelected` compares the
+     * import list's length against the selectable count, and the import list
+     * used to be inflated by the phantom tick above — so with an empty
+     * selection the two matched and the control rendered "Clear all" over a
+     * view where nothing was checked. Pressing it wrote `false` for every
+     * shown host, which on a real scan would have cleared the operator's
+     * actual ticks on every other row.
+     */
+    expect(
+      areAllShownHostsSelected({
+        hosts: [snmpHost("toString")],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toBe(false);
+
+    // One press selects it, as it would any other host.
+    expect(
+      toggleSelectionForShownHosts({
+        hosts: [snmpHost("toString")],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual({ toString: true });
+  });
+  test("a scan id colliding with Object.prototype reads as an empty record", () => {
+    /*
+     * The same unguarded index, one layer up.
+     * `importedByScanId[scanId] || []` finds an inherited member for these
+     * names, and a function or an object is truthy, so the `|| []` fallback
+     * never ran and the Set construction died on a non-iterable. Far less
+     * reachable than the address case (a scan id is an ObjectID today), but it
+     * is the same missing own-property check, it lives in the state the dialog
+     * reads on every open, and a throw there took the page with it.
+     */
+    for (const scanId of ["toString", "constructor", "__proto__"]) {
+      expect(
+        getImportedIpAddressesForScan({
+          importedByScanId: {},
+          scanId: scanId,
+        }),
+      ).toEqual(new Set<string>());
+
+      /*
+       * "__proto__" is the one that still cannot be stored: writing that key
+       * on an object literal runs the prototype setter. It reads back empty
+       * rather than throwing, which costs a re-offered host on reopen — the
+       * pre-existing footgun — instead of a blank page.
+       */
+      const stored: ImportedIpAddressesByScanId = withImportedIpAddresses({
+        importedByScanId: {},
+        scanId: scanId,
+        ipAddresses: ["10.0.0.1"],
+      });
+
+      expect(
+        getImportedIpAddressesForScan({
+          importedByScanId: stored,
+          scanId: scanId,
+        }),
+      ).toEqual(
+        scanId === "__proto__"
+          ? new Set<string>()
+          : new Set<string>(["10.0.0.1"]),
+      );
+    }
+  });
+  test("an empty scan renders its own sentence and disturbs nothing", () => {
+    /*
+     * The All message is deliberately not built from the filter label: "No " +
+     * "No SNMP" produced "No No SNMP hosts in this scan.", and a group of zero
+     * is one click away on any single-group sweep. Asserting the three exact
+     * strings is what stops that from being re-derived.
+     *
+     * The rest of the test is that an empty scan is inert: a selection carried
+     * in from a previous scan comes back untouched rather than being cleared
+     * by a view that shows nothing.
+     */
+    expect(getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.All)).toBe(
+      "This scan did not find any responding hosts.",
+    );
+    expect(getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.Snmp)).toBe(
+      "No host in this scan answered SNMP.",
+    );
+    expect(
+      getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.NoSnmp),
+    ).toBe("Every host in this scan answered SNMP.");
+
+    const carriedOver: Record<string, boolean> = { "10.0.0.1": true };
+
+    for (const filter of ALL_FILTERS) {
+      expect(getShownDiscoveredHosts({ hosts: [], filter: filter })).toEqual(
+        [],
+      );
+      expect(
+        toggleSelectionForShownHosts({
+          hosts: [],
+          filter: filter,
+          selectedIpAddresses: carriedOver,
+        }),
+      ).toEqual({ "10.0.0.1": true });
+    }
+
+    expect(
+      markDiscoveredHostsAsRegistered({
+        hosts: [],
+        importedIpAddresses: new Set<string>(["10.0.0.1"]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("a one-host scan opens already full and empties in a single press", () => {
+    /*
+     * The boundary either side of the "false for an empty view" rule: at
+     * exactly one selectable host the view IS full the moment it opens, so the
+     * control has to read "Clear all" and one press has to leave nothing
+     * importable. An off-by-one in the zero guard shows up here and nowhere
+     * else.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [snmpHost("10.0.0.1")];
+    const selection: Record<string, boolean> = getInitialSelection(hosts);
+
+    expect(
+      countSelectableShownHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(1);
+    expect(
+      areAllShownHostsSelected({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: selection,
+      }),
+    ).toBe(true);
+
+    const cleared: Record<string, boolean> = toggleSelectionForShownHosts({
+      hosts: hosts,
+      filter: DiscoveredHostFilter.All,
+      selectedIpAddresses: selection,
+    });
+
+    expect(cleared).toEqual({ "10.0.0.1": false });
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: cleared,
+      }),
+    ).toEqual([]);
+  });
+
+  test("a scan of nothing but blank addresses still counts every row", () => {
+    /*
+     * The badge is a group size, checked against the probe's own ICMP/SNMP
+     * tallies, so rows that cannot be imported are still counted — otherwise
+     * the two numbers disagree for a reason the badge cannot show. Everything
+     * downstream of the badge disagrees with it on purpose: nothing is
+     * selectable, nothing imports, the bulk control stays off, and no "" key
+     * is ever written into the selection.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      { ipAddress: "", snmpReachable: true },
+      { ipAddress: "", snmpReachable: false },
+    ];
+
+    expect(countDiscoveredHosts(hosts)).toEqual({ all: 2, snmp: 1, noSnmp: 1 });
+
+    for (const filter of ALL_FILTERS) {
+      expect(countSelectableShownHosts({ hosts: hosts, filter: filter })).toBe(
+        0,
+      );
+      expect(
+        areAllShownHostsSelected({
+          hosts: hosts,
+          filter: filter,
+          selectedIpAddresses: { "": true },
+        }),
+      ).toBe(false);
+      expect(
+        toggleSelectionForShownHosts({
+          hosts: hosts,
+          filter: filter,
+          selectedIpAddresses: {},
+        }),
+      ).toEqual({});
+    }
+
+    expect(getInitialSelection(hosts)).toEqual({});
+  });
+
+  test("a sweep where nothing answered SNMP leaves that group empty and says so", () => {
+    /*
+     * The single-group sweep in the direction #3322 actually reports: 2,890
+     * ICMP-only hosts and no switches. The SNMP button still has to render its
+     * zero — "SNMP (0)" is the answer to "did this sweep find any gear at
+     * all", and a button that hid the zero would look identical to one with
+     * results behind it — and clicking it has to produce a sentence rather
+     * than an empty box.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      pingOnlyHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      pingOnlyHost("10.0.0.3"),
+    ];
+
+    expect(
+      getDiscoveredHostFilterOptions(hosts).map(
+        (option: DiscoveredHostFilterOption) => {
+          return option.label;
+        },
+      ),
+    ).toEqual(["All (3)", "SNMP (0)", "No SNMP (3)"]);
+
+    expect(
+      filterDiscoveredHosts({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toEqual([]);
+    expect(
+      areAllShownHostsSelected({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: getInitialSelection(hosts),
+      }),
+    ).toBe(false);
+    expect(getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.Snmp)).toBe(
+      "No host in this scan answered SNMP.",
+    );
+  });
+
+  test("a sweep of nothing but legacy rows lands entirely in the SNMP group", () => {
+    /*
+     * A scan stored before `snmpReachable` existed: every row carries
+     * undefined, and every host on those scans answered SNMP because ping-only
+     * sweeps did not exist yet. Reading undefined as ping-only would move an
+     * entire historical scan into the No SNMP group and re-import real
+     * switches as monitor-backed devices with no polling at all — the whole
+     * reason the rule is `=== false` and not `!snmpReachable`.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      { ipAddress: "10.0.0.1" },
+      { ipAddress: "10.0.0.2", snmpReachable: undefined },
+    ];
+
+    expect(countDiscoveredHosts(hosts)).toEqual({ all: 2, snmp: 2, noSnmp: 0 });
+    expect(
+      ipAddressesOf(
+        filterDiscoveredHosts({
+          hosts: hosts,
+          filter: DiscoveredHostFilter.Snmp,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.2"]);
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: getInitialSelection(hosts),
+      }),
+    ).toEqual([]);
+    expect(
+      getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.NoSnmp),
+    ).toBe("Every host in this scan answered SNMP.");
+  });
+});
+
+describe("the numbers on the filter buttons", () => {
+  /** A scan of `size` identical SNMP hosts, sharing one object. */
+  function scanOfSize(size: number): Array<DiscoveredNetworkDevice> {
+    return new Array<DiscoveredNetworkDevice>(size).fill(snmpHost("10.0.0.1"));
+  }
+
+  function allLabel(size: number): string {
+    return getDiscoveredHostFilterOptions(scanOfSize(size))[0]!.label;
+  }
+
+  test("group sizes are grouped from four digits up, and never below", () => {
+    /*
+     * 999 and 1,000 are the boundary either side of the first separator, and
+     * 1,000,000 is the second one — a /8 sweep is not hypothetical for the
+     * people who filed #3322 (theirs was 17,850 addresses). A separator that
+     * appeared at three digits, or stopped at one, would put a number on the
+     * badge that cannot be checked against the probe's own tally by eye, which
+     * is the entire reason the grouping is there.
+     */
+    expect(allLabel(0)).toBe("All (0)");
+    expect(allLabel(1)).toBe("All (1)");
+    expect(allLabel(999)).toBe("All (999)");
+    expect(allLabel(1000)).toBe("All (1,000)");
+    expect(allLabel(1000000)).toBe("All (1,000,000)");
+  });
+
+  test("the locale is pinned, so the runner's default cannot change the label", () => {
+    /*
+     * `Number.prototype.toLocaleString()` with no argument follows the host's
+     * default locale. On a de-DE box 1000 renders "1.000" and 1000000 renders
+     * "1.000.000" — a dot is the DECIMAL separator in en-US, so the same badge
+     * would read as a fractional host count to everyone else, and a CI runner
+     * with a different ICU default would flip the assertion above without a
+     * line of code changing.
+     *
+     * Asserted twice on purpose. The behavioural half proves today's output is
+     * not the German grouping; the source half proves that is because the call
+     * names its locale rather than because this machine happens to be en-US,
+     * which is the part a value assertion alone can never show.
+     */
+    expect(allLabel(1000)).not.toContain((1000).toLocaleString("de-DE"));
+
+    /*
+     * Whitespace is squashed so Prettier stays free to reflow the argument
+     * onto its own line (which it has), and the trailing comma is optional for
+     * the same reason.
+     */
+    const source: string = fs
+      .readFileSync(FILTER_SOURCE, "utf8")
+      .replace(/\s+/g, "");
+
+    expect(source).toMatch(/toLocaleString\("en-US",?\)/);
+    expect(source).not.toContain("toLocaleString()");
+  });
+});
+
+describe("a filter value that is not one of the three", () => {
+  test("an unrecognised filter shows everything, matching the All it calls itself", () => {
+    /*
+     * The page casts its way into the enum — `setHostFilter(value as
+     * DiscoveredHostFilter)` — so nothing at runtime rejects a value that is
+     * not one of the three. The two halves used to disagree:
+     * `matchesDiscoveredHostFilter` fell through to `!isPingOnly` and showed
+     * the SNMP group, while `getDiscoveredHostFilterLabel` and the empty
+     * message both fell through to the All wording. The result was a dialog
+     * headed "All" that had silently hidden every ping-only host — the exact
+     * class of confusion #3322 was filed about.
+     *
+     * Unreachable through the current UI, where the values come from
+     * `getDiscoveredHostFilterOptions`, but one persisted filter or one URL
+     * parameter away — and showing everything is the only fall-through that
+     * cannot hide a group behind a heading that says it is showing them all.
+     */
+    const bogus: DiscoveredHostFilter = "Bogus" as DiscoveredHostFilter;
+
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+    ];
+
+    expect(
+      ipAddressesOf(filterDiscoveredHosts({ hosts: hosts, filter: bogus })),
+    ).toEqual(["10.0.0.1", "10.0.0.2"]);
+    expect(getDiscoveredHostFilterLabel(bogus)).toBe("All");
+    expect(getDiscoveredHostFilterEmptyMessage(bogus)).toBe(
+      "This scan did not find any responding hosts.",
+    );
+  });
+  test("every exported function answers the same twice, in any order", () => {
+    /*
+     * The dialog calls these on every render and in every combination: the
+     * counts, the shown list, the import list and the bulk-control state are
+     * all derived during one paint, and a memo, cache or accumulator hiding in
+     * the module would make the answer depend on what was rendered before it.
+     *
+     * The seen-address Set inside `getDiscoveredHostsToImport` and
+     * `countSelectableShownHosts` is exactly the shape of thing that gets
+     * hoisted out of a function "for performance" one day. Hoisted, it would
+     * make the SECOND press of Import return nothing at all — every address
+     * already seen — which is why this is checked by running the whole set
+     * twice, forwards and then interleaved, rather than by inspecting exports.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.0.0.1"),
+      pingOnlyHost("10.0.0.2"),
+      { ipAddress: "10.0.0.3" },
+      snmpHost("10.0.0.1"),
+      { ipAddress: "", snmpReachable: true },
+    ];
+
+    const selection: Record<string, boolean> = getInitialSelection(hosts);
+    const store: ImportedIpAddressesByScanId = { scan1: ["10.0.0.9"] };
+
+    const answer: () => string = (): string => {
+      const parts: Array<unknown> = [];
+
+      for (const filter of ALL_FILTERS) {
+        parts.push(filterDiscoveredHosts({ hosts: hosts, filter: filter }));
+        parts.push(getShownDiscoveredHosts({ hosts: hosts, filter: filter }));
+        parts.push(countSelectableShownHosts({ hosts: hosts, filter: filter }));
+        parts.push(
+          getDiscoveredHostsToImport({
+            hosts: hosts,
+            filter: filter,
+            selectedIpAddresses: selection,
+          }),
+        );
+        parts.push(
+          areAllShownHostsSelected({
+            hosts: hosts,
+            filter: filter,
+            selectedIpAddresses: selection,
+          }),
+        );
+        parts.push(
+          toggleSelectionForShownHosts({
+            hosts: hosts,
+            filter: filter,
+            selectedIpAddresses: selection,
+          }),
+        );
+        parts.push(getDiscoveredHostFilterLabel(filter));
+        parts.push(getDiscoveredHostFilterEmptyMessage(filter));
+      }
+
+      parts.push(countDiscoveredHosts(hosts));
+      parts.push(getDiscoveredHostFilterOptions(hosts));
+      parts.push(getInitialSelection(hosts));
+      parts.push(
+        markDiscoveredHostsAsRegistered({
+          hosts: hosts,
+          importedIpAddresses: new Set<string>(["10.0.0.1"]),
+        }),
+      );
+      parts.push(
+        Array.from(
+          getImportedIpAddressesForScan({
+            importedByScanId: store,
+            scanId: "scan1",
+          }),
+        ),
+      );
+      parts.push(
+        withImportedIpAddresses({
+          importedByScanId: store,
+          scanId: "scan1",
+          ipAddresses: ["10.0.0.1"],
+        }),
+      );
+
+      return JSON.stringify(parts);
+    };
+
+    const first: string = answer();
+
+    /*
+     * Reversed so the second sweep does not repeat the first one's call order:
+     * a cache keyed only on "have I been called before" would survive a
+     * straight repeat.
+     */
+    const reversedCounts: DiscoveredHostCounts = countDiscoveredHosts(
+      [...hosts].reverse(),
+    );
+
+    expect(reversedCounts).toEqual(countDiscoveredHosts(hosts));
+    expect(answer()).toBe(first);
+
+    // And the inputs themselves are untouched by any of it.
+    expect(selection).toEqual(getInitialSelection(hosts));
+    expect(store).toEqual({ scan1: ["10.0.0.9"] });
+    expect(ipAddressesOf(hosts)).toEqual([
+      "10.0.0.1",
+      "10.0.0.2",
+      "10.0.0.3",
+      "10.0.0.1",
+      "",
+    ]);
+  });
+});

--- a/App/Tests/Dashboard/DiscoveryImportScoping.test.ts
+++ b/App/Tests/Dashboard/DiscoveryImportScoping.test.ts
@@ -1,0 +1,852 @@
+import { describe, expect, test } from "@jest/globals";
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import {
+  DiscoveredHostFilter,
+  getDiscoveredHostsToImport,
+  normalizeDiscoveredHosts,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
+
+/*
+ * WHAT THIS FILE PINS
+ *
+ * `getDiscoveredHostsToImport` is the single answer to "what does pressing
+ * Import Selected create". Discovery.tsx loops over its result and issues one
+ * `ModelAPI.create<NetworkDevice>` per entry, and the count rendered on the
+ * button is that same list's length — so this function is simultaneously the
+ * promise on the button and the work the press does. One host too many here is
+ * one unwanted Network Device; at the size issue #3322 reports (2,866 SNMP +
+ * 2,890 ping-only in one scan) a scoping mistake is thousands of them, created
+ * one API call at a time, with a success toast at the end.
+ *
+ * Every expectation below is a hand-written literal — an explicit array of
+ * addresses or an explicit number — checkable by eye against the fixture right
+ * above it. Nothing here re-derives an expected value by calling the module,
+ * because a test that computes its expectation from the same primitives as the
+ * function under test agrees with any bug both of them share. For the same
+ * reason the selections passed in are built by this file's own `tick` /
+ * `tickEveryAddress` helpers rather than by `getInitialSelection`: the
+ * interesting cases are the ones where the selection and the selectable set
+ * DISAGREE, and handing the function a selection equal to exactly what it
+ * would have picked itself never exercises the selection branch at all.
+ *
+ * DiscoveredHostFilter.test.ts covers the grouping rules and the happy path.
+ * This file is about partial selections, ticks that point at nothing, jsonb
+ * that repeats an address, and the arithmetic at scan scale.
+ */
+
+/** Answered the SNMP walk: imports as a polled device with the scan's creds. */
+function snmpHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    sysName: `switch-${ipAddress}`,
+    snmpReachable: true,
+    ...overrides,
+  };
+}
+
+/** Answered ping only: imports as a monitor-backed device, no polling. */
+function pingOnlyHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    snmpReachable: false,
+    ...overrides,
+  };
+}
+
+/*
+ * A row written before `snmpReachable` existed. Ping-only sweeps did not exist
+ * then, so every host on those scans answered SNMP — reading `undefined` as
+ * ping-only would retroactively move real switches into the wrong group and
+ * import them with no polling.
+ */
+function legacyHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    sysName: `legacy-${ipAddress}`,
+    ...overrides,
+  };
+}
+
+function addressesOf(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+  return hosts.map((host: DiscoveredNetworkDevice) => {
+    return host.ipAddress;
+  });
+}
+
+/**
+ * A selection with exactly these addresses ticked, in this order.
+ *
+ * Written here rather than taken from `getInitialSelection` so the ticks are
+ * an independent input: what the operator left checked, not what the module
+ * thinks is checkable.
+ */
+function tick(...ipAddresses: Array<string>): Record<string, boolean> {
+  const selection: Record<string, boolean> = {};
+
+  for (const ipAddress of ipAddresses) {
+    selection[ipAddress] = true;
+  }
+
+  return selection;
+}
+
+/**
+ * Every address in the scan ticked — including the ones that must never
+ * import.
+ *
+ * Deliberately more generous than the dialog's own opening selection: a stale
+ * tick on an already-registered or blank-addressed host is exactly the state a
+ * second sitting leaves behind, and it has to be refused by the import rather
+ * than by the fact that nobody ticked it.
+ */
+function tickEveryAddress(
+  hosts: Array<DiscoveredNetworkDevice>,
+): Record<string, boolean> {
+  const selection: Record<string, boolean> = {};
+
+  for (const host of hosts) {
+    selection[host.ipAddress] = true;
+  }
+
+  return selection;
+}
+
+/*
+ * One mixed sweep, half of it left unticked by the operator.
+ *
+ * .1 SNMP, ticked          .2 ping-only, ticked
+ * .3 SNMP, NOT ticked      .4 ping-only, NOT ticked
+ * .5 legacy (SNMP), ticked .6 ping-only, ticked
+ */
+const mixedScan: Array<DiscoveredNetworkDevice> = [
+  snmpHost("10.0.0.1"),
+  pingOnlyHost("10.0.0.2"),
+  snmpHost("10.0.0.3"),
+  pingOnlyHost("10.0.0.4"),
+  legacyHost("10.0.0.5"),
+  pingOnlyHost("10.0.0.6"),
+];
+
+const mixedSelection: Record<string, boolean> = tick(
+  "10.0.0.1",
+  "10.0.0.2",
+  "10.0.0.5",
+  "10.0.0.6",
+);
+
+describe("a partial selection under each filter", () => {
+  test("All imports the four ticked hosts and leaves the two unticked ones alone", () => {
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: mixedSelection,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.5", "10.0.0.6"]);
+  });
+
+  test("SNMP imports the ticked SNMP hosts only — not the unticked switch, not the ticked ping-only hosts", () => {
+    /*
+     * Two independent narrowings at once, which is the state the dialog is
+     * actually in: a filter hiding one group and unticked rows inside the
+     * group that is showing. .3 is on screen and unticked; .2 and .6 are
+     * ticked and hidden. Neither may reach the import.
+     */
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.Snmp,
+          selectedIpAddresses: mixedSelection,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.5"]);
+  });
+
+  test("No SNMP imports the ticked ping-only hosts only", () => {
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: mixedSelection,
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.6"]);
+  });
+
+  test("a group whose every ticked host is hidden by the filter imports nothing at all", () => {
+    /*
+     * The zero case has to be a real zero rather than "fall back to the whole
+     * selection": Discovery.tsx returns early on an empty list and the button
+     * renders "Import Selected (0)" disabled, so a non-empty answer here is a
+     * press that creates devices the operator cannot see.
+     */
+    const pingOnlyTicks: Record<string, boolean> = tick(
+      "10.0.0.2",
+      "10.0.0.4",
+      "10.0.0.6",
+    );
+
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: mixedScan,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: pingOnlyTicks,
+      }),
+    ).toEqual([]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: pingOnlyTicks,
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.4", "10.0.0.6"]);
+  });
+});
+
+describe("what counts as a tick", () => {
+  test("only a truthy value imports — false and a removed key are both untick", () => {
+    /*
+     * `CheckboxElement` writes `false` on uncheck rather than dropping the
+     * key, and the bulk "Clear all" control writes `false` across the whole
+     * shown group, so a present-but-false entry is the COMMON shape of an
+     * unticked host — while a host never touched has no key at all. Reading
+     * presence instead of value would make Clear all import everything it just
+     * cleared.
+     */
+    const selection: Record<string, boolean> = {
+      "10.0.0.1": true,
+      "10.0.0.2": false,
+      "10.0.0.5": true,
+      "10.0.0.6": false,
+    };
+
+    delete selection["10.0.0.5"];
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: selection,
+        }),
+      ),
+    ).toEqual(["10.0.0.1"]);
+  });
+
+  test("ticks for addresses that are not in the scan are ignored rather than imported or thrown on", () => {
+    /*
+     * Selection state outlives the list it was made against: the same object
+     * is still in hand when a scan is re-opened after a re-sweep dropped hosts
+     * that no longer answer. Those ticks have no row, no sysName and no
+     * monitoring method — there is nothing to create from them.
+     */
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: tick(
+            "192.168.99.99",
+            "10.0.0.2",
+            "172.31.4.4",
+            "",
+          ),
+        }),
+      ),
+    ).toEqual(["10.0.0.2"]);
+  });
+
+  test("an empty selection against a full scan imports nothing under any filter", () => {
+    for (const filter of [
+      DiscoveredHostFilter.All,
+      DiscoveredHostFilter.Snmp,
+      DiscoveredHostFilter.NoSnmp,
+    ]) {
+      expect(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: filter,
+          selectedIpAddresses: {},
+        }),
+      ).toEqual([]);
+    }
+  });
+
+  test("an address that names an Object.prototype key is not imported unless it was ticked", () => {
+    /*
+     * The selection is a plain object, and the tick used to be read as
+     * `selectedIpAddresses[host.ipAddress]` — so an address colliding with
+     * something on Object.prototype ("constructor", "toString", "valueOf")
+     * resolved to an inherited function and was truthy for a host nobody
+     * ticked. `discoveredDevices` is jsonb written from the probe's payload
+     * and `ipAddress` is used verbatim as the device hostname, so the value is
+     * not guaranteed to be a dotted quad.
+     *
+     * `isSelectedIpAddress` now asks for an OWN property. "10.0.0.9" beside it
+     * is the control: an ordinary unticked address was always refused, and
+     * still is.
+     */
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: [snmpHost("constructor"), snmpHost("10.0.0.9")],
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: {},
+      }),
+    ).toEqual([]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: [snmpHost("constructor"), snmpHost("10.0.0.9")],
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: tick("constructor"),
+        }),
+      ),
+    ).toEqual(["constructor"]);
+  });
+});
+
+describe("hosts that must never be imported, however they are ticked", () => {
+  test("an already-registered host is skipped while the neighbours around it import", () => {
+    /*
+     * `isAlreadyRegistered` is computed server-side at probe-upload time and
+     * frozen into the jsonb, so the tick on it is genuinely stale rather than
+     * a fresh choice — and the row's checkbox is disabled, so the operator
+     * cannot clear it themselves. Importing it creates a second Network Device
+     * for an address the inventory already has.
+     */
+    const scan: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.5.0.1"),
+      snmpHost("10.5.0.2", { isAlreadyRegistered: true }),
+      pingOnlyHost("10.5.0.3", { isAlreadyRegistered: true }),
+      pingOnlyHost("10.5.0.4"),
+    ];
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: tickEveryAddress(scan),
+        }),
+      ),
+    ).toEqual(["10.5.0.1", "10.5.0.4"]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: tickEveryAddress(scan),
+        }),
+      ),
+    ).toEqual(["10.5.0.4"]);
+  });
+
+  test("a blank address is skipped even with the empty-string key ticked", () => {
+    /*
+     * The address is the device hostname AND the selection key, so a blank one
+     * would import as a nameless device that every other blank row shares a
+     * checkbox with. Grouping still works on it — this row is ping-only — so
+     * it has to be refused by selectability, not by falling outside a filter.
+     */
+    const scan: Array<DiscoveredNetworkDevice> = [
+      { ipAddress: "", snmpReachable: false },
+      pingOnlyHost("10.6.0.2"),
+    ];
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: tickEveryAddress(scan),
+        }),
+      ),
+    ).toEqual(["10.6.0.2"]);
+  });
+
+  test("a legacy row imports under SNMP and is invisible to No SNMP", () => {
+    /*
+     * The expensive half of the legacy rule: if `undefined` were read as
+     * ping-only, re-importing an old scan under No SNMP would create real
+     * switches as monitor-backed devices with polling switched off, and the
+     * SNMP press that was supposed to pick them up would come back empty.
+     */
+    const scan: Array<DiscoveredNetworkDevice> = [
+      legacyHost("10.7.0.1"),
+      { ipAddress: "10.7.0.2", snmpReachable: undefined },
+      pingOnlyHost("10.7.0.3"),
+    ];
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scan,
+          filter: DiscoveredHostFilter.Snmp,
+          selectedIpAddresses: tickEveryAddress(scan),
+        }),
+      ),
+    ).toEqual(["10.7.0.1", "10.7.0.2"]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: tickEveryAddress(scan),
+        }),
+      ),
+    ).toEqual(["10.7.0.3"]);
+  });
+});
+
+describe("an address that appears on more than one row", () => {
+  /*
+   * `discoveredDevices` is jsonb straight from the probe's payload, so the
+   * same address can appear twice — a re-walk that answered on two interfaces,
+   * a merged payload. One address is one checkbox, so two rows share a single
+   * tick, and importing both would create two devices from one decision.
+   */
+  const duplicateScan: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.8.0.1", { sysName: "first-walk" }),
+    pingOnlyHost("10.8.0.2"),
+    snmpHost("10.8.0.1", { sysName: "second-walk" }),
+    pingOnlyHost("10.8.0.2"),
+    snmpHost("10.8.0.3"),
+  ];
+
+  test("a duplicated address imports once under each of the three filters", () => {
+    const selection: Record<string, boolean> = tick("10.8.0.1", "10.8.0.2");
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: duplicateScan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: selection,
+        }),
+      ),
+    ).toEqual(["10.8.0.1", "10.8.0.2"]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: duplicateScan,
+          filter: DiscoveredHostFilter.Snmp,
+          selectedIpAddresses: selection,
+        }),
+      ),
+    ).toEqual(["10.8.0.1"]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: duplicateScan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: selection,
+        }),
+      ),
+    ).toEqual(["10.8.0.2"]);
+  });
+
+  test("the row that gets imported is the first one in scan order, which decides the device's name", () => {
+    /*
+     * Not cosmetic: Discovery.tsx builds the device from the returned row —
+     * `device.name = entry.sysName || entry.ipAddress` and the description
+     * from `sysDescr` — so which of the two rows survives is what the device
+     * ends up called. Scan order is the probe's order, so first-wins is the
+     * reading of the payload the operator saw at the top of the list.
+     */
+    const imported: Array<DiscoveredNetworkDevice> = getDiscoveredHostsToImport(
+      {
+        hosts: duplicateScan,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: tick("10.8.0.1"),
+      },
+    );
+
+    expect(imported).toHaveLength(1);
+    expect(imported[0]!.sysName).toBe("first-walk");
+  });
+
+  test("an unticked duplicate contributes nothing, however many rows carry it", () => {
+    /*
+     * The dedupe is a "seen" set, and a set that were updated before the tick
+     * was checked would still be harmless here — but one updated by the FIRST
+     * row of an unticked pair and consulted later is how a duplicate becomes
+     * un-importable forever. Both rows unticked must simply be absent, with
+     * the rest of the scan unaffected.
+     */
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: duplicateScan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: tick("10.8.0.3"),
+        }),
+      ),
+    ).toEqual(["10.8.0.3"]);
+  });
+
+  test("one address on two rows in DIFFERENT groups is offered by both groups but imported once under All", () => {
+    /*
+     * The awkward payload: the same address answered ping on one row and SNMP
+     * on another. Each filter shows its own row, so the address is importable
+     * from either group — and under All it collapses to the scan-first row,
+     * which here is the ping-only one, so the device is created WITHOUT
+     * polling even though a row claiming SNMP exists further down.
+     *
+     * This is the one case where the SNMP and No SNMP lists overlap, so it is
+     * asserted apart from the partition test below rather than being allowed
+     * to weaken it. Importing group by group does not double-create: the page
+     * marks the address registered after the first press, and
+     * `markDiscoveredHostsAsRegistered` keys on the address, so it retires
+     * both rows at once.
+     */
+    const crossGroupScan: Array<DiscoveredNetworkDevice> = [
+      pingOnlyHost("10.9.0.1", { sysName: "ping-row" }),
+      snmpHost("10.9.0.1", { sysName: "snmp-row" }),
+    ];
+
+    const selection: Record<string, boolean> = tick("10.9.0.1");
+
+    const underAll: Array<DiscoveredNetworkDevice> = getDiscoveredHostsToImport(
+      {
+        hosts: crossGroupScan,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: selection,
+      },
+    );
+
+    expect(underAll).toHaveLength(1);
+    expect(underAll[0]!.sysName).toBe("ping-row");
+    expect(underAll[0]!.snmpReachable).toBe(false);
+
+    const underSnmp: Array<DiscoveredNetworkDevice> =
+      getDiscoveredHostsToImport({
+        hosts: crossGroupScan,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selection,
+      });
+
+    expect(addressesOf(underSnmp)).toEqual(["10.9.0.1"]);
+    expect(underSnmp[0]!.sysName).toBe("snmp-row");
+
+    const underNoSnmp: Array<DiscoveredNetworkDevice> =
+      getDiscoveredHostsToImport({
+        hosts: crossGroupScan,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: selection,
+      });
+
+    expect(addressesOf(underNoSnmp)).toEqual(["10.9.0.1"]);
+    expect(underNoSnmp[0]!.sysName).toBe("ping-row");
+  });
+
+  test("a duplicated address registered on either row is not imported on the other", () => {
+    /*
+     * The dedup in getDiscoveredHostsToImport records an address only once a
+     * row has passed selectability, so a registered first row was refused
+     * WITHOUT claiming its address and the second row — same address, its own
+     * frozen `isAlreadyRegistered: false` — sailed through. A Network Device
+     * was created for an address the scan itself reports as already in the
+     * inventory, and which row won depended purely on payload order. The
+     * dialog renders the pair as one disabled "Already added" row and one
+     * enabled row, so the operator cannot see it is the same host twice.
+     *
+     * normalizeDiscoveredHosts settles it before any of that: registration is
+     * a fact about an ADDRESS, so it is propagated to every row carrying it.
+     * Asserted in both orders, because order-dependence was the original
+     * symptom.
+     */
+    const registeredFirst: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.10.0.1", {
+        sysName: "registered-row",
+        isAlreadyRegistered: true,
+      }),
+      snmpHost("10.10.0.1", { sysName: "unregistered-row" }),
+    ];
+
+    const registeredSecond: Array<DiscoveredNetworkDevice> = [
+      snmpHost("10.10.0.1", { sysName: "unregistered-row" }),
+      snmpHost("10.10.0.1", {
+        sysName: "registered-row",
+        isAlreadyRegistered: true,
+      }),
+    ];
+
+    for (const scan of [registeredFirst, registeredSecond]) {
+      expect(
+        getDiscoveredHostsToImport({
+          hosts: normalizeDiscoveredHosts(scan),
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: tick("10.10.0.1"),
+        }),
+      ).toEqual([]);
+    }
+  });
+});
+
+describe("the two groups partition the import", () => {
+  /*
+   * A fixture with one of everything that can change the answer: a legacy row,
+   * a ticked-but-registered host, an unticked ping-only host, and one plain
+   * member of each group.
+   *
+   * .1 legacy (SNMP), ticked            .2 ping-only, ticked
+   * .3 SNMP, ticked but registered      .4 ping-only, NOT ticked
+   * .5 SNMP, ticked
+   */
+  const partitionScan: Array<DiscoveredNetworkDevice> = [
+    legacyHost("172.16.0.1"),
+    pingOnlyHost("172.16.0.2"),
+    snmpHost("172.16.0.3", { isAlreadyRegistered: true }),
+    pingOnlyHost("172.16.0.4"),
+    snmpHost("172.16.0.5"),
+  ];
+
+  const partitionSelection: Record<string, boolean> = tick(
+    "172.16.0.1",
+    "172.16.0.2",
+    "172.16.0.3",
+    "172.16.0.5",
+  );
+
+  test("importing SNMP then No SNMP creates exactly what importing All would, no host twice and none stranded", () => {
+    /*
+     * This is the guarantee that makes "do the switches now, the endpoints
+     * later" safe. If a host could import under neither group it would be
+     * silently unreachable from the two-press flow even though All offers it;
+     * if it could import under both, the two presses would create it twice —
+     * and neither shows up as an error, only as a wrong inventory.
+     */
+    const underSnmp: Array<string> = addressesOf(
+      getDiscoveredHostsToImport({
+        hosts: partitionScan,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: partitionSelection,
+      }),
+    );
+
+    const underNoSnmp: Array<string> = addressesOf(
+      getDiscoveredHostsToImport({
+        hosts: partitionScan,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: partitionSelection,
+      }),
+    );
+
+    const underAll: Array<string> = addressesOf(
+      getDiscoveredHostsToImport({
+        hosts: partitionScan,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: partitionSelection,
+      }),
+    );
+
+    expect(underSnmp).toEqual(["172.16.0.1", "172.16.0.5"]);
+    expect(underNoSnmp).toEqual(["172.16.0.2"]);
+    expect(underAll).toEqual(["172.16.0.1", "172.16.0.2", "172.16.0.5"]);
+
+    // Together the two groups are the whole import, each host in exactly one.
+    expect([...underSnmp, ...underNoSnmp].sort()).toEqual([...underAll].sort());
+    expect(
+      underSnmp.filter((ipAddress: string) => {
+        return underNoSnmp.includes(ipAddress);
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("the order the devices are created in", () => {
+  test("import order follows the scan even when the boxes were ticked bottom-up", () => {
+    /*
+     * Discovery.tsx creates the devices sequentially in this order, reporting
+     * failures by address as it goes, and a run of thousands can be watched
+     * (or interrupted) part-way through. Scan order is the probe's address
+     * order — the order the operator just read down the dialog — whereas
+     * selection-key order is whatever sequence the boxes happened to be
+     * clicked in, which would make a partial run's progress unreadable.
+     */
+    const bottomUpSelection: Record<string, boolean> = tick(
+      "10.0.0.6",
+      "10.0.0.5",
+      "10.0.0.2",
+      "10.0.0.1",
+    );
+
+    // The selection genuinely disagrees with scan order, or this proves nothing.
+    expect(Object.keys(bottomUpSelection)).toEqual([
+      "10.0.0.6",
+      "10.0.0.5",
+      "10.0.0.2",
+      "10.0.0.1",
+    ]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: bottomUpSelection,
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.5", "10.0.0.6"]);
+
+    expect(
+      addressesOf(
+        getDiscoveredHostsToImport({
+          hosts: mixedScan,
+          filter: DiscoveredHostFilter.NoSnmp,
+          selectedIpAddresses: bottomUpSelection,
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.6"]);
+  });
+});
+
+describe("the scan from issue #3322, at its real size", () => {
+  /*
+   * 2,866 SNMP hosts and 2,890 ping-only ones in a single sweep. Every number
+   * below is written out and explained rather than computed, because the count
+   * on the button IS this list's length: if the arithmetic here is derived the
+   * same way the implementation derives it, a wrong number agrees with itself.
+   *
+   * SNMP addresses are 10.1.x.y, ping-only ones 10.2.x.y, so which group a
+   * returned host came from can be read off its address without asking the
+   * module.
+   */
+  const SNMP_COUNT: number = 2866;
+  const PING_ONLY_COUNT: number = 2890;
+
+  /** The two SNMP hosts a previous sitting already imported. */
+  const REGISTERED_SNMP: Array<string> = ["10.1.0.0", "10.1.4.7"];
+  /** The three switches the operator unticked by hand. */
+  const UNTICKED_SNMP: Array<string> = ["10.1.1.1", "10.1.2.2", "10.1.3.3"];
+  /** The four endpoints the operator unticked by hand. */
+  const UNTICKED_PING_ONLY: Array<string> = [
+    "10.2.0.1",
+    "10.2.0.2",
+    "10.2.5.5",
+    "10.2.9.9",
+  ];
+
+  function bigScan(): Array<DiscoveredNetworkDevice> {
+    const hosts: Array<DiscoveredNetworkDevice> = [];
+
+    for (let index: number = 0; index < SNMP_COUNT; index++) {
+      const ipAddress: string = `10.1.${Math.floor(index / 256)}.${index % 256}`;
+
+      hosts.push(
+        snmpHost(ipAddress, {
+          isAlreadyRegistered: REGISTERED_SNMP.includes(ipAddress),
+        }),
+      );
+    }
+
+    for (let index: number = 0; index < PING_ONLY_COUNT; index++) {
+      hosts.push(
+        pingOnlyHost(`10.2.${Math.floor(index / 256)}.${index % 256}`),
+      );
+    }
+
+    return hosts;
+  }
+
+  /** Everything ticked except the seven rows the operator cleared. */
+  function bigSelection(
+    hosts: Array<DiscoveredNetworkDevice>,
+  ): Record<string, boolean> {
+    const selection: Record<string, boolean> = tickEveryAddress(hosts);
+
+    for (const ipAddress of [...UNTICKED_SNMP, ...UNTICKED_PING_ONLY]) {
+      selection[ipAddress] = false;
+    }
+
+    return selection;
+  }
+
+  test("each filter imports its own group's ticked hosts, and the three counts are exactly 2,861 / 2,886 / 5,747", () => {
+    /*
+     * SNMP:     2,866 found - 2 already registered - 3 unticked = 2,861.
+     * No SNMP:  2,890 found - 4 unticked                        = 2,886.
+     * All:      2,861 + 2,886                                   = 5,747.
+     *
+     * The address-prefix checks are what turn a right total into a right list:
+     * a scoping bug that swapped the groups would keep All at 5,747 while
+     * making both group presses create the wrong thousands of devices.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = bigScan();
+    const selection: Record<string, boolean> = bigSelection(hosts);
+
+    const underSnmp: Array<string> = addressesOf(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selection,
+      }),
+    );
+
+    const underNoSnmp: Array<string> = addressesOf(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: selection,
+      }),
+    );
+
+    const underAll: Array<string> = addressesOf(
+      getDiscoveredHostsToImport({
+        hosts: hosts,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: selection,
+      }),
+    );
+
+    expect(underSnmp).toHaveLength(2861);
+    expect(underNoSnmp).toHaveLength(2886);
+    expect(underAll).toHaveLength(5747);
+
+    expect(
+      underSnmp.filter((ipAddress: string) => {
+        return !ipAddress.startsWith("10.1.");
+      }),
+    ).toEqual([]);
+
+    expect(
+      underNoSnmp.filter((ipAddress: string) => {
+        return !ipAddress.startsWith("10.2.");
+      }),
+    ).toEqual([]);
+
+    // The seven cleared rows and the two registered ones are absent from All.
+    for (const ipAddress of [
+      ...REGISTERED_SNMP,
+      ...UNTICKED_SNMP,
+      ...UNTICKED_PING_ONLY,
+    ]) {
+      expect(underAll).not.toContain(ipAddress);
+    }
+
+    // First and last of the whole sweep, so scan order survived at scale.
+    expect(underAll[0]).toBe("10.1.0.1");
+    expect(underAll[underAll.length - 1]).toBe("10.2.11.73");
+  });
+});

--- a/App/Tests/Dashboard/DiscoveryImportedHostRetirement.test.ts
+++ b/App/Tests/Dashboard/DiscoveryImportedHostRetirement.test.ts
@@ -1,0 +1,690 @@
+import { describe, expect, test } from "@jest/globals";
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import {
+  DiscoveredHostFilter,
+  ImportedIpAddressesByScanId,
+  countDiscoveredHosts,
+  countSelectableShownHosts,
+  getDiscoveredHostsToImport,
+  getImportedIpAddressesForScan,
+  getInitialSelection,
+  isSelectableDiscoveredHost,
+  markDiscoveredHostsAsRegistered,
+  withImportedIpAddresses,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
+
+/*
+ * WHAT THIS FILE GUARDS
+ *
+ * The Review Discovered Devices dialog decides what is still importable from
+ * `isAlreadyRegistered`, and that flag is computed server-side when the probe
+ * uploads its results and then FROZEN into the scan's jsonb column. Nothing
+ * recomputes it on read. So a host imported sixty seconds ago still reports
+ * false: the dialog re-offers it, pre-checked, and the next press of Import
+ * creates a SECOND Network Device for the same address. That was survivable
+ * when one press imported everything and closed the dialog; importing group by
+ * group is the intended flow since #3322, so coming back to a list that still
+ * contains what you just imported is now the normal case.
+ *
+ * The page closes that hole by keeping its own record of what it has imported
+ * and overlaying it on the scan — `withImportedIpAddresses` to write,
+ * `getImportedIpAddressesForScan` to read, `markDiscoveredHostsAsRegistered`
+ * to apply. This file is about that record and the duplicate it exists to
+ * prevent: the store's accumulation and immutability, its per-scan keying, and
+ * the two operator journeys that depend on both (import one group then the
+ * other; close the dialog and reopen the same scan).
+ *
+ * The record is keyed by scan id rather than being a bare set of addresses for
+ * a reason that is not theoretical: importing 2,866 hosts is thousands of
+ * sequential creates and runs for minutes, and nothing stops the operator
+ * closing the dialog and opening a DIFFERENT scan meanwhile. A bare set
+ * written when that run finally lands would mark the other scan's
+ * same-addressed hosts "Already added" — disabled, unticked, and silently
+ * excluded from its Import. Overlapping addresses across scans are the norm,
+ * not the exception: re-sweeping the same /24 next week is what discovery is
+ * for.
+ *
+ * Every failure here renders perfectly. A duplicate device looks exactly like
+ * a real one until someone counts them.
+ */
+
+/** An SNMP responder: imports as a polled device with the scan's credentials. */
+function snmpHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    sysName: `switch-${ipAddress}`,
+    snmpReachable: true,
+    ...overrides,
+  };
+}
+
+/** Answered ping only: imports as a monitor-backed device, no polling. */
+function pingOnlyHost(
+  ipAddress: string,
+  overrides?: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return {
+    ipAddress: ipAddress,
+    snmpReachable: false,
+    ...overrides,
+  };
+}
+
+function ipAddressesOf(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+  return hosts.map((host: DiscoveredNetworkDevice) => {
+    return host.ipAddress;
+  });
+}
+
+/*
+ * The list the dialog actually reasons about, assembled exactly the way
+ * Discovery.tsx's `getReviewHosts` assembles it: the probe's hosts with this
+ * scan's record overlaid. Reading the store and applying it are two functions
+ * because they are two different moments, but they are never used apart — so
+ * the composition is what these tests exercise.
+ */
+function reviewHostsFor(data: {
+  importedByScanId: ImportedIpAddressesByScanId;
+  scanId: string | null | undefined;
+  hosts: Array<DiscoveredNetworkDevice>;
+}): Array<DiscoveredNetworkDevice> {
+  return markDiscoveredHostsAsRegistered({
+    hosts: data.hosts,
+    importedIpAddresses: getImportedIpAddressesForScan({
+      importedByScanId: data.importedByScanId,
+      scanId: data.scanId,
+    }),
+  });
+}
+
+describe("getImportedIpAddressesForScan", () => {
+  const store: ImportedIpAddressesByScanId = {
+    "scan-a": ["10.0.0.1", "10.0.0.3"],
+    "scan-b": ["10.0.0.9"],
+  };
+
+  test("a scan's entry comes back as exactly the addresses recorded for it", () => {
+    expect(
+      getImportedIpAddressesForScan({
+        importedByScanId: store,
+        scanId: "scan-a",
+      }),
+    ).toEqual(new Set<string>(["10.0.0.1", "10.0.0.3"]));
+  });
+
+  test("a scan id the store has never seen reads empty, not as another scan's addresses", () => {
+    /*
+     * The default answer has to be "nothing has been imported from this scan
+     * yet", because that is the state every freshly opened scan is in. Reading
+     * anything else here would retire hosts the operator has never touched.
+     */
+    expect(
+      getImportedIpAddressesForScan({
+        importedByScanId: store,
+        scanId: "scan-never-opened",
+      }),
+    ).toEqual(new Set<string>());
+  });
+
+  test("a null, undefined or empty scan id reads empty rather than reaching for a key", () => {
+    /*
+     * The page passes `scan?._id`, so undefined is a real value on this path,
+     * and an unsaved model yields "". An empty-string key is the dangerous one:
+     * if the guard only rejected null/undefined, every scan without an id would
+     * share one bucket and retire each other's hosts. The store below has such
+     * a key precisely so a weakened guard is caught rather than being a
+     * theoretical concern.
+     */
+    const storeWithBlankKey: ImportedIpAddressesByScanId = {
+      ...store,
+      "": ["10.0.0.7"],
+    };
+
+    for (const scanId of [null, undefined, ""]) {
+      expect(
+        getImportedIpAddressesForScan({
+          importedByScanId: storeWithBlankKey,
+          scanId: scanId,
+        }),
+      ).toEqual(new Set<string>());
+    }
+  });
+
+  test("the set handed back is a copy, so nothing downstream can corrupt the record", () => {
+    /*
+     * The record is React state that outlives the dialog. If callers received
+     * the live collection, one stray `add` — or a caller building up "what I
+     * am about to import" from it — would silently retire hosts across every
+     * later read of this scan, with no import having happened.
+     */
+    const imported: Set<string> = getImportedIpAddressesForScan({
+      importedByScanId: store,
+      scanId: "scan-a",
+    });
+
+    imported.add("10.0.0.99");
+    imported.delete("10.0.0.1");
+
+    expect(store["scan-a"]).toEqual(["10.0.0.1", "10.0.0.3"]);
+    expect(
+      getImportedIpAddressesForScan({
+        importedByScanId: store,
+        scanId: "scan-a",
+      }),
+    ).toEqual(new Set<string>(["10.0.0.1", "10.0.0.3"]));
+  });
+});
+
+describe("withImportedIpAddresses", () => {
+  test("the first import of a sitting creates the scan's entry", () => {
+    expect(
+      withImportedIpAddresses({
+        importedByScanId: {},
+        scanId: "scan-a",
+        ipAddresses: ["10.0.0.1", "10.0.0.3"],
+      }),
+    ).toEqual({ "scan-a": ["10.0.0.1", "10.0.0.3"] });
+  });
+
+  test("a second import accumulates onto the first instead of replacing it", () => {
+    /*
+     * The whole point of #3322 is importing the SNMP group and then the
+     * ping-only group. If the second write replaced the first, the SNMP hosts
+     * would come back offered and pre-checked the moment the ping-only import
+     * landed — duplicates for the group the operator imported first.
+     */
+    const afterSnmp: ImportedIpAddressesByScanId = withImportedIpAddresses({
+      importedByScanId: {},
+      scanId: "scan-a",
+      ipAddresses: ["10.0.0.1", "10.0.0.3"],
+    });
+
+    expect(
+      withImportedIpAddresses({
+        importedByScanId: afterSnmp,
+        scanId: "scan-a",
+        ipAddresses: ["10.0.0.2", "10.0.0.4"],
+      }),
+    ).toEqual({
+      "scan-a": ["10.0.0.1", "10.0.0.3", "10.0.0.2", "10.0.0.4"],
+    });
+  });
+
+  test("an address recorded twice is stored once", () => {
+    /*
+     * A retry after a partial failure re-imports some of the same addresses,
+     * and the jsonb itself can carry an address twice. The record is a set of
+     * what is in the inventory, not a log of attempts.
+     */
+    expect(
+      withImportedIpAddresses({
+        importedByScanId: { "scan-a": ["10.0.0.1"] },
+        scanId: "scan-a",
+        ipAddresses: ["10.0.0.1", "10.0.0.2", "10.0.0.2"],
+      }),
+    ).toEqual({ "scan-a": ["10.0.0.1", "10.0.0.2"] });
+  });
+
+  test("importing nothing returns the very same store object", () => {
+    /*
+     * Identity, not just equality: this lands in a `useState` setter, and
+     * returning a fresh object for a run that created no devices would
+     * re-render the dialog — remounting rows whose checkbox seeds its checked
+     * state from `initialValue`, i.e. blanking the operator's selection for a
+     * frame in exchange for nothing.
+     */
+    const store: ImportedIpAddressesByScanId = { "scan-a": ["10.0.0.1"] };
+
+    expect(
+      withImportedIpAddresses({
+        importedByScanId: store,
+        scanId: "scan-a",
+        ipAddresses: [],
+      }),
+    ).toBe(store);
+  });
+
+  test("a missing or empty scan id records nothing at all", () => {
+    /*
+     * Same reasoning as the read side: a run that cannot say which scan it
+     * belongs to must not write, because the only bucket it could write to is
+     * one every other id-less scan would read back.
+     */
+    const store: ImportedIpAddressesByScanId = { "scan-a": ["10.0.0.1"] };
+
+    for (const scanId of [null, undefined, ""]) {
+      expect(
+        withImportedIpAddresses({
+          importedByScanId: store,
+          scanId: scanId,
+          ipAddresses: ["10.0.0.5"],
+        }),
+      ).toBe(store);
+    }
+  });
+
+  test("writing one scan's addresses leaves every other scan's entry untouched", () => {
+    /*
+     * This is the keying doing its job at the data level: an import that lands
+     * while a different scan is on screen adds a key, it does not disturb one.
+     */
+    const store: ImportedIpAddressesByScanId = { "scan-a": ["10.0.0.1"] };
+
+    const afterScanB: ImportedIpAddressesByScanId = withImportedIpAddresses({
+      importedByScanId: store,
+      scanId: "scan-b",
+      ipAddresses: ["10.0.0.2"],
+    });
+
+    expect(afterScanB["scan-a"]).toEqual(["10.0.0.1"]);
+    // The untouched entry is the same array, not a rebuilt copy of it.
+    expect(afterScanB["scan-a"]).toBe(store["scan-a"]);
+    expect(afterScanB["scan-b"]).toEqual(["10.0.0.2"]);
+  });
+
+  test("the store passed in is never mutated", () => {
+    /*
+     * The page also derives an `importedAfterThisRun` value from the current
+     * store while separately handing a functional update to React. If the write
+     * mutated in place, those two would be the same object and the "before"
+     * view of the store would silently change under whoever still held it.
+     */
+    const store: ImportedIpAddressesByScanId = { "scan-a": ["10.0.0.1"] };
+
+    withImportedIpAddresses({
+      importedByScanId: store,
+      scanId: "scan-a",
+      ipAddresses: ["10.0.0.2"],
+    });
+    withImportedIpAddresses({
+      importedByScanId: store,
+      scanId: "scan-b",
+      ipAddresses: ["10.0.0.3"],
+    });
+
+    expect(store).toEqual({ "scan-a": ["10.0.0.1"] });
+  });
+});
+
+describe("applying the record to the scan the dialog renders", () => {
+  const scan: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    snmpHost("10.0.0.3"),
+  ];
+
+  test("a scan nothing has been imported from renders the identical array", () => {
+    /*
+     * Identity again, and for the same React reason as the empty write: the
+     * overwhelmingly common case is a scan with no record, and rebuilding the
+     * list on every render would give the dialog a new array — and new row
+     * objects — each time anything at all changed.
+     */
+    expect(
+      reviewHostsFor({
+        importedByScanId: { "scan-b": ["10.0.0.1"] },
+        scanId: "scan-a",
+        hosts: scan,
+      }),
+    ).toBe(scan);
+  });
+
+  test("a host in the record loses its checkbox and drops out of what Import would create", () => {
+    const reviewHosts: Array<DiscoveredNetworkDevice> = reviewHostsFor({
+      importedByScanId: { "scan-a": ["10.0.0.1"] },
+      scanId: "scan-a",
+      hosts: scan,
+    });
+
+    expect(reviewHosts[0]!.isAlreadyRegistered).toBe(true);
+    expect(isSelectableDiscoveredHost(reviewHosts[0]!)).toBe(false);
+
+    /*
+     * The stale tick is the realistic state, not a contrived one: the address
+     * was ticked when the dialog opened and nothing unticks it on success — the
+     * overlay is what stops that tick meaning anything.
+     */
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: reviewHosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: getInitialSelection(scan),
+        }),
+      ),
+    ).toEqual(["10.0.0.2", "10.0.0.3"]);
+
+    expect(
+      countSelectableShownHosts({
+        hosts: reviewHosts,
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(1);
+  });
+
+  test("the group badges do not move as hosts are imported", () => {
+    /*
+     * The badge answers "how big is this group", which is how the number gets
+     * checked against the probe's own ICMP/SNMP tallies — it describes the
+     * sweep, not the operator's progress through it. Marking must therefore
+     * change selectability and nothing else about where a row belongs.
+     */
+    const reviewHosts: Array<DiscoveredNetworkDevice> = reviewHostsFor({
+      importedByScanId: { "scan-a": ["10.0.0.1", "10.0.0.2"] },
+      scanId: "scan-a",
+      hosts: scan,
+    });
+
+    expect(countDiscoveredHosts(reviewHosts)).toEqual({
+      all: 3,
+      snmp: 2,
+      noSnmp: 1,
+    });
+  });
+
+  test("the scan's own host objects are never written to", () => {
+    /*
+     * `scan` here stands in for the jsonb the model handed the page. The
+     * overlay is the page's opinion about this sitting, so it has to live in
+     * copies — otherwise the flag leaks into anything else reading the same
+     * model instance, including another scan's rows in the table behind the
+     * dialog.
+     */
+    reviewHostsFor({
+      importedByScanId: { "scan-a": ["10.0.0.1", "10.0.0.3"] },
+      scanId: "scan-a",
+      hosts: scan,
+    });
+
+    expect(scan[0]!.isAlreadyRegistered).toBeUndefined();
+    expect(scan[2]!.isAlreadyRegistered).toBeUndefined();
+  });
+});
+
+describe("one scan's imports never retire another scan's hosts", () => {
+  /*
+   * Two sweeps of the same subnet, a week apart, sharing an address — the
+   * ordinary case rather than a contrived one. The scenario the keying exists
+   * for: the operator imports 10.0.0.1 from scan A, closes the dialog while
+   * the run is still going, and opens scan B.
+   */
+  const sharedAddress: string = "10.0.0.1";
+
+  const scanAHosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost(sharedAddress),
+    snmpHost("10.0.0.2"),
+  ];
+
+  const scanBHosts: Array<DiscoveredNetworkDevice> = [
+    snmpHost(sharedAddress),
+    pingOnlyHost("10.0.0.8"),
+  ];
+
+  test("importing a shared address from scan A leaves it importable in scan B", () => {
+    const store: ImportedIpAddressesByScanId = withImportedIpAddresses({
+      importedByScanId: {},
+      scanId: "scan-a",
+      ipAddresses: [sharedAddress],
+    });
+
+    // Retired where it was actually imported from.
+    expect(
+      isSelectableDiscoveredHost(
+        reviewHostsFor({
+          importedByScanId: store,
+          scanId: "scan-a",
+          hosts: scanAHosts,
+        })[0]!,
+      ),
+    ).toBe(false);
+
+    /*
+     * And offered, ticked, and imported where it was not. A bare set would fail
+     * every assertion below — the host would render disabled and Import would
+     * quietly skip it, with nothing on screen explaining why.
+     */
+    const scanBReviewHosts: Array<DiscoveredNetworkDevice> = reviewHostsFor({
+      importedByScanId: store,
+      scanId: "scan-b",
+      hosts: scanBHosts,
+    });
+
+    expect(isSelectableDiscoveredHost(scanBReviewHosts[0]!)).toBe(true);
+    expect(getInitialSelection(scanBReviewHosts)).toEqual({
+      "10.0.0.1": true,
+      "10.0.0.8": true,
+    });
+    expect(
+      ipAddressesOf(
+        getDiscoveredHostsToImport({
+          hosts: scanBReviewHosts,
+          filter: DiscoveredHostFilter.All,
+          selectedIpAddresses: getInitialSelection(scanBReviewHosts),
+        }),
+      ),
+    ).toEqual(["10.0.0.1", "10.0.0.8"]);
+  });
+
+  test("an address imported from both scans is recorded once under each", () => {
+    /*
+     * Importing the same address from two scans really does create two devices
+     * — that is a server-side question about hostnames, not this record's. What
+     * the record must not do is conflate the two: each scan's dialog reports on
+     * what was imported from it.
+     */
+    const afterA: ImportedIpAddressesByScanId = withImportedIpAddresses({
+      importedByScanId: {},
+      scanId: "scan-a",
+      ipAddresses: [sharedAddress],
+    });
+
+    const afterB: ImportedIpAddressesByScanId = withImportedIpAddresses({
+      importedByScanId: afterA,
+      scanId: "scan-b",
+      ipAddresses: [sharedAddress, "10.0.0.8"],
+    });
+
+    expect(afterB).toEqual({
+      "scan-a": ["10.0.0.1"],
+      "scan-b": ["10.0.0.1", "10.0.0.8"],
+    });
+    expect(
+      countSelectableShownHosts({
+        hosts: reviewHostsFor({
+          importedByScanId: afterB,
+          scanId: "scan-b",
+          hosts: scanBHosts,
+        }),
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("the two-pass import an operator actually performs", () => {
+  /*
+   * Issue #3322's flow, scaled down and shaped the same: switches first,
+   * endpoints after, with the record carrying what happened between the two
+   * presses. Nothing is unticked by hand at any point.
+   */
+  const scanId: string = "scan-a";
+
+  const scan: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    snmpHost("10.0.0.3"),
+    pingOnlyHost("10.0.0.4"),
+  ];
+
+  test("import the SNMP group, then the ping-only group, with no duplicates in between", () => {
+    // The dialog opens with everything importable ticked.
+    const selection: Record<string, boolean> = getInitialSelection(
+      reviewHostsFor({ importedByScanId: {}, scanId: scanId, hosts: scan }),
+    );
+
+    expect(selection).toEqual({
+      "10.0.0.1": true,
+      "10.0.0.2": true,
+      "10.0.0.3": true,
+      "10.0.0.4": true,
+    });
+
+    // Narrow to SNMP and press Import: the ping-only hosts are out of scope.
+    const snmpImport: Array<DiscoveredNetworkDevice> =
+      getDiscoveredHostsToImport({
+        hosts: reviewHostsFor({
+          importedByScanId: {},
+          scanId: scanId,
+          hosts: scan,
+        }),
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selection,
+      });
+
+    expect(ipAddressesOf(snmpImport)).toEqual(["10.0.0.1", "10.0.0.3"]);
+
+    const afterSnmpStore: ImportedIpAddressesByScanId = withImportedIpAddresses(
+      {
+        importedByScanId: {},
+        scanId: scanId,
+        ipAddresses: ipAddressesOf(snmpImport),
+      },
+    );
+
+    expect(afterSnmpStore).toEqual({ "scan-a": ["10.0.0.1", "10.0.0.3"] });
+
+    const afterSnmp: Array<DiscoveredNetworkDevice> = reviewHostsFor({
+      importedByScanId: afterSnmpStore,
+      scanId: scanId,
+      hosts: scan,
+    });
+
+    /*
+     * The group is spent. Both of these matter: the count is what disables the
+     * bulk control and what the submit button shows, and the import list is
+     * what a second press would actually create. Every tick is still set, so
+     * without the record that second press creates two more devices.
+     */
+    expect(
+      countSelectableShownHosts({
+        hosts: afterSnmp,
+        filter: DiscoveredHostFilter.Snmp,
+      }),
+    ).toBe(0);
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: afterSnmp,
+        filter: DiscoveredHostFilter.Snmp,
+        selectedIpAddresses: selection,
+      }),
+    ).toEqual([]);
+
+    // The badges still describe the sweep, not what is left of it.
+    expect(countDiscoveredHosts(afterSnmp)).toEqual({
+      all: 4,
+      snmp: 2,
+      noSnmp: 2,
+    });
+
+    // The other group is untouched, still ticked, still fully importable.
+    const noSnmpImport: Array<DiscoveredNetworkDevice> =
+      getDiscoveredHostsToImport({
+        hosts: afterSnmp,
+        filter: DiscoveredHostFilter.NoSnmp,
+        selectedIpAddresses: selection,
+      });
+
+    expect(ipAddressesOf(noSnmpImport)).toEqual(["10.0.0.2", "10.0.0.4"]);
+    expect(
+      countSelectableShownHosts({
+        hosts: afterSnmp,
+        filter: DiscoveredHostFilter.NoSnmp,
+      }),
+    ).toBe(2);
+
+    const afterBothStore: ImportedIpAddressesByScanId = withImportedIpAddresses(
+      {
+        importedByScanId: afterSnmpStore,
+        scanId: scanId,
+        ipAddresses: ipAddressesOf(noSnmpImport),
+      },
+    );
+
+    expect(afterBothStore).toEqual({
+      "scan-a": ["10.0.0.1", "10.0.0.3", "10.0.0.2", "10.0.0.4"],
+    });
+
+    // Nothing importable is left anywhere in the scan.
+    const afterBoth: Array<DiscoveredNetworkDevice> = reviewHostsFor({
+      importedByScanId: afterBothStore,
+      scanId: scanId,
+      hosts: scan,
+    });
+
+    expect(
+      countSelectableShownHosts({
+        hosts: afterBoth,
+        filter: DiscoveredHostFilter.All,
+      }),
+    ).toBe(0);
+    expect(
+      getDiscoveredHostsToImport({
+        hosts: afterBoth,
+        filter: DiscoveredHostFilter.All,
+        selectedIpAddresses: selection,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("reopening a scan after importing from it", () => {
+  /*
+   * The record is kept for the life of the PAGE, not the life of the dialog,
+   * and this is why: `closeReviewModal` throws away the selection, so reopening
+   * re-derives it from scratch. If that derivation did not run through the
+   * overlay, every host imported a moment ago would come back ticked and the
+   * next press would duplicate all of them.
+   */
+  const scan: Array<DiscoveredNetworkDevice> = [
+    snmpHost("10.0.0.1"),
+    pingOnlyHost("10.0.0.2"),
+    snmpHost("10.0.0.3"),
+  ];
+
+  test("the opening selection does not re-tick what was already imported", () => {
+    const store: ImportedIpAddressesByScanId = {
+      "scan-a": ["10.0.0.1", "10.0.0.3"],
+    };
+
+    expect(
+      getInitialSelection(
+        reviewHostsFor({
+          importedByScanId: store,
+          scanId: "scan-a",
+          hosts: scan,
+        }),
+      ),
+    ).toEqual({ "10.0.0.2": true });
+  });
+
+  test("a scan with no id yet still opens with everything ticked", () => {
+    /*
+     * The page reads `scan?._id`, so undefined reaches the store on this path.
+     * Degrading to "nothing has been imported" is the safe direction: the
+     * operator is shown the whole scan as importable, which is what a scan the
+     * record cannot describe actually is.
+     */
+    expect(
+      getInitialSelection(
+        reviewHostsFor({
+          importedByScanId: { "scan-a": ["10.0.0.1"] },
+          scanId: undefined,
+          hosts: scan,
+        }),
+      ),
+    ).toEqual({ "10.0.0.1": true, "10.0.0.2": true, "10.0.0.3": true });
+  });
+});

--- a/App/Tests/Dashboard/DiscoveryReviewCopy.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewCopy.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, test } from "@jest/globals";
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import {
+  DiscoveredHostFilter,
+  DiscoveredHostFilterOption,
+  getDiscoveredHostFilterEmptyMessage,
+  getDiscoveredHostFilterLabel,
+  getDiscoveredHostFilterOptions,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
+import fs from "fs";
+import path from "path";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * Every string the SNMP / No SNMP filter (#3322) puts in front of an operator,
+ * and the wiring in Discovery.tsx that puts it there.
+ *
+ * The filter shipped with a copy defect of exactly the kind nothing else in
+ * the suite could catch. The empty-group line was built as
+ *
+ *     `No ${getDiscoveredHostFilterLabel(filter)} hosts in this scan.`
+ *
+ * and that label already returns "No SNMP", so the dialog read
+ * "No No SNMP hosts in this scan." It is not an obscure path either: it is one
+ * click away on any sweep where every host answered SNMP. The fix was to give
+ * the empty state its own function, `getDiscoveredHostFilterEmptyMessage`,
+ * instead of composing a button's noun phrase into a sentence frame.
+ *
+ * So this file pins two different things, and both are needed:
+ *
+ *   - The EXACT sentences and labels, so a reword is a deliberate act with a
+ *     failing test attached rather than a silent one.
+ *   - Properties that hold for ANY wording — no doubled word, no doubled
+ *     negation, sentences punctuated as sentences, and an option label that is
+ *     provably its own label plus its own count and nothing else. Those are
+ *     what survive a legitimate rewrite and still catch the defect CLASS, and
+ *     they run over every string the module can produce rather than only over
+ *     the three the exact assertions name.
+ *
+ * The source-level half follows InventoryTableInvariants.test.ts: the App
+ * suite runs in a plain Node environment with no React renderer, so the dialog
+ * cannot be mounted and read. Comments are stripped so that describing a rule
+ * in prose never counts as implementing it, and whitespace is squashed so
+ * Prettier can reflow props without making the test brittle.
+ */
+
+const DISCOVERY_PAGE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "NetworkDevice",
+  "Discovery.tsx",
+);
+
+function readSource(): string {
+  return fs.readFileSync(DISCOVERY_PAGE, "utf8");
+}
+
+function squash(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/** The page with comments removed and whitespace squashed to single spaces. */
+function readCode(): string {
+  return squash(stripComments(readSource()));
+}
+
+/*
+ * Slicing that refuses to hand back a lie.
+ *
+ * `String.indexOf` returns -1 for a miss, and `slice(-1, ...)` quietly yields
+ * the tail of the file (or an empty string) rather than failing. Both turn a
+ * `not.toContain` into a vacuous pass and a `toContain` into a check against
+ * the whole page — which is how source-level tests rot into passing for the
+ * wrong reason after a rename. Throwing here makes the rename a red test.
+ */
+function sliceBetween(data: {
+  code: string;
+  from: string;
+  to?: string | undefined;
+}): string {
+  const start: number = data.code.indexOf(data.from);
+
+  if (start === -1) {
+    throw new Error(`Discovery.tsx no longer contains "${data.from}"`);
+  }
+
+  if (!data.to) {
+    return data.code.slice(start);
+  }
+
+  const end: number = data.code.indexOf(data.to, start);
+
+  if (end === -1) {
+    throw new Error(
+      `Discovery.tsx no longer contains "${data.to}" after "${data.from}"`,
+    );
+  }
+
+  return data.code.slice(start, end);
+}
+
+/** Everything the Review Discovered Devices modal renders. */
+function modalSection(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: 'title="Review Discovered Devices"',
+  });
+}
+
+/** The sentence under the modal title, before the layout props. */
+function descriptionSection(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: 'title="Review Discovered Devices"',
+    to: "modalWidth={",
+  });
+}
+
+/** The per-row checkbox, up to its change handler. */
+function checkboxSection(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: "<CheckboxElement",
+    to: "onChange={(value: boolean)",
+  });
+}
+
+/** The "No SNMP" pill on a ping-only row. */
+function pingOnlyBadgeSection(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: "{isPingOnly && (",
+    to: "{entry.isAlreadyRegistered && (",
+  });
+}
+
+const ALL_FILTERS: Array<DiscoveredHostFilter> = [
+  DiscoveredHostFilter.All,
+  DiscoveredHostFilter.Snmp,
+  DiscoveredHostFilter.NoSnmp,
+];
+
+function snmpHost(ipAddress: string): DiscoveredNetworkDevice {
+  return { ipAddress: ipAddress, snmpReachable: true };
+}
+
+function pingOnlyHost(ipAddress: string): DiscoveredNetworkDevice {
+  return { ipAddress: ipAddress, snmpReachable: false };
+}
+
+/** A scan of a given shape, addresses spread over a /16 so none repeat. */
+function scanOf(data: {
+  snmpCount: number;
+  pingOnlyCount: number;
+}): Array<DiscoveredNetworkDevice> {
+  const hosts: Array<DiscoveredNetworkDevice> = [];
+
+  for (let index: number = 0; index < data.snmpCount; index++) {
+    hosts.push(snmpHost(`10.1.${Math.floor(index / 256)}.${index % 256}`));
+  }
+
+  for (let index: number = 0; index < data.pingOnlyCount; index++) {
+    hosts.push(pingOnlyHost(`10.2.${Math.floor(index / 256)}.${index % 256}`));
+  }
+
+  return hosts;
+}
+
+function labelsOf(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+  return getDiscoveredHostFilterOptions(hosts).map(
+    (option: DiscoveredHostFilterOption) => {
+      return option.label;
+    },
+  );
+}
+
+/*
+ * Every string this module can render, across scan shapes that exercise each
+ * group being empty, singular, and four digits long. The property tests below
+ * run over this rather than over the three sentences the exact assertions
+ * name, so a defect introduced in a BUTTON label — the empty message spliced
+ * into one, say — is caught by the same rule that caught it in the sentence.
+ */
+function everyUserVisibleString(): Array<string> {
+  const strings: Array<string> = [];
+
+  for (const filter of ALL_FILTERS) {
+    strings.push(getDiscoveredHostFilterLabel(filter));
+    strings.push(getDiscoveredHostFilterEmptyMessage(filter));
+  }
+
+  const scans: Array<Array<DiscoveredNetworkDevice>> = [
+    [],
+    scanOf({ snmpCount: 1, pingOnlyCount: 0 }),
+    scanOf({ snmpCount: 0, pingOnlyCount: 1 }),
+    scanOf({ snmpCount: 3, pingOnlyCount: 4 }),
+    scanOf({ snmpCount: 1000, pingOnlyCount: 0 }),
+  ];
+
+  for (const scan of scans) {
+    strings.push(...labelsOf(scan));
+  }
+
+  return strings;
+}
+
+describe("the empty-group sentences", () => {
+  test("each group says exactly what it says", () => {
+    /*
+     * The three sentences, verbatim. Note that none of them is the button's
+     * noun phrase dropped into a frame: the SNMP one is not "No SNMP hosts in
+     * this scan", and the ping-only one is phrased as what the sweep DID find
+     * ("every host answered SNMP") rather than as the absence of a group,
+     * because absence tells the operator nothing they can act on.
+     */
+    expect(
+      getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.All),
+    ).toEqual("This scan did not find any responding hosts.");
+
+    expect(
+      getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.Snmp),
+    ).toEqual("No host in this scan answered SNMP.");
+
+    expect(
+      getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.NoSnmp),
+    ).toEqual("Every host in this scan answered SNMP.");
+  });
+
+  test("no group's message is its button label dropped into a sentence frame", () => {
+    /*
+     * The shipped defect, stated as the rule it broke rather than as the one
+     * string it produced. `No ${label} hosts in this scan.` is wrong for the
+     * NoSnmp group specifically ("No No SNMP hosts...") but it is banned for
+     * all three, because the moment ANY of them is built that way the next
+     * label rename reintroduces the collision.
+     */
+    for (const filter of ALL_FILTERS) {
+      const message: string = getDiscoveredHostFilterEmptyMessage(filter);
+
+      for (const other of ALL_FILTERS) {
+        const label: string = getDiscoveredHostFilterLabel(other);
+
+        expect(message).not.toEqual(`No ${label} hosts in this scan.`);
+        expect(message.toLowerCase()).not.toContain(
+          `no ${label.toLowerCase()} hosts`,
+        );
+      }
+    }
+  });
+
+  test("a sentence is punctuated as one and a button label is not", () => {
+    /*
+     * The empty message is rendered as a standalone paragraph and the label
+     * as the text of a button, so they are different kinds of copy: one needs
+     * a capital and a full stop, the other must not carry a trailing full
+     * stop into a control. A label that grew one would be the first sign that
+     * a sentence had been routed into the button row.
+     */
+    for (const filter of ALL_FILTERS) {
+      const message: string = getDiscoveredHostFilterEmptyMessage(filter);
+
+      expect(message.length).toBeGreaterThan(0);
+      expect(message.slice(0, 1)).toEqual(message.slice(0, 1).toUpperCase());
+      expect(message.endsWith(".")).toBe(true);
+      expect(message.trim()).toEqual(message);
+
+      const label: string = getDiscoveredHostFilterLabel(filter);
+
+      expect(label.endsWith(".")).toBe(false);
+      expect(label.trim()).toEqual(label);
+    }
+  });
+
+  test("nothing the filter renders negates twice or repeats a word", () => {
+    /*
+     * The class-level guard, run over labels, sentences AND button labels at
+     * several scan shapes. "No No SNMP" is the instance that shipped; the
+     * general rule is that no string assembled from these parts may stutter,
+     * which is what happens whenever one piece of copy is concatenated into
+     * another that already contains it.
+     */
+    const doubledNegation: RegExp = /\bno\s+no\b/i;
+    const doubledWord: RegExp = /\b([a-z]+)\s+\1\b/i;
+
+    for (const value of everyUserVisibleString()) {
+      expect(doubledNegation.test(value)).toBe(false);
+      expect(doubledWord.test(value)).toBe(false);
+    }
+  });
+});
+
+describe("the group names", () => {
+  test("the three groups are named exactly this", () => {
+    expect(getDiscoveredHostFilterLabel(DiscoveredHostFilter.All)).toEqual(
+      "All",
+    );
+    expect(getDiscoveredHostFilterLabel(DiscoveredHostFilter.Snmp)).toEqual(
+      "SNMP",
+    );
+    expect(getDiscoveredHostFilterLabel(DiscoveredHostFilter.NoSnmp)).toEqual(
+      "No SNMP",
+    );
+  });
+
+  test("the No SNMP button is worded like the No SNMP pill on the row", () => {
+    /*
+     * The button filters TO the rows carrying that pill. If the two drift
+     * into near-synonyms — "Ping only" on one and "No SNMP" on the other —
+     * the operator has to work out that they are the same group, which is
+     * exactly the connection the filter exists to make for them. Read from
+     * the page rather than trusted, because the pill is hand-written JSX and
+     * the button label comes from the module.
+     */
+    const badgeText: string = getDiscoveredHostFilterLabel(
+      DiscoveredHostFilter.NoSnmp,
+    );
+
+    expect(pingOnlyBadgeSection()).toContain(`> ${badgeText} </span>`);
+  });
+});
+
+describe("the filter buttons", () => {
+  test("the buttons are always All, then SNMP, then No SNMP", () => {
+    /*
+     * Order is copy too: All is the default and the widest group, and the two
+     * specific groups read in the same order as the sentence in the modal
+     * description. Reordering would move the button under a cursor that has
+     * learned where it is.
+     */
+    for (const hosts of [
+      [],
+      scanOf({ snmpCount: 0, pingOnlyCount: 5 }),
+      scanOf({ snmpCount: 5, pingOnlyCount: 0 }),
+      scanOf({ snmpCount: 2, pingOnlyCount: 3 }),
+    ]) {
+      expect(
+        getDiscoveredHostFilterOptions(hosts).map(
+          (option: DiscoveredHostFilterOption) => {
+            return option.value;
+          },
+        ),
+      ).toEqual([
+        DiscoveredHostFilter.All,
+        DiscoveredHostFilter.Snmp,
+        DiscoveredHostFilter.NoSnmp,
+      ]);
+    }
+  });
+
+  test("counts read the way an operator checks them against the probe's tally", () => {
+    /*
+     * Zero renders as a zero rather than being hidden, one is not special,
+     * and the separator appears at exactly four digits — 999 stays bare,
+     * 1,000 is grouped. The last case is #3322's own sweep: 2,866 SNMP hosts
+     * and 2,890 ping-only ones, where "2866" and "2,866" are not equally easy
+     * to check against what the probe reported.
+     */
+    expect(labelsOf([])).toEqual(["All (0)", "SNMP (0)", "No SNMP (0)"]);
+
+    expect(labelsOf(scanOf({ snmpCount: 1, pingOnlyCount: 0 }))).toEqual([
+      "All (1)",
+      "SNMP (1)",
+      "No SNMP (0)",
+    ]);
+
+    expect(labelsOf(scanOf({ snmpCount: 0, pingOnlyCount: 999 }))).toEqual([
+      "All (999)",
+      "SNMP (0)",
+      "No SNMP (999)",
+    ]);
+
+    expect(labelsOf(scanOf({ snmpCount: 0, pingOnlyCount: 1000 }))).toEqual([
+      "All (1,000)",
+      "SNMP (0)",
+      "No SNMP (1,000)",
+    ]);
+
+    expect(labelsOf(scanOf({ snmpCount: 2866, pingOnlyCount: 2890 }))).toEqual([
+      "All (5,756)",
+      "SNMP (2,866)",
+      "No SNMP (2,890)",
+    ]);
+  });
+
+  test("a button's label is its own name and its own count, nothing else", () => {
+    /*
+     * The composition rule, asserted per option rather than as a literal, and
+     * it does two jobs at once:
+     *
+     *   - The `count` field and the number IN the label are the same number.
+     *     They are read by different things (the label by the operator, the
+     *     count by any caller that wants the size), so a label built from the
+     *     wrong group's count is invisible until someone compares them.
+     *   - No label is ever assembled out of the empty-state sentence. That is
+     *     the reverse of the shipped defect — one piece of copy composed into
+     *     another — and it would produce a button reading
+     *     "Every host in this scan answered SNMP. (0)".
+     */
+    for (const hosts of [
+      [],
+      scanOf({ snmpCount: 3, pingOnlyCount: 0 }),
+      scanOf({ snmpCount: 0, pingOnlyCount: 7 }),
+      scanOf({ snmpCount: 1200, pingOnlyCount: 41 }),
+    ]) {
+      for (const option of getDiscoveredHostFilterOptions(hosts)) {
+        expect(option.label).toEqual(
+          `${getDiscoveredHostFilterLabel(
+            option.value,
+          )} (${option.count.toLocaleString("en-US")})`,
+        );
+
+        for (const filter of ALL_FILTERS) {
+          expect(option.label).not.toContain(
+            getDiscoveredHostFilterEmptyMessage(filter),
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("the dialog puts that copy on screen", () => {
+  test("the anchors every slice below depends on are still in the page", () => {
+    /*
+     * A rename that lost one would make the slices throw rather than silently
+     * check the whole file. This test is where that is stated out loud, so
+     * the failure names the anchor instead of turning up as an unrelated
+     * assertion.
+     */
+    expect(modalSection().length).toBeGreaterThan(0);
+    expect(descriptionSection().length).toBeGreaterThan(0);
+    expect(checkboxSection().length).toBeGreaterThan(0);
+    expect(pingOnlyBadgeSection().length).toBeGreaterThan(0);
+  });
+
+  test("both empty states are rendered through the shared message", () => {
+    /*
+     * There are two of them and they say different things: a scan that found
+     * nothing at all (All, regardless of which filter happens to be active),
+     * and a scan that found hosts but none in the group on screen (the ACTIVE
+     * filter, which is the case the "No No SNMP" defect lived in). Both go
+     * through the module so neither can be reworded on its own.
+     */
+    const section: string = modalSection();
+
+    expect(section).toContain("reviewEntries.length === 0");
+    expect(section).toContain(
+      "getDiscoveredHostFilterEmptyMessage(DiscoveredHostFilter.All)",
+    );
+
+    expect(section).toContain("shownEntries.length === 0");
+    expect(section).toContain(
+      "getDiscoveredHostFilterEmptyMessage(hostFilter)",
+    );
+  });
+
+  test("the page never builds an empty state out of a button label again", () => {
+    /*
+     * The defect itself, banned at source. Any `No ${getDiscoveredHostFilterLabel(...)}`
+     * is the collision returning, and the old frame's tail is banned with it
+     * so the sentence cannot be reassembled around a different label call.
+     */
+    const code: string = readCode();
+
+    const labelDroppedIntoNoFrame: RegExp =
+      /no\s+\$\{\s*getDiscoveredHostFilterLabel/i;
+
+    expect(labelDroppedIntoNoFrame.test(code)).toBe(false);
+    expect(code).not.toContain("hosts in this scan.");
+  });
+
+  test("the description explains what each group imports as", () => {
+    /*
+     * It used to end "hosts without SNMP cannot be imported", which stopped
+     * being true when ping-only hosts started importing as monitor-backed
+     * devices — and which reads as a flat contradiction sitting directly
+     * above a No SNMP filter whose whole purpose is importing them as a
+     * batch. What replaced it has to be more than the removal: the two groups
+     * import into different kinds of device, and that is the fact the
+     * operator needs before choosing a filter.
+     */
+    const description: string = descriptionSection();
+
+    expect(description).not.toContain("cannot be imported");
+    expect(description).not.toContain("without SNMP cannot");
+    expect(description).toContain("polled devices");
+    expect(description).toContain("monitor-backed");
+  });
+
+  test("a row's checkbox says which host it is for", () => {
+    /*
+     * See CategoryProps.ariaLabel in Common/UI/Components/Checkbox/Checkbox.tsx:
+     * the box has no visible `title` beside it, so without an ariaLabel every
+     * one of thousands of rows is announced as "checkbox" and nothing else.
+     * The address is in the name because it is the selection key and the only
+     * thing guaranteed to differ between rows — sysName is optional.
+     */
+    const checkbox: string = checkboxSection();
+
+    expect(checkbox).toContain("ariaLabel={");
+    expect(checkbox).toContain("entry.ipAddress");
+    expect(checkbox).toContain('"no address"');
+  });
+
+  test("a checkbox that cannot be ticked says why", () => {
+    /*
+     * `hoverText` lands on the input's own title attribute, which on a
+     * DISABLED box is the only place the reason can live — and a box that
+     * cannot be ticked and does not say why reads as broken rather than as
+     * deliberate. Both disabling reasons are covered: already imported, and
+     * no address to import under.
+     */
+    const checkbox: string = checkboxSection();
+
+    expect(checkbox).toContain("hoverText={");
+    expect(checkbox).toContain('"Already added as a Network Device."');
+    expect(checkbox).toContain(
+      '"This host reported no address, so it cannot be imported."',
+    );
+  });
+});

--- a/App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewFilterInvariants.test.ts
@@ -27,6 +27,19 @@ import path from "path";
  * Whitespace is squashed so Prettier can reflow props without making the test
  * brittle, and comments are stripped so that describing a rule in prose never
  * counts as implementing it.
+ *
+ * THIS FILE'S TERRITORY is the filter row, the bulk selection control and the
+ * submit-button count. The dialog LIFECYCLE — the close gate, the stale-run
+ * guard, the per-scan imported-address overlay and row identity — is pinned by
+ * DiscoveryReviewLifecycleInvariants.test.ts, and the user-visible copy by
+ * DiscoveryReviewCopy.test.ts.
+ *
+ * ON SLICING, which is how a file like this rots: every `indexOf` used to cut
+ * a section out of the source is asserted to have found something. An
+ * unguarded -1 turns `slice` into "from the start of the file" or "the empty
+ * string", and every assertion under it then passes for a reason that has
+ * nothing to do with the rule it names. `section()` below refuses to return a
+ * slice it could not locate.
  */
 
 const DISCOVERY_PAGE: string = path.join(
@@ -60,29 +73,61 @@ function readCode(): string {
   return squash(stripComments(readSource()));
 }
 
-/** The body of `importSelectedDevices`, up to the render return. */
-function importSection(): string {
+/**
+ * The text between two markers, with both markers proven to exist.
+ *
+ * A rename that moves a marker fails the test loudly here instead of quietly
+ * widening or emptying the slice underneath it.
+ */
+function section(startMarker: string, endMarker: string): string {
   const code: string = readCode();
 
-  return code.slice(
-    code.indexOf("const importSelectedDevices"),
-    code.indexOf("if (isLoading)"),
-  );
+  const start: number = code.indexOf(startMarker);
+  const end: number = code.indexOf(endMarker, start + startMarker.length);
+
+  expect({ marker: startMarker, found: start > -1 }).toEqual({
+    marker: startMarker,
+    found: true,
+  });
+  expect({ marker: endMarker, found: end > -1 }).toEqual({
+    marker: endMarker,
+    found: true,
+  });
+
+  return code.slice(start, end);
+}
+
+/** The body of `importSelectedDevices`, up to the render return. */
+function importSection(): string {
+  return section("const importSelectedDevices", "if (isLoading)");
 }
 
 /** Everything the Review Discovered Devices modal renders. */
 function modalSection(): string {
   const code: string = readCode();
+  const start: number = code.indexOf('title="Review Discovered Devices"');
 
-  return code.slice(code.indexOf('title="Review Discovered Devices"'));
+  expect(start).toBeGreaterThan(-1);
+
+  return code.slice(start);
+}
+
+/** The bulk Select all / Clear all control alone, not the rows below it. */
+function bulkControlSection(): string {
+  return section("<Button title={", "/> </div>");
+}
+
+/** One rendered row of the discovered-host list. */
+function rowSection(): string {
+  return section("{shownEntries.map(", "</div> ); }, )}");
 }
 
 describe("the Review Discovered Devices dialog imports only what it is showing", () => {
   test("the import path goes through the filter-scoped helper", () => {
-    const section: string = importSection();
+    const code: string = importSection();
 
-    expect(section).toContain("getDiscoveredHostsToImport({");
-    expect(section).toContain("filter: hostFilter");
+    expect(code).toContain("getDiscoveredHostsToImport({");
+    expect(code).toContain("filter: hostFilter");
   });
 
   test("import does not re-implement the selection rule inline", () => {
@@ -96,177 +141,176 @@ describe("the Review Discovered Devices dialog imports only what it is showing",
   });
 
   test("the button's count is computed the same way the import is", () => {
-    const code: string = readCode();
-
-    const selectedCountDeclaration: string = code.slice(
-      code.indexOf("const selectedCount: number ="),
-      code.indexOf("const selectableShownCount"),
+    /*
+     * Asserted as one contiguous string rather than three independent
+     * substring checks: `getDiscoveredHostsToImport` and `filter: hostFilter`
+     * both appear elsewhere in the file, so checking for them separately would
+     * survive a mutant that computed the count from an unfiltered list.
+     */
+    const declaration: string = section(
+      "const selectedCount: number =",
+      "const selectableShownCount",
     );
 
-    expect(selectedCountDeclaration).toContain("getDiscoveredHostsToImport({");
-    expect(selectedCountDeclaration).toContain("filter: hostFilter");
-    expect(modalSection()).toContain(
-      "submitButtonText={`Import Selected (${selectedCount})`}",
+    expect(declaration).toContain(
+      "getDiscoveredHostsToImport({ hosts: reviewEntries, filter: hostFilter, selectedIpAddresses: selectedIps, })",
     );
-    expect(modalSection()).toContain(
-      "disableSubmitButton={selectedCount === 0}",
-    );
+    expect(declaration).toContain(".length");
   });
 
-  test("hosts imported in this sitting are retired from the dialog", () => {
-    /*
-     * `isAlreadyRegistered` is frozen into the scan's jsonb when the probe
-     * uploads. Importing group by group means returning to a list that still
-     * contains what you just imported, pre-checked — so the page overlays what
-     * it knows through markDiscoveredHostsAsRegistered.
-     */
-    const code: string = readCode();
+  test("the submit button shows that count and refuses an empty import", () => {
+    const code: string = modalSection();
 
-    expect(code).toContain("markDiscoveredHostsAsRegistered({");
-    expect(importSection()).toContain("setImportedIpAddresses(");
+    expect(code).toContain(
+      "submitButtonText={`Import Selected (${selectedCount})`}",
+    );
+    expect(code).toContain("disableSubmitButton={selectedCount === 0}");
   });
 });
 
 describe("the filter row", () => {
   test("the dialog renders FilterButtons bound to the filter state", () => {
-    const section: string = modalSection();
+    const code: string = section("<FilterButtons", "/>");
 
-    expect(section).toContain("<FilterButtons");
-    expect(section).toContain("selectedValue={hostFilter}");
-    expect(section).toContain("setHostFilter(value as DiscoveredHostFilter)");
+    expect(code).toContain("options={hostFilterOptions}");
+    expect(code).toContain("selectedValue={hostFilter}");
+    expect(code).toContain("setHostFilter(value as DiscoveredHostFilter)");
   });
 
   test("the buttons and their counts come from the tested helper", () => {
     // Not hand-built in JSX, where the counts could drift from the groups.
-    expect(readCode()).toContain(
+    const declaration: string = section(
+      "const hostFilterOptions",
+      "const shownEntries",
+    );
+
+    expect(declaration).toContain(
       "getDiscoveredHostFilterOptions(reviewEntries)",
     );
-    expect(modalSection()).toContain("options={hostFilterOptions}");
   });
 
   test("the list renders the filtered hosts, not the whole scan", () => {
-    const section: string = modalSection();
+    const code: string = modalSection();
 
-    expect(section).toContain("{shownEntries.map(");
-    expect(section).not.toContain("{reviewEntries.map(");
+    expect(code).toContain("{shownEntries.map(");
+    expect(code).not.toContain("{reviewEntries.map(");
   });
 
-  test("shownEntries is the filter applied to the scan", () => {
-    const code: string = readCode();
-
-    const declaration: string = code.slice(
-      code.indexOf("const shownEntries"),
-      code.indexOf("const selectedCount"),
-    );
-
-    expect(declaration).toContain("filterDiscoveredHosts({");
-    expect(declaration).toContain("hosts: reviewEntries");
-    expect(declaration).toContain("filter: hostFilter");
-  });
-
-  test("a scan opens on All, and closing resets to All", () => {
+  test("shownEntries is the filter applied to the scan, carrying scan position", () => {
     /*
-     * A filter that persisted across scans would mean opening a review and
-     * being shown a subset with no memory of having asked for it.
+     * getShownDiscoveredHosts rather than filterDiscoveredHosts: the rows need
+     * their position in the UNFILTERED scan for a React key that does not move
+     * when the filter does. See ShownDiscoveredHost.
      */
-    const code: string = readCode();
-
-    const openBody: string = code.slice(
-      code.indexOf("const openReviewModal"),
-      code.indexOf("const closeReviewModal"),
+    const declaration: string = section(
+      "const shownEntries",
+      "const selectedCount",
     );
 
-    const closeBody: string = code.slice(
-      code.indexOf("const closeReviewModal"),
-      code.indexOf("const importSelectedDevices"),
+    expect(declaration).toContain(
+      "getShownDiscoveredHosts({ hosts: reviewEntries, filter: hostFilter, })",
+    );
+  });
+
+  test("every group size is computed off the unfiltered scan", () => {
+    /*
+     * Deriving the badges from the filtered list would make every button
+     * except the active one read zero — and the badges are what you click to
+     * change the filter.
+     */
+    const declaration: string = section(
+      "const hostFilterOptions",
+      "const shownEntries",
     );
 
-    expect(openBody).toContain("setHostFilter(DiscoveredHostFilter.All)");
-    expect(closeBody).toContain("setHostFilter(DiscoveredHostFilter.All)");
-    expect(openBody).toContain("setImportedIpAddresses(new Set<string>())");
-    expect(closeBody).toContain("setImportedIpAddresses(new Set<string>())");
+    expect(declaration).not.toContain("shownEntries");
   });
 });
 
 describe("the bulk selection control", () => {
-  test("it exists, is addressable, and toggles only the shown group", () => {
-    const section: string = modalSection();
+  test("it exists and is addressable", () => {
+    expect(bulkControlSection()).toContain(
+      'dataTestId="discovered-device-select-all"',
+    );
+  });
 
-    expect(section).toContain('dataTestId="discovered-device-select-all"');
-    expect(section).toContain("toggleSelectionForShownHosts({");
-    expect(section).toContain("filter: hostFilter");
+  test("it toggles the shown group, and only the shown group", () => {
+    const code: string = bulkControlSection();
+
+    expect(code).toContain(
+      "toggleSelectionForShownHosts({ hosts: reviewEntries, filter: hostFilter, selectedIpAddresses: current, })",
+    );
   });
 
   test("it is disabled when the shown group has nothing to select", () => {
-    expect(modalSection()).toContain(
+    expect(bulkControlSection()).toContain(
       "disabled={selectableShownCount === 0 || isImporting}",
     );
   });
 
-  test("its label follows whether the shown group is already full", () => {
-    expect(modalSection()).toContain("areAllShownSelected");
+  test("a full group offers Clear all and a partial one offers Select all", () => {
+    /*
+     * Pinned as the whole ternary, both arms and their direction. Asserting
+     * only that the identifier `areAllShownSelected` appears — which is what
+     * this test used to do — passes just as happily with the two arms swapped,
+     * i.e. with a button that says "Select all" over an already-full group and
+     * clears it when pressed.
+     */
+    expect(bulkControlSection()).toContain(
+      "title={ areAllShownSelected " +
+        '? `Clear all (${selectableShownCount.toLocaleString("en-US")})` ' +
+        ': `Select all (${selectableShownCount.toLocaleString("en-US")})` }',
+    );
   });
 
   test("it updates selection functionally, not from a captured value", () => {
     /*
-     * Two presses in the same tick against a stale `selectedIps` would drop
-     * the first one's work.
+     * Scoped to the bulk control's own JSX. The per-row checkbox uses the same
+     * functional form a few lines below, so a file-wide search for it would
+     * pass even after the bulk control was rewritten to spread a stale
+     * `selectedIps` — which would drop the work of a first press when a second
+     * landed in the same tick.
      */
-    expect(modalSection()).toContain(
+    expect(bulkControlSection()).toContain(
       "setSelectedIps((current: Record<string, boolean>) =>",
     );
   });
 });
 
-describe("what the dialog tells the operator", () => {
-  test("it no longer claims hosts without SNMP cannot be imported", () => {
-    /*
-     * That stopped being true when ping-only hosts started importing as
-     * monitor-backed devices, and it reads as a flat contradiction next to a
-     * No SNMP filter whose entire purpose is importing them as a batch.
-     */
-    expect(readSource()).not.toContain(
-      "Select the ones you want to import as Network Devices — hosts without SNMP cannot be imported.",
-    );
-  });
-
-  test("an empty scan is not described as having found no SNMP devices", () => {
-    // Ping-only hosts are listed too, so "no SNMP devices" is the wrong claim.
-    expect(readSource()).not.toContain(
-      "This scan did not find any SNMP devices.",
-    );
-    expect(modalSection()).toContain(
-      "This scan did not find any responding hosts.",
-    );
-  });
-
-  test("a group that filters to nothing says so instead of rendering blank", () => {
-    const section: string = modalSection();
-
-    expect(section).toContain("shownEntries.length === 0");
-    expect(section).toContain("hosts in this scan.");
-  });
-
-  test("the row badge and the filter button use the same words", () => {
-    /*
-     * The pill on a ping-only row reads "No SNMP". The button that filters to
-     * those rows is labelled from getDiscoveredHostFilterLabel, which returns
-     * the same string — the two must not drift into near-synonyms the operator
-     * has to connect.
-     */
-    expect(modalSection()).toContain("No SNMP");
-    expect(readCode()).toContain("getDiscoveredHostFilterLabel(hostFilter)");
-  });
-
+describe("each row agrees with the counts above it", () => {
   test("the row badge is decided by the same predicate the filter groups by", () => {
     /*
-     * A row can carry the No SNMP pill and a filter can collect No SNMP rows;
-     * if those are two separate expressions they can drift, and the dialog
-     * ends up showing a badged host that the No SNMP filter hides.
+     * Pinned as the exact assignment. Asserting only that the substring
+     * `isPingOnlyDiscoveredHost(entry)` occurs somewhere survives a leading
+     * `!` — which is precisely how a badged row and a filtered row come to be
+     * different sets.
      */
-    expect(modalSection()).toContain("isPingOnlyDiscoveredHost(entry)");
-    expect(modalSection()).not.toContain(
-      "NetworkDeviceMonitoringMethod.Monitor",
+    expect(rowSection()).toContain(
+      "const isPingOnly: boolean = isPingOnlyDiscoveredHost(entry);",
+    );
+  });
+
+  test("the checkbox's enabled state is the shared selectability rule", () => {
+    /*
+     * Every count, the bulk toggle and the import list go through
+     * isSelectableDiscoveredHost. The row used to spell out its own version of
+     * that rule, which left a host with a blank address rendering an enabled
+     * checkbox that no count in the dialog agreed existed.
+     */
+    const code: string = rowSection();
+
+    expect(code).toContain(
+      "const isSelectable: boolean = isSelectableDiscoveredHost(entry);",
+    );
+    expect(code).toContain("disabled={!isSelectable || isImporting}");
+    expect(code).not.toContain("!isImportable");
+  });
+
+  test("a row that cannot be selected never renders as ticked", () => {
+    const code: string = rowSection();
+
+    expect(code).toContain(
+      "const isChecked: boolean = isSelectable && Boolean(selectedIps[entry.ipAddress]);",
     );
   });
 });
@@ -283,5 +327,6 @@ describe("the page reads the scan through the shared, tested helper", () => {
 
     expect(code).toContain("getDiscoveredHosts(");
     expect(code).not.toContain("const getDiscoveredDevices:");
+    expect(code).not.toContain("scan?.discoveredDevices");
   });
 });

--- a/App/Tests/Dashboard/DiscoveryReviewLifecycleInvariants.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewLifecycleInvariants.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * DiscoveredHostFilter.ts is where the SNMP / No SNMP rules are, and it is unit
+ * tested. What it cannot cover is the dialog's LIFECYCLE — when the Review
+ * Discovered Devices modal closes, which scan a finished import is allowed to
+ * touch, and what the page remembers between two imports in one sitting. All of
+ * that lives in JSX and in an async handler in Discovery.tsx, and the App suite
+ * runs in a plain Node environment with no React renderer (see
+ * jest.config.json), so none of it can be mounted and clicked.
+ *
+ * The failure modes are the expensive kind — every one of them renders
+ * perfectly:
+ *
+ *   - Closing the dialog as soon as the SHOWN group is empty throws away the
+ *     operator's review of the other group. That is the exact regression #3322
+ *     exists to remove: import the switches, and the 2,890 ping-only hosts you
+ *     had already triaged are gone from the screen.
+ *   - An import of thousands of hosts runs for minutes. If it does not check
+ *     which scan it belongs to when it lands, it pushes its errors onto — or
+ *     closes — a different scan's dialog that the operator opened meanwhile.
+ *   - `isAlreadyRegistered` is frozen into the scan's jsonb at probe-upload
+ *     time and never recomputed, so if the page's own record of what it just
+ *     imported is cleared or keyed wrong, a reopened dialog re-offers imported
+ *     hosts pre-checked and Import creates duplicate Network Devices.
+ *   - A row key taken from the filtered list's index changes on every filter
+ *     click, remounting each row; CheckboxElement seeds itself from
+ *     `initialValue` and only reconciles `value` in a passive effect, so the
+ *     whole selection paints unticked for a frame in a dialog whose entire job
+ *     is deciding what is ticked.
+ *
+ * METHOD. Comments are stripped before anything is asserted, so describing a
+ * rule in prose can never satisfy a test that the rule is implemented, and
+ * whitespace is squashed so Prettier may reflow props freely. Every slice goes
+ * through `sliceBetween` / `sliceFrom`, which assert their markers were found:
+ * a bare `indexOf` returning -1 silently makes a slice cover the whole file (or
+ * nothing at all), and every assertion under it then passes for the wrong
+ * reason. Same fs/path approach as InventoryTableInvariants.test.ts.
+ *
+ * SCOPE. The filter row, the bulk select-all control and the submit button's
+ * count are pinned by DiscoveryReviewFilterInvariants.test.ts; this file stays
+ * off that ground and covers only the lifecycle.
+ */
+
+const DISCOVERY_PAGE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "NetworkDevice",
+  "Discovery.tsx",
+);
+
+function readSource(): string {
+  return fs.readFileSync(DISCOVERY_PAGE, "utf8");
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/** The page with comments removed and whitespace squashed to single spaces. */
+function readCode(): string {
+  return stripComments(readSource()).replace(/\s+/g, " ");
+}
+
+/**
+ * A slice that cannot lie about what it covers.
+ *
+ * `code.slice(indexOf(a), indexOf(b))` with a missing marker yields either the
+ * whole file from the start or an empty string, and both make the assertions
+ * underneath meaningless while still going green. Failing here instead points
+ * at the rename that actually happened.
+ */
+function sliceBetween(data: {
+  code: string;
+  from: string;
+  to: string;
+}): string {
+  const start: number = data.code.indexOf(data.from);
+  const end: number = data.code.indexOf(data.to);
+
+  expect({ from: data.from, found: start > -1 }).toEqual({
+    from: data.from,
+    found: true,
+  });
+  expect({ to: data.to, after: end > start }).toEqual({
+    to: data.to,
+    after: true,
+  });
+
+  return data.code.slice(start, end);
+}
+
+/** Same guarantee for an open-ended slice to the end of the file. */
+function sliceFrom(data: { code: string; from: string }): string {
+  const start: number = data.code.indexOf(data.from);
+
+  expect({ from: data.from, found: start > -1 }).toEqual({
+    from: data.from,
+    found: true,
+  });
+
+  return data.code.slice(start);
+}
+
+/** The whole body of `importSelectedDevices`, up to the render return. */
+function importSection(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: "const importSelectedDevices",
+    to: "if (isLoading)",
+  });
+}
+
+/** The `else if` that decides whether a successful import closes the dialog. */
+function closeGate(): string {
+  return sliceBetween({
+    code: importSection(),
+    from: "} else if (",
+    to: "closeReviewModal();",
+  });
+}
+
+function openReviewModalBody(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: "const openReviewModal",
+    to: "const closeReviewModal",
+  });
+}
+
+function closeReviewModalBody(): string {
+  return sliceBetween({
+    code: readCode(),
+    from: "const closeReviewModal",
+    to: "const importSelectedDevices",
+  });
+}
+
+/** Everything the Review Discovered Devices modal renders. */
+function modalSection(): string {
+  return sliceFrom({
+    code: readCode(),
+    from: 'title="Review Discovered Devices"',
+  });
+}
+
+describe("the source this file slices", () => {
+  test("the page is where the test expects it", () => {
+    expect(fs.existsSync(DISCOVERY_PAGE)).toBe(true);
+  });
+
+  test("every marker the slices below anchor on appears exactly once", () => {
+    /*
+     * A marker that appears twice makes a slice cover a region chosen by
+     * source order rather than by meaning — the assertions under it would then
+     * be about whichever copy happened to come first. Checked once here so the
+     * individual tests can assume it.
+     */
+    const code: string = readCode();
+
+    const markers: Array<string> = [
+      "const getReviewHosts",
+      "const openReviewModal",
+      "const closeReviewModal",
+      "const importSelectedDevices",
+      "if (isLoading)",
+      "const entriesToImport",
+      "const importedAfterThisRun",
+      "const isStillTheSameReview",
+      "closeReviewModal();",
+      "{shownEntries.map(",
+      "<CheckboxElement",
+      'title="Review Discovered Devices"',
+    ];
+
+    for (const marker of markers) {
+      expect({
+        marker: marker,
+        occurrences: code.split(marker).length - 1,
+      }).toEqual({ marker: marker, occurrences: 1 });
+    }
+
+    // The `else if` markers in the status column must not reach the gate.
+    expect(importSection().split("} else if (").length - 1).toBe(1);
+  });
+});
+
+describe("closing the dialog after a successful import", () => {
+  test("the gate asks about the whole scan, not the group on screen", () => {
+    /*
+     * Gating on `hostFilter` would close the dialog the moment the SHOWN group
+     * emptied — import the SNMP hosts and the review of the ping-only ones
+     * vanishes with it, which is precisely the behaviour #3322 was filed to
+     * remove. The question has to be "is there anything left anywhere in this
+     * scan", so the filter in the gate is always All.
+     */
+    const gate: string = closeGate();
+
+    expect(gate).toContain("getDiscoveredHostsToImport({");
+    expect(gate).toContain("filter: DiscoveredHostFilter.All");
+    expect(gate).not.toContain("filter: hostFilter");
+    expect(gate).toContain("}).length === 0");
+  });
+
+  test("the gate asks what is still selected, not what is still selectable", () => {
+    /*
+     * Selectable-but-unticked is a deliberate operator decision. Gating on
+     * `countSelectableShownHosts` would keep the dialog open after a complete
+     * import whenever a host had been unticked on purpose, leaving a modal
+     * whose only button reads "Import Selected (0)" and is disabled.
+     */
+    const gate: string = closeGate();
+
+    expect(gate).toContain("selectedIpAddresses: selectedIps");
+    expect(gate).not.toContain("countSelectableShownHosts");
+    expect(gate).not.toContain("isSelectableDiscoveredHost");
+    expect(gate).not.toContain("selectableShownCount");
+  });
+
+  test("the gate reads the scan with this run's imports already applied", () => {
+    /*
+     * Asserted as one contiguous string: the hosts the gate counts have to be
+     * the overlaid list carrying `importedAfterThisRun`, not the page's
+     * captured store and not the raw scan. Fed the raw scan, the hosts just
+     * imported still look importable, the count is never zero, and the dialog
+     * never closes on success at all.
+     */
+    expect(closeGate()).toContain(
+      "hosts: getReviewHosts(scanToReview, importedAfterThisRun)",
+    );
+  });
+
+  test("the import path closes the dialog in exactly one place", () => {
+    /*
+     * A second, unguarded `closeReviewModal()` — in the failure branch, or as
+     * a bare `else` after it — reinstates the old close-on-success behaviour
+     * while every assertion above still passes on the guarded copy.
+     */
+    const section: string = importSection();
+
+    expect(section.split("closeReviewModal();").length - 1).toBe(1);
+    expect(section).not.toContain("} else { closeReviewModal();");
+  });
+});
+
+describe("an import that outlives the dialog it started in", () => {
+  test("the run remembers the scan it started on and rechecks it at the end", () => {
+    /*
+     * Thousands of sequential creates take minutes, and nothing stops the
+     * operator closing the dialog and opening another scan meanwhile. Without
+     * this comparison the run's side effects land on whatever is on screen
+     * when it happens to finish.
+     */
+    const section: string = importSection();
+
+    expect(section).toContain(
+      'const runScanId: string = scanToReview._id || ""',
+    );
+    expect(section).toContain(
+      "const isStillTheSameReview: boolean = reviewedScanIdRef.current === runScanId",
+    );
+  });
+
+  test("the scan under review is held in a ref, not in state", () => {
+    /*
+     * State would give the run the value captured when it began — exactly the
+     * value that cannot answer "is this still the dialog I am importing for".
+     * Only a ref reads the live one from inside a closure minutes old.
+     */
+    expect(readCode()).toContain(
+      'const reviewedScanIdRef: React.MutableRefObject<string> = useRef<string>("")',
+    );
+  });
+
+  test("a stale run cannot push its failures onto the dialog now open", () => {
+    /*
+     * The toasts still fire — the devices really were created and the operator
+     * needs to know — but the inline error belongs to a dialog that is gone.
+     * Contiguous, so the guard cannot drift away from the call it protects.
+     */
+    expect(importSection()).toContain(
+      'if (isStillTheSameReview) { setImportError(failures.join(" ")); }',
+    );
+  });
+
+  test("a stale run cannot close the dialog now open", () => {
+    expect(closeGate()).toContain("isStillTheSameReview &&");
+  });
+
+  test("the ref is set when a review opens and cleared when it closes", () => {
+    /*
+     * Left uncleared, the ref still names the scan just closed, so a run that
+     * finishes afterwards believes its dialog is open and closes whatever the
+     * operator opened next.
+     */
+    expect(openReviewModalBody()).toContain(
+      'reviewedScanIdRef.current = scan._id || ""',
+    );
+    expect(closeReviewModalBody()).toContain('reviewedScanIdRef.current = ""');
+  });
+});
+
+describe("the page's record of what this sitting has imported", () => {
+  test("the store is keyed by scan id and read back for the scan on screen", () => {
+    /*
+     * A bare set of addresses written when a long import finally lands would
+     * mark the OTHER scan's same-addressed hosts "Already added" — disabled,
+     * unticked, silently skipped by Import.
+     */
+    const code: string = readCode();
+
+    expect(code).toContain("useState<ImportedIpAddressesByScanId>({})");
+    expect(code).not.toContain("useState<Set<string>>");
+
+    expect(
+      sliceBetween({
+        code: code,
+        from: "const getReviewHosts",
+        to: "const openReviewModal",
+      }),
+    ).toContain(
+      "importedByScanId: importedByScanId || importedIpAddressesByScanId, scanId: scan?._id,",
+    );
+  });
+
+  test("the store is written against the run's own scan id", () => {
+    /*
+     * `scanToReview` at the end of a long run is the scan the CLOSURE started
+     * with, but the id the record is filed under still has to be stated
+     * explicitly as the run's — reading it off page state here is how one
+     * scan's imports get attributed to another.
+     */
+    const updater: string = sliceBetween({
+      code: importSection(),
+      from: "setImportedIpAddressesByScanId((current",
+      to: "const isStillTheSameReview",
+    });
+
+    expect(updater).toContain("scanId: runScanId");
+    expect(updater).not.toContain("scanId: scanToReview");
+
+    expect(
+      sliceBetween({
+        code: importSection(),
+        from: "const importedAfterThisRun",
+        to: "setImportedIpAddressesByScanId((current",
+      }),
+    ).toContain("scanId: runScanId");
+  });
+
+  test("the store is updated functionally, not from a captured value", () => {
+    /*
+     * Two imports can overlap — start the SNMP group, switch filters, start
+     * the ping-only group. Merging into the value captured at render loses
+     * whichever landed first, and the hosts it imported come back pre-checked.
+     */
+    expect(importSection()).toContain(
+      "setImportedIpAddressesByScanId((current: ImportedIpAddressesByScanId) => { return withImportedIpAddresses({ importedByScanId: current,",
+    );
+  });
+
+  test("neither opening nor closing a review clears the store", () => {
+    /*
+     * Clearing it is what resurrects imported hosts: the scan's own
+     * `isAlreadyRegistered` flags were frozen at probe-upload time, so a
+     * reopened dialog with no overlay offers what was just imported, ticked,
+     * and Import duplicates every one of those devices.
+     */
+    expect(openReviewModalBody()).not.toContain(
+      "setImportedIpAddressesByScanId",
+    );
+    expect(closeReviewModalBody()).not.toContain(
+      "setImportedIpAddressesByScanId",
+    );
+  });
+});
+
+describe("what the dialog opens with, imports, and resets", () => {
+  test("the list to import is the overlaid scan, not the raw scan", () => {
+    /*
+     * One contiguous string on purpose: three independent substring checks
+     * would all still pass on a version that called
+     * `getDiscoveredHostsToImport` with `getDiscoveredHosts(scanToReview)`,
+     * which re-imports everything the previous press already created.
+     */
+    expect(
+      sliceBetween({
+        code: importSection(),
+        from: "const entriesToImport",
+        to: "if (entriesToImport.length === 0)",
+      }),
+    ).toContain(
+      "getDiscoveredHostsToImport({ hosts: getReviewHosts(scanToReview),",
+    );
+  });
+
+  test("opening a review seeds its selection through the overlay", () => {
+    /*
+     * `getInitialSelection` ticks every selectable host, so handing it the raw
+     * scan re-ticks the ones imported a minute ago. The rest of the body is
+     * the dialog's own state: the scan being reviewed, a cleared error from
+     * whatever was open before, and the modal made visible.
+     */
+    const body: string = openReviewModalBody();
+
+    expect(body).toContain(
+      "setSelectedIps(getInitialSelection(getReviewHosts(scan)))",
+    );
+    expect(body).not.toContain("getInitialSelection(getDiscoveredHosts(");
+    expect(body).toContain("setScanToReview(scan)");
+    expect(body).toContain('setImportError("")');
+    expect(body).toContain("setShowReviewModal(true)");
+    expect(body).not.toContain("setShowReviewModal(false)");
+  });
+
+  test("closing a review drops the scan, the selection and the error", () => {
+    /*
+     * Anything left behind here is shown by the NEXT review before its own
+     * state lands: a stale error banner, or ticks belonging to another scan's
+     * addresses.
+     */
+    const body: string = closeReviewModalBody();
+
+    expect(body).toContain("setShowReviewModal(false)");
+    expect(body).toContain("setScanToReview(null)");
+    expect(body).toContain("setSelectedIps({})");
+    expect(body).toContain('setImportError("")');
+    expect(body).not.toContain("setShowReviewModal(true)");
+  });
+});
+
+describe("a filter change is a view change, not a remount", () => {
+  test("the row key is built from the host's position in the unfiltered scan", () => {
+    /*
+     * `scanIndex` does not move when the filter does. The map callback takes
+     * only the entry — there is no second parameter to key from — because an
+     * index into the FILTERED list changes on every filter click, changing the
+     * key, remounting every row, and repainting the whole selection unticked
+     * for a frame.
+     */
+    const section: string = modalSection();
+
+    expect(section).toContain(
+      "{shownEntries.map( (shownEntry: ShownDiscoveredHost): ReactElement => {",
+    );
+    expect(section).toContain(
+      "key={`${entry.ipAddress}-${shownEntry.scanIndex}`}",
+    );
+  });
+
+  test("the row's checkbox is seeded and reconciled from the same value", () => {
+    /*
+     * CheckboxElement holds its own state, seeded from `initialValue` and only
+     * corrected from `value` in a passive effect. With `value` alone a freshly
+     * mounted row is unticked until an effect flushes; with `initialValue`
+     * alone it never follows Select all or Clear all at all.
+     */
+    expect(
+      sliceFrom({ code: modalSection(), from: "<CheckboxElement" }),
+    ).toContain("initialValue={isChecked} value={isChecked}");
+  });
+});

--- a/App/Tests/Dashboard/DiscoveryScanOutcome.test.ts
+++ b/App/Tests/Dashboard/DiscoveryScanOutcome.test.ts
@@ -7,6 +7,7 @@ import {
 import NetworkDeviceDiscoveryScan, {
   DiscoveredNetworkDevice,
 } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { countDiscoveredHosts } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
 import { describe, expect, test } from "@jest/globals";
 
 /*
@@ -336,5 +337,92 @@ describe("summarizeDiscoveryScan — has this scan reported yet", () => {
       const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(scan);
       expect(outcome.hasReported).toBe(outcome.respondedHostSummary !== null);
     }
+  });
+});
+
+describe("the scans table and the review dialog count the same hosts", () => {
+  /*
+   * The table cell says "+N alive without SNMP" and the dialog's filter row
+   * says "No SNMP (N)". They describe the same set of hosts, one click apart,
+   * so an operator who reads 12 on the table and 9 on the badge has no way to
+   * tell which one is lying. Both now derive from the one predicate; these
+   * tests are what stops a future edit giving either of them its own copy of
+   * the rule again.
+   */
+
+  const mixedHosts: Array<DiscoveredNetworkDevice> = [
+    host({ ipAddress: "10.0.0.1", snmpReachable: true }),
+    host({ ipAddress: "10.0.0.2", snmpReachable: false }),
+    host({ ipAddress: "10.0.0.3" }),
+    host({ ipAddress: "10.0.0.4", snmpReachable: false }),
+    host({
+      ipAddress: "10.0.0.5",
+      isAlreadyRegistered: true,
+      snmpReachable: false,
+    }),
+  ];
+
+  test("the table's ping-only tally equals the dialog's No SNMP badge", () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      discoveredDevices: mixedHosts,
+    });
+
+    expect(countPingOnlyHosts(scan)).toBe(3);
+    expect(countDiscoveredHosts(getDiscoveredHosts(scan)).noSnmp).toBe(
+      countPingOnlyHosts(scan),
+    );
+  });
+
+  test("a legacy row is SNMP to both of them", () => {
+    /*
+     * Rows stored before `snmpReachable` existed carry undefined, and every
+     * host on those scans answered SNMP. Counting them as ping-only on either
+     * screen would invent alive-without-SNMP hosts for every historical scan
+     * in the project.
+     */
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      discoveredDevices: [host({ ipAddress: "10.0.0.9" })],
+    });
+
+    expect(countPingOnlyHosts(scan)).toBe(0);
+    expect(countDiscoveredHosts(getDiscoveredHosts(scan))).toEqual({
+      all: 1,
+      snmp: 1,
+      noSnmp: 0,
+    });
+  });
+
+  test("a junk row costs a wrong tally, not the whole table", () => {
+    /*
+     * `discoveredDevices` is jsonb written verbatim from the probe's payload,
+     * and getDiscoveredHosts guards only that the VALUE is an array — never
+     * that its elements are objects. Reading `host.snmpReachable` off a null
+     * element threw a TypeError from inside a table cell, taking the scans
+     * list down on a row it was only trying to summarise.
+     */
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      discoveredDevices: [
+        null,
+        undefined,
+        7,
+        "10.0.0.1",
+        host({ ipAddress: "10.0.0.2", snmpReachable: false }),
+      ] as unknown as Array<DiscoveredNetworkDevice>,
+    });
+
+    expect(countPingOnlyHosts(scan)).toBe(1);
+    expect(summarizeDiscoveryScan(scan).pingOnlyHostCount).toBe(1);
+  });
+
+  test("the two groups still account for every row the table can see", () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      discoveredDevices: mixedHosts,
+    });
+
+    const hosts: Array<DiscoveredNetworkDevice> = getDiscoveredHosts(scan);
+
+    expect(countPingOnlyHosts(scan) + countDiscoveredHosts(hosts).snmp).toBe(
+      hosts.length,
+    );
   });
 });

--- a/App/Tests/Dashboard/DiscoverySelectionProperties.test.ts
+++ b/App/Tests/Dashboard/DiscoverySelectionProperties.test.ts
@@ -1,0 +1,1377 @@
+import { describe, expect, test } from "@jest/globals";
+import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import {
+  DiscoveredHostCounts,
+  DiscoveredHostFilter,
+  ShownDiscoveredHost,
+  areAllShownHostsSelected,
+  countDiscoveredHosts,
+  countSelectableShownHosts,
+  filterDiscoveredHosts,
+  getDiscoveredHostsToImport,
+  getInitialSelection,
+  getShownDiscoveredHosts,
+  isSelectableDiscoveredHost,
+  markDiscoveredHostsAsRegistered,
+  toggleSelectionForShownHosts,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveredHostFilter";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * DiscoveredHostFilter.test.ts pins the SNMP / No SNMP filter (#3322) against
+ * hand-written scans: five hosts, one of each interesting shape, chosen by
+ * someone who already knew which shapes were interesting. That catches the bugs
+ * somebody thought of.
+ *
+ * The bugs that reach an operator are the combinations nobody thought of — a
+ * blank address that is also duplicated, a legacy row that is also
+ * already-registered, one address appearing once as an SNMP responder and again
+ * as a ping-only row (`discoveredDevices` is jsonb written straight from the
+ * probe's payload, so nothing forbids it). At the size the issue reports —
+ * 2,866 SNMP hosts and 2,890 ping-only ones in a single scan — every rare shape
+ * is present many times over, and a rule that only holds for tidy input is a
+ * rule that does not hold.
+ *
+ * So this file asserts LAWS rather than examples, over a few hundred generated
+ * scans: the two groups partition the scan, each badge equals the list under it,
+ * Import is always a subset of what is on screen, a tick never removes a device,
+ * "select all" is a per-group flip, and a row's React key does not move when the
+ * filter does. The corpus — not the author's imagination — decides which
+ * combinations get tested.
+ *
+ * DETERMINISM IS NOT OPTIONAL HERE. Math.random() would surface a counterexample
+ * once in CI and never again, which is worse than not testing: it costs the
+ * reader's trust and hands them nothing to debug. The generator below is a
+ * seeded LCG driven by a fixed seed table, so the corpus is identical on every
+ * machine and every run, and a failure prints the seed and the exact scan.
+ */
+
+/*
+ * A 32-bit linear congruential generator (Numerical Recipes constants).
+ *
+ * Deliberately tiny and self-contained: the point is a reproducible byte
+ * stream, not statistical quality, and taking a PRNG dependency for a test
+ * corpus would be a worse trade than eight lines of arithmetic.
+ */
+class SeededRandom {
+  private state: number;
+
+  public constructor(seed: number) {
+    // Unsigned, and never zero — a zero seed still advances, but reads badly.
+    this.state = seed >>> 0 || 1;
+  }
+
+  public nextUint32(): number {
+    this.state = (Math.imul(this.state, 1664525) + 1013904223) >>> 0;
+
+    return this.state;
+  }
+
+  /** An integer in [0, bound). Callers never pass 0. */
+  public nextInt(bound: number): number {
+    return this.nextUint32() % bound;
+  }
+
+  public chance(percent: number): boolean {
+    return this.nextInt(100) < percent;
+  }
+
+  public pick<T>(values: Array<T>): T {
+    /*
+     * `as T` rather than `!` because the value arrays deliberately contain
+     * `undefined` — that is the legacy `snmpReachable` — and `!` would strip it
+     * out of the type and therefore out of the corpus.
+     */
+    return values[this.nextInt(values.length)] as T;
+  }
+}
+
+/*
+ * Fixed seeds. Changing this table changes the corpus, which is exactly why it
+ * is a table and not a clock: a failure quotes its seed, and re-running the file
+ * reproduces that scan byte for byte.
+ */
+const SEEDS: Array<number> = [
+  1, 7, 42, 1337, 3322, 90210, 20260821, 4294967291,
+];
+
+const SCANS_PER_SEED: number = 45;
+
+const FILTERS: Array<DiscoveredHostFilter> = [
+  DiscoveredHostFilter.All,
+  DiscoveredHostFilter.Snmp,
+  DiscoveredHostFilter.NoSnmp,
+];
+
+/*
+ * An address that is deliberately absent from every generated scan: a selection
+ * can outlive the hosts it was made against, and a stale key must not conjure
+ * an import out of nothing.
+ */
+const FOREIGN_ADDRESS: string = "192.168.254.254";
+
+/** One generated case: a scan plus the tick state the operator is holding. */
+interface GeneratedScan {
+  seed: number;
+  index: number;
+  hosts: Array<DiscoveredNetworkDevice>;
+  selection: Record<string, boolean>;
+}
+
+function addressesOf(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+  return hosts.map((host: DiscoveredNetworkDevice) => {
+    return host.ipAddress;
+  });
+}
+
+/*
+ * Addresses are unique per row unless the generator deliberately repeats one, so
+ * two rows sharing an address always do so on purpose and object identity stays
+ * a usable way to tell rows apart in the laws below.
+ */
+function nextIpAddress(data: {
+  random: SeededRandom;
+  index: number;
+  addressesSoFar: Array<string>;
+}): string {
+  /*
+   * A blank address is a real row shape: the probe can report a host it could
+   * not name, and the address is both the checkbox key and the imported
+   * device's hostname, so blanks have to fall out of selection everywhere.
+   */
+  if (data.random.chance(8)) {
+    return "";
+  }
+
+  /*
+   * A repeated address is the shape that breaks naive code: one checkbox
+   * governs every row carrying it, so a single tick can span both groups.
+   */
+  if (data.addressesSoFar.length > 0 && data.random.chance(22)) {
+    return data.random.pick(data.addressesSoFar);
+  }
+
+  return `10.7.${Math.floor(data.index / 256)}.${data.index % 256}`;
+}
+
+function generateHosts(random: SeededRandom): Array<DiscoveredNetworkDevice> {
+  // Includes 0, because an empty scan is a state the dialog actually ships in.
+  const size: number = random.nextInt(26);
+
+  const hosts: Array<DiscoveredNetworkDevice> = [];
+  const addressesSoFar: Array<string> = [];
+
+  for (let index: number = 0; index < size; index++) {
+    const ipAddress: string = nextIpAddress({
+      random: random,
+      index: index,
+      addressesSoFar: addressesSoFar,
+    });
+
+    if (ipAddress !== "") {
+      addressesSoFar.push(ipAddress);
+    }
+
+    hosts.push({
+      ipAddress: ipAddress,
+      sysName: random.chance(50) ? `host-${index}` : undefined,
+      /*
+       * `undefined` is the legacy row, written before ping-only sweeps existed,
+       * and has to read as SNMP everywhere. Generating it as often as the other
+       * two keeps it out of the "rare shape nobody covered" category.
+       */
+      snmpReachable: random.pick<boolean | undefined>([true, false, undefined]),
+      isAlreadyRegistered: random.pick<boolean | undefined>([
+        true,
+        false,
+        undefined,
+        undefined,
+      ]),
+    });
+  }
+
+  return hosts;
+}
+
+/*
+ * The tick state, drawn from the states the dialog actually reaches: the
+ * pre-checked opening selection, nothing ticked, one group cleared with the
+ * bulk control, and arbitrary hand-ticking (including a key for an address that
+ * is not in this scan at all).
+ */
+function generateSelection(data: {
+  random: SeededRandom;
+  hosts: Array<DiscoveredNetworkDevice>;
+}): Record<string, boolean> {
+  const mode: number = data.random.nextInt(10);
+
+  if (mode <= 2) {
+    return getInitialSelection(data.hosts);
+  }
+
+  if (mode === 3) {
+    return {};
+  }
+
+  if (mode === 4 || mode === 5) {
+    return toggleSelectionForShownHosts({
+      hosts: data.hosts,
+      filter:
+        mode === 4 ? DiscoveredHostFilter.Snmp : DiscoveredHostFilter.NoSnmp,
+      selectedIpAddresses: getInitialSelection(data.hosts),
+    });
+  }
+
+  const selection: Record<string, boolean> = {};
+
+  const candidates: Array<string> = [
+    ...new Set<string>(addressesOf(data.hosts)),
+    FOREIGN_ADDRESS,
+  ];
+
+  candidates.forEach((address: string): void => {
+    const roll: number = data.random.nextInt(10);
+
+    if (roll < 5) {
+      selection[address] = true;
+    } else if (roll < 8) {
+      selection[address] = false;
+    }
+  });
+
+  return selection;
+}
+
+function buildCorpus(): Array<GeneratedScan> {
+  const corpus: Array<GeneratedScan> = [];
+
+  SEEDS.forEach((seed: number): void => {
+    const random: SeededRandom = new SeededRandom(seed);
+
+    for (let index: number = 0; index < SCANS_PER_SEED; index++) {
+      const hosts: Array<DiscoveredNetworkDevice> = generateHosts(random);
+
+      corpus.push({
+        seed: seed,
+        index: index,
+        hosts: hosts,
+        selection: generateSelection({ random: random, hosts: hosts }),
+      });
+    }
+  });
+
+  return corpus;
+}
+
+/*
+ * Built once. Every law runs over the same corpus, so a scan that breaks one of
+ * them can be read against the others.
+ */
+const CORPUS: Array<GeneratedScan> = buildCorpus();
+
+/*
+ * Small comparison helpers, so one scan can cost one assertion instead of one
+ * assertion per row — at this corpus size that is the difference between a
+ * two-minute suite and a five-second one.
+ */
+function sameRows(
+  left: Array<DiscoveredNetworkDevice>,
+  right: Array<DiscoveredNetworkDevice>,
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((host: DiscoveredNetworkDevice, position: number) => {
+      // Identity, not equality: duplicate rows can be value-identical.
+      return host === right[position];
+    })
+  );
+}
+
+function sameStrings(left: Array<string>, right: Array<string>): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value: string, position: number) => {
+      return value === right[position];
+    })
+  );
+}
+
+/** A selection compared by content, key order ignored. */
+function selectionSignature(selection: Record<string, boolean>): string {
+  return Object.keys(selection)
+    .sort()
+    .map((key: string) => {
+      return `${key}=${String(selection[key])}`;
+    })
+    .join(",");
+}
+
+function importAddresses(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+  selectedIpAddresses: Record<string, boolean>;
+}): Array<string> {
+  return addressesOf(getDiscoveredHostsToImport(data));
+}
+
+/** The addresses one group offers a checkbox for. */
+function selectableAddressesShown(data: {
+  hosts: Array<DiscoveredNetworkDevice>;
+  filter: DiscoveredHostFilter;
+}): Set<string> {
+  const addresses: Set<string> = new Set<string>();
+
+  filterDiscoveredHosts(data).forEach((host: DiscoveredNetworkDevice): void => {
+    if (isSelectableDiscoveredHost(host)) {
+      addresses.add(host.ipAddress);
+    }
+  });
+
+  return addresses;
+}
+
+/*
+ * Only the first few counterexamples are described in full. Beyond that the
+ * scans stop being evidence and start being noise, and rendering hundreds of
+ * them costs more than the law did.
+ */
+const MAX_REPORTED_VIOLATIONS: number = 4;
+
+/*
+ * Runs one law over every generated scan and returns the counterexamples.
+ *
+ * Each one carries the seed and the exact scan. Without that, a broken law
+ * reports "expected true, received false" about a scan the reader cannot see
+ * and cannot reproduce — which is how property suites end up deleted rather
+ * than debugged. With it, the failure names the seed (re-run the file, get the
+ * same corpus), the scan's index within that seed, and the hosts and ticks
+ * involved.
+ */
+function findViolations(
+  check: (scan: GeneratedScan, report: (problem: string) => void) => void,
+): Array<string> {
+  const described: Array<string> = [];
+  let total: number = 0;
+
+  CORPUS.forEach((scan: GeneratedScan): void => {
+    check(scan, (problem: string): void => {
+      total = total + 1;
+
+      if (described.length < MAX_REPORTED_VIOLATIONS) {
+        described.push(
+          [
+            problem,
+            `  seed=${scan.seed} scan=#${scan.index}`,
+            `  hosts=${JSON.stringify(scan.hosts)}`,
+            `  selection=${JSON.stringify(scan.selection)}`,
+          ].join("\n"),
+        );
+      }
+    });
+  });
+
+  if (total > described.length) {
+    described.push(`...and ${total - described.length} more counterexamples`);
+  }
+
+  return described;
+}
+
+describe("the SNMP / No SNMP split, over every generated scan", () => {
+  test("the two groups partition the scan — never both, never neither, order kept", () => {
+    /*
+     * A host that could land in both groups would be imported twice by an
+     * operator working group by group; one that could land in neither would be
+     * invisible under every filter while still being counted by All. Both
+     * render perfectly.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const snmp: Array<DiscoveredNetworkDevice> = filterDiscoveredHosts({
+            hosts: scan.hosts,
+            filter: DiscoveredHostFilter.Snmp,
+          });
+          const noSnmp: Array<DiscoveredNetworkDevice> = filterDiscoveredHosts({
+            hosts: scan.hosts,
+            filter: DiscoveredHostFilter.NoSnmp,
+          });
+
+          // Disjoint, by row identity rather than by address: duplicates exist.
+          const inBoth: Array<DiscoveredNetworkDevice> = snmp.filter(
+            (host: DiscoveredNetworkDevice) => {
+              return noSnmp.includes(host);
+            },
+          );
+
+          if (inBoth.length > 0) {
+            report(
+              `PARTITION: ${inBoth.length} row(s) are in both the SNMP and No SNMP groups`,
+            );
+          }
+
+          if (snmp.length + noSnmp.length !== scan.hosts.length) {
+            report(
+              `PARTITION: groups hold ${snmp.length}+${noSnmp.length} rows but the scan has ${scan.hosts.length}`,
+            );
+          }
+
+          // Each group keeps the probe's order, and together they are the scan.
+          if (
+            !sameRows(
+              scan.hosts.filter((host: DiscoveredNetworkDevice) => {
+                return snmp.includes(host);
+              }),
+              snmp,
+            )
+          ) {
+            report("PARTITION: the SNMP group is not the scan's own order");
+          }
+
+          if (
+            !sameRows(
+              scan.hosts.filter((host: DiscoveredNetworkDevice) => {
+                return noSnmp.includes(host);
+              }),
+              noSnmp,
+            )
+          ) {
+            report("PARTITION: the No SNMP group is not the scan's own order");
+          }
+
+          if (
+            !sameRows(
+              filterDiscoveredHosts({
+                hosts: scan.hosts,
+                filter: DiscoveredHostFilter.All,
+              }),
+              scan.hosts,
+            )
+          ) {
+            report("PARTITION: All is not the scan itself");
+          }
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("every badge equals the length of the list it filters to", () => {
+    /*
+     * The badge is what an operator checks against the probe's own ICMP/SNMP
+     * tallies before trusting the dialog at all. A badge computed from a
+     * different predicate than the list underneath it is what makes them stop.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const counts: DiscoveredHostCounts = countDiscoveredHosts(scan.hosts);
+
+          if (counts.all !== scan.hosts.length) {
+            report(
+              `COUNTS: all badge reads ${counts.all} for ${scan.hosts.length} rows`,
+            );
+          }
+
+          if (counts.snmp + counts.noSnmp !== counts.all) {
+            report(
+              `COUNTS: ${counts.snmp}+${counts.noSnmp} does not add up to ${counts.all}`,
+            );
+          }
+
+          const shownSnmp: number = filterDiscoveredHosts({
+            hosts: scan.hosts,
+            filter: DiscoveredHostFilter.Snmp,
+          }).length;
+          const shownNoSnmp: number = filterDiscoveredHosts({
+            hosts: scan.hosts,
+            filter: DiscoveredHostFilter.NoSnmp,
+          }).length;
+
+          if (counts.snmp !== shownSnmp) {
+            report(
+              `COUNTS: SNMP badge reads ${counts.snmp} but the group shows ${shownSnmp}`,
+            );
+          }
+
+          if (counts.noSnmp !== shownNoSnmp) {
+            report(
+              `COUNTS: No SNMP badge reads ${counts.noSnmp} but the group shows ${shownNoSnmp}`,
+            );
+          }
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("the rows rendered are the rows filtered, each pointing back at its own place in the scan", () => {
+    /*
+     * `scanIndex` is what the React key is built from. If it ever stopped
+     * indexing the UNFILTERED array, the key would change on a filter click,
+     * React would remount the row, and CheckboxElement — which seeds itself
+     * from `initialValue` and only reconciles in a passive effect — would paint
+     * it unchecked for a frame. Strictly increasing is the other half of the
+     * same guarantee: two rows sharing an index would share a key.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const shown: Array<ShownDiscoveredHost> = getShownDiscoveredHosts({
+              hosts: scan.hosts,
+              filter: filter,
+            });
+            const filtered: Array<DiscoveredNetworkDevice> =
+              filterDiscoveredHosts({ hosts: scan.hosts, filter: filter });
+
+            if (
+              !sameRows(
+                shown.map((row: ShownDiscoveredHost) => {
+                  return row.host;
+                }),
+                filtered,
+              )
+            ) {
+              report(
+                `SHOWN ROWS: ${filter} renders different rows than it filters to`,
+              );
+            }
+
+            const misindexed: Array<ShownDiscoveredHost> = shown.filter(
+              (row: ShownDiscoveredHost) => {
+                return scan.hosts[row.scanIndex] !== row.host;
+              },
+            );
+
+            if (misindexed.length > 0) {
+              report(
+                `SHOWN ROWS: ${filter} carries ${misindexed.length} scanIndex value(s) that do not point back at their own row`,
+              );
+            }
+
+            const outOfOrder: Array<ShownDiscoveredHost> = shown.filter(
+              (row: ShownDiscoveredHost, position: number) => {
+                return (
+                  position > 0 &&
+                  row.scanIndex <= shown[position - 1]!.scanIndex
+                );
+              },
+            );
+
+            if (outOfOrder.length > 0) {
+              report(
+                `SHOWN ROWS: ${filter} scanIndex sequence is not strictly increasing`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("a row's key is the same under All as under its own group", () => {
+    /*
+     * Stability stated directly: the (address, scanIndex) pair a row is keyed
+     * by must not depend on which filter is active, or every row remounts on
+     * every filter change and the whole selection appears to blank out and snap
+     * back — in a dialog whose only job is deciding what is ticked.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const keyUnderAll: Map<DiscoveredNetworkDevice, string> = new Map<
+            DiscoveredNetworkDevice,
+            string
+          >();
+
+          getShownDiscoveredHosts({
+            hosts: scan.hosts,
+            filter: DiscoveredHostFilter.All,
+          }).forEach((row: ShownDiscoveredHost): void => {
+            keyUnderAll.set(row.host, `${row.host.ipAddress}-${row.scanIndex}`);
+          });
+
+          [DiscoveredHostFilter.Snmp, DiscoveredHostFilter.NoSnmp].forEach(
+            (filter: DiscoveredHostFilter): void => {
+              getShownDiscoveredHosts({
+                hosts: scan.hosts,
+                filter: filter,
+              }).forEach((row: ShownDiscoveredHost): void => {
+                const groupKey: string = `${row.host.ipAddress}-${row.scanIndex}`;
+
+                if (groupKey !== keyUnderAll.get(row.host)) {
+                  report(
+                    `KEY STABILITY: a row keyed ${String(
+                      keyUnderAll.get(row.host),
+                    )} under All is keyed ${groupKey} under ${filter}`,
+                  );
+                }
+              });
+            },
+          );
+        },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("what pressing Import can possibly do, over every generated scan", () => {
+  test("the import list is always a deduplicated, ticked, selectable subset of what is on screen", () => {
+    /*
+     * The expensive failure in #3322 lives here: the dialog opens fully
+     * pre-checked, so anything that lets Import reach past the active filter
+     * creates the thousands of devices the operator just filtered away — and
+     * the toast still says it worked. Being a SUBSEQUENCE rather than merely a
+     * subset also pins that the import runs in scan order, and uniqueness pins
+     * that one checkbox creates one device however many rows the probe reported
+     * for that address.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const shown: Array<DiscoveredNetworkDevice> = filterDiscoveredHosts(
+              { hosts: scan.hosts, filter: filter },
+            );
+            const toImport: Array<DiscoveredNetworkDevice> =
+              getDiscoveredHostsToImport({
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: scan.selection,
+              });
+
+            if (
+              !sameRows(
+                shown.filter((host: DiscoveredNetworkDevice) => {
+                  return toImport.includes(host);
+                }),
+                toImport,
+              )
+            ) {
+              report(
+                `IMPORT SUBSET: ${filter} imports rows that are not the shown rows in shown order`,
+              );
+            }
+
+            const notSelectable: Array<DiscoveredNetworkDevice> =
+              toImport.filter((host: DiscoveredNetworkDevice) => {
+                return !isSelectableDiscoveredHost(host);
+              });
+
+            if (notSelectable.length > 0) {
+              report(
+                `IMPORT SUBSET: ${filter} imports ${notSelectable.length} row(s) that have no checkbox`,
+              );
+            }
+
+            const notTicked: Array<DiscoveredNetworkDevice> = toImport.filter(
+              (host: DiscoveredNetworkDevice) => {
+                return !scan.selection[host.ipAddress];
+              },
+            );
+
+            if (notTicked.length > 0) {
+              report(
+                `IMPORT SUBSET: ${filter} imports ${notTicked.length} row(s) nobody ticked`,
+              );
+            }
+
+            const addresses: Array<string> = addressesOf(toImport);
+
+            if (new Set<string>(addresses).size !== addresses.length) {
+              report(
+                `IMPORT SUBSET: ${filter} would create more than one device for the same address`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("ticking one address only ever adds that address, and unticking it only ever removes it", () => {
+    /*
+     * Monotonicity. A checkbox is the one control here an operator uses without
+     * thinking, so it has to be local: ticking a host must never drop an
+     * unrelated device out of the import — silent data loss the toast still
+     * reports as success — and unticking must never pull one in.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const candidates: Array<string> = [
+            ...new Set<string>(addressesOf(scan.hosts)),
+            FOREIGN_ADDRESS,
+          ];
+
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const base: Array<string> = importAddresses({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+
+            candidates.forEach((address: string): void => {
+              const withoutCandidate: Array<string> = base.filter(
+                (candidate: string) => {
+                  return candidate !== address;
+                },
+              );
+
+              const ticked: Array<string> = importAddresses({
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: { ...scan.selection, [address]: true },
+              });
+              const unticked: Array<string> = importAddresses({
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: { ...scan.selection, [address]: false },
+              });
+
+              // Ticking adds at most that address and removes nothing.
+              if (
+                !sameStrings(
+                  ticked.filter((candidate: string) => {
+                    return candidate !== address;
+                  }),
+                  withoutCandidate,
+                )
+              ) {
+                report(
+                  `MONOTONICITY: ticking ${address || "(blank)"} under ${filter} changed the import list beyond that address`,
+                );
+              }
+
+              // Unticking removes exactly that address and adds nothing.
+              if (!sameStrings(unticked, withoutCandidate)) {
+                report(
+                  `MONOTONICITY: unticking ${address || "(blank)"} under ${filter} did not leave exactly the rest of the import list`,
+                );
+              }
+            });
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("the opening selection offers exactly what every group has to offer", () => {
+    /*
+     * The dialog opens on All with everything pre-checked, and the operator's
+     * first move is a filter click. If the pre-check were computed per group,
+     * or missed a shape — a legacy row, a duplicate — that first click would
+     * land on a group that is not actually full, and the bulk control would
+     * read "Select all" over an already-complete list.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const initial: Record<string, boolean> = getInitialSelection(
+            scan.hosts,
+          );
+
+          const expectedKeys: Array<string> = Array.from(
+            selectableAddressesShown({
+              hosts: scan.hosts,
+              filter: DiscoveredHostFilter.All,
+            }),
+          ).sort();
+
+          if (!sameStrings(Object.keys(initial).sort(), expectedKeys)) {
+            report(
+              "INITIAL SELECTION: the opening ticks are not exactly the selectable addresses",
+            );
+          }
+
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const selectable: number = countSelectableShownHosts({
+              hosts: scan.hosts,
+              filter: filter,
+            });
+
+            const offered: number = importAddresses({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: initial,
+            }).length;
+
+            if (offered !== selectable) {
+              report(
+                `INITIAL SELECTION: ${filter} opens offering ${offered} of its ${selectable} selectable hosts`,
+              );
+            }
+
+            if (
+              areAllShownHostsSelected({
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: initial,
+              }) !==
+              selectable > 0
+            ) {
+              report(
+                `INITIAL SELECTION: ${filter} does not read as fully selected on open`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("importing a group empties that group and leaves the badges where they were", () => {
+    /*
+     * Group-by-group importing is the intended flow, and `isAlreadyRegistered`
+     * is computed server-side at probe-upload time and then frozen into the
+     * jsonb — nothing recomputes it on read — so the page has to overlay what it
+     * just imported or those hosts come back pre-checked and Import creates
+     * duplicates. The badges must NOT move while that happens: they describe
+     * the sweep, not the operator's progress through it.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const badgesBefore: DiscoveredHostCounts = countDiscoveredHosts(
+            scan.hosts,
+          );
+
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const imported: Array<string> = importAddresses({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+
+            const marked: Array<DiscoveredNetworkDevice> =
+              markDiscoveredHostsAsRegistered({
+                hosts: scan.hosts,
+                importedIpAddresses: new Set<string>(imported),
+              });
+
+            if (marked.length !== scan.hosts.length) {
+              report(
+                `IMPORT THEN RETIRE: marking ${filter} changed the scan from ${scan.hosts.length} rows to ${marked.length}`,
+              );
+            }
+
+            const badgesAfter: DiscoveredHostCounts =
+              countDiscoveredHosts(marked);
+
+            if (
+              badgesAfter.all !== badgesBefore.all ||
+              badgesAfter.snmp !== badgesBefore.snmp ||
+              badgesAfter.noSnmp !== badgesBefore.noSnmp
+            ) {
+              report(
+                `IMPORT THEN RETIRE: importing ${filter} moved the badges from ${JSON.stringify(badgesBefore)} to ${JSON.stringify(badgesAfter)}`,
+              );
+            }
+
+            // Pressing Import again on the same group would create nothing.
+            const leftOver: Array<string> = importAddresses({
+              hosts: marked,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+
+            if (leftOver.length > 0) {
+              report(
+                `IMPORT THEN RETIRE: ${filter} still offers ${leftOver.length} host(s) after importing it`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the bulk select-all control, over every generated scan", () => {
+  test("one press flips whether the group is full, and a group with nothing to tick is left alone", () => {
+    /*
+     * The control is what replaces "scroll 2,890 rows and uncheck them one at a
+     * time", so a press that lands on neither state is the feature not
+     * existing. The empty-group case is separate on purpose:
+     * `areAllShownHostsSelected` refuses to be vacuously true so the control
+     * reads "Select all" and stays disabled rather than offering to clear a
+     * selection that is not there — and the press must then be a no-op on the
+     * WHOLE selection, not merely on that group.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const selectable: number = countSelectableShownHosts({
+              hosts: scan.hosts,
+              filter: filter,
+            });
+
+            const before: boolean = areAllShownHostsSelected({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+
+            const toggled: Record<string, boolean> =
+              toggleSelectionForShownHosts({
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: scan.selection,
+              });
+
+            const after: boolean = areAllShownHostsSelected({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: toggled,
+            });
+
+            if (selectable === 0) {
+              if (before || after) {
+                report(
+                  `SELECT-ALL FLIP: ${filter} has nothing selectable but reads as fully selected`,
+                );
+              }
+
+              if (
+                selectionSignature(toggled) !==
+                selectionSignature(scan.selection)
+              ) {
+                report(
+                  `SELECT-ALL FLIP: pressing over an empty ${filter} group changed the selection`,
+                );
+              }
+
+              return;
+            }
+
+            if (after === before) {
+              report(
+                `SELECT-ALL FLIP: one press left ${filter} reading "${String(before)}" for fully-selected`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("pressing twice more lands back where the first press did", () => {
+    /*
+     * The honest shape of "toggle involution": the control is NOT an involution
+     * on an arbitrary selection, because the first press normalises a
+     * half-ticked group to fully ticked. From there it alternates, so the third
+     * press equals the first — exactly, over the WHOLE selection object, which
+     * is also how ticks belonging to the group that is NOT on screen are pinned
+     * to survive the round trip.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const first: Record<string, boolean> = toggleSelectionForShownHosts(
+              {
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: scan.selection,
+              },
+            );
+            const second: Record<string, boolean> =
+              toggleSelectionForShownHosts({
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: first,
+              });
+            const third: Record<string, boolean> = toggleSelectionForShownHosts(
+              {
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: second,
+              },
+            );
+
+            if (selectionSignature(third) !== selectionSignature(first)) {
+              report(
+                `TOGGLE ALTERNATION: a third press on ${filter} gave ${selectionSignature(third)} where the first gave ${selectionSignature(first)}`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("two presses leave the group empty, unless it started full", () => {
+    /*
+     * Where the alternation lands, stated as an import list rather than as a
+     * flag. From a partly-ticked group: press one fills it, press two clears
+     * it, so the group imports nothing. From a full group it runs the other way
+     * and the group comes back complete. Getting this backwards is the "I
+     * cleared it and it imported everything anyway" bug.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const startedFull: boolean = areAllShownHostsSelected({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+
+            const twice: Record<string, boolean> = toggleSelectionForShownHosts(
+              {
+                hosts: scan.hosts,
+                filter: filter,
+                selectedIpAddresses: toggleSelectionForShownHosts({
+                  hosts: scan.hosts,
+                  filter: filter,
+                  selectedIpAddresses: scan.selection,
+                }),
+              },
+            );
+
+            const expectedCount: number = startedFull
+              ? countSelectableShownHosts({
+                  hosts: scan.hosts,
+                  filter: filter,
+                })
+              : 0;
+
+            const actualCount: number = importAddresses({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: twice,
+            }).length;
+
+            if (actualCount !== expectedCount) {
+              report(
+                `TOGGLE LANDING: two presses on ${filter} (started ${startedFull ? "full" : "not full"}) left ${actualCount} hosts to import, expected ${expectedCount}`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("clearing one group only ever touches addresses that group offers", () => {
+    /*
+     * Locality, stated the way the data actually allows. The intended move is
+     * "clear the 2,866 SNMP hosts, keep the 2,890 ping-only ones ticked", and
+     * the bulk control must not reach outside the group on screen to do it.
+     *
+     * The caveat is real, and is why this is a restriction rather than plain
+     * equality: `discoveredDevices` is jsonb off the probe, so ONE address can
+     * appear as an SNMP row and again as a ping-only row, and a single checkbox
+     * governs both. Where that happens the other group's import genuinely
+     * changes — that is one tick, not two. So the law is that nothing OUTSIDE
+     * the pressed group's own addresses moves, and that a scan whose groups
+     * share no address sees no change at all.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const pairs: Array<Array<DiscoveredHostFilter>> = [
+            [DiscoveredHostFilter.Snmp, DiscoveredHostFilter.NoSnmp],
+            [DiscoveredHostFilter.NoSnmp, DiscoveredHostFilter.Snmp],
+          ];
+
+          pairs.forEach((pair: Array<DiscoveredHostFilter>): void => {
+            const pressed: DiscoveredHostFilter = pair[0]!;
+            const other: DiscoveredHostFilter = pair[1]!;
+
+            const touched: Set<string> = selectableAddressesShown({
+              hosts: scan.hosts,
+              filter: pressed,
+            });
+
+            const before: Array<string> = importAddresses({
+              hosts: scan.hosts,
+              filter: other,
+              selectedIpAddresses: scan.selection,
+            });
+            const after: Array<string> = importAddresses({
+              hosts: scan.hosts,
+              filter: other,
+              selectedIpAddresses: toggleSelectionForShownHosts({
+                hosts: scan.hosts,
+                filter: pressed,
+                selectedIpAddresses: scan.selection,
+              }),
+            });
+
+            const untouchedBefore: Array<string> = before.filter(
+              (address: string) => {
+                return !touched.has(address);
+              },
+            );
+            const untouchedAfter: Array<string> = after.filter(
+              (address: string) => {
+                return !touched.has(address);
+              },
+            );
+
+            if (!sameStrings(untouchedAfter, untouchedBefore)) {
+              report(
+                `TOGGLE LOCALITY: pressing ${pressed} changed ${other} hosts it does not even show`,
+              );
+            }
+
+            const sharesAnAddress: boolean = Array.from(
+              selectableAddressesShown({ hosts: scan.hosts, filter: other }),
+            ).some((address: string) => {
+              return touched.has(address);
+            });
+
+            if (!sharesAnAddress && !sameStrings(after, before)) {
+              report(
+                `TOGGLE LOCALITY: pressing ${pressed} changed the ${other} import list even though the groups share no address`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("'all selected' is exactly 'the import list is the whole group'", () => {
+    /*
+     * The bulk control's label and the submit button's count are read together,
+     * one line apart. If "all selected" were judged by any other arithmetic —
+     * counting duplicate rows twice, say, or counting already-registered hosts
+     * — the control would claim the group was full while the button underneath
+     * offered a smaller number.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            const selectable: number = countSelectableShownHosts({
+              hosts: scan.hosts,
+              filter: filter,
+            });
+            const importedCount: number = importAddresses({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            }).length;
+
+            if (importedCount > selectable) {
+              report(
+                `SELECT-ALL CONSISTENCY: ${filter} would import ${importedCount} hosts from a group offering ${selectable} checkboxes`,
+              );
+            }
+
+            const readsFull: boolean = areAllShownHostsSelected({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+
+            if (
+              readsFull !== (selectable > 0 && importedCount === selectable)
+            ) {
+              report(
+                `SELECT-ALL CONSISTENCY: ${filter} reads "${String(readsFull)}" for fully-selected with ${importedCount} of ${selectable} ticked`,
+              );
+            }
+          });
+        },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the rules keep their hands off React's state, over every generated scan", () => {
+  test("no rule mutates the scan or the selection it was handed", () => {
+    /*
+     * All of these read straight out of React state. A rule that wrote back
+     * into `discoveredDevices` or into the selection record would mutate state
+     * in place, so the next render would compare equal to itself and skip — the
+     * dialog would simply stop updating, with nothing in the console.
+     */
+    expect(
+      findViolations(
+        (scan: GeneratedScan, report: (problem: string) => void): void => {
+          const hostsBefore: string = JSON.stringify(scan.hosts);
+          const rowsBefore: Array<DiscoveredNetworkDevice> = [...scan.hosts];
+          const selectionBefore: string = JSON.stringify(scan.selection);
+
+          FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+            countDiscoveredHosts(scan.hosts);
+            filterDiscoveredHosts({ hosts: scan.hosts, filter: filter });
+            getShownDiscoveredHosts({ hosts: scan.hosts, filter: filter });
+            countSelectableShownHosts({ hosts: scan.hosts, filter: filter });
+            getInitialSelection(scan.hosts);
+            getDiscoveredHostsToImport({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+            areAllShownHostsSelected({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+            toggleSelectionForShownHosts({
+              hosts: scan.hosts,
+              filter: filter,
+              selectedIpAddresses: scan.selection,
+            });
+            markDiscoveredHostsAsRegistered({
+              hosts: scan.hosts,
+              importedIpAddresses: new Set<string>(addressesOf(scan.hosts)),
+            });
+          });
+
+          if (JSON.stringify(scan.hosts) !== hostsBefore) {
+            report("PURITY: the scan's rows were changed in place");
+          }
+
+          if (JSON.stringify(scan.selection) !== selectionBefore) {
+            report("PURITY: the selection record was written to");
+          }
+
+          /*
+           * Value equality alone would not notice rows being reordered into the
+           * same multiset, or replaced by equal-valued copies — both of which
+           * break identity-based React keys just as badly.
+           */
+          if (!sameRows(scan.hosts, rowsBefore)) {
+            report(
+              "PURITY: the scan's array was reordered or its rows swapped",
+            );
+          }
+        },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the corpus these laws are checked against", () => {
+  test("really contains every shape the laws are about", () => {
+    /*
+     * The one way a property suite lies: if the generator drifted — a changed
+     * seed table, a tweaked probability, a `size` that accidentally became zero
+     * — every law above would still pass, vacuously, over scans containing none
+     * of the shapes the rules exist for. This asserts the corpus covers them, so
+     * that a green run above means something.
+     */
+    const shapes: Record<string, number> = {};
+
+    const record: (shape: string) => void = (shape: string): void => {
+      shapes[shape] = (shapes[shape] || 0) + 1;
+    };
+
+    CORPUS.forEach((scan: GeneratedScan): void => {
+      if (scan.hosts.length === 0) {
+        record("an empty scan");
+      }
+
+      if (scan.hosts.length >= 20) {
+        record("a scan with 20+ hosts");
+      }
+
+      const seen: Set<string> = new Set<string>();
+
+      scan.hosts.forEach((host: DiscoveredNetworkDevice): void => {
+        if (host.snmpReachable === undefined) {
+          record("a legacy row with no snmpReachable");
+        }
+
+        if (host.snmpReachable === true) {
+          record("an SNMP responder");
+        }
+
+        if (host.snmpReachable === false) {
+          record("a ping-only host");
+        }
+
+        if (host.ipAddress === "") {
+          record("a blank address");
+        }
+
+        if (host.isAlreadyRegistered === true) {
+          record("an already-registered host");
+        }
+
+        if (host.ipAddress !== "" && seen.has(host.ipAddress)) {
+          record("a duplicated address");
+        }
+
+        seen.add(host.ipAddress);
+      });
+
+      const snmpAddresses: Set<string> = selectableAddressesShown({
+        hosts: scan.hosts,
+        filter: DiscoveredHostFilter.Snmp,
+      });
+      const noSnmpAddresses: Set<string> = selectableAddressesShown({
+        hosts: scan.hosts,
+        filter: DiscoveredHostFilter.NoSnmp,
+      });
+
+      if (
+        Array.from(snmpAddresses).some((address: string) => {
+          return noSnmpAddresses.has(address);
+        })
+      ) {
+        record("one address in both groups");
+      }
+
+      FILTERS.forEach((filter: DiscoveredHostFilter): void => {
+        const selectable: number = countSelectableShownHosts({
+          hosts: scan.hosts,
+          filter: filter,
+        });
+
+        if (selectable === 0) {
+          record("a group with nothing selectable");
+
+          return;
+        }
+
+        const importedCount: number = importAddresses({
+          hosts: scan.hosts,
+          filter: filter,
+          selectedIpAddresses: scan.selection,
+        }).length;
+
+        if (importedCount === selectable) {
+          record("a fully selected group");
+        } else if (importedCount === 0) {
+          record("a group with nothing ticked");
+        } else {
+          record("a partly selected group");
+        }
+      });
+    });
+
+    const requiredShapes: Array<string> = [
+      "an empty scan",
+      "a scan with 20+ hosts",
+      "a legacy row with no snmpReachable",
+      "an SNMP responder",
+      "a ping-only host",
+      "a blank address",
+      "an already-registered host",
+      "a duplicated address",
+      "one address in both groups",
+      "a group with nothing selectable",
+      "a fully selected group",
+      "a group with nothing ticked",
+      "a partly selected group",
+    ];
+
+    expect(
+      requiredShapes.filter((shape: string) => {
+        return (shapes[shape] || 0) === 0;
+      }),
+    ).toEqual([]);
+
+    // Enough scans that the laws are exercised rather than sampled.
+    expect(CORPUS.length).toBe(SEEDS.length * SCANS_PER_SEED);
+    expect(CORPUS.length).toBeGreaterThanOrEqual(300);
+  });
+});


### PR DESCRIPTION
Follow-up to #3322 / #3324 (merged). An adversarial review of that PR confirmed eight findings, three of them real defects it introduced. This fixes those, plus six more the new test suites turned up, and replaces the coverage that could not have caught any of them.

## Defects the filter introduced

**"No No SNMP hosts in this scan."** The empty-group message was built as `` `No ${getDiscoveredHostFilterLabel(filter)} hosts…` ``, and the No SNMP label already starts with "No". One click away on any all-SNMP sweep — including every scan written by a probe predating the ping-only feature. Empty-state wording now comes from a dedicated `getDiscoveredHostFilterEmptyMessage` instead of a sentence frame wrapped around a button label.

**Every row remounted on a filter click.** Rows were keyed by their index in the *filtered* list, so almost every key changed when the filter did. `CheckboxElement` seeds its checked state from `initialValue` and only reconciles `value` in a passive effect, so each remounted row painted **unticked** for a frame: on a 5,756-host scan the operator's entire selection appeared to blank out and snap back — in a dialog whose only job is deciding what is ticked. Rows now carry their position in the unfiltered scan (`ShownDiscoveredHost`) and pass `initialValue` alongside `value`.

**An import could outlive its dialog and write to a different one.** The tail of `importSelectedDevices` ran after minutes of sequential `ModelAPI.create` calls and wrote shared page state with no check that the dialog was still the same one — and Cancel/X/Escape/backdrop are all ungated on `isLoading`. A run started on scan A could push its errors onto scan B, close scan B's dialog, or mark scan B's same-addressed hosts "Already added" (disabled, unticked, silently skipped by Import). The imported-address record is now keyed by scan id and merged functionally; the error and close writes are gated on a scan-id ref.

**The close gate counted the wrong thing.** It tested how many hosts were still *selectable*, so importing everything after deliberately unticking one host left the dialog open on a disabled "Import Selected (0)" with nothing left to do in it. It now tests what is still *selected*.

## Defects in the surrounding code, found by the new suites

- A `null` element in the `discoveredDevices` jsonb threw a `TypeError` **inside the modal body during render**, on the operator's first filter click. Nothing on the read path checked element shape — only that the column held an array.
- A probe-supplied address spelling an `Object.prototype` key (`"constructor"`, `"toString"`) resolved through the prototype chain to a truthy function and **imported without anyone ticking it**. Selection lookups now require an own property; the same guard covers the per-scan store.
- A numeric address was recorded as the string `"10"` but matched back with `Set.has(10)`, so an imported host could never be retired and re-importing duplicated it.
- A whitespace-only address passed selectability and imported as a device named `" "`.
- The same address on two rows with different frozen `isAlreadyRegistered` values imported or not depending purely on payload order.
- An unrecognised filter value showed only the SNMP group while labelling itself "All" — the fall-through now shows everything.

The first five are settled once, in `normalizeDiscoveredHosts`, which every count, row and import path reads through, so they cannot end up working from different readings of the same payload. The per-scan imported-address record also outlives the dialog now, so closing and reopening a scan no longer resurrects what was just imported.

## Tests

**250 across ten suites, up from 91.** Six new files:

| Suite | What it pins |
|---|---|
| `DiscoveryImportScoping` | `getDiscoveredHostsToImport` against hand-written literals only — partial selections, stale ticks, duplicates (including one address in both groups), the group partition, import order, and the issue's own 2,866 / 2,890 scale |
| `DiscoverySelectionProperties` | 15 laws over 360 generated scans (seeded LCG, no `Math.random`) — partition, count agreement, import-subset, monotonicity, toggle alternation and locality, key stability, purity — plus a meta-test that the corpus really contains all 13 shapes the laws are about |
| `DiscoveryImportedHostRetirement` | The per-scan record and the duplicate-import footgun it closes, including cross-scan isolation and the two-pass and reopen flows |
| `DiscoveryReviewCopy` | Every user-visible string, including a doubled-negation check that would have caught "No No SNMP" |
| `DiscoveryReviewLifecycleInvariants` | The close gate, the stale-run guard, the per-scan overlay and row identity, at source level |
| `DiscoveredHostFilterEdgeCases` | Hostile jsonb — nullish rows, wire-format `snmpReachable: "false"`, prototype-named addresses, numeric and whitespace addresses, unknown filters |

The existing invariant suite was rewritten: its assertions were shown to survive mutants that swapped the Select all / Clear all arms, negated the badge predicate, and dropped the filter from the submit-button count. Every source-level slice now asserts its markers exist first — an unguarded `indexOf` returning `-1` silently turns an assertion into a check against the whole file or an empty string, which is how source-level tests rot into passing for the wrong reason.

**Verified by mutation, not by assertion count: 30 mutations of the implementation, 30 killed.** They cover dropping each guard in the import path, swapping filter branches, inverting the empty-group check, removing the thousands separator, making a pure function mutate its input, reverting the row key, dropping `initialValue` and `ariaLabel`, and re-clearing the imported store on open.

## One number, two screens

The scans table renders "+N alive without SNMP" and the dialog's filter row renders "No SNMP (N)". They describe the same set of hosts, one click apart, and each decided membership with its own copy of the rule — so an operator reading 12 on the table and 9 on the badge had nothing to tell them which was wrong. `countPingOnlyHosts` now asks the same `isPingOnlyDiscoveredHost` the badge does.

That also closes the null-element crash on the *other* surface: the bare `host.snmpReachable` it replaced threw a `TypeError` from inside a scans-table cell, on the very page you reach the dialog from.

## Also

- Per-row checkboxes now carry an accessible name, and disabled ones a reason — `Checkbox.tsx` documents both props for exactly this case and neither was passed.
- The row's checkbox now uses the shared `isSelectableDiscoveredHost` rather than its own copy of the rule, which had already drifted (a blank-address row rendered an enabled checkbox no count agreed existed).

## Verification

`App/Tests/Dashboard`: 176 suites / 6,143 tests green. eslint clean on everything touched. `tsc` reports no new errors — the one it does report (`js-yaml` types in `Common/Utils/SecurityEvent/Sigma/SigmaRuleParser.ts`) reproduces on a clean tree.

**Not verified in a running browser**, same as #3324: exercising this needs a probe that has actually swept a subnet and a completed scan with results. Two things stay explicitly out of scope and unfixed: the host list is still unvirtualized (the filter narrows it, but the dialog still opens on All), and `FilterButtons` is not a conforming radiogroup — it renders `role="radio"` children with no roving tabindex and a hardcoded `aria-label`, which is a pre-existing limitation of the shared component and affects its three other callers.

