### PR TITLE
feat(debuggability): change-event markers, episode telemetry, lossless pivots, dashboard chart sync (PR A / 3)

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -742,6 +742,15 @@ import LogService, {
 import SecurityEventService, {
   SecurityEventService as SecurityEventServiceType,
 } from "Common/Server/Services/SecurityEventService";
+/*
+ * Sibling-relative on purpose: the `Common` package specifier resolves
+ * through App/node_modules, which may symlink a checkout that predates
+ * this module; the relative path always resolves the sibling source this
+ * branch ships with (identical to the specifier once merged).
+ */
+import ChangeEventService, {
+  ChangeEventService as ChangeEventServiceType,
+} from "../../../Common/Server/Services/ChangeEventService";
 
 import MetricService from "Common/Server/Services/MetricService";
 import MetricAPI from "Common/Server/API/MetricAPI";
@@ -1059,6 +1068,7 @@ import Express, {
 import AuditLog from "Common/Models/AnalyticsModels/AuditLog";
 import Log from "Common/Models/AnalyticsModels/Log";
 import SecurityEvent from "Common/Models/AnalyticsModels/SecurityEvent";
+import ChangeEvent from "../../../Common/Models/AnalyticsModels/ChangeEvent";
 import Span from "Common/Models/AnalyticsModels/Span";
 import Profile from "Common/Models/AnalyticsModels/Profile";
 import ProfileSample from "Common/Models/AnalyticsModels/ProfileSample";
@@ -2911,6 +2921,14 @@ const BaseAPIFeatureSet: FeatureSet = {
       new BaseAnalyticsAPI<SecurityEvent, SecurityEventServiceType>(
         SecurityEvent,
         SecurityEventService,
+      ).getRouter(),
+    );
+
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new BaseAnalyticsAPI<ChangeEvent, ChangeEventServiceType>(
+        ChangeEvent,
+        ChangeEventService,
       ).getRouter(),
     );
 

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
@@ -42,6 +42,7 @@ export interface ComponentProps {
   };
   dashboardStartAndEndDate: RangeStartAndEndDateTime;
   refreshTick?: number | undefined;
+  chartSyncId?: string | undefined;
   variables?: Array<DashboardVariable> | undefined;
 }
 
@@ -261,6 +262,7 @@ const DashboardCanvas: FunctionComponent<ComponentProps> = (
           }}
           isSelected={isSelected}
           refreshTick={props.refreshTick}
