### PR TITLE
Investigate why UTM parameters and Google click IDs from oneuptime.com…

### DIFF
--- a/Docs/analytics/enterprise-conversion-tracking.md
+++ b/Docs/analytics/enterprise-conversion-tracking.md
@@ -80,21 +80,35 @@ browser `meeting_booked` event carries only `event_schema_version`,
 `booking_source`, `booking_kind`, `page_path`, `cal_event_type` and
 `cal_namespace`, for exactly this reason.
 
+Campaign parameters are different: the allowlisted UTM values and Google click
+IDs already present on the landing URL are copied to the Cal booking metadata.
+No form values or attendee fields are copied.
+
 ## Attribution
 
 The marketing site captures the visitor's campaign — UTM parameters, ad-platform
 click IDs and the first attributed visit — and holds it in localStorage
 (`Common/Server/Views/Partials/AnalyticsConsent.ejs`, gated on consent). It
-reaches the server through one door: the signup form, which posts it onto the
-User record. The key lists are shared in
+reaches the OneUptime application server through the signup form, which posts it
+onto the User record. The key lists are shared in
 `Common/Types/Marketing/Attribution.ts` so a key added for the browser cannot be
 silently dropped on arrival.
 
-A booking carries no attribution into OneUptime. The embeds used to put the
-visitor's campaign into Cal booking metadata for the webhook to read back; with
-the webhook gone, they no longer do. A booked demo is therefore attributable
-only through what the same person does later under the same address — a signup,
-or an enterprise licence issued to it.
+Bookings have a separate path. `Home/Views/Partials/cal-attribution.ejs`
+preserves the booking allowlist on links from a landing page to
+`/enterprise/demo`, then augments every Cal inline embed config. UTM values use
+Cal's first-class UTM fields and are also copied to custom booking metadata;
+`gclid`, `gbraid`, and `wbraid` are copied to custom booking metadata. This lets
+the external booking-webhook pipeline read attribution from the Cal booking and
+populate Marketing Conversion without receiving attendee details from browser
+analytics.
+
+The booking allowlist is:
+
+- `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`
+- `utm_id`, `utm_source_platform`, `utm_creative_format`,
+  `utm_marketing_tactic`
+- `gclid`, `gbraid`, `wbraid`
 
 ## Conversion chains
 
@@ -145,30 +159,27 @@ stored.
 ## Deliberately not implemented
 
 1. **A server-side record of a booking.** Bookings are not received, stored, or
-   emitted by OneUptime at all. If a booking needs to be a measured conversion
-   again, that means re-introducing a verified inbound webhook — not trusting
-   the browser event, which is neither authenticated nor reliable.
-2. **Attribution on a booking.** Follows from the above: with nothing reading
-   Cal booking metadata, the embeds send none.
-3. **Revenue joins.** Which stable native Revenue contact, account and deal
+   emitted by OneUptime itself. The external Cal webhook receiver is responsible
+   for authenticating and deduplicating booking webhook deliveries.
+2. **Revenue joins.** Which stable native Revenue contact, account and deal
    reference fields a booking would carry is still not defined, so bookings are
    not joined to Revenue records and nothing emitted claims otherwise.
-4. **Auto-qualification and Deal creation.** A booked meeting is not enterprise
+3. **Auto-qualification and Deal creation.** A booked meeting is not enterprise
    qualification, technical evaluation, or opportunity acceptance — and in
    particular not a signed licence. Native Revenue remains authoritative and
    must make those calls explicitly.
-5. **`QualifiedEnterpriseLead`, `TechnicalEvaluationStarted`,
+4. **`QualifiedEnterpriseLead`, `TechnicalEvaluationStarted`,
    `OpportunityCreated`, `ClosedWon`.** Add them only once native Revenue emits
    durable domain events with documented semantics, identifiers, idempotency
    and ownership.
-6. **Multi-touch attribution.** The browser keeps first touch and last touch and
+5. **Multi-touch attribution.** The browser keeps first touch and last touch and
    nothing in between, so a journey that crossed three campaigns is reportable
    as two of them. A bounded touch list would fix it.
-7. **Cross-device attribution before an email is known.** `emailHash` joins
+6. **Cross-device attribution before an email is known.** `emailHash` joins
    conversions once a person has identified themselves; an anonymous visitor
    who clicks an ad on a phone and signs up on a laptop is still two visitors
    until then.
-8. **Seat and plan expansion revenue.** `subscription_upgraded` reports MRR at
+7. **Seat and plan expansion revenue.** `subscription_upgraded` reports MRR at
    the moment of a TIER change. A customer who stays on one plan and grows from
    one seat to ten produces no event at all, because seat count is not a tier —
    so LTV and ROAS understate every account that expands without upgrading.
