### PR TITLE
feat(Telemetry): computed LLM cost, conversation grouping, and daily LLM cost budgets

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -466,6 +466,9 @@ import ServiceLevelObjectiveService, {
 import ServiceLevelObjectiveBurnRateRuleService, {
   Service as ServiceLevelObjectiveBurnRateRuleServiceType,
 } from "Common/Server/Services/ServiceLevelObjectiveBurnRateRuleService";
+import LlmCostBudgetService, {
+  Service as LlmCostBudgetServiceType,
+} from "Common/Server/Services/LlmCostBudgetService";
 import ServiceLevelObjectiveOwnerUserService, {
   Service as ServiceLevelObjectiveOwnerUserServiceType,
 } from "Common/Server/Services/ServiceLevelObjectiveOwnerUserService";
@@ -1144,6 +1147,7 @@ import ScheduledMaintenanceMeasurement from "Common/Models/DatabaseModels/Schedu
 import ScheduledMaintenanceMeasurementValue from "Common/Models/DatabaseModels/ScheduledMaintenanceMeasurementValue";
 import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
 import ServiceLevelObjectiveBurnRateRule from "Common/Models/DatabaseModels/ServiceLevelObjectiveBurnRateRule";
+import LlmCostBudget from "Common/Models/DatabaseModels/LlmCostBudget";
 import ServiceLevelObjectiveOwnerUser from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
 import ServiceLevelObjectiveOwnerTeam from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
 import SloHistory from "Common/Models/AnalyticsModels/SloHistory";
@@ -2654,10 +2658,10 @@ const BaseAPIFeatureSet: FeatureSet = {
     // IncidentMeasurementValue
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,
-      new BaseAPI<IncidentMeasurementValue, IncidentMeasurementValueServiceType>(
+      new BaseAPI<
         IncidentMeasurementValue,
-        IncidentMeasurementValueService,
-      ).getRouter(),
+        IncidentMeasurementValueServiceType
+      >(IncidentMeasurementValue, IncidentMeasurementValueService).getRouter(),
     );
 
     // AlertMeasurement
@@ -2681,7 +2685,10 @@ const BaseAPIFeatureSet: FeatureSet = {
     // ScheduledMaintenanceMeasurement
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,
-      new BaseAPI<ScheduledMaintenanceMeasurement, ScheduledMaintenanceMeasurementServiceType>(
+      new BaseAPI<
+        ScheduledMaintenanceMeasurement,
+        ScheduledMaintenanceMeasurementServiceType
+      >(
         ScheduledMaintenanceMeasurement,
         ScheduledMaintenanceMeasurementService,
       ).getRouter(),
@@ -2690,7 +2697,10 @@ const BaseAPIFeatureSet: FeatureSet = {
     // ScheduledMaintenanceMeasurementValue
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,
-      new BaseAPI<ScheduledMaintenanceMeasurementValue, ScheduledMaintenanceMeasurementValueServiceType>(
+      new BaseAPI<
+        ScheduledMaintenanceMeasurementValue,
+        ScheduledMaintenanceMeasurementValueServiceType
+      >(
         ScheduledMaintenanceMeasurementValue,
         ScheduledMaintenanceMeasurementValueService,
       ).getRouter(),
@@ -2714,6 +2724,15 @@ const BaseAPIFeatureSet: FeatureSet = {
       >(
         ServiceLevelObjectiveBurnRateRule,
         ServiceLevelObjectiveBurnRateRuleService,
+      ).getRouter(),
+    );
+
+    // LlmCostBudget
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new BaseAPI<LlmCostBudget, LlmCostBudgetServiceType>(
+        LlmCostBudget,
+        LlmCostBudgetService,
       ).getRouter(),
     );
 

--- a/App/FeatureSet/Dashboard/src/Components/AI/LlmCallsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AI/LlmCallsTable.tsx
@@ -173,6 +173,13 @@ const LlmCallsTable: FunctionComponent<ComponentProps> = (
         },
         {
           field: {
+            llmConversationId: true,
+          },
+          type: FieldType.Text,
+          title: "Conversation ID",
+        },
+        {
+          field: {
             startTime: true,
           },
           type: FieldType.DateTime,
@@ -186,6 +193,7 @@ const LlmCallsTable: FunctionComponent<ComponentProps> = (
         llmInputTokens: true,
         llmOutputTokens: true,
         llmResponseModel: true,
+        llmConversationId: true,
       }}
       columns={[
         {

--- a/App/FeatureSet/Dashboard/src/Components/AI/LlmNavTabs.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AI/LlmNavTabs.tsx
@@ -5,7 +5,7 @@ import PageMap from "../../Utils/PageMap";
 import Route from "Common/Types/API/Route";
 import IconProp from "Common/Types/Icon/IconProp";
 
-export type LlmTabKey = "overview" | "calls" | "setup";
+export type LlmTabKey = "overview" | "calls" | "budgets" | "setup";
 
 interface Props {
   active: LlmTabKey;
@@ -27,6 +27,12 @@ const LlmNavTabs: FunctionComponent<Props> = (props: Props): ReactElement => {
       label: "LLM Calls",
       icon: IconProp.Sparkles,
       to: RouteUtil.populateRouteParams(RouteMap[PageMap.LLM_CALLS] as Route),
+    },
+    {
+      key: "budgets",
+      label: "Budgets",
+      icon: IconProp.CurrencyDollar,
+      to: RouteUtil.populateRouteParams(RouteMap[PageMap.LLM_BUDGETS] as Route),
     },
     {
       key: "setup",

--- a/App/FeatureSet/Dashboard/src/Pages/Llm/Budgets.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Llm/Budgets.tsx
@@ -1,0 +1,293 @@
+import PageComponentProps from "../PageComponentProps";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import Pill from "Common/UI/Components/Pill/Pill";
+import { Green, Red } from "Common/Types/BrandColors";
+import LlmCostBudget from "Common/Models/DatabaseModels/LlmCostBudget";
+import Service from "Common/Models/DatabaseModels/Service";
+import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
+import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
+import ProjectUtil from "Common/UI/Utils/Project";
+import React, { FunctionComponent, ReactElement } from "react";
+
+const LlmBudgetsPage: FunctionComponent<PageComponentProps> = (
+  props: PageComponentProps,
+): ReactElement => {
+  const disableTelemetryForThisProject: boolean =
+    props.currentProject?.reseller?.enableTelemetryFeatures === false;
+
+  if (disableTelemetryForThisProject) {
+    return (
+      <ErrorMessage message="Looks like you have bought this plan from a reseller. It did not include telemetry features in your plan. Telemetry features are disabled for this project." />
+    );
+  }
+
+  return (
+    <ModelTable<LlmCostBudget>
+      modelType={LlmCostBudget}
+      query={{
+        projectId: ProjectUtil.getCurrentProjectId()!,
+      }}
+      id="llm-cost-budgets-table"
+      userPreferencesKey="llm-cost-budgets-table"
+      name="AI / LLM > Budgets"
+      isDeleteable={true}
+      isEditable={true}
+      isCreateable={true}
+      showRefreshButton={true}
+      showViewIdButton={true}
+      sortBy="name"
+      sortOrder={SortOrder.Ascending}
+      cardProps={{
+        title: "LLM Cost Budgets",
+        description:
+          "Daily USD budgets for LLM spend. A worker sums each UTC day's LLM span cost and raises alerts at the warning threshold and at 100%.",
+      }}
+      noItemsMessage={"No LLM cost budgets found."}
+      formSteps={[
+        { title: "Basic Info", id: "basic-info" },
+        { title: "Budget", id: "budget" },
+        { title: "Scope", id: "scope" },
+        { title: "Alerting", id: "alerting" },
+      ]}
+      formFields={[
+        {
+          field: { name: true },
+          title: "Name",
+          stepId: "basic-info",
+          fieldType: FormFieldSchemaType.Text,
+          required: true,
+          placeholder: "e.g. Daily OpenAI spend",
+          validation: { minLength: 2 },
+        },
+        {
+          field: { description: true },
+          title: "Description",
+          stepId: "basic-info",
+          fieldType: FormFieldSchemaType.LongText,
+          required: false,
+          placeholder: "What this budget covers and why.",
+        },
+        {
+          field: { isEnabled: true },
+          title: "Enabled",
+          description: "Whether this budget is evaluated.",
+          stepId: "basic-info",
+          fieldType: FormFieldSchemaType.Toggle,
+          required: false,
+          defaultValue: true,
+        },
+        {
+          field: { dailyBudgetInUSD: true },
+          title: "Daily Budget (USD)",
+          stepId: "budget",
+          fieldType: FormFieldSchemaType.Number,
+          required: true,
+          placeholder: "100",
+          description: "Daily budget in USD, evaluated over the UTC day.",
+        },
+        {
+          field: { warningThresholdPercent: true },
+          title: "Warning Threshold (%)",
+          stepId: "budget",
+          fieldType: FormFieldSchemaType.Number,
+          required: false,
+          placeholder: "80",
+          description:
+            "Raise a warning alert at this percent of the budget (1-99). A breach alert always fires at 100%.",
+        },
+        {
+          field: { service: true },
+          title: "Service (optional)",
+          stepId: "scope",
+          description:
+            "Scope this budget to a single telemetry service. Leave empty for a project-wide budget.",
+          fieldType: FormFieldSchemaType.Dropdown,
+          required: false,
+          dropdownModal: {
+            type: Service,
+            labelField: "name",
+            valueField: "_id",
+          },
+        },
+        {
+          field: { llmSystem: true },
+          title: "LLM Provider (optional)",
+          stepId: "scope",
+          fieldType: FormFieldSchemaType.Text,
+          required: false,
+          placeholder: "openai",
+          description:
+            "Only count spend from this provider (matches the span's gen_ai provider). Leave empty to count every provider.",
+        },
+        {
+          field: { llmModel: true },
+          title: "LLM Model (optional)",
+          stepId: "scope",
+          fieldType: FormFieldSchemaType.Text,
+          required: false,
+          placeholder: "gpt-4o",
+          description:
+            "Only count spend from this model (matches the span's requested model exactly). Leave empty to count every model.",
+        },
+        {
+          field: { alertSeverity: true },
+          title: "Alert Severity (optional)",
+          stepId: "alerting",
+          description:
+            "Severity of the alerts created when this budget crosses a threshold.",
+          fieldType: FormFieldSchemaType.Dropdown,
+          required: false,
+          dropdownModal: {
+            type: AlertSeverity,
+            labelField: "name",
+            valueField: "_id",
+          },
+        },
+        {
+          field: { onCallDutyPolicies: true },
+          title: "On-Call Duty Policies (optional)",
+          stepId: "alerting",
+          description:
+            "On-call duty policies to execute when this budget raises an alert.",
+          fieldType: FormFieldSchemaType.MultiSelectDropdown,
+          required: false,
+          dropdownModal: {
+            type: OnCallDutyPolicy,
+            labelField: "name",
+            valueField: "_id",
+          },
+        },
+      ]}
+      filters={[
+        {
+          field: { name: true },
+          type: FieldType.Text,
+          title: "Name",
+        },
+        {
+          field: { isEnabled: true },
+          type: FieldType.Boolean,
+          title: "Enabled",
+        },
+      ]}
+      selectMoreFields={{
+        warningThresholdPercent: true,
+        llmSystem: true,
+        llmModel: true,
+        currentDaySpendInUSD: true,
+        dailyBudgetInUSD: true,
+      }}
+      columns={[
+        {
+          field: { name: true, description: true },
+          title: "Name",
+          type: FieldType.Element,
+          getElement: (item: LlmCostBudget): ReactElement => {
+            return (
+              <div>
+                <div className="font-medium text-gray-900">
+                  {item.name || "Untitled"}
+                </div>
+                {item.description && (
+                  <div className="text-xs text-gray-500 mt-0.5">
+                    {item.description}
+                  </div>
+                )}
+              </div>
+            );
+          },
+        },
+        {
+          field: { dailyBudgetInUSD: true },
+          title: "Daily Budget",
+          type: FieldType.Element,
+          getElement: (item: LlmCostBudget): ReactElement => {
+            return (
+              <span className="text-sm text-gray-900">
+                {`$${(item.dailyBudgetInUSD || 0).toFixed(2)}`}
+              </span>
+            );
+          },
+        },
+        {
+          field: { currentDaySpendInUSD: true },
+          title: "Today's Spend",
+          type: FieldType.Element,
+          getElement: (item: LlmCostBudget): ReactElement => {
+            if (
+              item.currentDaySpendInUSD === undefined ||
+              item.currentDaySpendInUSD === null
+            ) {
+              return <span className="text-sm text-gray-500">—</span>;
+            }
+
+            const spend: number = item.currentDaySpendInUSD;
+            const budget: number = item.dailyBudgetInUSD || 0;
+
+            return (
+              <span className="text-sm text-gray-900">
+                {`$${spend.toFixed(2)}`}
+                {budget > 0 && (
+                  <span className="text-xs text-gray-500 ml-1">
+                    {`${Math.floor((spend / budget) * 100)}%`}
+                  </span>
+                )}
+              </span>
+            );
+          },
+        },
+        {
+          field: { service: { name: true } },
+          title: "Scope",
+          type: FieldType.Element,
+          getElement: (item: LlmCostBudget): ReactElement => {
+            const filters: Array<string> = [];
+
+            if (item.llmSystem) {
+              filters.push(`Provider: ${item.llmSystem}`);
+            }
+
+            if (item.llmModel) {
+              filters.push(`Model: ${item.llmModel}`);
+            }
+
+            return (
+              <div>
+                {item.service?.name ? (
+                  <span className="inline-flex items-center text-sm font-medium text-gray-900">
+                    <span className="text-gray-400 mr-1">Service:</span>
+                    {item.service.name}
+                  </span>
+                ) : (
+                  <span className="text-sm text-gray-500">Project-wide</span>
+                )}
+                {filters.length > 0 && (
+                  <div className="text-xs text-gray-500 mt-0.5">
+                    {filters.join(" · ")}
+                  </div>
+                )}
+              </div>
+            );
+          },
+        },
+        {
+          field: { isEnabled: true },
+          title: "Enabled",
+          type: FieldType.Boolean,
+          getElement: (item: LlmCostBudget): ReactElement => {
+            if (item.isEnabled) {
+              return <Pill color={Green} text="Enabled" />;
+            }
+            return <Pill color={Red} text="Disabled" />;
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default LlmBudgetsPage;

--- a/App/FeatureSet/Dashboard/src/Pages/Llm/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Llm/Layout.tsx
@@ -14,6 +14,9 @@ const getActiveLlmTab: (path: string) => LlmTabKey = (
   if (path.includes("/llm/calls")) {
     return "calls";
   }
+  if (path.includes("/llm/budgets")) {
+    return "budgets";
+  }
   if (path.includes("/llm/documentation")) {
     return "setup";
   }

--- a/App/FeatureSet/Dashboard/src/Routes/LlmRoutes.tsx
+++ b/App/FeatureSet/Dashboard/src/Routes/LlmRoutes.tsx
@@ -9,6 +9,7 @@ import { Route as PageRoute, Routes } from "react-router-dom";
 // Pages
 import LlmOverview from "../Pages/Llm/Overview";
 import LlmCalls from "../Pages/Llm/Calls";
+import LlmBudgets from "../Pages/Llm/Budgets";
 import LlmDocumentationPage from "../Pages/Llm/Documentation";
 
 const LlmRoutes: FunctionComponent<ComponentProps> = (
@@ -43,6 +44,16 @@ const LlmRoutes: FunctionComponent<ComponentProps> = (
             <LlmCalls
               {...props}
               pageRoute={RouteMap[PageMap.LLM_CALLS] as Route}
+            />
+          }
+        />
+
+        <PageRoute
+          path={LlmRoutePath[PageMap.LLM_BUDGETS] || ""}
+          element={
+            <LlmBudgets
+              {...props}
+              pageRoute={RouteMap[PageMap.LLM_BUDGETS] as Route}
             />
           }
         />

--- a/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/LlmBreadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/LlmBreadcrumbs.ts
@@ -16,6 +16,11 @@ export function getLlmBreadcrumbs(path: string): Array<Link> | undefined {
       "AI / LLM",
       "LLM Calls",
     ]),
+    ...BuildBreadcrumbLinksByTitles(PageMap.LLM_BUDGETS, [
+      "Project",
+      "AI / LLM",
+      "Budgets",
+    ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.LLM_DOCUMENTATION, [
       "Project",
       "AI / LLM",

--- a/App/FeatureSet/Dashboard/src/Utils/PageMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/PageMap.ts
@@ -1011,6 +1011,7 @@ enum PageMap {
   LLM = "LLM",
   LLM_OVERVIEW = "LLM_OVERVIEW",
   LLM_CALLS = "LLM_CALLS",
+  LLM_BUDGETS = "LLM_BUDGETS",
   LLM_DOCUMENTATION = "LLM_DOCUMENTATION",
 
   // AI Copilot (full-page chat over observability data)

--- a/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
@@ -557,6 +557,7 @@ export const LlmRoutePath: Dictionary<string> = {
   [PageMap.LLM]: "overview",
   [PageMap.LLM_OVERVIEW]: "overview",
   [PageMap.LLM_CALLS]: "calls",
+  [PageMap.LLM_BUDGETS]: "budgets",
   [PageMap.LLM_DOCUMENTATION]: "documentation",
 };
 
@@ -5622,6 +5623,12 @@ const RouteMap: Dictionary<Route> = {
 
   [PageMap.LLM_CALLS]: new Route(
     `/dashboard/${RouteParams.ProjectID}/llm/${LlmRoutePath[PageMap.LLM_CALLS]}`,
+  ),
+
+  [PageMap.LLM_BUDGETS]: new Route(
+    `/dashboard/${RouteParams.ProjectID}/llm/${
+      LlmRoutePath[PageMap.LLM_BUDGETS]
+    }`,
   ),
 
   [PageMap.LLM_DOCUMENTATION]: new Route(

--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-llm-observability.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-llm-observability.md
@@ -86,10 +86,17 @@ OneUptime reads the OpenTelemetry GenAI conventions first, and falls back to the
 | Cost (USD) | `gen_ai.usage.cost` | `llm.usage.total_cost` |
 | Agent name | `gen_ai.agent.name` | — |
 | Tool name | `gen_ai.tool.name` | — |
+| Conversation / session id | `gen_ai.conversation.id` | `session.id`, `langfuse.session.id`, `traceloop.association.properties.session_id` |
 
 **Prompt & completion content** is read from the standard content events (`gen_ai.system.message`, `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.choice`) or the indexed attributes (`gen_ai.prompt.N.content`, `gen_ai.completion.N.content`) and rendered in the AI / LLM panel.
 
-> **Cost note:** OneUptime does not maintain a model price list. Cost is shown only when your instrumentation reports it (e.g. OpenLLMetry can emit `gen_ai.usage.cost`).
+**Conversation grouping:** OneUptime extracts a conversation/session id from `gen_ai.conversation.id` (OTel semantic conventions), `session.id` (OpenInference / Langfuse-compatible SDKs), `langfuse.session.id`, or `traceloop.association.properties.session_id` (OpenLLMetry) and stores it as a first-class queryable column (`llmConversationId`) on the span. This lets you filter all LLM calls belonging to one user interaction, even when they span multiple traces.
+
+### How cost is calculated
+
+If your instrumentation reports a cost (`gen_ai.usage.cost`), OneUptime uses it as-is — the reported value always wins. When no cost is reported, OneUptime computes an **estimated cost at ingest** from the span's token counts and a built-in list-price catalog of common models from OpenAI, Anthropic, Google Gemini, Mistral, DeepSeek, xAI, Cohere, Amazon Nova and Meta Llama. Models are matched by name prefix, so dated snapshots like `gpt-4o-2024-08-06` and vendor-decorated ids like `us.anthropic.claude-3-5-sonnet-20241022-v2:0` resolve correctly. Unknown or custom models are never guessed — their cost stays `0`. Estimates use list prices and do not account for cache or batch discounts.
+
+Self-hosting OneUptime? The catalog lives in `Common/Types/Telemetry/LlmCostCatalog.ts` if you want to extend it.
 
 ## View your LLM calls
 
@@ -97,6 +104,7 @@ Open **AI / LLM** in the navigation bar (under Observability):
 
 - **Overview** — total calls, input/output tokens, cost, and error rate for the last 7 days, plus the most recent calls.
 - **LLM Calls** — a filterable list of every LLM, embedding, agent and tool call. Filter by provider, model, operation or service. Click a call to open it in the trace viewer.
+- **Budgets** — daily cost budgets with warning and breach alerts (see [Daily cost budgets](#daily-cost-budgets) below).
 - Each span has an **AI / LLM** tab/panel with the model, token counts, cost, request parameters, and the rendered prompt & completion.
 
 ## Dashboards and alerts
@@ -105,6 +113,17 @@ Because GenAI metrics arrive as ordinary OpenTelemetry metrics, you can:
 
 - Build **dashboards** charting `gen_ai.client.token.usage`, `gen_ai.client.operation.duration`, etc. (Dashboards → add a chart on the metric).
 - Create **metric monitors** to alert on token spend, latency or error rate — for example alert when `gen_ai.client.operation.duration` p95 crosses a threshold, grouped by model. See [Monitors](/docs/monitor/monitor).
+
+## Daily cost budgets
+
+The **AI / LLM** section has a **Budgets** tab. Each budget sets a daily USD limit, evaluated over the UTC day. Every 15 minutes a background worker sums the day's LLM span cost (SDK-reported or computed), records the current spend on the budget, and raises:
+
+- a **warning alert** at a configurable threshold (default 80%), and
+- a **breach alert** at 100%
+
+— each at most once per UTC day. Alerts carry a configurable severity and can trigger your on-call duty policies.
+
+Budgets can be scoped to a telemetry service, an LLM provider (the `gen_ai` provider name), or an exact model — or left project-wide. Multiple budgets can coexist, for example a project-wide budget plus a stricter one for an expensive model.
 
 ## Privacy & redaction
 

--- a/App/FeatureSet/Telemetry/Services/OtelTracesIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelTracesIngestService.ts
@@ -1293,6 +1293,7 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
       llmOutputTokens: data.llmFields.llmOutputTokens,
       llmTotalTokens: data.llmFields.llmTotalTokens,
       llmCost: data.llmFields.llmCost,
+      llmConversationId: data.llmFields.llmConversationId,
     };
   }
 

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -188,6 +188,9 @@ import "./Jobs/AutoRemediation/VerifyRemediations";
 // AI Insights — preventive telemetry scan (deterministic, no LLM).
 import "./Jobs/AIInsight/ScanForInsights";
 
+// LLM observability — daily cost budget evaluation over LLM spans.
+import "./Jobs/Llm/EvaluateLlmCostBudgets";
+
 // Telemetry Monitors.
 import "./Jobs/TelemetryMonitor/ScheduleTelemetryMonitorEvaluations";
 import "./Jobs/DetectionRules/EvaluateDetectionRules";

--- a/App/FeatureSet/Workers/Jobs/Llm/EvaluateLlmCostBudgets.ts
+++ b/App/FeatureSet/Workers/Jobs/Llm/EvaluateLlmCostBudgets.ts
@@ -1,0 +1,79 @@
+import RunCron from "../../Utils/Cron";
+import { EVERY_FIFTEEN_MINUTE } from "Common/Utils/CronTime";
+import OneUptimeDate from "Common/Types/Date";
+import Semaphore, {
+  SemaphoreMutex,
+} from "Common/Server/Infrastructure/Semaphore";
+import LlmCostBudgetEvaluator from "Common/Server/Utils/Telemetry/LlmCostBudgetEvaluator";
+import logger from "Common/Server/Utils/Logger";
+
+/**
+ * LLM cost budget watch loop: sums the UTC day's LLM span spend for every
+ * enabled budget and raises warning (default 80%) and breach (100%) alerts.
+ */
+const SWEEP_TIMEOUT_MINUTES: number = 10;
+
+/*
+ * The job timeout does NOT prevent overlap — runJobWithTimeout is a
+ * Promise.race with no cancellation, so a sweep body that outlives its
+ * timeout keeps running while the queue schedules the next tick. The
+ * budget alert dedup is read-then-write (stamps snapshotted at sweep start),
+ * so two interleaved sweeps could double-page on-call. Serialize sweeps with
+ * a Redis lock, same as Slo:EvaluateSlos. The lock timeout stays under the
+ * 15-minute tick so a crashed holder self-heals within one tick.
+ */
+const SWEEP_LOCK_KEY: string = "Llm:EvaluateLlmCostBudgets";
+const SWEEP_LOCK_NAMESPACE: string = "Workers.Cron";
+const SWEEP_LOCK_TIMEOUT_MS: number =
+  OneUptimeDate.convertMinutesToMilliseconds(14);
+
+RunCron(
+  "Llm:EvaluateLlmCostBudgets",
+  {
+    schedule: EVERY_FIFTEEN_MINUTE,
+    runOnStartup: false,
+    timeoutInMS: OneUptimeDate.convertMinutesToMilliseconds(
+      SWEEP_TIMEOUT_MINUTES,
+    ),
+  },
+  async () => {
+    /*
+     * acquireAttemptsLimit: 1 — never queue behind the in-flight sweep. The
+     * job re-runs every fifteen minutes anyway; skipping is the correct
+     * backpressure.
+     */
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: SWEEP_LOCK_KEY,
+        namespace: SWEEP_LOCK_NAMESPACE,
+        lockTimeout: SWEEP_LOCK_TIMEOUT_MS,
+        acquireAttemptsLimit: 1,
+      });
+    } catch (err) {
+      logger.debug(
+        `Llm:EvaluateLlmCostBudgets - Could not acquire the sweep lock; a sweep is already in flight (or Redis is unavailable). Skipping this tick: ${err}`,
+      );
+      return;
+    }
+
+    /*
+     * The lock is released in `finally` so a throw anywhere in the sweep
+     * still frees it for the next tick instead of wedging the job until the
+     * lock times out.
+     */
+    try {
+      await LlmCostBudgetEvaluator.evaluateAllBudgets();
+    } finally {
+      try {
+        await Semaphore.release(mutex);
+      } catch (err) {
+        // a release failure only means the lock expires on its own timeout.
+        logger.error(
+          `Llm:EvaluateLlmCostBudgets - Error releasing the sweep lock: ${err}`,
+        );
+      }
+    }
+  },
+);

--- a/Common/Models/AnalyticsModels/Span.ts
+++ b/Common/Models/AnalyticsModels/Span.ts
@@ -1120,7 +1120,7 @@ export default class Span extends AnalyticsBaseModel {
       key: "llmCost",
       title: "LLM Cost (USD)",
       description:
-        "Cost of this LLM call in USD. Only populated when the instrumentation reports it (gen_ai.usage.cost); OneUptime does not compute pricing.",
+        "Cost of this LLM call in USD. The instrumentation-reported cost (gen_ai.usage.cost) when present; otherwise estimated at ingest from token counts and the built-in model price catalog (Common/Types/Telemetry/LlmCostCatalog.ts). 0 when neither is available.",
       required: true,
       defaultValue: 0,
       /*
@@ -1130,6 +1130,25 @@ export default class Span extends AnalyticsBaseModel {
       type: TableColumnType.Decimal,
       accessControl: llmColumnAccessControl,
     });
+
+    const llmConversationIdColumn: AnalyticsTableColumn =
+      new AnalyticsTableColumn({
+        key: "llmConversationId",
+        title: "LLM Conversation ID",
+        description:
+          "Conversation / session id that groups the LLM calls of one user interaction across traces (gen_ai.conversation.id, session.id); '' when the instrumentation reports none.",
+        required: true,
+        defaultValue: "",
+        type: TableColumnType.Text,
+        codec: { codec: "ZSTD", level: 1 },
+        skipIndex: {
+          name: "idx_llm_conversation_id",
+          type: SkipIndexType.BloomFilter,
+          params: [0.01],
+          granularity: 1,
+        },
+        accessControl: llmColumnAccessControl,
+      });
 
     const retentionDateColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
       key: "retentionDate",
@@ -1225,6 +1244,7 @@ export default class Span extends AnalyticsBaseModel {
         llmOutputTokensColumn,
         llmTotalTokensColumn,
         llmCostColumn,
+        llmConversationIdColumn,
         retentionDateColumn,
       ],
       projections: [
@@ -1545,5 +1565,13 @@ export default class Span extends AnalyticsBaseModel {
 
   public set llmCost(v: number | undefined) {
     this.setColumnValue("llmCost", v);
+  }
+
+  public get llmConversationId(): string | undefined {
+    return this.getColumnValue("llmConversationId") as string | undefined;
+  }
+
+  public set llmConversationId(v: string | undefined) {
+    this.setColumnValue("llmConversationId", v);
   }
 }

--- a/Common/Models/DatabaseModels/Index.ts
+++ b/Common/Models/DatabaseModels/Index.ts
@@ -118,6 +118,7 @@ import DetectionRule from "./DetectionRule";
 import GoogleSecOpsConnection from "./GoogleSecOpsConnection";
 import LogScrubRule from "./LogScrubRule";
 import MetricPipelineRule from "./MetricPipelineRule";
+import LlmCostBudget from "./LlmCostBudget";
 import MetricRecordingRule from "./MetricRecordingRule";
 import TracePipeline from "./TracePipeline";
 import TracePipelineProcessor from "./TracePipelineProcessor";
@@ -465,6 +466,7 @@ const AllModelTypes: Array<{
   GoogleSecOpsConnection,
   LogScrubRule,
   MetricPipelineRule,
+  LlmCostBudget,
   MetricRecordingRule,
   TracePipeline,
   TracePipelineProcessor,

--- a/Common/Models/DatabaseModels/LlmCostBudget.ts
+++ b/Common/Models/DatabaseModels/LlmCostBudget.ts
@@ -1,0 +1,887 @@
+import AlertSeverity from "./AlertSeverity";
+import OnCallDutyPolicy from "./OnCallDutyPolicy";
+import Project from "./Project";
+import Service from "./Service";
+import User from "./User";
+import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
+import Route from "../../Types/API/Route";
+import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
+import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
+import ColumnLength from "../../Types/Database/ColumnLength";
+import ColumnType from "../../Types/Database/ColumnType";
+import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import EnableDocumentation from "../../Types/Database/EnableDocumentation";
+import EnableWorkflow from "../../Types/Database/EnableWorkflow";
+import TableColumn from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import TableMetadata from "../../Types/Database/TableMetadata";
+import TenantColumn from "../../Types/Database/TenantColumn";
+import IconProp from "../../Types/Icon/IconProp";
+import ObjectID from "../../Types/ObjectID";
+import Permission from "../../Types/Permission";
+import { PlanType } from "../../Types/Billing/SubscriptionPlan";
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+} from "typeorm";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+
+/*
+ * Postgres returns `decimal` columns as strings; without a transformer every
+ * arithmetic comparison downstream silently becomes a string comparison.
+ * Same convention as ServiceLevelObjectiveBurnRateRule / NetworkInterface.
+ */
+const decimalTransformer: ValueTransformer = {
+  to: (value: number | null | undefined): number | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    return value;
+  },
+  from: (value: string | number | null | undefined): number | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    if (typeof value === "number") {
+      return value;
+    }
+    const parsed: number = parseFloat(value);
+    return isNaN(parsed) ? null : parsed;
+  },
+};
+
+@EnableDocumentation()
+@TableBillingAccessControl({
+  create: PlanType.Free,
+  read: PlanType.Free,
+  update: PlanType.Free,
+  delete: PlanType.Free,
+})
+@TenantColumn("projectId")
+@CrudApiEndpoint(new Route("/llm-cost-budget"))
+@Entity({
+  name: "LlmCostBudget",
+})
+@EnableWorkflow({
+  create: true,
+  delete: true,
+  update: true,
+  read: true,
+})
+@TableMetadata({
+  tableName: "LlmCostBudget",
+  singularName: "LLM Cost Budget",
+  pluralName: "LLM Cost Budgets",
+  icon: IconProp.CurrencyDollar,
+  tableDescription:
+    "Daily USD spend budgets for LLM / GenAI telemetry. A worker sums the day's LLM span cost and raises alerts when spend crosses the warning and breach thresholds.",
+})
+@TableAccessControl({
+  create: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.CreateProjectLlmCostBudget,
+  ],
+  read: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.Viewer,
+    Permission.TelemetryAdmin,
+    Permission.TelemetryMember,
+    Permission.TelemetryViewer,
+    Permission.ReadProjectLlmCostBudget,
+  ],
+  delete: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.DeleteProjectLlmCostBudget,
+  ],
+  update: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.EditProjectLlmCostBudget,
+  ],
+})
+export default class LlmCostBudget extends BaseModel {
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "projectId",
+    type: TableColumnType.Entity,
+    modelType: Project,
+    title: "Project",
+    description: "Relation to the project this LLM cost budget belongs to.",
+  })
+  @ManyToOne(
+    () => {
+      return Project;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "CASCADE",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "projectId" })
+  public project?: Project = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: true,
+    canReadOnRelationQuery: true,
+    title: "Project ID",
+    description: "ID of the project this LLM cost budget belongs to.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: false,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public projectId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Name,
+    canReadOnRelationQuery: true,
+    title: "Name",
+    description: "Friendly name for this budget.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.Name,
+    length: ColumnLength.Name,
+  })
+  public name?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.LongText,
+    canReadOnRelationQuery: true,
+    title: "Description",
+    description: "Description of what this budget covers.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.LongText,
+    length: ColumnLength.LongText,
+  })
+  public description?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @Index()
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Boolean,
+    title: "Is Enabled",
+    description: "Whether this budget is evaluated.",
+    defaultValue: true,
+    isDefaultValueColumn: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    nullable: false,
+    default: true,
+  })
+  public isEnabled?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Number,
+    canReadOnRelationQuery: true,
+    title: "Daily Budget (USD)",
+    description:
+      "Daily LLM spend budget in USD, evaluated over the UTC day. Alerts fire at the warning threshold and at 100%.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.Decimal,
+    transformer: decimalTransformer,
+  })
+  public dailyBudgetInUSD?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Number,
+    title: "Warning Threshold (%)",
+    description:
+      "Percentage of the daily budget at which a warning alert is raised (1-99). A breach alert always fires at 100%.",
+    defaultValue: 80,
+    isDefaultValueColumn: true,
+  })
+  @Column({
+    type: ColumnType.Number,
+    nullable: false,
+    default: 80,
+  })
+  public warningThresholdPercent?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "serviceId",
+    type: TableColumnType.Entity,
+    modelType: Service,
+    required: false,
+    title: "Service",
+    description:
+      "Optional service scope. When set, only LLM spend of this telemetry service counts against the budget. Leave empty for a project-wide budget.",
+  })
+  @ManyToOne(
+    () => {
+      return Service;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "CASCADE",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "serviceId" })
+  public service?: Service = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Service ID",
+    description:
+      "Optional telemetry service ID scoping this budget. Null means the budget is project-wide.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public serviceId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "LLM Provider",
+    description:
+      "Optional provider filter, e.g. openai, anthropic, aws.bedrock (matches the span's gen_ai provider). Leave empty to count every provider.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public llmSystem?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "LLM Model",
+    description:
+      "Optional model filter, e.g. gpt-4o (matches the span's requested model exactly). Leave empty to count every model.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public llmModel?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "alertSeverityId",
+    type: TableColumnType.Entity,
+    modelType: AlertSeverity,
+    title: "Alert Severity",
+    description:
+      "Severity of the alerts created when this budget crosses a threshold. Defaults to the project's lowest-order severity when unset.",
+  })
+  @ManyToOne(
+    () => {
+      return AlertSeverity;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "alertSeverityId" })
+  public alertSeverity?: AlertSeverity = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    title: "Alert Severity ID",
+    description:
+      "ID of the Alert Severity of the alerts created by this budget.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public alertSeverityId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmCostBudget,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmCostBudget,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.EntityArray,
+    modelType: OnCallDutyPolicy,
+    title: "On-Call Duty Policies",
+    description:
+      "On-call duty policies to execute when this budget raises an alert.",
+  })
+  @ManyToMany(
+    () => {
+      return OnCallDutyPolicy;
+    },
+    { eager: false },
+  )
+  @JoinTable({
+    name: "LlmCostBudgetOnCallDutyPolicy",
+    inverseJoinColumn: {
+      name: "onCallDutyPolicyId",
+      referencedColumnName: "_id",
+    },
+    joinColumn: {
+      name: "llmCostBudgetId",
+      referencedColumnName: "_id",
+    },
+  })
+  public onCallDutyPolicies?: Array<OnCallDutyPolicy> = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.Number,
+    required: false,
+    title: "Current Day Spend (USD)",
+    description:
+      "LLM spend accrued so far in the current UTC day, in USD. Computed by the worker.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Decimal,
+    transformer: decimalTransformer,
+  })
+  public currentDaySpendInUSD?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Spend Last Evaluated At",
+    description:
+      "The last time the worker evaluated this budget. Computed by the worker.",
+  })
+  @Column({
+    type: ColumnType.Date,
+    nullable: true,
+  })
+  public spendLastEvaluatedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Last Warning Alert Created At",
+    description:
+      "The last time this budget raised a warning-threshold alert. Computed by the worker.",
+  })
+  @Column({
+    type: ColumnType.Date,
+    nullable: true,
+  })
+  public lastWarningAlertCreatedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Last Breach Alert Created At",
+    description:
+      "The last time this budget raised a 100% breach alert. Computed by the worker.",
+  })
+  @Column({
+    type: ColumnType.Date,
+    nullable: true,
+  })
+  public lastBreachAlertCreatedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "createdByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Created By User",
+    description: "Relation to the user who created this budget.",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "createdByUserId" })
+  public createdByUser?: User = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Created By User ID",
+    description: "ID of the user who created this budget.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public createdByUserId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "deletedByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Deleted By User",
+    description: "Relation to the user who deleted this budget.",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "deletedByUserId" })
+  public deletedByUser?: User = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmCostBudget,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Deleted By User ID",
+    description: "ID of the user who deleted this budget.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public deletedByUserId?: ObjectID = undefined;
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788100000000-AddMeasurements.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788100000000-AddMeasurements.ts
@@ -1,164 +1,457 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class AddMeasurements1788100000000 implements MigrationInterface {
-    name = 'AddMeasurements1788100000000'
+  public name: string = "AddMeasurements1788100000000";
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "IncidentMeasurement" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(100) NOT NULL, "key" character varying(100) NOT NULL, "description" character varying(500), "metricName" character varying(100) NOT NULL, "startAnchorType" character varying(100) NOT NULL, "endAnchorType" character varying(100) NOT NULL, "startIncidentStateId" uuid, "endIncidentStateId" uuid, "startIncidentStateRole" character varying(100), "endIncidentStateRole" character varying(100), "startStateOccurrence" character varying(100) DEFAULT 'First', "endStateOccurrence" character varying(100) DEFAULT 'First', "unit" character varying(100) DEFAULT 'seconds', "aggregationType" character varying(100) DEFAULT 'Avg', "isEnabled" boolean NOT NULL DEFAULT true, "showOnIncidentView" boolean NOT NULL DEFAULT true, "order" integer NOT NULL DEFAULT '1', "isSystemDefined" boolean NOT NULL DEFAULT false, "backfillRequestedAt" TIMESTAMP WITH TIME ZONE, "backfillCursorCreatedAt" TIMESTAMP WITH TIME ZONE, "backfillCompletedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_b63aa88c70bcc2a9092d4a2bb52" PRIMARY KEY ("_id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_4bb2eeba1479a85aaec28352d7" ON "IncidentMeasurement" ("projectId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_0228a178ab48344ffd16f6d161" ON "IncidentMeasurement" ("name") `);
-        await queryRunner.query(`CREATE INDEX "IDX_c90a0730d38919406d865fe407" ON "IncidentMeasurement" ("key") `);
-        await queryRunner.query(`CREATE INDEX "IDX_3270145bf369fa6ab151ed87a4" ON "IncidentMeasurement" ("startIncidentStateId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_7f532fc9bff46fe6c03a348068" ON "IncidentMeasurement" ("endIncidentStateId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_f9fc934cd452e16238e63f5029" ON "IncidentMeasurement" ("isEnabled") `);
-        await queryRunner.query(`CREATE INDEX "IDX_436b0a605f61be0db556a2832b" ON "IncidentMeasurement" ("order") `);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_8f7e13fe765b9e44a96617e6bc" ON "IncidentMeasurement" ("projectId", "key") `);
-        await queryRunner.query(`CREATE TABLE "IncidentMeasurementValue" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "incidentId" uuid NOT NULL, "incidentMeasurementId" uuid NOT NULL, "startedAt" TIMESTAMP WITH TIME ZONE, "endedAt" TIMESTAMP WITH TIME ZONE, "valueInSeconds" integer, "status" character varying(100) NOT NULL DEFAULT 'Pending', "statusMessage" character varying(500), "startIncidentStateTimelineId" uuid, "endIncidentStateTimelineId" uuid, "computedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_1ff18d23bfaa5e2bb41584fddf9" PRIMARY KEY ("_id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_b6ed656c48d7620108b99d81cd" ON "IncidentMeasurementValue" ("projectId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_24dbe2aac2f22edb6fa1e3ea8a" ON "IncidentMeasurementValue" ("incidentId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_47aa6f05bed26266dd2d5ade7d" ON "IncidentMeasurementValue" ("incidentMeasurementId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_48fb00fdbea5e11c3ea529071d" ON "IncidentMeasurementValue" ("valueInSeconds") `);
-        await queryRunner.query(`CREATE INDEX "IDX_ccd95220cefeb3fbfbe444a48b" ON "IncidentMeasurementValue" ("status") `);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_ad37a1c1f3c9b5f1d42b08de89" ON "IncidentMeasurementValue" ("incidentId", "incidentMeasurementId") `);
-        await queryRunner.query(`CREATE TABLE "AlertMeasurement" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(100) NOT NULL, "key" character varying(100) NOT NULL, "description" character varying(500), "metricName" character varying(100) NOT NULL, "startAnchorType" character varying(100) NOT NULL, "endAnchorType" character varying(100) NOT NULL, "startAlertStateId" uuid, "endAlertStateId" uuid, "startAlertStateRole" character varying(100), "endAlertStateRole" character varying(100), "startStateOccurrence" character varying(100) DEFAULT 'First', "endStateOccurrence" character varying(100) DEFAULT 'First', "unit" character varying(100) DEFAULT 'seconds', "aggregationType" character varying(100) DEFAULT 'Avg', "isEnabled" boolean NOT NULL DEFAULT true, "showOnAlertView" boolean NOT NULL DEFAULT true, "order" integer NOT NULL DEFAULT '1', "isSystemDefined" boolean NOT NULL DEFAULT false, "backfillRequestedAt" TIMESTAMP WITH TIME ZONE, "backfillCursorCreatedAt" TIMESTAMP WITH TIME ZONE, "backfillCompletedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_c217c4f44919c0fd1f38a6c0011" PRIMARY KEY ("_id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_4780aa79cfcb70140d25685ead" ON "AlertMeasurement" ("projectId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_3e5f5b2c335ef4e0641dc7aa62" ON "AlertMeasurement" ("name") `);
-        await queryRunner.query(`CREATE INDEX "IDX_9a06f185bdcfd6cee978297f21" ON "AlertMeasurement" ("key") `);
-        await queryRunner.query(`CREATE INDEX "IDX_80c93f51e33fce330f32e8ce2d" ON "AlertMeasurement" ("startAlertStateId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_17178f34b59610e3e4e659351d" ON "AlertMeasurement" ("endAlertStateId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_215c26643846e9ab43fb154f36" ON "AlertMeasurement" ("isEnabled") `);
-        await queryRunner.query(`CREATE INDEX "IDX_f62933bd4e82a45081970bef78" ON "AlertMeasurement" ("order") `);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b04c704778ad3b81a6085e4419" ON "AlertMeasurement" ("projectId", "key") `);
-        await queryRunner.query(`CREATE TABLE "AlertMeasurementValue" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "alertId" uuid NOT NULL, "alertMeasurementId" uuid NOT NULL, "startedAt" TIMESTAMP WITH TIME ZONE, "endedAt" TIMESTAMP WITH TIME ZONE, "valueInSeconds" integer, "status" character varying(100) NOT NULL DEFAULT 'Pending', "statusMessage" character varying(500), "startAlertStateTimelineId" uuid, "endAlertStateTimelineId" uuid, "computedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_9eabfe70b4734919fe55bd63313" PRIMARY KEY ("_id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_b914406e7723ecc476110fc79f" ON "AlertMeasurementValue" ("projectId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_59ea9279ec8500b77e649a2e8e" ON "AlertMeasurementValue" ("alertId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_00d9747fdfbd0e6740eb8fc69d" ON "AlertMeasurementValue" ("alertMeasurementId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_f23ff68f2848657f3ab5883440" ON "AlertMeasurementValue" ("valueInSeconds") `);
-        await queryRunner.query(`CREATE INDEX "IDX_26423cecf70d8a9436bd953a13" ON "AlertMeasurementValue" ("status") `);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_73bee7a7805ec991b991fb1a8d" ON "AlertMeasurementValue" ("alertId", "alertMeasurementId") `);
-        await queryRunner.query(`CREATE TABLE "ScheduledMaintenanceMeasurement" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(100) NOT NULL, "key" character varying(100) NOT NULL, "description" character varying(500), "metricName" character varying(100) NOT NULL, "startAnchorType" character varying(100) NOT NULL, "endAnchorType" character varying(100) NOT NULL, "startScheduledMaintenanceStateId" uuid, "endScheduledMaintenanceStateId" uuid, "startScheduledMaintenanceStateRole" character varying(100), "endScheduledMaintenanceStateRole" character varying(100), "startStateOccurrence" character varying(100) DEFAULT 'First', "endStateOccurrence" character varying(100) DEFAULT 'First', "unit" character varying(100) DEFAULT 'seconds', "aggregationType" character varying(100) DEFAULT 'Avg', "isEnabled" boolean NOT NULL DEFAULT true, "showOnScheduledMaintenanceView" boolean NOT NULL DEFAULT true, "order" integer NOT NULL DEFAULT '1', "isSystemDefined" boolean NOT NULL DEFAULT false, "backfillRequestedAt" TIMESTAMP WITH TIME ZONE, "backfillCursorCreatedAt" TIMESTAMP WITH TIME ZONE, "backfillCompletedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_99860965c14f50db32dad7ec9af" PRIMARY KEY ("_id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_c066bdc7849e2d4d73d5f11be7" ON "ScheduledMaintenanceMeasurement" ("projectId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_f61748d98aeec13c6010559a2a" ON "ScheduledMaintenanceMeasurement" ("name") `);
-        await queryRunner.query(`CREATE INDEX "IDX_fce9fc20f44a0bbb34b3b2fd63" ON "ScheduledMaintenanceMeasurement" ("key") `);
-        await queryRunner.query(`CREATE INDEX "IDX_4823f52854290b0205f17a9968" ON "ScheduledMaintenanceMeasurement" ("startScheduledMaintenanceStateId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_4e4bd9930063375be1d29cc244" ON "ScheduledMaintenanceMeasurement" ("endScheduledMaintenanceStateId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_5a474d68553920a24346e2a694" ON "ScheduledMaintenanceMeasurement" ("isEnabled") `);
-        await queryRunner.query(`CREATE INDEX "IDX_7cbd52c6913666c4656867a0a1" ON "ScheduledMaintenanceMeasurement" ("order") `);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_bb3486578e2e4a6cd437d1dbd2" ON "ScheduledMaintenanceMeasurement" ("projectId", "key") `);
-        await queryRunner.query(`CREATE TABLE "ScheduledMaintenanceMeasurementValue" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "scheduledMaintenanceId" uuid NOT NULL, "scheduledMaintenanceMeasurementId" uuid NOT NULL, "startedAt" TIMESTAMP WITH TIME ZONE, "endedAt" TIMESTAMP WITH TIME ZONE, "valueInSeconds" integer, "status" character varying(100) NOT NULL DEFAULT 'Pending', "statusMessage" character varying(500), "startScheduledMaintenanceStateTimelineId" uuid, "endScheduledMaintenanceStateTimelineId" uuid, "computedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_60f1ecbb3f29616d326144eb930" PRIMARY KEY ("_id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_9d005630c98d5147e70f1cb0e4" ON "ScheduledMaintenanceMeasurementValue" ("projectId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_1a56522d2f40a8a975f868364d" ON "ScheduledMaintenanceMeasurementValue" ("scheduledMaintenanceId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_5c7969aeb81562016806421dd3" ON "ScheduledMaintenanceMeasurementValue" ("scheduledMaintenanceMeasurementId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_cbaa06c1ac0024314ef03f4e86" ON "ScheduledMaintenanceMeasurementValue" ("valueInSeconds") `);
-        await queryRunner.query(`CREATE INDEX "IDX_90b70e49330e0f5db44b039460" ON "ScheduledMaintenanceMeasurementValue" ("status") `);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_815c11e4c8c9b6557995b6456f" ON "ScheduledMaintenanceMeasurementValue" ("scheduledMaintenanceId", "scheduledMaintenanceMeasurementId") `);
-        await queryRunner.query(`ALTER TABLE "Incident" ADD "impactStartedAt" TIMESTAMP WITH TIME ZONE`);
-        await queryRunner.query(`ALTER TABLE "Alert" ADD "impactStartedAt" TIMESTAMP WITH TIME ZONE`);
-        await queryRunner.query(`CREATE INDEX "IDX_7753a9da84cb33b66477f2eb13" ON "Incident" ("impactStartedAt") `);
-        await queryRunner.query(`CREATE INDEX "IDX_b2881110ef797a56914f86a557" ON "Alert" ("impactStartedAt") `);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_4bb2eeba1479a85aaec28352d79" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_3270145bf369fa6ab151ed87a44" FOREIGN KEY ("startIncidentStateId") REFERENCES "IncidentState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_7f532fc9bff46fe6c03a3480682" FOREIGN KEY ("endIncidentStateId") REFERENCES "IncidentState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_84efaebce32b0b58d41c2ff2f46" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_5132d6cca9f27d19ef0b5862ca8" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurementValue" ADD CONSTRAINT "FK_b6ed656c48d7620108b99d81cd6" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurementValue" ADD CONSTRAINT "FK_24dbe2aac2f22edb6fa1e3ea8a6" FOREIGN KEY ("incidentId") REFERENCES "Incident"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurementValue" ADD CONSTRAINT "FK_47aa6f05bed26266dd2d5ade7d4" FOREIGN KEY ("incidentMeasurementId") REFERENCES "IncidentMeasurement"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_4780aa79cfcb70140d25685ead0" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_80c93f51e33fce330f32e8ce2de" FOREIGN KEY ("startAlertStateId") REFERENCES "AlertState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_17178f34b59610e3e4e659351da" FOREIGN KEY ("endAlertStateId") REFERENCES "AlertState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_6e8dfe6c9bb387d5fbfc48d3b4c" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_3ad10caaff5f7ad20e9d3b803e9" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurementValue" ADD CONSTRAINT "FK_b914406e7723ecc476110fc79f2" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurementValue" ADD CONSTRAINT "FK_59ea9279ec8500b77e649a2e8e5" FOREIGN KEY ("alertId") REFERENCES "Alert"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurementValue" ADD CONSTRAINT "FK_00d9747fdfbd0e6740eb8fc69d7" FOREIGN KEY ("alertMeasurementId") REFERENCES "AlertMeasurement"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_c066bdc7849e2d4d73d5f11be70" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_4823f52854290b0205f17a9968b" FOREIGN KEY ("startScheduledMaintenanceStateId") REFERENCES "ScheduledMaintenanceState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_4e4bd9930063375be1d29cc2448" FOREIGN KEY ("endScheduledMaintenanceStateId") REFERENCES "ScheduledMaintenanceState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_b9930166086a2ece02297bcdeb5" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_50572dc7759e681975be5888cd9" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurementValue" ADD CONSTRAINT "FK_9d005630c98d5147e70f1cb0e4e" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurementValue" ADD CONSTRAINT "FK_1a56522d2f40a8a975f868364d0" FOREIGN KEY ("scheduledMaintenanceId") REFERENCES "ScheduledMaintenance"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurementValue" ADD CONSTRAINT "FK_5c7969aeb81562016806421dd31" FOREIGN KEY ("scheduledMaintenanceMeasurementId") REFERENCES "ScheduledMaintenanceMeasurement"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "IncidentMeasurement" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(100) NOT NULL, "key" character varying(100) NOT NULL, "description" character varying(500), "metricName" character varying(100) NOT NULL, "startAnchorType" character varying(100) NOT NULL, "endAnchorType" character varying(100) NOT NULL, "startIncidentStateId" uuid, "endIncidentStateId" uuid, "startIncidentStateRole" character varying(100), "endIncidentStateRole" character varying(100), "startStateOccurrence" character varying(100) DEFAULT 'First', "endStateOccurrence" character varying(100) DEFAULT 'First', "unit" character varying(100) DEFAULT 'seconds', "aggregationType" character varying(100) DEFAULT 'Avg', "isEnabled" boolean NOT NULL DEFAULT true, "showOnIncidentView" boolean NOT NULL DEFAULT true, "order" integer NOT NULL DEFAULT '1', "isSystemDefined" boolean NOT NULL DEFAULT false, "backfillRequestedAt" TIMESTAMP WITH TIME ZONE, "backfillCursorCreatedAt" TIMESTAMP WITH TIME ZONE, "backfillCompletedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_b63aa88c70bcc2a9092d4a2bb52" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4bb2eeba1479a85aaec28352d7" ON "IncidentMeasurement" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0228a178ab48344ffd16f6d161" ON "IncidentMeasurement" ("name") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c90a0730d38919406d865fe407" ON "IncidentMeasurement" ("key") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3270145bf369fa6ab151ed87a4" ON "IncidentMeasurement" ("startIncidentStateId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7f532fc9bff46fe6c03a348068" ON "IncidentMeasurement" ("endIncidentStateId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f9fc934cd452e16238e63f5029" ON "IncidentMeasurement" ("isEnabled") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_436b0a605f61be0db556a2832b" ON "IncidentMeasurement" ("order") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_8f7e13fe765b9e44a96617e6bc" ON "IncidentMeasurement" ("projectId", "key") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "IncidentMeasurementValue" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "incidentId" uuid NOT NULL, "incidentMeasurementId" uuid NOT NULL, "startedAt" TIMESTAMP WITH TIME ZONE, "endedAt" TIMESTAMP WITH TIME ZONE, "valueInSeconds" integer, "status" character varying(100) NOT NULL DEFAULT 'Pending', "statusMessage" character varying(500), "startIncidentStateTimelineId" uuid, "endIncidentStateTimelineId" uuid, "computedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_1ff18d23bfaa5e2bb41584fddf9" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b6ed656c48d7620108b99d81cd" ON "IncidentMeasurementValue" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_24dbe2aac2f22edb6fa1e3ea8a" ON "IncidentMeasurementValue" ("incidentId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_47aa6f05bed26266dd2d5ade7d" ON "IncidentMeasurementValue" ("incidentMeasurementId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_48fb00fdbea5e11c3ea529071d" ON "IncidentMeasurementValue" ("valueInSeconds") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ccd95220cefeb3fbfbe444a48b" ON "IncidentMeasurementValue" ("status") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_ad37a1c1f3c9b5f1d42b08de89" ON "IncidentMeasurementValue" ("incidentId", "incidentMeasurementId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "AlertMeasurement" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(100) NOT NULL, "key" character varying(100) NOT NULL, "description" character varying(500), "metricName" character varying(100) NOT NULL, "startAnchorType" character varying(100) NOT NULL, "endAnchorType" character varying(100) NOT NULL, "startAlertStateId" uuid, "endAlertStateId" uuid, "startAlertStateRole" character varying(100), "endAlertStateRole" character varying(100), "startStateOccurrence" character varying(100) DEFAULT 'First', "endStateOccurrence" character varying(100) DEFAULT 'First', "unit" character varying(100) DEFAULT 'seconds', "aggregationType" character varying(100) DEFAULT 'Avg', "isEnabled" boolean NOT NULL DEFAULT true, "showOnAlertView" boolean NOT NULL DEFAULT true, "order" integer NOT NULL DEFAULT '1', "isSystemDefined" boolean NOT NULL DEFAULT false, "backfillRequestedAt" TIMESTAMP WITH TIME ZONE, "backfillCursorCreatedAt" TIMESTAMP WITH TIME ZONE, "backfillCompletedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_c217c4f44919c0fd1f38a6c0011" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4780aa79cfcb70140d25685ead" ON "AlertMeasurement" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3e5f5b2c335ef4e0641dc7aa62" ON "AlertMeasurement" ("name") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_9a06f185bdcfd6cee978297f21" ON "AlertMeasurement" ("key") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_80c93f51e33fce330f32e8ce2d" ON "AlertMeasurement" ("startAlertStateId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_17178f34b59610e3e4e659351d" ON "AlertMeasurement" ("endAlertStateId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_215c26643846e9ab43fb154f36" ON "AlertMeasurement" ("isEnabled") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f62933bd4e82a45081970bef78" ON "AlertMeasurement" ("order") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_b04c704778ad3b81a6085e4419" ON "AlertMeasurement" ("projectId", "key") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "AlertMeasurementValue" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "alertId" uuid NOT NULL, "alertMeasurementId" uuid NOT NULL, "startedAt" TIMESTAMP WITH TIME ZONE, "endedAt" TIMESTAMP WITH TIME ZONE, "valueInSeconds" integer, "status" character varying(100) NOT NULL DEFAULT 'Pending', "statusMessage" character varying(500), "startAlertStateTimelineId" uuid, "endAlertStateTimelineId" uuid, "computedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_9eabfe70b4734919fe55bd63313" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b914406e7723ecc476110fc79f" ON "AlertMeasurementValue" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_59ea9279ec8500b77e649a2e8e" ON "AlertMeasurementValue" ("alertId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_00d9747fdfbd0e6740eb8fc69d" ON "AlertMeasurementValue" ("alertMeasurementId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f23ff68f2848657f3ab5883440" ON "AlertMeasurementValue" ("valueInSeconds") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_26423cecf70d8a9436bd953a13" ON "AlertMeasurementValue" ("status") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_73bee7a7805ec991b991fb1a8d" ON "AlertMeasurementValue" ("alertId", "alertMeasurementId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "ScheduledMaintenanceMeasurement" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(100) NOT NULL, "key" character varying(100) NOT NULL, "description" character varying(500), "metricName" character varying(100) NOT NULL, "startAnchorType" character varying(100) NOT NULL, "endAnchorType" character varying(100) NOT NULL, "startScheduledMaintenanceStateId" uuid, "endScheduledMaintenanceStateId" uuid, "startScheduledMaintenanceStateRole" character varying(100), "endScheduledMaintenanceStateRole" character varying(100), "startStateOccurrence" character varying(100) DEFAULT 'First', "endStateOccurrence" character varying(100) DEFAULT 'First', "unit" character varying(100) DEFAULT 'seconds', "aggregationType" character varying(100) DEFAULT 'Avg', "isEnabled" boolean NOT NULL DEFAULT true, "showOnScheduledMaintenanceView" boolean NOT NULL DEFAULT true, "order" integer NOT NULL DEFAULT '1', "isSystemDefined" boolean NOT NULL DEFAULT false, "backfillRequestedAt" TIMESTAMP WITH TIME ZONE, "backfillCursorCreatedAt" TIMESTAMP WITH TIME ZONE, "backfillCompletedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_99860965c14f50db32dad7ec9af" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c066bdc7849e2d4d73d5f11be7" ON "ScheduledMaintenanceMeasurement" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f61748d98aeec13c6010559a2a" ON "ScheduledMaintenanceMeasurement" ("name") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_fce9fc20f44a0bbb34b3b2fd63" ON "ScheduledMaintenanceMeasurement" ("key") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4823f52854290b0205f17a9968" ON "ScheduledMaintenanceMeasurement" ("startScheduledMaintenanceStateId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4e4bd9930063375be1d29cc244" ON "ScheduledMaintenanceMeasurement" ("endScheduledMaintenanceStateId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5a474d68553920a24346e2a694" ON "ScheduledMaintenanceMeasurement" ("isEnabled") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7cbd52c6913666c4656867a0a1" ON "ScheduledMaintenanceMeasurement" ("order") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_bb3486578e2e4a6cd437d1dbd2" ON "ScheduledMaintenanceMeasurement" ("projectId", "key") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "ScheduledMaintenanceMeasurementValue" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "scheduledMaintenanceId" uuid NOT NULL, "scheduledMaintenanceMeasurementId" uuid NOT NULL, "startedAt" TIMESTAMP WITH TIME ZONE, "endedAt" TIMESTAMP WITH TIME ZONE, "valueInSeconds" integer, "status" character varying(100) NOT NULL DEFAULT 'Pending', "statusMessage" character varying(500), "startScheduledMaintenanceStateTimelineId" uuid, "endScheduledMaintenanceStateTimelineId" uuid, "computedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_60f1ecbb3f29616d326144eb930" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_9d005630c98d5147e70f1cb0e4" ON "ScheduledMaintenanceMeasurementValue" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1a56522d2f40a8a975f868364d" ON "ScheduledMaintenanceMeasurementValue" ("scheduledMaintenanceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5c7969aeb81562016806421dd3" ON "ScheduledMaintenanceMeasurementValue" ("scheduledMaintenanceMeasurementId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_cbaa06c1ac0024314ef03f4e86" ON "ScheduledMaintenanceMeasurementValue" ("valueInSeconds") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_90b70e49330e0f5db44b039460" ON "ScheduledMaintenanceMeasurementValue" ("status") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_815c11e4c8c9b6557995b6456f" ON "ScheduledMaintenanceMeasurementValue" ("scheduledMaintenanceId", "scheduledMaintenanceMeasurementId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Incident" ADD "impactStartedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Alert" ADD "impactStartedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7753a9da84cb33b66477f2eb13" ON "Incident" ("impactStartedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b2881110ef797a56914f86a557" ON "Alert" ("impactStartedAt") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_4bb2eeba1479a85aaec28352d79" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_3270145bf369fa6ab151ed87a44" FOREIGN KEY ("startIncidentStateId") REFERENCES "IncidentState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_7f532fc9bff46fe6c03a3480682" FOREIGN KEY ("endIncidentStateId") REFERENCES "IncidentState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_84efaebce32b0b58d41c2ff2f46" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" ADD CONSTRAINT "FK_5132d6cca9f27d19ef0b5862ca8" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurementValue" ADD CONSTRAINT "FK_b6ed656c48d7620108b99d81cd6" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurementValue" ADD CONSTRAINT "FK_24dbe2aac2f22edb6fa1e3ea8a6" FOREIGN KEY ("incidentId") REFERENCES "Incident"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurementValue" ADD CONSTRAINT "FK_47aa6f05bed26266dd2d5ade7d4" FOREIGN KEY ("incidentMeasurementId") REFERENCES "IncidentMeasurement"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_4780aa79cfcb70140d25685ead0" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_80c93f51e33fce330f32e8ce2de" FOREIGN KEY ("startAlertStateId") REFERENCES "AlertState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_17178f34b59610e3e4e659351da" FOREIGN KEY ("endAlertStateId") REFERENCES "AlertState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_6e8dfe6c9bb387d5fbfc48d3b4c" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" ADD CONSTRAINT "FK_3ad10caaff5f7ad20e9d3b803e9" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurementValue" ADD CONSTRAINT "FK_b914406e7723ecc476110fc79f2" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurementValue" ADD CONSTRAINT "FK_59ea9279ec8500b77e649a2e8e5" FOREIGN KEY ("alertId") REFERENCES "Alert"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurementValue" ADD CONSTRAINT "FK_00d9747fdfbd0e6740eb8fc69d7" FOREIGN KEY ("alertMeasurementId") REFERENCES "AlertMeasurement"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_c066bdc7849e2d4d73d5f11be70" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_4823f52854290b0205f17a9968b" FOREIGN KEY ("startScheduledMaintenanceStateId") REFERENCES "ScheduledMaintenanceState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_4e4bd9930063375be1d29cc2448" FOREIGN KEY ("endScheduledMaintenanceStateId") REFERENCES "ScheduledMaintenanceState"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_b9930166086a2ece02297bcdeb5" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" ADD CONSTRAINT "FK_50572dc7759e681975be5888cd9" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurementValue" ADD CONSTRAINT "FK_9d005630c98d5147e70f1cb0e4e" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurementValue" ADD CONSTRAINT "FK_1a56522d2f40a8a975f868364d0" FOREIGN KEY ("scheduledMaintenanceId") REFERENCES "ScheduledMaintenance"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurementValue" ADD CONSTRAINT "FK_5c7969aeb81562016806421dd31" FOREIGN KEY ("scheduledMaintenanceMeasurementId") REFERENCES "ScheduledMaintenanceMeasurement"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurementValue" DROP CONSTRAINT "FK_5c7969aeb81562016806421dd31"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurementValue" DROP CONSTRAINT "FK_1a56522d2f40a8a975f868364d0"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurementValue" DROP CONSTRAINT "FK_9d005630c98d5147e70f1cb0e4e"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_50572dc7759e681975be5888cd9"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_b9930166086a2ece02297bcdeb5"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_4e4bd9930063375be1d29cc2448"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_4823f52854290b0205f17a9968b"`);
-        await queryRunner.query(`ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_c066bdc7849e2d4d73d5f11be70"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurementValue" DROP CONSTRAINT "FK_00d9747fdfbd0e6740eb8fc69d7"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurementValue" DROP CONSTRAINT "FK_59ea9279ec8500b77e649a2e8e5"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurementValue" DROP CONSTRAINT "FK_b914406e7723ecc476110fc79f2"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_3ad10caaff5f7ad20e9d3b803e9"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_6e8dfe6c9bb387d5fbfc48d3b4c"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_17178f34b59610e3e4e659351da"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_80c93f51e33fce330f32e8ce2de"`);
-        await queryRunner.query(`ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_4780aa79cfcb70140d25685ead0"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurementValue" DROP CONSTRAINT "FK_47aa6f05bed26266dd2d5ade7d4"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurementValue" DROP CONSTRAINT "FK_24dbe2aac2f22edb6fa1e3ea8a6"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurementValue" DROP CONSTRAINT "FK_b6ed656c48d7620108b99d81cd6"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_5132d6cca9f27d19ef0b5862ca8"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_84efaebce32b0b58d41c2ff2f46"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_7f532fc9bff46fe6c03a3480682"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_3270145bf369fa6ab151ed87a44"`);
-        await queryRunner.query(`ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_4bb2eeba1479a85aaec28352d79"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b2881110ef797a56914f86a557"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_7753a9da84cb33b66477f2eb13"`);
-        await queryRunner.query(`ALTER TABLE "Alert" DROP COLUMN "impactStartedAt"`);
-        await queryRunner.query(`ALTER TABLE "Incident" DROP COLUMN "impactStartedAt"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_815c11e4c8c9b6557995b6456f"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_90b70e49330e0f5db44b039460"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_cbaa06c1ac0024314ef03f4e86"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_5c7969aeb81562016806421dd3"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_1a56522d2f40a8a975f868364d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_9d005630c98d5147e70f1cb0e4"`);
-        await queryRunner.query(`DROP TABLE "ScheduledMaintenanceMeasurementValue"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_bb3486578e2e4a6cd437d1dbd2"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_7cbd52c6913666c4656867a0a1"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_5a474d68553920a24346e2a694"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_4e4bd9930063375be1d29cc244"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_4823f52854290b0205f17a9968"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_fce9fc20f44a0bbb34b3b2fd63"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_f61748d98aeec13c6010559a2a"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_c066bdc7849e2d4d73d5f11be7"`);
-        await queryRunner.query(`DROP TABLE "ScheduledMaintenanceMeasurement"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_73bee7a7805ec991b991fb1a8d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_26423cecf70d8a9436bd953a13"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_f23ff68f2848657f3ab5883440"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_00d9747fdfbd0e6740eb8fc69d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_59ea9279ec8500b77e649a2e8e"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b914406e7723ecc476110fc79f"`);
-        await queryRunner.query(`DROP TABLE "AlertMeasurementValue"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b04c704778ad3b81a6085e4419"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_f62933bd4e82a45081970bef78"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_215c26643846e9ab43fb154f36"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_17178f34b59610e3e4e659351d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_80c93f51e33fce330f32e8ce2d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_9a06f185bdcfd6cee978297f21"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_3e5f5b2c335ef4e0641dc7aa62"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_4780aa79cfcb70140d25685ead"`);
-        await queryRunner.query(`DROP TABLE "AlertMeasurement"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_ad37a1c1f3c9b5f1d42b08de89"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_ccd95220cefeb3fbfbe444a48b"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_48fb00fdbea5e11c3ea529071d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_47aa6f05bed26266dd2d5ade7d"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_24dbe2aac2f22edb6fa1e3ea8a"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b6ed656c48d7620108b99d81cd"`);
-        await queryRunner.query(`DROP TABLE "IncidentMeasurementValue"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_8f7e13fe765b9e44a96617e6bc"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_436b0a605f61be0db556a2832b"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_f9fc934cd452e16238e63f5029"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_7f532fc9bff46fe6c03a348068"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_3270145bf369fa6ab151ed87a4"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_c90a0730d38919406d865fe407"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_0228a178ab48344ffd16f6d161"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_4bb2eeba1479a85aaec28352d7"`);
-        await queryRunner.query(`DROP TABLE "IncidentMeasurement"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurementValue" DROP CONSTRAINT "FK_5c7969aeb81562016806421dd31"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurementValue" DROP CONSTRAINT "FK_1a56522d2f40a8a975f868364d0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurementValue" DROP CONSTRAINT "FK_9d005630c98d5147e70f1cb0e4e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_50572dc7759e681975be5888cd9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_b9930166086a2ece02297bcdeb5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_4e4bd9930063375be1d29cc2448"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_4823f52854290b0205f17a9968b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ScheduledMaintenanceMeasurement" DROP CONSTRAINT "FK_c066bdc7849e2d4d73d5f11be70"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurementValue" DROP CONSTRAINT "FK_00d9747fdfbd0e6740eb8fc69d7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurementValue" DROP CONSTRAINT "FK_59ea9279ec8500b77e649a2e8e5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurementValue" DROP CONSTRAINT "FK_b914406e7723ecc476110fc79f2"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_3ad10caaff5f7ad20e9d3b803e9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_6e8dfe6c9bb387d5fbfc48d3b4c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_17178f34b59610e3e4e659351da"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_80c93f51e33fce330f32e8ce2de"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AlertMeasurement" DROP CONSTRAINT "FK_4780aa79cfcb70140d25685ead0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurementValue" DROP CONSTRAINT "FK_47aa6f05bed26266dd2d5ade7d4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurementValue" DROP CONSTRAINT "FK_24dbe2aac2f22edb6fa1e3ea8a6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurementValue" DROP CONSTRAINT "FK_b6ed656c48d7620108b99d81cd6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_5132d6cca9f27d19ef0b5862ca8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_84efaebce32b0b58d41c2ff2f46"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_7f532fc9bff46fe6c03a3480682"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_3270145bf369fa6ab151ed87a44"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IncidentMeasurement" DROP CONSTRAINT "FK_4bb2eeba1479a85aaec28352d79"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b2881110ef797a56914f86a557"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7753a9da84cb33b66477f2eb13"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Alert" DROP COLUMN "impactStartedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Incident" DROP COLUMN "impactStartedAt"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_815c11e4c8c9b6557995b6456f"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_90b70e49330e0f5db44b039460"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_cbaa06c1ac0024314ef03f4e86"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5c7969aeb81562016806421dd3"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1a56522d2f40a8a975f868364d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_9d005630c98d5147e70f1cb0e4"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "ScheduledMaintenanceMeasurementValue"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_bb3486578e2e4a6cd437d1dbd2"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7cbd52c6913666c4656867a0a1"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5a474d68553920a24346e2a694"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_4e4bd9930063375be1d29cc244"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_4823f52854290b0205f17a9968"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_fce9fc20f44a0bbb34b3b2fd63"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f61748d98aeec13c6010559a2a"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c066bdc7849e2d4d73d5f11be7"`,
+    );
+    await queryRunner.query(`DROP TABLE "ScheduledMaintenanceMeasurement"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_73bee7a7805ec991b991fb1a8d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_26423cecf70d8a9436bd953a13"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f23ff68f2848657f3ab5883440"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_00d9747fdfbd0e6740eb8fc69d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_59ea9279ec8500b77e649a2e8e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b914406e7723ecc476110fc79f"`,
+    );
+    await queryRunner.query(`DROP TABLE "AlertMeasurementValue"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b04c704778ad3b81a6085e4419"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f62933bd4e82a45081970bef78"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_215c26643846e9ab43fb154f36"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_17178f34b59610e3e4e659351d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_80c93f51e33fce330f32e8ce2d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_9a06f185bdcfd6cee978297f21"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3e5f5b2c335ef4e0641dc7aa62"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_4780aa79cfcb70140d25685ead"`,
+    );
+    await queryRunner.query(`DROP TABLE "AlertMeasurement"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ad37a1c1f3c9b5f1d42b08de89"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ccd95220cefeb3fbfbe444a48b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_48fb00fdbea5e11c3ea529071d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_47aa6f05bed26266dd2d5ade7d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_24dbe2aac2f22edb6fa1e3ea8a"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b6ed656c48d7620108b99d81cd"`,
+    );
+    await queryRunner.query(`DROP TABLE "IncidentMeasurementValue"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_8f7e13fe765b9e44a96617e6bc"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_436b0a605f61be0db556a2832b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f9fc934cd452e16238e63f5029"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7f532fc9bff46fe6c03a348068"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3270145bf369fa6ab151ed87a4"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c90a0730d38919406d865fe407"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0228a178ab48344ffd16f6d161"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_4bb2eeba1479a85aaec28352d7"`,
+    );
+    await queryRunner.query(`DROP TABLE "IncidentMeasurement"`);
+  }
 }

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788200000000-AddLlmCostBudget.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788200000000-AddLlmCostBudget.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLlmCostBudget1788200000000 implements MigrationInterface {
+  public name: string = "AddLlmCostBudget1788200000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "LlmCostBudget" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "name" character varying(50) NOT NULL, "description" character varying(500), "isEnabled" boolean NOT NULL DEFAULT true, "dailyBudgetInUSD" numeric NOT NULL, "warningThresholdPercent" integer NOT NULL DEFAULT '80', "serviceId" uuid, "llmSystem" character varying(100), "llmModel" character varying(100), "alertSeverityId" uuid, "currentDaySpendInUSD" numeric, "spendLastEvaluatedAt" TIMESTAMP WITH TIME ZONE, "lastWarningAlertCreatedAt" TIMESTAMP WITH TIME ZONE, "lastBreachAlertCreatedAt" TIMESTAMP WITH TIME ZONE, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_d578bebf3f6052e17b704cf258f" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a2c16269206814b595fe8989fc" ON "LlmCostBudget" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_406f25110eaf6728f1621c25b4" ON "LlmCostBudget" ("isEnabled") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_040ebc679deb8d1153c1df38ec" ON "LlmCostBudget" ("serviceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_dfe6c27c42564e7422d26c8b1e" ON "LlmCostBudget" ("alertSeverityId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "LlmCostBudgetOnCallDutyPolicy" ("llmCostBudgetId" uuid NOT NULL, "onCallDutyPolicyId" uuid NOT NULL, CONSTRAINT "PK_1312da5439a5bc0ba61e5cbf005" PRIMARY KEY ("llmCostBudgetId", "onCallDutyPolicyId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d05f7b557fdd92c4c9ff42e910" ON "LlmCostBudgetOnCallDutyPolicy" ("llmCostBudgetId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_76020c2c8f8f264128f6adfd89" ON "LlmCostBudgetOnCallDutyPolicy" ("onCallDutyPolicyId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD CONSTRAINT "FK_a2c16269206814b595fe8989fcf" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD CONSTRAINT "FK_040ebc679deb8d1153c1df38ec4" FOREIGN KEY ("serviceId") REFERENCES "Service"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD CONSTRAINT "FK_dfe6c27c42564e7422d26c8b1ed" FOREIGN KEY ("alertSeverityId") REFERENCES "AlertSeverity"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD CONSTRAINT "FK_1b9d9408f33a0915ba0351d0040" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD CONSTRAINT "FK_74898628624d84ba6c9a55bb5fc" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudgetOnCallDutyPolicy" ADD CONSTRAINT "FK_d05f7b557fdd92c4c9ff42e9107" FOREIGN KEY ("llmCostBudgetId") REFERENCES "LlmCostBudget"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudgetOnCallDutyPolicy" ADD CONSTRAINT "FK_76020c2c8f8f264128f6adfd899" FOREIGN KEY ("onCallDutyPolicyId") REFERENCES "OnCallDutyPolicy"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudgetOnCallDutyPolicy" DROP CONSTRAINT "FK_76020c2c8f8f264128f6adfd899"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudgetOnCallDutyPolicy" DROP CONSTRAINT "FK_d05f7b557fdd92c4c9ff42e9107"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP CONSTRAINT "FK_74898628624d84ba6c9a55bb5fc"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP CONSTRAINT "FK_1b9d9408f33a0915ba0351d0040"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP CONSTRAINT "FK_dfe6c27c42564e7422d26c8b1ed"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP CONSTRAINT "FK_040ebc679deb8d1153c1df38ec4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP CONSTRAINT "FK_a2c16269206814b595fe8989fcf"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_76020c2c8f8f264128f6adfd89"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_d05f7b557fdd92c4c9ff42e910"`,
+    );
+    await queryRunner.query(`DROP TABLE "LlmCostBudgetOnCallDutyPolicy"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_dfe6c27c42564e7422d26c8b1e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_040ebc679deb8d1153c1df38ec"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_406f25110eaf6728f1621c25b4"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a2c16269206814b595fe8989fc"`,
+    );
+    await queryRunner.query(`DROP TABLE "LlmCostBudget"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -535,6 +535,7 @@ import { AddScopeToNetworkDeviceLinkRule1787800000000 } from "./1787800000000-Ad
 import { AddRestrictToAttachedProjectsToGlobalSso1787900000000 } from "./1787900000000-AddRestrictToAttachedProjectsToGlobalSso";
 import { AddDetectionRuleAndGoogleSecOpsConnection1788000000000 } from "./1788000000000-AddDetectionRuleAndGoogleSecOpsConnection";
 import { AddMeasurements1788100000000 } from "./1788100000000-AddMeasurements";
+import { AddLlmCostBudget1788200000000 } from "./1788200000000-AddLlmCostBudget";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1078,4 +1079,5 @@ export default [
   AddRestrictToAttachedProjectsToGlobalSso1787900000000,
   AddDetectionRuleAndGoogleSecOpsConnection1788000000000,
   AddMeasurements1788100000000,
+  AddLlmCostBudget1788200000000,
 ];

--- a/Common/Server/Services/Index.ts
+++ b/Common/Server/Services/Index.ts
@@ -269,6 +269,7 @@ import ScheduledMaintenanceMeasurementValueService from "./ScheduledMaintenanceM
 import IncidentSlaService from "./IncidentSlaService";
 import ServiceLevelObjectiveService from "./ServiceLevelObjectiveService";
 import ServiceLevelObjectiveBurnRateRuleService from "./ServiceLevelObjectiveBurnRateRuleService";
+import LlmCostBudgetService from "./LlmCostBudgetService";
 import ServiceLevelObjectiveOwnerUserService from "./ServiceLevelObjectiveOwnerUserService";
 import ServiceLevelObjectiveOwnerTeamService from "./ServiceLevelObjectiveOwnerTeamService";
 import SloHistoryService from "./SloHistoryService";
@@ -566,6 +567,7 @@ const services: Array<BaseService> = [
   IncidentSlaService,
   ServiceLevelObjectiveService,
   ServiceLevelObjectiveBurnRateRuleService,
+  LlmCostBudgetService,
   ServiceLevelObjectiveOwnerUserService,
   ServiceLevelObjectiveOwnerTeamService,
   IncidentReminderRuleService,

--- a/Common/Server/Services/LlmCostBudgetService.ts
+++ b/Common/Server/Services/LlmCostBudgetService.ts
@@ -1,0 +1,295 @@
+import Alert from "../../Models/DatabaseModels/Alert";
+import AlertStateTimeline from "../../Models/DatabaseModels/AlertStateTimeline";
+import Model from "../../Models/DatabaseModels/LlmCostBudget";
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import BadDataException from "../../Types/Exception/BadDataException";
+import ObjectID from "../../Types/ObjectID";
+import CreateBy from "../Types/Database/CreateBy";
+import DeleteBy from "../Types/Database/DeleteBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
+import UpdateBy from "../Types/Database/UpdateBy";
+import logger, { LogAttributes } from "../Utils/Logger";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import AlertService from "./AlertService";
+import AlertStateTimelineService from "./AlertStateTimelineService";
+import DatabaseService from "./DatabaseService";
+
+const BUDGET_ERROR_MESSAGE: string =
+  "Daily budget must be a number greater than 0.";
+const WARNING_THRESHOLD_ERROR_MESSAGE: string =
+  "Warning threshold must be a whole-number percentage between 1 and 99.";
+
+// The two alert kinds a budget can raise, encoded into the alert fingerprint.
+export type LlmCostBudgetAlertKind = "warning" | "breach";
+
+export class Service extends DatabaseService<Model> {
+  public constructor() {
+    super(Model);
+  }
+
+  /*
+   * Deterministic fingerprint carried on Alerts created by a budget. The
+   * evaluation worker sets this as `seriesFingerprint` when it fires an
+   * alert, and lifecycle hooks use it to find (and resolve) those alerts when
+   * the budget goes away. Warning and breach are separate series so a breach
+   * still pages when the warning alert is already open.
+   */
+  public getBudgetAlertFingerprint(data: {
+    llmCostBudgetId: ObjectID;
+    kind: LlmCostBudgetAlertKind;
+  }): string {
+    return `llm-cost-budget:${data.llmCostBudgetId.toString()}:${data.kind}`;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    /*
+     * Numeric columns can arrive as strings: the dashboard's number fields
+     * hand Formik `e.target.value`, ModelForm copies it verbatim and
+     * BaseModel.fromJSON does not coerce Number/Decimal columns. Coerce,
+     * validate, then write the number back onto the payload so Postgres never
+     * sees a string either. Same convention as
+     * ServiceLevelObjectiveBurnRateRuleService.
+     */
+    createBy.data.dailyBudgetInUSD = this.validateDailyBudget(
+      createBy.data.dailyBudgetInUSD,
+    );
+
+    if (
+      createBy.data.warningThresholdPercent !== undefined &&
+      createBy.data.warningThresholdPercent !== null
+    ) {
+      createBy.data.warningThresholdPercent = this.validateWarningThreshold(
+        createBy.data.warningThresholdPercent,
+      );
+    }
+
+    return {
+      createBy,
+      carryForward: null,
+    };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    // Same string-arrival path as onBeforeCreate: coerce, validate, write back.
+    const newBudget: unknown = updateBy.data.dailyBudgetInUSD as unknown;
+
+    if (newBudget !== undefined && newBudget !== null) {
+      updateBy.data.dailyBudgetInUSD = this.validateDailyBudget(newBudget);
+    }
+
+    const newThreshold: unknown = updateBy.data
+      .warningThresholdPercent as unknown;
+
+    if (newThreshold !== undefined && newThreshold !== null) {
+      updateBy.data.warningThresholdPercent =
+        this.validateWarningThreshold(newThreshold);
+    }
+
+    return {
+      updateBy,
+      carryForward: null,
+    };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    /*
+     * Resolve any open alert fired by the budgets being deleted — otherwise
+     * the alert (and its on-call escalations) stays open forever because the
+     * evaluation worker only touches budgets that still exist.
+     */
+    const itemsToDelete: Array<Model> = await this.findBy({
+      query: deleteBy.query,
+      limit: deleteBy.limit,
+      skip: deleteBy.skip,
+      select: {
+        _id: true,
+        projectId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    for (const item of itemsToDelete) {
+      if (!item.id || !item.projectId) {
+        continue;
+      }
+
+      try {
+        await this.resolveOpenAlertsForBudget({
+          llmCostBudgetId: item.id,
+          projectId: item.projectId,
+          rootCause:
+            "Alert auto-resolved because the LLM cost budget that created it was deleted.",
+        });
+      } catch (err) {
+        logger.error(
+          `Error resolving open alerts for LLM cost budget ${item.id?.toString()} before delete: ${err}`,
+          { projectId: item.projectId?.toString() } as LogAttributes,
+        );
+      }
+    }
+
+    return {
+      deleteBy,
+      carryForward: {
+        itemsToDelete: itemsToDelete,
+      },
+    };
+  }
+
+  /*
+   * Resolve all open Alerts carrying this budget's fingerprints (warning and
+   * breach) by appending a resolved AlertStateTimeline row. Mirrors
+   * ServiceLevelObjectiveBurnRateRuleService.resolveOpenAlertsForRule,
+   * including tolerating the benign same-state concurrency race.
+   */
+  @CaptureSpan()
+  public async resolveOpenAlertsForBudget(data: {
+    llmCostBudgetId: ObjectID;
+    projectId: ObjectID;
+    rootCause?: string | undefined;
+  }): Promise<void> {
+    const kinds: Array<LlmCostBudgetAlertKind> = ["warning", "breach"];
+
+    for (const kind of kinds) {
+      const fingerprint: string = this.getBudgetAlertFingerprint({
+        llmCostBudgetId: data.llmCostBudgetId,
+        kind: kind,
+      });
+
+      const openAlerts: Array<Alert> = await AlertService.findBy({
+        query: {
+          projectId: data.projectId,
+          seriesFingerprint: fingerprint,
+          currentAlertState: {
+            isResolvedState: false,
+          },
+        },
+        select: {
+          _id: true,
+          projectId: true,
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (openAlerts.length === 0) {
+        continue;
+      }
+
+      const resolvedStateId: ObjectID =
+        await AlertStateTimelineService.getResolvedStateIdForProject(
+          data.projectId,
+        );
+
+      for (const openAlert of openAlerts) {
+        try {
+          const alertStateTimeline: AlertStateTimeline =
+            new AlertStateTimeline();
+          alertStateTimeline.alertId = openAlert.id!;
+          alertStateTimeline.alertStateId = resolvedStateId;
+          alertStateTimeline.projectId = openAlert.projectId!;
+          alertStateTimeline.rootCause =
+            data.rootCause ||
+            "Alert auto-resolved because the LLM cost budget that created it is no longer active.";
+
+          try {
+            await AlertStateTimelineService.create({
+              data: alertStateTimeline,
+              props: {
+                isRoot: true,
+              },
+            });
+          } catch (err) {
+            /*
+             * Idempotent concurrency race: the evaluation worker and a
+             * lifecycle hook can both decide to resolve the same open alert
+             * near-simultaneously. The loser's onBeforeCreate dedupe throws
+             * this exact BadDataException. Treat as a no-op at debug level.
+             * Mirrors MonitorAlert.resolveOpenAlert.
+             */
+            if (
+              err instanceof BadDataException &&
+              err.message === "Alert state cannot be same as previous state."
+            ) {
+              logger.debug(
+                `${openAlert.id?.toString()} - Alert already in resolved state; skipping duplicate state timeline (concurrent race).`,
+              );
+            } else {
+              throw err;
+            }
+          }
+        } catch (err) {
+          logger.error(
+            `Error resolving open alert ${openAlert.id?.toString()} for LLM cost budget ${data.llmCostBudgetId?.toString()}: ${err}`,
+            { projectId: data.projectId?.toString() } as LogAttributes,
+          );
+        }
+      }
+    }
+  }
+
+  /*
+   * Coerce an API-supplied numeric column to a number. HTML number inputs hand
+   * Formik strings and neither ModelForm nor BaseModel.fromJSON coerces
+   * Number/Decimal columns, so "100" reaches these hooks as a string — and
+   * string comparison is lexicographic. Anything that is not a finite numeric
+   * string or number becomes NaN, which every caller below rejects.
+   */
+  private normalizeNumericInput(value: unknown): number {
+    if (typeof value === "string") {
+      const trimmed: string = value.trim();
+      return trimmed === "" ? Number.NaN : Number(trimmed);
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    return Number.NaN;
+  }
+
+  private validateDailyBudget(value: unknown): number {
+    const dailyBudgetInUSD: number = this.normalizeNumericInput(value);
+
+    if (!Number.isFinite(dailyBudgetInUSD) || dailyBudgetInUSD <= 0) {
+      throw new BadDataException(BUDGET_ERROR_MESSAGE);
+    }
+
+    return dailyBudgetInUSD;
+  }
+
+  private validateWarningThreshold(value: unknown): number {
+    const warningThresholdPercent: number = this.normalizeNumericInput(value);
+
+    /*
+     * The column is a Postgres integer, so a decimal that cleared only the
+     * range check would fail the INSERT with a raw driver error instead of
+     * this message. Mirrors ServiceLevelObjectiveService's percentage guard.
+     */
+    if (
+      !Number.isInteger(warningThresholdPercent) ||
+      warningThresholdPercent < 1 ||
+      warningThresholdPercent > 99
+    ) {
+      throw new BadDataException(WARNING_THRESHOLD_ERROR_MESSAGE);
+    }
+
+    return warningThresholdPercent;
+  }
+}
+
+export default new Service();

--- a/Common/Server/Utils/Telemetry/LlmCostBudgetEvaluator.ts
+++ b/Common/Server/Utils/Telemetry/LlmCostBudgetEvaluator.ts
@@ -1,0 +1,504 @@
+import Alert from "../../../Models/DatabaseModels/Alert";
+import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
+import LlmCostBudget from "../../../Models/DatabaseModels/LlmCostBudget";
+import OnCallDutyPolicy from "../../../Models/DatabaseModels/OnCallDutyPolicy";
+import Span from "../../../Models/AnalyticsModels/Span";
+import AggregatedModel from "../../../Types/BaseDatabase/AggregatedModel";
+import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
+import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Query from "../../../Types/BaseDatabase/Query";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import ObjectID from "../../../Types/ObjectID";
+import { DisableAutomaticAlertCreation } from "../../EnvironmentConfig";
+import AggregateBy from "../../Types/AnalyticsDatabase/AggregateBy";
+import AlertService from "../../Services/AlertService";
+import AlertSeverityService from "../../Services/AlertSeverityService";
+import LlmCostBudgetService, {
+  LlmCostBudgetAlertKind,
+} from "../../Services/LlmCostBudgetService";
+import SpanService from "../../Services/SpanService";
+import logger, { LogAttributes } from "../Logger";
+import CaptureSpan from "../Telemetry/CaptureSpan";
+
+/*
+ * Evaluates LLM cost budgets against the day's LLM span spend.
+ *
+ * The worker job (App/FeatureSet/Workers/Jobs/Llm/EvaluateLlmCostBudgets.ts)
+ * calls evaluateAllBudgets() on a 15-minute tick. For each enabled budget it
+ * sums the UTC day's llmCost from ClickHouse (scoped by the budget's optional
+ * service / provider / model filters), stamps the spend back onto the budget
+ * row for the dashboard, and raises a warning alert at the configured
+ * threshold and a breach alert at 100% — each at most once per UTC day, via
+ * the lastWarningAlertCreatedAt / lastBreachAlertCreatedAt state columns plus
+ * an open-alert fingerprint check.
+ *
+ * The threshold decision itself is a pure function (decide) so the alerting
+ * semantics are unit-testable without a database.
+ */
+
+export interface LlmCostBudgetDecisionInput {
+  // The day's spend so far, in USD.
+  spendInUSD: number;
+  dailyBudgetInUSD: number;
+  // Warning threshold in percent (1-99). Invalid values fall back to 80.
+  warningThresholdPercent: number | undefined;
+  lastWarningAlertCreatedAt: Date | undefined;
+  lastBreachAlertCreatedAt: Date | undefined;
+  now: Date;
+}
+
+export interface LlmCostBudgetDecision {
+  // Percent of the daily budget consumed (0 when the budget is invalid).
+  percentUsed: number;
+  shouldFireWarning: boolean;
+  shouldFireBreach: boolean;
+}
+
+export const DEFAULT_WARNING_THRESHOLD_PERCENT: number = 80;
+
+export default class LlmCostBudgetEvaluator {
+  /**
+   * Pure threshold decision. Breach (>= 100%) supersedes warning — a call
+   * that jumps straight past the budget raises one breach alert, not two
+   * alerts. Each kind fires at most once per UTC day, keyed off the
+   * last-created timestamps the caller persists after firing.
+   */
+  public static decide(
+    input: LlmCostBudgetDecisionInput,
+  ): LlmCostBudgetDecision {
+    const decision: LlmCostBudgetDecision = {
+      percentUsed: 0,
+      shouldFireWarning: false,
+      shouldFireBreach: false,
+    };
+
+    if (
+      !isFinite(input.dailyBudgetInUSD) ||
+      input.dailyBudgetInUSD <= 0 ||
+      !isFinite(input.spendInUSD) ||
+      input.spendInUSD < 0
+    ) {
+      return decision;
+    }
+
+    decision.percentUsed = (input.spendInUSD / input.dailyBudgetInUSD) * 100;
+
+    let warningThresholdPercent: number =
+      input.warningThresholdPercent ?? DEFAULT_WARNING_THRESHOLD_PERCENT;
+
+    if (
+      !isFinite(warningThresholdPercent) ||
+      warningThresholdPercent < 1 ||
+      warningThresholdPercent > 99
+    ) {
+      warningThresholdPercent = DEFAULT_WARNING_THRESHOLD_PERCENT;
+    }
+
+    const alreadyWarnedToday: boolean = this.isSameUtcDay(
+      input.lastWarningAlertCreatedAt,
+      input.now,
+    );
+    const alreadyBreachedToday: boolean = this.isSameUtcDay(
+      input.lastBreachAlertCreatedAt,
+      input.now,
+    );
+
+    if (decision.percentUsed >= 100) {
+      decision.shouldFireBreach = !alreadyBreachedToday;
+      return decision;
+    }
+
+    if (decision.percentUsed >= warningThresholdPercent) {
+      decision.shouldFireWarning = !alreadyWarnedToday;
+    }
+
+    return decision;
+  }
+
+  /**
+   * Start of the UTC day `now` falls in. UTC-explicit (not process-zone) so
+   * the budget day is the same day everywhere OneUptime runs.
+   */
+  public static getUtcDayStart(now: Date): Date {
+    return new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+  }
+
+  /**
+   * Whether two instants fall in the same UTC calendar day. False when the
+   * first is undefined.
+   */
+  public static isSameUtcDay(a: Date | undefined, b: Date): boolean {
+    if (!a) {
+      return false;
+    }
+
+    return (
+      a.getUTCFullYear() === b.getUTCFullYear() &&
+      a.getUTCMonth() === b.getUTCMonth() &&
+      a.getUTCDate() === b.getUTCDate()
+    );
+  }
+
+  /**
+   * Build the ClickHouse span filter for a budget: the UTC day so far,
+   * LLM spans only, narrowed by the budget's optional service / provider /
+   * model scoping.
+   */
+  public static buildSpanQuery(data: {
+    budget: LlmCostBudget;
+    dayStart: Date;
+    now: Date;
+  }): Query<Span> {
+    const query: Query<Span> = {
+      projectId: data.budget.projectId!,
+      isLlmSpan: true,
+      /*
+       * Bound rows to the window — aggregateBy's startTimestamp/endTimestamp
+       * only pick the bucket grid, they do not filter rows.
+       */
+      startTime: new InBetween(data.dayStart, data.now),
+    } as Query<Span>;
+
+    if (data.budget.serviceId) {
+      (query as Record<string, unknown>)["primaryEntityId"] =
+        data.budget.serviceId;
+    }
+
+    if (data.budget.llmSystem) {
+      (query as Record<string, unknown>)["llmSystem"] = data.budget.llmSystem;
+    }
+
+    if (data.budget.llmModel) {
+      (query as Record<string, unknown>)["llmRequestModel"] =
+        data.budget.llmModel;
+    }
+
+    return query;
+  }
+
+  /**
+   * Evaluate every enabled budget. One bad budget never aborts the sweep.
+   */
+  @CaptureSpan()
+  public static async evaluateAllBudgets(): Promise<void> {
+    const budgets: Array<LlmCostBudget> = await LlmCostBudgetService.findBy({
+      query: {
+        isEnabled: true,
+      },
+      select: {
+        _id: true,
+        projectId: true,
+        name: true,
+        dailyBudgetInUSD: true,
+        warningThresholdPercent: true,
+        serviceId: true,
+        llmSystem: true,
+        llmModel: true,
+        alertSeverityId: true,
+        onCallDutyPolicies: {
+          _id: true,
+        },
+        lastWarningAlertCreatedAt: true,
+        lastBreachAlertCreatedAt: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (budgets.length === 0) {
+      return;
+    }
+
+    logger.debug(
+      `Llm:EvaluateLlmCostBudgets: evaluating ${budgets.length} enabled budget(s)`,
+    );
+
+    const now: Date = new Date();
+
+    for (const budget of budgets) {
+      try {
+        await this.evaluateBudget({ budget, now });
+      } catch (err) {
+        logger.error(
+          `LLM cost budget ${budget.id?.toString()} for project ${budget.projectId?.toString() ?? "?"} failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { projectId: budget.projectId?.toString() } as LogAttributes,
+        );
+      }
+    }
+  }
+
+  /**
+   * Evaluate one budget: sum the day's spend, stamp it on the row, and fire
+   * whichever threshold alert the decision calls for.
+   */
+  @CaptureSpan()
+  public static async evaluateBudget(data: {
+    budget: LlmCostBudget;
+    now: Date;
+  }): Promise<void> {
+    const budget: LlmCostBudget = data.budget;
+
+    if (!budget.id || !budget.projectId || !budget.dailyBudgetInUSD) {
+      return;
+    }
+
+    const dayStart: Date = this.getUtcDayStart(data.now);
+
+    const spendInUSD: number = await this.getSpendInUSD({
+      budget: budget,
+      dayStart: dayStart,
+      now: data.now,
+    });
+
+    const decision: LlmCostBudgetDecision = this.decide({
+      spendInUSD: spendInUSD,
+      dailyBudgetInUSD: budget.dailyBudgetInUSD,
+      warningThresholdPercent: budget.warningThresholdPercent,
+      lastWarningAlertCreatedAt: budget.lastWarningAlertCreatedAt,
+      lastBreachAlertCreatedAt: budget.lastBreachAlertCreatedAt,
+      now: data.now,
+    });
+
+    // Stamp the spend for the dashboard even when nothing fires.
+    await LlmCostBudgetService.updateOneById({
+      id: budget.id,
+      data: {
+        currentDaySpendInUSD: spendInUSD,
+        spendLastEvaluatedAt: data.now,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (decision.shouldFireBreach) {
+      const created: boolean = await this.createBudgetAlert({
+        budget: budget,
+        kind: "breach",
+        spendInUSD: spendInUSD,
+        percentUsed: decision.percentUsed,
+      });
+
+      if (created) {
+        await LlmCostBudgetService.updateOneById({
+          id: budget.id,
+          data: {
+            lastBreachAlertCreatedAt: data.now,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+      }
+
+      return;
+    }
+
+    if (decision.shouldFireWarning) {
+      const created: boolean = await this.createBudgetAlert({
+        budget: budget,
+        kind: "warning",
+        spendInUSD: spendInUSD,
+        percentUsed: decision.percentUsed,
+      });
+
+      if (created) {
+        await LlmCostBudgetService.updateOneById({
+          id: budget.id,
+          data: {
+            lastWarningAlertCreatedAt: data.now,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+      }
+    }
+  }
+
+  /**
+   * Sum the day's llmCost for the budget's scope from ClickHouse.
+   */
+  @CaptureSpan()
+  private static async getSpendInUSD(data: {
+    budget: LlmCostBudget;
+    dayStart: Date;
+    now: Date;
+  }): Promise<number> {
+    const aggregateBy: AggregateBy<Span> = {
+      query: this.buildSpanQuery(data),
+      aggregationType: AggregationType.Sum,
+      aggregateColumnName: "llmCost",
+      aggregationTimestampColumnName: "startTime",
+      startTimestamp: data.dayStart,
+      endTimestamp: data.now,
+      // One total over the whole window — no time bucketing.
+      aggregationInterval: AggregationInterval.Total,
+      /*
+       * Alerting must fail loud on a query timeout: the default 'break'
+       * overflow mode returns silently-partial sums, which would understate
+       * spend and suppress a real budget breach.
+       */
+      timeoutOverflowMode: "throw",
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    };
+
+    const result: AggregatedResult = await SpanService.aggregateBy(aggregateBy);
+
+    return (result.data || []).reduce(
+      (acc: number, row: AggregatedModel): number => {
+        return acc + Number(row.value || 0);
+      },
+      0,
+    );
+  }
+
+  /**
+   * Create the warning/breach alert for a budget. Returns true when an alert
+   * was actually created (the caller stamps the per-day dedup timestamp only
+   * then).
+   */
+  @CaptureSpan()
+  private static async createBudgetAlert(data: {
+    budget: LlmCostBudget;
+    kind: LlmCostBudgetAlertKind;
+    spendInUSD: number;
+    percentUsed: number;
+  }): Promise<boolean> {
+    const budget: LlmCostBudget = data.budget;
+
+    const fingerprint: string = LlmCostBudgetService.getBudgetAlertFingerprint({
+      llmCostBudgetId: budget.id!,
+      kind: data.kind,
+    });
+
+    // An open alert in the same series means on-call is already looking.
+    const openAlert: Alert | null = await AlertService.findOneBy({
+      query: {
+        projectId: budget.projectId!,
+        seriesFingerprint: fingerprint,
+        currentAlertState: {
+          isResolvedState: false,
+        },
+      },
+      select: {
+        _id: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (openAlert) {
+      logger.debug(
+        `Llm:EvaluateLlmCostBudgets: open ${data.kind} alert already exists for budget ${budget.id?.toString()}; skipping.`,
+      );
+      return false;
+    }
+
+    if (DisableAutomaticAlertCreation) {
+      logger.debug(
+        `Llm:EvaluateLlmCostBudgets: automatic alert creation is disabled; skipping ${data.kind} alert for budget ${budget.id?.toString()}.`,
+      );
+      return false;
+    }
+
+    let alertSeverityId: ObjectID | undefined = budget.alertSeverityId;
+
+    if (!alertSeverityId) {
+      const severity: AlertSeverity | null =
+        await AlertSeverityService.findOneBy({
+          query: {
+            projectId: budget.projectId!,
+          },
+          sort: {
+            order: SortOrder.Ascending,
+          },
+          select: {
+            _id: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      alertSeverityId = severity?.id || undefined;
+    }
+
+    if (!alertSeverityId) {
+      logger.error(
+        `Llm:EvaluateLlmCostBudgets - Cannot create ${data.kind} alert for budget ${budget.id?.toString()}: project has no alert severity.`,
+        { projectId: budget.projectId?.toString() } as LogAttributes,
+      );
+      return false;
+    }
+
+    const spendFormatted: string = `$${data.spendInUSD.toFixed(2)}`;
+    const budgetFormatted: string = `$${(budget.dailyBudgetInUSD || 0).toFixed(2)}`;
+    const percentFormatted: string = `${Math.floor(data.percentUsed)}%`;
+
+    const scopeParts: Array<string> = [];
+
+    if (budget.llmSystem) {
+      scopeParts.push(`provider ${budget.llmSystem}`);
+    }
+
+    if (budget.llmModel) {
+      scopeParts.push(`model ${budget.llmModel}`);
+    }
+
+    const scopeSuffix: string =
+      scopeParts.length > 0 ? ` (${scopeParts.join(", ")})` : "";
+
+    const alert: Alert = new Alert();
+    alert.projectId = budget.projectId!;
+
+    if (data.kind === "breach") {
+      alert.title = `LLM cost budget exceeded: ${budget.name}`;
+      alert.description = `LLM spend${scopeSuffix} has reached ${spendFormatted} — ${percentFormatted} of the ${budgetFormatted} daily budget "${budget.name}". The daily budget is exhausted.`;
+      alert.rootCause = `LLM spend crossed 100% of the daily cost budget "${budget.name}".`;
+    } else {
+      alert.title = `LLM cost budget warning: ${budget.name}`;
+      alert.description = `LLM spend${scopeSuffix} has reached ${spendFormatted} — ${percentFormatted} of the ${budgetFormatted} daily budget "${budget.name}".`;
+      alert.rootCause = `LLM spend crossed the ${budget.warningThresholdPercent ?? DEFAULT_WARNING_THRESHOLD_PERCENT}% warning threshold of the daily cost budget "${budget.name}".`;
+    }
+
+    alert.alertSeverityId = alertSeverityId;
+    alert.seriesFingerprint = fingerprint;
+    alert.isCreatedAutomatically = true;
+
+    // On-call policy id-stubs, the MonitorAlert pattern.
+    alert.onCallDutyPolicies = (budget.onCallDutyPolicies || [])
+      .filter((policy: OnCallDutyPolicy) => {
+        return Boolean(policy.id);
+      })
+      .map((policy: OnCallDutyPolicy) => {
+        const policyStub: OnCallDutyPolicy = new OnCallDutyPolicy();
+        policyStub._id = policy.id!.toString();
+        return policyStub;
+      });
+
+    await AlertService.create({
+      data: alert,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return true;
+  }
+}

--- a/Common/Server/Utils/Telemetry/LlmSpan.ts
+++ b/Common/Server/Utils/Telemetry/LlmSpan.ts
@@ -1,7 +1,9 @@
 import Dictionary from "../../../Types/Dictionary";
+import { LlmCostCatalogUtil } from "../../../Types/Telemetry/LlmCostCatalog";
 import {
   LlmAgentNameAttributeKeys,
   LlmAttributeNamespacePrefixes,
+  LlmConversationIdAttributeKeys,
   LlmCostAttributeKeys,
   LlmInputTokenAttributeKeys,
   LlmOperationAttributeKeys,
@@ -44,11 +46,18 @@ export interface LlmSpanFields {
   llmInputTokens: number;
   llmOutputTokens: number;
   llmTotalTokens: number;
-  // Cost in USD. Only populated when the SDK reports it (no built-in pricing).
+  /*
+   * Cost in USD. The SDK-reported cost (gen_ai.usage.cost) when present;
+   * otherwise an estimate computed from token counts and the built-in
+   * list-price catalog (Common/Types/Telemetry/LlmCostCatalog.ts). 0 when
+   * neither is available.
+   */
   llmCost: number;
   // Agent / tool names for agent-framework spans.
   llmAgentName: string;
   llmToolName: string;
+  // Conversation / session id grouping calls of one interaction (gen_ai.conversation.id).
+  llmConversationId: string;
 }
 
 type SpanAttributes = Dictionary<AttributeType | Array<AttributeType>>;
@@ -70,6 +79,7 @@ export default class LlmSpanUtil {
       llmCost: 0,
       llmAgentName: "",
       llmToolName: "",
+      llmConversationId: "",
     };
   }
 
@@ -134,13 +144,58 @@ export default class LlmSpanUtil {
       fields.llmTotalTokens = fields.llmInputTokens + fields.llmOutputTokens;
     }
 
-    fields.llmCost = this.getNumber(attributes, LlmCostAttributeKeys);
+    /*
+     * Cost must distinguish "reported as 0" from "not reported at all": a
+     * gateway fronting a free local model (or a fully-cached call) reports an
+     * explicit cost of 0, and that 0 must win over any catalog estimate.
+     */
+    const reportedCost: number | null = this.getNumberOrNull(
+      attributes,
+      LlmCostAttributeKeys,
+    );
+
+    fields.llmCost = reportedCost ?? 0;
 
     fields.llmAgentName = this.getString(attributes, LlmAgentNameAttributeKeys);
 
     fields.llmToolName = this.getString(attributes, LlmToolNameAttributeKeys);
 
     fields.isLlmSpan = this.detectIsLlmSpan(keys, fields);
+
+    /*
+     * Conversation id is gated on isLlmSpan because one of its candidate keys
+     * ("session.id") is the generic OTel key RUM browser spans carry — those
+     * already denormalize it into the sessionId column, and stamping it here
+     * too would duplicate it (and its bloom-filter index) across the
+     * highest-volume span class for no reader.
+     */
+    if (fields.isLlmSpan) {
+      fields.llmConversationId = this.getString(
+        attributes,
+        LlmConversationIdAttributeKeys,
+      );
+    }
+
+    /*
+     * Cost fallback: the SDK-reported cost always wins — including an
+     * explicit 0 — but most instrumentations only report token counts. Price
+     * those against the built-in list-price catalog so spend shows up in
+     * dashboards and cost budgets without per-SDK pricing math. The response
+     * model is priced in preference to the request model — it names what the
+     * provider actually served (e.g. an alias like "gpt-4o" resolved to a
+     * dated snapshot).
+     */
+    if (fields.isLlmSpan && reportedCost === null) {
+      const computedCost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+        model: fields.llmResponseModel || fields.llmRequestModel,
+        inputTokens: fields.llmInputTokens,
+        outputTokens: fields.llmOutputTokens,
+      });
+
+      if (computedCost !== null) {
+        fields.llmCost = computedCost;
+      }
+    }
 
     return fields;
   }
@@ -199,6 +254,18 @@ export default class LlmSpanUtil {
     attributes: SpanAttributes,
     candidateKeys: Array<string>,
   ): number {
+    return this.getNumberOrNull(attributes, candidateKeys) ?? 0;
+  }
+
+  /**
+   * Like getNumber but null when no candidate key carries a parseable number
+   * — callers that must distinguish "reported as 0" from "absent" (cost) use
+   * this directly.
+   */
+  private static getNumberOrNull(
+    attributes: SpanAttributes,
+    candidateKeys: Array<string>,
+  ): number | null {
     for (const key of candidateKeys) {
       const value: AttributeType | Array<AttributeType> | undefined =
         attributes[key];
@@ -220,6 +287,6 @@ export default class LlmSpanUtil {
       }
     }
 
-    return 0;
+    return null;
   }
 }

--- a/Common/Tests/Server/Services/LlmCostBudgetService.test.ts
+++ b/Common/Tests/Server/Services/LlmCostBudgetService.test.ts
@@ -1,0 +1,181 @@
+import LlmCostBudget from "../../../Models/DatabaseModels/LlmCostBudget";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import LlmCostBudgetService from "../../../Server/Services/LlmCostBudgetService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The create/update hooks are protected; reach them the way the DatabaseService
+ * pipeline does, through the instance. They are pure validation (no DB access),
+ * so no mocking is needed.
+ */
+type HookAccess = {
+  onBeforeCreate: (
+    createBy: CreateBy<LlmCostBudget>,
+  ) => Promise<{ createBy: CreateBy<LlmCostBudget> }>;
+  onBeforeUpdate: (
+    updateBy: UpdateBy<LlmCostBudget>,
+  ) => Promise<{ updateBy: UpdateBy<LlmCostBudget> }>;
+};
+
+const service: HookAccess = LlmCostBudgetService as unknown as HookAccess;
+
+function makeCreateBy(data: Partial<LlmCostBudget>): CreateBy<LlmCostBudget> {
+  const budget: LlmCostBudget = new LlmCostBudget();
+  Object.assign(budget, data);
+
+  return {
+    data: budget,
+    props: { isRoot: true },
+  } as CreateBy<LlmCostBudget>;
+}
+
+function makeUpdateBy(data: Record<string, unknown>): UpdateBy<LlmCostBudget> {
+  return {
+    query: {},
+    data: data,
+    props: { isRoot: true },
+  } as unknown as UpdateBy<LlmCostBudget>;
+}
+
+describe("LlmCostBudgetService.onBeforeCreate — dailyBudgetInUSD", () => {
+  test("accepts a positive number", async () => {
+    const result: { createBy: CreateBy<LlmCostBudget> } =
+      await service.onBeforeCreate(makeCreateBy({ dailyBudgetInUSD: 250 }));
+
+    expect(result.createBy.data.dailyBudgetInUSD).toBe(250);
+  });
+
+  test("coerces a numeric string to a number", async () => {
+    const result: { createBy: CreateBy<LlmCostBudget> } =
+      await service.onBeforeCreate(
+        makeCreateBy({
+          dailyBudgetInUSD: "99.50" as unknown as number,
+        }),
+      );
+
+    expect(result.createBy.data.dailyBudgetInUSD).toBe(99.5);
+    expect(typeof result.createBy.data.dailyBudgetInUSD).toBe("number");
+  });
+
+  test.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["NaN string", "not-a-number"],
+    ["empty string", ""],
+    ["missing", undefined],
+  ])("rejects %s", async (_label: string, value: unknown) => {
+    await expect(
+      service.onBeforeCreate(
+        makeCreateBy({ dailyBudgetInUSD: value as number }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+});
+
+describe("LlmCostBudgetService.onBeforeCreate — warningThresholdPercent", () => {
+  test("accepts the boundary values 1 and 99", async () => {
+    for (const value of [1, 99]) {
+      const result: { createBy: CreateBy<LlmCostBudget> } =
+        await service.onBeforeCreate(
+          makeCreateBy({
+            dailyBudgetInUSD: 100,
+            warningThresholdPercent: value,
+          }),
+        );
+
+      expect(result.createBy.data.warningThresholdPercent).toBe(value);
+    }
+  });
+
+  test("coerces a numeric string threshold", async () => {
+    const result: { createBy: CreateBy<LlmCostBudget> } =
+      await service.onBeforeCreate(
+        makeCreateBy({
+          dailyBudgetInUSD: 100,
+          warningThresholdPercent: "75" as unknown as number,
+        }),
+      );
+
+    expect(result.createBy.data.warningThresholdPercent).toBe(75);
+  });
+
+  test("omitting the threshold is allowed — the column default applies", async () => {
+    const result: { createBy: CreateBy<LlmCostBudget> } =
+      await service.onBeforeCreate(makeCreateBy({ dailyBudgetInUSD: 100 }));
+
+    expect(result.createBy.data.warningThresholdPercent).toBeUndefined();
+  });
+
+  test.each([
+    ["zero", 0],
+    ["100 — breach territory", 100],
+    ["above 100", 150],
+    ["negative", -10],
+    ["non-numeric string", "eighty"],
+    /*
+     * The column is a Postgres integer — a fractional percent that passed
+     * validation would fail the INSERT with a raw driver error.
+     */
+    ["fractional percent", 87.5],
+    ["fractional percent string", "87.5"],
+  ])("rejects %s", async (_label: string, value: unknown) => {
+    await expect(
+      service.onBeforeCreate(
+        makeCreateBy({
+          dailyBudgetInUSD: 100,
+          warningThresholdPercent: value as number,
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+});
+
+describe("LlmCostBudgetService.onBeforeUpdate", () => {
+  test("coerces and validates an updated budget", async () => {
+    const result: { updateBy: UpdateBy<LlmCostBudget> } =
+      await service.onBeforeUpdate(makeUpdateBy({ dailyBudgetInUSD: "500" }));
+
+    expect(result.updateBy.data.dailyBudgetInUSD).toBe(500);
+  });
+
+  test("rejects an invalid updated budget", async () => {
+    await expect(
+      service.onBeforeUpdate(makeUpdateBy({ dailyBudgetInUSD: -1 })),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  test("rejects an invalid updated threshold", async () => {
+    await expect(
+      service.onBeforeUpdate(makeUpdateBy({ warningThresholdPercent: 100 })),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  test("an update touching neither numeric field passes through", async () => {
+    const result: { updateBy: UpdateBy<LlmCostBudget> } =
+      await service.onBeforeUpdate(makeUpdateBy({ name: "renamed" }));
+
+    expect(result.updateBy.data["name"]).toBe("renamed");
+  });
+});
+
+describe("LlmCostBudgetService.getBudgetAlertFingerprint", () => {
+  test("is deterministic and distinguishes warning from breach", () => {
+    const id: ObjectID = ObjectID.generate();
+
+    const warning: string = LlmCostBudgetService.getBudgetAlertFingerprint({
+      llmCostBudgetId: id,
+      kind: "warning",
+    });
+    const breach: string = LlmCostBudgetService.getBudgetAlertFingerprint({
+      llmCostBudgetId: id,
+      kind: "breach",
+    });
+
+    expect(warning).toBe(`llm-cost-budget:${id.toString()}:warning`);
+    expect(breach).toBe(`llm-cost-budget:${id.toString()}:breach`);
+    expect(warning).not.toBe(breach);
+  });
+});

--- a/Common/Tests/Server/Services/MutableMetricNameRouting.test.ts
+++ b/Common/Tests/Server/Services/MutableMetricNameRouting.test.ts
@@ -50,9 +50,12 @@ describe("MutableMetricService.isMutableMetricName", () => {
       expect(MutableMetricService.isMutableMetricName(metricName)).toBe(false);
     });
 
-    test.each([undefined, ""])("%p is not a mutable metric name", (value?: string) => {
-      expect(MutableMetricService.isMutableMetricName(value)).toBe(false);
-    });
+    test.each([undefined, ""])(
+      "%p is not a mutable metric name",
+      (value?: string) => {
+        expect(MutableMetricService.isMutableMetricName(value)).toBe(false);
+      },
+    );
   });
 
   test("every built-in metric name sits under one of the declared prefixes", () => {

--- a/Common/Tests/Server/Utils/Telemetry/LlmCostBudgetEvaluator.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LlmCostBudgetEvaluator.test.ts
@@ -1,0 +1,689 @@
+import LlmCostBudget from "../../../../Models/DatabaseModels/LlmCostBudget";
+import OnCallDutyPolicy from "../../../../Models/DatabaseModels/OnCallDutyPolicy";
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertSeverity from "../../../../Models/DatabaseModels/AlertSeverity";
+import Span from "../../../../Models/AnalyticsModels/Span";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import Query from "../../../../Types/BaseDatabase/Query";
+import ObjectID from "../../../../Types/ObjectID";
+import LlmCostBudgetEvaluator, {
+  DEFAULT_WARNING_THRESHOLD_PERCENT,
+  LlmCostBudgetDecision,
+} from "../../../../Server/Utils/Telemetry/LlmCostBudgetEvaluator";
+import AlertService from "../../../../Server/Services/AlertService";
+import AlertSeverityService from "../../../../Server/Services/AlertSeverityService";
+import LlmCostBudgetService from "../../../../Server/Services/LlmCostBudgetService";
+import SpanService from "../../../../Server/Services/SpanService";
+/*
+ * `jest` deliberately comes from the global scope, not @jest/globals — the
+ * imported value would shadow the global `jest` NAMESPACE and break the
+ * `jest.Mock` type annotations below (house convention, see
+ * Tests/UI/Components/Workflow/ModelSchema.test.ts).
+ */
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+jest.mock("../../../../Server/Services/SpanService", () => {
+  return {
+    __esModule: true,
+    default: {
+      aggregateBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/AlertService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/AlertSeverityService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/LlmCostBudgetService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      updateOneById: jest.fn(),
+      getBudgetAlertFingerprint: jest.fn(
+        (data: {
+          llmCostBudgetId: { toString: () => string };
+          kind: string;
+        }): string => {
+          return `llm-cost-budget:${data.llmCostBudgetId.toString()}:${data.kind}`;
+        },
+      ),
+    },
+  };
+});
+
+type MockedFn = jest.Mock;
+
+const mockedSpanService: { aggregateBy: MockedFn } = SpanService as unknown as {
+  aggregateBy: MockedFn;
+};
+
+const mockedAlertService: { findOneBy: MockedFn; create: MockedFn } =
+  AlertService as unknown as {
+    findOneBy: MockedFn;
+    create: MockedFn;
+  };
+
+const mockedAlertSeverityService: { findOneBy: MockedFn } =
+  AlertSeverityService as unknown as {
+    findOneBy: MockedFn;
+  };
+
+const mockedBudgetService: {
+  findBy: MockedFn;
+  updateOneById: MockedFn;
+  getBudgetAlertFingerprint: MockedFn;
+} = LlmCostBudgetService as unknown as {
+  findBy: MockedFn;
+  updateOneById: MockedFn;
+  getBudgetAlertFingerprint: MockedFn;
+};
+
+// 2026-08-21 14:30:00 UTC — an arbitrary mid-day instant.
+const NOW: Date = new Date(Date.UTC(2026, 7, 21, 14, 30, 0));
+
+function makeDecisionInput(overrides: {
+  spendInUSD?: number;
+  dailyBudgetInUSD?: number;
+  warningThresholdPercent?: number | undefined;
+  lastWarningAlertCreatedAt?: Date | undefined;
+  lastBreachAlertCreatedAt?: Date | undefined;
+  now?: Date;
+}): Parameters<typeof LlmCostBudgetEvaluator.decide>[0] {
+  return {
+    spendInUSD: overrides.spendInUSD ?? 0,
+    dailyBudgetInUSD: overrides.dailyBudgetInUSD ?? 100,
+    warningThresholdPercent: overrides.warningThresholdPercent,
+    lastWarningAlertCreatedAt: overrides.lastWarningAlertCreatedAt,
+    lastBreachAlertCreatedAt: overrides.lastBreachAlertCreatedAt,
+    now: overrides.now ?? NOW,
+  };
+}
+
+describe("LlmCostBudgetEvaluator.decide — thresholds", () => {
+  test("spend below the warning threshold fires nothing", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 50 }),
+    );
+
+    expect(decision.percentUsed).toBe(50);
+    expect(decision.shouldFireWarning).toBe(false);
+    expect(decision.shouldFireBreach).toBe(false);
+  });
+
+  test("spend exactly at the default 80% threshold fires a warning", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 80 }),
+    );
+
+    expect(decision.percentUsed).toBe(80);
+    expect(decision.shouldFireWarning).toBe(true);
+    expect(decision.shouldFireBreach).toBe(false);
+  });
+
+  test("spend just under 100% fires only a warning", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 99.99 }),
+    );
+
+    expect(decision.shouldFireWarning).toBe(true);
+    expect(decision.shouldFireBreach).toBe(false);
+  });
+
+  test("spend exactly at 100% fires a breach, not a warning", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 100 }),
+    );
+
+    expect(decision.percentUsed).toBe(100);
+    expect(decision.shouldFireWarning).toBe(false);
+    expect(decision.shouldFireBreach).toBe(true);
+  });
+
+  test("spend that jumps straight past 100% fires one breach only", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 250 }),
+    );
+
+    expect(decision.percentUsed).toBe(250);
+    expect(decision.shouldFireWarning).toBe(false);
+    expect(decision.shouldFireBreach).toBe(true);
+  });
+
+  test("a custom warning threshold is honored", () => {
+    const at49: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 49, warningThresholdPercent: 50 }),
+    );
+    const at50: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 50, warningThresholdPercent: 50 }),
+    );
+
+    expect(at49.shouldFireWarning).toBe(false);
+    expect(at50.shouldFireWarning).toBe(true);
+  });
+
+  test("invalid warning thresholds fall back to the default", () => {
+    for (const bad of [0, -5, 100, 150, NaN]) {
+      const below: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+        makeDecisionInput({
+          spendInUSD: DEFAULT_WARNING_THRESHOLD_PERCENT - 1,
+          warningThresholdPercent: bad,
+        }),
+      );
+      const at: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+        makeDecisionInput({
+          spendInUSD: DEFAULT_WARNING_THRESHOLD_PERCENT,
+          warningThresholdPercent: bad,
+        }),
+      );
+
+      expect(below.shouldFireWarning).toBe(false);
+      expect(at.shouldFireWarning).toBe(true);
+    }
+  });
+
+  test("undefined warning threshold uses the default", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({
+        spendInUSD: DEFAULT_WARNING_THRESHOLD_PERCENT,
+        warningThresholdPercent: undefined,
+      }),
+    );
+
+    expect(decision.shouldFireWarning).toBe(true);
+  });
+});
+
+describe("LlmCostBudgetEvaluator.decide — invalid inputs never fire", () => {
+  test.each([
+    ["zero budget", { spendInUSD: 100, dailyBudgetInUSD: 0 }],
+    ["negative budget", { spendInUSD: 100, dailyBudgetInUSD: -10 }],
+    ["NaN budget", { spendInUSD: 100, dailyBudgetInUSD: NaN }],
+    ["Infinity budget", { spendInUSD: 100, dailyBudgetInUSD: Infinity }],
+    ["negative spend", { spendInUSD: -1, dailyBudgetInUSD: 100 }],
+    ["NaN spend", { spendInUSD: NaN, dailyBudgetInUSD: 100 }],
+  ])("%s", (_label: string, input: Record<string, unknown>) => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput(input as { spendInUSD: number }),
+    );
+
+    expect(decision.percentUsed).toBe(0);
+    expect(decision.shouldFireWarning).toBe(false);
+    expect(decision.shouldFireBreach).toBe(false);
+  });
+
+  test("zero spend against a valid budget is quiet", () => {
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({ spendInUSD: 0 }),
+    );
+
+    expect(decision.percentUsed).toBe(0);
+    expect(decision.shouldFireWarning).toBe(false);
+    expect(decision.shouldFireBreach).toBe(false);
+  });
+});
+
+describe("LlmCostBudgetEvaluator.decide — once-per-UTC-day dedup", () => {
+  test("warning does not re-fire when already warned today", () => {
+    const earlierToday: Date = new Date(Date.UTC(2026, 7, 21, 2, 0, 0));
+
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({
+        spendInUSD: 90,
+        lastWarningAlertCreatedAt: earlierToday,
+      }),
+    );
+
+    expect(decision.shouldFireWarning).toBe(false);
+  });
+
+  test("warning re-fires the next UTC day", () => {
+    const yesterday: Date = new Date(Date.UTC(2026, 7, 20, 23, 59, 59));
+
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({
+        spendInUSD: 90,
+        lastWarningAlertCreatedAt: yesterday,
+      }),
+    );
+
+    expect(decision.shouldFireWarning).toBe(true);
+  });
+
+  test("breach does not re-fire when already breached today", () => {
+    const earlierToday: Date = new Date(Date.UTC(2026, 7, 21, 1, 0, 0));
+
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({
+        spendInUSD: 150,
+        lastBreachAlertCreatedAt: earlierToday,
+      }),
+    );
+
+    expect(decision.shouldFireBreach).toBe(false);
+    // Breach supersedes warning even when suppressed — no downgrade alert.
+    expect(decision.shouldFireWarning).toBe(false);
+  });
+
+  test("breach fires even when a warning already fired earlier today", () => {
+    const earlierToday: Date = new Date(Date.UTC(2026, 7, 21, 9, 0, 0));
+
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({
+        spendInUSD: 120,
+        lastWarningAlertCreatedAt: earlierToday,
+      }),
+    );
+
+    expect(decision.shouldFireBreach).toBe(true);
+  });
+
+  test("breach re-fires on a fresh UTC day", () => {
+    const yesterday: Date = new Date(Date.UTC(2026, 7, 20, 12, 0, 0));
+
+    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
+      makeDecisionInput({
+        spendInUSD: 150,
+        lastBreachAlertCreatedAt: yesterday,
+      }),
+    );
+
+    expect(decision.shouldFireBreach).toBe(true);
+  });
+});
+
+describe("LlmCostBudgetEvaluator UTC day helpers", () => {
+  test("getUtcDayStart returns midnight UTC of the same day", () => {
+    const dayStart: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
+
+    expect(dayStart.toISOString()).toBe("2026-08-21T00:00:00.000Z");
+  });
+
+  test("getUtcDayStart is idempotent", () => {
+    const once: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
+    const twice: Date = LlmCostBudgetEvaluator.getUtcDayStart(once);
+
+    expect(twice.getTime()).toBe(once.getTime());
+  });
+
+  test("isSameUtcDay is false for undefined", () => {
+    expect(LlmCostBudgetEvaluator.isSameUtcDay(undefined, NOW)).toBe(false);
+  });
+
+  test("isSameUtcDay is true across hours of the same UTC day", () => {
+    const morning: Date = new Date(Date.UTC(2026, 7, 21, 0, 0, 1));
+    const night: Date = new Date(Date.UTC(2026, 7, 21, 23, 59, 59));
+
+    expect(LlmCostBudgetEvaluator.isSameUtcDay(morning, night)).toBe(true);
+  });
+
+  test("isSameUtcDay is false one second across midnight UTC", () => {
+    const beforeMidnight: Date = new Date(Date.UTC(2026, 7, 20, 23, 59, 59));
+    const afterMidnight: Date = new Date(Date.UTC(2026, 7, 21, 0, 0, 0));
+
+    expect(
+      LlmCostBudgetEvaluator.isSameUtcDay(beforeMidnight, afterMidnight),
+    ).toBe(false);
+  });
+
+  test("isSameUtcDay does not confuse the same day-of-month across months or years", () => {
+    const sameDayOtherMonth: Date = new Date(Date.UTC(2026, 6, 21, 14, 0, 0));
+    const sameDayOtherYear: Date = new Date(Date.UTC(2025, 7, 21, 14, 0, 0));
+
+    expect(LlmCostBudgetEvaluator.isSameUtcDay(sameDayOtherMonth, NOW)).toBe(
+      false,
+    );
+    expect(LlmCostBudgetEvaluator.isSameUtcDay(sameDayOtherYear, NOW)).toBe(
+      false,
+    );
+  });
+});
+
+function makeBudget(overrides?: Partial<LlmCostBudget>): LlmCostBudget {
+  const budget: LlmCostBudget = new LlmCostBudget();
+  budget.id = ObjectID.generate();
+  budget.projectId = ObjectID.generate();
+  budget.name = "Prod LLM budget";
+  budget.dailyBudgetInUSD = 100;
+  budget.warningThresholdPercent = 80;
+
+  return Object.assign(budget, overrides);
+}
+
+describe("LlmCostBudgetEvaluator.buildSpanQuery", () => {
+  const dayStart: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
+
+  test("base query filters project, LLM spans, and the day window", () => {
+    const budget: LlmCostBudget = makeBudget();
+
+    const query: Query<Span> = LlmCostBudgetEvaluator.buildSpanQuery({
+      budget,
+      dayStart,
+      now: NOW,
+    });
+
+    const record: Record<string, unknown> = query as Record<string, unknown>;
+
+    expect(record["projectId"]).toBe(budget.projectId);
+    expect(record["isLlmSpan"]).toBe(true);
+    expect(record["startTime"]).toBeInstanceOf(InBetween);
+    expect(record["primaryEntityId"]).toBeUndefined();
+    expect(record["llmSystem"]).toBeUndefined();
+    expect(record["llmRequestModel"]).toBeUndefined();
+  });
+
+  test("optional scoping filters are applied when set", () => {
+    const serviceId: ObjectID = ObjectID.generate();
+    const budget: LlmCostBudget = makeBudget({
+      serviceId: serviceId,
+      llmSystem: "openai",
+      llmModel: "gpt-4o",
+    });
+
+    const query: Record<string, unknown> =
+      LlmCostBudgetEvaluator.buildSpanQuery({
+        budget,
+        dayStart,
+        now: NOW,
+      }) as Record<string, unknown>;
+
+    expect(query["primaryEntityId"]).toBe(serviceId);
+    expect(query["llmSystem"]).toBe("openai");
+    expect(query["llmRequestModel"]).toBe("gpt-4o");
+  });
+});
+
+describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSpanService.aggregateBy.mockResolvedValue({ data: [] } as never);
+    mockedAlertService.findOneBy.mockResolvedValue(null as never);
+    mockedAlertService.create.mockResolvedValue(new Alert() as never);
+    mockedAlertSeverityService.findOneBy.mockResolvedValue(null as never);
+    mockedBudgetService.updateOneById.mockResolvedValue(undefined as never);
+  });
+
+  function mockSpend(valueInUSD: number): void {
+    mockedSpanService.aggregateBy.mockResolvedValue({
+      data: [{ timestamp: NOW, value: valueInUSD }],
+    } as never);
+  }
+
+  test("stamps spend on the budget even when nothing fires", async () => {
+    const budget: LlmCostBudget = makeBudget();
+    mockSpend(10);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
+    const updateArg: { id: ObjectID; data: Record<string, unknown> } =
+      mockedBudgetService.updateOneById.mock.calls[0]![0] as {
+        id: ObjectID;
+        data: Record<string, unknown>;
+      };
+    // ObjectID getters return fresh instances — compare by value.
+    expect(updateArg.id.toString()).toBe(budget.id!.toString());
+    expect(updateArg.data["currentDaySpendInUSD"]).toBe(10);
+    expect(updateArg.data["spendLastEvaluatedAt"]).toBe(NOW);
+    expect(mockedAlertService.create).not.toHaveBeenCalled();
+  });
+
+  test("multiple aggregation rows are summed", async () => {
+    const budget: LlmCostBudget = makeBudget();
+    mockedSpanService.aggregateBy.mockResolvedValue({
+      data: [
+        { timestamp: NOW, value: 3.5 },
+        { timestamp: NOW, value: 4.5 },
+      ],
+    } as never);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    const updateArg: { data: Record<string, unknown> } = mockedBudgetService
+      .updateOneById.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(updateArg.data["currentDaySpendInUSD"]).toBe(8);
+  });
+
+  test("fires a warning alert with fingerprint, severity, and on-call stubs", async () => {
+    const severityId: ObjectID = ObjectID.generate();
+    const policyId: ObjectID = ObjectID.generate();
+    const policy: OnCallDutyPolicy = new OnCallDutyPolicy();
+    policy.id = policyId;
+
+    const budget: LlmCostBudget = makeBudget({
+      alertSeverityId: severityId,
+      onCallDutyPolicies: [policy],
+    });
+    mockSpend(85);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedAlertService.create).toHaveBeenCalledTimes(1);
+    const created: Alert = (
+      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
+    ).data;
+
+    expect(created.title).toContain("warning");
+    expect(created.title).toContain(budget.name!);
+    expect(created.description).toContain("$85.00");
+    expect(created.description).toContain("$100.00");
+    expect(created.description).toContain("85%");
+    expect(created.alertSeverityId).toBe(severityId);
+    expect(created.seriesFingerprint).toBe(
+      `llm-cost-budget:${budget.id!.toString()}:warning`,
+    );
+    expect(created.isCreatedAutomatically).toBe(true);
+    expect(created.onCallDutyPolicies).toHaveLength(1);
+    expect(created.onCallDutyPolicies![0]!._id).toBe(policyId.toString());
+
+    // Budget severity was provided — no fallback lookup.
+    expect(mockedAlertSeverityService.findOneBy).not.toHaveBeenCalled();
+
+    // Second update stamps the warning dedup timestamp.
+    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(2);
+    const stampArg: { data: Record<string, unknown> } = mockedBudgetService
+      .updateOneById.mock.calls[1]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(stampArg.data["lastWarningAlertCreatedAt"]).toBe(NOW);
+  });
+
+  test("fires a breach alert past 100% and stamps the breach timestamp", async () => {
+    const budget: LlmCostBudget = makeBudget({
+      alertSeverityId: ObjectID.generate(),
+    });
+    mockSpend(130);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedAlertService.create).toHaveBeenCalledTimes(1);
+    const created: Alert = (
+      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
+    ).data;
+
+    expect(created.title).toContain("exceeded");
+    expect(created.seriesFingerprint).toBe(
+      `llm-cost-budget:${budget.id!.toString()}:breach`,
+    );
+
+    const stampArg: { data: Record<string, unknown> } = mockedBudgetService
+      .updateOneById.mock.calls[1]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(stampArg.data["lastBreachAlertCreatedAt"]).toBe(NOW);
+    expect(stampArg.data["lastWarningAlertCreatedAt"]).toBeUndefined();
+  });
+
+  test("scope filters appear in the alert description", async () => {
+    const budget: LlmCostBudget = makeBudget({
+      alertSeverityId: ObjectID.generate(),
+      llmSystem: "openai",
+      llmModel: "gpt-4o",
+    });
+    mockSpend(85);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    const created: Alert = (
+      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
+    ).data;
+    expect(created.description).toContain("provider openai");
+    expect(created.description).toContain("model gpt-4o");
+  });
+
+  test("an open alert in the same series suppresses creation and the stamp", async () => {
+    const budget: LlmCostBudget = makeBudget({
+      alertSeverityId: ObjectID.generate(),
+    });
+    mockSpend(85);
+    mockedAlertService.findOneBy.mockResolvedValue(new Alert() as never);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedAlertService.create).not.toHaveBeenCalled();
+    // Only the spend stamp — no dedup-timestamp update.
+    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the project's lowest-order severity", async () => {
+    const fallbackSeverityId: ObjectID = ObjectID.generate();
+    const severity: AlertSeverity = new AlertSeverity();
+    severity.id = fallbackSeverityId;
+
+    // makeBudget sets no alertSeverityId — the fallback path.
+    const budget: LlmCostBudget = makeBudget();
+    mockSpend(85);
+    mockedAlertSeverityService.findOneBy.mockResolvedValue(severity as never);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedAlertSeverityService.findOneBy).toHaveBeenCalledTimes(1);
+    const created: Alert = (
+      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
+    ).data;
+    expect(created.alertSeverityId!.toString()).toBe(
+      fallbackSeverityId.toString(),
+    );
+  });
+
+  test("a project with no severity at all skips alert creation gracefully", async () => {
+    const budget: LlmCostBudget = makeBudget();
+    mockSpend(85);
+    mockedAlertSeverityService.findOneBy.mockResolvedValue(null as never);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedAlertService.create).not.toHaveBeenCalled();
+    // No stamp — the alert never fired, so tomorrow's evaluation retries.
+    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("a warning already fired today does not create another alert", async () => {
+    const budget: LlmCostBudget = makeBudget({
+      alertSeverityId: ObjectID.generate(),
+      lastWarningAlertCreatedAt: new Date(Date.UTC(2026, 7, 21, 3, 0, 0)),
+    });
+    mockSpend(85);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedAlertService.create).not.toHaveBeenCalled();
+  });
+
+  test("budgets missing required fields are skipped without side effects", async () => {
+    const budget: LlmCostBudget = makeBudget();
+    delete budget.dailyBudgetInUSD;
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedSpanService.aggregateBy).not.toHaveBeenCalled();
+    expect(mockedBudgetService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("the ClickHouse aggregation is scoped and fails loud", async () => {
+    const budget: LlmCostBudget = makeBudget();
+    mockSpend(1);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    const aggregateArg: Record<string, unknown> = mockedSpanService.aggregateBy
+      .mock.calls[0]![0] as Record<string, unknown>;
+
+    expect(aggregateArg["aggregateColumnName"]).toBe("llmCost");
+    expect(aggregateArg["timeoutOverflowMode"]).toBe("throw");
+    expect(aggregateArg["startTimestamp"]).toEqual(
+      LlmCostBudgetEvaluator.getUtcDayStart(NOW),
+    );
+    expect(aggregateArg["endTimestamp"]).toBe(NOW);
+    expect(
+      (aggregateArg["query"] as Record<string, unknown>)["isLlmSpan"],
+    ).toBe(true);
+  });
+});
+
+describe("LlmCostBudgetEvaluator.evaluateAllBudgets — sweep resilience", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAlertService.findOneBy.mockResolvedValue(null as never);
+    mockedAlertService.create.mockResolvedValue(new Alert() as never);
+    mockedBudgetService.updateOneById.mockResolvedValue(undefined as never);
+  });
+
+  test("one failing budget never aborts the sweep", async () => {
+    const failing: LlmCostBudget = makeBudget({ name: "failing" });
+    const healthy: LlmCostBudget = makeBudget({ name: "healthy" });
+
+    mockedBudgetService.findBy.mockResolvedValue([failing, healthy] as never);
+    mockedSpanService.aggregateBy
+      .mockRejectedValueOnce(new Error("ClickHouse timeout") as never)
+      .mockResolvedValueOnce({
+        data: [{ timestamp: NOW, value: 5 }],
+      } as never);
+
+    await LlmCostBudgetEvaluator.evaluateAllBudgets();
+
+    // The healthy budget still got its spend stamped.
+    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
+    const updateArg: { id: ObjectID } = mockedBudgetService.updateOneById.mock
+      .calls[0]![0] as { id: ObjectID };
+    expect(updateArg.id.toString()).toBe(healthy.id!.toString());
+  });
+
+  test("no enabled budgets means no ClickHouse queries at all", async () => {
+    mockedBudgetService.findBy.mockResolvedValue([] as never);
+
+    await LlmCostBudgetEvaluator.evaluateAllBudgets();
+
+    expect(mockedSpanService.aggregateBy).not.toHaveBeenCalled();
+  });
+
+  test("only enabled budgets are loaded", async () => {
+    mockedBudgetService.findBy.mockResolvedValue([] as never);
+
+    await LlmCostBudgetEvaluator.evaluateAllBudgets();
+
+    const findArg: { query: Record<string, unknown> } = mockedBudgetService
+      .findBy.mock.calls[0]![0] as {
+      query: Record<string, unknown>;
+    };
+    expect(findArg.query["isEnabled"]).toBe(true);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/LlmSpan.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LlmSpan.test.ts
@@ -162,3 +162,226 @@ describe("LlmSpanUtil.extract", () => {
     expect(fields.llmInputTokens).toBe(10);
   });
 });