+          chartSyncId={props.chartSyncId}
           variables={props.variables}
           onClick={() => {
             props.onComponentSelected(componentId);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
@@ -83,6 +83,11 @@ export interface DashboardBaseComponentProps {
   dashboardStartAndEndDate: RangeStartAndEndDateTime;
   metricTypes: Array<MetricType>;
   refreshTick?: number | undefined;
+  /*
+   * Dashboard-wide crosshair-sync channel for metric chart widgets (the
+   * dashboard id) — see ChartGroup.syncId.
+   */
+  chartSyncId?: string | undefined;
   variables?: Array<DashboardVariable> | undefined;
 }
 

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
@@ -149,8 +149,21 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
     useRef<MetricViewData>(metricViewData);
   metricViewDataRef.current = metricViewData;
 
+  /*
+   * Monotonic fetch sequence: zoom → reset (or rapid re-zooms) can put two
+   * aggregate calls in flight, and the SLOWER one answering last would
+   * paint the wrong window's data under the current window's axis. Each
+   * fetch takes a ticket; only the holder of the latest ticket may write
+   * results/errors back into state.
+   */
+  const fetchSequenceRef: React.MutableRefObject<number> = useRef<number>(0);
+
   const fetchAggregatedResults: () => Promise<void> = useCallback(async () => {
     const data: MetricViewData = metricViewDataRef.current;
+    const fetchSequence: number = ++fetchSequenceRef.current;
+    const isCurrentFetch: () => boolean = (): boolean => {
+      return fetchSequenceRef.current === fetchSequence;
+    };
     setIsLoading(true);
 
     if (!data.startAndEndDate?.startValue || !data.startAndEndDate?.endValue) {
@@ -190,13 +203,22 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
         topNOverrideScope,
       });
 
+      if (!isCurrentFetch()) {
+        return;
+      }
+
       setMetricResults(results);
       setError("");
     } catch (err: unknown) {
+      if (!isCurrentFetch()) {
+        return;
+      }
       setError(API.getFriendlyErrorMessage(err as Error));
     }
 
-    setIsLoading(false);
+    if (isCurrentFetch()) {
+      setIsLoading(false);
+    }
   }, [topNOverrideScope]);
 
   /*

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
@@ -28,6 +28,9 @@ import DashboardChartType from "Common/Types/Dashboard/Chart/ChartType";
 import DashboardVariableInterpolation from "Common/Utils/Dashboard/VariableInterpolation";
 import ExplorerLink from "../../Metrics/Utils/ExplorerLink";
 import { isPublicDashboard } from "../Utils/PublicDashboardContext";
+import useEventTimeReferenceLines, {
+  EventTimeReferenceLines,
+} from "../../Metrics/Utils/UseEventTimeReferenceLines";
 
 export interface ComponentProps extends DashboardBaseComponentProps {
   component: DashboardChartComponent;
@@ -329,6 +332,19 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
   const enableSeriesActions: boolean =
     !isPublicDashboard() && !props.isEditMode;
 
+  /*
+   * Incident/alert/change-event markers for this widget's window (the
+   * hook no-ops on public dashboards — no session to fetch with). Uses
+   * the EFFECTIVE window so zooming refetches markers for the zoomed
+   * range.
+   */
+  const { lines: eventReferenceLines }: EventTimeReferenceLines =
+    useEventTimeReferenceLines({
+      enabled: true,
+      window: effectiveStartAndEndDate,
+      refreshTick: props.refreshTick,
+    });
+
   if (isLoading && metricResults.length === 0) {
     // Skeleton loading for chart - only on initial load
     return (
@@ -448,6 +464,10 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
           hideCard={true}
           topNOverrideScope={topNOverrideScope}
           enableSeriesActions={enableSeriesActions}
+          chartSyncId={props.chartSyncId}
+          timeReferenceLines={
+            eventReferenceLines.length > 0 ? eventReferenceLines : undefined
+          }
           onTimeRangeSelect={
             enableChartZoom ? handleChartTimeRangeSelect : undefined
           }

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx
@@ -335,6 +335,14 @@ const DashboardDataSourceChartComponent: FunctionComponent<ComponentProps> = (
           metricViewData={chartMetricViewData}
           hideCard={true}
           topNOverrideScope={props.componentId.toString()}
+          /*
+           * These series come from an EXTERNAL data source through a
+           * synthetic query config — OneUptime's logs/traces/exceptions
+           * and the Metric Explorer know nothing about them, so the
+           * per-series investigate menu would only mislead (and it must
+           * never render on unauthenticated public dashboards).
+           */
+          enableSeriesActions={false}
         />
       </div>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx
@@ -343,6 +343,7 @@ const DashboardDataSourceChartComponent: FunctionComponent<ComponentProps> = (
            * never render on unauthenticated public dashboards).
            */
           enableSeriesActions={false}
+          chartSyncId={props.chartSyncId}
         />
       </div>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
@@ -832,6 +832,7 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
           metrics={metricsBundle}
           refreshTick={refreshTick}
           variables={dashboardVariables}
+          chartSyncId={props.dashboardId.toString()}
         />
       </div>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx
@@ -29,6 +29,21 @@ import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import Query from "Common/Types/BaseDatabase/Query";
 import ObjectID from "Common/Types/ObjectID";
 import Includes from "Common/Types/BaseDatabase/Includes";
+import AnalyticsModelAPI from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
+import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
+import {
+  EXCEPTION_ATTRIBUTE_FACET_PREFIX,
+  ExceptionAttributeSelections,
+  KNOWN_EXCEPTION_SEARCH_FIELDS,
+  NO_MATCH_FINGERPRINT,
+  MAX_SCOPED_FINGERPRINTS,
+  applyExceptionFingerprintScope,
+  buildExceptionInstanceAttributeQuery,
+  getExceptionAttributeScopeKey,
+  getExceptionAttributeSelections,
+  hasExceptionAttributeSelections,
+  isExceptionAttributeFacetKey,
+} from "../../Utils/ExceptionsAttributeScope";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import ProjectUtil from "Common/UI/Utils/Project";
 import UserUtil from "Common/UI/Utils/User";
@@ -585,6 +600,130 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
   }, []);
 
   // Build query
+  /*
+   * Attribute facet scope. TelemetryException has no attributes column —
+   * `attributes.<key>` chips (and unknown `@key:value` search tokens)
+   * resolve against the ClickHouse instance rows first, and the matching
+   * fingerprints narrow the Postgres list below (the ExceptionsTable
+   * entity-scope pattern).
+   */
+  const attributeSelections: ExceptionAttributeSelections = useMemo(() => {
+    const facetGroups: Record<string, Array<string>> = {};
+    for (const f of activeFilters) {
+      if (!facetGroups[f.facetKey]) {
+        facetGroups[f.facetKey] = [];
+      }
+      facetGroups[f.facetKey]!.push(f.value);
+    }
+    const { fieldFilters } = parseSearch(submittedSearch);
+    return getExceptionAttributeSelections({
+      facetGroups,
+      searchFieldFilters: fieldFilters,
+    });
+  }, [activeFilters, submittedSearch, parseSearch]);
+
+  const attributeScopeKey: string | null = useMemo(() => {
+    if (!hasExceptionAttributeSelections(attributeSelections)) {
+      return null;
+    }
+    const dateRange: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+    return getExceptionAttributeScopeKey({
+      selections: attributeSelections,
+      windowStartMs: dateRange.startValue.getTime(),
+      windowEndMs: dateRange.endValue.getTime(),
+    });
+  }, [attributeSelections, timeRange]);
+
+  const [attributeScope, setAttributeScope] = useState<{
+    key: string;
+    fingerprints: Array<string>;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!attributeScopeKey) {
+      setAttributeScope(null);
+      return;
+    }
+
+    let isCancelled: boolean = false;
+
+    const resolveFingerprints: () => Promise<void> =
+      async (): Promise<void> => {
+        const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+        if (!projectId) {
+          return;
+        }
+
+        const dateRange: InBetween<Date> =
+          RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+
+        try {
+          const instances: ModelListResult<ExceptionInstance> =
+            await AnalyticsModelAPI.getList<ExceptionInstance>({
+              modelType: ExceptionInstance,
+              query: buildExceptionInstanceAttributeQuery({
+                projectId,
+                window: new InBetween<Date>(
+                  dateRange.startValue,
+                  dateRange.endValue,
+                ),
+                selections: attributeSelections,
+              }),
+              groupBy: {
+                fingerprint: true,
+              },
+              select: {
+                fingerprint: true,
+              },
+              sort: {
+                fingerprint: SortOrder.Ascending,
+              },
+              limit: MAX_SCOPED_FINGERPRINTS,
+              skip: 0,
+            });
+
+          if (isCancelled) {
+            return;
+          }
+
+          const fingerprints: Array<string> = [];
+          for (const instance of instances.data || []) {
+            const fingerprint: string = instance.fingerprint?.toString() || "";
+            if (fingerprint !== "" && !fingerprints.includes(fingerprint)) {
+              fingerprints.push(fingerprint);
+            }
+          }
+
+          setAttributeScope({ key: attributeScopeKey, fingerprints });
+        } catch {
+          if (!isCancelled) {
+            /*
+             * Failed resolution keeps the sentinel-narrowed (empty) list
+             * rather than quietly showing unfiltered exceptions under an
+             * active-looking chip.
+             */
+            setAttributeScope({ key: attributeScopeKey, fingerprints: [] });
+          }
+        }
+      };
+
+    void resolveFingerprints();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [attributeScopeKey, attributeSelections, timeRange]);
+
+  /*
+   * Fingerprints to carry into the histogram/facets payloads — only once
+   * the resolution matches the CURRENT selections+window.
+   */
+  const resolvedScopeFingerprints: Array<string> | null =
+    attributeScopeKey && attributeScope?.key === attributeScopeKey
+      ? attributeScope.fingerprints
+      : null;
+
   const query: Query<TelemetryException> = useMemo(() => {
     const q: Query<TelemetryException> = {};
     const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
@@ -647,6 +786,10 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
       if (resourceFacetKeys.has(key)) {
         continue;
       }
+      // Instance-attribute chips narrow via the fingerprint scope below.
+      if (isExceptionAttributeFacetKey(key)) {
+        continue;
+      }
       const values: Array<string> = facetGroups[key]!;
       if (values.length === 1) {
         (q as Record<string, unknown>)[key] = values[0]!;
@@ -658,6 +801,14 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     // Search field filters
     const { fieldFilters, freeText } = parseSearch(submittedSearch);
     for (const key of Object.keys(fieldFilters)) {
+      /*
+       * Unknown fields (e.g. @http.method:GET) are instance attributes —
+       * previously they landed on the Postgres query as nonexistent
+       * columns; now they narrow via the fingerprint scope below.
+       */
+      if (!KNOWN_EXCEPTION_SEARCH_FIELDS.includes(key)) {
+        continue;
+      }
       const values: Array<string> = fieldFilters[key]!;
       if (values.length === 1) {
         (q as Record<string, unknown>)[key] = values[0]!;
@@ -680,6 +831,16 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
       dateRange.endValue,
     );
 
+    /*
+     * Attribute scope: resolved fingerprints narrow the list; while the
+     * resolution is still in flight the sentinel keeps the list EMPTY —
+     * a flash of unfiltered exceptions under an active chip would be a
+     * lie.
+     */
+    if (attributeScopeKey) {
+      applyExceptionFingerprintScope(q, resolvedScopeFingerprints || []);
+    }
+
     return q;
   }, [
     props.primaryEntityId,
@@ -688,6 +849,8 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     submittedSearch,
     parseSearch,
     timeRange,
+    attributeScopeKey,
+    resolvedScopeFingerprints,
   ]);
 
   // Fetch exceptions
@@ -801,6 +964,17 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     if (freeText && freeText.length > 0) {
       payload["messageSearchText"] = freeText;
     }
+    /*
+     * Attribute scope: the endpoint has no attribute dimension, but it
+     * accepts `fingerprints` — the resolved scope keeps the histogram
+     * aligned with the narrowed list.
+     */
+    if (attributeScopeKey) {
+      payload["fingerprints"] =
+        resolvedScopeFingerprints && resolvedScopeFingerprints.length > 0
+          ? resolvedScopeFingerprints
+          : [NO_MATCH_FINGERPRINT];
+    }
 
     try {
       const response: HTTPResponse<JSONObject> = await postApi(
@@ -822,6 +996,8 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     submittedSearch,
     parseSearch,
     props.primaryEntityId,
+    attributeScopeKey,
+    resolvedScopeFingerprints,
   ]);
 
   useEffect(() => {
@@ -1039,6 +1215,13 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     if (Object.keys(facetSearchTextActive).length > 0) {
       payload["facetSearchText"] = facetSearchTextActive;
     }
+    // Attribute scope narrows facet counts too (see fetchHistogram).
+    if (attributeScopeKey) {
+      payload["fingerprints"] =
+        resolvedScopeFingerprints && resolvedScopeFingerprints.length > 0
+          ? resolvedScopeFingerprints
+          : [NO_MATCH_FINGERPRINT];
+    }
 
     try {
       const response: HTTPResponse<JSONObject> = await postApi(
@@ -1061,6 +1244,8 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
     parseSearch,
     props.primaryEntityId,
     facetSearchText,
+    attributeScopeKey,
+    resolvedScopeFingerprints,
   ]);
 
   useEffect(() => {
@@ -1323,10 +1508,19 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
           handleFacetInclude(aliased, cleanValue);
           return;
         }
-        const newSearch: string = `@${fieldKey}:${value}`;
-        setSearchValue(newSearch);
-        setSubmittedSearch(newSearch);
-        setPage(1);
+        /*
+         * Unknown keys are instance attributes: chip them under the
+         * attributes. prefix so they narrow via the fingerprint scope —
+         * previously they fell back into the raw search string.
+         */
+        const cleanAttributeValue: string =
+          value.length >= 2 && value.startsWith('"') && value.endsWith('"')
+            ? value.slice(1, -1)
+            : value;
+        handleFacetInclude(
+          `${EXCEPTION_ATTRIBUTE_FACET_PREFIX}${fieldKey}`,
+          cleanAttributeValue,
+        );
       }}
       searchFieldAliasMap={FIELD_ALIAS_MAP}
       searchHelpRows={SEARCH_HELP_ROWS}

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/EmbeddedMetricCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/EmbeddedMetricCard.tsx
@@ -13,6 +13,9 @@ import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
 import MetricFormulaConfigData from "Common/Types/Metrics/MetricFormulaConfigData";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
+import useEventTimeReferenceLines, {
+  EventTimeReferenceLines,
+} from "./Utils/UseEventTimeReferenceLines";
 import OneUptimeDate from "Common/Types/Date";
 import RangeStartAndEndDateTime, {
   RangeStartAndEndDateTimeUtil,
@@ -131,6 +134,18 @@ const EmbeddedMetricCard: FunctionComponent<ComponentProps> = (
   }, [timeRangeKey]);
 
   const dateRange: InBetween<Date> = props.startAndEndDate || internalDateRange;
+
+  /*
+   * Incident/alert/change-event markers for the charted window — the
+   * card is the shared surface behind monitor metrics tabs,
+   * infrastructure resource tabs, and companion signal tabs, so one
+   * insertion covers them all.
+   */
+  const { lines: eventReferenceLines }: EventTimeReferenceLines =
+    useEventTimeReferenceLines({
+      enabled: true,
+      window: dateRange,
+    });
 
   const handleTimeRangeChange: (
     newTimeRange: RangeStartAndEndDateTime,
@@ -281,6 +296,9 @@ const EmbeddedMetricCard: FunctionComponent<ComponentProps> = (
           onChange={handleMetricViewChange}
           onTimeRangeSelect={handleChartTimeRangeSelect}
           refreshNonce={refreshNonce}
+          timeReferenceLines={
+            eventReferenceLines.length > 0 ? eventReferenceLines : undefined
+          }
         />
       ) : null}
       {props.renderExtraCharts ? props.renderExtraCharts(dateRange) : null}

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import ReactDOM from "react-dom";
 import OneUptimeDate from "Common/Types/Date";
 import XAxisType from "Common/UI/Components/Charts/Types/XAxis/XAxisType";
 import ChartGroup, {
@@ -882,8 +883,17 @@ function renderSeriesControls(input: {
    * per-series investigate menu, anchored under the button.
    */
   onInvestigateSeries?:
-    | ((seriesName: string, anchor: { x: number; y: number }) => void)
+    | ((
+        seriesName: string,
+        anchor: { x: number; y: number },
+        trigger: HTMLElement | null,
+      ) => void)
     | undefined;
+  /*
+   * The series whose investigate menu is currently open — drives
+   * aria-expanded on that chip's magnifier button.
+   */
+  investigatedSeriesName?: string | null | undefined;
 }): ReactElement {
   const {
     chartId,
@@ -905,6 +915,7 @@ function renderSeriesControls(input: {
     unitLabel,
     valueFormatter,
     onInvestigateSeries,
+    investigatedSeriesName,
   } = input;
 
   const sortBy: SeriesSortBy = controls.sortBy;
@@ -1292,6 +1303,8 @@ function renderSeriesControls(input: {
                   <button
                     type="button"
                     aria-label={`Investigate ${series.seriesName}`}
+                    aria-haspopup="menu"
+                    aria-expanded={investigatedSeriesName === series.seriesName}
                     title="Investigate this series — logs, traces, and more"
                     onClick={(
                       event: React.MouseEvent<HTMLButtonElement>,
@@ -1299,12 +1312,21 @@ function renderSeriesControls(input: {
                       event.stopPropagation();
                       const rect: DOMRect =
                         event.currentTarget.getBoundingClientRect();
-                      onInvestigateSeries(series.seriesName, {
-                        x: rect.left,
-                        y: rect.bottom + 4,
-                      });
+                      onInvestigateSeries(
+                        series.seriesName,
+                        {
+                          x: rect.left,
+                          y: rect.bottom + 4,
+                        },
+                        event.currentTarget,
+                      );
                     }}
-                    className="inline-flex items-center rounded-r-md border-l border-gray-100 px-1.5 text-gray-300 transition hover:bg-indigo-50 hover:text-indigo-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 group-hover:text-gray-400"
+                    /*
+                     * Idle gray-500, not gray-300/400: the icon-only
+                     * control needs >= 3:1 contrast on the white chip
+                     * (WCAG 1.4.11) in its resting state too.
+                     */
+                    className="inline-flex items-center rounded-r-md border-l border-gray-100 px-1.5 text-gray-500 transition hover:bg-indigo-50 hover:text-indigo-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
                   >
                     <Icon icon={IconProp.MagnifyingGlass} className="h-3 w-3" />
                   </button>
@@ -1572,21 +1594,34 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     setIsComponentVisible: setIsSeriesMenuVisible,
   } = useComponentOutsideClick(false);
 
+  /*
+   * The chip button that opened the menu, so Escape / an action click can
+   * hand focus back (menu-button keyboard pattern). Outside clicks leave
+   * focus where the user put it.
+   */
+  const seriesMenuTriggerRef: React.MutableRefObject<HTMLElement | null> =
+    useRef<HTMLElement | null>(null);
+
   const closeSeriesMenu: VoidFunction = useCallback((): void => {
     setIsSeriesMenuVisible(false);
     setSeriesMenu(null);
+    seriesMenuTriggerRef.current?.focus();
+    seriesMenuTriggerRef.current = null;
   }, [setIsSeriesMenuVisible]);
 
   const openSeriesMenu: (
     seriesName: string,
     groupByKeys: Array<string>,
     anchor: { x: number; y: number },
+    trigger?: HTMLElement | null,
   ) => void = useCallback(
     (
       seriesName: string,
       groupByKeys: Array<string>,
       anchor: { x: number; y: number },
+      trigger?: HTMLElement | null,
     ): void => {
+      seriesMenuTriggerRef.current = trigger || null;
       const maxX: number =
         window.innerWidth -
         SERIES_MENU_WIDTH_PX -
@@ -1675,13 +1710,23 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
       extraction.serviceNames,
     );
 
-    const serviceIds: Array<string> = extraction.serviceNames
+    const resolvedIds: Array<string> = extraction.serviceNames
       .map((serviceName: string): string => {
         return serviceIdsByName[serviceName] || "";
       })
       .filter((serviceId: string): boolean => {
         return serviceId !== "";
       });
+
+    /*
+     * All-or-nothing, matching the pivot ladder in
+     * buildCrossSignalScopeFromMetricViewData: filtering exceptions to
+     * only the RESOLVED subset of several service names would silently
+     * hide the unresolved services' exceptions while claiming to show
+     * "the" scoped list — better to carry nothing and report the drop.
+     */
+    const serviceIds: Array<string> =
+      resolvedIds.length === extraction.serviceNames.length ? resolvedIds : [];
 
     return { serviceIdsByName, serviceIds };
   };
@@ -1699,13 +1744,45 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     }
   };
 
-  const buildSignalTargetUrl: (pageMap: PageMap) => URL = (
+  /*
+   * SPA navigation with query params. Navigation.navigate(URL) is a full
+   * page load (window.location.href), which destroys the dropped-scope
+   * toast the instant it is shown — a Route goes through the router hook
+   * instead, so the toast survives into the target page. Values are
+   * pre-encoded because Route.addQueryParams concatenates verbatim; "~"
+   * is escaped by hand because encodeURIComponent leaves it alone and
+   * Route's character whitelist rejects it.
+   */
+  const navigateWithQueryParams: (
     pageMap: PageMap,
-  ): URL => {
-    const route: Route = RouteUtil.populateRouteParams(RouteMap[pageMap]!);
-    const currentUrl: URL = Navigation.getCurrentURL();
-    return new URL(currentUrl.protocol, currentUrl.hostname, route);
+    params: Dictionary<string>,
+  ) => void = (pageMap: PageMap, params: Dictionary<string>): void => {
+    const route: Route = new Route(
+      RouteUtil.populateRouteParams(RouteMap[pageMap]!).toString(),
+    );
+    const encodedParams: Dictionary<string> = {};
+    for (const paramName of Object.keys(params)) {
+      encodedParams[paramName] = encodeURIComponent(
+        params[paramName] as string,
+      ).replace(/~/g, "%7E");
+    }
+    if (Object.keys(encodedParams).length > 0) {
+      route.addQueryParams(encodedParams);
+    }
+    Navigation.navigate(route);
   };
+
+  const getChartWindowFallbackParams: () => Dictionary<string> =
+    (): Dictionary<string> => {
+      if (!exemplarWindow) {
+        return {};
+      }
+      return {
+        range: TimeRange.CUSTOM,
+        start: OneUptimeDate.toString(exemplarWindow.startValue),
+        end: OneUptimeDate.toString(exemplarWindow.endValue),
+      };
+    };
 
   const navigateSeriesToSignal: (
     menuState: SeriesMenuState,
@@ -1717,9 +1794,8 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     const { scopedViewData }: SeriesScopedViewData =
       getScopedViewDataForSeries(menuState);
 
-    const targetUrl: URL = buildSignalTargetUrl(
-      target === "traces" ? PageMap.TRACES : PageMap.LOGS,
-    );
+    const pageMap: PageMap =
+      target === "traces" ? PageMap.TRACES : PageMap.LOGS;
 
     try {
       const {
@@ -1733,33 +1809,12 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         serviceIdsByName,
       });
 
-      for (const paramName of Object.keys(pivot.params)) {
-        targetUrl.addQueryParam(
-          paramName,
-          pivot.params[paramName] as string,
-          true,
-        );
-      }
-
       showDroppedScopeToast(pivot.dropped);
+      navigateWithQueryParams(pageMap, pivot.params);
     } catch {
       // Degraded pivot: land on the target explorer in the chart's window.
-      if (exemplarWindow) {
-        targetUrl.addQueryParam("range", TimeRange.CUSTOM, true);
-        targetUrl.addQueryParam(
-          "start",
-          OneUptimeDate.toString(exemplarWindow.startValue),
-          true,
-        );
-        targetUrl.addQueryParam(
-          "end",
-          OneUptimeDate.toString(exemplarWindow.endValue),
-          true,
-        );
-      }
+      navigateWithQueryParams(pageMap, getChartWindowFallbackParams());
     }
-
-    Navigation.navigate(targetUrl);
   };
 
   const navigateSeriesToExceptions: (
@@ -1767,8 +1822,6 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
   ) => Promise<void> = async (menuState: SeriesMenuState): Promise<void> => {
     const { scopedViewData }: SeriesScopedViewData =
       getScopedViewDataForSeries(menuState);
-
-    const targetUrl: URL = buildSignalTargetUrl(PageMap.EXCEPTIONS_UNRESOLVED);
 
     try {
       const { serviceIds }: { serviceIds: Array<string> } =
@@ -1779,41 +1832,44 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         serviceIds,
       });
 
-      for (const paramName of Object.keys(pivot.params)) {
-        targetUrl.addQueryParam(
-          paramName,
-          pivot.params[paramName] as string,
-          true,
-        );
-      }
-
       showDroppedScopeToast(pivot.dropped);
+      navigateWithQueryParams(PageMap.EXCEPTIONS_UNRESOLVED, pivot.params);
     } catch {
       // Window-only fallback, same shape as the logs/traces catch above.
-      if (exemplarWindow) {
-        targetUrl.addQueryParam("range", TimeRange.CUSTOM, true);
-        targetUrl.addQueryParam(
-          "start",
-          OneUptimeDate.toString(exemplarWindow.startValue),
-          true,
-        );
-        targetUrl.addQueryParam(
-          "end",
-          OneUptimeDate.toString(exemplarWindow.endValue),
-          true,
-        );
-      }
+      navigateWithQueryParams(
+        PageMap.EXCEPTIONS_UNRESOLVED,
+        getChartWindowFallbackParams(),
+      );
     }
-
-    Navigation.navigate(targetUrl);
   };
 
   const openSeriesInExplorer: (menuState: SeriesMenuState) => void = (
     menuState: SeriesMenuState,
   ): void => {
-    ExplorerLink.openInExplorer(
-      getScopedViewDataForSeries(menuState).scopedViewData,
+    const { scopedViewData, seriesLabels }: SeriesScopedViewData =
+      getScopedViewDataForSeries(menuState);
+
+    /*
+     * An "(unset)" label narrows via the is-empty operator (IsNull),
+     * which the explorer URL grammar cannot carry (attributes serialize
+     * as string/number/boolean only) — say so instead of silently
+     * opening a wider view than the menu promised.
+     */
+    const hasUnsetLabel: boolean = Object.values(seriesLabels).some(
+      (labelValue: unknown): boolean => {
+        return labelValue === "";
+      },
     );
+    if (hasUnsetLabel) {
+      ShowToastNotification({
+        title: "Some filters were not carried over",
+        description:
+          'The "(unset)" narrowing cannot be expressed in an explorer link, so the opened view includes every value of that attribute.',
+        type: ToastType.INFO,
+      });
+    }
+
+    ExplorerLink.openInExplorer(scopedViewData);
   };
 
   const applySeriesFilter: (menuState: SeriesMenuState) => void = (
@@ -2006,8 +2062,13 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     serverTruncatedWithoutTopK?: boolean | undefined;
     warningElement?: ReactElement | undefined;
     onInvestigateSeries?:
-      | ((seriesName: string, anchor: { x: number; y: number }) => void)
+      | ((
+          seriesName: string,
+          anchor: { x: number; y: number },
+          trigger: HTMLElement | null,
+        ) => void)
       | undefined;
+    investigatedSeriesName?: string | null | undefined;
   }) => {
     displayableSeries: Array<SeriesPoint>;
     colorsOverride: Array<ChartColorValue> | undefined;
@@ -2028,8 +2089,13 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     serverTruncatedWithoutTopK?: boolean | undefined;
     warningElement?: ReactElement | undefined;
     onInvestigateSeries?:
-      | ((seriesName: string, anchor: { x: number; y: number }) => void)
+      | ((
+          seriesName: string,
+          anchor: { x: number; y: number },
+          trigger: HTMLElement | null,
+        ) => void)
       | undefined;
+    investigatedSeriesName?: string | null | undefined;
   }): {
     displayableSeries: Array<SeriesPoint>;
     colorsOverride: Array<ChartColorValue> | undefined;
@@ -2128,6 +2194,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
           unitLabel: input.unitLabel,
           valueFormatter: input.valueFormatter,
           onInvestigateSeries: input.onInvestigateSeries,
+          investigatedSeriesName: input.investigatedSeriesName,
         })
       : undefined;
 
@@ -2546,10 +2613,16 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         serverTruncatedWithoutTopK,
         warningElement: unitMismatchWarning,
         onInvestigateSeries: showSeriesActions
-          ? (seriesName: string, anchor: { x: number; y: number }): void => {
-              openSeriesMenu(seriesName, panelGroupByKeys, anchor);
+          ? (
+              seriesName: string,
+              anchor: { x: number; y: number },
+              trigger: HTMLElement | null,
+            ): void => {
+              openSeriesMenu(seriesName, panelGroupByKeys, anchor, trigger);
             }
           : undefined,
+        investigatedSeriesName:
+          seriesMenu && isSeriesMenuVisible ? seriesMenu.seriesName : null,
       });
 
       /*
@@ -2869,10 +2942,13 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
               ? (
                   seriesName: string,
                   anchor: { x: number; y: number },
+                  trigger: HTMLElement | null,
                 ): void => {
-                  openSeriesMenu(seriesName, formulaGroupKeys, anchor);
+                  openSeriesMenu(seriesName, formulaGroupKeys, anchor, trigger);
                 }
               : undefined,
+            investigatedSeriesName:
+              seriesMenu && isSeriesMenuVisible ? seriesMenu.seriesName : null,
           });
 
       const formulaChart: Chart = {
@@ -2975,145 +3051,170 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         hideCard={props.hideCard}
         chartCssClass={props.chartCssClass}
       />
-      {exemplarMenu && isExemplarMenuVisible ? (
-        <div
-          ref={exemplarMenuRef}
-          role="menu"
-          aria-orientation="vertical"
-          aria-label="Exemplar actions"
-          className="fixed z-50 w-48 rounded-lg bg-white py-1 shadow-xl ring-1 ring-gray-200 focus:outline-none"
-          style={{
-            left: `${exemplarMenu.position.x}px`,
-            top: `${exemplarMenu.position.y}px`,
-          }}
-          onKeyDown={handleExemplarMenuKeyDown}
-        >
-          <MoreMenuItem
-            key="exemplar-view-trace"
-            icon={IconProp.Layers}
-            text="View trace"
-            onClick={() => {
-              closeExemplarMenu();
-              navigateToExemplarTrace(exemplarMenu.exemplar);
-            }}
-          />
-          <MoreMenuItem
-            key="exemplar-view-logs"
-            icon={IconProp.Logs}
-            text="View logs"
-            onClick={() => {
-              closeExemplarMenu();
-              navigateToExemplarLogs(exemplarMenu.exemplar);
-            }}
-          />
-        </div>
-      ) : null}
-      {seriesMenu && isSeriesMenuVisible ? (
-        <div
-          ref={seriesMenuRef}
-          role="menu"
-          aria-orientation="vertical"
-          aria-label="Series investigation actions"
-          className="fixed z-50 w-64 rounded-lg bg-white py-1 shadow-xl ring-1 ring-gray-200 focus:outline-none"
-          style={{
-            left: `${seriesMenu.position.x}px`,
-            top: `${seriesMenu.position.y}px`,
-          }}
-          onKeyDown={handleSeriesMenuKeyDown}
-        >
-          <div className="mx-1 mb-1 border-b border-gray-100 px-3 pb-2 pt-1.5">
-            <p
-              className="truncate text-xs font-medium text-gray-900"
-              title={seriesMenu.seriesName}
+      {/*
+       * Both pivot menus render through a body portal: dashboard widget
+       * containers are overflow-hidden and (via the canvas) can sit in a
+       * transformed ancestor, which turns position:fixed into
+       * position-relative-to-that-ancestor — a menu anchored at viewport
+       * coordinates would land clipped or off-target. document.body has
+       * neither problem.
+       */}
+      {exemplarMenu && isExemplarMenuVisible
+        ? ReactDOM.createPortal(
+            <div
+              ref={exemplarMenuRef}
+              role="menu"
+              aria-orientation="vertical"
+              aria-label="Exemplar actions"
+              className="fixed z-50 w-48 rounded-lg bg-white py-1 shadow-xl ring-1 ring-gray-200 focus:outline-none"
+              style={{
+                left: `${exemplarMenu.position.x}px`,
+                top: `${exemplarMenu.position.y}px`,
+              }}
+              onKeyDown={handleExemplarMenuKeyDown}
             >
-              {seriesMenu.seriesName}
-            </p>
-            {seriesMenuNarrowSummary ? (
-              <p
-                className="mt-0.5 truncate text-[11px] text-gray-500"
-                title={seriesMenuNarrowSummary}
-              >
-                Scoped to {seriesMenuNarrowSummary}
-              </p>
-            ) : null}
-          </div>
-          {props.onQueryConfigsChange && seriesMenuScoped?.didNarrow ? (
-            <MoreMenuItem
-              key="series-filter"
-              icon={IconProp.Filter}
-              text="Filter to this series"
-              onClick={() => {
-                const menuState: SeriesMenuState = seriesMenu;
-                closeSeriesMenu();
-                applySeriesFilter(menuState);
-              }}
-            />
-          ) : null}
-          {!props.onQueryConfigsChange ? (
-            <MoreMenuItem
-              key="series-explorer"
-              icon={IconProp.ExternalLink}
-              text="Open in Metric Explorer"
-              onClick={() => {
-                const menuState: SeriesMenuState = seriesMenu;
-                closeSeriesMenu();
-                openSeriesInExplorer(menuState);
-              }}
-            />
-          ) : null}
-          <MoreMenuItem
-            key="series-view-logs"
-            icon={IconProp.Logs}
-            text="View logs"
-            onClick={() => {
-              const menuState: SeriesMenuState = seriesMenu;
-              closeSeriesMenu();
-              navigateSeriesToSignal(menuState, "logs").catch(() => {
-                // Best-effort navigation; failures already degrade inside.
-              });
-            }}
-          />
-          <MoreMenuItem
-            key="series-view-traces"
-            icon={IconProp.Layers}
-            text="View traces"
-            onClick={() => {
-              const menuState: SeriesMenuState = seriesMenu;
-              closeSeriesMenu();
-              navigateSeriesToSignal(menuState, "traces").catch(() => {
-                // Best-effort navigation; failures already degrade inside.
-              });
-            }}
-          />
-          <MoreMenuItem
-            key="series-view-exceptions"
-            icon={IconProp.Bug}
-            text="View exceptions"
-            onClick={() => {
-              const menuState: SeriesMenuState = seriesMenu;
-              closeSeriesMenu();
-              navigateSeriesToExceptions(menuState).catch(() => {
-                // Best-effort navigation; failures already degrade inside.
-              });
-            }}
-          />
-          {seriesMenuResourceTargets.map((target: SeriesResourceTarget) => {
-            return (
               <MoreMenuItem
-                key={`series-resource-${target.kind}`}
-                icon={resourceTargetIconByKind[target.kind]}
-                text={target.label}
+                key="exemplar-view-trace"
+                icon={IconProp.Layers}
+                text="View trace"
                 onClick={() => {
+                  closeExemplarMenu();
+                  navigateToExemplarTrace(exemplarMenu.exemplar);
+                }}
+              />
+              <MoreMenuItem
+                key="exemplar-view-logs"
+                icon={IconProp.Logs}
+                text="View logs"
+                onClick={() => {
+                  closeExemplarMenu();
+                  navigateToExemplarLogs(exemplarMenu.exemplar);
+                }}
+              />
+            </div>,
+            document.body,
+          )
+        : null}
+      {seriesMenu && isSeriesMenuVisible
+        ? ReactDOM.createPortal(
+            <div
+              ref={seriesMenuRef}
+              role="menu"
+              aria-orientation="vertical"
+              aria-label="Series investigation actions"
+              className="fixed z-50 w-64 rounded-lg bg-white py-1 shadow-xl ring-1 ring-gray-200 focus:outline-none"
+              style={{
+                left: `${seriesMenu.position.x}px`,
+                top: `${seriesMenu.position.y}px`,
+              }}
+              onKeyDown={handleSeriesMenuKeyDown}
+            >
+              <div className="mx-1 mb-1 border-b border-gray-100 px-3 pb-2 pt-1.5">
+                <p
+                  className="truncate text-xs font-medium text-gray-900"
+                  title={seriesMenu.seriesName}
+                >
+                  {seriesMenu.seriesName}
+                </p>
+                {seriesMenuNarrowSummary ? (
+                  <p
+                    className="mt-0.5 truncate text-[11px] text-gray-500"
+                    title={seriesMenuNarrowSummary}
+                  >
+                    Scoped to {seriesMenuNarrowSummary}
+                  </p>
+                ) : seriesMenu.groupByKeys.length > 0 ? (
+                  /*
+                   * A grouped chart whose series name did not parse back into
+                   * labels (e.g. overlay panels rename colliding series) —
+                   * being explicit beats implying a narrowing that never
+                   * happened.
+                   */
+                  <p className="mt-0.5 truncate text-[11px] text-gray-500">
+                    Couldn&apos;t scope to this series — actions cover the whole
+                    chart
+                  </p>
+                ) : null}
+              </div>
+              {props.onQueryConfigsChange && seriesMenuScoped?.didNarrow ? (
+                <MoreMenuItem
+                  key="series-filter"
+                  icon={IconProp.Filter}
+                  text="Filter to this series"
+                  onClick={() => {
+                    const menuState: SeriesMenuState = seriesMenu;
+                    closeSeriesMenu();
+                    applySeriesFilter(menuState);
+                  }}
+                />
+              ) : null}
+              {!props.onQueryConfigsChange ? (
+                <MoreMenuItem
+                  key="series-explorer"
+                  icon={IconProp.ExternalLink}
+                  text="Open in Metric Explorer"
+                  onClick={() => {
+                    const menuState: SeriesMenuState = seriesMenu;
+                    closeSeriesMenu();
+                    openSeriesInExplorer(menuState);
+                  }}
+                />
+              ) : null}
+              <MoreMenuItem
+                key="series-view-logs"
+                icon={IconProp.Logs}
+                text="View logs"
+                onClick={() => {
+                  const menuState: SeriesMenuState = seriesMenu;
                   closeSeriesMenu();
-                  openSeriesResource(target).catch(() => {
-                    // Resolution failures surface their own toast.
+                  navigateSeriesToSignal(menuState, "logs").catch(() => {
+                    // Best-effort navigation; failures already degrade inside.
                   });
                 }}
               />
-            );
-          })}
-        </div>
-      ) : null}
+              <MoreMenuItem
+                key="series-view-traces"
+                icon={IconProp.Layers}
+                text="View traces"
+                onClick={() => {
+                  const menuState: SeriesMenuState = seriesMenu;
+                  closeSeriesMenu();
+                  navigateSeriesToSignal(menuState, "traces").catch(() => {
+                    // Best-effort navigation; failures already degrade inside.
+                  });
+                }}
+              />
+              <MoreMenuItem
+                key="series-view-exceptions"
+                icon={IconProp.Bug}
+                text="View exceptions"
+                onClick={() => {
+                  const menuState: SeriesMenuState = seriesMenu;
+                  closeSeriesMenu();
+                  navigateSeriesToExceptions(menuState).catch(() => {
+                    // Best-effort navigation; failures already degrade inside.
+                  });
+                }}
+              />
+              {seriesMenuResourceTargets.map((target: SeriesResourceTarget) => {
+                return (
+                  <MoreMenuItem
+                    key={`series-resource-${target.kind}`}
+                    icon={resourceTargetIconByKind[target.kind]}
+                    text={target.label}
+                    onClick={() => {
+                      closeSeriesMenu();
+                      openSeriesResource(target).catch(() => {
+                        // Resolution failures surface their own toast.
+                      });
+                    }}
+                  />
+                );
+              })}
+            </div>,
+            document.body,
+          )
+        : null}
     </>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -148,6 +148,13 @@ export interface ComponentProps {
    * pass false.
    */
   enableSeriesActions?: boolean | undefined;
+  /*
+   * Crosshair-sync channel shared with OTHER MetricCharts instances
+   * (dashboards pass the dashboard id so hovering one widget highlights
+   * the same instant on every widget). Absent → sync within this
+   * instance's own panels only.
+   */
+  chartSyncId?: string | undefined;
 }
 
 /*
@@ -3050,6 +3057,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         charts={getCharts()}
         hideCard={props.hideCard}
         chartCssClass={props.chartCssClass}
+        syncId={props.chartSyncId}
       />
       {/*
        * Both pivot menus render through a body portal: dashboard widget

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
@@ -49,12 +49,6 @@ import Tooltip from "Common/UI/Components/Tooltip/Tooltip";
 import Icon from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
 import HintChip from "./HintChip";
-import ChartTimeReferenceLineProps from "Common/UI/Components/Charts/Types/TimeReferenceLineProps";
-import Incident from "Common/Models/DatabaseModels/Incident";
-import Alert from "Common/Models/DatabaseModels/Alert";
-import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
-import ProjectUtil from "Common/UI/Utils/Project";
-import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
 import Route from "Common/Types/API/Route";
@@ -66,37 +60,21 @@ import {
   buildMetricExplorerPivotParams,
   extractScopeFiltersFromQueryConfigs,
   formatDroppedScopeHint,
+  SERVICE_NAME_ATTRIBUTE_KEY,
   resolveServiceIdsByNames,
+  resolveServiceNamesByIds,
 } from "../../Utils/MetricsCrossSignalPivot";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import { DictionaryEntryValue } from "Common/UI/Components/Dictionary/DictionaryFilterOperator";
 import { ShowToastNotification } from "Common/UI/Components/Toast/ToastInit";
+import useEventTimeReferenceLines, {
+  EventTimeReferenceLines,
+} from "./Utils/UseEventTimeReferenceLines";
 import { ToastType } from "Common/UI/Components/Toast/Toast";
 
 const AUTO_REFRESH_STORAGE_KEY: string =
   "metric-explorer-auto-refresh-interval";
 const SHOW_EVENTS_STORAGE_KEY: string = "metric-explorer-show-events";
-
-// Max incidents and alerts (each) fetched for the event-overlay markers.
-const EVENT_OVERLAY_FETCH_LIMIT: number = 50;
-
-// Muted severity-ish marker colors (fallbacks when severity has no color).
-const INCIDENT_MARKER_COLOR: string = "#f87171"; // red-400
-const ALERT_MARKER_COLOR: string = "#fbbf24"; // amber-400
-
-/*
- * Marker labels render vertically along the reference line, so an
- * unbounded incident/alert title would run down the whole plot height.
- * Only the chart label truncates — the marker's click-through target
- * still opens the full record.
- */
-const EVENT_MARKER_TITLE_MAX_LENGTH: number = 40;
-
-function truncateEventMarkerTitle(title: string): string {
-  if (title.length <= EVENT_MARKER_TITLE_MAX_LENGTH) {
-    return title;
-  }
-
-  return `${title.slice(0, EVENT_MARKER_TITLE_MAX_LENGTH).trimEnd()}…`;
-}
 
 // One toolbar-button idiom for the explorer's investigation row.
 const TOOLBAR_BUTTON_CLASS_NAME: string =
@@ -107,14 +85,6 @@ const TOOLBAR_BUTTON_ACTIVE_CLASS_NAME: string =
   "bg-indigo-50 text-indigo-700 shadow-sm ring-1 ring-inset ring-indigo-200";
 const TOOLBAR_ACTION_BUTTON_CLASS_NAME: string =
   "inline-flex h-8 cursor-pointer select-none items-center gap-1.5 whitespace-nowrap rounded-md border border-gray-200 bg-white px-2.5 text-xs font-medium text-gray-600 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400";
-
-// One incident/alert mapped onto a chart time marker.
-interface EventMarker {
-  date: Date;
-  label: string;
-  color: string;
-  route: Route;
-}
 
 type ResolveRangeTokenFunction = (rangeToken: string) => InBetween<Date>;
 
@@ -229,6 +199,8 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
     params.delete("metricName");
     params.delete("attributes");
     params.delete("serviceName");
+    // One-shot service scope — folded into metricQueries above.
+    params.delete(MetricExplorerUrlParam.Services);
 
     const newQueryString: string = params.toString();
     const newUrl: string =
@@ -240,6 +212,106 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
 
     lastSerializedStateRef.current = serializedState;
   }, [metricViewData]);
