### PR TITLE
fix(frontend): stop the SPA fallbacks swallowing root-mounted ingest GETs

### DIFF
--- a/App/FeatureSet/Frontend/Index.ts
+++ b/App/FeatureSet/Frontend/Index.ts
@@ -73,6 +73,82 @@ interface RenderFrontendOptions {
   frontendConfig: FrontendConfig;
 }
 
+/*
+ * Ingest and internal service prefixes. These must never be answered with
+ * SPA HTML, on ANY host, which is why both fallbacks below spread this in
+ * rather than keeping two hand-synced copies.
+ *
+ * Why the reservation is needed at all: App/Index.ts runs
+ * FrontendRoutes.init() BEFORE the Docs/Workers/Telemetry/Workflow/Runbook
+ * feature sets, and several of those mount their routers on "/" as well as
+ * on a named prefix. Express matches in registration order, so the two
+ * app.get("*") fallbacks below are already registered by the time those
+ * routers mount, and every GET they would have answered comes back as the
+ * SPA's index page at HTTP 200 instead. That failure is silent - the caller
+ * gets a valid-looking page rather than an error - which is how #2986 (the
+ * heartbeat GET) survived to a release.
+ *
+ * Why BOTH lists and not just the dashboard one: the custom-domain fallback
+ * fires whenever the Host is not a primary host, and cluster-internal
+ * service-to-service traffic is addressed by Kubernetes service name, so it
+ * lands there too. KEDA polling
+ * http://<release>-telemetry-writer:<port>/metrics/telemetry-writer-shed-rate
+ * is exactly that shape - a non-primary Host on an ingest-only path - and
+ * the dashboard list alone would not have covered it.
+ *
+ * Reserving costs nothing: a prefix with no matching route falls through to
+ * the 404 handler in StartServer.addDefaultRoutes, so the worst case is an
+ * honest 404 rather than a misleading 200.
+ *
+ * App/Tests/FeatureSet/RootMountedRouteReservation.test.ts derives the
+ * required set from the mounts themselves and fails when a newly
+ * root-mounted GET route is not covered here.
+ */
+const IngestRoutePrefixesToSkip: Array<string> = [
+  "/telemetry",
+  "/otlp",
+  "/opentelemetry.proto.collector",
+  /*
+   * Session replay ingest is mounted on both "/telemetry" and "/", so
+   * without this entry a root-level /session-replay/v1/chunk would be
+   * answered with SPA HTML instead of reaching the ingest router.
+   */
+  "/session-replay",
+  /*
+   * Queue-depth and shed-rate endpoints polled by the KEDA metrics-api
+   * scaler (HelmChart/.../keda-scaledobjects.yaml). The worker and api tiers
+   * only kept working because App/Index.ts mounts AppMetricsAPI on "/"
+   * BEFORE the feature sets; telemetry-writer's shed-rate route has no such
+   * head start and is registered by the Telemetry feature set.
+   */
+  "/metrics",
+  "/probe-ingest",
+  "/ingestor",
+  /*
+   * ProbeIngest's routers are mounted on "/" as well as "/probe-ingest" and
+   * "/ingestor", so their own route prefixes are reachable at the root too.
+   */
+  "/probe",
+  "/monitor",
+  /*
+   * Both spellings are needed: the predicate matches a prefix exactly or
+   * followed by "/", so "/server-monitor" does NOT cover
+   * "/server-monitor-ingest/...".
+   */
+  "/server-monitor-ingest",
+  "/server-monitor",
+  "/incoming-request-ingest",
+  "/incoming-request",
+  /*
+   * Nginx rewrites /heartbeat/<key> to the /incoming-request route above, so
+   * the App normally never sees this prefix - it is reserved for the case
+   * where a request reaches the App without passing through that rewrite.
+   */
+  "/heartbeat",
+  "/incoming-email",
+  "/worker",
+];
+
 const DashboardFallbackRoutePrefixesToSkip: Array<string> = [
   "/status-page",
   "/status-page-api",
@@ -84,28 +160,12 @@ const DashboardFallbackRoutePrefixesToSkip: Array<string> = [
   "/api",
   "/identity",
   "/notification",
-  "/telemetry",
-  /*
-   * Session replay ingest is mounted on both "/telemetry" and "/", and
-   * FrontendRoutes.init() runs BEFORE TelemetryRoutes.init(), so without
-   * this entry a root-level /session-replay/v1/chunk would be answered with
-   * the Dashboard SPA's HTML instead of reaching the ingest router.
-   */
-  "/session-replay",
-  "/incoming-request-ingest",
-  "/incoming-request",
-  "/otlp",
-  "/opentelemetry.proto.collector",
-  "/probe-ingest",
-  "/ingestor",
-  "/server-monitor",
+  ...IngestRoutePrefixesToSkip,
   "/realtime",
   "/workflow",
   "/workers",
   "/mcp",
   "/analytics-api",
-  "/heartbeat",
-  "/incoming-email",
   "/file",
   "/docs",
   "/reference",
@@ -117,7 +177,6 @@ const DashboardFallbackRoutePrefixesToSkip: Array<string> = [
    * mistake is meant to be caught.
    */
   "/oneuptime-assets",
-  "/worker",
   "/.well-known",
   "/l",
   "/manifest.json",
@@ -134,6 +193,19 @@ const StatusPageDomainFallbackRoutePrefixesToSkip: Array<string> = [
   "/status-page-oidc-api",
   "/status-page-identity-api",
   "/public-dashboard-api",
+  /*
+   * Ingest is reserved here as well as on the dashboard list, deliberately.
+   * "Not a primary host" covers two very different callers: a customer's
+   * status-page custom domain, and any cluster-internal client addressing a
+   * pod by its Kubernetes service name. The second is why this matters - see
+   * the KEDA note on IngestRoutePrefixesToSkip.
+   *
+   * The cost to the first caller is nil: none of these prefixes is a
+   * StatusPage or PublicDashboard client route (their root-level routes are
+   * /incidents, /announcements, /scheduled-events, /subscribe, /login and
+   * friends), so no status page deep link is shadowed by this.
+   */
+  ...IngestRoutePrefixesToSkip,
   /* Same reservation as the dashboard list above. */
   "/oneuptime-assets",
   "/.well-known",

--- a/App/Tests/FeatureSet/HeartbeatRouteReservation.test.ts
+++ b/App/Tests/FeatureSet/HeartbeatRouteReservation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "@jest/globals";
-import fs from "fs";
-import path from "path";
+import {
+  APP_DIR,
+  REPO_ROOT,
+  arrayEntries,
+  isReserved,
+  readSource,
+  stripComments,
+} from "./RouteReservationSource";
 
 /*
  * Regression test for #2986: GET https://<host>/heartbeat/<secretkey> came
@@ -24,25 +30,16 @@ import path from "path";
  * un-mounting the root prefix, dropping the reservation, or deleting the GET
  * registration fails here rather than in a self-hosted install's monitor.
  *
- * The prefix arrays are module-private, so this reads the source the same way
- * VendorAssetRouteReservation.test.ts does. Reading source means the parsing
- * has to be exact: this file's house style is to precede a reserved prefix
- * with a comment that quotes OTHER paths, so a regex that scrapes every
- * quoted string out of the array literal also picks up comment prose. That
- * is not a cosmetic flaw - it lets an edit that deletes the reservation and
- * leaves a comment mentioning it keep the whole suite green, which is the
- * one edit this file exists to catch. Hence the line-shaped parser below:
- * it accepts only lines that are entirely one quoted entry. An entry written
- * some other way is missed and the reservation assertions FAIL, which is the
- * safe direction to be wrong in.
+ * The prefix arrays are module-private, so this reads the source, using the
+ * shared parser in ./RouteReservationSource. That parser strips comments
+ * before reading entries and resolves the `...IngestRoutePrefixesToSkip`
+ * spread the lists share; the reasoning for both is documented there, and
+ * the test below guards that this file still benefits from it.
+ *
+ * This file pins the specific #2986 path. The general rule - every GET route
+ * mounted at the root by a later feature set must be reserved - is derived
+ * from the mounts themselves in RootMountedRouteReservation.test.ts.
  */
-
-const APP_DIR: string = path.join(__dirname, "..", "..");
-const REPO_ROOT: string = path.join(APP_DIR, "..");
-
-function readSource(...segments: Array<string>): string {
-  return fs.readFileSync(path.join(...segments), "utf8");
-}
 
 const FRONTEND_INDEX: string = readSource(
   APP_DIR,
@@ -75,50 +72,6 @@ const TELEMETRY_INDEX: string = readSource(
 
 const APP_INDEX: string = readSource(APP_DIR, "Index.ts");
 
-/*
- * Entries only - never comment prose. A line has to BE one quoted string to
- * count, so `* mounted on both "/telemetry" and "/"` contributes nothing.
- */
-function arrayEntries(source: string, name: string): Array<string> {
-  const declaration: RegExpMatchArray | null = source.match(
-    new RegExp(`const ${name}: Array<string> = \\[([\\s\\S]*?)\\n\\];`),
-  );
-
-  if (!declaration || !declaration[1]) {
-    return [];
-  }
-
-  return declaration[1]
-    .split("\n")
-    .map((line: string): string => {
-      return line.trim();
-    })
-    .map((line: string): string | null => {
-      return line.match(/^"([^"]+)",?$/)?.[1] ?? null;
-    })
-    .filter((entry: string | null): entry is string => {
-      return entry !== null;
-    });
-}
-
-/*
- * A registration inside a block comment, or commented out at the start of a
- * line, is not a registration. Only whole-line "//" is stripped so that a
- * "https://" inside a real string literal survives.
- */
-function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/^[ \t]*\/\/.*$/gm, "");
-}
-
-/* Mirrors shouldSkipDashboardFallbackRoute in FeatureSet/Frontend/Index.ts. */
-function isReserved(prefixes: Array<string>, requestPath: string): boolean {
-  return prefixes.some((prefix: string) => {
-    return requestPath === prefix || requestPath.startsWith(`${prefix}/`);
-  });
-}
-
 describe("the nginx heartbeat rewrite target is reserved against the dashboard SPA fallback", () => {
   const rewriteTarget: string | undefined = NGINX_TEMPLATE.match(
     /rewrite\s+\^\/heartbeat\(\.\*\)\$\s+(\/\S+)\$1\s+break;/,
@@ -149,18 +102,26 @@ describe("the nginx heartbeat rewrite target is reserved against the dashboard S
 
   test("the parser reads entries only, never quoted paths in comments", () => {
     /*
-     * The guard on this file's own method. The array's comments quote real
-     * paths ("/telemetry", "/"), so a scrape-every-string parser reports
-     * more prefixes than the array has entries and would keep the suite
-     * green through the exact deletion below. Entry count must match the
-     * number of entry-shaped lines, and prose must contribute nothing.
+     * The guard on this file's own method. The reserved prefixes carry
+     * comments that quote OTHER real paths - "/telemetry" and "/" in the
+     * session-replay note, for instance - so a scrape-every-string parser
+     * reports more prefixes than there are entries, and "/" alone would make
+     * isReserved answer true for every path on earth. That parser would keep
+     * this suite green through the exact deletion it exists to catch.
+     *
+     * Stripping comments first must therefore change nothing.
      */
-    const body: string =
-      FRONTEND_INDEX.match(
-        /const DashboardFallbackRoutePrefixesToSkip: Array<string> = \[([\s\S]*?)\n\];/,
-      )?.[1] ?? "";
+    const source: string = FRONTEND_INDEX.slice(
+      FRONTEND_INDEX.indexOf("const IngestRoutePrefixesToSkip"),
+    );
+    const body: string = source.slice(0, source.indexOf("];"));
 
-    expect(body).toContain("*");
+    /*
+     * There is prose quoting a bare "/" in there, and it must not become an
+     * entry: a "/" prefix would make isReserved answer true for every path.
+     */
+    expect(body).toMatch(/\/\*[\s\S]*"\/"[\s\S]*?\*\//);
+    expect(prefixes).not.toContain("/");
     expect(prefixes).toEqual(
       arrayEntries(
         stripComments(FRONTEND_INDEX),

--- a/App/Tests/FeatureSet/RootMountedRouteReservation.test.ts
+++ b/App/Tests/FeatureSet/RootMountedRouteReservation.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import {
+  APP_DIR,
+  arrayEntries,
+  isReserved,
+  readSource,
+  stripComments,
+} from "./RouteReservationSource";
+
+/*
+ * A general guard for the bug class behind #2986, rather than one more
+ * entry in a denylist.
+ *
+ * App/Index.ts calls FrontendRoutes.init() before the remaining feature
+ * sets. Frontend registers two app.get("*") fallbacks, so by the time a
+ * later feature set mounts a router on "/" the catch-alls are already in
+ * Express's stack and win every GET the router would have answered. The
+ * caller gets SPA HTML at HTTP 200. Nothing logs and nothing 404s, so the
+ * failure surfaces as "the integration silently does nothing":
+ *
+ *   - #2986: heartbeat monitors stayed Offline forever.
+ *   - /metrics/telemetry-writer-shed-rate: KEDA cannot parse shedCount out
+ *     of HTML, falls back, and the writer tier never scales on shed rate.
+ *
+ * The two skip lists are what hold the class off, and keeping them correct
+ * by hand has failed repeatedly - each miss left a comment behind rather
+ * than a test. So this file does not hard-code the prefixes that need
+ * reserving. It derives them from the mounts themselves:
+ *
+ *   1. read the feature-set init order out of App/Index.ts and keep the
+ *      ones that run after FrontendRoutes;
+ *   2. in each of those, find every router mounted on "/";
+ *   3. read that router's GET registrations;
+ *   4. for every (mount x route) pair the router is reachable at, require
+ *      the first path segment to be reserved in BOTH lists.
+ *
+ * Add a root-mounted GET route without reserving its prefix and this fails,
+ * naming the route and the list that is missing it.
+ *
+ * Both lists, not just the dashboard one: the custom-domain fallback fires
+ * whenever the Host is not a primary host, and cluster-internal callers
+ * addressing a pod by Kubernetes service name land there too. KEDA polling
+ * http://<release>-telemetry-writer:<port>/metrics/... is exactly that.
+ */
+
+const APP_INDEX: string = readSource(APP_DIR, "Index.ts");
+const FRONTEND_INDEX: string = readSource(
+  APP_DIR,
+  "FeatureSet",
+  "Frontend",
+  "Index.ts",
+);
+
+/*
+ * The init() calls in App/Index.ts are `await <Name>Routes.init();`, and the
+ * feature set lives in FeatureSet/<Name>. Anything that does not resolve to
+ * a directory (Realtime, which is not a feature set) is skipped.
+ */
+function featureSetsInitialisedAfterFrontend(): Array<string> {
+  const code: string = stripComments(APP_INDEX);
+  const initialised: Array<string> = [
+    ...code.matchAll(/await (\w+)Routes\.init\(\);/g),
+  ].map((match: RegExpMatchArray): string => {
+    return match[1] as string;
+  });
+
+  const frontendIndex: number = initialised.indexOf("Frontend");
+
+  if (frontendIndex < 0) {
+    throw new Error(
+      "Could not find `await FrontendRoutes.init();` in App/Index.ts.",
+    );
+  }
+
+  return initialised
+    .slice(frontendIndex + 1)
+    .filter((featureSet: string): boolean => {
+      return fs.existsSync(path.join(APP_DIR, "FeatureSet", featureSet));
+    });
+}
+
+interface RootMount {
+  featureSet: string;
+  router: string;
+  routerPath: string;
+  mounts: Array<string>;
+}
+
+/*
+ * Routers mounted on "/" by a feature set that initialises after Frontend.
+ * The mount argument is either a literal, an inline array, or an
+ * Array<string> constant in the same file.
+ */
+function rootMountsIn(featureSet: string): Array<RootMount> {
+  const indexPath: string = path.join(
+    APP_DIR,
+    "FeatureSet",
+    featureSet,
+    "Index.ts",
+  );
+
+  if (!fs.existsSync(indexPath)) {
+    return [];
+  }
+
+  const source: string = readSource(indexPath);
+  const code: string = stripComments(source);
+  const mounted: Array<RootMount> = [];
+
+  const appUse: RegExp =
+    /app\.use\(\s*(?:"([^"]+)"|\[([^\]]*)\]|([A-Z_][A-Z0-9_]*))\s*,\s*(\w+)\s*\)/g;
+
+  for (const match of code.matchAll(appUse)) {
+    const [, literal, inline, constant] = match;
+    const router: string | undefined = match[4];
+
+    if (!router) {
+      throw new Error(
+        `Could not read the router name out of ${JSON.stringify(
+          match[0],
+        )} in FeatureSet/${featureSet}/Index.ts.`,
+      );
+    }
+
+    let mounts: Array<string>;
+
+    if (literal) {
+      mounts = [literal];
+    } else if (inline !== undefined) {
+      mounts = [...inline.matchAll(/"([^"]+)"/g)]
+        .map((entry: RegExpMatchArray): string | undefined => {
+          return entry[1];
+        })
+        .filter((entry: string | undefined): entry is string => {
+          return entry !== undefined;
+        });
+    } else if (constant) {
+      mounts = arrayEntries(source, constant);
+
+      if (mounts.length === 0) {
+        throw new Error(
+          `Could not resolve mount prefixes "${constant}" in ` +
+            `FeatureSet/${featureSet}/Index.ts.`,
+        );
+      }
+    } else {
+      throw new Error(
+        `Unrecognised mount argument in ${JSON.stringify(match[0])} in ` +
+          `FeatureSet/${featureSet}/Index.ts. It must be a string literal, ` +
+          `an inline array, or an Array<string> constant, so that this test ` +
+          `can tell whether the router is mounted at the root.`,
+      );
+    }
+
+    if (!mounts.includes("/")) {
+      continue;
+    }
+
+    const importMatch: RegExpMatchArray | null = code.match(
+      new RegExp(`import ${router} from "([^"]+)"`),
+    );
+
+    if (!importMatch || !importMatch[1]) {
+      throw new Error(
+        `"${router}" is mounted on "/" in FeatureSet/${featureSet}/Index.ts ` +
+          `but its import could not be found, so its GET routes cannot be ` +
+          `checked for reservation.`,
+      );
+    }
+
+    const routerPath: string = `${path.join(
+      APP_DIR,
+      "FeatureSet",
+      featureSet,
+      importMatch[1].replace(/^\.\//, ""),
+    )}.ts`;
+
+    if (!fs.existsSync(routerPath)) {
+      throw new Error(
+        `Router source for "${router}" not found at ${routerPath}.`,
+      );
+    }
+
+    mounted.push({
+      featureSet: featureSet,
+      router: router,
+      routerPath: routerPath,
+      mounts: mounts,
+    });
+  }
+
+  return mounted;
+}
+
+interface ReachableRoute {
+  origin: string;
+  requestPath: string;
+  segment: string;
+}
+
+/*
+ * Every path a root-mounted router answers GET on. A router mounted on
+ * ["/probe-ingest", "/"] with a route "/probe/queue/size" is reachable at
+ * both "/probe-ingest/probe/queue/size" and "/probe/queue/size", and the
+ * fallbacks are keyed on the FIRST segment, so both spellings matter -
+ * "/server-monitor" does not cover "/server-monitor-ingest/...".
+ */
+function reachableGetRoutes(): Array<ReachableRoute> {
+  const reachable: Array<ReachableRoute> = [];
+
+  for (const featureSet of featureSetsInitialisedAfterFrontend()) {
+    for (const mount of rootMountsIn(featureSet)) {
+      const routerSource: string = stripComments(readSource(mount.routerPath));
+
+      const routes: Array<string> = [
+        ...routerSource.matchAll(/router\.get\(\s*"([^"]+)"/g),
+      ].map((match: RegExpMatchArray): string => {
+        return match[1] as string;
+      });
+
+      for (const prefix of mount.mounts) {
+        for (const route of routes) {
+          const requestPath: string = `${prefix === "/" ? "" : prefix}${route}`;
+          const firstSegment: string | undefined = requestPath
+            .split("/")
+            .filter(Boolean)[0];
+
+          if (!firstSegment) {
+            continue;
+          }
+
+          reachable.push({
+            origin: `${mount.featureSet}/${mount.router}`,
+            requestPath: requestPath,
+            segment: `/${firstSegment}`,
+          });
+        }
+      }
+    }
+  }
+
+  return reachable;
+}
+
+const ROUTES: Array<ReachableRoute> = reachableGetRoutes();
+
+const LISTS: Array<string> = [
+  "DashboardFallbackRoutePrefixesToSkip",
+  "StatusPageDomainFallbackRoutePrefixesToSkip",
+];
+
+describe("every root-mounted GET route is reserved against the SPA fallbacks", () => {
+  test("the derivation actually found the root-mounted routes", () => {
+    /*
+     * Everything below is vacuous if the parsing silently found nothing, and
+     * a rename in App/Index.ts or a feature-set Index.ts is exactly the kind
+     * of change that would cause that.
+     */
+    expect(ROUTES.length).toBeGreaterThan(10);
+
+    const segments: Array<string> = [
+      ...new Set(
+        ROUTES.map((route: ReachableRoute): string => {
+          return route.segment;
+        }),
+      ),
+    ];
+
+    /*
+     * Spot-check the two the class has actually bitten: the heartbeat ingest
+     * path from #2986, and the KEDA shed-rate path. If either stops being
+     * derived, the derivation - not the reservation - is what broke.
+     */
+    expect(segments).toContain("/incoming-request");
+    expect(segments).toContain("/metrics");
+    expect(
+      ROUTES.some((route: ReachableRoute): boolean => {
+        return route.requestPath === "/metrics/telemetry-writer-shed-rate";
+      }),
+    ).toBe(true);
+  });
+
+  describe.each(LISTS)("%s", (list: string) => {
+    const prefixes: Array<string> = arrayEntries(FRONTEND_INDEX, list);
+
+    test("the list was found and parsed", () => {
+      expect(prefixes.length).toBeGreaterThan(3);
+      expect(
+        prefixes.every((prefix: string): boolean => {
+          return prefix.startsWith("/");
+        }),
+      ).toBe(true);
+    });
+
+    test("reserves the first path segment of every root-mounted GET route", () => {
+      const unreserved: Array<string> = [
+        ...new Set(
+          ROUTES.filter((route: ReachableRoute): boolean => {
+            return !isReserved(prefixes, route.requestPath);
+          }).map((route: ReachableRoute): string => {
+            return `${route.requestPath} (${route.origin}) needs ${route.segment}`;
+          }),
+        ),
+      ];
+
+      /*
+       * Printed rather than counted so the failure names the route and the
+       * prefix to add, which is the whole point of deriving this list.
+       */
+      expect(unreserved).toEqual([]);
+    });
+  });
+});
+
+describe("the reservation mechanism these tests model still exists", () => {
+  test("both fallbacks are registered as GET catch-alls", () => {
+    const code: string = stripComments(FRONTEND_INDEX);
+
+    expect(code).toContain("registerCustomDomainFallback();");
+    expect(code).toContain("registerDashboardFallbackForPrimaryHost();");
+    expect(code).toContain("app.get(");
+    expect(code).toContain('"*"');
+  });
+
+  test("stripping comments does not swallow the code being checked", () => {
+    /*
+     * Frontend/Index.ts contains a template literal ending in "/*", and a
+     * naive comment stripper reads that as the start of a block comment and
+     * deletes ~1,400 characters - the whole registerCustomDomainFallback
+     * declaration among them. It throws nothing; the assertions above simply
+     * stop seeing what they claim to check. Pinned here because that is a
+     * silent-false-pass, the same failure mode as the route bug itself.
+     */
+    const code: string = stripComments(FRONTEND_INDEX);
+
+    expect(FRONTEND_INDEX).toContain("`${frontendConfig.routePrefix}/*`");
+
+    for (const declaration of [
+      "const registerCustomDomainFallback",
+      "const registerDashboardFallbackForPrimaryHost",
+      "const IngestRoutePrefixesToSkip",
+      "const DashboardFallbackRoutePrefixesToSkip",
+      "const StatusPageDomainFallbackRoutePrefixesToSkip",
+    ]) {
+      expect(code).toContain(declaration);
+    }
+  });
+
+  test("the custom-domain fallback consults the status-page list", () => {
+    /*
+     * This is why /metrics has to be on BOTH lists. The custom-domain
+     * fallback is registered first and has no IsBillingEnabled gate, so it
+     * is the one that answers a request whose Host is a Kubernetes service
+     * name - which is every KEDA poll.
+     */
+    const code: string = stripComments(FRONTEND_INDEX);
+    const customDomainFallback: string = code.slice(
+      code.indexOf("const registerCustomDomainFallback"),
+      code.indexOf("const registerDashboardFallbackForPrimaryHost"),
+    );
+
+    expect(customDomainFallback).toContain(
+      "shouldSkipStatusPageDomainFallbackRoute(req.path)",
+    );
+    expect(customDomainFallback).not.toContain("IsBillingEnabled");
+  });
+
+  test("isReserved still mirrors the predicate the server runs", () => {
+    /*
+     * isReserved is a copy of the server's predicate. If the server ever
+     * switched to an exact match, the copy would keep passing while the
+     * server stopped covering "/metrics/telemetry-writer-shed-rate".
+     */
+    expect(FRONTEND_INDEX).toContain("path.startsWith(`${prefix}/`)");
+    expect(FRONTEND_INDEX).toContain("if (path === prefix)");
+  });
+
+  test("both lists share one ingest source of truth", () => {
+    /*
+     * The lists were hand-synced denylists and drifted: before this test the
+     * status-page list reserved none of the ingest prefixes, and the
+     * dashboard list had "/server-monitor" but not
+     * "/server-monitor-ingest". Sharing the entries is what keeps a single
+     * new mount from having to be remembered twice.
+     */
+    const code: string = stripComments(FRONTEND_INDEX);
+
+    for (const list of LISTS) {
+      const body: string = code.slice(
+        code.indexOf(`const ${list}: Array<string> = [`),
+      );
+
+      expect(body.slice(0, body.indexOf("];"))).toContain(
+        "...IngestRoutePrefixesToSkip",
+      );
+    }
+  });
+});

--- a/App/Tests/FeatureSet/RouteReservationSource.ts
+++ b/App/Tests/FeatureSet/RouteReservationSource.ts
@@ -1,0 +1,259 @@
+import fs from "fs";
+import path from "path";
+
+/*
+ * Shared source-reading helpers for the route-reservation tests.
+ *
+ * The prefix arrays in FeatureSet/Frontend/Index.ts are module-private, so
+ * the tests around them read the source rather than importing it. Reading
+ * source means the parsing has to be exact, and two traps have already been
+ * hit here:
+ *
+ *   1. This codebase's house style is to precede a reserved prefix with a
+ *      comment that quotes OTHER paths, so a regex that scrapes every quoted
+ *      string out of an array literal also picks up comment prose. That is
+ *      not cosmetic - it lets an edit that deletes a reservation but leaves
+ *      a comment mentioning it keep the suite green, which is the one edit
+ *      these tests exist to catch. Comments are stripped before entries are
+ *      read, so prose can never contribute an entry.
+ *
+ *   2. The lists now share their ingest entries through a spread
+ *      (`...IngestRoutePrefixesToSkip`), so a parser that only understands
+ *      string literals would silently report a list as missing exactly the
+ *      prefixes it does reserve.
+ *
+ * Anything these helpers cannot account for throws rather than returning a
+ * partial answer. A loud failure on an unrecognised entry shape is the safe
+ * direction: the alternative is a test that quietly checks less than it
+ * claims to.
+ */
+
+export const APP_DIR: string = path.join(__dirname, "..", "..");
+export const REPO_ROOT: string = path.join(APP_DIR, "..");
+
+export function readSource(...segments: Array<string>): string {
+  return fs.readFileSync(path.join(...segments), "utf8");
+}
+
+/*
+ * A registration inside a block comment, or commented out, is not a
+ * registration - so comments come out before any of the matching below.
+ *
+ * This is a scanner rather than a pair of regexes because a regex cannot
+ * tell a comment from the same characters inside a string. Frontend/Index.ts
+ * really does contain
+ *
+ *     [frontendConfig.routePrefix, `${frontendConfig.routePrefix}/*`],
+ *
+ * and a plain /\/\*[\s\S]*?\*\//g treats that "/*" as the start of a comment
+ * and deletes everything up to the next "*\/" - roughly 1,400 characters,
+ * including the whole registerCustomDomainFallback declaration. Nothing
+ * throws; the affected assertions just quietly stop seeing the code they are
+ * meant to be checking. Quotes, apostrophes and template literals are
+ * therefore tracked, and only comments found outside them are removed.
+ */
+export function stripComments(source: string): string {
+  let output: string = "";
+  let index: number = 0;
+
+  while (index < source.length) {
+    const character: string = source[index] as string;
+    const next: string | undefined = source[index + 1];
+
+    // Escapes are copied verbatim so "\\" cannot fake a quote.
+    if (character === "\\" && index + 1 < source.length) {
+      output += character + (next as string);
+      index += 2;
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === "`") {
+      const quote: string = character;
+      output += character;
+      index++;
+
+      while (index < source.length) {
+        const inner: string = source[index] as string;
+
+        if (inner === "\\" && index + 1 < source.length) {
+          output += inner + (source[index + 1] as string);
+          index += 2;
+          continue;
+        }
+
+        output += inner;
+        index++;
+
+        if (inner === quote) {
+          break;
+        }
+      }
+
+      continue;
+    }
+
+    if (character === "/" && next === "*") {
+      const close: number = source.indexOf("*/", index + 2);
+      index = close < 0 ? source.length : close + 2;
+      continue;
+    }
+
+    if (character === "/" && next === "/") {
+      const lineEnd: number = source.indexOf("\n", index);
+      index = lineEnd < 0 ? source.length : lineEnd;
+      continue;
+    }
+
+    output += character;
+    index++;
+  }
+
+  return output;
+}
+
+/*
+ * The body of `const <name>: Array<string> = [ ... ];`, found by balancing
+ * brackets rather than by matching a closing "\n];" - single-line arrays
+ * such as TELEMETRY_PREFIXES have no such line, and a lazy regex would run
+ * past them into the next declaration.
+ */
+function arrayBody(source: string, name: string): string | null {
+  const opening: RegExpMatchArray | null = source.match(
+    new RegExp(`const ${name}: Array<string> = \\[`),
+  );
+
+  if (!opening || opening.index === undefined) {
+    return null;
+  }
+
+  const start: number = opening.index + opening[0].length;
+  let depth: number = 1;
+  let index: number = start;
+
+  while (index < source.length && depth > 0) {
+    const character: string | undefined = source[index];
+
+    if (character === "[") {
+      depth++;
+    } else if (character === "]") {
+      depth--;
+    }
+
+    index++;
+  }
+
+  if (depth !== 0) {
+    throw new Error(`Unbalanced brackets in array literal "${name}".`);
+  }
+
+  return source.slice(start, index - 1);
+}
+
+/* Split on commas that are not nested inside brackets, braces or parens. */
+function splitTopLevel(body: string): Array<string> {
+  const elements: Array<string> = [];
+  let depth: number = 0;
+  let current: string = "";
+
+  for (const character of body) {
+    if (character === "[" || character === "{" || character === "(") {
+      depth++;
+    } else if (character === "]" || character === "}" || character === ")") {
+      depth--;
+    }
+
+    if (character === "," && depth === 0) {
+      elements.push(current);
+      current = "";
+      continue;
+    }
+
+    current += character;
+  }
+
+  elements.push(current);
+
+  return elements;
+}
+
+/*
+ * Entries of an `Array<string>` declaration, with `...Other` spreads
+ * resolved against declarations in the same source.
+ */
+export function arrayEntries(
+  source: string,
+  name: string,
+  seen: Array<string> = [],
+): Array<string> {
+  /*
+   * Comments come out before the brackets are balanced, not after: prose is
+   * free to contain a stray "[", and it must not be able to shift where the
+   * parser thinks the literal ends.
+   */
+  const code: string = stripComments(source);
+  const body: string | null = arrayBody(code, name);
+
+  if (body === null) {
+    return [];
+  }
+
+  if (seen.includes(name)) {
+    throw new Error(`Circular spread while resolving "${name}".`);
+  }
+
+  const entries: Array<string> = [];
+
+  for (const element of splitTopLevel(body)) {
+    const trimmed: string = element.trim();
+
+    if (!trimmed) {
+      continue;
+    }
+
+    const literal: RegExpMatchArray | null = trimmed.match(/^"([^"]+)"$/);
+
+    if (literal && literal[1]) {
+      entries.push(literal[1]);
+      continue;
+    }
+
+    const spread: RegExpMatchArray | null = trimmed.match(/^\.\.\.(\w+)$/);
+
+    if (spread && spread[1]) {
+      const resolved: Array<string> = arrayEntries(source, spread[1], [
+        ...seen,
+        name,
+      ]);
+
+      if (resolved.length === 0) {
+        throw new Error(
+          `Spread "...${spread[1]}" in "${name}" resolved to nothing.`,
+        );
+      }
+
+      entries.push(...resolved);
+      continue;
+    }
+
+    throw new Error(
+      `Unrecognised entry ${JSON.stringify(trimmed)} in "${name}". ` +
+        `Entries must be a plain string literal or a spread of another ` +
+        `Array<string> in the same file, so that these tests can read them.`,
+    );
+  }
+
+  return entries;
+}
+
+/*
+ * Mirrors shouldSkipDashboardFallbackRoute /
+ * shouldSkipStatusPageDomainFallbackRoute in FeatureSet/Frontend/Index.ts.
+ */
+export function isReserved(
+  prefixes: Array<string>,
+  requestPath: string,
+): boolean {
+  return prefixes.some((prefix: string) => {
+    return requestPath === prefix || requestPath.startsWith(`${prefix}/`);
+  });
+}


### PR DESCRIPTION
## The class, not the instance

#2986 (`GET /heartbeat/<key>` answered with dashboard HTML at 200) was fixed in #3316 by adding one prefix to one denylist. The same bug class was still live on other root-mounted GET routes.

`App/Index.ts` runs `FrontendRoutes.init()` **before** the Docs/Workers/Telemetry/Workflow/Runbook feature sets. Frontend registers two `app.get("*")` fallbacks, so by the time those feature sets mount routers on `"/"`, the catch-alls already win every GET. Any route whose top-level segment is on neither skip list is answered with SPA HTML at HTTP 200 instead of reaching its handler. Nothing logs, nothing 404s — the caller just gets a valid-looking page.

## What was exposed

Four prefixes were unreserved on the dashboard fallback:

| Prefix | Routes | Notes |
|---|---|---|
| `/metrics` | `GET /metrics/telemetry-writer-shed-rate` | see below |
| `/probe`, `/monitor` | ProbeIngest queue/pending GETs | cluster-key protected, lower impact |
| `/server-monitor-ingest` | ServerMonitor GETs via its prefixed alias | the list had `/server-monitor`; the predicate matches `<prefix>/` exactly, so it never covered `/server-monitor-ingest/...` |

That last one was not in the original report — the derived test found it.

### The high-impact one: KEDA autoscaling has never worked for telemetry-writer

`HelmChart/.../keda-scaledobjects.yaml:134` configures a metrics-api scaler that polls `http://<release>-telemetry-writer:<port>/metrics/telemetry-writer-shed-rate` and reads `shedCount` from the body.

That Host is a Kubernetes service name, so it is **not** a primary host (`{HOST, localhost, ingress}`), so the request is answered by `registerCustomDomainFallback` — which is registered *first* and has **no `IsBillingEnabled` gate**. This affects OneUptime Cloud as well as self-hosted. KEDA cannot parse `shedCount` out of HTML, silently falls back, and the shed-rate trigger is dead.

Verified end to end against express@4 (the version `Common` declares), replicating the real ordering and predicate:

```
KEDA polls Host: oneuptime-telemetry-writer:3600  path: /metrics/telemetry-writer-shed-rate
  BEFORE : 200 text/html         :: <!doctype html><title>Status Page SPA</title>
  AFTER  : 200 application/json  :: {"shedCount":42}

AFTER, GET /incidents on status.acme.com : 200 text/html  (status page unaffected)
```

The sibling `/metrics/queue-size` survives only because `App/Index.ts:148` mounts `AppMetricsAPI` on `"/"` *before* the feature sets. Reserving `/metrics` fixes both robustly.

## Why both lists, and why one shared list

Because the KEDA path arrives on a non-primary Host, reserving it on the dashboard list alone would **not** have fixed it — it had to go on the status-page list too.

The two lists were hand-synced denylists that had already drifted (the status-page list reserved none of the ingest prefixes). The ingest prefixes now live in a single `IngestRoutePrefixesToSkip` that both lists spread in, so a new mount is remembered once. Resolved-list diff: **nothing dropped, no duplicates**; dashboard `39 → 43`, status-page `9 → 25`.

Reserving is safe in both directions: an unmatched reserved prefix falls through to the 404 handler in `StartServer.addDefaultRoutes` (an honest 404 beats a misleading 200), and none of these prefixes is a StatusPage or PublicDashboard client route — those are `/incidents`, `/announcements`, `/scheduled-events`, `/subscribe`, `/login` and friends — so no status page deep link changes. Every Dashboard SPA route is under `/dashboard`, so root reservations cannot shadow it.

This also answers the open question about `/heartbeat` on custom domains: it is now reserved rather than left ambiguous, with a comment saying why.

## The test is derived, not hard-coded

`App/Tests/FeatureSet/RootMountedRouteReservation.test.ts` does not list prefixes. It reads the init order from `App/Index.ts`, finds routers mounted on `"/"` in the feature sets that follow Frontend, reads their GET registrations, and requires the first segment of every reachable *(mount × route)* pair to be reserved in **both** lists. Anything it cannot resolve throws rather than quietly passing.

Mutation-tested — all four caught:

| Mutation | Result |
|---|---|
| drop `/metrics` from the shared list | ✕ both lists, naming all 3 affected routes |
| add a new root-mounted GET with an unreserved prefix | ✕ `"/brand-new-ingest/thing (Telemetry/TelemetryWriterAPI) needs /brand-new-ingest"` |
| remove the spread from the status-page list | ✕ reservation + source-of-truth tests |
| revert the comment stripper to the old regex | ✕ the stripping test |

### Bonus: a silent-false-pass in the shared test helper

`Frontend/Index.ts` contains ``[frontendConfig.routePrefix, `${frontendConfig.routePrefix}/*`]``. The old regex comment-stripper read that `/*` as a comment opener and deleted ~1,400 characters — including the entire `registerCustomDomainFallback` declaration. It threw nothing; assertions just stopped seeing the code they claimed to check. It is now a string-aware scanner, and a test pins that the declarations survive stripping.

Parsing helpers are shared in `RouteReservationSource.ts`; per #3333 the parser is comment-immune (comments are stripped before entries are read), and it now also resolves the `...IngestRoutePrefixesToSkip` spread.

## On reordering `App/Index.ts` instead

Option 3 from #2986 — mounting the ingest feature sets before `FrontendRoutes.init()` — would kill the class outright, and it is the better long-term shape. I did not do it here: it changes boot ordering for every root-mounted router at once, including gRPC/MQTT server startup and queue-consumer registration in `TelemetryRoutes.init()`, and it is not verifiable by static tests — it needs a running cluster. It also does not subsume this PR, since the derived test is what makes either approach enforceable. Worth doing as its own change; the guard test here would protect the interim state and could then be relaxed to assert the ordering instead.

## Verification

- `cd App && npx jest Tests/FeatureSet/` → **493 passed, 0 failed**. (5 `Workflow` suites fail to load on `isolated-vm`, a pre-existing native-binary mismatch — confirmed identical on a clean `master`.)
- `npx tsc --noEmit` clean for all changed files.
- `eslint` and `prettier --check` clean.
