### PR TITLE
fix(enterprise-license): make the daily call home actually refresh the license

### DIFF
--- a/App/FeatureSet/Workers/Jobs/EnterpriseLicense/ReportUserCount.ts
+++ b/App/FeatureSet/Workers/Jobs/EnterpriseLicense/ReportUserCount.ts
@@ -20,9 +20,10 @@ import Crypto from "Common/Utils/Crypto";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import { JSONObject } from "Common/Types/JSON";
-import EnterpriseLicenseInstanceSummary from "Common/Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+import EnterpriseLicenseSyncUtil, {
+  EnterpriseLicenseSyncResult,
+} from "Common/Utils/EnterpriseLicense/EnterpriseLicenseSync";
 import LIMIT_MAX from "Common/Types/Database/LimitMax";
-import PartialEntity from "Common/Types/Database/PartialEntity";
 import logger from "Common/Server/Utils/Logger";
 
 type GetUserEmailHashesFunction = () => Promise<Array<string>>;
@@ -214,54 +215,56 @@ RunCron(
     const payload: JSONObject = (response.data as JSONObject) || {};
 
     /*
-     * The license server responds with the user count deduplicated across
-     * all instances that share this license, plus the instance list — store
-     * both so the license modal can show them. If the response has no valid
-     * count, keep whatever we had rather than storing a local-only count as
-     * if it were the cross-instance aggregate.
+     * The response is a full picture of the license as oneuptime.com knows it
+     * right now - the seat limit, the expiry, the company name, the
+     * evaluation flag, the deduplicated user count across every instance
+     * sharing this key, and the instance list. Mirroring all of it is what
+     * makes this daily call the thing that keeps a self-hosted installation
+     * current: before it did, buying seats or renewing on oneuptime.com only
+     * reached the customer when somebody re-typed the license key by hand.
+     *
+     * The mapper is deliberately conservative - a field the server did not
+     * send leaves the stored column alone - so an installation upgraded ahead
+     * of oneuptime.com cannot have its license blanked by the fields the older
+     * server has never heard of.
      */
-    const aggregatedUserCountRaw: unknown = payload["currentUserCount"];
+    const sync: EnterpriseLicenseSyncResult =
+      EnterpriseLicenseSyncUtil.getGlobalConfigUpdateFromLicenseResponse({
+        payload: payload,
+        reportedAt: reportedAt,
+      });
 
-    if (
-      typeof aggregatedUserCountRaw !== "number" ||
-      !Number.isFinite(aggregatedUserCountRaw)
-    ) {
+    for (const warning of sync.warnings) {
+      logger.error(`EnterpriseLicense:ReportUserCount: ${warning}`);
+    }
+
+    if (Object.keys(sync.updateData).length === 0) {
       logger.error(
-        "EnterpriseLicense:ReportUserCount: License server did not return a valid currentUserCount. Keeping previously stored usage.",
+        "EnterpriseLicense:ReportUserCount: The license server returned nothing this build could store. Keeping the previously stored license state.",
       );
       return;
     }
 
-    const aggregatedUserCount: number = aggregatedUserCountRaw;
-
-    const updateData: PartialEntity<GlobalConfig> = {
-      enterpriseLicenseCurrentUserCount: aggregatedUserCount,
-      enterpriseLicenseUserCountUpdatedAt: reportedAt,
-      /*
-       * Kept in sync on every report so that flipping a license to (or from)
-       * evaluation on oneuptime.com reaches the customer's modal within a day,
-       * rather than only when they next re-validate the key.
-       */
-      enterpriseLicenseIsEvaluation: payload["isEvaluationLicense"] === true,
-    };
-
-    if (Array.isArray(payload["instances"])) {
-      updateData.enterpriseLicenseInstances = payload[
-        "instances"
-      ] as Array<EnterpriseLicenseInstanceSummary>;
-    }
-
     await GlobalConfigService.updateOneById({
       id: ObjectID.getZeroObjectID(),
-      data: updateData,
+      data: sync.updateData,
       props: {
         isRoot: true,
         ignoreHooks: true,
       },
     });
 
+    const aggregatedUserCount: number | null | undefined = sync.updateData
+      .enterpriseLicenseCurrentUserCount as number | null | undefined;
+
     logger.debug(
-      `EnterpriseLicense:ReportUserCount: Reported ${userEmailHashes.length} users on this instance to OneUptime. Unique users across all instances: ${aggregatedUserCount}.`,
+      `EnterpriseLicense:ReportUserCount: Reported ${
+        userEmailHashes.length
+      } users on this instance to OneUptime. Unique users across all instances: ${
+        typeof aggregatedUserCount === "number"
+          ? aggregatedUserCount
+          : "unchanged"
+      }.`,
     );
   },
 );

