### PR TITLE
fix(home): point the media industry page at the real monitoring URL

### DIFF
--- a/Home/Tests/ViewRendering.test.ts
+++ b/Home/Tests/ViewRendering.test.ts
@@ -22,8 +22,9 @@ import {
   getClaimsMatrix,
   getClaimsNeedingReview,
 } from "../Utils/Claims";
-import { getPageSEO, PageSEOData } from "../Utils/PageSEO";
+import PageSEOConfig, { getPageSEO, PageSEOData } from "../Utils/PageSEO";
 import ejs from "ejs";
+import fs from "fs";
 import path from "path";
 
 /*
@@ -407,6 +408,145 @@ describe("claims-matrix.ejs review states", () => {
       },
     );
     expect(new Set(colours).size).toBe(colours.length);
+  });
+});
+
+/*
+ * Industry and solution pages are mostly grids of links into the product
+ * catalogue, and a wrong one is invisible until somebody clicks it:
+ * /product/uptime-monitoring reads right, but the canonical path is
+ * /product/monitoring. Every page in these two directories is rendered by
+ * Routes.ts with the same two locals, so walk the directories instead of
+ * naming the pages — the next page added is then checked the day it lands.
+ */
+
+type LinkedPage = [templateFileName: string, pagePath: string];
+
+function pagesUnder(directory: string): Array<LinkedPage> {
+  return fs
+    .readdirSync(path.join(VIEWS_ROOT, directory))
+    .filter((fileName: string): boolean => {
+      return fileName.endsWith(".ejs");
+    })
+    .map((fileName: string): LinkedPage => {
+      return [
+        `${directory}/${fileName}`,
+        `/${directory}/${path.basename(fileName, ".ejs")}`,
+      ];
+    });
+}
+
+const LINKED_PAGE_DIRECTORIES: Array<string> = ["industries", "solutions"];
+
+const LINKED_PAGES: Array<LinkedPage> = LINKED_PAGE_DIRECTORIES.flatMap(
+  (directory: string): Array<LinkedPage> => {
+    return pagesUnder(directory);
+  },
+);
+
+/*
+ * Paths that a page links to and that PageSEO.ts is the register for. Anything
+ * outside these namespaces — /docs, /pricing, /enterprise — is routed and
+ * documented elsewhere, so a missing SEO entry there proves nothing.
+ */
+const CATALOGUE_NAMESPACES: Array<string> = [
+  "/product/",
+  "/tool/",
+  "/solutions/",
+  "/industries/",
+];
+
+function catalogueLinksIn(html: string): Array<string> {
+  const hrefs: Set<string> = new Set<string>(
+    [...html.matchAll(/href="(\/[^"#]*)"/g)].map(
+      (match: RegExpMatchArray): string => {
+        return match[1]!;
+      },
+    ),
+  );
+
+  return [...hrefs].filter((href: string): boolean => {
+    return CATALOGUE_NAMESPACES.some((namespace: string): boolean => {
+      return href.startsWith(namespace);
+    });
+  });
+}
+
+/*
+ * Read only the page's own <main>: links in the shared nav, footer and CTA are
+ * not any one page's problem, and they have their own tests.
+ */
+function pageBodyOf(html: string): string {
+  const start: number = html.indexOf("<main");
+  const end: number = html.indexOf("</main>");
+
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  return html.slice(start, end);
+}
+
+describe("industry and solution pages", () => {
+  const rendered: Map<string, string> = new Map<string, string>();
+
+  beforeAll(async () => {
+    for (const [templateFileName, pagePath] of LINKED_PAGES) {
+      /*
+       * Exactly the locals Routes.ts hands these templates, plus homeUrl, which
+       * request middleware puts on res.locals rather than passing per render.
+       */
+      rendered.set(
+        templateFileName,
+        await render(templateFileName, {
+          enableGoogleTagManager: false,
+          seo: seoFor(pagePath),
+          homeUrl: HOME_URL,
+        }),
+      );
+    }
+  });
+
+  test("both directories are walked", () => {
+    // An empty walk would pass every assertion below without checking a thing.
+    expect(LINKED_PAGES.length).toBeGreaterThanOrEqual(14);
+  });
+
+  test.each(LINKED_PAGES)(
+    "%s renders a complete page",
+    (templateFileName: string) => {
+      const html: string = rendered.get(templateFileName)!;
+
+      expect(html).toContain("<!DOCTYPE html>");
+      expect(html).toContain("</html>");
+      expect(html.length).toBeGreaterThan(10000);
+    },
+  );
+
+  test.each(LINKED_PAGES)(
+    "%s links only to catalogue pages that exist",
+    (templateFileName: string) => {
+      for (const href of catalogueLinksIn(
+        pageBodyOf(rendered.get(templateFileName)!),
+      )) {
+        expect(PageSEOConfig[href]?.canonicalPath).toBe(href);
+      }
+    },
+  );
+
+  /*
+   * Four of these pages link nowhere into the catalogue, so a per-page floor
+   * would fail on them. Assert the scan over all of them instead: without
+   * this, a regex that stopped matching would quietly turn every check above
+   * into a pass.
+   */
+  test("the scan finds catalogue links to check", () => {
+    const found: Set<string> = new Set<string>(
+      LINKED_PAGES.flatMap(([templateFileName]: LinkedPage): Array<string> => {
+        return catalogueLinksIn(pageBodyOf(rendered.get(templateFileName)!));
+      }),
+    );
+
+    expect(found.size).toBeGreaterThanOrEqual(10);
   });
 });
 

--- a/Home/Views/industries/media.ejs
+++ b/Home/Views/industries/media.ejs
@@ -261,7 +261,7 @@
               <h3 class="text-base font-semibold text-gray-900 mb-1">Global CDN Monitoring</h3>
               <p class="text-sm text-gray-500 mb-3">Monitor every edge server, every PoP, every region. Know exactly where performance is degrading before viewers complain.</p>
               <div class="pt-3 border-t border-gray-100">
-                <a href="/product/uptime-monitoring" class="text-xs text-violet-600 hover:text-violet-800 font-medium flex items-center gap-1">
+                <a href="/product/monitoring" class="text-xs text-violet-600 hover:text-violet-800 font-medium flex items-center gap-1">
                   Learn More
                   <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />


### PR DESCRIPTION
### Title of this pull request?

fix(home): point the media industry page at the real monitoring URL

### Small Description?

**The bug.** `Home/Views/industries/media.ejs` linked its "Global CDN Monitoring" card at `/product/uptime-monitoring`. No route in `Home/Routes.ts` registers that path, there is no redirect for it, and `Home/Utils/PageSEO.ts` has no entry — so the only *Learn More* on that card 404'd. The canonical uptime monitoring page is `/product/monitoring`, which is what `nav.ejs` and `footer.ejs` already link to. One-token fix.

**The guard.** `Home/Tests/ViewRendering.test.ts` already had a "every product link in the page body is a real canonical page" assertion, but scoped to a single page, so it could not see this. It is now generalised: it walks `Views/industries/` and `Views/solutions/` with `readdirSync`, renders each of the 14 pages with exactly the locals `Routes.ts` passes it, and asserts every `/product/*`, `/tool/*`, `/solutions/*` and `/industries/*` href inside the page's own `<main>` resolves to a `PageSEOConfig` key whose `canonicalPath` matches. Walking the directories rather than naming the pages means the next page added is covered the day it lands.

**Two deviations from the single-page original**, both forced by what the pages actually contain, and worth a reviewer's attention:

- **The per-page `links.length > 4` floor is gone.** Four solutions pages — `incident-response`, `observability`, `status-communication`, `uptime-monitoring` — link nowhere into the catalogue at all, being the four that do not include `product-grid-section`. A per-page floor fails on them. That regex-sanity guard now runs once over the union of links found across all fourteen pages, so a pattern that stopped matching still fails loudly instead of turning every per-page check into a silent pass.
- **Nav, footer and CTA stay out of scope**, as in the original — they have their own test, and their links are not any single page's problem.

**Verified the test bites**, not just that it passes: reverting the `media.ejs` href makes `industries/media.ejs links only to catalogue pages that exist` fail with `Expected: "/product/uptime-monitoring"`.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

`cd Home && npx jest` → **12 suites, 710 tests, all passing** (was 68 tests in this suite, now 98). `npx tsc --noEmit`, `eslint` and `prettier --check` are clean on both touched files.

### Related Issue?

None filed — found while reading the industry pages.

### Notes for the reviewer

**The same broken href survives in two places this PR deliberately does not touch:**

| File | Status |
|---|---|
| `Home/Views/product-compare.ejs:177` | **Live 404.** Renders on every `/compare/:product` page. Not covered by the new test, which is scoped to `industries/` and `solutions/`. Worth its own fix. |
| `Home/Views/Partials/product-tabs.ejs:219` | Inert — no template includes this partial. Dead code. |
| `Home/Views/features-table.ejs:248` | Left alone: already fixed on `claude/security-events-marketing-page-870cf9`, and touching it here would conflict with that branch. |

**One thing the new test surfaced that is not a bug today:** those four solutions pages (`/solutions/incident-response`, `/observability`, `/status-communication`, `/uptime-monitoring`) are registered routes with no `PageSEOConfig` entry and no `Sitemap.ts` entry, so they fall back to generic site-wide SEO. Nothing links to them at present. If anything ever does, this test will flag the link as broken even though the route resolves — at which point the right fix is to give those four pages real SEO entries, not to loosen the test.

### Screenshots (if appropriate):

n/a — one href character change; no visual difference.
