### PR TITLE
refactor(Telemetry): publish LLM budget spend as metrics; Metrics monitors own alerting

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Llm/Budgets.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Llm/Budgets.tsx
@@ -8,8 +8,6 @@ import Pill from "Common/UI/Components/Pill/Pill";
 import { Green, Red } from "Common/Types/BrandColors";
 import LlmCostBudget from "Common/Models/DatabaseModels/LlmCostBudget";
 import Service from "Common/Models/DatabaseModels/Service";
-import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
-import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
 import ProjectUtil from "Common/UI/Utils/Project";
 import React, { FunctionComponent, ReactElement } from "react";
 
@@ -44,14 +42,13 @@ const LlmBudgetsPage: FunctionComponent<PageComponentProps> = (
       cardProps={{
         title: "LLM Cost Budgets",
         description:
-          "Daily USD budgets for LLM spend. A worker sums each UTC day's LLM span cost and raises alerts at the warning threshold and at 100%.",
+          "Daily USD budgets for LLM spend. Every 15 minutes a worker sums the UTC day's LLM span cost and publishes the oneuptime.llm.budget.spend.usd and oneuptime.llm.budget.percent.used metrics. Alert with a Metrics monitor (e.g. percent used >= 80) filtered by the oneuptime.llm.budget.id attribute, with a 30-minute rolling window.",
       }}
       noItemsMessage={"No LLM cost budgets found."}
       formSteps={[
         { title: "Basic Info", id: "basic-info" },
         { title: "Budget", id: "budget" },
         { title: "Scope", id: "scope" },
-        { title: "Alerting", id: "alerting" },
       ]}
       formFields={[
         {
@@ -87,17 +84,8 @@ const LlmBudgetsPage: FunctionComponent<PageComponentProps> = (
           fieldType: FormFieldSchemaType.Number,
           required: true,
           placeholder: "100",
-          description: "Daily budget in USD, evaluated over the UTC day.",
-        },
-        {
-          field: { warningThresholdPercent: true },
-          title: "Warning Threshold (%)",
-          stepId: "budget",
-          fieldType: FormFieldSchemaType.Number,
-          required: false,
-          placeholder: "80",
           description:
-            "Raise a warning alert at this percent of the budget (1-99). A breach alert always fires at 100%.",
+            "Daily budget in USD, evaluated over the UTC day. Spend and percent-used are published as metrics every 15 minutes — alert on them with a Metrics monitor.",
         },
         {
           field: { service: true },
@@ -133,34 +121,6 @@ const LlmBudgetsPage: FunctionComponent<PageComponentProps> = (
           description:
             "Only count spend from this model (matches the span's requested model exactly). Leave empty to count every model.",
         },
-        {
-          field: { alertSeverity: true },
-          title: "Alert Severity (optional)",
-          stepId: "alerting",
-          description:
-            "Severity of the alerts created when this budget crosses a threshold.",
-          fieldType: FormFieldSchemaType.Dropdown,
-          required: false,
-          dropdownModal: {
-            type: AlertSeverity,
-            labelField: "name",
-            valueField: "_id",
-          },
-        },
-        {
-          field: { onCallDutyPolicies: true },
-          title: "On-Call Duty Policies (optional)",
-          stepId: "alerting",
-          description:
-            "On-call duty policies to execute when this budget raises an alert.",
-          fieldType: FormFieldSchemaType.MultiSelectDropdown,
-          required: false,
-          dropdownModal: {
-            type: OnCallDutyPolicy,
-            labelField: "name",
-            valueField: "_id",
-          },
-        },
       ]}
       filters={[
         {
@@ -175,7 +135,6 @@ const LlmBudgetsPage: FunctionComponent<PageComponentProps> = (
         },
       ]}
       selectMoreFields={{
-        warningThresholdPercent: true,
         llmSystem: true,
         llmModel: true,
         currentDaySpendInUSD: true,

--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-agent-circuit-breaker.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-agent-circuit-breaker.md
@@ -2,14 +2,14 @@
 
 AI agents rarely fail by crashing. They fail by _continuing_ — retrying a broken tool in a loop, re-planning the same step forever, or fanning out sub-agents — while every iteration bills more tokens. This guide shows how to build an **async circuit breaker** with pieces OneUptime already gives you:
 
-1. A **trip-wire signal** — an [LLM cost budget](/docs/telemetry/ai-llm-observability) alert or a [Traces monitor](/docs/monitor/traces-monitor) that recognizes loop behavior in your `gen_ai.*` spans.
+1. A **trip-wire signal** — a [Metrics monitor](/docs/monitor/metrics-monitor) on the [LLM cost budget](/docs/telemetry/ai-llm-observability) metrics, or a [Traces monitor](/docs/monitor/traces-monitor) that recognizes loop behavior in your `gen_ai.*` spans.
 2. A **Workflow** triggered by that alert.
 3. An **outbound webhook** from the workflow to a kill endpoint _you_ own, which stops the runaway runner.
 
 ```mermaid
 flowchart LR
     A[Agent emits<br/>gen_ai.* spans] --> B[OneUptime<br/>OTLP ingest]
-    B --> C{Trip-wire:<br/>cost budget or<br/>Traces monitor}
+    B --> C{Trip-wire:<br/>budget metrics monitor<br/>or Traces monitor}
     C -->|Alert created| D[Workflow:<br/>Alert On Create]
     D --> E[API Post to your<br/>kill endpoint]
     E --> F[Your runner aborts<br/>or pauses the agent]
@@ -30,21 +30,26 @@ The circuit breaker here is **gateway-agnostic**. It watches the OpenTelemetry t
 
 Both options end the same way: an **alert** is created in OneUptime, which is what triggers the workflow. You can wire up both at once — the workflow doesn't care which one fired.
 
-### Option A: LLM cost budget alert
+### Option A: Metrics monitor on the budget metrics
 
-A runaway agent's most reliable symptom is spend. The **AI / LLM → Budgets** tab lets you set a daily USD limit with a warning alert (default 80%) and a breach alert (100%). Budgets are evaluated every 15 minutes against the day's LLM span cost — SDK-reported or [computed at ingest](/docs/telemetry/ai-llm-observability), so it works even if your instrumentation doesn't report cost.
+A runaway agent's most reliable symptom is spend. The **AI / LLM → Budgets** tab lets you set a daily USD limit; every 15 minutes a worker sums the day's LLM span cost — SDK-reported or [computed at ingest](/docs/telemetry/ai-llm-observability), so it works even if your instrumentation doesn't report cost — and publishes it as two gauge metrics:
 
-For circuit breaking, scope the budget so the alert identifies _what to kill_:
+- `oneuptime.llm.budget.spend.usd` — the day's spend in USD
+- `oneuptime.llm.budget.percent.used` — spend as a percent of the daily limit
 
-- Create one budget **per agent's telemetry service** (for example `agent-support-bot`), not just a project-wide one.
-- Name the budget after the runner it guards — the budget name is embedded in the alert title, and your kill endpoint can route on it.
+Create a [Metrics monitor](/docs/monitor/metrics-monitor) on `oneuptime.llm.budget.percent.used`:
 
-The alerts arrive with predictable titles you can filter on in the workflow:
+- **Attribute filter**: `oneuptime.llm.budget.id` = your budget's id (shown on the budget's row via **View ID**). Use the id, not the name — renaming the budget re-labels the series and would silently detach a name-filtered monitor.
+- **Rolling time**: **30 minutes**. Each budget publishes one point every 15 minutes; the 1-minute default window would find an empty series between sweeps and flap the alert — which for a breaker means tripping it once per sweep instead of once per episode.
+- **Criteria 1**: value **Greater Than or Equal To** `80` → create a warning-severity alert.
+- **Criteria 2**: value **Greater Than or Equal To** `100` → create a critical alert — this is the one that trips the breaker.
 
-- Warning: `LLM cost budget warning: <budget name>`
-- Breach: `LLM cost budget exceeded: <budget name>`
+For circuit breaking, scope things so the alert identifies _what to kill_:
 
-A good pattern is warning → page a human (via the alert's on-call policy), breach → trip the breaker.
+- Create one budget **per agent's telemetry service** (for example `agent-support-bot`), not just a project-wide one, and one monitor per budget (or one monitor grouped by the `oneuptime.llm.budget.id` attribute).
+- Put the runner's name in the criteria's **alert title** (for example `LLM budget exceeded: agent-support-bot`) — your kill endpoint routes on it.
+
+A good pattern is 80% → page a human (via the alert's on-call policy), 100% → trip the breaker.
 
 ### Option B: Traces monitor on loop behavior
 
@@ -65,10 +70,10 @@ Two variations worth knowing:
 
 ### Detection latency, honestly stated
 
-| Signal                                         | Typical time to alert              |
-| ---------------------------------------------- | ---------------------------------- |
-| Traces monitor, 1-minute interval, 120s window | ~1–3 minutes                       |
-| Budget warning / breach                        | up to ~15 minutes (worker cadence) |
+| Signal                                         | Typical time to alert                               |
+| ---------------------------------------------- | --------------------------------------------------- |
+| Traces monitor, 1-minute interval, 120s window | ~1–3 minutes                                        |
+| Budget metrics monitor                         | up to ~15 minutes (worker cadence) + monitor interval |
 
 ## Step 2 — Build the kill endpoint (your side)
 
@@ -95,8 +100,8 @@ app.post("/circuit-breaker", (req, res) => {
 
   const alertTitle: string = req.body.alertTitle ?? "";
 
-  // Budget names / monitor names map to runners, e.g.
-  // "LLM cost budget exceeded: agent-support-bot" -> "agent-support-bot"
+  // Your monitor criteria's alert titles map to runners, e.g.
+  // "LLM budget exceeded: agent-support-bot" -> "agent-support-bot"
   const runner: string = alertTitle.split(": ").pop() ?? "unknown";
 
   tripped.add(runner); // your run loop checks this set
@@ -128,7 +133,7 @@ You only want the breaker tripped by your trip-wire alerts, not every alert in t
 
 - **Left**: the trigger's `model.title` — inserted with the picker, it reads `{{local.components.alert-on-create-1.returnValues.model.title}}`
 - **Operator**: `contains`
-- **Right**: `LLM cost budget exceeded` (Option A) — or your Traces monitor's alert title (Option B)
+- **Right**: the alert title you set in the budget monitor's criteria, for example `LLM budget exceeded` (Option A) — or your Traces monitor's alert title (Option B)
 
 To react to several trip-wires, chain If / Else blocks from the **No** branch, or standardize your alert titles so one `contains` match covers them all.
 
@@ -165,14 +170,14 @@ Connect the API block's **Error** port to a **Slack** (or Email) block: a circui
 
 ## Step 4 — Test it
 
-1. **Dry-run the workflow**: alerts can be created by hand (**Alerts → Create Alert**). Create one titled `LLM cost budget exceeded: test`, then check the workflow fired under **Workflows → Runs & Logs**, and that your endpoint received the post.
-2. **Test the real signal**: create a scoped budget with a tiny limit (for example $0.01) against a dev service and let your agent run — you should see the alert, the workflow run, and the breaker trip end-to-end. For Option B, point a test agent at a stubbed failing tool and watch the loop trip the traces monitor.
+1. **Dry-run the workflow**: alerts can be created by hand (**Alerts → Create Alert**). Create one titled `LLM budget exceeded: test`, then check the workflow fired under **Workflows → Runs & Logs**, and that your endpoint received the post.
+2. **Test the real signal**: create a scoped budget with a tiny limit (for example $0.01) against a dev service, point your monitor at its `oneuptime.llm.budget.percent.used` series, and let your agent run — you should see the metric cross 100, the alert, the workflow run, and the breaker trip end-to-end. For Option B, point a test agent at a stubbed failing tool and watch the loop trip the traces monitor.
 3. **Verify idempotency** by firing the alert twice.
 
 ## Alert lifecycle caveats
 
-- Budget alerts fire **at most once per UTC day** per budget and kind (one warning, one breach), and only if no matching alert is still open — so the breaker trips once per bad day, not continuously. Resetting is a human decision on both sides: resolve the alert in OneUptime _and_ reset your breaker.
-- A Traces monitor keeps its alert open while the criteria stay met; the workflow triggers on **creation**, so you get one trip per episode.
+- The budget metrics reset at **UTC midnight** (a new day starts at 0% used), so a budget monitor's alert naturally resolves overnight and can fire again the next bad day. The workflow triggers on alert **creation**, so you get one trip per episode, not one per evaluation. Resetting is a human decision on both sides: resolve the alert in OneUptime _and_ reset your breaker.
+- A Traces monitor keeps its alert open while the criteria stay met; same creation-triggered semantics apply.
 - The workflow trigger fires for **every** new alert in the project — the If / Else filter is what keeps unrelated alerts from tripping the breaker. Don't skip it.
 
 ## Where to read next

--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-gateways.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-gateways.md
@@ -186,6 +186,6 @@ Nothing showing up?
 
 Once gateway spans land as `gen_ai.*` traces, everything in OneUptime's AI observability works on them:
 
-- **[Daily cost budgets](/docs/telemetry/ai-llm-observability)** across every app behind the gateway — with warning and breach alerts.
+- **[Daily cost budgets](/docs/telemetry/ai-llm-observability)** across every app behind the gateway — published as metrics your monitors alert on.
 - **[Traces monitors](/docs/monitor/traces-monitor)** on span patterns, like a runaway agent calling the same tool in a loop.
 - **[Async circuit breaking](/docs/telemetry/ai-agent-circuit-breaker)** — chain those alerts to a Workflow that calls your infrastructure to stop a runaway agent, without putting anything new in the request path.

--- a/App/FeatureSet/Docs/Content/en/telemetry/ai-llm-observability.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/ai-llm-observability.md
@@ -106,7 +106,7 @@ Open **AI / LLM** in the navigation bar (under Observability):
 
 - **Overview** — total calls, input/output tokens, cost, and error rate for the last 7 days, plus the most recent calls.
 - **LLM Calls** — a filterable list of every LLM, embedding, agent and tool call. Filter by provider, model, operation or service. Click a call to open it in the trace viewer.
-- **Budgets** — daily cost budgets with warning and breach alerts (see [Daily cost budgets](#daily-cost-budgets) below).
+- **Budgets** — daily cost budgets published as metrics for monitors to alert on (see [Daily cost budgets](#daily-cost-budgets) below).
 - Each span has an **AI / LLM** tab/panel with the model, token counts, cost, request parameters, and the rendered prompt & completion.
 
 ## Dashboards and alerts
@@ -118,16 +118,20 @@ Because GenAI metrics arrive as ordinary OpenTelemetry metrics, you can:
 
 ## Daily cost budgets
 
-The **AI / LLM** section has a **Budgets** tab. Each budget sets a daily USD limit, evaluated over the UTC day. Every 15 minutes a background worker sums the day's LLM span cost (SDK-reported or computed), records the current spend on the budget, and raises:
+The **AI / LLM** section has a **Budgets** tab. Each budget sets a daily USD limit, evaluated over the UTC day. Every 15 minutes a background worker sums the day's LLM span cost (SDK-reported or computed), records the current spend on the budget, and publishes two gauge metrics:
 
-- a **warning alert** at a configurable threshold (default 80%), and
-- a **breach alert** at 100%
+| Metric | Meaning |
+| --- | --- |
+| `oneuptime.llm.budget.spend.usd` | The day's spend so far, in USD |
+| `oneuptime.llm.budget.percent.used` | Spend as a percent of the daily limit |
 
-— each at most once per UTC day. Alerts carry a configurable severity and can trigger your on-call duty policies.
+Both carry `oneuptime.llm.budget.id` and `oneuptime.llm.budget.name` attributes (plus the budget's service/provider/model scope when set), so one metric series cleanly separates into one line per budget. Filter monitors by **`oneuptime.llm.budget.id`** — it is stable; the name attribute is convenient for chart labels but changes if you rename the budget, which would silently detach a name-filtered monitor.
+
+**Alerting is a [Metrics Monitor](/docs/monitor/metrics-monitor) on those metrics.** For the classic 80%/100% pattern, create a monitor on `oneuptime.llm.budget.percent.used`, filter by `oneuptime.llm.budget.id`, and add two criteria — value `>= 80` creating a warning-severity alert, and value `>= 100` creating a critical one, attached to your on-call policy. **Set the monitor's rolling time to 30 minutes**: each budget publishes one point every 15 minutes, so the 1-minute default window would find an empty series between sweeps and flap the alert. Because it's an ordinary metric, everything monitors can do applies: formulas, anomaly detection against learned baselines, dashboards charting spend across budgets.
 
 Budgets can be scoped to a telemetry service, an LLM provider (the `gen_ai` provider name), or an exact model — or left project-wide. Multiple budgets can coexist, for example a project-wide budget plus a stricter one for an expensive model.
 
-Budget alerts can do more than notify: chain one to a Workflow that calls a webhook in your infrastructure to stop a runaway agent — see [Circuit-Breaking Runaway AI Agents](/docs/telemetry/ai-agent-circuit-breaker).
+Budget monitors can do more than notify: chain one to a Workflow that calls a webhook in your infrastructure to stop a runaway agent — see [Circuit-Breaking Runaway AI Agents](/docs/telemetry/ai-agent-circuit-breaker).
 
 ## Privacy & redaction
 

--- a/App/FeatureSet/Workers/Jobs/Llm/EvaluateLlmCostBudgets.ts
+++ b/App/FeatureSet/Workers/Jobs/Llm/EvaluateLlmCostBudgets.ts
@@ -9,18 +9,19 @@ import logger from "Common/Server/Utils/Logger";
 
 /**
  * LLM cost budget watch loop: sums the UTC day's LLM span spend for every
- * enabled budget and raises warning (default 80%) and breach (100%) alerts.
+ * enabled budget, stamps it on the budget row, and publishes the
+ * oneuptime.llm.budget.* gauge metrics that Metrics monitors alert on.
  */
 const SWEEP_TIMEOUT_MINUTES: number = 10;
 
 /*
  * The job timeout does NOT prevent overlap — runJobWithTimeout is a
  * Promise.race with no cancellation, so a sweep body that outlives its
- * timeout keeps running while the queue schedules the next tick. The
- * budget alert dedup is read-then-write (stamps snapshotted at sweep start),
- * so two interleaved sweeps could double-page on-call. Serialize sweeps with
- * a Redis lock, same as Slo:EvaluateSlos. The lock timeout stays under the
- * 15-minute tick so a crashed holder self-heals within one tick.
+ * timeout keeps running while the queue schedules the next tick. Two
+ * interleaved sweeps would publish duplicate metric points into the budget
+ * series monitors evaluate. Serialize sweeps with a Redis lock, same as
+ * Slo:EvaluateSlos. The lock timeout stays under the 15-minute tick so a
+ * crashed holder self-heals within one tick.
  */
 const SWEEP_LOCK_KEY: string = "Llm:EvaluateLlmCostBudgets";
 const SWEEP_LOCK_NAMESPACE: string = "Workers.Cron";

--- a/Common/Models/DatabaseModels/LlmCostBudget.ts
+++ b/Common/Models/DatabaseModels/LlmCostBudget.ts
@@ -1,5 +1,3 @@
-import AlertSeverity from "./AlertSeverity";
-import OnCallDutyPolicy from "./OnCallDutyPolicy";
 import Project from "./Project";
 import Service from "./Service";
 import User from "./User";
@@ -21,15 +19,7 @@ import IconProp from "../../Types/Icon/IconProp";
 import ObjectID from "../../Types/ObjectID";
 import Permission from "../../Types/Permission";
 import { PlanType } from "../../Types/Billing/SubscriptionPlan";
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  JoinTable,
-  ManyToMany,
-  ManyToOne,
-} from "typeorm";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
 
 /*
@@ -80,7 +70,7 @@ const decimalTransformer: ValueTransformer = {
   pluralName: "LLM Cost Budgets",
   icon: IconProp.CurrencyDollar,
   tableDescription:
-    "Daily USD spend budgets for LLM / GenAI telemetry. A worker sums the day's LLM span cost and raises alerts when spend crosses the warning and breach thresholds.",
+    "Daily USD spend budgets for LLM / GenAI telemetry. A worker sums the day's LLM span cost and publishes it as the oneuptime.llm.budget.* metrics, so Metrics monitors, dashboards and anomaly detection can act on spend.",
 })
 @TableAccessControl({
   create: [
@@ -320,7 +310,7 @@ export default class LlmCostBudget extends BaseModel {
     canReadOnRelationQuery: true,
     title: "Daily Budget (USD)",
     description:
-      "Daily LLM spend budget in USD, evaluated over the UTC day. Alerts fire at the warning threshold and at 100%.",
+      "Daily LLM spend budget in USD, evaluated over the UTC day. Spend and percent-used are published as metrics for monitors to alert on.",
   })
   @Column({
     nullable: false,
@@ -328,44 +318,6 @@ export default class LlmCostBudget extends BaseModel {
     transformer: decimalTransformer,
   })
   public dailyBudgetInUSD?: number = undefined;
-
-  @ColumnAccessControl({
-    create: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.CreateProjectLlmCostBudget,
-    ],
-    read: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
-      Permission.ReadProjectLlmCostBudget,
-    ],
-    update: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.EditProjectLlmCostBudget,
-    ],
-  })
-  @TableColumn({
-    required: true,
-    type: TableColumnType.Number,
-    title: "Warning Threshold (%)",
-    description:
-      "Percentage of the daily budget at which a warning alert is raised (1-99). A breach alert always fires at 100%.",
-    defaultValue: 80,
-    isDefaultValueColumn: true,
-  })
-  @Column({
-    type: ColumnType.Number,
-    nullable: false,
-    default: 80,
-  })
-  public warningThresholdPercent?: number = undefined;
 
   @ColumnAccessControl({
     create: [
@@ -525,136 +477,6 @@ export default class LlmCostBudget extends BaseModel {
   public llmModel?: string = undefined;
 
   @ColumnAccessControl({
-    create: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.CreateProjectLlmCostBudget,
-    ],
-    read: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
-      Permission.ReadProjectLlmCostBudget,
-    ],
-    update: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.EditProjectLlmCostBudget,
-    ],
-  })
-  @TableColumn({
-    manyToOneRelationColumn: "alertSeverityId",
-    type: TableColumnType.Entity,
-    modelType: AlertSeverity,
-    title: "Alert Severity",
-    description:
-      "Severity of the alerts created when this budget crosses a threshold. Defaults to the project's lowest-order severity when unset.",
-  })
-  @ManyToOne(
-    () => {
-      return AlertSeverity;
-    },
-    {
-      eager: false,
-      nullable: true,
-      onDelete: "SET NULL",
-      orphanedRowAction: "nullify",
-    },
-  )
-  @JoinColumn({ name: "alertSeverityId" })
-  public alertSeverity?: AlertSeverity = undefined;
-
-  @ColumnAccessControl({
-    create: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.CreateProjectLlmCostBudget,
-    ],
-    read: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
-      Permission.ReadProjectLlmCostBudget,
-    ],
-    update: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.EditProjectLlmCostBudget,
-    ],
-  })
-  @Index()
-  @TableColumn({
-    type: TableColumnType.ObjectID,
-    required: false,
-    title: "Alert Severity ID",
-    description:
-      "ID of the Alert Severity of the alerts created by this budget.",
-  })
-  @Column({
-    type: ColumnType.ObjectID,
-    nullable: true,
-    transformer: ObjectID.getDatabaseTransformer(),
-  })
-  public alertSeverityId?: ObjectID = undefined;
-
-  @ColumnAccessControl({
-    create: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.CreateProjectLlmCostBudget,
-    ],
-    read: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
-      Permission.ReadProjectLlmCostBudget,
-    ],
-    update: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.EditProjectLlmCostBudget,
-    ],
-  })
-  @TableColumn({
-    required: false,
-    type: TableColumnType.EntityArray,
-    modelType: OnCallDutyPolicy,
-    title: "On-Call Duty Policies",
-    description:
-      "On-call duty policies to execute when this budget raises an alert.",
-  })
-  @ManyToMany(
-    () => {
-      return OnCallDutyPolicy;
-    },
-    { eager: false },
-  )
-  @JoinTable({
-    name: "LlmCostBudgetOnCallDutyPolicy",
-    inverseJoinColumn: {
-      name: "onCallDutyPolicyId",
-      referencedColumnName: "_id",
-    },
-    joinColumn: {
-      name: "llmCostBudgetId",
-      referencedColumnName: "_id",
-    },
-  })
-  public onCallDutyPolicies?: Array<OnCallDutyPolicy> = undefined;
-
-  @ColumnAccessControl({
     create: [],
     read: [
       Permission.ProjectOwner,
@@ -708,60 +530,6 @@ export default class LlmCostBudget extends BaseModel {
     nullable: true,
   })
   public spendLastEvaluatedAt?: Date = undefined;
-
-  @ColumnAccessControl({
-    create: [],
-    read: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
-      Permission.ReadProjectLlmCostBudget,
-    ],
-    update: [],
-  })
-  @TableColumn({
-    type: TableColumnType.Date,
-    required: false,
-    title: "Last Warning Alert Created At",
-    description:
-      "The last time this budget raised a warning-threshold alert. Computed by the worker.",
-  })
-  @Column({
-    type: ColumnType.Date,
-    nullable: true,
-  })
-  public lastWarningAlertCreatedAt?: Date = undefined;
-
-  @ColumnAccessControl({
-    create: [],
-    read: [
-      Permission.ProjectOwner,
-      Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
-      Permission.ReadProjectLlmCostBudget,
-    ],
-    update: [],
-  })
-  @TableColumn({
-    type: TableColumnType.Date,
-    required: false,
-    title: "Last Breach Alert Created At",
-    description:
-      "The last time this budget raised a 100% breach alert. Computed by the worker.",
-  })
-  @Column({
-    type: ColumnType.Date,
-    nullable: true,
-  })
-  public lastBreachAlertCreatedAt?: Date = undefined;
 
   @ColumnAccessControl({
     create: [],

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788500000000-RemoveLlmCostBudgetAlertColumns.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788500000000-RemoveLlmCostBudgetAlertColumns.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * LLM cost budgets no longer alert directly: the evaluation worker publishes
+ * spend / percent-used as oneuptime.llm.budget.* metrics and Metrics monitors
+ * own the alerting. Drop the alert-configuration columns and the on-call
+ * join table the direct-alerting design used.
+ */
+export class RemoveLlmCostBudgetAlertColumns1788500000000
+  implements MigrationInterface
+{
+  public name: string = "RemoveLlmCostBudgetAlertColumns1788500000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP CONSTRAINT "FK_dfe6c27c42564e7422d26c8b1ed"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_dfe6c27c42564e7422d26c8b1e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP COLUMN "warningThresholdPercent"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP COLUMN "alertSeverityId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP COLUMN "lastWarningAlertCreatedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" DROP COLUMN "lastBreachAlertCreatedAt"`,
+    );
+    /*
+     * The ManyToMany junction table is orphaned once the relation is gone;
+     * typeorm's generator does not emit a drop for it, so do it here.
+     */
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "LlmCostBudgetOnCallDutyPolicy"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "LlmCostBudgetOnCallDutyPolicy" ("llmCostBudgetId" uuid NOT NULL, "onCallDutyPolicyId" uuid NOT NULL, CONSTRAINT "PK_1312da5439a5bc0ba61e5cbf005" PRIMARY KEY ("llmCostBudgetId", "onCallDutyPolicyId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d05f7b557fdd92c4c9ff42e910" ON "LlmCostBudgetOnCallDutyPolicy" ("llmCostBudgetId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_76020c2c8f8f264128f6adfd89" ON "LlmCostBudgetOnCallDutyPolicy" ("onCallDutyPolicyId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudgetOnCallDutyPolicy" ADD CONSTRAINT "FK_d05f7b557fdd92c4c9ff42e9107" FOREIGN KEY ("llmCostBudgetId") REFERENCES "LlmCostBudget"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudgetOnCallDutyPolicy" ADD CONSTRAINT "FK_76020c2c8f8f264128f6adfd899" FOREIGN KEY ("onCallDutyPolicyId") REFERENCES "OnCallDutyPolicy"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD "lastBreachAlertCreatedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD "lastWarningAlertCreatedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD "alertSeverityId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD "warningThresholdPercent" integer NOT NULL DEFAULT '80'`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_dfe6c27c42564e7422d26c8b1e" ON "LlmCostBudget" ("alertSeverityId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmCostBudget" ADD CONSTRAINT "FK_dfe6c27c42564e7422d26c8b1ed" FOREIGN KEY ("alertSeverityId") REFERENCES "AlertSeverity"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -538,6 +538,7 @@ import { AddMeasurements1788100000000 } from "./1788100000000-AddMeasurements";
 import { AddLlmCostBudget1788200000000 } from "./1788200000000-AddLlmCostBudget";
 import { AddLlmModelPrice1788300000000 } from "./1788300000000-AddLlmModelPrice";
 import { AddMarketingConversionAttribution1788400000000 } from "./1788400000000-AddMarketingConversionAttribution";
+import { RemoveLlmCostBudgetAlertColumns1788500000000 } from "./1788500000000-RemoveLlmCostBudgetAlertColumns";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1084,4 +1085,5 @@ export default [
   AddLlmCostBudget1788200000000,
   AddLlmModelPrice1788300000000,
   AddMarketingConversionAttribution1788400000000,
+  RemoveLlmCostBudgetAlertColumns1788500000000,
 ];

--- a/Common/Server/Services/LlmCostBudgetService.ts
+++ b/Common/Server/Services/LlmCostBudgetService.ts
@@ -1,44 +1,23 @@
-import Alert from "../../Models/DatabaseModels/Alert";
-import AlertStateTimeline from "../../Models/DatabaseModels/AlertStateTimeline";
 import Model from "../../Models/DatabaseModels/LlmCostBudget";
-import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
-import ObjectID from "../../Types/ObjectID";
 import CreateBy from "../Types/Database/CreateBy";
-import DeleteBy from "../Types/Database/DeleteBy";
-import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import UpdateBy from "../Types/Database/UpdateBy";
-import logger, { LogAttributes } from "../Utils/Logger";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
-import AlertService from "./AlertService";
-import AlertStateTimelineService from "./AlertStateTimelineService";
 import DatabaseService from "./DatabaseService";
 
 const BUDGET_ERROR_MESSAGE: string =
   "Daily budget must be a number greater than 0.";
-const WARNING_THRESHOLD_ERROR_MESSAGE: string =
-  "Warning threshold must be a whole-number percentage between 1 and 99.";
 
-// The two alert kinds a budget can raise, encoded into the alert fingerprint.
-export type LlmCostBudgetAlertKind = "warning" | "breach";
-
+/*
+ * Budgets do not fire alerts themselves: the evaluation worker publishes each
+ * budget's spend and percent-used as oneuptime.llm.budget.* metrics, and
+ * Metrics monitors own the alerting (thresholds, anomaly baselines, on-call
+ * routing). This service only guards the budget definition itself.
+ */
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
-  }
-
-  /*
-   * Deterministic fingerprint carried on Alerts created by a budget. The
-   * evaluation worker sets this as `seriesFingerprint` when it fires an
-   * alert, and lifecycle hooks use it to find (and resolve) those alerts when
-   * the budget goes away. Warning and breach are separate series so a breach
-   * still pages when the warning alert is already open.
-   */
-  public getBudgetAlertFingerprint(data: {
-    llmCostBudgetId: ObjectID;
-    kind: LlmCostBudgetAlertKind;
-  }): string {
-    return `llm-cost-budget:${data.llmCostBudgetId.toString()}:${data.kind}`;
   }
 
   @CaptureSpan()
@@ -57,15 +36,6 @@ export class Service extends DatabaseService<Model> {
       createBy.data.dailyBudgetInUSD,
     );
 
-    if (
-      createBy.data.warningThresholdPercent !== undefined &&
-      createBy.data.warningThresholdPercent !== null
-    ) {
-      createBy.data.warningThresholdPercent = this.validateWarningThreshold(
-        createBy.data.warningThresholdPercent,
-      );
-    }
-
     return {
       createBy,
       carryForward: null,
@@ -83,163 +53,10 @@ export class Service extends DatabaseService<Model> {
       updateBy.data.dailyBudgetInUSD = this.validateDailyBudget(newBudget);
     }
 
-    const newThreshold: unknown = updateBy.data
-      .warningThresholdPercent as unknown;
-
-    if (newThreshold !== undefined && newThreshold !== null) {
-      updateBy.data.warningThresholdPercent =
-        this.validateWarningThreshold(newThreshold);
-    }
-
     return {
       updateBy,
       carryForward: null,
     };
-  }
-
-  @CaptureSpan()
-  protected override async onBeforeDelete(
-    deleteBy: DeleteBy<Model>,
-  ): Promise<OnDelete<Model>> {
-    /*
-     * Resolve any open alert fired by the budgets being deleted — otherwise
-     * the alert (and its on-call escalations) stays open forever because the
-     * evaluation worker only touches budgets that still exist.
-     */
-    const itemsToDelete: Array<Model> = await this.findBy({
-      query: deleteBy.query,
-      limit: deleteBy.limit,
-      skip: deleteBy.skip,
-      select: {
-        _id: true,
-        projectId: true,
-      },
-      props: {
-        isRoot: true,
-      },
-    });
-
-    for (const item of itemsToDelete) {
-      if (!item.id || !item.projectId) {
-        continue;
-      }
-
-      try {
-        await this.resolveOpenAlertsForBudget({
-          llmCostBudgetId: item.id,
-          projectId: item.projectId,
-          rootCause:
-            "Alert auto-resolved because the LLM cost budget that created it was deleted.",
-        });
-      } catch (err) {
-        logger.error(
-          `Error resolving open alerts for LLM cost budget ${item.id?.toString()} before delete: ${err}`,
-          { projectId: item.projectId?.toString() } as LogAttributes,
-        );
-      }
-    }
-
-    return {
-      deleteBy,
-      carryForward: {
-        itemsToDelete: itemsToDelete,
-      },
-    };
-  }
-
-  /*
-   * Resolve all open Alerts carrying this budget's fingerprints (warning and
-   * breach) by appending a resolved AlertStateTimeline row. Mirrors
-   * ServiceLevelObjectiveBurnRateRuleService.resolveOpenAlertsForRule,
-   * including tolerating the benign same-state concurrency race.
-   */
-  @CaptureSpan()
-  public async resolveOpenAlertsForBudget(data: {
-    llmCostBudgetId: ObjectID;
-    projectId: ObjectID;
-    rootCause?: string | undefined;
-  }): Promise<void> {
-    const kinds: Array<LlmCostBudgetAlertKind> = ["warning", "breach"];
-
-    for (const kind of kinds) {
-      const fingerprint: string = this.getBudgetAlertFingerprint({
-        llmCostBudgetId: data.llmCostBudgetId,
-        kind: kind,
-      });
-
-      const openAlerts: Array<Alert> = await AlertService.findBy({
-        query: {
-          projectId: data.projectId,
-          seriesFingerprint: fingerprint,
-          currentAlertState: {
-            isResolvedState: false,
-          },
-        },
-        select: {
-          _id: true,
-          projectId: true,
-        },
-        skip: 0,
-        limit: LIMIT_PER_PROJECT,
-        props: {
-          isRoot: true,
-        },
-      });
-
-      if (openAlerts.length === 0) {
-        continue;
-      }
-
-      const resolvedStateId: ObjectID =
-        await AlertStateTimelineService.getResolvedStateIdForProject(
-          data.projectId,
-        );
-
-      for (const openAlert of openAlerts) {
-        try {
-          const alertStateTimeline: AlertStateTimeline =
-            new AlertStateTimeline();
-          alertStateTimeline.alertId = openAlert.id!;
-          alertStateTimeline.alertStateId = resolvedStateId;
-          alertStateTimeline.projectId = openAlert.projectId!;
-          alertStateTimeline.rootCause =
-            data.rootCause ||
-            "Alert auto-resolved because the LLM cost budget that created it is no longer active.";
-
-          try {
-            await AlertStateTimelineService.create({
-              data: alertStateTimeline,
-              props: {
-                isRoot: true,
-              },
-            });
-          } catch (err) {
-            /*
-             * Idempotent concurrency race: the evaluation worker and a
-             * lifecycle hook can both decide to resolve the same open alert
-             * near-simultaneously. The loser's onBeforeCreate dedupe throws
-             * this exact BadDataException. Treat as a no-op at debug level.
-             * Mirrors MonitorAlert.resolveOpenAlert.
-             */
-            if (
-              err instanceof BadDataException &&
-              err.message === "Alert state cannot be same as previous state."
-            ) {
-              logger.debug(
-                `${openAlert.id?.toString()} - Alert already in resolved state; skipping duplicate state timeline (concurrent race).`,
-              );
-            } else {
-              throw err;
-            }
-          }
-        } catch (err) {
-          logger.error(
-            `Error resolving open alert ${openAlert.id?.toString()} for LLM cost budget ${data.llmCostBudgetId?.toString()}: ${err}`,
-            { projectId: data.projectId?.toString() } as LogAttributes,
-          );
-        }
-      }
-    }
   }
 
   /*
@@ -247,7 +64,7 @@ export class Service extends DatabaseService<Model> {
    * Formik strings and neither ModelForm nor BaseModel.fromJSON coerces
    * Number/Decimal columns, so "100" reaches these hooks as a string — and
    * string comparison is lexicographic. Anything that is not a finite numeric
-   * string or number becomes NaN, which every caller below rejects.
+   * string or number becomes NaN, which the caller below rejects.
    */
   private normalizeNumericInput(value: unknown): number {
     if (typeof value === "string") {
@@ -270,25 +87,6 @@ export class Service extends DatabaseService<Model> {
     }
 
     return dailyBudgetInUSD;
-  }
-
-  private validateWarningThreshold(value: unknown): number {
-    const warningThresholdPercent: number = this.normalizeNumericInput(value);
-
-    /*
-     * The column is a Postgres integer, so a decimal that cleared only the
-     * range check would fail the INSERT with a raw driver error instead of
-     * this message. Mirrors ServiceLevelObjectiveService's percentage guard.
-     */
-    if (
-      !Number.isInteger(warningThresholdPercent) ||
-      warningThresholdPercent < 1 ||
-      warningThresholdPercent > 99
-    ) {
-      throw new BadDataException(WARNING_THRESHOLD_ERROR_MESSAGE);
-    }
-
-    return warningThresholdPercent;
   }
 }
 

--- a/Common/Server/Utils/Telemetry/LlmCostBudgetEvaluator.ts
+++ b/Common/Server/Utils/Telemetry/LlmCostBudgetEvaluator.ts
@@ -1,27 +1,25 @@
-import Alert from "../../../Models/DatabaseModels/Alert";
-import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
 import LlmCostBudget from "../../../Models/DatabaseModels/LlmCostBudget";
-import OnCallDutyPolicy from "../../../Models/DatabaseModels/OnCallDutyPolicy";
+import MetricType from "../../../Models/DatabaseModels/MetricType";
 import Span from "../../../Models/AnalyticsModels/Span";
+import { MetricPointType } from "../../../Models/AnalyticsModels/Metric";
 import AggregatedModel from "../../../Types/BaseDatabase/AggregatedModel";
 import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
 import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
 import AggregationType from "../../../Types/BaseDatabase/AggregationType";
 import InBetween from "../../../Types/BaseDatabase/InBetween";
 import Query from "../../../Types/BaseDatabase/Query";
-import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import OneUptimeDate from "../../../Types/Date";
+import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
-import { DisableAutomaticAlertCreation } from "../../EnvironmentConfig";
+import ServiceType from "../../../Types/Telemetry/ServiceType";
 import AggregateBy from "../../Types/AnalyticsDatabase/AggregateBy";
-import AlertService from "../../Services/AlertService";
-import AlertSeverityService from "../../Services/AlertSeverityService";
-import LlmCostBudgetService, {
-  LlmCostBudgetAlertKind,
-} from "../../Services/LlmCostBudgetService";
+import LlmCostBudgetService from "../../Services/LlmCostBudgetService";
+import MetricService from "../../Services/MetricService";
 import SpanService from "../../Services/SpanService";
 import logger, { LogAttributes } from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
+import TelemetryUtil from "./Telemetry";
 
 /*
  * Evaluates LLM cost budgets against the day's LLM span spend.
@@ -30,92 +28,65 @@ import CaptureSpan from "../Telemetry/CaptureSpan";
  * calls evaluateAllBudgets() on a 15-minute tick. For each enabled budget it
  * sums the UTC day's llmCost from ClickHouse (scoped by the budget's optional
  * service / provider / model filters), stamps the spend back onto the budget
- * row for the dashboard, and raises a warning alert at the configured
- * threshold and a breach alert at 100% — each at most once per UTC day, via
- * the lastWarningAlertCreatedAt / lastBreachAlertCreatedAt state columns plus
- * an open-alert fingerprint check.
+ * row for the dashboard, and publishes two gauge metrics:
  *
- * The threshold decision itself is a pure function (decide) so the alerting
- * semantics are unit-testable without a database.
+ *   oneuptime.llm.budget.spend.usd      — the day's spend so far, in USD
+ *   oneuptime.llm.budget.percent.used   — spend as a percent of the budget
+ *
+ * Budgets do NOT alert directly. Alerting is a Metrics monitor on these
+ * series — filter by the oneuptime.llm.budget.id attribute (stable across
+ * renames; the name attribute is for charts and changes when the budget is
+ * renamed) — which brings thresholds, formulas, anomaly baselines, incidents
+ * and on-call routing without a parallel alerting pipeline here.
+ *
+ * The series gets ONE point per budget per 15-minute sweep. A monitor on it
+ * must use a rolling window of at least 15 minutes (30 recommended): the
+ * 1-minute default would see an empty series between sweeps and flap.
  */
 
-export interface LlmCostBudgetDecisionInput {
-  // The day's spend so far, in USD.
-  spendInUSD: number;
-  dailyBudgetInUSD: number;
-  // Warning threshold in percent (1-99). Invalid values fall back to 80.
-  warningThresholdPercent: number | undefined;
-  lastWarningAlertCreatedAt: Date | undefined;
-  lastBreachAlertCreatedAt: Date | undefined;
-  now: Date;
-}
+export const LLM_BUDGET_SPEND_METRIC_NAME: string =
+  "oneuptime.llm.budget.spend.usd";
+export const LLM_BUDGET_PERCENT_METRIC_NAME: string =
+  "oneuptime.llm.budget.percent.used";
 
-export interface LlmCostBudgetDecision {
-  // Percent of the daily budget consumed (0 when the budget is invalid).
-  percentUsed: number;
-  shouldFireWarning: boolean;
-  shouldFireBreach: boolean;
-}
+// Attribute keys carried by both budget metrics, for monitor/chart filtering.
+export const LLM_BUDGET_ID_ATTRIBUTE: string = "oneuptime.llm.budget.id";
+export const LLM_BUDGET_NAME_ATTRIBUTE: string = "oneuptime.llm.budget.name";
+export const LLM_BUDGET_PROVIDER_ATTRIBUTE: string =
+  "oneuptime.llm.budget.provider";
+export const LLM_BUDGET_MODEL_ATTRIBUTE: string = "oneuptime.llm.budget.model";
+export const LLM_BUDGET_SERVICE_ID_ATTRIBUTE: string =
+  "oneuptime.llm.budget.service.id";
 
-export const DEFAULT_WARNING_THRESHOLD_PERCENT: number = 80;
+/*
+ * Matches the derived-metric retention the trace/metric recording rules use.
+ * The series exists for monitors and short-range charts; long-range spend
+ * history belongs to the spans themselves.
+ */
+const BUDGET_METRIC_RETENTION_IN_DAYS: number = 15;
 
 export default class LlmCostBudgetEvaluator {
   /**
-   * Pure threshold decision. Breach (>= 100%) supersedes warning — a call
-   * that jumps straight past the budget raises one breach alert, not two
-   * alerts. Each kind fires at most once per UTC day, keyed off the
-   * last-created timestamps the caller persists after firing.
+   * Percent of the daily budget consumed. 0 when the budget is missing or
+   * invalid — never NaN/Infinity, since these values feed monitors.
    */
-  public static decide(
-    input: LlmCostBudgetDecisionInput,
-  ): LlmCostBudgetDecision {
-    const decision: LlmCostBudgetDecision = {
-      percentUsed: 0,
-      shouldFireWarning: false,
-      shouldFireBreach: false,
-    };
-
+  public static computePercentUsed(data: {
+    spendInUSD: number;
+    dailyBudgetInUSD: number;
+  }): number {
     if (
-      !isFinite(input.dailyBudgetInUSD) ||
-      input.dailyBudgetInUSD <= 0 ||
-      !isFinite(input.spendInUSD) ||
-      input.spendInUSD < 0
+      !isFinite(data.dailyBudgetInUSD) ||
+      data.dailyBudgetInUSD <= 0 ||
+      !isFinite(data.spendInUSD) ||
+      data.spendInUSD < 0
     ) {
-      return decision;
+      return 0;
     }
 
-    decision.percentUsed = (input.spendInUSD / input.dailyBudgetInUSD) * 100;
+    const percent: number = (data.spendInUSD / data.dailyBudgetInUSD) * 100;
 
-    let warningThresholdPercent: number =
-      input.warningThresholdPercent ?? DEFAULT_WARNING_THRESHOLD_PERCENT;
-
-    if (
-      !isFinite(warningThresholdPercent) ||
-      warningThresholdPercent < 1 ||
-      warningThresholdPercent > 99
-    ) {
-      warningThresholdPercent = DEFAULT_WARNING_THRESHOLD_PERCENT;
-    }
-
-    const alreadyWarnedToday: boolean = this.isSameUtcDay(
-      input.lastWarningAlertCreatedAt,
-      input.now,
-    );
-    const alreadyBreachedToday: boolean = this.isSameUtcDay(
-      input.lastBreachAlertCreatedAt,
-      input.now,
-    );
-
-    if (decision.percentUsed >= 100) {
-      decision.shouldFireBreach = !alreadyBreachedToday;
-      return decision;
-    }
-
-    if (decision.percentUsed >= warningThresholdPercent) {
-      decision.shouldFireWarning = !alreadyWarnedToday;
-    }
-
-    return decision;
+    // Trim float noise; hundredth-of-a-percent resolution is plenty.
+    return Math.round(percent * 100) / 100;
   }
 
   /**
@@ -125,22 +96,6 @@ export default class LlmCostBudgetEvaluator {
   public static getUtcDayStart(now: Date): Date {
     return new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-    );
-  }
-
-  /**
-   * Whether two instants fall in the same UTC calendar day. False when the
-   * first is undefined.
-   */
-  public static isSameUtcDay(a: Date | undefined, b: Date): boolean {
-    if (!a) {
-      return false;
-    }
-
-    return (
-      a.getUTCFullYear() === b.getUTCFullYear() &&
-      a.getUTCMonth() === b.getUTCMonth() &&
-      a.getUTCDate() === b.getUTCDate()
     );
   }
 
@@ -182,6 +137,66 @@ export default class LlmCostBudgetEvaluator {
   }
 
   /**
+   * Build the two metric rows one evaluation publishes for one budget.
+   * Pure — mirrors the derived-metric row shape the trace recording rules
+   * write — so the series shape is unit-testable.
+   */
+  public static buildBudgetMetricRows(data: {
+    budget: LlmCostBudget;
+    spendInUSD: number;
+    percentUsed: number;
+    now: Date;
+  }): Array<JSONObject> {
+    const attributes: Record<string, string> = {
+      [LLM_BUDGET_ID_ATTRIBUTE]: data.budget.id?.toString() || "",
+      [LLM_BUDGET_NAME_ATTRIBUTE]: data.budget.name || "",
+    };
+
+    if (data.budget.serviceId) {
+      attributes[LLM_BUDGET_SERVICE_ID_ATTRIBUTE] =
+        data.budget.serviceId.toString();
+    }
+
+    if (data.budget.llmSystem) {
+      attributes[LLM_BUDGET_PROVIDER_ATTRIBUTE] = data.budget.llmSystem;
+    }
+
+    if (data.budget.llmModel) {
+      attributes[LLM_BUDGET_MODEL_ATTRIBUTE] = data.budget.llmModel;
+    }
+
+    const retentionDate: Date = OneUptimeDate.addRemoveDays(
+      data.now,
+      BUDGET_METRIC_RETENTION_IN_DAYS,
+    );
+
+    const buildRow: (name: string, value: number) => JSONObject = (
+      name: string,
+      value: number,
+    ): JSONObject => {
+      return {
+        _id: ObjectID.generateTimeOrdered().toString(),
+        projectId: data.budget.projectId!.toString(),
+        createdAt: OneUptimeDate.toClickhouseDateTime(data.now),
+        time: OneUptimeDate.toClickhouseDateTime(data.now),
+        timeUnixNano: (data.now.getTime() * 1_000_000).toString(),
+        primaryEntityType: ServiceType.OpenTelemetry,
+        name: name,
+        metricPointType: MetricPointType.Gauge,
+        value: value,
+        attributes: attributes,
+        attributeKeys: Object.keys(attributes).sort(),
+        retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
+      };
+    };
+
+    return [
+      buildRow(LLM_BUDGET_SPEND_METRIC_NAME, data.spendInUSD),
+      buildRow(LLM_BUDGET_PERCENT_METRIC_NAME, data.percentUsed),
+    ];
+  }
+
+  /**
    * Evaluate every enabled budget. One bad budget never aborts the sweep.
    */
   @CaptureSpan()
@@ -195,16 +210,9 @@ export default class LlmCostBudgetEvaluator {
         projectId: true,
         name: true,
         dailyBudgetInUSD: true,
-        warningThresholdPercent: true,
         serviceId: true,
         llmSystem: true,
         llmModel: true,
-        alertSeverityId: true,
-        onCallDutyPolicies: {
-          _id: true,
-        },
-        lastWarningAlertCreatedAt: true,
-        lastBreachAlertCreatedAt: true,
       },
       limit: LIMIT_MAX,
       skip: 0,
@@ -238,8 +246,8 @@ export default class LlmCostBudgetEvaluator {
   }
 
   /**
-   * Evaluate one budget: sum the day's spend, stamp it on the row, and fire
-   * whichever threshold alert the decision calls for.
+   * Evaluate one budget: sum the day's spend, stamp it on the row, and
+   * publish the spend / percent-used metric points.
    */
   @CaptureSpan()
   public static async evaluateBudget(data: {
@@ -260,16 +268,12 @@ export default class LlmCostBudgetEvaluator {
       now: data.now,
     });
 
-    const decision: LlmCostBudgetDecision = this.decide({
+    const percentUsed: number = this.computePercentUsed({
       spendInUSD: spendInUSD,
       dailyBudgetInUSD: budget.dailyBudgetInUSD,
-      warningThresholdPercent: budget.warningThresholdPercent,
-      lastWarningAlertCreatedAt: budget.lastWarningAlertCreatedAt,
-      lastBreachAlertCreatedAt: budget.lastBreachAlertCreatedAt,
-      now: data.now,
     });
 
-    // Stamp the spend for the dashboard even when nothing fires.
+    // Stamp the spend for the dashboard's Budgets tab.
     await LlmCostBudgetService.updateOneById({
       id: budget.id,
       data: {
@@ -281,49 +285,12 @@ export default class LlmCostBudgetEvaluator {
       },
     });
 
-    if (decision.shouldFireBreach) {
-      const created: boolean = await this.createBudgetAlert({
-        budget: budget,
-        kind: "breach",
-        spendInUSD: spendInUSD,
-        percentUsed: decision.percentUsed,
-      });
-
-      if (created) {
-        await LlmCostBudgetService.updateOneById({
-          id: budget.id,
-          data: {
-            lastBreachAlertCreatedAt: data.now,
-          },
-          props: {
-            isRoot: true,
-          },
-        });
-      }
-
-      return;
-    }
-
-    if (decision.shouldFireWarning) {
-      const created: boolean = await this.createBudgetAlert({
-        budget: budget,
-        kind: "warning",
-        spendInUSD: spendInUSD,
-        percentUsed: decision.percentUsed,
-      });
-
-      if (created) {
-        await LlmCostBudgetService.updateOneById({
-          id: budget.id,
-          data: {
-            lastWarningAlertCreatedAt: data.now,
-          },
-          props: {
-            isRoot: true,
-          },
-        });
-      }
-    }
+    await this.writeBudgetMetrics({
+      budget: budget,
+      spendInUSD: spendInUSD,
+      percentUsed: percentUsed,
+      now: data.now,
+    });
   }
 
   /**
@@ -345,9 +312,9 @@ export default class LlmCostBudgetEvaluator {
       // One total over the whole window — no time bucketing.
       aggregationInterval: AggregationInterval.Total,
       /*
-       * Alerting must fail loud on a query timeout: the default 'break'
-       * overflow mode returns silently-partial sums, which would understate
-       * spend and suppress a real budget breach.
+       * The sum feeds monitors: fail loud on a query timeout — the default
+       * 'break' overflow mode returns silently-partial sums, which would
+       * understate spend and suppress a real budget breach downstream.
        */
       timeoutOverflowMode: "throw",
       limit: LIMIT_PER_PROJECT,
@@ -368,137 +335,45 @@ export default class LlmCostBudgetEvaluator {
   }
 
   /**
-   * Create the warning/breach alert for a budget. Returns true when an alert
-   * was actually created (the caller stamps the per-day dedup timestamp only
-   * then).
+   * Publish the budget's spend and percent-used gauge points, and register
+   * the metric names so they appear in the dashboard's metric picker and the
+   * Metrics-monitor builder.
    */
   @CaptureSpan()
-  private static async createBudgetAlert(data: {
+  private static async writeBudgetMetrics(data: {
     budget: LlmCostBudget;
-    kind: LlmCostBudgetAlertKind;
     spendInUSD: number;
     percentUsed: number;
-  }): Promise<boolean> {
-    const budget: LlmCostBudget = data.budget;
+    now: Date;
+  }): Promise<void> {
+    const rows: Array<JSONObject> = this.buildBudgetMetricRows(data);
 
-    const fingerprint: string = LlmCostBudgetService.getBudgetAlertFingerprint({
-      llmCostBudgetId: budget.id!,
-      kind: data.kind,
+    await MetricService.insertJsonRows(rows);
+
+    const spendType: MetricType = new MetricType();
+    spendType.name = LLM_BUDGET_SPEND_METRIC_NAME;
+    spendType.description =
+      "LLM spend accrued so far in the current UTC day for an LLM cost budget, in USD. One point per budget every 15 minutes; filter by the oneuptime.llm.budget.id attribute.";
+    spendType.unit = "USD";
+
+    const percentType: MetricType = new MetricType();
+    percentType.name = LLM_BUDGET_PERCENT_METRIC_NAME;
+    percentType.description =
+      "LLM spend as a percent of an LLM cost budget's daily limit. One point per budget every 15 minutes — alert with a Metrics monitor (e.g. value >= 80) using a rolling window of 30 minutes, filtered by oneuptime.llm.budget.id.";
+    percentType.unit = "%";
+
+    /*
+     * Registration is what makes the names show up in the metric picker —
+     * fire-and-forget, a registration failure must not fail the sweep.
+     */
+    TelemetryUtil.indexMetricNameServiceNameMap({
+      metricNameServiceNameMap: {
+        [LLM_BUDGET_SPEND_METRIC_NAME]: spendType,
+        [LLM_BUDGET_PERCENT_METRIC_NAME]: percentType,
+      },
+      projectId: data.budget.projectId!,
+    }).catch((err: Error) => {
+      logger.error(err);
     });
-
-    // An open alert in the same series means on-call is already looking.
-    const openAlert: Alert | null = await AlertService.findOneBy({
-      query: {
-        projectId: budget.projectId!,
-        seriesFingerprint: fingerprint,
-        currentAlertState: {
-          isResolvedState: false,
-        },
-      },
-      select: {
-        _id: true,
-      },
-      props: {
-        isRoot: true,
-      },
-    });
-
-    if (openAlert) {
-      logger.debug(
-        `Llm:EvaluateLlmCostBudgets: open ${data.kind} alert already exists for budget ${budget.id?.toString()}; skipping.`,
-      );
-      return false;
-    }
-
-    if (DisableAutomaticAlertCreation) {
-      logger.debug(
-        `Llm:EvaluateLlmCostBudgets: automatic alert creation is disabled; skipping ${data.kind} alert for budget ${budget.id?.toString()}.`,
-      );
-      return false;
-    }
-
-    let alertSeverityId: ObjectID | undefined = budget.alertSeverityId;
-
-    if (!alertSeverityId) {
-      const severity: AlertSeverity | null =
-        await AlertSeverityService.findOneBy({
-          query: {
-            projectId: budget.projectId!,
-          },
-          sort: {
-            order: SortOrder.Ascending,
-          },
-          select: {
-            _id: true,
-          },
-          props: {
-            isRoot: true,
-          },
-        });
-
-      alertSeverityId = severity?.id || undefined;
-    }
-
-    if (!alertSeverityId) {
-      logger.error(
-        `Llm:EvaluateLlmCostBudgets - Cannot create ${data.kind} alert for budget ${budget.id?.toString()}: project has no alert severity.`,
-        { projectId: budget.projectId?.toString() } as LogAttributes,
-      );
-      return false;
-    }
-
-    const spendFormatted: string = `$${data.spendInUSD.toFixed(2)}`;
-    const budgetFormatted: string = `$${(budget.dailyBudgetInUSD || 0).toFixed(2)}`;
-    const percentFormatted: string = `${Math.floor(data.percentUsed)}%`;
-
-    const scopeParts: Array<string> = [];
-
-    if (budget.llmSystem) {
-      scopeParts.push(`provider ${budget.llmSystem}`);
-    }
-
-    if (budget.llmModel) {
-      scopeParts.push(`model ${budget.llmModel}`);
-    }
-
-    const scopeSuffix: string =
-      scopeParts.length > 0 ? ` (${scopeParts.join(", ")})` : "";
-
-    const alert: Alert = new Alert();
-    alert.projectId = budget.projectId!;
-
-    if (data.kind === "breach") {
-      alert.title = `LLM cost budget exceeded: ${budget.name}`;
-      alert.description = `LLM spend${scopeSuffix} has reached ${spendFormatted} — ${percentFormatted} of the ${budgetFormatted} daily budget "${budget.name}". The daily budget is exhausted.`;
-      alert.rootCause = `LLM spend crossed 100% of the daily cost budget "${budget.name}".`;
-    } else {
-      alert.title = `LLM cost budget warning: ${budget.name}`;
-      alert.description = `LLM spend${scopeSuffix} has reached ${spendFormatted} — ${percentFormatted} of the ${budgetFormatted} daily budget "${budget.name}".`;
-      alert.rootCause = `LLM spend crossed the ${budget.warningThresholdPercent ?? DEFAULT_WARNING_THRESHOLD_PERCENT}% warning threshold of the daily cost budget "${budget.name}".`;
-    }
-
-    alert.alertSeverityId = alertSeverityId;
-    alert.seriesFingerprint = fingerprint;
-    alert.isCreatedAutomatically = true;
-
-    // On-call policy id-stubs, the MonitorAlert pattern.
-    alert.onCallDutyPolicies = (budget.onCallDutyPolicies || [])
-      .filter((policy: OnCallDutyPolicy) => {
-        return Boolean(policy.id);
-      })
-      .map((policy: OnCallDutyPolicy) => {
-        const policyStub: OnCallDutyPolicy = new OnCallDutyPolicy();
-        policyStub._id = policy.id!.toString();
-        return policyStub;
-      });
-
-    await AlertService.create({
-      data: alert,
-      props: {
-        isRoot: true,
-      },
-    });
-
-    return true;
   }
 }

--- a/Common/Tests/Server/Services/LlmCostBudgetService.test.ts
+++ b/Common/Tests/Server/Services/LlmCostBudgetService.test.ts
@@ -1,6 +1,5 @@
 import LlmCostBudget from "../../../Models/DatabaseModels/LlmCostBudget";
 import BadDataException from "../../../Types/Exception/BadDataException";
-import ObjectID from "../../../Types/ObjectID";
 import LlmCostBudgetService from "../../../Server/Services/LlmCostBudgetService";
 import CreateBy from "../../../Server/Types/Database/CreateBy";
 import UpdateBy from "../../../Server/Types/Database/UpdateBy";
@@ -48,6 +47,13 @@ describe("LlmCostBudgetService.onBeforeCreate — dailyBudgetInUSD", () => {
     expect(result.createBy.data.dailyBudgetInUSD).toBe(250);
   });
 
+  test("accepts a fractional budget", async () => {
+    const result: { createBy: CreateBy<LlmCostBudget> } =
+      await service.onBeforeCreate(makeCreateBy({ dailyBudgetInUSD: 0.5 }));
+
+    expect(result.createBy.data.dailyBudgetInUSD).toBe(0.5);
+  });
+
   test("coerces a numeric string to a number", async () => {
     const result: { createBy: CreateBy<LlmCostBudget> } =
       await service.onBeforeCreate(
@@ -75,64 +81,6 @@ describe("LlmCostBudgetService.onBeforeCreate — dailyBudgetInUSD", () => {
   });
 });
 
-describe("LlmCostBudgetService.onBeforeCreate — warningThresholdPercent", () => {
-  test("accepts the boundary values 1 and 99", async () => {
-    for (const value of [1, 99]) {
-      const result: { createBy: CreateBy<LlmCostBudget> } =
-        await service.onBeforeCreate(
-          makeCreateBy({
-            dailyBudgetInUSD: 100,
-            warningThresholdPercent: value,
-          }),
-        );
-
-      expect(result.createBy.data.warningThresholdPercent).toBe(value);
-    }
-  });
-
-  test("coerces a numeric string threshold", async () => {
-    const result: { createBy: CreateBy<LlmCostBudget> } =
-      await service.onBeforeCreate(
-        makeCreateBy({
-          dailyBudgetInUSD: 100,
-          warningThresholdPercent: "75" as unknown as number,
-        }),
-      );
-
-    expect(result.createBy.data.warningThresholdPercent).toBe(75);
-  });
-
-  test("omitting the threshold is allowed — the column default applies", async () => {
-    const result: { createBy: CreateBy<LlmCostBudget> } =
-      await service.onBeforeCreate(makeCreateBy({ dailyBudgetInUSD: 100 }));
-
-    expect(result.createBy.data.warningThresholdPercent).toBeUndefined();
-  });
-
-  test.each([
-    ["zero", 0],
-    ["100 — breach territory", 100],
-    ["above 100", 150],
-    ["negative", -10],
-    ["non-numeric string", "eighty"],
-    /*
-     * The column is a Postgres integer — a fractional percent that passed
-     * validation would fail the INSERT with a raw driver error.
-     */
-    ["fractional percent", 87.5],
-    ["fractional percent string", "87.5"],
-  ])("rejects %s", async (_label: string, value: unknown) => {
-    await expect(
-      service.onBeforeCreate(
-        makeCreateBy({
-          dailyBudgetInUSD: 100,
-          warningThresholdPercent: value as number,
-        }),
-      ),
-    ).rejects.toThrow(BadDataException);
-  });
-});
-
 describe("LlmCostBudgetService.onBeforeUpdate", () => {
   test("coerces and validates an updated budget", async () => {
     const result: { updateBy: UpdateBy<LlmCostBudget> } =
@@ -147,35 +95,10 @@ describe("LlmCostBudgetService.onBeforeUpdate", () => {
     ).rejects.toThrow(BadDataException);
   });
 
-  test("rejects an invalid updated threshold", async () => {
-    await expect(
-      service.onBeforeUpdate(makeUpdateBy({ warningThresholdPercent: 100 })),
-    ).rejects.toThrow(BadDataException);
-  });
-
-  test("an update touching neither numeric field passes through", async () => {
+  test("an update not touching the budget passes through", async () => {
     const result: { updateBy: UpdateBy<LlmCostBudget> } =
       await service.onBeforeUpdate(makeUpdateBy({ name: "renamed" }));
 
     expect(result.updateBy.data["name"]).toBe("renamed");
-  });
-});
-
-describe("LlmCostBudgetService.getBudgetAlertFingerprint", () => {
-  test("is deterministic and distinguishes warning from breach", () => {
-    const id: ObjectID = ObjectID.generate();
-
-    const warning: string = LlmCostBudgetService.getBudgetAlertFingerprint({
-      llmCostBudgetId: id,
-      kind: "warning",
-    });
-    const breach: string = LlmCostBudgetService.getBudgetAlertFingerprint({
-      llmCostBudgetId: id,
-      kind: "breach",
-    });
-
-    expect(warning).toBe(`llm-cost-budget:${id.toString()}:warning`);
-    expect(breach).toBe(`llm-cost-budget:${id.toString()}:breach`);
-    expect(warning).not.toBe(breach);
   });
 });

--- a/Common/Tests/Server/Utils/Telemetry/LlmCostBudgetEvaluator.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/LlmCostBudgetEvaluator.test.ts
@@ -1,19 +1,24 @@
 import LlmCostBudget from "../../../../Models/DatabaseModels/LlmCostBudget";
-import OnCallDutyPolicy from "../../../../Models/DatabaseModels/OnCallDutyPolicy";
-import Alert from "../../../../Models/DatabaseModels/Alert";
-import AlertSeverity from "../../../../Models/DatabaseModels/AlertSeverity";
 import Span from "../../../../Models/AnalyticsModels/Span";
+import { MetricPointType } from "../../../../Models/AnalyticsModels/Metric";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import Query from "../../../../Types/BaseDatabase/Query";
+import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
+import ServiceType from "../../../../Types/Telemetry/ServiceType";
 import LlmCostBudgetEvaluator, {
-  DEFAULT_WARNING_THRESHOLD_PERCENT,
-  LlmCostBudgetDecision,
+  LLM_BUDGET_ID_ATTRIBUTE,
+  LLM_BUDGET_MODEL_ATTRIBUTE,
+  LLM_BUDGET_NAME_ATTRIBUTE,
+  LLM_BUDGET_PERCENT_METRIC_NAME,
+  LLM_BUDGET_PROVIDER_ATTRIBUTE,
+  LLM_BUDGET_SERVICE_ID_ATTRIBUTE,
+  LLM_BUDGET_SPEND_METRIC_NAME,
 } from "../../../../Server/Utils/Telemetry/LlmCostBudgetEvaluator";
-import AlertService from "../../../../Server/Services/AlertService";
-import AlertSeverityService from "../../../../Server/Services/AlertSeverityService";
 import LlmCostBudgetService from "../../../../Server/Services/LlmCostBudgetService";
+import MetricService from "../../../../Server/Services/MetricService";
 import SpanService from "../../../../Server/Services/SpanService";
+import TelemetryUtil from "../../../../Server/Utils/Telemetry/Telemetry";
 /*
  * `jest` deliberately comes from the global scope, not @jest/globals — the
  * imported value would shadow the global `jest` NAMESPACE and break the
@@ -31,21 +36,11 @@ jest.mock("../../../../Server/Services/SpanService", () => {
   };
 });
 
-jest.mock("../../../../Server/Services/AlertService", () => {
+jest.mock("../../../../Server/Services/MetricService", () => {
   return {
     __esModule: true,
     default: {
-      findOneBy: jest.fn(),
-      create: jest.fn(),
-    },
-  };
-});
-
-jest.mock("../../../../Server/Services/AlertSeverityService", () => {
-  return {
-    __esModule: true,
-    default: {
-      findOneBy: jest.fn(),
+      insertJsonRows: jest.fn(),
     },
   };
 });
@@ -56,14 +51,15 @@ jest.mock("../../../../Server/Services/LlmCostBudgetService", () => {
     default: {
       findBy: jest.fn(),
       updateOneById: jest.fn(),
-      getBudgetAlertFingerprint: jest.fn(
-        (data: {
-          llmCostBudgetId: { toString: () => string };
-          kind: string;
-        }): string => {
-          return `llm-cost-budget:${data.llmCostBudgetId.toString()}:${data.kind}`;
-        },
-      ),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Telemetry/Telemetry", () => {
+  return {
+    __esModule: true,
+    default: {
+      indexMetricNameServiceNameMap: jest.fn(),
     },
   };
 });
@@ -74,286 +70,26 @@ const mockedSpanService: { aggregateBy: MockedFn } = SpanService as unknown as {
   aggregateBy: MockedFn;
 };
 
-const mockedAlertService: { findOneBy: MockedFn; create: MockedFn } =
-  AlertService as unknown as {
-    findOneBy: MockedFn;
-    create: MockedFn;
-  };
-
-const mockedAlertSeverityService: { findOneBy: MockedFn } =
-  AlertSeverityService as unknown as {
-    findOneBy: MockedFn;
+const mockedMetricService: { insertJsonRows: MockedFn } =
+  MetricService as unknown as {
+    insertJsonRows: MockedFn;
   };
 
 const mockedBudgetService: {
   findBy: MockedFn;
   updateOneById: MockedFn;
-  getBudgetAlertFingerprint: MockedFn;
 } = LlmCostBudgetService as unknown as {
   findBy: MockedFn;
   updateOneById: MockedFn;
-  getBudgetAlertFingerprint: MockedFn;
 };
 
-// 2026-08-21 14:30:00 UTC — an arbitrary mid-day instant.
-const NOW: Date = new Date(Date.UTC(2026, 7, 21, 14, 30, 0));
-
-function makeDecisionInput(overrides: {
-  spendInUSD?: number;
-  dailyBudgetInUSD?: number;
-  warningThresholdPercent?: number | undefined;
-  lastWarningAlertCreatedAt?: Date | undefined;
-  lastBreachAlertCreatedAt?: Date | undefined;
-  now?: Date;
-}): Parameters<typeof LlmCostBudgetEvaluator.decide>[0] {
-  return {
-    spendInUSD: overrides.spendInUSD ?? 0,
-    dailyBudgetInUSD: overrides.dailyBudgetInUSD ?? 100,
-    warningThresholdPercent: overrides.warningThresholdPercent,
-    lastWarningAlertCreatedAt: overrides.lastWarningAlertCreatedAt,
-    lastBreachAlertCreatedAt: overrides.lastBreachAlertCreatedAt,
-    now: overrides.now ?? NOW,
+const mockedTelemetryUtil: { indexMetricNameServiceNameMap: MockedFn } =
+  TelemetryUtil as unknown as {
+    indexMetricNameServiceNameMap: MockedFn;
   };
-}
 
-describe("LlmCostBudgetEvaluator.decide — thresholds", () => {
-  test("spend below the warning threshold fires nothing", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 50 }),
-    );
-
-    expect(decision.percentUsed).toBe(50);
-    expect(decision.shouldFireWarning).toBe(false);
-    expect(decision.shouldFireBreach).toBe(false);
-  });
-
-  test("spend exactly at the default 80% threshold fires a warning", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 80 }),
-    );
-
-    expect(decision.percentUsed).toBe(80);
-    expect(decision.shouldFireWarning).toBe(true);
-    expect(decision.shouldFireBreach).toBe(false);
-  });
-
-  test("spend just under 100% fires only a warning", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 99.99 }),
-    );
-
-    expect(decision.shouldFireWarning).toBe(true);
-    expect(decision.shouldFireBreach).toBe(false);
-  });
-
-  test("spend exactly at 100% fires a breach, not a warning", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 100 }),
-    );
-
-    expect(decision.percentUsed).toBe(100);
-    expect(decision.shouldFireWarning).toBe(false);
-    expect(decision.shouldFireBreach).toBe(true);
-  });
-
-  test("spend that jumps straight past 100% fires one breach only", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 250 }),
-    );
-
-    expect(decision.percentUsed).toBe(250);
-    expect(decision.shouldFireWarning).toBe(false);
-    expect(decision.shouldFireBreach).toBe(true);
-  });
-
-  test("a custom warning threshold is honored", () => {
-    const at49: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 49, warningThresholdPercent: 50 }),
-    );
-    const at50: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 50, warningThresholdPercent: 50 }),
-    );
-
-    expect(at49.shouldFireWarning).toBe(false);
-    expect(at50.shouldFireWarning).toBe(true);
-  });
-
-  test("invalid warning thresholds fall back to the default", () => {
-    for (const bad of [0, -5, 100, 150, NaN]) {
-      const below: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-        makeDecisionInput({
-          spendInUSD: DEFAULT_WARNING_THRESHOLD_PERCENT - 1,
-          warningThresholdPercent: bad,
-        }),
-      );
-      const at: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-        makeDecisionInput({
-          spendInUSD: DEFAULT_WARNING_THRESHOLD_PERCENT,
-          warningThresholdPercent: bad,
-        }),
-      );
-
-      expect(below.shouldFireWarning).toBe(false);
-      expect(at.shouldFireWarning).toBe(true);
-    }
-  });
-
-  test("undefined warning threshold uses the default", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({
-        spendInUSD: DEFAULT_WARNING_THRESHOLD_PERCENT,
-        warningThresholdPercent: undefined,
-      }),
-    );
-
-    expect(decision.shouldFireWarning).toBe(true);
-  });
-});
-
-describe("LlmCostBudgetEvaluator.decide — invalid inputs never fire", () => {
-  test.each([
-    ["zero budget", { spendInUSD: 100, dailyBudgetInUSD: 0 }],
-    ["negative budget", { spendInUSD: 100, dailyBudgetInUSD: -10 }],
-    ["NaN budget", { spendInUSD: 100, dailyBudgetInUSD: NaN }],
-    ["Infinity budget", { spendInUSD: 100, dailyBudgetInUSD: Infinity }],
-    ["negative spend", { spendInUSD: -1, dailyBudgetInUSD: 100 }],
-    ["NaN spend", { spendInUSD: NaN, dailyBudgetInUSD: 100 }],
-  ])("%s", (_label: string, input: Record<string, unknown>) => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput(input as { spendInUSD: number }),
-    );
-
-    expect(decision.percentUsed).toBe(0);
-    expect(decision.shouldFireWarning).toBe(false);
-    expect(decision.shouldFireBreach).toBe(false);
-  });
-
-  test("zero spend against a valid budget is quiet", () => {
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({ spendInUSD: 0 }),
-    );
-
-    expect(decision.percentUsed).toBe(0);
-    expect(decision.shouldFireWarning).toBe(false);
-    expect(decision.shouldFireBreach).toBe(false);
-  });
-});
-
-describe("LlmCostBudgetEvaluator.decide — once-per-UTC-day dedup", () => {
-  test("warning does not re-fire when already warned today", () => {
-    const earlierToday: Date = new Date(Date.UTC(2026, 7, 21, 2, 0, 0));
-
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({
-        spendInUSD: 90,
-        lastWarningAlertCreatedAt: earlierToday,
-      }),
-    );
-
-    expect(decision.shouldFireWarning).toBe(false);
-  });
-
-  test("warning re-fires the next UTC day", () => {
-    const yesterday: Date = new Date(Date.UTC(2026, 7, 20, 23, 59, 59));
-
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({
-        spendInUSD: 90,
-        lastWarningAlertCreatedAt: yesterday,
-      }),
-    );
-
-    expect(decision.shouldFireWarning).toBe(true);
-  });
-
-  test("breach does not re-fire when already breached today", () => {
-    const earlierToday: Date = new Date(Date.UTC(2026, 7, 21, 1, 0, 0));
-
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({
-        spendInUSD: 150,
-        lastBreachAlertCreatedAt: earlierToday,
-      }),
-    );
-
-    expect(decision.shouldFireBreach).toBe(false);
-    // Breach supersedes warning even when suppressed — no downgrade alert.
-    expect(decision.shouldFireWarning).toBe(false);
-  });
-
-  test("breach fires even when a warning already fired earlier today", () => {
-    const earlierToday: Date = new Date(Date.UTC(2026, 7, 21, 9, 0, 0));
-
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({
-        spendInUSD: 120,
-        lastWarningAlertCreatedAt: earlierToday,
-      }),
-    );
-
-    expect(decision.shouldFireBreach).toBe(true);
-  });
-
-  test("breach re-fires on a fresh UTC day", () => {
-    const yesterday: Date = new Date(Date.UTC(2026, 7, 20, 12, 0, 0));
-
-    const decision: LlmCostBudgetDecision = LlmCostBudgetEvaluator.decide(
-      makeDecisionInput({
-        spendInUSD: 150,
-        lastBreachAlertCreatedAt: yesterday,
-      }),
-    );
-
-    expect(decision.shouldFireBreach).toBe(true);
-  });
-});
-
-describe("LlmCostBudgetEvaluator UTC day helpers", () => {
-  test("getUtcDayStart returns midnight UTC of the same day", () => {
-    const dayStart: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
-
-    expect(dayStart.toISOString()).toBe("2026-08-21T00:00:00.000Z");
-  });
-
-  test("getUtcDayStart is idempotent", () => {
-    const once: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
-    const twice: Date = LlmCostBudgetEvaluator.getUtcDayStart(once);
-
-    expect(twice.getTime()).toBe(once.getTime());
-  });
-
-  test("isSameUtcDay is false for undefined", () => {
-    expect(LlmCostBudgetEvaluator.isSameUtcDay(undefined, NOW)).toBe(false);
-  });
-
-  test("isSameUtcDay is true across hours of the same UTC day", () => {
-    const morning: Date = new Date(Date.UTC(2026, 7, 21, 0, 0, 1));
-    const night: Date = new Date(Date.UTC(2026, 7, 21, 23, 59, 59));
-
-    expect(LlmCostBudgetEvaluator.isSameUtcDay(morning, night)).toBe(true);
-  });
-
-  test("isSameUtcDay is false one second across midnight UTC", () => {
-    const beforeMidnight: Date = new Date(Date.UTC(2026, 7, 20, 23, 59, 59));
-    const afterMidnight: Date = new Date(Date.UTC(2026, 7, 21, 0, 0, 0));
-
-    expect(
-      LlmCostBudgetEvaluator.isSameUtcDay(beforeMidnight, afterMidnight),
-    ).toBe(false);
-  });
-
-  test("isSameUtcDay does not confuse the same day-of-month across months or years", () => {
-    const sameDayOtherMonth: Date = new Date(Date.UTC(2026, 6, 21, 14, 0, 0));
-    const sameDayOtherYear: Date = new Date(Date.UTC(2025, 7, 21, 14, 0, 0));
-
-    expect(LlmCostBudgetEvaluator.isSameUtcDay(sameDayOtherMonth, NOW)).toBe(
-      false,
-    );
-    expect(LlmCostBudgetEvaluator.isSameUtcDay(sameDayOtherYear, NOW)).toBe(
-      false,
-    );
-  });
-});
+// 2026-08-22 14:30:00 UTC — an arbitrary mid-day instant.
+const NOW: Date = new Date(Date.UTC(2026, 7, 22, 14, 30, 0));
 
 function makeBudget(overrides?: Partial<LlmCostBudget>): LlmCostBudget {
   const budget: LlmCostBudget = new LlmCostBudget();
@@ -361,10 +97,80 @@ function makeBudget(overrides?: Partial<LlmCostBudget>): LlmCostBudget {
   budget.projectId = ObjectID.generate();
   budget.name = "Prod LLM budget";
   budget.dailyBudgetInUSD = 100;
-  budget.warningThresholdPercent = 80;
 
   return Object.assign(budget, overrides);
 }
+
+describe("LlmCostBudgetEvaluator.computePercentUsed", () => {
+  test("computes percent of budget", () => {
+    expect(
+      LlmCostBudgetEvaluator.computePercentUsed({
+        spendInUSD: 82,
+        dailyBudgetInUSD: 100,
+      }),
+    ).toBe(82);
+  });
+
+  test("supports values past 100%", () => {
+    expect(
+      LlmCostBudgetEvaluator.computePercentUsed({
+        spendInUSD: 250,
+        dailyBudgetInUSD: 100,
+      }),
+    ).toBe(250);
+  });
+
+  test("rounds to two decimal places — no float noise into monitors", () => {
+    expect(
+      LlmCostBudgetEvaluator.computePercentUsed({
+        spendInUSD: 1 / 3,
+        dailyBudgetInUSD: 100,
+      }),
+    ).toBe(0.33);
+  });
+
+  test.each([
+    ["zero budget", { spendInUSD: 100, dailyBudgetInUSD: 0 }],
+    ["negative budget", { spendInUSD: 100, dailyBudgetInUSD: -10 }],
+    ["NaN budget", { spendInUSD: 100, dailyBudgetInUSD: NaN }],
+    ["Infinity budget", { spendInUSD: 100, dailyBudgetInUSD: Infinity }],
+    ["negative spend", { spendInUSD: -1, dailyBudgetInUSD: 100 }],
+    ["NaN spend", { spendInUSD: NaN, dailyBudgetInUSD: 100 }],
+  ])(
+    "%s yields 0 — never NaN/Infinity into a metric series",
+    (_label: string, input: Record<string, number>) => {
+      expect(
+        LlmCostBudgetEvaluator.computePercentUsed(
+          input as { spendInUSD: number; dailyBudgetInUSD: number },
+        ),
+      ).toBe(0);
+    },
+  );
+
+  test("zero spend is 0%", () => {
+    expect(
+      LlmCostBudgetEvaluator.computePercentUsed({
+        spendInUSD: 0,
+        dailyBudgetInUSD: 100,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("LlmCostBudgetEvaluator.getUtcDayStart", () => {
+  test("returns midnight UTC of the same day", () => {
+    expect(LlmCostBudgetEvaluator.getUtcDayStart(NOW).toISOString()).toBe(
+      "2026-08-22T00:00:00.000Z",
+    );
+  });
+
+  test("is idempotent", () => {
+    const once: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
+    expect(LlmCostBudgetEvaluator.getUtcDayStart(once).getTime()).toBe(
+      once.getTime(),
+    );
+  });
+});
 
 describe("LlmCostBudgetEvaluator.buildSpanQuery", () => {
   const dayStart: Date = LlmCostBudgetEvaluator.getUtcDayStart(NOW);
@@ -409,14 +215,124 @@ describe("LlmCostBudgetEvaluator.buildSpanQuery", () => {
   });
 });
 
+describe("LlmCostBudgetEvaluator.buildBudgetMetricRows", () => {
+  test("builds one spend row and one percent row", () => {
+    const budget: LlmCostBudget = makeBudget();
+
+    const rows: Array<JSONObject> =
+      LlmCostBudgetEvaluator.buildBudgetMetricRows({
+        budget: budget,
+        spendInUSD: 42.5,
+        percentUsed: 42.5,
+        now: NOW,
+      });
+
+    expect(rows).toHaveLength(2);
+
+    const spendRow: JSONObject = rows[0]!;
+    const percentRow: JSONObject = rows[1]!;
+
+    expect(spendRow["name"]).toBe(LLM_BUDGET_SPEND_METRIC_NAME);
+    expect(spendRow["value"]).toBe(42.5);
+    expect(percentRow["name"]).toBe(LLM_BUDGET_PERCENT_METRIC_NAME);
+    expect(percentRow["value"]).toBe(42.5);
+  });
+
+  test("rows carry the derived-metric row shape monitors expect", () => {
+    const budget: LlmCostBudget = makeBudget();
+
+    const rows: Array<JSONObject> =
+      LlmCostBudgetEvaluator.buildBudgetMetricRows({
+        budget: budget,
+        spendInUSD: 1,
+        percentUsed: 1,
+        now: NOW,
+      });
+
+    for (const row of rows) {
+      expect(row["projectId"]).toBe(budget.projectId!.toString());
+      expect(row["metricPointType"]).toBe(MetricPointType.Gauge);
+      expect(row["primaryEntityType"]).toBe(ServiceType.OpenTelemetry);
+      expect(row["timeUnixNano"]).toBe((NOW.getTime() * 1_000_000).toString());
+      expect(row["_id"]).toBeTruthy();
+      expect(row["retentionDate"]).toBeTruthy();
+
+      const attributes: Record<string, string> = row["attributes"] as Record<
+        string,
+        string
+      >;
+      expect(attributes[LLM_BUDGET_ID_ATTRIBUTE]).toBe(budget.id!.toString());
+      expect(attributes[LLM_BUDGET_NAME_ATTRIBUTE]).toBe(budget.name);
+
+      const attributeKeys: Array<string> = row[
+        "attributeKeys"
+      ] as Array<string>;
+      expect(attributeKeys).toEqual(Object.keys(attributes).sort());
+    }
+  });
+
+  test("scope attributes appear only when the budget is scoped", () => {
+    const unscoped: Array<JSONObject> =
+      LlmCostBudgetEvaluator.buildBudgetMetricRows({
+        budget: makeBudget(),
+        spendInUSD: 1,
+        percentUsed: 1,
+        now: NOW,
+      });
+
+    const unscopedAttributes: Record<string, string> = unscoped[0]![
+      "attributes"
+    ] as Record<string, string>;
+    expect(unscopedAttributes[LLM_BUDGET_SERVICE_ID_ATTRIBUTE]).toBeUndefined();
+    expect(unscopedAttributes[LLM_BUDGET_PROVIDER_ATTRIBUTE]).toBeUndefined();
+    expect(unscopedAttributes[LLM_BUDGET_MODEL_ATTRIBUTE]).toBeUndefined();
+
+    const serviceId: ObjectID = ObjectID.generate();
+    const scoped: Array<JSONObject> =
+      LlmCostBudgetEvaluator.buildBudgetMetricRows({
+        budget: makeBudget({
+          serviceId: serviceId,
+          llmSystem: "openai",
+          llmModel: "gpt-4o",
+        }),
+        spendInUSD: 1,
+        percentUsed: 1,
+        now: NOW,
+      });
+
+    const scopedAttributes: Record<string, string> = scoped[0]![
+      "attributes"
+    ] as Record<string, string>;
+    expect(scopedAttributes[LLM_BUDGET_SERVICE_ID_ATTRIBUTE]).toBe(
+      serviceId.toString(),
+    );
+    expect(scopedAttributes[LLM_BUDGET_PROVIDER_ATTRIBUTE]).toBe("openai");
+    expect(scopedAttributes[LLM_BUDGET_MODEL_ATTRIBUTE]).toBe("gpt-4o");
+  });
+
+  test("the two rows share one point in time", () => {
+    const rows: Array<JSONObject> =
+      LlmCostBudgetEvaluator.buildBudgetMetricRows({
+        budget: makeBudget(),
+        spendInUSD: 5,
+        percentUsed: 5,
+        now: NOW,
+      });
+
+    expect(rows[0]!["time"]).toBe(rows[1]!["time"]);
+    expect(rows[0]!["timeUnixNano"]).toBe(rows[1]!["timeUnixNano"]);
+  });
+});
+
 describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedSpanService.aggregateBy.mockResolvedValue({ data: [] } as never);
-    mockedAlertService.findOneBy.mockResolvedValue(null as never);
-    mockedAlertService.create.mockResolvedValue(new Alert() as never);
-    mockedAlertSeverityService.findOneBy.mockResolvedValue(null as never);
+    mockedMetricService.insertJsonRows.mockResolvedValue(undefined as never);
     mockedBudgetService.updateOneById.mockResolvedValue(undefined as never);
+    mockedTelemetryUtil.indexMetricNameServiceNameMap.mockResolvedValue(
+      undefined as never,
+    );
   });
 
   function mockSpend(valueInUSD: number): void {
@@ -425,7 +341,7 @@ describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
     } as never);
   }
 
-  test("stamps spend on the budget even when nothing fires", async () => {
+  test("stamps spend on the budget row", async () => {
     const budget: LlmCostBudget = makeBudget();
     mockSpend(10);
 
@@ -441,7 +357,41 @@ describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
     expect(updateArg.id.toString()).toBe(budget.id!.toString());
     expect(updateArg.data["currentDaySpendInUSD"]).toBe(10);
     expect(updateArg.data["spendLastEvaluatedAt"]).toBe(NOW);
-    expect(mockedAlertService.create).not.toHaveBeenCalled();
+  });
+
+  test("publishes spend and percent metric points", async () => {
+    const budget: LlmCostBudget = makeBudget({ dailyBudgetInUSD: 200 });
+    mockSpend(164);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(mockedMetricService.insertJsonRows).toHaveBeenCalledTimes(1);
+    const rows: Array<JSONObject> = mockedMetricService.insertJsonRows.mock
+      .calls[0]![0] as Array<JSONObject>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!["name"]).toBe(LLM_BUDGET_SPEND_METRIC_NAME);
+    expect(rows[0]!["value"]).toBe(164);
+    expect(rows[1]!["name"]).toBe(LLM_BUDGET_PERCENT_METRIC_NAME);
+    expect(rows[1]!["value"]).toBe(82);
+  });
+
+  test("registers the metric names for the picker", async () => {
+    const budget: LlmCostBudget = makeBudget();
+    mockSpend(1);
+
+    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
+
+    expect(
+      mockedTelemetryUtil.indexMetricNameServiceNameMap,
+    ).toHaveBeenCalledTimes(1);
+    const registration: { metricNameServiceNameMap: Record<string, unknown> } =
+      mockedTelemetryUtil.indexMetricNameServiceNameMap.mock.calls[0]![0] as {
+        metricNameServiceNameMap: Record<string, unknown>;
+      };
+    expect(Object.keys(registration.metricNameServiceNameMap).sort()).toEqual(
+      [LLM_BUDGET_PERCENT_METRIC_NAME, LLM_BUDGET_SPEND_METRIC_NAME].sort(),
+    );
   });
 
   test("multiple aggregation rows are summed", async () => {
@@ -462,152 +412,6 @@ describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
     expect(updateArg.data["currentDaySpendInUSD"]).toBe(8);
   });
 
-  test("fires a warning alert with fingerprint, severity, and on-call stubs", async () => {
-    const severityId: ObjectID = ObjectID.generate();
-    const policyId: ObjectID = ObjectID.generate();
-    const policy: OnCallDutyPolicy = new OnCallDutyPolicy();
-    policy.id = policyId;
-
-    const budget: LlmCostBudget = makeBudget({
-      alertSeverityId: severityId,
-      onCallDutyPolicies: [policy],
-    });
-    mockSpend(85);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    expect(mockedAlertService.create).toHaveBeenCalledTimes(1);
-    const created: Alert = (
-      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
-    ).data;
-
-    expect(created.title).toContain("warning");
-    expect(created.title).toContain(budget.name!);
-    expect(created.description).toContain("$85.00");
-    expect(created.description).toContain("$100.00");
-    expect(created.description).toContain("85%");
-    expect(created.alertSeverityId).toBe(severityId);
-    expect(created.seriesFingerprint).toBe(
-      `llm-cost-budget:${budget.id!.toString()}:warning`,
-    );
-    expect(created.isCreatedAutomatically).toBe(true);
-    expect(created.onCallDutyPolicies).toHaveLength(1);
-    expect(created.onCallDutyPolicies![0]!._id).toBe(policyId.toString());
-
-    // Budget severity was provided — no fallback lookup.
-    expect(mockedAlertSeverityService.findOneBy).not.toHaveBeenCalled();
-
-    // Second update stamps the warning dedup timestamp.
-    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(2);
-    const stampArg: { data: Record<string, unknown> } = mockedBudgetService
-      .updateOneById.mock.calls[1]![0] as {
-      data: Record<string, unknown>;
-    };
-    expect(stampArg.data["lastWarningAlertCreatedAt"]).toBe(NOW);
-  });
-
-  test("fires a breach alert past 100% and stamps the breach timestamp", async () => {
-    const budget: LlmCostBudget = makeBudget({
-      alertSeverityId: ObjectID.generate(),
-    });
-    mockSpend(130);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    expect(mockedAlertService.create).toHaveBeenCalledTimes(1);
-    const created: Alert = (
-      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
-    ).data;
-
-    expect(created.title).toContain("exceeded");
-    expect(created.seriesFingerprint).toBe(
-      `llm-cost-budget:${budget.id!.toString()}:breach`,
-    );
-
-    const stampArg: { data: Record<string, unknown> } = mockedBudgetService
-      .updateOneById.mock.calls[1]![0] as {
-      data: Record<string, unknown>;
-    };
-    expect(stampArg.data["lastBreachAlertCreatedAt"]).toBe(NOW);
-    expect(stampArg.data["lastWarningAlertCreatedAt"]).toBeUndefined();
-  });
-
-  test("scope filters appear in the alert description", async () => {
-    const budget: LlmCostBudget = makeBudget({
-      alertSeverityId: ObjectID.generate(),
-      llmSystem: "openai",
-      llmModel: "gpt-4o",
-    });
-    mockSpend(85);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    const created: Alert = (
-      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
-    ).data;
-    expect(created.description).toContain("provider openai");
-    expect(created.description).toContain("model gpt-4o");
-  });
-
-  test("an open alert in the same series suppresses creation and the stamp", async () => {
-    const budget: LlmCostBudget = makeBudget({
-      alertSeverityId: ObjectID.generate(),
-    });
-    mockSpend(85);
-    mockedAlertService.findOneBy.mockResolvedValue(new Alert() as never);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    expect(mockedAlertService.create).not.toHaveBeenCalled();
-    // Only the spend stamp — no dedup-timestamp update.
-    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
-  });
-
-  test("falls back to the project's lowest-order severity", async () => {
-    const fallbackSeverityId: ObjectID = ObjectID.generate();
-    const severity: AlertSeverity = new AlertSeverity();
-    severity.id = fallbackSeverityId;
-
-    // makeBudget sets no alertSeverityId — the fallback path.
-    const budget: LlmCostBudget = makeBudget();
-    mockSpend(85);
-    mockedAlertSeverityService.findOneBy.mockResolvedValue(severity as never);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    expect(mockedAlertSeverityService.findOneBy).toHaveBeenCalledTimes(1);
-    const created: Alert = (
-      mockedAlertService.create.mock.calls[0]![0] as { data: Alert }
-    ).data;
-    expect(created.alertSeverityId!.toString()).toBe(
-      fallbackSeverityId.toString(),
-    );
-  });
-
-  test("a project with no severity at all skips alert creation gracefully", async () => {
-    const budget: LlmCostBudget = makeBudget();
-    mockSpend(85);
-    mockedAlertSeverityService.findOneBy.mockResolvedValue(null as never);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    expect(mockedAlertService.create).not.toHaveBeenCalled();
-    // No stamp — the alert never fired, so tomorrow's evaluation retries.
-    expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
-  });
-
-  test("a warning already fired today does not create another alert", async () => {
-    const budget: LlmCostBudget = makeBudget({
-      alertSeverityId: ObjectID.generate(),
-      lastWarningAlertCreatedAt: new Date(Date.UTC(2026, 7, 21, 3, 0, 0)),
-    });
-    mockSpend(85);
-
-    await LlmCostBudgetEvaluator.evaluateBudget({ budget, now: NOW });
-
-    expect(mockedAlertService.create).not.toHaveBeenCalled();
-  });
-
   test("budgets missing required fields are skipped without side effects", async () => {
     const budget: LlmCostBudget = makeBudget();
     delete budget.dailyBudgetInUSD;
@@ -616,6 +420,7 @@ describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
 
     expect(mockedSpanService.aggregateBy).not.toHaveBeenCalled();
     expect(mockedBudgetService.updateOneById).not.toHaveBeenCalled();
+    expect(mockedMetricService.insertJsonRows).not.toHaveBeenCalled();
   });
 
   test("the ClickHouse aggregation is scoped and fails loud", async () => {
@@ -642,9 +447,11 @@ describe("LlmCostBudgetEvaluator.evaluateBudget — orchestration", () => {
 describe("LlmCostBudgetEvaluator.evaluateAllBudgets — sweep resilience", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedAlertService.findOneBy.mockResolvedValue(null as never);
-    mockedAlertService.create.mockResolvedValue(new Alert() as never);
+    mockedMetricService.insertJsonRows.mockResolvedValue(undefined as never);
     mockedBudgetService.updateOneById.mockResolvedValue(undefined as never);
+    mockedTelemetryUtil.indexMetricNameServiceNameMap.mockResolvedValue(
+      undefined as never,
+    );
   });
 
   test("one failing budget never aborts the sweep", async () => {
@@ -660,11 +467,12 @@ describe("LlmCostBudgetEvaluator.evaluateAllBudgets — sweep resilience", () =>
 
     await LlmCostBudgetEvaluator.evaluateAllBudgets();
 
-    // The healthy budget still got its spend stamped.
+    // The healthy budget still got its spend stamped and metrics published.
     expect(mockedBudgetService.updateOneById).toHaveBeenCalledTimes(1);
     const updateArg: { id: ObjectID } = mockedBudgetService.updateOneById.mock
       .calls[0]![0] as { id: ObjectID };
     expect(updateArg.id.toString()).toBe(healthy.id!.toString());
+    expect(mockedMetricService.insertJsonRows).toHaveBeenCalledTimes(1);
   });
 
   test("no enabled budgets means no ClickHouse queries at all", async () => {


### PR DESCRIPTION
## What changed

LLM cost budgets are now pure spend tracking + a derived metric series; the metric-monitor system owns all alerting. This replaces the direct-alerting design from #3337 before it reached any real users.

Every 15 minutes the worker sums each enabled budget's UTC-day LLM spend and publishes two gauge metrics — `oneuptime.llm.budget.spend.usd` and `oneuptime.llm.budget.percent.used` — carrying stable `oneuptime.llm.budget.id` (+ name and scope) attributes, registered as MetricTypes for the picker. The classic 80%/100% alerts become a Metrics monitor on the percent series, which also unlocks formulas, anomaly baselines, incidents, dashboards, and arbitrary windows for free.

Removed: `warningThresholdPercent`, `alertSeverity`, `onCallDutyPolicies`, per-day alert dedup columns, the alert creation/resolution machinery, and the Budgets form's Alerting step. Migration `1788500000000` drops the columns + join table and was drift-verified by migrating an empty Postgres from scratch and re-running the generator (zero drift). The Redis sweep lock stays (prevents duplicate points from overlapping sweeps).

Docs rewritten: budget section of `ai-llm-observability.md`, the circuit-breaker guide's Option A (trip-wire is now the budget metrics monitor), `ai-gateways.md`.

## Review findings fixed pre-merge

An adversarial review pass flagged two real issues, both fixed and documented:
1. **Sparse-series flapping**: one point per 15 minutes vs. the monitor's 1-minute default rolling window → docs, dashboard copy, and MetricType descriptions now require a 30-minute rolling window.
2. **Rename hazard**: guidance now filters monitors by the immutable `oneuptime.llm.budget.id`, not the renameable name attribute.

## Testing

- 115 unit tests across the four LLM suites (metric row shape vs. the recording-rules precedent, percent edge cases — never NaN/Infinity into a series, scoped attributes, sweep resilience, service validation).
- `npm run compile` clean in Common and App; `npm run fix` clean.
- Schema drift verified clean against a from-scratch migrated database (same procedure as the CI drift job).

Merging directly per maintainer instruction.