--- a/App/Tests/Workers/Jobs/EnterpriseLicense/ReportUserCount.test.ts
+++ b/App/Tests/Workers/Jobs/EnterpriseLicense/ReportUserCount.test.ts
@@ -1,0 +1,555 @@
+import { EVERY_DAY } from "Common/Utils/CronTime";
+import { beforeEach, afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * The daily call home, and the bug it was reported for.
+ *
+ * A customer raised their seat limit on oneuptime.com. Their self-hosted
+ * installation called home every day exactly as designed, and the modal went
+ * on showing the old limit — not for a day, forever, because the only other
+ * writer of that column is a human re-typing the license key into a box that
+ * is hidden while the license is valid. The job read four fields out of the
+ * response and dropped userLimit, which the license server had been sending
+ * all along.
+ *
+ * What these tests pin:
+ *   1. the seat limit (and the expiry, company name, evaluation flag and
+ *      token) actually reach GlobalConfig,
+ *   2. the three-state contract that makes that safe — a field the server did
+ *      not mention leaves the stored column alone, so an installation upgraded
+ *      ahead of oneuptime.com cannot have its license blanked,
+ *   3. one bad field no longer costs the whole day's sync,
+ *   4. the gating and the report body, so the fix did not disturb them.
+ *
+ * The job registers itself through RunCron at import time and exports nothing,
+ * so Cron is mocked to capture the handler and each test drives one tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+interface CronOptions {
+  schedule: string;
+  runOnStartup: boolean;
+}
+
+interface CapturedJob {
+  options: CronOptions;
+  handler: CronHandler;
+}
+
+// Must be declared before the job import so the mock factory closure sees it.
+const mockCapturedJobs: Record<string, CapturedJob> = {};
+
+let mockBillingEnabled: boolean = false;
+let mockEnterpriseEdition: boolean = true;
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (
+        jobName: string,
+        options: CronOptions,
+        runFunction: CronHandler,
+      ): void => {
+        mockCapturedJobs[jobName] = { options, handler: runFunction };
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+    },
+  };
+});
+
+/*
+ * Only the two deployment flags are swapped; everything else in this module
+ * stays real. They have to be live accessors rather than values, because
+ * object spread compiles to Object.assign, which reads each accessor once and
+ * flattens it to whatever it returned at that moment — and the job reads these
+ * when it runs, not when it was imported.
+ */
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  const mocked: Record<string, unknown> = {
+    ...actual,
+    __esModule: true,
+    IsDevelopment: false,
+  };
+
+  Object.defineProperty(mocked, "IsBillingEnabled", {
+    get: (): boolean => {
+      return mockBillingEnabled;
+    },
+  });
+
+  Object.defineProperty(mocked, "IsEnterpriseEdition", {
+    get: (): boolean => {
+      return mockEnterpriseEdition;
+    },
+  });
+
+  return mocked;
+});
+
+/*
+ * Imported after the mocks and after the `mock*` bindings they close over:
+ * TypeScript emits requires where the import sits, so an import hoisted above
+ * those `let`s would touch them in their temporal dead zone.
+ */
+import "../../../../FeatureSet/Workers/Jobs/EnterpriseLicense/ReportUserCount";
+import GlobalConfigService from "Common/Server/Services/GlobalConfigService";
+import UserService from "Common/Server/Services/UserService";
+import GlobalConfig from "Common/Models/DatabaseModels/GlobalConfig";
+import User from "Common/Models/DatabaseModels/User";
+import API from "Common/Utils/API";
+import Crypto from "Common/Utils/Crypto";
+import Email from "Common/Types/Email";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import logger from "Common/Server/Utils/Logger";
+
+const JOB_NAME: string = "EnterpriseLicense:ReportUserCount";
+const LICENSE_KEY: string = "acme-license-key";
+const INSTANCE_ID: ObjectID = ObjectID.generate();
+
+type SpiedApi = {
+  mockResolvedValue: (value: unknown) => void;
+  mock: { calls: Array<Array<unknown>> };
+};
+
+let apiPost: SpiedApi;
+
+type RunTickFunction = () => Promise<void>;
+
+const runTick: RunTickFunction = async (): Promise<void> => {
+  const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+  if (!captured) {
+    throw new Error(
+      "ReportUserCount did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await captured.handler();
+};
+
+type MakeUserFunction = (email: string) => User;
+
+const makeUser: MakeUserFunction = (email: string): User => {
+  return { email: new Email(email) } as unknown as User;
+};
+
+type RespondFunction = (body: JSONObject, statusCode?: number) => void;
+
+const respondWith: RespondFunction = (
+  body: JSONObject,
+  statusCode: number = 200,
+): void => {
+  apiPost.mockResolvedValue(new HTTPResponse<JSONObject>(statusCode, body, {}));
+};
+
+/*
+ * The body oneuptime.com sends back for a healthy license, matching
+ * Common/Server/API/EnterpriseLicenseAPI.ts.
+ */
+type ServerBodyFunction = (overrides?: JSONObject) => JSONObject;
+
+const serverBody: ServerBodyFunction = (overrides?: JSONObject): JSONObject => {
+  return {
+    companyName: "Acme Inc",
+    expiresAt: "2027-01-01T00:00:00.000Z",
+    licenseKey: LICENSE_KEY,
+    userLimit: 150,
+    currentUserCount: 3,
+    userCountUpdatedAt: "2026-08-24T09:59:00.000Z",
+    isEvaluationLicense: false,
+    instances: [{ instanceId: INSTANCE_ID.toString(), host: "acme.internal" }],
+    token: "signed.jwt.token",
+    ...overrides,
+  };
+};
+
+type GetLicenseUpdateFunction = () => JSONObject;
+
+/*
+ * The data payload of the single license write. Anything the job persists on
+ * the way in (a generated instance id) is filtered out so the assertions are
+ * about the sync and nothing else.
+ */
+const getLicenseUpdate: GetLicenseUpdateFunction = (): JSONObject => {
+  const calls: Array<Array<unknown>> = (
+    GlobalConfigService.updateOneById as unknown as SpiedApi
+  ).mock.calls;
+
+  const licenseWrites: Array<JSONObject> = calls
+    .map((call: Array<unknown>): JSONObject => {
+      return (call[0] as JSONObject)["data"] as JSONObject;
+    })
+    .filter((data: JSONObject): boolean => {
+      return !Object.prototype.hasOwnProperty.call(data, "instanceId");
+    });
+
+  expect(licenseWrites).toHaveLength(1);
+
+  return licenseWrites[0] as JSONObject;
+};
+
+describe("EnterpriseLicense:ReportUserCount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockBillingEnabled = false;
+    mockEnterpriseEdition = true;
+
+    (GlobalConfigService.findOneById as unknown as SpiedApi).mockResolvedValue({
+      enterpriseLicenseKey: LICENSE_KEY,
+      instanceId: INSTANCE_ID,
+    } as unknown as GlobalConfig);
+
+    (
+      GlobalConfigService.updateOneById as unknown as SpiedApi
+    ).mockResolvedValue(undefined);
+
+    (UserService.findBy as unknown as SpiedApi).mockResolvedValue([
+      makeUser("a@acme.com"),
+      makeUser("b@acme.com"),
+      makeUser("c@acme.com"),
+    ]);
+
+    apiPost = jest.spyOn(API, "post") as unknown as SpiedApi;
+
+    respondWith(serverBody());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("registration", () => {
+    it("runs once a day and does not fire on boot", () => {
+      const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+      expect(captured).toBeDefined();
+      expect(captured!.options.schedule).toBe(EVERY_DAY);
+      expect(captured!.options.runOnStartup).toBe(false);
+    });
+  });
+
+  describe("who reports", () => {
+    it("stays silent on oneuptime.com itself, which issues the licenses", async () => {
+      mockBillingEnabled = true;
+
+      await runTick();
+
+      expect(API.post).not.toHaveBeenCalled();
+      expect(GlobalConfigService.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("stays silent on a community edition install", async () => {
+      mockEnterpriseEdition = false;
+
+      await runTick();
+
+      expect(API.post).not.toHaveBeenCalled();
+    });
+
+    it("stays silent when no license key has been entered yet", async () => {
+      (
+        GlobalConfigService.findOneById as unknown as SpiedApi
+      ).mockResolvedValue({} as unknown as GlobalConfig);
+
+      await runTick();
+
+      expect(API.post).not.toHaveBeenCalled();
+      expect(GlobalConfigService.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("what it reports", () => {
+    it("sends the key, the seat count, this instance's identity and its version", async () => {
+      await runTick();
+
+      const body: JSONObject = (apiPost.mock.calls[0]![0] as JSONObject)[
+        "data"
+      ] as JSONObject;
+
+      expect(body["licenseKey"]).toBe(LICENSE_KEY);
+      expect(body["userCount"]).toBe(3);
+      expect(body["instanceId"]).toBe(INSTANCE_ID.toString());
+      expect(body).toHaveProperty("host");
+      expect(body).toHaveProperty("version");
+    });
+
+    it("sends hashes rather than addresses, so users stay anonymous", async () => {
+      await runTick();
+
+      const body: JSONObject = (apiPost.mock.calls[0]![0] as JSONObject)[
+        "data"
+      ] as JSONObject;
+
+      expect(body["userEmailHashes"]).toEqual([
+        Crypto.getSha256Hash("a@acme.com"),
+        Crypto.getSha256Hash("b@acme.com"),
+        Crypto.getSha256Hash("c@acme.com"),
+      ]);
+      expect(JSON.stringify(body["userEmailHashes"])).not.toContain("acme.com");
+    });
+
+    it("counts the same person once however they capitalized their address", async () => {
+      (UserService.findBy as unknown as SpiedApi).mockResolvedValue([
+        makeUser("A@Acme.com"),
+        makeUser(" a@acme.com "),
+      ]);
+
+      await runTick();
+
+      const body: JSONObject = (apiPost.mock.calls[0]![0] as JSONObject)[
+        "data"
+      ] as JSONObject;
+
+      expect(body["userCount"]).toBe(1);
+    });
+
+    it("generates and persists an instance id for an install that predates them", async () => {
+      (
+        GlobalConfigService.findOneById as unknown as SpiedApi
+      ).mockResolvedValue({
+        enterpriseLicenseKey: LICENSE_KEY,
+      } as unknown as GlobalConfig);
+
+      await runTick();
+
+      const calls: Array<Array<unknown>> = (
+        GlobalConfigService.updateOneById as unknown as SpiedApi
+      ).mock.calls;
+
+      const instanceWrite: JSONObject | undefined = calls
+        .map((call: Array<unknown>): JSONObject => {
+          return (call[0] as JSONObject)["data"] as JSONObject;
+        })
+        .find((data: JSONObject): boolean => {
+          return Object.prototype.hasOwnProperty.call(data, "instanceId");
+        });
+
+      expect(instanceWrite).toBeDefined();
+
+      const reported: JSONObject = (apiPost.mock.calls[0]![0] as JSONObject)[
+        "data"
+      ] as JSONObject;
+
+      // The id it persisted is the id it reported.
+      expect(reported["instanceId"]).toBe(
+        (instanceWrite!["instanceId"] as ObjectID).toString(),
+      );
+    });
+  });
+
+  describe("what it brings back - the reported bug", () => {
+    it("stores the seat limit the license server just told it", async () => {
+      await runTick();
+
+      expect(getLicenseUpdate()["enterpriseLicenseUserLimit"]).toBe(150);
+    });
+
+    it("stores a lowered seat limit too", async () => {
+      respondWith(serverBody({ userLimit: 5 }));
+
+      await runTick();
+
+      expect(getLicenseUpdate()["enterpriseLicenseUserLimit"]).toBe(5);
+    });
+
+    it("clears the seat limit when the license no longer has one", async () => {
+      respondWith(serverBody({ userLimit: null }));
+
+      await runTick();
+
+      const update: JSONObject = getLicenseUpdate();
+
+      expect(Object.keys(update)).toContain("enterpriseLicenseUserLimit");
+      expect(update["enterpriseLicenseUserLimit"]).toBeNull();
+    });
+
+    it("stores the renewed expiry, the company name and the fresh token", async () => {
+      await runTick();
+
+      const update: JSONObject = getLicenseUpdate();
+
+      expect(update["enterpriseLicenseExpiresAt"]).toEqual(
+        new Date("2027-01-01T00:00:00.000Z"),
+      );
+      expect(update["enterpriseCompanyName"]).toBe("Acme Inc");
+      expect(update["enterpriseLicenseToken"]).toBe("signed.jwt.token");
+    });
+
+    it("stores the deduplicated count across every instance, not this one's count", async () => {
+      /*
+       * This install has 3 users; the license spans instances totalling 11.
+       * The number the customer is measured against is the license-wide one.
+       */
+      respondWith(serverBody({ currentUserCount: 11 }));
+
+      await runTick();
+
+      expect(getLicenseUpdate()["enterpriseLicenseCurrentUserCount"]).toBe(11);
+    });
+
+    it("stores the evaluation flag and the instance list", async () => {
+      respondWith(serverBody({ isEvaluationLicense: true }));
+
+      await runTick();
+
+      const update: JSONObject = getLicenseUpdate();
+
+      expect(update["enterpriseLicenseIsEvaluation"]).toBe(true);
+      expect(update["enterpriseLicenseInstances"]).toHaveLength(1);
+    });
+
+    it("writes to the singleton config row with hooks off", async () => {
+      await runTick();
+
+      const calls: Array<Array<unknown>> = (
+        GlobalConfigService.updateOneById as unknown as SpiedApi
+      ).mock.calls;
+
+      const licenseCall: JSONObject = calls[calls.length - 1]![0] as JSONObject;
+
+      expect((licenseCall["id"] as ObjectID).toString()).toBe(
+        ObjectID.getZeroObjectID().toString(),
+      );
+      expect(licenseCall["props"]).toEqual({
+        isRoot: true,
+        ignoreHooks: true,
+      });
+    });
+
+    it("writes the license state exactly once per tick", async () => {
+      await runTick();
+
+      expect(GlobalConfigService.updateOneById).toHaveBeenCalledTimes(1);
+    });
+
+    it("never adopts a license key handed to it by the response", async () => {
+      respondWith(serverBody({ licenseKey: "somebody-elses-key" }));
+
+      await runTick();
+
+      expect(Object.keys(getLicenseUpdate())).not.toContain(
+        "enterpriseLicenseKey",
+      );
+    });
+  });
+
+  describe("talking to an oneuptime.com older than this build", () => {
+    it("leaves every field the old server never mentions exactly as it was", async () => {
+      /*
+       * The pre-change /report-user-count body, verbatim. The seat limit was
+       * always in it, so the fix works against every deployed license server;
+       * the fields added alongside it must be a no-op here rather than a
+       * clear, or upgrading ahead of oneuptime.com would blank a live license.
+       */
+      respondWith({
+        currentUserCount: 3,
+        userCountUpdatedAt: "2026-08-24T09:59:00.000Z",
+        userLimit: 150,
+        isEvaluationLicense: false,
+        instances: [],
+      });
+
+      await runTick();
+
+      const update: JSONObject = getLicenseUpdate();
+
+      expect(update["enterpriseLicenseUserLimit"]).toBe(150);
+      expect(Object.keys(update)).not.toContain("enterpriseLicenseExpiresAt");
+      expect(Object.keys(update)).not.toContain("enterpriseCompanyName");
+      expect(Object.keys(update)).not.toContain("enterpriseLicenseToken");
+    });
+  });
+
+  describe("when the answer is not what it should be", () => {
+    it("keeps the stored license state when the call home fails", async () => {
+      apiPost.mockResolvedValue(new HTTPErrorResponse(500, {}, {}));
+
+      await runTick();
+
+      expect(GlobalConfigService.updateOneById).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("keeps the stored license state when the body is empty", async () => {
+      respondWith({});
+
+      await runTick();
+
+      expect(GlobalConfigService.updateOneById).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("still syncs the license terms when only the count is unusable", async () => {
+      /*
+       * The job used to give up here, so one malformed number also cost the
+       * customer that day's seat limit and expiry.
+       */
+      respondWith(serverBody({ currentUserCount: "lots" }));
+
+      await runTick();
+
+      const update: JSONObject = getLicenseUpdate();
+
+      expect(update["enterpriseLicenseUserLimit"]).toBe(150);
+      expect(update["enterpriseLicenseExpiresAt"]).toEqual(
+        new Date("2027-01-01T00:00:00.000Z"),
+      );
+      expect(Object.keys(update)).not.toContain(
+        "enterpriseLicenseCurrentUserCount",
+      );
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("still syncs the count when only the seat limit is unusable", async () => {
+      respondWith(serverBody({ userLimit: "one hundred and fifty" }));
+
+      await runTick();
+
+      const update: JSONObject = getLicenseUpdate();
+
+      expect(update["enterpriseLicenseCurrentUserCount"]).toBe(3);
+      expect(Object.keys(update)).not.toContain("enterpriseLicenseUserLimit");
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Server/API/EnterpriseLicenseAPI.ts
+++ b/Common/Server/API/EnterpriseLicenseAPI.ts
@@ -1,7 +1,6 @@
 import EnterpriseLicense from "../../Models/DatabaseModels/EnterpriseLicense";
 import EnterpriseLicenseInstance from "../../Models/DatabaseModels/EnterpriseLicenseInstance";
 import BadDataException from "../../Types/Exception/BadDataException";
-import { JSONObject } from "../../Types/JSON";
 import PartialEntity from "../../Types/Database/PartialEntity";
 import EnterpriseLicenseInstanceSummary from "../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
 import EnterpriseLicenseUsageUtil from "../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
@@ -25,6 +24,20 @@ import {
 } from "../Utils/Express";
 import BaseAPI from "./BaseAPI";
 // import { Host } from "../EnvironmentConfig";
+
+/*
+ * The license state every installation of a license key mirrors locally.
+ * Returned by both /validate and /report-user-count so that the daily report
+ * keeps a self-hosted installation current on its own.
+ */
+export interface LicenseTerms {
+  companyName: string;
+  // ISO 8601, or null for a license with no expiry set.
+  expiresAt: string | null;
+  licenseKey: string;
+  // Null means the license carries no seat limit.
+  userLimit: number | null;
+}
 
 export interface LicenseInstanceUpsert {
   licenseId: ObjectID;
@@ -137,24 +150,15 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
           const instances: Array<EnterpriseLicenseInstance> =
             await this.findLicenseInstances(license.id!);
 
-          const payload: JSONObject = {
-            companyName: license.companyName || "",
-            expiresAt: license.expiresAt.toISOString(),
-            licenseKey: license.licenseKey || "",
-            userLimit:
-              typeof license.userLimit === "number" ? license.userLimit : null,
-          };
+          const terms: LicenseTerms = this.getLicenseTerms(license);
 
-          const token: string = JSONWebToken.signJsonPayload(
-            payload,
-            Math.max(secondsUntilExpiry, 1),
-          );
+          const token: string | null = this.signLicenseToken(license);
 
           return Response.sendJsonObjectResponse(req, res, {
-            companyName: payload["companyName"] as string,
-            expiresAt: payload["expiresAt"] as string,
-            licenseKey: payload["licenseKey"] as string,
-            userLimit: payload["userLimit"],
+            companyName: terms.companyName,
+            expiresAt: terms.expiresAt,
+            licenseKey: terms.licenseKey,
+            userLimit: terms.userLimit,
             currentUserCount:
               typeof license.currentUserCount === "number"
                 ? license.currentUserCount
@@ -202,8 +206,19 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
               query: {
                 licenseKey: licenseKey,
               },
+              /*
+               * The full set of terms, not just the usage columns: this
+               * response is what a self-hosted installation mirrors into its
+               * own GlobalConfig every day, so anything it is missing here is
+               * a field the customer keeps the stale value of until somebody
+               * re-types the license key by hand. Same indexed lookup either
+               * way.
+               */
               select: {
                 _id: true,
+                companyName: true,
+                expiresAt: true,
+                licenseKey: true,
                 userLimit: true,
                 isEvaluationLicense: true,
               },
@@ -282,18 +297,78 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
             });
           }
 
+          const terms: LicenseTerms = this.getLicenseTerms(license);
+
           return Response.sendJsonObjectResponse(req, res, {
+            companyName: terms.companyName,
+            expiresAt: terms.expiresAt,
+            licenseKey: terms.licenseKey,
+            userLimit: terms.userLimit,
             currentUserCount: currentUserCount,
             userCountUpdatedAt: reportedAt.toISOString(),
-            userLimit:
-              typeof license.userLimit === "number" ? license.userLimit : null,
             isEvaluationLicense: Boolean(license.isEvaluationLicense),
             instances: this.getInstanceSummaries(instances),
+            /*
+             * Null once the license has expired. Unlike /validate this route
+             * does not reject an expired license - the instance is still
+             * expected to report, and the expiry notification emails are built
+             * from what it reports - but it must not keep being handed a fresh
+             * token, and the expiresAt above is what tells it the truth.
+             */
+            token: this.signLicenseToken(license),
           });
         } catch (err) {
           next(err);
         }
       },
+    );
+  }
+
+  /*
+   * The license terms a self-hosted installation mirrors locally. Built in one
+   * place so /validate and /report-user-count cannot drift: the seat limit was
+   * missing from what an instance could refresh for exactly as long as the two
+   * responses were written out by hand, separately.
+   */
+  private getLicenseTerms(license: EnterpriseLicense): LicenseTerms {
+    return {
+      companyName: license.companyName || "",
+      expiresAt: license.expiresAt ? license.expiresAt.toISOString() : null,
+      licenseKey: license.licenseKey || "",
+      userLimit:
+        typeof license.userLimit === "number" ? license.userLimit : null,
+    };
+  }
+
+  /*
+   * Signed with the license server's own secret, so it is opaque to the
+   * installation holding it - it is the proof that oneuptime.com recognized
+   * the key, and the instance only checks that it exists. An expired license
+   * gets none, which is why this returns null rather than a short-lived token.
+   */
+  private signLicenseToken(license: EnterpriseLicense): string | null {
+    if (!license.expiresAt) {
+      return null;
+    }
+
+    const secondsUntilExpiry: number = Math.floor(
+      (license.expiresAt.getTime() - Date.now()) / 1000,
+    );
+
+    if (secondsUntilExpiry <= 0) {
+      return null;
+    }
+
+    const terms: LicenseTerms = this.getLicenseTerms(license);
+
+    return JSONWebToken.signJsonPayload(
+      {
+        companyName: terms.companyName,
+        expiresAt: terms.expiresAt,
+        licenseKey: terms.licenseKey,
+        userLimit: terms.userLimit,
+      },
+      Math.max(secondsUntilExpiry, 1),
     );
   }
 

--- a/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
+++ b/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
@@ -1,0 +1,763 @@
+import EnterpriseLicenseAPI from "../../../Server/API/EnterpriseLicenseAPI";
+import EnterpriseLicenseService from "../../../Server/Services/EnterpriseLicenseService";
+import EnterpriseLicenseInstanceService from "../../../Server/Services/EnterpriseLicenseInstanceService";
+import JSONWebToken from "../../../Server/Utils/JsonWebToken";
+import Response from "../../../Server/Utils/Response";
+import EnterpriseLicense from "../../../Models/DatabaseModels/EnterpriseLicense";
+import EnterpriseLicenseInstance from "../../../Models/DatabaseModels/EnterpriseLicenseInstance";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import { JSONObject } from "../../../Types/JSON";
+import EnterpriseLicenseSyncUtil, {
+  EnterpriseLicenseSyncResult,
+} from "../../../Utils/EnterpriseLicense/EnterpriseLicenseSync";
+import {
+  NextFunction,
+  OneUptimeRequest,
+  OneUptimeResponse,
+} from "../../../Server/Utils/Express";
+import { mockRouter } from "./Helpers";
+import { beforeEach, afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * The license-server half of the seat-limit sync.
+ *
+ * /report-user-count is the daily call a self-hosted installation makes, and
+ * its response is the ONLY thing that installation can learn from without a
+ * human re-typing the license key. It used to answer with the usage numbers
+ * and the seat limit but nothing else, and the job on the other end dropped
+ * the seat limit on the floor — so raising a customer's limit on oneuptime.com
+ * never reached the installation enforcing it.
+ *
+ * These tests pin the response as a complete statement of the license terms,
+ * and pin the one thing that must NOT be unconditional: an expired license
+ * still gets a straight answer (it has to keep reporting, the expiry emails
+ * are built from those reports) but it does not get a fresh token.
+ */
+
+/*
+ * PasswordHash carries a pre-existing TS diagnostic that fails any suite whose
+ * require graph reaches it, and DatabaseService — the base of every concrete
+ * service below — imports it. Replaced with a factory rather than automocked,
+ * because an automock still type-checks the real file.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+/*
+ * Same story as PasswordHash: a pre-existing local-only TS diagnostic in a
+ * module the service graph drags in. Nothing here verifies a code.
+ */
+jest.mock("../../../Server/Utils/VerificationCode", () => {
+  return {
+    __esModule: true,
+    default: {
+      generate: jest.fn(),
+      hashCode: jest.fn(),
+      isHashEqual: jest.fn(),
+      generateUnusableHash: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendJsonObjectResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendErrorResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+  };
+});
+
+/*
+ * Signed with the server's own secret in production; here it only has to be
+ * deterministic and countable, so the expiry gating can be asserted on whether
+ * it was called at all.
+ */
+jest.mock("../../../Server/Utils/JsonWebToken", () => {
+  return {
+    __esModule: true,
+    default: {
+      signJsonPayload: jest.fn().mockReturnValue("signed.jwt.token"),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/EnterpriseLicenseService");
+jest.mock("../../../Server/Services/EnterpriseLicenseInstanceService");
+
+const REPORT_ROUTE: string = "/enterprise-license/report-user-count";
+const VALIDATE_ROUTE: string = "/enterprise-license/validate";
+
+const LICENSE_ID: ObjectID = ObjectID.generate();
+const LICENSE_KEY: string = "acme-license-key";
+
+// A hash the sanitizer accepts: 64 hex characters.
+type HashFunction = (seed: string) => string;
+
+const hashOf: HashFunction = (seed: string): string => {
+  return seed
+    .repeat(64)
+    .replace(/[^a-f0-9]/g, "a")
+    .substring(0, 64);
+};
+
+/*
+ * Overrides are loosely typed on purpose: several tests need to express
+ * "this column is not set", which exactOptionalPropertyTypes forbids on
+ * Partial<EnterpriseLicense>.
+ */
+type MakeLicenseFunction = (
+  overrides?: Record<string, unknown>,
+) => EnterpriseLicense;
+
+const makeLicense: MakeLicenseFunction = (
+  overrides?: Record<string, unknown>,
+): EnterpriseLicense => {
+  return {
+    id: LICENSE_ID,
+    companyName: "Acme Inc",
+    licenseKey: LICENSE_KEY,
+    expiresAt: OneUptimeDate.addRemoveDays(OneUptimeDate.getCurrentDate(), 90),
+    userLimit: 150,
+    currentUserCount: 42,
+    userCountUpdatedAt: OneUptimeDate.getCurrentDate(),
+    isEvaluationLicense: false,
+    ...overrides,
+  } as unknown as EnterpriseLicense;
+};
+
+type MakeInstanceFunction = (
+  overrides?: Record<string, unknown>,
+) => EnterpriseLicenseInstance;
+
+const makeInstance: MakeInstanceFunction = (
+  overrides?: Record<string, unknown>,
+): EnterpriseLicenseInstance => {
+  return {
+    id: ObjectID.generate(),
+    instanceId: "instance-1",
+    host: "oneuptime.acme.internal",
+    userCount: 2,
+    userEmailHashes: [hashOf("1"), hashOf("2")],
+    lastReportedAt: OneUptimeDate.getCurrentDate(),
+    oneuptimeVersion: "12.0.19",
+    ...overrides,
+  } as unknown as EnterpriseLicenseInstance;
+};
+
+type GetResponseBodyFunction = () => JSONObject;
+
+/*
+ * The third argument of the single sendJsonObjectResponse call: the literal
+ * body that goes on the wire.
+ */
+const getResponseBody: GetResponseBodyFunction = (): JSONObject => {
+  const calls: Array<Array<unknown>> = (
+    Response.sendJsonObjectResponse as unknown as jest.Mock
+  ).mock.calls as Array<Array<unknown>>;
+
+  expect(calls).toHaveLength(1);
+
+  return calls[0]![2] as JSONObject;
+};
+
+describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () => {
+  let mockRequest: OneUptimeRequest;
+  let mockResponse: OneUptimeResponse;
+  let nextFunction: NextFunction;
+
+  type CallRouteFunction = (route?: string) => Promise<void>;
+
+  const callRoute: CallRouteFunction = async (
+    route: string = REPORT_ROUTE,
+  ): Promise<void> => {
+    await mockRouter
+      .match("post", route)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    new EnterpriseLicenseAPI();
+
+    EnterpriseLicenseService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(makeLicense());
+    EnterpriseLicenseService.updateOneById = jest
+      .fn()
+      .mockResolvedValue(undefined);
+
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([]);
+    EnterpriseLicenseInstanceService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(null);
+    EnterpriseLicenseInstanceService.updateOneById = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    EnterpriseLicenseInstanceService.create = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    EnterpriseLicenseInstanceService.countBy = jest
+      .fn()
+      .mockResolvedValue(new PositiveNumber(0));
+
+    mockRequest = {
+      body: {
+        licenseKey: LICENSE_KEY,
+        userCount: 2,
+        instanceId: "instance-1",
+        host: "oneuptime.acme.internal",
+        version: "12.0.19",
+        userEmailHashes: [hashOf("1"), hashOf("2")],
+        masterAdminEmails: ["admin@acme.com"],
+      },
+    } as unknown as OneUptimeRequest;
+
+    mockResponse = {
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as OneUptimeResponse;
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("the license terms it reports back", () => {
+    it("returns the seat limit, which is the field the installation was missing", async () => {
+      await callRoute();
+
+      expect(getResponseBody()["userLimit"]).toBe(150);
+    });
+
+    it("returns null for a license with no seat limit, so the limit can be cleared", async () => {
+      EnterpriseLicenseService.findOneBy = jest
+        .fn()
+        .mockResolvedValue(makeLicense({ userLimit: undefined }));
+
+      await callRoute();
+
+      expect(getResponseBody()).toHaveProperty("userLimit", null);
+    });
+
+    it("returns the company name and the expiry, so a renewal reaches the installation", async () => {
+      const expiresAt: Date = new Date("2027-01-01T00:00:00.000Z");
+
+      EnterpriseLicenseService.findOneBy = jest
+        .fn()
+        .mockResolvedValue(makeLicense({ expiresAt: expiresAt }));
+
+      await callRoute();
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["companyName"]).toBe("Acme Inc");
+      expect(body["expiresAt"]).toBe("2027-01-01T00:00:00.000Z");
+    });
+
+    it("selects the term columns it reports - a trimmed select is how this broke", async () => {
+      await callRoute();
+
+      expect(EnterpriseLicenseService.findOneBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { licenseKey: LICENSE_KEY },
+          select: expect.objectContaining({
+            companyName: true,
+            expiresAt: true,
+            licenseKey: true,
+            userLimit: true,
+            isEvaluationLicense: true,
+          }),
+        }),
+      );
+    });
+
+    it("mirrors the evaluation flag", async () => {
+      EnterpriseLicenseService.findOneBy = jest
+        .fn()
+        .mockResolvedValue(makeLicense({ isEvaluationLicense: true }));
+
+      await callRoute();
+
+      expect(getResponseBody()["isEvaluationLicense"]).toBe(true);
+    });
+
+    it("reports the usage numbers alongside the terms", async () => {
+      await callRoute();
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["currentUserCount"]).toBe(2);
+      expect(typeof body["userCountUpdatedAt"]).toBe("string");
+    });
+  });
+
+  describe("the token", () => {
+    it("mints one for a live license", async () => {
+      await callRoute();
+
+      expect(getResponseBody()["token"]).toBe("signed.jwt.token");
+      expect(JSONWebToken.signJsonPayload).toHaveBeenCalledTimes(1);
+    });
+
+    it("signs the current terms into it, not a stale copy", async () => {
+      await callRoute();
+
+      expect(JSONWebToken.signJsonPayload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          companyName: "Acme Inc",
+          licenseKey: LICENSE_KEY,
+          userLimit: 150,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it("withholds it once the license has expired, rather than renewing it daily", async () => {
+      EnterpriseLicenseService.findOneBy = jest.fn().mockResolvedValue(
+        makeLicense({
+          expiresAt: OneUptimeDate.addRemoveDays(
+            OneUptimeDate.getCurrentDate(),
+            -1,
+          ),
+        }),
+      );
+
+      await callRoute();
+
+      expect(getResponseBody()).toHaveProperty("token", null);
+      expect(JSONWebToken.signJsonPayload).not.toHaveBeenCalled();
+    });
+
+    it("still answers an expired license in full, because it must keep reporting", async () => {
+      const expiredAt: Date = OneUptimeDate.addRemoveDays(
+        OneUptimeDate.getCurrentDate(),
+        -1,
+      );
+
+      EnterpriseLicenseService.findOneBy = jest
+        .fn()
+        .mockResolvedValue(makeLicense({ expiresAt: expiredAt }));
+
+      await callRoute();
+
+      const body: JSONObject = getResponseBody();
+
+      /*
+       * The expiry notification emails are built from what expired instances
+       * keep reporting, so this route deliberately does not reject them the
+       * way /validate does. Telling them the truth about the expiry is what
+       * makes the installation show itself as expired.
+       */
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(body["expiresAt"]).toBe(expiredAt.toISOString());
+      expect(body["userLimit"]).toBe(150);
+    });
+
+    it("withholds it for a license with no expiry set at all", async () => {
+      EnterpriseLicenseService.findOneBy = jest
+        .fn()
+        .mockResolvedValue(makeLicense({ expiresAt: undefined }));
+
+      await callRoute();
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body).toHaveProperty("token", null);
+      expect(body).toHaveProperty("expiresAt", null);
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects a missing license key", async () => {
+      mockRequest.body["licenseKey"] = undefined;
+
+      await callRoute();
+
+      expect(nextFunction).toHaveBeenCalledWith(
+        new BadDataException("License key is required"),
+      );
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["a missing count", undefined],
+      ["a negative count", -1],
+      ["a fractional count", 1.5],
+      ["a non-numeric count", "many"],
+    ])("rejects %s", async (_label: string, value: unknown) => {
+      mockRequest.body["userCount"] = value;
+
+      await callRoute();
+
+      expect(nextFunction).toHaveBeenCalledWith(
+        new BadDataException("userCount must be a non-negative integer"),
+      );
+    });
+
+    it("accepts a count of zero", async () => {
+      mockRequest.body["userCount"] = 0;
+      mockRequest.body["userEmailHashes"] = [];
+
+      await callRoute();
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(getResponseBody()["currentUserCount"]).toBe(0);
+    });
+
+    it("rejects an unknown license key", async () => {
+      EnterpriseLicenseService.findOneBy = jest.fn().mockResolvedValue(null);
+
+      await callRoute();
+
+      expect(nextFunction).toHaveBeenCalledWith(
+        new BadDataException("License key is invalid"),
+      );
+    });
+
+    it("stays unauthenticated - instances report before anyone signs in", () => {
+      expect(mockRouter.match("post", REPORT_ROUTE).middlewares).toHaveLength(
+        0,
+      );
+    });
+  });
+
+  describe("usage accounting", () => {
+    it("records this instance's usage against the license", async () => {
+      await callRoute();
+
+      expect(EnterpriseLicenseInstanceService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            instanceId: "instance-1",
+            userCount: 2,
+          }),
+        }),
+      );
+    });
+
+    it("counts a user on two instances once", async () => {
+      const shared: string = hashOf("1");
+
+      EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+        makeInstance({
+          instanceId: "instance-1",
+          userCount: 2,
+          userEmailHashes: [shared, hashOf("2")],
+        }),
+        makeInstance({
+          instanceId: "instance-2",
+          userCount: 2,
+          userEmailHashes: [shared, hashOf("3")],
+        }),
+      ]);
+
+      await callRoute();
+
+      // Union of {1,2} and {1,3} is three seats, not four.
+      expect(getResponseBody()["currentUserCount"]).toBe(3);
+    });
+
+    it("writes the deduplicated count back onto the license row", async () => {
+      EnterpriseLicenseInstanceService.findBy = jest
+        .fn()
+        .mockResolvedValue([makeInstance()]);
+
+      await callRoute();
+
+      expect(EnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: LICENSE_ID,
+          data: expect.objectContaining({ currentUserCount: 2 }),
+        }),
+      );
+    });
+
+    it("never writes the seat limit back from a report", async () => {
+      /*
+       * The limit flows one way only: oneuptime.com to the installation. A
+       * report that could raise it would make the license meaningless.
+       */
+      await callRoute();
+
+      const updateCall: JSONObject = (
+        EnterpriseLicenseService.updateOneById as unknown as jest.Mock
+      ).mock.calls[0]![0] as JSONObject;
+
+      expect(Object.keys(updateCall["data"] as JSONObject)).toEqual([
+        "currentUserCount",
+        "userCountUpdatedAt",
+      ]);
+    });
+
+    it("leaves a decommissioned instance out of the seat count but still lists it", async () => {
+      EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+        makeInstance({
+          instanceId: "live",
+          userCount: 1,
+          userEmailHashes: [hashOf("1")],
+        }),
+        makeInstance({
+          instanceId: "retired",
+          userCount: 2,
+          userEmailHashes: [hashOf("2"), hashOf("3")],
+          lastReportedAt: OneUptimeDate.addRemoveDays(
+            OneUptimeDate.getCurrentDate(),
+            -400,
+          ),
+        }),
+      ]);
+
+      await callRoute();
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["currentUserCount"]).toBe(1);
+      expect(body["instances"]).toHaveLength(2);
+    });
+
+    it("counts users an instance could not send hashes for, so a huge install is not undercounted", async () => {
+      /*
+       * Hash lists are capped, so an instance may report more users than
+       * hashes. The overflow cannot be deduplicated against anyone else and is
+       * counted as-is.
+       */
+      EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+        makeInstance({
+          instanceId: "big",
+          userCount: 10,
+          userEmailHashes: [hashOf("1"), hashOf("2")],
+        }),
+      ]);
+
+      await callRoute();
+
+      expect(getResponseBody()["currentUserCount"]).toBe(10);
+    });
+
+    it("does not let a legacy report with no instance id stomp the deduplicated count", async () => {
+      mockRequest.body["instanceId"] = undefined;
+      mockRequest.body["userCount"] = 99;
+
+      EnterpriseLicenseInstanceService.findBy = jest
+        .fn()
+        .mockResolvedValue([makeInstance()]);
+
+      await callRoute();
+
+      expect(getResponseBody()["currentUserCount"]).toBe(2);
+      expect(EnterpriseLicenseService.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
+  let mockRequest: OneUptimeRequest;
+  let mockResponse: OneUptimeResponse;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    new EnterpriseLicenseAPI();
+
+    EnterpriseLicenseService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(makeLicense());
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([]);
+    EnterpriseLicenseInstanceService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(null);
+    EnterpriseLicenseInstanceService.create = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    EnterpriseLicenseInstanceService.countBy = jest
+      .fn()
+      .mockResolvedValue(new PositiveNumber(0));
+
+    mockRequest = {
+      body: {
+        licenseKey: LICENSE_KEY,
+        instanceId: "instance-1",
+        host: "oneuptime.acme.internal",
+        version: "12.0.19",
+      },
+    } as unknown as OneUptimeRequest;
+
+    mockResponse = {
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as OneUptimeResponse;
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("still answers with the same terms after the shared refactor", async () => {
+    const expiresAt: Date = OneUptimeDate.addRemoveDays(
+      OneUptimeDate.getCurrentDate(),
+      90,
+    );
+
+    EnterpriseLicenseService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(makeLicense({ expiresAt: expiresAt }));
+
+    await mockRouter
+      .match("post", VALIDATE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+
+    const body: JSONObject = getResponseBody();
+
+    expect(body["companyName"]).toBe("Acme Inc");
+    expect(body["licenseKey"]).toBe(LICENSE_KEY);
+    expect(body["userLimit"]).toBe(150);
+    expect(body["expiresAt"]).toBe(expiresAt.toISOString());
+    expect(body["token"]).toBe("signed.jwt.token");
+  });
+
+  it("keeps rejecting an expired license, unlike the report route", async () => {
+    EnterpriseLicenseService.findOneBy = jest.fn().mockResolvedValue(
+      makeLicense({
+        expiresAt: OneUptimeDate.addRemoveDays(
+          OneUptimeDate.getCurrentDate(),
+          -1,
+        ),
+      }),
+    );
+
+    await mockRouter
+      .match("post", VALIDATE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).toHaveBeenCalledWith(
+      new BadDataException("License key has expired"),
+    );
+  });
+});
+
+describe("the contract between the two halves of the sync", () => {
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    new EnterpriseLicenseAPI();
+
+    EnterpriseLicenseService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(makeLicense());
+    EnterpriseLicenseService.updateOneById = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    EnterpriseLicenseInstanceService.findBy = jest
+      .fn()
+      .mockResolvedValue([makeInstance()]);
+    EnterpriseLicenseInstanceService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(null);
+    EnterpriseLicenseInstanceService.create = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    EnterpriseLicenseInstanceService.countBy = jest
+      .fn()
+      .mockResolvedValue(new PositiveNumber(0));
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("lands every license term when the real response body is fed to the real mapper", async () => {
+    /*
+     * The end of the bug, asserted end to end: the literal object the license
+     * server puts on the wire, through the mapper the installation runs. If
+     * either side renames a field, this fails and nothing else has to.
+     */
+    await mockRouter.match("post", REPORT_ROUTE).handlerFunction(
+      {
+        body: {
+          licenseKey: LICENSE_KEY,
+          userCount: 2,
+          instanceId: "instance-1",
+          host: "oneuptime.acme.internal",
+          version: "12.0.19",
+          userEmailHashes: [hashOf("1"), hashOf("2")],
+          masterAdminEmails: ["admin@acme.com"],
+        },
+      } as unknown as OneUptimeRequest,
+      {
+        send: jest.fn(),
+        json: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+      } as unknown as OneUptimeResponse,
+      nextFunction,
+    );
+
+    expect(nextFunction).not.toHaveBeenCalled();
+
+    const wireBody: JSONObject = getResponseBody();
+
+    const result: EnterpriseLicenseSyncResult =
+      EnterpriseLicenseSyncUtil.getGlobalConfigUpdateFromLicenseResponse({
+        payload: wireBody,
+        reportedAt: OneUptimeDate.getCurrentDate(),
+      });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.updateData.enterpriseLicenseUserLimit).toBe(150);
+    expect(result.updateData.enterpriseLicenseCurrentUserCount).toBe(2);
+    expect(result.updateData.enterpriseCompanyName).toBe("Acme Inc");
+    expect(result.updateData.enterpriseLicenseIsEvaluation).toBe(false);
+    expect(result.updateData.enterpriseLicenseToken).toBe("signed.jwt.token");
+    expect(result.updateData.enterpriseLicenseExpiresAt).toBeInstanceOf(Date);
+    expect(result.updateData.enterpriseLicenseInstances).toHaveLength(1);
+
+    // The installation never adopts a key handed to it by a response.
+    expect(Object.keys(result.updateData)).not.toContain(
+      "enterpriseLicenseKey",
+    );
+  });
+});

--- a/Common/Tests/Utils/EnterpriseLicenseSync.test.ts
+++ b/Common/Tests/Utils/EnterpriseLicenseSync.test.ts
@@ -1,0 +1,562 @@
+import EnterpriseLicenseSyncUtil, {
+  EnterpriseLicenseSyncResult,
+} from "../../Utils/EnterpriseLicense/EnterpriseLicenseSync";
+import { JSONObject } from "../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The mapper that turns a license-server response into the GlobalConfig
+ * columns a self-hosted installation mirrors.
+ *
+ * This exists because of a real, reported bug: a customer raised their seat
+ * limit on oneuptime.com, their installation called home every day as
+ * designed, and the modal kept showing the old limit forever. The daily job
+ * read four fields out of the response and silently dropped userLimit, and the
+ * only other writer of that column is a human re-typing the license key.
+ *
+ * Every field here is three-state, and keeping those states apart IS the
+ * contract:
+ *
+ *   key absent -> leave the stored column alone. This is what an oneuptime.com
+ *                 older than the installation looks like, and collapsing it to
+ *                 null would let a daily report wipe a valid license expiry
+ *                 and take the installation down.
+ *   null       -> the server means "no value"; write null.
+ *   a value    -> validate, then write.
+ *
+ * The absent case cannot be asserted with toBeUndefined(): reading a missing
+ * key and reading a key set to undefined both give undefined, and only one of
+ * them is safe to hand to updateOneById. Every "left alone" assertion below
+ * therefore goes through Object.keys / toHaveProperty.
+ */
+
+const REPORTED_AT: Date = new Date("2026-08-24T10:00:00.000Z");
+
+type SyncFunction = (payload: JSONObject) => EnterpriseLicenseSyncResult;
+
+const sync: SyncFunction = (
+  payload: JSONObject,
+): EnterpriseLicenseSyncResult => {
+  return EnterpriseLicenseSyncUtil.getGlobalConfigUpdateFromLicenseResponse({
+    payload: payload,
+    reportedAt: REPORTED_AT,
+  });
+};
+
+type KeysFunction = (payload: JSONObject) => Array<string>;
+
+const keys: KeysFunction = (payload: JSONObject): Array<string> => {
+  return Object.keys(sync(payload).updateData);
+};
+
+/*
+ * The exact body Common/Server/API/EnterpriseLicenseAPI.ts sends from
+ * /report-user-count for a healthy license. Kept in one place so the contract
+ * test at the bottom and the happy-path tests cannot drift apart.
+ */
+type ServerResponseFunction = (overrides?: JSONObject) => JSONObject;
+
+const serverResponse: ServerResponseFunction = (
+  overrides?: JSONObject,
+): JSONObject => {
+  return {
+    companyName: "Acme Inc",
+    expiresAt: "2027-01-01T00:00:00.000Z",
+    licenseKey: "the-key-the-server-knows",
+    userLimit: 150,
+    currentUserCount: 42,
+    userCountUpdatedAt: "2026-08-24T09:59:00.000Z",
+    isEvaluationLicense: false,
+    instances: [
+      {
+        instanceId: "instance-1",
+        host: "oneuptime.acme.internal",
+        userCount: 42,
+        lastReportedAt: "2026-08-24T09:59:00.000Z",
+        version: "12.0.19",
+      },
+    ],
+    token: "signed.jwt.token",
+    ...overrides,
+  };
+};
+
+describe("EnterpriseLicenseSyncUtil - the reported bug: the seat limit", () => {
+  it("writes a raised seat limit, which is the regression this whole file guards", () => {
+    const result: EnterpriseLicenseSyncResult = sync({ userLimit: 150 });
+
+    expect(result.updateData.enterpriseLicenseUserLimit).toBe(150);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("writes a lowered seat limit too - the sync is not one-directional", () => {
+    expect(sync({ userLimit: 5 }).updateData.enterpriseLicenseUserLimit).toBe(
+      5,
+    );
+  });
+
+  it("writes an explicit null, so clearing the limit on oneuptime.com clears it here", () => {
+    const result: EnterpriseLicenseSyncResult = sync({ userLimit: null });
+
+    expect(Object.keys(result.updateData)).toContain(
+      "enterpriseLicenseUserLimit",
+    );
+    expect(result.updateData.enterpriseLicenseUserLimit).toBeNull();
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("leaves the stored limit alone when the server never mentions it", () => {
+    // An oneuptime.com older than this build. Must be a no-op, not a clear.
+    expect(keys({ currentUserCount: 3 })).not.toContain(
+      "enterpriseLicenseUserLimit",
+    );
+  });
+
+  it("treats an explicit undefined as silence, not as a clear", () => {
+    expect(keys({ userLimit: undefined })).not.toContain(
+      "enterpriseLicenseUserLimit",
+    );
+  });
+
+  it("writes zero rather than skipping it on a truthiness check", () => {
+    const result: EnterpriseLicenseSyncResult = sync({ userLimit: 0 });
+
+    expect(Object.keys(result.updateData)).toContain(
+      "enterpriseLicenseUserLimit",
+    );
+    expect(result.updateData.enterpriseLicenseUserLimit).toBe(0);
+  });
+
+  it.each([
+    ["a numeric string", "150"],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["a fraction", 12.5],
+    ["a negative number", -1],
+    ["a boolean", true],
+    ["an object", {}],
+    ["an array", [150]],
+  ])(
+    "refuses to store %s as the seat limit, and says so",
+    (_label: string, value: unknown) => {
+      const result: EnterpriseLicenseSyncResult = sync({
+        userLimit: value,
+      } as JSONObject);
+
+      expect(Object.keys(result.updateData)).not.toContain(
+        "enterpriseLicenseUserLimit",
+      );
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("userLimit");
+    },
+  );
+});
+
+describe("EnterpriseLicenseSyncUtil - user count and its timestamp", () => {
+  it("stores the deduplicated count the server computed across every instance", () => {
+    const result: EnterpriseLicenseSyncResult = sync({
+      currentUserCount: 42,
+      userCountUpdatedAt: "2026-08-24T09:59:00.000Z",
+    });
+
+    expect(result.updateData.enterpriseLicenseCurrentUserCount).toBe(42);
+    expect(result.updateData.enterpriseLicenseUserCountUpdatedAt).toEqual(
+      new Date("2026-08-24T09:59:00.000Z"),
+    );
+  });
+
+  it("falls back to the caller's clock when the server sends a count but no stamp", () => {
+    const result: EnterpriseLicenseSyncResult = sync({ currentUserCount: 7 });
+
+    expect(result.updateData.enterpriseLicenseUserCountUpdatedAt).toEqual(
+      REPORTED_AT,
+    );
+  });
+
+  it("falls back to the caller's clock when the stamp is unparseable", () => {
+    const result: EnterpriseLicenseSyncResult = sync({
+      currentUserCount: 7,
+      userCountUpdatedAt: "last tuesday",
+    });
+
+    expect(result.updateData.enterpriseLicenseUserCountUpdatedAt).toEqual(
+      REPORTED_AT,
+    );
+  });
+
+  it("stores a count of zero", () => {
+    const result: EnterpriseLicenseSyncResult = sync({ currentUserCount: 0 });
+
+    expect(result.updateData.enterpriseLicenseCurrentUserCount).toBe(0);
+  });
+
+  it("never stamps a timestamp onto a count it did not store", () => {
+    /*
+     * A fresh stamp on a stale count is the specific lie that made this bug
+     * hard to see: the modal reads "last reported today" underneath a number
+     * from weeks ago.
+     */
+    const result: EnterpriseLicenseSyncResult = sync({
+      currentUserCount: "many",
+      userCountUpdatedAt: "2026-08-24T09:59:00.000Z",
+    } as JSONObject);
+
+    expect(Object.keys(result.updateData)).not.toContain(
+      "enterpriseLicenseCurrentUserCount",
+    );
+    expect(Object.keys(result.updateData)).not.toContain(
+      "enterpriseLicenseUserCountUpdatedAt",
+    );
+  });
+
+  it.each([
+    ["a string", "42"],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["a fraction", 4.5],
+    ["a negative number", -3],
+  ])(
+    "keeps the previously stored usage when the count arrives as %s",
+    (_label: string, value: unknown) => {
+      const result: EnterpriseLicenseSyncResult = sync({
+        currentUserCount: value,
+      } as JSONObject);
+
+      expect(Object.keys(result.updateData)).not.toContain(
+        "enterpriseLicenseCurrentUserCount",
+      );
+      expect(result.warnings).toHaveLength(1);
+    },
+  );
+
+  it("keeps the previously stored usage when the server reports null", () => {
+    const result: EnterpriseLicenseSyncResult = sync({
+      currentUserCount: null,
+    });
+
+    expect(Object.keys(result.updateData)).not.toContain(
+      "enterpriseLicenseCurrentUserCount",
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it("leaves both usage columns alone when the server never mentions the count", () => {
+    expect(keys({ userLimit: 10 })).toEqual(["enterpriseLicenseUserLimit"]);
+  });
+
+  it("still syncs everything else when only the count is unusable", () => {
+    /*
+     * The job used to bail out entirely here, so one malformed count also cost
+     * the customer that day's seat limit, expiry and evaluation flag.
+     */
+    const result: EnterpriseLicenseSyncResult = sync(
+      serverResponse({ currentUserCount: "nope" }),
+    );
+
+    expect(result.updateData.enterpriseLicenseUserLimit).toBe(150);
+    expect(result.updateData.enterpriseLicenseExpiresAt).toEqual(
+      new Date("2027-01-01T00:00:00.000Z"),
+    );
+    expect(result.updateData.enterpriseLicenseIsEvaluation).toBe(false);
+    expect(result.updateData.enterpriseCompanyName).toBe("Acme Inc");
+    expect(result.updateData.enterpriseLicenseToken).toBe("signed.jwt.token");
+  });
+});
+
+describe("EnterpriseLicenseSyncUtil - expiry", () => {
+  it("stores a renewal, so extending a license on oneuptime.com reaches the installation", () => {
+    const result: EnterpriseLicenseSyncResult = sync({
+      expiresAt: "2027-01-01T00:00:00.000Z",
+    });
+
+    expect(result.updateData.enterpriseLicenseExpiresAt).toEqual(
+      new Date("2027-01-01T00:00:00.000Z"),
+    );
+  });
+
+  it("stores an expiry in the past, because an instance must be able to learn it expired", () => {
+    const result: EnterpriseLicenseSyncResult = sync({
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    expect(result.updateData.enterpriseLicenseExpiresAt).toEqual(
+      new Date("2020-01-01T00:00:00.000Z"),
+    );
+  });
+
+  it("leaves the stored expiry alone when the server never mentions it", () => {
+    /*
+     * The compatibility case that matters most: an installation upgraded ahead
+     * of oneuptime.com must not have its expiry blanked and go dark.
+     */
+    expect(keys({ currentUserCount: 1 })).not.toContain(
+      "enterpriseLicenseExpiresAt",
+    );
+  });
+
+  it("treats an explicit null as silence - a report never strips an expiry", () => {
+    expect(keys({ expiresAt: null })).not.toContain(
+      "enterpriseLicenseExpiresAt",
+    );
+    expect(sync({ expiresAt: null }).warnings).toEqual([]);
+  });
+
+  it.each([
+    ["an unparseable string", "not a date"],
+    ["an empty string", ""],
+    ["a number", 1767225600000],
+    ["a boolean", true],
+  ])(
+    "keeps the stored expiry when the server sends %s, and says so",
+    (_label: string, value: unknown) => {
+      const result: EnterpriseLicenseSyncResult = sync({
+        expiresAt: value,
+      } as JSONObject);
+
+      expect(Object.keys(result.updateData)).not.toContain(
+        "enterpriseLicenseExpiresAt",
+      );
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("expiresAt");
+    },
+  );
+
+  it("accepts a Date instance, in case the transport ever deserializes one", () => {
+    const expiry: Date = new Date("2027-06-01T00:00:00.000Z");
+
+    expect(
+      sync({ expiresAt: expiry }).updateData.enterpriseLicenseExpiresAt,
+    ).toEqual(expiry);
+  });
+});
+
+describe("EnterpriseLicenseSyncUtil - evaluation flag", () => {
+  it.each([
+    [true, true],
+    [false, false],
+  ])(
+    "mirrors the boolean the server sent (%s)",
+    (value: boolean, expected: boolean) => {
+      expect(
+        sync({ isEvaluationLicense: value }).updateData
+          .enterpriseLicenseIsEvaluation,
+      ).toBe(expected);
+    },
+  );
+
+  it("leaves the stored flag alone when the server never mentions it", () => {
+    expect(keys({ userLimit: 1 })).not.toContain(
+      "enterpriseLicenseIsEvaluation",
+    );
+  });
+
+  it.each([
+    ['the string "true"', "true"],
+    ["a number", 1],
+    ["null", null],
+  ])(
+    "refuses to guess at %s and keeps the stored flag",
+    (_label: string, value: unknown) => {
+      const result: EnterpriseLicenseSyncResult = sync({
+        isEvaluationLicense: value,
+      } as JSONObject);
+
+      expect(Object.keys(result.updateData)).not.toContain(
+        "enterpriseLicenseIsEvaluation",
+      );
+      expect(result.warnings).toHaveLength(1);
+    },
+  );
+});
+
+describe("EnterpriseLicenseSyncUtil - company name", () => {
+  it("stores a rename", () => {
+    expect(
+      sync({ companyName: "Acme Inc" }).updateData.enterpriseCompanyName,
+    ).toBe("Acme Inc");
+  });
+
+  it("trims what it stores", () => {
+    expect(
+      sync({ companyName: "  Acme Inc  " }).updateData.enterpriseCompanyName,
+    ).toBe("Acme Inc");
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["whitespace", "   "],
+    ["null", null],
+    ["a number", 42],
+  ])(
+    "keeps the stored name rather than blanking the modal for %s",
+    (_label: string, value: unknown) => {
+      expect(
+        Object.keys(sync({ companyName: value } as JSONObject).updateData),
+      ).not.toContain("enterpriseCompanyName");
+    },
+  );
+
+  it("leaves the stored name alone when the server never mentions it", () => {
+    expect(keys({ userLimit: 1 })).not.toContain("enterpriseCompanyName");
+  });
+});
+
+describe("EnterpriseLicenseSyncUtil - token", () => {
+  it("stores a freshly signed token", () => {
+    expect(sync({ token: "a.b.c" }).updateData.enterpriseLicenseToken).toBe(
+      "a.b.c",
+    );
+  });
+
+  it.each([
+    ["null, as an expired license gets", null],
+    ["an empty string", ""],
+    ["a non-string", 7],
+  ])(
+    "never clears the stored token for %s",
+    (_label: string, value: unknown) => {
+      /*
+       * An expired license is legitimately issued no token. Clearing the stored
+       * one would compound an expiry the customer may be in the middle of
+       * renewing, and the refreshed expiresAt already tells the truth.
+       */
+      expect(
+        Object.keys(sync({ token: value } as JSONObject).updateData),
+      ).not.toContain("enterpriseLicenseToken");
+    },
+  );
+
+  it("leaves the stored token alone when the server never mentions it", () => {
+    expect(keys({ userLimit: 1 })).not.toContain("enterpriseLicenseToken");
+  });
+});
+
+describe("EnterpriseLicenseSyncUtil - instances", () => {
+  it("stores the instance list", () => {
+    const instances: Array<JSONObject> = [
+      { instanceId: "a", host: "a.example.com" },
+    ];
+
+    expect(
+      sync({ instances: instances } as JSONObject).updateData
+        .enterpriseLicenseInstances,
+    ).toEqual(instances);
+  });
+
+  it("stores an empty list, so a license that lost its instances shows none", () => {
+    const result: EnterpriseLicenseSyncResult = sync({ instances: [] });
+
+    expect(Object.keys(result.updateData)).toContain(
+      "enterpriseLicenseInstances",
+    );
+    expect(result.updateData.enterpriseLicenseInstances).toEqual([]);
+  });
+
+  it.each([
+    ["null", null],
+    ["an object", {}],
+    ["a string", "instance"],
+  ])(
+    "keeps the stored list when the server sends %s",
+    (_label: string, value: unknown) => {
+      const result: EnterpriseLicenseSyncResult = sync({
+        instances: value,
+      } as JSONObject);
+
+      expect(Object.keys(result.updateData)).not.toContain(
+        "enterpriseLicenseInstances",
+      );
+      expect(result.warnings).toHaveLength(1);
+    },
+  );
+
+  it("leaves the stored list alone when the server never mentions it", () => {
+    expect(keys({ userLimit: 1 })).not.toContain("enterpriseLicenseInstances");
+  });
+});
+
+describe("EnterpriseLicenseSyncUtil - what it must never write", () => {
+  it("never syncs the license key back onto the installation", () => {
+    /*
+     * The installation authenticates with the key it already holds. A response
+     * must not be able to swap it for a different one.
+     */
+    expect(keys(serverResponse())).not.toContain("enterpriseLicenseKey");
+  });
+
+  it("never invents columns from unknown fields", () => {
+    expect(
+      keys({ somethingNew: "from a future oneuptime.com" } as JSONObject),
+    ).toEqual([]);
+  });
+
+  it("returns an empty update for an empty response rather than a pile of nulls", () => {
+    const result: EnterpriseLicenseSyncResult = sync({});
+
+    expect(result.updateData).toEqual({});
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("survives a null payload", () => {
+    const result: EnterpriseLicenseSyncResult =
+      EnterpriseLicenseSyncUtil.getGlobalConfigUpdateFromLicenseResponse({
+        payload: null as unknown as JSONObject,
+        reportedAt: REPORTED_AT,
+      });
+
+    expect(result.updateData).toEqual({});
+  });
+});
+
+describe("EnterpriseLicenseSyncUtil - the whole response at once", () => {
+  it("mirrors every field of a healthy report", () => {
+    const result: EnterpriseLicenseSyncResult = sync(serverResponse());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.updateData).toEqual({
+      enterpriseCompanyName: "Acme Inc",
+      enterpriseLicenseExpiresAt: new Date("2027-01-01T00:00:00.000Z"),
+      enterpriseLicenseUserLimit: 150,
+      enterpriseLicenseCurrentUserCount: 42,
+      enterpriseLicenseUserCountUpdatedAt: new Date("2026-08-24T09:59:00.000Z"),
+      enterpriseLicenseIsEvaluation: false,
+      enterpriseLicenseToken: "signed.jwt.token",
+      enterpriseLicenseInstances: [
+        {
+          instanceId: "instance-1",
+          host: "oneuptime.acme.internal",
+          userCount: 42,
+          lastReportedAt: "2026-08-24T09:59:00.000Z",
+          version: "12.0.19",
+        },
+      ],
+    });
+  });
+
+  it("is a no-op against the response an oneuptime.com from before this change would send", () => {
+    /*
+     * The old /report-user-count body, verbatim. userLimit already shipped in
+     * it, so the fix works against every deployed license server; the fields
+     * added alongside it must simply be left alone.
+     */
+    const legacyBody: JSONObject = {
+      currentUserCount: 42,
+      userCountUpdatedAt: "2026-08-24T09:59:00.000Z",
+      userLimit: 150,
+      isEvaluationLicense: false,
+      instances: [],
+    };
+
+    const result: EnterpriseLicenseSyncResult = sync(legacyBody);
+
+    expect(result.warnings).toEqual([]);
+    expect(Object.keys(result.updateData).sort()).toEqual([
+      "enterpriseLicenseCurrentUserCount",
+      "enterpriseLicenseInstances",
+      "enterpriseLicenseIsEvaluation",
+      "enterpriseLicenseUserCountUpdatedAt",
+      "enterpriseLicenseUserLimit",
+    ]);
+    expect(result.updateData.enterpriseLicenseUserLimit).toBe(150);
+  });
+});

--- a/Common/Utils/EnterpriseLicense/EnterpriseLicenseSync.ts
+++ b/Common/Utils/EnterpriseLicense/EnterpriseLicenseSync.ts
@@ -1,0 +1,244 @@
+import GlobalConfig from "../../Models/DatabaseModels/GlobalConfig";
+import PartialEntity from "../../Types/Database/PartialEntity";
+import EnterpriseLicenseInstanceSummary from "../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+import { JSONObject } from "../../Types/JSON";
+
+export interface EnterpriseLicenseSyncResult {
+  /*
+   * Only the columns the license server actually spoke about. A column the
+   * response did not mention is absent from this object, so updateOneById
+   * leaves whatever is stored alone.
+   */
+  updateData: PartialEntity<GlobalConfig>;
+
+  /*
+   * Fields the server sent in a shape this build cannot use. Returned rather
+   * than logged so this stays a pure function the tests can drive directly;
+   * the caller decides how loud to be about them.
+   */
+  warnings: Array<string>;
+}
+
+/*
+ * Maps a license-server response (from /enterprise-license/validate or
+ * /enterprise-license/report-user-count) onto the GlobalConfig columns a
+ * self-hosted installation mirrors locally.
+ *
+ * Every field is three-state, and the distinction is the whole contract:
+ *
+ *   key absent  - the license server did not speak about this field. That is
+ *                 what an oneuptime.com older than this build looks like, so
+ *                 the stored value is left exactly as it is. Collapsing this
+ *                 to null is how a daily report would wipe a perfectly good
+ *                 license expiry and take the installation down.
+ *   null        - the server explicitly says "there is no value". Written as
+ *                 null, so clearing a seat limit on oneuptime.com actually
+ *                 clears it on the customer's installation.
+ *   a value     - validated, then written.
+ *
+ * Anything that is neither absent, null, nor a usable value is treated as
+ * absent and reported as a warning: a malformed response must never be able
+ * to corrupt license state that was correct a moment ago.
+ */
+export default class EnterpriseLicenseSyncUtil {
+  /*
+   * The license key is deliberately NOT synced. The installation authenticates
+   * with the key it already holds, and a response must never be able to swap
+   * it for another one.
+   */
+  public static getGlobalConfigUpdateFromLicenseResponse(data: {
+    payload: JSONObject;
+    /*
+     * Used as the "user count as of" stamp when the server reports a count but
+     * no timestamp for it. Passed in rather than read from the clock so the
+     * function stays pure.
+     */
+    reportedAt: Date;
+  }): EnterpriseLicenseSyncResult {
+    const payload: JSONObject = data.payload || {};
+    const updateData: PartialEntity<GlobalConfig> = {};
+    const warnings: Array<string> = [];
+
+    /*
+     * The seat limit. This is the field customers change on oneuptime.com and
+     * then wait for: without it here, buying seats never reaches the
+     * installation that is enforcing the old number.
+     */
+    if (this.isPresent(payload, "userLimit")) {
+      const rawUserLimit: unknown = payload["userLimit"];
+
+      if (rawUserLimit === null) {
+        updateData.enterpriseLicenseUserLimit = null;
+      } else if (this.isNonNegativeInteger(rawUserLimit)) {
+        updateData.enterpriseLicenseUserLimit = rawUserLimit as number;
+      } else {
+        warnings.push(
+          `Ignored userLimit "${String(
+            rawUserLimit,
+          )}" from the license server: it is not a non-negative whole number.`,
+        );
+      }
+    }
+
+    /*
+     * The count and its timestamp move together: a count with a stamp from a
+     * previous report would read as "confirmed today", which is the exact
+     * lie this whole sync exists to stop telling.
+     */
+    if (this.isPresent(payload, "currentUserCount")) {
+      const rawUserCount: unknown = payload["currentUserCount"];
+
+      if (this.isNonNegativeInteger(rawUserCount)) {
+        updateData.enterpriseLicenseCurrentUserCount = rawUserCount as number;
+        updateData.enterpriseLicenseUserCountUpdatedAt =
+          this.parseDate(payload["userCountUpdatedAt"]) || data.reportedAt;
+      } else if (rawUserCount === null) {
+        /*
+         * The server has never had a count for this license. Nothing useful to
+         * store, and blanking the last known count would be worse than keeping
+         * it, so leave both columns alone.
+         */
+        warnings.push(
+          "The license server reported no user count for this license. Keeping the previously stored usage.",
+        );
+      } else {
+        warnings.push(
+          `Ignored currentUserCount "${String(
+            rawUserCount,
+          )}" from the license server: it is not a non-negative whole number. Keeping the previously stored usage.`,
+        );
+      }
+    }
+
+    /*
+     * Expiry drives licenseValid on the installation, so a renewal that never
+     * arrives here shows up as a license that expires on its original date
+     * however much the customer paid. Null is treated as absent on purpose: a
+     * report is not the place to strip an installation of its expiry.
+     */
+    if (this.isPresent(payload, "expiresAt") && payload["expiresAt"] !== null) {
+      const expiresAt: Date | null = this.parseDate(payload["expiresAt"]);
+
+      if (expiresAt) {
+        updateData.enterpriseLicenseExpiresAt = expiresAt;
+      } else {
+        warnings.push(
+          `Ignored expiresAt "${String(
+            payload["expiresAt"],
+          )}" from the license server: it is not a date.`,
+        );
+      }
+    }
+
+    if (this.isPresent(payload, "isEvaluationLicense")) {
+      const rawIsEvaluation: unknown = payload["isEvaluationLicense"];
+
+      if (typeof rawIsEvaluation === "boolean") {
+        updateData.enterpriseLicenseIsEvaluation = rawIsEvaluation;
+      } else {
+        warnings.push(
+          `Ignored isEvaluationLicense "${String(
+            rawIsEvaluation,
+          )}" from the license server: it is not a boolean.`,
+        );
+      }
+    }
+
+    if (this.isPresent(payload, "companyName")) {
+      const companyName: string = this.parseNonEmptyString(
+        payload["companyName"],
+      );
+
+      /*
+       * An empty company name is what the server sends for a license with none
+       * set, and overwriting a good name with "" would be a visible regression
+       * in the modal. Only a real name is worth writing.
+       */
+      if (companyName) {
+        updateData.enterpriseCompanyName = companyName;
+      }
+    }
+
+    /*
+     * The token is opaque here - it is signed with the license server's secret
+     * and this side only checks that it exists. It is never cleared: a license
+     * that has expired is legitimately issued no token, and clearing it on the
+     * way past would compound an expiry the customer may be about to renew.
+     */
+    if (this.isPresent(payload, "token")) {
+      const token: string = this.parseNonEmptyString(payload["token"]);
+
+      if (token) {
+        updateData.enterpriseLicenseToken = token;
+      }
+    }
+
+    if (this.isPresent(payload, "instances")) {
+      const rawInstances: unknown = payload["instances"];
+
+      if (Array.isArray(rawInstances)) {
+        updateData.enterpriseLicenseInstances =
+          rawInstances as Array<EnterpriseLicenseInstanceSummary>;
+      } else {
+        warnings.push(
+          "Ignored the instance list from the license server: it is not an array.",
+        );
+      }
+    }
+
+    return {
+      updateData: updateData,
+      warnings: warnings,
+    };
+  }
+
+  /*
+   * Present means the key is on the object, even when it carries null or
+   * undefined. `"x" in payload` rather than a truthiness or undefined check,
+   * because "the server said null" and "the server said nothing" have to stay
+   * distinguishable all the way down.
+   */
+  private static isPresent(payload: JSONObject, key: string): boolean {
+    if (!Object.prototype.hasOwnProperty.call(payload, key)) {
+      return false;
+    }
+
+    // An explicit undefined is indistinguishable from silence. Treat it as one.
+    return payload[key] !== undefined;
+  }
+
+  private static isNonNegativeInteger(value: unknown): boolean {
+    return (
+      typeof value === "number" &&
+      Number.isFinite(value) &&
+      Number.isInteger(value) &&
+      value >= 0
+    );
+  }
+
+  private static parseNonEmptyString(value: unknown): string {
+    if (typeof value !== "string") {
+      return "";
+    }
+
+    return value.trim();
+  }
+
+  private static parseDate(value: unknown): Date | null {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    if (typeof value !== "string" || !value.trim()) {
+      return null;
+    }
+
+    const parsed: Date = new Date(value.trim());
+
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+
+    return parsed;
+  }
+}


### PR DESCRIPTION
## The bug

Raising a customer's seat limit on oneuptime.com never reached their self-hosted installation. The installation showed the old number — not for a day, **forever**.

The daily call home ran exactly as designed. The license server had been sending `userLimit` in its `/report-user-count` response all along. The job on the other end read four fields out of that response and dropped it:

```ts
// App/FeatureSet/Workers/Jobs/EnterpriseLicense/ReportUserCount.ts (before)
const updateData: PartialEntity<GlobalConfig> = {
  enterpriseLicenseCurrentUserCount: aggregatedUserCount,
  enterpriseLicenseUserCountUpdatedAt: reportedAt,
  enterpriseLicenseIsEvaluation: payload["isEvaluationLicense"] === true,
};
// payload["userLimit"] is never read.
```

The only other writer of `GlobalConfig.enterpriseLicenseUserLimit` is `POST /global-config/license`, driven by a human typing the key into a box the modal hides while the license is valid (`EditionLabel.tsx` — `showLicenseKeyInput = IS_ENTERPRISE_EDITION && (!licenseValid || isChangingLicense)`). So there was no self-serve way to refresh it and no reason to suspect one was needed.

It was actively disguised, too: the job kept refreshing `enterpriseLicenseUserCountUpdatedAt` on every run, so the modal read "last reported today" directly underneath a limit from months ago.

### The seat limit was not alone

`/report-user-count` returned no `expiresAt`, no `companyName` and no `token`, so those were frozen by the same mechanism. A renewal on oneuptime.com could not reach an installation at all: it would flip to "License Required" on its original expiry date however much the customer had paid, while the license server went on happily accepting its reports.

## The fix

**`Common/Server/API/EnterpriseLicenseAPI.ts`** — `/report-user-count` now selects and returns the full license terms (`companyName`, `expiresAt`, `licenseKey`, `userLimit`) plus a token, and shares `getLicenseTerms()` / `signLicenseToken()` with `/validate` so the two responses cannot drift apart again — writing them out separately by hand is how this happened. The widened `select` is the same indexed lookup.

The route still answers an expired license **in full** rather than rejecting it the way `/validate` does: it has to keep reporting, because `SendLicenseNotificationEmails` builds the expiry emails from those reports. It just stops handing it a fresh token every day — `signLicenseToken` returns `null` past expiry, and the refreshed `expiresAt` is what tells the installation the truth.

**`Common/Utils/EnterpriseLicense/EnterpriseLicenseSync.ts` (new)** — a pure mapper from that response to a `PartialEntity<GlobalConfig>`, under a strict three-state contract:

| server sends | mapper does |
|---|---|
| key absent | omit the column — leave what is stored alone |
| `null` | write `null` — clearing a seat limit on oneuptime.com clears it here |
| a value | validate, then write |
| anything else | treat as absent, return a warning, never write |

The absent case is not a nicety. The license-server URLs are hardcoded to production oneuptime.com with no env override, so an installation upgraded ahead of oneuptime.com is a real window — and collapsing `undefined` to `null` there would let a daily report wipe a valid `enterpriseLicenseExpiresAt` and take a working installation down.

Per-field exceptions, each commented in place: the **token** is never cleared (an expired license is legitimately issued none, and clearing it would compound an expiry the customer may be renewing); **companyName** is never blanked; an `expiresAt` of `null` is treated as silence; and the **license key is never synced back** — the installation authenticates with the key it already holds and a response must not be able to swap it.

**`App/FeatureSet/Workers/Jobs/EnterpriseLicense/ReportUserCount.ts`** — uses the mapper. One unusable field no longer costs the whole day's sync: a malformed `currentUserCount` used to `return` early, taking that day's seat limit, expiry and evaluation flag with it.

## Scope note

The reported bug is the seat limit, and the `ReportUserCount` half fixes it against **every currently deployed oneuptime.com**, since `userLimit` already shipped in that response. The expiry / company / token fields ride along because they are frozen by the same three lines and the same one-writer problem — refreshing the limit while leaving the expiry stale would be a half-fix in the same block.

Not changed, and worth a follow-up: the modal still has no explicit "refresh license" control, so a seat bump takes up to 24 hours to appear rather than being pullable on demand.

## Tests

117 new cases, all passing.

| Suite | Cases | Covers |
|---|---|---|
| `Common/Tests/Utils/EnterpriseLicenseSync.test.ts` | 66 | every field × absent / null / valid / malformed, and what must never be written |
| `Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts` | 29 | the response body, the `select`, token gating on expiry, validation, cross-instance dedup, and that `/validate` is byte-identical after the refactor |
| `App/Tests/Workers/Jobs/EnterpriseLicense/ReportUserCount.test.ts` | 22 | gating, the report body, the write-back, and an old-server response as a no-op |

Key-absence is asserted with `Object.keys` / `toHaveProperty` throughout — `toBeUndefined()` cannot tell "the server said nothing" from "the server said undefined", and that distinction is the entire compatibility contract.

The last one is a contract test that feeds the **literal object the API handler puts on the wire** through the **real mapper the installation runs**. If either side renames a field, that fails and nothing else has to.

```
Common:  110 passed  (66 new + 29 new + 15 existing EnterpriseLicenseUsage)
App:      22 passed
```

`npx tsc --noEmit` clean for both packages on the changed files; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGxNkRZmG62nV8R7pY1ebg
