### PR TITLE
feat(debuggability): investigate drawer, bucket inspector, compare overlays, service signals (PR B / 3)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
@@ -28,6 +28,7 @@ import DashboardChartType from "Common/Types/Dashboard/Chart/ChartType";
 import DashboardVariableInterpolation from "Common/Utils/Dashboard/VariableInterpolation";
 import ExplorerLink from "../../Metrics/Utils/ExplorerLink";
 import { isPublicDashboard } from "../Utils/PublicDashboardContext";
+import InvestigationDrawer from "../../Telemetry/InvestigationDrawer";
 import useEventTimeReferenceLines, {
   EventTimeReferenceLines,
 } from "../../Metrics/Utils/UseEventTimeReferenceLines";
@@ -128,6 +129,10 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
    * statement about what the user wants to see everywhere.
    */
   const [zoomWindow, setZoomWindow] = useState<InBetween<Date> | null>(null);
+
+  // The zoomed window under investigation (opens the side panel).
+  const [investigationWindow, setInvestigationWindow] =
+    useState<InBetween<Date> | null>(null);
 
   useEffect(() => {
     setZoomWindow(null);
@@ -445,16 +450,39 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
             Reset
           </button>
           {showOpenInExplorer ? (
-            <button
-              type="button"
-              className="text-[11px] font-medium text-indigo-600 underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
-              title="Open this window in Metric Explorer"
-              onClick={handleOpenInExplorer}
-            >
-              Open in Explorer
-            </button>
+            <>
+              <button
+                type="button"
+                className="text-[11px] font-semibold text-indigo-700 underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                title="Investigate this window — logs, traces, exceptions"
+                onClick={(event: React.MouseEvent<HTMLButtonElement>): void => {
+                  event.stopPropagation();
+                  setInvestigationWindow(zoomWindow);
+                }}
+              >
+                Investigate
+              </button>
+              <button
+                type="button"
+                className="text-[11px] font-medium text-indigo-600 underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                title="Open this window in Metric Explorer"
+                onClick={handleOpenInExplorer}
+              >
+                Open in Explorer
+              </button>
+            </>
           ) : null}
         </div>
+      ) : null}
+      {investigationWindow ? (
+        <InvestigationDrawer
+          title={props.component.arguments.chartTitle || "Chart widget"}
+          window={investigationWindow}
+          metricViewData={chartMetricViewData}
+          onClose={() => {
+            setInvestigationWindow(null);
+          }}
+        />
       ) : null}
       <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
         <MetricCharts

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsInsightsApi.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsInsightsApi.ts
@@ -67,6 +67,25 @@ export async function fetchInsightsHistogram(
   return Array.isArray(buckets) ? (buckets as Array<JSONObject>) : [];
 }
 
+/**
+ * Severity-bucketed volume for an arbitrary prebuilt request body — the
+ * seam for callers whose scope includes ATTRIBUTE filters
+ * (LogsHistogramRequest.buildLogsHistogramRequest), which
+ * LogsInsightsScope deliberately does not model.
+ */
+export async function fetchLogsHistogramRaw(
+  body: JSONObject,
+): Promise<Array<JSONObject>> {
+  const response: HTTPResponse<JSONObject> = await postApi(
+    "/telemetry/logs/histogram",
+    body,
+  );
+
+  const buckets: unknown = response.data["buckets"];
+
+  return Array.isArray(buckets) ? (buckets as Array<JSONObject>) : [];
+}
+
 /** The distinct error messages in the window, most frequent first. */
 export async function fetchTopErrorPatterns(
   scope: LogsInsightsScope,

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -84,6 +84,8 @@ import {
   splitSeriesNameIntoSegments,
 } from "../../Utils/MetricSeriesInvestigation";
 import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import { PREVIOUS_PERIOD_SERIES_SUFFIX } from "Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries";
+import InvestigationDrawer from "../Telemetry/InvestigationDrawer";
 import ExplorerLink from "./Utils/ExplorerLink";
 import { ShowToastNotification } from "Common/UI/Components/Toast/ToastInit";
 import { ToastType } from "Common/UI/Components/Toast/Toast";
@@ -148,6 +150,15 @@ export interface ComponentProps {
    * pass false.
    */
   enableSeriesActions?: boolean | undefined;
+  /*
+   * Compare-to-previous-period overlays: results for the SAME queries
+   * over the window shifted back by `compareOffsetMs`, index-aligned to
+   * queryConfigs like metricResults. Rendered as dashed, faded ghost
+   * lines behind each displayed series — never consuming Top-N slots,
+   * legend chips, or tooltip cap slots.
+   */
+  metricResultsPrevious?: Array<AggregatedResult> | undefined;
+  compareOffsetMs?: number | undefined;
   /*
    * Crosshair-sync channel shared with OTHER MetricCharts instances
    * (dashboards pass the dashboard id so hovering one widget highlights
@@ -440,6 +451,21 @@ interface ExemplarMenuState {
  * clamp its fixed position the same way the exemplar menu is clamped.
  */
 const SERIES_MENU_WIDTH_PX: number = 260;
+
+/*
+ * Pinned bucket inspector card dimensions (viewport clamping, same
+ * scheme as the pivot menus).
+ */
+const BUCKET_INSPECTOR_WIDTH_PX: number = 300;
+const BUCKET_INSPECTOR_HEIGHT_PX: number = 340;
+// At most this many series rows in the inspector; the rest summarize.
+const BUCKET_INSPECTOR_MAX_ROWS: number = 8;
+/*
+ * A single bucket can be seconds wide — too narrow a window to find
+ * correlated logs/traces in. Investigations open on at least this span,
+ * centered on the clicked bucket.
+ */
+const MIN_INVESTIGATION_WINDOW_MS: number = 5 * 60 * 1000;
 const SERIES_MENU_HEIGHT_PX: number = 280;
 
 // One open per-series investigate menu.
@@ -1679,6 +1705,135 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     });
   };
 
+  /*
+   * The in-context investigation drawer: opened from the series menu, the
+   * bucket inspector, or (in hosts) zoom bars — everything that happened
+   * in one window, without leaving the page.
+   */
+  const [investigation, setInvestigation] = useState<{
+    title: string;
+    window: InBetween<Date>;
+    viewData: MetricViewData;
+  } | null>(null);
+
+  // One pinned bucket inspector (chart click), portalled like the menus.
+  interface BucketInspectorEntry {
+    name: string;
+    value: number;
+  }
+  const [bucketInspector, setBucketInspector] = useState<{
+    title: string;
+    bucketStart: Date;
+    bucketEnd: Date;
+    entries: Array<BucketInspectorEntry>;
+    hiddenCount: number;
+    formatValue: (value: number) => string;
+    position: { x: number; y: number };
+  } | null>(null);
+
+  const {
+    ref: bucketInspectorRef,
+    isComponentVisible: isBucketInspectorVisible,
+    setIsComponentVisible: setIsBucketInspectorVisible,
+  } = useComponentOutsideClick(false);
+
+  const closeBucketInspector: VoidFunction = useCallback((): void => {
+    setIsBucketInspectorVisible(false);
+    setBucketInspector(null);
+  }, [setIsBucketInspectorVisible]);
+
+  const openBucketInspector: (input: {
+    title: string;
+    bucketStart: Date;
+    bucketEnd: Date;
+    valuesAtBucket: Record<string, number | string>;
+    seriesNames: Array<string>;
+    formatValue: (value: number) => string;
+  }) => void = useCallback(
+    (input: {
+      title: string;
+      bucketStart: Date;
+      bucketEnd: Date;
+      valuesAtBucket: Record<string, number | string>;
+      seriesNames: Array<string>;
+      formatValue: (value: number) => string;
+    }): void => {
+      /*
+       * Highest value first — the same "which series is spiking?"
+       * ordering the hover tooltip uses, but pinned.
+       */
+      const entries: Array<BucketInspectorEntry> = input.seriesNames
+        .map((name: string): BucketInspectorEntry | null => {
+          const value: unknown = input.valuesAtBucket[name];
+          return typeof value === "number" && Number.isFinite(value)
+            ? { name, value }
+            : null;
+        })
+        .filter((entry: BucketInspectorEntry | null): boolean => {
+          return entry !== null;
+        })
+        .map((entry: BucketInspectorEntry | null): BucketInspectorEntry => {
+          return entry as BucketInspectorEntry;
+        })
+        .sort((a: BucketInspectorEntry, b: BucketInspectorEntry): number => {
+          return b.value - a.value;
+        });
+
+      const pointer: { x: number; y: number } = lastPointerPositionRef.current;
+      const maxX: number =
+        window.innerWidth -
+        BUCKET_INSPECTOR_WIDTH_PX -
+        EXEMPLAR_MENU_VIEWPORT_MARGIN_PX;
+      const maxY: number =
+        window.innerHeight -
+        BUCKET_INSPECTOR_HEIGHT_PX -
+        EXEMPLAR_MENU_VIEWPORT_MARGIN_PX;
+
+      setBucketInspector({
+        title: input.title,
+        bucketStart: input.bucketStart,
+        bucketEnd: input.bucketEnd,
+        entries: entries.slice(0, BUCKET_INSPECTOR_MAX_ROWS),
+        hiddenCount: Math.max(0, entries.length - BUCKET_INSPECTOR_MAX_ROWS),
+        formatValue: input.formatValue,
+        position: {
+          x: Math.max(
+            EXEMPLAR_MENU_VIEWPORT_MARGIN_PX,
+            Math.min(pointer.x, maxX),
+          ),
+          y: Math.max(
+            EXEMPLAR_MENU_VIEWPORT_MARGIN_PX,
+            Math.min(pointer.y, maxY),
+          ),
+        },
+      });
+      setIsBucketInspectorVisible(true);
+    },
+    [setIsBucketInspectorVisible],
+  );
+
+  const investigateBucket: VoidFunction = useCallback((): void => {
+    if (!bucketInspector) {
+      return;
+    }
+    const widthMs: number =
+      bucketInspector.bucketEnd.getTime() -
+      bucketInspector.bucketStart.getTime();
+    const padMs: number = Math.max(
+      0,
+      (MIN_INVESTIGATION_WINDOW_MS - widthMs) / 2,
+    );
+    setInvestigation({
+      title: bucketInspector.title,
+      window: new InBetween<Date>(
+        new Date(bucketInspector.bucketStart.getTime() - padMs),
+        new Date(bucketInspector.bucketEnd.getTime() + padMs),
+      ),
+      viewData: props.metricViewData,
+    });
+    closeBucketInspector();
+  }, [bucketInspector, closeBucketInspector, props.metricViewData]);
+
   const getScopedViewDataForSeries: (
     menuState: SeriesMenuState,
   ) => SeriesScopedViewData = (
@@ -2633,6 +2788,84 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
       });
 
       /*
+       * Compare-to-previous-period ghosts. Built AFTER presentation so
+       * they never consume Top-N slots, legend chips, or color positions
+       * of live series — for each DISPLAYED series with a same-named
+       * previous-window series, append a time-shifted "<name> (previous)"
+       * twin. The shift is mandatory: the bucketer indexes points against
+       * the CURRENT window's intervals and silently drops anything
+       * outside it.
+       */
+      let renderSeries: Array<SeriesPoint> = displayableSeries;
+      let renderColors: Array<ChartColorValue> | undefined = colorsOverride;
+      let ghostSeriesNames: Array<string> | undefined = undefined;
+
+      if (
+        props.metricResultsPrevious &&
+        props.compareOffsetMs &&
+        props.compareOffsetMs > 0
+      ) {
+        const previousSeriesByName: Map<string, SeriesPoint> = new Map<
+          string,
+          SeriesPoint
+        >();
+        for (const member of members) {
+          const previousResult: AggregatedResult | undefined =
+            props.metricResultsPrevious[member.queryConfigIndex];
+          if (!previousResult) {
+            continue;
+          }
+          for (const series of buildQuerySeries(
+            member.queryConfig,
+            previousResult,
+          )) {
+            previousSeriesByName.set(series.seriesName, series);
+          }
+        }
+
+        const resolveColorForRender: SeriesColorResolver =
+          makeResolveColor(displayableSeries);
+        const ghosts: Array<SeriesPoint> = [];
+        const ghostColors: Array<ChartColorValue> = [];
+        const baseColors: Array<ChartColorValue> = displayableSeries.map(
+          (series: SeriesPoint, index: number): ChartColorValue => {
+            return (
+              colorsOverride?.[index] ||
+              resolveColorForRender(series.seriesName, index)
+            );
+          },
+        );
+
+        displayableSeries.forEach((series: SeriesPoint, index: number) => {
+          const previous: SeriesPoint | undefined = previousSeriesByName.get(
+            series.seriesName,
+          );
+          if (!previous || previous.data.length === 0) {
+            return;
+          }
+          ghosts.push({
+            seriesName: `${series.seriesName}${PREVIOUS_PERIOD_SERIES_SUFFIX}`,
+            data: previous.data.map((point: { x: Date; y: number }) => {
+              return {
+                x: new Date(point.x.getTime() + props.compareOffsetMs!),
+                y: point.y,
+              };
+            }),
+          });
+          // A ghost wears its live twin's color; dash/fade distinguish.
+          ghostColors.push(baseColors[index]!);
+        });
+
+        if (ghosts.length > 0) {
+          renderSeries = [...displayableSeries, ...ghosts];
+          renderColors = [...baseColors, ...ghostColors];
+          ghostSeriesNames = ghosts.map((ghost: SeriesPoint): string => {
+            return ghost.seriesName;
+          });
+        }
+      }
+
+      /*
        * Soft 0–100% range computed from the currently visible series, so
        * hiding the dominant series via the legend rescales the axis to
        * what's actually on screen instead of staying anchored to the
@@ -2651,7 +2884,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         let observedMax: number = Number.NEGATIVE_INFINITY;
         let observedMin: number = 0;
         let hasFinitePoint: boolean = false;
-        for (const series of displayableSeries) {
+        for (const series of renderSeries) {
           for (const point of series.data) {
             if (typeof point.y === "number" && Number.isFinite(point.y)) {
               hasFinitePoint = true;
@@ -2691,7 +2924,8 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
         onExemplarClick: handleExemplarClick,
         seriesControls: seriesControls,
         props: {
-          data: displayableSeries,
+          data: renderSeries,
+          ghostSeriesNames,
           xAxis: {
             legend: "Time",
             options: {
@@ -2730,10 +2964,30 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
           },
           curve: ChartCurve.MONOTONE,
           sync: true,
-          colors: colorsOverride,
+          colors: renderColors,
           referenceLines:
             referenceLines.length > 0 ? referenceLines : undefined,
           onTimeRangeSelect: props.onTimeRangeSelect,
+          onBucketClick: showSeriesActions
+            ? (
+                bucketStart: Date,
+                bucketEnd: Date,
+                valuesAtBucket: Record<string, number | string>,
+              ): void => {
+                openBucketInspector({
+                  title: chart.title,
+                  bucketStart,
+                  bucketEnd,
+                  valuesAtBucket,
+                  seriesNames: displayableSeries.map(
+                    (series: SeriesPoint): string => {
+                      return series.seriesName;
+                    },
+                  ),
+                  formatValue: seriesValueFormatter,
+                });
+              }
+            : undefined,
           timeReferenceLines: props.timeReferenceLines,
           referenceRegions: props.referenceRegions,
         },
@@ -3007,6 +3261,28 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
               ? formulaReferenceLines
               : undefined,
           onTimeRangeSelect: props.onTimeRangeSelect,
+          onBucketClick: showSeriesActions
+            ? (
+                bucketStart: Date,
+                bucketEnd: Date,
+                valuesAtBucket: Record<string, number | string>,
+              ): void => {
+                openBucketInspector({
+                  title: formulaChart.title,
+                  bucketStart,
+                  bucketEnd,
+                  valuesAtBucket,
+                  seriesNames: formulaDisplayableSeries.map(
+                    (series: SeriesPoint): string => {
+                      return series.seriesName;
+                    },
+                  ),
+                  formatValue: (value: number): string => {
+                    return ValueFormatter.formatValue(value, formulaUnit);
+                  },
+                });
+              }
+            : undefined,
           timeReferenceLines: props.timeReferenceLines,
           referenceRegions: props.referenceRegions,
         },
@@ -3144,6 +3420,23 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
                   </p>
                 ) : null}
               </div>
+              {exemplarWindow ? (
+                <MoreMenuItem
+                  key="series-investigate-window"
+                  icon={IconProp.MagnifyingGlassPlus}
+                  text="Investigate in panel"
+                  onClick={() => {
+                    const menuState: SeriesMenuState = seriesMenu;
+                    closeSeriesMenu();
+                    setInvestigation({
+                      title: menuState.seriesName,
+                      window: exemplarWindow,
+                      viewData:
+                        getScopedViewDataForSeries(menuState).scopedViewData,
+                    });
+                  }}
+                />
+              ) : null}
               {props.onQueryConfigsChange && seriesMenuScoped?.didNarrow ? (
                 <MoreMenuItem
                   key="series-filter"
@@ -3223,6 +3516,107 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
             document.body,
           )
         : null}
+      {bucketInspector && isBucketInspectorVisible
+        ? ReactDOM.createPortal(
+            <div
+              ref={bucketInspectorRef}
+              role="dialog"
+              aria-label={`Values at ${OneUptimeDate.getDateAsFormattedString(bucketInspector.bucketStart)}`}
+              className="fixed z-50 w-[300px] rounded-lg bg-white shadow-xl ring-1 ring-gray-200 focus:outline-none"
+              style={{
+                left: `${bucketInspector.position.x}px`,
+                top: `${bucketInspector.position.y}px`,
+              }}
+              onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  closeBucketInspector();
+                }
+              }}
+            >
+              <div className="border-b border-gray-100 px-3 py-2">
+                <p
+                  className="truncate text-xs font-semibold text-gray-900"
+                  title={bucketInspector.title}
+                >
+                  {bucketInspector.title}
+                </p>
+                <p className="mt-0.5 text-[11px] tabular-nums text-gray-500">
+                  {OneUptimeDate.getInBetweenDatesAsFormattedString(
+                    new InBetween<Date>(
+                      bucketInspector.bucketStart,
+                      bucketInspector.bucketEnd,
+                    ),
+                  )}
+                </p>
+              </div>
+              <div className="max-h-52 space-y-0.5 overflow-y-auto px-3 py-2">
+                {bucketInspector.entries.length === 0 ? (
+                  <p className="text-xs text-gray-400">
+                    No data points in this bucket.
+                  </p>
+                ) : (
+                  bucketInspector.entries.map(
+                    (entry: { name: string; value: number }, index: number) => {
+                      return (
+                        <div
+                          key={entry.name}
+                          className="flex items-baseline justify-between gap-3"
+                        >
+                          <span className="min-w-0 flex-1 truncate text-xs text-gray-700">
+                            <span className="mr-1.5 tabular-nums text-gray-400">
+                              {index + 1}.
+                            </span>
+                            {entry.name}
+                          </span>
+                          <span className="shrink-0 text-xs font-medium tabular-nums text-gray-900">
+                            {bucketInspector.formatValue(entry.value)}
+                          </span>
+                        </div>
+                      );
+                    },
+                  )
+                )}
+                {bucketInspector.hiddenCount > 0 ? (
+                  <p className="pt-1 text-[11px] text-gray-400">
+                    +{bucketInspector.hiddenCount} more series
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex items-center justify-end gap-2 border-t border-gray-100 px-3 py-2">
+                <button
+                  type="button"
+                  className="rounded-md px-2 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                  onClick={closeBucketInspector}
+                >
+                  Close
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-2.5 py-1 text-xs font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                  onClick={investigateBucket}
+                >
+                  <Icon
+                    icon={IconProp.MagnifyingGlassPlus}
+                    className="h-3.5 w-3.5"
+                  />
+                  Investigate this moment
+                </button>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+      {investigation ? (
+        <InvestigationDrawer
+          title={investigation.title}
+          window={investigation.window}
+          metricViewData={investigation.viewData}
+          onClose={() => {
+            setInvestigation(null);
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
@@ -70,11 +70,13 @@ import { ShowToastNotification } from "Common/UI/Components/Toast/ToastInit";
 import useEventTimeReferenceLines, {
   EventTimeReferenceLines,
 } from "./Utils/UseEventTimeReferenceLines";
+import InvestigationDrawer from "../Telemetry/InvestigationDrawer";
 import { ToastType } from "Common/UI/Components/Toast/Toast";
 
 const AUTO_REFRESH_STORAGE_KEY: string =
   "metric-explorer-auto-refresh-interval";
 const SHOW_EVENTS_STORAGE_KEY: string = "metric-explorer-show-events";
+const COMPARE_PREVIOUS_STORAGE_KEY: string = "metric-explorer-compare-previous";
 
 // One toolbar-button idiom for the explorer's investigation row.
 const TOOLBAR_BUTTON_CLASS_NAME: string =
@@ -381,6 +383,36 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
     enabled: showEvents,
     window: metricViewData.startAndEndDate,
   });
+
+  /*
+   * The in-context investigation panel for the CURRENT window + filters —
+   * companion signals and the log summary without leaving the explorer.
+   */
+  const [isInvestigationOpen, setIsInvestigationOpen] =
+    useState<boolean>(false);
+
+  // Compare-to-previous-period ghost overlays (persisted per browser).
+  const [showCompare, setShowCompare] = useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return (
+      window.localStorage?.getItem(COMPARE_PREVIOUS_STORAGE_KEY) === "true"
+    );
+  });
+
+  const toggleShowCompare: VoidFunction = (): void => {
+    setShowCompare((previous: boolean): boolean => {
+      const next: boolean = !previous;
+      if (typeof window !== "undefined") {
+        window.localStorage?.setItem(
+          COMPARE_PREVIOUS_STORAGE_KEY,
+          String(next),
+        );
+      }
+      return next;
+    });
+  };
 
   // -- Saved explorer views --
 
