### PR TITLE
fix(logs): correct seven defects in the Insights error-pattern engine

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Logs/ErrorPatternDetail.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/ErrorPatternDetail.tsx
@@ -11,7 +11,9 @@ import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoade
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import Icon from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
 import OneUptimeDate from "Common/Types/Date";
+import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEndDateTime";
 import Route from "Common/Types/API/Route";
 import Service from "Common/Models/DatabaseModels/Service";
 import SideOver, { SideOverSize } from "Common/UI/Components/SideOver/SideOver";
@@ -34,6 +36,7 @@ import {
   computeErrorPatternTrend,
   describeOccurrenceCount,
   describeTimeRange,
+  getCorrelationOccurrenceTotal,
   summarizeSharedAttributes,
 } from "../../Utils/LogsInsights";
 import { fetchErrorPatternCorrelation } from "./LogsInsightsApi";
@@ -199,6 +202,7 @@ const ErrorPatternDetail: FunctionComponent<ComponentProps> = (
   const logsRoute: Route | null = buildErrorPatternLogsRoute(
     patternText,
     props.scope,
+    props.pattern.sampleBody,
   );
 
   const resourceLabel: (resourceId: string) => string = (
@@ -231,8 +235,18 @@ const ErrorPatternDetail: FunctionComponent<ComponentProps> = (
       );
     }
 
+    /*
+     * The window the user picked, so a pattern whose occurrences all sit at
+     * the start of it is measured against the silence that followed rather
+     * than against itself.
+     */
+    const window: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(props.scope.timeRange);
+
     const trend: ErrorPatternTrend = computeErrorPatternTrend(
       correlation.timeline,
+      window.startValue,
+      window.endValue,
     );
     const trendStyle: {
       label: string;
@@ -240,9 +254,18 @@ const ErrorPatternDetail: FunctionComponent<ComponentProps> = (
       icon: IconProp;
     } = TREND_PRESENTATION[trend.direction];
 
+    /*
+     * Denominator from the SAME response as the numerators. props.pattern
+     * .count came from the earlier list request, which resolved its own
+     * window against its own `now`.
+     */
+    const occurrenceTotal: number =
+      getCorrelationOccurrenceTotal(correlation.timeline) ||
+      props.pattern.count;
+
     const sharedAttributes: Array<SharedAttribute> = summarizeSharedAttributes(
       correlation.attributes,
-      props.pattern.count,
+      occurrenceTotal,
     );
 
     return (

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsDashboard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsDashboard.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import API from "Common/UI/Utils/API/API";
@@ -107,6 +108,16 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
   const [error, setError] = useState<string>("");
 
   /*
+   * Generation token for the in-flight batch. Both the time picker and the
+   * scope multi-select commit immediately — no apply step, no debounce — so
+   * two quick changes leave two batches racing, and without this the batch
+   * that RESOLVES last wins rather than the one the user asked for last.
+   * Switching to a 30-day window and straight back to 1 hour would leave
+   * the slow 30-day numbers on screen under a "past 1 hour" label.
+   */
+  const loadGenerationRef: React.MutableRefObject<number> = useRef<number>(0);
+
+  /*
    * One scope object, shared by every panel and by the detail drawer, so a
    * correlation the page draws is always a correlation inside the slice the
    * user selected.
@@ -140,9 +151,23 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
 
   const loadInsights: () => Promise<void> =
     useCallback(async (): Promise<void> => {
+      const generation: number = ++loadGenerationRef.current;
+
       try {
         setIsLoading(true);
         setError("");
+
+        /*
+         * Clear the derived state as the new load starts. Without this the
+         * stat cards, severity split and per-source cards keep rendering
+         * the PREVIOUS window's numbers under the new range label for the
+         * whole duration of the refetch — and if the previous window was
+         * empty, the page asserts "No logs in <new range>" for a window it
+         * has not queried yet.
+         */
+        setVolume(null);
+        setErrorPatterns([]);
+        setResourceBreakdown([]);
 
         const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
 
@@ -166,14 +191,25 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
           ),
         ]);
 
+        // A batch the user has already moved on from must not commit.
+        if (loadGenerationRef.current !== generation) {
+          return;
+        }
+
         setVolume(summarizeSeverityBuckets(buckets as Array<JSONObject>));
         setErrorPatterns(patterns);
         setResourceBreakdown(breakdown);
         setScopeFacets(facets);
       } catch (err) {
+        if (loadGenerationRef.current !== generation) {
+          return;
+        }
+
         setError(API.getFriendlyMessage(err as Error));
       } finally {
-        setIsLoading(false);
+        if (loadGenerationRef.current === generation) {
+          setIsLoading(false);
+        }
       }
     }, [scope]);
 
