### PR TITLE
feat(monitor): baseline anomaly detection for Traces and Logs monitors

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
@@ -721,6 +721,8 @@ const CriteriaFilterElement: FunctionComponent<ComponentProps> = (
             ))}
 
         {(criteriaFilter?.checkOn === CheckOn.MetricValue ||
+          criteriaFilter?.checkOn === CheckOn.SpanCount ||
+          criteriaFilter?.checkOn === CheckOn.LogCount ||
           criteriaFilter?.checkOn ===
             CheckOn.SnmpInterfaceUtilizationPercent) &&
           CriteriaFilterUtil.isAnomalyFilterType(
@@ -828,8 +830,8 @@ const CriteriaFilterElement: FunctionComponent<ComponentProps> = (
                 />
               </div>
               <p className="mt-2 text-xs text-gray-500">
-                Anomaly detection requires at least the chosen window of metric
-                history before firing — until then the rule sits in
+                Anomaly detection requires at least the chosen window of
+                telemetry history before firing — until then the rule sits in
                 &quot;Learning&quot; state and produces no alerts.
               </p>
             </div>

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -475,7 +475,18 @@ export default class CriteriaFilterUtil {
       checkOn === CheckOn.SecurityEventCount ||
       checkOn === CheckOn.MetricValue
     ) {
-      const allowAnomaly: boolean = checkOn === CheckOn.MetricValue;
+      /*
+       * Span/log counts also support the baseline anomaly filters — the
+       * server evaluators (TraceMonitorCriteria / LogMonitorCriteria)
+       * compare the observed per-minute rate to the monitor's scope in
+       * the same-hour-of-week SpanCountBaseline / LogCountBaseline,
+       * mirroring the Metric monitor path. Security events have no
+       * volume baseline yet, so they keep the static comparators only.
+       */
+      const allowAnomaly: boolean =
+        checkOn === CheckOn.MetricValue ||
+        checkOn === CheckOn.LogCount ||
+        checkOn === CheckOn.SpanCount;
       options = options.filter((i: DropdownOption) => {
         const baseStatic: boolean =
           i.value === FilterType.GreaterThan ||

--- a/Common/Models/AnalyticsModels/Index.ts
+++ b/Common/Models/AnalyticsModels/Index.ts
@@ -8,6 +8,8 @@ import MetricItemAggMV1mByService from "./MetricItemAggMV1mByService";
 import MetricItemAggMV1mByK8sCluster from "./MetricItemAggMV1mByK8sCluster";
 import MetricItemAggMV1mByContainer from "./MetricItemAggMV1mByContainer";
 import MetricBaselineHourly from "./MetricBaselineHourly";
+import SpanCountBaseline from "./SpanCountBaseline";
+import LogCountBaseline from "./LogCountBaseline";
 import SloHistory from "./SloHistory";
 import Span from "./Span";
 import ExceptionInstance from "./ExceptionInstance";
@@ -44,6 +46,12 @@ const AnalyticsModels: Array<{ new (): AnalyticsBaseModel }> = [
   MetricItemAggMV1mByK8sCluster,
   MetricItemAggMV1mByContainer,
   MetricBaselineHourly,
+  /*
+   * Hour-of-week volume baselines for span/log count anomaly criteria.
+   * AggregatingMergeTree targets populated by MVs on Span/Log inserts.
+   */
+  SpanCountBaseline,
+  LogCountBaseline,
   SloHistory,
   ExceptionInstance,
   MonitorLog,

--- a/Common/Models/AnalyticsModels/LogCountBaseline.ts
+++ b/Common/Models/AnalyticsModels/LogCountBaseline.ts
@@ -1,0 +1,174 @@
+import AnalyticsBaseModel from "./AnalyticsBaseModel/AnalyticsBaseModel";
+import AnalyticsTableEngine from "../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableName from "../../Types/AnalyticsDatabase/AnalyticsTableName";
+import AnalyticsTableColumn from "../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../Types/AnalyticsDatabase/TableColumnType";
+
+/**
+ * Per-(day, hour-of-week, minute-of-hour) log-volume baseline —
+ * backbone of log-count anomaly detection for Logs monitors. Peer of
+ * `SpanCountBaseline` (see that model for the full rationale on the
+ * minute-of-hour sub-bucket, cold start and read semantics) and of
+ * `MetricBaselineHourly` for count-shaped telemetry.
+ *
+ * Populated by `LogCountBaseline_mv`, which fires on every insert into
+ * `LogItemV3` and groups by `(projectId, primaryEntityId, severityText,
+ * day, hourOfWeek, minuteOfHour)`. Each row holds a single
+ * AggregateFunction(count) state — finalize via `countMerge()`.
+ *
+ * `severityText` is part of the key so a monitor scoped to Error/Fatal
+ * logs baselines error volume only — not total log traffic. Read-side
+ * queries that don't filter on it merge across the values.
+ *
+ * Read access goes through `LogCountBaselineService`. No CRUD API is
+ * exposed; this is read-only baseline storage.
+ */
+export default class LogCountBaseline extends AnalyticsBaseModel {
+  public constructor() {
+    const projectIdColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "projectId",
+      title: "Project ID",
+      description: "ID of project (tenant key, replicated from LogItemV3)",
+      required: true,
+      type: TableColumnType.Text,
+      isTenantId: true,
+    });
+
+    const primaryEntityIdColumn: AnalyticsTableColumn =
+      new AnalyticsTableColumn({
+        key: "primaryEntityId",
+        title: "Service ID",
+        description:
+          "Telemetry service the logs belong to (replicated from LogItemV3)",
+        required: true,
+        type: TableColumnType.Text,
+      });
+
+    const severityTextColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "severityText",
+      title: "Severity Text",
+      description:
+        "Log severity (Information, Error, ...). In the key so error-scoped monitors baseline error volume only.",
+      required: true,
+      type: TableColumnType.Text,
+      isLowCardinality: true,
+    });
+
+    const dayColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "day",
+      title: "Day",
+      description:
+        "Calendar day this row aggregates (toDate(time)). Drives the table TTL of 90 days.",
+      required: true,
+      type: TableColumnType.Date,
+    });
+
+    const hourOfWeekColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "hourOfWeek",
+      title: "Hour Of Week",
+      description:
+        "(toDayOfWeek(time, 1) - 1) * 24 + toHour(time). Range 0..167 with Mon 00:00 = 0.",
+      required: true,
+      type: TableColumnType.UInt8,
+    });
+
+    const minuteOfHourColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "minuteOfHour",
+      title: "Minute Of Hour",
+      description:
+        "toMinute(time), 0..59. One cell per minute — a per-minute log count is the baseline's raw sample.",
+      required: true,
+      type: TableColumnType.UInt8,
+    });
+
+    const logCountStateColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "logCountState",
+      title: "Log Count (state)",
+      description:
+        "AggregateFunction(count) state — logs in this minute cell. Read via countMerge(logCountState).",
+      required: true,
+      type: TableColumnType.AggregateFunction,
+      aggregateFunctionDefinition: "count",
+    });
+
+    super({
+      tableName: AnalyticsTableName.LogCountBaseline,
+      tableEngine: AnalyticsTableEngine.AggregatingMergeTree,
+      singularName: "Log Count Baseline",
+      pluralName: "Log Count Baselines",
+      tableColumns: [
+        projectIdColumn,
+        primaryEntityIdColumn,
+        severityTextColumn,
+        dayColumn,
+        hourOfWeekColumn,
+        minuteOfHourColumn,
+        logCountStateColumn,
+      ],
+      projections: [],
+      /*
+       * Baseline materialized view. Canonical definition applied
+       * idempotently by the analytics schema-sync on every boot (see
+       * AnalyticsTableManagement.createMaterializedViews), so a
+       * wiped/recreated ClickHouse volume self-heals. Counts each log
+       * into its (day, hour-of-week, minute-of-hour, severity) cell.
+       */
+      materializedViews: [
+        {
+          name: "LogCountBaseline_mv",
+          query: `CREATE MATERIALIZED VIEW IF NOT EXISTS LogCountBaseline_mv
+TO LogCountBaseline
+AS
+SELECT
+  projectId,
+  primaryEntityId,
+  severityText,
+  toDate(time) AS day,
+  toUInt8((toDayOfWeek(time, 1) - 1) * 24 + toHour(time)) AS hourOfWeek,
+  toUInt8(toMinute(time)) AS minuteOfHour,
+  countState() AS logCountState
+FROM LogItemV3
+GROUP BY projectId, primaryEntityId, severityText, day, hourOfWeek, minuteOfHour`,
+        },
+      ],
+      /*
+       * Sort key prefix matches the read-side WHERE clause of
+       * LogCountBaselineService.getBaseline (project → service →
+       * hourOfWeek → day range) so lookups touch a tight granule range.
+       * severityText sits last: most reads merge across it.
+       */
+      sortKeys: [
+        "projectId",
+        "primaryEntityId",
+        "hourOfWeek",
+        "day",
+        "minuteOfHour",
+        "severityText",
+      ],
+      primaryKeys: [
+        "projectId",
+        "primaryEntityId",
+        "hourOfWeek",
+        "day",
+        "minuteOfHour",
+        "severityText",
+      ],
+      partitionKey: "toYYYYMM(day)",
+      /*
+       * Shard by (project, service) so each service's baseline states
+       * stay on a single shard and countMerge folds locally.
+       */
+      shardingKey: "cityHash64(projectId, primaryEntityId)",
+      tableSettings:
+        "ttl_only_drop_parts = 1, non_replicated_deduplication_window = 10000",
+      /*
+       * Locked to MetricBaselineService.MAX_WINDOW_DAYS (90) — the
+       * longest baseline window the criteria form offers. Bump both
+       * together or reads will silently truncate caller intent.
+       */
+      ttlExpression: "day + INTERVAL 90 DAY",
+      includeBaseColumns: false,
+      defaultSortColumn: "day",
+    });
+  }
+}