@@ -706,6 +738,22 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
                   <span>Traces</span>
                 </button>
               </Tooltip>
+              <Tooltip text="Investigate this window in a side panel — logs, traces, exceptions">
+                <button
+                  type="button"
+                  aria-label="Investigate this time window in a side panel"
+                  className={`${TOOLBAR_BUTTON_CLASS_NAME} ${TOOLBAR_BUTTON_IDLE_CLASS_NAME}`}
+                  onClick={() => {
+                    setIsInvestigationOpen(true);
+                  }}
+                >
+                  <Icon
+                    icon={IconProp.MagnifyingGlassPlus}
+                    className="h-3.5 w-3.5"
+                  />
+                  <span>Investigate</span>
+                </button>
+              </Tooltip>
               <Tooltip
                 text={
                   showEvents
@@ -731,6 +779,31 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
                       {eventMarkerCount}
                     </span>
                   ) : null}
+                </button>
+              </Tooltip>
+              <Tooltip
+                text={
+                  showCompare
+                    ? "Hide the previous period's ghost lines"
+                    : "Overlay each chart with the previous period (dashed)"
+                }
+              >
+                <button
+                  type="button"
+                  aria-label="Toggle compare with previous period"
+                  aria-pressed={showCompare}
+                  onClick={toggleShowCompare}
+                  className={`${TOOLBAR_BUTTON_CLASS_NAME} ${
+                    showCompare
+                      ? TOOLBAR_BUTTON_ACTIVE_CLASS_NAME
+                      : TOOLBAR_BUTTON_IDLE_CLASS_NAME
+                  }`}
+                >
+                  <Icon
+                    icon={IconProp.ArrowUturnLeft}
+                    className="h-3.5 w-3.5"
+                  />
+                  <span>Compare</span>
                 </button>
               </Tooltip>
             </div>
@@ -806,10 +879,23 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
         </div>
       </div>
 
+      {isInvestigationOpen &&
+      metricViewData.startAndEndDate?.startValue instanceof Date &&
+      metricViewData.startAndEndDate?.endValue instanceof Date ? (
+        <InvestigationDrawer
+          title="Investigate this view"
+          window={metricViewData.startAndEndDate}
+          metricViewData={metricViewData}
+          onClose={() => {
+            setIsInvestigationOpen(false);
+          }}
+        />
+      ) : null}
       <MetricView
         data={metricViewData}
         hideStartAndEndDate={true}
         refreshNonce={refreshNonce}
+        compareWithPreviousPeriod={showCompare}
         timeReferenceLines={
           eventReferenceLines.length > 0 ? eventReferenceLines : undefined
         }

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -171,6 +171,12 @@ export interface ComponentProps {
    * unsaved monitor form is an invitation to lose work.
    */
   enableSeriesActions?: boolean | undefined;
+  /*
+   * Overlay each chart with the SAME queries fetched one window earlier
+   * (dashed, faded ghost lines) — "is this spike normal for this hour?"
+   * answered in place.
+   */
+  compareWithPreviousPeriod?: boolean | undefined;
   // Time-anchored annotations forwarded to every chart (see MetricCharts).
   timeReferenceLines?: Array<ChartTimeReferenceLineProps> | undefined;
   referenceRegions?: Array<ChartReferenceRegionProps> | undefined;
@@ -376,6 +382,8 @@ const MetricView: FunctionComponent<ComponentProps> = (
     const currentFetchSnapshot: string = JSON.stringify({
       fetchState: getFetchRelevantState(effectiveData),
       refreshNonce: props.refreshNonce ?? null,
+      // Toggling compare adds/removes the shifted fetch — refetch.
+      compareWithPreviousPeriod: props.compareWithPreviousPeriod === true,
     });
 
     const shouldFetch: boolean =
@@ -395,6 +403,9 @@ const MetricView: FunctionComponent<ComponentProps> = (
     }
   }, [props.data, effectiveData, props.refreshNonce]);
 
+  const [metricResultsPrevious, setMetricResultsPrevious] =
+    useState<Array<AggregatedResult> | null>(null);
+  const [compareOffsetMs, setCompareOffsetMs] = useState<number>(0);
   const [metricResults, setMetricResults] = useState<Array<AggregatedResult>>(
     [],
   );
