### PR TITLE
fix(analytics): bind fractional attribute thresholds as Double, not Int32

### DIFF
--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -1068,6 +1068,15 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
            * values (including the empty-string default for missing
            * keys), which compares to false against any numeric
            * threshold and naturally drops those rows.
+           *
+           * The threshold binds as Decimal (ClickHouse `Double`), not
+           * Number (`Int32`): the attribute filter form builds these
+           * with `Number(input)` (see buildDictionaryValue in
+           * Common/UI/Components/Dictionary/DictionaryFilterOperator.ts),
+           * so a user can legitimately ask for `duration > 0.5` and an
+           * Int32 bind would fail to parse the fractional value. Double
+           * represents every Int32 exactly, so integer thresholds are
+           * unaffected, and it matches the Float64 comparison side.
            */
           if (mapEntry instanceof GreaterThan) {
             this.appendMapKeyPresenceFilter({
@@ -1082,7 +1091,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
                 type: TableColumnType.Text,
               }}]) > ${{
                 value: Number((mapEntry as GreaterThan<any>).value),
-                type: TableColumnType.Number,
+                type: TableColumnType.Decimal,
               }}`,
             );
             continue;
@@ -1101,7 +1110,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
                 type: TableColumnType.Text,
               }}]) >= ${{
                 value: Number((mapEntry as GreaterThanOrEqual<any>).value),
-                type: TableColumnType.Number,
+                type: TableColumnType.Decimal,
               }}`,
             );
             continue;
@@ -1120,7 +1129,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
                 type: TableColumnType.Text,
               }}]) < ${{
                 value: Number((mapEntry as LessThan<any>).value),
-                type: TableColumnType.Number,
+                type: TableColumnType.Decimal,
               }}`,
             );
             continue;
@@ -1139,7 +1148,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
                 type: TableColumnType.Text,
               }}]) <= ${{
                 value: Number((mapEntry as LessThanOrEqual<any>).value),
-                type: TableColumnType.Number,
+                type: TableColumnType.Decimal,
               }}`,
             );
             continue;

--- a/Common/Server/Utils/SecurityEvent/Sigma/SigmaClickhouseCompiler.ts
+++ b/Common/Server/Utils/SecurityEvent/Sigma/SigmaClickhouseCompiler.ts
@@ -183,8 +183,16 @@ function textParam(value: string): Statement {
   return SQL`${{ type: TableColumnType.Text, value: value }}`;
 }
 