@@ -177,13 +188,13 @@ stored.
    (Enterprise contract value is no longer part of this gap: it is reported by
    `enterprise_license_issued` and attributed through `EnterpriseLicense.email`.)
 
-9. **The remaining `mailto:` CTAs.** `/support` and `/enterprise/demo` still
+8. **The remaining `mailto:` CTAs.** `/support` and `/enterprise/demo` still
    offer `mailto:sales@oneuptime.com`, and the pricing page prompts
    "contact sales@oneuptime.com" when a visitor self-qualifies as enterprise
    (>100 monitors, >1TB ingest, >6 months retention, >10M tokens). Those are
    the same unmeasurable shape the self-hosted page had, and the same fix
    applies: point them at a booking.
-10. **Reconciling the legacy browser events.** Dashboards and GTM still mix the
-    canonical `meeting_booked` with the older `bookingSuccessful`-derived
-    events. Separating them, and documenting the historical discontinuity, is
-    follow-up work.
+9. **Reconciling the legacy browser events.** Dashboards and GTM still mix the
+   canonical `meeting_booked` with the older `bookingSuccessful`-derived
+   events. Separating them, and documenting the historical discontinuity, is
+   follow-up work.

--- a/Home/Tests/CalAttribution.test.ts
+++ b/Home/Tests/CalAttribution.test.ts
@@ -1,0 +1,184 @@
+import ejs from "ejs";
+import path from "path";
+
+const PARTIAL_PATH: string = path.join(
+  __dirname,
+  "..",
+  "Views",
+  "Partials",
+  "cal-attribution.ejs",
+);
+
+const ALL_ATTRIBUTION: Record<string, string> = {
+  utm_source: "google",
+  utm_medium: "cpc",
+  utm_campaign: "enterprise-q3",
+  utm_term: "observability",
+  utm_content: "comparison-ad",
+  utm_id: "campaign-123",
+  utm_source_platform: "google_ads",
+  utm_creative_format: "text",
+  utm_marketing_tactic: "prospecting",
+  gclid: "google-click",
+  gbraid: "google-app-click",
+  wbraid: "google-web-click",
+};
+
+type FakeLink = {
+  href: string;
+  getAttribute: (name: string) => string | null;
+  setAttribute: (name: string, value: string) => void;
+};
+
+type Harness = {
+  inlineOptions: Record<string, unknown>;
+  links: Array<FakeLink>;
+};
+
+async function loadHarness(
+  attribution: Record<string, string> = ALL_ATTRIBUTION,
+): Promise<Harness> {
+  const html: string = (await ejs.renderFile(PARTIAL_PATH, {})) as string;
+  const source: string = html.slice(
+    html.indexOf("(function ()"),
+    html.lastIndexOf("</script>"),
+  );
+  const search: string = `?${new URLSearchParams(attribution).toString()}`;
+  const links: Array<FakeLink> = [
+    makeLink("/enterprise/demo"),
+    makeLink("/enterprise/demo?utm_source=partner#book-demo"),
+    makeLink("/pricing"),
+    makeLink("https://example.com/enterprise/demo"),
+  ];
+  let onDomReady: (() => void) | null = null;
+  const fakeWindow: Record<string, unknown> = {
+    location: {
+      href: `https://oneuptime.com/${search}`,
+      origin: "https://oneuptime.com",
+      search,
+    },
+  };
+  const fakeDocument: Record<string, unknown> = {
+    addEventListener: (name: string, callback: () => void): void => {
+      if (name === "DOMContentLoaded") {
+        onDomReady = callback;
+      }
+    },
+    querySelectorAll: (): Array<FakeLink> => {
+      return links;
+    },
+  };
+
+  // eslint-disable-next-line no-new-func
+  const install: (...args: Array<unknown>) => void = new Function(
+    "window",
+    "document",
+    "URL",
+    "URLSearchParams",
+    source,
+  ) as (...args: Array<unknown>) => void;
+  install(fakeWindow, fakeDocument, URL, URLSearchParams);
+
+  const calls: Array<Array<unknown>> = [];
+  fakeWindow["Cal"] = function (...args: Array<unknown>): void {
+    calls.push(args);
+  };
+
+  (fakeWindow["Cal"] as (...args: Array<unknown>) => void)("inline", {
+    elementOrSelector: "#my-cal-inline",
+    calLink: "oneuptimehq/demo",
+    config: { theme: "light" },
+  });
+  const dispatchDomReady: (() => void) | null = onDomReady;
+  if (dispatchDomReady) {
+    dispatchDomReady();
+  }
+
+  return {
+    inlineOptions: calls[0]?.[1] as Record<string, unknown>,
+    links,
+  };
+}
+
+function makeLink(href: string): FakeLink {
+  return {
+    href,
+    getAttribute(name: string): string | null {
+      return name === "href" ? this.href : null;
+    },
+    setAttribute(name: string, value: string): void {
+      if (name === "href") {
+        this.href = value;
+      }
+    },
+  };
+}
+
+describe("Cal booking attribution", () => {
+  test("passes every supported UTM and Google click id into Cal metadata", async () => {
+    const harness: Harness = await loadHarness();
+    const config: Record<string, string> = harness.inlineOptions[
+      "config"
+    ] as Record<string, string>;
+
+    for (const [key, value] of Object.entries(ALL_ATTRIBUTION)) {
+      expect(config[`metadata[${key}]`]).toBe(value);
+    }
+  });
+
+  test("also uses Cal's first-class UTM config fields", async () => {
+    const harness: Harness = await loadHarness();
+    const config: Record<string, string> = harness.inlineOptions[
+      "config"
+    ] as Record<string, string>;
+
+    for (const [key, value] of Object.entries(ALL_ATTRIBUTION)) {
+      if (key.startsWith("utm_")) {
+        expect(config[key]).toBe(value);
+      }
+    }
+    expect(config["gclid"]).toBeUndefined();
+    expect(config["theme"]).toBe("light");
+  });
+
+  test("preserves attribution on homepage links to the demo page", async () => {
+    const harness: Harness = await loadHarness();
+    const firstDestination: URL = new URL(
+      harness.links[0]!.href,
+      "https://oneuptime.com",
+    );
+
+    for (const [key, value] of Object.entries(ALL_ATTRIBUTION)) {
+      expect(firstDestination.searchParams.get(key)).toBe(value);
+    }
+  });
+
+  test("does not overwrite destination attribution or decorate unrelated links", async () => {
+    const harness: Harness = await loadHarness();
+    const attributedDestination: URL = new URL(
+      harness.links[1]!.href,
+      "https://oneuptime.com",
+    );
+
+    expect(attributedDestination.searchParams.get("utm_source")).toBe("partner");
+    expect(attributedDestination.searchParams.get("gclid")).toBe("google-click");
+    expect(attributedDestination.hash).toBe("#book-demo");
+    expect(harness.links[2]!.href).toBe("/pricing");
+    expect(harness.links[3]!.href).toBe(
+      "https://example.com/enterprise/demo",
+    );
+  });
+
+  test("does not add empty attribution values", async () => {
+    const harness: Harness = await loadHarness({
+      utm_source: "google",
+      gclid: "",
+    });
+    const config: Record<string, string> = harness.inlineOptions[
+      "config"
+    ] as Record<string, string>;
+
+    expect(config["metadata[utm_source]"]).toBe("google");
+    expect(config["metadata[gclid]"]).toBeUndefined();
+  });
+});