@@ -728,17 +739,56 @@ const MetricView: FunctionComponent<ComponentProps> = (
       }
 
       try {
-        const results: Array<AggregatedResult> = await MetricUtil.fetchResults({
-          metricViewData: effectiveData,
-          aggregationInterval: aggregationInterval,
-          refreshNonce: props.refreshNonce,
-          /*
-           * MetricView renders MetricCharts' Top-N controls and the
-           * "Showing top k of N" truncation banner, so it opts in to
-           * the default server-side Top-N cap for grouped queries.
-           */
-          defaultTopN: true,
-        });
+        /*
+         * Compare mode: the SAME queries over the window shifted back by
+         * exactly one window width, same aggregation interval so previous
+         * buckets are congruent with current ones modulo the shift. The
+         * distinct window gives it its own fetch-cache identity.
+         */
+        const windowStart: Date | undefined =
+          effectiveData.startAndEndDate?.startValue;
+        const windowEnd: Date | undefined =
+          effectiveData.startAndEndDate?.endValue;
+        const windowMs: number =
+          props.compareWithPreviousPeriod &&
+          windowStart instanceof Date &&
+          windowEnd instanceof Date
+            ? windowEnd.getTime() - windowStart.getTime()
+            : 0;
+
+        const [results, previousResults]: [
+          Array<AggregatedResult>,
+          Array<AggregatedResult> | null,
+        ] = await Promise.all([
+          MetricUtil.fetchResults({
+            metricViewData: effectiveData,
+            aggregationInterval: aggregationInterval,
+            refreshNonce: props.refreshNonce,
+            /*
+             * MetricView renders MetricCharts' Top-N controls and the
+             * "Showing top k of N" truncation banner, so it opts in to
+             * the default server-side Top-N cap for grouped queries.
+             */
+            defaultTopN: true,
+          }),
+          windowMs > 0
+            ? MetricUtil.fetchResults({
+                metricViewData: {
+                  ...effectiveData,
+                  startAndEndDate: new InBetween<Date>(
+                    new Date(windowStart!.getTime() - windowMs),
+                    new Date(windowEnd!.getTime() - windowMs),
+                  ),
+                },
+                aggregationInterval: aggregationInterval,
+                refreshNonce: props.refreshNonce,
+                defaultTopN: true,
+              }).catch((): null => {
+                // Ghosts are best-effort — never break the live charts.
+                return null;
+              })
+            : Promise.resolve(null),
+        ]);
 
         // A newer fetch superseded this one — drop the stale results.
         if (fetchSeqRef.current !== fetchSeq) {
@@ -746,6 +796,8 @@ const MetricView: FunctionComponent<ComponentProps> = (
         }
 
         setMetricResults(results);
+        setMetricResultsPrevious(windowMs > 0 ? previousResults : null);
+        setCompareOffsetMs(windowMs);
         setMetricResultsError("");
         setHasFetchedResultsOnce(true);
       } catch (err: unknown) {
@@ -1299,6 +1351,16 @@ const MetricView: FunctionComponent<ComponentProps> = (
                     metricViewData={effectiveData}
                     chartCssClass={props.chartCssClass}
                     enableSeriesActions={props.enableSeriesActions}
+                    metricResultsPrevious={
+                      props.compareWithPreviousPeriod && metricResultsPrevious
+                        ? metricResultsPrevious
+                        : undefined
+                    }
+                    compareOffsetMs={
+                      props.compareWithPreviousPeriod && metricResultsPrevious
+                        ? compareOffsetMs
+                        : undefined
+                    }
                     onQueryConfigsChange={(
                       queryConfigs: Array<MetricQueryConfigData>,
                     ) => {

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer.tsx
@@ -1,0 +1,411 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import Dictionary from "Common/Types/Dictionary";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import OneUptimeDate from "Common/Types/Date";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import TimeRange from "Common/Types/Time/TimeRange";
+import { JSONObject } from "Common/Types/JSON";
+import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
+import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import Card from "Common/UI/Components/Card/Card";
+import Icon from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
+import SideOver, { SideOverSize } from "Common/UI/Components/SideOver/SideOver";
+import { HistogramBucket } from "Common/UI/Components/LogsViewer/types";
+import LogsHistogram from "Common/UI/Components/LogsViewer/components/LogsHistogram";
+import Navigation from "Common/UI/Utils/Navigation";
+import HintChip from "../Metrics/HintChip";
+import EmbeddedMetricCard from "../Metrics/EmbeddedMetricCard";
+import ExplorerLink from "../Metrics/Utils/ExplorerLink";
+import TelemetryCompanionSignalTabs from "./TelemetryCompanionSignalTabs";
+import { buildLogsHistogramRequest } from "../Logs/LogsHistogramRequest";
+import {
+  fetchLogsHistogramRaw,
+  fetchTopErrorPatterns,
+} from "../Logs/LogsInsightsApi";
+import {
+  LogVolumeSummary,
+  LogsInsightsScope,
+  TopErrorPatternRow,
+  buildErrorPatternLogsRoute,
+  describeOccurrenceCount,
+  summarizeSeverityBuckets,
+} from "../../Utils/LogsInsights";
+import {
+  MetricScopeFilterExtraction,
+  extractScopeFiltersFromQueryConfigs,
+  formatDroppedScopeHint,
+  resolveServiceIdsByNames,
+} from "../../Utils/MetricsCrossSignalPivot";
+
+export interface ComponentProps {
+  /** What the user is investigating, e.g. `CPU by host · 12:01–12:14`. */
+  title?: string | undefined;
+  /** The pinned window under investigation (a zoom, a bucket, a spike). */
+  window: InBetween<Date>;
+  /**
+   * The metric view scoped to what the user clicked (series labels and
+   * filters already folded into the query configs' attributes).
+   */
+  metricViewData: MetricViewData;
+  onClose: () => void;
+}
+
+const TOP_ERROR_PATTERN_LIMIT: number = 5;
+
+/**
+ * The in-context investigation panel: everything that happened in one
+ * window, without leaving the page. A log-signal summary (volume by
+ * severity + top error patterns), the metric charts pinned to the
+ * window, and the companion logs/traces/exceptions tabs scoped the same
+ * way — with escape hatches into the full explorers.
+ */
+const InvestigationDrawer: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const windowStartMs: number = props.window.startValue.getTime();
+  const windowEndMs: number = props.window.endValue.getTime();
+
+  /*
+   * Everything handed to the companion machinery MUST be referentially
+   * stable — CompanionMetricsTab's discovery effect keys on spec
+   * identity, and an inline-recreated query would put it in a refetch
+   * loop.
+   */
+  const pinnedWindow: InBetween<Date> = useMemo(() => {
+    return new InBetween<Date>(new Date(windowStartMs), new Date(windowEndMs));
+  }, [windowStartMs, windowEndMs]);
+
+  const pinnedViewData: MetricViewData = useMemo(() => {
+    return {
+      queryConfigs: props.metricViewData.queryConfigs,
+      formulaConfigs: props.metricViewData.formulaConfigs || [],
+      /*
+       * Pinned on purpose — no rangeToken: an investigation window must
+       * not re-anchor to "now" on refresh.
+       */
+      startAndEndDate: pinnedWindow,
+    };
+  }, [props.metricViewData, pinnedWindow]);
+
+  const telemetryQuery: TelemetryQuery = useMemo(() => {
+    return {
+      telemetryType: TelemetryType.Metric,
+      telemetryQuery: null,
+      metricViewData: pinnedViewData,
+    } as TelemetryQuery;
+  }, [pinnedViewData]);
+
+  const pinnedTimeRange: RangeStartAndEndDateTime = useMemo(() => {
+    return {
+      range: TimeRange.CUSTOM,
+      startAndEndDate: pinnedWindow,
+    };
+  }, [pinnedWindow]);
+
+  const extraction: MetricScopeFilterExtraction = useMemo(() => {
+    return extractScopeFiltersFromQueryConfigs(
+      pinnedViewData.queryConfigs || [],
+    );
+  }, [pinnedViewData]);
+
+  // -- Log signal summary (volume + top error patterns) --
+
+  const [logBuckets, setLogBuckets] = useState<Array<HistogramBucket> | null>(
+    null,
+  );
+  const [errorPatterns, setErrorPatterns] =
+    useState<Array<TopErrorPatternRow> | null>(null);
+
+  useEffect(() => {
+    let isCancelled: boolean = false;
+
+    const fetchLogSignal: () => Promise<void> = async (): Promise<void> => {
+      /*
+       * Service names resolve to ids first (cached) so the log queries
+       * scope by the primaryEntityId column the log rows actually store.
+       */
+      let serviceIds: Array<string> = [];
+      if (extraction.serviceNames.length > 0) {
+        const mapping: Dictionary<string> = await resolveServiceIdsByNames(
+          extraction.serviceNames,
+        );
+        serviceIds = extraction.serviceNames
+          .map((serviceName: string): string => {
+            return mapping[serviceName] || "";
+          })
+          .filter((serviceId: string): boolean => {
+            return serviceId !== "";
+          });
+      }
+
+      if (isCancelled) {
+        return;
+      }
+
+      const scope: LogsInsightsScope = {
+        timeRange: {
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date(windowStartMs),
+            new Date(windowEndMs),
+          ),
+        },
+        ...(serviceIds.length > 0 ? { serviceIds } : {}),
+      };
+
+      const [buckets, patterns]: [
+        Array<JSONObject>,
+        Array<TopErrorPatternRow>,
+      ] = await Promise.all([
+        fetchLogsHistogramRaw(
+          buildLogsHistogramRequest({
+            timeRange: scope.timeRange,
+            ...(serviceIds.length > 0 ? { serviceIds } : {}),
+            /*
+             * Unlike the pattern analysis, the histogram can carry the
+             * metric view's attribute filters — logs tagged the same way
+             * the metric rows are.
+             */
+            attributes:
+              Object.keys(extraction.attributes).length > 0
+                ? extraction.attributes
+                : undefined,
+            appliedFacetFilters: new Map<string, Set<string>>(),
+          }),
+        ).catch((): Array<JSONObject> => {
+          return [];
+        }),
+        fetchTopErrorPatterns(scope, TOP_ERROR_PATTERN_LIMIT).catch(
+          (): Array<TopErrorPatternRow> => {
+            return [];
+          },
+        ),
+      ]);
+
+      if (isCancelled) {
+        return;
+      }
+
+      setLogBuckets(buckets as unknown as Array<HistogramBucket>);
+      setErrorPatterns(patterns);
+    };
+
+    void fetchLogSignal();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [windowStartMs, windowEndMs, extraction]);
+
+  const logVolume: LogVolumeSummary | null = useMemo(() => {
+    if (!logBuckets) {
+      return null;
+    }
+    return summarizeSeverityBuckets(logBuckets as unknown as Array<JSONObject>);
+  }, [logBuckets]);
+
+  const droppedHint: string = formatDroppedScopeHint(
+    extraction.droppedFilterKeys,
+  );
+
+  const scopeChips: Array<string> = useMemo(() => {
+    const chips: Array<string> = [];
+    for (const serviceName of extraction.serviceNames) {
+      chips.push(`service = ${serviceName}`);
+    }
+    for (const key of Object.keys(extraction.attributes)) {
+      chips.push(`${key} = ${extraction.attributes[key]}`);
+    }
+    return chips;
+  }, [extraction]);
+
+  const openPattern: (pattern: TopErrorPatternRow) => void = (
+    pattern: TopErrorPatternRow,
+  ): void => {
+    const scope: LogsInsightsScope = {
+      timeRange: pinnedTimeRange,
+    };
+    const route: ReturnType<typeof buildErrorPatternLogsRoute> =
+      buildErrorPatternLogsRoute(pattern.pattern, scope, pattern.sampleBody);
+    if (!route) {
+      return;
+    }
+    // Navigation replaces the page under the drawer — close first.
+    props.onClose();
+    Navigation.navigate(route);
+  };
+
+  const openInExplorer: VoidFunction = (): void => {
+    props.onClose();
+    ExplorerLink.openInExplorer(pinnedViewData);
+  };
+
+  return (
+    <SideOver
+      title={props.title || "Investigate window"}
+      description={OneUptimeDate.getInBetweenDatesAsFormattedString(
+        pinnedWindow,
+      )}
+      size={SideOverSize.Large}
+      onClose={props.onClose}
+    >
+      {/* One wrapper element — SideOver divides its children. */}
+      <div className="space-y-5 py-5">
+        {/* Scope strip */}
+        <div className="flex flex-wrap items-center gap-1.5">
+          {scopeChips.length > 0 ? (
+            scopeChips.map((chip: string) => {
+              return (
+                <span
+                  key={chip}
+                  className="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] font-medium text-gray-600"
+                >
+                  {chip}
+                </span>
+              );
+            })
+          ) : (
+            <span className="text-xs text-gray-500">
+              Scoped by time window only — results cover the whole project.
+            </span>
+          )}
+          {droppedHint ? (
+            <HintChip variant="amber">{droppedHint}</HintChip>
+          ) : null}
+          <button
+            type="button"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+            onClick={openInExplorer}
+          >
+            <Icon icon={IconProp.ExternalLink} className="h-3.5 w-3.5" />
+            Open in Metric Explorer
+          </button>
+        </div>
+
+        {/* Log signal summary */}
+        <Card
+          title="Log signal"
+          description="Log volume and the loudest error patterns inside this window."
+        >
+          <div className="space-y-4">
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                {
+                  label: "Log lines",
+                  value: logVolume ? logVolume.total.toLocaleString() : "…",
+                },
+                {
+                  label: "Errors",
+                  value: logVolume
+                    ? logVolume.errorCount.toLocaleString()
+                    : "…",
+                },
+                {
+                  label: "Error rate",
+                  value: logVolume
+                    ? `${logVolume.errorRatePercent.toFixed(1)}%`
+                    : "…",
+                },
+              ].map((stat: { label: string; value: string }) => {
+                return (
+                  <div
+                    key={stat.label}
+                    className="rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+                      {stat.label}
+                    </p>
+                    <p className="mt-1 text-lg font-semibold tabular-nums text-gray-900">
+                      {stat.value}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+
+            <LogsHistogram
+              buckets={logBuckets || []}
+              isLoading={logBuckets === null}
+            />
+
+            <div>
+              <p className="text-xs font-medium text-gray-700">
+                Top error patterns
+              </p>
+              {errorPatterns === null ? (
+                <p className="mt-1 text-xs text-gray-400">Loading…</p>
+              ) : errorPatterns.length === 0 ? (
+                <p className="mt-1 text-xs text-gray-500">
+                  No error-severity logs in this window.
+                </p>
+              ) : (
+                <ul className="mt-1.5 space-y-1">
+                  {errorPatterns.map((pattern: TopErrorPatternRow) => {
+                    return (
+                      <li key={pattern.pattern}>
+                        <button
+                          type="button"
+                          className="group flex w-full items-baseline gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                          title="Open these logs in the explorer"
+                          onClick={() => {
+                            openPattern(pattern);
+                          }}
+                        >
+                          <span className="shrink-0 rounded bg-red-50 px-1.5 py-0.5 text-[11px] font-semibold tabular-nums text-red-700">
+                            {pattern.count.toLocaleString()}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate font-mono text-xs text-gray-700 group-hover:text-gray-900">
+                            {pattern.sampleBody || pattern.pattern}
+                          </span>
+                          <span className="hidden shrink-0 text-[11px] text-gray-400 sm:inline">
+                            {describeOccurrenceCount(
+                              pattern.count,
+                              pinnedTimeRange,
+                            )}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+              {scopeChips.length > 0 &&
+              Object.keys(extraction.attributes).length > 0 ? (
+                <p className="mt-1.5 text-[11px] text-gray-400">
+                  Patterns are scoped by service and window; attribute filters
+                  apply to the volume chart above.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </Card>
+
+        {/* Metrics + companion signals, all pinned to the window */}
+        <TelemetryCompanionSignalTabs
+          telemetryQuery={telemetryQuery}
+          snapshotWindow={pinnedWindow}
+          eventNoun="view"
+          primarySignalElement={
+            <EmbeddedMetricCard
+              title="Metrics"
+              description="The charts this investigation started from, pinned to the window."
+              queryConfigs={pinnedViewData.queryConfigs}
+              formulaConfigs={pinnedViewData.formulaConfigs}
+              defaultTimeRange={pinnedTimeRange}
+            />
+          }
+        />
+      </div>
+    </SideOver>
+  );
+};
+
+export default InvestigationDrawer;

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs.tsx
@@ -65,7 +65,12 @@ export interface ComponentProps {
   snapshotWindow: InBetween<Date> | null;
   // Shared with the page's own preview cards (may be undefined — no window).
   snapshotWindowAlert?: ReactElement | undefined;
-  eventNoun: "incident" | "alert";
+  /*
+   * Noun the tab copy hangs on ("Logs in this incident's telemetry
+   * scope…"). "view" is what window-scoped hosts (the investigation
+   * drawer) pass.
+   */
+  eventNoun: "incident" | "alert" | "view";
   /*
    * The page's existing single-signal preview block, passed through
    * verbatim so the default tab has zero behavior change.

--- a/App/FeatureSet/Dashboard/src/Components/TelemetryResource/telemetryMetrics.ts
+++ b/App/FeatureSet/Dashboard/src/Components/TelemetryResource/telemetryMetrics.ts
@@ -10,6 +10,13 @@ import ProjectUtil from "Common/UI/Utils/Project";
 import AggregateBy from "Common/Types/BaseDatabase/AggregateBy";
 import AggregatedResult from "Common/Types/BaseDatabase/AggregatedResult";
 import AggregatedModel from "Common/Types/BaseDatabase/AggregatedModel";
+import API from "Common/UI/Utils/API/API";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import URL from "Common/Types/API/URL";
+import { APP_API_URL } from "Common/UI/Config";
+import { JSONObject } from "Common/Types/JSON";
 
 export interface TimePoint {
   x: Date;
@@ -435,4 +442,177 @@ export const formatBytes: (bytes: number | null) => string = (
     i++;
   }
   return `${v.toFixed(v < 10 ? 1 : 0)} ${units[i]}`;
+};
+
+/*
+ * Log + exception signal summaries for a resource's overview page —
+ * one projection-backed histogram call per pillar, both scoped by the
+ * resource's primaryEntityId. Complements SpanMetrics so an overview can
+ * show all four golden-ish signals (rate, errors, duration, and the
+ * log/exception context) without a raw-row scan.
+ */
+
+export interface LogSignalSummary {
+  total: number;
+  errorCount: number;
+  countSeries: Array<TimePoint>;
+  errorSeries: Array<TimePoint>;
+}
+
+export interface ExceptionSignalSummary {
+  total: number;
+  unhandledCount: number;
+  unhandledSeries: Array<TimePoint>;
+  handledSeries: Array<TimePoint>;
+}
+
+export interface LogAndExceptionSignals {
+  logs: LogSignalSummary;
+  exceptions: ExceptionSignalSummary;
+}
+
+// Log severities that count as errors (matches the server's default set).
+const ERROR_LOG_SEVERITY_SET: Set<string> = new Set<string>(["Error", "Fatal"]);
+
+interface RawHistogramBucket {
+  time?: string;
+  severity?: string;
+  series?: string;
+  count?: number;
+}
+
+function addPoint(
+  seriesByTime: Map<number, number>,
+  time: string | undefined,
+  count: number,
+): void {
+  if (!time) {
+    return;
+  }
+  const ms: number = new Date(time).getTime();
+  if (Number.isNaN(ms)) {
+    return;
+  }
+  seriesByTime.set(ms, (seriesByTime.get(ms) || 0) + count);
+}
+
+function toSortedSeries(seriesByTime: Map<number, number>): Array<TimePoint> {
+  return Array.from(seriesByTime.entries())
+    .sort((a: [number, number], b: [number, number]) => {
+      return a[0] - b[0];
+    })
+    .map(([ms, y]: [number, number]): TimePoint => {
+      return { x: new Date(ms), y };
+    });
+}
+
+export const fetchLogAndExceptionSignals: (scope: {
+  primaryEntityId: ObjectID;
+  start: Date;
+  end: Date;
+}) => Promise<LogAndExceptionSignals> = async (scope: {
+  primaryEntityId: ObjectID;
+  start: Date;
+  end: Date;
+}): Promise<LogAndExceptionSignals> => {
+  const empty: LogAndExceptionSignals = {
+    logs: { total: 0, errorCount: 0, countSeries: [], errorSeries: [] },
+    exceptions: {
+      total: 0,
+      unhandledCount: 0,
+      unhandledSeries: [],
+      handledSeries: [],
+    },
+  };
+
+  const body: JSONObject = {
+    startTime: scope.start.toISOString(),
+    endTime: scope.end.toISOString(),
+    serviceIds: [scope.primaryEntityId.toString()],
+  };
+
+  const postHistogram: (
+    path: string,
+  ) => Promise<Array<RawHistogramBucket>> = async (
+    path: string,
+  ): Promise<Array<RawHistogramBucket>> => {
+    const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await API.post({
+        url: URL.fromString(APP_API_URL.toString()).addRoute(path),
+        data: body,
+        headers: ModelAPI.getCommonHeaders(),
+      });
+    if (response instanceof HTTPErrorResponse) {
+      throw response;
+    }
+    const buckets: unknown = response.data["buckets"];
+    return Array.isArray(buckets) ? (buckets as Array<RawHistogramBucket>) : [];
+  };
+
+  try {
+    const [logBuckets, exceptionBuckets]: [
+      Array<RawHistogramBucket>,
+      Array<RawHistogramBucket>,
+    ] = await Promise.all([
+      postHistogram("/telemetry/logs/histogram").catch(
+        (): Array<RawHistogramBucket> => {
+          return [];
+        },
+      ),
+      postHistogram("/telemetry/exceptions/histogram").catch(
+        (): Array<RawHistogramBucket> => {
+          return [];
+        },
+      ),
+    ]);
+
+    const logCountByTime: Map<number, number> = new Map<number, number>();
+    const logErrorByTime: Map<number, number> = new Map<number, number>();
+    let logTotal: number = 0;
+    let logErrorCount: number = 0;
+
+    for (const bucket of logBuckets) {
+      const count: number = typeof bucket.count === "number" ? bucket.count : 0;
+      logTotal += count;
+      addPoint(logCountByTime, bucket.time, count);
+      if (ERROR_LOG_SEVERITY_SET.has(bucket.severity || "")) {
+        logErrorCount += count;
+        addPoint(logErrorByTime, bucket.time, count);
+      }
+    }
+
+    const unhandledByTime: Map<number, number> = new Map<number, number>();
+    const handledByTime: Map<number, number> = new Map<number, number>();
+    let exceptionTotal: number = 0;
+    let unhandledCount: number = 0;
+
+    for (const bucket of exceptionBuckets) {
+      const count: number = typeof bucket.count === "number" ? bucket.count : 0;
+      exceptionTotal += count;
+      if (bucket.series === "unhandled") {
+        unhandledCount += count;
+        addPoint(unhandledByTime, bucket.time, count);
+      } else {
+        addPoint(handledByTime, bucket.time, count);
+      }
+    }
+
+    return {
+      logs: {
+        total: logTotal,
+        errorCount: logErrorCount,
+        countSeries: toSortedSeries(logCountByTime),
+        errorSeries: toSortedSeries(logErrorByTime),
+      },
+      exceptions: {
+        total: exceptionTotal,
+        unhandledCount,
+        unhandledSeries: toSortedSeries(unhandledByTime),
+        handledSeries: toSortedSeries(handledByTime),
+      },
+    };
+  } catch {
+    // Overview signals are best-effort — never break the page.
+    return empty;
+  }
 };

--- a/App/FeatureSet/Dashboard/src/Pages/Service/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Service/View/Index.tsx
@@ -45,10 +45,12 @@ import AutoRefreshControl from "../../../Components/TelemetryResource/AutoRefres
 import useAutoRefresh from "../../../Components/TelemetryResource/useAutoRefresh";
 import OneUptimeDate from "Common/Types/Date";
 import {
+  fetchLogAndExceptionSignals,
   fetchSpanMetrics,
   formatCompact,
   formatDurationMs,
   formatPercent,
+  LogAndExceptionSignals,
   SpanMetrics,
   TimePoint,
 } from "../../../Components/TelemetryResource/telemetryMetrics";
@@ -89,6 +91,8 @@ const ServiceView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [lastRefreshedAt, setLastRefreshedAt] = useState<Date | null>(null);
   const [error, setError] = useState<string>("");
   const [spanMetrics, setSpanMetrics] = useState<SpanMetrics | null>(null);
+  const [logExceptionSignals, setLogExceptionSignals] =
+    useState<LogAndExceptionSignals | null>(null);
   const [runtimeCharts, setRuntimeCharts] = useState<Array<ProbedRuntimeChart>>(
     [],
   );
@@ -194,15 +198,23 @@ const ServiceView: FunctionComponent<PageComponentProps> = (): ReactElement => {
     Promise.all([
       fetchSpanMetrics({ primaryEntityId: modelId, start, end }),
       probeRuntimeCharts({ language, primaryEntityId: modelId, start, end }),
+      fetchLogAndExceptionSignals({ primaryEntityId: modelId, start, end }),
     ])
-      .then(([m, runtime]: [SpanMetrics, Array<ProbedRuntimeChart>]) => {
-        if (ignore) {
-          return;
-        }
-        setSpanMetrics(m);
-        setRuntimeCharts(runtime);
-        setMetricsLoading(false);
-      })
+      .then(
+        ([m, runtime, signals]: [
+          SpanMetrics,
+          Array<ProbedRuntimeChart>,
+          LogAndExceptionSignals,
+        ]) => {
+          if (ignore) {
+            return;
+          }
+          setSpanMetrics(m);
+          setRuntimeCharts(runtime);
+          setLogExceptionSignals(signals);
+          setMetricsLoading(false);
+        },
+      )
       .catch(() => {
         if (ignore) {
           return;
@@ -384,6 +396,50 @@ const ServiceView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         yFormatter={(n: number): string => {
           return formatDurationMs(n);
         }}
+        loading={metricsLoading}
+      />
+      <ChartCard
+        title="Logs"
+        icon={IconProp.Logs}
+        iconColor="amber"
+        series={
+          [
+            {
+              seriesName: "Log lines",
+              data: logExceptionSignals?.logs.countSeries ?? [],
+            },
+            {
+              seriesName: "Errors",
+              data: logExceptionSignals?.logs.errorSeries ?? [],
+            },
+          ] as Array<SeriesPoint>
+        }
+        windowStart={chartWindow?.start ?? null}
+        windowEnd={chartWindow?.end ?? null}
+        syncId={syncId}
+        showLegend={true}
+        loading={metricsLoading}
+      />
+      <ChartCard
+        title="Exceptions"
+        icon={IconProp.Bug}
+        iconColor="rose"
+        series={
+          [
+            {
+              seriesName: "Unhandled",
+              data: logExceptionSignals?.exceptions.unhandledSeries ?? [],
+            },
+            {
+              seriesName: "Handled",
+              data: logExceptionSignals?.exceptions.handledSeries ?? [],
+            },
+          ] as Array<SeriesPoint>
+        }
+        windowStart={chartWindow?.start ?? null}
+        windowEnd={chartWindow?.end ?? null}
+        syncId={syncId}
+        showLegend={true}
         loading={metricsLoading}
       />
       {runtimeCharts.map((chart: ProbedRuntimeChart): ReactElement => {

--- a/App/Tests/Dashboard/InvestigationSurfaces.test.ts
+++ b/App/Tests/Dashboard/InvestigationSurfaces.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Wiring pins for PR B's investigation surfaces — App's node test env
+ * cannot render React, so the load-bearing mounting is pinned as
+ * whitespace-squashed source strings (the MetricsCrossSignalPivot.test
+ * pattern). Behavior itself is covered by the RTL suites in
+ * Common/Tests/App/Dashboard.
+ */
+
+function readSquashed(relative: string): string {
+  return fs
+    .readFileSync(path.join(__dirname, "../../..", relative), "utf8")
+    .replace(/\s+/g, " ");
+}
+
+describe("investigation drawer wiring", () => {
+  test("MetricCharts hosts the drawer, the bucket inspector, and the series-menu opener", () => {
+    const source: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx",
+    );
+
+    expect(source).toContain("<InvestigationDrawer");
+    expect(source).toContain("openBucketInspector");
+    expect(source).toContain("Investigate this moment");
+    expect(source).toContain('text="Investigate in panel"');
+    // Bucket clicks are gated the same way the series menu is.
+    expect(source).toContain("onBucketClick: showSeriesActions");
+    // The inspector orders values highest-first, like the tooltip.
+    expect(source).toContain("b.value - a.value");
+  });
+
+  test("the widget zoom bar and the explorer toolbar both open the drawer", () => {
+    const widget: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx",
+    );
+    expect(widget).toContain("<InvestigationDrawer");
+    expect(widget).toContain("setInvestigationWindow(zoomWindow)");
+
+    const explorer: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx",
+    );
+    expect(explorer).toContain("<InvestigationDrawer");
+    expect(explorer).toContain("setIsInvestigationOpen(true)");
+  });
+
+  test("annotation clicks never leak into bucket pinning", () => {
+    for (const lib of [
+      "Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx",
+      "Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx",
+    ]) {
+      const source: string = readSquashed(lib);
+      // exemplar + region + time-ref-line handlers all stop propagation.
+      expect(
+        source.match(/stopChartEventPropagation\(\.\.\.args\)/g)?.length,
+      ).toBe(3);
+      // Clicks that clear a selection never also pin.
+      expect(source).toContain("onValueChange?.(null); return;");
+    }
+  });
+});
+
+describe("compare-to-previous wiring", () => {
+  test("the explorer toggle persists and feeds MetricView", () => {
+    const explorer: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx",
+    );
+    expect(explorer).toContain("metric-explorer-compare-previous");
+    expect(explorer).toContain("compareWithPreviousPeriod={showCompare}");
+  });
+
+  test("MetricView's fetch snapshot includes the compare flag — toggling refetches", () => {
+    const view: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx",
+    );
+    expect(view).toContain(
+      "compareWithPreviousPeriod: props.compareWithPreviousPeriod === true",
+    );
+    // The shifted fetch is best-effort.
+    expect(view).toContain("Ghosts are best-effort");
+  });
+
+  test("MetricCharts keeps ghosts out of Top-N, chips, and the inspector", () => {
+    const charts: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx",
+    );
+    // Merge happens AFTER presentation (post-Top-N/chips)…
+    expect(charts).toContain("PREVIOUS_PERIOD_SERIES_SUFFIX");
+    expect(charts).toContain("let renderSeries: Array<SeriesPoint>");
+    // …and the ghost x-values are shifted onto the current window's grid.
+    expect(charts).toContain("point.x.getTime() + props.compareOffsetMs!");
+  });
+});
+
+describe("service overview signal wiring", () => {
+  test("the overview adds log + exception signal charts from the histogram endpoints", () => {
+    const util: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Components/TelemetryResource/telemetryMetrics.ts",
+    );
+    expect(util).toContain("fetchLogAndExceptionSignals");
+    expect(util).toContain("/telemetry/logs/histogram");
+    expect(util).toContain("/telemetry/exceptions/histogram");
+
+    const overview: string = readSquashed(
+      "App/FeatureSet/Dashboard/src/Pages/Service/View/Index.tsx",
+    );
+    expect(overview).toContain("fetchLogAndExceptionSignals");
+    expect(overview).toContain('title="Logs"');
+    expect(overview).toContain('title="Exceptions"');
+  });
+});

--- a/Common/Tests/App/Dashboard/InvestigationDrawer.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationDrawer.test.tsx
@@ -1,0 +1,258 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The investigation drawer is the "what happened in this window?" panel:
+ * it must summarize the log signal for the window+scope, hand every
+ * companion signal the SAME pinned window, and route escape hatches
+ * (patterns, explorer) through onClose so the page underneath doesn't
+ * change behind an open drawer.
+ */
+
+const histogramMock: MockFunction = getJestMockFunction();
+const patternsMock: MockFunction = getJestMockFunction();
+const companionTabsMock: MockFunction = getJestMockFunction();
+const embeddedCardMock: MockFunction = getJestMockFunction();
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Logs/LogsInsightsApi",
+  () => {
+    return {
+      __esModule: true,
+      fetchLogsHistogramRaw: (...args: Array<any>) => {
+        return histogramMock(...args);
+      },
+      fetchTopErrorPatterns: (...args: Array<any>) => {
+        return patternsMock(...args);
+      },
+    };
+  },
+);
+
+/*
+ * The companion tabs and the embedded metric card are heavy, separately
+ * tested surfaces — here they only need to prove WHAT they were handed.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: Record<string, unknown>): React.ReactElement => {
+        companionTabsMock(props);
+        return React.createElement(
+          "div",
+          { "data-testid": "companion-tabs" },
+          props["primarySignalElement"] as React.ReactElement,
+        );
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/EmbeddedMetricCard",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: Record<string, unknown>): React.ReactElement => {
+        embeddedCardMock(props);
+        return React.createElement("div", {
+          "data-testid": "embedded-metric-card",
+        });
+      },
+    };
+  },
+);
+
+import InvestigationDrawer from "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import TelemetryType from "../../../Types/Telemetry/TelemetryType";
+import Navigation from "../../../UI/Utils/Navigation";
+
+const WINDOW: InBetween<Date> = new InBetween<Date>(
+  new Date("2026-08-20T10:00:00.000Z"),
+  new Date("2026-08-20T10:15:00.000Z"),
+);
+
+function buildViewData(): MetricViewData {
+  return {
+    queryConfigs: [
+      {
+        metricAliasData: { metricVariable: "a" },
+        metricQueryData: {
+          filterData: {
+            metricName: "cpu.usage",
+            attributes: { "host.name": "web-01" },
+            aggegationType: MetricsAggregationType.Avg,
+          },
+        },
+      },
+    ],
+    formulaConfigs: [],
+    startAndEndDate: null,
+  } as unknown as MetricViewData;
+}
+
+let navigateSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  histogramMock.mockReset();
+  patternsMock.mockReset();
+  companionTabsMock.mockReset();
+  embeddedCardMock.mockReset();
+  histogramMock.mockReturnValue(
+    Promise.resolve([
+      { time: "2026-08-20T10:00:00.000Z", severity: "Information", count: 90 },
+      { time: "2026-08-20T10:05:00.000Z", severity: "Error", count: 10 },
+    ]),
+  );
+  patternsMock.mockReturnValue(
+    Promise.resolve([
+      {
+        pattern: "connection refused to <IP>",
+        sampleBody: "connection refused to 10.0.0.5",
+        count: 42,
+        resourceIds: [],
+        severities: ["Error"],
+        sampleTraceIds: [],
+      },
+    ]),
+  );
+  navigateSpy = jest.spyOn(Navigation, "navigate").mockImplementation(() => {
+    return undefined;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  cleanup();
+});
+
+describe("InvestigationDrawer", () => {
+  test("summarizes the window's log signal and lists top error patterns", async () => {
+    render(
+      <InvestigationDrawer
+        title="host.name=web-01"
+        window={WINDOW}
+        metricViewData={buildViewData()}
+        onClose={() => {
+          // not exercised here
+        }}
+      />,
+    );
+
+    // Scope chips reflect the metric view's filters.
+    expect(screen.getByText("host.name = web-01")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("100")).toBeInTheDocument();
+    });
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("10.0%")).toBeInTheDocument();
+    expect(
+      screen.getByText("connection refused to 10.0.0.5"),
+    ).toBeInTheDocument();
+
+    // The histogram request carried the attribute scope.
+    const histogramBody: Record<string, unknown> = histogramMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(
+      (histogramBody["attributes"] as Record<string, unknown>)["host.name"],
+    ).toBe("web-01");
+  });
+
+  test("hands the companion tabs the SAME pinned window and metric queries", async () => {
+    render(
+      <InvestigationDrawer
+        window={WINDOW}
+        metricViewData={buildViewData()}
+        onClose={() => {
+          // not exercised here
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(companionTabsMock).toHaveBeenCalled();
+    });
+
+    const tabsProps: Record<string, unknown> = companionTabsMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    const telemetryQuery: Record<string, unknown> = tabsProps[
+      "telemetryQuery"
+    ] as Record<string, unknown>;
+
+    expect(telemetryQuery["telemetryType"]).toBe(TelemetryType.Metric);
+    const viewData: MetricViewData = telemetryQuery[
+      "metricViewData"
+    ] as MetricViewData;
+    expect(viewData.startAndEndDate?.startValue.getTime()).toBe(
+      WINDOW.startValue.getTime(),
+    );
+    // Pinned — never a rolling token.
+    expect(viewData.rangeToken).toBeUndefined();
+    expect(tabsProps["eventNoun"]).toBe("view");
+
+    const snapshotWindow: InBetween<Date> = tabsProps[
+      "snapshotWindow"
+    ] as InBetween<Date>;
+    expect(snapshotWindow.endValue.getTime()).toBe(WINDOW.endValue.getTime());
+
+    // The primary element is the interactive metric card, same queries.
+    expect(screen.getByTestId("embedded-metric-card")).toBeInTheDocument();
+    const cardProps: Record<string, unknown> = embeddedCardMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    const cardConfigs: Array<Record<string, any>> = cardProps[
+      "queryConfigs"
+    ] as Array<Record<string, any>>;
+    expect(
+      cardConfigs[0]?.["metricQueryData"]["filterData"]["metricName"],
+    ).toBe("cpu.usage");
+  });
+
+  test("escape hatches close the drawer before navigating", async () => {
+    const onClose: MockFunction = getJestMockFunction();
+
+    render(
+      <InvestigationDrawer
+        window={WINDOW}
+        metricViewData={buildViewData()}
+        onClose={(...args: Array<any>) => {
+          onClose(...args);
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Open in Metric Explorer"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("connection refused to 10.0.0.5"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("connection refused to 10.0.0.5"));
+    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(navigateSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Common/Tests/App/Dashboard/MetricChartsCompare.test.tsx
+++ b/Common/Tests/App/Dashboard/MetricChartsCompare.test.tsx
@@ -1,0 +1,171 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Ghost overlays end-to-end through the real MetricCharts: previous-
+ * period results must render as dashed twins of DISPLAYED series only —
+ * never as legend chips, never consuming Top-N slots, and always
+ * time-shifted onto the current window's bucket grid (unshifted points
+ * would be silently dropped by the bucketer).
+ */
+
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts") as Record<
+    string,
+    any
+  >;
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, {
+        width: 600,
+        height: 300,
+      } as Record<string, unknown>);
+    },
+  };
+});
+
+const fetchExemplarsMock: MockFunction = getJestMockFunction();
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        fetchExemplars: (...args: Array<any>) => {
+          fetchExemplarsMock(...args);
+          return new Promise(() => {
+            // Intentionally never settles.
+          });
+        },
+        setQueryTopNOverride: () => {
+          return undefined;
+        },
+        getQueryConfigTopNKey: (
+          _queryConfig: unknown,
+          index: number,
+          scope?: string,
+        ) => {
+          return `${scope || ""}:${index}`;
+        },
+        clearQueryTopNOverridesForScope: () => {
+          return undefined;
+        },
+        serializeAttributeFiltersForKey: (attributes: unknown) => {
+          return JSON.stringify(attributes || {});
+        },
+      },
+      DEFAULT_TOP_N_SERIES: 10,
+      SHOW_ALL_SERIES_TOP_N: 10_000,
+      sanitizeAttributeFilters: (attributes: unknown) => {
+        return attributes;
+      },
+    };
+  },
+);
+
+import MetricCharts from "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts";
+import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricQueryConfigData from "../../../Types/Metrics/MetricQueryConfigData";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+
+const WINDOW_START: Date = new Date("2026-08-20T10:00:00.000Z");
+const WINDOW_END: Date = new Date("2026-08-20T11:00:00.000Z");
+const WINDOW_MS: number = WINDOW_END.getTime() - WINDOW_START.getTime();
+
+function buildViewData(): MetricViewData {
+  return {
+    queryConfigs: [
+      {
+        metricAliasData: { metricVariable: "a", legend: "CPU" },
+        metricQueryData: {
+          filterData: {
+            metricName: "cpu.usage",
+            attributes: {},
+            aggegationType: MetricsAggregationType.Avg,
+          },
+        },
+      } as unknown as MetricQueryConfigData,
+    ],
+    formulaConfigs: [],
+    startAndEndDate: new InBetween<Date>(WINDOW_START, WINDOW_END),
+  } as MetricViewData;
+}
+
+function buildResult(offsetMs: number): AggregatedResult {
+  return {
+    data: [
+      {
+        timestamp: new Date(
+          new Date("2026-08-20T10:10:00.000Z").getTime() - offsetMs,
+        ),
+        value: 40,
+      },
+      {
+        timestamp: new Date(
+          new Date("2026-08-20T10:30:00.000Z").getTime() - offsetMs,
+        ),
+        value: 70,
+      },
+    ],
+    truncated: false,
+  } as unknown as AggregatedResult;
+}
+
+beforeEach(() => {
+  fetchExemplarsMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MetricCharts compare overlays", () => {
+  test("renders a dashed ghost twin without adding legend chips", () => {
+    const { container } = render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={[buildResult(0)]}
+        metricResultsPrevious={[buildResult(WINDOW_MS)]}
+        compareOffsetMs={WINDOW_MS}
+        metricTypes={[]}
+      />,
+    );
+
+    // The ghost line is on the chart, dashed…
+    expect(
+      container.querySelector('path[stroke-dasharray="6 4"]'),
+    ).toBeInTheDocument();
+
+    // …but the chip legend shows only the live series.
+    expect(screen.getAllByText("CPU").length).toBeGreaterThan(0);
+    expect(screen.queryByText("CPU (previous)")).toBeNull();
+    // And the series count still reads 1.
+    expect(screen.getByText("1 series")).toBeInTheDocument();
+  });
+
+  test("no previous results means no ghosts", () => {
+    const { container } = render(
+      <MetricCharts
+        metricViewData={buildViewData()}
+        metricResults={[buildResult(0)]}
+        metricTypes={[]}
+      />,
+    );
+
+    expect(container.querySelector('path[stroke-dasharray="6 4"]')).toBeNull();
+  });
+});

--- a/Common/Tests/App/Dashboard/MetricViewCompare.test.tsx
+++ b/Common/Tests/App/Dashboard/MetricViewCompare.test.tsx
@@ -1,0 +1,233 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Compare-to-previous-period: MetricView must fetch the SAME queries a
+ * second time over the window shifted back by exactly one window width,
+ * hand both result sets to MetricCharts, and degrade to live-only when
+ * the shifted fetch fails.
+ */
+
+const fetchResultsMock: MockFunction = getJestMockFunction();
+const metricChartsMock: MockFunction = getJestMockFunction();
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        fetchResults: (...args: Array<any>) => {
+          return fetchResultsMock(...args);
+        },
+        getMetricTypes: () => {
+          return Promise.resolve([]);
+        },
+        loadAllMetricsTypes: () => {
+          return Promise.resolve({
+            metricTypes: [],
+            telemetryServices: [],
+          });
+        },
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: Record<string, unknown>): React.ReactElement => {
+        metricChartsMock(props);
+        return React.createElement("div", {
+          "data-testid": "metric-charts",
+        });
+      },
+    };
+  },
+);
+
+import MetricView from "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricView";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+
+const WINDOW_START: Date = new Date("2026-08-20T10:00:00.000Z");
+const WINDOW_END: Date = new Date("2026-08-20T11:00:00.000Z");
+const WINDOW_MS: number = WINDOW_END.getTime() - WINDOW_START.getTime();
+
+function buildData(): MetricViewData {
+  return {
+    queryConfigs: [
+      {
+        metricAliasData: { metricVariable: "a" },
+        metricQueryData: {
+          filterData: {
+            metricName: "cpu.usage",
+            attributes: {},
+            aggegationType: MetricsAggregationType.Avg,
+          },
+        },
+      },
+    ],
+    formulaConfigs: [],
+    startAndEndDate: new InBetween<Date>(WINDOW_START, WINDOW_END),
+  } as unknown as MetricViewData;
+}
+
+interface CapturedFetch {
+  metricViewData: MetricViewData;
+}
+
+beforeEach(() => {
+  fetchResultsMock.mockReset();
+  metricChartsMock.mockReset();
+  fetchResultsMock.mockReturnValue(
+    Promise.resolve([{ data: [], truncated: false }]),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MetricView compare with previous period", () => {
+  test("fetches the shifted window alongside the live one and hands both down", async () => {
+    render(
+      <MetricView
+        data={buildData()}
+        hideQueryElements={true}
+        hideStartAndEndDate={true}
+        compareWithPreviousPeriod={true}
+        onChange={() => {
+          // not exercised
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchResultsMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    const windows: Array<[number, number]> = fetchResultsMock.mock.calls.map(
+      (call: Array<unknown>): [number, number] => {
+        const args: CapturedFetch = call[0] as CapturedFetch;
+        return [
+          args.metricViewData.startAndEndDate!.startValue.getTime(),
+          args.metricViewData.startAndEndDate!.endValue.getTime(),
+        ];
+      },
+    );
+
+    /*
+     * One live window and one shifted back by EXACTLY the window width
+     * (bucket-congruent modulo the shift). Alignment may floor the live
+     * start onto the bucket grid, so assert the relationship between the
+     * two fetches rather than raw instants.
+     */
+    const [liveWindow, previousWindow] = windows as [
+      [number, number],
+      [number, number],
+    ];
+    const liveWidth: number = liveWindow[1] - liveWindow[0];
+    expect(previousWindow[0]).toBe(liveWindow[0] - liveWidth);
+    expect(previousWindow[1]).toBe(liveWindow[1] - liveWidth);
+    expect(liveWidth).toBeGreaterThanOrEqual(WINDOW_MS);
+
+    await waitFor(() => {
+      const lastProps: Record<string, unknown> = metricChartsMock.mock.calls[
+        metricChartsMock.mock.calls.length - 1
+      ]?.[0] as Record<string, unknown>;
+      expect(lastProps["metricResultsPrevious"]).toBeTruthy();
+      expect(lastProps["compareOffsetMs"]).toBe(liveWidth);
+    });
+  });
+
+  test("compare off means exactly one fetch and no ghost props", async () => {
+    render(
+      <MetricView
+        data={buildData()}
+        hideQueryElements={true}
+        hideStartAndEndDate={true}
+        onChange={() => {
+          // not exercised
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchResultsMock).toHaveBeenCalled();
+    });
+    // Let any (wrong) shifted fetch get scheduled before asserting.
+    await new Promise((resolve: (value: unknown) => void) => {
+      setTimeout(resolve, 30);
+    });
+    /*
+     * MetricView may legitimately refetch the LIVE window more than once
+     * on mount — what compare-off forbids is any fetch of a SHIFTED
+     * (earlier) window.
+     */
+    const anyShiftedFetch: boolean = fetchResultsMock.mock.calls.some(
+      (call: Array<unknown>): boolean => {
+        const args: CapturedFetch = call[0] as CapturedFetch;
+        return (
+          args.metricViewData.startAndEndDate!.endValue.getTime() <=
+          WINDOW_START.getTime()
+        );
+      },
+    );
+    expect(anyShiftedFetch).toBe(false);
+    const lastProps: Record<string, unknown> = metricChartsMock.mock.calls[
+      metricChartsMock.mock.calls.length - 1
+    ]?.[0] as Record<string, unknown>;
+    expect(lastProps["metricResultsPrevious"]).toBeUndefined();
+  });
+
+  test("a failed shifted fetch degrades to live-only, never an error", async () => {
+    fetchResultsMock.mockImplementation(
+      (args: { metricViewData: MetricViewData }) => {
+        const start: number =
+          args.metricViewData.startAndEndDate!.startValue.getTime();
+        // The shifted (earlier) fetch fails; the live one succeeds.
+        if (start < WINDOW_START.getTime()) {
+          return Promise.reject(new Error("clickhouse hiccup"));
+        }
+        return Promise.resolve([{ data: [], truncated: false }]);
+      },
+    );
+
+    render(
+      <MetricView
+        data={buildData()}
+        hideQueryElements={true}
+        hideStartAndEndDate={true}
+        compareWithPreviousPeriod={true}
+        onChange={() => {
+          // not exercised
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(metricChartsMock).toHaveBeenCalled();
+    });
+
+    const lastProps: Record<string, unknown> = metricChartsMock.mock.calls[
+      metricChartsMock.mock.calls.length - 1
+    ]?.[0] as Record<string, unknown>;
+    expect(lastProps["metricResults"]).toBeTruthy();
+    expect(lastProps["metricResultsPrevious"]).toBeUndefined();
+  });
+});

--- a/Common/Tests/UI/Components/Charts/ChartGhostSeries.test.tsx
+++ b/Common/Tests/UI/Components/Charts/ChartGhostSeries.test.tsx
@@ -1,0 +1,103 @@
+import { AreaChart } from "../../../../UI/Components/Charts/ChartLibrary/AreaChart/AreaChart";
+import { LineChart } from "../../../../UI/Components/Charts/ChartLibrary/LineChart/LineChart";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * ResponsiveContainer measures its parent, which is always 0x0 in jsdom,
+ * so the chart renders nothing without a fixed size.
+ */
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts") as Record<
+    string,
+    any
+  >;
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, {
+        width: 600,
+        height: 300,
+      } as Record<string, unknown>);
+    },
+  };
+});
+
+/*
+ * Compare-to-previous ghost series must be visually and interactively
+ * second-class: dashed, and never part of the fat invisible click-target
+ * lines that make live series selectable.
+ */
+
+type ChartRow = Record<string, any>;
+
+const data: Array<ChartRow> = [
+  { time: "10:00", live: 10, "live (previous)": 8 },
+  { time: "10:05", live: 20, "live (previous)": 12 },
+  { time: "10:10", live: 15, "live (previous)": 9 },
+];
+
+describe.each([
+  ["LineChart", LineChart],
+  ["AreaChart", AreaChart],
+] as Array<[string, typeof LineChart | typeof AreaChart]>)(
+  "%s ghost series",
+  (_name: string, Chart: typeof LineChart | typeof AreaChart) => {
+    test("ghost categories render dashed; live ones do not", () => {
+      const { container } = render(
+        <Chart
+          data={data}
+          index="time"
+          categories={["live", "live (previous)"]}
+          ghostCategories={["live (previous)"]}
+        />,
+      );
+
+      const dashed: Array<Element> = Array.from(
+        container.querySelectorAll('path[stroke-dasharray="6 4"]'),
+      );
+      expect(dashed.length).toBeGreaterThan(0);
+
+      /*
+       * The live series' curve must NOT be dashed — recharts names each
+       * series path group; assert at least one series curve without the
+       * ghost dash exists.
+       */
+      const allCurves: Array<Element> = Array.from(
+        container.querySelectorAll(".recharts-layer path"),
+      ).filter((el: Element) => {
+        return el.getAttribute("stroke-dasharray") !== "6 4";
+      });
+      expect(allCurves.length).toBeGreaterThan(0);
+    });
+
+    test("ghosts are excluded from the fat click-target lines", () => {
+      const { container } = render(
+        <Chart
+          data={data}
+          index="time"
+          categories={["live", "live (previous)"]}
+          ghostCategories={["live (previous)"]}
+          onValueChange={() => {
+            // Enables the click-target machinery, like the wrappers do.
+          }}
+        />,
+      );
+
+      /*
+       * LineChart renders invisible strokeWidth-12 click-targets per
+       * SELECTABLE series; ghosts must not get one. (AreaChart has no
+       * fat-line mechanism — zero is correct there.)
+       */
+      const fatLines: Array<Element> = Array.from(
+        container.querySelectorAll('path[stroke-width="12"]'),
+      );
+      expect(fatLines.length).toBeLessThanOrEqual(1);
+      for (const fatLine of fatLines) {
+        expect(fatLine.getAttribute("name")).not.toContain("(previous)");
+      }
+    });
+  },
+);