+/*
+ * Numeric literals bind as Decimal (ClickHouse `Double`) rather than Number
+ * (`Int32`). Sigma rules routinely carry fractional thresholds — a
+ * `|gte: 0.5` on an attribute compiles to a toFloat64OrNull comparison, and
+ * an Int32 bind cannot parse `0.5`, failing the whole query at runtime.
+ * Double represents every Int32 exactly, so the integer cases (port numbers,
+ * severity ids, `1 of them` quantifiers) are unaffected.
+ */
 function numberParam(value: number): Statement {
-  return SQL`${{ type: TableColumnType.Number, value: value }}`;
+  return SQL`${{ type: TableColumnType.Decimal, value: value }}`;
 }
 
 function group(inner: Statement): Statement {

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/FractionalAttributeThreshold.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/FractionalAttributeThreshold.test.ts
@@ -1,0 +1,224 @@
+import { ClickhouseAppInstance } from "../../../../Server/Infrastructure/ClickhouseDatabase";
+import { Statement } from "../../../../Server/Utils/AnalyticsDatabase/Statement";
+import StatementGenerator from "../../../../Server/Utils/AnalyticsDatabase/StatementGenerator";
+import "../../TestingUtils/Init";
+import AnalyticsBaseModel from "../../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../../../Types/API/Route";
+import AnalyticsTableEngine from "../../../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableColumn from "../../../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../../../Types/AnalyticsDatabase/TableColumnType";
+import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../../Types/BaseDatabase/GreaterThanOrEqual";
+import LessThan from "../../../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../../../Types/BaseDatabase/LessThanOrEqual";
+import JSONFunctions from "../../../../Types/JSONFunctions";
+import { JSONObject } from "../../../../Types/JSON";
+import {
+  DictionaryEntryValue,
+  DictionaryFilterOperator,
+  buildDictionaryValue,
+  detectOperatorFromValue,
+} from "../../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * A numeric attribute filter travels a long way before it becomes SQL:
+ * the user types a threshold into the Dictionary filter form, that string
+ * is turned into a comparison wrapper by buildDictionaryValue, the wrapper
+ * is serialized over the API, the server deserializes it, and
+ * StatementGenerator finally binds it as a ClickHouse query parameter.
+ *
+ * Every hop in that chain has to keep the value fractional. The form
+ * builds the wrapper with `Number(input)`, so `0.5` is a threshold a user
+ * can genuinely produce — and the map-attribute predicate already casts
+ * the stored value with toFloat64OrNull, so only the bound parameter type
+ * ever constrained it. These tests walk the whole chain rather than any
+ * single hop, because a regression at any one of them silently reduces to
+ * "the query fails at runtime" for the user.
+ */
+
+class AttributeModel extends AnalyticsBaseModel {
+  public constructor() {
+    super({
+      tableName: "<attribute-table>",
+      singularName: "<singular>",
+      pluralName: "<plural>",
+      tableColumns: [
+        new AnalyticsTableColumn({
+          key: "_id",
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.ObjectID,
+        }),
+        new AnalyticsTableColumn({
+          key: "attributes",
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          defaultValue: {},
+          type: TableColumnType.MapStringString,
+        }),
+      ],
+      crudApiPath: new Route("route"),
+      primaryKeys: ["_id"],
+      sortKeys: ["_id"],
+      partitionKey: "_id",
+      tableEngine: AnalyticsTableEngine.MergeTree,
+    });
+  }
+}
+
+function whereStatementFor(value: unknown): Statement {
+  const generator: StatementGenerator<AttributeModel> =
+    new StatementGenerator<AttributeModel>({
+      modelType: AttributeModel,
+      database: ClickhouseAppInstance,
+    });
+
+  return generator.toWhereStatement({
+    attributes: { duration: value },
+  } as any);
+}
+
+/**
+ * Push a value through the JSON round trip the API boundary performs, so
+ * the test exercises the deserialized wrapper the server actually sees
+ * rather than the instance the form happened to build in-process.
+ */
+function overTheWire(value: DictionaryEntryValue): unknown {
+  const serialized: JSONObject = JSON.parse(
+    JSON.stringify({ value: value }),
+  ) as JSONObject;
+
+  return JSONFunctions.deserializeValue(serialized["value"] as JSONObject);
+}
+
+describe("fractional attribute thresholds, form to SQL", () => {
+  const operatorCases: Array<{
+    operator: DictionaryFilterOperator;
+    sqlOperator: string;
+    wrapperType: unknown;
+  }> = [
+    {
+      operator: DictionaryFilterOperator.GreaterThan,
+      sqlOperator: ">",
+      wrapperType: GreaterThan,
+    },
+    {
+      operator: DictionaryFilterOperator.GreaterThanOrEqual,
+      sqlOperator: ">=",
+      wrapperType: GreaterThanOrEqual,
+    },
+    {
+      operator: DictionaryFilterOperator.LessThan,
+      sqlOperator: "<",
+      wrapperType: LessThan,
+    },
+    {
+      operator: DictionaryFilterOperator.LessThanOrEqual,
+      sqlOperator: "<=",
+      wrapperType: LessThanOrEqual,
+    },
+  ];
+
+  test.each(operatorCases)(
+    "$operator: a typed 0.5 reaches ClickHouse as a Double parameter",
+    ({
+      operator,
+      sqlOperator,
+      wrapperType,
+    }: {
+      operator: DictionaryFilterOperator;
+      sqlOperator: string;
+      wrapperType: unknown;
+    }) => {
+      // 1. What the filter form builds from the user's keystrokes.
+      const built: DictionaryEntryValue = buildDictionaryValue({
+        operator: operator,
+        rawValue: "0.5",
+      });
+
+      expect(built).toBeInstanceOf(wrapperType as never);
+      expect((built as GreaterThan<number>).value).toBe(0.5);
+
+      // 2. What the server receives after the API round trip.
+      const received: unknown = overTheWire(built);
+
+      expect(received).toBeInstanceOf(wrapperType as never);
+      expect((received as GreaterThan<number>).value).toBe(0.5);
+
+      // 3. What ClickHouse is finally asked to run.
+      const statement: Statement = whereStatementFor(received);
+
+      expect(statement.query).toBe(
+        `AND toFloat64OrNull({p0:Identifier}[{p1:String}]) ${sqlOperator} {p2:Double}`,
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "attributes",
+        p1: "duration",
+        p2: 0.5,
+      });
+    },
+  );
+
+  test("the threshold is never inlined into the SQL text", () => {
+    const statement: Statement = whereStatementFor(
+      overTheWire(
+        buildDictionaryValue({
+          operator: DictionaryFilterOperator.GreaterThan,
+          rawValue: "0.5",
+        }),
+      ),
+    );
+
+    expect(statement.query).not.toContain("0.5");
+    expect(statement.query).not.toContain("duration");
+  });
+
+  test("a saved fractional filter reopens in the form with its value intact", () => {
+    const built: DictionaryEntryValue = buildDictionaryValue({
+      operator: DictionaryFilterOperator.GreaterThanOrEqual,
+      rawValue: "0.5",
+    });
+
+    /*
+     * Saved views persist the serialized wrapper; reopening the filter row
+     * has to recover both the operator and the fractional text, otherwise
+     * the user sees their threshold silently rewritten.
+     */
+    const reopened: {
+      operator: DictionaryFilterOperator;
+      rawValue: string;
+    } = detectOperatorFromValue(
+      JSON.parse(JSON.stringify(built)) as JSONObject,
+    );
+
+    expect(reopened.operator).toBe(DictionaryFilterOperator.GreaterThanOrEqual);
+    expect(reopened.rawValue).toBe("0.5");
+  });
+
+  test.each([
+    ["0.5", 0.5],
+    ["0.001", 0.001],
+    ["-12.75", -12.75],
+    ["3.14159265", 3.14159265],
+    ["1024", 1024],
+    ["3000000000", 3000000000],
+  ])(
+    "a typed %s binds as %p without truncation",
+    (typed: string, expected: number) => {
+      const statement: Statement = whereStatementFor(
+        overTheWire(
+          buildDictionaryValue({
+            operator: DictionaryFilterOperator.GreaterThan,
+            rawValue: typed,
+          }),
+        ),
+      );
+
+      expect(statement.query).toContain("{p2:Double}");
+      expect(statement.query_params["p2"]).toBe(expected);
+    },
+  );
+});

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
@@ -18,6 +18,9 @@ import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
 import IsNull from "../../../../Types/BaseDatabase/IsNull";
 import NotNull from "../../../../Types/BaseDatabase/NotNull";
 import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../../Types/BaseDatabase/GreaterThanOrEqual";
