### PR TITLE
feat(billing): price Security Events ingest

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
@@ -60,7 +60,7 @@ export const TELEMETRY_PRICE_SENTENCE: string = `${TELEMETRY_PRICE_PER_GB_TEXT} 
  */
 export const SESSION_REPLAY_PRICE_SENTENCE: string = `${SESSION_REPLAY_PRICE_PER_GB_TEXT} per GB, with ${TELEMETRY_PRICE_RETENTION_IN_DAYS} day retention`;
 
-export const TELEMETRY_RATES_SENTENCE: string = `Logs, traces, metrics and profiles are billed at ${TELEMETRY_PRICE_SENTENCE}. Session replay recordings are billed at ${SESSION_REPLAY_PRICE_SENTENCE}.`;
+export const TELEMETRY_RATES_SENTENCE: string = `Logs, traces, metrics, profiles and security events are billed at ${TELEMETRY_PRICE_SENTENCE}. Session replay recordings are billed at ${SESSION_REPLAY_PRICE_SENTENCE}.`;
 
 export const ACTIVE_MONITOR_PRICE_SENTENCE: string = `${ACTIVE_MONITOR_PRICE_TEXT} per monitor per month`;
 

--- a/App/FeatureSet/Workers/Jobs/MeteredPlan/ReportTelemetryMeteredPlan.ts
+++ b/App/FeatureSet/Workers/Jobs/MeteredPlan/ReportTelemetryMeteredPlan.ts
@@ -86,42 +86,15 @@ RunCron(
 
           await Sleep.sleep(1000);
 
-          /*
-           * Session replay is reported in its own try/catch, and last.
-           *
-           * Its Stripe price ids do not exist yet, so
-           * getMeteredPlanPriceId throws for it. Everything else in this loop
-           * shares one try/catch per project, so letting that throw escape
-           * would abort the remaining pillars for the project and log a fresh
-           * error every run. Usage still accrues in TelemetryUsageBilling and
-           * will be reported once the price ids are set - only this final push
-           * is unavailable.
-           */
-          try {
-            await SessionReplayDataIngestMeteredPlan.reportQuantityToBillingProvider(
-              project.id,
-            );
-          } catch (sessionReplayError) {
-            logger.debug(
-              `MeteredPlan:ReportTelemetryMeteredPlan Skipping session replay for project ${project.id}: ${sessionReplayError}`,
-            );
-          }
+          await SessionReplayDataIngestMeteredPlan.reportQuantityToBillingProvider(
+            project.id,
+          );
 
-          /*
-           * Security events: same deal as session replay — usage stages
-           * into TelemetryUsageBilling regardless, and the final push to
-           * the billing provider is skipped until its Stripe price ids
-           * exist (getMeteredPlanPriceId throws until then).
-           */
-          try {
-            await SecurityEventsDataIngestMeteredPlan.reportQuantityToBillingProvider(
-              project.id,
-            );
-          } catch (securityEventsError) {
-            logger.debug(
-              `MeteredPlan:ReportTelemetryMeteredPlan Skipping security events for project ${project.id}: ${securityEventsError}`,
-            );
-          }
+          await Sleep.sleep(1000);
+
+          await SecurityEventsDataIngestMeteredPlan.reportQuantityToBillingProvider(
+            project.id,
+          );
 
           await Sleep.sleep(1000);
         }

--- a/Common/Server/Services/BillingService.ts
+++ b/Common/Server/Services/BillingService.ts
@@ -2074,6 +2074,14 @@ export class BillingService extends BaseService {
       return "price_1U0iWJANuQdJ93r7iVAXwhdP";
     }
 
+    if (productType === ProductType.SecurityEvents) {
+      if (this.isTestEnvironment()) {
+        return "price_1U7efaANuQdJ93r74hFVOgdS";
+      }
+
+      return "price_1U7edTANuQdJ93r7hR9jpBfv";
+    }
+
     throw new BadDataException(
       "Plan with productType " + productType + " not found",
     );

--- a/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
@@ -120,6 +120,23 @@ describe("Pay as you go notices", () => {
       expect(card).toHaveTextContent("Starting at");
     });
 
+    it("names security events among the pillars billed at the telemetry rate", () => {
+      /*
+       * Security events ingest on the same key and meter at the same
+       * $0.10/GB as the other telemetry pillars. This sentence is the body of
+       * the consent checkbox a user has to tick to create a key, so a pillar
+       * missing from it is a pillar the user is charged for without ever
+       * having been told.
+       */
+      render(<TelemetryPayAsYouGoCard />);
+
+      expect(
+        screen.getByTestId("telemetry-pay-as-you-go-card"),
+      ).toHaveTextContent(
+        "Logs, traces, metrics, profiles and security events are billed at",
+      );
+    });
+
     it("says the charge stops when the key is deleted, so the notice is not just a threat", () => {
       render(<TelemetryPayAsYouGoCard />);
 

--- a/Common/Tests/Server/Services/BillingService.test.ts
+++ b/Common/Tests/Server/Services/BillingService.test.ts
@@ -882,6 +882,9 @@ describe("BillingService", () => {
         expect(service.hasMeteredPlanPriceId(ProductType.SessionReplay)).toBe(
           true,
         );
+        expect(service.hasMeteredPlanPriceId(ProductType.SecurityEvents)).toBe(
+          true,
+        );
       });
 
       it("should return false for a product type with no Stripe price", () => {
@@ -900,6 +903,23 @@ describe("BillingService", () => {
         expect(ActiveMonitoringMeteredPlan.hasPriceId()).toBe(true);
         expect(LogDataIngestMeteredPlan.hasPriceId()).toBe(true);
         expect(SessionReplayDataIngestMeteredPlan.hasPriceId()).toBe(true);
+      });
+
+      /*
+       * Security Events shipped its ingest, metering and staging without a
+       * Stripe price, so usage accrued in TelemetryUsageBilling and was never
+       * invoiced - silently, because the callers treat a missing price as
+       * "skip this plan". Enumerate the enum rather than listing types by
+       * hand so the next pillar added cannot repeat that.
+       */
+      it("should have a Stripe price for every ProductType", () => {
+        const unpriced: Array<ProductType> = Object.values(ProductType).filter(
+          (productType: ProductType) => {
+            return !service.hasMeteredPlanPriceId(productType);
+          },
+        );
+
+        expect(unpriced).toEqual([]);
       });
     });
 

--- a/Common/Types/Billing/PayAsYouGoPricing.ts
+++ b/Common/Types/Billing/PayAsYouGoPricing.ts
@@ -10,7 +10,7 @@
  * worse than quoting no price at all, so there is exactly one copy.
  */
 
-// Telemetry ingest - logs, traces, metrics and profiles.
+// Telemetry ingest - logs, traces, metrics, profiles and security events.
 export const TELEMETRY_PRICE_IN_USD_PER_GB: number = 0.1;
 
 /*


### PR DESCRIPTION
## What

Security Events shipped its ingest, metering and usage staging without a Stripe price. `getMeteredPlanPriceId` threw for the product type, so `hasPriceId()` was `false`, the plan was skipped when building Stripe subscription items, and `ReportTelemetryMeteredPlan` swallowed the throw at `debug` level. Usage accrued in `TelemetryUsageBilling` and was never invoiced.

This adds the metered price ids and removes the scaffolding their absence required.

## Changes

**`Common/Server/Services/BillingService.ts`** — adds the `ProductType.SecurityEvents` branch to `getMeteredPlanPriceId` (test `price_1U7efaANuQdJ93r74hFVOgdS`, live `price_1U7edTANuQdJ93r7hR9jpBfv`), matching the shape of the other pillars.

**`App/FeatureSet/Workers/Jobs/MeteredPlan/ReportTelemetryMeteredPlan.ts`** — drops the per-pillar `try/catch` wrappers around session replay and security events. Both existed only because `getMeteredPlanPriceId` threw, and both comments said so explicitly ("will be reported once the price ids are set"). Session replay was priced in e71b6c76c3 and its wrapper was left behind. With every pillar priced, both report like the others, and a genuine Stripe failure now surfaces through the shared per-project catch at `error` level rather than being hidden at `debug`. Also adds the missing `Sleep` between the two calls, which every other pillar boundary has.

**`App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx`** — names security events in `TELEMETRY_RATES_SENTENCE`.

> ⚠️ This one is load-bearing, not cosmetic. That string is the body of the consent checkbox a Free-plan user must tick to create an ingestion key (`PayAsYouGo.tsx:358`, gated by `validateTelemetryConsent`), and it is also rendered by the Security Events setup guide itself via `IngestionKeySelector`. Security events meter on that same key at the same \$0.10/GB. Pricing the pillar without this change would charge users for a data type the disclosure they accepted did not list.

**`Common/Types/Billing/PayAsYouGoPricing.ts`** — stale comment now names security events.

## Tests

- `BillingService.test.ts` — asserts `hasMeteredPlanPriceId(SecurityEvents)`, plus a new test that enumerates `ProductType` and fails on **any** unpriced member, so the next pillar cannot ship unpriced the same way. Verified it has teeth: with the new branch removed it fails with `Array [ "Security Events" ]`.
- `PayAsYouGoNotices.test.tsx` — pins security events into the disclosure sentence.

## Verification

- `BillingService.test.ts` — 91/91 pass
- `PayAsYouGoNotices.test.tsx` — 50/50 pass
- `tsc --noEmit` clean in both `Common` and `App`
- `eslint` and `prettier --check` clean on all changed files

## Note on going live

The live price id is real, so security events usage starts being pushed to Stripe on the next daily `ReportTelemetryMeteredPlan` run. Usage already staged in `TelemetryUsageBilling` from before this change is unreported and will be picked up on that first run.