--- a/Common/Models/AnalyticsModels/SpanCountBaseline.ts
+++ b/Common/Models/AnalyticsModels/SpanCountBaseline.ts
@@ -1,0 +1,198 @@
+import AnalyticsBaseModel from "./AnalyticsBaseModel/AnalyticsBaseModel";
+import AnalyticsTableEngine from "../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableName from "../../Types/AnalyticsDatabase/AnalyticsTableName";
+import AnalyticsTableColumn from "../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../Types/AnalyticsDatabase/TableColumnType";
+
+/**
+ * Per-(day, hour-of-week, minute-of-hour) span-volume baseline —
+ * backbone of span-count anomaly detection for Traces monitors. Peer of
+ * `MetricBaselineHourly` for count-shaped telemetry.
+ *
+ * Populated by `SpanCountBaseline_mv` (declared below, applied
+ * idempotently by the analytics schema-sync on every boot), which fires
+ * on every insert into `SpanItemV3` and groups by `(projectId,
+ * primaryEntityId, statusCode, day, hourOfWeek, minuteOfHour)`. Each row
+ * holds a single AggregateFunction(count) state — finalize at read time
+ * via `countMerge()`.
+ *
+ * Why a minute-of-hour sub-bucket where the metric baseline stops at the
+ * hour: a metric baseline cell folds many raw samples per hour, but a
+ * count baseline's raw "sample" must itself be a count over a fixed
+ * interval. One minute is that interval — so a 14-day window yields
+ * ~120 per-minute samples per hour-of-week cell (2 matching days × 60
+ * minutes), enough to clear the `minSamples` reliability gate, and the
+ * baseline's unit ("spans per minute") matches the Traces monitor's
+ * default 60-second evaluation window. Hour-grained cells would give
+ * only 2 samples per 14-day window and could never leave Learning.
+ *
+ * `statusCode` (SpanStatus: 0 Unset / 1 Ok / 2 Error; NULL folded to 0)
+ * is part of the key so a monitor scoped to error spans (429/500 spike
+ * alerts) baselines error volume only — not total traffic. Read-side
+ * queries that don't filter on it simply merge across the values.
+ *
+ * Read access goes through `SpanCountBaselineService`, which fetches the
+ * per-minute counts for one `hourOfWeek` across a rolling window
+ * (default 14 days, max 90 — capped by the table's `day + INTERVAL 90
+ * DAY` TTL) and computes mean/stddev/median/MAD in app code. The 168
+ * hour-of-week buckets capture daily and weekly seasonality (Mon 09:00
+ * → 8, Sun 23:00 → 167) using ISO week numbering.
+ *
+ * Cold start: the evaluator refuses to fire while a baseline cell has
+ * fewer than `minSamples` samples (default 5) — the "Learning" state.
+ * Minutes with zero spans produce no rows (nothing inserts), so sparse
+ * streams stay in Learning rather than fabricating a zero-heavy band.
+ *
+ * No CRUD API is exposed (`crudApiPath` and `enableMCP` are unset);
+ * this is read-only baseline storage.
+ */
+export default class SpanCountBaseline extends AnalyticsBaseModel {
+  public constructor() {
+    const projectIdColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "projectId",
+      title: "Project ID",
+      description: "ID of project (tenant key, replicated from SpanItemV3)",
+      required: true,
+      type: TableColumnType.Text,
+      isTenantId: true,
+    });
+
+    const primaryEntityIdColumn: AnalyticsTableColumn =
+      new AnalyticsTableColumn({
+        key: "primaryEntityId",
+        title: "Service ID",
+        description:
+          "Telemetry service the spans belong to (replicated from SpanItemV3)",
+        required: true,
+        type: TableColumnType.Text,
+      });
+
+    const statusCodeColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "statusCode",
+      title: "Span Status Code",
+      description:
+        "SpanStatus (0 Unset, 1 Ok, 2 Error; NULL folded to 0). In the key so error-scoped monitors baseline error volume only.",
+      required: true,
+      type: TableColumnType.UInt8,
+    });
+
+    const dayColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "day",
+      title: "Day",
+      description:
+        "Calendar day this row aggregates (toDate(startTime)). Drives the table TTL of 90 days.",
+      required: true,
+      type: TableColumnType.Date,
+    });
+
+    const hourOfWeekColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "hourOfWeek",
+      title: "Hour Of Week",
+      description:
+        "(toDayOfWeek(startTime, 1) - 1) * 24 + toHour(startTime). Range 0..167 with Mon 00:00 = 0.",
+      required: true,
+      type: TableColumnType.UInt8,
+    });
+
+    const minuteOfHourColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "minuteOfHour",
+      title: "Minute Of Hour",
+      description:
+        "toMinute(startTime), 0..59. One cell per minute — a per-minute span count is the baseline's raw sample.",
+      required: true,
+      type: TableColumnType.UInt8,
+    });
+
+    const spanCountStateColumn: AnalyticsTableColumn = new AnalyticsTableColumn(
+      {
+        key: "spanCountState",
+        title: "Span Count (state)",
+        description:
+          "AggregateFunction(count) state — spans in this minute cell. Read via countMerge(spanCountState).",
+        required: true,
+        type: TableColumnType.AggregateFunction,
+        aggregateFunctionDefinition: "count",
+      },
+    );
+
+    super({
+      tableName: AnalyticsTableName.SpanCountBaseline,
+      tableEngine: AnalyticsTableEngine.AggregatingMergeTree,
+      singularName: "Span Count Baseline",
+      pluralName: "Span Count Baselines",
+      tableColumns: [
+        projectIdColumn,
+        primaryEntityIdColumn,
+        statusCodeColumn,
+        dayColumn,
+        hourOfWeekColumn,
+        minuteOfHourColumn,
+        spanCountStateColumn,
+      ],
+      projections: [],
+      /*
+       * Baseline materialized view. Canonical definition applied
+       * idempotently by the analytics schema-sync on every boot (see
+       * AnalyticsTableManagement.createMaterializedViews), so a
+       * wiped/recreated ClickHouse volume self-heals. Counts each span
+       * into its (day, hour-of-week, minute-of-hour, status) cell.
+       */
+      materializedViews: [
+        {
+          name: "SpanCountBaseline_mv",
+          query: `CREATE MATERIALIZED VIEW IF NOT EXISTS SpanCountBaseline_mv
+TO SpanCountBaseline
+AS
+SELECT
+  projectId,
+  primaryEntityId,
+  toUInt8(coalesce(statusCode, 0)) AS statusCode,
+  toDate(startTime) AS day,
+  toUInt8((toDayOfWeek(startTime, 1) - 1) * 24 + toHour(startTime)) AS hourOfWeek,
+  toUInt8(toMinute(startTime)) AS minuteOfHour,
+  countState() AS spanCountState
+FROM SpanItemV3
+GROUP BY projectId, primaryEntityId, statusCode, day, hourOfWeek, minuteOfHour`,
+        },
+      ],
+      /*
+       * Sort key prefix matches the read-side WHERE clause of
+       * SpanCountBaselineService.getBaseline (project → service →
+       * hourOfWeek → day range) so lookups touch a tight granule range.
+       * statusCode sits last: most reads merge across it.
+       */
+      sortKeys: [
+        "projectId",
+        "primaryEntityId",
+        "hourOfWeek",
+        "day",
+        "minuteOfHour",
+        "statusCode",
+      ],
+      primaryKeys: [
+        "projectId",
+        "primaryEntityId",
+        "hourOfWeek",
+        "day",
+        "minuteOfHour",
+        "statusCode",
+      ],
+      partitionKey: "toYYYYMM(day)",
+      /*
+       * Shard by (project, service) so each service's baseline states
+       * stay on a single shard and countMerge folds locally.
+       */
+      shardingKey: "cityHash64(projectId, primaryEntityId)",
+      tableSettings:
+        "ttl_only_drop_parts = 1, non_replicated_deduplication_window = 10000",
+      /*
+       * Locked to MetricBaselineService.MAX_WINDOW_DAYS (90) — the
+       * longest baseline window the criteria form offers. Bump both
+       * together or reads will silently truncate caller intent.
+       */
+      ttlExpression: "day + INTERVAL 90 DAY",
+      includeBaseColumns: false,
+      defaultSortColumn: "day",
+    });
+  }
+}

--- a/Common/Server/Services/Index.ts
+++ b/Common/Server/Services/Index.ts
@@ -86,6 +86,8 @@ import MetricItemAggMV1mByK8sClusterService from "./MetricItemAggMV1mByK8sCluste
 import MetricItemAggMV1mByContainerService from "./MetricItemAggMV1mByContainerService";
 import MutableMetricService from "./MutableMetricService";
 import MetricBaselineService from "./MetricBaselineService";
+import SpanCountBaselineService from "./SpanCountBaselineService";
+import LogCountBaselineService from "./LogCountBaselineService";
 import MonitorCustomFieldService from "./MonitorCustomFieldService";
 import MonitorGroupOwnerTeamService from "./MonitorGroupOwnerTeamService";
 import MonitorGroupOwnerUserService from "./MonitorGroupOwnerUserService";
@@ -612,6 +614,12 @@ export const AnalyticsServices: Array<
   MetricItemAggMV1mByK8sClusterService,
   MetricItemAggMV1mByContainerService,
   MetricBaselineService,
+  /*
+   * Span/log volume baselines for the count anomaly criteria. Same MV
+   * target pattern as MetricBaselineService.
+   */
+  SpanCountBaselineService,
+  LogCountBaselineService,
   ExceptionInstanceService,
   KubernetesCostAllocationService,
   MonitorLogService,

