### PR TITLE
feat(Telemetry): per-project custom LLM pricing overrides

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -469,6 +469,9 @@ import ServiceLevelObjectiveBurnRateRuleService, {
 import LlmCostBudgetService, {
   Service as LlmCostBudgetServiceType,
 } from "Common/Server/Services/LlmCostBudgetService";
+import LlmModelPriceService, {
+  Service as LlmModelPriceServiceType,
+} from "Common/Server/Services/LlmModelPriceService";
 import ServiceLevelObjectiveOwnerUserService, {
   Service as ServiceLevelObjectiveOwnerUserServiceType,
 } from "Common/Server/Services/ServiceLevelObjectiveOwnerUserService";
@@ -1148,6 +1151,7 @@ import ScheduledMaintenanceMeasurementValue from "Common/Models/DatabaseModels/S
 import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
 import ServiceLevelObjectiveBurnRateRule from "Common/Models/DatabaseModels/ServiceLevelObjectiveBurnRateRule";
 import LlmCostBudget from "Common/Models/DatabaseModels/LlmCostBudget";
+import LlmModelPrice from "Common/Models/DatabaseModels/LlmModelPrice";
 import ServiceLevelObjectiveOwnerUser from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
 import ServiceLevelObjectiveOwnerTeam from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
 import SloHistory from "Common/Models/AnalyticsModels/SloHistory";
@@ -2733,6 +2737,15 @@ const BaseAPIFeatureSet: FeatureSet = {
       new BaseAPI<LlmCostBudget, LlmCostBudgetServiceType>(
         LlmCostBudget,
         LlmCostBudgetService,
+      ).getRouter(),
+    );
+
+    // LlmModelPrice
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new BaseAPI<LlmModelPrice, LlmModelPriceServiceType>(
+        LlmModelPrice,
+        LlmModelPriceService,
       ).getRouter(),
     );
 

--- a/App/FeatureSet/Dashboard/src/Components/AI/LlmNavTabs.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AI/LlmNavTabs.tsx
@@ -5,7 +5,7 @@ import PageMap from "../../Utils/PageMap";
 import Route from "Common/Types/API/Route";
 import IconProp from "Common/Types/Icon/IconProp";
 
