### PR TITLE
docs(analytics): star the activation key events now that they fire

### DIFF
--- a/Docs/analytics/revenue-funnel.md
+++ b/Docs/analytics/revenue-funnel.md
@@ -84,20 +84,32 @@ The property had eight events starred before any of them could possibly fire,
 which is why the list looked configured while the container dropped everything.
 Current state:
 
-| Event               | Key event | Why                                                                                     |
-| ------------------- | --------- | --------------------------------------------------------------------------------------- |
-| `sign_up`           | yes       | The primary self-serve conversion.                                                      |
-| `cta_get_started`   | yes       | Micro-conversion, useful early signal while volume is low.                              |
-| `cta_request_demo`  | yes       | Same.                                                                                   |
-| `purchase`          | forced    | A GA4 default that cannot be unmarked. Nothing emits it, so it stays at zero.           |
-| `page_view_pricing` | no        | Fires on every pricing page load — as a key event it reported browsing as a conversion. |
-| `page_view_demo`    | no        | Same.                                                                                   |
-| `demo_request`      | no        | Never had a working delivery path and is no longer emitted at all.                      |
-| `generate_lead`     | no        | Nothing emits it.                                                                       |
+| Event                     | Key event | Why                                                                                              |
+| ------------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `sign_up`                 | yes       | The primary self-serve conversion.                                                               |
+| `workspace_created`       | yes       | Activation.                                                                                      |
+| `monitor_created`         | yes       | Activation.                                                                                      |
+| `teammate_invited`        | yes       | Collaboration.                                                                                   |
+| `cta_get_started`         | yes       | Micro-conversion, useful early signal while volume is low.                                       |
+| `cta_request_demo`        | yes       | Same.                                                                                            |
+| `purchase`                | forced    | A GA4 default that cannot be unmarked. Nothing emits it, so it stays at zero.                    |
+| `signup_started`          | no        | A funnel step, not a conversion — starring it would inflate conversions against real signups.    |
+| `page_view_pricing`       | no        | Fires on every pricing page load — as a key event it reported browsing as a conversion.          |
+| `page_view_demo`          | no        | Same.                                                                                            |
+| `demo_request`            | no        | Never had a working delivery path and is no longer emitted at all.                               |
+| `generate_lead`           | no        | Nothing emits it.                                                                                |
+| `subscription_upgraded`   | not yet   | Carries `value`/`currency`. Cannot be starred until it fires once — nobody has changed plan yet. |
+| `subscription_downgraded` | not yet   | Same.                                                                                            |
+| `meeting_booked`          | not yet   | Same — no booking since the deploy.                                                              |
 
-Still to star, once each has fired at least once and appeared in the list:
-`subscription_upgraded` (the only event carrying `value`/`currency`),
-`meeting_booked`, `workspace_created`, `monitor_created`, `teammate_invited`.
+`subscription_upgraded`, `subscription_downgraded` and `meeting_booked` are
+the three left. Star each one the first time it appears in the list; until
+then GA4 has nothing to star.
+
+`subscription_upgraded` is worth a closer look when it does arrive — it is the
+only event carrying `value` and `currency`, and that mapping has never been
+exercised against real data. Check the first one in DebugView rather than
+assuming the revenue lands.
 
 If you point Google Ads at this property, choose which key events count as
 conversion actions there rather than assuming all of them should. `sign_up` and


### PR DESCRIPTION
Follow-up to #3291 and #3294. Docs-only.

The deploy landed, so I checked the property and starred what GA4 would now let me.

## The funnel is live

GA4 has gone from **7 event names — all Google's own auto-collected ones — to 16**. Everything the code emits is arriving:

`sign_up`, `signup_started`, `workspace_created`, `monitor_created`, `teammate_invited`, `cta_get_started`, `cta_request_demo`, `page_view_pricing`, `page_view_demo`.

`sign_up` in particular is confirmed flowing, which also settles the concern I raised in #3291 about the conversion firing into a redirect — the `sendBeacon` survives it.

I also verified on the live marketing site that the code half deployed cleanly: `window.oneUptimeTrackMeetingBooked` is defined and called, and all three duplicate emissions (`gtag('event','demo_request')`, the `demo_booked` push, and the `meeting_booked` gtag mirror) are gone.

## Starred

`workspace_created`, `monitor_created`, `teammate_invited` — these could not be starred before, because GA4 only offers the star for events it has already received.

Left `signup_started` deliberately unstarred: it marks a submission *attempt*, not a completed signup, so as a key event it would inflate conversions against `sign_up`.

## Still not starrable

`subscription_upgraded`, `subscription_downgraded` and `meeting_booked` have not fired — they need a real plan change or demo booking. Star each the first time it appears.

`subscription_upgraded` is the one worth checking in DebugView when it first arrives: it is the only event carrying `value` and `currency`, and that mapping has never been exercised against real data. The tag config is right, but "the config looks right" is exactly what was true of this whole setup before.

## A note on verifying deploys here

The app is now code-split — the dashboard entry chunk is 391 KB where it used to be 11.5 MB — so grepping the bundle for event names gives false negatives. `monitor_created` and `teammate_invited` are absent from the entry chunk yet demonstrably reached GA4. Trust what the property received, not what the bundle contains.