--- a/Common/Server/Services/LogCountBaselineService.ts
+++ b/Common/Server/Services/LogCountBaselineService.ts
@@ -1,0 +1,163 @@
+import AnalyticsDatabaseService from "./AnalyticsDatabaseService";
+import ClickhouseDatabase from "../Infrastructure/ClickhouseDatabase";
+import LogCountBaseline from "../../Models/AnalyticsModels/LogCountBaseline";
+import { MetricBaselineService } from "./MetricBaselineService";
+import CountAnomaly, {
+  CountBaselineStats,
+  CountBaselineSummary,
+} from "../Utils/Monitor/Criteria/CountAnomaly";
+import logger, { LogAttributes } from "../Utils/Logger";
+import ObjectID from "../../Types/ObjectID";
+
+/**
+ * Read-side service for the `LogCountBaseline` MV target table — the
+ * log-volume peer of `SpanCountBaselineService` (see that service and
+ * `MetricBaselineService` for the shared design notes).
+ *
+ * `getBaseline(...)` fetches the per-minute log counts of one
+ * hour-of-week cell over the rolling window and computes the stats in
+ * app code via {@link CountAnomaly.computeStats}. Window/minSamples
+ * defaults and caps are shared with MetricBaselineService so every
+ * anomaly criterion behaves alike.
+ */
+export class LogCountBaselineService extends AnalyticsDatabaseService<LogCountBaseline> {
+  public constructor(clickhouseDatabase?: ClickhouseDatabase | undefined) {
+    super({ modelType: LogCountBaseline, database: clickhouseDatabase });
+  }
+
+  /**
+   * Fetch the rolling-window baseline of logs-per-minute for one
+   * (project, [services], [severities], hour-of-week) cell. Returns
+   * null when no data exists.
+   *
+   * `telemetryServiceIds` empty/omitted aggregates across every service
+   * in the project; `severityTexts` empty/omitted aggregates across
+   * every severity — matching how the Logs monitor query itself
+   * broadens when those filters are unset.
+   */
+  public async getBaseline(input: {
+    projectId: ObjectID | string;
+    telemetryServiceIds?: Array<ObjectID | string> | undefined;
+    severityTexts?: Array<string> | undefined;
+    hourOfWeek: number;
+    windowDays?: number | undefined;
+    minSamples?: number | undefined;
+  }): Promise<CountBaselineSummary | null> {
+    const windowDays: number = Math.min(
+      input.windowDays || MetricBaselineService.DEFAULT_WINDOW_DAYS,
+      MetricBaselineService.MAX_WINDOW_DAYS,
+    );
+    const minSamples: number =
+      input.minSamples || MetricBaselineService.DEFAULT_MIN_SAMPLES;
+
+    const projectIdStr: string = this.escapeString(
+      input.projectId instanceof ObjectID
+        ? input.projectId.toString()
+        : input.projectId,
+    );
+    const hour: number = Math.max(
+      0,
+      Math.min(167, Math.floor(input.hourOfWeek)),
+    );
+
+    const serviceIds: Array<string> = (input.telemetryServiceIds || []).map(
+      (id: ObjectID | string) => {
+        return this.escapeString(id instanceof ObjectID ? id.toString() : id);
+      },
+    );
+    const serviceIdClause: string =
+      serviceIds.length > 0
+        ? `AND primaryEntityId IN (${serviceIds
+            .map((id: string) => {
+              return `'${id}'`;
+            })
+            .join(", ")})`
+        : "";
+
+    const severities: Array<string> = (input.severityTexts || [])
+      .filter((severity: string) => {
+        return Boolean(severity);
+      })
+      .map((severity: string) => {
+        return this.escapeString(severity);
+      });
+    const severityClause: string =
+      severities.length > 0
+        ? `AND severityText IN (${severities
+            .map((severity: string) => {
+              return `'${severity}'`;
+            })
+            .join(", ")})`
+        : "";
+
+    /*
+     * One row per non-empty minute cell; each row's merged count is a
+     * raw baseline sample ("logs in that minute"). GROUP BY day +
+     * minuteOfHour also folds across services/severities when the IN
+     * clauses are broad, so a multi-service monitor baselines its
+     * combined volume — matching what its observed logCount measures.
+     */
+    const sql: string = `
+      SELECT
+        countMerge(logCountState) AS c
+      FROM LogCountBaseline
+      WHERE projectId = '${projectIdStr}'
+        ${serviceIdClause}
+        ${severityClause}
+        AND hourOfWeek = ${hour}
+        AND day >= today() - INTERVAL ${windowDays} DAY
+      GROUP BY day, minuteOfHour
+    `;
+
+    const resultSet: {
+      json: () => Promise<{ data: Array<{ c: number | string }> }>;
+    } = (await this.executeQuery(sql)) as unknown as {
+      json: () => Promise<{ data: Array<{ c: number | string }> }>;
+    };
+
+    const parsed: { data: Array<{ c: number | string }> } =
+      await resultSet.json();
+
+    const counts: Array<number> = parsed.data.map(
+      (row: { c: number | string }) => {
+        return this.toNumber(row.c);
+      },
+    );
+
+    const stats: CountBaselineStats | null = CountAnomaly.computeStats(counts);
+    if (!stats) {
+      return null;
+    }
+
+    const summary: CountBaselineSummary = {
+      ...stats,
+      isReliable: stats.sampleCount >= minSamples,
+      windowDays,
+      hourOfWeek: hour,
+    };
+
+    logger.debug("LogCountBaselineService.getBaseline", {
+      projectId: projectIdStr,
+      hourOfWeek: hour,
+      sampleCount: summary.sampleCount,
+      isReliable: summary.isReliable,
+    } as LogAttributes);
+
+    return summary;
+  }
+
+  private toNumber(v: number | string | undefined): number {
+    if (typeof v === "number") {
+      return v;
+    }
+    const n: number = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  private escapeString(v: string): string {
+    // ClickHouse string-literal escape for backslash and single quote.
+    return v.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+  }
+}
+
+export default new LogCountBaselineService();

--- a/Common/Server/Services/SpanCountBaselineService.ts
+++ b/Common/Server/Services/SpanCountBaselineService.ts
@@ -1,0 +1,173 @@
+import AnalyticsDatabaseService from "./AnalyticsDatabaseService";
+import ClickhouseDatabase from "../Infrastructure/ClickhouseDatabase";
+import SpanCountBaseline from "../../Models/AnalyticsModels/SpanCountBaseline";
+import { MetricBaselineService } from "./MetricBaselineService";
+import CountAnomaly, {
+  CountBaselineStats,
+  CountBaselineSummary,
+} from "../Utils/Monitor/Criteria/CountAnomaly";
+import logger, { LogAttributes } from "../Utils/Logger";
+import ObjectID from "../../Types/ObjectID";
+
+/**
+ * Read-side service for the `SpanCountBaseline` MV target table — the
+ * span-volume peer of `MetricBaselineService`.
+ *
+ * The table is declared by the {@link SpanCountBaseline} model and
+ * created by the boot-time analytics schema-sync (table + MV, both
+ * idempotent). Rows are populated by the attached MV; this service only
+ * reads.
+ *
+ * `getBaseline(...)` fetches the per-minute span counts of one
+ * hour-of-week cell over the rolling window and computes the stats in
+ * app code via {@link CountAnomaly.computeStats} — the input is at most
+ * `60 × ceil(windowDays / 7)` rows, and keeping the math in TS makes it
+ * unit-testable. Window/minSamples defaults and caps are shared with
+ * MetricBaselineService so every anomaly criterion behaves alike.
+ */
+export class SpanCountBaselineService extends AnalyticsDatabaseService<SpanCountBaseline> {
+  public constructor(clickhouseDatabase?: ClickhouseDatabase | undefined) {
+    super({ modelType: SpanCountBaseline, database: clickhouseDatabase });
+  }
+
+  /**
+   * Fetch the rolling-window baseline of spans-per-minute for one
+   * (project, [services], [statuses], hour-of-week) cell. Returns null
+   * when no data exists.
+   *
+   * `telemetryServiceIds` empty/omitted aggregates across every service
+   * in the project; `spanStatusCodes` empty/omitted aggregates across
+   * every span status — matching how the Traces monitor query itself
+   * broadens when those filters are unset.
+   */
+  public async getBaseline(input: {
+    projectId: ObjectID | string;
+    telemetryServiceIds?: Array<ObjectID | string> | undefined;
+    spanStatusCodes?: Array<number> | undefined;
+    hourOfWeek: number;
+    windowDays?: number | undefined;
+    minSamples?: number | undefined;
+  }): Promise<CountBaselineSummary | null> {
+    const windowDays: number = Math.min(
+      input.windowDays || MetricBaselineService.DEFAULT_WINDOW_DAYS,
+      MetricBaselineService.MAX_WINDOW_DAYS,
+    );
+    const minSamples: number =
+      input.minSamples || MetricBaselineService.DEFAULT_MIN_SAMPLES;
+
+    const projectIdStr: string = this.escapeString(
+      input.projectId instanceof ObjectID
+        ? input.projectId.toString()
+        : input.projectId,
+    );
+    const hour: number = Math.max(
+      0,
+      Math.min(167, Math.floor(input.hourOfWeek)),
+    );
+
+    const serviceIds: Array<string> = (input.telemetryServiceIds || []).map(
+      (id: ObjectID | string) => {
+        return this.escapeString(id instanceof ObjectID ? id.toString() : id);
+      },
+    );
+    const serviceIdClause: string =
+      serviceIds.length > 0
+        ? `AND primaryEntityId IN (${serviceIds
+            .map((id: string) => {
+              return `'${id}'`;
+            })
+            .join(", ")})`
+        : "";
+
+    /*
+     * Persisted monitor steps round-trip through JSON, so status codes
+     * can arrive as numeric strings — coerce before filtering rather
+     * than silently dropping the criterion's scope.
+     */
+    const statusCodes: Array<number> = (input.spanStatusCodes || [])
+      .map((code: number) => {
+        return Number(code);
+      })
+      .filter((code: number) => {
+        return Number.isFinite(code);
+      });
+    const statusCodeClause: string =
+      statusCodes.length > 0
+        ? `AND statusCode IN (${statusCodes
+            .map((code: number) => {
+              return String(Math.floor(code));
+            })
+            .join(", ")})`
+        : "";
+
+    /*
+     * One row per non-empty minute cell; each row's merged count is a
+     * raw baseline sample ("spans in that minute"). GROUP BY day +
+     * minuteOfHour also folds across services/statuses when the IN
+     * clauses are broad, so a multi-service monitor baselines its
+     * combined volume — matching what its observed spanCount measures.
+     */
+    const sql: string = `
+      SELECT
+        countMerge(spanCountState) AS c
+      FROM SpanCountBaseline
+      WHERE projectId = '${projectIdStr}'
+        ${serviceIdClause}
+        ${statusCodeClause}
+        AND hourOfWeek = ${hour}
+        AND day >= today() - INTERVAL ${windowDays} DAY
+      GROUP BY day, minuteOfHour
+    `;
+
+    const resultSet: {
+      json: () => Promise<{ data: Array<{ c: number | string }> }>;
+    } = (await this.executeQuery(sql)) as unknown as {
+      json: () => Promise<{ data: Array<{ c: number | string }> }>;
+    };
+
+    const parsed: { data: Array<{ c: number | string }> } =
+      await resultSet.json();
+
+    const counts: Array<number> = parsed.data.map(
+      (row: { c: number | string }) => {
+        return this.toNumber(row.c);
+      },
+    );
+
+    const stats: CountBaselineStats | null = CountAnomaly.computeStats(counts);
+    if (!stats) {
+      return null;
+    }
+
+    const summary: CountBaselineSummary = {
+      ...stats,
+      isReliable: stats.sampleCount >= minSamples,
+      windowDays,
+      hourOfWeek: hour,
+    };
+
+    logger.debug("SpanCountBaselineService.getBaseline", {
+      projectId: projectIdStr,
+      hourOfWeek: hour,
+      sampleCount: summary.sampleCount,
+      isReliable: summary.isReliable,
+    } as LogAttributes);
+
+    return summary;
+  }
+
+  private toNumber(v: number | string | undefined): number {
+    if (typeof v === "number") {
+      return v;
+    }
+    const n: number = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  private escapeString(v: string): string {
+    // ClickHouse string-literal escape for backslash and single quote.
+    return v.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+  }
+}
+
+export default new SpanCountBaselineService();

--- a/Common/Server/Utils/Monitor/Criteria/CountAnomaly.ts
+++ b/Common/Server/Utils/Monitor/Criteria/CountAnomaly.ts
@@ -1,0 +1,182 @@
+import {
+  AnomalyDetectionMethod,
+  FilterType,
+} from "../../../../Types/Monitor/CriteriaFilter";
+
+/**
+ * Consistency constant that maps a Median Absolute Deviation to the
+ * standard deviation of a Gaussian (σ ≈ 1.4826 × MAD), so the same
+ * sigmaCount sensitivity levels apply to both anomaly methods.
+ */
+export const MAD_TO_SIGMA: number = 1.4826;
+
+/**
+ * Descriptive statistics of a set of per-minute telemetry counts —
+ * one hour-of-week baseline cell aggregated over a rolling window.
+ * Computed in app code (not SQL) so the math is pure and unit-testable;
+ * the input is at most `60 × ceil(windowDays / 7)` numbers.
+ */
+export interface CountBaselineStats {
+  /** Number of non-empty minute cells that contributed. */
+  sampleCount: number;
+  mean: number;
+  /** Population standard deviation. */
+  stddev: number;
+  median: number;
+  /** MAD × 1.4826 → σ-equivalent, used by the MedianMad method. */
+  madSigma: number;
+  minObserved: number;
+  maxObserved: number;
+}
+
+/**
+ * Baseline summary returned by the span/log count baseline services:
+ * the stats plus the reliability verdict and lookup coordinates.
+ * Mirrors `BaselineSummary` from MetricBaselineService.
+ */
+export interface CountBaselineSummary extends CountBaselineStats {
+  /**
+   * Whether this cell meets the minimum sample threshold to be trusted.
+   * Callers must refuse to evaluate against an unreliable baseline —
+   * the "Learning" cold-start state.
+   */
+  isReliable: boolean;
+  /** Window the baseline was computed over (days). */
+  windowDays: number;
+  hourOfWeek: number;
+}
+
+export interface CountAnomalyEvaluation {
+  breaches: boolean;
+  /** (observed - center) / spread — signed sigma distance. */
+  observedSigma: number;
+  expectedHigh: number;
+  expectedLow: number;
+  /** Baseline center actually compared against (mean or median). */
+  center: number;
+  /** Baseline spread actually compared against (stddev or MAD×1.4826). */
+  spread: number;
+}
+
+/**
+ * Pure math for count-based anomaly criteria (CheckOn.SpanCount /
+ * CheckOn.LogCount with FilterType.AnomalouslyHigh/Low/Anomalous).
+ * The services compute stats through here so the write-side MV cells
+ * and the eval-time comparison agree on what a "sample" is.
+ */
+export default class CountAnomaly {
+  /**
+   * Compute baseline stats over a cell's per-minute counts. Returns
+   * null for an empty input — the caller treats that as "no baseline"
+   * (Learning), same as a missing row.
+   */
+  public static computeStats(counts: Array<number>): CountBaselineStats | null {
+    if (counts.length === 0) {
+      return null;
+    }
+
+    let sum: number = 0;
+    let min: number = counts[0]!;
+    let max: number = counts[0]!;
+    for (const value of counts) {
+      sum += value;
+      if (value < min) {
+        min = value;
+      }
+      if (value > max) {
+        max = value;
+      }
+    }
+    const mean: number = sum / counts.length;
+
+    let sumSquaredDeviation: number = 0;
+    for (const value of counts) {
+      sumSquaredDeviation += (value - mean) * (value - mean);
+    }
+    const stddev: number = Math.sqrt(sumSquaredDeviation / counts.length);
+
+    const median: number = CountAnomaly.medianOf(counts);
+    const absoluteDeviations: Array<number> = counts.map((value: number) => {
+      return Math.abs(value - median);
+    });
+    const madSigma: number =
+      CountAnomaly.medianOf(absoluteDeviations) * MAD_TO_SIGMA;
+
+    return {
+      sampleCount: counts.length,
+      mean,
+      stddev,
+      median,
+      madSigma,
+      minObserved: min,
+      maxObserved: max,
+    };
+  }
+
+  /**
+   * Compare an observed per-minute rate to a baseline cell. Returns
+   * null when the baseline has zero spread — any deviation at all would
+   * fire, so the caller must skip rather than alert (mirrors the metric
+   * evaluator's zero-variance guard).
+   */
+  public static evaluate(input: {
+    observedPerMinute: number;
+    stats: CountBaselineStats;
+    sigmaCount: number;
+    method: AnomalyDetectionMethod;
+    filterType: FilterType | undefined;
+  }): CountAnomalyEvaluation | null {
+    const isMedianMad: boolean =
+      input.method === AnomalyDetectionMethod.MedianMad;
+    const center: number = isMedianMad ? input.stats.median : input.stats.mean;
+    const spread: number = isMedianMad
+      ? input.stats.madSigma
+      : input.stats.stddev;
+
+    if (!Number.isFinite(spread) || spread <= 0) {
+      return null;
+    }
+
+    const expectedHigh: number = center + input.sigmaCount * spread;
+    const expectedLow: number = center - input.sigmaCount * spread;
+    const observedSigma: number = (input.observedPerMinute - center) / spread;
+
+    const isHighBreach: boolean = input.observedPerMinute > expectedHigh;
+    const isLowBreach: boolean = input.observedPerMinute < expectedLow;
+
+    let breaches: boolean = false;
+    switch (input.filterType) {
+      case FilterType.AnomalouslyHigh:
+        breaches = isHighBreach;
+        break;
+      case FilterType.AnomalouslyLow:
+        breaches = isLowBreach;
+        break;
+      case FilterType.Anomalous:
+        breaches = isHighBreach || isLowBreach;
+        break;
+      default:
+        breaches = false;
+    }
+
+    return {
+      breaches,
+      observedSigma,
+      expectedHigh,
+      expectedLow,
+      center,
+      spread,
+    };
+  }
+
+  private static medianOf(values: Array<number>): number {
+    const sorted: Array<number> = [...values].sort((a: number, b: number) => {
+      return a - b;
+    });
+    const mid: number = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 0) {
+      return (sorted[mid - 1]! + sorted[mid]!) / 2;
+    }
+    return sorted[mid]!;
+  }
+}

--- a/Common/Server/Utils/Monitor/Criteria/LogMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/LogMonitorCriteria.ts
@@ -1,17 +1,38 @@
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
+import CountAnomaly, {
+  CountAnomalyEvaluation,
+  CountBaselineSummary,
+} from "./CountAnomaly";
 import {
+  AnomalyDetectionMethod,
+  AnomalyDetectionSensitivity,
   CheckOn,
   CriteriaFilter,
+  CriteriaFilterUtil,
 } from "../../../../Types/Monitor/CriteriaFilter";
 import LogMonitorResponse from "../../../../Types/Monitor/LogMonitor/LogMonitorResponse";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorStepLogMonitor from "../../../../Types/Monitor/MonitorStepLogMonitor";
+import OneUptimeDate from "../../../../Types/Date";
+import ObjectID from "../../../../Types/ObjectID";
+import LogCountBaselineService from "../../../Services/LogCountBaselineService";
+import { MetricBaselineService as MetricBaselineServiceClass } from "../../../Services/MetricBaselineService";
+import logger from "../../Logger";
 
 export default class LogMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor step carries the log query (services / severities /
+     * evaluation window) the anomaly path scopes its baseline lookup
+     * to. Optional for backward compatibility — static threshold
+     * filters never need it.
+     */
+    monitorStep?: MonitorStep | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
@@ -19,6 +40,22 @@ export default class LogMonitorCriteria {
       input.criteriaFilter.value;
 
     if (input.criteriaFilter.checkOn === CheckOn.LogCount) {
+      /*
+       * Anomaly filters skip the static threshold entirely: the
+       * observed log rate is compared to this monitor's scope in the
+       * same-hour-of-week LogCountBaseline, mirroring the metric
+       * monitor's baseline path.
+       */
+      if (
+        CriteriaFilterUtil.isAnomalyFilterType(input.criteriaFilter.filterType)
+      ) {
+        return await LogMonitorCriteria.evaluateLogCountAnomaly({
+          logResponse: input.dataToProcess as LogMonitorResponse,
+          criteriaFilter: input.criteriaFilter,
+          monitorStep: input.monitorStep,
+        });
+      }
+
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const currentLogCount: number =
@@ -32,5 +69,100 @@ export default class LogMonitorCriteria {
     }
 
     return null;
+  }
+
+  /*
+   * Anomaly path for log counts: normalizes the observed count to a
+   * per-minute rate (the baseline's sample unit) and compares it to the
+   * rolling same-hour-of-week baseline of the monitor's scope (services
+   * and severities; body/attribute filters are not baselined — the
+   * baseline is that scope's full volume, a documented superset).
+   *
+   * Missing or unreliable baselines mean the rule is still learning —
+   * never alert from a thin baseline. Zero-variance baselines are
+   * skipped too: any deviation at all would fire.
+   */
+  private static async evaluateLogCountAnomaly(input: {
+    logResponse: LogMonitorResponse;
+    criteriaFilter: CriteriaFilter;
+    monitorStep?: MonitorStep | undefined;
+  }): Promise<string | null> {
+    const logMonitorStep: MonitorStepLogMonitor | undefined =
+      input.monitorStep?.data?.logMonitor;
+
+    const windowSeconds: number =
+      logMonitorStep?.lastXSecondsOfLogs &&
+      logMonitorStep.lastXSecondsOfLogs > 0
+        ? logMonitorStep.lastXSecondsOfLogs
+        : 60;
+
+    const logCount: number = input.logResponse.logCount || 0;
+    const observedPerMinute: number = (logCount * 60) / windowSeconds;
+
+    const sensitivity: AnomalyDetectionSensitivity =
+      (input.criteriaFilter.metricMonitorOptions?.anomalyDetection
+        ?.sensitivity as AnomalyDetectionSensitivity | undefined) ||
+      AnomalyDetectionSensitivity.Medium;
+    const sigmaCount: number =
+      MetricBaselineServiceClass.sigmaForSensitivity(sensitivity);
+    const method: AnomalyDetectionMethod =
+      (input.criteriaFilter.metricMonitorOptions?.anomalyDetection?.method as
+        | AnomalyDetectionMethod
+        | undefined) || AnomalyDetectionMethod.MeanStddev;
+
+    let baseline: CountBaselineSummary | null = null;
+    try {
+      baseline = await LogCountBaselineService.getBaseline({
+        projectId: input.logResponse.projectId.toString(),
+        telemetryServiceIds: logMonitorStep?.telemetryServiceIds?.map(
+          (id: ObjectID) => {
+            return id.toString();
+          },
+        ),
+        severityTexts: logMonitorStep?.severityTexts,
+        hourOfWeek: MetricBaselineServiceClass.computeHourOfWeek(
+          OneUptimeDate.getCurrentDate(),
+        ),
+        windowDays:
+          input.criteriaFilter.metricMonitorOptions?.anomalyDetection
+            ?.windowDays,
+        minSamples:
+          input.criteriaFilter.metricMonitorOptions?.anomalyDetection
+            ?.minSamples,
+      });
+    } catch (err) {
+      logger.error("Error fetching log count baseline for anomaly criteria");
+      logger.error(err);
+      return null;
+    }
+
+    if (!baseline || !baseline.isReliable) {
+      // Cold start: the baseline is still learning; nothing to compare to.
+      return null;
+    }
+
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute,
+      stats: baseline,
+      sigmaCount,
+      method,
+      filterType: input.criteriaFilter.filterType,
+    });
+
+    if (!evaluation || !evaluation.breaches) {
+      return null;
+    }
+
+    const direction: string = evaluation.observedSigma >= 0 ? "above" : "below";
+
+    return (
+      `Log count ${logCount} over the last ${windowSeconds} seconds ` +
+      `(${observedPerMinute.toFixed(2)} logs/min) is ` +
+      `${Math.abs(evaluation.observedSigma).toFixed(2)}σ ${direction} the same-hour baseline ` +
+      `(${method === AnomalyDetectionMethod.MedianMad ? "median" : "mean"} ` +
+      `${evaluation.center.toFixed(2)} logs/min, σ ${evaluation.spread.toFixed(2)}, ` +
+      `${baseline.sampleCount} samples over ${baseline.windowDays} days, ` +
+      `sensitivity ${sensitivity}).`
+    );
   }
 }

