### PR TITLE
fix(telemetry): fix Compile job — tsc errors under exactOptionalPropertyTypes

### DIFF
--- a/App/Tests/Telemetry/LlmModelPriceService.test.ts
+++ b/App/Tests/Telemetry/LlmModelPriceService.test.ts
@@ -76,9 +76,20 @@ function priceRow(
   outputPrice: number | undefined,
 ): LlmModelPriceModel {
   const row: LlmModelPriceModel = new LlmModelPriceModel();
-  row.modelPrefix = modelPrefix;
-  row.inputPricePerMillionTokensInUSD = inputPrice;
-  row.outputPricePerMillionTokensInUSD = outputPrice;
+  /*
+   * Assign only when defined: under exactOptionalPropertyTypes an optional
+   * column cannot be assigned an explicit `undefined`. Leaving it unset is
+   * exactly the "missing price" state the skip-invalid-rows cases exercise.
+   */
+  if (modelPrefix !== undefined) {
+    row.modelPrefix = modelPrefix;
+  }
+  if (inputPrice !== undefined) {
+    row.inputPricePerMillionTokensInUSD = inputPrice;
+  }
+  if (outputPrice !== undefined) {
+    row.outputPricePerMillionTokensInUSD = outputPrice;
+  }
   return row;
 }
 

--- a/Common/Server/Services/LlmModelPriceService.ts
+++ b/Common/Server/Services/LlmModelPriceService.ts
@@ -63,8 +63,17 @@ export class Service extends DatabaseService<Model> {
     // Same string-arrival path as onBeforeCreate: coerce, validate, write back.
     const newPrefix: unknown = updateBy.data.modelPrefix as unknown;
 
+    /*
+     * The validated prefix is held in a string-typed local because the
+     * model's update-data field type is `string | (() => string)` (it
+     * allows the deferred function form), so reading it back below would
+     * otherwise not narrow to the plain string throwIfDuplicatePrefix wants.
+     */
+    let validatedPrefix: string | undefined = undefined;
+
     if (newPrefix !== undefined && newPrefix !== null) {
-      updateBy.data.modelPrefix = this.validateModelPrefix(newPrefix);
+      validatedPrefix = this.validateModelPrefix(newPrefix);
+      updateBy.data.modelPrefix = validatedPrefix;
     }
 
     const newInputPrice: unknown = updateBy.data
@@ -88,7 +97,7 @@ export class Service extends DatabaseService<Model> {
     }
 
     // Renaming a prefix must not collide with another entry of the project.
-    if (updateBy.data.modelPrefix) {
+    if (validatedPrefix) {
       const itemsToUpdate: Array<Model> = await this.findBy({
         query: updateBy.query,
         skip: 0,
@@ -109,7 +118,7 @@ export class Service extends DatabaseService<Model> {
 
         await this.throwIfDuplicatePrefix({
           projectId: item.projectId,
-          modelPrefix: updateBy.data.modelPrefix,
+          modelPrefix: validatedPrefix,
           excludeId: item.id || undefined,
         });
       }


### PR DESCRIPTION
## Problem

The **Compile** job (compile-app, compile-common, compile-mobile-app) — and the **Build** / **Push Test Images** jobs that cascade from it — were red on master. `tsc` is stricter than the ts-jest transpile the test suites run under, so two type errors only surfaced in Compile:

1. **`Common/Server/Services/LlmModelPriceService.ts:112` (TS2322)** — in `onBeforeUpdate`, the validated `modelPrefix` was read back off `updateBy.data`, whose field type is `string | (() => string)` (the deferred-function query form), so it would not narrow to the plain `string` that `throwIfDuplicatePrefix` expects. Introduced by the per-project pricing-overrides feature (commit 482ef5ad06). Fixed by capturing the validated prefix in a string-typed local and using it for both the collision guard and the duplicate check.

2. **`App/Tests/Telemetry/LlmModelPriceService.test.ts` (TS2412)** — the `priceRow` helper assigned `T | undefined` values straight onto optional model columns, which `exactOptionalPropertyTypes` rejects. Fixed by assigning each column only when defined; leaving it unset is exactly the 'missing price' state the skip-invalid-rows cases exercise.

## Verification
- `cd Common && npx tsc` → exit 0, 0 errors
- `cd App && npx tsc` → exit 0, 0 errors
- `LlmModelPriceService.test.ts` → 16/16 pass
- eslint clean on both files