### PR TITLE
fix(monitor): name attribute filter operators on the criteria page

### DIFF
--- a/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
@@ -10,6 +10,7 @@ import MonitorStep, { MonitorStepType } from "Common/Types/Monitor/MonitorStep";
 import MonitorType from "Common/Types/Monitor/MonitorType";
 import RollingTime from "Common/Types/RollingTime/RollingTime";
 import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
+import { formatDictionaryValueForDisplay } from "Common/UI/Components/Dictionary/DictionaryFilterOperator";
 
 /*
  * WHY THIS FILE EXISTS
@@ -30,7 +31,11 @@ import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
  * suite can hold to every monitor type at once.
  *
  * Rows carry a `valueType` rather than a UI FieldType so this file never
- * imports from the component layer. The viewer translates them.
+ * imports the component layer's rendering. The viewer translates them.
+ * `formatDictionaryValueForDisplay` is the one import from under
+ * `Common/UI`: a pure string function with no React in it, shared so the
+ * criteria page names filter operators exactly the way the log viewer's
+ * chips do.
  */
 
 export enum MonitorStepViewValueType {
@@ -161,6 +166,38 @@ const toSpanStatusText: (status: SpanStatus) => string = (
     default:
       return "Unset";
   }
+};
+
+/*
+ * Attribute filters are typed as scalars, but only the implicit `=` actually
+ * stores one. Since these rows gained an operator dropdown, every other
+ * operator stores an operator instance (`Search`, `Includes`, `IsNull`, ...)
+ * — see `buildDictionaryValue` — or, for a step read straight back from
+ * storage, the `{_type, value}` JSON those serialize to.
+ *
+ * Emitting the raw object as a JSON row printed that wire shape at the
+ * operator, so the criteria page showed
+ * `{ "env": { "_type": "Search", "value": "web" } }` where it meant
+ * `env: contains web`. The shared formatter names the operator instead, and
+ * the row leaves here as a dictionary of strings so the viewer tabulates it
+ * the way it already tabulates request headers.
+ */
+const toAttributeFilters: (
+  attributes: Dictionary<string | number | boolean> | undefined,
+) => Dictionary<string> | undefined = (
+  attributes: Dictionary<string | number | boolean> | undefined,
+): Dictionary<string> | undefined => {
+  if (!attributes) {
+    return undefined;
+  }
+
+  const filters: Dictionary<string> = {};
+
+  for (const key of Object.keys(attributes)) {
+    filters[key] = formatDictionaryValueForDisplay(attributes[key]);
+  }
+
+  return filters;
 };
 
 const safeMetricsViewConfig: (
@@ -940,8 +977,8 @@ export default class MonitorStepViewModel {
         key: "logAttributes",
         title: "Log Attributes",
         description: "Attributes of the logs to monitor.",
-        valueType: MonitorStepViewValueType.JSON,
-        value: logMonitor?.attributes as JSONObject | undefined,
+        valueType: MonitorStepViewValueType.DictionaryOfStrings,
+        value: toAttributeFilters(logMonitor?.attributes),
         placeholder: "No attributes entered",
       }),
       optional({
@@ -1018,8 +1055,8 @@ export default class MonitorStepViewModel {
         key: "securityEventAttributes",
         title: "Event Attributes",
         description: "Attributes of the security events to monitor.",
-        valueType: MonitorStepViewValueType.JSON,
-        value: securityEventsMonitor?.attributes as JSONObject | undefined,
+        valueType: MonitorStepViewValueType.DictionaryOfStrings,
+        value: toAttributeFilters(securityEventsMonitor?.attributes),
         placeholder: "No attributes entered",
       }),
       optional({
@@ -1073,8 +1110,8 @@ export default class MonitorStepViewModel {
         key: "spanAttributes",
         title: "Span Attributes",
         description: "Attributes of the spans to monitor.",
-        valueType: MonitorStepViewValueType.JSON,
-        value: traceMonitor?.attributes as JSONObject | undefined,
+        valueType: MonitorStepViewValueType.DictionaryOfStrings,
+        value: toAttributeFilters(traceMonitor?.attributes),
         placeholder: "No attributes entered",
       }),
       optional({

--- a/App/Tests/Dashboard/MonitorStepViewModel.test.ts
+++ b/App/Tests/Dashboard/MonitorStepViewModel.test.ts
@@ -4,6 +4,10 @@ import Hostname from "Common/Types/API/Hostname";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
 import URL from "Common/Types/API/URL";
 import AggregationType from "Common/Types/BaseDatabase/AggregationType";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import Search from "Common/Types/BaseDatabase/Search";
+import Dictionary from "Common/Types/Dictionary";
 import IP from "Common/Types/IP/IP";
 import LogSeverity from "Common/Types/Log/LogSeverity";
 import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
@@ -24,6 +28,11 @@ import ScreenSizeType from "Common/Types/Monitor/SyntheticMonitors/ScreenSizeTyp
 import ObjectID from "Common/Types/ObjectID";
 import Port from "Common/Types/Port";
 import RollingTime from "Common/Types/RollingTime/RollingTime";
+import {
+  buildDictionaryValue,
+  DictionaryEntryValue,
+  DictionaryFilterOperator,
+} from "Common/UI/Components/Dictionary/DictionaryFilterOperator";
 import MonitorStepViewModel, {
   MonitorStepViewRow,
   MonitorStepViewValueType,
@@ -763,6 +772,359 @@ describe("MonitorStepViewModel.getRows — telemetry monitors", () => {
     expect(row?.value).toBe("44444444-4444-4444-8444-444444444444");
   });
 });
+
+/*
+ * WHY THIS BLOCK EXISTS
+ *
+ * "Filter by Attributes" grew an operator dropdown, and only the implicit
+ * `=` still stores a bare string. Every other operator stores an operator
+ * instance (`Search`, `Includes`, `IsNull`, ...) — or, once the step has
+ * been read back from storage, the `{_type, value}` JSON those serialize to.
+ *
+ * The three attribute rows used to leave the view model typed JSON, so
+ * `Detail` ran them through `JSON.stringify` and the criteria page printed
+ * the wire shape where the operator belonged:
+ *
+ *   { "env": { "_type": "Search", "value": "web" } }
+ *
+ * for a monitor that means `env: contains web`. Nothing threw — the JSON
+ * branch stringifies rather than handing an object to React — so the row
+ * was unreadable without ever being a failure that showed up anywhere but
+ * on the page itself. That is why it outlived the fix for the criteria
+ * modal crash sitting right next to it.
+ *
+ * Every operator is pinned here, on every monitor type that has an
+ * attribute row, because "renders as its own internals" is exactly the bug
+ * that a spot check of one operator walks straight past.
+ */
+
+interface AttributeFilterFixture {
+  label: string;
+  monitorType: MonitorType;
+  rowKey: string;
+  buildStepWithAttributes: (
+    attributes: Dictionary<DictionaryEntryValue>,
+  ) => MonitorStep;
+}
+
+/*
+ * The step shapes declare `attributes` as a map of scalars, which stopped
+ * being true when the operator dropdown shipped. Production reads it back
+ * through that same lie (see `toAttributeFilters`), so the fixtures store
+ * values the way the form actually writes them rather than the way the
+ * type claims.
+ */
+function asStoredAttributes(
+  attributes: Dictionary<DictionaryEntryValue>,
+): Dictionary<string | number | boolean> {
+  return attributes as unknown as Dictionary<string | number | boolean>;
+}
+
+const ATTRIBUTE_FILTER_FIXTURES: Array<AttributeFilterFixture> = [
+  {
+    label: "log",
+    monitorType: MonitorType.Logs,
+    rowKey: "logAttributes",
+    buildStepWithAttributes: (
+      attributes: Dictionary<DictionaryEntryValue>,
+    ): MonitorStep => {
+      const step: MonitorStep = buildStepForMonitorType(MonitorType.Logs);
+      const data: MonitorStepType = step.data as MonitorStepType;
+
+      data.logMonitor = {
+        ...data.logMonitor!,
+        attributes: asStoredAttributes(attributes),
+      };
+
+      return step;
+    },
+  },
+  {
+    label: "trace",
+    monitorType: MonitorType.Traces,
+    rowKey: "spanAttributes",
+    buildStepWithAttributes: (
+      attributes: Dictionary<DictionaryEntryValue>,
+    ): MonitorStep => {
+      const step: MonitorStep = buildStepForMonitorType(MonitorType.Traces);
+      const data: MonitorStepType = step.data as MonitorStepType;
+
+      data.traceMonitor = {
+        ...data.traceMonitor!,
+        attributes: asStoredAttributes(attributes),
+      };
+
+      return step;
+    },
+  },
+  {
+    label: "security events",
+    monitorType: MonitorType.SecurityEvents,
+    rowKey: "securityEventAttributes",
+    buildStepWithAttributes: (
+      attributes: Dictionary<DictionaryEntryValue>,
+    ): MonitorStep => {
+      const step: MonitorStep = buildStepForMonitorType(
+        MonitorType.SecurityEvents,
+      );
+      const data: MonitorStepType = step.data as MonitorStepType;
+
+      data.securityEventsMonitor = {
+        ...data.securityEventsMonitor!,
+        attributes: asStoredAttributes(attributes),
+      };
+
+      return step;
+    },
+  },
+];
+
+interface AttributeOperatorCase {
+  label: string;
+  operator: DictionaryFilterOperator;
+  rawValue: string;
+  rawValues?: Array<string> | undefined;
+  rendersAs: string;
+}
+
+const ATTRIBUTE_OPERATOR_CASES: Array<AttributeOperatorCase> = [
+  {
+    label: "equals",
+    operator: DictionaryFilterOperator.EqualTo,
+    rawValue: "web",
+    // Bare, because `=` is the implicit operator and how these have always read.
+    rendersAs: "web",
+  },
+  {
+    label: "does not equal",
+    operator: DictionaryFilterOperator.NotEqual,
+    rawValue: "web",
+    rendersAs: "does not equal web",
+  },
+  {
+    label: "is any of",
+    operator: DictionaryFilterOperator.IsAnyOf,
+    rawValue: "",
+    rawValues: ["web", "api"],
+    rendersAs: "is any of web, api",
+  },
+  {
+    label: "is none of",
+    operator: DictionaryFilterOperator.IsNoneOf,
+    rawValue: "",
+    rawValues: ["web", "api"],
+    rendersAs: "is none of web, api",
+  },
+  {
+    label: "contains",
+    operator: DictionaryFilterOperator.Contains,
+    rawValue: "web",
+    rendersAs: "contains web",
+  },
+  {
+    label: "does not contain",
+    operator: DictionaryFilterOperator.NotContains,
+    rawValue: "web",
+    rendersAs: "does not contain web",
+  },
+  {
+    label: "starts with",
+    operator: DictionaryFilterOperator.StartsWith,
+    rawValue: "web",
+    rendersAs: "starts with web",
+  },
+  {
+    label: "ends with",
+    operator: DictionaryFilterOperator.EndsWith,
+    rawValue: "web",
+    rendersAs: "ends with web",
+  },
+  {
+    label: "greater than",
+    operator: DictionaryFilterOperator.GreaterThan,
+    rawValue: "500",
+    rendersAs: "greater than 500",
+  },
+  {
+    label: "greater than or equal",
+    operator: DictionaryFilterOperator.GreaterThanOrEqual,
+    rawValue: "500",
+    rendersAs: "greater than or equal 500",
+  },
+  {
+    label: "less than",
+    operator: DictionaryFilterOperator.LessThan,
+    rawValue: "500",
+    rendersAs: "less than 500",
+  },
+  {
+    label: "less than or equal",
+    operator: DictionaryFilterOperator.LessThanOrEqual,
+    rawValue: "500",
+    rendersAs: "less than or equal 500",
+  },
+  {
+    label: "is empty",
+    operator: DictionaryFilterOperator.IsEmpty,
+    rawValue: "",
+    rendersAs: "is empty",
+  },
+  {
+    label: "is not empty",
+    operator: DictionaryFilterOperator.IsNotEmpty,
+    rawValue: "",
+    rendersAs: "is not empty",
+  },
+];
+
+function getAttributeRow(
+  fixture: AttributeFilterFixture,
+  attributes: Dictionary<DictionaryEntryValue>,
+): MonitorStepViewRow | undefined {
+  return MonitorStepViewModel.getRows({
+    monitorStep: fixture.buildStepWithAttributes(attributes),
+    monitorType: fixture.monitorType,
+  }).find((row: MonitorStepViewRow) => {
+    return row.key === fixture.rowKey;
+  });
+}
+
+describe("MonitorStepViewModel.getRows — attribute filter operators", () => {
+  /*
+   * The cases below are the whole point of this block, so an operator added
+   * to the dropdown must not be able to slip past them untested.
+   */
+  it("names every operator the dropdown offers", () => {
+    const covered: Array<string> = ATTRIBUTE_OPERATOR_CASES.map(
+      (operatorCase: AttributeOperatorCase) => {
+        return String(operatorCase.operator);
+      },
+    ).sort();
+
+    expect(covered).toEqual(Object.values(DictionaryFilterOperator).sort());
+  });
+
+  it("covers every monitor type whose step carries attribute filters", () => {
+    const covered: Array<MonitorType> = ATTRIBUTE_FILTER_FIXTURES.map(
+      (fixture: AttributeFilterFixture) => {
+        return fixture.monitorType;
+      },
+    );
+
+    expect(covered).toEqual([
+      MonitorType.Logs,
+      MonitorType.Traces,
+      MonitorType.SecurityEvents,
+    ]);
+  });
+});
+
+describe.each(ATTRIBUTE_FILTER_FIXTURES)(
+  "MonitorStepViewModel.getRows — $label monitor attribute filters",
+  (fixture: AttributeFilterFixture) => {
+    it.each(ATTRIBUTE_OPERATOR_CASES)(
+      'renders "$label" as text instead of the operator object it is stored as',
+      (operatorCase: AttributeOperatorCase) => {
+        const row: MonitorStepViewRow | undefined = getAttributeRow(fixture, {
+          env: buildDictionaryValue({
+            operator: operatorCase.operator,
+            rawValue: operatorCase.rawValue,
+            rawValues: operatorCase.rawValues,
+          }),
+        });
+
+        /*
+         * A JSON row would be handed to `JSON.stringify`; a dictionary of
+         * strings is tabulated as-is. The value type is half the fix.
+         */
+        expect(row?.valueType).toBe(
+          MonitorStepViewValueType.DictionaryOfStrings,
+        );
+        expect(row?.value).toEqual({ env: operatorCase.rendersAs });
+      },
+    );
+
+    it("names the operator for a step read back from storage as raw JSON", () => {
+      /*
+       * What the API actually returns: the operator instances serialized to
+       * their `{_type, value}` form, never rehydrated into classes. That
+       * shape printed verbatim on the page before this fix.
+       */
+      const row: MonitorStepViewRow | undefined = getAttributeRow(fixture, {
+        env: new Search<string>(
+          "web",
+        ).toJSON() as unknown as DictionaryEntryValue,
+        tier: new Includes([
+          "web",
+          "api",
+        ]).toJSON() as unknown as DictionaryEntryValue,
+        region: new IsNull().toJSON() as unknown as DictionaryEntryValue,
+      });
+
+      expect(row?.value).toEqual({
+        env: "contains web",
+        tier: "is any of web, api",
+        region: "is empty",
+      });
+    });
+
+    it("renders every value as a string, whatever the operator mix", () => {
+      const attributes: Dictionary<DictionaryEntryValue> = {};
+
+      for (const operatorCase of ATTRIBUTE_OPERATOR_CASES) {
+        attributes[operatorCase.label] = buildDictionaryValue({
+          operator: operatorCase.operator,
+          rawValue: operatorCase.rawValue,
+          rawValues: operatorCase.rawValues,
+        });
+      }
+
+      const row: MonitorStepViewRow | undefined = getAttributeRow(
+        fixture,
+        attributes,
+      );
+
+      const values: Array<unknown> = Object.values(
+        row?.value as Dictionary<string>,
+      );
+
+      expect(values).toHaveLength(ATTRIBUTE_OPERATOR_CASES.length);
+
+      for (const value of values) {
+        expect(typeof value).toBe("string");
+      }
+    });
+
+    it("shows the operator alone when a membership filter names no values", () => {
+      /*
+       * An empty `Includes` is a no-op downstream — StatementGenerator skips
+       * the predicate rather than emitting `IN ()` — so there is nothing to
+       * list after the label.
+       */
+      const row: MonitorStepViewRow | undefined = getAttributeRow(fixture, {
+        env: buildDictionaryValue({
+          operator: DictionaryFilterOperator.IsAnyOf,
+          rawValue: "",
+          rawValues: [],
+        }),
+      });
+
+      expect(row?.value).toEqual({ env: "is any of" });
+    });
+
+    it("keeps a plain string filter unchanged, as saved before operators shipped", () => {
+      const row: MonitorStepViewRow | undefined = getAttributeRow(fixture, {
+        "service.name": "checkout",
+      });
+
+      expect(row?.value).toEqual({ "service.name": "checkout" });
+    });
+
+    it("drops the row when no attributes are configured", () => {
+      expect(getAttributeRow(fixture, {})).toBeUndefined();
+    });
+  },
+);
 
 describe("MonitorStepViewModel.getRows — metric-backed monitors", () => {
   const METRIC_MONITOR_TYPES: Array<MonitorType> = [


### PR DESCRIPTION
### Title of this pull request?

fix(monitor): name attribute filter operators on the criteria page

### Small Description?

A monitor's **Criteria** tab rendered its attribute filters as the raw internal wire shape. "Log Attributes", "Span Attributes" and the security event "Attributes" rows all left `MonitorStepViewModel` typed `JSON`, so `Detail` ran them through `JSON.stringify` and the page printed the operator's own internals where the operator belonged:

```
{ "env": { "_type": "Search",   "value": "web" } }
{ "env": { "_type": "IsNull",   "value": null } }
{ "env": { "_type": "Includes", "value": ["web", "api"] } }
```

for monitors that plainly mean `env: contains web`, `env: is empty` and `env: is any of web, api`.

**Why it happened.** Since these rows gained an operator dropdown, only the implicit `=` stores a bare string; every other operator stores an operator instance (`Search`, `Includes`, `IsNull`, …), or the `{_type, value}` JSON it serializes to once the step has been read back from storage.

**Why it survived the last fix.** Nothing throws here — the JSON branch stringifies rather than handing an object to React — so the row was unreadable without ever being a failure that surfaced anywhere but on the page itself. That is why it outlived the criteria-modal crash fix sitting right next to it (#3339).

#### What changed

The three rows now go through `formatDictionaryValueForDisplay` — the shared formatter #3339 introduced — and leave the view model as a `DictionaryOfStrings`:

- [`MonitorStepViewModel.ts:977`](https://github.com/OneUptime/oneuptime/blob/claude/agitated-yalow-d56e7b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts#L977) — Log Attributes
- [`MonitorStepViewModel.ts:1055`](https://github.com/OneUptime/oneuptime/blob/claude/agitated-yalow-d56e7b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts#L1055) — Event Attributes
- [`MonitorStepViewModel.ts:1110`](https://github.com/OneUptime/oneuptime/blob/claude/agitated-yalow-d56e7b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts#L1110) — Span Attributes

**No component changed.** `DictionaryOfStrings` was chosen over a new value type because both the view model and `MonitorStep.tsx:67` already supported it, and `Detail` routes it to the same key/value table the API monitor's Request Headers row already uses.

#### Notes for the reviewer

- **Formatting happens in the view model, not the viewer**, to keep it a pure React-free function the test suite can hold directly. That adds the one import from under `Common/UI` to a file whose header comment said it never imports the component layer — the comment now names the exception and the reason (it is a pure string function, and sharing it is what keeps this page and the log viewer's chips saying the same thing).
- **Complementary to #3339, not overlapping.** That PR fixed the edit modal and viewer chips; this one fixes the read-only criteria page. Its `LogMonitorAttributeOperatorPreview` test touches neither `MonitorStepViewModel` nor `MonitorStep.tsx`.
- **Display-only.** No change to what is stored, queried or evaluated.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Verification run locally:**

| Check | Result |
| --- | --- |
| `MonitorStepViewModel.test.ts` | 161 passed (was 102 — **59 new**) |
| Full `App/Tests/Dashboard` | 182 suites, 6534 tests passed |
| `tsc --noEmit` (App + Common) | clean |
| `eslint` on changed files | clean |

Tests cover **all fourteen operators across the log, trace and security event monitors**, built through `buildDictionaryValue` so they track the real write path rather than a hand-rolled fixture. Also covered: the raw `{_type, value}` shape the API actually returns, an all-values-are-strings guard, an empty `Includes`, a pre-operator plain string, and the empty-attributes row drop.

Two invariants fail if an operator or an attribute-carrying monitor type is added without coverage:

- `names every operator the dropdown offers` — asserts the case table equals `Object.values(DictionaryFilterOperator)`
- `covers every monitor type whose step carries attribute filters`

I verified the tests actually catch the bug by temporarily reverting the log row to `JSON`: **17 tests fail on exactly that fixture**, then pass again once restored.

### Related Issue?

Follow-up to #3339, which fixed the criteria-modal crash and introduced the shared formatter this PR reuses. The display bug was knowingly left out of that PR because it causes no crash.

### Screenshots (if appropriate):

Before and after, for the row a log monitor renders on its Criteria tab:

| | Log Attributes row |
| --- | --- |
| **Before** | <code>{ "env": { "_type": "Search", "value": "web" } }</code> in a code block |
| **After** | `env` → `contains web`, in the standard key/value table |