+import LessThan from "../../../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../../../Types/BaseDatabase/LessThanOrEqual";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../../Types/BaseDatabase/Includes";
 import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
@@ -333,8 +336,175 @@ describe("StatementGenerator", () => {
           attributes: { httpStatus: new GreaterThan(500) },
         } as any);
         expect(statement.query).toBe(
-          "AND toFloat64OrNull({p0:Identifier}[{p1:String}]) > {p2:Int32}",
+          "AND toFloat64OrNull({p0:Identifier}[{p1:String}]) > {p2:Double}",
         );
+      });
+
+      /*
+       * Fractional thresholds. The attribute filter form builds these
+       * wrappers with `Number(input)` (buildDictionaryValue in
+       * Common/UI/Components/Dictionary/DictionaryFilterOperator.ts), so
+       * `duration > 0.5` is a filter a user can genuinely produce. The
+       * comparison side already casts with toFloat64OrNull; the threshold
+       * has to bind as Double to match, because ClickHouse cannot parse a
+       * fractional value into an Int32 parameter and rejects the query.
+       */
+      describe("fractional numeric thresholds", () => {
+        type NumericOperatorCase = {
+          name: string;
+          sqlOperator: string;
+          build: (value: number) => unknown;
+        };
+
+        const numericOperatorCases: Array<NumericOperatorCase> = [
+          {
+            name: "GreaterThan",
+            sqlOperator: ">",
+            build: (value: number) => {
+              return new GreaterThan(value);
+            },
+          },
+          {
+            name: "GreaterThanOrEqual",
+            sqlOperator: ">=",
+            build: (value: number) => {
+              return new GreaterThanOrEqual(value);
+            },
+          },
+          {
+            name: "LessThan",
+            sqlOperator: "<",
+            build: (value: number) => {
+              return new LessThan(value);
+            },
+          },
+          {
+            name: "LessThanOrEqual",
+            sqlOperator: "<=",
+            build: (value: number) => {
+              return new LessThanOrEqual(value);
+            },
+          },
+        ];
+
+        test.each(numericOperatorCases)(
+          "binds a fractional $name threshold as Double",
+          ({ sqlOperator, build }: NumericOperatorCase) => {
+            const statement: Statement = mapGenerator.toWhereStatement({
+              attributes: { duration: build(0.5) },
+            } as any);
+
+            expect(statement.query).toBe(
+              `AND toFloat64OrNull({p0:Identifier}[{p1:String}]) ${sqlOperator} {p2:Double}`,
+            );
+            expect(statement.query_params).toStrictEqual({
+              p0: "attributes",
+              p1: "duration",
+              p2: 0.5,
+            });
+          },
+        );
+
+        test.each(numericOperatorCases)(
+          "keeps an integer $name threshold exact under the Double bind",
+          ({ sqlOperator, build }: NumericOperatorCase) => {
+            const statement: Statement = mapGenerator.toWhereStatement({
+              attributes: { httpStatus: build(500) },
+            } as any);
+
+            expect(statement.query).toBe(
+              `AND toFloat64OrNull({p0:Identifier}[{p1:String}]) ${sqlOperator} {p2:Double}`,
+            );
+            expect(statement.query_params["p2"]).toBe(500);
+          },
+        );
+
+        test("preserves a threshold smaller than one instead of truncating it", () => {
+          const statement: Statement = mapGenerator.toWhereStatement({
+            attributes: { errorRate: new GreaterThan(0.001) },
+          } as any);
+
+          // Truncation toward Int32 would have turned this into 0.
+          expect(statement.query_params["p2"]).toBe(0.001);
+          expect(statement.query_params["p2"]).not.toBe(0);
+        });
+
+        test("preserves a negative fractional threshold", () => {
+          const statement: Statement = mapGenerator.toWhereStatement({
+            attributes: { tempCelsius: new LessThan(-12.75) },
+          } as any);
+
+          expect(statement.query).toBe(
+            "AND toFloat64OrNull({p0:Identifier}[{p1:String}]) < {p2:Double}",
+          );
+          expect(statement.query_params["p2"]).toBe(-12.75);
+        });
+
+        test("preserves many decimal places", () => {
+          const statement: Statement = mapGenerator.toWhereStatement({
+            attributes: { ratio: new GreaterThanOrEqual(3.14159265) },
+          } as any);
+
+          expect(statement.query_params["p2"]).toBe(3.14159265);
+        });
+
+        /*
+         * Double also widens the integer range: Int32 tops out at
+         * 2147483647, so a threshold above that used to be unbindable
+         * even though it is a whole number.
+         */
+        test("binds an integer threshold beyond the Int32 range", () => {
+          const statement: Statement = mapGenerator.toWhereStatement({
+            attributes: { bytes: new GreaterThan(3000000000) },
+          } as any);
+
+          expect(statement.query).toBe(
+            "AND toFloat64OrNull({p0:Identifier}[{p1:String}]) > {p2:Double}",
+          );
+          expect(statement.query_params["p2"]).toBe(3000000000);
+        });
+
+        test("coerces a numeric string threshold to a fractional number", () => {
+          const statement: Statement = mapGenerator.toWhereStatement({
+            attributes: { duration: new GreaterThan("0.5" as any) },
+          } as any);
+
+          expect(statement.query_params["p2"]).toBe(0.5);
+        });
+
+        test("combines a fractional threshold with other attribute filters", () => {
+          const statement: Statement = mapGenerator.toWhereStatement({
+            attributes: {
+              duration: new GreaterThan(0.5),
+              requestId: "uuid-123",
+            },
+          } as any);
+
+          expect(statement.query).toBe(
+            "AND toFloat64OrNull({p0:Identifier}[{p1:String}]) > {p2:Double}" +
+              "AND {p3:Identifier}[{p4:String}] = {p5:String}",
+          );
+          expect(statement.query_params).toStrictEqual({
+            p0: "attributes",
+            p1: "duration",
+            p2: 0.5,
+            p3: "attributes",
+            p4: "requestId",
+            p5: "uuid-123",
+          });
+        });
+
+        test("binds a fractional lower and upper bound on the same attribute independently", () => {
+          const lower: Statement = mapGenerator.toWhereStatement({
+            attributes: { duration: new GreaterThanOrEqual(0.25) },
+          } as any);
+          const upper: Statement = mapGenerator.toWhereStatement({
+            attributes: { duration: new LessThanOrEqual(1.75) },
+          } as any);
+
+          expect(lower.query_params["p2"]).toBe(0.25);
+          expect(upper.query_params["p2"]).toBe(1.75);
+        });
       });
 
       test("keeps case-insensitive arrayExists for Search wrapper", () => {
@@ -1439,7 +1609,7 @@ describe("StatementGenerator", () => {
         });
         expect(statement.query).toBe(
           "AND (empty({p0_t:Identifier}.{p0_c:Identifier}) OR hasAny({p1_t:Identifier}.{p1_c:Identifier}, {p2:Array(String)})) " +
-            "AND toFloat64OrNull({p3_t:Identifier}.{p3_c:Identifier}[{p4:String}]) > {p5:Int32}",
+            "AND toFloat64OrNull({p3_t:Identifier}.{p3_c:Identifier}[{p4:String}]) > {p5:Double}",
         );
         expectQualifiers(statement, ["attrKeys", "attrKeys", "attributes"]);
       });

