### PR TITLE
Debuggability 3/3: deterministic spike findings, AI explain hand-off, pin investigation to incident

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
@@ -12,6 +12,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import EventName from "../../Utils/EventName";
@@ -40,10 +41,31 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
 
   const chat: UseAiChat = useAiChat({ enabled: isOpen });
 
+  /*
+   * The toggle listener mounts once; a ref keeps it pointed at the
+   * CURRENT chat state so a prompt dispatch can pre-fill the input.
+   */
+  const chatRef: React.MutableRefObject<UseAiChat> = useRef<UseAiChat>(chat);
+  chatRef.current = chat;
+
   // ---- open/close ----------------------------------------------------------
 
   useEffect(() => {
-    const toggle: () => void = (): void => {
+    const toggle: (event: CustomEvent) => void = (event: CustomEvent): void => {
+      /*
+       * A dispatch carrying a `prompt` OPENS the panel (never closes it)
+       * and pre-fills the input with the prompt — investigation surfaces
+       * use this to hand the user a prepared, editable question. A plain
+       * dispatch keeps the historic toggle behavior.
+       */
+      const prompt: unknown = (event?.detail as Record<string, unknown>)?.[
+        "prompt"
+      ];
+      if (typeof prompt === "string" && prompt.trim() !== "") {
+        setIsOpen(true);
+        chatRef.current?.setInputValue(prompt);
+        return;
+      }
       setIsOpen((open: boolean) => {
         return !open;
       });

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer.tsx
@@ -44,6 +44,28 @@ import {
   formatDroppedScopeHint,
   resolveServiceIdsByNames,
 } from "../../Utils/MetricsCrossSignalPivot";
+import useEventTimeReferenceLines, {
+  EventTimeReferenceLines,
+} from "../Metrics/Utils/UseEventTimeReferenceLines";
+import ChartTimeReferenceLineProps from "Common/UI/Components/Charts/Types/TimeReferenceLineProps";
+import {
+  InvestigationEvidence,
+  InvestigationFinding,
+  InvestigationMarker,
+  buildInvestigationFindings,
+  buildInvestigationNoteMarkdown,
+  buildInvestigationPrompt,
+} from "../../Utils/InvestigationFindings";
+import GlobalEvents from "Common/UI/Utils/GlobalEvents";
+import EventName from "../../Utils/EventName";
+import Incident from "Common/Models/DatabaseModels/Incident";
+import IncidentInternalNote from "Common/Models/DatabaseModels/IncidentInternalNote";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ObjectID from "Common/Types/ObjectID";
+import ProjectUtil from "Common/UI/Utils/Project";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { ShowToastNotification } from "Common/UI/Components/Toast/ToastInit";
+import { ToastType } from "Common/UI/Components/Toast/Toast";
 
 export interface ComponentProps {
   /** What the user is investigating, e.g. `CPU by host · 12:01–12:14`. */
@@ -216,7 +238,29 @@ const InvestigationDrawer: FunctionComponent<ComponentProps> = (
     extraction.droppedFilterKeys,
   );
 
-  const scopeChips: Array<string> = useMemo(() => {
+  // -- Findings: deterministic "explain this spike" over the evidence --
+
+  const { lines: eventLines }: EventTimeReferenceLines =
+    useEventTimeReferenceLines({
+      enabled: true,
+      window: pinnedWindow,
+    });
+
+  const markers: Array<InvestigationMarker> = useMemo(() => {
+    return eventLines.map(
+      (line: ChartTimeReferenceLineProps): InvestigationMarker => {
+        const label: string = line.label || "Event";
+        const kind: InvestigationMarker["kind"] = label.startsWith("Incident:")
+          ? "incident"
+          : label.startsWith("Alert:")
+            ? "alert"
+            : "change";
+        return { kind, label, timeMs: line.date.getTime() };
+      },
+    );
+  }, [eventLines]);
+
+  const scopeChipsForEvidence: Array<string> = useMemo(() => {
     const chips: Array<string> = [];
     for (const serviceName of extraction.serviceNames) {
       chips.push(`service = ${serviceName}`);
@@ -226,6 +270,125 @@ const InvestigationDrawer: FunctionComponent<ComponentProps> = (
     }
     return chips;
   }, [extraction]);
+
+  const evidence: InvestigationEvidence = useMemo(() => {
+    return {
+      windowStartMs,
+      windowEndMs,
+      scopeChips: scopeChipsForEvidence,
+      logVolume,
+      errorPatterns: errorPatterns || [],
+      logBuckets: (logBuckets || []) as unknown as Array<JSONObject>,
+      markers,
+    };
+  }, [
+    windowStartMs,
+    windowEndMs,
+    scopeChipsForEvidence,
+    logVolume,
+    errorPatterns,
+    logBuckets,
+    markers,
+  ]);
+
+  const findings: Array<InvestigationFinding> = useMemo(() => {
+    return buildInvestigationFindings(evidence);
+  }, [evidence]);
+
+  const explainWithAi: VoidFunction = (): void => {
+    /*
+     * Opens (never toggles closed) the Ask AI panel with the evidence as
+     * an editable prompt. The panel sits above the drawer (z-40 > z-30),
+     * so the user keeps the evidence in view while they ask.
+     */
+    GlobalEvents.dispatchEvent(EventName.AI_CHAT_TOGGLE, {
+      prompt: buildInvestigationPrompt(evidence, findings),
+    });
+  };
+
+  // -- Save to incident: pin the investigation to a timeline --
+
+  const [isIncidentPickerOpen, setIsIncidentPickerOpen] =
+    useState<boolean>(false);
+  const [recentIncidents, setRecentIncidents] =
+    useState<Array<Incident> | null>(null);
+  const [selectedIncidentId, setSelectedIncidentId] = useState<string>("");
+  const [isSavingNote, setIsSavingNote] = useState<boolean>(false);
+
+  const openIncidentPicker: VoidFunction = (): void => {
+    setIsIncidentPickerOpen(true);
+    if (recentIncidents !== null) {
+      return;
+    }
+    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+    if (!projectId) {
+      setRecentIncidents([]);
+      return;
+    }
+    ModelAPI.getList<Incident>({
+      modelType: Incident,
+      query: { projectId },
+      select: {
+        _id: true,
+        title: true,
+        incidentNumberWithPrefix: true,
+        incidentNumber: true,
+      },
+      sort: { createdAt: SortOrder.Descending },
+      limit: 10,
+      skip: 0,
+    })
+      .then((result: ListResult<Incident>) => {
+        setRecentIncidents(result.data);
+        if (result.data[0]?.id) {
+          setSelectedIncidentId(result.data[0].id.toString());
+        }
+      })
+      .catch(() => {
+        setRecentIncidents([]);
+      });
+  };
+
+  const saveNoteToIncident: VoidFunction = (): void => {
+    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+    if (!projectId || !selectedIncidentId || isSavingNote) {
+      return;
+    }
+    setIsSavingNote(true);
+
+    const note: IncidentInternalNote = new IncidentInternalNote();
+    note.projectId = projectId;
+    note.incidentId = new ObjectID(selectedIncidentId);
+    note.note = buildInvestigationNoteMarkdown({
+      evidence,
+      findings,
+      explorerUrl: ExplorerLink.buildExplorerUrl(pinnedViewData).toString(),
+    });
+
+    ModelAPI.create<IncidentInternalNote>({
+      model: note,
+      modelType: IncidentInternalNote,
+    })
+      .then(() => {
+        ShowToastNotification({
+          title: "Investigation pinned",
+          description:
+            "The snapshot was added to the incident as a private note.",
+          type: ToastType.SUCCESS,
+        });
+        setIsIncidentPickerOpen(false);
+      })
+      .catch(() => {
+        ShowToastNotification({
+          title: "Could not save the note",
+          description: "The incident note API rejected the request.",
+          type: ToastType.DANGER,
+        });
+      })
+      .finally(() => {
+        setIsSavingNote(false);
+      });
+  };
 
   const openPattern: (pattern: TopErrorPatternRow) => void = (
     pattern: TopErrorPatternRow,
@@ -261,8 +424,8 @@ const InvestigationDrawer: FunctionComponent<ComponentProps> = (
       <div className="space-y-5 py-5">
         {/* Scope strip */}
         <div className="flex flex-wrap items-center gap-1.5">
-          {scopeChips.length > 0 ? (
-            scopeChips.map((chip: string) => {
+          {scopeChipsForEvidence.length > 0 ? (
+            scopeChipsForEvidence.map((chip: string) => {
               return (
                 <span
                   key={chip}
@@ -289,6 +452,121 @@ const InvestigationDrawer: FunctionComponent<ComponentProps> = (
             Open in Metric Explorer
           </button>
         </div>
+
+        {/* Findings — the deterministic "explain this spike" readout */}
+        <Card
+          title="Findings"
+          description="What stands out in this window, from the evidence below."
+          rightElement={
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                title="Open Ask AI with this evidence as an editable prompt"
+                onClick={explainWithAi}
+              >
+                <Icon icon={IconProp.Sparkles} className="h-3.5 w-3.5" />
+                Explain with AI
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                title="Pin this investigation to an incident as a private note"
+                onClick={openIncidentPicker}
+              >
+                <Icon icon={IconProp.MapPin} className="h-3.5 w-3.5" />
+                Save to incident
+              </button>
+            </div>
+          }
+        >
+          <div className="space-y-3">
+            <ul className="space-y-1.5">
+              {findings.map((finding: InvestigationFinding, index: number) => {
+                return (
+                  <li key={index} className="flex items-start gap-2">
+                    <span
+                      aria-hidden="true"
+                      className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${
+                        finding.severity === "critical"
+                          ? "bg-red-500"
+                          : finding.severity === "warning"
+                            ? "bg-amber-500"
+                            : "bg-blue-400"
+                      }`}
+                    />
+                    <span className="text-sm text-gray-700">
+                      {finding.text}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {isIncidentPickerOpen ? (
+              <div className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-2.5">
+                {recentIncidents === null ? (
+                  <span className="text-xs text-gray-500">
+                    Loading incidents…
+                  </span>
+                ) : recentIncidents.length === 0 ? (
+                  <span className="text-xs text-gray-500">
+                    No incidents found in this project.
+                  </span>
+                ) : (
+                  <>
+                    <label
+                      htmlFor="investigation-incident-picker"
+                      className="text-xs font-medium text-gray-700"
+                    >
+                      Pin to
+                    </label>
+                    <select
+                      id="investigation-incident-picker"
+                      value={selectedIncidentId}
+                      onChange={(
+                        event: React.ChangeEvent<HTMLSelectElement>,
+                      ): void => {
+                        setSelectedIncidentId(event.target.value);
+                      }}
+                      className="min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                    >
+                      {recentIncidents.map((incident: Incident) => {
+                        return (
+                          <option
+                            key={incident.id?.toString()}
+                            value={incident.id?.toString()}
+                          >
+                            {incident.incidentNumberWithPrefix ||
+                              `#${incident.incidentNumber || "?"}`}{" "}
+                            — {incident.title}
+                          </option>
+                        );
+                      })}
+                    </select>
+                    <button
+                      type="button"
+                      disabled={isSavingNote || !selectedIncidentId}
+                      className="rounded-md bg-indigo-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                      onClick={saveNoteToIncident}
+                    >
+                      {isSavingNote ? "Saving…" : "Save note"}
+                    </button>
+                  </>
+                )}
+                <button
+                  type="button"
+                  className="rounded-md px-2 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                  onClick={() => {
+                    setIsIncidentPickerOpen(false);
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </Card>
 
         {/* Log signal summary */}
         <Card
@@ -377,7 +655,7 @@ const InvestigationDrawer: FunctionComponent<ComponentProps> = (
                   })}
                 </ul>
               )}
-              {scopeChips.length > 0 &&
+              {scopeChipsForEvidence.length > 0 &&
               Object.keys(extraction.attributes).length > 0 ? (
                 <p className="mt-1.5 text-[11px] text-gray-400">
                   Patterns are scoped by service and window; attribute filters

--- a/App/FeatureSet/Dashboard/src/Utils/InvestigationFindings.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/InvestigationFindings.ts
@@ -1,0 +1,296 @@
+import OneUptimeDate from "Common/Types/Date";
+import { JSONObject } from "Common/Types/JSON";
+import { LogVolumeSummary, TopErrorPatternRow } from "./LogsInsights";
+
+/*
+ * The deterministic "explain this spike" engine: correlates the evidence
+ * the investigation drawer already fetched — the window's log signal,
+ * top error patterns, and the event markers (deploys, incidents,
+ * alerts) — into ranked, human findings. No model calls, no heuristics
+ * that cannot be pointed at: every finding names its evidence. Pure so
+ * App/Tests can pin each rule.
+ */
+
+export type InvestigationMarkerKind = "incident" | "alert" | "change";
+
+export interface InvestigationMarker {
+  kind: InvestigationMarkerKind;
+  label: string;
+  timeMs: number;
+}
+
+export interface InvestigationEvidence {
+  windowStartMs: number;
+  windowEndMs: number;
+  /** "host.name = web-01" style chips describing the scope. */
+  scopeChips: Array<string>;
+  logVolume: LogVolumeSummary | null;
+  errorPatterns: Array<TopErrorPatternRow>;
+  /** Raw histogram buckets ({time, severity, count}) for trend math. */
+  logBuckets: Array<JSONObject>;
+  markers: Array<InvestigationMarker>;
+}
+
+export type InvestigationFindingSeverity = "info" | "warning" | "critical";
+
+export interface InvestigationFinding {
+  severity: InvestigationFindingSeverity;
+  text: string;
+}
+
+// Log severities that count as errors (matches the server's default set).
+const ERROR_SEVERITIES: Set<string> = new Set<string>(["Error", "Fatal"]);
+
+/*
+ * Trend thresholds: below these the halves comparison is noise, not a
+ * finding.
+ */
+const MIN_ERRORS_FOR_TREND: number = 10;
+const TREND_RATIO_THRESHOLD: number = 1.5;
+
+// A single pattern "dominates" when it carries at least this error share.
+const DOMINANT_PATTERN_SHARE: number = 0.5;
+
+// Error rates at or above this are called out on their own.
+const HIGH_ERROR_RATE_PERCENT: number = 5;
+
+export interface ErrorHalves {
+  firstHalf: number;
+  secondHalf: number;
+}
+
+/**
+ * Error-severity counts for the two halves of the window, split by
+ * bucket timestamp (not index — buckets can be sparse).
+ */
+export function computeErrorHalves(
+  buckets: Array<JSONObject>,
+  windowStartMs: number,
+  windowEndMs: number,
+): ErrorHalves {
+  const midpointMs: number = windowStartMs + (windowEndMs - windowStartMs) / 2;
+  const halves: ErrorHalves = { firstHalf: 0, secondHalf: 0 };
+
+  for (const bucket of buckets || []) {
+    if (!ERROR_SEVERITIES.has(String(bucket["severity"] || ""))) {
+      continue;
+    }
+    const count: number =
+      typeof bucket["count"] === "number" ? (bucket["count"] as number) : 0;
+    const timeMs: number = new Date(String(bucket["time"] || "")).getTime();
+    if (Number.isNaN(timeMs)) {
+      continue;
+    }
+    if (timeMs < midpointMs) {
+      halves.firstHalf += count;
+    } else {
+      halves.secondHalf += count;
+    }
+  }
+
+  return halves;
+}
+
+function formatMinutesBefore(eventMs: number, windowEndMs: number): string {
+  const minutes: number = Math.max(
+    0,
+    Math.round((windowEndMs - eventMs) / 60000),
+  );
+  if (minutes === 0) {
+    return "moments before the end of this window";
+  }
+  return `${minutes} minute${minutes === 1 ? "" : "s"} before the end of this window`;
+}
+
+/**
+ * The ranked findings. Change events lead (deploys are the most common
+ * root cause), then error-signal shifts, then concurrent incidents —
+ * ending with honest guidance when nothing stands out.
+ */
+export function buildInvestigationFindings(
+  evidence: InvestigationEvidence,
+): Array<InvestigationFinding> {
+  const findings: Array<InvestigationFinding> = [];
+
+  const changeMarkers: Array<InvestigationMarker> = evidence.markers.filter(
+    (marker: InvestigationMarker): boolean => {
+      return marker.kind === "change";
+    },
+  );
+  for (const marker of changeMarkers) {
+    findings.push({
+      severity: "critical",
+      text: `${marker.label} landed ${formatMinutesBefore(marker.timeMs, evidence.windowEndMs)} — deployments and config changes are the most common cause of behavior shifts.`,
+    });
+  }
+
+  const halves: ErrorHalves = computeErrorHalves(
+    evidence.logBuckets,
+    evidence.windowStartMs,
+    evidence.windowEndMs,
+  );
+  if (
+    halves.secondHalf >= MIN_ERRORS_FOR_TREND &&
+    halves.secondHalf >= halves.firstHalf * TREND_RATIO_THRESHOLD
+  ) {
+    const ratioLabel: string =
+      halves.firstHalf === 0
+        ? "from zero"
+        : `${(halves.secondHalf / halves.firstHalf).toFixed(1)}×`;
+    findings.push({
+      severity: "warning",
+      text: `Error-severity log volume rose ${ratioLabel} in the second half of the window (${halves.firstHalf} → ${halves.secondHalf}).`,
+    });
+  }
+
+  const topPattern: TopErrorPatternRow | undefined = evidence.errorPatterns[0];
+  const errorCount: number = evidence.logVolume?.errorCount || 0;
+  if (
+    topPattern &&
+    errorCount > 0 &&
+    topPattern.count >= errorCount * DOMINANT_PATTERN_SHARE
+  ) {
+    const share: number = Math.min(
+      100,
+      Math.round((topPattern.count / errorCount) * 100),
+    );
+    findings.push({
+      severity: "warning",
+      text: `One error pattern accounts for ~${share}% of the window's errors: "${topPattern.sampleBody || topPattern.pattern}".`,
+    });
+  }
+
+  if (
+    evidence.logVolume &&
+    evidence.logVolume.errorRatePercent >= HIGH_ERROR_RATE_PERCENT
+  ) {
+    findings.push({
+      severity: "warning",
+      text: `${evidence.logVolume.errorRatePercent.toFixed(1)}% of the window's log lines are error severity (${evidence.logVolume.errorCount.toLocaleString()} of ${evidence.logVolume.total.toLocaleString()}).`,
+    });
+  }
+
+  for (const marker of evidence.markers) {
+    if (marker.kind === "change") {
+      continue;
+    }
+    findings.push({
+      severity: "info",
+      text: `${marker.label} was declared inside this window — it may share this root cause.`,
+    });
+  }
+
+  if (findings.length === 0) {
+    findings.push({
+      severity: "info",
+      text: "No change events, error-pattern shifts, or concurrent incidents stand out in this window — try widening the window, or check the traces and exceptions tabs below.",
+    });
+  }
+
+  return findings;
+}
+
+function describeWindow(evidence: InvestigationEvidence): string {
+  return `${OneUptimeDate.getDateAsFormattedString(new Date(evidence.windowStartMs))} — ${OneUptimeDate.getDateAsFormattedString(new Date(evidence.windowEndMs))}`;
+}
+
+function describeScope(evidence: InvestigationEvidence): string {
+  return evidence.scopeChips.length > 0
+    ? evidence.scopeChips.join(", ")
+    : "the whole project (time window only)";
+}
+
+/**
+ * A prepared prompt for the Ask AI panel — the evidence, restated, with
+ * a clear question. Pre-fills the chat input; the user reviews and
+ * sends.
+ */
+export function buildInvestigationPrompt(
+  evidence: InvestigationEvidence,
+  findings: Array<InvestigationFinding>,
+): string {
+  const lines: Array<string> = [
+    `I'm investigating a metric anomaly in the window ${describeWindow(evidence)}, scoped to ${describeScope(evidence)}.`,
+  ];
+
+  if (evidence.logVolume) {
+    lines.push(
+      `Log signal: ${evidence.logVolume.total.toLocaleString()} lines, ${evidence.logVolume.errorCount.toLocaleString()} errors (${evidence.logVolume.errorRatePercent.toFixed(1)}%).`,
+    );
+  }
+
+  if (evidence.errorPatterns.length > 0) {
+    lines.push("Top error patterns:");
+    for (const pattern of evidence.errorPatterns.slice(0, 5)) {
+      lines.push(
+        `- (${pattern.count}×) ${pattern.sampleBody || pattern.pattern}`,
+      );
+    }
+  }
+
+  if (findings.length > 0) {
+    lines.push("What already stands out:");
+    for (const finding of findings) {
+      lines.push(`- ${finding.text}`);
+    }
+  }
+
+  lines.push(
+    "What is the most likely root cause, and what should I check next?",
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Markdown for the incident's internal note — the investigation,
+ * pinned to the incident timeline where the team collaborates.
+ */
+export function buildInvestigationNoteMarkdown(input: {
+  evidence: InvestigationEvidence;
+  findings: Array<InvestigationFinding>;
+  explorerUrl: string | null;
+}): string {
+  const { evidence, findings } = input;
+  const lines: Array<string> = [
+    "### Investigation snapshot",
+    "",
+    `**Window:** ${describeWindow(evidence)}`,
+    `**Scope:** ${describeScope(evidence)}`,
+  ];
+
+  if (evidence.logVolume) {
+    lines.push(
+      `**Log signal:** ${evidence.logVolume.total.toLocaleString()} lines · ${evidence.logVolume.errorCount.toLocaleString()} errors · ${evidence.logVolume.errorRatePercent.toFixed(1)}% error rate`,
+    );
+  }
+
+  lines.push("", "**Findings:**");
+  for (const finding of findings) {
+    const marker: string =
+      finding.severity === "critical"
+        ? "🔴"
+        : finding.severity === "warning"
+          ? "🟠"
+          : "🔵";
+    lines.push(`- ${marker} ${finding.text}`);
+  }
+
+  if (evidence.errorPatterns.length > 0) {
+    lines.push("", "**Top error patterns:**");
+    for (const pattern of evidence.errorPatterns.slice(0, 5)) {
+      lines.push(
+        `- \`${(pattern.sampleBody || pattern.pattern).replace(/`/g, "'")}\` — ${pattern.count.toLocaleString()}×`,
+      );
+    }
+  }
+
+  if (input.explorerUrl) {
+    lines.push(
+      "",
+      `[Open these charts in the Metric Explorer](${input.explorerUrl})`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/App/Tests/Dashboard/InvestigationFindings.test.ts
+++ b/App/Tests/Dashboard/InvestigationFindings.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  InvestigationEvidence,
+  InvestigationFinding,
+  buildInvestigationFindings,
+  buildInvestigationNoteMarkdown,
+  buildInvestigationPrompt,
+  computeErrorHalves,
+} from "../../FeatureSet/Dashboard/src/Utils/InvestigationFindings";
+
+/*
+ * The deterministic "explain this spike" engine: every rule pinned, so a
+ * finding can always be traced back to its evidence.
+ */
+
+const WINDOW_START_MS: number = new Date("2026-08-20T10:00:00.000Z").getTime();
+const WINDOW_END_MS: number = new Date("2026-08-20T10:30:00.000Z").getTime();
+
+function bucket(
+  minuteOffset: number,
+  severity: string,
+  count: number,
+): JSONObject {
+  return {
+    time: new Date(WINDOW_START_MS + minuteOffset * 60000).toISOString(),
+    severity,
+    count,
+  };
+}
+
+function evidence(
+  overrides: Partial<InvestigationEvidence> = {},
+): InvestigationEvidence {
+  return {
+    windowStartMs: WINDOW_START_MS,
+    windowEndMs: WINDOW_END_MS,
+    scopeChips: ["host.name = web-01"],
+    logVolume: {
+      total: 1000,
+      errorCount: 20,
+      warnCount: 0,
+      errorRatePercent: 2,
+      severities: [],
+      series: [],
+    },
+    errorPatterns: [],
+    logBuckets: [],
+    markers: [],
+    ...overrides,
+  } as InvestigationEvidence;
+}
+
+describe("computeErrorHalves", () => {
+  test("splits error-severity counts at the window midpoint by timestamp", () => {
+    const halves: ReturnType<typeof computeErrorHalves> = computeErrorHalves(
+      [
+        bucket(2, "Error", 3),
+        bucket(5, "Information", 100),
+        bucket(20, "Error", 12),
+        bucket(25, "Fatal", 5),
+      ],
+      WINDOW_START_MS,
+      WINDOW_END_MS,
+    );
+
+    expect(halves).toEqual({ firstHalf: 3, secondHalf: 17 });
+  });
+});
+
+describe("buildInvestigationFindings", () => {
+  test("a change event leads the findings, as critical, with its lead time", () => {
+    const findings: Array<InvestigationFinding> = buildInvestigationFindings(
+      evidence({
+        markers: [
+          {
+            kind: "change",
+            label: "Deploy: v2.31.0",
+            timeMs: WINDOW_END_MS - 3 * 60000,
+          },
+          {
+            kind: "incident",
+            label: "Incident: API down",
+            timeMs: WINDOW_END_MS - 60000,
+          },
+        ],
+      }),
+    );
+
+    expect(findings[0]?.severity).toBe("critical");
+    expect(findings[0]?.text).toContain("Deploy: v2.31.0");
+    expect(findings[0]?.text).toContain("3 minutes before");
+    // The concurrent incident trails as info.
+    expect(
+      findings.find((finding: InvestigationFinding) => {
+        return finding.text.includes("Incident: API down");
+      })?.severity,
+    ).toBe("info");
+  });
+
+  test("a rising error trend is a warning with the halves spelled out", () => {
+    const findings: Array<InvestigationFinding> = buildInvestigationFindings(
+      evidence({
+        logBuckets: [bucket(5, "Error", 4), bucket(25, "Error", 40)],
+      }),
+    );
+
+    const trend: InvestigationFinding | undefined = findings.find(
+      (finding: InvestigationFinding) => {
+        return finding.text.includes("rose");
+      },
+    );
+    expect(trend?.severity).toBe("warning");
+    expect(trend?.text).toContain("10.0×");
+    expect(trend?.text).toContain("(4 → 40)");
+  });
+
+  test("a dominant error pattern is called out with its share", () => {
+    const findings: Array<InvestigationFinding> = buildInvestigationFindings(
+      evidence({
+        errorPatterns: [
+          {
+            pattern: "conn refused <IP>",
+            sampleBody: "conn refused 10.0.0.5",
+            count: 15,
+          } as never,
+        ],
+      }),
+    );
+
+    const dominant: InvestigationFinding | undefined = findings.find(
+      (finding: InvestigationFinding) => {
+        return finding.text.includes("accounts for");
+      },
+    );
+    expect(dominant?.severity).toBe("warning");
+    expect(dominant?.text).toContain("~75%");
+    expect(dominant?.text).toContain("conn refused 10.0.0.5");
+  });
+
+  test("a quiet window yields honest guidance, never silence", () => {
+    const findings: Array<InvestigationFinding> = buildInvestigationFindings(
+      evidence({
+        logVolume: {
+          total: 100,
+          errorCount: 0,
+          warnCount: 0,
+          errorRatePercent: 0,
+          severities: [],
+          series: [],
+        },
+      }),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("info");
+    expect(findings[0]?.text).toContain("widening the window");
+  });
+
+  test("a high absolute error rate stands alone as a warning", () => {
+    const findings: Array<InvestigationFinding> = buildInvestigationFindings(
+      evidence({
+        logVolume: {
+          total: 200,
+          errorCount: 30,
+          warnCount: 0,
+          errorRatePercent: 15,
+          severities: [],
+          series: [],
+        },
+      }),
+    );
+
+    expect(
+      findings.some((finding: InvestigationFinding) => {
+        return finding.severity === "warning" && finding.text.includes("15.0%");
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("prompt and note builders", () => {
+  const sampleEvidence: InvestigationEvidence = evidence({
+    errorPatterns: [
+      {
+        pattern: "timeout <N>",
+        sampleBody: "timeout 30000ms",
+        count: 12,
+      } as never,
+    ],
+    markers: [
+      { kind: "change", label: "Deploy: v9", timeMs: WINDOW_END_MS - 60000 },
+    ],
+  });
+  const sampleFindings: Array<InvestigationFinding> =
+    buildInvestigationFindings(sampleEvidence);
+
+  test("the AI prompt restates the evidence and ends with the question", () => {
+    const prompt: string = buildInvestigationPrompt(
+      sampleEvidence,
+      sampleFindings,
+    );
+
+    expect(prompt).toContain("host.name = web-01");
+    expect(prompt).toContain("1,000 lines");
+    expect(prompt).toContain("timeout 30000ms");
+    expect(prompt).toContain("Deploy: v9");
+    expect(prompt.trim().endsWith("check next?")).toBe(true);
+  });
+
+  test("the incident note is markdown with findings, patterns, and the explorer link", () => {
+    const note: string = buildInvestigationNoteMarkdown({
+      evidence: sampleEvidence,
+      findings: sampleFindings,
+      explorerUrl: "https://oneuptime.example/metrics/view?x=1",
+    });
+
+    expect(note).toContain("### Investigation snapshot");
+    expect(note).toContain("**Scope:** host.name = web-01");
+    expect(note).toContain("🔴");
+    expect(note).toContain("`timeout 30000ms` — 12×");
+    expect(note).toContain(
+      "[Open these charts in the Metric Explorer](https://oneuptime.example/metrics/view?x=1)",
+    );
+  });
+});
+
+describe("explain/pin wiring", () => {
+  function readSquashed(relative: string): string {
+    return fs
+      .readFileSync(
+        path.join(__dirname, "../../FeatureSet/Dashboard/src", relative),
+        "utf8",
+      )
+      .replace(/\s+/g, " ");
+  }
+
+  test("the drawer builds findings from its own evidence and offers both actions", () => {
+    const drawer: string = readSquashed(
+      "Components/Telemetry/InvestigationDrawer.tsx",
+    );
+    expect(drawer).toContain("buildInvestigationFindings");
+    expect(drawer).toContain("Explain with AI");
+    expect(drawer).toContain("Save to incident");
+    expect(drawer).toContain("buildInvestigationNoteMarkdown");
+    // The AI dispatch carries the prompt, never auto-sends.
+    expect(drawer).toContain(
+      "GlobalEvents.dispatchEvent(EventName.AI_CHAT_TOGGLE, { prompt:",
+    );
+  });
+
+  test("the AI chat panel opens and pre-fills on a prompt dispatch", () => {
+    const panel: string = readSquashed("Components/AIChat/AIChatPanel.tsx");
+    expect(panel).toContain("setIsOpen(true)");
+    expect(panel).toContain("chatRef.current?.setInputValue(prompt)");
+  });
+});

--- a/Common/Tests/App/Dashboard/InvestigationArtifacts.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationArtifacts.test.tsx
@@ -1,0 +1,315 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * PR C surfaces on the investigation drawer: the deterministic findings
+ * card (built from the drawer's OWN evidence — log signal, patterns,
+ * event markers), the "Explain with AI" hand-off (prefill, never
+ * auto-send), and "Save to incident" (the evidence pinned to an incident
+ * timeline as a markdown internal note).
+ */
+
+const histogramMock: MockFunction = getJestMockFunction();
+const patternsMock: MockFunction = getJestMockFunction();
+const eventLinesMock: MockFunction = getJestMockFunction();
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Logs/LogsInsightsApi",
+  () => {
+    return {
+      __esModule: true,
+      fetchLogsHistogramRaw: (...args: Array<any>) => {
+        return histogramMock(...args);
+      },
+      fetchTopErrorPatterns: (...args: Array<any>) => {
+        return patternsMock(...args);
+      },
+    };
+  },
+);
+
+// The marker hook is separately tested — here it hands back a fixed set.
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/UseEventTimeReferenceLines",
+  () => {
+    return {
+      __esModule: true,
+      default: (...args: Array<any>) => {
+        return eventLinesMock(...args);
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetryCompanionSignalTabs",
+  () => {
+    return {
+      __esModule: true,
+      default: (): React.ReactElement => {
+        return React.createElement("div", { "data-testid": "companion-tabs" });
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/EmbeddedMetricCard",
+  () => {
+    return {
+      __esModule: true,
+      default: (): React.ReactElement => {
+        return React.createElement("div", {
+          "data-testid": "embedded-metric-card",
+        });
+      },
+    };
+  },
+);
+
+import InvestigationDrawer from "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer";
+import EventName from "../../../../App/FeatureSet/Dashboard/src/Utils/EventName";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentInternalNote from "../../../Models/DatabaseModels/IncidentInternalNote";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import ObjectID from "../../../Types/ObjectID";
+import GlobalEvents from "../../../UI/Utils/GlobalEvents";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../../UI/Utils/Project";
+
+const WINDOW: InBetween<Date> = new InBetween<Date>(
+  new Date("2026-08-20T10:00:00.000Z"),
+  new Date("2026-08-20T10:15:00.000Z"),
+);
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-1111-1111-111111111111",
+);
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "22222222-2222-2222-2222-222222222222",
+);
+
+function buildViewData(): MetricViewData {
+  return {
+    queryConfigs: [
+      {
+        metricAliasData: { metricVariable: "a" },
+        metricQueryData: {
+          filterData: {
+            metricName: "cpu.usage",
+            attributes: { "host.name": "web-01" },
+            aggegationType: MetricsAggregationType.Avg,
+          },
+        },
+      },
+    ],
+    formulaConfigs: [],
+    startAndEndDate: null,
+  } as unknown as MetricViewData;
+}
+
+function buildIncident(): Incident {
+  return {
+    id: INCIDENT_ID,
+    _id: INCIDENT_ID.toString(),
+    title: "API latency spike",
+    incidentNumberWithPrefix: "INC-42",
+    incidentNumber: 42,
+  } as unknown as Incident;
+}
+
+let dispatchSpy: ReturnType<typeof jest.spyOn>;
+let getListSpy: ReturnType<typeof jest.spyOn>;
+let createSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  histogramMock.mockReset();
+  patternsMock.mockReset();
+  eventLinesMock.mockReset();
+  histogramMock.mockReturnValue(
+    Promise.resolve([
+      { time: "2026-08-20T10:00:00.000Z", severity: "Information", count: 90 },
+      { time: "2026-08-20T10:12:00.000Z", severity: "Error", count: 10 },
+    ]),
+  );
+  patternsMock.mockReturnValue(
+    Promise.resolve([
+      {
+        pattern: "connection refused to <IP>",
+        sampleBody: "connection refused to 10.0.0.5",
+        count: 8,
+        resourceIds: [],
+        severities: ["Error"],
+        sampleTraceIds: [],
+      },
+    ]),
+  );
+  eventLinesMock.mockReturnValue({
+    lines: [
+      {
+        date: new Date("2026-08-20T10:05:00.000Z"),
+        label: "Deploy: v2.31.0",
+        color: "#6366f1",
+      },
+    ],
+    markerCount: 1,
+  });
+
+  dispatchSpy = jest
+    .spyOn(GlobalEvents, "dispatchEvent")
+    .mockImplementation(() => {
+      return undefined;
+    });
+  jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+  getListSpy = jest.spyOn(ModelAPI, "getList").mockReturnValue(
+    Promise.resolve({
+      data: [buildIncident()],
+      count: 1,
+      skip: 0,
+      limit: 10,
+    }) as never,
+  );
+  createSpy = jest.spyOn(ModelAPI, "create").mockImplementation(((input: {
+    model: IncidentInternalNote;
+  }) => {
+    return Promise.resolve(input.model);
+  }) as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  cleanup();
+});
+
+function renderDrawer(): void {
+  render(
+    <InvestigationDrawer
+      window={WINDOW}
+      metricViewData={buildViewData()}
+      onClose={() => {
+        // not exercised here
+      }}
+    />,
+  );
+}
+
+describe("findings card", () => {
+  test("correlates markers and the log signal into ranked findings", async () => {
+    renderDrawer();
+
+    /*
+     * The change event leads (its marker came from the hook, scoped to
+     * the pinned window)…
+     */
+    expect(
+      screen.getByText(/Deploy: v2\.31\.0 landed .*before the end/),
+    ).toBeInTheDocument();
+    const hookArgs: Record<string, unknown> = eventLinesMock.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect((hookArgs["window"] as InBetween<Date>).startValue.getTime()).toBe(
+      WINDOW.startValue.getTime(),
+    );
+
+    // …and once the log signal lands, the error-rate finding joins it.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/10\.0% of the window's log lines/),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("explain with AI", () => {
+  test("dispatches the chat-open event with the evidence as the prompt", async () => {
+    renderDrawer();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("connection refused to 10.0.0.5"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Explain with AI"));
+
+    const aiCalls: Array<Array<unknown>> = dispatchSpy.mock.calls.filter(
+      (call: Array<unknown>): boolean => {
+        return call[0] === EventName.AI_CHAT_TOGGLE;
+      },
+    );
+    expect(aiCalls).toHaveLength(1);
+    const prompt: string = (aiCalls[0]?.[1] as Record<string, string>)[
+      "prompt"
+    ] as string;
+    expect(prompt).toContain("host.name = web-01");
+    expect(prompt).toContain("connection refused to 10.0.0.5");
+    expect(prompt).toContain("Deploy: v2.31.0");
+    expect(prompt).toContain("What is the most likely root cause");
+  });
+});
+
+describe("save to incident", () => {
+  test("lists recent incidents, then pins the markdown snapshot as an internal note", async () => {
+    renderDrawer();
+
+    fireEvent.click(screen.getByText("Save to incident"));
+
+    // The picker fetched the project's recent incidents.
+    await waitFor(() => {
+      expect(screen.getByText(/INC-42/)).toBeInTheDocument();
+    });
+    const listArgs: Record<string, unknown> = getListSpy.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(listArgs["modelType"]).toBe(Incident);
+    expect(listArgs["limit"]).toBe(10);
+
+    fireEvent.click(screen.getByText("Save note"));
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    const created: IncidentInternalNote = (
+      createSpy.mock.calls[0]?.[0] as { model: IncidentInternalNote }
+    ).model;
+    expect(created.incidentId?.toString()).toBe(INCIDENT_ID.toString());
+    expect(created.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(created.note).toContain("### Investigation snapshot");
+    expect(created.note).toContain("**Scope:** host.name = web-01");
+    expect(created.note).toContain("Open these charts in the Metric Explorer");
+
+    // Success closes the picker.
+    await waitFor(() => {
+      expect(screen.queryByText("Save note")).toBeNull();
+    });
+  });
+
+  test("cancel closes the picker without any write", async () => {
+    renderDrawer();
+
+    fireEvent.click(screen.getByText("Save to incident"));
+    await waitFor(() => {
+      expect(screen.getByText(/INC-42/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText(/INC-42/)).toBeNull();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> **Stacked PR C / 3** — base is `claude/debuggability-insights` (#3380), which stacks on `claude/debuggability-foundations` (#3379). Merge order: #3379 → #3380 → this one (retarget to `master` as each lands). Only the last commit is new here.

Closes the investigation loop: the drawer stops being a read-only evidence panel and starts answering *"so what caused this, and where do I put what I learned?"*

## Findings — deterministic "explain this spike"

A new pure engine (`InvestigationFindings.ts`) correlates the evidence the drawer already fetched — no model calls, no black-box heuristics; every finding names its evidence:

- 🔴 **Change events lead.** A deploy/config change inside the window is called out first, with its lead time ("landed 3 minutes before the end of this window") — deployments are the most common root cause.
- 🟠 **Error trend.** Error-severity log volume split at the window midpoint by timestamp; a ≥1.5× second-half rise (≥10 errors) is reported with the raw halves ("4 → 40").
- 🟠 **Dominant pattern.** One error pattern carrying ≥50% of the window's errors is named with its share.
- 🟠 **High error rate.** ≥5% error-severity lines is called out on its own.
- 🔵 **Concurrent incidents/alerts** are listed as possibly sharing the root cause.
- A quiet window yields honest guidance (widen the window, check the companion tabs) — never silence.

## Explain with AI

One click opens the Ask AI panel with the whole evidence bundle — window, scope, log signal, top patterns, current findings — restated as an **editable, prefilled prompt** ending in "What is the most likely root cause, and what should I check next?". Never auto-sent; the panel (z-40) sits above the drawer (z-30) so the evidence stays in view. `AIChatPanel` now reads an optional `prompt` from the toggle event's detail and pre-fills its input (a plain dispatch still just toggles).

## Save to incident

Pins the investigation to an incident timeline as a **markdown internal note**: window, scope, log signal, severity-marked findings, top error patterns, and a deep link back to the exact Metric Explorer view. An inline picker lists the project's 10 most recent incidents; success/failure surfaces as toasts.

## Tests

- `App/Tests/Dashboard/InvestigationFindings.test.ts` — every findings rule pinned (change-event lead + lead-time wording, trend halves math incl. sparse-bucket timestamp split, dominant-pattern share, error-rate threshold, empty-window guidance), prompt/note builder content, and drawer/panel wiring pins.
- `Common/Tests/App/Dashboard/InvestigationArtifacts.test.tsx` — RTL through the real drawer: findings card renders from marker + log evidence, "Explain with AI" dispatches the toggle event with the exact prompt payload, "Save to incident" lists incidents and creates an `IncidentInternalNote` with the right incident/project/markdown (plus the cancel-makes-no-write path).
- Full sweep: App `Tests/Dashboard` 194 suites / 6728 tests green; Common drawer suites green; filtered `tsc` clean in both workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HxEiCGGsLcTyJe4cR7ofb