### PR TITLE
fix(monitor): make the attribute-filter type tell the truth

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts
@@ -1,4 +1,6 @@
 import { JSONObject } from "Common/Types/JSON";
+import Dictionary from "Common/Types/Dictionary";
+import DictionaryEntryValue from "Common/Types/BaseDatabase/DictionaryEntryValue";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import RangeStartAndEndDateTime, {
   RangeStartAndEndDateTimeUtil,
@@ -26,7 +28,12 @@ export interface LogsHistogramRequestParams {
   serviceIds?: Array<string> | undefined;
   traceIds?: Array<string> | undefined;
   spanIds?: Array<string> | undefined;
-  attributes?: Record<string, string> | undefined;
+  /*
+   * Attribute filters from the host page. Values may be operator wrappers
+   * (contains / != / is any of / ...), not just scalars — they are
+   * forwarded verbatim and deserialized server-side.
+   */
+  attributes?: Dictionary<DictionaryEntryValue> | undefined;
   entityKeys?: Array<string> | undefined;
   /** Facet chips the user has applied in the sidebar / search bar. */
   appliedFacetFilters: Map<string, Set<string>>;

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -89,6 +89,8 @@ import { shouldAdoptTimeRangeOverride } from "../../Utils/SharedTelemetryTimeCur
 import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
 import Navigation from "Common/UI/Utils/Navigation";
 import Dictionary from "Common/Types/Dictionary";
+import DictionaryEntryValue from "Common/Types/BaseDatabase/DictionaryEntryValue";
+import { formatDictionaryEntryValue } from "Common/UI/Components/Dictionary/DictionaryFilterOperator";
 import IconProp from "Common/Types/Icon/IconProp";
 import {
   CrossSignalQueryParams,
@@ -733,22 +735,30 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
     return [...props.sessionIds];
   }, [props.sessionIds]);
 
-  // Extract attribute filters from logQuery for histogram/facets API calls
-  const logQueryAttributes: Record<string, string> | undefined = useMemo(() => {
-    if (!props.logQuery) {
-      return undefined;
-    }
+  /*
+   * Extract attribute filters from logQuery for histogram/facets API calls.
+   *
+   * A value is not necessarily a scalar: the "Filter by Attributes" editor
+   * emits operator wrappers (contains / != / is any of / ...), and a log
+   * monitor's saved filters arrive here through its logQuery. They travel to
+   * the API as-is — the serializer understands them — but anything that
+   * renders one has to flatten it first (formatDictionaryEntryValue).
+   */
+  const logQueryAttributes: Dictionary<DictionaryEntryValue> | undefined =
+    useMemo(() => {
+      if (!props.logQuery) {
+        return undefined;
+      }
 
-    const attributes: Record<string, string> | undefined = (
-      props.logQuery as any
-    ).attributes as Record<string, string> | undefined;
+      const attributes: Dictionary<DictionaryEntryValue> | undefined = props
+        .logQuery.attributes as Dictionary<DictionaryEntryValue> | undefined;
 
-    if (!attributes || Object.keys(attributes).length === 0) {
-      return undefined;
-    }
+      if (!attributes || Object.keys(attributes).length === 0) {
+        return undefined;
+      }
 
-    return attributes;
-  }, [props.logQuery]);
+      return attributes;
+    }, [props.logQuery]);
 
   /*
    * Extract the entityKeys membership filter from logQuery so the histogram
@@ -760,9 +770,7 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
       return undefined;
     }
 
-    const values: Array<string> = getQueryValues(
-      (props.logQuery as any)["entityKeys"],
-    );
+    const values: Array<string> = getQueryValues(props.logQuery["entityKeys"]);
 
     if (values.length === 0) {
       return undefined;
@@ -1933,11 +1941,13 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
       };
 
       for (const [attrKey, attrValue] of Object.entries(logQueryAttributes)) {
+        const displayValue: string = formatDictionaryEntryValue(attrValue);
+
         filters.push({
           facetKey: `attributes.${attrKey}`,
-          value: attrValue,
+          value: displayValue,
           displayKey: attributeDisplayNames[attrKey] || attrKey,
-          displayValue: attrValue,
+          displayValue: displayValue,
           readOnly: true,
         });
       }

--- a/App/FeatureSet/Dashboard/src/Utils/LogsCrossSignalPivot.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/LogsCrossSignalPivot.ts
@@ -3,6 +3,7 @@ import InBetween from "Common/Types/BaseDatabase/InBetween";
 import Search from "Common/Types/BaseDatabase/Search";
 import Query from "Common/Types/BaseDatabase/Query";
 import Dictionary from "Common/Types/Dictionary";
+import DictionaryEntryValue from "Common/Types/BaseDatabase/DictionaryEntryValue";
 import Log from "Common/Models/AnalyticsModels/Log";
 import RumSession from "Common/Models/AnalyticsModels/RumSession";
 import Span from "Common/Models/AnalyticsModels/Span";
@@ -60,8 +61,12 @@ export interface LogsPivotScopeInput {
   traceIds?: Array<string> | undefined;
   spanIds?: Array<string> | undefined;
   sessionIds?: Array<string> | undefined;
-  /** Base attribute filters from the host page's logQuery. */
-  attributes?: Record<string, string> | undefined;
+  /*
+   * Base attribute filters from the host page's logQuery. Values may be
+   * operator wrappers (contains / != / is any of / ...); the cross-signal
+   * scope carries exact matches only, so anything else is reported dropped.
+   */
+  attributes?: Dictionary<DictionaryEntryValue> | undefined;
   /** Facet chips the user has applied in the sidebar / search bar. */
   appliedFacetFilters: Map<string, Set<string>>;
   /** Current picker selection; preset ranges resolve against "now". */
@@ -147,9 +152,21 @@ export const buildLogsPivotScope: BuildLogsPivotScopeFunction = (
   const attributes: Dictionary<string> = {};
 
   for (const [key, value] of Object.entries(input.attributes || {})) {
-    if (key && value) {
-      attributes[key] = value;
+    if (!key || !value) {
+      continue;
     }
+
+    /*
+     * `scope.attributes` is an exact-match map. An operator filter has no
+     * representation there, so it is reported dropped rather than silently
+     * degraded to an equality on its operand.
+     */
+    if (typeof value === "object") {
+      dropped.push(`${ATTRIBUTE_FACET_PREFIX}${key}`);
+      continue;
+    }
+
+    attributes[key] = String(value);
   }
 
   const knownFacetKeys: Set<string> = new Set<string>([

--- a/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
@@ -941,7 +941,7 @@ export default class MonitorStepViewModel {
         title: "Log Attributes",
         description: "Attributes of the logs to monitor.",
         valueType: MonitorStepViewValueType.JSON,
-        value: logMonitor?.attributes as JSONObject | undefined,
+        value: logMonitor?.attributes,
         placeholder: "No attributes entered",
       }),
       optional({
@@ -1019,7 +1019,7 @@ export default class MonitorStepViewModel {
         title: "Event Attributes",
         description: "Attributes of the security events to monitor.",
         valueType: MonitorStepViewValueType.JSON,
-        value: securityEventsMonitor?.attributes as JSONObject | undefined,
+        value: securityEventsMonitor?.attributes,
         placeholder: "No attributes entered",
       }),
       optional({
@@ -1074,7 +1074,7 @@ export default class MonitorStepViewModel {
         title: "Span Attributes",
         description: "Attributes of the spans to monitor.",
         valueType: MonitorStepViewValueType.JSON,
-        value: traceMonitor?.attributes as JSONObject | undefined,
+        value: traceMonitor?.attributes,
         placeholder: "No attributes entered",
       }),
       optional({

--- a/App/Tests/Dashboard/LogsCrossSignalPivot.test.ts
+++ b/App/Tests/Dashboard/LogsCrossSignalPivot.test.ts
@@ -277,6 +277,25 @@ describe("buildLogsPivotScope", () => {
     expect(result.dropped).toEqual([]);
   });
 
+  test("an operator-valued base attribute is reported dropped, not degraded to an equality", () => {
+    const result: LogsPivotScopeResult = Pivot.buildLogsPivotScope(
+      input({
+        attributes: {
+          "http.method": "GET",
+          "http.route": new Search<string>("/api"),
+        },
+      }),
+    );
+
+    /*
+     * scope.attributes is an exact-match map. Carrying `contains /api` across
+     * as `= /api` would silently narrow the pivot to a filter the user never
+     * set, so the operator entry travels in `dropped` instead.
+     */
+    expect(result.scope.attributes).toEqual({ "http.method": "GET" });
+    expect(result.dropped).toEqual(["attributes.http.route"]);
+  });
+
   test("a multi-valued attribute selection has no representation and is reported dropped", () => {
     const result: LogsPivotScopeResult = Pivot.buildLogsPivotScope(
       input({

--- a/Common/Tests/UI/Components/DictionaryFilterOperator.test.ts
+++ b/Common/Tests/UI/Components/DictionaryFilterOperator.test.ts
@@ -3,9 +3,16 @@ import {
   DictionaryFilterOperator,
   buildDictionaryValue,
   detectOperatorFromValue,
+  formatDictionaryEntryValue,
 } from "../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import EqualTo from "../../../Types/BaseDatabase/EqualTo";
+import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
 import Includes from "../../../Types/BaseDatabase/Includes";
 import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import NotEqual from "../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../Types/BaseDatabase/NotNull";
+import Search from "../../../Types/BaseDatabase/Search";
 import { ObjectType } from "../../../Types/JSON";
 import { describe, expect, it } from "@jest/globals";
 
@@ -170,5 +177,64 @@ describe("DictionaryFilterOperator - IsNoneOf (multi-value exclusion)", () => {
 
     expect(detected.operator).toBe(DictionaryFilterOperator.IsNoneOf);
     expect(detected.rawValues).toEqual(["nice", "softirq"]);
+  });
+});
+
+describe("formatDictionaryEntryValue", () => {
+  /*
+   * These values reach React children (filter chips, read-only viewers).
+   * Rendering an operator instance directly throws "Objects are not valid as
+   * a React child", so every branch has to come back as a string.
+   */
+  it("renders a bare scalar unchanged so pre-operator filters look the same", () => {
+    expect(formatDictionaryEntryValue("prod")).toBe("prod");
+    expect(formatDictionaryEntryValue(42)).toBe("42");
+    expect(formatDictionaryEntryValue(true)).toBe("true");
+  });
+
+  it("renders an EqualTo wrapper without a redundant '=' prefix", () => {
+    expect(formatDictionaryEntryValue(new EqualTo<string>("prod"))).toBe(
+      "prod",
+    );
+  });
+
+  it("prefixes every other operator with its symbol", () => {
+    expect(formatDictionaryEntryValue(new NotEqual<string>("prod"))).toBe(
+      "!= prod",
+    );
+    expect(formatDictionaryEntryValue(new Search<string>("prod"))).toBe(
+      "contains prod",
+    );
+    expect(formatDictionaryEntryValue(new GreaterThan<number>(500))).toBe(
+      "> 500",
+    );
+  });
+
+  it("joins multi-value operators", () => {
+    expect(formatDictionaryEntryValue(new Includes(["system", "user"]))).toBe(
+      "is any of system, user",
+    );
+    expect(
+      formatDictionaryEntryValue(new IncludesNone(["system", "user"])),
+    ).toBe("is none of system, user");
+  });
+
+  it("renders value-less operators as the symbol alone", () => {
+    expect(formatDictionaryEntryValue(new IsNull())).toBe("is empty");
+    expect(formatDictionaryEntryValue(new NotNull())).toBe("is not empty");
+  });
+
+  it("renders raw `{_type, value}` JSON straight out of storage", () => {
+    expect(
+      formatDictionaryEntryValue({
+        _type: ObjectType.Search,
+        value: "prod",
+      }),
+    ).toBe("contains prod");
+  });
+
+  it("returns a string for null / undefined rather than throwing", () => {
+    expect(formatDictionaryEntryValue(null)).toBe("");
+    expect(formatDictionaryEntryValue(undefined)).toBe("");
   });
 });

--- a/Common/Types/BaseDatabase/DictionaryEntryValue.ts
+++ b/Common/Types/BaseDatabase/DictionaryEntryValue.ts
@@ -1,0 +1,49 @@
+import EndsWith from "./EndsWith";
+import EqualTo from "./EqualTo";
+import GreaterThan from "./GreaterThan";
+import GreaterThanOrEqual from "./GreaterThanOrEqual";
+import Includes from "./Includes";
+import IncludesNone from "./IncludesNone";
+import IsNull from "./IsNull";
+import LessThan from "./LessThan";
+import LessThanOrEqual from "./LessThanOrEqual";
+import NotContains from "./NotContains";
+import NotEqual from "./NotEqual";
+import NotNull from "./NotNull";
+import Search from "./Search";
+import StartsWith from "./StartsWith";
+
+/*
+ * One value in an attribute-filter map ("Filter by Attributes" rows and the
+ * persisted `attributes` maps that mirror them).
+ *
+ * A row is either a bare scalar — the `equals` operator, kept bare for
+ * backwards compatibility with filters saved before operators existed — or
+ * one of the query-operator wrappers below.
+ *
+ * This lives in Types rather than next to the Dictionary UI component
+ * because the persisted types (monitor steps, dashboard components) and the
+ * query builders that read them are typed with it, and Types must not depend
+ * on UI. `Common/UI/Components/Dictionary/DictionaryFilterOperator` re-exports
+ * it for the UI callers that already import it from there.
+ */
+export type DictionaryEntryValue =
+  | string
+  | number
+  | boolean
+  | EqualTo<string>
+  | NotEqual<string>
+  | Search<string>
+  | NotContains<string>
+  | StartsWith<string>
+  | EndsWith<string>
+  | GreaterThan<number>
+  | GreaterThanOrEqual<number>
+  | LessThan<number>
+  | LessThanOrEqual<number>
+  | IsNull
+  | NotNull
+  | Includes
+  | IncludesNone;
+
+export default DictionaryEntryValue;

--- a/Common/Types/Dashboard/DashboardComponents/DashboardTableComponent.ts
+++ b/Common/Types/Dashboard/DashboardComponents/DashboardTableComponent.ts
@@ -3,7 +3,7 @@ import MetricQueryConfigData from "../../Metrics/MetricQueryConfigData";
 import MetricsAggregationType from "../../Metrics/MetricsAggregationType";
 import ObjectID from "../../ObjectID";
 import Dictionary from "../../Dictionary";
-import { DictionaryEntryValue } from "../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import DictionaryEntryValue from "../../BaseDatabase/DictionaryEntryValue";
 import DashboardComponentType from "../DashboardComponentType";
 import BaseComponent from "./DashboardBaseComponent";
 

--- a/Common/Types/Monitor/MonitorStepLogMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepLogMonitor.ts
@@ -4,13 +4,18 @@ import Includes from "../BaseDatabase/Includes";
 import Query from "../BaseDatabase/Query";
 import Search from "../BaseDatabase/Search";
 import OneUptimeDate from "../Date";
+import DictionaryEntryValue from "../BaseDatabase/DictionaryEntryValue";
 import Dictionary from "../Dictionary";
 import { JSONObject } from "../JSON";
 import LogSeverity from "../Log/LogSeverity";
 import ObjectID from "../ObjectID";
 
 export default interface MonitorStepLogMonitor {
-  attributes: Dictionary<string | number | boolean>;
+  /*
+   * Attribute filters. A value is a bare scalar (`equals`) or one of the
+   * query-operator wrappers the "Filter by Attributes" editor emits.
+   */
+  attributes: Dictionary<DictionaryEntryValue>;
   body: string;
   severityTexts: Array<LogSeverity>;
   telemetryServiceIds: Array<ObjectID>;
@@ -90,7 +95,7 @@ export class MonitorStepLogMonitorUtil {
   public static fromJSON(json: JSONObject): MonitorStepLogMonitor {
     return {
       attributes:
-        (json["attributes"] as Dictionary<string | number | boolean>) || {},
+        (json["attributes"] as Dictionary<DictionaryEntryValue>) || {},
       body: json["body"] as string,
       severityTexts: json["severityTexts"] as Array<LogSeverity>,
       telemetryServiceIds: ObjectID.fromJSONArray(

--- a/Common/Types/Monitor/MonitorStepSecurityEventsMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepSecurityEventsMonitor.ts
@@ -4,13 +4,18 @@ import Includes from "../BaseDatabase/Includes";
 import Query from "../BaseDatabase/Query";
 import Search from "../BaseDatabase/Search";
 import OneUptimeDate from "../Date";
+import DictionaryEntryValue from "../BaseDatabase/DictionaryEntryValue";
 import Dictionary from "../Dictionary";
 import { JSONObject } from "../JSON";
 import ObjectID from "../ObjectID";
 import OcsfSeverity from "../SecurityEvent/OcsfSeverity";
 
 export default interface MonitorStepSecurityEventsMonitor {
-  attributes: Dictionary<string | number | boolean>;
+  /*
+   * Attribute filters. A value is a bare scalar (`equals`) or one of the
+   * query-operator wrappers the "Filter by Attributes" editor emits.
+   */
+  attributes: Dictionary<DictionaryEntryValue>;
   messageContains: string;
   severityNames: Array<OcsfSeverity>;
   classNames: Array<string>;
@@ -76,7 +81,7 @@ export class MonitorStepSecurityEventsMonitorUtil {
   public static fromJSON(json: JSONObject): MonitorStepSecurityEventsMonitor {
     return {
       attributes:
-        (json["attributes"] as Dictionary<string | number | boolean>) || {},
+        (json["attributes"] as Dictionary<DictionaryEntryValue>) || {},
       messageContains: (json["messageContains"] as string) || "",
       severityNames: (json["severityNames"] as Array<OcsfSeverity>) || [],
       classNames: (json["classNames"] as Array<string>) || [],

--- a/Common/Types/Monitor/MonitorStepTraceMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepTraceMonitor.ts
@@ -4,12 +4,17 @@ import Includes from "../BaseDatabase/Includes";
 import Query from "../BaseDatabase/Query";
 import Search from "../BaseDatabase/Search";
 import OneUptimeDate from "../Date";
+import DictionaryEntryValue from "../BaseDatabase/DictionaryEntryValue";
 import Dictionary from "../Dictionary";
 import { JSONObject } from "../JSON";
 import ObjectID from "../ObjectID";
 
 export default interface MonitorStepTraceMonitor {
-  attributes: Dictionary<string | number | boolean>;
+  /*
+   * Attribute filters. A value is a bare scalar (`equals`) or one of the
+   * query-operator wrappers the "Filter by Attributes" editor emits.
+   */
+  attributes: Dictionary<DictionaryEntryValue>;
   spanStatuses: Array<SpanStatus>;
   telemetryServiceIds: Array<ObjectID>;
   /*
@@ -89,7 +94,7 @@ export class MonitorStepTraceMonitorUtil {
   public static fromJSON(json: JSONObject): MonitorStepTraceMonitor {
     return {
       attributes:
-        (json["attributes"] as Dictionary<string | number | boolean>) || {},
+        (json["attributes"] as Dictionary<DictionaryEntryValue>) || {},
       spanName: json["spanName"] as string,
       spanStatuses: json["spanStatuses"] as Array<SpanStatus>,
       telemetryServiceIds: ObjectID.fromJSONArray(

--- a/Common/UI/Components/Dictionary/DictionaryFilterOperator.ts
+++ b/Common/UI/Components/Dictionary/DictionaryFilterOperator.ts
@@ -13,6 +13,7 @@ import NotNull from "../../../Types/BaseDatabase/NotNull";
 import Includes from "../../../Types/BaseDatabase/Includes";
 import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
 import { ObjectType } from "../../../Types/JSON";
+import DictionaryEntryValue from "../../../Types/BaseDatabase/DictionaryEntryValue";
 
 /*
  * UI-facing operator identifiers. We store these in the Dictionary form
@@ -133,24 +134,12 @@ export const DICTIONARY_FILTER_OPERATOR_OPTIONS: ReadonlyArray<DictionaryFilterO
     },
   ];
 
-export type DictionaryEntryValue =
-  | string
-  | number
-  | boolean
-  | EqualTo<string>
-  | NotEqual<string>
-  | Search<string>
-  | NotContains<string>
-  | StartsWith<string>
-  | EndsWith<string>
-  | GreaterThan<number>
-  | GreaterThanOrEqual<number>
-  | LessThan<number>
-  | LessThanOrEqual<number>
-  | IsNull
-  | NotNull
-  | Includes
-  | IncludesNone;
+/*
+ * Defined in Types (the persisted monitor-step and dashboard types are typed
+ * with it, and Types must not depend on UI) and re-exported here so the UI
+ * callers that already import it from this module keep working.
+ */
+export type { DictionaryEntryValue };
 
 export const getOperatorOption: (
   operator: DictionaryFilterOperator,
@@ -449,4 +438,33 @@ export const buildDictionaryValue: (input: {
     default:
       return trimmed;
   }
+};
+
+/**
+ * Render a stored dictionary entry value as text.
+ *
+ * Chips, read-only viewers and tooltips take a `string`; the stored value may
+ * be an operator instance, so it has to be flattened before it reaches a
+ * React child. Bare equality renders as just the value, which keeps
+ * pre-operator filters looking exactly as they did; every other operator is
+ * prefixed with its symbol ("!= prod", "contains prod", "is empty").
+ */
+export const formatDictionaryEntryValue: (value: unknown) => string = (
+  value: unknown,
+): string => {
+  const detected: RawValueAndOperator = detectOperatorFromValue(value);
+
+  if (detected.operator === DictionaryFilterOperator.EqualTo) {
+    return detected.rawValue;
+  }
+
+  const option: DictionaryFilterOperatorOption = getOperatorOption(
+    detected.operator,
+  );
+
+  if (option.hidesValueInput) {
+    return option.symbol;
+  }
+
+  return `${option.symbol} ${detected.rawValue}`;
 };


### PR DESCRIPTION
### Title of this pull request?

fix(monitor): make the attribute-filter type tell the truth

### Small Description?

`MonitorStepLogMonitor.attributes` was declared `Dictionary<string | number | boolean>`, and the same declaration appeared on `MonitorStepTraceMonitor` and `MonitorStepSecurityEventsMonitor`.

That declaration has been a lie since the "Filter by Attributes" rows gained an operator dropdown. `buildDictionaryValue` writes operator **instances** — `Search`, `Includes`, `IncludesNone`, `IsNull`, `NotNull`, `NotEqual`, `StartsWith`, `EndsWith`, `NotContains`, `GreaterThan`/`OrEqual`, `LessThan`/`OrEqual` — into that field, and `fromJSON` casts DB JSON straight back to it without hydrating.

**This is the root cause of the React-child crash fixed downstream.** Because the compiler believed the values were scalars, `DashboardLogsViewer` could write `(props.logQuery as any).attributes as Record<string, string>` and hand one of those values to `ActiveFilter.displayValue` (typed `string`) without complaint — compiling fine, then throwing `Objects are not valid as a React child (found: object with keys {_values})` in front of a customer.

The point of this PR is that the compiler, not a customer, catches the next instance.

#### What changed

**1. The union moved down into Types.** New `Common/Types/BaseDatabase/DictionaryEntryValue.ts`, sitting alongside the operator classes it references. It could not simply be imported from `Common/UI/...` — that would make Types depend on UI — so it lives in Types and `Common/UI/Components/Dictionary/DictionaryFilterOperator` re-exports it. All ~30 existing UI call sites are untouched.

While there, `Common/Types/Dashboard/DashboardComponents/DashboardTableComponent.ts` was fixed: it was already reaching up into `Common/UI/...` for this exact type. It now imports from Types.

**2. All three MonitorStep types widened** to `Dictionary<DictionaryEntryValue>`, declaration and `fromJSON` cast alike.

**3. The fallout — which is where the real work was.**

Widening the declaration *alone* changed nothing: all three packages still compiled clean, because every downstream site was already behind an escape hatch that kept the build green while the lie stayed intact. Removing those hatches is the fix:

- `MonitorStep*Util.toQuery()` needed **no** change — the widened dictionary is assignable to `Query<...>["attributes"]` as-is.
- `MonitorStepViewModel.ts:944/1022/1077` — the three `as JSONObject | undefined` casts are now redundant and are gone, so those assignments are genuinely typechecked.
- `LogsViewer.tsx` — `props.logQuery as any` removed and `logQueryAttributes` typed honestly. That immediately surfaced the shipped bug: the chip built `displayValue` straight from the raw value. It now goes through a new `formatDictionaryEntryValue`, which renders `contains prod` / `!= prod` / `is empty` and leaves bare scalars looking exactly as they did. The adjacent `(props.logQuery as any)["entityKeys"]` also went — it typechecks fine without the cast.
- `LogsHistogramRequestParams.attributes` was also `Record<string, string>` — widened, since the values forward verbatim and deserialize server-side.
- `LogsPivotScopeInput.attributes` likewise, but `scope.attributes` is genuinely an exact-match map, so an operator entry is now reported in `dropped` rather than silently degraded to an equality on its operand. That matches how the same function already handles multi-valued selections.

The three step forms needed no change — they bind the field by name through `BasicForm`.

#### Verifying the guarantee

I compiled a throwaway file reproducing the original bug, both halves of it:

```ts
const attrs: Record<string, string> = m.attributes;          // TS2322
const chip: ActiveFilter = { displayValue: m.attributes["env"]! };  // TS2322
```

Both are compile errors now. That file was deleted; it is not part of the diff.

#### Reviewer notes

- **No runtime behaviour changed for scalar filters.** `formatDictionaryEntryValue` returns bare equality values unchanged, so pre-operator filters render byte-identically.
- **The one deliberate behaviour change** is the cross-signal pivot: an operator-valued attribute now lands in `dropped` (surfaced to the user as a tooltip hint) instead of being carried across as an equality the user never set. Covered by a new test.
- **Known display wart, left alone:** the monitor's read-only step view renders attributes as a `FieldType.JSON` blob, so an operator filter displays as `{"_type":"Search","value":"prod"}`. That is `JSON.stringify`, not a crash, and it predates this PR — flagging it since `formatDictionaryEntryValue` is now available if we want that view to read like the chips do.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Lint:** `npx eslint --fix` run over every changed file, clean.

**Compile:** `tsc --noEmit` clean in `Common` and `App`. `App/FeatureSet/Dashboard` has exactly one error, and it is pre-existing and unrelated — `IconProp.Network` does not exist (`NetworkTopologyExplorer.tsx:865`, from `88814b917e`). Confirmed identical on a stashed tree; tracked separately.

**Tests:** Common 5222/5222 across `Types/Monitor`, `Types/Dashboard`, `UI/Components`, `Server/Utils/AnalyticsDatabase`. App 6983/6983 across `Tests/Dashboard` and `Tests/Workers`.

New coverage: 7 cases for `formatDictionaryEntryValue` (scalars, bare `EqualTo`, symbol-prefixed operators, multi-value joins, value-less operators, raw `{_type, value}` JSON out of storage, null/undefined), plus one for the pivot reporting an operator-valued attribute as dropped rather than degrading it.

Two groups of pre-existing failures were confirmed **not** caused by this change, by re-running against a stashed tree and getting identical counts:

- 10 suites under `Common/Tests/Server/Utils/Monitor` fail to load at all — `isolated-vm`'s native binary is built against a different Node ABI than the local v24.1.0 (`dlopen ... symbol not found`). Every test that executes passes (1188/1188). Environment-only; CI is unaffected.
- 4 side-menu/breadcrumb suites fail on route-list assertions.

### Related Issue?

None.

### Screenshots (if appropriate):

Not applicable — this is a type-level change. The only user-visible difference is that a log-monitor attribute filter using an operator now renders as a readable chip (`env: contains prod`) instead of crashing the logs viewer.