+
+describe("LlmSpanUtil.extract — cost fallback from the pricing catalog", () => {
+  test("SDK-reported cost always wins over the catalog", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 1_000_000,
+      // Catalog would say $12.50; the SDK (negotiated rate) says less.
+      "gen_ai.usage.cost": 9.99,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(9.99);
+  });
+
+  test("an explicitly reported zero cost wins — no catalog estimate", () => {
+    // A gateway fronting a free/local model reports cost 0; that 0 is real.
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 500_000,
+      "gen_ai.usage.cost": 0,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(0);
+  });
+
+  test("a reported zero cost as a string also wins", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "meta",
+      "gen_ai.request.model": "llama-3.1-8b-instant",
+      "gen_ai.usage.input_tokens": 100_000,
+      "gen_ai.usage.cost": "0",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(0);
+  });
+
+  test("a malformed reported cost falls back to the catalog", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 0,
+      "gen_ai.usage.cost": "not-a-number",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(2.5);
+  });
+
+  test("cost is computed from tokens when the SDK reports none", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 100_000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+
+    // 1M * $2.50/M + 0.1M * $10/M = $3.50
+    expect(fields.llmCost).toBe(3.5);
+  });
+
+  test("response model is priced in preference to the request model", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      // Alias requested; cheaper mini snapshot actually served.
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 0,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+
+    // Priced as gpt-4o-mini ($0.15/M input), not gpt-4o ($2.50/M).
+    expect(fields.llmCost).toBe(0.15);
+  });
+
+  test("request model prices the call when no response model exists", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "anthropic",
+      "gen_ai.request.model": "claude-3-5-sonnet-20241022",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 0,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(3);
+  });
+
+  test("unknown model leaves cost at zero — no guessing", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "my-private-finetune",
+      "gen_ai.usage.input_tokens": 5000,
+      "gen_ai.usage.output_tokens": 5000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(0);
+  });
+
+  test("no tokens leaves cost at zero even for a known model", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(0);
+  });
+
+  test("no model leaves cost at zero even with tokens", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.usage.input_tokens": 42,
+      "gen_ai.usage.output_tokens": 8,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(0);
+  });
+
+  test("Bedrock-decorated model id is priced via normalization", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "aws.bedrock",
+      "gen_ai.request.model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 0,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(3);
+  });
+
+  test("tool spans without tokens are not priced", () => {
+    const attrs: Attrs = {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "web_search",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.isLlmSpan).toBe(true);
+    expect(fields.llmCost).toBe(0);
+  });
+});
+
+describe("LlmSpanUtil.extract — conversation id", () => {
+  test("gen_ai.conversation.id is extracted", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.conversation.id": "conv-1234",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmConversationId).toBe("conv-1234");
+  });
+
+  test("session.id (OpenInference / Langfuse) is the fallback", () => {
+    const attrs: Attrs = {
+      "llm.model_name": "gpt-4o",
+      "session.id": "sess-abc",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmConversationId).toBe("sess-abc");
+  });
+
+  test("OpenLLMetry association property is recognized", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "anthropic",
+      "traceloop.association.properties.session_id": "chat-42",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmConversationId).toBe("chat-42");
+  });
+
+  test("the semconv key wins when multiple conventions are present", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.conversation.id": "conv-semconv",
+      "session.id": "sess-openinference",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmConversationId).toBe("conv-semconv");
+  });
+
+  test("absent conversation id yields an empty string", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmConversationId).toBe("");
+  });
+
+  test("a non-LLM RUM span with session.id gets no conversation id", () => {
+    /*
+     * "session.id" is a generic OTel key browser/RUM spans carry — it is
+     * already denormalized into the sessionId column. It must only become a
+     * conversation id on LLM spans, never on the RUM fleet.
+     */
+    const attrs: Attrs = {
+      "http.method": "GET",
+      "http.route": "/checkout",
+      "session.id": "rum-session-123",
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.isLlmSpan).toBe(false);
+    expect(fields.llmConversationId).toBe("");
+  });
+});

