### PR TITLE
fix(analytics): stop sign_up outrunning signup_started

### DIFF
--- a/App/FeatureSet/Accounts/src/Pages/Register.tsx
+++ b/App/FeatureSet/Accounts/src/Pages/Register.tsx
@@ -45,7 +45,16 @@ const RegisterPage: () => JSX.Element = () => {
 
   const [initialValues, setInitialValues] = React.useState<JSONObject>({});
 
+  /*
+   * One mounted register form is one signup at most: a success logs the user
+   * in and navigates away. Both funnel events are latched so a form that
+   * calls back more than once still reports a single attempt and a single
+   * completion, and sign_up can never outrun signup_started.
+   */
   const hasCapturedSignupStart: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
+
+  const hasCapturedSignupComplete: React.MutableRefObject<boolean> =
     useRef<boolean>(false);
 
   const [error, setError] = useState<string>("");
@@ -461,7 +470,8 @@ const RegisterPage: () => JSX.Element = () => {
                 return;
               }
 
-              if (value && value.email) {
+              if (value && value.email && !hasCapturedSignupComplete.current) {
+                hasCapturedSignupComplete.current = true;
                 UiAnalytics.userAuth(value.email);
                 UiAnalytics.capture("accounts/register");
                 UiAnalytics.captureRevenueEvent(


### PR DESCRIPTION
Follow-up to #3291 / #3294 / #3349. One-line behaviour change in `Register.tsx`.

## The anomaly

Now that the funnel actually reaches GA4, the numbers are internally inconsistent. Over the last 28 days:

| Event | Count | Users |
|---|---|---|
| `sign_up` | **780** | 511 |
| `signup_started` | **636** | 505 |

`sign_up` exceeding `signup_started` is not something the funnel can produce.

## Why that is impossible

- [`ModelForm.tsx:811`](Common/UI/Components/Forms/ModelForm.tsx:811) calls `onBeforeCreate` immediately before every create, and `onSuccess` after it at line 829.
- [`Register.tsx:371`](App/FeatureSet/Accounts/src/Pages/Register.tsx:371) fires `signup_started` in `onBeforeCreate`, latched behind `hasCapturedSignupStart` so it fires once per mounted form.
- `sign_up` fires in `onSuccess` with no latch.
- A successful signup calls `LoginUtil.login()` and navigates away, so one mounted form yields at most one completed signup.

So per mount each event fires at most once, and a `sign_up` always implies a `signup_started`. In aggregate `sign_up` ≤ `signup_started`. It exceeds it by at least 144 events — and since not every start converts, the true overcount is larger.

## Ruling out the alternatives

- **A second emitter in the repo?** No — `grep` finds exactly one call site for each of `SignupCompleted` and `SignupStarted`.
- **GA4 synthesising it?** No. I checked the property's **Custom configurations**: "No custom events yet" and "No modifications yet". Neither list has a single entry, so nothing GA4-side can be generating `sign_up`.

That leaves the browser, and `onSuccess` is the one half of the pair without a latch.

## The change

Latch it the same way `signup_started` already is, covering the whole success block so a form that calls back twice still produces one `identify`, one PostHog capture and one `sign_up`. Latching is safe precisely because a success navigates away — a mounted form has no legitimate second signup.

## Why it matters now

`sign_up` is the conversion Google Ads will bid on. Reading roughly a quarter high inflates reported conversions and understates CPA, and it does so silently.

## Verification

`tsc --noEmit` and Prettier both clean on the Accounts app.

I could not verify the exact duplicate mechanism at runtime without creating a real account, so the fix is aimed at the invariant rather than a reproduced stack trace. **Worth confirming against the first real signup in DebugView: it should produce exactly one `sign_up` hit.** If duplicates persist after this, the cause is upstream in `ModelForm` rather than in this page, and the daily `sign_up` vs `signup_started` counts will show it immediately.