+
+  /*
+   * One-shot `services` param (cross-signal pivots from logs/traces carry
+   * service scope as ObjectIDs — see toMetricsExplorerQueryParams).
+   * Resolve ids -> names, fold into every query's resource.service.name
+   * attribute filter, then drop the param so the scope lives on as
+   * ordinary, user-editable filters. Ids that resolve to nothing are
+   * reported, never silently discarded.
+   */
+  useEffect(() => {
+    const servicesParam: string | null = Navigation.getQueryStringByName(
+      MetricExplorerUrlParam.Services,
+    );
+
+    if (!servicesParam) {
+      return;
+    }
+
+    const serviceIds: Array<string> =
+      MetricExplorerUrl.parseServicesParam(servicesParam);
+
+    if (serviceIds.length === 0) {
+      return;
+    }
+
+    let isCancelled: boolean = false;
+
+    const foldServicesIntoFilters: () => Promise<void> =
+      async (): Promise<void> => {
+        const namesById: Dictionary<string> =
+          await resolveServiceNamesByIds(serviceIds);
+
+        if (isCancelled) {
+          return;
+        }
+
+        const serviceNames: Array<string> = serviceIds
+          .map((serviceId: string): string => {
+            return namesById[serviceId] || "";
+          })
+          .filter((serviceName: string): boolean => {
+            return serviceName !== "";
+          });
+
+        if (serviceNames.length === 0) {
+          ShowToastNotification({
+            title: "Service scope was not carried over",
+            description:
+              "The linked services could not be resolved in this project.",
+            type: ToastType.INFO,
+          });
+          return;
+        }
+
+        if (serviceNames.length < serviceIds.length) {
+          ShowToastNotification({
+            title: "Some services were not carried over",
+            description: `${serviceIds.length - serviceNames.length} of the linked services could not be resolved in this project.`,
+            type: ToastType.INFO,
+          });
+        }
+
+        const serviceFilterValue: DictionaryEntryValue =
+          serviceNames.length === 1
+            ? (serviceNames[0] as string)
+            : new Includes(serviceNames);
+
+        setMetricViewData((previous: MetricViewData): MetricViewData => {
+          return {
+            ...previous,
+            queryConfigs: previous.queryConfigs.map(
+              (queryConfig: MetricQueryConfigData): MetricQueryConfigData => {
+                return {
+                  ...queryConfig,
+                  metricQueryData: {
+                    ...queryConfig.metricQueryData,
+                    filterData: {
+                      ...queryConfig.metricQueryData.filterData,
+                      attributes: {
+                        ...((queryConfig.metricQueryData.filterData[
+                          "attributes"
+                        ] as Dictionary<DictionaryEntryValue>) || {}),
+                        [SERVICE_NAME_ATTRIBUTE_KEY]: serviceFilterValue,
+                      },
+                    },
+                  },
+                };
+              },
+            ),
+          };
+        });
+      };
+
+    void foldServicesIntoFilters();
+
+    return () => {
+      isCancelled = true;
+    };
+    // One-shot on mount: the param is consumed, not watched.
+  }, []);
 
   /*
    * Refresh plumbing. A refresh re-anchors the relative token to now (the
@@ -297,159 +369,18 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
     });
   };
 
-  const [eventMarkers, setEventMarkers] = useState<Array<EventMarker>>([]);
-
-  const eventsWindowStartMs: number | undefined =
-    metricViewData.startAndEndDate?.startValue instanceof Date
-      ? (metricViewData.startAndEndDate.startValue as Date).getTime()
-      : undefined;
-  const eventsWindowEndMs: number | undefined =
-    metricViewData.startAndEndDate?.endValue instanceof Date
-      ? (metricViewData.startAndEndDate.endValue as Date).getTime()
-      : undefined;
-
-  useEffect(() => {
-    if (
-      !showEvents ||
-      eventsWindowStartMs === undefined ||
-      eventsWindowEndMs === undefined
-    ) {
-      return;
-    }
-
-    let isCancelled: boolean = false;
-
-    const fetchEventMarkers: () => Promise<void> = async (): Promise<void> => {
-      const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
-      if (!projectId) {
-        return;
-      }
-
-      const eventsWindow: InBetween<Date> = new InBetween<Date>(
-        new Date(eventsWindowStartMs),
-        new Date(eventsWindowEndMs),
-      );
-
-      try {
-        const [incidents, alerts]: [ListResult<Incident>, ListResult<Alert>] =
-          await Promise.all([
-            ModelAPI.getList<Incident>({
-              modelType: Incident,
-              query: {
-                projectId: projectId,
-                createdAt: eventsWindow,
-              },
-              select: {
-                _id: true,
-                title: true,
-                createdAt: true,
-                incidentSeverity: {
-                  name: true,
-                  color: true,
-                },
-              },
-              sort: {
-                createdAt: SortOrder.Descending,
-              },
-              limit: EVENT_OVERLAY_FETCH_LIMIT,
-              skip: 0,
-            }),
-            ModelAPI.getList<Alert>({
-              modelType: Alert,
-              query: {
-                projectId: projectId,
-                createdAt: eventsWindow,
-              },
-              select: {
-                _id: true,
-                title: true,
-                createdAt: true,
-                alertSeverity: {
-                  name: true,
-                  color: true,
-                },
-              },
-              sort: {
-                createdAt: SortOrder.Descending,
-              },
-              limit: EVENT_OVERLAY_FETCH_LIMIT,
-              skip: 0,
-            }),
-          ]);
-
-        if (isCancelled) {
-          return;
-        }
-
-        const markers: Array<EventMarker> = [];
-
-        for (const incident of incidents.data) {
-          if (!incident.createdAt || !incident.id) {
-            continue;
-          }
-          markers.push({
-            date: OneUptimeDate.fromString(
-              incident.createdAt as unknown as string,
-            ),
-            label: `Incident: ${truncateEventMarkerTitle(incident.title || "")}`,
-            color:
-              incident.incidentSeverity?.color?.toString() ||
-              INCIDENT_MARKER_COLOR,
-            route: RouteUtil.populateRouteParams(
-              RouteMap[PageMap.INCIDENT_VIEW]!,
-              { modelId: incident.id },
-            ),
-          });
-        }
-
-        for (const alert of alerts.data) {
-          if (!alert.createdAt || !alert.id) {
-            continue;
-          }
-          markers.push({
-            date: OneUptimeDate.fromString(
-              alert.createdAt as unknown as string,
-            ),
-            label: `Alert: ${truncateEventMarkerTitle(alert.title || "")}`,
-            color: alert.alertSeverity?.color?.toString() || ALERT_MARKER_COLOR,
-            route: RouteUtil.populateRouteParams(
-              RouteMap[PageMap.ALERT_VIEW]!,
-              { modelId: alert.id },
-            ),
-          });
-        }
-
-        setEventMarkers(markers);
-      } catch {
-        // Event markers are best-effort — never break the charts.
-      }
-    };
-
-    void fetchEventMarkers();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [showEvents, eventsWindowStartMs, eventsWindowEndMs]);
-
-  const eventReferenceLines: Array<ChartTimeReferenceLineProps> =
-    useMemo((): Array<ChartTimeReferenceLineProps> => {
-      if (!showEvents) {
-        return [];
-      }
-      return eventMarkers.map(
-        (marker: EventMarker): ChartTimeReferenceLineProps => {
-          return {
-            date: marker.date,
-            label: marker.label,
-            color: marker.color,
-            onClick: () => {
-              Navigation.navigate(marker.route);
-            },
-          };
-        },
-      );
-    }, [showEvents, eventMarkers]);
+  /*
+   * Incident/alert/change-event markers for the charted window — shared
+   * hook (also used by dashboard chart widgets and embedded metric
+   * cards); the explorer adds its show/hide toggle on top.
+   */
+  const {
+    lines: eventReferenceLines,
+    markerCount: eventMarkerCount,
+  }: EventTimeReferenceLines = useEventTimeReferenceLines({
+    enabled: showEvents,
+    window: metricViewData.startAndEndDate,
+  });
 
   // -- Saved explorer views --
 
@@ -458,7 +389,13 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
   // A deep link (metricQueries param) must not be clobbered by the default view.
   const hasInitialUrlState: boolean = useMemo((): boolean => {
     return Boolean(
-      Navigation.getQueryStringByName(MetricExplorerUrlParam.MetricQueries),
+      Navigation.getQueryStringByName(MetricExplorerUrlParam.MetricQueries) ||
+        /*
+         * A pure service deep link ("metrics for service X") carries no
+         * metricQueries — without this the default saved view would
+         * clobber the incoming scope.
+         */
+        Navigation.getQueryStringByName(MetricExplorerUrlParam.Services),
     );
   }, []);
 
@@ -789,9 +726,9 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
                 >
                   <Icon icon={IconProp.Bolt} className="h-3.5 w-3.5" />
                   <span>Events</span>
