### PR TITLE
fix(topology): unbreak compile-dashboard by using an IconProp that exists

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyExplorer.tsx
@@ -773,7 +773,7 @@ const NetworkTopologyExplorer: FunctionComponent<ComponentProps> = (
         {visibleSites.length === 0 ? (
           <EmptyState
             id="topology-hierarchy-empty"
-            icon={IconProp.Network}
+            icon={IconProp.FlowDiagram}
             title={
               normalizedSearch || healthFilterMode !== "all"
                 ? "Nothing here matches"


### PR DESCRIPTION
### Title of this pull request?

fix(topology): unbreak `compile-dashboard` by using an IconProp that exists

### Small Description?

`master`'s `compile-dashboard` job has been failing since the hierarchy-topology work merged (#3329, `c9efe0e5e`). Because the Compile workflow runs on every pull request, the failure blocks **all** open PRs, not just the topology work.

The failure is a single TypeScript error:

```
App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyExplorer.tsx(776,28):
error TS2339: Property 'Network' does not exist on type 'typeof IconProp'.
```

The hierarchy view renders its empty state with `IconProp.Network`, but that member was never added to the `IconProp` enum in `Common/Types/Icon/IconProp.ts`. That one line was the only reference to it in the repo.

**The change** — one line, `NetworkTopologyExplorer.tsx:776`:

```diff
-            icon={IconProp.Network}
+            icon={IconProp.FlowDiagram}
```

**Why swap the icon rather than add a `Network` member**

The design intent is already settled elsewhere in the codebase — `FlowDiagram` *is* the Topology feature's icon:

- the Topology nav entry uses it (`App/FeatureSet/Dashboard/src/Utils/NavigationItems.tsx:258`)
- both `EmptyState`s in the sibling `InfrastructureGraph.tsx` — same directory, same component family, same empty-state role — already use it

Its renderer case at `Common/UI/Components/Icon/Icon.tsx:1355` draws connected nodes, so it reads correctly for a topology empty state and cannot render blank. Adding a `Network` enum member plus a hand-authored SVG would have introduced a second, near-duplicate topology icon for no visual gain — and an enum member without a matching renderer case yields a silently blank icon rather than a compile error.

**Notes for the reviewer**

- I swept every `IconProp.X` reference in the Dashboard against the enum. `Network` was the only unresolved one, so nothing similar is hiding behind it.
- `npm install` also wants to refresh `App/FeatureSet/Dashboard/package-lock.json` (it still reads `12.0.9` against a `12.0.14` `package.json`). That drift is pre-existing and unrelated, so I reverted it to keep this diff to the single line. Probably worth a separate look.
- **Not fixed here:** `master`'s `js-lint` job is also red, on three unrelated files from the measurements work — `App/FeatureSet/BaseAPI/Index.ts`, `Common/Server/Infrastructure/Postgres/SchemaMigrations/1788100000000-AddMeasurements.ts`, and `Common/Tests/Server/Services/MutableMetricNameRouting.test.ts` (prettier / member-accessibility complaints that `npx eslint --fix` should clear). That is a separate fix and is deliberately out of scope for this PR, so `js-lint` will still be red on this branch.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

Verified with `npx tsc --noEmit -p tsconfig.json` in `App/FeatureSet/Dashboard` (after `npm install` in both `Common` and the Dashboard, matching CI): **exit 0, zero errors**.

Note on the first checkbox: `compile-dashboard` is fixed and verified locally, but `js-lint` remains red on this branch for the unrelated reason described above.

### Related Issue?

Regression from #3329 (`c9efe0e5e`).

### Screenshots (if appropriate):

n/a — swaps one empty-state glyph for the icon already used by the sibling topology empty states.
