### PR TITLE
fix(analytics): subscribe to every name Cal fires a booking under

### DIFF
--- a/Home/Tests/MeetingBookedAnalytics.test.ts
+++ b/Home/Tests/MeetingBookedAnalytics.test.ts
@@ -215,6 +215,17 @@ describe("meeting_booked analytics", () => {
      * Event trigger forwards the dataLayer push. The dataLayer is the only
      * sanctioned path.
      */
+    /*
+     * The subscriber is what actually connects Cal to the tracker. A booking
+     * that fires only the action name we did not subscribe to reports nothing
+     * at all, while the booking itself still succeeds - the failure mode that
+     * hid a real demo booking from GA4.
+     */
+    test("subscribes to both of Cal's booking action names", () => {
+      expect(html).toContain("bookingSuccessfulV2");
+      expect(html).toContain("oneUptimeOnCalBookingSuccess");
+    });
+
     test("reaches Google exactly once, through the dataLayer only", () => {
       const harness: TrackerHarness = loadTracker(html);
 
@@ -338,8 +349,15 @@ describe("meeting_booked analytics", () => {
         html = await renderPage();
       });
 
-      test("still listens for a successful Cal booking", () => {
-        expect(html).toContain('action: "bookingSuccessful"');
+      /*
+       * Cal renames this action - 'bookingSuccessful' became
+       * 'bookingSuccessfulV2' - and embed.js is loaded unpinned, so
+       * subscribing to a single name lets a third party silently switch the
+       * enterprise lead conversion off. The page must take both.
+       */
+      test("subscribes to every name Cal fires a booking under", () => {
+        expect(html).toContain("oneUptimeOnCalBookingSuccess");
+        expect(html).not.toContain('action: "bookingSuccessful"');
       });
 
       test("reports the booking through the shared helper", () => {

--- a/Home/Views/demo.ejs
+++ b/Home/Views/demo.ejs
@@ -221,37 +221,23 @@
           });
         }
         
-        Cal("on", {
-          action: "bookingSuccessful",
-          callback: (e) => {
-            const { type, namespace } = e.detail;
-
-            /*
-             * Canonical meeting_booked, plus the legacy events. e.detail.data
-             * carries the attendee's name and email and is deliberately not
-             * forwarded to any analytics destination.
-             */
-            window.oneUptimeTrackMeetingBooked({
-              bookingKind: 'enterprise_demo',
-              legacyEventName: 'home/demo-booked',
-              calEventType: type,
-              calNamespace: namespace
-            });
-
-            /*
-             * No extra emissions here. One booking must produce exactly one
-             * conversion event, or GA4 key-event counts and Google Ads bidding
-             * are inflated. This block previously also sent 'demo_request'
-             * through the gtag shim and 'demo_booked' through dataLayer, so a
-             * single booking looked like three conversions under three names.
-             *
-             * The 'demo_request' path could never arrive at all: `gtag` here is
-             * the shim defined in head-basic.ejs (`dataLayer.push(arguments)`),
-             * which pushes an Arguments object carrying no `event` key, so no
-             * GTM Custom Event trigger can match it. support.ejs already had
-             * this shape; demo.ejs was the outlier.
-             */
-          }
+        /*
+         * Canonical meeting_booked. e.detail.data carries the attendee's name
+         * and email and is deliberately not forwarded to any destination.
+         *
+         * One booking must produce exactly one conversion event, or GA4
+         * key-event counts and Google Ads bidding are inflated. This block
+         * used to also send 'demo_request' through the gtag shim and
+         * 'demo_booked' through dataLayer, so a single booking looked like
+         * three conversions under three names.
+         */
+        window.oneUptimeOnCalBookingSuccess(function (detail) {
+          window.oneUptimeTrackMeetingBooked({
+            bookingKind: 'enterprise_demo',
+            legacyEventName: 'home/demo-booked',
+            calEventType: detail.type,
+            calNamespace: detail.namespace
+          });
         });
       </script>
     </section>

--- a/Home/Views/head-basic.ejs
+++ b/Home/Views/head-basic.ejs
@@ -350,6 +350,39 @@
     existing dashboards keep their history.
 -->
 <script>
+    /*
+     * Cal fires the booking event under more than one action name: the older
+     * 'bookingSuccessful' and the newer 'bookingSuccessfulV2'. embed.js is
+     * loaded unpinned from app.cal.com, so which name arrives is Cal's
+     * decision on any given day - and a booking that fires only the name we
+     * are not subscribed to reports no conversion at all, silently, while the
+     * booking itself still succeeds. Subscribing to one name makes the
+     * enterprise lead conversion depend on a third party not renaming it.
+     *
+     * Subscribe to both and latch: whichever arrives first reports the
+     * booking, and a second name for the same booking is ignored, so one
+     * booking stays one meeting_booked.
+     */
+    window.oneUptimeOnCalBookingSuccess = function (handler) {
+        if (typeof Cal !== 'function') {
+            return;
+        }
+
+        var reported = false;
+
+        var once = function (e) {
+            if (reported) {
+                return;
+            }
+            reported = true;
+            handler(e && e.detail ? e.detail : {});
+        };
+
+        ['bookingSuccessful', 'bookingSuccessfulV2'].forEach(function (action) {
+            Cal('on', { action: action, callback: once });
+        });
+    };
+
     window.oneUptimeTrackMeetingBooked = function (options) {
         options = options || {};
 

--- a/Home/Views/support.ejs
+++ b/Home/Views/support.ejs
@@ -374,23 +374,18 @@
 
                                 Cal("ui", { "styles": { "branding": { "brandColor": "#3b82f6" } }, "hideEventTypeDetails": false, "layout": "month_view" });
 
-                                Cal("on", {
-                                    action: "bookingSuccessful",
-                                    callback: (e) => {
-                                        const { type, namespace } = e.detail;
-
-                                        /*
-                                         * Canonical meeting_booked, plus the legacy event.
-                                         * e.detail.data carries the attendee's name and email
-                                         * and is deliberately not forwarded to analytics.
-                                         */
-                                        window.oneUptimeTrackMeetingBooked({
-                                            bookingKind: 'support_call',
-                                            legacyEventName: 'home/support-call-booked',
-                                            calEventType: type,
-                                            calNamespace: namespace
-                                        });
-                                    }
+                                /*
+                                 * Canonical meeting_booked, plus the legacy event.
+                                 * detail.data carries the attendee's name and email
+                                 * and is deliberately not forwarded to analytics.
+                                 */
+                                window.oneUptimeOnCalBookingSuccess(function (detail) {
+                                    window.oneUptimeTrackMeetingBooked({
+                                        bookingKind: 'support_call',
+                                        legacyEventName: 'home/support-call-booked',
+                                        calEventType: detail.type,
+                                        calNamespace: detail.namespace
+                                    });
                                 })
                             </script>
                             <!-- Cal inline embed code ends -->


### PR DESCRIPTION
Your real booking did not produce a `meeting_booked` event. This is why.

## What happened

You booked a demo through `oneuptime.com/enterprise/demo`. The booking succeeded. GA4 Realtime showed nine event names in the following half hour — `page_view`, `session_start`, `first_visit`, `user_engagement`, `scroll`, `monitor_created`, `workspace_created`, `sign_up`, `signup_started` — and no `meeting_booked` anywhere.

## Bisecting it

**Everything below the callback works.** I invoked the page's own `oneUptimeTrackMeetingBooked` helper on the live site: it pushed `meeting_booked` to the dataLayer and the container forwarded it, observed on the wire as `en=meeting_booked&tid=G-76XZF1WF3Z`. Separately I fetched the live `gtm.js?id=GTM-PKQD5WH` and confirmed the published allow-list contains `meeting_booked` and the `booking_kind` variable.

**So the callback never ran.** `demo.ejs` and `support.ejs` each subscribed to exactly one action name:

```js
Cal("on", { action: "bookingSuccessful", callback: ... })
```

Cal renamed that event to `bookingSuccessfulV2`, and [demo.ejs:186](Home/Views/demo.ejs:186) loads `embed.js` **unpinned** from `app.cal.com`. Which name arrives is Cal's decision on any given day. Subscribing to one name means a third party can switch the enterprise lead conversion off with a rename — silently, while every booking still lands on the calendar and looks completely healthy.

I could not read the action name out of Cal's iframe to prove the rename is what bit you today; `embed.js` is a generic postMessage relay and contains no booking action names at all. But the single-name subscription is the exposure regardless, and it is the only link in the chain I have not been able to verify working.

## The change

A shared `oneUptimeOnCalBookingSuccess` helper in `head-basic.ejs` subscribes to **both** names and latches, so whichever arrives first reports the booking and a second name for the same booking is ignored. One booking stays one `meeting_booked` — the invariant #3291 established.

`support.ejs` had the identical single-name subscription and the identical exposure, so it is fixed the same way.

## Scope of the damage

Browser-side only. The `MeetingBooked` row in the `MarketingConversion` ledger is written server-side from Cal's `BOOKING_CREATED` webhook ([CalWebhook.ts:494](App/API/CalWebhook.ts:494)) and was never at risk. Bookings were still being recorded commercially and still uploaded to ad platforms — it was GA4, and therefore GA4-based reporting, that saw nothing.

## Verification

20 tests pass, including two new ones asserting both names are subscribed and that no page pins itself to a single name again. `tsc --noEmit` and Prettier clean.

Worth confirming with one more real booking after this deploys.

## Note on GA4

`meeting_booked` now exists in the property, from the diagnostic event I fired (tagged `booking_kind: analytics_probe` so it is identifiable — worth excluding or annotating). It is not starrable yet: GA4's Events admin list only refreshes on its daily cycle, so it can be marked as a key event tomorrow.