-                  {showEvents && eventMarkers.length > 0 ? (
+                  {showEvents && eventMarkerCount > 0 ? (
                     <span className="rounded-full bg-indigo-100 px-1.5 text-[11px] font-semibold text-indigo-700">
-                      {eventMarkers.length}
+                      {eventMarkerCount}
                     </span>
                   ) : null}
                 </button>

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -165,6 +165,12 @@ export interface ComponentProps {
    * instead of rendering an interaction that silently does nothing.
    */
   disableChartZoom?: boolean | undefined;
+  /*
+   * Per-series investigate menus (see MetricCharts.enableSeriesActions).
+   * Form-embedded previews pass false — a navigation menu inside an
+   * unsaved monitor form is an invitation to lose work.
+   */
+  enableSeriesActions?: boolean | undefined;
   // Time-anchored annotations forwarded to every chart (see MetricCharts).
   timeReferenceLines?: Array<ChartTimeReferenceLineProps> | undefined;
   referenceRegions?: Array<ChartReferenceRegionProps> | undefined;
@@ -1292,24 +1298,23 @@ const MetricView: FunctionComponent<ComponentProps> = (
                     metricTypes={metricTypes}
                     metricViewData={effectiveData}
                     chartCssClass={props.chartCssClass}
-                    onQueryConfigsChange={
+                    enableSeriesActions={props.enableSeriesActions}
+                    onQueryConfigsChange={(
+                      queryConfigs: Array<MetricQueryConfigData>,
+                    ) => {
                       /*
-                       * Only claim the write path when a parent onChange
-                       * can actually persist it. Passing an always-present
-                       * wrapper made read-only hosts route Top-N writes
-                       * (and the series menu's "Filter to this series")
-                       * into a no-op instead of the transient-override /
-                       * explorer-link fallbacks.
+                       * onChange is a required prop, so MetricView hosts
+                       * always own the write path — Top-N writes and the
+                       * series menu's "Filter to this series" both round-
+                       * trip through the host's onChange. (Read-only
+                       * surfaces render MetricCharts directly, without
+                       * this wrapper — e.g. dashboard widgets.)
                        */
-                      props.onChange
-                        ? (queryConfigs: Array<MetricQueryConfigData>) => {
-                            props.onChange?.({
-                              ...props.data,
-                              queryConfigs: queryConfigs,
-                            });
-                          }
-                        : undefined
-                    }
+                      props.onChange({
+                        ...props.data,
+                        queryConfigs: queryConfigs,
+                      });
+                    }}
                     onTimeRangeSelect={
                       /*
                        * Charts advertise drag-to-zoom (crosshair, hint,

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/Utils/UseEventTimeReferenceLines.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/Utils/UseEventTimeReferenceLines.ts
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useState } from "react";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import ObjectID from "Common/Types/ObjectID";
+import OneUptimeDate from "Common/Types/Date";
+import Query from "Common/Types/BaseDatabase/Query";
+import Route from "Common/Types/API/Route";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import Alert from "Common/Models/DatabaseModels/Alert";
+/*
+ * Sibling-relative on purpose — the `Common` specifier can resolve a
+ * checkout that predates this branch-new model.
+ */
+import ChangeEvent from "../../../../../../../Common/Models/AnalyticsModels/ChangeEvent";
+import Incident from "Common/Models/DatabaseModels/Incident";
+import ChartTimeReferenceLineProps from "Common/UI/Components/Charts/Types/TimeReferenceLineProps";
+import AnalyticsModelAPI, {
+  ListResult as AnalyticsListResult,
+} from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import Navigation from "Common/UI/Utils/Navigation";
+import ProjectUtil from "Common/UI/Utils/Project";
+import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
+import PageMap from "../../../Utils/PageMap";
+import { isPublicDashboard } from "../../Dashboard/Utils/PublicDashboardContext";
+
+/*
+ * Event overlay for metric charts: incidents, alerts, and change events
+ * (deploys/config changes) inside the charted window, mapped to the
+ * chart layer's time-anchored vertical markers. Extracted from
+ * MetricExplorer so every chart surface — the explorer, dashboard chart
+ * widgets, embedded metric cards — draws the same "what happened here"
+ * context; the explorer keeps its own show/hide toggle on top.
+ */
+
+// Max incidents, alerts, and change events (each) fetched for markers.
+export const EVENT_OVERLAY_FETCH_LIMIT: number = 50;
+
+// Muted severity-ish marker colors (fallbacks when severity has no color).
+export const INCIDENT_MARKER_COLOR: string = "#f87171"; // red-400
+export const ALERT_MARKER_COLOR: string = "#fbbf24"; // amber-400
+export const CHANGE_EVENT_MARKER_COLOR: string = "#6366f1"; // indigo-500
+
+/*
+ * Marker labels render vertically along the reference line, so an
+ * unbounded title would run down the whole plot height. Only the chart
+ * label truncates — a marker's click-through target still opens the full
+ * record.
+ */
+export const EVENT_MARKER_TITLE_MAX_LENGTH: number = 40;
+
+export function truncateEventMarkerTitle(title: string): string {
+  if (title.length <= EVENT_MARKER_TITLE_MAX_LENGTH) {
+    return title;
+  }
+
+  return `${title.slice(0, EVENT_MARKER_TITLE_MAX_LENGTH).trimEnd()}…`;
+}
+
+/*
+ * Human prefix for a change event's marker label, keyed by the ingest
+ * API's normalized (lowercased) eventType. Unknown types fall back to
+ * "Change".
+ */
+const CHANGE_EVENT_TYPE_LABELS: Record<string, string> = {
+  deployment: "Deploy",
+  "config-change": "Config change",
+  scaling: "Scaling",
+  rollback: "Rollback",
+  "feature-flag": "Feature flag",
+};
+
+export function getChangeEventMarkerLabel(
+  eventType: string | undefined,
+  title: string,
+): string {
+  const prefix: string =
+    CHANGE_EVENT_TYPE_LABELS[(eventType || "").toLowerCase()] || "Change";
+  return `${prefix}: ${truncateEventMarkerTitle(title)}`;
+}
+
+// One incident/alert/change event mapped onto a chart time marker.
+export interface EventMarker {
+  date: Date;
+  label: string;
+  color: string;
+  /** Absent for change events — they have no detail page (yet). */
+  route?: Route | undefined;
+  /** Dashed for change events, solid for incidents/alerts. */
+  strokeDasharray?: string | undefined;
+}
+
+export interface EventTimeReferenceLines {
+  lines: Array<ChartTimeReferenceLineProps>;
+  markerCount: number;
+}
+
+/**
+ * Fetch the events inside `window` and shape them into chart markers.
+ * Best-effort throughout: each of the three fetches degrades to no
+ * markers on failure, and nothing runs without a project session (public
+ * dashboards) or an unresolved window.
+ */
+export default function useEventTimeReferenceLines(input: {
+  enabled: boolean;
+  window: InBetween<Date> | null | undefined;
+  /** Bump to re-fetch (dashboards pass their auto-refresh tick). */
+  refreshTick?: number | undefined;
+}): EventTimeReferenceLines {
+  const [eventMarkers, setEventMarkers] = useState<Array<EventMarker>>([]);
+
+  /*
+   * Depend on primitive ms values, not the InBetween object — hosts hand
+   * over referentially-new-but-equal windows on most renders, and each
+   * refire is three list calls.
+   */
+  const windowStartMs: number | undefined =
+    input.window?.startValue instanceof Date
+      ? input.window.startValue.getTime()
+      : undefined;
+  const windowEndMs: number | undefined =
+    input.window?.endValue instanceof Date
+      ? input.window.endValue.getTime()
+      : undefined;
+
+  const enabled: boolean =
+    input.enabled &&
+    windowStartMs !== undefined &&
+    windowEndMs !== undefined &&
+    !isPublicDashboard();
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let isCancelled: boolean = false;
+
+    const fetchEventMarkers: () => Promise<void> = async (): Promise<void> => {
+      const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+      if (!projectId) {
+        return;
+      }
+
+      const eventsWindow: InBetween<Date> = new InBetween<Date>(
+        new Date(windowStartMs!),
+        new Date(windowEndMs!),
+      );
+
+      /*
+       * The three sources fail independently: a ClickHouse hiccup must
+       * not take the incident markers down with it, and vice versa.
+       */
+      const [incidents, alerts, changeEvents]: [
+        ListResult<Incident>,
+        ListResult<Alert>,
+        AnalyticsListResult<ChangeEvent>,
+      ] = await Promise.all([
+        ModelAPI.getList<Incident>({
+          modelType: Incident,
+          query: {
+            projectId: projectId,
+            createdAt: eventsWindow,
+          },
+          select: {
+            _id: true,
+            title: true,
+            createdAt: true,
+            incidentSeverity: {
+              name: true,
+              color: true,
+            },
+          },
+          sort: {
+            createdAt: SortOrder.Descending,
+          },
+          limit: EVENT_OVERLAY_FETCH_LIMIT,
+          skip: 0,
+        }).catch((): ListResult<Incident> => {
+          return { data: [], count: 0, skip: 0, limit: 0 };
+        }),
+        ModelAPI.getList<Alert>({
+          modelType: Alert,
+          query: {
+            projectId: projectId,
+            createdAt: eventsWindow,
+          },
+          select: {
+            _id: true,
+            title: true,
+            createdAt: true,
+            alertSeverity: {
+              name: true,
+              color: true,
+            },
+          },
+          sort: {
+            createdAt: SortOrder.Descending,
+          },
+          limit: EVENT_OVERLAY_FETCH_LIMIT,
+          skip: 0,
+        }).catch((): ListResult<Alert> => {
+          return { data: [], count: 0, skip: 0, limit: 0 };
+        }),
+        AnalyticsModelAPI.getList<ChangeEvent>({
+          modelType: ChangeEvent,
+          query: {
+            projectId: projectId,
+            time: eventsWindow,
+          } as Query<ChangeEvent>,
+          select: {
+            _id: true,
+            time: true,
+            title: true,
+            eventType: true,
+          },
+          sort: {
+            time: SortOrder.Descending,
+          },
+          limit: EVENT_OVERLAY_FETCH_LIMIT,
+          skip: 0,
+        }).catch((): AnalyticsListResult<ChangeEvent> => {
+          return { data: [], count: 0, skip: 0, limit: 0 };
+        }),
+      ]);
+
+      if (isCancelled) {
+        return;
+      }
+
+      const markers: Array<EventMarker> = [];
+
+      for (const incident of incidents.data) {
+        if (!incident.createdAt || !incident.id) {
+          continue;
+        }
+        markers.push({
+          date: OneUptimeDate.fromString(
+            incident.createdAt as unknown as string,
+          ),
+          label: `Incident: ${truncateEventMarkerTitle(incident.title || "")}`,
+          color:
+            incident.incidentSeverity?.color?.toString() ||
+            INCIDENT_MARKER_COLOR,
+          route: RouteUtil.populateRouteParams(
+            RouteMap[PageMap.INCIDENT_VIEW]!,
+            { modelId: incident.id },
+          ),
+        });
+      }
+
+      for (const alert of alerts.data) {
+        if (!alert.createdAt || !alert.id) {
+          continue;
+        }
+        markers.push({
+          date: OneUptimeDate.fromString(alert.createdAt as unknown as string),
+          label: `Alert: ${truncateEventMarkerTitle(alert.title || "")}`,
+          color: alert.alertSeverity?.color?.toString() || ALERT_MARKER_COLOR,
+          route: RouteUtil.populateRouteParams(RouteMap[PageMap.ALERT_VIEW]!, {
+            modelId: alert.id,
+          }),
+        });
+      }
+
+      for (const changeEvent of changeEvents.data) {
+        if (!changeEvent.time) {
+          continue;
+        }
+        markers.push({
+          date: OneUptimeDate.fromString(changeEvent.time as unknown as string),
+          label: getChangeEventMarkerLabel(
+            changeEvent.eventType,
+            changeEvent.title || "",
+          ),
+          color: CHANGE_EVENT_MARKER_COLOR,
+          strokeDasharray: "4 4",
+        });
+      }
+
+      setEventMarkers(markers);
+    };
+
+    void fetchEventMarkers();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [enabled, windowStartMs, windowEndMs, input.refreshTick]);
+
+  const lines: Array<ChartTimeReferenceLineProps> =
+    useMemo((): Array<ChartTimeReferenceLineProps> => {
+      if (!enabled) {
+        return [];
+      }
+      return eventMarkers.map(
+        (marker: EventMarker): ChartTimeReferenceLineProps => {
+          return {
+            date: marker.date,
+            label: marker.label,
+            color: marker.color,
+            strokeDasharray: marker.strokeDasharray,
+            onClick: marker.route
+              ? () => {
+                  Navigation.navigate(marker.route!);
+                }
+              : undefined,
+          };
+        },
+      );
+    }, [enabled, eventMarkers]);
+
+  return { lines, markerCount: lines.length };
+}

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MetricMonitor/MetricMonitorPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MetricMonitor/MetricMonitorPreview.tsx
@@ -142,6 +142,7 @@ const MetricMonitorPreview: FunctionComponent<ComponentProps> = (
     >
       <MetricView
         data={metricViewData}
+        enableSeriesActions={false}
         hideQueryElements={true}
         chartCssClass="rounded-lg border border-gray-200 shadow-sm"
         hideStartAndEndDate={true}

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStepMetricPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStepMetricPreview.tsx
@@ -50,6 +50,7 @@ const MonitorStepMetricPreview: FunctionComponent<ComponentProps> = (
           hideStartAndEndDate={true}
           hideCardInCharts={true}
           disableChartZoom={true}
+          enableSeriesActions={false}
           chartCssClass="rounded-lg border border-gray-200 shadow-sm"
           data={{
             startAndEndDate: startAndEndDate,

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotPanel.tsx
@@ -1,0 +1,135 @@
+import React, { Fragment, FunctionComponent, ReactElement } from "react";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Query from "Common/Types/BaseDatabase/Query";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
+import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
+import Log from "Common/Models/AnalyticsModels/Log";
+import Span from "Common/Models/AnalyticsModels/Span";
+import Card from "Common/UI/Components/Card/Card";
+import DashboardLogsViewer from "../Logs/LogsViewer";
+import ExceptionInstanceTable from "../Exceptions/ExceptionInstanceTable";
+import MetricView from "../Metrics/MetricView";
+import TraceTable from "../Traces/TraceTable";
+import TelemetryCompanionSignalTabs from "./TelemetryCompanionSignalTabs";
+import TelemetrySnapshotWindowAlert from "./TelemetrySnapshotWindowAlert";
+
+export interface ComponentProps {
+  telemetryQuery: TelemetryQuery;
+  snapshotWindow: InBetween<Date> | null;
+  /*
+   * "host.name = prod-01" — what the metric charts were narrowed to, from
+   * MetricSeriesScope.getAppliedSeriesLabelSummary. "" when nothing was
+   * narrowed.
+   */
+  seriesSummary: string;
+  eventNoun: "incident" | "alert";
+}
+
+/**
+ * The telemetry snapshot block of an incident/alert/episode page: the
+ * primary signal (logs / traces / metrics / exceptions, whichever the
+ * monitor evaluated) pinned to the evaluation window, wrapped in the
+ * companion-signal tabs that add the other pillars scoped the same way.
+ *
+ * Extracted from Pages/Incidents/View so the EPISODE pages can mount the
+ * identical experience for their first member event without copying a
+ * hundred lines of branching JSX.
+ */
+const TelemetrySnapshotPanel: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const { telemetryQuery, snapshotWindow, seriesSummary, eventNoun } = props;
+
+  /*
+   * Deliberately `undefined`, not an empty fragment — Card lays out
+   * rightElement from presence.
+   */
+  const snapshotWindowAlert: ReactElement | undefined = snapshotWindow ? (
+    <TelemetrySnapshotWindowAlert window={snapshotWindow} />
+  ) : undefined;
+
+  return (
+    <TelemetryCompanionSignalTabs
+      telemetryQuery={telemetryQuery}
+      snapshotWindow={snapshotWindow}
+      snapshotWindowAlert={snapshotWindowAlert}
+      eventNoun={eventNoun}
+      primarySignalElement={
+        <Fragment>
+          {telemetryQuery.telemetryType === TelemetryType.Log &&
+            telemetryQuery.telemetryQuery && (
+              <div>
+                <Card
+                  title={"Logs"}
+                  description={`Logs for this ${eventNoun}.`}
+                  rightElement={snapshotWindowAlert}
+                >
+                  <DashboardLogsViewer
+                    id="logs-preview"
+                    logQuery={telemetryQuery.telemetryQuery as Query<Log>}
+                    limit={10}
+                    noLogsMessage="No logs found"
+                  />
+                </Card>
+              </div>
+            )}
+
+          {telemetryQuery.telemetryType === TelemetryType.Trace &&
+            telemetryQuery.telemetryQuery && (
+              <div>
+                <TraceTable
+                  spanQuery={telemetryQuery.telemetryQuery as Query<Span>}
+                  rightElement={snapshotWindowAlert}
+                  // Pinned to the snapshot; a URL-restored filter must not replace it.
+                  disableUrlState={true}
+                />
+              </div>
+            )}
+
+          {telemetryQuery.telemetryType === TelemetryType.Metric &&
+            telemetryQuery.metricViewData && (
+              <Card
+                title={"Metrics"}
+                description={
+                  seriesSummary
+                    ? `Metrics related to this ${eventNoun}, scoped to the affected series (${seriesSummary}).`
+                    : `Metrics related to this ${eventNoun}.`
+                }
+                rightElement={snapshotWindowAlert}
+              >
+                <MetricView
+                  data={telemetryQuery.metricViewData}
+                  hideQueryElements={true}
+                  chartCssClass="rounded-lg border border-gray-200 shadow-sm"
+                  hideStartAndEndDate={true}
+                  // Read-only host: onChange is a no-op, so zoom can't apply.
+                  disableChartZoom={true}
+                  onChange={(_data: MetricViewData) => {
+                    // do nothing!
+                  }}
+                />
+              </Card>
+            )}
+
+          {telemetryQuery.telemetryType === TelemetryType.Exception &&
+            telemetryQuery.telemetryQuery && (
+              <ExceptionInstanceTable
+                title="Exceptions"
+                description={`Exceptions related to this ${eventNoun}.`}
+                query={
+                  telemetryQuery.telemetryQuery as Query<ExceptionInstance>
+                }
+                rightElement={snapshotWindowAlert}
+                // Pinned to the snapshot; a URL-restored filter must not replace it.
+                disableUrlState={true}
+              />
+            )}
+        </Fragment>
+      }
+    />
+  );
+};
+
+export default TelemetrySnapshotPanel;

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/EpisodeView/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/EpisodeView/Index.tsx
@@ -32,6 +32,14 @@ import React, {
 } from "react";
 import UserElement from "../../../Components/User/User";
 import ChangeEpisodeState from "../../../Components/AlertEpisode/ChangeState";
+import Alert from "Common/Models/DatabaseModels/Alert";
+import TelemetrySnapshotPanel from "../../../Components/Telemetry/TelemetrySnapshotPanel";
+import {
+  DerivedTelemetrySnapshot,
+  EMPTY_TELEMETRY_SNAPSHOT,
+  deriveTelemetrySnapshot,
+} from "../../../Utils/TelemetrySnapshot";
+import { JSONObject } from "Common/Types/JSON";
 
 const AlertEpisodeView: FunctionComponent<
   PageComponentProps
@@ -46,9 +54,43 @@ const AlertEpisodeView: FunctionComponent<
   const [error, setError] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
+  /*
+   * Telemetry snapshot of the episode's FIRST member alert (earliest
+   * created): the first member's evaluation window is the "what kicked
+   * this off" view.
+   */
+  const [telemetrySnapshot, setTelemetrySnapshot] =
+    useState<DerivedTelemetrySnapshot>(EMPTY_TELEMETRY_SNAPSHOT);
+
   const fetchData: PromiseVoidFunction = async (): Promise<void> => {
     try {
       setIsLoading(true);
+
+      const memberAlerts: ListResult<Alert> = await ModelAPI.getList({
+        modelType: Alert,
+        query: {
+          alertEpisodeId: modelId,
+        },
+        limit: 1,
+        skip: 0,
+        select: {
+          _id: true,
+          telemetryQuery: true,
+          seriesLabels: true,
+        },
+        sort: {
+          createdAt: SortOrder.Ascending,
+        },
+      });
+
+      const firstMember: Alert | undefined = memberAlerts.data[0];
+
+      setTelemetrySnapshot(
+        deriveTelemetrySnapshot({
+          storedTelemetryQuery: firstMember?.telemetryQuery,
+          seriesLabels: firstMember?.seriesLabels as JSONObject | undefined,
+        }),
+      );
 
       const episodeTimelines: ListResult<AlertEpisodeStateTimeline> =
         await ModelAPI.getList({
@@ -489,6 +531,17 @@ const AlertEpisodeView: FunctionComponent<
           className="w-1/2"
         />
       </div>
+
+      {telemetrySnapshot.telemetryQuery && (
+        <div className="mb-5">
+          <TelemetrySnapshotPanel
+            telemetryQuery={telemetrySnapshot.telemetryQuery}
+            snapshotWindow={telemetrySnapshot.snapshotWindow}
+            seriesSummary={telemetrySnapshot.seriesSummary}
+            eventNoun="alert"
+          />
+        </div>
+      )}
 
       <AlertEpisodeFeedElement alertEpisodeId={modelId} />
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/EpisodeView/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/EpisodeView/Index.tsx
@@ -33,6 +33,14 @@ import React, {
 } from "react";
 import UserElement from "../../../Components/User/User";
 import ChangeEpisodeState from "../../../Components/IncidentEpisode/ChangeState";
+import Incident from "Common/Models/DatabaseModels/Incident";
+import TelemetrySnapshotPanel from "../../../Components/Telemetry/TelemetrySnapshotPanel";
+import {
+  DerivedTelemetrySnapshot,
+  EMPTY_TELEMETRY_SNAPSHOT,
+  deriveTelemetrySnapshot,
+} from "../../../Utils/TelemetrySnapshot";
+import { JSONObject } from "Common/Types/JSON";
 
 const IncidentEpisodeView: FunctionComponent<
   PageComponentProps
@@ -47,9 +55,43 @@ const IncidentEpisodeView: FunctionComponent<
   const [error, setError] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
+  /*
+   * Telemetry snapshot of the episode's FIRST member incident (earliest
+   * declared): episodes group many incidents from one root cause, so the
+   * first member's evaluation window is the "what kicked this off" view.
+   */
+  const [telemetrySnapshot, setTelemetrySnapshot] =
+    useState<DerivedTelemetrySnapshot>(EMPTY_TELEMETRY_SNAPSHOT);
+
   const fetchData: PromiseVoidFunction = async (): Promise<void> => {
     try {
       setIsLoading(true);
+
+      const memberIncidents: ListResult<Incident> = await ModelAPI.getList({
+        modelType: Incident,
+        query: {
+          incidentEpisodeId: modelId,
+        },
+        limit: 1,
+        skip: 0,
+        select: {
+          _id: true,
+          telemetryQuery: true,
+          seriesLabels: true,
+        },
+        sort: {
+          declaredAt: SortOrder.Ascending,
+        },
+      });
+
+      const firstMember: Incident | undefined = memberIncidents.data[0];
+
+      setTelemetrySnapshot(
+        deriveTelemetrySnapshot({
+          storedTelemetryQuery: firstMember?.telemetryQuery,
+          seriesLabels: firstMember?.seriesLabels as JSONObject | undefined,
+        }),
+      );
 
       const episodeTimelines: ListResult<IncidentEpisodeStateTimeline> =
         await ModelAPI.getList({
@@ -481,6 +523,17 @@ const IncidentEpisodeView: FunctionComponent<
           className="w-1/2"
         />
       </div>
+
+      {telemetrySnapshot.telemetryQuery && (
+        <div className="mb-5">
+          <TelemetrySnapshotPanel
+            telemetryQuery={telemetrySnapshot.telemetryQuery}
+            snapshotWindow={telemetrySnapshot.snapshotWindow}
+            seriesSummary={telemetrySnapshot.seriesSummary}
+            eventNoun="incident"
+          />
+        </div>
+      )}
 
       <IncidentEpisodeFeedElement incidentEpisodeId={modelId} />
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Utils/ExceptionsAttributeScope.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/ExceptionsAttributeScope.ts
@@ -1,0 +1,181 @@
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+import Query from "Common/Types/BaseDatabase/Query";
+import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
+import TelemetryException from "Common/Models/DatabaseModels/TelemetryException";
+
+/*
+ * Attribute facet scope for the Exceptions list.
+ *
+ * TelemetryException (the Postgres group row) deliberately has no
+ * attributes column — attributes live on the ClickHouse ExceptionInstance
+ * rows. An `attributes.<key>` chip therefore compiles as a two-step,
+ * client-side cross-store join (the pattern ExceptionsTable already uses
+ * for entity scope): (1) one instance query with EVERY attribute filter
+ * ANDed + the time window, grouped by fingerprint; (2) the resulting
+ * fingerprints narrow the Postgres list and ride the histogram/facets
+ * payloads (both already accept `fingerprints`).
+ */
+
+export const EXCEPTION_ATTRIBUTE_FACET_PREFIX: string = "attributes.";
+
+/*
+ * Sentinel injected when the attribute scope matched no instances — an
+ * impossible fingerprint that forces an empty list instead of silently
+ * showing the UNFILTERED list.
+ */
+export const NO_MATCH_FINGERPRINT: string = "__attribute-scope-no-match__";
+
+/*
+ * Cap on the fingerprints carried into the Postgres IN() — same bound
+ * ExceptionsTable uses for its entity-scope join.
+ */
+export const MAX_SCOPED_FINGERPRINTS: number = 10_000;
+
+/*
+ * Search fields the exceptions backend can filter as real columns; any
+ * OTHER `@key:value` search token is an instance attribute.
+ */
+export const KNOWN_EXCEPTION_SEARCH_FIELDS: Array<string> = [
+  "exceptionType",
+  "primaryEntityId",
+  "environment",
+];
+
+/** attributeKey -> selected values (chip order preserved). */
+export type ExceptionAttributeSelections = Dictionary<Array<string>>;
+
+export function isExceptionAttributeFacetKey(facetKey: string): boolean {
+  return (
+    facetKey.startsWith(EXCEPTION_ATTRIBUTE_FACET_PREFIX) &&
+    facetKey.length > EXCEPTION_ATTRIBUTE_FACET_PREFIX.length
+  );
+}
+
+/**
+ * Pull the attribute selections out of grouped facet values + parsed
+ * search field filters. Facet keys carry the `attributes.` prefix (only
+ * the FIRST prefix strips — dots in the key survive); search keys are
+ * bare and count as attributes when they are not known backend fields.
+ */
+export function getExceptionAttributeSelections(input: {
+  facetGroups: Record<string, Array<string>>;
+  searchFieldFilters: Record<string, Array<string>>;
+}): ExceptionAttributeSelections {
+  const selections: ExceptionAttributeSelections = {};
+
+  const addValues: (attributeKey: string, values: Array<string>) => void = (
+    attributeKey: string,
+    values: Array<string>,
+  ): void => {
+    const cleanValues: Array<string> = values.filter(
+      (value: string): boolean => {
+        return typeof value === "string" && value.trim() !== "";
+      },
+    );
+    if (attributeKey.trim() === "" || cleanValues.length === 0) {
+      return;
+    }
+    if (!selections[attributeKey]) {
+      selections[attributeKey] = [];
+    }
+    for (const value of cleanValues) {
+      if (!selections[attributeKey]!.includes(value)) {
+        selections[attributeKey]!.push(value);
+      }
+    }
+  };
+
+  for (const facetKey of Object.keys(input.facetGroups)) {
+    if (!isExceptionAttributeFacetKey(facetKey)) {
+      continue;
+    }
+    addValues(
+      facetKey.slice(EXCEPTION_ATTRIBUTE_FACET_PREFIX.length),
+      input.facetGroups[facetKey] || [],
+    );
+  }
+
+  for (const fieldKey of Object.keys(input.searchFieldFilters)) {
+    if (KNOWN_EXCEPTION_SEARCH_FIELDS.includes(fieldKey)) {
+      continue;
+    }
+    addValues(fieldKey, input.searchFieldFilters[fieldKey] || []);
+  }
+
+  return selections;
+}
+
+export function hasExceptionAttributeSelections(
+  selections: ExceptionAttributeSelections,
+): boolean {
+  return Object.keys(selections).length > 0;
+}
+
+/**
+ * Stable identity of one attribute-scope resolution — the effect uses it
+ * to pair a resolved fingerprint set with the selections+window that
+ * produced it (and to skip stale responses).
+ */
+export function getExceptionAttributeScopeKey(input: {
+  selections: ExceptionAttributeSelections;
+  windowStartMs: number;
+  windowEndMs: number;
+}): string {
+  const orderedSelections: Record<string, Array<string>> = {};
+  for (const key of Object.keys(input.selections).sort()) {
+    orderedSelections[key] = [...(input.selections[key] || [])].sort();
+  }
+  return JSON.stringify([
+    orderedSelections,
+    input.windowStartMs,
+    input.windowEndMs,
+  ]);
+}
+
+/**
+ * The single ClickHouse instance query resolving the scope: every
+ * attribute filter ANDs on the SAME instance (a chip on `http.method`
+ * and one on `host` match instances carrying both), bounded to the
+ * viewer's window.
+ */
+export function buildExceptionInstanceAttributeQuery(input: {
+  projectId: ObjectID;
+  window: InBetween<Date>;
+  selections: ExceptionAttributeSelections;
+}): Query<ExceptionInstance> {
+  const attributes: Dictionary<string | Includes> = {};
+
+  for (const attributeKey of Object.keys(input.selections)) {
+    const values: Array<string> = input.selections[attributeKey] || [];
+    if (values.length === 1) {
+      attributes[attributeKey] = values[0] as string;
+    } else if (values.length > 1) {
+      attributes[attributeKey] = new Includes(values);
+    }
+  }
+
+  return {
+    projectId: input.projectId,
+    time: input.window,
+    attributes,
+  } as Query<ExceptionInstance>;
+}
+
+/**
+ * Narrow the Postgres list query to the resolved fingerprints. An empty
+ * resolution injects the no-match sentinel — the scope matched nothing,
+ * and the list must say so rather than quietly widening.
+ */
+export function applyExceptionFingerprintScope(
+  query: Query<TelemetryException>,
+  fingerprints: Array<string>,
+): void {
+  const scoped: Array<string> =
+    fingerprints.length > 0
+      ? fingerprints.slice(0, MAX_SCOPED_FINGERPRINTS)
+      : [NO_MATCH_FINGERPRINT];
+  (query as Record<string, unknown>)["fingerprint"] = new Includes(scoped);
+}

--- a/App/FeatureSet/Dashboard/src/Utils/MetricSeriesInvestigation.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MetricSeriesInvestigation.ts
@@ -22,6 +22,14 @@ import {
 } from "./MetricsCrossSignalPivot";
 
 /*
+ * A route parameter sourced from telemetry must be a well-formed UUID.
+ * Named const (not inline) to sidestep the wrap-regex vs prettier
+ * circular-fix conflict.
+ */
+const UUID_ROUTE_PARAM: RegExp =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/*
  * Per-SERIES investigation for grouped metric charts: the machinery that
  * turns one series of a group-by chart ("host.name=prod-01, cpu=3") back
  * into structured scope — the exact attribute filters that isolate that
@@ -404,11 +412,14 @@ const lookupModelId: LookupModelIdFunction = async (input: {
  * needs. Best-effort: unknown names and network failures return null so
  * the caller can say "no matching host" instead of navigating nowhere.
  *
- * Host and Kubernetes rows store CANONICALIZED identifiers (trimmed,
- * lowercased `host.name` / `k8s.cluster.name` — see EntityKey), so the
- * lookup canonicalizes the attribute value the same way. Services store
- * verbatim names and go through the shared (cached) service resolver.
- * Network devices carry their own ObjectID in the attribute value.
+ * Host rows store a CANONICALIZED identifier (trimmed, lowercased
+ * `host.name` — HostService canonicalizes on write), so the host lookup
+ * canonicalizes the same way. Kubernetes rows store `clusterIdentifier`
+ * VERBATIM (KubernetesClusterService keeps the stored casing as-is), so
+ * the cluster lookup only trims. Services store verbatim names and go
+ * through the shared (cached) service resolver. Network devices carry
+ * their own ObjectID in the attribute value (validated before use as a
+ * route parameter).
  */
 export async function resolveSeriesResourceModelId(
   target: SeriesResourceTarget,
@@ -427,7 +438,7 @@ export async function resolveSeriesResourceModelId(
       }
       const hostIdentifier: string = canonicalizeEntityValue(value);
       return lookupModelId({
-        cacheKey: `host:${hostIdentifier}`,
+        cacheKey: `${projectId.toString()}:host:${hostIdentifier}`,
         modelType: Host,
         query: { projectId, hostIdentifier } as Query<Host>,
       });
@@ -436,9 +447,9 @@ export async function resolveSeriesResourceModelId(
       if (!projectId) {
         return null;
       }
-      const clusterIdentifier: string = canonicalizeEntityValue(value);
+      const clusterIdentifier: string = value.trim();
       return lookupModelId({
-        cacheKey: `k8s:${clusterIdentifier}`,
+        cacheKey: `${projectId.toString()}:k8s:${clusterIdentifier}`,
         modelType: KubernetesCluster,
         query: { projectId, clusterIdentifier } as Query<KubernetesCluster>,
       });
@@ -450,8 +461,12 @@ export async function resolveSeriesResourceModelId(
       return mapping[value] || null;
     }
     case "networkDevice": {
-      // The attribute value IS the device's ObjectID.
-      return value;
+      /*
+       * The attribute value IS the device's ObjectID — but it arrives
+       * from telemetry, so only a well-formed UUID may become a route
+       * parameter.
+       */
+      return UUID_ROUTE_PARAM.test(value) ? value : null;
     }
     default:
       return null;

--- a/App/FeatureSet/Dashboard/src/Utils/MetricsCrossSignalPivot.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MetricsCrossSignalPivot.ts
@@ -400,6 +400,88 @@ export const resolveServiceIdsByNames: ResolveServiceIdsByNamesFunction =
     }
   };
 
+/*
+ * Mirror of resolveServiceIdsByNames for the opposite direction: Service
+ * ObjectID strings -> names (the `resource.service.name` value the metric
+ * store filters on). Same cache-successes-only, empty-on-failure posture.
+ */
+const serviceNamesByIdCache: Map<string, Dictionary<string>> = new Map<
+  string,
+  Dictionary<string>
+>();
+
+type ResolveServiceNamesByIdsFunction = (
+  serviceIds: Array<string>,
+) => Promise<Dictionary<string>>;
+
+export const resolveServiceNamesByIds: ResolveServiceNamesByIdsFunction =
+  async (serviceIds: Array<string>): Promise<Dictionary<string>> => {
+    const uniqueIds: Array<string> = [];
+
+    for (const serviceId of serviceIds || []) {
+      if (
+        typeof serviceId === "string" &&
+        serviceId.trim() !== "" &&
+        !uniqueIds.includes(serviceId)
+      ) {
+        uniqueIds.push(serviceId);
+      }
+    }
+
+    if (uniqueIds.length === 0) {
+      return {};
+    }
+
+    const cacheKey: string = JSON.stringify([...uniqueIds].sort());
+    const cached: Dictionary<string> | undefined =
+      serviceNamesByIdCache.get(cacheKey);
+
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+
+      if (!projectId) {
+        return {};
+      }
+
+      const query: Query<Service> = { projectId: projectId } as Query<Service>;
+      (query as Record<string, unknown>)["_id"] = new Includes(uniqueIds);
+
+      const result: ListResult<Service> = await ModelAPI.getList<Service>({
+        modelType: Service,
+        query: query,
+        select: {
+          _id: true,
+          name: true,
+        },
+        sort: {
+          name: SortOrder.Ascending,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+      });
+
+      const mapping: Dictionary<string> = {};
+
+      for (const service of result.data || []) {
+        const name: string = service.name?.toString() || "";
+        const id: string = service.id?.toString() || "";
+        if (name !== "" && id !== "") {
+          mapping[id] = name;
+        }
+      }
+
+      serviceNamesByIdCache.set(cacheKey, mapping);
+
+      return mapping;
+    } catch {
+      return {};
+    }
+  };
+
 export type CrossSignalPivotTarget = "logs" | "traces";
 
 type BuildMetricExplorerPivotParamsFunction = (input: {

--- a/App/FeatureSet/Dashboard/src/Utils/TelemetrySnapshot.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/TelemetrySnapshot.ts
@@ -1,0 +1,79 @@
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import { JSONObject } from "Common/Types/JSON";
+import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+
+export interface DerivedTelemetrySnapshot {
+  telemetryQuery: TelemetryQuery | null;
+  snapshotWindow: InBetween<Date> | null;
+  /** "host.name = prod-01" — the narrowing actually applied; "" if none. */
+  seriesSummary: string;
+}
+
+export const EMPTY_TELEMETRY_SNAPSHOT: DerivedTelemetrySnapshot = {
+  telemetryQuery: null,
+  snapshotWindow: null,
+  seriesSummary: "",
+};
+
+/**
+ * Stored incident/alert `telemetryQuery` blob -> render-ready snapshot:
+ * deserialize, rebuild the window's Date bounds (the JSON round trip
+ * leaves InBetween holding ISO strings), and narrow grouped metric
+ * queries to the event's own series via its `seriesLabels`.
+ *
+ * Pure — the same recipe Pages/Incidents/View and Pages/Alerts/View run
+ * inline, packaged so the episode pages (which read the blob off their
+ * first member event) can't drift from it.
+ */
+export function deriveTelemetrySnapshot(input: {
+  storedTelemetryQuery: unknown;
+  seriesLabels: JSONObject | undefined;
+}): DerivedTelemetrySnapshot {
+  if (!input.storedTelemetryQuery) {
+    return EMPTY_TELEMETRY_SNAPSHOT;
+  }
+
+  let telemetryQuery: TelemetryQuery | null = JSONFunctions.deserialize(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    input.storedTelemetryQuery as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+
+  if (!telemetryQuery) {
+    return EMPTY_TELEMETRY_SNAPSHOT;
+  }
+
+  telemetryQuery = TelemetryQueryTimeRange.hydrate(telemetryQuery);
+
+  const snapshotWindow: InBetween<Date> | null =
+    TelemetryQueryTimeRange.getSnapshotWindow(telemetryQuery);
+
+  let seriesSummary: string = "";
+
+  /*
+   * The stored telemetryQuery is the monitor's whole-evaluation view: a
+   * grouped metric monitor that breached on five hosts stamps the SAME
+   * query configs onto all five events. Narrow to this event's own
+   * series so the chart shows the host it is about.
+   */
+  if (telemetryQuery?.metricViewData) {
+    seriesSummary = MetricSeriesScope.getAppliedSeriesLabelSummary({
+      queryConfigs: telemetryQuery.metricViewData.queryConfigs,
+      seriesLabels: input.seriesLabels,
+    });
+
+    telemetryQuery = {
+      ...telemetryQuery,
+      metricViewData:
+        MetricSeriesScope.scopeMetricViewDataToSeries({
+          metricViewData: telemetryQuery.metricViewData,
+          seriesLabels: input.seriesLabels,
+        }) || null,
+    };
+  }
+
+  return { telemetryQuery, snapshotWindow, seriesSummary };
+}

--- a/App/FeatureSet/Telemetry/API/ChangeEventsIngest.ts
+++ b/App/FeatureSet/Telemetry/API/ChangeEventsIngest.ts
@@ -1,0 +1,50 @@
+import TelemetryIngest, {
+  TelemetryRequest,
+} from "Common/Server/Middleware/TelemetryIngest";
+import TelemetryIngestionDisabled from "Common/Server/Middleware/TelemetryIngestionDisabled";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+import Express, {
+  ExpressRequest,
+  ExpressResponse,
+  ExpressRouter,
+  NextFunction,
+  RequestHandler,
+} from "Common/Server/Utils/Express";
+import ChangeEventsIngestService from "../Services/ChangeEventsIngestService";
+
+const router: ExpressRouter = Express.getRouter();
+
+const setChangeEventsProductType: RequestHandler = (
+  req: ExpressRequest,
+  _res: ExpressResponse,
+  next: NextFunction,
+): void => {
+  /*
+   * Change events are a tiny annotation stream, not a metered firehose —
+   * they ride the Logs product type for the ingestion middleware's
+   * bookkeeping.
+   */
+  (req as TelemetryRequest).productType = ProductType.Logs;
+  next();
+};
+
+/*
+ * Deploy/config-change markers posted by CI/CD. Same ingestion-key auth
+ * as the rest of telemetry; synchronous 2xx/4xx so pipeline steps get a
+ * definitive answer.
+ */
+router.post(
+  "/change-events/v1/ingest",
+  TelemetryIngestionDisabled.middleware,
+  setChangeEventsProductType,
+  TelemetryIngest.isAuthorizedServiceMiddleware,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    return ChangeEventsIngestService.ingestChangeEvents(req, res, next);
+  },
+);
+
+export default router;

--- a/App/FeatureSet/Telemetry/Index.ts
+++ b/App/FeatureSet/Telemetry/Index.ts
@@ -4,6 +4,7 @@ import MetricsAPI from "./API/Metrics";
 import SyslogAPI from "./API/Syslog";
 import FluentAPI from "./API/Fluent";
 import SecurityEventsIngestAPI from "./API/SecurityEventsIngest";
+import ChangeEventsIngestAPI from "./API/ChangeEventsIngest";
 import PyroscopeAPI from "./API/Pyroscope";
 import SessionReplayIngestAPI from "./API/SessionReplayIngest";
 import TelemetryWriterAPI from "./API/TelemetryWriter";
@@ -76,6 +77,7 @@ const TelemetryFeatureSet: FeatureSet = {
       app.use(TELEMETRY_PREFIXES, SyslogAPI);
       app.use(TELEMETRY_PREFIXES, FluentAPI);
       app.use(TELEMETRY_PREFIXES, SecurityEventsIngestAPI);
+      app.use(TELEMETRY_PREFIXES, ChangeEventsIngestAPI);
       app.use(TELEMETRY_PREFIXES, PyroscopeAPI);
       /*
        * Session replay ingest. Mounted on both prefixes like the rest, which

--- a/App/FeatureSet/Telemetry/Services/ChangeEventsIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/ChangeEventsIngestService.ts
@@ -1,0 +1,166 @@
+import { TelemetryRequest } from "Common/Server/Middleware/TelemetryIngest";
+import BadRequestException from "Common/Types/Exception/BadRequestException";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import Response from "Common/Server/Utils/Response";
+import CaptureSpan from "Common/Server/Utils/Telemetry/CaptureSpan";
+import ObjectID from "Common/Types/ObjectID";
+import { resolveTelemetryRetentionInDays } from "Common/Types/Telemetry/TelemetryRetentionConfig";
+import {
+  DEFAULT_CHANGE_EVENT_RETENTION_IN_DAYS,
+  MAX_CHANGE_EVENTS_PER_REQUEST,
+  ParsedChangeEventEntry,
+  buildChangeEventDbRow,
+  extractChangeEventEntries,
+  parseChangeEventIngestEntry,
+} from "../../../../Common/Server/Utils/Telemetry/ChangeEventRow";
+import { JSONObject } from "Common/Types/JSON";
+import logger from "Common/Server/Utils/Logger";
+import OTelIngestService, {
+  TelemetryServiceMetadata,
+} from "Common/Server/Services/OpenTelemetryIngestService";
+/*
+ * Sibling-relative on purpose — see the note in BaseAPI/Index.ts: the
+ * `Common` specifier can resolve a checkout that predates these modules.
+ */
+import ChangeEventService from "../../../../Common/Server/Services/ChangeEventService";
+import OtelIngestBaseService from "./OtelIngestBaseService";
+import TelemetryFanInWriter, {
+  FanInSubmitResult,
+} from "Common/Server/Utils/Telemetry/TelemetryFanInWriter";
+
+/*
+ * Change-events ingest: a small, synchronous JSON endpoint meant to be
+ * called from CI/CD pipelines ("we just deployed v2.31 of checkout").
+ *
+ * Unlike the log/trace firehoses there is no queue hop: a deploy step
+ * wants a definitive 2xx/4xx before it moves on, volumes are tiny (a
+ * handful of rows per deploy), and rows go through the same fan-in
+ * writer the other telemetry pillars use.
+ *
+ *   POST /telemetry/change-events/v1/ingest
+ *   x-oneuptime-token: <telemetry ingestion key>
+ *   { "events": [ { "title": "Deploy v2.31.0",
+ *                   "eventType": "deployment",
+ *                   "time": "2026-08-24T12:03:00Z",
+ *                   "serviceName": "checkout",
+ *                   "attributes": { "version": "2.31.0", "sha": "..." } } ] }
+ */
+export default class ChangeEventsIngestService extends OtelIngestBaseService {
+  @CaptureSpan()
+  public static async ingestChangeEvents(
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const projectId: ObjectID | undefined = (req as TelemetryRequest)
+        .projectId;
+
+      if (!projectId) {
+        throw new BadRequestException(
+          "Invalid request - projectId not found in request.",
+        );
+      }
+
+      const entries: Array<JSONObject> = extractChangeEventEntries(
+        req.body,
+      ).slice(0, MAX_CHANGE_EVENTS_PER_REQUEST);
+
+      if (entries.length === 0) {
+        throw new BadRequestException(
+          'No change events found in request body. Send { "events": [ { "title": "..." } ] }.',
+        );
+      }
+
+      const rows: Array<JSONObject> = [];
+      let skipped: number = 0;
+
+      /*
+       * Service metadata is resolved once per distinct serviceName in the
+       * batch (deploys usually name one service). Serviceless events are
+       * project-wide markers with the flat default retention.
+       */
+      const serviceMetadataByName: Map<string, TelemetryServiceMetadata> =
+        new Map<string, TelemetryServiceMetadata>();
+
+      const headerServiceName: string = this.getServiceNameFromHeaders(req, "");
+
+      for (const entry of entries) {
+        const parsed: ParsedChangeEventEntry | null =
+          parseChangeEventIngestEntry(entry);
+
+        if (!parsed) {
+          skipped++;
+          continue;
+        }
+
+        const serviceName: string =
+          typeof entry["serviceName"] === "string" &&
+          (entry["serviceName"] as string).trim() !== ""
+            ? (entry["serviceName"] as string).trim()
+            : headerServiceName;
+
+        let serviceMetadata: TelemetryServiceMetadata | null = null;
+        let retentionDays: number = DEFAULT_CHANGE_EVENT_RETENTION_IN_DAYS;
+
+        if (serviceName) {
+          serviceMetadata =
+            serviceMetadataByName.get(serviceName) ||
+            (await OTelIngestService.telemetryServiceFromName({
+              serviceName,
+              projectId,
+            }));
+          serviceMetadataByName.set(serviceName, serviceMetadata);
+
+          /*
+           * Change markers live alongside metric charts, so they follow
+           * the metrics retention ladder of the service they annotate.
+           */
+          retentionDays = resolveTelemetryRetentionInDays({
+            pillar: "metrics",
+            serviceConfig: serviceMetadata.serviceRetentionConfig,
+            serviceRetentionInDays: serviceMetadata.serviceRetentionInDays,
+            projectConfig: serviceMetadata.projectRetentionConfig,
+            projectRetentionInDays: serviceMetadata.projectRetentionInDays,
+          });
+        }
+
+        rows.push(
+          buildChangeEventDbRow({
+            parsed,
+            projectId,
+            serviceMetadata,
+            retentionDays,
+          }),
+        );
+      }
+
+      if (rows.length === 0) {
+        throw new BadRequestException(
+          "No valid change events in request body — every entry needs a non-empty title.",
+        );
+      }
+
+      const submission: FanInSubmitResult = await TelemetryFanInWriter.submit(
+        ChangeEventService,
+        rows,
+      );
+      await submission.flushed;
+
+      logger.debug(
+        `Change events ingest: stored ${rows.length} events for project ${projectId.toString()}`,
+      );
+
+      return Response.sendJsonObjectResponse(req, res, {
+        ingested: rows.length,
+        skipped: skipped,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+}

--- a/App/Tests/Dashboard/ChangeEventRow.test.ts
+++ b/App/Tests/Dashboard/ChangeEventRow.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+/*
+ * Sibling-relative like the modules under test: the `Common` specifier
+ * can resolve a checkout that predates this branch's files.
+ */
+import {
+  DEFAULT_CHANGE_EVENT_TYPE,
+  MAX_CHANGE_EVENT_ATTRIBUTES,
+  MAX_CHANGE_EVENT_DESCRIPTION_LENGTH,
+  MAX_CHANGE_EVENT_TITLE_LENGTH,
+  ParsedChangeEventEntry,
+  buildChangeEventDbRow,
+  extractChangeEventEntries,
+  parseChangeEventIngestEntry,
+} from "../../../Common/Server/Utils/Telemetry/ChangeEventRow";
+import ChangeEvent from "../../../Common/Models/AnalyticsModels/ChangeEvent";
+import AnalyticsTableName from "Common/Types/AnalyticsDatabase/AnalyticsTableName";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "5a1b6b0e-0000-4000-8000-0000000000cc",
+);
+
+function repoPath(relative: string): string {
+  return path.join(__dirname, "../../..", relative);
+}
+
+function readSquashed(relative: string): string {
+  return fs.readFileSync(repoPath(relative), "utf8").replace(/\s+/g, " ");
+}
+
+describe("extractChangeEventEntries", () => {
+  test("accepts { events: [...] }, bare arrays, and a single bare object", () => {
+    expect(
+      extractChangeEventEntries({ events: [{ title: "a" }, { title: "b" }] }),
+    ).toHaveLength(2);
+    expect(extractChangeEventEntries([{ title: "a" }])).toHaveLength(1);
+    expect(extractChangeEventEntries({ title: "solo" })).toHaveLength(1);
+  });
+
+  test("rejects garbage shapes", () => {
+    expect(extractChangeEventEntries(null)).toEqual([]);
+    expect(extractChangeEventEntries("deploy")).toEqual([]);
+    expect(extractChangeEventEntries({ events: "not-an-array" })).toEqual([]);
+    expect(extractChangeEventEntries([1, "x", null])).toEqual([]);
+    expect(extractChangeEventEntries({})).toEqual([]);
+  });
+});
+
+describe("parseChangeEventIngestEntry", () => {
+  test("a title is the one hard requirement", () => {
+    expect(parseChangeEventIngestEntry({} as JSONObject)).toBeNull();
+    expect(parseChangeEventIngestEntry({ title: "   " })).toBeNull();
+    expect(parseChangeEventIngestEntry({ title: 42 } as JSONObject)).toBeNull();
+    // "name" is accepted as an alias.
+    expect(parseChangeEventIngestEntry({ name: "Deploy" })?.title).toBe(
+      "Deploy",
+    );
+  });
+
+  test("repairs rather than rejects: defaults, trims, caps", () => {
+    const parsed: ParsedChangeEventEntry | null = parseChangeEventIngestEntry({
+      title: `  ${"x".repeat(MAX_CHANGE_EVENT_TITLE_LENGTH + 50)}  `,
+      eventType: "  DEPLOYMENT  ",
+      description: "y".repeat(MAX_CHANGE_EVENT_DESCRIPTION_LENGTH + 50),
+    });
+
+    expect(parsed?.title).toHaveLength(MAX_CHANGE_EVENT_TITLE_LENGTH);
+    expect(parsed?.eventType).toBe("deployment");
+    expect(parsed?.description).toHaveLength(
+      MAX_CHANGE_EVENT_DESCRIPTION_LENGTH,
+    );
+
+    const defaulted: ParsedChangeEventEntry | null =
+      parseChangeEventIngestEntry({ title: "Deploy" });
+    expect(defaulted?.eventType).toBe(DEFAULT_CHANGE_EVENT_TYPE);
+    expect(defaulted?.description).toBe("");
+    expect(defaulted?.time).toBeNull();
+  });
+
+  test("parses ISO strings, epoch seconds, and epoch milliseconds", () => {
+    const iso: ParsedChangeEventEntry | null = parseChangeEventIngestEntry({
+      title: "a",
+      time: "2026-08-20T10:00:00.000Z",
+    });
+    expect(iso?.time?.toISOString()).toBe("2026-08-20T10:00:00.000Z");
+
+    const seconds: ParsedChangeEventEntry | null = parseChangeEventIngestEntry({
+      title: "a",
+      timestamp: 1_787_479_200,
+    });
+    expect(seconds?.time?.getTime()).toBe(1_787_479_200_000);
+
+    const millis: ParsedChangeEventEntry | null = parseChangeEventIngestEntry({
+      title: "a",
+      time: 1_787_479_200_000,
+    });
+    expect(millis?.time?.getTime()).toBe(1_787_479_200_000);
+
+    const garbage: ParsedChangeEventEntry | null = parseChangeEventIngestEntry({
+      title: "a",
+      time: "not-a-date",
+    });
+    expect(garbage?.time).toBeNull();
+  });
+
+  test("keeps only scalar attributes, capped", () => {
+    const bigAttributes: JSONObject = {};
+    for (let i: number = 0; i < MAX_CHANGE_EVENT_ATTRIBUTES + 10; i++) {
+      bigAttributes[`k${i}`] = i;
+    }
+    const parsed: ParsedChangeEventEntry | null = parseChangeEventIngestEntry({
+      title: "a",
+      attributes: {
+        ...bigAttributes,
+        nested: { drop: "me" },
+        list: ["drop"],
+        ok: true,
+      },
+    });
+
+    expect(Object.keys(parsed?.attributes || {}).length).toBeLessThanOrEqual(
+      MAX_CHANGE_EVENT_ATTRIBUTES,
+    );
+    expect(parsed?.attributes["nested"]).toBeUndefined();
+    expect(parsed?.attributes["list"]).toBeUndefined();
+    expect(parsed?.attributes["k0"]).toBe("0");
+  });
+});
+
+describe("buildChangeEventDbRow", () => {
+  function build(overrides: Partial<ParsedChangeEventEntry> = {}): JSONObject {
+    return buildChangeEventDbRow({
+      parsed: {
+        time: new Date(Date.now() - 60_000),
+        eventType: "deployment",
+        title: "Deploy v1",
+        description: "",
+        attributes: { version: "1.0.0" },
+        ...overrides,
+      },
+      projectId: PROJECT_ID,
+      serviceMetadata: null,
+      retentionDays: 30,
+    });
+  }
+
+  test("serviceless rows omit the service columns entirely", () => {
+    const row: JSONObject = build();
+    expect(row["projectId"]).toBe(PROJECT_ID.toString());
+    expect("primaryEntityId" in row).toBe(false);
+    expect("primaryEntityType" in row).toBe(false);
+    expect(row["eventType"]).toBe("deployment");
+    expect(row["title"]).toBe("Deploy v1");
+    expect(row["attributeKeys"]).toEqual(["version"]);
+    expect(typeof row["_id"]).toBe("string");
+    expect(typeof row["retentionDate"]).toBe("string");
+  });
+
+  test("stamps service attribution when metadata is present", () => {
+    const serviceId: ObjectID = new ObjectID(
+      "6b1b6b0e-0000-4000-8000-0000000000dd",
+    );
+    const row: JSONObject = buildChangeEventDbRow({
+      parsed: {
+        time: null,
+        eventType: "deployment",
+        title: "Deploy",
+        description: "",
+        attributes: {},
+      },
+      projectId: PROJECT_ID,
+      serviceMetadata: {
+        primaryEntityId: serviceId,
+        primaryEntityType: "OpenTelemetry",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      retentionDays: 30,
+    });
+
+    expect(row["primaryEntityId"]).toBe(serviceId.toString());
+    expect(row["primaryEntityType"]).toBe("OpenTelemetry");
+  });
+
+  test("clamps ancient and far-future timestamps to ingestion time, preserving the original", () => {
+    for (const badTime of [
+      new Date("2019-01-01T00:00:00.000Z"),
+      new Date(Date.now() + 3 * 60 * 60 * 1000),
+    ]) {
+      const row: JSONObject = build({ time: badTime });
+      const attributes: JSONObject = row["attributes"] as JSONObject;
+      expect(attributes["oneuptime.original_time"]).toBe(String(badTime));
+      // The clamped time is "now"-ish, not the forged one.
+      expect(String(row["time"])).not.toContain("2019");
+    }
+  });
+
+  test("a recent in-window timestamp is kept verbatim", () => {
+    const row: JSONObject = build({
+      time: new Date("2026-08-20T10:00:00.000Z"),
+    });
+    const attributes: JSONObject = row["attributes"] as JSONObject;
+    expect(attributes["oneuptime.original_time"]).toBeUndefined();
+    expect(String(row["time"])).toContain("2026-08-20");
+  });
+});
+
+describe("ChangeEvent model + registries", () => {
+  test("the model declares the annotation-stream table contract", () => {
+    const model: ChangeEvent = new ChangeEvent();
+    expect(model.tableName).toBe(AnalyticsTableName.ChangeEvent);
+    expect(model.crudApiPath?.toString()).toBe("/change-events");
+    expect(model.ttlExpression).toBe("retentionDate DELETE");
+    expect(model.sortKeys).toEqual(["projectId", "time"]);
+    const columnKeys: Array<string> = model.tableColumns.map(
+      (column: { key: string }) => {
+        return column.key;
+      },
+    );
+    for (const requiredKey of [
+      "projectId",
+      "time",
+      "eventType",
+      "title",
+      "attributes",
+      "attributeKeys",
+      "retentionDate",
+    ]) {
+      expect(columnKeys).toContain(requiredKey);
+    }
+  });
+
+  test("both registries carry the model — table creation iterates AnalyticsServices", () => {
+    expect(readSquashed("Common/Models/AnalyticsModels/Index.ts")).toContain(
+      "ChangeEvent,",
+    );
+    /*
+     * Boot-time createTables() iterates ONLY this array — a model missing
+     * here is silently never created.
+     */
+    expect(readSquashed("Common/Server/Services/Index.ts")).toContain(
+      "ChangeEventService, ];",
+    );
+  });
+
+  test("the ingest route is mounted with ingestion-key auth", () => {
+    const route: string = readSquashed(
+      "App/FeatureSet/Telemetry/API/ChangeEventsIngest.ts",
+    );
+    expect(route).toContain("/change-events/v1/ingest");
+    expect(route).toContain("TelemetryIngest.isAuthorizedServiceMiddleware");
+    expect(route).toContain("TelemetryIngestionDisabled.middleware");
+
+    expect(readSquashed("App/FeatureSet/Telemetry/Index.ts")).toContain(
+      "ChangeEventsIngestAPI",
+    );
+    expect(readSquashed("App/FeatureSet/BaseAPI/Index.ts")).toContain(
+      "BaseAnalyticsAPI<ChangeEvent, ChangeEventServiceType>",
+    );
+  });
+
+  test("the chart surfaces fetch markers through the shared hook", () => {
+    const hook: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/Utils/UseEventTimeReferenceLines.ts",
+    );
+    expect(hook).toContain("AnalyticsModelAPI.getList<ChangeEvent>");
+    expect(hook).toContain("isPublicDashboard()");
+    expect(hook).toContain('strokeDasharray: "4 4"');
+
+    for (const surface of [
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx",
+      "App/FeatureSet/Dashboard/src/Components/Metrics/EmbeddedMetricCard.tsx",
+      "App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx",
+    ]) {
+      expect(readSquashed(surface)).toContain("useEventTimeReferenceLines");
+    }
+  });
+});

--- a/App/Tests/Dashboard/ExceptionsAttributeScope.test.ts
+++ b/App/Tests/Dashboard/ExceptionsAttributeScope.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+import Query from "Common/Types/BaseDatabase/Query";
+import TelemetryException from "Common/Models/DatabaseModels/TelemetryException";
+import {
+  EXCEPTION_ATTRIBUTE_FACET_PREFIX,
+  ExceptionAttributeSelections,
+  MAX_SCOPED_FINGERPRINTS,
+  NO_MATCH_FINGERPRINT,
+  applyExceptionFingerprintScope,
+  buildExceptionInstanceAttributeQuery,
+  getExceptionAttributeScopeKey,
+  getExceptionAttributeSelections,
+  isExceptionAttributeFacetKey,
+} from "../../FeatureSet/Dashboard/src/Utils/ExceptionsAttributeScope";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "7c1b6b0e-0000-4000-8000-0000000000ee",
+);
+const WINDOW: InBetween<Date> = new InBetween<Date>(
+  new Date("2026-08-20T10:00:00.000Z"),
+  new Date("2026-08-20T11:00:00.000Z"),
+);
+
+describe("getExceptionAttributeSelections", () => {
+  test("splits attribute chips from column facets, stripping only the first prefix", () => {
+    const selections: ExceptionAttributeSelections =
+      getExceptionAttributeSelections({
+        facetGroups: {
+          "attributes.http.method": ["GET", "POST"],
+          // Dots in the key survive — only the leading prefix strips.
+          "attributes.attributes.weird": ["x"],
+          exceptionType: ["TypeError"],
+          primaryEntityId: ["some-service"],
+        },
+        searchFieldFilters: {},
+      });
+
+    expect(selections).toEqual({
+      "http.method": ["GET", "POST"],
+      "attributes.weird": ["x"],
+    });
+  });
+
+  test("unknown search fields are attributes; known backend fields are not", () => {
+    const selections: ExceptionAttributeSelections =
+      getExceptionAttributeSelections({
+        facetGroups: {},
+        searchFieldFilters: {
+          "http.method": ["GET"],
+          exceptionType: ["TypeError"],
+          environment: ["prod"],
+          primaryEntityId: ["svc"],
+        },
+      });
+
+    expect(selections).toEqual({ "http.method": ["GET"] });
+  });
+
+  test("blank keys/values never become selections", () => {
+    expect(
+      getExceptionAttributeSelections({
+        facetGroups: { "attributes.": ["x"], "attributes.k": ["  ", ""] },
+        searchFieldFilters: {},
+      }),
+    ).toEqual({});
+  });
+
+  test("facet-key detection is exact about the prefix", () => {
+    expect(isExceptionAttributeFacetKey("attributes.http.method")).toBe(true);
+    expect(isExceptionAttributeFacetKey("attributes.")).toBe(false);
+    expect(isExceptionAttributeFacetKey("exceptionType")).toBe(false);
+    expect(EXCEPTION_ATTRIBUTE_FACET_PREFIX).toBe("attributes.");
+  });
+});
+
+describe("getExceptionAttributeScopeKey", () => {
+  test("is stable across selection insertion order", () => {
+    const a: string = getExceptionAttributeScopeKey({
+      selections: { b: ["2", "1"], a: ["x"] },
+      windowStartMs: 1,
+      windowEndMs: 2,
+    });
+    const b: string = getExceptionAttributeScopeKey({
+      selections: { a: ["x"], b: ["1", "2"] },
+      windowStartMs: 1,
+      windowEndMs: 2,
+    });
+    expect(a).toBe(b);
+  });
+
+  test("changes when the window changes", () => {
+    const a: string = getExceptionAttributeScopeKey({
+      selections: { a: ["x"] },
+      windowStartMs: 1,
+      windowEndMs: 2,
+    });
+    const b: string = getExceptionAttributeScopeKey({
+      selections: { a: ["x"] },
+      windowStartMs: 1,
+      windowEndMs: 3,
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildExceptionInstanceAttributeQuery", () => {
+  test("ANDs every attribute on one instance query, equality for one value, membership for many", () => {
+    const query: Record<string, unknown> = buildExceptionInstanceAttributeQuery(
+      {
+        projectId: PROJECT_ID,
+        window: WINDOW,
+        selections: {
+          "http.method": ["GET", "POST"],
+          host: ["web-1"],
+        },
+      },
+    ) as Record<string, unknown>;
+
+    expect(query["projectId"]).toBe(PROJECT_ID);
+    expect(query["time"]).toBe(WINDOW);
+
+    const attributes: Record<string, unknown> = query["attributes"] as Record<
+      string,
+      unknown
+    >;
+    expect(attributes["host"]).toBe("web-1");
+    expect(attributes["http.method"]).toBeInstanceOf(Includes);
+    expect((attributes["http.method"] as Includes).values).toEqual([
+      "GET",
+      "POST",
+    ]);
+  });
+});
+
+describe("applyExceptionFingerprintScope", () => {
+  test("narrows to the resolved fingerprints, capped", () => {
+    const query: Query<TelemetryException> = {} as Query<TelemetryException>;
+    const fingerprints: Array<string> = Array.from(
+      { length: MAX_SCOPED_FINGERPRINTS + 5 },
+      (_: unknown, index: number) => {
+        return `fp-${index}`;
+      },
+    );
+
+    applyExceptionFingerprintScope(query, fingerprints);
+
+    const scoped: Includes = (query as Record<string, unknown>)[
+      "fingerprint"
+    ] as Includes;
+    expect(scoped).toBeInstanceOf(Includes);
+    expect(scoped.values).toHaveLength(MAX_SCOPED_FINGERPRINTS);
+  });
+
+  test("an empty resolution injects the no-match sentinel — never the unfiltered list", () => {
+    const query: Query<TelemetryException> = {} as Query<TelemetryException>;
+    applyExceptionFingerprintScope(query, []);
+
+    const scoped: Includes = (query as Record<string, unknown>)[
+      "fingerprint"
+    ] as Includes;
+    expect(scoped.values).toEqual([NO_MATCH_FINGERPRINT]);
+  });
+});
+
+describe("exceptions viewer wiring", () => {
+  test("the viewer resolves, injects, and carries the scope everywhere counts are computed", () => {
+    const source: string = fs
+      .readFileSync(
+        path.join(
+          __dirname,
+          "../../FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx",
+        ),
+        "utf8",
+      )
+      .replace(/\s+/g, " ");
+
+    expect(source).toContain("getExceptionAttributeSelections");
+    expect(source).toContain("applyExceptionFingerprintScope");
+    expect(source).toContain("AnalyticsModelAPI.getList<ExceptionInstance>");
+    // Histogram AND facets payloads carry the scope.
+    expect(source.match(/payload\["fingerprints"\]/g)?.length).toBe(2);
+    // Unknown search selections chip as attribute facets.
+    expect(source).toContain(
+      "`${EXCEPTION_ATTRIBUTE_FACET_PREFIX}${fieldKey}`",
+    );
+    // Unknown search fields no longer land on the Postgres query as columns.
+    expect(source).toContain("KNOWN_EXCEPTION_SEARCH_FIELDS.includes(key)");
+  });
+});

--- a/App/Tests/Dashboard/LogsCrossSignalPivot.test.ts
+++ b/App/Tests/Dashboard/LogsCrossSignalPivot.test.ts
@@ -451,15 +451,14 @@ describe("metrics pivot round-trip (buildLogsPivotScope -> toMetricsExplorerQuer
     expect(result.params["startTime"]).toBe(WINDOW_START.toISOString());
     expect(result.params["endTime"]).toBe(WINDOW_END.toISOString());
 
+    /*
+     * serviceIds now CARRY (the explorer's one-shot `services` param) —
+     * only the fields the metric grammar truly cannot express drop.
+     */
     expect(new Set(result.dropped)).toEqual(
-      new Set([
-        "sessionIds",
-        "serviceIds",
-        "traceIds",
-        "spanIds",
-        "severityTexts",
-      ]),
+      new Set(["sessionIds", "traceIds", "spanIds", "severityTexts"]),
     );
+    expect(JSON.parse(result.params["services"] as string)).toHaveLength(1);
   });
 
   test("no attributes means no metricQueries param — the window alone still pivots", () => {

--- a/App/Tests/Dashboard/MetricExplorerServicesParam.test.ts
+++ b/App/Tests/Dashboard/MetricExplorerServicesParam.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import Dictionary from "Common/Types/Dictionary";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * ModelAPI / ProjectUtil transitively load Common/UI/Config, which reads
+ * `window` at import time — mock them (they double as the resolver seam).
+ */
+jest.mock("Common/UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: jest.fn(),
+    },
+  };
+});
+
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import MetricExplorerUrl, {
+  MetricExplorerUrlParam,
+  SerializedMetricQuery,
+} from "../../../Common/Utils/Metrics/MetricExplorerUrl";
+import {
+  CrossSignalQueryParams,
+  toMetricsExplorerQueryParams,
+} from "../../../Common/Utils/Telemetry/CrossSignalScope";
+import { resolveServiceNamesByIds } from "../../FeatureSet/Dashboard/src/Utils/MetricsCrossSignalPivot";
+
+const getListMock: jest.Mock = ModelAPI.getList as unknown as jest.Mock;
+const getCurrentProjectIdMock: jest.Mock =
+  ProjectUtil.getCurrentProjectId as unknown as jest.Mock;
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "8d1b6b0e-0000-4000-8000-0000000000ff",
+);
+
+beforeEach(() => {
+  getListMock.mockReset();
+  getCurrentProjectIdMock.mockReset();
+  getCurrentProjectIdMock.mockReturnValue(PROJECT_ID);
+});
+
+describe("MetricExplorerUrl.parseServicesParam", () => {
+  test("parses a JSON array of ids, deduped, capped, garbage-safe", () => {
+    expect(
+      MetricExplorerUrl.parseServicesParam('["a", "b", "a", "", 5]'),
+    ).toEqual(["a", "b"]);
+    expect(MetricExplorerUrl.parseServicesParam("not-json")).toEqual([]);
+    expect(MetricExplorerUrl.parseServicesParam('{"a": 1}')).toEqual([]);
+    expect(
+      MetricExplorerUrl.parseServicesParam(
+        JSON.stringify(
+          Array.from({ length: 50 }, (_: unknown, index: number) => {
+            return `id-${index}`;
+          }),
+        ),
+      ).length,
+    ).toBeLessThanOrEqual(20);
+  });
+});
+
+describe("multi-value attribute round trip", () => {
+  test("Includes instances survive build -> JSON -> parse as Includes again", () => {
+    const query: SerializedMetricQuery = {
+      metricName: "cpu.usage",
+      attributes: {
+        "resource.service.name": new Includes(["checkout", "payments"]),
+        env: "prod",
+      },
+    };
+
+    const parsed: Array<SerializedMetricQuery> =
+      MetricExplorerUrl.parseMetricQueriesParam(JSON.stringify([query]));
+
+    const attributes: Dictionary<unknown> = (parsed[0]?.attributes ||
+      {}) as Dictionary<unknown>;
+    expect(attributes["env"]).toBe("prod");
+    expect(attributes["resource.service.name"]).toBeInstanceOf(Includes);
+    expect((attributes["resource.service.name"] as Includes).values).toEqual([
+      "checkout",
+      "payments",
+    ]);
+  });
+
+  test("garbage membership shapes are dropped, not corrupted", () => {
+    const parsed: Array<SerializedMetricQuery> =
+      MetricExplorerUrl.parseMetricQueriesParam(
+        JSON.stringify([
+          {
+            metricName: "cpu.usage",
+            attributes: {
+              ok: { _type: "Includes", value: ["a"] },
+              empty: { _type: "Includes", value: [] },
+              wrongShape: { _type: "Includes", value: "not-an-array" },
+              nested: { deep: true },
+            },
+          },
+        ]),
+      );
+
+    const attributes: Dictionary<unknown> = (parsed[0]?.attributes ||
+      {}) as Dictionary<unknown>;
+    expect(attributes["ok"]).toBeInstanceOf(Includes);
+    expect(attributes["empty"]).toBeUndefined();
+    expect(attributes["nested"]).toBeUndefined();
+  });
+});
+
+describe("toMetricsExplorerQueryParams service scope", () => {
+  test("serviceIds ride the services param instead of being dropped", () => {
+    const result: CrossSignalQueryParams = toMetricsExplorerQueryParams(
+      {
+        serviceIds: ["id-1", "id-2", "id-1", ""],
+        startTime: new Date("2026-08-20T10:00:00.000Z"),
+        endTime: new Date("2026-08-20T11:00:00.000Z"),
+      },
+      "cpu.usage",
+    );
+
+    expect(
+      JSON.parse(result.params[MetricExplorerUrlParam.Services] || "[]"),
+    ).toEqual(["id-1", "id-2"]);
+    expect(result.dropped).not.toContain("serviceIds");
+  });
+
+  test("no services -> no param", () => {
+    const result: CrossSignalQueryParams = toMetricsExplorerQueryParams(
+      {},
+      "cpu.usage",
+    );
+    expect(result.params[MetricExplorerUrlParam.Services]).toBeUndefined();
+  });
+});
+
+describe("resolveServiceNamesByIds", () => {
+  test("resolves ids to names through one list call and caches the hit", async () => {
+    getListMock.mockResolvedValue({
+      data: [
+        {
+          name: "checkout",
+          id: new ObjectID("11111111-aaaa-4aaa-8aaa-111111111111"),
+        },
+        {
+          name: "payments",
+          id: new ObjectID("22222222-bbbb-4bbb-8bbb-222222222222"),
+        },
+      ],
+    });
+
+    const ids: Array<string> = [
+      "11111111-aaaa-4aaa-8aaa-111111111111",
+      "22222222-bbbb-4bbb-8bbb-222222222222",
+    ];
+
+    const mapping: Dictionary<string> = await resolveServiceNamesByIds(ids);
+    expect(mapping[ids[0] as string]).toBe("checkout");
+    expect(mapping[ids[1] as string]).toBe("payments");
+
+    await resolveServiceNamesByIds(ids);
+    expect(getListMock).toHaveBeenCalledTimes(1);
+
+    const callArgs: Record<string, unknown> = getListMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    const query: Record<string, unknown> = callArgs["query"] as Record<
+      string,
+      unknown
+    >;
+    expect(query["_id"]).toBeInstanceOf(Includes);
+  });
+
+  test("degrades to an empty mapping without a project or on failure", async () => {
+    getCurrentProjectIdMock.mockReturnValue(null);
+    expect(await resolveServiceNamesByIds(["some-unresolvable-id"])).toEqual(
+      {},
+    );
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("explorer + chart-sync wiring", () => {
+  function readSquashed(relative: string): string {
+    return fs
+      .readFileSync(path.join(__dirname, "../../..", relative), "utf8")
+      .replace(/\s+/g, " ");
+  }
+
+  test("the explorer consumes the one-shot services param", () => {
+    const explorer: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx",
+    );
+    expect(explorer).toContain("MetricExplorerUrl.parseServicesParam");
+    expect(explorer).toContain("resolveServiceNamesByIds");
+    expect(explorer).toContain("SERVICE_NAME_ATTRIBUTE_KEY");
+    // Consumed on write-back so the param never lingers.
+    expect(explorer).toContain(
+      "params.delete(MetricExplorerUrlParam.Services)",
+    );
+    // A pure service deep link must not be clobbered by the default view.
+    expect(explorer).toContain(
+      "Navigation.getQueryStringByName(MetricExplorerUrlParam.Services)",
+    );
+  });
+
+  test("dashboards share one crosshair-sync channel across widgets", () => {
+    expect(
+      readSquashed("Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx"),
+    ).toContain("props.syncId || fallbackSyncId");
+    expect(
+      readSquashed(
+        "App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx",
+      ),
+    ).toContain("chartSyncId={props.dashboardId.toString()}");
+    for (const widget of [
+      "App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx",
+      "App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx",
+    ]) {
+      expect(readSquashed(widget)).toContain("chartSyncId={props.chartSyncId}");
+    }
+    // "" must never become an accidental page-wide sync channel.
+    for (const lib of [
+      "Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx",
+      "Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx",
+      "Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx",
+    ]) {
+      expect(readSquashed(lib)).toContain(
+        "{...(props.syncid ? { syncId: props.syncid.toString() } : {})}",
+      );
+    }
+  });
+});

--- a/App/Tests/Dashboard/MetricSeriesInvestigation.test.ts
+++ b/App/Tests/Dashboard/MetricSeriesInvestigation.test.ts
@@ -449,23 +449,28 @@ describe("resolveSeriesResourceModelId", () => {
     expect(getListMock).toHaveBeenCalledTimes(1);
   });
 
-  test("resolves a Kubernetes cluster by clusterIdentifier", async () => {
+  test("resolves a Kubernetes cluster by its VERBATIM-cased identifier", async () => {
     getListMock.mockResolvedValue({ data: [{ _id: "cluster-object-id-1" }] });
 
     const resolved: string | null = await resolveSeriesResourceModelId({
       kind: "kubernetesCluster",
       label: 'Open Kubernetes cluster "Cluster-A"',
       attributeKey: "k8s.cluster.name",
-      attributeValue: "Cluster-A",
+      attributeValue: " Cluster-A ",
     });
 
     expect(resolved).toBe("cluster-object-id-1");
     const callArgs: Record<string, unknown> = getListMock.mock
       .calls[0]?.[0] as Record<string, unknown>;
     expect(callArgs["modelType"]).toBe(KubernetesCluster);
+    /*
+     * KubernetesClusterService stores clusterIdentifier exactly as
+     * ingested (only host identifiers are canonicalized) — lowercasing
+     * here would make every uppercase-named cluster unfindable.
+     */
     expect(callArgs["query"]).toEqual({
       projectId: PROJECT_ID,
-      clusterIdentifier: "cluster-a",
+      clusterIdentifier: "Cluster-A",
     });
   });
 
@@ -513,6 +518,25 @@ describe("resolveSeriesResourceModelId", () => {
     });
 
     expect(resolved).toBe("service-object-id-9");
+  });
+
+  test("a malformed network device id from telemetry never becomes a route param", async () => {
+    expect(
+      await resolveSeriesResourceModelId({
+        kind: "networkDevice",
+        label: "Open network device",
+        attributeKey: "networkDeviceId",
+        attributeValue: "../../../etc/passwd",
+      }),
+    ).toBeNull();
+    expect(
+      await resolveSeriesResourceModelId({
+        kind: "networkDevice",
+        label: "Open network device",
+        attributeKey: "networkDeviceId",
+        attributeValue: "not-a-uuid",
+      }),
+    ).toBeNull();
   });
 
   test("a network device target carries its own ObjectID", async () => {
@@ -586,13 +610,25 @@ describe("investigation wiring", () => {
     expect(source).toContain("rangeToken: zoomWindow ? undefined :");
   });
 
-  test("MetricView only claims the query-config write path when a parent can persist it", () => {
+  test("the external Data Source chart widget never offers telemetry pivots", () => {
     const source: string = readSquashedSource(
-      "Components/Metrics/MetricView.tsx",
+      "Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx",
     );
 
-    expect(source).toContain(
-      "props.onChange ? (queryConfigs: Array<MetricQueryConfigData>) =>",
+    /*
+     * Its series come from an external data source through a synthetic
+     * query config — OneUptime's telemetry pivots would only mislead,
+     * and the widget renders on unauthenticated public dashboards.
+     */
+    expect(source).toContain("enableSeriesActions={false}");
+  });
+
+  test("the chart widget guards against out-of-order fetch responses", () => {
+    const source: string = readSquashedSource(
+      "Components/Dashboard/Components/DashboardChartComponent.tsx",
     );
+
+    expect(source).toContain("fetchSequenceRef");
+    expect(source).toContain("isCurrentFetch");
   });
 });

--- a/App/Tests/Dashboard/TelemetrySnapshot.test.ts
+++ b/App/Tests/Dashboard/TelemetrySnapshot.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import MetricsAggregationType from "Common/Types/Metrics/MetricsAggregationType";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  DerivedTelemetrySnapshot,
+  EMPTY_TELEMETRY_SNAPSHOT,
+  deriveTelemetrySnapshot,
+} from "../../FeatureSet/Dashboard/src/Utils/TelemetrySnapshot";
+
+/*
+ * The stored blob shape: what an Incident/Alert row's telemetryQuery
+ * column actually holds after the JSON round trip — InBetween bounds as
+ * ISO STRINGS, not Dates. The derivation must rebuild real Dates and
+ * narrow grouped metric queries to the event's own series.
+ */
+function buildStoredMetricBlob(): JSONObject {
+  return {
+    telemetryType: TelemetryType.Metric,
+    metricViewData: {
+      queryConfigs: [
+        {
+          metricAliasData: { metricVariable: "a" },
+          metricQueryData: {
+            filterData: {
+              metricName: "cpu.usage",
+              attributes: {},
+              aggegationType: MetricsAggregationType.Avg,
+            },
+            groupByAttributeKeys: ["host.name"],
+          },
+        },
+      ],
+      formulaConfigs: [],
+      startAndEndDate: {
+        _type: "InBetween",
+        startValue: "2026-08-20T10:00:00.000Z",
+        endValue: "2026-08-20T11:00:00.000Z",
+      },
+    },
+  } as unknown as JSONObject;
+}
+
+function getScopedAttributes(
+  snapshot: DerivedTelemetrySnapshot,
+): Record<string, unknown> {
+  return ((
+    snapshot.telemetryQuery?.metricViewData?.queryConfigs[0]?.metricQueryData
+      .filterData as Record<string, unknown>
+  )?.["attributes"] || {}) as Record<string, unknown>;
+}
+
+describe("deriveTelemetrySnapshot", () => {
+  test("no stored blob yields the empty snapshot", () => {
+    expect(
+      deriveTelemetrySnapshot({
+        storedTelemetryQuery: undefined,
+        seriesLabels: undefined,
+      }),
+    ).toBe(EMPTY_TELEMETRY_SNAPSHOT);
+    expect(
+      deriveTelemetrySnapshot({
+        storedTelemetryQuery: null,
+        seriesLabels: { "host.name": "x" },
+      }),
+    ).toBe(EMPTY_TELEMETRY_SNAPSHOT);
+  });
+
+  test("rehydrates the stored ISO window into real Dates", () => {
+    const snapshot: DerivedTelemetrySnapshot = deriveTelemetrySnapshot({
+      storedTelemetryQuery: buildStoredMetricBlob(),
+      seriesLabels: undefined,
+    });
+
+    expect(snapshot.snapshotWindow?.startValue).toBeInstanceOf(Date);
+    expect(snapshot.snapshotWindow?.startValue.toISOString()).toBe(
+      "2026-08-20T10:00:00.000Z",
+    );
+    expect(snapshot.snapshotWindow?.endValue.toISOString()).toBe(
+      "2026-08-20T11:00:00.000Z",
+    );
+  });
+
+  test("narrows grouped metric queries to the event's own series", () => {
+    const snapshot: DerivedTelemetrySnapshot = deriveTelemetrySnapshot({
+      storedTelemetryQuery: buildStoredMetricBlob(),
+      seriesLabels: { "host.name": "prod-01" },
+    });
+
+    expect(snapshot.seriesSummary).toBe("host.name = prod-01");
+    expect(getScopedAttributes(snapshot)["host.name"]).toBe("prod-01");
+  });
+
+  test('an empty series label narrows with the is-empty operator and says "(unset)"', () => {
+    const snapshot: DerivedTelemetrySnapshot = deriveTelemetrySnapshot({
+      storedTelemetryQuery: buildStoredMetricBlob(),
+      seriesLabels: { "host.name": "" },
+    });
+
+    expect(getScopedAttributes(snapshot)["host.name"]).toBeInstanceOf(IsNull);
+    expect(snapshot.seriesSummary).toContain("(unset)");
+  });
+
+  test("labels the queries never grouped by narrow nothing and claim nothing", () => {
+    const snapshot: DerivedTelemetrySnapshot = deriveTelemetrySnapshot({
+      storedTelemetryQuery: buildStoredMetricBlob(),
+      seriesLabels: { "pod.name": "api-1" },
+    });
+
+    expect(snapshot.seriesSummary).toBe("");
+    expect(getScopedAttributes(snapshot)["pod.name"]).toBeUndefined();
+  });
+
+  test("non-metric blobs pass through with their own window semantics", () => {
+    const snapshot: DerivedTelemetrySnapshot = deriveTelemetrySnapshot({
+      storedTelemetryQuery: {
+        telemetryType: TelemetryType.Log,
+        telemetryQuery: {
+          time: {
+            _type: "InBetween",
+            startValue: "2026-08-20T10:00:00.000Z",
+            endValue: "2026-08-20T10:15:00.000Z",
+          },
+          severityText: "Error",
+        },
+      } as unknown as JSONObject,
+      seriesLabels: undefined,
+    });
+
+    expect(snapshot.telemetryQuery?.telemetryType).toBe(TelemetryType.Log);
+    expect(snapshot.seriesSummary).toBe("");
+    expect(snapshot.snapshotWindow?.endValue.toISOString()).toBe(
+      "2026-08-20T10:15:00.000Z",
+    );
+  });
+});
+
+describe("episode telemetry wiring", () => {
+  function readSquashed(relative: string): string {
+    return fs
+      .readFileSync(
+        path.join(__dirname, "../../FeatureSet/Dashboard/src", relative),
+        "utf8",
+      )
+      .replace(/\s+/g, " ");
+  }
+
+  test("both episode pages fetch their first member's snapshot and mount the panel", () => {
+    const incident: string = readSquashed(
+      "Pages/Incidents/EpisodeView/Index.tsx",
+    );
+    expect(incident).toContain("incidentEpisodeId: modelId");
+    expect(incident).toContain("telemetryQuery: true");
+    expect(incident).toContain("seriesLabels: true");
+    expect(incident).toContain("deriveTelemetrySnapshot");
+    expect(incident).toContain("<TelemetrySnapshotPanel");
+    expect(incident).toContain('eventNoun="incident"');
+    // First member = earliest declared.
+    expect(incident).toContain("declaredAt: SortOrder.Ascending");
+
+    const alert: string = readSquashed("Pages/Alerts/EpisodeView/Index.tsx");
+    expect(alert).toContain("alertEpisodeId: modelId");
+    expect(alert).toContain("deriveTelemetrySnapshot");
+    expect(alert).toContain("<TelemetrySnapshotPanel");
+    expect(alert).toContain('eventNoun="alert"');
+    // Alerts have no declaredAt — earliest created.
+    expect(alert).toContain("createdAt: SortOrder.Ascending");
+  });
+
+  test("the shared panel renders all four primary-signal branches", () => {
+    const panel: string = readSquashed(
+      "Components/Telemetry/TelemetrySnapshotPanel.tsx",
+    );
+    expect(panel).toContain("TelemetryCompanionSignalTabs");
+    expect(panel).toContain("TelemetryType.Log");
+    expect(panel).toContain("TelemetryType.Trace");
+    expect(panel).toContain("TelemetryType.Metric");
+    expect(panel).toContain("TelemetryType.Exception");
+    expect(panel).toContain("disableUrlState={true}");
+  });
+});

--- a/App/Tests/Dashboard/TraceCorrelatedSignals.test.ts
+++ b/App/Tests/Dashboard/TraceCorrelatedSignals.test.ts
@@ -607,11 +607,16 @@ describe("buildTracesPivotScope", () => {
       result.scope,
     );
 
-    expect(serialized.dropped.sort()).toEqual(
-      ["serviceIds", "spanIds", "traceIds"].sort(),
-    );
+    /*
+     * serviceIds now CARRY via the explorer's one-shot `services` param;
+     * spans/traces remain inexpressible in the metric grammar.
+     */
+    expect(serialized.dropped.sort()).toEqual(["spanIds", "traceIds"].sort());
+    expect(JSON.parse(serialized.params["services"] as string)).toEqual([
+      "svc-1",
+    ]);
     expect(describeDroppedScopeFields(serialized.dropped).sort()).toEqual(
-      ["service filters", "span ids", "trace ids"].sort(),
+      ["span ids", "trace ids"].sort(),
     );
   });
 });

--- a/Common/Models/AnalyticsModels/ChangeEvent.ts
+++ b/Common/Models/AnalyticsModels/ChangeEvent.ts
@@ -1,0 +1,331 @@
+import AnalyticsBaseModel from "./AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../Types/API/Route";
+import AnalyticsTableEngine from "../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableName from "../../Types/AnalyticsDatabase/AnalyticsTableName";
+import AnalyticsTableColumn, {
+  SkipIndexType,
+} from "../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../Types/AnalyticsDatabase/TableColumnType";
+import OperationalResource from "../../Types/Database/AccessControl/OperationalResource";
+import OwnedThrough from "../../Types/Database/AccessControl/OwnedThrough";
+import { JSONObject } from "../../Types/JSON";
+import ObjectID from "../../Types/ObjectID";
+import Permission from "../../Types/Permission";
+import Service from "../DatabaseModels/Service";
+import ServiceType from "../../Types/Telemetry/ServiceType";
+
+/*
+ * Deploys, config changes, scaling events — the "what changed?" signal.
+ * Rows are posted by CI/CD pipelines through the change-events ingest API
+ * (or created from the product) and rendered as vertical dashed markers
+ * on metric charts, so "the spike started 40 seconds after deploy X" is
+ * visible without leaving the chart.
+ *
+ * Peer of LogItemV3 in layout: tenant projectId, per-row retentionDate
+ * TTL, Map(String,String) attributes with a bloom-indexed keys sidecar.
+ * Deliberately narrow — this is an annotation stream, not a log store.
+ */
+
+const readPermissions: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.ProjectMember,
+  Permission.Viewer,
+  Permission.TelemetryAdmin,
+  Permission.TelemetryMember,
+  Permission.TelemetryViewer,
+];
+
+const createPermissions: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.ProjectMember,
+  Permission.TelemetryAdmin,
+  Permission.TelemetryMember,
+];
+
+@OperationalResource()
+@OwnedThrough("primaryEntityId", Service, { includeProjectScope: true })
+export default class ChangeEvent extends AnalyticsBaseModel {
+  public constructor() {
+    const projectIdColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "projectId",
+      title: "Project ID",
+      description: "ID of project",
+      required: true,
+      type: TableColumnType.ObjectID,
+      isTenantId: true,
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const primaryEntityIdColumn: AnalyticsTableColumn =
+      new AnalyticsTableColumn({
+        key: "primaryEntityId",
+        title: "Service ID",
+        description:
+          "ID of the telemetry Service this change belongs to (the deployed service). Optional — project-wide changes carry none.",
+        required: false,
+        type: TableColumnType.ObjectID,
+        accessControl: {
+          read: readPermissions,
+          create: createPermissions,
+          update: [],
+        },
+      });
+
+    const primaryEntityTypeColumn: AnalyticsTableColumn =
+      new AnalyticsTableColumn({
+        key: "primaryEntityType",
+        isLowCardinality: true,
+        title: "Service Type",
+        description: "Discriminator for primaryEntityId",
+        required: false,
+        type: TableColumnType.Text,
+        accessControl: {
+          read: readPermissions,
+          create: createPermissions,
+          update: [],
+        },
+      });
+
+    const timeColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "time",
+      title: "Time",
+      description: "When the change happened",
+      required: true,
+      type: TableColumnType.DateTime64,
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const eventTypeColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "eventType",
+      isLowCardinality: true,
+      title: "Event Type",
+      description:
+        'Kind of change — e.g. "deployment", "config-change", "scaling", "rollback", "custom"',
+      required: true,
+      defaultValue: "deployment",
+      type: TableColumnType.Text,
+      skipIndex: {
+        name: "idx_change_event_type",
+        type: SkipIndexType.Set,
+        params: [16],
+        granularity: 4,
+      },
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const titleColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "title",
+      title: "Title",
+      description: 'Short human label, e.g. "Deploy v2.31.0"',
+      required: true,
+      type: TableColumnType.Text,
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const descriptionColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "description",
+      title: "Description",
+      description: "Optional detail — commit message, change summary, links",
+      required: false,
+      type: TableColumnType.Text,
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const attributesColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "attributes",
+      codec: { codec: "ZSTD", level: 3 },
+      title: "Attributes",
+      description:
+        "Arbitrary tags — version, commit sha, pipeline url, environment",
+      required: true,
+      defaultValue: {},
+      type: TableColumnType.MapStringString,
+      mapKeysColumn: "attributeKeys",
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const attributeKeysColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "attributeKeys",
+      codec: { codec: "ZSTD", level: 3 },
+      title: "Attribute Keys",
+      description: "Attribute keys extracted from attributes",
+      required: true,
+      defaultValue: [],
+      type: TableColumnType.ArrayText,
+      skipIndex: {
+        name: "idx_attribute_keys",
+        type: SkipIndexType.BloomFilter,
+        params: [0.01],
+        granularity: 1,
+      },
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const retentionDateColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "retentionDate",
+      codec: [{ codec: "DoubleDelta" }, { codec: "ZSTD", level: 1 }],
+      title: "Retention Date",
+      description:
+        "Date after which this row is eligible for TTL deletion, computed at ingest time",
+      required: true,
+      type: TableColumnType.Date,
+      defaultValue: undefined,
+    });
+
+    super({
+      tableName: AnalyticsTableName.ChangeEvent,
+      tableEngine: AnalyticsTableEngine.MergeTree,
+      singularName: "Change Event",
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+        delete: [
+          Permission.ProjectOwner,
+          Permission.ProjectAdmin,
+          Permission.TelemetryAdmin,
+        ],
+      },
+      pluralName: "Change Events",
+      crudApiPath: new Route("/change-events"),
+      enableMCP: true,
+      enableDocumentation: true,
+      tableDescription:
+        "Change events (deployments, config changes, scaling) posted by CI/CD pipelines. Rendered as markers on metric charts so spikes can be correlated with what changed.",
+      tableColumns: [
+        projectIdColumn,
+        primaryEntityIdColumn,
+        primaryEntityTypeColumn,
+        timeColumn,
+        eventTypeColumn,
+        titleColumn,
+        descriptionColumn,
+        attributesColumn,
+        attributeKeysColumn,
+        retentionDateColumn,
+      ],
+      sortKeys: ["projectId", "time"],
+      primaryKeys: ["projectId", "time"],
+      partitionKey: "toYYYYMMDD(time)",
+      /*
+       * Tiny volume (a handful of rows per deploy) — shard by the
+       * always-present tenant + time pair; no hotspot risk at this rate.
+       */
+      shardingKey: "cityHash64(projectId, time)",
+      tableSettings:
+        "ttl_only_drop_parts = 1, non_replicated_deduplication_window = 10000",
+      ttlExpression: "retentionDate DELETE",
+      defaultSortColumn: "time",
+    });
+  }
+
+  public get projectId(): ObjectID | undefined {
+    return this.getColumnValue("projectId") as ObjectID | undefined;
+  }
+
+  public set projectId(v: ObjectID | undefined) {
+    this.setColumnValue("projectId", v);
+  }
+
+  public get primaryEntityId(): ObjectID | undefined {
+    return this.getColumnValue("primaryEntityId") as ObjectID | undefined;
+  }
+
+  public set primaryEntityId(v: ObjectID | undefined) {
+    this.setColumnValue("primaryEntityId", v);
+  }
+
+  public get primaryEntityType(): ServiceType | undefined {
+    return this.getColumnValue("primaryEntityType") as ServiceType | undefined;
+  }
+
+  public set primaryEntityType(v: ServiceType | undefined) {
+    this.setColumnValue("primaryEntityType", v);
+  }
+
+  public get time(): Date | undefined {
+    return this.getColumnValue("time") as Date | undefined;
+  }
+
+  public set time(v: Date | undefined) {
+    this.setColumnValue("time", v);
+  }
+
+  public get eventType(): string | undefined {
+    return this.getColumnValue("eventType") as string | undefined;
+  }
+
+  public set eventType(v: string | undefined) {
+    this.setColumnValue("eventType", v);
+  }
+
+  public get title(): string | undefined {
+    return this.getColumnValue("title") as string | undefined;
+  }
+
+  public set title(v: string | undefined) {
+    this.setColumnValue("title", v);
+  }
+
+  public get description(): string | undefined {
+    return this.getColumnValue("description") as string | undefined;
+  }
+
+  public set description(v: string | undefined) {
+    this.setColumnValue("description", v);
+  }
+
+  public get attributes(): JSONObject | undefined {
+    return this.getColumnValue("attributes") as JSONObject | undefined;
+  }
+
+  public set attributes(v: JSONObject | undefined) {
+    this.setColumnValue("attributes", v);
+  }
+
+  public get attributeKeys(): Array<string> | undefined {
+    return this.getColumnValue("attributeKeys") as Array<string> | undefined;
+  }
+
+  public set attributeKeys(v: Array<string> | undefined) {
+    this.setColumnValue("attributeKeys", v);
+  }
+
+  public get retentionDate(): Date | undefined {
+    return this.getColumnValue("retentionDate") as Date | undefined;
+  }
+
+  public set retentionDate(v: Date | undefined) {
+    this.setColumnValue("retentionDate", v);
+  }
+}

--- a/Common/Models/AnalyticsModels/Index.ts
+++ b/Common/Models/AnalyticsModels/Index.ts
@@ -21,6 +21,7 @@ import ProfileSample from "./ProfileSample";
 import RumSession from "./RumSession";
 import RumSessionChunk from "./RumSessionChunk";
 import AuditLog from "./AuditLog";
+import ChangeEvent from "./ChangeEvent";
 
 const AnalyticsModels: Array<{ new (): AnalyticsBaseModel }> = [
   Log,
@@ -69,6 +70,7 @@ const AnalyticsModels: Array<{ new (): AnalyticsBaseModel }> = [
   RumSessionChunk,
   AuditLog,
   SecurityEvent,
+  ChangeEvent,
 ];
 
 const modelTypeMap: { [key: string]: { new (): AnalyticsBaseModel } } = {};

--- a/Common/Server/Services/ChangeEventService.ts
+++ b/Common/Server/Services/ChangeEventService.ts
@@ -1,0 +1,11 @@
+import ClickhouseDatabase from "../Infrastructure/ClickhouseDatabase";
+import AnalyticsDatabaseService from "./AnalyticsDatabaseService";
+import ChangeEvent from "../../Models/AnalyticsModels/ChangeEvent";
+
+export class ChangeEventService extends AnalyticsDatabaseService<ChangeEvent> {
+  public constructor(clickhouseDatabase?: ClickhouseDatabase | undefined) {
+    super({ modelType: ChangeEvent, database: clickhouseDatabase });
+  }
+}
+
+export default new ChangeEventService();

--- a/Common/Server/Services/Index.ts
+++ b/Common/Server/Services/Index.ts
@@ -77,6 +77,7 @@ import DataSourceService from "./DataSourceService";
 import AuditLogService from "./AuditLogService";
 import LogService from "./LogService";
 import SecurityEventService from "./SecurityEventService";
+import ChangeEventService from "./ChangeEventService";
 import MailService from "./MailService";
 import MetricService from "./MetricService";
 import MetricItemAggMV1mService from "./MetricItemAggMV1mService";
@@ -641,6 +642,7 @@ export const AnalyticsServices: Array<
   RumSessionChunkService,
   AuditLogService,
   SecurityEventService,
+  ChangeEventService,
 ];
 
 export default services;

--- a/Common/Server/Utils/Telemetry/ChangeEventRow.ts
+++ b/Common/Server/Utils/Telemetry/ChangeEventRow.ts
@@ -1,0 +1,228 @@
+import Dictionary from "../../../Types/Dictionary";
+import OneUptimeDate from "../../../Types/Date";
+import ObjectID from "../../../Types/ObjectID";
+import { JSONArray, JSONObject } from "../../../Types/JSON";
+/*
+ * Type-only: pulling the ingest service's runtime graph into this pure
+ * module would drag ClickHouse/DB deps into every test that touches it.
+ */
+import type { TelemetryServiceMetadata } from "../../Services/OpenTelemetryIngestService";
+
+/*
+ * Change-event ingest parsing + ClickHouse row building. Pure on purpose
+ * (no network, no request objects) so App/Tests can pin every validation
+ * rule without a server.
+ */
+
+/*
+ * Events whose source timestamp is outside this window are stamped with
+ * the ingestion time instead (original preserved in attributes). The
+ * table partitions by toYYYYMMDD(time), so a forged or garbage timestamp
+ * must not be allowed to create arbitrary partitions.
+ */
+export const MAX_CHANGE_EVENT_AGE_IN_DAYS: number = 366;
+export const MAX_CHANGE_EVENT_FUTURE_SKEW_IN_MINUTES: number = 60;
+
+// Caps keep a CI script's mistake from becoming a storage problem.
+export const MAX_CHANGE_EVENTS_PER_REQUEST: number = 100;
+export const MAX_CHANGE_EVENT_TITLE_LENGTH: number = 500;
+export const MAX_CHANGE_EVENT_DESCRIPTION_LENGTH: number = 5000;
+export const MAX_CHANGE_EVENT_TYPE_LENGTH: number = 50;
+export const MAX_CHANGE_EVENT_ATTRIBUTES: number = 50;
+
+export const DEFAULT_CHANGE_EVENT_TYPE: string = "deployment";
+
+/*
+ * Serviceless change events (project-wide markers) have no service
+ * retention ladder to consult; deploy markers are tiny and valuable for
+ * long-baseline comparisons, so keep them a year.
+ */
+export const DEFAULT_CHANGE_EVENT_RETENTION_IN_DAYS: number = 365;
+
+export interface ParsedChangeEventEntry {
+  /** null → stamp with the ingestion time. */
+  time: Date | null;
+  eventType: string;
+  title: string;
+  description: string;
+  attributes: Dictionary<string>;
+}
+
+function parseEntryTime(value: unknown): Date | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    /*
+     * Epoch seconds vs milliseconds: anything below 1e12 read as ms would
+     * be before 2001 — CI clocks don't say that; treat it as seconds.
+     */
+    const ms: number = value < 1e12 ? value * 1000 : value;
+    const date: Date = new Date(ms);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const date: Date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+/**
+ * Validate one raw ingest entry. Returns null when the entry cannot be a
+ * change event at all (no usable title); every other malformation is
+ * repaired (defaults, trims, caps) rather than rejected — CI pipelines
+ * should not fail a deploy over a long description.
+ */
+export function parseChangeEventIngestEntry(
+  entry: JSONObject,
+): ParsedChangeEventEntry | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
+
+  const rawTitle: unknown = entry["title"] ?? entry["name"];
+  const title: string =
+    typeof rawTitle === "string"
+      ? rawTitle.trim().slice(0, MAX_CHANGE_EVENT_TITLE_LENGTH)
+      : "";
+
+  if (title === "") {
+    return null;
+  }
+
+  const rawEventType: unknown = entry["eventType"] ?? entry["type"];
+  const eventType: string =
+    typeof rawEventType === "string" && rawEventType.trim() !== ""
+      ? rawEventType.trim().toLowerCase().slice(0, MAX_CHANGE_EVENT_TYPE_LENGTH)
+      : DEFAULT_CHANGE_EVENT_TYPE;
+
+  const rawDescription: unknown = entry["description"];
+  const description: string =
+    typeof rawDescription === "string"
+      ? rawDescription.trim().slice(0, MAX_CHANGE_EVENT_DESCRIPTION_LENGTH)
+      : "";
+
+  const attributes: Dictionary<string> = {};
+  const rawAttributes: unknown = entry["attributes"];
+  if (
+    rawAttributes &&
+    typeof rawAttributes === "object" &&
+    !Array.isArray(rawAttributes)
+  ) {
+    for (const key of Object.keys(rawAttributes as JSONObject)) {
+      if (key.trim() === "") {
+        continue;
+      }
+      if (Object.keys(attributes).length >= MAX_CHANGE_EVENT_ATTRIBUTES) {
+        break;
+      }
+      const value: unknown = (rawAttributes as JSONObject)[key];
+      if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ) {
+        attributes[key] = String(value);
+      }
+    }
+  }
+
+  return {
+    time: parseEntryTime(entry["time"] ?? entry["timestamp"]),
+    eventType,
+    title,
+    description,
+    attributes,
+  };
+}
+
+/**
+ * Accept the shapes CI scripts actually send: a bare object (one event),
+ * a bare array, or { events: [...] }.
+ */
+export function extractChangeEventEntries(body: unknown): Array<JSONObject> {
+  if (!body) {
+    return [];
+  }
+
+  if (Array.isArray(body)) {
+    return (body as JSONArray).filter((item: unknown): boolean => {
+      return typeof item === "object" && item !== null && !Array.isArray(item);
+    }) as Array<JSONObject>;
+  }
+
+  if (typeof body !== "object") {
+    return [];
+  }
+
+  const asObject: JSONObject = body as JSONObject;
+  const nested: unknown = asObject["events"];
+  if (Array.isArray(nested)) {
+    return extractChangeEventEntries(nested);
+  }
+
+  // A single bare event object — but not the {events: <non-array>} shape.
+  if (nested === undefined && Object.keys(asObject).length > 0) {
+    return [asObject];
+  }
+
+  return [];
+}
+
+/**
+ * ParsedChangeEventEntry -> ChangeEvent ClickHouse row.
+ */
+export function buildChangeEventDbRow(data: {
+  parsed: ParsedChangeEventEntry;
+  projectId: ObjectID;
+  serviceMetadata: TelemetryServiceMetadata | null;
+  retentionDays: number;
+}): JSONObject {
+  const { parsed, projectId, serviceMetadata, retentionDays } = data;
+
+  const ingestionDate: Date = OneUptimeDate.getCurrentDate();
+
+  let eventTime: Date = parsed.time || ingestionDate;
+  let attributes: Dictionary<string> = { ...parsed.attributes };
+
+  const ageInDays: number = OneUptimeDate.getNumberOfDaysBetweenDates(
+    eventTime,
+    ingestionDate,
+  );
+  const futureSkewInMinutes: number =
+    (eventTime.getTime() - ingestionDate.getTime()) / (60 * 1000);
+
+  if (
+    Number.isNaN(eventTime.getTime()) ||
+    ageInDays > MAX_CHANGE_EVENT_AGE_IN_DAYS ||
+    futureSkewInMinutes > MAX_CHANGE_EVENT_FUTURE_SKEW_IN_MINUTES
+  ) {
+    attributes = {
+      ...attributes,
+      "oneuptime.original_time": String(parsed.time),
+    };
+    eventTime = ingestionDate;
+  }
+
+  const retentionDate: Date = OneUptimeDate.addRemoveDays(
+    ingestionDate,
+    retentionDays,
+  );
+
+  return {
+    _id: ObjectID.generateTimeOrdered().toString(),
+    createdAt: OneUptimeDate.toClickhouseDateTime(ingestionDate),
+    projectId: projectId.toString(),
+    ...(serviceMetadata
+      ? {
+          primaryEntityId: serviceMetadata.primaryEntityId.toString(),
+          primaryEntityType: serviceMetadata.primaryEntityType,
+        }
+      : {}),
+    time: OneUptimeDate.toClickhouseDateTime64(eventTime),
+    eventType: parsed.eventType,
+    title: parsed.title,
+    description: parsed.description,
+    attributes,
+    attributeKeys: Object.keys(attributes).sort(),
+    retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
+  } satisfies JSONObject;
+}

--- a/Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx
@@ -184,6 +184,7 @@ function renderWidget(
 
 interface CapturedChartProps {
   metricViewData: MetricViewData;
+  metricResults?: Array<Record<string, unknown>> | undefined;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
   enableSeriesActions?: boolean | undefined;
 }
@@ -286,6 +287,69 @@ describe("dashboard chart widget drag-to-zoom", () => {
       ).toEqual(DASHBOARD_START);
     });
     expect(lastChartProps().metricViewData.rangeToken).toBe(TimeRange.CUSTOM);
+  });
+
+  test("a stale fetch response can never overwrite a newer window's data", async () => {
+    /*
+     * Zoom then Reset puts two aggregate calls in flight; if the SLOWER
+     * (zoom) response lands last, its data must be discarded — otherwise
+     * the chart paints the zoomed window's series under the dashboard
+     * window's axis.
+     */
+    const pendingFetches: Array<(value: unknown) => void> = [];
+    fetchResultsMock.mockImplementation(() => {
+      return new Promise((resolve: (value: unknown) => void) => {
+        pendingFetches.push(resolve);
+      });
+    });
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(pendingFetches.length).toBe(1);
+    });
+    act(() => {
+      pendingFetches[0]?.([{ data: [], truncated: false }]);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    act(() => {
+      lastChartProps().onTimeRangeSelect?.(ZOOM_START, ZOOM_END);
+    });
+    await waitFor(() => {
+      expect(pendingFetches.length).toBe(2);
+    });
+
+    fireEvent.click(screen.getByText("Reset"));
+    await waitFor(() => {
+      expect(pendingFetches.length).toBe(3);
+    });
+
+    const staleZoomResults: Array<Record<string, unknown>> = [
+      { data: [{ marker: "stale-zoom" }], truncated: false },
+    ];
+    const freshResetResults: Array<Record<string, unknown>> = [
+      { data: [], truncated: false },
+    ];
+
+    // The newer (reset) fetch answers first…
+    act(() => {
+      pendingFetches[2]?.(freshResetResults);
+    });
+    await waitFor(() => {
+      expect(lastChartProps().metricResults).toBe(freshResetResults);
+    });
+
+    // …then the stale zoom fetch answers last and must be ignored.
+    act(() => {
+      pendingFetches[1]?.(staleZoomResults);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(lastChartProps().metricResults).toBe(freshResetResults);
   });
 
   test("edit mode disables zoom and series navigation", async () => {

--- a/Common/Tests/App/Dashboard/EventOverlayHook.test.tsx
+++ b/Common/Tests/App/Dashboard/EventOverlayHook.test.tsx
@@ -1,0 +1,249 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The shared event-overlay hook is what puts "what happened here" on every
+ * metric chart: incidents and alerts as solid severity-colored markers
+ * with click-through, change events (deploys) as dashed indigo markers.
+ * It must fetch nothing on public dashboards and survive any single
+ * source failing.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+const analyticsGetListMock: MockFunction = getJestMockFunction();
+const isPublicDashboardMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the
+ * compiled requires, so the mock variables above are still unassigned when
+ * the factory runs.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return analyticsGetListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext",
+  () => {
+    return {
+      __esModule: true,
+      isPublicDashboard: (...args: Array<any>) => {
+        return isPublicDashboardMock(...args);
+      },
+    };
+  },
+);
+
+import useEventTimeReferenceLines, {
+  EventTimeReferenceLines,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/UseEventTimeReferenceLines";
+import ChartTimeReferenceLineProps from "../../../UI/Components/Charts/Types/TimeReferenceLineProps";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import ObjectID from "../../../Types/ObjectID";
+import ProjectUtil from "../../../UI/Utils/Project";
+
+const WINDOW: InBetween<Date> = new InBetween<Date>(
+  new Date("2026-08-20T10:00:00.000Z"),
+  new Date("2026-08-20T11:00:00.000Z"),
+);
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "9e1b6b0e-0000-4000-8000-000000000011",
+);
+
+function Probe(props: {
+  enabled: boolean;
+  window: InBetween<Date> | null;
+}): React.ReactElement {
+  const { lines, markerCount }: EventTimeReferenceLines =
+    useEventTimeReferenceLines({
+      enabled: props.enabled,
+      window: props.window,
+    });
+
+  return (
+    <div>
+      <span data-testid="marker-count">{markerCount}</span>
+      {lines.map((line: ChartTimeReferenceLineProps, index: number) => {
+        return (
+          <div
+            key={index}
+            data-testid="marker"
+            data-color={line.color}
+            data-dash={line.strokeDasharray || "solid"}
+            data-clickable={line.onClick ? "yes" : "no"}
+          >
+            {line.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+beforeEach(() => {
+  getListMock.mockReset();
+  analyticsGetListMock.mockReset();
+  isPublicDashboardMock.mockReset();
+  isPublicDashboardMock.mockReturnValue(false);
+  jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  cleanup();
+});
+
+describe("useEventTimeReferenceLines", () => {
+  test("maps incidents, alerts, and change events onto distinct marker styles", async () => {
+    getListMock.mockImplementation((args: { modelType: { name: string } }) => {
+      if (args.modelType.name === "Incident") {
+        return Promise.resolve({
+          data: [
+            {
+              id: new ObjectID("11111111-0000-4000-8000-000000000001"),
+              createdAt: "2026-08-20T10:10:00.000Z",
+              title: "API is down",
+              incidentSeverity: { color: "#123456" },
+            },
+          ],
+        });
+      }
+      return Promise.resolve({
+        data: [
+          {
+            id: new ObjectID("22222222-0000-4000-8000-000000000002"),
+            createdAt: "2026-08-20T10:20:00.000Z",
+            title: "High latency",
+            alertSeverity: undefined,
+          },
+        ],
+      });
+    });
+    analyticsGetListMock.mockResolvedValue({
+      data: [
+        {
+          time: "2026-08-20T10:03:00.000Z",
+          title: "v2.31.0",
+          eventType: "deployment",
+        },
+      ],
+    });
+
+    render(<Probe enabled={true} window={WINDOW} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("marker-count").textContent).toBe("3");
+    });
+
+    const markers: Array<HTMLElement> = screen.getAllByTestId("marker");
+    const byLabel: (needle: string) => HTMLElement = (
+      needle: string,
+    ): HTMLElement => {
+      const found: HTMLElement | undefined = markers.find(
+        (marker: HTMLElement) => {
+          return (marker.textContent || "").includes(needle);
+        },
+      );
+      if (!found) {
+        throw new Error(`no marker containing ${needle}`);
+      }
+      return found;
+    };
+
+    const incident: HTMLElement = byLabel("Incident: API is down");
+    expect(incident.dataset["color"]).toBe("#123456");
+    expect(incident.dataset["dash"]).toBe("solid");
+    expect(incident.dataset["clickable"]).toBe("yes");
+
+    // Alert without a severity color falls back to amber.
+    expect(byLabel("Alert: High latency").dataset["color"]).toBe("#fbbf24");
+
+    const deploy: HTMLElement = byLabel("Deploy: v2.31.0");
+    expect(deploy.dataset["color"]).toBe("#6366f1");
+    expect(deploy.dataset["dash"]).toBe("4 4");
+    // Change events have no detail page — no dead-end click handler.
+    expect(deploy.dataset["clickable"]).toBe("no");
+  });
+
+  test("one source failing never takes the others down", async () => {
+    getListMock.mockImplementation((args: { modelType: { name: string } }) => {
+      if (args.modelType.name === "Incident") {
+        return Promise.resolve({
+          data: [
+            {
+              id: new ObjectID("11111111-0000-4000-8000-000000000001"),
+              createdAt: "2026-08-20T10:10:00.000Z",
+              title: "Still here",
+              incidentSeverity: undefined,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+    analyticsGetListMock.mockRejectedValue(new Error("clickhouse hiccup"));
+
+    render(<Probe enabled={true} window={WINDOW} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("marker-count").textContent).toBe("1");
+    });
+    expect(screen.getByText(/Incident: Still here/)).toBeInTheDocument();
+  });
+
+  test("public dashboards fetch nothing at all", async () => {
+    isPublicDashboardMock.mockReturnValue(true);
+
+    render(<Probe enabled={true} window={WINDOW} />);
+
+    // Give any (wrong) fetch a chance to fire.
+    await new Promise((resolve: (value: unknown) => void) => {
+      setTimeout(resolve, 20);
+    });
+
+    expect(getListMock).not.toHaveBeenCalled();
+    expect(analyticsGetListMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("marker-count").textContent).toBe("0");
+  });
+
+  test("disabled and windowless states fetch nothing and yield no lines", async () => {
+    render(<Probe enabled={false} window={WINDOW} />);
+    render(<Probe enabled={true} window={null} />);
+
+    await new Promise((resolve: (value: unknown) => void) => {
+      setTimeout(resolve, 20);
+    });
+
+    expect(getListMock).not.toHaveBeenCalled();
+    expect(analyticsGetListMock).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/UI/Components/Charts/TooltipEntries.test.ts
+++ b/Common/Tests/UI/Components/Charts/TooltipEntries.test.ts
@@ -53,24 +53,24 @@ describe("prepareTooltipEntries", () => {
     expect(categories(prepared)).toEqual(["cpu1", "cpu2", "cpu10"]);
   });
 
-  test("sorts non-finite values last without dropping them", () => {
+  test("sorts non-finite values last and drops band tuples entirely", () => {
     const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries([
       item("nan-series", NaN),
       item("real-low", 1),
       item("infinite", Infinity),
       item("real-high", 7),
-      // The anomaly band's dataKey yields a [low, high] tuple at runtime.
+      /*
+       * The anomaly band's dataKey yields a [low, high] tuple at runtime
+       * — a shaded region, not a series, so it must not render as a row
+       * nor count toward the overflow footer.
+       */
       item("band", [2, 9] as unknown as number),
     ]);
 
     expect(categories(prepared).slice(0, 2)).toEqual(["real-high", "real-low"]);
     // Non-finite tail keeps natural name order among itself.
-    expect(categories(prepared).slice(2)).toEqual([
-      "band",
-      "infinite",
-      "nan-series",
-    ]);
-    expect(prepared.totalCount).toBe(5);
+    expect(categories(prepared).slice(2)).toEqual(["infinite", "nan-series"]);
+    expect(prepared.totalCount).toBe(4);
   });
 
   test('filters out type "none" entries (hidden click-target lines, band fills)', () => {

--- a/Common/Tests/Utils/Telemetry/CrossSignalScope.test.ts
+++ b/Common/Tests/Utils/Telemetry/CrossSignalScope.test.ts
@@ -597,9 +597,20 @@ describe("toMetricsExplorerQueryParams", () => {
     });
 
     test("reports the signal-specific fields the metric grammar cannot express", () => {
+      const result: CrossSignalQueryParams = toMetricsExplorerQueryParams(
+        fullScope(),
+        "container.cpu.time",
+      );
+
+      /*
+       * serviceIds now CARRY: they ride the explorer's one-shot
+       * `services` param (resolved to resource.service.name filters on
+       * load) instead of being reported dropped.
+       */
+      expect(result.dropped).toEqual(["traceIds", "spanIds", "severityTexts"]);
       expect(
-        toMetricsExplorerQueryParams(fullScope(), "container.cpu.time").dropped,
-      ).toEqual(["serviceIds", "traceIds", "spanIds", "severityTexts"]);
+        JSON.parse(result.params["services"] as string).length,
+      ).toBeGreaterThan(0);
     });
   });
 

--- a/Common/Types/AnalyticsDatabase/AnalyticsTableName.ts
+++ b/Common/Types/AnalyticsDatabase/AnalyticsTableName.ts
@@ -7,6 +7,13 @@ enum AnalyticsTableName {
    * attributes with a keys sidecar for arbitrary-field filtering.
    */
   SecurityEvent = "SecurityEventItemV1",
+  /*
+   * Deploy/config-change markers posted by CI/CD, rendered as dashed
+   * vertical lines on metric charts. Peer of LogItemV3 in layout (tenant
+   * projectId, per-row retentionDate TTL, attributes Map + keys sidecar)
+   * but tiny in volume.
+   */
+  ChangeEvent = "ChangeEventV1",
   Metric = "MetricItemV3",
   ExceptionInstance = "ExceptionItemV3",
   Span = "SpanItemV3",

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -57,12 +57,27 @@ export interface ComponentProps {
   charts: Array<Chart>;
   hideCard?: boolean | undefined;
   chartCssClass?: string | undefined;
+  /**
+   * Share one crosshair-sync channel across SEVERAL ChartGroup instances
+   * (e.g. every metric widget on one dashboard passes the dashboard id,
+   * so hovering an instant on one widget highlights it on all of them).
+   * Absent → this group syncs only within itself.
+   */
+  syncId?: string | undefined;
 }
 
 const ChartGroup: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const syncId: string = Text.generateRandomText(10);
+  /*
+   * Stable per-mount fallback: a plain const regenerated the id on every
+   * render, which forced recharts to tear down and re-subscribe its sync
+   * listeners on each parent re-render (auto-refresh ticks included).
+   */
+  const [fallbackSyncId] = useState<string>(() => {
+    return Text.generateRandomText(10);
+  });
+  const syncId: string = props.syncId || fallbackSyncId;
   const [metricInfoModalChart, setMetricInfoModalChart] =
     useState<ChartMetricInfo | null>(null);
 

--- a/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
@@ -928,7 +928,12 @@ const AreaChart: React.ForwardRefExoticComponent<
         <ResponsiveContainer>
           <RechartsAreaChart
             data={data}
-            syncId={props.syncid?.toString() || ""}
+            /*
+             * Omitted, not "": recharts treats "" as a real sync
+             * channel, so every unsynced chart page-wide would
+             * accidentally sync with every other one.
+             */
+            {...(props.syncid ? { syncId: props.syncid.toString() } : {})}
             {...(hasOnTimeRangeSelect
               ? {
                   onMouseDown: handleRangeSelectMouseDown,

--- a/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
@@ -843,7 +843,12 @@ const BarChart: React.ForwardRefExoticComponent<
         <ResponsiveContainer>
           <RechartsBarChart
             data={data}
-            syncId={props.syncid?.toString() || ""}
+            /*
+             * Omitted, not "": recharts treats "" as a real sync
+             * channel, so every unsynced chart page-wide would
+             * accidentally sync with every other one.
+             */
+            {...(props.syncid ? { syncId: props.syncid.toString() } : {})}
             {...(hasOnValueChange && (activeLegend || activeBar)
               ? {
                   onClick: handleChartClick,

--- a/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
@@ -935,7 +935,12 @@ const LineChart: React.ForwardRefExoticComponent<
         <ResponsiveContainer>
           <RechartsLineChart
             data={data}
-            syncId={props.syncid?.toString() || ""}
+            /*
+             * Omitted, not "": recharts treats "" as a real sync
+             * channel, so every unsynced chart page-wide would
+             * accidentally sync with every other one.
+             */
+            {...(props.syncid ? { syncId: props.syncid.toString() } : {})}
             {...(hasOnTimeRangeSelect
               ? {
                   onMouseDown: handleRangeSelectMouseDown,

--- a/Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries.ts
+++ b/Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries.ts
@@ -46,12 +46,17 @@ export function prepareTooltipEntries<T extends SortableTooltipItem>(
   maxEntries: number = DEFAULT_TOOLTIP_MAX_ENTRIES,
 ): PreparedTooltipEntries<T> {
   /*
-   * `type === "none"` entries are series excluded from legends/tooltips
-   * (recharts tooltipType) — every chart filtered them before this
-   * module existed, so the filter lives here now to stay uniform.
+   * Two kinds of non-series entries are excluded:
+   *  - `type === "none"` (recharts tooltipType) — series explicitly
+   *    excluded from tooltips; every chart filtered these before this
+   *    module existed, so the filter lives here now to stay uniform.
+   *  - Array values — the anomaly band's range Area yields a
+   *    [low, high] tuple per point; it is a shaded region, not a series
+   *    reading, so it must neither render as a row nor count toward the
+   *    "+N more series" overflow.
    */
   const visibleEntries: Array<T> = (payload || []).filter((item: T) => {
-    return item.type !== "none";
+    return item.type !== "none" && !Array.isArray(item.value);
   });
 
   const sortedEntries: Array<T> = visibleEntries

--- a/Common/Utils/Metrics/MetricExplorerUrl.ts
+++ b/Common/Utils/Metrics/MetricExplorerUrl.ts
@@ -1,4 +1,5 @@
 import Dictionary from "../../Types/Dictionary";
+import Includes from "../../Types/BaseDatabase/Includes";
 import JSONFunctions from "../../Types/JSONFunctions";
 import OneUptimeDate from "../../Types/Date";
 import MetricFormulaConfigData from "../../Types/Metrics/MetricFormulaConfigData";
@@ -32,6 +33,15 @@ export enum MetricExplorerUrlParam {
    * (which never had a range param) keep working as pinned windows.
    */
   Range = "range",
+  /*
+   * One-shot service scope: a JSON array of Service ObjectID strings,
+   * emitted by cross-signal pivots (logs/traces -> metrics). The explorer
+   * resolves the ids to service names on load, folds them into every
+   * query's `resource.service.name` attribute filter (the metric store's
+   * service dimension), and then DELETES the param on its next write-back
+   * — the scope lives on as ordinary, user-editable attribute filters.
+   */
+  Services = "services",
 }
 
 export interface SerializedMetricQueryAlias {
@@ -60,7 +70,7 @@ export interface SerializedMetricQuery {
    * lettering (a, b, ...).
    */
   variable?: string | undefined;
-  attributes?: Dictionary<string | number | boolean> | undefined;
+  attributes?: Dictionary<SerializedMetricAttributeValue> | undefined;
   aggregationType?: MetricsAggregationType | undefined;
   alias?: SerializedMetricQueryAlias | undefined;
   groupByAttributeKeys?: Array<string> | undefined;
@@ -90,7 +100,59 @@ export interface SerializedMetricFormula {
   criticalThreshold?: number | undefined;
 }
 
+/*
+ * One attribute filter value inside the serialized `metricQueries` param.
+ * Scalars are equality filters; Includes is the "any of" membership the
+ * UI's operator layer and the query layer both understand. It JSON-
+ * serializes to {_type: "Includes", value: [...]} (its toJSON), which the
+ * parse side rebuilds into a real instance — that round trip is how a
+ * multi-service scope survives Copy Link and saved views.
+ */
+export type SerializedMetricAttributeValue =
+  | string
+  | number
+  | boolean
+  | Includes;
+
+const MAX_SERVICES_PARAM_ENTRIES: number = 20;
+
 export default class MetricExplorerUrl {
+  /**
+   * Parses the `services` param: a JSON array of non-empty strings,
+   * deduped, capped. Garbage yields [] — same defensive posture as the
+   * other param parsers.
+   */
+  public static parseServicesParam(raw: string): Array<string> {
+    let parsedValue: unknown = null;
+
+    try {
+      parsedValue = JSONFunctions.parse(raw);
+    } catch {
+      return [];
+    }
+
+    if (!Array.isArray(parsedValue)) {
+      return [];
+    }
+
+    const serviceIds: Array<string> = [];
+
+    for (const entry of parsedValue) {
+      if (
+        typeof entry === "string" &&
+        entry.trim() !== "" &&
+        !serviceIds.includes(entry)
+      ) {
+        serviceIds.push(entry);
+      }
+      if (serviceIds.length >= MAX_SERVICES_PARAM_ENTRIES) {
+        break;
+      }
+    }
+
+    return serviceIds;
+  }
+
   /*
    * Builds the full URL param dictionary for a metric-view state. Keys
    * are only present when they carry a value (empty/meaningless queries
@@ -188,7 +250,7 @@ export default class MetricExplorerUrl {
     const metricName: string =
       typeof metricNameValue === "string" ? metricNameValue : "";
 
-    const attributes: Dictionary<string | number | boolean> =
+    const attributes: Dictionary<SerializedMetricAttributeValue> =
       MetricExplorerUrl.sanitizeAttributes(filterDataRecord["attributes"]);
 
     const aggregationType: MetricsAggregationType | undefined =
@@ -336,7 +398,7 @@ export default class MetricExplorerUrl {
           ? (entryRecord["variable"] as string)
           : undefined;
 
-      const attributes: Dictionary<string | number | boolean> =
+      const attributes: Dictionary<SerializedMetricAttributeValue> =
         MetricExplorerUrl.sanitizeAttributes(entryRecord["attributes"]);
 
       const aggregationType: MetricsAggregationType | undefined =
@@ -552,7 +614,7 @@ export default class MetricExplorerUrl {
 
   public static sanitizeAttributes(
     value: unknown,
-  ): Dictionary<string | number | boolean> {
+  ): Dictionary<SerializedMetricAttributeValue> {
     if (value === null || value === undefined) {
       return {};
     }
@@ -575,7 +637,7 @@ export default class MetricExplorerUrl {
       return {};
     }
 
-    const attributes: Dictionary<string | number | boolean> = {};
+    const attributes: Dictionary<SerializedMetricAttributeValue> = {};
 
     for (const key in candidate as Record<string, unknown>) {
       const attributeValue: unknown = (candidate as Record<string, unknown>)[
@@ -588,10 +650,62 @@ export default class MetricExplorerUrl {
         typeof attributeValue === "boolean"
       ) {
         attributes[key] = attributeValue;
+        continue;
+      }
+
+      /*
+       * "Any of" membership filters. Live view state holds Includes
+       * INSTANCES; parsed URLs hold the plain {_type, value} JSON shape.
+       * Both normalize to a fresh instance so multi-value filters (e.g.
+       * a multi-service scope) survive Copy Link / saved views instead
+       * of being silently dropped — and downstream consumers (the query
+       * layer, the operator detector, the monitor evaluator's deep-link
+       * builder) all already speak Includes.
+       */
+      const membershipValues: Array<string> | null =
+        MetricExplorerUrl.getIncludesShapeValues(attributeValue);
+
+      if (membershipValues !== null && membershipValues.length > 0) {
+        attributes[key] = new Includes(membershipValues);
       }
     }
 
     return attributes;
+  }
+
+  private static getIncludesShapeValues(value: unknown): Array<string> | null {
+    let rawValues: unknown = null;
+
+    if (value instanceof Includes) {
+      rawValues = value.values;
+    } else if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      (value as Record<string, unknown>)["_type"] === "Includes"
+    ) {
+      rawValues = (value as Record<string, unknown>)["value"];
+    } else {
+      return null;
+    }
+
+    if (!Array.isArray(rawValues)) {
+      return [];
+    }
+
+    const values: Array<string> = [];
+
+    for (const entry of rawValues) {
+      if (
+        (typeof entry === "string" && entry.trim() !== "") ||
+        typeof entry === "number" ||
+        typeof entry === "boolean"
+      ) {
+        values.push(String(entry));
+      }
+    }
+
+    return values;
   }
 
   private static buildAliasFromMetricAliasData(

--- a/Common/Utils/Telemetry/CrossSignalScope.ts
+++ b/Common/Utils/Telemetry/CrossSignalScope.ts
@@ -51,7 +51,9 @@ const WHITESPACE: RegExp = /\s/;
  *  - Metric explorer (Common/Utils/Metrics/MetricExplorerUrl.ts): the
  *    JSON-encoded `metricQueries` param plus absolute `startTime`/`endTime`
  *    (a pinned Custom window is represented by the absolute params alone —
- *    no `range` token).
+ *    no `range` token), plus the one-shot `services` param (JSON array of
+ *    Service ObjectID strings) that the explorer resolves to
+ *    `resource.service.name` attribute filters on load.
  */
 
 /**
@@ -535,11 +537,11 @@ export function toTracesExplorerQueryParams(
  * Custom by the absolute params alone — see MetricExplorerUrl). The
  * optional `metricName` argument names the query.
  *
- * Dropped: serviceIds, resourceFacetSelections, traceIds, spanIds,
- * severityTexts, bodyContains — the metric explorer's URL grammar has no
- * service / resource / trace / span / severity / message dimension (metrics
- * carry a primaryEntityId column, but the explorer only parses metricName +
- * attributes out of `metricQueries`).
+ * Dropped: resourceFacetSelections, traceIds, spanIds, severityTexts,
+ * bodyContains — the metric explorer's URL grammar has no resource /
+ * trace / span / severity / message dimension. serviceIds DO carry, via
+ * the `services` param the explorer folds into `resource.service.name`
+ * attribute filters on load.
  */
 export function toMetricsExplorerQueryParams(
   scope: TelemetryCrossSignalScope,
@@ -567,6 +569,17 @@ export function toMetricsExplorerQueryParams(
     params[MetricExplorerUrlParam.MetricQueries] = JSON.stringify([query]);
   }
 
+  /*
+   * Service scope rides the one-shot `services` param — the explorer
+   * resolves ids to names and folds them into `resource.service.name`
+   * attribute filters on load, so serviceIds is no longer dropped.
+   */
+  const scopedServiceIds: Array<string> = sanitizeValues(scope.serviceIds);
+
+  if (scopedServiceIds.length > 0) {
+    params[MetricExplorerUrlParam.Services] = JSON.stringify(scopedServiceIds);
+  }
+
   const window: ResolvedTimeWindow = resolveTimeWindow(scope);
 
   if (window.startTime && window.endTime) {
@@ -576,10 +589,6 @@ export function toMetricsExplorerQueryParams(
     params[MetricExplorerUrlParam.EndTime] = OneUptimeDate.toString(
       window.endTime,
     );
-  }
-
-  if (sanitizeValues(scope.serviceIds).length > 0) {
-    dropped.push("serviceIds");
   }
 
   for (const [facetKey] of sanitizeResourceFacetSelections(


### PR DESCRIPTION
**PR A of the debuggability stack** (items 1–4 of the roadmap; PR B — investigate drawer, service golden-signals, baselines, pinnable tooltips — and PR C — AI "explain this spike", investigation artifacts — will stack on this branch).

## 1. Change events (deploys / config changes) on every metric chart
- New **ChangeEvent** ClickHouse signal (`ChangeEventV1`): Log's proven layout — tenant `projectId`, per-row `retentionDate` TTL, `attributes` Map + bloom-indexed keys sidecar. Table auto-creates at boot (registered in both `AnalyticsModels` and `AnalyticsServices`); standard analytics CRUD API at `/change-events`; MCP + docs enabled.
- **CI/CD ingest**: `POST /telemetry/change-events/v1/ingest` with the standard telemetry ingestion-key auth. Synchronous 2xx/4xx (deploy steps want a definitive answer), entries validated/capped, timestamps clock-clamped (partition-forging protection, original preserved in attributes), rows written through the shared fan-in writer. Service-attributed events follow the service's metrics retention ladder; project-wide markers keep a year.
- **Rendering**: the metric explorer's incident/alert event overlay is extracted into a shared `useEventTimeReferenceLines` hook, which now also fetches change events (dashed indigo markers, distinct from solid severity-colored incident/alert markers with click-through). Mounted on the surfaces that previously had **no event context**: dashboard chart widgets and `EmbeddedMetricCard` (which covers monitor metrics tabs, infrastructure resource tabs, and companion signal tabs). Public dashboards fetch nothing; each source fails independently.

## 2. Telemetry snapshots on episode pages
Incident/alert **episode** views now mount the same primary-signal + companion-tabs experience their member events have: the first member's stored `telemetryQuery` is fetched, rehydrated, and narrowed to its own series via a new pure `deriveTelemetrySnapshot` util (extracted from the incident view's inline recipe), rendered by a shared `TelemetrySnapshotPanel`.

## 3. Lossless cross-signal pivots, both directions
- **logs/traces → metrics** no longer drop service scope: `toMetricsExplorerQueryParams` emits a one-shot `services` param (Service ObjectIDs); the explorer resolves ids → names on load, folds them into `resource.service.name` filters on every query, deletes the param on write-back, and reports unresolvable ids in a toast. `hasInitialUrlState` counts the param so a pure service deep link isn't clobbered by the default saved view.
- **Multi-value attribute filters round-trip**: the explorer URL serializer now carries `Includes` memberships (previously silently dropped on Copy Link / saved views).
- **metrics/series → exceptions** can carry attribute scope: the Exceptions list gains `attributes.<key>` facet chips; unknown `@key:value` search tokens become attribute chips instead of compiling to invalid Postgres columns. Compiled as a fingerprint join against ClickHouse instance rows (the `ExceptionsTable` entity-scope pattern): one instance query ANDs all attribute filters + window, and the resolved fingerprints narrow the list **and** the histogram/facets counts. A pending or empty scope shows an empty list via a no-match sentinel — never a flash of unfiltered data.

## 4. Dashboard-wide crosshair sync
All metric chart widgets on one dashboard share a recharts sync channel (the dashboard id) — hover an instant on one widget and it highlights on all of them. Fixes en route: ChartGroup's sync id was regenerated **every render** (tearing recharts sync subscriptions down on every tick) — now a stable per-mount fallback; and an unset sync no longer degrades to the `""` channel that would accidentally sync every unsynced chart page-wide.

## Also carried
The adversarial-review hardening of the series-investigation feature (parent commit `494b149594`): verbatim-cased K8s cluster lookup, widget zoom fetch-race guard, body-portaled pivot menus, SPA navigation so dropped-scope toasts survive, DataSource-widget/public-dashboard gating, focus restore + ARIA + WCAG contrast on the magnifier, project-keyed resolver caches, UUID validation on telemetry-sourced route params.

## Tests
6 new suites + updated serializer pins; ~90 new cases: change-event parsing/row-building/model/registry pins, telemetry snapshot derivation (incl. `(unset)` → is-empty and ISO rehydration), exceptions attribute scope (prefix rules, scope-key stability, AND-composition, sentinel), services param + `Includes` round trip + cached id→name resolver, and an RTL suite for the overlay hook (marker styles per source, per-source failure isolation, public-dashboard/disabled guards). Full local runs: **App 192 suites / 6711 tests**, **Common 103 suites / 2937 tests** in affected areas; `tsc --noEmit` clean in both workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HxEiCGGsLcTyJe4cR7ofb