--- a/Common/Tests/Types/Telemetry/LlmCostCatalog.test.ts
+++ b/Common/Tests/Types/Telemetry/LlmCostCatalog.test.ts
@@ -1,0 +1,284 @@
+import {
+  LlmCostCatalogUtil,
+  LlmModelPrice,
+  LlmModelPricingCatalog,
+} from "../../../Types/Telemetry/LlmCostCatalog";
+import { describe, expect, test } from "@jest/globals";
+
+describe("LlmModelPricingCatalog", () => {
+  test("every entry has a lowercase prefix and non-negative prices", () => {
+    for (const entry of LlmModelPricingCatalog) {
+      expect(entry.modelPrefix).toBe(entry.modelPrefix.toLowerCase());
+      expect(entry.modelPrefix.trim()).toBe(entry.modelPrefix);
+      expect(entry.modelPrefix.length).toBeGreaterThan(0);
+      expect(entry.inputPricePerMillionTokensInUSD).toBeGreaterThanOrEqual(0);
+      expect(entry.outputPricePerMillionTokensInUSD).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("prefixes are unique — a duplicate would make the match ambiguous", () => {
+    const prefixes: Array<string> = LlmModelPricingCatalog.map(
+      (entry: LlmModelPrice) => {
+        return entry.modelPrefix;
+      },
+    );
+
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+});
+
+describe("LlmCostCatalogUtil.findPriceForModel", () => {
+  test("exact model name matches", () => {
+    const price: LlmModelPrice | null =
+      LlmCostCatalogUtil.findPriceForModel("gpt-4o");
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4o");
+  });
+
+  test("dated snapshot resolves via prefix", () => {
+    const price: LlmModelPrice | null =
+      LlmCostCatalogUtil.findPriceForModel("gpt-4o-2024-08-06");
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4o");
+  });
+
+  test("longest prefix wins: gpt-4o-mini does not price as gpt-4o", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gpt-4o-mini-2024-07-18",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4o-mini");
+  });
+
+  test("longest prefix wins: gpt-4-turbo does not price as gpt-4", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gpt-4-turbo-2024-04-09",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4-turbo");
+  });
+
+  test("gpt-5 variants disambiguate by longest prefix", () => {
+    expect(LlmCostCatalogUtil.findPriceForModel("gpt-5")!.modelPrefix).toBe(
+      "gpt-5",
+    );
+    expect(
+      LlmCostCatalogUtil.findPriceForModel("gpt-5-mini-2026-01-01")!
+        .modelPrefix,
+    ).toBe("gpt-5-mini");
+    expect(
+      LlmCostCatalogUtil.findPriceForModel("gpt-5-nano")!.modelPrefix,
+    ).toBe("gpt-5-nano");
+  });
+
+  test("matching is case-insensitive and trims whitespace", () => {
+    const price: LlmModelPrice | null =
+      LlmCostCatalogUtil.findPriceForModel("  GPT-4o-Mini  ");
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4o-mini");
+  });
+
+  test("Anthropic dated model ids resolve", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "claude-3-5-sonnet-20241022",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("claude-3-5-sonnet");
+  });
+
+  test("Bedrock model id with provider namespace resolves", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("claude-3-5-sonnet");
+  });
+
+  test("Bedrock cross-region inference profile id resolves", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("claude-3-5-haiku");
+  });
+
+  test("OpenRouter-style provider/model path resolves", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "anthropic/claude-3-opus",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("claude-3-opus");
+  });
+
+  test("Google models/ path prefix resolves", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "models/gemini-2.5-pro",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gemini-2.5-pro");
+  });
+
+  test("dots inside real model names are not treated as routing prefixes", () => {
+    // "gpt-4.1" contains a dot; nothing before it is a routing token.
+    const price: LlmModelPrice | null =
+      LlmCostCatalogUtil.findPriceForModel("gpt-4.1-2025-04-14");
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4.1");
+  });
+
+  test("o1-pro does not price as o1 — a 10x price difference", () => {
+    expect(LlmCostCatalogUtil.findPriceForModel("o1-pro")!.modelPrefix).toBe(
+      "o1-pro",
+    );
+    expect(
+      LlmCostCatalogUtil.findPriceForModel("o1-pro-2025-03-19")!.modelPrefix,
+    ).toBe("o1-pro");
+  });
+
+  test("gemini flash-lite does not price as flash", () => {
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gemini-2.5-flash-lite",
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gemini-2.5-flash-lite");
+  });
+
+  test("unknown model returns null, never a guess", () => {
+    expect(
+      LlmCostCatalogUtil.findPriceForModel("totally-unknown-model-9000"),
+    ).toBeNull();
+  });
+
+  test("empty and malformed inputs return null", () => {
+    expect(LlmCostCatalogUtil.findPriceForModel("")).toBeNull();
+    expect(LlmCostCatalogUtil.findPriceForModel("   ")).toBeNull();
+    expect(
+      LlmCostCatalogUtil.findPriceForModel(undefined as unknown as string),
+    ).toBeNull();
+    expect(
+      LlmCostCatalogUtil.findPriceForModel(null as unknown as string),
+    ).toBeNull();
+  });
+
+  test("a bare routing token does not match anything", () => {
+    expect(LlmCostCatalogUtil.findPriceForModel("anthropic.")).toBeNull();
+    expect(LlmCostCatalogUtil.findPriceForModel("us.anthropic.")).toBeNull();
+    expect(LlmCostCatalogUtil.findPriceForModel("models/")).toBeNull();
+  });
+});
+
+describe("LlmCostCatalogUtil.computeCostInUSD", () => {
+  test("computes input + output priced independently", () => {
+    // gpt-4o: $2.50/M input, $10/M output.
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+    });
+
+    expect(cost).toBe(2.5 + 5);
+  });
+
+  test("small token counts produce exact fractional cost", () => {
+    // gpt-4o-mini: $0.15/M input, $0.60/M output.
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "gpt-4o-mini",
+      inputTokens: 500,
+      outputTokens: 120,
+    });
+
+    expect(cost).toBeCloseTo(0.000147, 9);
+  });
+
+  test("float noise is trimmed to 8 decimal places", () => {
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "claude-3-5-sonnet-20241022",
+      inputTokens: 3,
+      outputTokens: 7,
+    });
+
+    // 3 * 3/1M + 7 * 15/1M = 0.000009 + 0.000105 = 0.000114
+    expect(cost).toBe(0.000114);
+  });
+
+  test("input-only usage (embeddings) is priceable", () => {
+    // text-embedding-3-small: $0.02/M input, $0 output.
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "text-embedding-3-small",
+      inputTokens: 2_000_000,
+      outputTokens: 0,
+    });
+
+    expect(cost).toBe(0.04);
+  });
+
+  test("output-only usage is priceable", () => {
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "gpt-4o",
+      inputTokens: 0,
+      outputTokens: 100_000,
+    });
+
+    expect(cost).toBe(1);
+  });
+
+  test("zero tokens returns null — nothing to price", () => {
+    expect(
+      LlmCostCatalogUtil.computeCostInUSD({
+        model: "gpt-4o",
+        inputTokens: 0,
+        outputTokens: 0,
+      }),
+    ).toBeNull();
+  });
+
+  test("unknown model returns null even with tokens", () => {
+    expect(
+      LlmCostCatalogUtil.computeCostInUSD({
+        model: "my-custom-finetune",
+        inputTokens: 1000,
+        outputTokens: 1000,
+      }),
+    ).toBeNull();
+  });
+
+  test("negative and non-finite token counts are treated as zero", () => {
+    expect(
+      LlmCostCatalogUtil.computeCostInUSD({
+        model: "gpt-4o",
+        inputTokens: -50,
+        outputTokens: NaN,
+      }),
+    ).toBeNull();
+
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "gpt-4o",
+      inputTokens: -50,
+      outputTokens: 100_000,
+    });
+
+    expect(cost).toBe(1);
+  });
+
+  test("empty model returns null", () => {
+    expect(
+      LlmCostCatalogUtil.computeCostInUSD({
+        model: "",
+        inputTokens: 1000,
+        outputTokens: 1000,
+      }),
+    ).toBeNull();
+  });
+});