--- a/Common/Tests/UI/Components/Charts/TooltipEntries.test.ts
+++ b/Common/Tests/UI/Components/Charts/TooltipEntries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import {
   DEFAULT_TOOLTIP_MAX_ENTRIES,
+  PREVIOUS_PERIOD_SERIES_SUFFIX,
   PreparedTooltipEntries,
   SortableTooltipItem,
   prepareTooltipEntries,
@@ -141,6 +142,41 @@ describe("prepareTooltipEntries", () => {
       expect(prepared.overflowCount).toBe(0);
       expect(prepared.totalCount).toBe(0);
     }
+  });
+
+  test("previous-period ghosts sort after every live series, whatever their value", () => {
+    const prepared: PreparedTooltipEntries<TestItem> = prepareTooltipEntries([
+      item(`host-a${PREVIOUS_PERIOD_SERIES_SUFFIX}`, 999),
+      item("host-a", 10),
+      item("host-b", 50),
+      item(`host-b${PREVIOUS_PERIOD_SERIES_SUFFIX}`, 60),
+    ]);
+
+    expect(categories(prepared)).toEqual([
+      "host-b",
+      "host-a",
+      // Ghost tier keeps its own value ordering.
+      `host-a${PREVIOUS_PERIOD_SERIES_SUFFIX}`,
+      `host-b${PREVIOUS_PERIOD_SERIES_SUFFIX}`,
+    ]);
+  });
+
+  test("ghosts never displace live readings under the cap", () => {
+    const payload: Array<TestItem> = [];
+    for (let index: number = 0; index < DEFAULT_TOOLTIP_MAX_ENTRIES; index++) {
+      payload.push(item(`live-${index}`, index));
+      payload.push(item(`live-${index}${PREVIOUS_PERIOD_SERIES_SUFFIX}`, 1e6));
+    }
+
+    const prepared: PreparedTooltipEntries<TestItem> =
+      prepareTooltipEntries(payload);
+
+    expect(
+      prepared.entries.every((entry: TestItem) => {
+        return !entry.category.endsWith(PREVIOUS_PERIOD_SERIES_SUFFIX);
+      }),
+    ).toBe(true);
+    expect(prepared.overflowCount).toBe(DEFAULT_TOOLTIP_MAX_ENTRIES);
   });
 
   test("does not mutate the input payload", () => {

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -63,6 +63,19 @@ export interface ComponentProps {
    * buckets calls back with the [start, end) of the selected time range.
    */
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  // Plain click on a bucket — see ChartLibrary onBucketClick.
+  onBucketClick?:
+    | ((
+        bucketStart: Date,
+        bucketEnd: Date,
+        valuesAtBucket: Record<string, number | string>,
+      ) => void)
+    | undefined;
+  /*
+   * Series rendered as compare-to-previous-period ghosts (dashed, faded,
+   * dotless). Names must exist in `data`.
+   */
+  ghostSeriesNames?: Array<string> | undefined;
   showLegend?: boolean | undefined;
   /**
    * Render a shaded "expected range" band underneath the plotted lines.
@@ -228,6 +241,8 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
         }
         onExemplarClick={props.onExemplarClick}
         onTimeRangeSelect={props.onTimeRangeSelect}
+        onBucketClick={props.onBucketClick}
+        ghostCategories={props.ghostSeriesNames}
         anomalyBandLowerKey={bandLower}
         anomalyBandUpperKey={bandUpper}
       />

--- a/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
@@ -54,6 +54,24 @@ import ChartCurve from "../../Types/ChartCurve";
  */
 const MAX_LABELED_TIME_REFERENCE_LINES: number = 6;
 
+/*
+ * recharts invokes child event handlers with varying shapes ((event) for
+ * plain SVG passthrough, (data, event) for adapted children) — find the
+ * DOM event wherever it is so propagation can be stopped reliably.
+ */
+function stopChartEventPropagation(...args: Array<unknown>): void {
+  for (const candidate of args) {
+    if (
+      candidate &&
+      typeof (candidate as { stopPropagation?: unknown }).stopPropagation ===
+        "function"
+    ) {
+      (candidate as { stopPropagation: () => void }).stopPropagation();
+      return;
+    }
+  }
+}
+
 //#region Legend
 
 interface LegendItemProps {
@@ -614,6 +632,26 @@ interface AreaChartProps extends React.HTMLAttributes<HTMLDivElement> {
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
   /**
+   * Plain click on a time bucket (the plot background — dot/legend clicks
+   * and drag-selections never reach this). [bucketStart, bucketEnd) uses
+   * the same adjacent-row width derivation as drag-to-select. Fires only
+   * when no toggle-selection is active: a click that clears an active
+   * legend/dot selection keeps its existing meaning.
+   */
+  onBucketClick?:
+    | ((
+        bucketStart: Date,
+        bucketEnd: Date,
+        // The clicked row: one numeric entry per series + the axis keys.
+        valuesAtBucket: Record<string, number | string>,
+      ) => void)
+    | undefined;
+  /**
+   * Categories rendered as compare-to-previous-period ghosts: dashed,
+   * faded, no fill, no dots — context, not data.
+   */
+  ghostCategories?: Array<string> | undefined;
+  /**
    * Render a shaded "expected range" band underneath the data lines.
    * Both keys must already be present on every entry of `data` (the
    * caller is responsible for merging baseline values into the data
@@ -661,6 +699,8 @@ const AreaChart: React.ForwardRefExoticComponent<
       formattedTimeReferenceLines,
       formattedReferenceRegions,
       onTimeRangeSelect,
+      onBucketClick,
+      ghostCategories,
       ...other
     } = props;
     const CustomTooltip: React.ComponentType<TooltipProps> | undefined =
@@ -941,19 +981,51 @@ const AreaChart: React.ForwardRefExoticComponent<
                   onMouseUp: handleRangeSelectMouseUp,
                 }
               : {})}
-            onClick={
-              hasOnValueChange && (activeLegend || activeDot)
-                ? () => {
-                    // Ignore the click that follows a drag-to-select.
-                    if (suppressNextClickRef.current) {
-                      return;
-                    }
-                    setActiveDot(undefined);
-                    setActiveLegend(undefined);
-                    onValueChange?.(null);
-                  }
-                : () => {}
-            }
+            onClick={(chartState: RangeSelectionChartState) => {
+              // Ignore the click that follows a drag-to-select.
+              if (suppressNextClickRef.current) {
+                return;
+              }
+              /*
+               * A click while a legend/dot selection is active keeps its
+               * long-standing meaning — clear the selection — and never
+               * also pins a bucket.
+               */
+              if (hasOnValueChange && (activeLegend || activeDot)) {
+                setActiveDot(undefined);
+                setActiveLegend(undefined);
+                onValueChange?.(null);
+                return;
+              }
+              if (!onBucketClick) {
+                return;
+              }
+              const rowIndex: number | null =
+                getRowIndexFromChartState(chartState);
+              if (rowIndex === null) {
+                return;
+              }
+              const bucketStart: Date | null = getBucketDateAtIndex(rowIndex);
+              if (!bucketStart) {
+                return;
+              }
+              /*
+               * Cover the full bucket: width from adjacent row dates, the
+               * same derivation drag-to-select uses.
+               */
+              const adjacentDate: Date | null =
+                rowIndex > 0
+                  ? getBucketDateAtIndex(rowIndex - 1)
+                  : getBucketDateAtIndex(rowIndex + 1);
+              const bucketWidthInMs: number = adjacentDate
+                ? Math.abs(bucketStart.getTime() - adjacentDate.getTime())
+                : 0;
+              onBucketClick(
+                bucketStart,
+                new Date(bucketStart.getTime() + bucketWidthInMs),
+                (data[rowIndex] || {}) as Record<string, number | string>,
+              );
+            }}
             margin={{
               bottom: (xAxisLabel
                 ? 40
@@ -1178,6 +1250,8 @@ const AreaChart: React.ForwardRefExoticComponent<
               ) as ChartColorValue;
               const hex: string = getColorHex(colorKey);
               const isCustomColor: boolean = isHexColorValue(colorKey);
+              const isGhost: boolean =
+                ghostCategories?.includes(category) || false;
 
               return (
                 <Area
@@ -1186,92 +1260,103 @@ const AreaChart: React.ForwardRefExoticComponent<
                   type={props.curve || ChartCurve.MONOTONE}
                   dataKey={category}
                   stroke={hex}
-                  strokeWidth={2}
+                  strokeWidth={isGhost ? 1.5 : 2}
                   strokeLinejoin="round"
                   strokeLinecap="round"
                   fill={`url(#${gradientId})`}
-                  fillOpacity={1}
+                  fillOpacity={isGhost ? 0 : 1}
                   strokeOpacity={
-                    activeDot || (activeLegend && activeLegend !== category)
+                    (activeDot || (activeLegend && activeLegend !== category)
                       ? 0.3
-                      : 1
+                      : 1) * (isGhost ? 0.45 : 1)
                   }
                   isAnimationActive={false}
                   connectNulls={connectNulls}
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  activeDot={(dotProps: any) => {
-                    const {
-                      cx: cxCoord,
-                      cy: cyCoord,
-                      stroke,
-                      strokeLinecap: slc,
-                      strokeLinejoin: slj,
-                      strokeWidth,
-                    } = dotProps;
-                    return (
-                      <Dot
-                        className={cx(
-                          "stroke-white",
-                          onValueChange ? "cursor-pointer" : "",
-                          getColorClassName(colorKey, "fill"),
-                        )}
-                        cx={cxCoord}
-                        cy={cyCoord}
-                        r={5}
-                        fill={isCustomColor ? hex : ""}
-                        stroke={stroke}
-                        strokeLinecap={slc}
-                        strokeLinejoin={slj}
-                        strokeWidth={strokeWidth}
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        onClick={(_: any, event: any) => {
-                          return onDotClick(dotProps, event);
-                        }}
-                      />
-                    );
-                  }}
+                  activeDot={
+                    isGhost
+                      ? false
+                      : (dotProps: any) => {
+                          const {
+                            cx: cxCoord,
+                            cy: cyCoord,
+                            stroke,
+                            strokeLinecap: slc,
+                            strokeLinejoin: slj,
+                            strokeWidth,
+                          } = dotProps;
+                          return (
+                            <Dot
+                              className={cx(
+                                "stroke-white",
+                                onValueChange ? "cursor-pointer" : "",
+                                getColorClassName(colorKey, "fill"),
+                              )}
+                              cx={cxCoord}
+                              cy={cyCoord}
+                              r={5}
+                              fill={isCustomColor ? hex : ""}
+                              stroke={stroke}
+                              strokeLinecap={slc}
+                              strokeLinejoin={slj}
+                              strokeWidth={strokeWidth}
+                              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                              onClick={(_: any, event: any) => {
+                                return onDotClick(dotProps, event);
+                              }}
+                            />
+                          );
+                        }
+                  }
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  dot={(dotProps: any) => {
-                    const {
-                      stroke,
-                      strokeLinecap: slc,
-                      strokeLinejoin: slj,
-                      strokeWidth,
-                      cx: cxCoord,
-                      cy: cyCoord,
-                      index: dotIndex,
-                    } = dotProps;
+                  dot={
+                    isGhost
+                      ? false
+                      : (dotProps: any) => {
+                          const {
+                            stroke,
+                            strokeLinecap: slc,
+                            strokeLinejoin: slj,
+                            strokeWidth,
+                            cx: cxCoord,
+                            cy: cyCoord,
+                            index: dotIndex,
+                          } = dotProps;
 
-                    if (
-                      (hasOnlyOneValueForKey(data, category) &&
-                        !(
-                          activeDot ||
-                          (activeLegend && activeLegend !== category)
-                        )) ||
-                      (activeDot?.index === dotIndex &&
-                        activeDot?.dataKey === category)
-                    ) {
-                      return (
-                        <Dot
-                          key={dotIndex}
-                          cx={cxCoord}
-                          cy={cyCoord}
-                          r={5}
-                          stroke={stroke}
-                          fill={isCustomColor ? hex : ""}
-                          strokeLinecap={slc}
-                          strokeLinejoin={slj}
-                          strokeWidth={strokeWidth}
-                          className={cx(
-                            "stroke-white",
-                            onValueChange ? "cursor-pointer" : "",
-                            getColorClassName(colorKey, "fill"),
-                          )}
-                        />
-                      );
-                    }
-                    return <React.Fragment key={dotIndex}></React.Fragment>;
-                  }}
+                          if (
+                            (hasOnlyOneValueForKey(data, category) &&
+                              !(
+                                activeDot ||
+                                (activeLegend && activeLegend !== category)
+                              )) ||
+                            (activeDot?.index === dotIndex &&
+                              activeDot?.dataKey === category)
+                          ) {
+                            return (
+                              <Dot
+                                key={dotIndex}
+                                cx={cxCoord}
+                                cy={cyCoord}
+                                r={5}
+                                stroke={stroke}
+                                fill={isCustomColor ? hex : ""}
+                                strokeLinecap={slc}
+                                strokeLinejoin={slj}
+                                strokeWidth={strokeWidth}
+                                className={cx(
+                                  "stroke-white",
+                                  onValueChange ? "cursor-pointer" : "",
+                                  getColorClassName(colorKey, "fill"),
+                                )}
+                              />
+                            );
+                          }
+                          return (
+                            <React.Fragment key={dotIndex}></React.Fragment>
+                          );
+                        }
+                  }
+                  {...(isGhost ? { strokeDasharray: "6 4" } : {})}
                 />
               );
             })}
@@ -1315,7 +1400,9 @@ const AreaChart: React.ForwardRefExoticComponent<
                     {...(region.original.onClick
                       ? {
                           style: { cursor: "pointer" as const },
-                          onClick: (): void => {
+                          onClick: (...args: Array<unknown>): void => {
+                            // Never let an annotation click also pin a bucket.
+                            stopChartEventPropagation(...args);
                             if (suppressNextClickRef.current) {
                               return;
                             }
@@ -1357,7 +1444,9 @@ const AreaChart: React.ForwardRefExoticComponent<
                     {...(timeRefLine.original.onClick
                       ? {
                           style: { cursor: "pointer" as const },
-                          onClick: (): void => {
+                          onClick: (...args: Array<unknown>): void => {
+                            // Never let an annotation click also pin a bucket.
+                            stopChartEventPropagation(...args);
                             if (suppressNextClickRef.current) {
                               return;
                             }
@@ -1403,7 +1492,9 @@ const AreaChart: React.ForwardRefExoticComponent<
                     stroke="var(--ou-chart-marker-ring, #ffffff)"
                     strokeWidth={2}
                     style={{ cursor: "pointer" }}
-                    onClick={() => {
+                    onClick={(...args: Array<unknown>) => {
+                      // Never let an exemplar click also pin a bucket.
+                      stopChartEventPropagation(...args);
                       // Ignore the click that follows a drag-to-select.
                       if (suppressNextClickRef.current) {
                         return;

--- a/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
@@ -55,6 +55,24 @@ import ChartCurve from "../../Types/ChartCurve";
  */
 const MAX_LABELED_TIME_REFERENCE_LINES: number = 6;
 
+/*
+ * recharts invokes child event handlers with varying shapes ((event) for
+ * plain SVG passthrough, (data, event) for adapted children) — find the
+ * DOM event wherever it is so propagation can be stopped reliably.
+ */
+function stopChartEventPropagation(...args: Array<unknown>): void {
+  for (const candidate of args) {
+    if (
+      candidate &&
+      typeof (candidate as { stopPropagation?: unknown }).stopPropagation ===
+        "function"
+    ) {
+      (candidate as { stopPropagation: () => void }).stopPropagation();
+      return;
+    }
+  }
+}
+
 //#region Legend
 
 interface LegendItemProps {
@@ -631,6 +649,26 @@ interface LineChartProps extends React.HTMLAttributes<HTMLDivElement> {
   formattedExemplarPoints?: Array<FormattedExemplarPoint> | undefined;
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  /**
+   * Plain click on a time bucket (the plot background — dot/legend clicks
+   * and drag-selections never reach this). [bucketStart, bucketEnd) uses
+   * the same adjacent-row width derivation as drag-to-select. Fires only
+   * when no toggle-selection is active: a click that clears an active
+   * legend/dot selection keeps its existing meaning.
+   */
+  onBucketClick?:
+    | ((
+        bucketStart: Date,
+        bucketEnd: Date,
+        // The clicked row: one numeric entry per series + the axis keys.
+        valuesAtBucket: Record<string, number | string>,
+      ) => void)
+    | undefined;
+  /**
+   * Categories rendered as compare-to-previous-period ghosts: dashed,
+   * faded, no dots, not click-selectable — context, not data.
+   */
+  ghostCategories?: Array<string> | undefined;
 }
 
 const LineChart: React.ForwardRefExoticComponent<
@@ -670,6 +708,8 @@ const LineChart: React.ForwardRefExoticComponent<
       formattedTimeReferenceLines,
       formattedReferenceRegions,
       onTimeRangeSelect,
+      onBucketClick,
+      ghostCategories,
       ...other
     } = props;
     const CustomTooltip: React.ComponentType<TooltipProps> | undefined =
@@ -948,19 +988,51 @@ const LineChart: React.ForwardRefExoticComponent<
                   onMouseUp: handleRangeSelectMouseUp,
                 }
               : {})}
-            onClick={
-              hasOnValueChange && (activeLegend || activeDot)
-                ? () => {
-                    // Ignore the click that follows a drag-to-select.
-                    if (suppressNextClickRef.current) {
-                      return;
-                    }
-                    setActiveDot(undefined);
-                    setActiveLegend(undefined);
-                    onValueChange?.(null);
-                  }
-                : () => {} // do nothing
-            }
+            onClick={(chartState: RangeSelectionChartState) => {
+              // Ignore the click that follows a drag-to-select.
+              if (suppressNextClickRef.current) {
+                return;
+              }
+              /*
+               * A click while a legend/dot selection is active keeps its
+               * long-standing meaning — clear the selection — and never
+               * also pins a bucket.
+               */
+              if (hasOnValueChange && (activeLegend || activeDot)) {
+                setActiveDot(undefined);
+                setActiveLegend(undefined);
+                onValueChange?.(null);
+                return;
+              }
+              if (!onBucketClick) {
+                return;
+              }
+              const rowIndex: number | null =
+                getRowIndexFromChartState(chartState);
+              if (rowIndex === null) {
+                return;
+              }
+              const bucketStart: Date | null = getBucketDateAtIndex(rowIndex);
+              if (!bucketStart) {
+                return;
+              }
+              /*
+               * Cover the full bucket: width from adjacent row dates, the
+               * same derivation drag-to-select uses.
+               */
+              const adjacentDate: Date | null =
+                rowIndex > 0
+                  ? getBucketDateAtIndex(rowIndex - 1)
+                  : getBucketDateAtIndex(rowIndex + 1);
+              const bucketWidthInMs: number = adjacentDate
+                ? Math.abs(bucketStart.getTime() - adjacentDate.getTime())
+                : 0;
+              onBucketClick(
+                bucketStart,
+                new Date(bucketStart.getTime() + bucketWidthInMs),
+                (data[rowIndex] || {}) as Record<string, number | string>,
+              );
+            }}
             margin={{
               /*
                * Tick labels are 10px font with a translate(0, 6) — they
@@ -1146,85 +1218,95 @@ const LineChart: React.ForwardRefExoticComponent<
               ) as ChartColorValue;
               const isCustomColor: boolean = isHexColorValue(lineColor);
               const lineHex: string = getColorHex(lineColor);
+              const isGhost: boolean =
+                ghostCategories?.includes(category) || false;
               return (
                 <Line
                   className={cx(getColorClassName(lineColor, "stroke"))}
                   strokeOpacity={
-                    activeDot || (activeLegend && activeLegend !== category)
+                    (activeDot || (activeLegend && activeLegend !== category)
                       ? 0.3
-                      : 1
+                      : 1) * (isGhost ? 0.45 : 1)
                   }
-                  activeDot={(props: any) => {
-                    const {
-                      cx: cxCoord,
-                      cy: cyCoord,
-                      stroke,
-                      strokeLinecap,
-                      strokeLinejoin,
-                      strokeWidth,
-                    } = props;
-                    return (
-                      <Dot
-                        className={cx(
-                          "stroke-white",
-                          onValueChange ? "cursor-pointer" : "",
-                          getColorClassName(lineColor, "fill"),
-                        )}
-                        cx={cxCoord}
-                        cy={cyCoord}
-                        r={5}
-                        fill={isCustomColor ? lineHex : ""}
-                        stroke={stroke}
-                        strokeLinecap={strokeLinecap}
-                        strokeLinejoin={strokeLinejoin}
-                        strokeWidth={strokeWidth}
-                        onClick={(_: any, event: any) => {
-                          return onDotClick(props, event);
-                        }}
-                      />
-                    );
-                  }}
-                  dot={(props: any) => {
-                    const {
-                      stroke,
-                      strokeLinecap,
-                      strokeLinejoin,
-                      strokeWidth,
-                      cx: cxCoord,
-                      cy: cyCoord,
-                      index,
-                    } = props;
+                  activeDot={
+                    isGhost
+                      ? false
+                      : (props: any) => {
+                          const {
+                            cx: cxCoord,
+                            cy: cyCoord,
+                            stroke,
+                            strokeLinecap,
+                            strokeLinejoin,
+                            strokeWidth,
+                          } = props;
+                          return (
+                            <Dot
+                              className={cx(
+                                "stroke-white",
+                                onValueChange ? "cursor-pointer" : "",
+                                getColorClassName(lineColor, "fill"),
+                              )}
+                              cx={cxCoord}
+                              cy={cyCoord}
+                              r={5}
+                              fill={isCustomColor ? lineHex : ""}
+                              stroke={stroke}
+                              strokeLinecap={strokeLinecap}
+                              strokeLinejoin={strokeLinejoin}
+                              strokeWidth={strokeWidth}
+                              onClick={(_: any, event: any) => {
+                                return onDotClick(props, event);
+                              }}
+                            />
+                          );
+                        }
+                  }
+                  dot={
+                    isGhost
+                      ? false
+                      : (props: any) => {
+                          const {
+                            stroke,
+                            strokeLinecap,
+                            strokeLinejoin,
+                            strokeWidth,
+                            cx: cxCoord,
+                            cy: cyCoord,
+                            index,
+                          } = props;
 
-                    if (
-                      (hasOnlyOneValueForKey(data, category) &&
-                        !(
-                          activeDot ||
-                          (activeLegend && activeLegend !== category)
-                        )) ||
-                      (activeDot?.index === index &&
-                        activeDot?.dataKey === category)
-                    ) {
-                      return (
-                        <Dot
-                          key={index}
-                          cx={cxCoord}
-                          cy={cyCoord}
-                          r={5}
-                          stroke={stroke}
-                          fill={isCustomColor ? lineHex : ""}
-                          strokeLinecap={strokeLinecap}
-                          strokeLinejoin={strokeLinejoin}
-                          strokeWidth={strokeWidth}
-                          className={cx(
-                            "stroke-white",
-                            onValueChange ? "cursor-pointer" : "",
-                            getColorClassName(lineColor, "fill"),
-                          )}
-                        />
-                      );
-                    }
-                    return <React.Fragment key={index}></React.Fragment>;
-                  }}
+                          if (
+                            (hasOnlyOneValueForKey(data, category) &&
+                              !(
+                                activeDot ||
+                                (activeLegend && activeLegend !== category)
+                              )) ||
+                            (activeDot?.index === index &&
+                              activeDot?.dataKey === category)
+                          ) {
+                            return (
+                              <Dot
+                                key={index}
+                                cx={cxCoord}
+                                cy={cyCoord}
+                                r={5}
+                                stroke={stroke}
+                                fill={isCustomColor ? lineHex : ""}
+                                strokeLinecap={strokeLinecap}
+                                strokeLinejoin={strokeLinejoin}
+                                strokeWidth={strokeWidth}
+                                className={cx(
+                                  "stroke-white",
+                                  onValueChange ? "cursor-pointer" : "",
+                                  getColorClassName(lineColor, "fill"),
+                                )}
+                              />
+                            );
+                          }
+                          return <React.Fragment key={index}></React.Fragment>;
+                        }
+                  }
                   key={category}
                   name={category}
                   type={props.curve || ChartCurve.LINEAR}
@@ -1234,39 +1316,45 @@ const LineChart: React.ForwardRefExoticComponent<
                    * so the `stroke-*` Tailwind class on the Line applies.
                    */
                   stroke={isCustomColor ? lineHex : ""}
-                  strokeWidth={2}
+                  strokeWidth={isGhost ? 1.5 : 2}
                   strokeLinejoin="round"
                   strokeLinecap="round"
                   isAnimationActive={false}
                   connectNulls={connectNulls}
+                  {...(isGhost ? { strokeDasharray: "6 4" } : {})}
                 />
               );
             })}
             {/* hidden lines to increase clickable target area */}
             {onValueChange
-              ? categories.map((category: string) => {
-                  return (
-                    <Line
-                      className={cx("cursor-pointer")}
-                      strokeOpacity={0}
-                      key={category}
-                      name={category}
-                      type={props.curve || ChartCurve.LINEAR}
-                      dataKey={category}
-                      stroke="transparent"
-                      fill="transparent"
-                      legendType="none"
-                      tooltipType="none"
-                      strokeWidth={12}
-                      connectNulls={connectNulls}
-                      onClick={(props: any, event: any) => {
-                        event.stopPropagation();
-                        const { name } = props;
-                        onCategoryClick(name);
-                      }}
-                    />
-                  );
-                })
+              ? categories
+                  .filter((category: string) => {
+                    // Ghosts are context, not click-selectable series.
+                    return !(ghostCategories?.includes(category) || false);
+                  })
+                  .map((category: string) => {
+                    return (
+                      <Line
+                        className={cx("cursor-pointer")}
+                        strokeOpacity={0}
+                        key={category}
+                        name={category}
+                        type={props.curve || ChartCurve.LINEAR}
+                        dataKey={category}
+                        stroke="transparent"
+                        fill="transparent"
+                        legendType="none"
+                        tooltipType="none"
+                        strokeWidth={12}
+                        connectNulls={connectNulls}
+                        onClick={(props: any, event: any) => {
+                          event.stopPropagation();
+                          const { name } = props;
+                          onCategoryClick(name);
+                        }}
+                      />
+                    );
+                  })
               : null}
             {props.referenceLines?.map(
               (refLine: ChartReferenceLineProps, refIndex: number) => {
@@ -1308,7 +1396,9 @@ const LineChart: React.ForwardRefExoticComponent<
                     {...(region.original.onClick
                       ? {
                           style: { cursor: "pointer" as const },
-                          onClick: (): void => {
+                          onClick: (...args: Array<unknown>): void => {
+                            // Never let an annotation click also pin a bucket.
+                            stopChartEventPropagation(...args);
                             if (suppressNextClickRef.current) {
                               return;
                             }
@@ -1350,7 +1440,9 @@ const LineChart: React.ForwardRefExoticComponent<
                     {...(timeRefLine.original.onClick
                       ? {
                           style: { cursor: "pointer" as const },
-                          onClick: (): void => {
+                          onClick: (...args: Array<unknown>): void => {
+                            // Never let an annotation click also pin a bucket.
+                            stopChartEventPropagation(...args);
                             if (suppressNextClickRef.current) {
                               return;
                             }
@@ -1396,7 +1488,9 @@ const LineChart: React.ForwardRefExoticComponent<
                     stroke="var(--ou-chart-marker-ring, #ffffff)"
                     strokeWidth={2}
                     style={{ cursor: "pointer" }}
-                    onClick={() => {
+                    onClick={(...args: Array<unknown>) => {
+                      // Never let an exemplar click also pin a bucket.
+                      stopChartEventPropagation(...args);
                       // Ignore the click that follows a drag-to-select.
                       if (suppressNextClickRef.current) {
                         return;

--- a/Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries.ts
+++ b/Common/UI/Components/Charts/ChartLibrary/Utils/TooltipEntries.ts
@@ -21,6 +21,14 @@ export interface SortableTooltipItem {
 
 export const DEFAULT_TOOLTIP_MAX_ENTRIES: number = 10;
 
+/*
+ * Series carrying this suffix are compare-to-previous-period ghosts.
+ * They still read out in the tooltip (that is the point of comparing)
+ * but sort after every live series so they can never displace a real
+ * reading under the entry cap.
+ */
+export const PREVIOUS_PERIOD_SERIES_SUFFIX: string = " (previous)";
+
 export interface PreparedTooltipEntries<T extends SortableTooltipItem> {
   /** Entries to render, highest value first, capped at maxEntries. */
   entries: Array<T>;
@@ -59,34 +67,36 @@ export function prepareTooltipEntries<T extends SortableTooltipItem>(
     return item.type !== "none" && !Array.isArray(item.value);
   });
 
+  /*
+   * Sort tiers: live finite readings first (value desc), then
+   * previous-period ghosts (value desc), then non-finite entries
+   * (missing points) — lower tiers must never displace a real reading
+   * under the entry cap.
+   */
+  const getTier: (item: T) => number = (item: T): number => {
+    const hasFiniteValue: boolean =
+      typeof item.value === "number" && Number.isFinite(item.value);
+    if (!hasFiniteValue) {
+      return 2;
+    }
+    return String(item.category).endsWith(PREVIOUS_PERIOD_SERIES_SUFFIX)
+      ? 1
+      : 0;
+  };
+
   const sortedEntries: Array<T> = visibleEntries
     .slice()
     .sort((a: T, b: T): number => {
-      /*
-       * Non-finite values (missing points, the anomaly band's [low, high]
-       * array) sort last — they carry no "how high is this series right
-       * now" signal, so they must never displace a real reading.
-       */
-      const aValue: number | null =
-        typeof a.value === "number" && Number.isFinite(a.value)
-          ? a.value
-          : null;
-      const bValue: number | null =
-        typeof b.value === "number" && Number.isFinite(b.value)
-          ? b.value
-          : null;
-
-      if (aValue === null && bValue === null) {
+      const aTier: number = getTier(a);
+      const bTier: number = getTier(b);
+      if (aTier !== bTier) {
+        return aTier - bTier;
+      }
+      if (aTier === 2) {
         return compareCategoryNames(a.category, b.category);
       }
-      if (aValue === null) {
-        return 1;
-      }
-      if (bValue === null) {
-        return -1;
-      }
-      if (bValue !== aValue) {
-        return bValue - aValue;
+      if (b.value !== a.value) {
+        return b.value - a.value;
       }
       return compareCategoryNames(a.category, b.category);
     });

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -62,6 +62,19 @@ export interface ComponentProps {
    * buckets calls back with the [start, end) of the selected time range.
    */
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  // Plain click on a bucket — see ChartLibrary onBucketClick.
+  onBucketClick?:
+    | ((
+        bucketStart: Date,
+        bucketEnd: Date,
+        valuesAtBucket: Record<string, number | string>,
+      ) => void)
+    | undefined;
+  /*
+   * Series rendered as compare-to-previous-period ghosts (dashed, faded,
+   * dotless). Names must exist in `data`.
+   */
+  ghostSeriesNames?: Array<string> | undefined;
   showLegend?: boolean | undefined;
   /*
    * Optional per-series color override (named palette keys or hex strings).
@@ -208,6 +221,8 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
         }
         onExemplarClick={props.onExemplarClick}
         onTimeRangeSelect={props.onTimeRangeSelect}
+        onBucketClick={props.onBucketClick}
+        ghostCategories={props.ghostSeriesNames}
       />
       {hasNoData && <NoDataMessage />}
     </div>


### PR DESCRIPTION
**PR B of the debuggability stack** — stacked on #3379 (PR A). Items 5–8 of the roadmap; PR C (AI "explain this spike", investigation artifacts) stacks on this.

## 5. In-context investigation drawer
A `SideOver` panel answering *"what happened in this window?"* without leaving the page:
- **Log signal summary**: volume by severity, error count/rate tiles, a severity-stacked histogram, and the top 5 error patterns — one projection-backed histogram call (carrying the metric view's **attribute** filters) plus one pattern call (service+window scoped), service names resolved to IDs through the shared cached resolver. Pattern rows deep-link into the logs explorer.
- **Metrics pinned to the window** (interactive `EmbeddedMetricCard`) wrapped in the **companion logs/traces/exceptions tabs** scoped the same way (reusing `TelemetryCompanionSignalTabs` with a synthesized, *memoized* metric-primary query — an inline-recreated spec would loop the companion discovery effect; `eventNoun` union widened with `"view"`).
- **Four openers**: dashboard widget zoom bar (**Investigate**), explorer toolbar (**Investigate**), the per-series menu (**Investigate in panel**, series-scoped), and the bucket inspector below. Escape hatches close the drawer before navigating.

## 6. Pinned bucket inspector
Click a time bucket on any Line/Area metric chart → a pinned portal card lists that instant's series values highest-first (the tooltip's ordering, persistent) with **Investigate this moment** (opens the drawer on the bucket, padded to a 5-minute floor). Interaction contract preserved: drags still zoom, clicks that clear a legend/dot selection never also pin, and exemplar/region/event-line clicks stop propagation (robust to both recharts handler calling conventions) so they never double-fire.

## 7. Compare with previous period
Explorer toolbar toggle (persisted per browser): the same queries fetched over the window shifted back exactly one width (same aggregation interval → bucket-congruent; distinct fetch-cache identity; best-effort — a failed shifted fetch degrades to live-only). Each displayed series gets a dashed, faded, dotless **ghost twin in the same hue**:
- merged **after** series presentation — ghosts never consume Top-N slots, legend chips, or color positions;
- x-values shifted onto the current window's grid (the bucketer silently drops out-of-window points);
- tooltip sorts ghosts in their own tier below every live reading (`" (previous)"` suffix contract in the shared `TooltipEntries` util);
- excluded from click-target fat lines; included in percent-axis autoscale so they never clip.

## 8. Service overview: all four signal pillars
The golden-signals overview gains **Logs** (lines vs errors) and **Exceptions** (unhandled vs handled) charts via a new `fetchLogAndExceptionSignals` (two projection-backed histogram calls), sharing the page's crosshair sync — rate, errors, duration, logs, and exceptions on one page.

## Tests
7 new/extended suites (~20 new cases): tooltip ghost tiers (never displace live readings under the cap), ghost rendering for Line **and** Area (dashed + excluded from click-targets), the drawer end-to-end (scope chips, attribute carry into the histogram request, pinned-window handoff to companions, close-before-navigate), `MetricView`'s shifted fetch (exact-width shift; off ⇒ no shifted fetch; failure ⇒ live-only), `MetricCharts` ghost merge through the real component (dashed twin, no chips, series count unchanged), plus wiring pins for every opener and the annotation-propagation contract. Full runs: **App 194 suites / 6725 tests**, **Common Tests/App/Dashboard + Charts 70 suites / 1653 tests**; `tsc` clean in both workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HxEiCGGsLcTyJe4cR7ofb