--- a/Common/Tests/Server/Utils/SecurityEvent/SigmaClickhouseCompiler.test.ts
+++ b/Common/Tests/Server/Utils/SecurityEvent/SigmaClickhouseCompiler.test.ts
@@ -247,7 +247,7 @@ detection:
       singleFieldRule("targetPort|gt: 1024"),
     );
 
-    expect(statement.query).toContain("targetPort > {p0:Int32}");
+    expect(statement.query).toContain("targetPort > {p0:Double}");
     expect(statement.query_params["p0"]).toBe(1024);
   });
 
@@ -255,8 +255,92 @@ detection:
     const statement: Statement = compile(singleFieldRule("event.count|gte: 5"));
 
     expect(statement.query).toContain(
-      "toFloat64OrNull(attributes[{p0:String}]) >= {p1:Int32}",
+      "toFloat64OrNull(attributes[{p0:String}]) >= {p1:Double}",
     );
+  });
+
+  /*
+   * Sigma rules routinely carry fractional thresholds (rates, ratios,
+   * durations in seconds). The attribute comparison side is already
+   * toFloat64OrNull, so the bound threshold has to be Double — an Int32
+   * bind cannot parse `0.5` and fails the whole query at runtime.
+   */
+  describe("fractional numeric thresholds", () => {
+    const comparisonModifiers: Array<{ modifier: string; sql: string }> = [
+      { modifier: "gt", sql: ">" },
+      { modifier: "gte", sql: ">=" },
+      { modifier: "lt", sql: "<" },
+      { modifier: "lte", sql: "<=" },
+    ];
+
+    test.each(comparisonModifiers)(
+      "binds a fractional |$modifier attribute threshold as Double",
+      ({ modifier, sql }: { modifier: string; sql: string }) => {
+        const statement: Statement = compile(
+          singleFieldRule(`event.errorRate|${modifier}: 0.5`),
+        );
+
+        expect(statement.query).toContain(
+          `toFloat64OrNull(attributes[{p0:String}]) ${sql} {p1:Double}`,
+        );
+        expect(statement.query_params["p1"]).toBe(0.5);
+      },
+    );
+
+    test("preserves a threshold smaller than one instead of truncating it", () => {
+      const statement: Statement = compile(
+        singleFieldRule("event.errorRate|gt: 0.001"),
+      );
+
+      expect(statement.query_params["p1"]).toBe(0.001);
+      expect(statement.query_params["p1"]).not.toBe(0);
+    });
+
+    test("preserves a negative fractional threshold", () => {
+      const statement: Statement = compile(
+        singleFieldRule("event.drift|lt: -2.5"),
+      );
+
+      expect(statement.query).toContain(
+        "toFloat64OrNull(attributes[{p0:String}]) < {p1:Double}",
+      );
+      expect(statement.query_params["p1"]).toBe(-2.5);
+    });
+
+    test("binds a fractional threshold on a number column as Double", () => {
+      const statement: Statement = compile(
+        singleFieldRule("targetPort|gte: 1024.5"),
+      );
+
+      expect(statement.query).toContain("targetPort >= {p0:Double}");
+      expect(statement.query_params["p0"]).toBe(1024.5);
+    });
+
+    test("keeps integer thresholds exact under the Double bind", () => {
+      const statement: Statement = compile(
+        singleFieldRule("targetPort|gt: 1024"),
+      );
+
+      expect(statement.query_params["p0"]).toBe(1024);
+    });
+
+    test("binds an integer threshold beyond the Int32 range", () => {
+      const statement: Statement = compile(
+        singleFieldRule("event.bytes|gt: 3000000000"),
+      );
+
+      expect(statement.query_params["p1"]).toBe(3000000000);
+    });
+
+    test("a fractional threshold still leaves nothing user-controlled in the SQL text", () => {
+      const statement: Statement = compile(
+        singleFieldRule("event.errorRate|gte: 0.5"),
+      );
+
+      expect(statement.query).not.toContain("0.5");
+      expect(statement.query).not.toContain("event.errorRate");
+      expect(paramValues(statement)).toContain(0.5);
+    });
   });
 
   test("numeric comparison with a non-numeric value is rejected", () => {
@@ -268,7 +352,7 @@ detection:
   test("numeric equality on a number column", () => {
     const statement: Statement = compile(singleFieldRule("classUid: 3002"));
 
-    expect(statement.query).toContain("classUid = {p0:Int32}");
+    expect(statement.query).toContain("classUid = {p0:Double}");
     expect(statement.query_params["p0"]).toBe(3002);
   });
 
@@ -349,7 +433,7 @@ detection:
     const statement: Statement = compileWithCondition("1 of sel_*");
 
     expect(statement.query).toContain("toUInt8((");
-    expect(statement.query).toContain(") >= {p2:Int32}");
+    expect(statement.query).toContain(") >= {p2:Double}");
     expect(statement.query_params["p2"]).toBe(1);
   });
 