-export type LlmTabKey = "overview" | "calls" | "budgets" | "setup";
+export type LlmTabKey = "overview" | "calls" | "budgets" | "pricing" | "setup";
 
 interface Props {
   active: LlmTabKey;
@@ -33,6 +33,12 @@ const LlmNavTabs: FunctionComponent<Props> = (props: Props): ReactElement => {
       label: "Budgets",
       icon: IconProp.CurrencyDollar,
       to: RouteUtil.populateRouteParams(RouteMap[PageMap.LLM_BUDGETS] as Route),
+    },
+    {
+      key: "pricing",
+      label: "Pricing",
+      icon: IconProp.Tag,
+      to: RouteUtil.populateRouteParams(RouteMap[PageMap.LLM_PRICING] as Route),
     },
     {
       key: "setup",

--- a/App/FeatureSet/Dashboard/src/Pages/Llm/Layout.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Llm/Layout.tsx
@@ -17,6 +17,9 @@ const getActiveLlmTab: (path: string) => LlmTabKey = (
   if (path.includes("/llm/budgets")) {
     return "budgets";
   }
+  if (path.includes("/llm/pricing")) {
+    return "pricing";
+  }
   if (path.includes("/llm/documentation")) {
     return "setup";
   }

--- a/App/FeatureSet/Dashboard/src/Pages/Llm/Pricing.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Llm/Pricing.tsx
@@ -1,0 +1,175 @@
+import PageComponentProps from "../PageComponentProps";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import Pill from "Common/UI/Components/Pill/Pill";
+import { Green, Red } from "Common/Types/BrandColors";
+import LlmModelPrice from "Common/Models/DatabaseModels/LlmModelPrice";
+import ProjectUtil from "Common/UI/Utils/Project";
+import React, { FunctionComponent, ReactElement } from "react";
+
+const LlmPricingPage: FunctionComponent<PageComponentProps> = (
+  props: PageComponentProps,
+): ReactElement => {
+  const disableTelemetryForThisProject: boolean =
+    props.currentProject?.reseller?.enableTelemetryFeatures === false;
+
+  if (disableTelemetryForThisProject) {
+    return (
+      <ErrorMessage message="Looks like you have bought this plan from a reseller. It did not include telemetry features in your plan. Telemetry features are disabled for this project." />
+    );
+  }
+
+  return (
+    <ModelTable<LlmModelPrice>
+      modelType={LlmModelPrice}
+      query={{
+        projectId: ProjectUtil.getCurrentProjectId()!,
+      }}
+      id="llm-model-prices-table"
+      userPreferencesKey="llm-model-prices-table"
+      name="AI / LLM > Pricing"
+      isDeleteable={true}
+      isEditable={true}
+      isCreateable={true}
+      showRefreshButton={true}
+      showViewIdButton={true}
+      sortBy="modelPrefix"
+      sortOrder={SortOrder.Ascending}
+      cardProps={{
+        title: "Custom LLM Pricing",
+        description:
+          "Custom per-million-token prices for this project — negotiated rates, self-hosted models, or fine-tunes the built-in catalog does not know. When a span reports tokens but no cost, the longest matching model prefix wins across your entries and the built-in catalog; your entry beats the built-in one on ties.",
+      }}
+      noItemsMessage={
+        "No custom LLM prices found. Spans are priced with the built-in list-price catalog."
+      }
+      formSteps={[
+        { title: "Model", id: "model" },
+        { title: "Pricing", id: "pricing" },
+      ]}
+      formFields={[
+        {
+          field: { modelPrefix: true },
+          title: "Model Prefix",
+          stepId: "model",
+          fieldType: FormFieldSchemaType.Text,
+          required: true,
+          placeholder: "gpt-4o or my-custom-finetune",
+          description:
+            "Model-name prefix this price matches (case-insensitive). The longest matching prefix wins, so gpt-4o also matches gpt-4o-2024-08-06 unless a longer entry exists.",
+        },
+        {
+          field: { description: true },
+          title: "Description",
+          stepId: "model",
+          fieldType: FormFieldSchemaType.LongText,
+          required: false,
+          placeholder:
+            "e.g. Negotiated OpenAI enterprise rate, or self-hosted Llama pricing.",
+        },
+        {
+          field: { isEnabled: true },
+          title: "Enabled",
+          description: "Whether this price is used when pricing LLM spans.",
+          stepId: "model",
+          fieldType: FormFieldSchemaType.Toggle,
+          required: false,
+          defaultValue: true,
+        },
+        {
+          field: { inputPricePerMillionTokensInUSD: true },
+          title: "Input Price (USD per 1M tokens)",
+          stepId: "pricing",
+          fieldType: FormFieldSchemaType.Number,
+          required: true,
+          placeholder: "2.50",
+          description:
+            "Price of one million input (prompt) tokens in USD. Use 0 for free input tokens.",
+        },
+        {
+          field: { outputPricePerMillionTokensInUSD: true },
+          title: "Output Price (USD per 1M tokens)",
+          stepId: "pricing",
+          fieldType: FormFieldSchemaType.Number,
+          required: true,
+          placeholder: "10.00",
+          description:
+            "Price of one million output (completion) tokens in USD. Use 0 for models that bill input only (e.g. embeddings).",
+        },
+      ]}
+      filters={[
+        {
+          field: { modelPrefix: true },
+          type: FieldType.Text,
+          title: "Model Prefix",
+        },
+        {
+          field: { isEnabled: true },
+          type: FieldType.Boolean,
+          title: "Enabled",
+        },
+      ]}
+      columns={[
+        {
+          field: { modelPrefix: true, description: true },
+          title: "Model Prefix",
+          type: FieldType.Element,
+          getElement: (item: LlmModelPrice): ReactElement => {
+            return (
+              <div>
+                <div className="font-medium text-gray-900 font-mono text-sm">
+                  {item.modelPrefix || "-"}
+                </div>
+                {item.description && (
+                  <div className="text-xs text-gray-500 mt-0.5">
+                    {item.description}
+                  </div>
+                )}
+              </div>
+            );
+          },
+        },
+        {
+          field: { inputPricePerMillionTokensInUSD: true },
+          title: "Input / 1M Tokens",
+          type: FieldType.Element,
+          getElement: (item: LlmModelPrice): ReactElement => {
+            return (
+              <span className="text-sm text-gray-900">
+                {`$${(item.inputPricePerMillionTokensInUSD || 0).toFixed(2)}`}
+              </span>
+            );
+          },
+        },
+        {
+          field: { outputPricePerMillionTokensInUSD: true },
+          title: "Output / 1M Tokens",
+          type: FieldType.Element,
+          getElement: (item: LlmModelPrice): ReactElement => {
+            return (
+              <span className="text-sm text-gray-900">
+                {`$${(item.outputPricePerMillionTokensInUSD || 0).toFixed(2)}`}
+              </span>
+            );
+          },
+        },
+        {
+          field: { isEnabled: true },
+          title: "Enabled",
+          type: FieldType.Boolean,
+          getElement: (item: LlmModelPrice): ReactElement => {
+            if (item.isEnabled) {
+              return <Pill color={Green} text="Enabled" />;
+            }
+            return <Pill color={Red} text="Disabled" />;
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default LlmPricingPage;

--- a/App/FeatureSet/Dashboard/src/Routes/LlmRoutes.tsx
+++ b/App/FeatureSet/Dashboard/src/Routes/LlmRoutes.tsx
@@ -10,6 +10,7 @@ import { Route as PageRoute, Routes } from "react-router-dom";
 import LlmOverview from "../Pages/Llm/Overview";
 import LlmCalls from "../Pages/Llm/Calls";
 import LlmBudgets from "../Pages/Llm/Budgets";
+import LlmPricing from "../Pages/Llm/Pricing";
 import LlmDocumentationPage from "../Pages/Llm/Documentation";
 
 const LlmRoutes: FunctionComponent<ComponentProps> = (
@@ -54,6 +55,16 @@ const LlmRoutes: FunctionComponent<ComponentProps> = (
             <LlmBudgets
               {...props}
               pageRoute={RouteMap[PageMap.LLM_BUDGETS] as Route}
+            />
+          }
+        />
+
+        <PageRoute
+          path={LlmRoutePath[PageMap.LLM_PRICING] || ""}
+          element={
+            <LlmPricing
+              {...props}
+              pageRoute={RouteMap[PageMap.LLM_PRICING] as Route}
             />
           }
         />

--- a/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/LlmBreadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Breadcrumbs/LlmBreadcrumbs.ts
@@ -21,6 +21,11 @@ export function getLlmBreadcrumbs(path: string): Array<Link> | undefined {
       "AI / LLM",
       "Budgets",
     ]),
+    ...BuildBreadcrumbLinksByTitles(PageMap.LLM_PRICING, [
+      "Project",
+      "AI / LLM",
+      "Pricing",
+    ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.LLM_DOCUMENTATION, [
       "Project",
       "AI / LLM",

--- a/App/FeatureSet/Dashboard/src/Utils/PageMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/PageMap.ts
@@ -1012,6 +1012,7 @@ enum PageMap {
   LLM_OVERVIEW = "LLM_OVERVIEW",
   LLM_CALLS = "LLM_CALLS",
   LLM_BUDGETS = "LLM_BUDGETS",
+  LLM_PRICING = "LLM_PRICING",
   LLM_DOCUMENTATION = "LLM_DOCUMENTATION",
 
   // AI Copilot (full-page chat over observability data)

--- a/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
@@ -558,6 +558,7 @@ export const LlmRoutePath: Dictionary<string> = {
   [PageMap.LLM_OVERVIEW]: "overview",
   [PageMap.LLM_CALLS]: "calls",
   [PageMap.LLM_BUDGETS]: "budgets",
+  [PageMap.LLM_PRICING]: "pricing",
   [PageMap.LLM_DOCUMENTATION]: "documentation",
 };
 
@@ -5628,6 +5629,12 @@ const RouteMap: Dictionary<Route> = {
   [PageMap.LLM_BUDGETS]: new Route(
     `/dashboard/${RouteParams.ProjectID}/llm/${
       LlmRoutePath[PageMap.LLM_BUDGETS]
+    }`,
+  ),
+
+  [PageMap.LLM_PRICING]: new Route(
+    `/dashboard/${RouteParams.ProjectID}/llm/${
+      LlmRoutePath[PageMap.LLM_PRICING]
     }`,
   ),
 

--- a/App/FeatureSet/Telemetry/Services/LlmModelPriceService.ts
+++ b/App/FeatureSet/Telemetry/Services/LlmModelPriceService.ts
@@ -1,0 +1,97 @@
+import LlmModelPriceModel from "Common/Models/DatabaseModels/LlmModelPrice";
+import DatabaseService from "Common/Server/Services/DatabaseService";
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import ObjectID from "Common/Types/ObjectID";
+import { LlmModelPrice } from "Common/Types/Telemetry/LlmCostCatalog";
+
+const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
+
+const modelPriceCache: InMemoryTTLCache<Array<LlmModelPrice>> =
+  new InMemoryTTLCache<Array<LlmModelPrice>>(MAX_CACHED_PROJECTS);
+
+/*
+ * Per-project custom LLM prices for span-ingest cost computation. Loaded
+ * once per ingest batch with the same 60s in-process cache the trace scrub
+ * rules use, and handed to LlmSpanUtil.extract as catalog-shaped entries
+ * (Common/Types/Telemetry/LlmCostCatalog.ts) so the price lookup can weigh
+ * them against the built-in catalog.
+ */
+export class LlmModelPriceService {
+  public static async loadModelPrices(
+    projectId: ObjectID,
+  ): Promise<Array<LlmModelPrice>> {
+    const cacheKey: string = projectId.toString();
+    const cached: Array<LlmModelPrice> | undefined =
+      modelPriceCache.get(cacheKey);
+
+    // Empty arrays are truthy — zero-override projects stay negatively cached.
+    if (cached) {
+      return cached;
+    }
+
+    const service: DatabaseService<LlmModelPriceModel> =
+      new DatabaseService<LlmModelPriceModel>(LlmModelPriceModel);
+
+    const rows: Array<LlmModelPriceModel> = await service.findBy({
+      query: {
+        projectId: projectId,
+        isEnabled: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      sort: {
+        modelPrefix: SortOrder.Ascending,
+      },
+      select: {
+        modelPrefix: true,
+        inputPricePerMillionTokensInUSD: true,
+        outputPricePerMillionTokensInUSD: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const entries: Array<LlmModelPrice> = [];
+
+    for (const row of rows) {
+      /*
+       * The service normalizes and validates on write, but rows predating a
+       * rule change (or edited out-of-band) must not poison span pricing —
+       * skip anything unpriceable instead of trusting it.
+       */
+      const modelPrefix: string = (row.modelPrefix || "").trim().toLowerCase();
+      const inputPrice: number | undefined =
+        row.inputPricePerMillionTokensInUSD;
+      const outputPrice: number | undefined =
+        row.outputPricePerMillionTokensInUSD;
+
+      if (
+        !modelPrefix ||
+        typeof inputPrice !== "number" ||
+        !isFinite(inputPrice) ||
+        inputPrice < 0 ||
+        typeof outputPrice !== "number" ||
+        !isFinite(outputPrice) ||
+        outputPrice < 0
+      ) {
+        continue;
+      }
+
+      entries.push({
+        modelPrefix: modelPrefix,
+        inputPricePerMillionTokensInUSD: inputPrice,
+        outputPricePerMillionTokensInUSD: outputPrice,
+      });
+    }
+
+    modelPriceCache.set(cacheKey, entries, CACHE_TTL_MS);
+
+    return entries;
+  }
+}
+
+export default LlmModelPriceService;

--- a/App/FeatureSet/Telemetry/Services/OtelTracesIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelTracesIngestService.ts
@@ -56,6 +56,8 @@ import TraceScrubRuleService from "./TraceScrubRuleService";
 import TracePipelineService, {
   LoadedTracePipeline,
 } from "./TracePipelineService";
+import LlmModelPriceService from "./LlmModelPriceService";
+import { LlmModelPrice } from "Common/Types/Telemetry/LlmCostCatalog";
 import TraceScrubRule from "Common/Models/DatabaseModels/TraceScrubRule";
 import {
   TELEMETRY_EXCEPTION_FLUSH_BATCH_SIZE,
@@ -334,12 +336,15 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
       let dropFilters: Array<LoadedTraceDropFilter> = [];
       let scrubRules: Array<CompiledTraceScrubRule> = [];
       let pipelines: Array<LoadedTracePipeline> = [];
+      let modelPriceOverrides: Array<LlmModelPrice> = [];
       try {
-        [dropFilters, scrubRules, pipelines] = await Promise.all([
-          TraceDropFilterService.loadDropFilters(projectId),
-          TraceScrubRuleService.loadScrubRules(projectId),
-          TracePipelineService.loadPipelines(projectId),
-        ]);
+        [dropFilters, scrubRules, pipelines, modelPriceOverrides] =
+          await Promise.all([
+            TraceDropFilterService.loadDropFilters(projectId),
+            TraceScrubRuleService.loadScrubRules(projectId),
+            TracePipelineService.loadPipelines(projectId),
+            LlmModelPriceService.loadModelPrices(projectId),
+          ]);
       } catch (err) {
         logger.warn(
           `Failed to load trace pipeline rules for project ${projectId.toString()}; skipping: ${
@@ -349,6 +354,7 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
         dropFilters = [];
         scrubRules = [];
         pipelines = [];
+        modelPriceOverrides = [];
       }
 
       let resourceSpanCounter: number = 0;
@@ -657,9 +663,13 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
                   /*
                    * Denormalize first-class LLM / GenAI / agent fields (if any)
                    * from the span attributes for fast AI-observability queries.
+                   * Project price overrides join the built-in catalog in the
+                   * cost fallback for spans that report tokens but no cost.
                    */
-                  const llmFields: LlmSpanFields =
-                    LlmSpanUtil.extract(spanAttributes);
+                  const llmFields: LlmSpanFields = LlmSpanUtil.extract(
+                    spanAttributes,
+                    modelPriceOverrides,
+                  );
 
                   const spanEvaluationRow: JSONObject =
                     this.buildSpanEvaluationRow({

--- a/Common/Models/DatabaseModels/Index.ts
+++ b/Common/Models/DatabaseModels/Index.ts
@@ -119,6 +119,7 @@ import GoogleSecOpsConnection from "./GoogleSecOpsConnection";
 import LogScrubRule from "./LogScrubRule";
 import MetricPipelineRule from "./MetricPipelineRule";
 import LlmCostBudget from "./LlmCostBudget";
+import LlmModelPrice from "./LlmModelPrice";
 import MetricRecordingRule from "./MetricRecordingRule";
 import TracePipeline from "./TracePipeline";
 import TracePipelineProcessor from "./TracePipelineProcessor";
@@ -467,6 +468,7 @@ const AllModelTypes: Array<{
   LogScrubRule,
   MetricPipelineRule,
   LlmCostBudget,
+  LlmModelPrice,
   MetricRecordingRule,
   TracePipeline,
   TracePipelineProcessor,

--- a/Common/Models/DatabaseModels/LlmModelPrice.ts
+++ b/Common/Models/DatabaseModels/LlmModelPrice.ts
@@ -1,0 +1,481 @@
+import Project from "./Project";
+import User from "./User";
+import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
+import Route from "../../Types/API/Route";
+import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
+import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
+import ColumnLength from "../../Types/Database/ColumnLength";
+import ColumnType from "../../Types/Database/ColumnType";
+import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import EnableDocumentation from "../../Types/Database/EnableDocumentation";
+import EnableWorkflow from "../../Types/Database/EnableWorkflow";
+import TableColumn from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import TableMetadata from "../../Types/Database/TableMetadata";
+import TenantColumn from "../../Types/Database/TenantColumn";
+import IconProp from "../../Types/Icon/IconProp";
+import ObjectID from "../../Types/ObjectID";
+import Permission from "../../Types/Permission";
+import { PlanType } from "../../Types/Billing/SubscriptionPlan";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+
+/*
+ * Postgres returns `decimal` columns as strings; without a transformer every
+ * arithmetic comparison downstream silently becomes a string comparison.
+ * Same convention as LlmCostBudget / ServiceLevelObjectiveBurnRateRule.
+ */
+const decimalTransformer: ValueTransformer = {
+  to: (value: number | null | undefined): number | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    return value;
+  },
+  from: (value: string | number | null | undefined): number | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    if (typeof value === "number") {
+      return value;
+    }
+    const parsed: number = parseFloat(value);
+    return isNaN(parsed) ? null : parsed;
+  },
+};
+
+@EnableDocumentation()
+@TableBillingAccessControl({
+  create: PlanType.Free,
+  read: PlanType.Free,
+  update: PlanType.Free,
+  delete: PlanType.Free,
+})
+@TenantColumn("projectId")
+@CrudApiEndpoint(new Route("/llm-model-price"))
+@Entity({
+  name: "LlmModelPrice",
+})
+@EnableWorkflow({
+  create: true,
+  delete: true,
+  update: true,
+  read: true,
+})
+@TableMetadata({
+  tableName: "LlmModelPrice",
+  singularName: "LLM Model Price",
+  pluralName: "LLM Model Prices",
+  icon: IconProp.Tag,
+  tableDescription:
+    "Custom per-project LLM pricing. When a span carries token counts but no reported cost, ingest prices it against these entries and the built-in list-price catalog — the longest matching model prefix wins, and a project entry beats a built-in one on ties.",
+})
+@TableAccessControl({
+  create: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.CreateProjectLlmModelPrice,
+  ],
+  read: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.Viewer,
+    Permission.TelemetryAdmin,
+    Permission.TelemetryMember,
+    Permission.TelemetryViewer,
+    Permission.ReadProjectLlmModelPrice,
+  ],
+  delete: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.DeleteProjectLlmModelPrice,
+  ],
+  update: [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.EditProjectLlmModelPrice,
+  ],
+})
+export default class LlmModelPrice extends BaseModel {
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "projectId",
+    type: TableColumnType.Entity,
+    modelType: Project,
+    title: "Project",
+    description: "Relation to the project this LLM model price belongs to.",
+  })
+  @ManyToOne(
+    () => {
+      return Project;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "CASCADE",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "projectId" })
+  public project?: Project = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: true,
+    canReadOnRelationQuery: true,
+    title: "Project ID",
+    description: "ID of the project this LLM model price belongs to.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: false,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public projectId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmModelPrice,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "Model Prefix",
+    description:
+      "Model-name prefix this price matches, e.g. gpt-4o or my-custom-finetune. Stored lowercase; the longest matching prefix wins and a project entry beats a built-in catalog entry on ties.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public modelPrefix?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmModelPrice,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.LongText,
+    canReadOnRelationQuery: true,
+    title: "Description",
+    description:
+      "Description of this price entry, e.g. which negotiated rate or self-hosted deployment it reflects.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.LongText,
+    length: ColumnLength.LongText,
+  })
+  public description?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmModelPrice,
+    ],
+  })
+  @Index()
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Boolean,
+    title: "Is Enabled",
+    description: "Whether this price entry is used when pricing LLM spans.",
+    defaultValue: true,
+    isDefaultValueColumn: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    nullable: false,
+    default: true,
+  })
+  public isEnabled?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmModelPrice,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Number,
+    canReadOnRelationQuery: true,
+    title: "Input Price (USD / 1M tokens)",
+    description:
+      "Price of one million input (prompt) tokens in USD. Use 0 for free input tokens.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.Decimal,
+    transformer: decimalTransformer,
+  })
+  public inputPricePerMillionTokensInUSD?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectLlmModelPrice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectLlmModelPrice,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Number,
+    canReadOnRelationQuery: true,
+    title: "Output Price (USD / 1M tokens)",
+    description:
+      "Price of one million output (completion) tokens in USD. Use 0 for free output tokens (e.g. embeddings).",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.Decimal,
+    transformer: decimalTransformer,
+  })
+  public outputPricePerMillionTokensInUSD?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "createdByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Created By User",
+    description: "Relation to the user who created this price entry.",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "createdByUserId" })
+  public createdByUser?: User = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Created By User ID",
+    description: "ID of the user who created this price entry.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public createdByUserId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "deletedByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Deleted By User",
+    description: "Relation to the user who deleted this price entry.",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "deletedByUserId" })
+  public deletedByUser?: User = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadProjectLlmModelPrice,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Deleted By User ID",
+    description: "ID of the user who deleted this price entry.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public deletedByUserId?: ObjectID = undefined;
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788300000000-AddLlmModelPrice.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788300000000-AddLlmModelPrice.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLlmModelPrice1788300000000 implements MigrationInterface {
+  public name: string = "AddLlmModelPrice1788300000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "LlmModelPrice" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "modelPrefix" character varying(100) NOT NULL, "description" character varying(500), "isEnabled" boolean NOT NULL DEFAULT true, "inputPricePerMillionTokensInUSD" numeric NOT NULL, "outputPricePerMillionTokensInUSD" numeric NOT NULL, "createdByUserId" uuid, "deletedByUserId" uuid, CONSTRAINT "PK_c4cf92c47ce15b3fae65debb444" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0f137c3e611115556a475ca9f8" ON "LlmModelPrice" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e2e35a60cd0af1750162829984" ON "LlmModelPrice" ("isEnabled") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmModelPrice" ADD CONSTRAINT "FK_0f137c3e611115556a475ca9f88" FOREIGN KEY ("projectId") REFERENCES "Project"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmModelPrice" ADD CONSTRAINT "FK_0955d9d3b7b49d0dbeb2011610f" FOREIGN KEY ("createdByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmModelPrice" ADD CONSTRAINT "FK_fe6a5aa119cbb45391d3daa4801" FOREIGN KEY ("deletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "LlmModelPrice" DROP CONSTRAINT "FK_fe6a5aa119cbb45391d3daa4801"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmModelPrice" DROP CONSTRAINT "FK_0955d9d3b7b49d0dbeb2011610f"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmModelPrice" DROP CONSTRAINT "FK_0f137c3e611115556a475ca9f88"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e2e35a60cd0af1750162829984"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0f137c3e611115556a475ca9f8"`,
+    );
+    await queryRunner.query(`DROP TABLE "LlmModelPrice"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -536,6 +536,7 @@ import { AddRestrictToAttachedProjectsToGlobalSso1787900000000 } from "./1787900
 import { AddDetectionRuleAndGoogleSecOpsConnection1788000000000 } from "./1788000000000-AddDetectionRuleAndGoogleSecOpsConnection";
 import { AddMeasurements1788100000000 } from "./1788100000000-AddMeasurements";
 import { AddLlmCostBudget1788200000000 } from "./1788200000000-AddLlmCostBudget";
+import { AddLlmModelPrice1788300000000 } from "./1788300000000-AddLlmModelPrice";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1080,4 +1081,5 @@ export default [
   AddDetectionRuleAndGoogleSecOpsConnection1788000000000,
   AddMeasurements1788100000000,
   AddLlmCostBudget1788200000000,
+  AddLlmModelPrice1788300000000,
 ];

--- a/Common/Server/Services/Index.ts
+++ b/Common/Server/Services/Index.ts
@@ -270,6 +270,7 @@ import IncidentSlaService from "./IncidentSlaService";
 import ServiceLevelObjectiveService from "./ServiceLevelObjectiveService";
 import ServiceLevelObjectiveBurnRateRuleService from "./ServiceLevelObjectiveBurnRateRuleService";
 import LlmCostBudgetService from "./LlmCostBudgetService";
+import LlmModelPriceService from "./LlmModelPriceService";
 import ServiceLevelObjectiveOwnerUserService from "./ServiceLevelObjectiveOwnerUserService";
 import ServiceLevelObjectiveOwnerTeamService from "./ServiceLevelObjectiveOwnerTeamService";
 import SloHistoryService from "./SloHistoryService";
@@ -568,6 +569,7 @@ const services: Array<BaseService> = [
   ServiceLevelObjectiveService,
   ServiceLevelObjectiveBurnRateRuleService,
   LlmCostBudgetService,
+  LlmModelPriceService,
   ServiceLevelObjectiveOwnerUserService,
   ServiceLevelObjectiveOwnerTeamService,
   IncidentReminderRuleService,

--- a/Common/Server/Services/LlmModelPriceService.ts
+++ b/Common/Server/Services/LlmModelPriceService.ts
@@ -1,0 +1,193 @@
+import Model from "../../Models/DatabaseModels/LlmModelPrice";
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import BadDataException from "../../Types/Exception/BadDataException";
+import ObjectID from "../../Types/ObjectID";
+import CreateBy from "../Types/Database/CreateBy";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import UpdateBy from "../Types/Database/UpdateBy";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import DatabaseService from "./DatabaseService";
+
+const MODEL_PREFIX_ERROR_MESSAGE: string =
+  "Model prefix is required and cannot be empty.";
+const PRICE_ERROR_MESSAGE: string =
+  "must be a number greater than or equal to 0.";
+
+export class Service extends DatabaseService<Model> {
+  public constructor() {
+    super(Model);
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    /*
+     * Numeric columns can arrive as strings: the dashboard's number fields
+     * hand Formik `e.target.value`, ModelForm copies it verbatim and
+     * BaseModel.fromJSON does not coerce Number/Decimal columns. Coerce,
+     * validate, then write the number back onto the payload so Postgres never
+     * sees a string either. Same convention as LlmCostBudgetService.
+     */
+    createBy.data.modelPrefix = this.validateModelPrefix(
+      createBy.data.modelPrefix,
+    );
+
+    createBy.data.inputPricePerMillionTokensInUSD = this.validatePrice(
+      createBy.data.inputPricePerMillionTokensInUSD,
+      "Input price",
+    );
+
+    createBy.data.outputPricePerMillionTokensInUSD = this.validatePrice(
+      createBy.data.outputPricePerMillionTokensInUSD,
+      "Output price",
+    );
+
+    if (createBy.data.projectId) {
+      await this.throwIfDuplicatePrefix({
+        projectId: createBy.data.projectId,
+        modelPrefix: createBy.data.modelPrefix,
+      });
+    }
+
+    return {
+      createBy,
+      carryForward: null,
+    };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    // Same string-arrival path as onBeforeCreate: coerce, validate, write back.
+    const newPrefix: unknown = updateBy.data.modelPrefix as unknown;
+
+    if (newPrefix !== undefined && newPrefix !== null) {
+      updateBy.data.modelPrefix = this.validateModelPrefix(newPrefix);
+    }
+
+    const newInputPrice: unknown = updateBy.data
+      .inputPricePerMillionTokensInUSD as unknown;
+
+    if (newInputPrice !== undefined && newInputPrice !== null) {
+      updateBy.data.inputPricePerMillionTokensInUSD = this.validatePrice(
+        newInputPrice,
+        "Input price",
+      );
+    }
+
+    const newOutputPrice: unknown = updateBy.data
+      .outputPricePerMillionTokensInUSD as unknown;
+
+    if (newOutputPrice !== undefined && newOutputPrice !== null) {
+      updateBy.data.outputPricePerMillionTokensInUSD = this.validatePrice(
+        newOutputPrice,
+        "Output price",
+      );
+    }
+
+    // Renaming a prefix must not collide with another entry of the project.
+    if (updateBy.data.modelPrefix) {
+      const itemsToUpdate: Array<Model> = await this.findBy({
+        query: updateBy.query,
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        select: {
+          _id: true,
+          projectId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      for (const item of itemsToUpdate) {
+        if (!item.projectId) {
+          continue;
+        }
+
+        await this.throwIfDuplicatePrefix({
+          projectId: item.projectId,
+          modelPrefix: updateBy.data.modelPrefix,
+          excludeId: item.id || undefined,
+        });
+      }
+    }
+
+    return {
+      updateBy,
+      carryForward: null,
+    };
+  }
+
+  /*
+   * Two entries with the same prefix would make the ingest-time price lookup
+   * ambiguous (first-loaded wins), so reject the duplicate at write time
+   * instead of silently pricing with one of them.
+   */
+  private async throwIfDuplicatePrefix(data: {
+    projectId: ObjectID;
+    modelPrefix: string;
+    excludeId?: ObjectID | undefined;
+  }): Promise<void> {
+    const existing: Model | null = await this.findOneBy({
+      query: {
+        projectId: data.projectId,
+        modelPrefix: data.modelPrefix,
+      },
+      select: {
+        _id: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!existing) {
+      return;
+    }
+
+    if (
+      data.excludeId &&
+      existing.id?.toString() === data.excludeId.toString()
+    ) {
+      return;
+    }
+
+    throw new BadDataException(
+      `A price for the model prefix "${data.modelPrefix}" already exists in this project.`,
+    );
+  }
+
+  /*
+   * Prefixes are matched lowercase against normalized model names
+   * (LlmCostCatalogUtil), so store them lowercase — otherwise an entry saved
+   * as "GPT-4o" would never match anything.
+   */
+  private validateModelPrefix(value: unknown): string {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new BadDataException(MODEL_PREFIX_ERROR_MESSAGE);
+    }
+
+    return value.trim().toLowerCase();
+  }
+
+  private validatePrice(value: unknown, label: string): number {
+    let price: number | null = null;
+
+    if (typeof value === "number") {
+      price = value;
+    } else if (typeof value === "string" && value.trim() !== "") {
+      price = Number(value);
+    }
+
+    if (price === null || !isFinite(price) || price < 0) {
+      throw new BadDataException(`${label} ${PRICE_ERROR_MESSAGE}`);
+    }
+
+    return price;
+  }
+}
+
+export default new Service();

--- a/Common/Server/Utils/Telemetry/LlmSpan.ts
+++ b/Common/Server/Utils/Telemetry/LlmSpan.ts
@@ -1,5 +1,8 @@
 import Dictionary from "../../../Types/Dictionary";
-import { LlmCostCatalogUtil } from "../../../Types/Telemetry/LlmCostCatalog";
+import {
+  LlmCostCatalogUtil,
+  LlmModelPrice,
+} from "../../../Types/Telemetry/LlmCostCatalog";
 import {
   LlmAgentNameAttributeKeys,
   LlmAttributeNamespacePrefixes,
@@ -48,9 +51,9 @@ export interface LlmSpanFields {
   llmTotalTokens: number;
   /*
    * Cost in USD. The SDK-reported cost (gen_ai.usage.cost) when present;
-   * otherwise an estimate computed from token counts and the built-in
-   * list-price catalog (Common/Types/Telemetry/LlmCostCatalog.ts). 0 when
-   * neither is available.
+   * otherwise an estimate computed from token counts against the project's
+   * custom price overrides and the built-in list-price catalog
+   * (Common/Types/Telemetry/LlmCostCatalog.ts). 0 when none is available.
    */
   llmCost: number;
   // Agent / tool names for agent-framework spans.
@@ -86,8 +89,15 @@ export default class LlmSpanUtil {
   /**
    * Extract first-class LLM fields from a flattened span attribute dictionary.
    * Pure + side-effect free so it can be unit tested in isolation.
+   *
+   * `projectPriceOverrides` are the project's custom model prices (loaded by
+   * the ingest pipeline); they take part in the cost fallback below with
+   * longest-prefix-wins semantics against the built-in catalog.
    */
-  public static extract(attributes: SpanAttributes): LlmSpanFields {
+  public static extract(
+    attributes: SpanAttributes,
+    projectPriceOverrides?: Array<LlmModelPrice>,
+  ): LlmSpanFields {
     const fields: LlmSpanFields = this.empty();
 
     if (!attributes || typeof attributes !== "object") {
@@ -179,17 +189,19 @@ export default class LlmSpanUtil {
     /*
      * Cost fallback: the SDK-reported cost always wins — including an
      * explicit 0 — but most instrumentations only report token counts. Price
-     * those against the built-in list-price catalog so spend shows up in
-     * dashboards and cost budgets without per-SDK pricing math. The response
-     * model is priced in preference to the request model — it names what the
-     * provider actually served (e.g. an alias like "gpt-4o" resolved to a
-     * dated snapshot).
+     * those against the project's custom price overrides and the built-in
+     * list-price catalog (longest prefix wins across both, project entries
+     * beat built-ins on ties) so spend shows up in dashboards and cost
+     * budgets without per-SDK pricing math. The response model is priced in
+     * preference to the request model — it names what the provider actually
+     * served (e.g. an alias like "gpt-4o" resolved to a dated snapshot).
      */
     if (fields.isLlmSpan && reportedCost === null) {
       const computedCost: number | null = LlmCostCatalogUtil.computeCostInUSD({
         model: fields.llmResponseModel || fields.llmRequestModel,
         inputTokens: fields.llmInputTokens,
         outputTokens: fields.llmOutputTokens,
+        projectPriceOverrides: projectPriceOverrides,
       });
 
       if (computedCost !== null) {

--- a/Common/Tests/Server/Utils/Telemetry/LlmSpan.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LlmSpan.test.ts
@@ -3,6 +3,7 @@ import LlmSpanUtil, {
 } from "../../../../Server/Utils/Telemetry/LlmSpan";
 import { AttributeType } from "../../../../Server/Utils/Telemetry/Telemetry";
 import Dictionary from "../../../../Types/Dictionary";
+import { LlmModelPrice } from "../../../../Types/Telemetry/LlmCostCatalog";
 import { describe, expect, test } from "@jest/globals";
 
 type Attrs = Dictionary<AttributeType | Array<AttributeType>>;
@@ -383,5 +384,131 @@ describe("LlmSpanUtil.extract — conversation id", () => {
     const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
     expect(fields.isLlmSpan).toBe(false);
     expect(fields.llmConversationId).toBe("");
+  });
+});
+
+describe("LlmSpanUtil.extract — project price overrides", () => {
+  test("an override prices a custom model the catalog does not know", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "my-custom-finetune",
+        inputPricePerMillionTokensInUSD: 1,
+        outputPricePerMillionTokensInUSD: 2,
+      },
+    ];
+
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "my-custom-finetune-v3",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 500_000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs, overrides);
+
+    expect(fields.isLlmSpan).toBe(true);
+    // 1M * $1/M + 0.5M * $2/M = 2.
+    expect(fields.llmCost).toBe(2);
+  });
+
+  test("an override beats the built-in catalog on a prefix-length tie", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: 1.25,
+        outputPricePerMillionTokensInUSD: 5,
+      },
+    ];
+
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 1_000_000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs, overrides);
+
+    // Built-in gpt-4o would price this at 2.5 + 10 = 12.5.
+    expect(fields.llmCost).toBe(6.25);
+  });
+
+  test("a longer built-in prefix still beats a shorter override", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: 1.25,
+        outputPricePerMillionTokensInUSD: 5,
+      },
+    ];
+
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o-mini-2024-07-18",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 1_000_000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs, overrides);
+
+    // Built-in gpt-4o-mini: 0.15 + 0.6 = 0.75.
+    expect(fields.llmCost).toBe(0.75);
+  });
+
+  test("an SDK-reported cost still wins over any override", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: 1.25,
+        outputPricePerMillionTokensInUSD: 5,
+      },
+    ];
+
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 1_000_000,
+      "gen_ai.usage.cost": 0.42,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs, overrides);
+
+    expect(fields.llmCost).toBe(0.42);
+  });
+
+  test("a zero-price override marks the span free rather than unpriced", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "llama-self-hosted",
+        inputPricePerMillionTokensInUSD: 0,
+        outputPricePerMillionTokensInUSD: 0,
+      },
+    ];
+
+    const attrs: Attrs = {
+      "gen_ai.system": "ollama",
+      "gen_ai.request.model": "llama-self-hosted-70b",
+      "gen_ai.usage.input_tokens": 5000,
+      "gen_ai.usage.output_tokens": 5000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs, overrides);
+
+    expect(fields.isLlmSpan).toBe(true);
+    expect(fields.llmCost).toBe(0);
+  });
+
+  test("without overrides an unknown model still costs zero", () => {
+    const attrs: Attrs = {
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "my-custom-finetune-v3",
+      "gen_ai.usage.input_tokens": 1_000_000,
+      "gen_ai.usage.output_tokens": 500_000,
+    };
+
+    const fields: LlmSpanFields = LlmSpanUtil.extract(attrs);
+
+    expect(fields.llmCost).toBe(0);
   });
 });

--- a/Common/Tests/Types/Telemetry/LlmCostCatalog.test.ts
+++ b/Common/Tests/Types/Telemetry/LlmCostCatalog.test.ts
@@ -282,3 +282,235 @@ describe("LlmCostCatalogUtil.computeCostInUSD", () => {
     ).toBeNull();
   });
 });
+
+describe("LlmCostCatalogUtil.findPriceForModel — project price overrides", () => {
+  test("an override prices a model the built-in catalog does not know", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "my-custom-finetune",
+        inputPricePerMillionTokensInUSD: 1,
+        outputPricePerMillionTokensInUSD: 2,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "my-custom-finetune-v3",
+      overrides,
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("my-custom-finetune");
+    expect(price!.inputPricePerMillionTokensInUSD).toBe(1);
+    expect(price!.outputPricePerMillionTokensInUSD).toBe(2);
+  });
+
+  test("a project entry beats the built-in entry on a prefix-length tie", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: 1.25,
+        outputPricePerMillionTokensInUSD: 5,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gpt-4o-2024-08-06",
+      overrides,
+    );
+
+    expect(price).not.toBeNull();
+    // Built-in gpt-4o is $2.50/M input — the negotiated override must win.
+    expect(price!.inputPricePerMillionTokensInUSD).toBe(1.25);
+    expect(price!.outputPricePerMillionTokensInUSD).toBe(5);
+  });
+
+  test("a longer built-in prefix still beats a shorter override", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: 1.25,
+        outputPricePerMillionTokensInUSD: 5,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gpt-4o-mini-2024-07-18",
+      overrides,
+    );
+
+    expect(price).not.toBeNull();
+    // Built-in gpt-4o-mini (longer prefix) wins over the gpt-4o override.
+    expect(price!.modelPrefix).toBe("gpt-4o-mini");
+    expect(price!.inputPricePerMillionTokensInUSD).toBe(0.15);
+  });
+
+  test("a longer override prefix beats a shorter built-in", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o-mini-2024",
+        inputPricePerMillionTokensInUSD: 0.1,
+        outputPricePerMillionTokensInUSD: 0.4,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gpt-4o-mini-2024-07-18",
+      overrides,
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("gpt-4o-mini-2024");
+    expect(price!.inputPricePerMillionTokensInUSD).toBe(0.1);
+  });
+
+  test("override prefixes are normalized: case and whitespace", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "  My-Custom-Model  ",
+        inputPricePerMillionTokensInUSD: 3,
+        outputPricePerMillionTokensInUSD: 6,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "my-custom-model-v2",
+      overrides,
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.modelPrefix).toBe("my-custom-model");
+  });
+
+  test("overrides match vendor-decorated model ids via normalization", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "claude-3-5-sonnet",
+        inputPricePerMillionTokensInUSD: 2,
+        outputPricePerMillionTokensInUSD: 10,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      overrides,
+    );
+
+    expect(price).not.toBeNull();
+    expect(price!.inputPricePerMillionTokensInUSD).toBe(2);
+  });
+
+  test("unpriceable override entries are ignored, not matched", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "",
+        inputPricePerMillionTokensInUSD: 1,
+        outputPricePerMillionTokensInUSD: 1,
+      },
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: -5,
+        outputPricePerMillionTokensInUSD: 1,
+      },
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: NaN,
+        outputPricePerMillionTokensInUSD: 1,
+      },
+    ];
+
+    const price: LlmModelPrice | null = LlmCostCatalogUtil.findPriceForModel(
+      "gpt-4o",
+      overrides,
+    );
+
+    // The invalid overrides are dropped; the built-in catalog entry wins.
+    expect(price).not.toBeNull();
+    expect(price!.inputPricePerMillionTokensInUSD).toBe(2.5);
+  });
+
+  test("an empty override list behaves exactly like no overrides", () => {
+    const withEmpty: LlmModelPrice | null =
+      LlmCostCatalogUtil.findPriceForModel("gpt-4o", []);
+    const without: LlmModelPrice | null =
+      LlmCostCatalogUtil.findPriceForModel("gpt-4o");
+
+    expect(withEmpty).toEqual(without);
+  });
+
+  test("overrides do not make an unknown model match", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "my-custom-finetune",
+        inputPricePerMillionTokensInUSD: 1,
+        outputPricePerMillionTokensInUSD: 2,
+      },
+    ];
+
+    expect(
+      LlmCostCatalogUtil.findPriceForModel(
+        "totally-unknown-model-9000",
+        overrides,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("LlmCostCatalogUtil.computeCostInUSD — project price overrides", () => {
+  test("cost is computed from the override's prices", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "my-custom-finetune",
+        inputPricePerMillionTokensInUSD: 1,
+        outputPricePerMillionTokensInUSD: 2,
+      },
+    ];
+
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "my-custom-finetune-v3",
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      projectPriceOverrides: overrides,
+    });
+
+    expect(cost).toBe(1 + 1);
+  });
+
+  test("a zero-price override yields cost 0, not null — free is not unpriceable", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "llama-self-hosted",
+        inputPricePerMillionTokensInUSD: 0,
+        outputPricePerMillionTokensInUSD: 0,
+      },
+    ];
+
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "llama-self-hosted-70b",
+      inputTokens: 1000,
+      outputTokens: 1000,
+      projectPriceOverrides: overrides,
+    });
+
+    expect(cost).toBe(0);
+  });
+
+  test("an override tie-win changes the computed cost", () => {
+    const overrides: Array<LlmModelPrice> = [
+      {
+        modelPrefix: "gpt-4o",
+        inputPricePerMillionTokensInUSD: 1.25,
+        outputPricePerMillionTokensInUSD: 5,
+      },
+    ];
+
+    const cost: number | null = LlmCostCatalogUtil.computeCostInUSD({
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      projectPriceOverrides: overrides,
+    });
+
+    // Built-in would be 2.5 + 10 = 12.5; the override prices it at 6.25.
+    expect(cost).toBe(6.25);
+  });
+});

--- a/Common/Types/Permission.ts
+++ b/Common/Types/Permission.ts
@@ -213,6 +213,11 @@ enum Permission {
   EditProjectLlmCostBudget = "EditProjectLlmCostBudget",
   ReadProjectLlmCostBudget = "ReadProjectLlmCostBudget",
 
+  CreateProjectLlmModelPrice = "CreateProjectLlmModelPrice",
+  DeleteProjectLlmModelPrice = "DeleteProjectLlmModelPrice",
+  EditProjectLlmModelPrice = "EditProjectLlmModelPrice",
+  ReadProjectLlmModelPrice = "ReadProjectLlmModelPrice",
+
   // Metric Recording Rules (derived metrics)
   CreateProjectMetricRecordingRule = "CreateProjectMetricRecordingRule",
   DeleteProjectMetricRecordingRule = "DeleteProjectMetricRecordingRule",
@@ -7377,6 +7382,48 @@ export class PermissionHelper {
         title: "Read LLM Cost Budget",
         description:
           "This permission can read LLM Cost Budgets of this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+
+      // LLM Model Price Permissions
+      {
+        permission: Permission.CreateProjectLlmModelPrice,
+        title: "Create LLM Model Price",
+        description:
+          "This permission can create LLM Model Prices in this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.DeleteProjectLlmModelPrice,
+        title: "Delete LLM Model Price",
+        description:
+          "This permission can delete LLM Model Prices of this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.EditProjectLlmModelPrice,
+        title: "Edit LLM Model Price",
+        description:
+          "This permission can edit LLM Model Prices of this project.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: false,
+        group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.ReadProjectLlmModelPrice,
+        title: "Read LLM Model Price",
+        description:
+          "This permission can read LLM Model Prices of this project.",
         isAssignableToTenant: true,
         isAccessControlPermission: false,
         isRolePermission: false,

--- a/Common/Types/Telemetry/LlmCostCatalog.ts
+++ b/Common/Types/Telemetry/LlmCostCatalog.ts
@@ -350,27 +350,108 @@ const RoutingPrefixTokens: Array<string> = [
 
 export class LlmCostCatalogUtil {
   /**
-   * Find the catalog entry for a (possibly vendor-decorated) model name.
+   * Find the price entry for a (possibly vendor-decorated) model name.
    * Returns null when the model is unknown — callers must not guess a price.
+   *
+   * `projectPriceOverrides` are per-project custom prices (negotiated rates,
+   * self-hosted models, fine-tunes) consulted alongside the built-in catalog.
+   * The longest matching prefix wins across BOTH lists; on a prefix-length
+   * tie the project entry beats the built-in one.
    */
-  public static findPriceForModel(model: string): LlmModelPrice | null {
+  public static findPriceForModel(
+    model: string,
+    projectPriceOverrides?: Array<LlmModelPrice>,
+  ): LlmModelPrice | null {
     const candidates: Array<string> = this.normalizedCandidates(model);
 
+    const overrides: Array<LlmModelPrice> = this.sanitizeOverrides(
+      projectPriceOverrides,
+    );
+
     let best: LlmModelPrice | null = null;
+    let bestIsProjectOverride: boolean = false;
 
     for (const candidate of candidates) {
+      for (const entry of overrides) {
+        if (!candidate.startsWith(entry.modelPrefix)) {
+          continue;
+        }
+
+        if (
+          !best ||
+          entry.modelPrefix.length > best.modelPrefix.length ||
+          (entry.modelPrefix.length === best.modelPrefix.length &&
+            !bestIsProjectOverride)
+        ) {
+          best = entry;
+          bestIsProjectOverride = true;
+        }
+      }
+
       for (const entry of LlmModelPricingCatalog) {
         if (!candidate.startsWith(entry.modelPrefix)) {
           continue;
         }
 
+        // Strictly longer only — an equal-length project entry keeps winning.
         if (!best || entry.modelPrefix.length > best.modelPrefix.length) {
           best = entry;
+          bestIsProjectOverride = false;
         }
       }
     }
 
     return best;
+  }
+
+  /*
+   * Normalize project override entries the same way catalog prefixes are
+   * stored (trimmed, lowercase) and drop unpriceable rows — user-authored
+   * data must never break span ingest or price a call negatively.
+   */
+  private static sanitizeOverrides(
+    projectPriceOverrides?: Array<LlmModelPrice>,
+  ): Array<LlmModelPrice> {
+    if (!projectPriceOverrides || projectPriceOverrides.length === 0) {
+      return [];
+    }
+
+    const sanitized: Array<LlmModelPrice> = [];
+
+    for (const entry of projectPriceOverrides) {
+      if (!entry || typeof entry.modelPrefix !== "string") {
+        continue;
+      }
+
+      const modelPrefix: string = entry.modelPrefix.trim().toLowerCase();
+
+      const inputPrice: number = entry.inputPricePerMillionTokensInUSD;
+      const outputPrice: number = entry.outputPricePerMillionTokensInUSD;
+
+      if (
+        !modelPrefix ||
+        typeof inputPrice !== "number" ||
+        !isFinite(inputPrice) ||
+        inputPrice < 0 ||
+        typeof outputPrice !== "number" ||
+        !isFinite(outputPrice) ||
+        outputPrice < 0
+      ) {
+        continue;
+      }
+
+      if (modelPrefix === entry.modelPrefix) {
+        sanitized.push(entry);
+      } else {
+        sanitized.push({
+          modelPrefix: modelPrefix,
+          inputPricePerMillionTokensInUSD: inputPrice,
+          outputPricePerMillionTokensInUSD: outputPrice,
+        });
+      }
+    }
+
+    return sanitized;
   }
 
   /**
@@ -383,6 +464,7 @@ export class LlmCostCatalogUtil {
     model: string;
     inputTokens: number;
     outputTokens: number;
+    projectPriceOverrides?: Array<LlmModelPrice> | undefined;
   }): number | null {
     const inputTokens: number =
       isFinite(data.inputTokens) && data.inputTokens > 0 ? data.inputTokens : 0;
@@ -395,7 +477,10 @@ export class LlmCostCatalogUtil {
       return null;
     }
 
-    const price: LlmModelPrice | null = this.findPriceForModel(data.model);
+    const price: LlmModelPrice | null = this.findPriceForModel(
+      data.model,
+      data.projectPriceOverrides,
+    );
 
     if (!price) {
       return null;


### PR DESCRIPTION
### Title of this pull request?

feat(Telemetry): per-project custom LLM pricing overrides

### Small Description?

Adds per-project custom LLM pricing on top of the built-in list-price catalog from #3337. When a span reports token counts but no cost (`gen_ai.usage.cost`), ingest now prices it against the project's own `LlmModelPrice` entries **and** the built-in catalog: the longest matching model prefix wins across both lists, and a project entry beats a built-in one on prefix-length ties. This lets projects price negotiated rates, self-hosted models, and fine-tunes the catalog does not know.

**What changed:**

- **Model/CRUD** (follows the `LlmCostBudget` pattern): new `LlmModelPrice` Postgres model (`projectId`, `modelPrefix`, `inputPricePerMillionTokensInUSD`, `outputPricePerMillionTokensInUSD`, `isEnabled`, `description`), `LlmModelPriceService` with validation hooks (lowercases prefixes, coerces string-arriving numbers, rejects negative prices and duplicate prefixes per project), permissions in `Common/Types/Permission.ts`, registrations in `DatabaseModels/Index.ts`, `Services/Index.ts`, and `BaseAPI/Index.ts` (`/llm-model-price`).
- **Catalog**: `LlmCostCatalogUtil.findPriceForModel` / `computeCostInUSD` accept optional `projectPriceOverrides`; entries are sanitized (trim/lowercase, unpriceable rows dropped) so user data can never break span ingest. Vendor-decorated ids (`us.anthropic.…`, `models/…`) normalize before matching, same as built-ins.
- **Ingest**: new cached loader `App/FeatureSet/Telemetry/Services/LlmModelPriceService.ts` mirroring `TraceScrubRuleService` (60s `InMemoryTTLCache`, negative caching); `OtelTracesIngestService` loads it in the existing per-batch `Promise.all` and passes entries to `LlmSpanUtil.extract`. An SDK-reported cost — including an explicit 0 — still always wins over any estimate.
- **Dashboard**: new **Pricing** tab in the AI / LLM section (`/llm/pricing`) with a ModelTable to manage entries, wired through PageMap/RouteMap/routes/nav tabs/breadcrumbs like the Budgets tab.
- **Migration**: generated via `npm run generate-postgres-migration` (`1788300000000-AddLlmModelPrice`), registered in `SchemaMigrations/Index.ts`; `npm run check-postgres-schema-drift` reports no drift.

**Reviewer notes:**

- Tie-break rule lives in one place (`findPriceForModel`): built-ins replace the current best only when *strictly* longer, overrides on longer-or-equal.
- A zero-price override marks spans free (cost 0) rather than unpriceable (null) — intentional, so self-hosted models show as $0 instead of unpriced.
- The DB model name `LlmModelPrice` intentionally matches the catalog interface name; they only meet in the ingest loader, which converts rows into catalog-shaped entries.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate? (17 new tests across `LlmCostCatalog.test.ts` and `LlmSpan.test.ts`; both suites pass 75/75)

### Related Issue?

Follow-up to #3337 (computed LLM cost, conversation grouping, and daily LLM cost budgets).

### Screenshots (if appropriate):

N/A (new Pricing tab follows the existing Budgets tab layout).