### PR TITLE
feat(metrics): make every metric chart an investigation starting point

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
@@ -21,6 +21,8 @@ import MetricQueryConfigData, {
 import MetricFormulaConfigData from "Common/Types/Metrics/MetricFormulaConfigData";
 import Icon from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import OneUptimeDate from "Common/Types/Date";
 import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEndDateTime";
 import DashboardChartType from "Common/Types/Dashboard/Chart/ChartType";
 import DashboardVariableInterpolation from "Common/Utils/Dashboard/VariableInterpolation";
@@ -113,13 +115,31 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
     );
   }, [props.dashboardStartAndEndDate, props.refreshTick]);
 
+  /*
+   * Drag-to-zoom: a widget-local window narrowed by drag-selecting a
+   * range on the chart. It overrides the dashboard's window for THIS
+   * widget only (spike investigation shouldn't retime every other
+   * widget), survives auto-refresh ticks (the user is mid-investigation;
+   * a rolling re-anchor would yank the window away), and clears when the
+   * dashboard's own time range changes — an explicit range pick is a
+   * statement about what the user wants to see everywhere.
+   */
+  const [zoomWindow, setZoomWindow] = useState<InBetween<Date> | null>(null);
+
+  useEffect(() => {
+    setZoomWindow(null);
+  }, [props.dashboardStartAndEndDate]);
+
+  const effectiveStartAndEndDate: InBetween<Date> | null =
+    zoomWindow || startAndEndDate;
+
   const metricViewData: MetricViewData = useMemo(() => {
     return {
       queryConfigs: queryConfigs,
-      startAndEndDate: startAndEndDate,
+      startAndEndDate: effectiveStartAndEndDate,
       formulaConfigs: formulaConfigs,
     };
-  }, [queryConfigs, startAndEndDate, formulaConfigs]);
+  }, [queryConfigs, effectiveStartAndEndDate, formulaConfigs]);
 
   /*
    * Latest props in a ref so fetchAggregatedResults can stay stable
@@ -189,7 +209,7 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
   useEffect(() => {
     fetchAggregatedResults();
   }, [
-    startAndEndDate,
+    effectiveStartAndEndDate,
     queryConfigs,
     formulaConfigs,
     props.refreshTick,
@@ -224,7 +244,14 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
           chartType: config.chartType || getMetricChartType(),
         };
       }),
-      startAndEndDate: startAndEndDate,
+      startAndEndDate: effectiveStartAndEndDate,
+      /*
+       * Relative dashboard ranges ("Past 1 hour") carry their token so
+       * explorer links keep ROLLING instead of pinning the instant the
+       * link was built; a zoomed window is a deliberate pin and carries
+       * none (getValidRangeToken drops Custom/garbage on serialization).
+       */
+      rangeToken: zoomWindow ? undefined : props.dashboardStartAndEndDate.range,
       formulaConfigs: formulaConfigs.map((config: MetricFormulaConfigData) => {
         return {
           ...config,
@@ -232,7 +259,14 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
         };
       }),
     };
-  }, [queryConfigs, formulaConfigs, startAndEndDate, getMetricChartType]);
+  }, [
+    queryConfigs,
+    formulaConfigs,
+    effectiveStartAndEndDate,
+    zoomWindow,
+    props.dashboardStartAndEndDate.range,
+    getMetricChartType,
+  ]);
 
   /*
    * "Open in Explorer" deep link for this widget's queries. Suppressed on
@@ -253,6 +287,25 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
     },
     [chartMetricViewData],
   );
+
+  /*
+   * Drag-to-zoom is a view-mode affordance: in edit mode the drag gesture
+   * belongs to widget move/resize, and mid-edit navigation state (the
+   * zoom bar's explorer link) would invite losing unsaved changes.
+   */
+  const handleChartTimeRangeSelect: (startTime: Date, endTime: Date) => void =
+    useCallback((startTime: Date, endTime: Date): void => {
+      setZoomWindow(new InBetween<Date>(startTime, endTime));
+    }, []);
+
+  const enableChartZoom: boolean = !props.isEditMode;
+
+  /*
+   * Series investigate menus navigate to explorer/telemetry pages, so
+   * they follow the same gating as the Open in Explorer button.
+   */
+  const enableSeriesActions: boolean =
+    !isPublicDashboard() && !props.isEditMode;
 
   if (isLoading && metricResults.length === 0) {
     // Skeleton loading for chart - only on initial load
@@ -333,6 +386,38 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
           )}
         </div>
       )}