--- a/Common/Types/Permission.ts
+++ b/Common/Types/Permission.ts
@@ -208,6 +208,11 @@ enum Permission {
   EditProjectMetricPipelineRule = "EditProjectMetricPipelineRule",
   ReadProjectMetricPipelineRule = "ReadProjectMetricPipelineRule",
 
+  CreateProjectLlmCostBudget = "CreateProjectLlmCostBudget",
+  DeleteProjectLlmCostBudget = "DeleteProjectLlmCostBudget",
+  EditProjectLlmCostBudget = "EditProjectLlmCostBudget",
+  ReadProjectLlmCostBudget = "ReadProjectLlmCostBudget",
+
   // Metric Recording Rules (derived metrics)
   CreateProjectMetricRecordingRule = "CreateProjectMetricRecordingRule",
   DeleteProjectMetricRecordingRule = "DeleteProjectMetricRecordingRule",
@@ -7330,6 +7335,48 @@ export class PermissionHelper {
         title: "Read Metric Pipeline Rule",
         description:
           "This permission can read Metric Pipeline Rules of this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+
+      // LLM Cost Budget Permissions
+      {
+        permission: Permission.CreateProjectLlmCostBudget,
+        title: "Create LLM Cost Budget",
+        description:
+          "This permission can create LLM Cost Budgets in this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.DeleteProjectLlmCostBudget,
+        title: "Delete LLM Cost Budget",
+        description:
+          "This permission can delete LLM Cost Budgets of this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.EditProjectLlmCostBudget,
+        title: "Edit LLM Cost Budget",
+        description:
+          "This permission can edit LLM Cost Budgets of this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.ReadProjectLlmCostBudget,
+        title: "Read LLM Cost Budget",
+        description:
+          "This permission can read LLM Cost Budgets of this project.",
         isAssignableToTenant: true,
         isAccessControlPermission: false,
         isRolePermission: false,

--- a/Common/Types/Telemetry/LlmConventions.ts
+++ b/Common/Types/Telemetry/LlmConventions.ts
@@ -64,12 +64,28 @@ export const LlmTotalTokenAttributeKeys: Array<string> = [
   "llm.usage.total_tokens",
 ];
 
-// Cost in USD. Only populated when the SDK reports it (no built-in pricing).
+/*
+ * Cost in USD. A reported cost always wins; when absent, ingest computes an
+ * estimate from token counts via Common/Types/Telemetry/LlmCostCatalog.ts.
+ */
 export const LlmCostAttributeKeys: Array<string> = [
   "gen_ai.usage.cost",
   "gen_ai.usage.cost_usd",
   "gen_ai.usage.total_cost",
   "llm.usage.total_cost",
+];
+
+/*
+ * Conversation / session id that groups the LLM calls of one user interaction
+ * across traces. gen_ai.conversation.id is the OTel semconv key; session.id is
+ * emitted by OpenInference and Langfuse-compatible SDKs; the traceloop
+ * association property is OpenLLMetry's spelling.
+ */
+export const LlmConversationIdAttributeKeys: Array<string> = [
+  "gen_ai.conversation.id",
+  "session.id",
+  "langfuse.session.id",
+  "traceloop.association.properties.session_id",
 ];
 
 export const LlmAgentNameAttributeKeys: Array<string> = [

--- a/Common/Types/Telemetry/LlmCostCatalog.ts
+++ b/Common/Types/Telemetry/LlmCostCatalog.ts
@@ -1,0 +1,472 @@
+/*
+ * Built-in list-price catalog for computing LLM call cost from token counts.
+ *
+ * OneUptime prefers the cost the instrumentation reports (gen_ai.usage.cost)
+ * — a vendor-negotiated or gateway-computed number is always more accurate
+ * than a list price. This catalog is the fallback: when a span carries token
+ * counts but no reported cost, the ingest pipeline computes an estimated cost
+ * from these rates so token spend is visible in dashboards and enforceable by
+ * cost budgets without requiring every SDK to do pricing math.
+ *
+ * Rates are USD per one million tokens, taken from the providers' public
+ * pricing pages. They are list prices: they ignore prompt-cache discounts,
+ * batch pricing, and negotiated rates, and they go stale as vendors reprice —
+ * update them here, once, like Common/Types/Billing/PayAsYouGoPricing.ts.
+ * Matching is by normalized model-name prefix with the LONGEST prefix winning,
+ * so "gpt-4o-mini-2024-07-18" resolves to the gpt-4o-mini entry, not gpt-4o.
+ */
+
+export interface LlmModelPrice {
+  // Normalized (lowercase) model-name prefix this entry matches.
+  modelPrefix: string;
+  inputPricePerMillionTokensInUSD: number;
+  outputPricePerMillionTokensInUSD: number;
+}
+
+export const LlmModelPricingCatalog: Array<LlmModelPrice> = [
+  // ---- OpenAI ----
+  {
+    modelPrefix: "gpt-5-nano",
+    inputPricePerMillionTokensInUSD: 0.05,
+    outputPricePerMillionTokensInUSD: 0.4,
+  },
+  {
+    modelPrefix: "gpt-5-mini",
+    inputPricePerMillionTokensInUSD: 0.25,
+    outputPricePerMillionTokensInUSD: 2,
+  },
+  {
+    modelPrefix: "gpt-5",
+    inputPricePerMillionTokensInUSD: 1.25,
+    outputPricePerMillionTokensInUSD: 10,
+  },
+  {
+    modelPrefix: "gpt-4.1-nano",
+    inputPricePerMillionTokensInUSD: 0.1,
+    outputPricePerMillionTokensInUSD: 0.4,
+  },
+  {
+    modelPrefix: "gpt-4.1-mini",
+    inputPricePerMillionTokensInUSD: 0.4,
+    outputPricePerMillionTokensInUSD: 1.6,
+  },
+  {
+    modelPrefix: "gpt-4.1",
+    inputPricePerMillionTokensInUSD: 2,
+    outputPricePerMillionTokensInUSD: 8,
+  },
+  {
+    modelPrefix: "gpt-4o-mini",
+    inputPricePerMillionTokensInUSD: 0.15,
+    outputPricePerMillionTokensInUSD: 0.6,
+  },
+  {
+    modelPrefix: "gpt-4o",
+    inputPricePerMillionTokensInUSD: 2.5,
+    outputPricePerMillionTokensInUSD: 10,
+  },
+  {
+    modelPrefix: "gpt-4-turbo",
+    inputPricePerMillionTokensInUSD: 10,
+    outputPricePerMillionTokensInUSD: 30,
+  },
+  {
+    modelPrefix: "gpt-4",
+    inputPricePerMillionTokensInUSD: 30,
+    outputPricePerMillionTokensInUSD: 60,
+  },
+  {
+    modelPrefix: "gpt-3.5-turbo",
+    inputPricePerMillionTokensInUSD: 0.5,
+    outputPricePerMillionTokensInUSD: 1.5,
+  },
+  {
+    modelPrefix: "o3-pro",
+    inputPricePerMillionTokensInUSD: 20,
+    outputPricePerMillionTokensInUSD: 80,
+  },
+  {
+    modelPrefix: "o3-mini",
+    inputPricePerMillionTokensInUSD: 1.1,
+    outputPricePerMillionTokensInUSD: 4.4,
+  },
+  {
+    modelPrefix: "o3",
+    inputPricePerMillionTokensInUSD: 2,
+    outputPricePerMillionTokensInUSD: 8,
+  },
+  {
+    modelPrefix: "o4-mini",
+    inputPricePerMillionTokensInUSD: 1.1,
+    outputPricePerMillionTokensInUSD: 4.4,
+  },
+  {
+    modelPrefix: "o1-mini",
+    inputPricePerMillionTokensInUSD: 1.1,
+    outputPricePerMillionTokensInUSD: 4.4,
+  },
+  {
+    // Priced 10x above bare o1 — must never fall through to that prefix.
+    modelPrefix: "o1-pro",
+    inputPricePerMillionTokensInUSD: 150,
+    outputPricePerMillionTokensInUSD: 600,
+  },
+  {
+    modelPrefix: "o1",
+    inputPricePerMillionTokensInUSD: 15,
+    outputPricePerMillionTokensInUSD: 60,
+  },
+  {
+    modelPrefix: "text-embedding-3-small",
+    inputPricePerMillionTokensInUSD: 0.02,
+    outputPricePerMillionTokensInUSD: 0,
+  },
+  {
+    modelPrefix: "text-embedding-3-large",
+    inputPricePerMillionTokensInUSD: 0.13,
+    outputPricePerMillionTokensInUSD: 0,
+  },
+  {
+    modelPrefix: "text-embedding-ada-002",
+    inputPricePerMillionTokensInUSD: 0.1,
+    outputPricePerMillionTokensInUSD: 0,
+  },
+
+  // ---- Anthropic ----
+  {
+    modelPrefix: "claude-opus-4",
+    inputPricePerMillionTokensInUSD: 15,
+    outputPricePerMillionTokensInUSD: 75,
+  },
+  {
+    modelPrefix: "claude-sonnet-4",
+    inputPricePerMillionTokensInUSD: 3,
+    outputPricePerMillionTokensInUSD: 15,
+  },
+  {
+    modelPrefix: "claude-haiku-4",
+    inputPricePerMillionTokensInUSD: 1,
+    outputPricePerMillionTokensInUSD: 5,
+  },
+  {
+    modelPrefix: "claude-3-7-sonnet",
+    inputPricePerMillionTokensInUSD: 3,
+    outputPricePerMillionTokensInUSD: 15,
+  },
+  {
+    modelPrefix: "claude-3-5-sonnet",
+    inputPricePerMillionTokensInUSD: 3,
+    outputPricePerMillionTokensInUSD: 15,
+  },
+  {
+    modelPrefix: "claude-3-5-haiku",
+    inputPricePerMillionTokensInUSD: 0.8,
+    outputPricePerMillionTokensInUSD: 4,
+  },
+  {
+    modelPrefix: "claude-3-opus",
+    inputPricePerMillionTokensInUSD: 15,
+    outputPricePerMillionTokensInUSD: 75,
+  },
+  {
+    modelPrefix: "claude-3-haiku",
+    inputPricePerMillionTokensInUSD: 0.25,
+    outputPricePerMillionTokensInUSD: 1.25,
+  },
+
+  // ---- Google Gemini ----
+  {
+    modelPrefix: "gemini-2.5-pro",
+    inputPricePerMillionTokensInUSD: 1.25,
+    outputPricePerMillionTokensInUSD: 10,
+  },
+  {
+    modelPrefix: "gemini-2.5-flash-lite",
+    inputPricePerMillionTokensInUSD: 0.1,
+    outputPricePerMillionTokensInUSD: 0.4,
+  },
+  {
+    modelPrefix: "gemini-2.5-flash",
+    inputPricePerMillionTokensInUSD: 0.3,
+    outputPricePerMillionTokensInUSD: 2.5,
+  },
+  {
+    modelPrefix: "gemini-2.0-flash-lite",
+    inputPricePerMillionTokensInUSD: 0.075,
+    outputPricePerMillionTokensInUSD: 0.3,
+  },
+  {
+    modelPrefix: "gemini-2.0-flash",
+    inputPricePerMillionTokensInUSD: 0.1,
+    outputPricePerMillionTokensInUSD: 0.4,
+  },
+  {
+    modelPrefix: "gemini-1.5-pro",
+    inputPricePerMillionTokensInUSD: 1.25,
+    outputPricePerMillionTokensInUSD: 5,
+  },
+  {
+    modelPrefix: "gemini-1.5-flash",
+    inputPricePerMillionTokensInUSD: 0.075,
+    outputPricePerMillionTokensInUSD: 0.3,
+  },
+
+  // ---- Mistral ----
+  {
+    modelPrefix: "mistral-large",
+    inputPricePerMillionTokensInUSD: 2,
+    outputPricePerMillionTokensInUSD: 6,
+  },
+  {
+    modelPrefix: "mistral-medium",
+    inputPricePerMillionTokensInUSD: 0.4,
+    outputPricePerMillionTokensInUSD: 2,
+  },
+  {
+    modelPrefix: "mistral-small",
+    inputPricePerMillionTokensInUSD: 0.1,
+    outputPricePerMillionTokensInUSD: 0.3,
+  },
+  {
+    modelPrefix: "codestral",
+    inputPricePerMillionTokensInUSD: 0.3,
+    outputPricePerMillionTokensInUSD: 0.9,
+  },
+
+  // ---- DeepSeek ----
+  {
+    modelPrefix: "deepseek-chat",
+    inputPricePerMillionTokensInUSD: 0.27,
+    outputPricePerMillionTokensInUSD: 1.1,
+  },
+  {
+    modelPrefix: "deepseek-reasoner",
+    inputPricePerMillionTokensInUSD: 0.55,
+    outputPricePerMillionTokensInUSD: 2.19,
+  },
+
+  // ---- xAI ----
+  {
+    modelPrefix: "grok-4",
+    inputPricePerMillionTokensInUSD: 3,
+    outputPricePerMillionTokensInUSD: 15,
+  },
+  {
+    modelPrefix: "grok-3-mini",
+    inputPricePerMillionTokensInUSD: 0.3,
+    outputPricePerMillionTokensInUSD: 0.5,
+  },
+  {
+    modelPrefix: "grok-3",
+    inputPricePerMillionTokensInUSD: 3,
+    outputPricePerMillionTokensInUSD: 15,
+  },
+
+  // ---- Cohere ----
+  {
+    modelPrefix: "command-r-plus",
+    inputPricePerMillionTokensInUSD: 2.5,
+    outputPricePerMillionTokensInUSD: 10,
+  },
+  {
+    modelPrefix: "command-r",
+    inputPricePerMillionTokensInUSD: 0.15,
+    outputPricePerMillionTokensInUSD: 0.6,
+  },
+  {
+    modelPrefix: "command-a",
+    inputPricePerMillionTokensInUSD: 2.5,
+    outputPricePerMillionTokensInUSD: 10,
+  },
+
+  // ---- Amazon Nova ----
+  {
+    modelPrefix: "nova-micro",
+    inputPricePerMillionTokensInUSD: 0.035,
+    outputPricePerMillionTokensInUSD: 0.14,
+  },
+  {
+    modelPrefix: "nova-lite",
+    inputPricePerMillionTokensInUSD: 0.06,
+    outputPricePerMillionTokensInUSD: 0.24,
+  },
+  {
+    modelPrefix: "nova-pro",
+    inputPricePerMillionTokensInUSD: 0.8,
+    outputPricePerMillionTokensInUSD: 3.2,
+  },
+
+  // ---- Meta Llama (typical hosted per-token rates) ----
+  {
+    modelPrefix: "llama-3.3-70b",
+    inputPricePerMillionTokensInUSD: 0.72,
+    outputPricePerMillionTokensInUSD: 0.72,
+  },
+  {
+    modelPrefix: "llama-3.1-405b",
+    inputPricePerMillionTokensInUSD: 2.4,
+    outputPricePerMillionTokensInUSD: 2.4,
+  },
+  {
+    modelPrefix: "llama-3.1-70b",
+    inputPricePerMillionTokensInUSD: 0.72,
+    outputPricePerMillionTokensInUSD: 0.72,
+  },
+  {
+    modelPrefix: "llama-3.1-8b",
+    inputPricePerMillionTokensInUSD: 0.22,
+    outputPricePerMillionTokensInUSD: 0.22,
+  },
+];
+
+/*
+ * Leading tokens that carry deployment routing, not model identity. Bedrock
+ * model ids look like "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+ * OpenRouter-style ids like "anthropic/claude-3-5-sonnet", Google's like
+ * "models/gemini-2.5-pro" — all of them must resolve to the same catalog
+ * entry as the bare model name.
+ */
+const RoutingPrefixTokens: Array<string> = [
+  // Bedrock cross-region inference profiles.
+  "us",
+  "eu",
+  "apac",
+  "global",
+  // Provider namespaces.
+  "anthropic",
+  "openai",
+  "google",
+  "meta",
+  "amazon",
+  "mistral",
+  "mistralai",
+  "cohere",
+  "ai21",
+  "deepseek",
+  "xai",
+  "azure",
+  "models",
+];
+
+export class LlmCostCatalogUtil {
+  /**
+   * Find the catalog entry for a (possibly vendor-decorated) model name.
+   * Returns null when the model is unknown — callers must not guess a price.
+   */
+  public static findPriceForModel(model: string): LlmModelPrice | null {
+    const candidates: Array<string> = this.normalizedCandidates(model);
+
+    let best: LlmModelPrice | null = null;
+
+    for (const candidate of candidates) {
+      for (const entry of LlmModelPricingCatalog) {
+        if (!candidate.startsWith(entry.modelPrefix)) {
+          continue;
+        }
+
+        if (!best || entry.modelPrefix.length > best.modelPrefix.length) {
+          best = entry;
+        }
+      }
+    }
+
+    return best;
+  }
+
+  /**
+   * Compute the estimated USD cost of a call from its token counts, or null
+   * when the model is unknown or there are no tokens to price. Never guesses:
+   * an unknown model yields null, not zero, so the caller can distinguish
+   * "free" from "unpriceable".
+   */
+  public static computeCostInUSD(data: {
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+  }): number | null {
+    const inputTokens: number =
+      isFinite(data.inputTokens) && data.inputTokens > 0 ? data.inputTokens : 0;
+    const outputTokens: number =
+      isFinite(data.outputTokens) && data.outputTokens > 0
+        ? data.outputTokens
+        : 0;
+
+    if (inputTokens === 0 && outputTokens === 0) {
+      return null;
+    }
+
+    const price: LlmModelPrice | null = this.findPriceForModel(data.model);
+
+    if (!price) {
+      return null;
+    }
+
+    const cost: number =
+      (inputTokens * price.inputPricePerMillionTokensInUSD) / 1_000_000 +
+      (outputTokens * price.outputPricePerMillionTokensInUSD) / 1_000_000;
+
+    /*
+     * Trim float noise (e.g. 0.30000000000000004) — 8 decimal places is
+     * sub-hundredth-of-a-cent resolution, far below list-price accuracy.
+     */
+    return Math.round(cost * 1e8) / 1e8;
+  }
+
+  /**
+   * Expand a raw model string into normalized lookup candidates, most-specific
+   * first: the full lowercase name, then the name with routing/provider
+   * prefixes (path segments, dotted namespaces, region tokens) stripped away.
+   */
+  private static normalizedCandidates(model: string): Array<string> {
+    if (!model || typeof model !== "string") {
+      return [];
+    }
+
+    const normalized: string = model.trim().toLowerCase();
+
+    if (!normalized) {
+      return [];
+    }
+
+    const candidates: Array<string> = [normalized];
+
+    // "anthropic/claude-3-5-sonnet" or "models/gemini-2.5-pro" → last segment.
+    const lastSlashSegment: string = normalized.split("/").pop() || "";
+
+    if (lastSlashSegment && !candidates.includes(lastSlashSegment)) {
+      candidates.push(lastSlashSegment);
+    }
+
+    /*
+     * "us.anthropic.claude-3-5-sonnet-20241022-v2:0" → progressively strip
+     * leading routing tokens ("us", "anthropic") that sit before the model
+     * name. Only recognized routing tokens are stripped, so a model whose name
+     * legitimately contains a dot (gpt-4.1, gemini-2.5-pro) is untouched.
+     */
+    for (const base of [...candidates]) {
+      let remainder: string = base;
+
+      for (;;) {
+        const dotIndex: number = remainder.indexOf(".");
+
+        if (dotIndex <= 0) {
+          break;
+        }
+
+        const leadingToken: string = remainder.substring(0, dotIndex);
+
+        if (!RoutingPrefixTokens.includes(leadingToken)) {
+          break;
+        }
+
+        remainder = remainder.substring(dotIndex + 1);
+
+        if (remainder && !candidates.includes(remainder)) {
+          candidates.push(remainder);
+        }
+      }
+    }
+
+    return candidates;
+  }
+}


### PR DESCRIPTION
## What this is

Implements the buildable core of a customer's *AI Observability & Guardrails* PRD, extending the existing AI/LLM observability pillar. Three capabilities:

### 1. LLM cost computed at ingest
- New built-in list-price catalog ([`Common/Types/Telemetry/LlmCostCatalog.ts`](../blob/claude/ai-observability-guardrails-5da296/Common/Types/Telemetry/LlmCostCatalog.ts)) — OpenAI, Anthropic, Google Gemini, Mistral, DeepSeek, xAI, Cohere, Amazon Nova, Meta Llama. Longest-prefix matching on normalized model names, so `gpt-4o-2024-08-06`, `us.anthropic.claude-3-5-sonnet-20241022-v2:0`, `anthropic/claude-3-opus`, and `models/gemini-2.5-pro` all resolve.
- `LlmSpanUtil` now prices token counts through the catalog when the SDK reports no `gen_ai.usage.cost`. **A reported cost always wins — including an explicit \$0** (gateway fronting a free/local model, fully cached call). Unknown/custom models stay at 0: the catalog never guesses.
- This removes the previous documented gap ("OneUptime does not maintain a model price list") and lights up the existing LLM Overview/Calls cost UI for the ~everyone whose instrumentation only reports tokens.

### 2. Conversation grouping
- New `llmConversationId` Span column (boot-reconciled ClickHouse column, bloom-filter indexed) extracted from `gen_ai.conversation.id`, `session.id`, `langfuse.session.id`, and OpenLLMetry association properties — gated on `isLlmSpan` so RUM browser spans carrying the generic `session.id` key never duplicate it.
- Filterable in the LLM Calls table.

### 3. Daily LLM cost budgets (the PRD's "cost threshold alerts")
- New `LlmCostBudget` model: daily USD budget, optional scoping to a telemetry service / provider / exact model, alert severity, on-call duty policies. Full CRUD API + permissions + generated Postgres migration.
- A 15-minute worker sums the UTC day's `llmCost` per budget from ClickHouse and raises a **warning alert at a configurable threshold (default 80%)** and a **breach alert at 100%** — each at most once per UTC day, deduped by alert series fingerprint, serialized by a Redis sweep lock (same pattern as `Slo:EvaluateSlos`) so overlapping sweeps can't double-page on-call. Deleting a budget auto-resolves its open alerts.
- New **Budgets** tab in the dashboard AI/LLM section with live spend-vs-budget.

Docs updated: `telemetry/ai-llm-observability.md` (cost calculation, conversation grouping, budgets).

## What this deliberately does not build

The PRD's third pillar — a synchronous inline AI gateway (token blocking, prompt-injection filtering, output scrubbing) — is intentionally out of scope. That market is commoditized (LiteLLM, Portkey, Kong, Cloudflare), and OneUptime's leverage is being the OTel-native pane of glass over whichever gateway a customer runs, plus async circuit-breaking via monitors → workflows → webhooks. Follow-up work is tracked separately.

## Testing

- **121 unit tests** across four suites: pricing-catalog matching/normalization/edge cases, span extraction (all three instrumentation conventions, cost precedence incl. reported-zero, conversation-id gating), budget decision logic (threshold boundaries, UTC-day dedup, breach-supersedes-warning), evaluation orchestration (mocked services: alert creation, fingerprints, severity fallback, sweep resilience), and service validation hooks (string coercion, integer threshold).
- `npm run compile` clean in `Common` and `App`; `npm run fix` clean.
- Migration generated with `npm run generate-postgres-migration` (not hand-written).
- A 10-agent adversarial review pass ran over the diff before this PR; all 6 confirmed findings (reported-zero cost override, RUM `session.id` leak into the conversation column, `o1-pro` prefix mispricing, missing sweep-overlap lock, fractional-percent integer-column error, docs mismatch) are fixed and pinned by tests.

## Notes for review

- Catalog prices are list prices (no cache/batch discounts) and will need periodic refresh — single source of truth, one file.
- `warningThresholdPercent` is integer 1–99 by validation; the evaluator itself tolerates fractional values if the column ever widens.
- Drive-by: added the missing accessibility modifier in `1788100000000-AddMeasurements.ts` — it was failing `npm run fix`.
- The customer PRD also asks for PagerDuty notifications; that's a product decision (OneUptime competes with PagerDuty) — native on-call covers the need, or a small Events API v2 notifier could be added.