### PR TITLE
fix(monitor): stop exposing monitor secret keys to read-only roles

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Documentation.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Documentation.tsx
@@ -24,6 +24,7 @@ import React, {
 } from "react";
 import ExceptionMessages from "Common/Types/Exception/ExceptionMessages";
 import useAsyncEffect from "use-async-effect";
+import { getReadableMonitorSecretKeySelect } from "../../../Utils/MonitorSecretKeySelect";
 
 const MonitorDocumentation: FunctionComponent<
   PageComponentProps
@@ -53,9 +54,7 @@ const MonitorDocumentation: FunctionComponent<
         id: modelId,
         select: {
           monitorType: true,
-          incomingRequestSecretKey: true,
-          incomingEmailSecretKey: true,
-          serverMonitorSecretKey: true,
+          ...getReadableMonitorSecretKeySelect(),
         },
       });
 

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -74,6 +74,7 @@ import Incident from "Common/Models/DatabaseModels/Incident";
 import UptimeBarTooltipIncident from "Common/Types/Monitor/UptimeBarTooltipIncident";
 import UptimeBarDayModal from "Common/UI/Components/MonitorGraphs/UptimeBarDayModal";
 import Color from "Common/Types/Color";
+import { getReadableMonitorSecretKeySelect } from "../../../Utils/MonitorSecretKeySelect";
 
 const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID();
@@ -232,9 +233,8 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             name: true,
             color: true,
           },
-          incomingRequestSecretKey: true,
+          ...getReadableMonitorSecretKeySelect(),
           incomingRequestMonitorHeartbeatCheckedAt: true,
-          serverMonitorSecretKey: true,
           serverMonitorRequestReceivedAt: true,
           incomingMonitorRequest: true,
           serverMonitorResponse: true,
@@ -244,7 +244,6 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
           telemetryMonitorNextMonitorAt: true,
           monitorSteps: true,
           // Incoming Email Monitor fields
-          incomingEmailSecretKey: true,
           incomingEmailMonitorRequest: true,
           incomingEmailMonitorHeartbeatCheckedAt: true,
           incomingEmailMonitorLastEmailReceivedAt: true,

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Settings.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Settings.tsx
@@ -31,6 +31,7 @@ import React, {
 import ExceptionMessages from "Common/Types/Exception/ExceptionMessages";
 import useAsyncEffect from "use-async-effect";
 import OneUptimeDate from "Common/Types/Date";
+import { getReadableMonitorSecretKeySelect } from "../../../Utils/MonitorSecretKeySelect";
 
 const MonitorCriteria: FunctionComponent<
   PageComponentProps
@@ -58,9 +59,7 @@ const MonitorCriteria: FunctionComponent<
         id: modelId,
         select: {
           monitorType: true,
-          incomingRequestSecretKey: true,
-          incomingEmailSecretKey: true,
-          serverMonitorSecretKey: true,
+          ...getReadableMonitorSecretKeySelect(),
         },
         requestOptions: {},
       });

--- a/App/FeatureSet/Dashboard/src/Utils/MonitorSecretKeySelect.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MonitorSecretKeySelect.ts
@@ -1,0 +1,45 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Select from "Common/Types/BaseDatabase/Select";
+import PermissionGate from "Common/UI/Utils/PermissionGate";
+
+/*
+ * The monitor secret-key columns, and whether the signed-in user may ask for
+ * them.
+ *
+ * These three columns are bearer credentials, so their read ACL is gated on
+ * the ability to ROTATE the key rather than on the ability to view the monitor
+ * (see Monitor.serverMonitorSecretKey and issue #3360). That makes them the
+ * first columns on Monitor that a legitimate dashboard user can be refused --
+ * and an unreadable column in a select is fatal, not degraded: ColumnPermission
+ * throws and the entire getItem fails, so a Viewer opening the monitor page
+ * would get an error screen instead of a monitor.
+ *
+ * Every page that wants a secret key spreads this into its select instead of
+ * naming the columns directly, so the three pages cannot drift apart on which
+ * ones they gate. The pages already render the "no key" branch (`monitor
+ * ?.serverMonitorSecretKey ? ... : <></>`), so omitting the field degrades to
+ * simply not offering the key -- which is the correct outcome for someone who
+ * is not allowed to see it.
+ */
+export const MONITOR_SECRET_KEY_COLUMNS: Array<keyof Monitor> = [
+  "serverMonitorSecretKey",
+  "incomingRequestSecretKey",
+  "incomingEmailSecretKey",
+];
+
+export type GetReadableMonitorSecretKeySelectFunction = () => Select<Monitor>;
+
+export const getReadableMonitorSecretKeySelect: GetReadableMonitorSecretKeySelectFunction =
+  (): Select<Monitor> => {
+    const select: Select<Monitor> = {};
+
+    for (const column of MONITOR_SECRET_KEY_COLUMNS) {
+      if (PermissionGate.canReadColumn(new Monitor(), column as string)) {
+        (select as Record<string, boolean>)[column as string] = true;
+      }
+    }
+
+    return select;
+  };
+
+export default getReadableMonitorSecretKeySelect;

--- a/App/FeatureSet/Telemetry/Jobs/ServerMonitorIngest/ProcessServerMonitorIngest.ts
+++ b/App/FeatureSet/Telemetry/Jobs/ServerMonitorIngest/ProcessServerMonitorIngest.ts
@@ -12,6 +12,7 @@ import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import OneUptimeDate from "Common/Types/Date";
 import ProjectService from "Common/Server/Services/ProjectService";