--- a/Home/Views/Partials/cal-attribution.ejs
+++ b/Home/Views/Partials/cal-attribution.ejs
@@ -1,0 +1,156 @@
+<!--
+    Carry paid-acquisition attribution into Cal.com bookings.
+
+    Cal's embed turns `config` entries into booking-link query parameters. UTM
+    fields are sent both under their native names and as custom metadata;
+    Google click IDs are sent as custom metadata. The metadata copy is the
+    stable contract consumed by the booking webhook pipeline.
+
+    This runs before each page's stock Cal embed snippet. The snippet assigns
+    window.Cal, so the setter below wraps that function and augments only
+    `inline` calls. Keeping this here avoids three subtly different copies in
+    demo.ejs, support.ejs and self-hosted.ejs.
+-->
+<script>
+    (function () {
+        var ATTRIBUTION_PARAMS = [
+            'utm_source',
+            'utm_medium',
+            'utm_campaign',
+            'utm_term',
+            'utm_content',
+            'utm_id',
+            'utm_source_platform',
+            'utm_creative_format',
+            'utm_marketing_tactic',
+            'gclid',
+            'gbraid',
+            'wbraid'
+        ];
+        var UTM_PREFIX = 'utm_';
+        var MAX_VALUE_LENGTH = 500;
+        var calValue;
+
+        function attributionFromLocation() {
+            var result = {};
+            var searchParams = new URLSearchParams(window.location.search || '');
+
+            ATTRIBUTION_PARAMS.forEach(function (key) {
+                var value = searchParams.get(key);
+                if (value) {
+                    result[key] = String(value).slice(0, MAX_VALUE_LENGTH);
+                }
+            });
+
+            return result;
+        }
+
+        function calConfigWithAttribution(existingConfig) {
+            var config = Object.assign({}, existingConfig || {});
+            var attribution = attributionFromLocation();
+
+            Object.keys(attribution).forEach(function (key) {
+                var value = attribution[key];
+
+                // Cal has first-class UTM fields. Preserve those as well as the
+                // metadata copy read by OneUptime's booking webhook pipeline.
+                if (key.indexOf(UTM_PREFIX) === 0 && !config[key]) {
+                    config[key] = value;
+                }
+
+                var metadataKey = 'metadata[' + key + ']';
+                if (!config[metadataKey]) {
+                    config[metadataKey] = value;
+                }
+            });
+
+            return config;
+        }
+
+        function wrapCal(cal) {
+            if (typeof cal !== 'function' || cal.__oneUptimeAttributionWrapped) {
+                return cal;
+            }
+
+            var wrapped = function () {
+                var args = Array.prototype.slice.call(arguments);
+
+                if (args[0] === 'inline' && args[1] && typeof args[1] === 'object') {
+                    args[1] = Object.assign({}, args[1], {
+                        config: calConfigWithAttribution(args[1].config)
+                    });
+                }
+
+                return cal.apply(this, args);
+            };
+
+            Object.keys(cal).forEach(function (key) {
+                wrapped[key] = cal[key];
+            });
+            wrapped.__oneUptimeAttributionWrapped = true;
+
+            return wrapped;
+        }
+
+        /*
+         * Every current booking page uses Cal's generated loader, which assigns
+         * window.Cal after this partial runs. Intercept that assignment rather
+         * than changing three vendor snippets independently.
+         */
+        try {
+            Object.defineProperty(window, 'Cal', {
+                configurable: true,
+                enumerable: true,
+                get: function () {
+                    return calValue;
+                },
+                set: function (value) {
+                    calValue = wrapCal(value);
+                }
+            });
+        } catch (e) {
+            // Very old browsers may refuse redefining a Window property.
+            // Booking still works; only attribution becomes best-effort.
+        }
+
+        /*
+         * A paid visitor commonly lands on `/`, then follows a clean
+         * `/enterprise/demo` link. Without this normalization the next page has
+         * no campaign query and the Cal config has nothing to carry. Append only
+         * the attribution allowlist and never replace values already present on
+         * a destination URL.
+         */
+        document.addEventListener('DOMContentLoaded', function () {
+            var attribution = attributionFromLocation();
+            if (Object.keys(attribution).length === 0) {
+                return;
+            }
+
+            document.querySelectorAll('a[href]').forEach(function (link) {
+                var rawHref = link.getAttribute('href');
+                if (!rawHref) {
+                    return;
+                }
+
+                var destination;
+                try {
+                    destination = new URL(rawHref, window.location.href);
+                } catch (e) {
+                    return;
+                }
+
+                if (destination.origin !== window.location.origin || destination.pathname !== '/enterprise/demo') {
+                    return;
+                }
+
+                Object.keys(attribution).forEach(function (key) {
+                    if (!destination.searchParams.has(key)) {
+                        destination.searchParams.set(key, attribution[key]);
+                    }
+                });
+
+                link.setAttribute('href', destination.pathname + destination.search + destination.hash);
+            });
+        });
+    })();
+</script>