### PR DESCRIPTION
## The bug

Numeric attribute filter operators (`>`, `>=`, `<`, `<=`) bound their threshold with `TableColumnType.Number`, which [`Statement.toColumnType`](Common/Server/Utils/AnalyticsDatabase/Statement.ts:225) maps to ClickHouse `Int32`.

The Dictionary attribute filter form builds these wrappers with `Number(trimmed)` (see `buildDictionaryValue` in [DictionaryFilterOperator.ts](Common/UI/Components/Dictionary/DictionaryFilterOperator.ts:437)), so a user can type `0.5` and produce a fractional threshold. ClickHouse cannot parse a fractional value into an `Int32` parameter, so the whole query fails at runtime.

The predicate already casts the stored map value with `toFloat64OrNull(v)`, so the comparison side was float-ready — only the bound parameter type was wrong.

## The fix

`TableColumnType.Decimal` maps to `Double`. Every `Int32` is exactly representable as a `Double`, so integer thresholds are unaffected, and the bindable integer range actually widens past `Int32`'s 2147483647 ceiling.

Two sites shared the bug and are fixed together:

- **[StatementGenerator.ts](Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts:1091)** — the map-attribute `GreaterThan` / `GreaterThanOrEqual` / `LessThan` / `LessThanOrEqual` branches.
- **[SigmaClickhouseCompiler.ts](Common/Server/Utils/SecurityEvent/Sigma/SigmaClickhouseCompiler.ts:194)** — `numberParam()`, which feeds the same `toFloat64OrNull` comparison for Sigma rules such as `event.errorRate|gte: 0.5`.