+import { stripAgentCredentials } from "Common/Server/Utils/Monitor/MonitorPayloadRedaction";
 
 export async function processServerMonitorFromQueue(
   jobData: ServerMonitorIngestJobData,
@@ -43,10 +44,22 @@ export async function processServerMonitorFromQueue(
     throw new BadDataException(ExceptionMessages.MonitorNotFound);
   }
 
-  const serverMonitorResponse: ServerMonitorResponse =
+  /*
+   * The agent puts the monitor secret in the request body as well as the URL
+   * (ServerMonitorReport.SecretKey / `json:"secretKey"`). The URL copy is what
+   * authenticated the request above and is already spent; the body copy has no
+   * further use here, and everything downstream of this line PERSISTS the
+   * payload — MonitorLog.logBody, Monitor.serverMonitorResponse and
+   * MonitorProbe.lastMonitoringLog are all readable by Permission.Viewer.
+   * Strip it here, at the last point where the payload is still just a
+   * request, so the shared agent secret is never written at rest.
+   * https://github.com/OneUptime/oneuptime/issues/3360
+   */
+  const serverMonitorResponse: ServerMonitorResponse = stripAgentCredentials(
     JSONFunctions.deserialize(
       jobData.serverMonitorResponse["serverMonitorResponse"] as JSONObject,
-    ) as any;
+    ),
+  ) as any;
 
   if (!serverMonitorResponse) {
     throw new BadDataException("Invalid Server Monitor Response");

--- a/App/Tests/Dashboard/MonitorSecretKeySelect.test.ts
+++ b/App/Tests/Dashboard/MonitorSecretKeySelect.test.ts
@@ -1,0 +1,194 @@
+/*
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * Monitor's three secret-key columns are no longer readable by Viewer,
+ * MonitorViewer or ReadProjectMonitor. That closes the direct-read path, but it
+ * opens a second-order hazard in the dashboard: asking for an unreadable column
+ * is FATAL, not degraded. ColumnPermission throws `User is not allowed to read
+ * on serverMonitorSecretKey column of Monitor` and the whole getItem fails, so
+ * three pages that used to name these columns unconditionally --
+ * Monitor > View, Monitor > Settings and Monitor > Documentation -- would show
+ * a Viewer an error screen instead of a monitor.
+ *
+ * getReadableMonitorSecretKeySelect is what those pages spread into their
+ * select instead. These tests pin the two things that matter: it never asks for
+ * a column the user cannot read (or the page breaks), and it does ask for the
+ * ones they can (or setting up an agent becomes impossible).
+ */
+
+const mockUser: { isMasterAdmin: boolean } = { isMasterAdmin: false };
+const mockPermissions: { all: Array<unknown> } = { all: [] };
+
+jest.mock("Common/UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return mockUser.isMasterAdmin;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("Common/UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return mockPermissions.all;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+import {
+  MONITOR_SECRET_KEY_COLUMNS,
+  getReadableMonitorSecretKeySelect,
+} from "../../FeatureSet/Dashboard/src/Utils/MonitorSecretKeySelect";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Permission, { PermissionHelper } from "Common/Types/Permission";
+import { ColumnAccessControl } from "Common/Types/BaseDatabase/AccessControl";
+import Dictionary from "Common/Types/Dictionary";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const accessControl: Dictionary<ColumnAccessControl> =
+  new Monitor().getColumnAccessControlForAllColumns();
+
+type SelectedColumnsFunction = () => Array<string>;
+
+const selectedColumns: SelectedColumnsFunction = (): Array<string> => {
+  return Object.keys(
+    getReadableMonitorSecretKeySelect() as Record<string, boolean>,
+  );
+};
+
+describe("getReadableMonitorSecretKeySelect", () => {
+  beforeEach(() => {
+    mockUser.isMasterAdmin = false;
+    mockPermissions.all = [];
+  });
+
+  it("asks for nothing at all when the user is a Viewer", () => {
+    /*
+     * The regression that would break the monitor page. An empty select spread
+     * is a no-op, so the page loads and simply does not offer a key.
+     */
+    mockPermissions.all = [Permission.Viewer];
+
+    expect(selectedColumns()).toEqual([]);
+  });
+
+  it.each([Permission.MonitorViewer, Permission.ReadProjectMonitor])(
+    "asks for nothing when the user holds only %s",
+    (permission: Permission) => {
+      mockPermissions.all = [permission];
+
+      expect(selectedColumns()).toEqual([]);
+    },
+  );
+
+  it("asks for all three keys for a project owner", () => {
+    mockPermissions.all = [Permission.ProjectOwner];
+
+    expect(selectedColumns().sort()).toEqual(
+      [...MONITOR_SECRET_KEY_COLUMNS].sort(),
+    );
+  });
+
+  it.each([
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.MonitorAdmin,
+    Permission.MonitorMember,
+    Permission.EditProjectMonitor,
+  ])("asks for all three keys for %s", (permission: Permission) => {
+    /*
+     * Monitor > Settings has to render the current key for anyone who can
+     * reset it, and Monitor > Documentation has to render the agent install
+     * command. A member who cannot see the key cannot set an agent up.
+     */
+    mockPermissions.all = [permission];
+
+    expect(selectedColumns().sort()).toEqual(
+      [...MONITOR_SECRET_KEY_COLUMNS].sort(),
+    );
+  });
+
+  it("asks for all three keys for a master admin with no project permissions", () => {
+    mockUser.isMasterAdmin = true;
+    mockPermissions.all = [];
+
+    expect(selectedColumns().sort()).toEqual(
+      [...MONITOR_SECRET_KEY_COLUMNS].sort(),
+    );
+  });
+
+  it("asks for nothing while the permission snapshot has not loaded", () => {
+    /*
+     * The snapshot arrives on a response header and is empty for the first
+     * paint after a login. Guessing "probably allowed" here would hard-fail
+     * that first render of every monitor page.
+     */
+    mockPermissions.all = [];
+
+    expect(selectedColumns()).toEqual([]);
+  });
+
+  it("only ever names columns the server would actually let through", () => {
+    /*
+     * The property, rather than a role-by-role table: for any permission set,
+     * every column this helper selects must pass the same intersection check
+     * ColumnPermission runs server-side. If the two ever disagree, the page
+     * 400s.
+     */
+    const permissionSets: Array<Array<Permission>> = [
+      [],
+      [Permission.Viewer],
+      [Permission.MonitorViewer],
+      [Permission.ReadProjectMonitor],
+      [Permission.Viewer, Permission.MonitorViewer],
+      [Permission.ProjectMember],
+      [Permission.ProjectOwner, Permission.Viewer],
+      [Permission.Viewer, Permission.EditProjectMonitor],
+    ];
+
+    for (const permissions of permissionSets) {
+      mockPermissions.all = permissions;
+
+      for (const column of selectedColumns()) {
+        expect(
+          PermissionHelper.doesPermissionsIntersect(
+            permissions,
+            accessControl[column]?.read || [],
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("covers every secret key column the Monitor model declares", () => {
+    /*
+     * If someone adds a fourth secret to Monitor and wires a page to select it
+     * directly, this list goes stale and that page breaks for read-only users
+     * exactly the way the first three did.
+     */
+    const declaredSecretColumns: Array<string> = Object.keys(
+      accessControl,
+    ).filter((column: string) => {
+      return column.toLowerCase().endsWith("secretkey");
+    });
+
+    expect([...MONITOR_SECRET_KEY_COLUMNS].sort()).toEqual(
+      declaredSecretColumns.sort(),
+    );
+  });
+});

--- a/App/Tests/Telemetry/ServerMonitorIngestSecretRedaction.test.ts
+++ b/App/Tests/Telemetry/ServerMonitorIngestSecretRedaction.test.ts
@@ -1,0 +1,255 @@
+/*
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * The infrastructure agent sends its secret TWICE: once as the last path
+ * segment of the ingest URL, and once inside the JSON body
+ * (InfrastructureAgent/model/server_monitor_report.go:
+ * `SecretKey string \`json:"secretKey"\``). Only the URL copy authenticates.
+ * The body copy used to survive `JSONFunctions.deserialize` -- which copies
+ * every key it is given and does not care that `ServerMonitorResponse`
+ * declares no `secretKey` -- and become `dataToProcess`, at which point
+ * MonitorResource persists it into three Viewer-readable places:
+ * MonitorLog.logBody, Monitor.serverMonitorResponse and
+ * MonitorProbe.lastMonitoringLog.
+ *
+ * This suite pins the boundary: whatever the agent puts in the body, the
+ * object handed to MonitorResourceUtil.monitorResource carries no credential.
+ * That is the "never at rest" half of the fix -- redaction inside
+ * MonitorLogUtil is the net underneath it, not a substitute, because the other
+ * two sinks never go through MonitorLogUtil at all.
+ *
+ * MonitorResource is mocked wholesale: it is the assertion target here, and
+ * importing it for real drags in the isolated-vm sandbox the criteria
+ * evaluator uses.
+ */
+
+jest.mock("Common/Server/Utils/Monitor/MonitorResource", () => {
+  return {
+    __esModule: true,
+    default: {
+      monitorResource: jest.fn(() => {
+        return Promise.resolve({});
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      getEnabledMonitorQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getActiveProjectStatusQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import { processServerMonitorFromQueue } from "../../FeatureSet/Telemetry/Jobs/ServerMonitorIngest/ProcessServerMonitorIngest";
+import { ServerMonitorIngestJobData } from "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
+import MonitorService from "Common/Server/Services/MonitorService";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const SECRET: string = "b1946ac9-2492-4b0f-9b2f-ee9b6cbe36ba";
+
+const MONITOR_ID: string = "8f14e45f-ceea-467a-9575-1b0d0d3e7a9c";
+
+const monitorResource: jest.Mock =
+  MonitorResourceUtil.monitorResource as unknown as jest.Mock;
+
+const findOneBy: jest.Mock = MonitorService.findOneBy as unknown as jest.Mock;
+
+type AgentBodyFunction = () => JSONObject;
+
+/*
+ * Byte-for-byte the JSON the Go agent marshals: `reqData` wraps the report
+ * under a `serverMonitorResponse` key, and the API handler stores that whole
+ * object as the job's `serverMonitorResponse`. Hence the double nesting below
+ * -- it is not a typo, it is the wire format.
+ */
+const agentBody: AgentBodyFunction = (): JSONObject => {
+  return {
+    serverMonitorResponse: {
+      secretKey: SECRET,
+      basicInfrastructureMetrics: {
+        cpuMetrics: { percentUsed: 12.5, cores: 8 },
+        memoryMetrics: { total: 16_777_216, percentUsed: 75, cached: 4096 },
+      },
+      requestReceivedAt: "2026-08-23T10:00:00.000Z",
+      onlyCheckRequestReceivedAt: false,
+      processes: [
+        { pid: 1, name: "systemd", command: "/sbin/init" },
+        { pid: 42, name: "node", command: "node index.js" },
+      ],
+      hostname: "web-01.internal",
+    },
+  };
+};
+
+type JobDataFunction = (body?: JSONObject) => ServerMonitorIngestJobData;
+
+const jobData: JobDataFunction = (
+  body?: JSONObject,
+): ServerMonitorIngestJobData => {
+  return {
+    secretKey: SECRET,
+    serverMonitorResponse: body ?? agentBody(),
+    ingestionTimestamp: new Date("2026-08-23T10:00:00.000Z"),
+  };
+};
+
+type ProcessedPayloadFunction = () => JSONObject;
+
+const processedPayload: ProcessedPayloadFunction = (): JSONObject => {
+  expect(monitorResource).toHaveBeenCalledTimes(1);
+
+  const calls: Array<Array<unknown>> = monitorResource.mock
+    .calls as unknown as Array<Array<unknown>>;
+
+  return calls[0]![0] as JSONObject;
+};
+
+describe("processServerMonitorFromQueue", () => {
+  beforeEach(() => {
+    monitorResource.mockClear();
+    findOneBy.mockReset();
+
+    const monitor: Monitor = new Monitor();
+    monitor._id = MONITOR_ID;
+
+    findOneBy.mockImplementation(() => {
+      return Promise.resolve(monitor);
+    });
+  });
+
+  it("does not pass the agent's secret on to the monitor pipeline", async () => {
+    await processServerMonitorFromQueue(jobData());
+
+    const payload: JSONObject = processedPayload();
+
+    expect(payload["secretKey"]).toBeUndefined();
+    expect("secretKey" in payload).toBe(false);
+    expect(JSON.stringify(payload)).not.toContain(SECRET);
+  });
+
+  it("still authenticates using the secret from the URL", async () => {
+    /*
+     * Stripping the body copy must not break authentication -- the URL copy is
+     * what the lookup uses, and it is untouched.
+     */
+    await processServerMonitorFromQueue(jobData());
+
+    expect(findOneBy).toHaveBeenCalledTimes(1);
+
+    const query: JSONObject = (
+      (
+        findOneBy.mock.calls as unknown as Array<Array<JSONObject>>
+      )[0]![0] as JSONObject
+    )["query"] as JSONObject;
+
+    expect((query["serverMonitorSecretKey"] as ObjectID).toString()).toBe(
+      SECRET,
+    );
+  });
+
+  it("forwards every observation the beat carried", async () => {
+    await processServerMonitorFromQueue(jobData());
+
+    const payload: JSONObject = processedPayload();
+
+    expect(payload["hostname"]).toBe("web-01.internal");
+    expect(payload["onlyCheckRequestReceivedAt"]).toBe(false);
+    expect(payload["basicInfrastructureMetrics"]).toEqual({
+      cpuMetrics: { percentUsed: 12.5, cores: 8 },
+      memoryMetrics: { total: 16_777_216, percentUsed: 75, cached: 4096 },
+    });
+    expect(payload["processes"]).toEqual([
+      { pid: 1, name: "systemd", command: "/sbin/init" },
+      { pid: 42, name: "node", command: "node index.js" },
+    ]);
+  });
+
+  it("still stamps the fields the pipeline depends on", async () => {
+    /*
+     * These three assignments happen after the strip. If redaction ever ran
+     * over the object again afterwards, or replaced it, monitorId would be
+     * lost and the evaluation would be scoped to nothing.
+     */
+    await processServerMonitorFromQueue(jobData());
+
+    const payload: JSONObject = processedPayload();
+
+    expect((payload["monitorId"] as ObjectID).toString()).toBe(MONITOR_ID);
+    expect(payload["requestReceivedAt"] instanceof Date).toBe(true);
+    expect(payload["timeNow"] instanceof Date).toBe(true);
+  });
+
+  it("strips a credential the agent nested inside the metrics block", async () => {
+    /*
+     * Defence against a payload that is not the shape we expect. A body-copy
+     * strip that only looked at the top level would be trivially bypassed by a
+     * future agent version that moved the field.
+     */
+    const body: JSONObject = agentBody();
+
+    (
+      (body["serverMonitorResponse"] as JSONObject)[
+        "basicInfrastructureMetrics"
+      ] as JSONObject
+    )["apiKey"] = SECRET;
+
+    await processServerMonitorFromQueue(jobData(body));
+
+    expect(JSON.stringify(processedPayload())).not.toContain(SECRET);
+  });
+
+  it("refuses a beat whose monitor cannot be found", async () => {
+    findOneBy.mockImplementation(() => {
+      return Promise.resolve(null);
+    });
+
+    await expect(processServerMonitorFromQueue(jobData())).rejects.toThrow();
+
+    expect(monitorResource).not.toHaveBeenCalled();
+  });
+
+  it("refuses a beat with no secret key at all", async () => {
+    await expect(
+      processServerMonitorFromQueue({
+        ...jobData(),
+        secretKey: "",
+      }),
+    ).rejects.toThrow();
+
+    expect(monitorResource).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Models/DatabaseModels/Monitor.ts
+++ b/Common/Models/DatabaseModels/Monitor.ts
@@ -1220,15 +1220,25 @@ export default class Monitor extends BaseModel {
 
   @ColumnAccessControl({
     create: [],
+    /*
+     * Gated on the ability to ROTATE the secret, not on the ability to view
+     * the monitor: this read list is deliberately identical to the update list
+     * below. A holder of this key can authenticate as any host
+     * agent reporting to the monitor -- forging or suppressing heartbeats.
+     *
+     * Viewer, MonitorViewer and ReadProjectMonitor used to be here. Viewer is
+     * the least privilege OneUptime grants and is what gets handed to
+     * dashboards, auditors, contractors and automations, so "read-only" also
+     * meant "can read a live bearer credential".
+     * https://github.com/OneUptime/oneuptime/issues/3360
+     */
     read: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
       Permission.ProjectMember,
-      Permission.Viewer,
       Permission.MonitorAdmin,
       Permission.MonitorMember,
-      Permission.MonitorViewer,
-      Permission.ReadProjectMonitor,
+      Permission.EditProjectMonitor,
     ],
     update: [
       Permission.ProjectOwner,
@@ -1258,15 +1268,25 @@ export default class Monitor extends BaseModel {
 
   @ColumnAccessControl({
     create: [],
+    /*
+     * Gated on the ability to ROTATE the secret, not on the ability to view
+     * the monitor: this read list is deliberately identical to the update list
+     * below. This key IS the heartbeat URL: a holder can beat the
+     * monitor and keep a dead service looking alive.
+     *
+     * Viewer, MonitorViewer and ReadProjectMonitor used to be here. Viewer is
+     * the least privilege OneUptime grants and is what gets handed to
+     * dashboards, auditors, contractors and automations, so "read-only" also
+     * meant "can read a live bearer credential".
+     * https://github.com/OneUptime/oneuptime/issues/3360
+     */
     read: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
       Permission.ProjectMember,
-      Permission.Viewer,
       Permission.MonitorAdmin,
       Permission.MonitorMember,
-      Permission.MonitorViewer,
-      Permission.ReadProjectMonitor,
+      Permission.EditProjectMonitor,
     ],
     update: [
       Permission.ProjectOwner,
@@ -1333,15 +1353,25 @@ export default class Monitor extends BaseModel {
 
   @ColumnAccessControl({
     create: [],
+    /*
+     * Gated on the ability to ROTATE the secret, not on the ability to view
+     * the monitor: this read list is deliberately identical to the update list
+     * below. This key IS the monitor's inbound address: a holder can
+     * send mail that the monitor counts as a heartbeat.
+     *
+     * Viewer, MonitorViewer and ReadProjectMonitor used to be here. Viewer is
+     * the least privilege OneUptime grants and is what gets handed to
+     * dashboards, auditors, contractors and automations, so "read-only" also
+     * meant "can read a live bearer credential".
+     * https://github.com/OneUptime/oneuptime/issues/3360
+     */
     read: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
       Permission.ProjectMember,
-      Permission.Viewer,
       Permission.MonitorAdmin,
       Permission.MonitorMember,
-      Permission.MonitorViewer,
-      Permission.ReadProjectMonitor,
+      Permission.EditProjectMonitor,
     ],
     update: [
       Permission.ProjectOwner,

--- a/Common/Server/Utils/Monitor/MonitorLogUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorLogUtil.ts
@@ -7,6 +7,7 @@ import OneUptimeDate from "../../../Types/Date";
 import ObjectID from "../../../Types/ObjectID";
 import { JSONObject } from "../../../Types/JSON";
 import DataToProcess from "./DataToProcess";
+import { redactForPersistence } from "./MonitorPayloadRedaction";
 
 /*
  * Maximum rows held in memory before we force a flush, and the
@@ -138,7 +139,19 @@ export default class MonitorLogUtil {
           projectId: data.projectId.toString(),
           monitorId: data.monitorId.toString(),
           time: logTimestamp,
-          logBody: JSON.parse(JSON.stringify(data.dataToProcess)),
+          /*
+           * Redact on the way out, never in place: `dataToProcess` is still
+           * live here (saveMonitorLog is fire-and-forget and the caller keeps
+           * evaluating criteria against it), so the stringify/parse clone is
+           * what gets masked. logBody is readable by Permission.Viewer, which
+           * makes it the widest-reach sink in the product — anything
+           * credential-shaped in it is readable by the least-privileged role
+           * OneUptime grants. See MonitorPayloadRedaction.
+           * https://github.com/OneUptime/oneuptime/issues/3360
+           */
+          logBody: redactForPersistence(
+            JSON.parse(JSON.stringify(data.dataToProcess)),
+          ),
           retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
         };
 

--- a/Common/Server/Utils/Monitor/MonitorPayloadRedaction.ts
+++ b/Common/Server/Utils/Monitor/MonitorPayloadRedaction.ts
@@ -1,0 +1,164 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import { isSensitiveLogKey, REDACTED } from "../LogRedaction";
+
+/*
+ * Credential stripping for monitor ingest payloads.
+ *
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * The infrastructure agent authenticates by putting the monitor's
+ * `serverMonitorSecretKey` in BOTH the ingest URL and the JSON body
+ * (`ServerMonitorReport.SecretKey`, `json:"secretKey"`). The URL copy is
+ * transient. The body copy is not: the deserialized body becomes
+ * `dataToProcess`, and `dataToProcess` is written verbatim to three places
+ * that a read-only principal can select from:
+ *
+ *   - `MonitorLog.logBody` (ClickHouse, `Permission.Viewer` readable),
+ *   - `Monitor.serverMonitorResponse` (Postgres jsonb, `Viewer` readable),
+ *   - `MonitorProbe.lastMonitoringLog`.
+ *
+ * So the shared secret that authenticates every agent in the project sat at
+ * rest, in plaintext, behind the lowest privilege OneUptime grants. Rotating
+ * did not help: the replacement re-entered the payload on the very next beat.
+ *
+ * Two entry points, because the two sinks want different things:
+ *
+ *   - `stripAgentCredentials` DELETES the key. It runs at the ingest boundary,
+ *     before `dataToProcess` exists, so the secret never reaches any sink and
+ *     never enters the process's monitor-evaluation state at all. Deleting
+ *     rather than masking keeps `Monitor.serverMonitorResponse` faithful to
+ *     the `ServerMonitorResponse` interface, which declares no `secretKey`.
+ *
+ *   - `redactForPersistence` MASKS the value with `[REDACTED]`. It runs on the
+ *     copy `MonitorLogUtil` writes to `logBody`. Masking is the better choice
+ *     there because `logBody` is a diagnostic record: an operator debugging an
+ *     API monitor wants to see THAT an `Authorization` header was sent without
+ *     seeing what it was. It is also the net underneath the boundary strip —
+ *     it applies to every monitor type and every future payload field, so a
+ *     credential added to some other ingest path does not silently start
+ *     accumulating in ClickHouse.
+ *
+ * What counts as a credential is delegated to `isSensitiveLogKey`, the same
+ * deny-by-default classifier the logger uses, so there is one list to keep
+ * current rather than two. It is structural only (decided by key name): the
+ * textual sweeps in `redactLogString` are right for log lines but would mangle
+ * a captured HTTP response body, which is legitimate monitor evidence.
+ */
+
+// Deep enough for any real ingest payload, shallow enough to bound the walk.
+const MAX_DEPTH: number = 12;
+
+type WalkFunction = (
+  value: JSONValue,
+  drop: boolean,
+  depth: number,
+) => JSONValue;
+
+/*
+ * One walker, two behaviours. `drop` picks whether a sensitive key is removed
+ * from its parent object or kept with its value replaced.
+ *
+ * Always returns a new object/array rather than mutating in place. The ingest
+ * caller hands us an object it is about to keep using, and `MonitorLogUtil`
+ * hands us a payload that is still being read by the criteria evaluator — so
+ * mutating the input would change what the monitor evaluates, not just what
+ * gets stored.
+ */
+const walk: WalkFunction = (
+  value: JSONValue,
+  drop: boolean,
+  depth: number,
+): JSONValue => {
+  /*
+   * Past the depth ceiling we cannot keep vouching for what is nested below,
+   * and a payload that deep is not something a monitor legitimately reports.
+   * Drop the subtree instead of passing it through unredacted.
+   */
+  if (depth > MAX_DEPTH) {
+    return null;
+  }
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item: JSONValue) => {
+      return walk(item, drop, depth + 1);
+    });
+  }
+
+  /*
+   * Dates and ObjectIDs survive the JSON round-trip as strings, but callers
+   * may hand us live instances (the ingest boundary runs before
+   * `JSON.stringify`). Anything that is not a plain object is a leaf.
+   */
+  if (
+    typeof value !== "object" ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    return value;
+  }
+
+  const source: JSONObject = value as JSONObject;
+  const result: JSONObject = {};
+
+  for (const key of Object.keys(source)) {
+    const child: JSONValue = source[key] as JSONValue;
+
+    if (isSensitiveLogKey(key, child)) {
+      if (drop) {
+        continue;
+      }
+
+      result[key] = REDACTED;
+      continue;
+    }
+
+    result[key] = walk(child, drop, depth + 1);
+  }
+
+  return result;
+};
+
+export type StripAgentCredentialsFunction = <T>(payload: T) => T;
+
+/*
+ * Ingest boundary. Removes agent-supplied credentials from a freshly
+ * deserialized payload so the secret never becomes part of `dataToProcess`.
+ *
+ * Generic over the payload type because the caller immediately treats the
+ * result as its declared interface (`ServerMonitorResponse` and friends) —
+ * none of which declare a credential field, so removing one cannot invalidate
+ * the type.
+ */
+export const stripAgentCredentials: StripAgentCredentialsFunction = <T>(
+  payload: T,
+): T => {
+  if (payload === null || payload === undefined) {
+    return payload;
+  }
+
+  return walk(payload as JSONValue, true, 0) as T;
+};
+
+export type RedactForPersistenceFunction = (payload: JSONValue) => JSONValue;
+
+/*
+ * Storage boundary. Masks credentials in the copy that is about to be written
+ * to `MonitorLog.logBody`.
+ */
+export const redactForPersistence: RedactForPersistenceFunction = (
+  payload: JSONValue,
+): JSONValue => {
+  if (payload === null || payload === undefined) {
+    return payload;
+  }
+
+  return walk(payload, false, 0);
+};
+
+export default {
+  stripAgentCredentials,
+  redactForPersistence,
+};

--- a/Common/Tests/Models/DatabaseModels/DomainRoleTierCoverage.test.ts
+++ b/Common/Tests/Models/DatabaseModels/DomainRoleTierCoverage.test.ts
@@ -117,6 +117,30 @@ const NOT_READABLE_BY_THEIR_DOMAIN_ROLES: Array<string> = [
   "IncomingCallPolicyEscalationRule",
 ];
 
+/*
+ * Columns inside an in-domain table whose read list deliberately stops short of
+ * the domain's full tier set, and why. The table-level list above is about
+ * whole tables a role holder is kept out of; this is the same idea one level
+ * down, for a table they are otherwise welcome in.
+ *
+ * Entries are the exact `<table>.<column> is missing <tier>` strings the sweep
+ * produces, so the list is self-policing: widen one of these read lists again
+ * and the entry stops being produced and the assertion fails.
+ *
+ * https://github.com/OneUptime/oneuptime/issues/3360 - Monitor's three secret
+ * keys are bearer credentials, not monitor data. Reading one is gated on being
+ * able to ROTATE it, which is what separates MonitorMember (may edit a monitor,
+ * so may see and reset its key) from MonitorViewer (read-only, so may not).
+ * Viewer used to be on these lists, which made "read-only" mean "can read a
+ * live credential for every agent in the project" -- the same reasoning that
+ * keeps MonitorSecret out of the table list above.
+ */
+const COLUMNS_NOT_READABLE_BY_THEIR_DOMAIN_ROLES: Array<string> = [
+  "Monitor.incomingEmailSecretKey is missing MonitorViewer",
+  "Monitor.incomingRequestSecretKey is missing MonitorViewer",
+  "Monitor.serverMonitorSecretKey is missing MonitorViewer",
+];
+
 type ModelNameFunction = (modelType: ModelType) => string;
 
 const modelName: ModelNameFunction = (modelType: ModelType): string => {
@@ -317,7 +341,9 @@ describe("Domain role tier coverage", () => {
       }
     }
 
-    expect(missing.sort()).toEqual([]);
+    expect(missing.sort()).toEqual(
+      COLUMNS_NOT_READABLE_BY_THEIR_DOMAIN_ROLES.slice().sort(),
+    );
     expect(checked).toBeGreaterThan(500);
   });
 });

--- a/Common/Tests/Models/DatabaseModels/MonitorSecretKeyColumnAccessControl.test.ts
+++ b/Common/Tests/Models/DatabaseModels/MonitorSecretKeyColumnAccessControl.test.ts
@@ -1,0 +1,214 @@
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import { ColumnAccessControl } from "../../../Types/BaseDatabase/AccessControl";
+import Dictionary from "../../../Types/Dictionary";
+import Permission, { PermissionHelper } from "../../../Types/Permission";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * Monitor carries three bearer credentials as ordinary columns:
+ *
+ *   serverMonitorSecretKey    - authenticates every host agent reporting in
+ *   incomingRequestSecretKey  - IS the heartbeat URL
+ *   incomingEmailSecretKey    - IS the monitor's inbound address
+ *
+ * All three used to list Permission.Viewer in their read ACL. Viewer is the
+ * least privilege OneUptime offers and is precisely what gets handed to a
+ * dashboard, an auditor, a contractor or an automation -- so "read-only" also
+ * meant "can read a live credential and then forge or suppress this monitor's
+ * heartbeats". Redacting the secret out of MonitorLog.logBody (the other half
+ * of the fix) does nothing about this path: it is a plain column select.
+ *
+ * The rule these tests encode is a single sentence: reading a monitor secret
+ * requires the ability to ROTATE it. Anything weaker is a credential handed to
+ * someone who cannot revoke it.
+ */
+
+const SECRET_KEY_COLUMNS: Array<string> = [
+  "serverMonitorSecretKey",
+  "incomingRequestSecretKey",
+  "incomingEmailSecretKey",
+];
+
+/*
+ * The read-only roles. Every one of these was on the read list before the fix,
+ * and none of them can rotate a key.
+ */
+const READ_ONLY_PERMISSIONS: Array<Permission> = [
+  Permission.Viewer,
+  Permission.MonitorViewer,
+  Permission.ReadProjectMonitor,
+];
+
+// The roles that can reset a monitor secret, and so may also see it.
+const ROTATION_PERMISSIONS: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.ProjectMember,
+  Permission.MonitorAdmin,
+  Permission.MonitorMember,
+  Permission.EditProjectMonitor,
+];
+
+const accessControl: Dictionary<ColumnAccessControl> =
+  new Monitor().getColumnAccessControlForAllColumns();
+
+type CanReadFunction = (
+  columnName: string,
+  userPermissions: Array<Permission>,
+) => boolean;
+
+/*
+ * ColumnPermission.checkDataColumnPermissions, reduced to the question that
+ * matters. Note what the server does when this is false: it THROWS
+ * `User is not allowed to read on <column> column of Monitor` and the whole
+ * request fails. There is no partial response -- which is why the dashboard
+ * has to gate the select rather than the render.
+ */
+const canRead: CanReadFunction = (
+  columnName: string,
+  userPermissions: Array<Permission>,
+): boolean => {
+  const columnPermissions: Array<Permission> =
+    accessControl[columnName]?.read || [];
+
+  return PermissionHelper.doesPermissionsIntersect(
+    userPermissions,
+    columnPermissions,
+  );
+};
+
+describe("Monitor secret key columns are not readable by read-only roles", () => {
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s is unreadable by a Viewer-only principal",
+    (columnName: string) => {
+      /*
+       * This is step 2 of the reproduction in the issue: an API key whose only
+       * permission is Viewer.
+       */
+      expect(canRead(columnName, [Permission.Viewer])).toBe(false);
+    },
+  );
+
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s is unreadable by every read-only role, individually",
+    (columnName: string) => {
+      for (const permission of READ_ONLY_PERMISSIONS) {
+        expect(canRead(columnName, [permission])).toBe(false);
+      }
+    },
+  );
+
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s is unreadable even when all the read-only roles are held at once",
+    (columnName: string) => {
+      /*
+       * Intersection semantics mean any single surviving read-only permission
+       * re-opens the hole, so hold them all and assert the union is still
+       * refused.
+       */
+      expect(canRead(columnName, READ_ONLY_PERMISSIONS)).toBe(false);
+    },
+  );
+
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s names none of the read-only roles in its read ACL",
+    (columnName: string) => {
+      const readPermissions: Array<Permission> =
+        accessControl[columnName]?.read || [];
+
+      for (const permission of READ_ONLY_PERMISSIONS) {
+        expect(readPermissions).not.toContain(permission);
+      }
+    },
+  );
+});
+
+describe("Monitor secret key columns stay readable by the roles that can rotate them", () => {
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s is readable by each rotation-capable role",
+    (columnName: string) => {
+      /*
+       * The other failure mode. Locking these down too far breaks Monitor >
+       * Settings for a project member, who legitimately needs the key to set
+       * an agent up.
+       */
+      for (const permission of ROTATION_PERMISSIONS) {
+        expect(canRead(columnName, [permission])).toBe(true);
+      }
+    },
+  );
+
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s gates read on exactly the same roles as update",
+    (columnName: string) => {
+      /*
+       * The invariant, stated directly: you may see a monitor secret if and
+       * only if you may replace it. If someone later widens read without
+       * widening update, this is the test that should stop them and make them
+       * say why.
+       */
+      const column: ColumnAccessControl | undefined = accessControl[columnName];
+
+      expect(column).toBeDefined();
+      expect([...(column?.read || [])].sort()).toEqual(
+        [...(column?.update || [])].sort(),
+      );
+    },
+  );
+
+  it.each(SECRET_KEY_COLUMNS)(
+    "%s is never writable on create",
+    (columnName: string) => {
+      // The keys are computed server-side by MonitorService, never supplied.
+      expect(accessControl[columnName]?.create || []).toEqual([]);
+    },
+  );
+});
+
+describe("the rest of the monitor page still loads for a Viewer", () => {
+  /*
+   * Tightening the secret columns must not collaterally break the monitor view
+   * for read-only users: an unreadable column in a select fails the WHOLE
+   * request, so if any of these regressed, a Viewer would get an error screen
+   * instead of a monitor. These are the other columns
+   * Pages/Monitor/View/Index.tsx asks for.
+   */
+  const VIEWER_READABLE_COLUMNS: Array<string> = [
+    "monitorType",
+    "serverMonitorRequestReceivedAt",
+    "incomingRequestMonitorHeartbeatCheckedAt",
+    "incomingEmailMonitorHeartbeatCheckedAt",
+    "incomingEmailMonitorLastEmailReceivedAt",
+    "monitorSteps",
+  ];
+
+  it.each(VIEWER_READABLE_COLUMNS)(
+    "%s is still readable by a Viewer",
+    (columnName: string) => {
+      expect(canRead(columnName, [Permission.Viewer])).toBe(true);
+    },
+  );
+});
+
+describe("the payload columns rely on redaction, not on access control", () => {
+  /*
+   * serverMonitorResponse and incomingMonitorRequest are the OTHER two places
+   * the agent payload lands, and both remain Viewer-readable -- deliberately:
+   * they are what the monitor page renders. That is exactly why the secret has
+   * to be stripped at the ingest boundary (see MonitorPayloadRedaction) rather
+   * than merely hidden behind a permission. If someone ever removes that
+   * strip, no ACL here will catch it.
+   *
+   * This test is a signpost, not a guard. If these columns are deliberately
+   * locked down later, delete it -- but do not delete the redaction.
+   */
+  it("serverMonitorResponse is readable by a Viewer", () => {
+    expect(canRead("serverMonitorResponse", [Permission.Viewer])).toBe(true);
+  });
+
+  it("incomingMonitorRequest is readable by a Viewer", () => {
+    expect(canRead("incomingMonitorRequest", [Permission.Viewer])).toBe(true);
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorLogUtilRedaction.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorLogUtilRedaction.test.ts
@@ -1,0 +1,300 @@
+/*
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * MonitorLogUtil is the widest-reach persistence sink in the monitoring path:
+ * every monitor type, every evaluation, straight into `MonitorLog.logBody` --
+ * a column whose read ACL includes `Permission.Viewer`. Whatever
+ * `saveMonitorLog` is handed is what a read-only API key can select back out.
+ *
+ * The unit-level behaviour of the redactor is pinned in
+ * MonitorPayloadRedaction.test.ts. What THIS suite pins is the wiring: that
+ * the row actually enqueued for ClickHouse is the redacted one, that the
+ * caller's live `dataToProcess` is not collaterally damaged on the way, and
+ * that the rest of the row (ids, timestamps, retention) is unchanged -- so the
+ * fix cannot be quietly reverted by someone reinstating the raw
+ * `JSON.parse(JSON.stringify(...))`.
+ *
+ * Flushing: the buffer drains on a 5s timer or at 10,000 rows, neither of
+ * which a test should wait for. Rather than reach into a private, the suite
+ * drives the flush through MonitorLogUtil's own PUBLIC contract -- the
+ * GracefulShutdown handler it registers, which awaits `flushAndWait()`. The
+ * mock below captures that callback so a test can invoke it directly.
+ */
+
+const mockShutdown: { callback: (() => Promise<void> | void) | null } = {
+  callback: null,
+};
+
+jest.mock("../../../../Server/Utils/GracefulShutdown", () => {
+  return {
+    __esModule: true,
+    default: {
+      registerHandler: (
+        _name: string,
+        _priority: number,
+        callback: () => Promise<void> | void,
+      ): void => {
+        mockShutdown.callback = callback;
+      },
+    },
+    ShutdownPriority: {
+      HttpServer: 10,
+      Workers: 20,
+      Buffers: 30,
+      DataStores: 40,
+      Telemetry: 50,
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/MonitorLogService", () => {
+  return {
+    __esModule: true,
+    default: {
+      insertJsonRows: jest.fn(() => {
+        return Promise.resolve();
+      }),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(() => {
+        return Promise.resolve({ monitorLogRetentionInDays: 7 });
+      }),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import MonitorLogUtil from "../../../../Server/Utils/Monitor/MonitorLogUtil";
+import MonitorLogService from "../../../../Server/Services/MonitorLogService";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import { REDACTED } from "../../../../Server/Utils/LogRedaction";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const SECRET: string = "b1946ac9-2492-4b0f-9b2f-ee9b6cbe36ba";
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "8f14e45f-ceea-467a-9575-1b0d0d3e7a9c",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "3c6e0b8a-9c15-4f8b-a1d2-7e5f4c3b2a19",
+);
+
+/*
+ * Loosely typed on purpose: the module factory above returns an untyped
+ * jest.fn(), and pinning a signature here only fights ts-jest without making
+ * the assertions any stronger.
+ */
+const insertJsonRows: jest.Mock =
+  MonitorLogService.insertJsonRows as unknown as jest.Mock;
+
+type SaveAndFlushFunction = (
+  dataToProcess: DataToProcess,
+) => Promise<JSONObject>;
+
+/*
+ * Run one payload all the way through to the row handed to ClickHouse.
+ *
+ * `saveMonitorLog` is deliberately fire-and-forget (the monitor hot path must
+ * not block on a retention lookup), so the promise chain has to be given a
+ * turn of the event loop before the row exists in the buffer at all.
+ */
+const saveAndFlush: SaveAndFlushFunction = async (
+  dataToProcess: DataToProcess,
+): Promise<JSONObject> => {
+  MonitorLogUtil.saveMonitorLog({
+    monitorId: MONITOR_ID,
+    projectId: PROJECT_ID,
+    dataToProcess: dataToProcess,
+  });
+
+  await new Promise<void>((resolve: () => void) => {
+    setTimeout(resolve, 0);
+  });
+
+  if (!mockShutdown.callback) {
+    throw new Error(
+      "MonitorLogUtil did not register its shutdown flush handler",
+    );
+  }
+
+  await mockShutdown.callback();
+
+  const calls: Array<Array<unknown>> = insertJsonRows.mock
+    .calls as unknown as Array<Array<unknown>>;
+
+  expect(calls.length).toBeGreaterThan(0);
+
+  const rows: Array<JSONObject> = calls[
+    calls.length - 1
+  ]![0] as Array<JSONObject>;
+
+  expect(rows).toHaveLength(1);
+
+  return rows[0]!;
+};
+
+type ServerBeatFunction = () => JSONObject;
+
+// The payload the Go agent sends, with the two fields MonitorResource stamps on.
+const serverBeat: ServerBeatFunction = (): JSONObject => {
+  return {
+    secretKey: SECRET,
+    hostname: "web-01.internal",
+    monitorId: MONITOR_ID,
+    projectId: PROJECT_ID,
+    requestReceivedAt: new Date("2026-08-23T10:00:00.000Z"),
+    onlyCheckRequestReceivedAt: false,
+    basicInfrastructureMetrics: {
+      cpuMetrics: { percentUsed: 12.5, cores: 8 },
+      memoryMetrics: { total: 16_777_216, percentUsed: 75 },
+    },
+    processes: [{ pid: 42, name: "node", command: "node index.js" }],
+  };
+};
+
+describe("MonitorLogUtil.saveMonitorLog", () => {
+  beforeEach(() => {
+    insertJsonRows.mockClear();
+  });
+
+  it("does not write the server-agent secret into logBody", async () => {
+    const row: JSONObject = await saveAndFlush(
+      serverBeat() as unknown as DataToProcess,
+    );
+
+    const logBody: JSONObject = row["logBody"] as JSONObject;
+
+    expect(logBody["secretKey"]).toBe(REDACTED);
+    expect(JSON.stringify(row)).not.toContain(SECRET);
+  });
+
+  it("still writes everything the monitor is actually for", async () => {
+    const row: JSONObject = await saveAndFlush(
+      serverBeat() as unknown as DataToProcess,
+    );
+
+    const logBody: JSONObject = row["logBody"] as JSONObject;
+
+    expect(logBody["hostname"]).toBe("web-01.internal");
+    expect(logBody["onlyCheckRequestReceivedAt"]).toBe(false);
+    expect(
+      (logBody["basicInfrastructureMetrics"] as JSONObject)["cpuMetrics"],
+    ).toEqual({ percentUsed: 12.5, cores: 8 });
+    expect(logBody["processes"]).toEqual([
+      { pid: 42, name: "node", command: "node index.js" },
+    ]);
+  });
+
+  it("leaves the caller's live payload untouched", async () => {
+    /*
+     * saveMonitorLog returns immediately and MonitorResource keeps evaluating
+     * criteria against the same object afterwards. Redacting in place would
+     * change the monitor's verdict, not just its stored log -- so the clone,
+     * not the original, must be what gets masked.
+     */
+    const live: JSONObject = serverBeat();
+
+    await saveAndFlush(live as unknown as DataToProcess);
+
+    expect(live["secretKey"]).toBe(SECRET);
+    expect(live["hostname"]).toBe("web-01.internal");
+  });
+
+  it("keeps the rest of the row intact", async () => {
+    /*
+     * Redaction must not disturb the columns ClickHouse partitions, sorts and
+     * expires on. A row that loses its retentionDate never gets TTL'd.
+     */
+    const row: JSONObject = await saveAndFlush(
+      serverBeat() as unknown as DataToProcess,
+    );
+
+    expect(row["monitorId"]).toBe(MONITOR_ID.toString());
+    expect(row["projectId"]).toBe(PROJECT_ID.toString());
+    expect(typeof row["_id"]).toBe("string");
+    expect(typeof row["time"]).toBe("string");
+    expect(typeof row["createdAt"]).toBe("string");
+    expect(typeof row["retentionDate"]).toBe("string");
+  });
+
+  it("masks caller-supplied auth headers on an incoming-request monitor", async () => {
+    /*
+     * The other half of the issue: an incoming-request monitor stores the
+     * headers and body of whatever called it, so a caller's bearer token was
+     * landing in Viewer-readable logBody as well.
+     */
+    const row: JSONObject = await saveAndFlush({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      incomingRequestReceivedAt: new Date("2026-08-23T10:00:00.000Z"),
+      checkedAt: new Date("2026-08-23T10:00:01.000Z"),
+      requestHeaders: {
+        authorization: `Bearer ${SECRET}`,
+        "content-type": "application/json",
+      },
+      requestBody: { status: "ok" },
+    } as unknown as DataToProcess);
+
+    const logBody: JSONObject = row["logBody"] as JSONObject;
+    const headers: JSONObject = logBody["requestHeaders"] as JSONObject;
+
+    expect(headers["authorization"]).toBe(REDACTED);
+    expect(headers["content-type"]).toBe("application/json");
+    expect((logBody["requestBody"] as JSONObject)["status"]).toBe("ok");
+    expect(JSON.stringify(row)).not.toContain(SECRET);
+  });
+
+  it("writes nothing at all when required ids are missing", async () => {
+    /*
+     * Pins the existing guards, which the redaction change sits directly on
+     * top of: a row with no monitorId cannot be scoped or TTL'd.
+     */
+    MonitorLogUtil.saveMonitorLog({
+      monitorId: undefined as unknown as ObjectID,
+      projectId: PROJECT_ID,
+      dataToProcess: serverBeat() as unknown as DataToProcess,
+    });
+
+    MonitorLogUtil.saveMonitorLog({
+      monitorId: MONITOR_ID,
+      projectId: undefined as unknown as ObjectID,
+      dataToProcess: serverBeat() as unknown as DataToProcess,
+    });
+
+    MonitorLogUtil.saveMonitorLog({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      dataToProcess: undefined as unknown as DataToProcess,
+    });
+
+    await new Promise<void>((resolve: () => void) => {
+      setTimeout(resolve, 0);
+    });
+
+    if (mockShutdown.callback) {
+      await mockShutdown.callback();
+    }
+
+    expect(insertJsonRows).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorPayloadRedaction.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorPayloadRedaction.test.ts
@@ -1,0 +1,381 @@
+import {
+  redactForPersistence,
+  stripAgentCredentials,
+} from "../../../../Server/Utils/Monitor/MonitorPayloadRedaction";
+import { REDACTED } from "../../../../Server/Utils/LogRedaction";
+import { JSONObject } from "../../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Regression tests for https://github.com/OneUptime/oneuptime/issues/3360.
+ *
+ * The infrastructure agent authenticates with the monitor's
+ * `serverMonitorSecretKey` and sends that key in the request BODY as well as
+ * the URL (InfrastructureAgent/model/server_monitor_report.go:
+ * `SecretKey string \`json:"secretKey"\``). The body became `dataToProcess`,
+ * and `dataToProcess` was written verbatim into three columns that
+ * `Permission.Viewer` -- the least privilege OneUptime grants -- can select:
+ * `MonitorLog.logBody`, `Monitor.serverMonitorResponse` and
+ * `MonitorProbe.lastMonitoringLog`.
+ *
+ * The property under test is therefore not "the redactor works" in the
+ * abstract. It is: given the payload the real agent actually sends, the secret
+ * does not appear ANYWHERE in the output, in any spelling, at any depth --
+ * while every legitimate monitor observation survives untouched, because a
+ * redactor that eats the metrics is a redactor somebody will turn off.
+ */
+
+// A value distinctive enough that a substring search for it is meaningful.
+const SECRET: string = "b1946ac9-2492-4b0f-9b2f-ee9b6cbe36ba";
+
+type AgentPayloadFunction = () => JSONObject;
+
+/*
+ * The real shape, key-for-key, that the Go agent marshals and
+ * ProcessServerMonitorIngest deserializes -- plus the two fields
+ * MonitorResource stamps on before anything is persisted (`projectId`,
+ * `evaluationSummary`). Reproduced faithfully because a redactor tested only
+ * against a toy `{secretKey: "x"}` proves nothing about the payload that
+ * actually leaked.
+ */
+const agentPayload: AgentPayloadFunction = (): JSONObject => {
+  return {
+    secretKey: SECRET,
+    basicInfrastructureMetrics: {
+      memoryMetrics: {
+        total: 16_777_216,
+        free: 4_194_304,
+        used: 12_582_912,
+        percentUsed: 75,
+        percentFree: 25,
+        cached: 1_048_576,
+        swapTotal: 0,
+      },
+      cpuMetrics: {
+        percentUsed: 12.5,
+        cores: 8,
+        perCorePercent: [10, 15, 12, 11, 14, 13, 12, 13],
+      },
+      diskMetrics: [{ diskPath: "/", total: 500, free: 200, percentUsed: 60 }],
+    },
+    requestReceivedAt: "2026-08-23T10:00:00.000Z",
+    onlyCheckRequestReceivedAt: false,
+    processes: [
+      { pid: 1, name: "systemd", command: "/sbin/init", cpuPercent: 0.1 },
+      { pid: 42, name: "node", command: "node index.js", cpuPercent: 3.2 },
+    ],
+    hostname: "web-01.internal",
+    monitorId: "8f14e45f-ceea-467a-9575-1b0d0d3e7a9c",
+    timeNow: "2026-08-23T10:00:01.000Z",
+    evaluationSummary: {
+      evaluatedAt: "2026-08-23T10:00:01.000Z",
+      criteriaResults: [],
+      events: [],
+    },
+    projectId: "3c6e0b8a-9c15-4f8b-a1d2-7e5f4c3b2a19",
+  };
+};
+
+type ContainsSecretFunction = (value: unknown) => boolean;
+
+/*
+ * The assertion that actually matters. Checking `output.secretKey` alone would
+ * pass for an implementation that merely moved the value one level down, so
+ * every test asserts on the serialized whole.
+ */
+const containsSecret: ContainsSecretFunction = (value: unknown): boolean => {
+  return JSON.stringify(value)?.includes(SECRET) ?? false;
+};
+
+describe("stripAgentCredentials - the ingest boundary", () => {
+  it("removes the secret the agent puts in the request body", () => {
+    const output: JSONObject = stripAgentCredentials(agentPayload());
+
+    expect(output["secretKey"]).toBeUndefined();
+    expect("secretKey" in output).toBe(false);
+    expect(containsSecret(output)).toBe(false);
+  });
+
+  it("keeps every legitimate observation in the beat", () => {
+    const input: JSONObject = agentPayload();
+    const output: JSONObject = stripAgentCredentials(input);
+
+    /*
+     * The whole point of a server monitor. If redaction ever starts eating
+     * these, criteria stop evaluating and the feature is dead -- so pin the
+     * metrics block as deep-equal rather than spot-checking one field.
+     */
+    expect(output["basicInfrastructureMetrics"]).toEqual(
+      input["basicInfrastructureMetrics"],
+    );
+    expect(output["processes"]).toEqual(input["processes"]);
+    expect(output["hostname"]).toBe("web-01.internal");
+    expect(output["monitorId"]).toBe("8f14e45f-ceea-467a-9575-1b0d0d3e7a9c");
+    expect(output["projectId"]).toBe("3c6e0b8a-9c15-4f8b-a1d2-7e5f4c3b2a19");
+    expect(output["onlyCheckRequestReceivedAt"]).toBe(false);
+    expect(output["requestReceivedAt"]).toBe("2026-08-23T10:00:00.000Z");
+    expect(output["evaluationSummary"]).toEqual(input["evaluationSummary"]);
+  });
+
+  it("drops the key rather than masking it, so the typed column stays faithful", () => {
+    /*
+     * `Monitor.serverMonitorResponse` is typed as ServerMonitorResponse, which
+     * declares no `secretKey`. Masking would persist a phantom field on a
+     * typed jsonb column; removing keeps the stored object a valid instance of
+     * its own interface.
+     */
+    const output: JSONObject = stripAgentCredentials(agentPayload());
+
+    expect(Object.keys(output)).not.toContain("secretKey");
+    expect(JSON.stringify(output)).not.toContain(REDACTED);
+  });
+
+  it("does not mutate the payload it was handed", () => {
+    /*
+     * The caller keeps using the input object. An in-place strip would be a
+     * different bug wearing the same fix: it would change what the monitor
+     * evaluates, not just what gets stored.
+     */
+    const input: JSONObject = agentPayload();
+
+    stripAgentCredentials(input);
+
+    expect(input["secretKey"]).toBe(SECRET);
+  });
+
+  it("returns a defensive copy, not the same object", () => {
+    const input: JSONObject = agentPayload();
+    const output: JSONObject = stripAgentCredentials(input);
+
+    expect(output).not.toBe(input);
+    expect(output["processes"]).not.toBe(input["processes"]);
+  });
+});
+
+describe("stripAgentCredentials - spellings and nesting", () => {
+  it("catches the secret under every spelling of the key", () => {
+    /*
+     * The Go struct tag is `secretKey` today. A future agent, a proxy that
+     * renames fields, or a different ingest path may spell it otherwise, and
+     * the classifier normalizes case and separators for exactly that reason.
+     */
+    for (const key of [
+      "secretKey",
+      "secret_key",
+      "SecretKey",
+      "SECRET_KEY",
+      "secret-key",
+      "monitorSecretKey",
+      "serverMonitorSecretKey",
+    ]) {
+      const output: JSONObject = stripAgentCredentials({
+        [key]: SECRET,
+        hostname: "web-01",
+      });
+
+      expect(containsSecret(output)).toBe(false);
+      expect(output["hostname"]).toBe("web-01");
+    }
+  });
+
+  it("finds a credential buried below the top level", () => {
+    const output: JSONObject = stripAgentCredentials({
+      hostname: "web-01",
+      nested: { deeper: { secretKey: SECRET, keep: "yes" } },
+    });
+
+    expect(containsSecret(output)).toBe(false);
+    expect(
+      ((output["nested"] as JSONObject)["deeper"] as JSONObject)["keep"],
+    ).toBe("yes");
+  });
+
+  it("finds a credential inside an array element", () => {
+    const output: JSONObject = stripAgentCredentials({
+      beats: [{ secretKey: SECRET }, { hostname: "web-02" }],
+    });
+
+    expect(containsSecret(output)).toBe(false);
+    expect(output["beats"] as Array<JSONObject>).toHaveLength(2);
+    expect((output["beats"] as Array<JSONObject>)[1]!["hostname"]).toBe(
+      "web-02",
+    );
+  });
+
+  it("handles null, undefined and empty payloads without throwing", () => {
+    expect(stripAgentCredentials(null)).toBeNull();
+    expect(stripAgentCredentials(undefined)).toBeUndefined();
+    expect(stripAgentCredentials({})).toEqual({});
+    expect(stripAgentCredentials({ a: null, b: undefined })).toEqual({
+      a: null,
+      b: undefined,
+    });
+  });
+
+  it("passes class instances through as leaves", () => {
+    /*
+     * The ingest boundary runs on JSONFunctions.deserialize output, which
+     * rehydrates Dates and ObjectIDs into live instances. Walking into them
+     * would rebuild them as plain objects and destroy the type.
+     */
+    const date: Date = new Date("2026-08-23T10:00:00.000Z");
+
+    const output: JSONObject = stripAgentCredentials({
+      requestReceivedAt: date,
+      secretKey: SECRET,
+    });
+
+    expect(output["requestReceivedAt"]).toBe(date);
+    expect(output["requestReceivedAt"] instanceof Date).toBe(true);
+    expect(containsSecret(output)).toBe(false);
+  });
+});
+
+describe("redactForPersistence - the logBody sink", () => {
+  it("masks the secret instead of dropping it", () => {
+    /*
+     * logBody is a diagnostic record, so the useful answer is "a credential
+     * was here" rather than silence. The value still must not survive.
+     */
+    const output: JSONObject = redactForPersistence(
+      agentPayload(),
+    ) as JSONObject;
+
+    expect(output["secretKey"]).toBe(REDACTED);
+    expect(containsSecret(output)).toBe(false);
+  });
+
+  it("masks the auth headers an incoming-request monitor records", () => {
+    /*
+     * The second half of the issue: IncomingMonitorRequest carries
+     * requestHeaders and requestBody straight from the caller, so whatever
+     * token the caller sent was landing in Viewer-readable logBody too.
+     */
+    const output: JSONObject = redactForPersistence({
+      requestHeaders: {
+        Authorization: `Bearer ${SECRET}`,
+        Cookie: `session=${SECRET}`,
+        "x-api-key": SECRET,
+        "content-type": "application/json",
+        "user-agent": "curl/8.0",
+      },
+      requestBody: { password: SECRET, orderId: "A-1001" },
+      incomingRequestReceivedAt: "2026-08-23T10:00:00.000Z",
+    }) as JSONObject;
+
+    const headers: JSONObject = output["requestHeaders"] as JSONObject;
+
+    expect(headers["Authorization"]).toBe(REDACTED);
+    expect(headers["Cookie"]).toBe(REDACTED);
+    expect(headers["x-api-key"]).toBe(REDACTED);
+
+    // Non-credential headers are exactly why masking beats dropping the block.
+    expect(headers["content-type"]).toBe("application/json");
+    expect(headers["user-agent"]).toBe("curl/8.0");
+
+    expect((output["requestBody"] as JSONObject)["password"]).toBe(REDACTED);
+    expect((output["requestBody"] as JSONObject)["orderId"]).toBe("A-1001");
+    expect(containsSecret(output)).toBe(false);
+  });
+
+  it("leaves probe observations that only look credential-shaped alone", () => {
+    /*
+     * Over-redaction is a real cost here: these are the fields monitor
+     * criteria are written against, and `code` in particular is classified by
+     * VALUE, so an error code must survive while an OAuth code must not.
+     */
+    const output: JSONObject = redactForPersistence({
+      responseCode: 200,
+      responseTimeInMs: 143,
+      requestFailedDetails: {
+        failedPhase: "TCP Connection",
+        errorCode: "ECONNREFUSED",
+        errorDescription: "Connection refused",
+      },
+      sslResponse: {
+        certificateValidationErrorCode: "CERT_HAS_EXPIRED",
+        fingerprint: "AA:BB:CC",
+        serialNumber: "0123456789",
+        commonName: "example.com",
+      },
+      customCodeMonitorResponse: {
+        executionTimeInMS: 12,
+        scriptError: undefined,
+      },
+      code: "ECONNREFUSED",
+    }) as JSONObject;
+
+    expect(output["responseCode"]).toBe(200);
+    expect(output["responseTimeInMs"]).toBe(143);
+    expect((output["requestFailedDetails"] as JSONObject)["errorCode"]).toBe(
+      "ECONNREFUSED",
+    );
+    expect(
+      (output["sslResponse"] as JSONObject)["certificateValidationErrorCode"],
+    ).toBe("CERT_HAS_EXPIRED");
+    expect((output["sslResponse"] as JSONObject)["commonName"]).toBe(
+      "example.com",
+    );
+    expect(
+      (output["customCodeMonitorResponse"] as JSONObject)["executionTimeInMS"],
+    ).toBe(12);
+    expect(output["code"]).toBe("ECONNREFUSED");
+  });
+
+  it("still redacts a code that is actually a credential", () => {
+    const output: JSONObject = redactForPersistence({
+      code: SECRET,
+    }) as JSONObject;
+
+    expect(output["code"]).toBe(REDACTED);
+  });
+
+  it("does not mutate the payload it was handed", () => {
+    const input: JSONObject = agentPayload();
+
+    redactForPersistence(input);
+
+    expect(input["secretKey"]).toBe(SECRET);
+  });
+
+  it("handles null and undefined without throwing", () => {
+    expect(redactForPersistence(null)).toBeNull();
+    expect(redactForPersistence(undefined as never)).toBeUndefined();
+  });
+
+  it("drops rather than passes through a subtree past the depth ceiling", () => {
+    /*
+     * A payload nested deeper than the walk will go is not something a monitor
+     * legitimately reports, and passing the tail through unredacted would be
+     * an trivially exploitable way to smuggle a secret past the walk.
+     */
+    let deep: JSONObject = { secretKey: SECRET };
+
+    for (let i: number = 0; i < 40; i++) {
+      deep = { nested: deep };
+    }
+
+    expect(containsSecret(redactForPersistence(deep))).toBe(false);
+    expect(containsSecret(stripAgentCredentials(deep))).toBe(false);
+  });
+});
+
+describe("the reproduction in the issue", () => {
+  it("no longer yields the monitor secret from a stored beat", () => {
+    /*
+     * Issue #3360, steps 1-4: register an agent, select logBody with a
+     * Viewer-only key, read logBody.secretKey, compare to
+     * Monitor.serverMonitorSecretKey. The comparison is what must now fail.
+     */
+    const stored: JSONObject = redactForPersistence(
+      stripAgentCredentials(agentPayload()),
+    ) as JSONObject;
+
+    expect(stored["secretKey"]).toBeUndefined();
+    expect(JSON.stringify(stored)).not.toContain(SECRET);
+
+    // And the beat is still a usable monitor observation.
+    expect(stored["hostname"]).toBe("web-01.internal");
+    expect(stored["basicInfrastructureMetrics"]).toBeDefined();
+  });
+});

--- a/Common/Tests/UI/Utils/PermissionGate.test.ts
+++ b/Common/Tests/UI/Utils/PermissionGate.test.ts
@@ -464,4 +464,109 @@ describe("PermissionGate", () => {
       ).toBeNull();
     });
   });
+  /*
+   * Column-level gating, added for https://github.com/OneUptime/oneuptime/issues/3360.
+   *
+   * Record-level gating decides whether to render a button. Column-level
+   * gating decides whether a field may go into a SELECT, and the consequence
+   * of getting it wrong is much worse: ColumnPermission on the server throws
+   * `User is not allowed to read on <column> column of <model>` and fails the
+   * ENTIRE request, so one over-eager field blanks the whole page rather than
+   * one value. Monitor's secret keys are the first columns on Monitor a
+   * legitimate dashboard user can be refused, which is what made this helper
+   * necessary.
+   */
+  describe("canReadColumn", () => {
+    test("refuses a secret key column to a Viewer", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      expect(
+        PermissionGate.canReadColumn(new Monitor(), "serverMonitorSecretKey"),
+      ).toBe(false);
+    });
+
+    test("allows a secret key column to a role that can rotate it", () => {
+      permissionsForTest = [Permission.ProjectAdmin];
+
+      expect(
+        PermissionGate.canReadColumn(new Monitor(), "serverMonitorSecretKey"),
+      ).toBe(true);
+    });
+
+    test("still allows the columns a Viewer is meant to see", () => {
+      /*
+       * The regression that would break the monitor page for read-only users:
+       * if this ever returns false, Pages/Monitor/View/Index.tsx stops asking
+       * for monitorType and the page cannot decide what kind of monitor it is
+       * looking at.
+       */
+      permissionsForTest = [Permission.Viewer];
+
+      expect(PermissionGate.canReadColumn(new Monitor(), "monitorType")).toBe(
+        true,
+      );
+    });
+
+    test("allows a master admin everything", () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      expect(
+        PermissionGate.canReadColumn(new Monitor(), "serverMonitorSecretKey"),
+      ).toBe(true);
+    });
+
+    test("fails closed while the permission snapshot has not loaded", () => {
+      /*
+       * The opposite call from PermissionGate.check, and deliberately so.
+       * check() hides a button rather than accuse someone of lacking a
+       * permission they hold. Here the recoverable outcome is omitting the
+       * field - the page renders without one value. Failing open would send
+       * the column and hard-fail the request.
+       */
+      permissionsForTest = [];
+
+      expect(
+        PermissionGate.canReadColumn(new Monitor(), "serverMonitorSecretKey"),
+      ).toBe(false);
+    });
+
+    test("allows a column that declares no read access control", () => {
+      /*
+       * Nothing to enforce, and ColumnPermission agrees - it only refuses
+       * columns that name permissions the user does not hold.
+       */
+      permissionsForTest = [Permission.Viewer];
+
+      expect(
+        PermissionGate.canReadColumn(
+          {
+            getColumnAccessControlForAllColumns: () => {
+              return { someColumn: { create: [], read: [], update: [] } };
+            },
+          },
+          "someColumn",
+        ),
+      ).toBe(true);
+    });
+
+    test("allows a column name the model does not know about", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      expect(PermissionGate.canReadColumn(new Monitor(), "noSuchColumn")).toBe(
+        true,
+      );
+    });
+
+    test("honours an explicitly supplied permission snapshot", () => {
+      // Storage says Viewer; the caller passes something else and wins.
+      permissionsForTest = [Permission.Viewer];
+
+      expect(
+        PermissionGate.canReadColumn(new Monitor(), "serverMonitorSecretKey", {
+          permissions: [Permission.ProjectOwner],
+        }),
+      ).toBe(true);
+    });
+  });
 });

--- a/Common/UI/Utils/PermissionGate.ts
+++ b/Common/UI/Utils/PermissionGate.ts
@@ -4,6 +4,7 @@ import Permission, {
   PermissionHelper,
   PermissionProps,
 } from "../../Types/Permission";
+import { ColumnAccessControl } from "../../Types/BaseDatabase/AccessControl";
 import PermissionUtil from "./Permission";
 import User from "./User";
 
@@ -50,6 +51,15 @@ export interface PermissionCheckableModel {
   getReadPermissions: () => Array<Permission>;
   getUpdatePermissions: () => Array<Permission>;
   getDeletePermissions: () => Array<Permission>;
+}
+
+/*
+ * A model that declares column-level access control. Separate from
+ * PermissionCheckableModel because column gating answers a different question
+ * ("may this field be SELECTED?") and only the database models carry it.
+ */
+export interface ColumnPermissionCheckableModel {
+  getColumnAccessControlForAllColumns: () => Dictionary<ColumnAccessControl>;
 }
 
 export interface PermissionGateOptions {
@@ -268,6 +278,52 @@ export default class PermissionGate {
         // Locked. The tooltip says which permission is missing.
       },
     };
+  }
+
+  /*
+   * Whether the signed-in user may SELECT a column.
+   *
+   * Column access control is enforced differently from record access control:
+   * asking for a column you cannot read is not degraded, it is fatal.
+   * ColumnPermission throws `User is not allowed to read on <column> column of
+   * <model>` and the whole request fails, so one unreadable field in a select
+   * takes down the entire page rather than blanking one value. That is why
+   * ModelAction has no column-level members (see the comment on the enum) and
+   * why callers must ask this BEFORE building the select, not after.
+   *
+   * Deliberately fails closed. When the permission snapshot has not landed yet
+   * this returns false and the caller omits the field: the page renders
+   * without that one value, which is recoverable. Failing open would send the
+   * column anyway and hard-fail the request, which is not.
+   *
+   * A column with no declared read ACL is readable - there is nothing to
+   * enforce, and ColumnPermission agrees.
+   */
+  public static canReadColumn(
+    model: ColumnPermissionCheckableModel,
+    columnName: string,
+    options?: PermissionGateOptions | undefined,
+  ): boolean {
+    if (User.isMasterAdmin()) {
+      return true;
+    }
+
+    const accessControl: ColumnAccessControl | undefined =
+      model.getColumnAccessControlForAllColumns()[columnName];
+
+    const columnPermissions: Array<Permission> = accessControl?.read || [];
+
+    if (columnPermissions.length === 0) {
+      return true;
+    }
+
+    const userPermissions: Array<Permission> =
+      options?.permissions ?? PermissionUtil.getAllPermissions();
+
+    return PermissionHelper.doesPermissionsIntersect(
+      userPermissions,
+      columnPermissions,
+    );
   }
 
   /* Test seam - the props lookup is memoized for the lifetime of the page. */


### PR DESCRIPTION
Fixes #3360.

## The report checks out

I verified each claim against the code before writing anything:

| Claim | Verdict |
|---|---|
| `MonitorLog.logBody` read ACL includes `Permission.Viewer` | ✅ [MonitorLog.ts](Common/Models/AnalyticsModels/MonitorLog.ts) |
| `logBody` is written verbatim, unredacted | ✅ `logBody: JSON.parse(JSON.stringify(dataToProcess))` |
| Server-monitor `logBody` contains `secretKey` == `serverMonitorSecretKey` | ✅ the Go agent sends it: `SecretKey string \`json:"secretKey"\`` in [server_monitor_report.go](InfrastructureAgent/model/server_monitor_report.go), and `JSONFunctions.deserialize` copies every key it is given |
| `Monitor.serverMonitorSecretKey` is itself `Viewer`-readable | ✅ [Monitor.ts](Common/Models/DatabaseModels/Monitor.ts) |
| `logBody` can carry `requestHeaders` / `requestBody` and `processes` | ✅ via `IncomingMonitorRequest` and `ServerMonitorResponse` |

The reporter's key list matches exactly what the code produces, including the two fields `MonitorResource` stamps on after ingest (`projectId`, `evaluationSummary`) — a detail you only get by actually running it.

**One thing the report understates:** there is a *third* sink. `MonitorService.updateColumnsByIdWithoutHooks` persists the same payload into `Monitor.serverMonitorResponse` (jsonb, also `Viewer`-readable), and `MonitorProbe.lastMonitoringLog` gets it too. So the secret was at rest in three places, not one.

One small correction to the report: it describes `requestHeaders` as "whatever auth header an API monitor sends" (outbound). It is actually the *inbound* headers an incoming-request monitor received. Same exposure, opposite direction.

## The fix

Two independent leak paths, so two fixes. Redaction alone would have been theatre — `serverMonitorSecretKey` is directly selectable, which is an *easier* path than reading `logBody`.

**1. Never write the secret at rest.** New `MonitorPayloadRedaction` strips agent-supplied credentials at the ingest boundary, before `dataToProcess` exists — covering all three sinks at once. A second pass masks credential-shaped values in the copy `MonitorLogUtil` writes to `logBody`: the net underneath, covering every monitor type and any future payload field, and why an incoming-request monitor no longer stores the caller's `Authorization` header either. What counts as a credential is delegated to `LogRedaction`'s existing classifier, so there is one list to maintain rather than two.

This is the issue's own primary recommendation, and the only option that helps instances with retained log rows.

**2. Close the direct read.** `serverMonitorSecretKey` — plus `incomingRequestSecretKey` and `incomingEmailSecretKey`, which had the identical defect — no longer list `Viewer`, `MonitorViewer` or `ReadProjectMonitor`. Reading a monitor secret is now gated on being able to **rotate** it: the read list is deliberately identical to the update list.

### Why the dashboard changes are here

Selecting an unreadable column is fatal, not degraded — `ColumnPermission` throws and the *entire* request fails. Three pages named these columns unconditionally, so without this a `Viewer` opening any monitor page would get an error screen instead of a monitor. They now spread `getReadableMonitorSecretKeySelect()`, backed by a new `PermissionGate.canReadColumn` that fails closed.

### Deliberately not changed

- **`logBody`'s own ACL.** Redacting keeps its diagnostic value and, unlike an ACL, helps rows already on disk.
- **Host process inventory** in `logBody` / `Monitor.serverMonitorResponse`. That is monitor data the operator opted into, not a credential. Worth a separate discussion — command lines can incidentally contain secrets — but changing it here would break process-based criteria.

## Tests

81 new tests across five suites, plus a documented exemption in an existing invariant sweep:

| Suite | Tests | Pins |
|---|---|---|
| `MonitorPayloadRedaction.test.ts` | 18 | the redactor against the payload the Go agent *actually* marshals; key spellings, nesting, arrays, depth ceiling, non-mutation; that metrics/processes/response codes survive |
| `MonitorLogUtilRedaction.test.ts` | 6 | `saveMonitorLog` end to end to the row handed to ClickHouse; the caller's live payload is not collaterally damaged |
| `ServerMonitorIngestSecretRedaction.test.ts` | 7 | the ingest boundary; auth still works off the URL copy |
| `MonitorSecretKeyColumnAccessControl.test.ts` | 29 | the column ACLs, and that the rest of the monitor page still loads for a Viewer |
| `MonitorSecretKeySelect.test.ts` | 13 | the dashboard select gate never names a column the server would refuse |
| `PermissionGate.test.ts` | +8 | `canReadColumn`, including that it fails closed |

Assertions are on the serialized whole (`JSON.stringify(...)` must not contain the sentinel), not just `output.secretKey` — an implementation that merely moved the value one level down would pass the narrow check.

`DomainRoleTierCoverage` enforces that any `ProjectMember`-readable column carries all three domain tiers. Dropping `MonitorViewer` trips it, so it gains a column-level exemption in the same self-policing style the file already uses for tables: the entry is the exact string the sweep emits, so widening one of these read lists again makes the assertion fail. The reasoning: `MonitorMember` may edit a monitor, so may see and reset its key; `MonitorViewer` is read-only, so may not.

### Verification

- Common: 11,032 tests pass across `Tests/Server/*`, `Tests/Models/DatabaseModels`, `Tests/UI/Utils`, `Tests/Types/Permission` — 0 failures.
- App: 10,260 tests pass across all `Tests/*` directories and `FeatureSet/MCP/Tests` — 0 failures.
- `tsc --noEmit` clean for both packages; eslint and prettier clean.

A handful of suites fail to *load* on `dlopen` of the prebuilt `isolated-vm` native binary. I confirmed this is pre-existing by stashing the branch and reproducing it identically on a clean tree — it is a local Node-version/environment issue, unrelated to these changes.