--- a/Home/Views/head.ejs
+++ b/Home/Views/head.ejs
@@ -1,4 +1,5 @@
 <%- include('./head-basic', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>
+<%- include('./Partials/cal-attribution') -%>
 <%- include('./head-social') -%>


### PR DESCRIPTION
**Asked for**
Investigate why UTM parameters and Google click IDs from oneuptime.com landing URLs are not preserved and passed into the homepage Cal.com booking widget/webhook metadata. Locate the homepage redirect/query normalization and Cal.com embed code, identify the exact root cause, and implement a focused fix if safely supported by the current Cal.com integration. Preserve utm_source, utm_medium, utm_campaign, utm_term, utm_content, utm_id, utm_source_platform, utm_creative_format, utm_marketing_tactic, gclid, gbraid, and wbraid through the booking so the existing Genosyn webhook pipeline can populate Marketing Conversion. Add or update tests where practical. Commit the coherent change for human review; do not push or merge.

**What the AI employee reported**
Implemented and committed as `46440d449f4b1378f796efa0dd852b62c265ddeb`.

### Root cause
- Homepage links to `/enterprise/demo` dropped the landing page query string.
- Cal inline embeds were initialized without attribution in their `config`.
- The existing attribution capture only served signup analytics/localStorage, not Cal booking metadata.

### Fix
- Added a shared Cal attribution partial used by all booking pages.
- Preserves these parameters on internal demo links and passes them into Cal booking metadata:
  - All requested UTM fields
  - `gclid`, `gbraid`, `wbraid`
- Also sets Cal’s first-class UTM configuration fields.
- Leaves existing destination values untouched and ignores unrelated/external links.
- Added focused tests covering the allowlist, metadata, link propagation, empty values, and overwrite protection.
- Updated the conversion-tracking documentation.

I could not run tests, `npm run fix`, or compile because this repository session only exposes file and commit operations. No push or merge performed.

_Opened from a Genosyn AI work session._