### PR TITLE
Docs: AI gateway observability (LiteLLM, Portkey) and async agent circuit breaking

### DIFF
--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-agent-circuit-breaker.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-agent-circuit-breaker.md
@@ -1,0 +1,183 @@
+# Circuit-Breaking Runaway AI Agents
+
+AI agents rarely fail by crashing. They fail by _continuing_ — retrying a broken tool in a loop, re-planning the same step forever, or fanning out sub-agents — while every iteration bills more tokens. This guide shows how to build an **async circuit breaker** with pieces OneUptime already gives you:
+
+1. A **trip-wire signal** — an [LLM cost budget](/docs/telemetry/ai-llm-observability) alert or a [Traces monitor](/docs/monitor/traces-monitor) that recognizes loop behavior in your `gen_ai.*` spans.
+2. A **Workflow** triggered by that alert.
+3. An **outbound webhook** from the workflow to a kill endpoint _you_ own, which stops the runaway runner.
+
+```mermaid
+flowchart LR
+    A[Agent emits<br/>gen_ai.* spans] --> B[OneUptime<br/>OTLP ingest]
+    B --> C{Trip-wire:<br/>cost budget or<br/>Traces monitor}
+    C -->|Alert created| D[Workflow:<br/>Alert On Create]
+    D --> E[API Post to your<br/>kill endpoint]
+    E --> F[Your runner aborts<br/>or pauses the agent]
+```
+
+## Why async instead of an inline gateway?
+
+Inline guardrails put a proxy in the request path: every LLM call detours through a gateway that can veto request N+1. That works, but it couples you to one gateway, adds latency to every call, and becomes a single point of failure for all AI traffic.
+
+The circuit breaker here is **gateway-agnostic**. It watches the OpenTelemetry traces your app already sends (directly, or [through a gateway](/docs/telemetry/ai-gateways) — both work), and reacts out-of-band. Nothing sits in your hot path, and switching providers, SDKs or gateways doesn't break it. The trade-off is honesty about latency: this is a **backstop that stops a runaway in minutes, not milliseconds**. Keep per-run step limits and timeouts in your agent code as the first line of defense; use this to catch what slips through.
+
+## Prerequisites
+
+- Your agent emits GenAI spans to OneUptime — see [AI / LLM Observability](/docs/telemetry/ai-llm-observability) or [Observing AI Gateways](/docs/telemetry/ai-gateways).
+- An HTTP endpoint in your infrastructure that can stop or pause your agent runner (built in Step 2).
+
+## Step 1 — Pick a trip-wire signal
+
+Both options end the same way: an **alert** is created in OneUptime, which is what triggers the workflow. You can wire up both at once — the workflow doesn't care which one fired.
+
+### Option A: LLM cost budget alert
+
+A runaway agent's most reliable symptom is spend. The **AI / LLM → Budgets** tab lets you set a daily USD limit with a warning alert (default 80%) and a breach alert (100%). Budgets are evaluated every 15 minutes against the day's LLM span cost — SDK-reported or [computed at ingest](/docs/telemetry/ai-llm-observability), so it works even if your instrumentation doesn't report cost.
+
+For circuit breaking, scope the budget so the alert identifies _what to kill_:
+
+- Create one budget **per agent's telemetry service** (for example `agent-support-bot`), not just a project-wide one.
+- Name the budget after the runner it guards — the budget name is embedded in the alert title, and your kill endpoint can route on it.
+
+The alerts arrive with predictable titles you can filter on in the workflow:
+
+- Warning: `LLM cost budget warning: <budget name>`
+- Breach: `LLM cost budget exceeded: <budget name>`
+
+A good pattern is warning → page a human (via the alert's on-call policy), breach → trip the breaker.
+
+### Option B: Traces monitor on loop behavior
+
+Cost catches slow burns; a [Traces monitor](/docs/monitor/traces-monitor) catches loops faster. A stuck agent produces a very recognizable trace shape: the **same tool-call span, over and over**. Healthy runs don't call one tool dozens of times in a couple of minutes.
+
+Create a monitor with **Monitors → Create Monitor → Traces**:
+
+- **Telemetry service**: your agent's service.
+- **Attributes**: `gen_ai.tool.name` = the tool you expect loops on (for example `search_web`) — or use **Span Name** if your instrumentation names tool spans directly.
+- **Time Window**: 120 seconds.
+- **Criteria**: Span Count **Greater Than** a threshold no healthy run reaches (say `30`), and have the criteria **create an alert** with an appropriate severity.
+- **Monitoring interval**: every minute, so detection lag stays around one to three minutes.
+
+Two variations worth knowing:
+
+- A second criteria filtering **Span Statuses = ERROR** with a lower threshold catches retry storms (tool keeps failing, agent keeps retrying).
+- A [Metrics monitor](/docs/monitor/metrics-monitor) on `gen_ai.client.token.usage` gives you a token-rate version of the same idea.
+
+### Detection latency, honestly stated
+
+| Signal                                         | Typical time to alert              |
+| ---------------------------------------------- | ---------------------------------- |
+| Traces monitor, 1-minute interval, 120s window | ~1–3 minutes                       |
+| Budget warning / breach                        | up to ~15 minutes (worker cadence) |
+
+## Step 2 — Build the kill endpoint (your side)
+
+The workflow will `POST` a JSON payload to an endpoint you host. What "kill" means is your call — common blast-radius choices, smallest first:
+
+1. **Stop new work**: flip a flag so the runner picks up no new agent runs.
+2. **Abort matching runs**: cancel in-flight runs for the affected agent/service.
+3. **Pause the whole pool**: drain every worker until a human resets the breaker.
+
+A minimal Express example that trips a per-runner breaker:
+
+```ts
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+const tripped = new Set<string>(); // runner names with an open breaker
+
+app.post("/circuit-breaker", (req, res) => {
+  if (req.headers["authorization"] !== `Bearer ${process.env.KILL_TOKEN}`) {
+    return res.status(401).end();
+  }
+
+  const alertTitle: string = req.body.alertTitle ?? "";
+
+  // Budget names / monitor names map to runners, e.g.
+  // "LLM cost budget exceeded: agent-support-bot" -> "agent-support-bot"
+  const runner: string = alertTitle.split(": ").pop() ?? "unknown";
+
+  tripped.add(runner); // your run loop checks this set
+  abortActiveRuns(runner); // cancel in-flight jobs for that runner
+
+  // Acknowledge fast — do the heavy cleanup async.
+  return res.status(200).json({ tripped: runner });
+});
+```
+
+Design notes:
+
+- **Make it idempotent.** The breaker may be tripped more than once (warning then breach, or budget plus traces monitor firing together). Tripping an already-tripped breaker must be harmless.
+- **Acknowledge quickly** and do slow cleanup in the background; the workflow's API component treats any 2xx as success.
+- **Require a secret.** Anyone who can call this endpoint can stop your agents. Check a bearer token (stored as a secret OneUptime [global variable](/docs/workflows/variables) on the sending side).
+- **Human reset.** A tripped breaker should stay tripped until someone looks at the run — auto-resetting defeats the purpose. Investigate with **AI / LLM → LLM Calls**, filtering by the conversation/session id to see exactly what the agent was doing.
+
+## Step 3 — The workflow
+
+Open **Workflows** in the left navigation, click **Create Workflow**, and build these blocks on the canvas. See [Authoring a Workflow](/docs/workflows/authoring) for canvas basics.
+
+### 1. Trigger: Alert → On Create
+
+Add the **On Create Alert** trigger ([OneUptime event triggers](/docs/workflows/triggers)). Every new alert in the project starts the workflow and passes the full alert record as `model`. Give the trigger a stable ID — the examples below assume `alert-on-create-1`.
+
+### 2. Filter: If / Else on the alert title
+
+You only want the breaker tripped by your trip-wire alerts, not every alert in the project. Add an **If / Else** block (Conditions category):
+
+- **Left**: the trigger's `model.title` — inserted with the picker, it reads `{{local.components.alert-on-create-1.returnValues.model.title}}`
+- **Operator**: `contains`
+- **Right**: `LLM cost budget exceeded` (Option A) — or your Traces monitor's alert title (Option B)
+
+To react to several trip-wires, chain If / Else blocks from the **No** branch, or standardize your alert titles so one `contains` match covers them all.
+
+### 3. Act: API Post to your kill endpoint
+
+From the **Yes** branch, add an **API Post (JSON)** component ([Components](/docs/workflows/components)):
+
+- **URL**: `https://your-infra.example.com/circuit-breaker`
+- **Request Headers**:
+
+```json
+{
+  "Authorization": "Bearer {{global.variables.AGENT_KILL_TOKEN}}",
+  "Content-Type": "application/json"
+}
+```
+
+- **Request Body**:
+
+```json
+{
+  "source": "oneuptime-circuit-breaker",
+  "alertId": "{{local.components.alert-on-create-1.returnValues.model._id}}",
+  "alertTitle": "{{local.components.alert-on-create-1.returnValues.model.title}}",
+  "alertDescription": "{{local.components.alert-on-create-1.returnValues.model.description}}"
+}
+```
+
+Store the token as a **secret global variable** (`AGENT_KILL_TOKEN`) under **Workflows → Global Variables** so it stays out of run logs. The simpler outbound **Webhook** component also works for fire-and-forget posts, but the API component lets you set the auth header and branch on the response — use it here.
+
+### 4. Don't fail silently
+
+Connect the API block's **Error** port to a **Slack** (or Email) block: a circuit breaker that fails to trip is exactly the alert you want a human to see. Optionally connect **Success** to a Slack message too — "breaker tripped for `<runner>`" is a message your on-call will appreciate.
+
+## Step 4 — Test it
+
+1. **Dry-run the workflow**: alerts can be created by hand (**Alerts → Create Alert**). Create one titled `LLM cost budget exceeded: test`, then check the workflow fired under **Workflows → Runs & Logs**, and that your endpoint received the post.
+2. **Test the real signal**: create a scoped budget with a tiny limit (for example $0.01) against a dev service and let your agent run — you should see the alert, the workflow run, and the breaker trip end-to-end. For Option B, point a test agent at a stubbed failing tool and watch the loop trip the traces monitor.
+3. **Verify idempotency** by firing the alert twice.
+
+## Alert lifecycle caveats
+
+- Budget alerts fire **at most once per UTC day** per budget and kind (one warning, one breach), and only if no matching alert is still open — so the breaker trips once per bad day, not continuously. Resetting is a human decision on both sides: resolve the alert in OneUptime _and_ reset your breaker.
+- A Traces monitor keeps its alert open while the criteria stay met; the workflow triggers on **creation**, so you get one trip per episode.
+- The workflow trigger fires for **every** new alert in the project — the If / Else filter is what keeps unrelated alerts from tripping the breaker. Don't skip it.
+
+## Where to read next
+
+- [AI / LLM Observability](/docs/telemetry/ai-llm-observability) — GenAI spans, cost computation, and daily budgets.
+- [Observing AI Gateways](/docs/telemetry/ai-gateways) — get gateway-level traces in with one config change.
+- [Traces Monitor](/docs/monitor/traces-monitor) — span filters and criteria in detail.
+- [Workflows](/docs/workflows/index) — triggers, components, variables, runs.

--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-gateways.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-gateways.md
@@ -1,0 +1,191 @@
+# Observing AI Gateways (LiteLLM & Portkey)
+
+An AI gateway is a natural observability choke point: every LLM call from every app flows through it. Point the gateway's OpenTelemetry export at OneUptime once, and you get [AI / LLM observability](/docs/telemetry/ai-llm-observability) — traces, token usage, cost, prompts and completions — for everything behind it, without instrumenting each application.
+
+This guide covers the two most common gateways:
+
+- **[LiteLLM Proxy](#litellm-proxy)** — built-in OTel export in the open-source proxy.
+- **[Portkey](#portkey)** — built-in export on self-hosted/enterprise deployments; a client-side pattern for the open-source and hosted gateway.
+
+## Before you start
+
+1. Create a telemetry ingestion token in OneUptime: **Project Settings → Telemetry & APM → Ingestion Keys → Create Ingestion Key**.
+2. Note your OTLP endpoint: `https://oneuptime.com/otlp` — or `https://YOUR-ONEUPTIME-HOST/otlp` if you self-host. Traces are accepted at `/otlp/v1/traces` over OTLP HTTP, in both protobuf and JSON encoding.
+3. The token travels as the `x-oneuptime-token` header on every export request.
+
+## LiteLLM Proxy
+
+LiteLLM's OpenTelemetry callback ships in the open-source proxy. The official Docker image (`ghcr.io/berriai/litellm`) bundles the OpenTelemetry packages, so export is purely a matter of configuration. (Installing via pip instead? `pip install litellm[proxy]` does **not** include them — add `pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp`.)
+
+### 1. Enable the OTel callback
+
+In your LiteLLM `config.yaml`:
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  callbacks: ["otel"]
+```
+
+### 2. Point the exporter at OneUptime
+
+Set three environment variables on the proxy:
+
+```bash
+export OTEL_EXPORTER="otlp_http"
+export OTEL_ENDPOINT="https://oneuptime.com/otlp/v1/traces"
+export OTEL_HEADERS="x-oneuptime-token=YOUR_INGESTION_TOKEN"
+```
+
+Notes on the exact values:
+
+- Use the **full `/v1/traces` path** in `OTEL_ENDPOINT`. LiteLLM v1.79+ normalizes a base URL like `https://oneuptime.com/otlp` to the right per-signal path automatically, but older versions pass the endpoint through verbatim — the full path works on every version.
+- `OTEL_HEADERS` takes comma-separated `key=value` pairs, so multiple headers are `key1=val1,key2=val2`.
+- The standard OpenTelemetry names (`OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) also work and take precedence over LiteLLM's short names.
+- `OTEL_SERVICE_NAME` sets the service the spans appear under in OneUptime (default: `litellm`).
+
+### 3. Run it
+
+Docker example, all together:
+
+```bash
+docker run \
+  -v $(pwd)/config.yaml:/app/config.yaml \
+  -e OPENAI_API_KEY="sk-..." \
+  -e OTEL_EXPORTER="otlp_http" \
+  -e OTEL_ENDPOINT="https://oneuptime.com/otlp/v1/traces" \
+  -e OTEL_HEADERS="x-oneuptime-token=YOUR_INGESTION_TOKEN" \
+  -e OTEL_SERVICE_NAME="litellm-gateway" \
+  -p 4000:4000 \
+  ghcr.io/berriai/litellm:main-stable \
+  --config /app/config.yaml
+```
+
+Every request through the proxy now produces a span named `litellm_request` carrying `gen_ai.system` (provider), `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`, request parameters, and the prompt and completion content — all attributes OneUptime [recognizes natively](/docs/telemetry/ai-llm-observability).
+
+**Cost:** LiteLLM prices each call itself and reports it on the span (`gen_ai.cost.total_cost`, or `litellm.cost.total` in v2 mode). OneUptime reads that as the span's reported cost, so LiteLLM's own pricing — including any custom per-model rates you configured on the proxy — wins over OneUptime's catalog estimate. When LiteLLM can't price a call (a custom model with no pricing configured), OneUptime falls back to [computing an estimate](/docs/telemetry/ai-llm-observability) from the token counts.
+
+### Prompt content and privacy
+
+The `otel` callback captures **full prompt and completion content by default**. Three ways to turn that off, if your gateway fronts sensitive traffic:
+
+```yaml
+# Option 1: global kill-switch for all logging callbacks
+litellm_settings:
+  callbacks: ["otel"]
+  turn_off_message_logging: true
+```
+
+```yaml
+# Option 2: just the otel callback (callback_settings is a TOP-LEVEL key)
+litellm_settings:
+  callbacks: ["otel"]
+
+callback_settings:
+  otel:
+    message_logging: False
+```
+
+```bash
+# Option 3: environment variable
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="NO_CONTENT"
+```
+
+You can also keep content flowing and redact selectively with OneUptime's telemetry scrub rules under **Traces → Settings**.
+
+### Optional: unified traces with OTel v2
+
+Newer LiteLLM versions ship an opt-in "OpenTelemetry v2" mode (`LITELLM_OTEL_V2=true`, no `config.yaml` change needed) that emits one unified trace per request — HTTP handling, auth, guardrails, and the LLM call as canonical GenAI-semantic-convention spans named like `chat gpt-4o`. In v2 mode, prompt content is **off** by default and opted in via `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Pick one mode or the other, not both.
+
+### Troubleshooting
+
+- Set `OTEL_EXPORTER="console"` temporarily — if spans print to the proxy's stdout, LiteLLM is instrumenting fine and the problem is the endpoint or token.
+- Set `DEBUG_OTEL="true"` for verbose exporter logging.
+- Only traces are exported by default; LiteLLM's OTel metrics/events are separate opt-ins and aren't needed for OneUptime's AI / LLM features.
+
+## Portkey
+
+Portkey's story depends on how you run it — check your deployment against these three rows first:
+
+| Deployment                                 | OTel trace export to OneUptime                                      |
+| ------------------------------------------ | ------------------------------------------------------------------- |
+| Self-hosted / enterprise gateway           | **Built-in** (experimental) — configure with env vars below         |
+| Open-source gateway (`portkey-ai/gateway`) | Not available — use client-side instrumentation                     |
+| Hosted (portkey.ai)                        | Not available on the gateway side — use client-side instrumentation |
+
+Don't confuse this with Portkey's own OpenTelemetry **ingestion** endpoint (`api.portkey.ai/v1/otel`) — that receives traces _into_ Portkey and is the opposite direction from what this guide sets up.
+
+### Self-hosted / enterprise gateway: built-in export
+
+Portkey's enterprise and self-hosted gateway can push every LLM request/response as an OTLP trace span, following GenAI semantic conventions (1.40.0). Set these environment variables on the gateway container:
+
+```yaml
+EXPERIMENTAL_GEN_AI_OTEL_TRACES_ENABLED: "true"
+EXPERIMENTAL_GEN_AI_OTEL_EXPORTER_OTLP_ENDPOINT: "https://oneuptime.com/otlp"
+EXPERIMENTAL_GEN_AI_OTEL_EXPORTER_OTLP_HEADERS: "x-oneuptime-token=YOUR_INGESTION_TOKEN"
+```
+
+Details worth knowing:
+
+- Give the **base** OTLP URL — Portkey appends `/v1/traces` itself.
+- Headers are comma-separated `key=value` pairs.
+- The export is OTLP over **HTTP/JSON** (no gRPC). OneUptime's OTLP endpoint accepts JSON, so no collector is needed in between.
+- Spans are named `{operation} {model}` (for example `chat gpt-4o`) and arrive under the service name `portkey`, carrying `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`, `gen_ai.conversation.id`, and structured `gen_ai.input.messages` / `gen_ai.output.messages`.
+- Exports happen asynchronously after the response (no request latency), but there is **no batching and no retry** — a failed export is dropped, so treat this as observability, not an audit log.
+- **Full prompt and completion content is included.** Apply OneUptime scrub rules (**Traces → Settings**) if you need redaction.
+- If Portkey reuses your `x-portkey-trace-id` as the trace id (it does when the id is a valid 32-hex string), gateway spans correlate with your app's own traces.
+
+Portkey marks the feature experimental; if the variables have no effect, check their current docs and your gateway image version — older Helm charts documented earlier variable names.
+
+### Open-source and hosted gateway: instrument the client
+
+The open-source `portkey-ai/gateway` has no OTel exporter, and on the hosted gateway you can't set server env vars. The supported pattern for both: **instrument the application that calls through Portkey**, and export those spans to OneUptime.
+
+Portkey is OpenAI-API-compatible, so the same GenAI instrumentations from the [AI / LLM Observability guide](/docs/telemetry/ai-llm-observability) — OpenLLMetry, OpenInference, OpenLIT — wrap your OpenAI/Anthropic SDK calls normally even when the base URL points at Portkey:
+
+```python
+from traceloop.sdk import Traceloop
+from openai import OpenAI
+
+Traceloop.init(
+    app_name="my-ai-agent",
+    api_endpoint="https://oneuptime.com/otlp",
+    headers={"x-oneuptime-token": "YOUR_INGESTION_TOKEN"},
+)
+
+client = OpenAI(
+    base_url="https://api.portkey.ai/v1",   # or your gateway's URL
+    default_headers={"x-portkey-api-key": "PORTKEY_API_KEY"},
+)
+# Calls through Portkey are now traced to OneUptime.
+```
+
+One honest caveat: client-side spans describe the call _as your app made it_ — requested model, latency as observed, tokens as returned. Gateway-internal decisions (fallback routing, retries, cache hits) stay visible only inside Portkey. If you need those in OneUptime, that's what the enterprise export above is for.
+
+## Verify the spans landed
+
+Send a test request through the gateway, wait a few seconds, then open **AI / LLM** in OneUptime's navigation (under Observability):
+
+1. **LLM Calls** should list the call — provider, model, and token counts filled in. LiteLLM spans are named `litellm_request`; Portkey's enterprise export names them `chat <model>`.
+2. Click the call to open the trace, and check the span's **AI / LLM panel**: model, input/output tokens, request parameters, and (unless you disabled content capture) the prompt and completion.
+3. **Overview** should show the call in the totals; cost appears too — reported by the gateway where available, otherwise [computed at ingest](/docs/telemetry/ai-llm-observability) from token counts for known models.
+
+Nothing showing up?
+
+- Re-check the token — a wrong `x-oneuptime-token` is rejected at ingest.
+- Re-check the endpoint spelling for your setup: LiteLLM wants the full `/otlp/v1/traces` path; Portkey wants the base `/otlp`.
+- Use each gateway's debug switch (`OTEL_EXPORTER=console` for LiteLLM; gateway logs for Portkey) to confirm spans are being produced at all.
+- Filter the **Traces** page by the gateway's service name (`litellm`, `portkey`, or your `OTEL_SERVICE_NAME`) to see raw spans even if they aren't classified as LLM calls.
+
+## What this unlocks
+
+Once gateway spans land as `gen_ai.*` traces, everything in OneUptime's AI observability works on them:
+
+- **[Daily cost budgets](/docs/telemetry/ai-llm-observability)** across every app behind the gateway — with warning and breach alerts.
+- **[Traces monitors](/docs/monitor/traces-monitor)** on span patterns, like a runaway agent calling the same tool in a loop.
+- **[Async circuit breaking](/docs/telemetry/ai-agent-circuit-breaker)** — chain those alerts to a Workflow that calls your infrastructure to stop a runaway agent, without putting anything new in the request path.

--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-llm-observability.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-llm-observability.md
@@ -24,6 +24,8 @@ Use any OpenTelemetry GenAI instrumentation. Popular choices:
 - **OpenInference** (Arize) — instrumentors for OpenAI, LangChain, LlamaIndex, DSPy, etc.
 - **Native OpenTelemetry** GenAI instrumentations.
 
+Routing your LLM traffic through a gateway like **LiteLLM** or **Portkey**? You can export traces from the gateway itself instead of instrumenting every app — see [Observing AI Gateways](/docs/telemetry/ai-gateways).
+
 ### Python (OpenLLMetry)
 
 ```bash
@@ -74,19 +76,19 @@ Self-hosting OneUptime? Replace `https://oneuptime.com/otlp` with `https://YOUR-
 
 OneUptime reads the OpenTelemetry GenAI conventions first, and falls back to the OpenLLMetry and OpenInference variants so popular libraries work out of the box.
 
-| What | Primary attribute | Also accepted |
-|------|-------------------|---------------|
-| Provider / system | `gen_ai.system` | `gen_ai.provider.name`, `llm.system` |
-| Operation | `gen_ai.operation.name` | `llm.request.type`, `openinference.span.kind` |
-| Requested model | `gen_ai.request.model` | `llm.model_name` |
-| Response model | `gen_ai.response.model` | — |
-| Input tokens | `gen_ai.usage.input_tokens` | `gen_ai.usage.prompt_tokens`, `llm.token_count.prompt` |
-| Output tokens | `gen_ai.usage.output_tokens` | `gen_ai.usage.completion_tokens`, `llm.token_count.completion` |
-| Total tokens | `gen_ai.usage.total_tokens` | derived from input + output |
-| Cost (USD) | `gen_ai.usage.cost` | `llm.usage.total_cost` |
-| Agent name | `gen_ai.agent.name` | — |
-| Tool name | `gen_ai.tool.name` | — |
-| Conversation / session id | `gen_ai.conversation.id` | `session.id`, `langfuse.session.id`, `traceloop.association.properties.session_id` |
+| What                      | Primary attribute            | Also accepted                                                                                               |
+| ------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Provider / system         | `gen_ai.system`              | `gen_ai.provider.name`, `llm.system`                                                                        |
+| Operation                 | `gen_ai.operation.name`      | `llm.request.type`, `openinference.span.kind`                                                               |
+| Requested model           | `gen_ai.request.model`       | `llm.model_name`                                                                                            |
+| Response model            | `gen_ai.response.model`      | —                                                                                                           |
+| Input tokens              | `gen_ai.usage.input_tokens`  | `gen_ai.usage.prompt_tokens`, `llm.token_count.prompt`                                                      |
+| Output tokens             | `gen_ai.usage.output_tokens` | `gen_ai.usage.completion_tokens`, `llm.token_count.completion`                                              |
+| Total tokens              | `gen_ai.usage.total_tokens`  | derived from input + output                                                                                 |
+| Cost (USD)                | `gen_ai.usage.cost`          | `gen_ai.usage.total_cost`, `llm.usage.total_cost`, `gen_ai.cost.total_cost` (LiteLLM), `litellm.cost.total` |
+| Agent name                | `gen_ai.agent.name`          | —                                                                                                           |
+| Tool name                 | `gen_ai.tool.name`           | —                                                                                                           |
+| Conversation / session id | `gen_ai.conversation.id`     | `session.id`, `langfuse.session.id`, `traceloop.association.properties.session_id`                          |
 
 **Prompt & completion content** is read from the standard content events (`gen_ai.system.message`, `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.choice`) or the indexed attributes (`gen_ai.prompt.N.content`, `gen_ai.completion.N.content`) and rendered in the AI / LLM panel.
 
@@ -112,7 +114,7 @@ Open **AI / LLM** in the navigation bar (under Observability):
 Because GenAI metrics arrive as ordinary OpenTelemetry metrics, you can:
 
 - Build **dashboards** charting `gen_ai.client.token.usage`, `gen_ai.client.operation.duration`, etc. (Dashboards → add a chart on the metric).
-- Create **metric monitors** to alert on token spend, latency or error rate — for example alert when `gen_ai.client.operation.duration` p95 crosses a threshold, grouped by model. See [Monitors](/docs/monitor/monitor).
+- Create **metric monitors** to alert on token spend, latency or error rate — for example alert when `gen_ai.client.operation.duration` p95 crosses a threshold, grouped by model. See [Metrics Monitor](/docs/monitor/metrics-monitor).
 
 ## Daily cost budgets
 
@@ -124,6 +126,8 @@ The **AI / LLM** section has a **Budgets** tab. Each budget sets a daily USD lim
 — each at most once per UTC day. Alerts carry a configurable severity and can trigger your on-call duty policies.
 
 Budgets can be scoped to a telemetry service, an LLM provider (the `gen_ai` provider name), or an exact model — or left project-wide. Multiple budgets can coexist, for example a project-wide budget plus a stricter one for an expensive model.
+
+Budget alerts can do more than notify: chain one to a Workflow that calls a webhook in your infrastructure to stop a runaway agent — see [Circuit-Breaking Runaway AI Agents](/docs/telemetry/ai-agent-circuit-breaker).
 
 ## Privacy & redaction
 

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -639,6 +639,14 @@ const DocsNav: NavGroup[] = [
         url: "/docs/telemetry/ai-llm-observability",
       },
       {
+        title: "AI Gateways (LiteLLM, Portkey)",
+        url: "/docs/telemetry/ai-gateways",
+      },
+      {
+        title: "AI Agent Circuit Breakers",
+        url: "/docs/telemetry/ai-agent-circuit-breaker",
+      },
+      {
         title: "Continuous Profiling",
         url: "/docs/telemetry/profiles",
       },

--- a/Common/Tests/Server/Utils/Telemetry/LlmSpan.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LlmSpan.test.ts
@@ -204,6 +204,36 @@ describe("LlmSpanUtil.extract — cost fallback from the pricing catalog", () =>
     expect(fields.llmCost).toBe(0);
   });
 
+  test("LiteLLM's v1 cost breakdown key is read as reported cost", () => {
+    /*
+     * LiteLLM's otel callback reports cost under gen_ai.cost.*, not
+     * gen_ai.usage.cost — its total must win over the catalog estimate.
+     */
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 1_000_000,
+      "gen_ai.cost.total_cost": 7.25,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(7.25);
+  });
+
+  test("LiteLLM's OTel v2 cost key is read as reported cost", () => {
+    const attrs: Attrs = {
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 1_000_000,
+      "litellm.cost.total": 6.5,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+    expect(fields.llmCost).toBe(6.5);
+  });
+
   test("a malformed reported cost falls back to the catalog", () => {
     const attrs: Attrs = {
       "gen_ai.system": "openai",

--- a/Common/Types/Telemetry/LlmConventions.ts
+++ b/Common/Types/Telemetry/LlmConventions.ts
@@ -73,6 +73,9 @@ export const LlmCostAttributeKeys: Array<string> = [
   "gen_ai.usage.cost_usd",
   "gen_ai.usage.total_cost",
   "llm.usage.total_cost",
+  // LiteLLM proxy: v1 otel callback / opt-in OTel v2 mode.
+  "gen_ai.cost.total_cost",
+  "litellm.cost.total",
 ];
 
 /*


### PR DESCRIPTION
### Title of this pull request?

Docs: AI gateway observability (LiteLLM, Portkey) and async agent circuit breaking

### Small Description?

Adds two product docs pages under `App/FeatureSet/Docs/Content/en/telemetry/`, linked from the AI / LLM Observability page and registered in the docs nav, plus a small ingest fix the research surfaced.

**1. [Observing AI Gateways (LiteLLM & Portkey)](https://github.com/OneUptime/oneuptime/blob/claude/kind-swirles-c7fae7/App/FeatureSet/Docs/Content/en/telemetry/ai-gateways.md)** — step-by-step configs for exporting OpenTelemetry traces from the gateway into OneUptime's OTLP endpoint (`x-oneuptime-token` header). Each gateway's current export mechanism was verified against official docs and source before writing:

- **LiteLLM proxy**: `litellm_settings: callbacks: ["otel"]` + `OTEL_EXPORTER` / `OTEL_ENDPOINT` / `OTEL_HEADERS`. The doc uses the full `/otlp/v1/traces` path since LiteLLM only auto-appends the signal path from v1.79 onward. Covers the Docker image (bundles OTel; plain pip does not), prompt-content capture switches (on by default in the v1 callback), the opt-in OTel v2 mode, and troubleshooting.
- **Portkey**: OTLP trace export exists only on the enterprise/self-hosted gateway (`EXPERIMENTAL_GEN_AI_OTEL_*` env vars, OTLP HTTP/JSON — our ingest accepts JSON, verified in `TelemetryQueueService`). The open-source gateway has no exporter (confirmed by inspecting the repo), so the doc plainly says so and documents the client-side instrumentation pattern (OpenLLMetry etc. exporting to OneUptime while calling through Portkey's OpenAI-compatible API).
- Ends with a "verify the spans landed" walkthrough of the AI / LLM section.

**2. [Circuit-Breaking Runaway AI Agents](https://github.com/OneUptime/oneuptime/blob/claude/kind-swirles-c7fae7/App/FeatureSet/Docs/Content/en/telemetry/ai-agent-circuit-breaker.md)** — the gateway-agnostic "guardrails" recipe, positioned against inline gateways (async backstop, nothing in the request hot path). Chains a trip-wire signal — an LLM cost budget alert (#3337; the doc uses the evaluator's real alert titles like `LLM cost budget exceeded: <name>`) or a Traces monitor on repeated identical `gen_ai.tool.name` spans — to a Workflow: **Alert → On Create** trigger → **If/Else** title filter → **API Post** to a customer-owned kill endpoint, authed via a secret global variable. Includes a mermaid architecture diagram, an example kill-endpoint handler, an honest detection-latency table (~1–3 min traces monitor, up to ~15 min budget worker), a test plan, and alert-lifecycle caveats.

**Ingest fix**: LiteLLM reports its computed cost as `gen_ai.cost.total_cost` (v1) / `litellm.cost.total` (v2) — keys `LlmCostAttributeKeys` didn't include, so LiteLLM's own pricing (incl. custom per-model rates) was ignored in favor of the catalog estimate. Added both keys + two tests in `LlmSpan.test.ts`, and documented the behavior in the attributes table.

Also fixes a pre-existing broken `/docs/monitor/monitor` link (→ `/docs/monitor/metrics-monitor`).

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

Follows up on #3337 (LLM cost budgets and computed cost).

### Screenshots (if appropriate):

N/A — docs pages (markdown) and a two-key ingest list addition. Verified locally: `tsc` passes in App and Common, all 31 `LlmSpan` tests pass (incl. 2 new), ESLint/Prettier clean, all internal doc links resolve.