+      {zoomWindow ? (
+        <div className="mx-2 mb-1 flex flex-shrink-0 flex-wrap items-center gap-x-2 gap-y-1 rounded-md bg-indigo-50 px-2 py-1">
+          <Icon
+            icon={IconProp.MagnifyingGlassPlus}
+            className="h-3 w-3 flex-shrink-0 text-indigo-500"
+          />
+          <span className="min-w-0 truncate text-[11px] text-indigo-700">
+            Zoomed:{" "}
+            {OneUptimeDate.getInBetweenDatesAsFormattedString(zoomWindow)}
+          </span>
+          <button
+            type="button"
+            className="text-[11px] font-medium text-indigo-600 underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+            onClick={(event: React.MouseEvent<HTMLButtonElement>): void => {
+              event.stopPropagation();
+              setZoomWindow(null);
+            }}
+          >
+            Reset
+          </button>
+          {showOpenInExplorer ? (
+            <button
+              type="button"
+              className="text-[11px] font-medium text-indigo-600 underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+              title="Open this window in Metric Explorer"
+              onClick={handleOpenInExplorer}
+            >
+              Open in Explorer
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
         <MetricCharts
           metricResults={metricResults}
@@ -340,6 +425,10 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
           metricViewData={chartMetricViewData}
           hideCard={true}
           topNOverrideScope={topNOverrideScope}
+          enableSeriesActions={enableSeriesActions}
+          onTimeRangeSelect={
+            enableChartZoom ? handleChartTimeRangeSelect : undefined
+          }
         />
       </div>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -65,9 +65,28 @@ import MoreMenuItem from "Common/UI/Components/MoreMenu/MoreMenuItem";
 import useComponentOutsideClick from "Common/UI/Types/UseComponentOutsideClick";
 import {
   CrossSignalQueryParams,
+  MetricScopeFilterExtraction,
   buildExemplarLogsPivotParams,
+  buildMetricExplorerPivotParams,
+  extractScopeFiltersFromQueryConfigs,
+  formatDroppedScopeHint,
   getExemplarTraceQueryParams,
+  resolveServiceIdsByNames,
 } from "../../Utils/MetricsCrossSignalPivot";
+import {
+  SeriesResourceTarget,
+  SeriesScopedViewData,
+  buildSeriesExceptionsPivotParams,
+  getSeriesResourceTargets,
+  resolveSeriesResourceModelId,
+  scopeViewDataToSeries,
+  splitSeriesNameIntoSegments,
+} from "../../Utils/MetricSeriesInvestigation";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import ExplorerLink from "./Utils/ExplorerLink";
+import { ShowToastNotification } from "Common/UI/Components/Toast/ToastInit";
+import { ToastType } from "Common/UI/Components/Toast/Toast";
+import TimeRange from "Common/Types/Time/TimeRange";
 import {
   DictionaryEntryValue,
   DictionaryFilterOperator,
@@ -119,6 +138,15 @@ export interface ComponentProps {
    */
   timeReferenceLines?: Array<ChartTimeReferenceLineProps> | undefined;
   referenceRegions?: Array<ChartReferenceRegionProps> | undefined;
+  /*
+   * Per-series investigate menu on the legend chips: pivots to
+   * logs/traces/exceptions and to the resource page (host/service/…) the
+   * series is about, each scoped to that one series' group-by labels. On
+   * by default; surfaces with no project session (public dashboards) or
+   * where navigating away would lose unsaved state (dashboard edit mode)
+   * pass false.
+   */
+  enableSeriesActions?: boolean | undefined;
 }
 
 /*
@@ -306,37 +334,10 @@ function getChartPalette(
 }
 
 /*
- * Split a composed grouped-series name back into its "key=value" segments,
- * using the known group keys so it stays correct when a value itself contains
- * the ", " that also joins multi-key segments. A single-key group-by has
- * exactly one segment (the whole name), so a comma in the value can never be
- * mis-split. For multi-key names, a fragment that doesn't start with a known
- * "key=" prefix is treated as a continuation of the previous value.
+ * splitSeriesNameIntoSegments moved to Utils/MetricSeriesInvestigation so
+ * the per-series investigate menu's label parsing and the color pins here
+ * share one key-aware splitter.
  */
-function splitSeriesNameIntoSegments(
-  seriesName: string,
-  groupByKeys: Array<string>,
-): Array<string> {
-  if (groupByKeys.length <= 1) {
-    return [seriesName];
-  }
-  const startsWithKnownKey: (fragment: string) => boolean = (
-    fragment: string,
-  ): boolean => {
-    return groupByKeys.some((key: string): boolean => {
-      return fragment.startsWith(`${key}=`);
-    });
-  };
-  const segments: Array<string> = [];
-  for (const fragment of seriesName.split(", ")) {
-    if (segments.length > 0 && !startsWithKnownKey(fragment)) {
-      segments[segments.length - 1] += `, ${fragment}`;
-    } else {
-      segments.push(fragment);
-    }
-  }
-  return segments;
-}
 
 /*
  * Resolve the color for one series. Per-group pins win first: `colorsByGroup`
@@ -424,6 +425,70 @@ const EXEMPLAR_MENU_VIEWPORT_MARGIN_PX: number = 8;
 interface ExemplarMenuState {
   exemplar: ExemplarPoint;
   position: { x: number; y: number };
+}
+
+/*
+ * Approximate rendered size of the per-series investigate menu, used to
+ * clamp its fixed position the same way the exemplar menu is clamped.
+ */
+const SERIES_MENU_WIDTH_PX: number = 260;
+const SERIES_MENU_HEIGHT_PX: number = 280;
+
+// One open per-series investigate menu.
+interface SeriesMenuState {
+  seriesName: string;
+  /*
+   * The owning panel's group-by keys (union across overlaid queries, or
+   * the formula's group keys) — panel-accurate so a value containing
+   * ", " can't be mis-split against an unrelated panel's keys.
+   */
+  groupByKeys: Array<string>;
+  position: { x: number; y: number };
+}
+
+/*
+ * Shared roving-focus keyboard handling for the fixed-position pivot
+ * menus (exemplar + series): Escape closes, ArrowUp/ArrowDown cycle
+ * through the menu items.
+ */
+function navigateMenuWithKeyboard(input: {
+  event: React.KeyboardEvent<HTMLDivElement>;
+  menuElement: HTMLElement | null;
+  onClose: VoidFunction;
+}): void {
+  const { event, menuElement, onClose } = input;
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    onClose();
+    return;
+  }
+
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+    return;
+  }
+
+  event.preventDefault();
+
+  if (!menuElement) {
+    return;
+  }
+
+  const items: Array<HTMLElement> = Array.from(
+    menuElement.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+  );
+
+  if (items.length === 0) {
+    return;
+  }
+
+  const activeIndex: number = items.findIndex((item: HTMLElement) => {
+    return item === document.activeElement;
+  });
+  const delta: number = event.key === "ArrowDown" ? 1 : -1;
+  const nextIndex: number = (activeIndex + delta + items.length) % items.length;
+
+  items[nextIndex]?.focus();
 }
 
 // Composite key for exemplar fetch/state: metric name + sanitized filters.
@@ -812,6 +877,13 @@ function renderSeriesControls(input: {
    * using the same unit/precision as the chart's y-axis.
    */
   valueFormatter: (value: number) => string;
+  /*
+   * When set, every chip grows a magnifier button that opens the
+   * per-series investigate menu, anchored under the button.
+   */
+  onInvestigateSeries?:
+    | ((seriesName: string, anchor: { x: number; y: number }) => void)
+    | undefined;
 }): ReactElement {
   const {
     chartId,
@@ -832,6 +904,7 @@ function renderSeriesControls(input: {
     warningElement,
     unitLabel,
     valueFormatter,
+    onInvestigateSeries,
   } = input;
 
   const sortBy: SeriesSortBy = controls.sortBy;
@@ -1156,56 +1229,87 @@ function renderSeriesControls(input: {
             const valueLabel: string | null =
               statValue === null ? null : valueFormatter(statValue);
             return (
-              <button
+              <div
                 key={series.seriesName}
-                type="button"
-                aria-pressed={!isHidden}
-                onClick={(): void => {
-                  toggleSeries(series.seriesName);
-                }}
-                className={`group inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 ${
+                className={`group inline-flex items-stretch rounded-md border transition ${
                   isHidden
-                    ? "border-gray-100 bg-white text-gray-400 hover:border-gray-200 hover:text-gray-500"
-                    : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900"
+                    ? "border-gray-100 bg-white hover:border-gray-200"
+                    : "border-gray-200 bg-white hover:border-gray-300"
                 }`}
-                title={
-                  isHidden
-                    ? `${series.seriesName} — click to show`
-                    : `${series.seriesName} — click to hide`
-                }
               >
-                <span
-                  aria-hidden="true"
-                  className={`h-2 w-2 shrink-0 rounded-full ${
-                    showColor
-                      ? showCustomColor
-                        ? ""
-                        : getColorClassName(color!, "bg")
-                      : "bg-gray-300"
+                <button
+                  type="button"
+                  aria-pressed={!isHidden}
+                  onClick={(): void => {
+                    toggleSeries(series.seriesName);
+                  }}
+                  className={`inline-flex items-center gap-1.5 px-2 py-1 text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 ${
+                    onInvestigateSeries ? "rounded-l-md" : "rounded-md"
+                  } ${
+                    isHidden
+                      ? "text-gray-400 hover:text-gray-500"
+                      : "text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                   }`}
-                  style={
-                    showCustomColor
-                      ? { backgroundColor: getColorHex(color!) }
-                      : undefined
+                  title={
+                    isHidden
+                      ? `${series.seriesName} — click to show`
+                      : `${series.seriesName} — click to hide`
                   }
-                />
-                <span
-                  className={`max-w-[240px] truncate ${
-                    isHidden ? "line-through" : ""
-                  }`}
                 >
-                  {series.seriesName}
-                </span>
-                {valueLabel !== null ? (
                   <span
-                    className={`shrink-0 tabular-nums font-medium ${
-                      isHidden ? "text-gray-300" : "text-gray-500"
+                    aria-hidden="true"
+                    className={`h-2 w-2 shrink-0 rounded-full ${
+                      showColor
+                        ? showCustomColor
+                          ? ""
+                          : getColorClassName(color!, "bg")
+                        : "bg-gray-300"
+                    }`}
+                    style={
+                      showCustomColor
+                        ? { backgroundColor: getColorHex(color!) }
+                        : undefined
+                    }
+                  />
+                  <span
+                    className={`max-w-[240px] truncate ${
+                      isHidden ? "line-through" : ""
                     }`}
                   >
-                    {valueLabel}
+                    {series.seriesName}
                   </span>
+                  {valueLabel !== null ? (
+                    <span
+                      className={`shrink-0 tabular-nums font-medium ${
+                        isHidden ? "text-gray-300" : "text-gray-500"
+                      }`}
+                    >
+                      {valueLabel}
+                    </span>
+                  ) : null}
+                </button>
+                {onInvestigateSeries ? (
+                  <button
+                    type="button"
+                    aria-label={`Investigate ${series.seriesName}`}
+                    title="Investigate this series — logs, traces, and more"
+                    onClick={(
+                      event: React.MouseEvent<HTMLButtonElement>,
+                    ): void => {
+                      event.stopPropagation();
+                      const rect: DOMRect =
+                        event.currentTarget.getBoundingClientRect();
+                      onInvestigateSeries(series.seriesName, {
+                        x: rect.left,
+                        y: rect.bottom + 4,
+                      });
+                    }}
+                    className="inline-flex items-center rounded-r-md border-l border-gray-100 px-1.5 text-gray-300 transition hover:bg-indigo-50 hover:text-indigo-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 group-hover:text-gray-400"
+                  >
+                    <Icon icon={IconProp.MagnifyingGlass} className="h-3 w-3" />
+                  </button>
                 ) : null}
-              </button>
+              </div>
             );
           })
         )}
@@ -1446,41 +1550,317 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
   const handleExemplarMenuKeyDown: (
     event: React.KeyboardEvent<HTMLDivElement>,
   ) => void = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeExemplarMenu();
+    navigateMenuWithKeyboard({
+      event,
+      menuElement: exemplarMenuRef.current as HTMLElement | null,
+      onClose: closeExemplarMenu,
+    });
+  };
+
+  /*
+   * Per-series investigate menu, opened from a legend chip's magnifier
+   * button. Mirrors the exemplar menu's structure (fixed position clamped
+   * to the viewport, outside-click close, roving keyboard focus).
+   */
+  const showSeriesActions: boolean = props.enableSeriesActions !== false;
+
+  const [seriesMenu, setSeriesMenu] = useState<SeriesMenuState | null>(null);
+
+  const {
+    ref: seriesMenuRef,
+    isComponentVisible: isSeriesMenuVisible,
+    setIsComponentVisible: setIsSeriesMenuVisible,
+  } = useComponentOutsideClick(false);
+
+  const closeSeriesMenu: VoidFunction = useCallback((): void => {
+    setIsSeriesMenuVisible(false);
+    setSeriesMenu(null);
+  }, [setIsSeriesMenuVisible]);
+
+  const openSeriesMenu: (
+    seriesName: string,
+    groupByKeys: Array<string>,
+    anchor: { x: number; y: number },
+  ) => void = useCallback(
+    (
+      seriesName: string,
+      groupByKeys: Array<string>,
+      anchor: { x: number; y: number },
+    ): void => {
+      const maxX: number =
+        window.innerWidth -
+        SERIES_MENU_WIDTH_PX -
+        EXEMPLAR_MENU_VIEWPORT_MARGIN_PX;
+      const maxY: number =
+        window.innerHeight -
+        SERIES_MENU_HEIGHT_PX -
+        EXEMPLAR_MENU_VIEWPORT_MARGIN_PX;
+
+      setSeriesMenu({
+        seriesName,
+        groupByKeys,
+        position: {
+          x: Math.max(
+            EXEMPLAR_MENU_VIEWPORT_MARGIN_PX,
+            Math.min(anchor.x, maxX),
+          ),
+          y: Math.max(
+            EXEMPLAR_MENU_VIEWPORT_MARGIN_PX,
+            Math.min(anchor.y, maxY),
+          ),
+        },
+      });
+      setIsSeriesMenuVisible(true);
+    },
+    [setIsSeriesMenuVisible],
+  );
+
+  // Focus the first action when the series menu opens (menu keyboard pattern).
+  useEffect(() => {
+    if (!seriesMenu || !isSeriesMenuVisible) {
       return;
     }
+    requestAnimationFrame(() => {
+      const menuElement: HTMLElement | null =
+        seriesMenuRef.current as HTMLElement | null;
+      menuElement?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    });
+  }, [seriesMenu, isSeriesMenuVisible, seriesMenuRef]);
 
-    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
-      return;
+  const handleSeriesMenuKeyDown: (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) => void = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    navigateMenuWithKeyboard({
+      event,
+      menuElement: seriesMenuRef.current as HTMLElement | null,
+      onClose: closeSeriesMenu,
+    });
+  };
+
+  const getScopedViewDataForSeries: (
+    menuState: SeriesMenuState,
+  ) => SeriesScopedViewData = (
+    menuState: SeriesMenuState,
+  ): SeriesScopedViewData => {
+    return scopeViewDataToSeries({
+      metricViewData: props.metricViewData,
+      seriesName: menuState.seriesName,
+      groupByKeys: menuState.groupByKeys,
+    });
+  };
+
+  /*
+   * Resolve `resource.service.name` filters (including ones the series
+   * scoping just added) to Service ObjectIDs — the value logs/traces/
+   * exceptions actually store in primaryEntityId. Best-effort and cached;
+   * an empty mapping degrades to attribute passthrough downstream.
+   */
+  const resolveScopedServiceIds: (scopedViewData: MetricViewData) => Promise<{
+    serviceIdsByName: Dictionary<string> | undefined;
+    serviceIds: Array<string>;
+  }> = async (
+    scopedViewData: MetricViewData,
+  ): Promise<{
+    serviceIdsByName: Dictionary<string> | undefined;
+    serviceIds: Array<string>;
+  }> => {
+    const extraction: MetricScopeFilterExtraction =
+      extractScopeFiltersFromQueryConfigs(scopedViewData.queryConfigs || []);
+
+    if (extraction.serviceNames.length === 0) {
+      return { serviceIdsByName: undefined, serviceIds: [] };
     }
 
-    event.preventDefault();
-
-    const menuElement: HTMLElement | null =
-      exemplarMenuRef.current as HTMLElement | null;
-
-    if (!menuElement) {
-      return;
-    }
-
-    const items: Array<HTMLElement> = Array.from(
-      menuElement.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    const serviceIdsByName: Dictionary<string> = await resolveServiceIdsByNames(
+      extraction.serviceNames,
     );
 
-    if (items.length === 0) {
+    const serviceIds: Array<string> = extraction.serviceNames
+      .map((serviceName: string): string => {
+        return serviceIdsByName[serviceName] || "";
+      })
+      .filter((serviceId: string): boolean => {
+        return serviceId !== "";
+      });
+
+    return { serviceIdsByName, serviceIds };
+  };
+
+  const showDroppedScopeToast: (dropped: Array<string>) => void = (
+    dropped: Array<string>,
+  ): void => {
+    const droppedHint: string = formatDroppedScopeHint(dropped);
+    if (droppedHint) {
+      ShowToastNotification({
+        title: "Some filters were not carried over",
+        description: droppedHint,
+        type: ToastType.INFO,
+      });
+    }
+  };
+
+  const buildSignalTargetUrl: (pageMap: PageMap) => URL = (
+    pageMap: PageMap,
+  ): URL => {
+    const route: Route = RouteUtil.populateRouteParams(RouteMap[pageMap]!);
+    const currentUrl: URL = Navigation.getCurrentURL();
+    return new URL(currentUrl.protocol, currentUrl.hostname, route);
+  };
+
+  const navigateSeriesToSignal: (
+    menuState: SeriesMenuState,
+    target: "logs" | "traces",
+  ) => Promise<void> = async (
+    menuState: SeriesMenuState,
+    target: "logs" | "traces",
+  ): Promise<void> => {
+    const { scopedViewData }: SeriesScopedViewData =
+      getScopedViewDataForSeries(menuState);
+
+    const targetUrl: URL = buildSignalTargetUrl(
+      target === "traces" ? PageMap.TRACES : PageMap.LOGS,
+    );
+
+    try {
+      const {
+        serviceIdsByName,
+      }: { serviceIdsByName: Dictionary<string> | undefined } =
+        await resolveScopedServiceIds(scopedViewData);
+
+      const pivot: CrossSignalQueryParams = buildMetricExplorerPivotParams({
+        target,
+        metricViewData: scopedViewData,
+        serviceIdsByName,
+      });
+
+      for (const paramName of Object.keys(pivot.params)) {
+        targetUrl.addQueryParam(
+          paramName,
+          pivot.params[paramName] as string,
+          true,
+        );
+      }
+
+      showDroppedScopeToast(pivot.dropped);
+    } catch {
+      // Degraded pivot: land on the target explorer in the chart's window.
+      if (exemplarWindow) {
+        targetUrl.addQueryParam("range", TimeRange.CUSTOM, true);
+        targetUrl.addQueryParam(
+          "start",
+          OneUptimeDate.toString(exemplarWindow.startValue),
+          true,
+        );
+        targetUrl.addQueryParam(
+          "end",
+          OneUptimeDate.toString(exemplarWindow.endValue),
+          true,
+        );
+      }
+    }
+
+    Navigation.navigate(targetUrl);
+  };
+
+  const navigateSeriesToExceptions: (
+    menuState: SeriesMenuState,
+  ) => Promise<void> = async (menuState: SeriesMenuState): Promise<void> => {
+    const { scopedViewData }: SeriesScopedViewData =
+      getScopedViewDataForSeries(menuState);
+
+    const targetUrl: URL = buildSignalTargetUrl(PageMap.EXCEPTIONS_UNRESOLVED);
+
+    try {
+      const { serviceIds }: { serviceIds: Array<string> } =
+        await resolveScopedServiceIds(scopedViewData);
+
+      const pivot: CrossSignalQueryParams = buildSeriesExceptionsPivotParams({
+        metricViewData: scopedViewData,
+        serviceIds,
+      });
+
+      for (const paramName of Object.keys(pivot.params)) {
+        targetUrl.addQueryParam(
+          paramName,
+          pivot.params[paramName] as string,
+          true,
+        );
+      }
+
+      showDroppedScopeToast(pivot.dropped);
+    } catch {
+      // Window-only fallback, same shape as the logs/traces catch above.
+      if (exemplarWindow) {
+        targetUrl.addQueryParam("range", TimeRange.CUSTOM, true);
+        targetUrl.addQueryParam(
+          "start",
+          OneUptimeDate.toString(exemplarWindow.startValue),
+          true,
+        );
+        targetUrl.addQueryParam(
+          "end",
+          OneUptimeDate.toString(exemplarWindow.endValue),
+          true,
+        );
+      }
+    }
+
+    Navigation.navigate(targetUrl);
+  };
+
+  const openSeriesInExplorer: (menuState: SeriesMenuState) => void = (
+    menuState: SeriesMenuState,
+  ): void => {
+    ExplorerLink.openInExplorer(
+      getScopedViewDataForSeries(menuState).scopedViewData,
+    );
+  };
+
+  const applySeriesFilter: (menuState: SeriesMenuState) => void = (
+    menuState: SeriesMenuState,
+  ): void => {
+    const { scopedViewData, didNarrow }: SeriesScopedViewData =
+      getScopedViewDataForSeries(menuState);
+    if (didNarrow && props.onQueryConfigsChange) {
+      props.onQueryConfigsChange(scopedViewData.queryConfigs);
+    }
+  };
+
+  const openSeriesResource: (
+    target: SeriesResourceTarget,
+  ) => Promise<void> = async (target: SeriesResourceTarget): Promise<void> => {
+    const modelId: string | null = await resolveSeriesResourceModelId(target);
+
+    const pageMapByKind: Record<SeriesResourceTarget["kind"], PageMap> = {
+      host: PageMap.HOST_VIEW,
+      service: PageMap.SERVICE_VIEW,
+      kubernetesCluster: PageMap.KUBERNETES_CLUSTER_VIEW,
+      networkDevice: PageMap.NETWORK_DEVICE_VIEW,
+    };
+
+    if (!modelId) {
+      ShowToastNotification({
+        title: "No matching resource",
+        description: `Nothing in this project matches "${target.attributeValue}".`,
+        type: ToastType.INFO,
+      });
       return;
     }
 
-    const activeIndex: number = items.findIndex((item: HTMLElement) => {
-      return item === document.activeElement;
-    });
-    const delta: number = event.key === "ArrowDown" ? 1 : -1;
-    const nextIndex: number =
-      (activeIndex + delta + items.length) % items.length;
-
-    items[nextIndex]?.focus();
+    try {
+      const route: Route = RouteUtil.populateRouteParams(
+        RouteMap[pageMapByKind[target.kind]]!,
+        { modelId },
+      );
+      Navigation.navigate(route);
+    } catch {
+      // Unroutable id (route path chars) — leave the user where they are.
+      ShowToastNotification({
+        title: "No matching resource",
+        description: `Nothing in this project matches "${target.attributeValue}".`,
+        type: ToastType.INFO,
+      });
+    }
   };
 
   const navigateToExemplarTrace: (exemplar: ExemplarPoint) => void = (
@@ -1625,6 +2005,9 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     serverTotalGroups?: number | undefined;
     serverTruncatedWithoutTopK?: boolean | undefined;
     warningElement?: ReactElement | undefined;
+    onInvestigateSeries?:
+      | ((seriesName: string, anchor: { x: number; y: number }) => void)
+      | undefined;
   }) => {
     displayableSeries: Array<SeriesPoint>;
     colorsOverride: Array<ChartColorValue> | undefined;
@@ -1644,6 +2027,9 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     serverTotalGroups?: number | undefined;
     serverTruncatedWithoutTopK?: boolean | undefined;
     warningElement?: ReactElement | undefined;
+    onInvestigateSeries?:
+      | ((seriesName: string, anchor: { x: number; y: number }) => void)
+      | undefined;
   }): {
     displayableSeries: Array<SeriesPoint>;
     colorsOverride: Array<ChartColorValue> | undefined;
@@ -1741,6 +2127,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
           warningElement: input.warningElement,
           unitLabel: input.unitLabel,
           valueFormatter: input.valueFormatter,
+          onInvestigateSeries: input.onInvestigateSeries,
         })
       : undefined;
 
@@ -1817,6 +2204,20 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
       const firstQuery: MetricQueryConfigData = firstMember.queryConfig;
 
       applyPanelSeriesNaming(members);
+
+      /*
+       * The panel's group-by keys (union across overlaid queries) — what
+       * the investigate menu parses series names against.
+       */
+      const panelGroupByKeys: Array<string> = [];
+      for (const member of members) {
+        for (const key of member.queryConfig.metricQueryData
+          .groupByAttributeKeys || []) {
+          if (key && !panelGroupByKeys.includes(key)) {
+            panelGroupByKeys.push(key);
+          }
+        }
+      }
 
       /*
        * Merged panel series + owner lookup (which member query a series
@@ -2144,6 +2545,11 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         serverTotalGroups,
         serverTruncatedWithoutTopK,
         warningElement: unitMismatchWarning,
+        onInvestigateSeries: showSeriesActions
+          ? (seriesName: string, anchor: { x: number; y: number }): void => {
+              openSeriesMenu(seriesName, panelGroupByKeys, anchor);
+            }
+          : undefined,
       });
 
       /*
@@ -2452,6 +2858,21 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
             valueFormatter: (value: number): string => {
               return ValueFormatter.formatValue(value, formulaUnit);
             },
+            /*
+             * Formula series carry the same key=value group labels as
+             * query series (the evaluator stamps group attributes onto
+             * output rows), so per-series pivots scope the UNDERLYING
+             * queries by those labels — the formula itself has no filter
+             * representation.
+             */
+            onInvestigateSeries: showSeriesActions
+              ? (
+                  seriesName: string,
+                  anchor: { x: number; y: number },
+                ): void => {
+                  openSeriesMenu(seriesName, formulaGroupKeys, anchor);
+                }
+              : undefined,
           });
 
       const formulaChart: Chart = {
@@ -2514,6 +2935,39 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     return charts;
   };
 
+  /*
+   * Derived only while the series menu is open: the series-scoped view
+   * (drives which items render), the "host.name = prod-01" narrowing
+   * summary, and the resource pages this series can jump to.
+   */
+  const seriesMenuScoped: SeriesScopedViewData | null =
+    seriesMenu && isSeriesMenuVisible
+      ? getScopedViewDataForSeries(seriesMenu)
+      : null;
+  const seriesMenuNarrowSummary: string = seriesMenuScoped
+    ? MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: props.metricViewData.queryConfigs,
+        seriesLabels: seriesMenuScoped.seriesLabels,
+      })
+    : "";
+  const seriesMenuResourceTargets: Array<SeriesResourceTarget> =
+    seriesMenuScoped
+      ? getSeriesResourceTargets({
+          seriesLabels: seriesMenuScoped.seriesLabels,
+          queryConfigs: props.metricViewData.queryConfigs,
+        })
+      : [];
+
+  const resourceTargetIconByKind: Record<
+    SeriesResourceTarget["kind"],
+    IconProp
+  > = {
+    host: IconProp.ServerStack,
+    service: IconProp.Cube,
+    kubernetesCluster: IconProp.SquareStack3D,
+    networkDevice: IconProp.Signal,
+  };
+
   return (
     <>
       <ChartGroup
@@ -2552,6 +3006,112 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
               navigateToExemplarLogs(exemplarMenu.exemplar);
             }}
           />
+        </div>
+      ) : null}
+      {seriesMenu && isSeriesMenuVisible ? (
+        <div
+          ref={seriesMenuRef}
+          role="menu"
+          aria-orientation="vertical"
+          aria-label="Series investigation actions"
+          className="fixed z-50 w-64 rounded-lg bg-white py-1 shadow-xl ring-1 ring-gray-200 focus:outline-none"
+          style={{
+            left: `${seriesMenu.position.x}px`,
+            top: `${seriesMenu.position.y}px`,
+          }}
+          onKeyDown={handleSeriesMenuKeyDown}
+        >
+          <div className="mx-1 mb-1 border-b border-gray-100 px-3 pb-2 pt-1.5">
+            <p
+              className="truncate text-xs font-medium text-gray-900"
+              title={seriesMenu.seriesName}
+            >
+              {seriesMenu.seriesName}
+            </p>
+            {seriesMenuNarrowSummary ? (
+              <p
+                className="mt-0.5 truncate text-[11px] text-gray-500"
+                title={seriesMenuNarrowSummary}
+              >
+                Scoped to {seriesMenuNarrowSummary}
+              </p>
+            ) : null}
+          </div>
+          {props.onQueryConfigsChange && seriesMenuScoped?.didNarrow ? (
+            <MoreMenuItem
+              key="series-filter"
+              icon={IconProp.Filter}
+              text="Filter to this series"
+              onClick={() => {
+                const menuState: SeriesMenuState = seriesMenu;
+                closeSeriesMenu();
+                applySeriesFilter(menuState);
+              }}
+            />
+          ) : null}
+          {!props.onQueryConfigsChange ? (
+            <MoreMenuItem
+              key="series-explorer"
+              icon={IconProp.ExternalLink}
+              text="Open in Metric Explorer"
+              onClick={() => {
+                const menuState: SeriesMenuState = seriesMenu;
+                closeSeriesMenu();
+                openSeriesInExplorer(menuState);
+              }}
+            />
+          ) : null}
+          <MoreMenuItem
+            key="series-view-logs"
+            icon={IconProp.Logs}
+            text="View logs"
+            onClick={() => {
+              const menuState: SeriesMenuState = seriesMenu;
+              closeSeriesMenu();
+              navigateSeriesToSignal(menuState, "logs").catch(() => {
+                // Best-effort navigation; failures already degrade inside.
+              });
+            }}
+          />
+          <MoreMenuItem
+            key="series-view-traces"
+            icon={IconProp.Layers}
+            text="View traces"
+            onClick={() => {
+              const menuState: SeriesMenuState = seriesMenu;
+              closeSeriesMenu();
+              navigateSeriesToSignal(menuState, "traces").catch(() => {
+                // Best-effort navigation; failures already degrade inside.
+              });
+            }}
+          />
+          <MoreMenuItem
+            key="series-view-exceptions"
+            icon={IconProp.Bug}
+            text="View exceptions"
+            onClick={() => {
+              const menuState: SeriesMenuState = seriesMenu;
+              closeSeriesMenu();
+              navigateSeriesToExceptions(menuState).catch(() => {
+                // Best-effort navigation; failures already degrade inside.
+              });
+            }}
+          />
+          {seriesMenuResourceTargets.map((target: SeriesResourceTarget) => {
+            return (
+              <MoreMenuItem
+                key={`series-resource-${target.kind}`}
+                icon={resourceTargetIconByKind[target.kind]}
+                text={target.label}
+                onClick={() => {
+                  closeSeriesMenu();
+                  openSeriesResource(target).catch(() => {
+                    // Resolution failures surface their own toast.
+                  });
+                }}
+              />
+            );
+          })}
         </div>
       ) : null}
     </>

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -1292,16 +1292,24 @@ const MetricView: FunctionComponent<ComponentProps> = (
                     metricTypes={metricTypes}
                     metricViewData={effectiveData}
                     chartCssClass={props.chartCssClass}
-                    onQueryConfigsChange={(
-                      queryConfigs: Array<MetricQueryConfigData>,
-                    ) => {
-                      if (props.onChange) {
-                        props.onChange({
-                          ...props.data,
-                          queryConfigs: queryConfigs,
-                        });
-                      }
-                    }}
+                    onQueryConfigsChange={
+                      /*
+                       * Only claim the write path when a parent onChange
+                       * can actually persist it. Passing an always-present
+                       * wrapper made read-only hosts route Top-N writes
+                       * (and the series menu's "Filter to this series")
+                       * into a no-op instead of the transient-override /
+                       * explorer-link fallbacks.
+                       */
+                      props.onChange
+                        ? (queryConfigs: Array<MetricQueryConfigData>) => {
+                            props.onChange?.({
+                              ...props.data,
+                              queryConfigs: queryConfigs,
+                            });
+                          }
+                        : undefined
+                    }
                     onTimeRangeSelect={
                       /*
                        * Charts advertise drag-to-zoom (crosshair, hint,

--- a/App/FeatureSet/Dashboard/src/Utils/MetricSeriesInvestigation.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MetricSeriesInvestigation.ts
@@ -1,0 +1,459 @@
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import ObjectID from "Common/Types/ObjectID";
+import OneUptimeDate from "Common/Types/Date";
+import Query from "Common/Types/BaseDatabase/Query";
+import TimeRange from "Common/Types/Time/TimeRange";
+import { JSONObject } from "Common/Types/JSON";
+import Host from "Common/Models/DatabaseModels/Host";
+import KubernetesCluster from "Common/Models/DatabaseModels/KubernetesCluster";
+import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
+import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import { canonicalizeEntityValue } from "Common/Utils/Telemetry/EntityKey";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import {
+  CrossSignalQueryParams,
+  extractScopeFiltersFromQueryConfigs,
+  MetricScopeFilterExtraction,
+  resolveServiceIdsByNames,
+} from "./MetricsCrossSignalPivot";
+
+/*
+ * Per-SERIES investigation for grouped metric charts: the machinery that
+ * turns one series of a group-by chart ("host.name=prod-01, cpu=3") back
+ * into structured scope — the exact attribute filters that isolate that
+ * series, the telemetry pivots carrying them, and the OneUptime resource
+ * page (host / service / cluster / device) the series is about.
+ *
+ * Everything except the resolve* functions is pure so App/Tests/Dashboard
+ * can exercise it without a renderer; the resolvers' network seam
+ * (ModelAPI.getList) is mocked in tests the same way
+ * MetricsCrossSignalPivot's is.
+ */
+
+/*
+ * Split a composed grouped-series name back into its "key=value" segments,
+ * using the known group keys so it stays correct when a value itself
+ * contains the ", " that also joins multi-key segments. A single-key
+ * group-by has exactly one segment (the whole name), so a comma in the
+ * value can never be mis-split. For multi-key names, a fragment that
+ * doesn't start with a known "key=" prefix is treated as a continuation of
+ * the previous value. (Moved here from MetricCharts so label parsing and
+ * the chart's color pins share one splitter.)
+ */
+export function splitSeriesNameIntoSegments(
+  seriesName: string,
+  groupByKeys: Array<string>,
+): Array<string> {
+  if (groupByKeys.length <= 1) {
+    return [seriesName];
+  }
+  const startsWithKnownKey: (fragment: string) => boolean = (
+    fragment: string,
+  ): boolean => {
+    return groupByKeys.some((key: string): boolean => {
+      return fragment.startsWith(`${key}=`);
+    });
+  };
+  const segments: Array<string> = [];
+  for (const fragment of seriesName.split(", ")) {
+    if (segments.length > 0 && !startsWithKnownKey(fragment)) {
+      segments[segments.length - 1] += `, ${fragment}`;
+    } else {
+      segments.push(fragment);
+    }
+  }
+  return segments;
+}
+
+/**
+ * Recover the group-by labels from a composed series name. Returns one
+ * entry per "key=value" segment whose key is a known group-by key; the
+ * "(unset)" display value maps back to "" so MetricSeriesScope turns it
+ * into the is-empty filter rather than an equality against the literal
+ * text "(unset)". Segments that match no known key (e.g. an overlay
+ * panel's "queryLabel: " disambiguation prefix) are skipped — fewer
+ * labels just means a wider scope, never a wrong one.
+ */
+export function parseSeriesLabels(input: {
+  seriesName: string;
+  groupByKeys: Array<string>;
+}): JSONObject {
+  const labels: JSONObject = {};
+
+  if (input.groupByKeys.length === 0) {
+    return labels;
+  }
+
+  const segments: Array<string> = splitSeriesNameIntoSegments(
+    input.seriesName,
+    input.groupByKeys,
+  );
+
+  for (const segment of segments) {
+    for (const key of input.groupByKeys) {
+      if (!key || !segment.startsWith(`${key}=`)) {
+        continue;
+      }
+      const value: string = segment.slice(key.length + 1);
+      labels[key] =
+        value === MetricSeriesScope.UnsetLabelDisplayValue ? "" : value;
+      break;
+    }
+  }
+
+  return labels;
+}
+
+/** Union of every query's group-by keys, in first-seen order. */
+export function getGroupByKeysForViewData(
+  metricViewData: MetricViewData,
+): Array<string> {
+  const keys: Array<string> = [];
+  for (const queryConfig of metricViewData?.queryConfigs || []) {
+    for (const key of queryConfig.metricQueryData?.groupByAttributeKeys || []) {
+      if (key && !keys.includes(key)) {
+        keys.push(key);
+      }
+    }
+  }
+  return keys;
+}
+
+export interface SeriesScopedViewData {
+  scopedViewData: MetricViewData;
+  seriesLabels: JSONObject;
+  /** False when the name yielded no usable labels (nothing was narrowed). */
+  didNarrow: boolean;
+}
+
+/**
+ * Narrow a whole metric view down to the one series the user picked, by
+ * parsing the series name back into group-by labels and pushing them into
+ * each query's attribute filters (via MetricSeriesScope, which only
+ * touches keys a query actually groups by). Identity-preserving when
+ * there is nothing to narrow.
+ */
+export function scopeViewDataToSeries(input: {
+  metricViewData: MetricViewData;
+  seriesName: string;
+  /** Panel-accurate group keys; defaults to the view-wide union. */
+  groupByKeys?: Array<string> | undefined;
+}): SeriesScopedViewData {
+  const groupByKeys: Array<string> =
+    input.groupByKeys && input.groupByKeys.length > 0
+      ? input.groupByKeys
+      : getGroupByKeysForViewData(input.metricViewData);
+
+  const seriesLabels: JSONObject = parseSeriesLabels({
+    seriesName: input.seriesName,
+    groupByKeys,
+  });
+
+  const scopedViewData: MetricViewData =
+    (MetricSeriesScope.scopeMetricViewDataToSeries({
+      metricViewData: input.metricViewData,
+      seriesLabels,
+    }) as MetricViewData) || input.metricViewData;
+
+  return {
+    scopedViewData,
+    seriesLabels,
+    didNarrow: scopedViewData !== input.metricViewData,
+  };
+}
+
+export type SeriesResourceTargetKind =
+  | "host"
+  | "service"
+  | "kubernetesCluster"
+  | "networkDevice";
+
+export interface SeriesResourceTarget {
+  kind: SeriesResourceTargetKind;
+  /** Menu label, e.g. `Open host "prod-01"`. */
+  label: string;
+  attributeKey: string;
+  attributeValue: string;
+}
+
+/*
+ * Attribute keys that name a OneUptime resource, per kind. The resource
+ * attribute spellings ("resource.host.name") are what the metric pipeline
+ * stores at ingest; the bare spellings cover agents and hostmetrics
+ * receivers that tag without the resource prefix.
+ */
+const HOST_ATTRIBUTE_KEYS: Array<string> = [
+  "resource.host.name",
+  "host.name",
+  "host",
+  "hostname",
+];
+const SERVICE_ATTRIBUTE_KEYS: Array<string> = [
+  "resource.service.name",
+  "service.name",
+  "service",
+];
+const KUBERNETES_CLUSTER_ATTRIBUTE_KEYS: Array<string> = [
+  "resource.k8s.cluster.name",
+  "k8s.cluster.name",
+];
+const NETWORK_DEVICE_ATTRIBUTE_KEYS: Array<string> = ["networkDeviceId"];
+
+const TARGET_KEYS_BY_KIND: Array<{
+  kind: SeriesResourceTargetKind;
+  keys: Array<string>;
+}> = [
+  { kind: "host", keys: HOST_ATTRIBUTE_KEYS },
+  { kind: "service", keys: SERVICE_ATTRIBUTE_KEYS },
+  { kind: "kubernetesCluster", keys: KUBERNETES_CLUSTER_ATTRIBUTE_KEYS },
+  { kind: "networkDevice", keys: NETWORK_DEVICE_ATTRIBUTE_KEYS },
+];
+
+function getTargetLabel(kind: SeriesResourceTargetKind, value: string): string {
+  switch (kind) {
+    case "host":
+      return `Open host "${value}"`;
+    case "service":
+      return `Open service "${value}"`;
+    case "kubernetesCluster":
+      return `Open Kubernetes cluster "${value}"`;
+    case "networkDevice":
+      return "Open network device";
+    default:
+      return `Open "${value}"`;
+  }
+}
+
+/**
+ * The OneUptime resource pages a series can jump to. A series' own labels
+ * win; when the series doesn't carry a kind, the queries' exact-equality
+ * attribute FILTERS fill in (a per-host chart filtered on host.name=X is
+ * about host X even though nothing groups by it). At most one target per
+ * kind, in the key lists' precedence order.
+ */
+export function getSeriesResourceTargets(input: {
+  seriesLabels: JSONObject;
+  queryConfigs: Array<MetricQueryConfigData>;
+}): Array<SeriesResourceTarget> {
+  const extraction: MetricScopeFilterExtraction =
+    extractScopeFiltersFromQueryConfigs(input.queryConfigs || []);
+
+  const getValueForKey: (key: string) => string | null = (
+    key: string,
+  ): string | null => {
+    const labelValue: unknown = (input.seriesLabels || {})[key];
+    if (typeof labelValue === "string" && labelValue.trim() !== "") {
+      return labelValue;
+    }
+    /*
+     * The extractor peels resource.service.name equalities into
+     * serviceNames rather than attributes — check both.
+     */
+    const filterValue: string | undefined = extraction.attributes[key];
+    if (typeof filterValue === "string" && filterValue.trim() !== "") {
+      return filterValue;
+    }
+    if (
+      SERVICE_ATTRIBUTE_KEYS.includes(key) &&
+      extraction.serviceNames.length === 1
+    ) {
+      return extraction.serviceNames[0]!;
+    }
+    return null;
+  };
+
+  const targets: Array<SeriesResourceTarget> = [];
+
+  for (const { kind, keys } of TARGET_KEYS_BY_KIND) {
+    for (const key of keys) {
+      const value: string | null = getValueForKey(key);
+      if (value === null) {
+        continue;
+      }
+      targets.push({
+        kind,
+        label: getTargetLabel(kind, value),
+        attributeKey: key,
+        attributeValue: value,
+      });
+      break;
+    }
+  }
+
+  return targets;
+}
+
+/**
+ * Exceptions-list params for a (series-scoped) metric view. The
+ * exceptions grammar (ExceptionsViewer.readInitialUrlState) has service +
+ * window dimensions but no attribute facets, so everything else is
+ * reported in `dropped` — same contract as the CrossSignalScope
+ * serializers. `status=all` keeps resolved/archived groups visible on
+ * arrival (the spike may already be triaged).
+ */
+export function buildSeriesExceptionsPivotParams(input: {
+  metricViewData: MetricViewData;
+  serviceIds: Array<string>;
+}): CrossSignalQueryParams {
+  const params: Dictionary<string> = { status: "all" };
+  const dropped: Array<string> = [];
+
+  const serviceIds: Array<string> = (input.serviceIds || []).filter(
+    (serviceId: string): boolean => {
+      return typeof serviceId === "string" && serviceId.trim() !== "";
+    },
+  );
+
+  if (serviceIds.length > 0) {
+    params["filters"] = JSON.stringify(
+      serviceIds.map((serviceId: string): [string, string] => {
+        return ["primaryEntityId", serviceId];
+      }),
+    );
+  }
+
+  const window: InBetween<Date> | null = TelemetryQueryTimeRange.toDateWindow(
+    input.metricViewData?.startAndEndDate,
+  );
+
+  if (window) {
+    params["range"] = TimeRange.CUSTOM;
+    params["start"] = OneUptimeDate.toString(window.startValue);
+    params["end"] = OneUptimeDate.toString(window.endValue);
+  }
+
+  const extraction: MetricScopeFilterExtraction =
+    extractScopeFiltersFromQueryConfigs(
+      input.metricViewData?.queryConfigs || [],
+    );
+
+  for (const key of Object.keys(extraction.attributes)) {
+    if (!dropped.includes(key)) {
+      dropped.push(key);
+    }
+  }
+  for (const key of extraction.droppedFilterKeys) {
+    if (!dropped.includes(key)) {
+      dropped.push(key);
+    }
+  }
+  if (extraction.severityTexts.length > 0) {
+    dropped.push("severityTexts");
+  }
+  if (extraction.serviceNames.length > 0 && serviceIds.length === 0) {
+    dropped.push("serviceIds");
+  }
+
+  return { params, dropped };
+}
+
+/*
+ * One resolution per distinct successful lookup, so reopening the menu
+ * costs nothing. Failures are intentionally NOT cached — the next click
+ * retries.
+ */
+const resolvedIdCache: Map<string, string | null> = new Map<
+  string,
+  string | null
+>();
+
+type LookupModelIdFunction = (input: {
+  cacheKey: string;
+  modelType: typeof Host | typeof KubernetesCluster;
+  query: Query<Host> | Query<KubernetesCluster>;
+}) => Promise<string | null>;
+
+const lookupModelId: LookupModelIdFunction = async (input: {
+  cacheKey: string;
+  modelType: typeof Host | typeof KubernetesCluster;
+  query: Query<Host> | Query<KubernetesCluster>;
+}): Promise<string | null> => {
+  if (resolvedIdCache.has(input.cacheKey)) {
+    return resolvedIdCache.get(input.cacheKey) ?? null;
+  }
+
+  try {
+    const result: ListResult<Host | KubernetesCluster> = await ModelAPI.getList<
+      Host | KubernetesCluster
+    >({
+      modelType: input.modelType as typeof Host,
+      query: input.query as Query<Host>,
+      select: { _id: true },
+      sort: {},
+      skip: 0,
+      limit: 1,
+    });
+
+    const id: string | undefined = result.data[0]?._id;
+    if (!id) {
+      return null;
+    }
+    resolvedIdCache.set(input.cacheKey, id);
+    return id;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Resolve a series resource target to the ObjectID string its view route
+ * needs. Best-effort: unknown names and network failures return null so
+ * the caller can say "no matching host" instead of navigating nowhere.
+ *
+ * Host and Kubernetes rows store CANONICALIZED identifiers (trimmed,
+ * lowercased `host.name` / `k8s.cluster.name` — see EntityKey), so the
+ * lookup canonicalizes the attribute value the same way. Services store
+ * verbatim names and go through the shared (cached) service resolver.
+ * Network devices carry their own ObjectID in the attribute value.
+ */
+export async function resolveSeriesResourceModelId(
+  target: SeriesResourceTarget,
+): Promise<string | null> {
+  const value: string = (target.attributeValue || "").trim();
+  if (value === "") {
+    return null;
+  }
+
+  const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+
+  switch (target.kind) {
+    case "host": {
+      if (!projectId) {
+        return null;
+      }
+      const hostIdentifier: string = canonicalizeEntityValue(value);
+      return lookupModelId({
+        cacheKey: `host:${hostIdentifier}`,
+        modelType: Host,
+        query: { projectId, hostIdentifier } as Query<Host>,
+      });
+    }
+    case "kubernetesCluster": {
+      if (!projectId) {
+        return null;
+      }
+      const clusterIdentifier: string = canonicalizeEntityValue(value);
+      return lookupModelId({
+        cacheKey: `k8s:${clusterIdentifier}`,
+        modelType: KubernetesCluster,
+        query: { projectId, clusterIdentifier } as Query<KubernetesCluster>,
+      });
+    }
+    case "service": {
+      const mapping: Dictionary<string> = await resolveServiceIdsByNames([
+        value,
+      ]);
+      return mapping[value] || null;
+    }
+    case "networkDevice": {
+      // The attribute value IS the device's ObjectID.
+      return value;
+    }
+    default:
+      return null;
+  }
+}

--- a/App/Tests/Dashboard/MetricSeriesInvestigation.test.ts
+++ b/App/Tests/Dashboard/MetricSeriesInvestigation.test.ts
@@ -1,0 +1,598 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import MetricsAggregationType from "Common/Types/Metrics/MetricsAggregationType";
+import ObjectID from "Common/Types/ObjectID";
+import TimeRange from "Common/Types/Time/TimeRange";
+import { JSONObject } from "Common/Types/JSON";
+import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
+import MetricViewData from "Common/Types/Metrics/MetricViewData";
+
+/*
+ * MetricSeriesInvestigation imports ModelAPI (host/cluster/service
+ * lookups) and ProjectUtil, both of which transitively load
+ * Common/UI/Config — which reads `window` at import time and throws in
+ * this node test environment. Mocking both keeps the import graph
+ * browser-free and doubles as the seam for the resolver tests (same
+ * pattern as MetricsCrossSignalPivot.test.ts).
+ */
+jest.mock("Common/UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: jest.fn(),
+    },
+  };
+});
+
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import Host from "Common/Models/DatabaseModels/Host";
+import KubernetesCluster from "Common/Models/DatabaseModels/KubernetesCluster";
+import {
+  SeriesResourceTarget,
+  SeriesScopedViewData,
+  buildSeriesExceptionsPivotParams,
+  getGroupByKeysForViewData,
+  getSeriesResourceTargets,
+  parseSeriesLabels,
+  resolveSeriesResourceModelId,
+  scopeViewDataToSeries,
+  splitSeriesNameIntoSegments,
+} from "../../FeatureSet/Dashboard/src/Utils/MetricSeriesInvestigation";
+import { CrossSignalQueryParams } from "../../FeatureSet/Dashboard/src/Utils/MetricsCrossSignalPivot";
+
+const getListMock: jest.Mock = ModelAPI.getList as unknown as jest.Mock;
+const getCurrentProjectIdMock: jest.Mock =
+  ProjectUtil.getCurrentProjectId as unknown as jest.Mock;
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "3c1b6b0e-0000-4000-8000-0000000000bb",
+);
+
+const WINDOW_START: Date = new Date("2026-08-20T10:00:00.000Z");
+const WINDOW_END: Date = new Date("2026-08-20T11:00:00.000Z");
+
+function makeQueryConfig(input: {
+  attributes?: Dictionary<unknown>;
+  groupByAttributeKeys?: Array<string>;
+  metricName?: string;
+}): MetricQueryConfigData {
+  return {
+    metricQueryData: {
+      filterData: {
+        metricName: input.metricName || "cpu.usage",
+        attributes: input.attributes || {},
+        aggegationType: MetricsAggregationType.Avg,
+      },
+      ...(input.groupByAttributeKeys
+        ? { groupByAttributeKeys: input.groupByAttributeKeys }
+        : {}),
+    },
+  } as unknown as MetricQueryConfigData;
+}
+
+function makeViewData(input: {
+  queryConfigs: Array<MetricQueryConfigData>;
+  startAndEndDate?: InBetween<Date> | null;
+}): MetricViewData {
+  return {
+    queryConfigs: input.queryConfigs,
+    formulaConfigs: [],
+    startAndEndDate:
+      input.startAndEndDate === undefined ? null : input.startAndEndDate,
+  } as MetricViewData;
+}
+
+function getScopedAttributes(
+  viewData: MetricViewData,
+  queryIndex: number = 0,
+): Dictionary<unknown> {
+  return ((
+    viewData.queryConfigs[queryIndex]?.metricQueryData.filterData as Record<
+      string,
+      unknown
+    >
+  )?.["attributes"] || {}) as Dictionary<unknown>;
+}
+
+beforeEach(() => {
+  getListMock.mockReset();
+  getCurrentProjectIdMock.mockReset();
+  getCurrentProjectIdMock.mockReturnValue(PROJECT_ID);
+});
+
+describe("splitSeriesNameIntoSegments", () => {
+  test("single group key never splits, even on a comma in the value", () => {
+    expect(
+      splitSeriesNameIntoSegments("region=us-east, extra", ["region"]),
+    ).toEqual(["region=us-east, extra"]);
+  });
+
+  test("multi-key names split at known key= prefixes only", () => {
+    expect(
+      splitSeriesNameIntoSegments(
+        "host.name=prod-01, tags=a, b, service.name=api",
+        ["host.name", "tags", "service.name"],
+      ),
+    ).toEqual(["host.name=prod-01", "tags=a, b", "service.name=api"]);
+  });
+});
+
+describe("parseSeriesLabels", () => {
+  test("recovers key=value labels from a composed series name", () => {
+    expect(
+      parseSeriesLabels({
+        seriesName: "host.name=prod-01, service.name=api",
+        groupByKeys: ["host.name", "service.name"],
+      }),
+    ).toEqual({ "host.name": "prod-01", "service.name": "api" });
+  });
+
+  test("keeps a comma-containing value intact on a single-key group-by", () => {
+    expect(
+      parseSeriesLabels({
+        seriesName: "query=select a, b from t",
+        groupByKeys: ["query"],
+      }),
+    ).toEqual({ query: "select a, b from t" });
+  });
+
+  test('maps the "(unset)" display value back to empty (is-empty filter)', () => {
+    expect(
+      parseSeriesLabels({
+        seriesName: "host.name=(unset)",
+        groupByKeys: ["host.name"],
+      }),
+    ).toEqual({ "host.name": "" });
+  });
+
+  test("yields nothing for names that carry no known key (overlay prefixes)", () => {
+    expect(
+      parseSeriesLabels({
+        seriesName: "api: host.name=prod-01",
+        groupByKeys: ["host.name", "pod"],
+      }),
+    ).toEqual({});
+    expect(
+      parseSeriesLabels({ seriesName: "cpu.usage", groupByKeys: [] }),
+    ).toEqual({});
+  });
+});
+
+describe("getGroupByKeysForViewData", () => {
+  test("unions group keys across queries in first-seen order", () => {
+    const viewData: MetricViewData = makeViewData({
+      queryConfigs: [
+        makeQueryConfig({ groupByAttributeKeys: ["host.name", "pod"] }),
+        makeQueryConfig({ groupByAttributeKeys: ["pod", "container"] }),
+        makeQueryConfig({}),
+      ],
+    });
+    expect(getGroupByKeysForViewData(viewData)).toEqual([
+      "host.name",
+      "pod",
+      "container",
+    ]);
+  });
+});
+
+describe("scopeViewDataToSeries", () => {
+  test("pushes the series labels into the grouping query's attribute filters", () => {
+    const viewData: MetricViewData = makeViewData({
+      queryConfigs: [
+        makeQueryConfig({
+          attributes: { env: "prod" },
+          groupByAttributeKeys: ["host.name"],
+        }),
+      ],
+    });
+
+    const scoped: SeriesScopedViewData = scopeViewDataToSeries({
+      metricViewData: viewData,
+      seriesName: "host.name=prod-01",
+    });
+
+    expect(scoped.didNarrow).toBe(true);
+    expect(scoped.seriesLabels).toEqual({ "host.name": "prod-01" });
+    expect(getScopedAttributes(scoped.scopedViewData)).toEqual({
+      env: "prod",
+      "host.name": "prod-01",
+    });
+    // The input view data must stay untouched (identity-preserving util).
+    expect(getScopedAttributes(viewData)).toEqual({ env: "prod" });
+  });
+
+  test('an "(unset)" series narrows with the is-empty operator', () => {
+    const viewData: MetricViewData = makeViewData({
+      queryConfigs: [makeQueryConfig({ groupByAttributeKeys: ["host.name"] })],
+    });
+
+    const scoped: SeriesScopedViewData = scopeViewDataToSeries({
+      metricViewData: viewData,
+      seriesName: "host.name=(unset)",
+    });
+
+    expect(scoped.didNarrow).toBe(true);
+    expect(
+      getScopedAttributes(scoped.scopedViewData)["host.name"],
+    ).toBeInstanceOf(IsNull);
+  });
+
+  test("a query that does not group by the label's key stays untouched", () => {
+    const viewData: MetricViewData = makeViewData({
+      queryConfigs: [makeQueryConfig({})],
+    });
+
+    const scoped: SeriesScopedViewData = scopeViewDataToSeries({
+      metricViewData: viewData,
+      seriesName: "host.name=prod-01",
+      groupByKeys: ["host.name"],
+    });
+
+    expect(scoped.didNarrow).toBe(false);
+    expect(scoped.scopedViewData).toBe(viewData);
+  });
+
+  test("explicit panel group keys win over the view-wide union", () => {
+    const viewData: MetricViewData = makeViewData({
+      queryConfigs: [makeQueryConfig({ groupByAttributeKeys: ["host.name"] })],
+    });
+
+    const scoped: SeriesScopedViewData = scopeViewDataToSeries({
+      metricViewData: viewData,
+      // "pod" is not in this panel's keys — the label must not parse.
+      seriesName: "host.name=prod-01",
+      groupByKeys: ["pod"],
+    });
+
+    expect(scoped.didNarrow).toBe(false);
+  });
+});
+
+describe("getSeriesResourceTargets", () => {
+  test("detects a host from the series labels", () => {
+    const targets: Array<SeriesResourceTarget> = getSeriesResourceTargets({
+      seriesLabels: { "host.name": "Prod-01" } as JSONObject,
+      queryConfigs: [],
+    });
+
+    expect(targets).toEqual([
+      {
+        kind: "host",
+        label: 'Open host "Prod-01"',
+        attributeKey: "host.name",
+        attributeValue: "Prod-01",
+      },
+    ]);
+  });
+
+  test("resource-prefixed keys take precedence within a kind", () => {
+    const targets: Array<SeriesResourceTarget> = getSeriesResourceTargets({
+      seriesLabels: {
+        "resource.host.name": "a-host",
+        "host.name": "b-host",
+      } as JSONObject,
+      queryConfigs: [],
+    });
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.attributeValue).toBe("a-host");
+  });
+
+  test("falls back to the queries' equality attribute filters", () => {
+    const targets: Array<SeriesResourceTarget> = getSeriesResourceTargets({
+      seriesLabels: {},
+      queryConfigs: [makeQueryConfig({ attributes: { "host.name": "web-1" } })],
+    });
+
+    expect(targets).toEqual([
+      {
+        kind: "host",
+        label: 'Open host "web-1"',
+        attributeKey: "host.name",
+        attributeValue: "web-1",
+      },
+    ]);
+  });
+
+  test("detects a service through the extractor's peeled service names", () => {
+    const targets: Array<SeriesResourceTarget> = getSeriesResourceTargets({
+      seriesLabels: {},
+      queryConfigs: [
+        makeQueryConfig({
+          attributes: { "resource.service.name": "checkout" },
+        }),
+      ],
+    });
+
+    expect(targets).toEqual([
+      {
+        kind: "service",
+        label: 'Open service "checkout"',
+        attributeKey: "resource.service.name",
+        attributeValue: "checkout",
+      },
+    ]);
+  });
+
+  test("an unset (empty) label never becomes a target", () => {
+    expect(
+      getSeriesResourceTargets({
+        seriesLabels: { "host.name": "" } as JSONObject,
+        queryConfigs: [],
+      }),
+    ).toEqual([]);
+  });
+
+  test("reports one target per kind, together", () => {
+    const targets: Array<SeriesResourceTarget> = getSeriesResourceTargets({
+      seriesLabels: {
+        "host.name": "prod-01",
+        "k8s.cluster.name": "cluster-a",
+        networkDeviceId: "aaaaaaaa-0000-4000-8000-000000000001",
+      } as JSONObject,
+      queryConfigs: [
+        makeQueryConfig({
+          attributes: { "resource.service.name": "checkout-two" },
+        }),
+      ],
+    });
+
+    expect(
+      targets.map((target: SeriesResourceTarget) => {
+        return target.kind;
+      }),
+    ).toEqual(["host", "service", "kubernetesCluster", "networkDevice"]);
+    expect(
+      targets.find((target: SeriesResourceTarget) => {
+        return target.kind === "networkDevice";
+      })?.label,
+    ).toBe("Open network device");
+  });
+});
+
+describe("buildSeriesExceptionsPivotParams", () => {
+  test("carries service ids, the window, and status=all", () => {
+    const pivot: CrossSignalQueryParams = buildSeriesExceptionsPivotParams({
+      metricViewData: makeViewData({
+        queryConfigs: [makeQueryConfig({})],
+        startAndEndDate: new InBetween<Date>(WINDOW_START, WINDOW_END),
+      }),
+      serviceIds: ["service-id-1", "service-id-2"],
+    });
+
+    expect(pivot.params["status"]).toBe("all");
+    expect(JSON.parse(pivot.params["filters"] || "[]")).toEqual([
+      ["primaryEntityId", "service-id-1"],
+      ["primaryEntityId", "service-id-2"],
+    ]);
+    expect(pivot.params["range"]).toBe(TimeRange.CUSTOM);
+    expect(pivot.params["start"]).toBeTruthy();
+    expect(pivot.params["end"]).toBeTruthy();
+    expect(pivot.dropped).toEqual([]);
+  });
+
+  test("reports attribute filters as dropped — the exceptions grammar has no attribute facets", () => {
+    const pivot: CrossSignalQueryParams = buildSeriesExceptionsPivotParams({
+      metricViewData: makeViewData({
+        queryConfigs: [
+          makeQueryConfig({
+            attributes: { "host.name": "prod-01", severityText: "Error" },
+          }),
+        ],
+      }),
+      serviceIds: [],
+    });
+
+    expect(pivot.params["filters"]).toBeUndefined();
+    expect(pivot.params["range"]).toBeUndefined();
+    expect(pivot.dropped).toContain("host.name");
+    expect(pivot.dropped).toContain("severityTexts");
+  });
+
+  test("reports unresolvable service names as dropped instead of filtering on nothing", () => {
+    const pivot: CrossSignalQueryParams = buildSeriesExceptionsPivotParams({
+      metricViewData: makeViewData({
+        queryConfigs: [
+          makeQueryConfig({
+            attributes: { "resource.service.name": "unresolved-svc" },
+          }),
+        ],
+      }),
+      serviceIds: [],
+    });
+
+    expect(pivot.params["filters"]).toBeUndefined();
+    expect(pivot.dropped).toContain("serviceIds");
+  });
+});
+
+describe("resolveSeriesResourceModelId", () => {
+  test("resolves a host by its canonicalized identifier and caches the hit", async () => {
+    getListMock.mockResolvedValue({ data: [{ _id: "host-object-id-1" }] });
+
+    const target: SeriesResourceTarget = {
+      kind: "host",
+      label: 'Open host "  Prod-01 "',
+      attributeKey: "host.name",
+      attributeValue: "  Prod-01 ",
+    };
+
+    const first: string | null = await resolveSeriesResourceModelId(target);
+    expect(first).toBe("host-object-id-1");
+
+    const callArgs: Record<string, unknown> = getListMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(callArgs["modelType"]).toBe(Host);
+    expect(callArgs["query"]).toEqual({
+      projectId: PROJECT_ID,
+      // trim + lowercase, matching how Host.hostIdentifier is stored.
+      hostIdentifier: "prod-01",
+    });
+    expect(callArgs["limit"]).toBe(1);
+
+    const second: string | null = await resolveSeriesResourceModelId(target);
+    expect(second).toBe("host-object-id-1");
+    expect(getListMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("resolves a Kubernetes cluster by clusterIdentifier", async () => {
+    getListMock.mockResolvedValue({ data: [{ _id: "cluster-object-id-1" }] });
+
+    const resolved: string | null = await resolveSeriesResourceModelId({
+      kind: "kubernetesCluster",
+      label: 'Open Kubernetes cluster "Cluster-A"',
+      attributeKey: "k8s.cluster.name",
+      attributeValue: "Cluster-A",
+    });
+
+    expect(resolved).toBe("cluster-object-id-1");
+    const callArgs: Record<string, unknown> = getListMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(callArgs["modelType"]).toBe(KubernetesCluster);
+    expect(callArgs["query"]).toEqual({
+      projectId: PROJECT_ID,
+      clusterIdentifier: "cluster-a",
+    });
+  });
+
+  test("misses are not cached — the next click retries", async () => {
+    getListMock.mockResolvedValue({ data: [] });
+
+    const target: SeriesResourceTarget = {
+      kind: "host",
+      label: 'Open host "ghost"',
+      attributeKey: "host.name",
+      attributeValue: "ghost-host-never-seen",
+    };
+
+    expect(await resolveSeriesResourceModelId(target)).toBeNull();
+    expect(await resolveSeriesResourceModelId(target)).toBeNull();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns null without a network call when no project is selected", async () => {
+    getCurrentProjectIdMock.mockReturnValue(null);
+
+    expect(
+      await resolveSeriesResourceModelId({
+        kind: "host",
+        label: 'Open host "x"',
+        attributeKey: "host.name",
+        attributeValue: "some-host-no-project",
+      }),
+    ).toBeNull();
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("resolves a service through the shared name resolver", async () => {
+    getListMock.mockResolvedValue({
+      data: [
+        { name: "series-invest-svc", id: new ObjectID("service-object-id-9") },
+      ],
+    });
+
+    const resolved: string | null = await resolveSeriesResourceModelId({
+      kind: "service",
+      label: 'Open service "series-invest-svc"',
+      attributeKey: "resource.service.name",
+      attributeValue: "series-invest-svc",
+    });
+
+    expect(resolved).toBe("service-object-id-9");
+  });
+
+  test("a network device target carries its own ObjectID", async () => {
+    expect(
+      await resolveSeriesResourceModelId({
+        kind: "networkDevice",
+        label: "Open network device",
+        attributeKey: "networkDeviceId",
+        attributeValue: "bbbbbbbb-0000-4000-8000-000000000002",
+      }),
+    ).toBe("bbbbbbbb-0000-4000-8000-000000000002");
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("blank values resolve to null", async () => {
+    expect(
+      await resolveSeriesResourceModelId({
+        kind: "host",
+        label: "Open host",
+        attributeKey: "host.name",
+        attributeValue: "   ",
+      }),
+    ).toBeNull();
+  });
+});
+
+/*
+ * Wiring pins: the pure utils above are only useful if the UI actually
+ * mounts them. App's node test environment cannot render React, so — like
+ * MetricsCrossSignalPivot.test.ts — these read the component sources and
+ * pin the load-bearing wiring as (whitespace-squashed) strings.
+ */
+describe("investigation wiring", () => {
+  function readSquashedSource(relativePath: string): string {
+    return fs
+      .readFileSync(
+        path.join(__dirname, "../../FeatureSet/Dashboard/src", relativePath),
+        "utf8",
+      )
+      .replace(/\s+/g, " ");
+  }
+
+  test("MetricCharts mounts the per-series investigate menu", () => {
+    const source: string = readSquashedSource(
+      "Components/Metrics/MetricCharts.tsx",
+    );
+
+    expect(source).toContain("openSeriesMenu");
+    expect(source).toContain("Investigate this series");
+    expect(source).toContain("scopeViewDataToSeries");
+    expect(source).toContain("getSeriesResourceTargets");
+    expect(source).toContain("resolveSeriesResourceModelId");
+    expect(source).toContain("buildSeriesExceptionsPivotParams");
+    expect(source).toContain('text="View exceptions"');
+    expect(source).toContain("enableSeriesActions");
+    // Read-only hosts deep-link out; read-write hosts filter in place.
+    expect(source).toContain('text="Filter to this series"');
+    expect(source).toContain('text="Open in Metric Explorer"');
+  });
+
+  test("the dashboard chart widget wires zoom, series actions, and a rolling range token", () => {
+    const source: string = readSquashedSource(
+      "Components/Dashboard/Components/DashboardChartComponent.tsx",
+    );
+
+    expect(source).toContain("setZoomWindow(new InBetween<Date>(");
+    expect(source).toContain("enableSeriesActions={enableSeriesActions}");
+    expect(source).toContain(
+      "onTimeRangeSelect={ enableChartZoom ? handleChartTimeRangeSelect : undefined }",
+    );
+    expect(source).toContain("rangeToken: zoomWindow ? undefined :");
+  });
+
+  test("MetricView only claims the query-config write path when a parent can persist it", () => {
+    const source: string = readSquashedSource(
+      "Components/Metrics/MetricView.tsx",
+    );
+
+    expect(source).toContain(
+      "props.onChange ? (queryConfigs: Array<MetricQueryConfigData>) =>",
+    );
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx
@@ -1,0 +1,302 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  RenderResult,
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Drag-to-zoom on a dashboard chart widget is the "investigate this
+ * spike" entry point: selecting a window must narrow THIS widget only
+ * (never the dashboard-wide range), refetch for the narrowed window, and
+ * offer a way back (Reset) and a way deeper (Open in Explorer, carrying
+ * the zoomed window). Edit mode must not zoom — the drag gesture belongs
+ * to widget move/resize there, and series pivots would navigate away from
+ * unsaved dashboard changes.
+ */
+
+const fetchResultsMock: MockFunction = getJestMockFunction();
+const metricChartsRenderMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the
+ * compiled requires, so the mock variables above are still unassigned when
+ * the factory runs. Dereferencing them lazily, at call time, is what makes
+ * this work.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        fetchResults: (...args: Array<any>) => {
+          return fetchResultsMock(...args);
+        },
+        clearQueryTopNOverridesForScope: () => {
+          return undefined;
+        },
+      },
+    };
+  },
+);
+
+/*
+ * The widget's job under test is which window it ASKS for and which
+ * affordances it hands down; a real recharts surface in jsdom would test
+ * neither.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: Record<string, unknown>): React.ReactElement => {
+        metricChartsRenderMock(props);
+        return React.createElement(
+          "div",
+          { "data-testid": "metric-charts" },
+          "chart",
+        );
+      },
+    };
+  },
+);
+
+import DashboardChartComponentElement from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent";
+import { DashboardBaseComponentProps } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import DashboardChartType from "../../../Types/Dashboard/Chart/ChartType";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardChartComponent from "../../../Types/Dashboard/DashboardComponents/DashboardChartComponent";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { ObjectType } from "../../../Types/JSON";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import ObjectID from "../../../Types/ObjectID";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+const COMPONENT_ID: ObjectID = new ObjectID(
+  "22222222-1111-4111-8111-222222222222",
+);
+
+const DASHBOARD_START: Date = new Date("2026-08-20T09:00:00.000Z");
+const DASHBOARD_END: Date = new Date("2026-08-20T10:00:00.000Z");
+const ZOOM_START: Date = new Date("2026-08-20T09:20:00.000Z");
+const ZOOM_END: Date = new Date("2026-08-20T09:35:00.000Z");
+
+/*
+ * A CUSTOM range pins the window to fixed instants — a relative range
+ * would resolve against the wall clock and make the window assertions
+ * untestable.
+ */
+const DASHBOARD_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(DASHBOARD_START, DASHBOARD_END),
+};
+
+const DASHBOARD_VIEW_CONFIG: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [],
+  heightInDashboardUnits: 60,
+};
+
+function buildBaseProps(
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): DashboardBaseComponentProps {
+  return {
+    componentId: COMPONENT_ID,
+    isEditMode: false,
+    isSelected: false,
+    key: "chart-widget",
+    onComponentUpdate: (): void => {
+      // The widget under test never writes back through this.
+    },
+    totalCurrentDashboardWidthInPx: 1200,
+    dashboardCanvasTopInPx: 0,
+    dashboardCanvasLeftInPx: 0,
+    dashboardCanvasWidthInPx: 1200,
+    dashboardCanvasHeightInPx: 800,
+    dashboardComponentHeightInPx: 320,
+    dashboardComponentWidthInPx: 480,
+    dashboardViewConfig: DASHBOARD_VIEW_CONFIG,
+    dashboardStartAndEndDate: DASHBOARD_RANGE,
+    metricTypes: [],
+    refreshTick: 0,
+    variables: undefined,
+    ...overrides,
+  } as DashboardBaseComponentProps;
+}
+
+function buildChartComponent(): DashboardChartComponent {
+  return {
+    _type: ObjectType.DashboardComponent,
+    componentId: COMPONENT_ID,
+    componentType: DashboardComponentType.Chart,
+    topInDashboardUnits: 0,
+    leftInDashboardUnits: 0,
+    widthInDashboardUnits: 6,
+    heightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 6,
+    minHeightInDashboardUnits: 3,
+    arguments: {
+      chartTitle: "CPU by host",
+      chartType: DashboardChartType.Line,
+      metricQueryConfig: {
+        metricAliasData: { metricVariable: "a" },
+        metricQueryData: {
+          filterData: {
+            metricName: "cpu.usage",
+            aggegationType: MetricsAggregationType.Avg,
+          },
+          groupByAttributeKeys: ["host.name"],
+        },
+      },
+    },
+  } as unknown as DashboardChartComponent;
+}
+
+function renderWidget(
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): RenderResult {
+  return render(
+    <DashboardChartComponentElement
+      {...buildBaseProps(overrides)}
+      component={buildChartComponent()}
+    />,
+  );
+}
+
+interface CapturedChartProps {
+  metricViewData: MetricViewData;
+  onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  enableSeriesActions?: boolean | undefined;
+}
+
+function lastChartProps(): CapturedChartProps {
+  const calls: Array<Array<unknown>> = metricChartsRenderMock.mock.calls;
+  return calls[calls.length - 1]?.[0] as CapturedChartProps;
+}
+
+interface CapturedFetchArgs {
+  metricViewData: MetricViewData;
+}
+
+function lastFetchArgs(): CapturedFetchArgs {
+  const calls: Array<Array<unknown>> = fetchResultsMock.mock.calls;
+  return calls[calls.length - 1]?.[0] as CapturedFetchArgs;
+}
+
+beforeEach(() => {
+  fetchResultsMock.mockReset();
+  metricChartsRenderMock.mockReset();
+  fetchResultsMock.mockReturnValue(
+    Promise.resolve([{ data: [], truncated: false }]),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("dashboard chart widget drag-to-zoom", () => {
+  test("drag-selecting a window refetches THIS widget for that window and shows the zoom bar", async () => {
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    // Initial fetch asks for the dashboard's window.
+    expect(lastFetchArgs().metricViewData.startAndEndDate?.startValue).toEqual(
+      DASHBOARD_START,
+    );
+
+    const initialProps: CapturedChartProps = lastChartProps();
+    expect(initialProps.onTimeRangeSelect).toBeDefined();
+    expect(initialProps.enableSeriesActions).toBe(true);
+    // A pinned Custom dashboard window is not a rolling token.
+    expect(initialProps.metricViewData.rangeToken).toBe(TimeRange.CUSTOM);
+
+    const fetchCountBeforeZoom: number = fetchResultsMock.mock.calls.length;
+
+    act(() => {
+      initialProps.onTimeRangeSelect?.(ZOOM_START, ZOOM_END);
+    });
+
+    // The zoom bar names the window and offers the escape hatches.
+    expect(screen.getByText(/Zoomed:/)).toBeInTheDocument();
+    expect(screen.getByText("Reset")).toBeInTheDocument();
+    expect(screen.getByText("Open in Explorer")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchResultsMock.mock.calls.length).toBeGreaterThan(
+        fetchCountBeforeZoom,
+      );
+    });
+
+    // The refetch and the chart both use the ZOOMED window…
+    expect(lastFetchArgs().metricViewData.startAndEndDate?.startValue).toEqual(
+      ZOOM_START,
+    );
+    expect(lastFetchArgs().metricViewData.startAndEndDate?.endValue).toEqual(
+      ZOOM_END,
+    );
+    // …and a zoomed window is a deliberate pin: no rolling range token.
+    await waitFor(() => {
+      expect(lastChartProps().metricViewData.rangeToken).toBeUndefined();
+    });
+  });
+
+  test("Reset returns to the dashboard's window", async () => {
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    act(() => {
+      lastChartProps().onTimeRangeSelect?.(ZOOM_START, ZOOM_END);
+    });
+
+    expect(screen.getByText(/Zoomed:/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Reset"));
+
+    expect(screen.queryByText(/Zoomed:/)).toBeNull();
+
+    await waitFor(() => {
+      expect(
+        lastFetchArgs().metricViewData.startAndEndDate?.startValue,
+      ).toEqual(DASHBOARD_START);
+    });
+    expect(lastChartProps().metricViewData.rangeToken).toBe(TimeRange.CUSTOM);
+  });
+
+  test("edit mode disables zoom and series navigation", async () => {
+    renderWidget({ isEditMode: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    const captured: CapturedChartProps = lastChartProps();
+    expect(captured.onTimeRangeSelect).toBeUndefined();
+    expect(captured.enableSeriesActions).toBe(false);
+  });
+});

--- a/Common/Tests/App/Dashboard/MetricSeriesInvestigateMenu.test.tsx
+++ b/Common/Tests/App/Dashboard/MetricSeriesInvestigateMenu.test.tsx
@@ -1,0 +1,368 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The per-series investigate menu is the chart's bridge from "this series
+ * is spiking" to the signals that explain it: the chip's magnifier must
+ * open a menu whose pivots carry the series' group-by labels as REAL
+ * filters (logs/traces URLs), whose "Filter to this series" narrows the
+ * live explorer view, and whose resource entry lands on the host page the
+ * series is about. Rendering the real MetricCharts (not a stub) pins the
+ * whole chain: series naming → chip → menu → scoped URL.
+ */
+
+/*
+ * ResponsiveContainer measures its parent, which is always 0x0 in jsdom,
+ * so the chart renders nothing without a fixed size.
+ */
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts") as Record<
+    string,
+    any
+  >;
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, {
+        width: 600,
+        height: 300,
+      } as Record<string, unknown>);
+    },
+  };
+});
+
+const getListMock: MockFunction = getJestMockFunction();
+const fetchExemplarsMock: MockFunction = getJestMockFunction();
+const showToastMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the
+ * compiled requires, so the mock variables above are still unassigned when
+ * the factory runs. Dereferencing them lazily, at call time, is what makes
+ * this work.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/Toast/ToastInit", () => {
+  return {
+    __esModule: true,
+    ShowToastNotification: (...args: Array<any>) => {
+      return showToastMock(...args);
+    },
+  };
+});
+
+/*
+ * Keep the exemplar fetch (fired by MetricCharts whenever the view has a
+ * resolvable window) off the network; everything else on the Metrics util
+ * surface that MetricCharts touches is pure enough to stub inline.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        fetchExemplars: (...args: Array<any>) => {
+          fetchExemplarsMock(...args);
+          /*
+           * Never resolves: a resolved exemplar set would setState after
+           * each test's assertions and trip React's act() warning; no
+           * test here cares about exemplar dots.
+           */
+          return new Promise(() => {
+            // Intentionally never settles.
+          });
+        },
+        setQueryTopNOverride: () => {
+          return undefined;
+        },
+        getQueryConfigTopNKey: (
+          _queryConfig: unknown,
+          index: number,
+          scope?: string,
+        ) => {
+          return `${scope || ""}:${index}`;
+        },
+        clearQueryTopNOverridesForScope: () => {
+          return undefined;
+        },
+        serializeAttributeFiltersForKey: (attributes: unknown) => {
+          return JSON.stringify(attributes || {});
+        },
+      },
+      DEFAULT_TOP_N_SERIES: 10,
+      SHOW_ALL_SERIES_TOP_N: 10_000,
+      sanitizeAttributeFilters: (attributes: unknown) => {
+        return attributes;
+      },
+    };
+  },
+);
+
+import MetricCharts from "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts";
+import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricQueryConfigData from "../../../Types/Metrics/MetricQueryConfigData";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import ObjectID from "../../../Types/ObjectID";
+import Navigation from "../../../UI/Utils/Navigation";
+import ProjectUtil from "../../../UI/Utils/Project";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "77777777-1111-4111-8111-777777777777",
+);
+const HOST_MODEL_ID: string = "88888888-2222-4222-8222-888888888888";
+
+const WINDOW_START: Date = new Date("2026-08-20T10:00:00.000Z");
+const WINDOW_END: Date = new Date("2026-08-20T11:00:00.000Z");
+
+function buildQueryConfig(): MetricQueryConfigData {
+  return {
+    metricAliasData: { metricVariable: "a" },
+    metricQueryData: {
+      filterData: {
+        metricName: "cpu.usage",
+        attributes: {},
+        aggegationType: MetricsAggregationType.Avg,
+      },
+      groupByAttributeKeys: ["host.name"],
+    },
+  } as unknown as MetricQueryConfigData;
+}
+
+function buildViewData(): MetricViewData {
+  return {
+    queryConfigs: [buildQueryConfig()],
+    formulaConfigs: [],
+    startAndEndDate: new InBetween<Date>(WINDOW_START, WINDOW_END),
+  } as MetricViewData;
+}
+
+function buildResults(): Array<AggregatedResult> {
+  const timestamps: Array<string> = [
+    "2026-08-20T10:10:00.000Z",
+    "2026-08-20T10:20:00.000Z",
+  ];
+  const data: Array<Record<string, unknown>> = [];
+  for (const host of ["web-01", "web-02"]) {
+    for (const [index, timestamp] of timestamps.entries()) {
+      data.push({
+        timestamp: new Date(timestamp),
+        value: host === "web-01" ? 90 + index : 10 + index,
+        attributes: { "host.name": host },
+      });
+    }
+  }
+  return [{ data, truncated: false } as unknown as AggregatedResult];
+}
+
+let navigateSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  getListMock.mockReset();
+  fetchExemplarsMock.mockReset();
+  showToastMock.mockReset();
+  navigateSpy = jest.spyOn(Navigation, "navigate").mockImplementation(() => {
+    return undefined;
+  });
+  jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  cleanup();
+});
+
+function getNavigatedUrl(): string {
+  const lastCall: Array<unknown> | undefined =
+    navigateSpy.mock.calls[navigateSpy.mock.calls.length - 1];
+  return decodeURIComponent(String(lastCall?.[0]));
+}
+
+describe("per-series investigate menu", () => {
+  test("each series chip carries an investigate button that opens the menu", () => {
+    render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Investigate host.name=web-01"));
+
+    const menu: HTMLElement = screen.getByRole("menu", {
+      name: "Series investigation actions",
+    });
+    expect(menu).toBeInTheDocument();
+    expect(screen.getByText("View logs")).toBeInTheDocument();
+    expect(screen.getByText("View traces")).toBeInTheDocument();
+    expect(screen.getByText("View exceptions")).toBeInTheDocument();
+    // The menu header names the series and what it is scoped to.
+    expect(menu.textContent).toContain("host.name = web-01");
+  });
+
+  test("read-only hosts get an explorer deep link; read-write hosts filter in place", () => {
+    const onQueryConfigsChange: MockFunction = getJestMockFunction();
+
+    const { unmount } = render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Investigate host.name=web-01"));
+    expect(screen.getByText("Open in Metric Explorer")).toBeInTheDocument();
+    expect(screen.queryByText("Filter to this series")).toBeNull();
+    unmount();
+
+    render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+        onQueryConfigsChange={(...args: Array<any>) => {
+          onQueryConfigsChange(...args);
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Investigate host.name=web-01"));
+    expect(screen.queryByText("Open in Metric Explorer")).toBeNull();
+
+    fireEvent.click(screen.getByText("Filter to this series"));
+
+    expect(onQueryConfigsChange).toHaveBeenCalledTimes(1);
+    const narrowedConfigs: Array<MetricQueryConfigData> = onQueryConfigsChange
+      .mock.calls[0]?.[0] as Array<MetricQueryConfigData>;
+    expect(
+      (
+        narrowedConfigs[0]?.metricQueryData.filterData as Record<
+          string,
+          unknown
+        >
+      )["attributes"],
+    ).toEqual({ "host.name": "web-01" });
+  });
+
+  test("View logs navigates to the logs explorer scoped to the series and window", async () => {
+    render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Investigate host.name=web-02"));
+    fireEvent.click(screen.getByText("View logs"));
+
+    await waitFor(() => {
+      expect(navigateSpy).toHaveBeenCalled();
+    });
+
+    const url: string = getNavigatedUrl();
+    expect(url).toContain("/logs");
+    expect(url).toContain('["attributes.host.name",["web-02"]]');
+    expect(url).toContain("range=Custom");
+    expect(url).toContain("start=");
+    expect(url).toContain("end=");
+  });
+
+  test("View exceptions reports what the exceptions grammar cannot carry", async () => {
+    render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Investigate host.name=web-01"));
+    fireEvent.click(screen.getByText("View exceptions"));
+
+    await waitFor(() => {
+      expect(navigateSpy).toHaveBeenCalled();
+    });
+
+    const url: string = getNavigatedUrl();
+    expect(url).toContain("/exceptions");
+    expect(url).toContain("status=all");
+    // The host.name narrowing has no exceptions facet — the user is told.
+    expect(showToastMock).toHaveBeenCalled();
+  });
+
+  test("the host series jumps to the matching Host page", async () => {
+    getListMock.mockReturnValue(
+      Promise.resolve({ data: [{ _id: HOST_MODEL_ID }] }),
+    );
+
+    render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Investigate host.name=web-01"));
+    fireEvent.click(screen.getByText('Open host "web-01"'));
+
+    await waitFor(() => {
+      expect(navigateSpy).toHaveBeenCalled();
+    });
+
+    const listArgs: Record<string, unknown> = getListMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(listArgs["query"]).toEqual({
+      projectId: PROJECT_ID,
+      hostIdentifier: "web-01",
+    });
+    expect(getNavigatedUrl()).toContain(`/host/${HOST_MODEL_ID}`);
+  });
+
+  test("enableSeriesActions={false} renders plain chips with no investigate affordance", () => {
+    render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={buildResults()}
+        metricTypes={[]}
+        enableSeriesActions={false}
+      />,
+    );
+
+    // The chips themselves still render…
+    expect(screen.getByText("host.name=web-01")).toBeInTheDocument();
+    // …but nothing offers navigation.
+    expect(screen.queryByLabelText("Investigate host.name=web-01")).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Charts/ChartTooltipSorted.test.tsx
+++ b/Common/Tests/UI/Components/Charts/ChartTooltipSorted.test.tsx
@@ -1,0 +1,129 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { ChartTooltip as AreaChartTooltip } from "../../../../UI/Components/Charts/ChartLibrary/AreaChart/AreaChart";
+import { ChartTooltip as BarChartTooltip } from "../../../../UI/Components/Charts/ChartLibrary/BarChart/BarChart";
+import { ChartTooltip as LineChartTooltip } from "../../../../UI/Components/Charts/ChartLibrary/LineChart/LineChart";
+
+/*
+ * The rendered tooltip is where "which host is this spike?" gets answered:
+ * with a 20-series group-by chart the entries must arrive highest-value
+ * first (recharts hands them over in series-mount order, effectively
+ * alphabetical) and the tail past the cap must be summarized, not
+ * silently dropped. All three chart types ship their own ChartTooltip, so
+ * all three are pinned to the same contract here.
+ */
+
+type TooltipComponent =
+  | typeof AreaChartTooltip
+  | typeof LineChartTooltip
+  | typeof BarChartTooltip;
+
+interface TooltipCase {
+  name: string;
+  Tooltip: TooltipComponent;
+}
+
+const TOOLTIP_CASES: Array<TooltipCase> = [
+  { name: "AreaChart", Tooltip: AreaChartTooltip },
+  { name: "LineChart", Tooltip: LineChartTooltip },
+  { name: "BarChart", Tooltip: BarChartTooltip },
+];
+
+function buildPayload(count: number): Array<{
+  category: string;
+  value: number;
+  index: string;
+  color: string;
+  payload: Record<string, unknown>;
+}> {
+  return Array.from({ length: count }, (_: unknown, index: number) => {
+    return {
+      /*
+       * Alphabetical categories with ASCENDING values — exactly the shape
+       * where mount order (host-00 first) and value order (host-NN first)
+       * disagree, so a pass proves the sort actually ran.
+       */
+      category: `host-${String(index).padStart(2, "0")}`,
+      value: index,
+      index: "10:00",
+      color: "blue",
+      payload: {},
+    };
+  });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe.each(TOOLTIP_CASES)("$name tooltip", ({ Tooltip }: TooltipCase) => {
+  test("renders entries highest-value first with an overflow summary", () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <Tooltip
+        active={true}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payload={buildPayload(14) as any}
+        label="10:00"
+        valueFormatter={(value: number): string => {
+          return `${value}%`;
+        }}
+      />,
+    );
+
+    const text: string = container.textContent || "";
+
+    // The top-valued series leads; the lowest-valued ones are elided.
+    expect(text.indexOf("host-13")).toBeGreaterThan(-1);
+    expect(text.indexOf("host-13")).toBeLessThan(text.indexOf("host-12"));
+    expect(text.indexOf("host-12")).toBeLessThan(text.indexOf("host-04"));
+    expect(text).not.toContain("host-03");
+    expect(text).not.toContain("host-00");
+
+    // 14 series, 10 shown → 4 summarized.
+    expect(
+      screen.getByText(/\+4 more series — highest values shown/),
+    ).toBeInTheDocument();
+
+    // Values run through the caller's formatter.
+    expect(text).toContain("13%");
+  });
+
+  test("shows no overflow line when everything fits", () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <Tooltip
+        active={true}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payload={buildPayload(3) as any}
+        label="10:00"
+        valueFormatter={(value: number): string => {
+          return String(value);
+        }}
+      />,
+    );
+
+    expect(container.textContent).not.toContain("more series");
+    expect(container.textContent).toContain("host-02");
+    expect(container.textContent).toContain("host-00");
+  });
+
+  test("renders nothing when inactive", () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <Tooltip
+        active={false}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payload={buildPayload(3) as any}
+        label="10:00"
+        valueFormatter={(value: number): string => {
+          return String(value);
+        }}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Charts/TooltipEntries.test.ts
+++ b/Common/Tests/UI/Components/Charts/TooltipEntries.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  DEFAULT_TOOLTIP_MAX_ENTRIES,
+  PreparedTooltipEntries,
+  SortableTooltipItem,
+  prepareTooltipEntries,
+} from "../../../../UI/Components/Charts/ChartLibrary/Utils/TooltipEntries";
+
+/*
+ * The tooltip ordering contract: on a grouped chart the series that is
+ * spiking AT THE HOVERED TIMESTAMP must be the first tooltip line, the
+ * list must stay readable at high cardinality (cap + "+N more"), and
+ * non-data entries (hidden series, band fills) must never displace a real
+ * reading. The chips already rank by peak; the tooltip is the only place
+ * the user reads per-timestamp values, so its order is what answers
+ * "which host is this spike?".
+ */
+
+interface TestItem extends SortableTooltipItem {
+  color?: string;
+}
+
+function item(category: string, value: number, type?: string): TestItem {
+  return { category, value, ...(type ? { type } : {}) };
+}
+
+function categories(prepared: PreparedTooltipEntries<TestItem>): Array<string> {
+  return prepared.entries.map((entry: TestItem) => {
+    return entry.category;
+  });
+}
+
+describe("prepareTooltipEntries", () => {
+  test("orders entries by value at the hovered point, highest first", () => {
+    const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries([
+      item("host-b", 10),
+      item("host-a", 90),
+      item("host-c", 40),
+    ]);
+
+    expect(categories(prepared)).toEqual(["host-a", "host-c", "host-b"]);
+    expect(prepared.overflowCount).toBe(0);
+    expect(prepared.totalCount).toBe(3);
+  });
+
+  test("breaks value ties by natural name order (cpu2 before cpu10)", () => {
+    const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries([
+      item("cpu10", 5),
+      item("cpu2", 5),
+      item("cpu1", 5),
+    ]);
+
+    expect(categories(prepared)).toEqual(["cpu1", "cpu2", "cpu10"]);
+  });
+
+  test("sorts non-finite values last without dropping them", () => {
+    const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries([
+      item("nan-series", NaN),
+      item("real-low", 1),
+      item("infinite", Infinity),
+      item("real-high", 7),
+      // The anomaly band's dataKey yields a [low, high] tuple at runtime.
+      item("band", [2, 9] as unknown as number),
+    ]);
+
+    expect(categories(prepared).slice(0, 2)).toEqual(["real-high", "real-low"]);
+    // Non-finite tail keeps natural name order among itself.
+    expect(categories(prepared).slice(2)).toEqual([
+      "band",
+      "infinite",
+      "nan-series",
+    ]);
+    expect(prepared.totalCount).toBe(5);
+  });
+
+  test('filters out type "none" entries (hidden click-target lines, band fills)', () => {
+    const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries([
+      item("visible", 3),
+      item("hidden", 99, "none"),
+    ]);
+
+    expect(categories(prepared)).toEqual(["visible"]);
+    expect(prepared.totalCount).toBe(1);
+    expect(prepared.overflowCount).toBe(0);
+  });
+
+  test("caps at the default and reports the overflow", () => {
+    const payload: Array<TestItem> = Array.from(
+      { length: 25 },
+      (_: unknown, index: number) => {
+        return item(`series-${index}`, index);
+      },
+    );
+
+    const prepared: PreparedTooltipEntries<TestItem> =
+      prepareTooltipEntries(payload);
+
+    expect(prepared.entries).toHaveLength(DEFAULT_TOOLTIP_MAX_ENTRIES);
+    expect(prepared.overflowCount).toBe(25 - DEFAULT_TOOLTIP_MAX_ENTRIES);
+    expect(prepared.totalCount).toBe(25);
+    // The cap keeps the HIGHEST values, not the first-mounted series.
+    expect(categories(prepared)[0]).toBe("series-24");
+    expect(categories(prepared)[DEFAULT_TOOLTIP_MAX_ENTRIES - 1]).toBe(
+      `series-${25 - DEFAULT_TOOLTIP_MAX_ENTRIES}`,
+    );
+  });
+
+  test("exactly at the cap means no overflow", () => {
+    const payload: Array<TestItem> = Array.from(
+      { length: DEFAULT_TOOLTIP_MAX_ENTRIES },
+      (_: unknown, index: number) => {
+        return item(`series-${index}`, index);
+      },
+    );
+
+    const prepared: PreparedTooltipEntries<TestItem> =
+      prepareTooltipEntries(payload);
+
+    expect(prepared.entries).toHaveLength(DEFAULT_TOOLTIP_MAX_ENTRIES);
+    expect(prepared.overflowCount).toBe(0);
+  });
+
+  test("honors a custom cap and rejects nonsense caps", () => {
+    const payload: Array<TestItem> = [item("a", 1), item("b", 2), item("c", 3)];
+
+    expect(prepareTooltipEntries(payload, 2).entries).toHaveLength(2);
+    expect(prepareTooltipEntries(payload, 2).overflowCount).toBe(1);
+
+    // Zero, negative, and fractional caps fall back to the default.
+    expect(prepareTooltipEntries(payload, 0).entries).toHaveLength(3);
+    expect(prepareTooltipEntries(payload, -5).entries).toHaveLength(3);
+    expect(prepareTooltipEntries(payload, 1.5).entries).toHaveLength(3);
+  });
+
+  test("tolerates empty, null, and undefined payloads", () => {
+    for (const payload of [[], null, undefined]) {
+      const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries(
+        payload as Array<TestItem>,
+      );
+      expect(prepared.entries).toEqual([]);
+      expect(prepared.overflowCount).toBe(0);
+      expect(prepared.totalCount).toBe(0);
+    }
+  });
+
+  test("does not mutate the input payload", () => {
+    const payload: Array<TestItem> = [item("low", 1), item("high", 2)];
+    prepareTooltipEntries(payload);
+    expect(
+      payload.map((entry: TestItem) => {
+        return entry.category;
+      }),
+    ).toEqual(["low", "high"]);
+  });
+});

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -181,7 +181,14 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
 
   return (
     <div
-      className="relative flex flex-1"
+      /*
+       * `isolate` opens a stacking context so the recharts tooltip's
+       * z-index competes only inside this chart — without it the tooltip
+       * (zIndex 10, pinned to the chart's top edge) ties with the app
+       * header's sticky z-10 in the root context and paints over the
+       * navbar on half-scrolled charts.
+       */
+      className="relative isolate flex flex-1"
       style={props.heightInPx ? { height: `${props.heightInPx}px` } : undefined}
     >
       <AreaChart

--- a/Common/UI/Components/Charts/Bar/BarChart.tsx
+++ b/Common/UI/Components/Charts/Bar/BarChart.tsx
@@ -115,7 +115,14 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
 
   return (
     <div
-      className="relative flex flex-1"
+      /*
+       * `isolate` opens a stacking context so the recharts tooltip's
+       * z-index competes only inside this chart — without it the tooltip
+       * (zIndex 10, pinned to the chart's top edge) ties with the app
+       * header's sticky z-10 in the root context and paints over the
+       * navbar on half-scrolled charts.
+       */
+      className="relative isolate flex flex-1"
       style={props.heightInPx ? { height: `${props.heightInPx}px` } : undefined}
     >
       <BarChart

--- a/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
@@ -39,6 +39,10 @@ import {
 import { cx } from "../Utils/Cx";
 import { getYAxisDomain } from "../Utils/GetYAxisDomain";
 import { hasOnlyOneValueForKey } from "../Utils/HasOnlyOneValueForKey";
+import {
+  PreparedTooltipEntries,
+  prepareTooltipEntries,
+} from "../Utils/TooltipEntries";
 import ChartCurve from "../../Types/ChartCurve";
 
 /*
@@ -475,9 +479,15 @@ const ChartTooltip: ({
   valueFormatter,
 }: ChartTooltipProps): React.JSX.Element | null => {
   if (active && payload && payload.length) {
-    const legendPayload: PayloadItem[] = payload.filter((item: PayloadItem) => {
-      return item.type !== "none";
-    });
+    /*
+     * Highest value at the hovered timestamp first, capped — on a grouped
+     * chart (one series per host/pod), the spiking series must be the
+     * first line of the tooltip, not buried at its alphabetical position.
+     */
+    const {
+      entries: legendPayload,
+      overflowCount,
+    }: PreparedTooltipEntries<PayloadItem> = prepareTooltipEntries(payload);
     return (
       <div
         className={cx(
@@ -531,6 +541,11 @@ const ChartTooltip: ({
               );
             },
           )}
+          {overflowCount > 0 ? (
+            <p className={cx("pt-1 text-xs", "text-gray-400")}>
+              +{overflowCount} more series — highest values shown
+            </p>
+          ) : null}
         </div>
       </div>
     );
@@ -1426,4 +1441,4 @@ const AreaChart: React.ForwardRefExoticComponent<
 
 AreaChart.displayName = "AreaChart";
 
-export { AreaChart, type AreaChartEventProps, type TooltipProps };
+export { AreaChart, ChartTooltip, type AreaChartEventProps, type TooltipProps };

--- a/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
@@ -33,6 +33,10 @@ import {
 } from "../Utils/ChartColors";
 import { cx } from "../Utils/Cx";
 import { getYAxisDomain } from "../Utils/GetYAxisDomain";
+import {
+  PreparedTooltipEntries,
+  prepareTooltipEntries,
+} from "../Utils/TooltipEntries";
 import { useOnWindowResize } from "../Utils/UseWindowOnResize";
 
 /*
@@ -562,6 +566,15 @@ const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({
   valueFormatter,
 }: ChartTooltipProps): React.ReactElement | null => {
   if (active && payload && payload.length) {
+    /*
+     * Highest value at the hovered bucket first, capped — on a grouped
+     * chart (one series per host/pod), the spiking series must be the
+     * first line of the tooltip, not buried at its alphabetical position.
+     */
+    const {
+      entries: sortedPayload,
+      overflowCount,
+    }: PreparedTooltipEntries<PayloadItem> = prepareTooltipEntries(payload);
     return (
       <div
         className={cx(
@@ -586,7 +599,7 @@ const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({
           </p>
         </div>
         <div className={cx("space-y-1 px-4 py-2")}>
-          {payload.map(
+          {sortedPayload.map(
             ({ value, category, color }: PayloadItem, index: number) => {
               return (
                 <div
@@ -631,6 +644,11 @@ const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({
               );
             },
           )}
+          {overflowCount > 0 ? (
+            <p className={cx("pt-1 text-xs", "text-gray-400")}>
+              +{overflowCount} more series — highest values shown
+            </p>
+          ) : null}
         </div>
       </div>
     );
@@ -1194,4 +1212,4 @@ const BarChart: React.ForwardRefExoticComponent<
 
 BarChart.displayName = "BarChart";
 
-export { BarChart, type BarChartEventProps, type TooltipProps };
+export { BarChart, ChartTooltip, type BarChartEventProps, type TooltipProps };

--- a/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
@@ -40,6 +40,10 @@ import {
 import { cx } from "../Utils/Cx";
 import { getYAxisDomain } from "../Utils/GetYAxisDomain";
 import { hasOnlyOneValueForKey } from "../Utils/HasOnlyOneValueForKey";
+import {
+  PreparedTooltipEntries,
+  prepareTooltipEntries,
+} from "../Utils/TooltipEntries";
 import ChartCurve from "../../Types/ChartCurve";
 
 /*
@@ -478,9 +482,15 @@ const ChartTooltip: ({
   valueFormatter,
 }: ChartTooltipProps): React.JSX.Element | null => {
   if (active && payload && payload.length) {
-    const legendPayload: PayloadItem[] = payload.filter((item: PayloadItem) => {
-      return item.type !== "none";
-    });
+    /*
+     * Highest value at the hovered timestamp first, capped — on a grouped
+     * chart (one series per host/pod), the spiking series must be the
+     * first line of the tooltip, not buried at its alphabetical position.
+     */
+    const {
+      entries: legendPayload,
+      overflowCount,
+    }: PreparedTooltipEntries<PayloadItem> = prepareTooltipEntries(payload);
     return (
       <div
         className={cx(
@@ -550,6 +560,11 @@ const ChartTooltip: ({
               );
             },
           )}
+          {overflowCount > 0 ? (
+            <p className={cx("pt-1 text-xs", "text-gray-400")}>
+              +{overflowCount} more series — highest values shown
+            </p>
+          ) : null}
         </div>
       </div>
     );
@@ -1419,4 +1434,4 @@ const LineChart: React.ForwardRefExoticComponent<
 
 LineChart.displayName = "LineChart";
 
-export { LineChart, type LineChartEventProps, type TooltipProps };
+export { ChartTooltip, LineChart, type LineChartEventProps, type TooltipProps };

--- a/Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries.ts
+++ b/Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries.ts
@@ -1,0 +1,105 @@
+/*
+ * Shared ordering/capping for the hover tooltip of the Area / Line / Bar
+ * charts. With a grouped metric (say 20 hosts on one chart) the recharts
+ * payload arrives in series-render order — effectively alphabetical — so
+ * the series that is actually spiking at the hovered timestamp is buried
+ * mid-list. Sorting by the value AT THE HOVERED POINT puts the top series
+ * first, and capping the list keeps a high-cardinality chart's tooltip
+ * readable (the "+N more" line reports what was elided).
+ */
+
+/*
+ * The slice of a recharts tooltip payload item the ordering needs. The
+ * three chart implementations each declare their own structurally-equal
+ * PayloadItem, so this stays generic instead of importing any of them.
+ */
+export interface SortableTooltipItem {
+  category: string;
+  value: number;
+  type?: string | undefined;
+}
+
+export const DEFAULT_TOOLTIP_MAX_ENTRIES: number = 10;
+
+export interface PreparedTooltipEntries<T extends SortableTooltipItem> {
+  /** Entries to render, highest value first, capped at maxEntries. */
+  entries: Array<T>;
+  /** How many entries the cap hid (0 when everything fits). */
+  overflowCount: number;
+  /** Entry count after filtering, before capping. */
+  totalCount: number;
+}
+
+/*
+ * Natural compare so host names order like cpu0 < cpu2 < cpu10 instead of
+ * lexicographically — mirrors the series chips' name ordering.
+ */
+function compareCategoryNames(a: string, b: string): number {
+  return String(a).localeCompare(String(b), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+export function prepareTooltipEntries<T extends SortableTooltipItem>(
+  payload: Array<T> | undefined | null,
+  maxEntries: number = DEFAULT_TOOLTIP_MAX_ENTRIES,
+): PreparedTooltipEntries<T> {
+  /*
+   * `type === "none"` entries are series excluded from legends/tooltips
+   * (recharts tooltipType) — every chart filtered them before this
+   * module existed, so the filter lives here now to stay uniform.
+   */
+  const visibleEntries: Array<T> = (payload || []).filter((item: T) => {
+    return item.type !== "none";
+  });
+
+  const sortedEntries: Array<T> = visibleEntries
+    .slice()
+    .sort((a: T, b: T): number => {
+      /*
+       * Non-finite values (missing points, the anomaly band's [low, high]
+       * array) sort last — they carry no "how high is this series right
+       * now" signal, so they must never displace a real reading.
+       */
+      const aValue: number | null =
+        typeof a.value === "number" && Number.isFinite(a.value)
+          ? a.value
+          : null;
+      const bValue: number | null =
+        typeof b.value === "number" && Number.isFinite(b.value)
+          ? b.value
+          : null;
+
+      if (aValue === null && bValue === null) {
+        return compareCategoryNames(a.category, b.category);
+      }
+      if (aValue === null) {
+        return 1;
+      }
+      if (bValue === null) {
+        return -1;
+      }
+      if (bValue !== aValue) {
+        return bValue - aValue;
+      }
+      return compareCategoryNames(a.category, b.category);
+    });
+
+  const totalCount: number = sortedEntries.length;
+
+  const cap: number =
+    Number.isInteger(maxEntries) && maxEntries > 0
+      ? maxEntries
+      : DEFAULT_TOOLTIP_MAX_ENTRIES;
+
+  if (totalCount <= cap) {
+    return { entries: sortedEntries, overflowCount: 0, totalCount };
+  }
+
+  return {
+    entries: sortedEntries.slice(0, cap),
+    overflowCount: totalCount - cap,
+    totalCount,
+  };
+}

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -161,7 +161,14 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
 
   return (
     <div
-      className="relative flex flex-1"
+      /*
+       * `isolate` opens a stacking context so the recharts tooltip's
+       * z-index competes only inside this chart — without it the tooltip
+       * (zIndex 10, pinned to the chart's top edge) ties with the app
+       * header's sticky z-10 in the root context and paints over the
+       * navbar on half-scrolled charts.
+       */
+      className="relative isolate flex flex-1"
       style={props.heightInPx ? { height: `${props.heightInPx}px` } : undefined}
     >
       <LineChart


### PR DESCRIPTION
## What this does

Turns every metric chart — dashboard widgets and the Metric Explorer alike — into a starting point for investigating a spike, instead of a dead end.

### 1. Tooltips answer "which series is spiking?" (all three chart types)
- Hover-tooltip entries are now ordered by the value **at the hovered timestamp**, highest first — previously they rendered in series-mount order (effectively alphabetical), so with a 20-series group-by the spiking host was buried mid-list.
- Capped at 10 entries with a `+N more series — highest values shown` summary so high-cardinality charts stay readable.
- The ordering is one shared util (`ChartLibrary/Utils/TooltipEntries.ts`) instead of three divergent copies in Area/Line/Bar.
- Chart wrappers gain `isolate` so the tooltip's z-index is scoped to the chart and can no longer paint over the sticky app header (same stacking-context bug class as #3373).

### 2. Per-series investigate menu (legend chips)
Every series chip grows a magnifier button opening a menu scoped to **that one series** — its `key=value` group-by labels are parsed back out of the composed name and pushed into the query's attribute filters via `MetricSeriesScope`:
- **View logs / View traces** — deep links into the explorers carrying the series labels as real facet filters (`attributes.<key>` tuples / `@key:value` tokens), `resource.service.name` resolved to Service ObjectIDs, plus the chart's window. Scope that can't be expressed is reported in a toast, never silently dropped.
- **View exceptions** — service + window scoped exceptions list (`status=all`), with inexpressible attribute scope reported.
- **Filter to this series** (read-write hosts, i.e. the explorer) — narrows the live view in place via `onQueryConfigsChange`.
- **Open in Metric Explorer** (read-only hosts, i.e. dashboard widgets) — the same narrowing as a deep link.
- **Open host "prod-01" / Open service … / Open Kubernetes cluster … / Open network device** — when the series labels (or the query's own equality filters) name a OneUptime resource, resolves the record (`hostIdentifier` / `clusterIdentifier` canonicalized, services via the shared cached resolver) and lands on its page.

Suppressed on public dashboards (no session) and in dashboard edit mode (navigation would drop unsaved changes). Formula-chart series get the same menu (labels scope the underlying queries).

### 3. Dashboard widget drag-to-zoom
Drag-selecting a range on a chart widget zooms **that widget only** to the selected window — a zoom bar names the window and offers **Reset** and **Open in Explorer** (carrying the zoomed window). The dashboard-wide time range is untouched; auto-refresh no longer yanks the window away mid-investigation. Widget explorer links now also carry the dashboard's relative range token, so a "Past 1 hour" widget opens a *rolling* explorer view instead of a pinned one.

### 4. Correctness fix en route
`MetricView` only claims the query-config write path when its host can actually persist it — previously read-only hosts routed Top-N writes (and now the series menu's filter action) into a silent no-op instead of the transient-override fallback.

## Tests
- `Common/Tests/UI/Components/Charts/TooltipEntries.test.ts` — ordering/cap/filter contract (9 cases).
- `Common/Tests/UI/Components/Charts/ChartTooltipSorted.test.tsx` — rendered tooltip order + overflow for Area/Line/Bar.
- `App/Tests/Dashboard/MetricSeriesInvestigation.test.ts` — label parsing, series scoping (incl. `(unset)` → is-empty), resource-target detection, exceptions pivot params, host/cluster/service resolution with caching, wiring pins (30 cases).
- `Common/Tests/App/Dashboard/MetricSeriesInvestigateMenu.test.tsx` — the menu end-to-end against the real `MetricCharts`: chip → menu → scoped logs URL / host page / in-place filter / gating.
- `Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx` — zoom → refetch narrowed window → reset lifecycle, edit-mode gating.

Full local runs: App `Tests/Dashboard` 187 suites / 6651 tests green; Common `Tests/App/Dashboard + Tests/Utils/Metrics + Tests/Utils/Telemetry + Tests/UI/Components/Charts` green; `tsc --noEmit` clean in both workspaces; eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HxEiCGGsLcTyJe4cR7ofb