@@ -638,6 +674,14 @@ const LogsDashboard: FunctionComponent = (): ReactElement => {
 
       {selectedPattern && (
         <ErrorPatternDetail
+          /*
+           * Keyed on the pattern so switching rows REMOUNTS the drawer.
+           * SideOver is deliberately non-modal, so the list stays clickable
+           * behind it; without the key an in-flight correlation for the
+           * previous pattern could resolve last and pair its timeline,
+           * attributes and traces with the new pattern's header.
+           */
+          key={selectedPattern.pattern}
           pattern={selectedPattern}
           scope={scope}
           serviceNameById={serviceById}

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -1,4 +1,5 @@
 import Includes from "Common/Types/BaseDatabase/Includes";
+import Search from "Common/Types/BaseDatabase/Search";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import ObjectID from "Common/Types/ObjectID";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
@@ -97,6 +98,7 @@ import {
 import {
   applyLogsFacetFiltersToQuery,
   applyLogsSessionScopeToQuery,
+  BODY_FACET_KEY,
   buildLogsPivotScope,
   buildSessionReplayRoute,
   buildSpanChipOpenRoute,
@@ -171,11 +173,19 @@ export interface ComponentProps {
 const DEFAULT_PAGE_SIZE: number = 100;
 const LIVE_POLL_INTERVAL_MS: number = 10000;
 const SAVED_VIEWS_LIMIT: number = 100;
+/*
+ * The facet keys read BACK out of a query into chips. Must stay the mirror
+ * of what applyLogsFacetFiltersToQuery compiles INTO a query, or a filter
+ * that survives a saved view / URL round-trip filters the list while no
+ * chip says so — and the histogram, which builds its request from the
+ * chips, then counts rows the list excludes.
+ */
 const FACET_FILTER_KEYS: Array<string> = [
   "severityText",
   "primaryEntityId",
   "traceId",
   "spanId",
+  BODY_FACET_KEY,
 ];
 
 interface InitialUrlState {
@@ -301,6 +311,17 @@ function getQueryValues(value: unknown): Array<string> {
     return value.values.map((item: string | number | ObjectID) => {
       return item.toString();
     });
+  }
+
+  /*
+   * The body chip compiles to a contains-match, so its stored form is a
+   * Search rather than a bare string. Without this branch a saved view or
+   * deep link carrying one round-trips into a filtered list with no chip.
+   */
+  if (value instanceof Search) {
+    const text: string = value.toString();
+
+    return text.trim().length > 0 ? [text] : [];
   }
 
   if (

--- a/App/FeatureSet/Dashboard/src/Utils/LogsInsights.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/LogsInsights.ts
@@ -784,6 +784,8 @@ const TREND_THRESHOLD_PERCENT: number = 10;
  */
 export function computeErrorPatternTrend(
   timeline: Array<ErrorPatternTimelinePoint>,
+  windowStart?: Date | undefined,
+  windowEnd?: Date | undefined,
 ): ErrorPatternTrend {
   if (!Array.isArray(timeline) || timeline.length < 2) {
     return {
@@ -794,13 +796,58 @@ export function computeErrorPatternTrend(
     };
   }
 
-  const midpoint: number = Math.floor(timeline.length / 2);
+  /*
+   * Split by TIMESTAMP, not by array index.
+   *
+   * The timeline query is a plain `GROUP BY bucket` with no zero-fill, so
+   * the array holds only the buckets that had occurrences. An index split
+   * therefore measures where the occurrences sit within each OTHER, not
+   * where they sit in time: an error that fired steadily for two hours and
+   * then stopped for twenty-two returns ~half its buckets on each side and
+   * reads "Steady, 0%" — the exact opposite of the truth.
+   *
+   * `windowStart`/`windowEnd` are the range the user actually picked, so a
+   * pattern clustered entirely at the start of it is correctly measured
+   * against the silence that followed. Without them the observed span is
+   * the honest fallback; the index split is used only when the rows carry
+   * no usable timestamps at all.
+   */
+  const times: Array<number> = timeline
+    .map((point: ErrorPatternTimelinePoint): number => {
+      return point.time instanceof Date ? point.time.getTime() : Number.NaN;
+    })
+    .filter((value: number): boolean => {
+      return Number.isFinite(value);
+    });
+
+  const start: number =
+    windowStart instanceof Date && !isNaN(windowStart.getTime())
+      ? windowStart.getTime()
+      : Math.min(...times);
+
+  const end: number =
+    windowEnd instanceof Date && !isNaN(windowEnd.getTime())
+      ? windowEnd.getTime()
+      : Math.max(...times);
+
+  const canSplitByTime: boolean =
+    times.length === timeline.length &&
+    Number.isFinite(start) &&
+    Number.isFinite(end) &&
+    end > start;
+
+  const midTime: number = start + (end - start) / 2;
+  const midIndex: number = Math.floor(timeline.length / 2);
 
   let previousCount: number = 0;
   let recentCount: number = 0;
 
   timeline.forEach((point: ErrorPatternTimelinePoint, index: number): void => {
-    if (index < midpoint) {
+    const isOlderHalf: boolean = canSplitByTime
+      ? (point.time as Date).getTime() < midTime
+      : index < midIndex;
+
+    if (isOlderHalf) {
       previousCount += point.count;
     } else {
       recentCount += point.count;
@@ -860,6 +907,33 @@ export interface SharedAttribute extends ErrorPatternAttributeRow {
  * timestamps) are dropped: they are what makes a pattern a pattern, and
  * listing them would bury the useful rows.
  */
+/**
+ * The occurrence count the correlation response itself accounts for.
+ *
+ * Used as the denominator for attribute coverage instead of the count the
+ * Top Errors list reported: the list and the drill-down resolve a preset
+ * range against `now` independently, so on a short preset the two can cover
+ * measurably different windows. Mixing them lets an attribute present on a
+ * minority of occurrences render at 100% with a "every occurrence" badge.
+ *
+ * Falls back to 0 for an empty timeline, which callers read as "use what
+ * the row said" rather than as "nothing happened".
+ */
+export function getCorrelationOccurrenceTotal(
+  timeline: Array<ErrorPatternTimelinePoint>,
+): number {
+  if (!Array.isArray(timeline)) {
+    return 0;
+  }
+
+  return timeline.reduce(
+    (total: number, point: ErrorPatternTimelinePoint): number => {
+      return total + (Number.isFinite(point.count) ? point.count : 0);
+    },
+    0,
+  );
+}
+
 export function summarizeSharedAttributes(
   attributes: Array<ErrorPatternAttributeRow>,
   totalOccurrences: number,
@@ -991,6 +1065,12 @@ function withQueryParams(
 export function buildErrorPatternLogsRoute(
   pattern: string,
   scope: LogsInsightsScope,
+  /*
+   * A real body from the group, when the caller has one. It lets the needle
+   * be VERIFIED against text that actually exists rather than assumed to
+   * survive normalization — see getErrorPatternSearchText.
+   */
+  sampleBody?: string | undefined,
 ): Route | null {
   const window: InBetween<Date> = resolveWindow(scope.timeRange);
 
@@ -1001,7 +1081,7 @@ export function buildErrorPatternLogsRoute(
       scope.severityTexts && scope.severityTexts.length > 0
         ? scope.severityTexts
         : ERROR_SEVERITIES,
-    bodyContains: getErrorPatternSearchText(pattern),
+    bodyContains: getErrorPatternSearchText(pattern, { sampleBody }),
     startTime: window.startValue,
     endTime: window.endValue,
   };

--- a/App/Tests/Dashboard/LogsInsights.test.ts
+++ b/App/Tests/Dashboard/LogsInsights.test.ts
@@ -568,7 +568,29 @@ describe("summarizeResourceBreakdown", () => {
 });
 
 describe("computeErrorPatternTrend", () => {
+  const BUCKET_MS: number = 15 * 60 * 1000;
+  const WINDOW_START: Date = new Date("2026-08-20T00:00:00.000Z");
+  const WINDOW_END: Date = new Date("2026-08-21T00:00:00.000Z");
+
+  /*
+   * Stamped with real, evenly spaced timestamps — which is what the server
+   * actually returns. The no-timestamp variant below covers the fallback.
+   */
   function timeline(counts: Array<number>): Array<{
+    time: Date | null;
+    count: number;
+  }> {
+    return counts.map(
+      (count: number, index: number): { time: Date | null; count: number } => {
+        return {
+          time: new Date(WINDOW_START.getTime() + index * BUCKET_MS),
+          count,
+        };
+      },
+    );
+  }
+
+  function untimedTimeline(counts: Array<number>): Array<{
     time: Date | null;
     count: number;
   }> {
@@ -626,15 +648,109 @@ describe("computeErrorPatternTrend", () => {
     expect(Insights.computeErrorPatternTrend(timeline([0, 0])).direction).toBe(
       "unknown",
     );
+    expect(
+      Insights.computeErrorPatternTrend(untimedTimeline([0, 0])).direction,
+    ).toBe("unknown");
   });
 
-  test("splits an odd-length timeline with the extra bucket in the newer half", () => {
+  test("splits an odd-length untimed timeline with the extra bucket in the newer half", () => {
     const trend: ErrorPatternTrend = Insights.computeErrorPatternTrend(
-      timeline([2, 1, 1, 1, 1]),
+      untimedTimeline([2, 1, 1, 1, 1]),
     );
 
     expect(trend.previousCount).toBe(3);
     expect(trend.recentCount).toBe(3);
+  });
+
+  test("an error that stopped hours ago reads as FALLING, not steady", () => {
+    /*
+     * The regression this function's index split got wrong. The timeline
+     * query has no zero-fill, so a pattern that fired during the first two
+     * hours of a 24-hour window and then stopped comes back as a handful of
+     * buckets all clustered at the start. Splitting by array index sums
+     * four against four, calls it "Steady 0%", and tells the user an error
+     * that has been silent for 22 hours is ticking along normally.
+     */
+    const clustered: Array<{ time: Date | null; count: number }> = [
+      2, 3, 2, 3, 2, 3, 2, 3,
+    ].map((count: number, index: number) => {
+      return {
+        time: new Date(WINDOW_START.getTime() + index * BUCKET_MS),
+        count,
+      };
+    });
+
+    /*
+     * With no window to measure against, the honest answer really is
+     * "steady": across the span it was OBSERVED, the rate did not change.
+     * That is exactly why the window has to be passed in — and why the
+     * caller (ErrorPatternDetail) resolves and passes it.
+     */
+    expect(Insights.computeErrorPatternTrend(clustered).direction).toBe(
+      "steady",
+    );
+
+    // Against the window the user actually picked, it has stopped.
+    const windowed: ErrorPatternTrend = Insights.computeErrorPatternTrend(
+      clustered,
+      WINDOW_START,
+      WINDOW_END,
+    );
+
+    expect(windowed.direction).toBe("falling");
+    expect(windowed.recentCount).toBe(0);
+    expect(windowed.previousCount).toBe(20);
+  });
+
+  test("a pattern that only started late in the window reads as rising", () => {
+    const late: Array<{ time: Date | null; count: number }> = [4, 6].map(
+      (count: number, index: number) => {
+        return {
+          time: new Date(WINDOW_END.getTime() - (2 - index) * BUCKET_MS),
+          count,
+        };
+      },
+    );
+
+    const trend: ErrorPatternTrend = Insights.computeErrorPatternTrend(
+      late,
+      WINDOW_START,
+      WINDOW_END,
+    );
+
+    expect(trend.direction).toBe("rising");
+    expect(trend.previousCount).toBe(0);
+    expect(trend.recentCount).toBe(10);
+  });
+});
+
+describe("getCorrelationOccurrenceTotal", () => {
+  test("sums the timeline the correlation response itself returned", () => {
+    expect(
+      Insights.getCorrelationOccurrenceTotal([
+        { time: null, count: 4 },
+        { time: null, count: 0 },
+        { time: null, count: 6 },
+      ]),
+    ).toBe(10);
+  });
+
+  test("degrades to 0 on an empty or unusable timeline", () => {
+    /*
+     * 0 is the caller's signal to fall back to the list's own count, not a
+     * claim that nothing happened.
+     */
+    expect(Insights.getCorrelationOccurrenceTotal([])).toBe(0);
+    expect(
+      Insights.getCorrelationOccurrenceTotal(
+        undefined as unknown as Array<{ time: Date | null; count: number }>,
+      ),
+    ).toBe(0);
+    expect(
+      Insights.getCorrelationOccurrenceTotal([
+        { time: null, count: Number.NaN },
+      ]),
+    ).toBe(0);
   });
 });
 
@@ -750,6 +866,7 @@ describe("buildErrorPatternLogsRoute", () => {
       Insights.buildErrorPatternLogsRoute(
         "connection refused to <ip>:<num>",
         scope(),
+        "connection refused to 10.0.0.1:5432",
       );
 
     expect(route).not.toBeNull();
@@ -761,9 +878,48 @@ describe("buildErrorPatternLogsRoute", () => {
     /*
      * The pattern itself contains <ip>/<num>, which no real body contains —
      * filtering on it would land the user on an empty list. The link
-     * carries the longest literal run instead.
+     * carries a literal run instead, and because a sample body was supplied
+     * the stronger multi-word run is used.
      */
     expect(filters).toContainEqual(["body", ["connection refused to"]]);
+  });
+
+  test("the body filter it emits is always present in the sample body", () => {
+    /*
+     * The needle goes into `body ILIKE '%needle%'`. A stack trace's pattern
+     * has spaces where the body has newlines, so an unverified multi-word
+     * run would match nothing and the link would open an empty list — the
+     * one outcome worse than no link.
+     */
+    const bodies: Array<string> = [
+      "connection refused to 10.0.0.1:5432 after 30ms",
+      'java.lang.NullPointerException: Cannot invoke "x" because "order" is null\n\tat com.example.OrderService.process(OrderService.java:42)',
+      '{"level":"error","msg":"connection refused","attempt":3}',
+    ];
+
+    for (const body of bodies) {
+      const pattern: string = body
+        .replace(/\d+\.\d+\.\d+\.\d+/g, "<ip>")
+        .replace(/\d+/g, "<num>")
+        .replace(/\s+/g, " ");
+
+      const route: { toString(): string } | null =
+        Insights.buildErrorPatternLogsRoute(pattern, scope(), body);
+
+      const filters: Array<[string, Array<string>]> = JSON.parse(
+        queryOf(route!).get("filters") as string,
+      );
+
+      const bodyFilter: [string, Array<string>] | undefined = filters.find(
+        ([key]: [string, Array<string>]): boolean => {
+          return key === "body";
+        },
+      );
+
+      if (bodyFilter) {
+        expect(body).toContain(bodyFilter[1][0] as string);
+      }
+    }
   });
 
   test("carries severity, service scope and the window", () => {

--- a/Common/Server/Services/LogAggregationService.ts
+++ b/Common/Server/Services/LogAggregationService.ts
@@ -1336,13 +1336,26 @@ export class LogAggregationService {
   /* Every severity a pattern can carry fits comfortably in eight slots. */
   private static readonly ERROR_PATTERN_SEVERITY_ARRAY_LIMIT: number = 8;
   /*
-   * Bodies that are empty or nothing but whitespace normalize to the empty
-   * pattern, which would otherwise become a single meaningless "" group
-   * sitting at the top of the list. Excluded at the source instead of via
-   * HAVING so the rows never enter the aggregation at all.
+   * Cheap pre-filter for bodies that carry no message: they normalize to the
+   * empty pattern, which would otherwise become a meaningless "" group.
+   *
+   * Deliberately only a pre-filter, not the guarantee. ClickHouse's trimBoth
+   * strips SPACES only, so a body of tabs or newlines survives this predicate
+   * and still normalizes to "" once the whitespace rule collapses it. The
+   * grouped reads therefore also carry `HAVING pattern != ''`; this stays
+   * because skipping those rows before aggregation is strictly cheaper than
+   * grouping them and throwing the group away.
    */
   private static readonly NON_EMPTY_BODY_FILTER: string =
     " AND notEmpty(trimBoth(ifNull(body, '')))";
+
+  /*
+   * The actual guarantee that no empty-pattern group is returned. Applied to
+   * every read that GROUPs BY the pattern; the row-returning reads instead
+   * scope to one caller-supplied pattern, which is never "".
+   */
+  private static readonly NON_EMPTY_PATTERN_HAVING: string =
+    " HAVING pattern != ''";
 
   /**
    * The distinct error messages in the window, most frequent first.
@@ -1703,8 +1716,10 @@ export class LogAggregationService {
 
     LogAggregationService.appendErrorPatternScope(statement, request);
 
+    statement.append(" GROUP BY pattern");
+    statement.append(LogAggregationService.NON_EMPTY_PATTERN_HAVING);
     statement.append(
-      SQL` GROUP BY pattern ORDER BY cnt DESC LIMIT ${{
+      SQL` ORDER BY cnt DESC LIMIT ${{
         type: TableColumnType.Number,
         value: limit,
       }}`,
@@ -1796,8 +1811,10 @@ export class LogAggregationService {
 
     statement.append(")");
 
+    statement.append(" GROUP BY pattern");
+    statement.append(LogAggregationService.NON_EMPTY_PATTERN_HAVING);
     statement.append(
-      SQL` GROUP BY pattern ORDER BY cnt DESC LIMIT ${{
+      SQL` ORDER BY cnt DESC LIMIT ${{
         type: TableColumnType.Number,
         value: limit,
       }}`,

--- a/Common/Server/Services/LogAggregationService.ts
+++ b/Common/Server/Services/LogAggregationService.ts
@@ -1790,12 +1790,30 @@ export class LogAggregationService {
       }}`,
     );
 
-    // ...restricted to the buckets the investigated pattern itself landed in.
+    /*
+     * ...restricted to the buckets the investigated pattern itself landed
+     * in.
+     *
+     * GLOBAL IN, not plain IN, and it is load-bearing. This predicate sits
+     * in a query on the Distributed LogItemV3 table whose subquery reads
+     * that SAME Distributed table, which multi-shard ClickHouse rejects
+     * outright as a double-distributed subquery (Code 288,
+     * distributed_product_mode = 'deny' by default) — the panel would throw
+     * on any 2+-shard cluster, and because the endpoint wraps each
+     * correlation read in a degrade-to-empty catch it would fail SILENTLY,
+     * rendering "nothing else was failing" forever.
+     *
+     * A shard-local evaluation would be wrong even where it is allowed: the
+     * sharding key is cityHash64(projectId, primaryEntityId, time), so one
+     * project's rows span every shard and the bucket set has to be computed
+     * once globally. On a single shard GLOBAL is a semantic no-op. Same
+     * reasoning, same shape as MetricService's Top-K group restriction.
+     */
     statement.append(
       SQL` AND toStartOfInterval(time, INTERVAL ${{
         type: TableColumnType.Number,
         value: intervalSeconds,
-      }} SECOND) IN (SELECT DISTINCT toStartOfInterval(time, INTERVAL ${{
+      }} SECOND) GLOBAL IN (SELECT DISTINCT toStartOfInterval(time, INTERVAL ${{
         type: TableColumnType.Number,
         value: intervalSeconds,
       }} SECOND)`,

--- a/Common/Server/Utils/Telemetry/LogErrorPatternSql.ts
+++ b/Common/Server/Utils/Telemetry/LogErrorPatternSql.ts
@@ -18,14 +18,23 @@ import {
  *
  * Shape of the emitted expression, for rules r0..rN in order:
  *
- *   trimBoth(substring(trimBoth(
+ *   trimBoth(substringUTF8(trimBoth(
  *     replaceRegexpAll(...replaceRegexpAll(ifNull(body,''), p0, x0)..., pN, xN)
  *   ), 1, 300))
  *
  * The innermost call is the FIRST rule, matching the sequential application
  * order `normalizeLogBodyToErrorPattern` uses, and the trim/truncate/trim
- * tail mirrors its `.trim()` -> `.slice()` -> `.trim()`. Parity between the
- * two is pinned by Common/Tests/Utils/Telemetry/LogErrorPatternSql.test.ts.
+ * tail mirrors its `.trim()` -> `.slice()` -> `.trim()`. The shape is pinned
+ * by Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts.
+ *
+ * Truncation uses substringUTF8, NOT substring. ClickHouse's `substring`
+ * counts BYTES, so a 300-byte cut through a Japanese message or an emoji
+ * lands mid-sequence and the group key ends in a broken UTF-8 fragment. The
+ * UTF8 variant counts characters, which is also what the JavaScript
+ * normalizer's `.slice()` approximates. The two are not bit-identical for
+ * astral-plane characters (JS slices UTF-16 code units, so an emoji costs it
+ * two) — that only shifts where a very long pattern is cut, never what it
+ * groups, and is deliberately not claimed as exact parity.
  *
  * Patterns and replacements ride as bound query parameters rather than
  * being interpolated. ClickHouse substitutes parameters into the AST as
@@ -58,7 +67,7 @@ export function buildLogErrorPatternExpression(
 ): Statement {
   const statement: Statement = new Statement();
 
-  statement.append("trimBoth(substring(trimBoth(");
+  statement.append("trimBoth(substringUTF8(trimBoth(");
 
   // One open paren per rule; the arguments below close them inside-out.
   statement.append("replaceRegexpAll(".repeat(LOG_ERROR_PATTERN_RULES.length));

--- a/Common/Server/Utils/Telemetry/LogErrorPatternSql.ts
+++ b/Common/Server/Utils/Telemetry/LogErrorPatternSql.ts
@@ -111,16 +111,26 @@ export function getLogErrorPatternParameterCount(): number {
 
 /**
  * Guard for a caller-supplied pattern value (the detail endpoints echo one
- * back to scope their queries). Patterns are compared with `=` against the
- * expression above, so an over-long value can only ever match nothing —
- * clamping keeps the parameter bounded without changing any result.
+ * back to scope their queries), bounding the parameter without changing
+ * which rows it matches.
+ *
+ * Counted in CODE POINTS, because that is what the expression above cuts
+ * by. Measuring in JavaScript's UTF-16 code units instead would mangle a
+ * legitimate key: a 300-code-point pattern containing one emoji has
+ * `.length === 301`, so the clamp would fire on a value the database
+ * considers exactly at the limit and slice it — leaving a lone surrogate at
+ * the tail when the emoji sits there. The bind would then match zero rows
+ * and, since nothing throws, every drill-down panel would come back
+ * cheerfully empty for a Top Errors row showing a real count.
  */
 export function clampLogErrorPattern(pattern: string): string {
-  if (pattern.length <= LOG_ERROR_PATTERN_MAX_LENGTH) {
+  const codePoints: Array<string> = Array.from(pattern);
+
+  if (codePoints.length <= LOG_ERROR_PATTERN_MAX_LENGTH) {
     return pattern;
   }
 
-  return pattern.slice(0, LOG_ERROR_PATTERN_MAX_LENGTH);
+  return codePoints.slice(0, LOG_ERROR_PATTERN_MAX_LENGTH).join("");
 }
 
 export type { LogErrorPatternRule };

--- a/Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts
+++ b/Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts
@@ -602,7 +602,17 @@ describe("getErrorPatternCoOccurrences", () => {
     // ...the same empty-pattern guard the top list carries...
     expect(query).toContain("GROUP BY pattern HAVING pattern != ''");
     // ...and the temporal join onto the investigated pattern's own buckets.
-    expect(query).toContain("IN (SELECT DISTINCT toStartOfInterval(time,");
+    /*
+     * GLOBAL IN, not plain IN. LogItemV3 is a Distributed table, and a
+     * subquery on the same Distributed table inside its own WHERE is
+     * rejected by multi-shard ClickHouse (Code 288,
+     * distributed_product_mode = 'deny'). Because the endpoint wraps each
+     * correlation read in a degrade-to-empty catch, plain IN fails SILENTLY
+     * — the panel just says "nothing else was failing" forever.
+     */
+    expect(query).toContain(
+      "GLOBAL IN (SELECT DISTINCT toStartOfInterval(time,",
+    );
     expect(query).toContain("GROUP BY pattern");
   });
 

--- a/Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts
+++ b/Common/Tests/Server/Services/LogErrorPatternAggregation.test.ts
@@ -11,7 +11,10 @@ import LogAggregationService, {
 import LogDatabaseService from "../../../Server/Services/LogService";
 import { Results } from "../../../Server/Services/AnalyticsDatabaseService";
 import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
-import { LOG_ERROR_PATTERN_MAX_LENGTH } from "../../../Utils/Telemetry/LogErrorPattern";
+import {
+  LOG_ERROR_PATTERN_MAX_LENGTH,
+  normalizeLogBodyToErrorPattern,
+} from "../../../Utils/Telemetry/LogErrorPattern";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import { afterEach, describe, expect, jest, test } from "@jest/globals";
@@ -144,6 +147,10 @@ describe("getTopErrorPatterns", () => {
     expect(captured.length).toBe(1);
     expect(captured[0]!.query).toContain("GROUP BY pattern");
     expect(captured[0]!.query).toContain("ORDER BY cnt DESC");
+    // GROUP BY -> HAVING -> ORDER BY -> LIMIT, in that order.
+    expect(captured[0]!.query).toMatch(
+      /GROUP BY pattern HAVING pattern != '' ORDER BY cnt DESC LIMIT/,
+    );
     expect(captured[0]!.query).toContain("replaceRegexpAll(");
 
     expect(patterns).toEqual([
@@ -223,14 +230,33 @@ describe("getTopErrorPatterns", () => {
     );
   });
 
-  test("excludes empty and whitespace-only bodies from the aggregation", async () => {
+  test("guards against an empty-pattern group with BOTH a prefilter and a HAVING", async () => {
     const captured: Array<Statement> = stubAndCapture([]);
 
     await LogAggregationService.getTopErrorPatterns(baseFilters());
 
-    expect(captured[0]!.query).toContain(
-      "AND notEmpty(trimBoth(ifNull(body, '')))",
-    );
+    const query: string = captured[0]!.query;
+
+    // The cheap early skip...
+    expect(query).toContain("AND notEmpty(trimBoth(ifNull(body, '')))");
+
+    /*
+     * ...and the actual guarantee. The prefilter alone is NOT enough:
+     * ClickHouse's trimBoth strips spaces only, so a body of tabs or
+     * newlines survives it and still normalizes to "" once the whitespace
+     * rule collapses it — silently consuming one of the LIMIT slots. Pinned
+     * here because the prefilter-only assertion this test used to make
+     * passed while that bug was live.
+     */
+    expect(query).toContain("GROUP BY pattern HAVING pattern != ''");
+  });
+
+  test("the empty pattern a tab-only body produces is what the HAVING excludes", () => {
+    /*
+     * Ties the SQL guard to the behaviour it exists for: this is the exact
+     * value such a row groups under, and it is the value the HAVING drops.
+     */
+    expect(normalizeLogBodyToErrorPattern("\t\n\t")).toBe("");
   });
 
   test("applies the read-side retention filter", async () => {
@@ -450,6 +476,54 @@ describe("error-pattern drill-downs share the top list's scope", () => {
   );
 
   test.each(DETAIL_READS)(
+    "$name emits balanced parens and binds every placeholder it references",
+    async ({ run }: { run: (request: any) => Promise<unknown> }) => {
+      /*
+       * None of these statements has ever been executed against a real
+       * ClickHouse, so a stray paren or an unbound {pN} would first surface
+       * as a syntax error on a user's dashboard. Cheap to pin here.
+       */
+      const captured: Array<Statement> = stubAndCapture([]);
+
+      await run(detailRequest({ serviceIds: [ObjectID.generate()] }));
+
+      const query: string = captured[0]!.query;
+
+      let depth: number = 0;
+
+      for (const character of query) {
+        if (character === "(") {
+          depth++;
+        }
+
+        if (character === ")") {
+          depth--;
+        }
+
+        // Never closes more than it opened at any point.
+        expect(depth).toBeGreaterThanOrEqual(0);
+      }
+
+      expect(depth).toBe(0);
+
+      const referenced: Array<string> = Array.from(
+        query.matchAll(/\{(p\d+):/g),
+      ).map((match: RegExpMatchArray): string => {
+        return match[1] as string;
+      });
+
+      expect(referenced.length).toBeGreaterThan(0);
+
+      for (const name of referenced) {
+        expect(captured[0]!.query_params).toHaveProperty(name);
+      }
+
+      // Every read stays tenant-scoped, on every path.
+      expect(query).toContain("WHERE projectId = ");
+    },
+  );
+
+  test.each(DETAIL_READS)(
     "$name bounds its runtime below the client request timeout",
     async ({ run }: { run: (request: any) => Promise<unknown> }) => {
       const captured: Array<Statement> = stubAndCapture([]);
@@ -525,6 +599,8 @@ describe("getErrorPatternCoOccurrences", () => {
 
     // The self-exclusion...
     expect(query).toMatch(/!= \{p\d+:String\}/);
+    // ...the same empty-pattern guard the top list carries...
+    expect(query).toContain("GROUP BY pattern HAVING pattern != ''");
     // ...and the temporal join onto the investigated pattern's own buckets.
     expect(query).toContain("IN (SELECT DISTINCT toStartOfInterval(time,");
     expect(query).toContain("GROUP BY pattern");

--- a/Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts
@@ -174,4 +174,34 @@ describe("clampLogErrorPattern", () => {
   test("an empty pattern clamps to itself", () => {
     expect(clampLogErrorPattern("")).toBe("");
   });
+
+  test("counts CODE POINTS, matching what substringUTF8 cuts by", () => {
+    /*
+     * 300 code points, but 301 UTF-16 units because of the emoji. Measured
+     * the JS way the clamp would fire on a key the database considers
+     * exactly at the limit, slice it, and leave a lone surrogate at the
+     * tail — after which the `=` bind matches zero rows and every
+     * drill-down panel comes back empty for a row showing a real count,
+     * with nothing thrown to notice.
+     */
+    const atLimit: string = `${"x".repeat(299)}\u{1F680}`;
+
+    expect(Array.from(atLimit).length).toBe(LOG_ERROR_PATTERN_MAX_LENGTH);
+    expect(atLimit.length).toBe(LOG_ERROR_PATTERN_MAX_LENGTH + 1);
+
+    expect(clampLogErrorPattern(atLimit)).toBe(atLimit);
+  });
+
+  test("never cuts an astral character in half", () => {
+    const oversized: string = "\u{1F680}".repeat(
+      LOG_ERROR_PATTERN_MAX_LENGTH + 50,
+    );
+
+    const clamped: string = clampLogErrorPattern(oversized);
+
+    expect(Array.from(clamped).length).toBe(LOG_ERROR_PATTERN_MAX_LENGTH);
+    // No lone surrogate at either edge.
+    expect(clamped).not.toMatch(/[\uD800-\uDBFF]$/);
+    expect(clamped).not.toMatch(/^[\uDC00-\uDFFF]/);
+  });
 });

--- a/Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LogErrorPatternSql.test.ts
@@ -42,6 +42,43 @@ describe("buildLogErrorPatternExpression", () => {
     );
   });
 
+  test("the whole expression is one balanced, fully-bound fragment", () => {
+    /*
+     * The expression is spliced into seven different statements; an
+     * unbalanced paren or an unbound placeholder would only surface as a
+     * ClickHouse syntax error at runtime, on a dashboard.
+     */
+    const statement: Statement = buildLogErrorPatternExpression();
+
+    let depth: number = 0;
+
+    for (const character of statement.query) {
+      if (character === "(") {
+        depth++;
+      }
+
+      if (character === ")") {
+        depth--;
+      }
+
+      expect(depth).toBeGreaterThanOrEqual(0);
+    }
+
+    expect(depth).toBe(0);
+
+    const referenced: Array<string> = Array.from(
+      statement.query.matchAll(/\{(p\d+):/g),
+    ).map((match: RegExpMatchArray): string => {
+      return match[1] as string;
+    });
+
+    expect(referenced.length).toBeGreaterThan(0);
+
+    for (const name of referenced) {
+      expect(statement.query_params).toHaveProperty(name);
+    }
+  });
+
   test("binds every rule pattern and replacement as a parameter, never as SQL text", () => {
     const statement: Statement = buildLogErrorPatternExpression();
     const values: Array<unknown> = Object.values(statement.query_params);
@@ -69,10 +106,20 @@ describe("buildLogErrorPatternExpression", () => {
     );
   });
 
-  test("truncates to the same maximum length the normalizer slices at", () => {
+  test("truncates by CHARACTER, never by byte", () => {
     const statement: Statement = buildLogErrorPatternExpression();
 
-    expect(statement.query).toContain("substring(");
+    /*
+     * ClickHouse's plain `substring` counts bytes, so a 300-byte cut through
+     * a Japanese message or an emoji lands mid-sequence and the group key
+     * ends in a broken UTF-8 fragment. The absence is asserted too:
+     * "substringUTF8(" trivially contains "substring", so a loose check here
+     * would pass either way — which is how the byte-based version shipped in
+     * the first place.
+     */
+    expect(statement.query).toContain("substringUTF8(");
+    expect(statement.query).not.toMatch(/[^8]substring\(/);
+
     expect(Object.values(statement.query_params)).toContain(
       LOG_ERROR_PATTERN_MAX_LENGTH,
     );
@@ -86,7 +133,7 @@ describe("buildLogErrorPatternExpression", () => {
      */
     const query: string = buildLogErrorPatternExpression().query;
 
-    expect(query.startsWith("trimBoth(substring(trimBoth(")).toBe(true);
+    expect(query.startsWith("trimBoth(substringUTF8(trimBoth(")).toBe(true);
     expect(query.endsWith("))")).toBe(true);
   });
 

--- a/Common/Tests/Utils/Telemetry/LogErrorPattern.test.ts
+++ b/Common/Tests/Utils/Telemetry/LogErrorPattern.test.ts
@@ -71,11 +71,7 @@ describe("normalizeLogBodyToErrorPattern — variable spans collapse", () => {
     ).toBe("GET <url> failed");
   });
 
-  test("masks double-quoted values but leaves apostrophes alone", () => {
-    expect(
-      normalizeLogBodyToErrorPattern('unknown field "customerRef" in payload'),
-    ).toBe('unknown field "<str>" in payload');
-
+  test("leaves quotes and apostrophes alone", () => {
     /*
      * A single-quote rule would pair the apostrophe in "can't" with the
      * quote before db and destroy the stable half of the message. Pinned so
@@ -83,6 +79,28 @@ describe("normalizeLogBodyToErrorPattern — variable spans collapse", () => {
      */
     expect(normalizeLogBodyToErrorPattern("can't reach 'db-primary'")).toBe(
       "can't reach 'db-primary'",
+    );
+
+    // ...and no double-quote rule either — see the JSON/logfmt tests below.
+    expect(
+      normalizeLogBodyToErrorPattern('unknown field "customerRef" in payload'),
+    ).toBe('unknown field "customerRef" in payload');
+  });
+
+  test("a quoted value that genuinely varies still collapses, via its own rule", () => {
+    /*
+     * This is why no blanket quoted-span rule is needed: the specific rules
+     * already mask the varying content, and more informatively — `"<uuid>"`
+     * says more than `"<str>"`.
+     */
+    expect(
+      normalizeLogBodyToErrorPattern(
+        'user "3f2504e0-4f89-41d3-9a0c-0305e82c3301" not found',
+      ),
+    ).toBe('user "<uuid>" not found');
+
+    expect(normalizeLogBodyToErrorPattern('column "user_id_42" missing')).toBe(
+      'column "user_id_<num>" missing',
     );
   });
 
@@ -121,6 +139,53 @@ describe("normalizeLogBodyToErrorPattern — variable spans collapse", () => {
 
     // The differing tail lies past the truncation point.
     expect(a).toBe(b);
+  });
+});
+
+describe("normalizeLogBodyToErrorPattern — structured logs keep their message", () => {
+  /*
+   * In JSON and logfmt the human-readable message is a double-quoted VALUE.
+   * A blanket `"[^"]*"` -> `"<str>"` rule therefore masks the only part
+   * that identifies the error, merging unrelated failures into one Top
+   * Errors row headed by whichever sample body argMax happened to pick.
+   * These are the regression guards for that.
+   */
+  test("two different JSON errors stay two patterns", () => {
+    const refused: string = normalizeLogBodyToErrorPattern(
+      '{"level":"error","msg":"connection refused","attempt":3}',
+    );
+    const denied: string = normalizeLogBodyToErrorPattern(
+      '{"level":"error","msg":"permission denied","attempt":3}',
+    );
+
+    expect(refused).not.toBe(denied);
+    expect(refused).toContain("connection refused");
+    expect(denied).toContain("permission denied");
+  });
+
+  test("the same JSON error at different attempt counts still collapses to one", () => {
+    expect(
+      normalizeLogBodyToErrorPattern(
+        '{"level":"error","msg":"connection refused","attempt":3}',
+      ),
+    ).toBe(
+      normalizeLogBodyToErrorPattern(
+        '{"level":"error","msg":"connection refused","attempt":17}',
+      ),
+    );
+  });
+
+  test("two different logfmt errors stay two patterns", () => {
+    const timeout: string = normalizeLogBodyToErrorPattern(
+      'level=error msg="upstream timeout" upstream=10.0.0.1:8080',
+    );
+    const down: string = normalizeLogBodyToErrorPattern(
+      'level=error msg="db down" upstream=10.0.0.2:5432',
+    );
+
+    expect(timeout).not.toBe(down);
+    // ...while the host and port, which do vary, are still masked.
+    expect(timeout).toContain("<ip>:<num>");
   });
 });
 
@@ -242,19 +307,111 @@ describe("LOG_ERROR_PATTERN_RULES — cross-engine constraints", () => {
   });
 });
 
+describe("getErrorPatternSearchText — the needle must exist in the raw body", () => {
+  /*
+   * A pattern is NOT a substring of the body it came from: the last rule
+   * collapses `\s+` to one space, so any run spanning a line break reads
+   * with a space where the body has `\n\t`. Handing that to
+   * `body ILIKE '%...%'` matches nothing — the deep link lands the user on
+   * an empty list, which is the precise failure this function exists to
+   * avoid.
+   */
+  const STACK: string = [
+    'java.lang.NullPointerException: Cannot invoke "OrderService.get()" because "order" is null',
+    "\tat com.example.OrderService.process(OrderService.java:42)",
+    "\tat com.example.Main.run(Main.java:11)",
+  ].join("\n");
+
+  test("a multi-line body yields a needle that is genuinely contained in it", () => {
+    const needle: string = getErrorPatternSearchText(
+      normalizeLogBodyToErrorPattern(STACK),
+    );
+
+    expect(needle.length).toBeGreaterThan(0);
+    expect(STACK).toContain(needle);
+  });
+
+  test("a needle never spans a collapsed whitespace boundary unverified", () => {
+    /*
+     * Without a sample body to check against, only whitespace-free tokens
+     * are safe — anything with a space in it might have been a newline.
+     */
+    const needle: string = getErrorPatternSearchText(
+      normalizeLogBodyToErrorPattern(STACK),
+    );
+
+    expect(needle).not.toMatch(/\s/);
+  });
+
+  test("a sample body unlocks the longer multi-word needle when it really survives", () => {
+    const singleLine: string = "connection refused to 10.0.0.1:5432";
+    const pattern: string = normalizeLogBodyToErrorPattern(singleLine);
+
+    // Verified against a real body, the stronger multi-word run is used.
+    expect(getErrorPatternSearchText(pattern, { sampleBody: singleLine })).toBe(
+      "connection refused to",
+    );
+
+    // ...and is still a genuine substring.
+    expect(singleLine).toContain(
+      getErrorPatternSearchText(pattern, { sampleBody: singleLine }),
+    );
+  });
+
+  test("a sample body that does NOT contain the run falls back to a safe token", () => {
+    const pattern: string = normalizeLogBodyToErrorPattern(STACK);
+
+    const needle: string = getErrorPatternSearchText(pattern, {
+      sampleBody: STACK,
+    });
+
+    expect(STACK).toContain(needle);
+  });
+
+  test("every candidate it can return is a substring of the body, across shapes", () => {
+    const bodies: Array<string> = [
+      STACK,
+      "connection refused to 10.0.0.1:5432 after 30ms",
+      'Traceback (most recent call last):\n  File "app.py", line 42, in run\n    raise ValueError("boom")',
+      "nginx: [error] 1234#0: *5 upstream timed out while reading response header",
+      '{"level":"error","msg":"connection refused","attempt":3}',
+    ];
+
+    for (const body of bodies) {
+      const pattern: string = normalizeLogBodyToErrorPattern(body);
+
+      for (const needle of [
+        getErrorPatternSearchText(pattern),
+        getErrorPatternSearchText(pattern, { sampleBody: body }),
+      ]) {
+        if (needle.length > 0) {
+          expect(body).toContain(needle);
+        }
+      }
+    }
+  });
+});
+
 describe("getErrorPatternSearchText", () => {
-  test("returns the longest literal run, which is what a body search can match", () => {
+  test("without a sample body, returns the longest SAFE (whitespace-free) run", () => {
+    /*
+     * "connection refused to" is longer, but a multi-word run is only
+     * returned once a sample body proves it survived the whitespace
+     * collapse — see the suite above.
+     */
     expect(
       getErrorPatternSearchText(
         "connection refused to <ip>:<num> after <num>ms",
       ),
-    ).toBe("connection refused to");
+    ).toBe("connection");
   });
 
   test("strips the punctuation a placeholder leaves behind", () => {
-    expect(getErrorPatternSearchText("<timestamp>: upstream timed out")).toBe(
-      "upstream timed out",
-    );
+    expect(
+      getErrorPatternSearchText("<timestamp>: upstream timed out", {
+        sampleBody: "2026-08-21T10:00:00Z: upstream timed out",
+      }),
+    ).toBe("upstream timed out");
   });
 
   test("returns empty when nothing selective survives", () => {
@@ -266,14 +423,25 @@ describe("getErrorPatternSearchText", () => {
     expect(getErrorPatternSearchText(undefined)).toBe("");
   });
 
-  test("honours a caller-supplied minimum length", () => {
+  test("honours a caller-supplied minimum length, in both call forms", () => {
+    // Legacy positional form.
     expect(getErrorPatternSearchText("<num> ms <num>", 2)).toBe("ms");
+    // ...and the options form.
+    expect(
+      getErrorPatternSearchText("<num> ms <num>", { minimumLength: 2 }),
+    ).toBe("ms");
   });
 
-  test("a pattern with no placeholders is its own search text", () => {
+  test("a placeholder-free pattern yields its longest safe token, or the whole run when verified", () => {
     expect(getErrorPatternSearchText("connection reset by peer")).toBe(
-      "connection reset by peer",
+      "connection",
     );
+
+    expect(
+      getErrorPatternSearchText("connection reset by peer", {
+        sampleBody: "connection reset by peer",
+      }),
+    ).toBe("connection reset by peer");
   });
 });
 

--- a/Common/Utils/Telemetry/LogErrorPattern.ts
+++ b/Common/Utils/Telemetry/LogErrorPattern.ts
@@ -98,16 +98,31 @@ export const LOG_ERROR_PATTERN_RULES: Array<LogErrorPatternRule> = [
     pattern: "\\b[0-9a-fA-F]{16,}\\b",
     replacement: "<hex>",
   },
-  {
-    /*
-     * Double quotes only. A single-quote rule would eat English
-     * apostrophes: in `can't reach 'db'` the first `'` pairs with the one
-     * before `db`, mangling the stable half of the message.
-     */
-    name: "quoted",
-    pattern: '"[^"]*"',
-    replacement: '"<str>"',
-  },
+  /*
+   * DELIBERATELY NO "mask any quoted span" RULE HERE.
+   *
+   * A `"[^"]*"` -> `"<str>"` rule looks reasonable on prose like
+   * `unknown field "customerRef"`, and it is catastrophic on structured
+   * logs. In JSON and logfmt — the two commonest shapes there are — the
+   * human-readable message IS a quoted value, so such a rule masks the only
+   * part that identifies the error:
+   *
+   *   {"level":"error","msg":"connection refused","attempt":3}
+   *   {"level":"error","msg":"permission denied","attempt":3}
+   *
+   * would both collapse to `{"<str>":"<str>","<str>":"<str>","<str>":<num>}`,
+   * summing two unrelated failures into one Top Errors row headed by
+   * whichever sample body argMax happened to pick.
+   *
+   * Nothing is lost by leaving it out: every quoted span that genuinely
+   * VARIES is a uuid, number, ip, url, timestamp, hex id or email, and the
+   * rules above already mask those — more informatively, since `"<uuid>"`
+   * says more than `"<str>"`. All such a rule uniquely added was collapsing
+   * quoted WORDS, which is exactly the destructive case. Two different
+   * quoted field names therefore stay two rows: under-collapsing is the
+   * safe direction, because a split incident is still visible while a
+   * merged one is hidden.
+   */
   {
     name: "number",
     pattern: "\\d+(\\.\\d+)?",
@@ -150,10 +165,9 @@ export const LOG_ERROR_PATTERN_PLACEHOLDERS: Array<string> =
 
 /*
  * Any placeholder token, for splitting a pattern back into its literal
- * spans. Built from the rule table rather than hardcoded so a new rule's
- * placeholder is understood here automatically. `<str>` is included even
- * though its rule's replacement is `"<str>"` — the surrounding quotes are
- * literal text that belongs to the stable half of the message.
+ * spans. Matches the shape every rule's replacement uses rather than being
+ * built from the table itself, so a rule added later is understood here
+ * without a second edit.
  */
 const PLACEHOLDER_TOKEN: RegExp = /<[a-z]+>/g;
 
@@ -196,48 +210,121 @@ export function normalizeLogBodyToErrorPattern(
   return normalized;
 }
 
+export interface ErrorPatternSearchTextOptions {
+  /** Literal runs shorter than this are not selective enough to be useful. */
+  minimumLength?: number | undefined;
+  /**
+   * A real body from the group, when the caller has one. Used to CHECK a
+   * candidate rather than to produce it — see below.
+   */
+  sampleBody?: string | undefined;
+}
+
+/*
+ * Leading punctuation a placeholder leaves behind — `to <ip>:<num>` splits
+ * into `to ` and `:` — so the search text comes out as words, not as the
+ * glue between them.
+ */
+const LEADING_GLUE: RegExp = /^[\s"':,;=([{]+/;
+
+/*
+ * Named rather than inlined at the use sites: an inline literal used as
+ * `/\s/.test(x)` trips eslint's wrap-regex, whose fix prettier then undoes
+ * (the same fight CrossSignalScope documents).
+ */
+const ANY_WHITESPACE: RegExp = /\s/;
+const WHITESPACE_RUN: RegExp = /\s+/;
+
 /**
- * The longest placeholder-free run inside a pattern — the part of the
- * message that is identical in every occurrence, and therefore the only
- * part that can be handed to a substring search.
+ * A literal run from the pattern that can be handed to a substring search.
  *
- * Used to turn "Insights says this error happened 30 times" into a Logs
+ * This is what turns "Insights says this happened 30 times" into a Logs
  * viewer deep link that actually lists those 30 rows: the viewer filters
  * `body` with a contains-match, which a pattern containing `<num>` would
  * never satisfy.
  *
+ * The subtlety is that a pattern is NOT a substring of the body it came
+ * from, even between placeholders. The last normalization rule collapses
+ * `\s+` to a single space, so any run spanning a line break in the original
+ * — every stack trace — reads `is null at com.example.Service.process(` in
+ * the pattern where the body has `is null\n\tat com.example...`. Handing
+ * that to `body ILIKE '%...%'` matches nothing, landing the user on an
+ * empty list: the precise failure this function exists to avoid.
+ *
+ * So the candidates are ranked longest-first and the first SAFE one wins:
+ *
+ *  - a whitespace-free token is always safe, because there was no
+ *    whitespace inside it to collapse;
+ *  - a longer multi-word run is used only when `sampleBody` proves it
+ *    survived the collapse verbatim.
+ *
  * Returns "" when nothing usable survives (an all-placeholder pattern, or
- * literal runs too short to be selective), which callers read as "no body
- * filter" rather than as a filter matching everything.
+ * runs too short to be selective), which callers read as "no body filter"
+ * rather than as a filter matching everything.
  */
 export function getErrorPatternSearchText(
   pattern: string | undefined | null,
-  minimumLength: number = 4,
+  options: ErrorPatternSearchTextOptions | number = {},
 ): string {
+  /*
+   * Number form kept for the original `(pattern, minimumLength)` callers.
+   */
+  const resolved: ErrorPatternSearchTextOptions =
+    typeof options === "number" ? { minimumLength: options } : options;
+
+  const minimumLength: number = resolved.minimumLength ?? 4;
+  const sampleBody: string =
+    typeof resolved.sampleBody === "string" ? resolved.sampleBody : "";
+
   if (typeof pattern !== "string" || pattern.length === 0) {
     return "";
   }
 
-  let longest: string = "";
+  const candidates: Array<string> = [];
 
   for (const segment of pattern.split(PLACEHOLDER_TOKEN)) {
-    /*
-     * Trim the punctuation a placeholder leaves behind — `to <ip>:<num>`
-     * splits into `to ` and `:` — so the search text is words, not the
-     * glue between them.
-     */
-    const candidate: string = segment.replace(/^[\s"':,;=([{]+/, "").trim();
+    const run: string = segment.replace(LEADING_GLUE, "").trim();
 
-    if (candidate.length > longest.length) {
-      longest = candidate;
+    if (run.length > 0) {
+      // The multi-word run: strongest, but only safe when verified.
+      candidates.push(run);
+    }
+
+    /*
+     * ...and every whitespace-free token inside it, which needs no
+     * verification at all.
+     */
+    for (const token of segment.split(WHITESPACE_RUN)) {
+      const trimmed: string = token.replace(LEADING_GLUE, "").trim();
+
+      if (trimmed.length > 0) {
+        candidates.push(trimmed);
+      }
     }
   }
 
-  if (longest.length < minimumLength) {
-    return "";
+  candidates.sort((a: string, b: string): number => {
+    return b.length - a.length;
+  });
+
+  for (const candidate of candidates) {
+    if (candidate.length < minimumLength) {
+      // Sorted longest-first, so everything after this is too short too.
+      break;
+    }
+
+    const isSingleToken: boolean = !ANY_WHITESPACE.test(candidate);
+
+    if (isSingleToken) {
+      return candidate;
+    }
+
+    if (sampleBody.length > 0 && sampleBody.includes(candidate)) {
+      return candidate;
+    }
   }
 
-  return longest;
+  return "";
 }
 
 /**


### PR DESCRIPTION
### Title of this pull request?

fix(logs): correct seven defects in the Insights error-pattern engine

### Small Description?

Follow-up to #3331 (merged). I kept reviewing after it merged — first by printing the SQL the seven statement builders actually emit, then with a six-lens adversarial review where every candidate finding had to survive a refutation pass. Seven defects survived. **Every one was verified by executing the real code before it was fixed**, and every fix has a test that fails without it.

Three of these are severe enough that the feature would have been quietly wrong in production rather than visibly broken.

---

#### 1. The co-occurrence panel would have said "nothing" forever, on every real cluster

The correlation query put a plain `IN (SELECT ... FROM LogItemV3 ...)` inside the WHERE of a query on **that same Distributed table** — the double-distributed shape multi-shard ClickHouse rejects outright (Code 288, `distributed_product_mode = 'deny'`).

It would not have shown up as an error. The endpoint wraps each correlation read in a degrade-to-empty catch, so *"What else was failing at the same time"* would simply have rendered empty on every 2+-shard deployment, permanently, with nothing logged. Single-shard dev clusters hide it completely.

Now `GLOBAL IN` — which is also the only *correct* evaluation, since the sharding key `cityHash64(projectId, primaryEntityId, time)` spreads one project's rows across every shard, so the bucket set must be computed once globally rather than per shard. `MetricService.ts` already documents this exact hazard for this exact query shape.

#### 2. Structured logs were clustered into nonsense

The `"[^"]*"` → `"<str>"` rule reads fine on prose like `unknown field "customerRef"`. In JSON and logfmt — the two commonest log shapes there are — the human-readable message **is** a quoted value, so the rule masked the only part that identifies the error. Executed against the real rule table:

```
{"level":"error","msg":"connection refused","attempt":3}
{"level":"error","msg":"permission denied","attempt":3}
```

both normalized to the identical `{"<str>":"<str>","<str>":"<str>","<str>":<num>}` — two unrelated failures summed into one Top Errors row, headed by whichever body `argMax` happened to pick, with every drill-down panel computed over the mixed cluster.

The rule is **removed**. Nothing is lost: every quoted span that genuinely *varies* is a uuid, number, ip, url, timestamp, hex id or email, and the specific rules already mask those — more informatively, since `"<uuid>"` says more than `"<str>"`. All the rule uniquely added was collapsing quoted *words*, which is precisely the destructive case. Two different quoted field names now stay two rows; under-collapsing is the safe direction, because a split incident is still visible while a merged one is hidden.

#### 3. "Open matching logs" opened an empty list for every stack trace

The needle came from the pattern, in which the final `\s+` → `" "` rule has already run. So any run spanning a line break is **not a substring of the body it came from**:

```
needle:  "is null at com.example.OrderService.process(OrderService.java:"
body:    ...is null\n\tat com.example.OrderService.process(OrderService.java:42)
         rawBody.includes(needle) === false
```

That fed `body ILIKE '%needle%'`, which matched zero rows — landing the user on an empty list, the exact outcome the builder's own comment claimed to prevent. Single-line bodies were fine, which is why the tests missed it.

Candidates are now ranked longest-first and the first **safe** one wins: a whitespace-free token is always safe (no whitespace inside it to collapse), and a longer multi-word run is used only when a sample body proves it survived verbatim.

#### 4. A stopped error reported itself as healthy

`computeErrorPatternTrend` split the timeline at `Math.floor(length / 2)` — by array **index** — but the timeline query is a plain `GROUP BY bucket` with no zero-fill, so the array holds only non-empty buckets. An error that fired steadily for two hours and then went silent for twenty-two returned roughly half its buckets on each side and rendered **"Steady 0%"**. It now splits on the window the user actually picked.

#### 5 & 6. Two request races

The page committed every batch unconditionally, so switching to a 30-day window and straight back to 1 hour left the slow 30-day numbers on screen under a *"past 1 hour"* label until the next manual refresh. A generation token now discards superseded batches, and the derived state is cleared as each load starts so stale figures never sit under a new label. Separately, the drawer is keyed on its pattern, so switching rows cannot pair one error's header with another error's timeline, attributes and traces.

#### 7. Two correctness leaks around the edges

`clampLogErrorPattern` measured UTF-16 code units while the group key is cut by `substringUTF8` (code points): a 300-code-point pattern containing one emoji has `.length === 301`, so the clamp fired on a key already at the limit and left a lone surrogate on the tail — after which the bind matched zero rows and every drill-down came back cheerfully empty, without throwing. And the Logs viewer's chip round-trip was asymmetric: a saved view or deep link carrying a body filter restored the filter but not its chip, so the list was filtered with nothing on screen saying so and the histogram counted rows the list excluded.

---

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Verified locally:** `Common` tsc clean; eslint clean across all changed files; 116 Common tests and 60 Insights tests pass. The first commit's two fixes are mutation-checked — reverting either makes 5 tests fail.

⚠️ **`compile-dashboard` is currently failing on `master` itself**, unrelated to this PR: `NetworkTopologyExplorer.tsx:776` references `IconProp.Network`, which does not exist in `IconProp` (both are on master; neither file is touched here). Happy to send a separate one-line PR for that if useful.

### Related Issue?

Follow-up to #3331 / #3318. No new behaviour — this only corrects the defects above.

### Screenshots (if appropriate):

None — the changes are in generated SQL, clustering rules and state handling, with no intentional visual change.
