### PR TITLE
fix(telemetry): repair OtelTracesDropFilterDeferral test after LLM cost changes

### DIFF
--- a/App/Tests/Telemetry/OtelTracesDropFilterDeferral.test.ts
+++ b/App/Tests/Telemetry/OtelTracesDropFilterDeferral.test.ts
@@ -18,6 +18,7 @@ import TraceDropFilterService, {
 } from "../../FeatureSet/Telemetry/Services/TraceDropFilterService";
 import TraceScrubRuleService from "../../FeatureSet/Telemetry/Services/TraceScrubRuleService";
 import TracePipelineService from "../../FeatureSet/Telemetry/Services/TracePipelineService";
+import LlmModelPriceService from "../../FeatureSet/Telemetry/Services/LlmModelPriceService";
 import { compileFilter } from "../../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
 import ExceptionUtil from "../../FeatureSet/Telemetry/Utils/Exception";
 import TraceDropFilter from "Common/Models/DatabaseModels/TraceDropFilter";
@@ -107,6 +108,7 @@ const EXPECTED_SPAN_ROW_KEY_ORDER: Array<string> = [
   "llmOutputTokens",
   "llmTotalTokens",
   "llmCost",
+  "llmConversationId",
   "retentionDate",
 ];
 
@@ -240,6 +242,17 @@ function setupIngestMocks(
     .mockResolvedValue([] as any);
   jest
     .spyOn(TracePipelineService, "loadPipelines")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue([] as any);
+  /*
+   * Ingest loads project LLM price overrides alongside the drop/scrub/pipeline
+   * rules in the same Promise.all. Without this mock the real loader hits the
+   * database, the Promise.all rejects, and the catch resets EVERY rule set
+   * (drop filters included) to empty — silently disabling the drop filters
+   * this suite is asserting on.
+   */
+  jest
+    .spyOn(LlmModelPriceService, "loadModelPrices")
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .mockResolvedValue([] as any);
   jest


### PR DESCRIPTION
## Problem

The **App Test** job on master was failing (and would keep failing after the newest telemetry commits).

Two regressions in `App/Tests/Telemetry/OtelTracesDropFilterDeferral.test.ts`:

1. **Golden key order stale.** The conversation-grouping change added an `llmConversationId` column to the Span model between `llmCost` and `retentionDate`, but the test's `EXPECTED_SPAN_ROW_KEY_ORDER` array wasn't updated → the *'kept row carries the historical field order'* assertion failed. (This is the failure seen in the last completed master run.)

2. **Missing mock silently disables drop filters.** The per-project LLM pricing-overrides change added `LlmModelPriceService.loadModelPrices(projectId)` to the same `Promise.all` that loads drop/scrub/pipeline rules in `OtelTracesIngestService`. `setupIngestMocks` didn't mock it, so the real loader ran with no database, the `Promise.all` rejected, and the `catch` reset **every** rule set (drop filters included) to empty — silently disabling the drop filters the four drop/deferral tests assert on.

## Fix

- Add `llmConversationId` to the golden `EXPECTED_SPAN_ROW_KEY_ORDER`.
- Mock `LlmModelPriceService.loadModelPrices` in `setupIngestMocks`.

## Verification

- Target file: 8/8 pass.
- Full `Tests/Telemetry/` folder: 56 suites, 800 tests pass.
- Full App suite: 9958 tests pass (the only remaining suite-load failures are a local-only `isolated-vm` native-module mismatch, unrelated to this change and green in CI).