## A note on scope

The issue as filed named `LogAggregationService.appendAttributeOperatorFilter` (and a `numeric()` helper) as the second site. **That helper does not exist in this repo** — no ref contains it, and `LogAttributeFilterValue` is typed `string | Array<string>`, so the aggregation service structurally cannot carry operator wrappers today. Its attribute filters are equality/`IN` only.

A repo-wide sweep of every `TableColumnType.Number` / `ArrayNumber` parameter binding turned up `SigmaClickhouseCompiler`'s `numberParam()` as the genuine second instance of this exact bug, so that is what is fixed alongside. Every other `Number` binding I checked is integer-by-construction (limits, offsets, counts, severity numbers, bucket sizes) and is left alone.

Two things deliberately **not** changed:

- `JSONExtractInt(...) = {p:Int32}` in `StatementGenerator` (~line 1264) — a JSON-column equality whose extraction is integer on both sides. Making it float would change semantics, not just the bind width.
- NaN handling. `Number("abc")` yields `NaN`, and `sanitizeAttributeFilters` only drops empty raw values. This was equally broken before and is a separate concern.

## Tests

New [FractionalAttributeThreshold.test.ts](Common/Tests/Server/Utils/AnalyticsDatabase/FractionalAttributeThreshold.test.ts) walks the full chain for all four operators — what the filter form builds from the user's keystrokes, what survives the JSON round trip across the API boundary, and what is finally bound into the SQL.

Extended the two existing suites with truncation, sign, precision, above-`Int32`, numeric-string, and combined-filter cases, plus a check that a fractional threshold still never lands in the SQL text itself (the Sigma suite treats that as an injection regression).

Existing expectations that asserted `{pN:Int32}` on these paths were updated to `{pN:Double}`.

## Verification

| Suite | Result |
|---|---|
| `Tests/Server/Utils/AnalyticsDatabase/` | 159 passed |
| `Tests/Server/Utils/SecurityEvent/SigmaClickhouseCompiler` | 48 passed |
| Aggregation services + `AnalyticsDatabaseService` | 159 passed |
| Dictionary UI components + `SessionReplayAPI` | 114 passed |

`tsc --noEmit` on `Common` is clean; eslint is clean on all changed files.

Unrelated pre-existing local failure: the `Monitor` and `VM` suites cannot load `isolated-vm` (`dlopen … symbol not found`, a native-module ABI mismatch against Node 24.1.0). None of those suites reference the changed modules.