### PR TITLE
fix(monitor): stop echoing the incoming-email ingest key into stored payloads

### DIFF
--- a/App/FeatureSet/Telemetry/Jobs/IncomingRequestIngest/ProcessIncomingRequestIngest.ts
+++ b/App/FeatureSet/Telemetry/Jobs/IncomingRequestIngest/ProcessIncomingRequestIngest.ts
@@ -11,6 +11,7 @@ import MonitorType from "Common/Types/Monitor/MonitorType";
 import ObjectID from "Common/Types/ObjectID";
 import MonitorService from "Common/Server/Services/MonitorService";
 import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
+import { redactMonitorSecret } from "Common/Server/Utils/Monitor/MonitorPayloadRedaction";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 
 export async function processIncomingRequestFromQueue(
@@ -86,11 +87,37 @@ export async function processIncomingRequestFromQueue(
 
   const now: Date = OneUptimeDate.getCurrentDate();
 
+  /*
+   * Ingest boundary, matching the incoming-email path above it.
+   *
+   * `incomingRequestSecretKey` travels in the URL path (`/incoming-request/
+   * :secretkey`) and only the method, headers and body are captured here, so
+   * unlike the email address the key is not systematically echoed into what we
+   * store. It is still reachable: a relay or ingress that reflects the request
+   * target (`X-Original-URI`, `X-Forwarded-Uri`, `Referer`) puts the path into
+   * `requestHeaders`, and a sender is free to repeat its own key in the body.
+   * Either way it would land in `Monitor.incomingMonitorRequest`, which -- like
+   * its email sibling -- is `Permission.Viewer` readable.
+   *
+   * Sweeping the payload for this monitor's own key costs one pass over data we
+   * are about to persist anyway and makes the invariant uniform: nothing a
+   * read-only role can select ever contains a live ingest key.
+   */
+  const redactedRequestHeaders: Dictionary<string> = redactMonitorSecret(
+    requestHeaders,
+    monitorSecretKeyAsString,
+  );
+
+  const redactedRequestBody: string | JSONObject = redactMonitorSecret(
+    requestBody,
+    monitorSecretKeyAsString,
+  );
+
   const incomingRequest: IncomingMonitorRequest = {
     projectId: monitor.projectId,
     monitorId: new ObjectID(monitor._id.toString()),
-    requestHeaders: requestHeaders,
-    requestBody: requestBody,
+    requestHeaders: redactedRequestHeaders,
+    requestBody: redactedRequestBody,
     incomingRequestReceivedAt: now,
     onlyCheckForIncomingRequestReceivedAt: false,
     requestMethod: httpMethod,

--- a/App/FeatureSet/Telemetry/Jobs/ProbeIngest/ProcessProbeIngest.ts
+++ b/App/FeatureSet/Telemetry/Jobs/ProbeIngest/ProcessProbeIngest.ts
@@ -26,6 +26,7 @@ import ProbeService from "Common/Server/Services/ProbeService";
 import SnmpTrapLogWriter from "../../Services/SnmpTrapLogWriter";
 import { JSONObject } from "Common/Types/JSON";
 import ExceptionMessages from "Common/Types/Exception/ExceptionMessages";
+import { redactMonitorSecret } from "Common/Server/Utils/Monitor/MonitorPayloadRedaction";
 
 export async function processProbeFromQueue(
   jobData: ProbeIngestJobData,
@@ -351,20 +352,44 @@ export async function processIncomingEmailFromQueue(
     throw new BadDataException("Project not found");
   }
 
+  /*
+   * Ingest boundary. This monitor's `incomingEmailSecretKey` IS its inbound
+   * address -- `generateMonitorEmailAddress` builds
+   * `monitor-{secretKey}@{inboundDomain}` and `extractSecretKeyFromEmail` reads
+   * the key straight back out -- so every copy of the recipient in this payload
+   * is a copy of a live bearer credential: `emailTo`, the `To:` header, and the
+   * `Received:` / `Delivered-To:` headers the relay stamped on the way in.
+   *
+   * Mask it here, before the payload becomes evidence, rather than at each
+   * sink. Everything downstream of this point is fed from `dataToProcess`, and
+   * it fans out into places a read-only principal can select from:
+   * `Monitor.incomingEmailMonitorRequest` just below, and -- via
+   * `monitorResource` -> `MonitorSummaryCapture` -- `Incident.monitorSummary`
+   * and `Alert.monitorSummary`, plus `MonitorLog.logBody`. One strip at the
+   * boundary covers all of them and any sink added later, which is the same
+   * shape as `stripAgentCredentials` on the server-monitor path.
+   *
+   * https://github.com/OneUptime/oneuptime/issues/3360
+   */
+  const redactedEmailData: IncomingEmailJobData = redactMonitorSecret(
+    emailData,
+    monitorSecretKeyAsString,
+  );
+
   const now: Date = OneUptimeDate.getCurrentDate();
 
   const incomingEmailRequest: IncomingEmailMonitorRequest = {
     projectId: monitor.projectId,
     monitorId: new ObjectID(monitor._id.toString()),
-    emailFrom: emailData.emailFrom,
-    emailTo: emailData.emailTo,
-    emailSubject: emailData.emailSubject,
-    emailBody: emailData.emailBody,
-    emailBodyHtml: emailData.emailBodyHtml,
-    emailHeaders: emailData.emailHeaders,
+    emailFrom: redactedEmailData.emailFrom,
+    emailTo: redactedEmailData.emailTo,
+    emailSubject: redactedEmailData.emailSubject,
+    emailBody: redactedEmailData.emailBody,
+    emailBodyHtml: redactedEmailData.emailBodyHtml,
+    emailHeaders: redactedEmailData.emailHeaders,
     emailReceivedAt: now,
     checkedAt: now,
-    attachments: emailData.attachments,
+    attachments: redactedEmailData.attachments,
     onlyCheckForIncomingEmailReceivedAt: false,
   };
 

--- a/App/Tests/Telemetry/IncomingMonitorIngestSecretRedaction.test.ts
+++ b/App/Tests/Telemetry/IncomingMonitorIngestSecretRedaction.test.ts
@@ -1,0 +1,486 @@
+/*
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * The fix for #3360 narrowed the read ACL on the three `Monitor` secret-key
+ * columns, but `incomingEmailSecretKey` has a second, indirect way out.
+ *
+ * The key IS the monitor's inbound address:
+ * `SendGridInboundProvider.generateMonitorEmailAddress` builds
+ * `monitor-{secretKey}@{inboundDomain}`, and `extractSecretKeyFromEmail` parses
+ * the key straight back out of it. So every stored copy of the RECIPIENT is a
+ * stored copy of a live bearer credential -- `emailTo`, the `To:` header, and
+ * the `Received:` / `Delivered-To:` headers a relay stamps on in transit. Those
+ * land in `Monitor.incomingEmailMonitorRequest`, whose read ACL still lists
+ * `Permission.Viewer`, and -- through `MonitorSummaryCapture` -- in
+ * `Incident.monitorSummary` and `Alert.monitorSummary` as well.
+ *
+ * The property under test is the one the advisory turns on, stated as an
+ * invariant rather than as a list of fields: nothing a read-only principal can
+ * select ever contains a string matching the monitor's secret key. Asserting
+ * only on `emailTo` would pass for an implementation that cleaned the obvious
+ * field and left the headers carrying the same address, which is exactly the
+ * shape of the original miss.
+ *
+ * The second half matters just as much: an Incoming Email monitor is evaluated
+ * on this payload (`IncomingEmailCriteria` reads `emailTo` for the "Email to"
+ * check), and mail that arrives through an alias carries a genuinely different
+ * recipient. A redactor that flattened every address would break criteria and
+ * destroy legitimate evidence, so these tests pin what must SURVIVE too.
+ *
+ * MonitorResource is mocked wholesale: it is an assertion target here, and
+ * importing it for real drags in the isolated-vm sandbox the criteria
+ * evaluator uses.
+ */
+
+jest.mock("Common/Server/Utils/Monitor/MonitorResource", () => {
+  return {
+    __esModule: true,
+    default: {
+      monitorResource: jest.fn(() => {
+        return Promise.resolve({});
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(() => {
+        return Promise.resolve();
+      }),
+      getEnabledMonitorQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getActiveProjectStatusQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import { processIncomingEmailFromQueue } from "../../FeatureSet/Telemetry/Jobs/ProbeIngest/ProcessProbeIngest";
+import { processIncomingRequestFromQueue } from "../../FeatureSet/Telemetry/Jobs/IncomingRequestIngest/ProcessIncomingRequestIngest";
+import {
+  IncomingEmailJobData,
+  IncomingRequestIngestJobData,
+  ProbeIngestJobData,
+} from "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
+import MonitorService from "Common/Server/Services/MonitorService";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import { ColumnAccessControl } from "Common/Types/BaseDatabase/AccessControl";
+import Dictionary from "Common/Types/Dictionary";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import Permission, { PermissionHelper } from "Common/Types/Permission";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * A uuid, because that is what `ObjectID.generate()` mints for
+ * `incomingEmailSecretKey` / `incomingRequestSecretKey`, and distinctive enough
+ * that a substring search for it is meaningful.
+ */
+const EMAIL_SECRET: string = "b1946ac9-2492-4b0f-9b2f-ee9b6cbe36ba";
+const REQUEST_SECRET: string = "1d229271-17c4-4b4f-9a3b-3c6ff1a1a2ee";
+
+const MONITOR_ID: string = "8f14e45f-ceea-467a-9575-1b0d0d3e7a9c";
+const PROJECT_ID: string = "3c6e0b8a-9c15-4f8b-a1d2-7e5f4c3b2a19";
+
+const INBOUND_DOMAIN: string = "inbound.oneuptime.example";
+
+// Exactly what `generateMonitorEmailAddress` returns for this monitor.
+const MONITOR_ADDRESS: string = `monitor-${EMAIL_SECRET}@${INBOUND_DOMAIN}`;
+
+const monitorResource: jest.Mock =
+  MonitorResourceUtil.monitorResource as unknown as jest.Mock;
+
+const findOneBy: jest.Mock = MonitorService.findOneBy as unknown as jest.Mock;
+
+const updateColumns: jest.Mock =
+  MonitorService.updateColumnsByIdWithoutHooks as unknown as jest.Mock;
+
+/*
+ * The read-only roles. All three are on the read list of
+ * `incomingEmailMonitorRequest` and `incomingMonitorRequest`, and none of them
+ * can rotate a monitor key -- which is the whole reason the secret must not be
+ * inside those columns' VALUES either.
+ */
+const READ_ONLY_PERMISSIONS: Array<Permission> = [
+  Permission.Viewer,
+  Permission.MonitorViewer,
+  Permission.ReadProjectMonitor,
+];
+
+const accessControl: Dictionary<ColumnAccessControl> =
+  new Monitor().getColumnAccessControlForAllColumns();
+
+type ViewerReadableColumnsFunction = () => Array<string>;
+
+/*
+ * `SelectPermission.checkSelectPermission` reduced to the question that
+ * matters: which columns does a project Viewer get to ask for? This is the set
+ * the repro in the report selects from.
+ */
+const viewerReadableColumns: ViewerReadableColumnsFunction =
+  (): Array<string> => {
+    return Object.keys(accessControl).filter((column: string) => {
+      return PermissionHelper.doesPermissionsIntersect(
+        READ_ONLY_PERMISSIONS,
+        accessControl[column]?.read || [],
+      );
+    });
+  };
+
+type ContainsFunction = (value: unknown, secret: string) => boolean;
+
+/*
+ * The assertion that actually matters. Serializing the whole value means an
+ * implementation that merely moved the secret one level down, or left it in a
+ * header, still fails.
+ */
+const contains: ContainsFunction = (
+  value: unknown,
+  secret: string,
+): boolean => {
+  return JSON.stringify(value)?.includes(secret) ?? false;
+};
+
+type MonitorFixtureFunction = () => Monitor;
+
+const monitorFixture: MonitorFixtureFunction = (): Monitor => {
+  const monitor: Monitor = new Monitor();
+  monitor._id = MONITOR_ID;
+  monitor.projectId = new ObjectID(PROJECT_ID);
+  return monitor;
+};
+
+type EmailJobFunction = (
+  overrides?: Partial<IncomingEmailJobData>,
+) => ProbeIngestJobData;
+
+/*
+ * The shape `IncomingEmail.ts` enqueues: the provider's parsed email, verbatim.
+ * `emailTo` is the recipient SendGrid reported and the headers are the ones the
+ * relay chain stamped on -- three independent copies of the same address, which
+ * is why redacting one field was never going to be enough.
+ */
+const emailJob: EmailJobFunction = (
+  overrides?: Partial<IncomingEmailJobData>,
+): ProbeIngestJobData => {
+  return {
+    jobType: "incoming-email",
+    ingestionTimestamp: new Date("2026-08-23T10:00:00.000Z"),
+    incomingEmail: {
+      secretKey: EMAIL_SECRET,
+      emailFrom: "alerts@acme.example",
+      emailTo: MONITOR_ADDRESS,
+      emailSubject: "Nightly backup completed",
+      emailBody: "Backup finished in 42 minutes. 0 errors.",
+      emailBodyHtml: "<p>Backup finished in 42 minutes. 0 errors.</p>",
+      emailHeaders: {
+        To: MONITOR_ADDRESS,
+        From: "alerts@acme.example",
+        Subject: "Nightly backup completed",
+        "Delivered-To": MONITOR_ADDRESS,
+        Received: `by mx.sendgrid.net with SMTP id xW9 for <${MONITOR_ADDRESS}>; Sun, 23 Aug 2026 10:00:00 +0000`,
+        "Message-Id": "<20260823100000.1@acme.example>",
+      },
+      attachments: [
+        { filename: "backup.log", contentType: "text/plain", size: 2048 },
+      ],
+      ...overrides,
+    },
+  } as ProbeIngestJobData;
+};
+
+type PersistedRequestFunction = () => JSONObject;
+
+/*
+ * What `updateColumnsByIdWithoutHooks` was asked to write into
+ * `Monitor.incomingEmailMonitorRequest` -- i.e. the exact bytes a Viewer's
+ * select would hand back.
+ */
+const persistedEmailRequest: PersistedRequestFunction = (): JSONObject => {
+  expect(updateColumns).toHaveBeenCalledTimes(1);
+
+  const input: JSONObject = (
+    updateColumns.mock.calls as unknown as Array<Array<JSONObject>>
+  )[0]![0] as JSONObject;
+
+  return (input["data"] as JSONObject)[
+    "incomingEmailMonitorRequest"
+  ] as JSONObject;
+};
+
+type EvaluatedPayloadFunction = () => JSONObject;
+
+/*
+ * What reached `monitorResource` -- the object `MonitorSummaryCapture` snapshots
+ * onto `Incident.monitorSummary` and `Alert.monitorSummary`, and that
+ * `MonitorLogUtil` writes to `MonitorLog.logBody`.
+ */
+const evaluatedPayload: EvaluatedPayloadFunction = (): JSONObject => {
+  expect(monitorResource).toHaveBeenCalledTimes(1);
+
+  return (
+    monitorResource.mock.calls as unknown as Array<Array<unknown>>
+  )[0]![0] as JSONObject;
+};
+
+beforeEach(() => {
+  monitorResource.mockClear();
+  updateColumns.mockClear();
+  findOneBy.mockReset();
+
+  findOneBy.mockImplementation(() => {
+    return Promise.resolve(monitorFixture());
+  });
+});
+
+describe("Incoming Email ingest - the monitor's address is its secret", () => {
+  it("keeps the secret out of every column a Viewer may select", async () => {
+    /*
+     * The repro from the report, expressed as the invariant rather than as one
+     * field: build the monitor a Viewer's `get-list` would return, populated
+     * with what ingest actually persisted, and assert no readable column
+     * carries the key.
+     */
+    await processIncomingEmailFromQueue(emailJob());
+
+    const monitor: Monitor = monitorFixture();
+    (monitor as unknown as JSONObject)["incomingEmailMonitorRequest"] =
+      persistedEmailRequest();
+
+    const readable: Array<string> = viewerReadableColumns();
+
+    /*
+     * Guard the guard: if this column ever stops being Viewer-readable the
+     * test would otherwise silently assert nothing.
+     */
+    expect(readable).toContain("incomingEmailMonitorRequest");
+
+    for (const column of readable) {
+      expect(
+        contains((monitor as unknown as JSONObject)[column], EMAIL_SECRET),
+      ).toBe(false);
+    }
+  });
+
+  it("redacts the secret in the recipient, the To: header and the relay chain", async () => {
+    await processIncomingEmailFromQueue(emailJob());
+
+    const persisted: JSONObject = persistedEmailRequest();
+    const headers: JSONObject = persisted["emailHeaders"] as JSONObject;
+
+    expect(persisted["emailTo"]).not.toContain(EMAIL_SECRET);
+    expect(headers["To"]).not.toContain(EMAIL_SECRET);
+    expect(headers["Delivered-To"]).not.toContain(EMAIL_SECRET);
+    expect(headers["Received"]).not.toContain(EMAIL_SECRET);
+  });
+
+  it("keeps the secret out of the incident and alert summary source", async () => {
+    /*
+     * `Monitor.incomingEmailMonitorRequest` is not the only sink. Narrowing
+     * that one column's ACL would have left this path -- gated on incident and
+     * alert permissions, not monitor ones -- wide open, which is why the strip
+     * happens at the ingest boundary instead.
+     */
+    await processIncomingEmailFromQueue(emailJob());
+
+    expect(contains(evaluatedPayload(), EMAIL_SECRET)).toBe(false);
+  });
+
+  it("still authenticates with the secret from the address", async () => {
+    // Redacting the payload must not break the lookup that finds the monitor.
+    await processIncomingEmailFromQueue(emailJob());
+
+    const query: JSONObject = (
+      (
+        findOneBy.mock.calls as unknown as Array<Array<JSONObject>>
+      )[0]![0] as JSONObject
+    )["query"] as JSONObject;
+
+    expect((query["incomingEmailSecretKey"] as ObjectID).toString()).toBe(
+      EMAIL_SECRET,
+    );
+  });
+
+  it("leaves the rest of the address readable so the evidence still reads", async () => {
+    /*
+     * Masking only the secret, not the whole value: an operator looking at the
+     * monitor still sees that the mail arrived at this monitor's inbound
+     * domain.
+     */
+    await processIncomingEmailFromQueue(emailJob());
+
+    const persisted: JSONObject = persistedEmailRequest();
+
+    expect(persisted["emailTo"]).toContain(INBOUND_DOMAIN);
+    expect(persisted["emailTo"]).toContain("monitor-");
+  });
+
+  it("preserves a genuine recipient that is not the monitor's own address", async () => {
+    /*
+     * Mail forwarded from an alias carries the ALIAS in To:, and
+     * `IncomingEmailCriteria` evaluates that string for the "Email to" check.
+     * Only the monitor's own key may be masked; a blanket sweep of the
+     * recipient would silently break every such criteria filter.
+     */
+    await processIncomingEmailFromQueue(
+      emailJob({
+        emailTo: "oncall@acme.example",
+        emailHeaders: {
+          To: "oncall@acme.example",
+          "Delivered-To": MONITOR_ADDRESS,
+        },
+      }),
+    );
+
+    const persisted: JSONObject = persistedEmailRequest();
+    const headers: JSONObject = persisted["emailHeaders"] as JSONObject;
+
+    expect(persisted["emailTo"]).toBe("oncall@acme.example");
+    expect(headers["Delivered-To"]).not.toContain(EMAIL_SECRET);
+  });
+
+  it("redacts an address a relay rewrote to a different case", async () => {
+    /*
+     * `extractEmailAddress` lowercases what it parses, but relay headers keep
+     * whatever case the sender used, and a uuid is hex -- so a case-sensitive
+     * sweep would miss the copy that matters.
+     */
+    await processIncomingEmailFromQueue(
+      emailJob({
+        emailHeaders: {
+          To: `MONITOR-${EMAIL_SECRET.toUpperCase()}@${INBOUND_DOMAIN}`,
+        },
+      }),
+    );
+
+    expect(contains(persistedEmailRequest(), EMAIL_SECRET.toUpperCase())).toBe(
+      false,
+    );
+  });
+
+  it("forwards every observation the email carried", async () => {
+    // A redactor that eats the evidence is a redactor somebody will turn off.
+    await processIncomingEmailFromQueue(emailJob());
+
+    const persisted: JSONObject = persistedEmailRequest();
+
+    expect(persisted["emailFrom"]).toBe("alerts@acme.example");
+    expect(persisted["emailSubject"]).toBe("Nightly backup completed");
+    expect(persisted["emailBody"]).toBe(
+      "Backup finished in 42 minutes. 0 errors.",
+    );
+    expect(persisted["attachments"]).toEqual([
+      { filename: "backup.log", contentType: "text/plain", size: 2048 },
+    ]);
+  });
+
+  it("still stamps the identity fields the pipeline depends on", async () => {
+    /*
+     * These are assigned around the strip. If redaction ever replaced the
+     * object wholesale, or ran over it again afterwards, `monitorId` would
+     * arrive as a plain string and the evaluation would be scoped to nothing.
+     */
+    await processIncomingEmailFromQueue(emailJob());
+
+    const payload: JSONObject = evaluatedPayload();
+
+    expect((payload["monitorId"] as ObjectID).toString()).toBe(MONITOR_ID);
+    expect((payload["projectId"] as ObjectID).toString()).toBe(PROJECT_ID);
+    expect(payload["emailReceivedAt"] instanceof Date).toBe(true);
+  });
+});
+
+describe("Incoming Request ingest - the same invariant", () => {
+  /*
+   * `incomingRequestSecretKey` travels in the URL path, and only the method,
+   * headers and body are captured -- so unlike the email address it is not
+   * systematically echoed into what gets stored. It is still reachable: an
+   * ingress that reflects the request target puts the path into a header, and a
+   * sender may repeat its own key in the body. Both would land in
+   * `Monitor.incomingMonitorRequest`, which is Viewer-readable too.
+   */
+  type RequestJobFunction = (
+    overrides?: Partial<IncomingRequestIngestJobData>,
+  ) => IncomingRequestIngestJobData;
+
+  const requestJob: RequestJobFunction = (
+    overrides?: Partial<IncomingRequestIngestJobData>,
+  ): IncomingRequestIngestJobData => {
+    return {
+      secretKey: REQUEST_SECRET,
+      requestHeaders: {
+        "content-type": "application/json",
+        "user-agent": "acme-cron/1.4",
+      },
+      requestBody: { status: "ok", durationMs: 1200 },
+      requestMethod: "POST",
+      ...overrides,
+    } as IncomingRequestIngestJobData;
+  };
+
+  it("keeps a reflected request target out of the stored headers", async () => {
+    await processIncomingRequestFromQueue(
+      requestJob({
+        requestHeaders: {
+          "content-type": "application/json",
+          "x-original-uri": `/incoming-request/${REQUEST_SECRET}`,
+        },
+      }),
+    );
+
+    expect(contains(evaluatedPayload(), REQUEST_SECRET)).toBe(false);
+  });
+
+  it("keeps a self-quoted key out of the stored body", async () => {
+    await processIncomingRequestFromQueue(
+      requestJob({
+        requestBody: {
+          status: "ok",
+          calledUrl: `/heartbeat/${REQUEST_SECRET}`,
+        },
+      }),
+    );
+
+    expect(contains(evaluatedPayload(), REQUEST_SECRET)).toBe(false);
+  });
+
+  it("forwards an ordinary heartbeat untouched", async () => {
+    await processIncomingRequestFromQueue(requestJob());
+
+    const payload: JSONObject = evaluatedPayload();
+
+    expect(payload["requestBody"]).toEqual({ status: "ok", durationMs: 1200 });
+    expect(payload["requestHeaders"]).toEqual({
+      "content-type": "application/json",
+      "user-agent": "acme-cron/1.4",
+    });
+  });
+});

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788900000000-RedactStoredMonitorIngestSecrets.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788900000000-RedactStoredMonitorIngestSecrets.ts
@@ -1,0 +1,117 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Scrub monitor ingest keys out of payloads that were already persisted.
+ *
+ * https://github.com/OneUptime/oneuptime/issues/3360
+ *
+ * An Incoming Email monitor's `incomingEmailSecretKey` IS its inbound address:
+ * `SendGridInboundProvider.generateMonitorEmailAddress` builds
+ * `monitor-{secretKey}@{inboundDomain}`, and `extractSecretKeyFromEmail` reads
+ * the key straight back out. Every stored copy of the recipient was therefore a
+ * stored copy of a live bearer credential — `emailTo`, the `To:` header, and
+ * the `Received:` / `Delivered-To:` headers added in transit.
+ *
+ * `ProcessProbeIngest.processIncomingEmailFromQueue` now masks the key at the
+ * ingest boundary, so nothing written from here on carries it. That fixes the
+ * flow and not the stock: rows written before this deploy still hold the key in
+ * plaintext, in columns a `Permission.Viewer` can select. Narrowing a read ACL
+ * would not have helped either — the same snapshot is copied onto incidents and
+ * alerts, which are gated on their own permissions.
+ *
+ * The four Postgres sinks, all of them jsonb:
+ *
+ *   - `Monitor.incomingEmailMonitorRequest`  (the reported leak)
+ *   - `Monitor.incomingMonitorRequest`       (same shape, `incomingRequestSecretKey`)
+ *   - `Incident.monitorSummary`              (via MonitorSummaryCapture)
+ *   - `Alert.monitorSummary`                 (via MonitorSummaryCapture)
+ *
+ * `MonitorLog.logBody` is the fifth sink and is deliberately not touched here:
+ * it lives in ClickHouse, not Postgres, and every row carries a `retentionDate`
+ * with a `retentionDate DELETE` TTL, so historical rows age out on their own.
+ *
+ * Matching is case-insensitive (`gi`). A uuid renders lowercase in Postgres,
+ * but the key reaches these payloads through relay headers that preserve
+ * whatever case the sender used. A uuid is made of hex digits and hyphens, so
+ * it needs no regex escaping, and the replacement text contains no backslash,
+ * so it needs none either.
+ */
+export class RedactStoredMonitorIngestSecrets1788900000000
+  implements MigrationInterface
+{
+  public name: string = "RedactStoredMonitorIngestSecrets1788900000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    /*
+     * The monitor's own row: the key and the payload quoting it are on the
+     * same row, so this needs no join.
+     */
+    await queryRunner.query(
+      `UPDATE "Monitor"
+          SET "incomingEmailMonitorRequest" = regexp_replace(
+                "incomingEmailMonitorRequest"::text,
+                "incomingEmailSecretKey"::text,
+                '[REDACTED]',
+                'gi'
+              )::jsonb
+        WHERE "incomingEmailSecretKey" IS NOT NULL
+          AND "incomingEmailMonitorRequest" IS NOT NULL
+          AND "incomingEmailMonitorRequest"::text ILIKE '%' || "incomingEmailSecretKey"::text || '%'`,
+    );
+
+    await queryRunner.query(
+      `UPDATE "Monitor"
+          SET "incomingMonitorRequest" = regexp_replace(
+                "incomingMonitorRequest"::text,
+                "incomingRequestSecretKey"::text,
+                '[REDACTED]',
+                'gi'
+              )::jsonb
+        WHERE "incomingRequestSecretKey" IS NOT NULL
+          AND "incomingMonitorRequest" IS NOT NULL
+          AND "incomingMonitorRequest"::text ILIKE '%' || "incomingRequestSecretKey"::text || '%'`,
+    );
+
+    /*
+     * Incident and Alert keep a copy of the snapshot the monitor was evaluated
+     * from. The key is not on those rows, so join back to the monitor. The
+     * `projectId` equality keeps the join from degenerating into a cross
+     * product; the ILIKE is what actually selects the affected rows, and a
+     * snapshot describes exactly one monitor, so at most one monitor row can
+     * match a given summary.
+     */
+    for (const table of ["Incident", "Alert"]) {
+      for (const secretColumn of [
+        "incomingEmailSecretKey",
+        "incomingRequestSecretKey",
+      ]) {
+        await queryRunner.query(
+          `UPDATE "${table}" AS t
+              SET "monitorSummary" = regexp_replace(
+                    t."monitorSummary"::text,
+                    m."${secretColumn}"::text,
+                    '[REDACTED]',
+                    'gi'
+                  )::jsonb
+             FROM "Monitor" AS m
+            WHERE m."${secretColumn}" IS NOT NULL
+              AND m."projectId" = t."projectId"
+              AND t."monitorSummary" IS NOT NULL
+              AND t."monitorSummary"::text ILIKE '%' || m."${secretColumn}"::text || '%'`,
+        );
+      }
+    }
+  }
+
+  public async down(): Promise<void> {
+    /*
+     * Deliberately empty. The whole point of the up migration is that these
+     * values are gone; the original text is not recoverable from anything else
+     * in the schema, and recovering it would mean re-publishing the leak.
+     *
+     * Nothing depends on the redacted text either: `IncomingEmailCriteria`
+     * re-evaluates against live mail, and the summary cards render whatever
+     * string is stored. Rolling the schema back therefore needs no data change.
+     */
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -542,6 +542,7 @@ import { RemoveLlmCostBudgetAlertColumns1788500000000 } from "./1788500000000-Re
 import { AddDetectionRuleIncidentColumns1788600000000 } from "./1788600000000-AddDetectionRuleIncidentColumns";
 import { RemoveMarketingConversionUploadState1788700000000 } from "./1788700000000-RemoveMarketingConversionUploadState";
 import { DropMarketingConversionAddEnterpriseLicenseEmail1788800000000 } from "./1788800000000-DropMarketingConversionAddEnterpriseLicenseEmail";
+import { RedactStoredMonitorIngestSecrets1788900000000 } from "./1788900000000-RedactStoredMonitorIngestSecrets";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1092,4 +1093,5 @@ export default [
   AddDetectionRuleIncidentColumns1788600000000,
   RemoveMarketingConversionUploadState1788700000000,
   DropMarketingConversionAddEnterpriseLicenseEmail1788800000000,
+  RedactStoredMonitorIngestSecrets1788900000000,
 ];

--- a/Common/Server/Utils/Monitor/MonitorPayloadRedaction.ts
+++ b/Common/Server/Utils/Monitor/MonitorPayloadRedaction.ts
@@ -158,7 +158,164 @@ export const redactForPersistence: RedactForPersistenceFunction = (
   return walk(payload, false, 0);
 };
 
+export type RedactMonitorSecretFunction = <T>(
+  payload: T,
+  secret: string | null | undefined,
+) => T;
+
+/*
+ * Value boundary. Masks every textual occurrence of ONE monitor's own secret
+ * key inside an ingest payload.
+ *
+ * The two walkers above are structural: they decide by key name, which is the
+ * right test when a credential arrives as its own field (`secretKey`). The
+ * incoming-email path has the other shape. There the secret is not a field at
+ * all -- it is baked into a value that is otherwise legitimate evidence.
+ * `MonitorService` mints `incomingEmailSecretKey`, and
+ * `SendGridInboundProvider.generateMonitorEmailAddress` turns it into the
+ * monitor's ingest address, `monitor-{secretKey}@{inboundDomain}`. The address
+ * IS the credential -- `extractSecretKeyFromEmail` parses the key straight back
+ * out of it -- so everything that quotes the recipient quotes the key:
+ * `emailTo`, the `To:` header, and the `Received:` / `Delivered-To:` headers a
+ * relay adds on the way in.
+ *
+ * No key name marks any of those as sensitive, and none of them can simply be
+ * dropped. `IncomingEmailCriteria` evaluates `emailTo` for the "Email to"
+ * check, and mail that reaches the monitor through an alias or a forwarding
+ * rule carries a genuinely different -- and genuinely interesting -- recipient.
+ * So this masks the secret substring and leaves the rest of the value intact:
+ * domain, alias and relay chain all survive, and a filter written against them
+ * keeps matching.
+ *
+ * Matching is case-insensitive because the key is a UUID that reaches us
+ * through address normalisation (`extractEmailAddress` lowercases) and through
+ * relay headers that preserve whatever case the sender happened to use.
+ */
+
+/*
+ * A secret shorter than this is not a key we minted -- `ObjectID.generate()`
+ * returns a 36-character UUID. Sweeping for a short string would mask ordinary
+ * text that merely contains it, destroying the evidence this is trying to keep
+ * readable, so treat it as nothing to do rather than over-redact.
+ */
+const MIN_SWEEPABLE_SECRET_LENGTH: number = 8;
+
+type ReplaceAllInsensitiveFunction = (
+  haystack: string,
+  needle: string,
+) => string;
+
+/*
+ * Case-insensitive replace-all done by scan rather than by `RegExp`, so a
+ * secret that happens to contain regex metacharacters needs no escaping and
+ * cannot alter the pattern. Compares on lowercased copies but slices from the
+ * original, so the surrounding text keeps its own casing.
+ */
+const replaceAllInsensitive: ReplaceAllInsensitiveFunction = (
+  haystack: string,
+  needle: string,
+): string => {
+  const lowerHaystack: string = haystack.toLowerCase();
+  const lowerNeedle: string = needle.toLowerCase();
+
+  let result: string = "";
+  let cursor: number = 0;
+  let index: number = lowerHaystack.indexOf(lowerNeedle, cursor);
+
+  while (index !== -1) {
+    result += haystack.slice(cursor, index) + REDACTED;
+    cursor = index + lowerNeedle.length;
+    index = lowerHaystack.indexOf(lowerNeedle, cursor);
+  }
+
+  return result + haystack.slice(cursor);
+};
+
+type SweepFunction = (
+  value: JSONValue,
+  secret: string,
+  depth: number,
+) => JSONValue;
+
+const sweep: SweepFunction = (
+  value: JSONValue,
+  secret: string,
+  depth: number,
+): JSONValue => {
+  // Same reasoning as `walk`: below the ceiling we cannot vouch for the value.
+  if (depth > MAX_DEPTH) {
+    return null;
+  }
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return replaceAllInsensitive(value, secret);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item: JSONValue) => {
+      return sweep(item, secret, depth + 1);
+    });
+  }
+
+  /*
+   * Leaf. Dates and ObjectIDs land here as live instances on the ingest side;
+   * neither can carry the secret as text, so they pass through untouched.
+   */
+  if (
+    typeof value !== "object" ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    return value;
+  }
+
+  const source: JSONObject = value as JSONObject;
+  const result: JSONObject = {};
+
+  /*
+   * Keys are swept too. `emailHeaders` is a `Dictionary<string>` built from
+   * whatever header names the relay sent, so a key is no more trustworthy than
+   * a value -- and a redacted key still serialises into the stored jsonb.
+   */
+  for (const key of Object.keys(source)) {
+    result[replaceAllInsensitive(key, secret)] = sweep(
+      source[key] as JSONValue,
+      secret,
+      depth + 1,
+    );
+  }
+
+  return result;
+};
+
+/*
+ * Generic over the payload type for the same reason as `stripAgentCredentials`:
+ * the caller goes on treating the result as its declared interface. Masking
+ * only ever rewrites strings in place, so every field keeps its declared type.
+ */
+export const redactMonitorSecret: RedactMonitorSecretFunction = <T>(
+  payload: T,
+  secret: string | null | undefined,
+): T => {
+  if (payload === null || payload === undefined) {
+    return payload;
+  }
+
+  if (
+    typeof secret !== "string" ||
+    secret.length < MIN_SWEEPABLE_SECRET_LENGTH
+  ) {
+    return payload;
+  }
+
+  return sweep(payload as JSONValue, secret, 0) as T;
+};
+
 export default {
   stripAgentCredentials,
   redactForPersistence,
+  redactMonitorSecret,
 };


### PR DESCRIPTION
### Title of this pull request?

fix(monitor): stop echoing the incoming-email ingest key into stored payloads

### Small Description?

Completes the remediation for #3360.

That fix narrowed the read ACL on the three `Monitor` secret-key columns, but `incomingEmailSecretKey` has a second way out that the ACL change does not touch. **The key IS the monitor's inbound address**: `generateMonitorEmailAddress` builds `monitor-{secretKey}@{inboundDomain}` and `extractSecretKeyFromEmail` parses it straight back out. So every stored copy of the *recipient* is a stored copy of a live bearer credential — `emailTo`, the `To:` header, and the `Received:` / `Delivered-To:` headers a relay stamps on in transit.

`processIncomingEmailFromQueue` persisted all of that verbatim into `Monitor.incomingEmailMonitorRequest`, whose read ACL lists `Viewer`, `MonitorViewer` and `ReadProjectMonitor`. A project Viewer could select the column and read a key that lets them send mail the monitor counts as a heartbeat — and the dashboard selects it unconditionally, right after calling the previous fix's own `getReadableMonitorSecretKeySelect()` helper.

**The disclosure is wider than the reported column.** The same payload goes to `monitorResource`, so `MonitorSummaryCapture` copies it onto `Incident.monitorSummary` and `Alert.monitorSummary` — gated on incident/alert permissions, not monitor ones — and `MonitorLogUtil` writes it to `MonitorLog.logBody`.

#### Why redact on write rather than narrow the ACL

Narrowing `incomingEmailMonitorRequest`'s read list would have been an **incomplete** fix — it leaves the incident and alert summary paths open — and it would have broken the monitor page for Viewers (an unreadable column in a select throws, it does not degrade) while removing evidence they are entitled to see. Redacting at the ingest boundary closes every sink at once, including any added later. Happy to add the ACL narrowing as belt-and-braces if you'd prefer both.

#### What changed

- **`redactMonitorSecret`** (new, in `MonitorPayloadRedaction`) masks a monitor's own key wherever it appears as text. The existing walkers there are *structural* — they decide by key name, which is right when a credential arrives as its own field (`secretKey`) and useless here, where the secret is baked into a value that is otherwise legitimate evidence. Case-insensitive (relay headers preserve sender casing), and done by scan rather than `RegExp` so a secret needs no escaping.
- **Applied at the ingest boundary** in `processIncomingEmailFromQueue`, the same shape as `stripAgentCredentials` on the server-monitor path, so the key never becomes part of `dataToProcess`.
- **Migration `1788900000000`** scrubs the four Postgres sinks for rows written before this deploy. Redaction fixes the flow, not the stock.

Two things the redactor deliberately preserves: `IncomingEmailCriteria` evaluates `emailTo` for the "Email to" check and forwarded mail carries a genuinely different recipient, so **only the monitor's own key is masked, never the whole address**; and the domain survives, so the stored value reads `monitor-[REDACTED]@inbound.example` and an operator can still see where the mail landed.

`MonitorLog.logBody` is deliberately not migrated: it lives in ClickHouse and every row carries a `retentionDate DELETE` TTL, so historical rows age out on their own.

#### `incomingRequestSecretKey` — checked, no equivalent echo

It travels in the URL path and only the method, headers and body are captured, so the path never enters `incomingMonitorRequest`. It is still *reachable* — an ingress reflecting the request target (`X-Original-URI`, `X-Forwarded-Uri`) or a sender quoting its own key would land it in that column, which is Viewer-readable too — so the same sweep runs there and the invariant is uniform.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Verification run locally:**

- `tsc --noEmit` clean on both `Common` and `App`
- **855** App tests and **673** Common tests pass, including the existing #3360 suites and all monitor criteria
- eslint and prettier clean on every changed file
- Migration verified against a throwaway database: all four sinks cleaned, mixed-case header caught, a row in a *different* project carrying the same string correctly not matched, non-secret evidence intact, output still valid `jsonb`, and a second run a no-op

**On the tests (12 new).** The headline one states the requirement as an invariant rather than a field check: it builds the monitor a Viewer's `get-list` would return, populated with what ingest actually persisted, computes the Viewer-readable column set from the real ACLs, and asserts none carries the key. It asserts `incomingEmailMonitorRequest` is in that set, so it cannot pass by asserting nothing.

I checked they actually catch the bug — with the redactor neutralised **7 fail**, and the 5 covering "evidence survives" and "authentication still works" pass either way. That split is what makes them regression tests rather than restatements of the implementation.

### Related Issue?

Follow-up to #3360 (incomplete remediation — deliberately not using a closing keyword, since the original issue is already closed by f7f5b19f95).

This is also the blocker for the pending draft security advisory. I have left the advisory identifier out of this public PR body — please add it yourself if you want it linked.

### Screenshots (if appropriate):

n/a — no user-visible change. The monitor page renders the same fields for every role; the stored recipient now reads `monitor-[REDACTED]@inbound.example` instead of embedding the live key.