--- a/Common/Server/Utils/Monitor/Criteria/TraceMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/TraceMonitorCriteria.ts
@@ -2,16 +2,37 @@ import TraceMonitorResponse from "../../../../Types/Monitor/TraceMonitor/TraceMo
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
+import CountAnomaly, {
+  CountAnomalyEvaluation,
+  CountBaselineSummary,
+} from "./CountAnomaly";
 import {
+  AnomalyDetectionMethod,
+  AnomalyDetectionSensitivity,
   CheckOn,
   CriteriaFilter,
+  CriteriaFilterUtil,
 } from "../../../../Types/Monitor/CriteriaFilter";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorStepTraceMonitor from "../../../../Types/Monitor/MonitorStepTraceMonitor";
+import OneUptimeDate from "../../../../Types/Date";
+import ObjectID from "../../../../Types/ObjectID";
+import SpanCountBaselineService from "../../../Services/SpanCountBaselineService";
+import { MetricBaselineService as MetricBaselineServiceClass } from "../../../Services/MetricBaselineService";
+import logger from "../../Logger";
 
 export default class TraceMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor step carries the trace query (services / statuses /
+     * evaluation window) the anomaly path scopes its baseline lookup
+     * to. Optional for backward compatibility — static threshold
+     * filters never need it.
+     */
+    monitorStep?: MonitorStep | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
@@ -19,6 +40,22 @@ export default class TraceMonitorCriteria {
       input.criteriaFilter.value;
 
     if (input.criteriaFilter.checkOn === CheckOn.SpanCount) {
+      /*
+       * Anomaly filters skip the static threshold entirely: the
+       * observed span rate is compared to this monitor's scope in the
+       * same-hour-of-week SpanCountBaseline, mirroring the metric
+       * monitor's baseline path.
+       */
+      if (
+        CriteriaFilterUtil.isAnomalyFilterType(input.criteriaFilter.filterType)
+      ) {
+        return await TraceMonitorCriteria.evaluateSpanCountAnomaly({
+          traceResponse: input.dataToProcess as TraceMonitorResponse,
+          criteriaFilter: input.criteriaFilter,
+          monitorStep: input.monitorStep,
+        });
+      }
+
       threshold = CompareCriteria.convertToNumber(threshold);
 
       const currentSpanCount: number =
@@ -32,5 +69,100 @@ export default class TraceMonitorCriteria {
     }
 
     return null;
+  }
+
+  /*
+   * Anomaly path for span counts: normalizes the observed count to a
+   * per-minute rate (the baseline's sample unit) and compares it to the
+   * rolling same-hour-of-week baseline of the monitor's scope (services
+   * and span statuses; attribute/name filters are not baselined — the
+   * baseline is that scope's full volume, a documented superset).
+   *
+   * Missing or unreliable baselines mean the rule is still learning —
+   * never alert from a thin baseline. Zero-variance baselines are
+   * skipped too: any deviation at all would fire.
+   */
+  private static async evaluateSpanCountAnomaly(input: {
+    traceResponse: TraceMonitorResponse;
+    criteriaFilter: CriteriaFilter;
+    monitorStep?: MonitorStep | undefined;
+  }): Promise<string | null> {
+    const traceMonitorStep: MonitorStepTraceMonitor | undefined =
+      input.monitorStep?.data?.traceMonitor;
+
+    const windowSeconds: number =
+      traceMonitorStep?.lastXSecondsOfSpans &&
+      traceMonitorStep.lastXSecondsOfSpans > 0
+        ? traceMonitorStep.lastXSecondsOfSpans
+        : 60;
+
+    const spanCount: number = input.traceResponse.spanCount || 0;
+    const observedPerMinute: number = (spanCount * 60) / windowSeconds;
+
+    const sensitivity: AnomalyDetectionSensitivity =
+      (input.criteriaFilter.metricMonitorOptions?.anomalyDetection
+        ?.sensitivity as AnomalyDetectionSensitivity | undefined) ||
+      AnomalyDetectionSensitivity.Medium;
+    const sigmaCount: number =
+      MetricBaselineServiceClass.sigmaForSensitivity(sensitivity);
+    const method: AnomalyDetectionMethod =
+      (input.criteriaFilter.metricMonitorOptions?.anomalyDetection?.method as
+        | AnomalyDetectionMethod
+        | undefined) || AnomalyDetectionMethod.MeanStddev;
+
+    let baseline: CountBaselineSummary | null = null;
+    try {
+      baseline = await SpanCountBaselineService.getBaseline({
+        projectId: input.traceResponse.projectId.toString(),
+        telemetryServiceIds: traceMonitorStep?.telemetryServiceIds?.map(
+          (id: ObjectID) => {
+            return id.toString();
+          },
+        ),
+        spanStatusCodes: traceMonitorStep?.spanStatuses,
+        hourOfWeek: MetricBaselineServiceClass.computeHourOfWeek(
+          OneUptimeDate.getCurrentDate(),
+        ),
+        windowDays:
+          input.criteriaFilter.metricMonitorOptions?.anomalyDetection
+            ?.windowDays,
+        minSamples:
+          input.criteriaFilter.metricMonitorOptions?.anomalyDetection
+            ?.minSamples,
+      });
+    } catch (err) {
+      logger.error("Error fetching span count baseline for anomaly criteria");
+      logger.error(err);
+      return null;
+    }
+
+    if (!baseline || !baseline.isReliable) {
+      // Cold start: the baseline is still learning; nothing to compare to.
+      return null;
+    }
+
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute,
+      stats: baseline,
+      sigmaCount,
+      method,
+      filterType: input.criteriaFilter.filterType,
+    });
+
+    if (!evaluation || !evaluation.breaches) {
+      return null;
+    }
+
+    const direction: string = evaluation.observedSigma >= 0 ? "above" : "below";
+
+    return (
+      `Span count ${spanCount} over the last ${windowSeconds} seconds ` +
+      `(${observedPerMinute.toFixed(2)} spans/min) is ` +
+      `${Math.abs(evaluation.observedSigma).toFixed(2)}σ ${direction} the same-hour baseline ` +
+      `(${method === AnomalyDetectionMethod.MedianMad ? "median" : "mean"} ` +
+      `${evaluation.center.toFixed(2)} spans/min, σ ${evaluation.spread.toFixed(2)}, ` +
+      `${baseline.sampleCount} samples over ${baseline.windowDays} days, ` +
+      `sensitivity ${sensitivity}).`
+    );
   }
 }

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -764,6 +764,7 @@ ${contextBlock}
         await LogMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitorStep: input.monitorStep,
         });
 
       if (logMonitorResult) {
@@ -811,6 +812,7 @@ ${contextBlock}
         await TraceMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitorStep: input.monitorStep,
         });
 
       if (traceMonitorResult) {

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/ClusterAwareSchema.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/ClusterAwareSchema.test.ts
@@ -31,6 +31,8 @@ import MetricItemAggMV1mByService from "../../../../Models/AnalyticsModels/Metri
 import MetricItemAggMV1mByK8sCluster from "../../../../Models/AnalyticsModels/MetricItemAggMV1mByK8sCluster";
 import MetricItemAggMV1mByContainer from "../../../../Models/AnalyticsModels/MetricItemAggMV1mByContainer";
 import MetricBaselineHourly from "../../../../Models/AnalyticsModels/MetricBaselineHourly";
+import SpanCountBaseline from "../../../../Models/AnalyticsModels/SpanCountBaseline";
+import LogCountBaseline from "../../../../Models/AnalyticsModels/LogCountBaseline";
 
 const CLUSTER_ENV_KEY: string = "CLICKHOUSE_CLUSTER_NAME";
 const SHARDING_ENV_KEY: string = "CLICKHOUSE_SHARDING_KEY";
@@ -296,6 +298,8 @@ describe("ClickHouse cluster-aware schema (always-on)", () => {
         new MetricItemAggMV1mByK8sCluster(),
         new MetricItemAggMV1mByContainer(),
         new MetricBaselineHourly(),
+        new SpanCountBaseline(),
+        new LogCountBaseline(),
       ];
 
       for (const model of models) {
@@ -340,6 +344,8 @@ describe("ClickHouse cluster-aware schema (always-on)", () => {
         MetricItemAggMV1mByK8sCluster,
         MetricItemAggMV1mByContainer,
         MetricBaselineHourly,
+        SpanCountBaseline,
+        LogCountBaseline,
       ];
 
       for (const modelType of modelTypes) {

--- a/Common/Tests/Server/Utils/Monitor/Criteria/CountAnomaly.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/CountAnomaly.test.ts
@@ -1,0 +1,221 @@
+import CountAnomaly, {
+  CountAnomalyEvaluation,
+  CountBaselineStats,
+  MAD_TO_SIGMA,
+} from "../../../../../Server/Utils/Monitor/Criteria/CountAnomaly";
+import {
+  AnomalyDetectionMethod,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+
+/*
+ * Pure math behind the span/log count anomaly criteria. The baseline
+ * services feed per-minute counts through computeStats, and the
+ * trace/log evaluators compare the observed rate through evaluate —
+ * these tests pin both halves, mirroring the metric baseline's
+ * mean±kσ / median+MAD semantics.
+ */
+describe("CountAnomaly.computeStats", () => {
+  test("empty input → null (no baseline, caller stays in Learning)", () => {
+    expect(CountAnomaly.computeStats([])).toBeNull();
+  });
+
+  test("computes mean, population stddev, median, MAD-sigma and min/max", () => {
+    const stats: CountBaselineStats | null = CountAnomaly.computeStats([
+      1, 2, 3, 4, 5,
+    ]);
+
+    expect(stats).not.toBeNull();
+    expect(stats!.sampleCount).toBe(5);
+    expect(stats!.mean).toBe(3);
+    // Population stddev of 1..5 is sqrt(2).
+    expect(stats!.stddev).toBeCloseTo(Math.sqrt(2), 10);
+    expect(stats!.median).toBe(3);
+    // Absolute deviations from the median are [2,1,0,1,2] → MAD 1.
+    expect(stats!.madSigma).toBeCloseTo(MAD_TO_SIGMA, 10);
+    expect(stats!.minObserved).toBe(1);
+    expect(stats!.maxObserved).toBe(5);
+  });
+
+  test("even-length input → median is the midpoint of the middle pair", () => {
+    const stats: CountBaselineStats | null = CountAnomaly.computeStats([
+      4, 1, 3, 2,
+    ]);
+    expect(stats!.median).toBe(2.5);
+  });
+
+  test("constant counts → zero stddev and zero MAD (zero-variance baseline)", () => {
+    const stats: CountBaselineStats | null = CountAnomaly.computeStats([
+      10, 10, 10, 10,
+    ]);
+    expect(stats!.mean).toBe(10);
+    expect(stats!.stddev).toBe(0);
+    expect(stats!.madSigma).toBe(0);
+  });
+
+  test("median/MAD are robust to a single outlier that inflates mean/stddev", () => {
+    const counts: Array<number> = [10, 10, 10, 10, 10, 10, 10, 10, 10, 1000];
+    const stats: CountBaselineStats | null = CountAnomaly.computeStats(counts);
+
+    expect(stats!.median).toBe(10);
+    expect(stats!.madSigma).toBe(0);
+    expect(stats!.mean).toBeGreaterThan(100);
+    expect(stats!.stddev).toBeGreaterThan(100);
+  });
+});
+
+describe("CountAnomaly.evaluate", () => {
+  const baseline: CountBaselineStats = {
+    sampleCount: 120,
+    mean: 20,
+    stddev: 5,
+    median: 18,
+    madSigma: 4,
+    minObserved: 8,
+    maxObserved: 33,
+  };
+
+  test("AnomalouslyHigh breaches above mean + kσ and reports signed sigma", () => {
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 45,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.AnomalouslyHigh,
+    });
+
+    expect(evaluation).not.toBeNull();
+    expect(evaluation!.breaches).toBe(true);
+    expect(evaluation!.expectedHigh).toBe(35);
+    expect(evaluation!.expectedLow).toBe(5);
+    expect(evaluation!.observedSigma).toBe(5);
+    expect(evaluation!.center).toBe(20);
+    expect(evaluation!.spread).toBe(5);
+  });
+
+  test("AnomalouslyHigh does not breach inside the band", () => {
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 30,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.AnomalouslyHigh,
+    });
+    expect(evaluation!.breaches).toBe(false);
+  });
+
+  test("AnomalouslyHigh ignores a low breach", () => {
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 0,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.AnomalouslyHigh,
+    });
+    expect(evaluation!.breaches).toBe(false);
+  });
+
+  test("AnomalouslyLow breaches below mean - kσ", () => {
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 0,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.AnomalouslyLow,
+    });
+    expect(evaluation!.breaches).toBe(true);
+    expect(evaluation!.observedSigma).toBe(-4);
+  });
+
+  test("Anomalous breaches in either direction", () => {
+    const high: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 45,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.Anomalous,
+    });
+    const low: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 0,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.Anomalous,
+    });
+    expect(high!.breaches).toBe(true);
+    expect(low!.breaches).toBe(true);
+  });
+
+  test("sigmaCount widens the band (Low sensitivity = 4σ does not fire where 2σ does)", () => {
+    const observedPerMinute: number = 38; // 3.6σ above the mean of 20
+    const highSensitivity: CountAnomalyEvaluation | null =
+      CountAnomaly.evaluate({
+        observedPerMinute,
+        stats: baseline,
+        sigmaCount: 2,
+        method: AnomalyDetectionMethod.MeanStddev,
+        filterType: FilterType.AnomalouslyHigh,
+      });
+    const lowSensitivity: CountAnomalyEvaluation | null = CountAnomaly.evaluate(
+      {
+        observedPerMinute,
+        stats: baseline,
+        sigmaCount: 4,
+        method: AnomalyDetectionMethod.MeanStddev,
+        filterType: FilterType.AnomalouslyHigh,
+      },
+    );
+    expect(highSensitivity!.breaches).toBe(true);
+    expect(lowSensitivity!.breaches).toBe(false);
+  });
+
+  test("MedianMad method compares against median and MAD-sigma", () => {
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 31, // > 18 + 3×4 = 30
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MedianMad,
+      filterType: FilterType.AnomalouslyHigh,
+    });
+    expect(evaluation!.breaches).toBe(true);
+    expect(evaluation!.center).toBe(18);
+    expect(evaluation!.spread).toBe(4);
+  });
+
+  test("zero-spread baseline → null (caller must skip, never alert)", () => {
+    const flat: CountBaselineStats = {
+      ...baseline,
+      stddev: 0,
+      madSigma: 0,
+    };
+    expect(
+      CountAnomaly.evaluate({
+        observedPerMinute: 100,
+        stats: flat,
+        sigmaCount: 3,
+        method: AnomalyDetectionMethod.MeanStddev,
+        filterType: FilterType.AnomalouslyHigh,
+      }),
+    ).toBeNull();
+    expect(
+      CountAnomaly.evaluate({
+        observedPerMinute: 100,
+        stats: flat,
+        sigmaCount: 3,
+        method: AnomalyDetectionMethod.MedianMad,
+        filterType: FilterType.AnomalouslyHigh,
+      }),
+    ).toBeNull();
+  });
+
+  test("non-anomaly filter type never breaches", () => {
+    const evaluation: CountAnomalyEvaluation | null = CountAnomaly.evaluate({
+      observedPerMinute: 1000,
+      stats: baseline,
+      sigmaCount: 3,
+      method: AnomalyDetectionMethod.MeanStddev,
+      filterType: FilterType.GreaterThan,
+    });
+    expect(evaluation!.breaches).toBe(false);
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/LogMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/LogMonitorCriteria.test.ts
@@ -1,11 +1,19 @@
 import LogMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/LogMonitorCriteria";
+import LogCountBaselineService from "../../../../../Server/Services/LogCountBaselineService";
+import { CountBaselineSummary } from "../../../../../Server/Utils/Monitor/Criteria/CountAnomaly";
 import {
+  AnomalyDetectionSensitivity,
   CheckOn,
   CriteriaFilter,
   FilterType,
 } from "../../../../../Types/Monitor/CriteriaFilter";
 import LogMonitorResponse from "../../../../../Types/Monitor/LogMonitor/LogMonitorResponse";
 import DataToProcess from "../../../../../Server/Utils/Monitor/DataToProcess";
+import MonitorStep from "../../../../../Types/Monitor/MonitorStep";
+import MonitorStepLogMonitor, {
+  MonitorStepLogMonitorUtil,
+} from "../../../../../Types/Monitor/MonitorStepLogMonitor";
+import LogSeverity from "../../../../../Types/Log/LogSeverity";
 import ObjectID from "../../../../../Types/ObjectID";
 
 /*
@@ -188,6 +196,234 @@ describe("LogMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
           checkOn: CheckOn.SpanCount,
           filterType: FilterType.GreaterThan,
           value: 0,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  /*
+   * Anomaly filters on LogCount: the evaluator normalizes the observed
+   * count to logs-per-minute (the LogCountBaseline sample unit) and
+   * compares it to the same-hour-of-week baseline of the monitor's
+   * scope, mirroring the Metric/SNMP baseline paths — including the
+   * Learning cold-start and zero-variance guards. Full matrix coverage
+   * of the shared math lives in CountAnomaly.test.ts and the trace
+   * sibling in TraceMonitorCriteria.test.ts.
+   */
+  describe("LogCount anomaly filters", () => {
+    let getBaselineSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getBaselineSpy = jest.spyOn(LogCountBaselineService, "getBaseline");
+    });
+
+    afterEach(() => {
+      getBaselineSpy.mockRestore();
+    });
+
+    function buildBaseline(
+      overrides: Partial<CountBaselineSummary>,
+    ): CountBaselineSummary {
+      return {
+        sampleCount: 120,
+        mean: 20,
+        stddev: 5,
+        median: 19,
+        madSigma: 4,
+        minObserved: 8,
+        maxObserved: 33,
+        isReliable: true,
+        windowDays: 14,
+        hourOfWeek: 8,
+        ...overrides,
+      };
+    }
+
+    function buildMonitorStep(
+      overrides: Partial<MonitorStepLogMonitor>,
+    ): MonitorStep {
+      const monitorStep: MonitorStep = new MonitorStep();
+      monitorStep.data = {
+        id: ObjectID.generate().toString(),
+        monitorCriteria: { data: undefined } as never,
+      } as unknown as MonitorStep["data"];
+      monitorStep.data!.logMonitor = {
+        ...MonitorStepLogMonitorUtil.getDefault(),
+        ...overrides,
+      };
+      return monitorStep;
+    }
+
+    function evaluateAnomaly(input: {
+      logCount: number;
+      criteriaFilter: CriteriaFilter;
+      monitorStep?: MonitorStep | undefined;
+    }): Promise<string | null> {
+      return LogMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+        dataToProcess: buildResponse(input.logCount),
+        criteriaFilter: input.criteriaFilter,
+        monitorStep: input.monitorStep,
+      });
+    }
+
+    test("AnomalouslyHigh fires when the log rate exceeds mean + 3σ (Medium default)", async () => {
+      // mean 20/min, σ 5 → 3σ band is [5, 35]; 90 logs in 60s = 90/min.
+      getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+      const result: string | null = await evaluateAnomaly({
+        logCount: 90,
+        criteriaFilter: {
+          checkOn: CheckOn.LogCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
+      });
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("above the same-hour baseline");
+      expect(result).toContain("90.00 logs/min");
+    });
+
+    test("no fire when the log rate is inside the expected band", async () => {
+      getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+      expect(
+        await evaluateAnomaly({
+          logCount: 25,
+          criteriaFilter: {
+            checkOn: CheckOn.LogCount,
+            filterType: FilterType.AnomalouslyLow,
+            value: undefined,
+          },
+        }),
+      ).toBeNull();
+    });
+
+    test("AnomalouslyLow fires when the log rate drops below mean - 3σ", async () => {
+      // mean 60/min, σ 10 → low band edge 30; 0 logs breaches low.
+      getBaselineSpy.mockResolvedValue(buildBaseline({ mean: 60, stddev: 10 }));
+
+      const result: string | null = await evaluateAnomaly({
+        logCount: 0,
+        criteriaFilter: {
+          checkOn: CheckOn.LogCount,
+          filterType: FilterType.AnomalouslyLow,
+          value: undefined,
+        },
+      });
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("below the same-hour baseline");
+    });
+
+    test("observed count is normalized by the monitor's evaluation window", async () => {
+      getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+      // 100 logs over 300s = 20/min — exactly the mean, inside the band.
+      expect(
+        await evaluateAnomaly({
+          logCount: 100,
+          criteriaFilter: {
+            checkOn: CheckOn.LogCount,
+            filterType: FilterType.AnomalouslyHigh,
+            value: undefined,
+          },
+          monitorStep: buildMonitorStep({ lastXSecondsOfLogs: 300 }),
+        }),
+      ).toBeNull();
+    });
+
+    test("baseline lookup is keyed by project, services, severities and anomaly options", async () => {
+      getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+      const serviceId: ObjectID = ObjectID.generate();
+      const monitorStep: MonitorStep = buildMonitorStep({
+        telemetryServiceIds: [serviceId],
+        severityTexts: [LogSeverity.Error, LogSeverity.Fatal],
+      });
+
+      const dataToProcess: DataToProcess = buildResponse(90);
+
+      await LogMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+        dataToProcess,
+        criteriaFilter: {
+          checkOn: CheckOn.LogCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+          metricMonitorOptions: {
+            anomalyDetection: {
+              sensitivity: AnomalyDetectionSensitivity.Low,
+              windowDays: 90,
+              minSamples: 20,
+            },
+          },
+        },
+        monitorStep,
+      });
+
+      expect(getBaselineSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: (dataToProcess as LogMonitorResponse).projectId.toString(),
+          telemetryServiceIds: [serviceId.toString()],
+          severityTexts: [LogSeverity.Error, LogSeverity.Fatal],
+          windowDays: 90,
+          minSamples: 20,
+        }),
+      );
+    });
+
+    test("Learning state (unreliable or missing baseline) never fires", async () => {
+      getBaselineSpy.mockResolvedValue(buildBaseline({ isReliable: false }));
+      expect(
+        await evaluateAnomaly({
+          logCount: 10000,
+          criteriaFilter: {
+            checkOn: CheckOn.LogCount,
+            filterType: FilterType.AnomalouslyHigh,
+            value: undefined,
+          },
+        }),
+      ).toBeNull();
+
+      getBaselineSpy.mockResolvedValue(null);
+      expect(
+        await evaluateAnomaly({
+          logCount: 10000,
+          criteriaFilter: {
+            checkOn: CheckOn.LogCount,
+            filterType: FilterType.AnomalouslyHigh,
+            value: undefined,
+          },
+        }),
+      ).toBeNull();
+    });
+
+    test("zero-variance baseline never fires", async () => {
+      getBaselineSpy.mockResolvedValue(
+        buildBaseline({ stddev: 0, madSigma: 0 }),
+      );
+      expect(
+        await evaluateAnomaly({
+          logCount: 10000,
+          criteriaFilter: {
+            checkOn: CheckOn.LogCount,
+            filterType: FilterType.AnomalouslyHigh,
+            value: undefined,
+          },
+        }),
+      ).toBeNull();
+    });
+
+    test("a baseline lookup error is swallowed and never fires", async () => {
+      getBaselineSpy.mockRejectedValue(new Error("clickhouse down"));
+      expect(
+        await evaluateAnomaly({
+          logCount: 10000,
+          criteriaFilter: {
+            checkOn: CheckOn.LogCount,
+            filterType: FilterType.AnomalouslyHigh,
+            value: undefined,
+          },
         }),
       ).toBeNull();
     });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/TraceMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/TraceMonitorCriteria.test.ts
