### PR TITLE
fix(kubernetes-agent): grant nodes/metrics so the cAdvisor scrape is …

### DIFF
--- a/HelmChart/Public/kubernetes-agent/Chart.yaml
+++ b/HelmChart/Public/kubernetes-agent/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
 
 type: application
 
-version: 0.6.2
+version: 0.6.3
 
 appVersion: "1.0.0"
 

--- a/HelmChart/Public/kubernetes-agent/templates/rbac.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/rbac.yaml
@@ -106,8 +106,17 @@ rules:
       - poddisruptionbudgets
     verbs: ["get", "list", "watch"]
 {{- end }}
-  # For kubeletstats receiver (and the bundled cost Prometheus's
-  # cAdvisor scrape via the API-server node proxy, when cost is on)
+  # For the cAdvisor scrape in the DaemonSet collector: it reads
+  # /metrics/cadvisor off the local kubelet on NODE_IP:10250, and the
+  # kubelet authorizes that path as the nodes/metrics subresource.
+  - apiGroups: [""]
+    resources:
+      - nodes/metrics
+    verbs: ["get"]
+  # For endpoints the API server itself serves. The bundled cost
+  # Prometheus reaches cAdvisor through the API-server node proxy, which
+  # the nodes/proxy grant above covers; nonResourceURLs never apply to
+  # the kubelet, which authorizes by resource + subresource instead.
   - nonResourceURLs:
       - /metrics
       - /metrics/cadvisor

--- a/HelmChart/Public/kubernetes-agent/values.yaml
+++ b/HelmChart/Public/kubernetes-agent/values.yaml
@@ -479,8 +479,8 @@ kubeletstats:
 # Scrape the kubelet's cAdvisor endpoint (`/metrics/cadvisor`) for the
 # container-level metrics that the kubeletstats receiver doesn't
 # translate: CFS throttling counters and OOM kill events. Runs as a
-# Prometheus scrape in the Deployment collector (RBAC for
-# `/metrics/cadvisor` is already granted at templates/rbac.yaml).
+# Prometheus scrape in every DaemonSet collector, against its own node's
+# kubelet (authorized by the nodes/metrics grant in templates/rbac.yaml).
 #
 # Enables: OOM Kills, High CPU Throttling, CPU Throttle Ratio monitors.
 #


### PR DESCRIPTION
## Problem

The `kubernetes-agent` chart ships a cAdvisor scrape it never authorizes. Every scrape has been failing with a 403 since the scrape was added, on every node of every cluster, so none of the three allowlisted metrics have ever reached OneUptime.

The DaemonSet collector's log shows one of these per node per `cadvisor.scrapeInterval`:

```
warn internal/transaction.go  Failed to scrape Prometheus endpoint
  {"scrape_timestamp": ..., "target_labels": "{__name__=\"up\", instance=\"10.x.x.x:10250\", job=\"cadvisor\"}"}
```

Asking the kubelet directly with the agent's own ServiceAccount token from inside the cluster gives the reason:

```
$ curl -sk -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
       https://$NODE_IP:10250/metrics/cadvisor
HTTP 403
Forbidden (user=system:serviceaccount:monitoring:oneuptime-kubernetes-agent,
verb=get, resource=nodes, subresource(s)=[metrics])
```

## Root cause

`templates/configmap-daemonset.yaml` scrapes `/metrics/cadvisor` straight off the local kubelet at `${env:NODE_IP}:10250`. The kubelet's authorizer maps that path to the **`nodes/metrics` subresource**, and the agent's ClusterRole does not grant it — it grants `nodes`, `nodes/proxy` and `nodes/stats`.

The `nonResourceURLs: [/metrics, /metrics/cadvisor]` rule in `templates/rbac.yaml` does not cover it: nonResourceURLs only apply to endpoints the **API server itself** serves, never to a request the kubelet authorizes. That rule predates the DaemonSet scrape — it was added in bc9949abe4, when the only cAdvisor consumer was the bundled cost Prometheus, which reaches cAdvisor through the API-server node proxy (`/api/v1/nodes/$1/proxy/metrics/cadvisor`) and is authorized by `nodes/proxy`. The direct-kubelet scrape arrived later, in a7ffa8fd26, without the matching grant.

Three things kept this quiet:

- **`kubeletstats` is unaffected**, because `/stats/summary` maps to `nodes/stats`, which *is* granted. Node and pod metrics keep flowing, so the agent looks healthy.
- **Two comments assert the permission exists.** `values.yaml` said the scrape "Runs as a Prometheus scrape in the Deployment collector (RBAC for `/metrics/cadvisor` is already granted at templates/rbac.yaml)" — it runs in the DaemonSet, and the grant does not apply there. The `rbac.yaml` comment attributed the nonResourceURLs rule to the kubeletstats receiver, which does not use it either.
- **`troubleshoot.sh` doesn't look.** Its cAdvisor checks (lines ~895–912) inspect the *cost* Prometheus's `kubernetes-nodes-cadvisor` job, not the DaemonSet's `cadvisor` job.

## Impact

`cadvisor.enabled` defaults to `true`, so every install is affected.

- The three allowlisted metrics are absent from the metric store: `container_cpu_cfs_throttled_seconds_total`, `container_cpu_cfs_periods_total`, `container_oom_events_total`. Per the chart's own docs these are what enable the **OOM Kills**, **High CPU Throttling** and **CPU Throttle Ratio** monitors, so those cannot fire.
- The failed scrapes still bill telemetry. Prometheus synthetic series (`up`, `scrape_duration_seconds`, `scrape_samples_scraped`, `scrape_samples_post_metric_relabeling`, `scrape_series_added`) are added after `metric_relabel_configs`, so the allowlist does not drop them. In a 22-node cluster at the default 30s interval, `up = 0` alone is 63,353 samples/day, and the five together are roughly 5× that — permanently, for a scrape that returns nothing.

## Fix

Grant `nodes/metrics` (get) in the agent's ClusterRole, and correct the two comments that described the proxy path and hid the gap.

## Verification

Before: `up{job="cadvisor"} == 0` on every node; the three metrics missing from the metric store.

After `helm upgrade`, on a real GKE Standard cluster:

```
$ kubectl auth can-i get nodes/metrics \
    --as=system:serviceaccount:monitoring:oneuptime-kubernetes-agent
yes
```

the 403 stops, `up{job="cadvisor"} == 1`, and the three container metrics appear.

Worth noting for anyone reproducing: `kubectl auth can-i get nodes/metrics` answers `yes` even *before* the fix, because RBAC evaluates a resource-less request against the nonResourceURL rule differently than the kubelet's SubjectAccessReview, which carries the node's name. Only a real request to `NODE_IP:10250/metrics/cadvisor` shows the failure.

`helm lint` and `helm template` clean; RBAC renders identically with `cadvisor.enabled=false`.

## Notes

- The grant is ungated, matching its neighbours `nodes/proxy` and `nodes/stats` (both read-only node subresources granted unconditionally). Happy to gate it on `cadvisor.enabled` instead, the way `pods/log` is gated on the log tailer, if you'd prefer strict least privilege.
- `README.md` already describes the scrape correctly ("from each node's DaemonSet pod"), so it needed no change.
- Chart version bumped 0.6.2 → 0.6.3, following the convention in 6d072ca7c6 and 29b9eb949d.