@@ -1,11 +1,20 @@
 import TraceMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/TraceMonitorCriteria";
+import SpanCountBaselineService from "../../../../../Server/Services/SpanCountBaselineService";
+import { CountBaselineSummary } from "../../../../../Server/Utils/Monitor/Criteria/CountAnomaly";
 import {
+  AnomalyDetectionMethod,
+  AnomalyDetectionSensitivity,
   CheckOn,
   CriteriaFilter,
   FilterType,
 } from "../../../../../Types/Monitor/CriteriaFilter";
 import TraceMonitorResponse from "../../../../../Types/Monitor/TraceMonitor/TraceMonitorResponse";
 import DataToProcess from "../../../../../Server/Utils/Monitor/DataToProcess";
+import MonitorStep from "../../../../../Types/Monitor/MonitorStep";
+import MonitorStepTraceMonitor, {
+  MonitorStepTraceMonitorUtil,
+} from "../../../../../Types/Monitor/MonitorStepTraceMonitor";
+import { SpanStatus } from "../../../../../Models/AnalyticsModels/Span";
 import ObjectID from "../../../../../Types/ObjectID";
 
 /*
@@ -80,6 +89,271 @@ describe("TraceMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         checkOn: CheckOn.LogCount,
         filterType: FilterType.GreaterThan,
         value: 0,
+      }),
+    ).toBeNull();
+  });
+});
+
+/*
+ * Anomaly filters on SpanCount: the evaluator normalizes the observed
+ * count to spans-per-minute (the SpanCountBaseline sample unit) and
+ * compares it to the same-hour-of-week baseline of the monitor's scope,
+ * mirroring the Metric/SNMP baseline paths — including the Learning
+ * cold-start and zero-variance guards.
+ */
+describe("TraceMonitorCriteria SpanCount anomaly filters", () => {
+  let getBaselineSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getBaselineSpy = jest.spyOn(SpanCountBaselineService, "getBaseline");
+  });
+
+  afterEach(() => {
+    getBaselineSpy.mockRestore();
+  });
+
+  function buildBaseline(
+    overrides: Partial<CountBaselineSummary>,
+  ): CountBaselineSummary {
+    return {
+      sampleCount: 120,
+      mean: 20,
+      stddev: 5,
+      median: 19,
+      madSigma: 4,
+      minObserved: 8,
+      maxObserved: 33,
+      isReliable: true,
+      windowDays: 14,
+      hourOfWeek: 8,
+      ...overrides,
+    };
+  }
+
+  function buildMonitorStep(
+    overrides: Partial<MonitorStepTraceMonitor>,
+  ): MonitorStep {
+    const monitorStep: MonitorStep = new MonitorStep();
+    monitorStep.data = {
+      id: ObjectID.generate().toString(),
+      monitorCriteria: { data: undefined } as never,
+    } as unknown as MonitorStep["data"];
+    monitorStep.data!.traceMonitor = {
+      ...MonitorStepTraceMonitorUtil.getDefault(),
+      ...overrides,
+    };
+    return monitorStep;
+  }
+
+  function evaluateAnomaly(input: {
+    spanCount: number;
+    criteriaFilter: CriteriaFilter;
+    monitorStep?: MonitorStep | undefined;
+  }): Promise<string | null> {
+    return TraceMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+      dataToProcess: buildResponse(input.spanCount),
+      criteriaFilter: input.criteriaFilter,
+      monitorStep: input.monitorStep,
+    });
+  }
+
+  test("AnomalouslyHigh fires when the span rate exceeds mean + 3σ (Medium default)", async () => {
+    // mean 20/min, σ 5 → 3σ band is [5, 35]; 90 spans in 60s = 90/min.
+    getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+    const result: string | null = await evaluateAnomaly({
+      spanCount: 90,
+      criteriaFilter: {
+        checkOn: CheckOn.SpanCount,
+        filterType: FilterType.AnomalouslyHigh,
+        value: undefined,
+      },
+    });
+
+    expect(result).toBeTruthy();
+    expect(result).toContain("above the same-hour baseline");
+    expect(result).toContain("90.00 spans/min");
+    expect(result).toContain("sensitivity Medium");
+  });
+
+  test("no fire when the span rate is inside the expected band", async () => {
+    getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+    expect(
+      await evaluateAnomaly({
+        spanCount: 25,
+        criteriaFilter: {
+          checkOn: CheckOn.SpanCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("observed count is normalized by the monitor's evaluation window", async () => {
+    getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+    const monitorStep: MonitorStep = buildMonitorStep({
+      lastXSecondsOfSpans: 300,
+    });
+
+    // 100 spans over 300s = 20/min — exactly the mean, inside the band.
+    expect(
+      await evaluateAnomaly({
+        spanCount: 100,
+        criteriaFilter: {
+          checkOn: CheckOn.SpanCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
+        monitorStep,
+      }),
+    ).toBeNull();
+
+    // 300 spans over 300s = 60/min — well above mean + 3σ = 35.
+    const result: string | null = await evaluateAnomaly({
+      spanCount: 300,
+      criteriaFilter: {
+        checkOn: CheckOn.SpanCount,
+        filterType: FilterType.AnomalouslyHigh,
+        value: undefined,
+      },
+      monitorStep,
+    });
+    expect(result).toBeTruthy();
+    expect(result).toContain("300 over the last 300 seconds");
+    expect(result).toContain("60.00 spans/min");
+  });
+
+  test("AnomalouslyLow fires when the span rate drops below mean - 3σ", async () => {
+    // mean 60/min, σ 10 → low band edge 30; 0 spans breaches low.
+    getBaselineSpy.mockResolvedValue(buildBaseline({ mean: 60, stddev: 10 }));
+
+    const result: string | null = await evaluateAnomaly({
+      spanCount: 0,
+      criteriaFilter: {
+        checkOn: CheckOn.SpanCount,
+        filterType: FilterType.AnomalouslyLow,
+        value: undefined,
+      },
+    });
+
+    expect(result).toBeTruthy();
+    expect(result).toContain("below the same-hour baseline");
+  });
+
+  test("baseline lookup is keyed by project, services, statuses and anomaly options", async () => {
+    getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+    const serviceId: ObjectID = ObjectID.generate();
+    const monitorStep: MonitorStep = buildMonitorStep({
+      telemetryServiceIds: [serviceId],
+      spanStatuses: [SpanStatus.Error],
+    });
+
+    const dataToProcess: DataToProcess = buildResponse(90);
+
+    await TraceMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+      dataToProcess,
+      criteriaFilter: {
+        checkOn: CheckOn.SpanCount,
+        filterType: FilterType.AnomalouslyHigh,
+        value: undefined,
+        metricMonitorOptions: {
+          anomalyDetection: {
+            sensitivity: AnomalyDetectionSensitivity.High,
+            windowDays: 28,
+            minSamples: 10,
+          },
+        },
+      },
+      monitorStep,
+    });
+
+    expect(getBaselineSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: (dataToProcess as TraceMonitorResponse).projectId.toString(),
+        telemetryServiceIds: [serviceId.toString()],
+        spanStatusCodes: [SpanStatus.Error],
+        windowDays: 28,
+        minSamples: 10,
+      }),
+    );
+  });
+
+  test("Learning state (unreliable or missing baseline) never fires", async () => {
+    getBaselineSpy.mockResolvedValue(buildBaseline({ isReliable: false }));
+    expect(
+      await evaluateAnomaly({
+        spanCount: 10000,
+        criteriaFilter: {
+          checkOn: CheckOn.SpanCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
+      }),
+    ).toBeNull();
+
+    getBaselineSpy.mockResolvedValue(null);
+    expect(
+      await evaluateAnomaly({
+        spanCount: 10000,
+        criteriaFilter: {
+          checkOn: CheckOn.SpanCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("zero-variance baseline never fires", async () => {
+    getBaselineSpy.mockResolvedValue(buildBaseline({ stddev: 0, madSigma: 0 }));
+    expect(
+      await evaluateAnomaly({
+        spanCount: 10000,
+        criteriaFilter: {
+          checkOn: CheckOn.SpanCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("MedianMad method compares against the median and reports it", async () => {
+    // median 19, MAD-σ 4 → 3σ band edge 31; 90/min breaches high.
+    getBaselineSpy.mockResolvedValue(buildBaseline({}));
+
+    const result: string | null = await evaluateAnomaly({
+      spanCount: 90,
+      criteriaFilter: {
+        checkOn: CheckOn.SpanCount,
+        filterType: FilterType.AnomalouslyHigh,
+        value: undefined,
+        metricMonitorOptions: {
+          anomalyDetection: {
+            method: AnomalyDetectionMethod.MedianMad,
+          },
+        },
+      },
+    });
+
+    expect(result).toBeTruthy();
+    expect(result).toContain("median 19.00 spans/min");
+  });
+
+  test("a baseline lookup error is swallowed and never fires", async () => {
+    getBaselineSpy.mockRejectedValue(new Error("clickhouse down"));
+    expect(
+      await evaluateAnomaly({
+        spanCount: 10000,
+        criteriaFilter: {
+          checkOn: CheckOn.SpanCount,
+          filterType: FilterType.AnomalouslyHigh,
+          value: undefined,
+        },
       }),
     ).toBeNull();
   });

--- a/Common/Types/AnalyticsDatabase/AnalyticsTableName.ts
+++ b/Common/Types/AnalyticsDatabase/AnalyticsTableName.ts
@@ -40,6 +40,15 @@ enum AnalyticsTableName {
   MetricItemAggMV1mByK8sCluster = "MetricItemAggMV1mByK8sCluster",
   MetricItemAggMV1mByContainer = "MetricItemAggMV1mByContainer",
   MetricBaselineHourly = "MetricBaselineHourly",
+  /*
+   * Hour-of-week volume baselines for Traces and Logs monitors —
+   * span/log counts per (project, service, status/severity, day,
+   * hour-of-week, minute-of-hour) cell, populated by MVs on
+   * SpanItemV3/LogItemV3 inserts. Peers of MetricBaselineHourly for the
+   * AnomalouslyHigh/Low criteria on CheckOn.SpanCount / CheckOn.LogCount.
+   */
+  SpanCountBaseline = "SpanCountBaseline",
+  LogCountBaseline = "LogCountBaseline",
   MutableMetric = "MutableMetricItem",
   /*
    * SLO / Error Budget history rollup. ReplacingMergeTree keyed by


### PR DESCRIPTION
### Title of this pull request?

feat(monitor): baseline anomaly detection for Traces and Logs monitors

### Small Description?

Extends the `AnomalouslyHigh` / `AnomalouslyLow` / `Anomalous` criteria filters — previously offered only for `CheckOn.MetricValue` (and SNMP interface utilization) — to `CheckOn.SpanCount` and `CheckOn.LogCount`, so span/log volume spikes and drops alert without hand-set thresholds. This covers the AI observability PRD's ask for anomaly alerts on LLM API call volumes and error rates (429/500 spikes): a Traces monitor filtered on `isLlmSpan=true` (or scoped to Error spans) with an anomaly criterion now works end to end.

**ClickHouse** — two new AggregatingMergeTree MV targets, `SpanCountBaseline` and `LogCountBaseline`, fed on every `SpanItemV3`/`LogItemV3` insert and created by the boot-time analytics schema sync (no DataMigration, matching recent tables like RumSession). They follow `MetricBaselineHourly`'s 168-bucket hour-of-week pattern with two count-specific twists:

- **Minute-of-hour sub-buckets.** A count baseline's raw sample must itself be a count over a fixed interval. Hourly cells would yield only 2 samples per hour-of-week bucket in the default 14-day window — below the `minSamples=5` reliability gate, so the rule could never leave Learning. Per-minute cells give ~120 samples per bucket, and the baseline unit (per minute) matches the monitors' default 60s evaluation window.
- **`statusCode` / `severityText` in the key.** An error-scoped monitor baselines error volume only, instead of comparing error counts against total traffic. Unscoped monitors merge across the dimension.

**Read side** — `SpanCountBaselineService` / `LogCountBaselineService` fetch one hour-of-week cell's per-minute counts over the rolling window (defaults and the 90-day cap shared with `MetricBaselineService`) and compute stats through a new pure `CountAnomaly` util: mean±kσ plus a working median+MAD (×1.4826) path.

**Evaluators** — `TraceMonitorCriteria` / `LogMonitorCriteria` normalize the observed count by the monitor's `lastXSeconds` window into a per-minute rate, scope the baseline lookup by the monitor's services and statuses/severities (read from `monitorStep`, now passed through by `MonitorCriteriaEvaluator`), and mirror the metric/SNMP guards: Learning cold-start, zero-variance skip, and swallowed lookup errors never fire. Sensitivity/window/method reuse `metricMonitorOptions.anomalyDetection`, where the dashboard already stores them.

**Dashboard** — the criteria form offers the three anomaly filter types for Span Count / Log Count and shows the existing sensitivity + baseline-window controls for them.

**Reviewer notes**

- Attribute/name/body filters are *not* baselined — the baseline is the service/status scope's full volume, the same documented superset trade-off the SNMP utilization anomaly path makes.
- Both new models are added to the cluster schema suite's strict-invariant checks; the MV queries follow the single-source `TO`/`FROM` shape `applyClusterToMaterializedViewQuery` rewrites for cluster mode.
- Pre-existing and unrelated: master's Dashboard `tsc` fails on a missing `IconProp.Network` in `NetworkTopologyExplorer.tsx` (tracked separately).

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

AI observability PRD (anomaly alerts on LLM call volumes / error rates without hand-set thresholds).

### Screenshots (if appropriate):

N/A — form changes reuse the existing anomaly sensitivity/window controls already shipped for Metric monitors.