### PR TITLE
feat(discovery): name your discovery scans (#3391)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -25,15 +25,21 @@ import OneUptimeDate from "Common/Types/Date";
 import PageLoader from "Common/UI/Components/Loader/PageLoader";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
+import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import ModelField from "Common/UI/Components/Forms/Types/Field";
+import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
+import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
+import PermissionGate, { ModelAction } from "Common/UI/Utils/PermissionGate";
 import { getSnmpConfigFormFields } from "./SnmpConfigFormFields";
 import {
   MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
   validateRescanInterval,
+  validateScanName,
   validateScanTarget,
 } from "./DiscoveryScanFormValidation";
 import { buildNetworkDeviceFromDiscoveredHost } from "Common/Utils/NetworkDiscovery/DiscoveredDeviceBuilder";
@@ -74,6 +80,37 @@ import React, {
 
 type DiscoveredDeviceEntry = DiscoveredNetworkDevice;
 
+/*
+ * The scan's optional name, defined once and used twice: as the first field of
+ * the create wizard, and as the only field of the Rename dialog. Two copies
+ * would be two chances for the wizard's guidance and the rename dialog's to
+ * drift apart, on a field whose entire job is to be read later.
+ *
+ * It keeps its `stepId` in both places. The rename dialog declares no steps at
+ * all, and BasicForm renders every field when there are none — see
+ * Common/UI/Components/Forms/BasicForm.
+ */
+const SCAN_NAME_FORM_FIELD: ModelField<NetworkDeviceDiscoveryScan> = {
+  field: {
+    name: true,
+  },
+  title: "Name",
+  stepId: "scan-target",
+  fieldType: FormFieldSchemaType.Text,
+  required: false,
+  placeholder: "Router Discovery - Region 1100",
+  /*
+   * Deliberately the FIRST thing the wizard asks for, and deliberately not
+   * required. A scan is identified in the list by whatever is here, falling
+   * back to its target — so the question is worth asking before the target is
+   * typed, and worth not insisting on for the operator sweeping one subnet
+   * once (issue #3391).
+   */
+  description:
+    "Optional. What this scan is for - 'Router Discovery - Region 1100' - so you can tell it apart from other scans without matching address ranges by eye. The list shows the scan target instead when this is empty.",
+  customValidation: validateScanName,
+};
+
 const NetworkDeviceDiscovery: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
@@ -85,6 +122,14 @@ const NetworkDeviceDiscovery: FunctionComponent<
 
   // Review Results modal state.
   const [showReviewModal, setShowReviewModal] = useState<boolean>(false);
+  /*
+   * The scan the Rename dialog is open for, or null. A name that cannot be
+   * corrected is worse than no name at all — "Region 1100" on the wrong range
+   * misleads every operator who reads the list afterwards — and the only other
+   * way to fix one would be to delete the scan and lose its results with it.
+   */
+  const [scanToRename, setScanToRename] =
+    useState<NetworkDeviceDiscoveryScan | null>(null);
   const [scanToReview, setScanToReview] =
     useState<NetworkDeviceDiscoveryScan | null>(null);
   const [selectedIps, setSelectedIps] = useState<Record<string, boolean>>({});
@@ -396,7 +441,27 @@ const NetworkDeviceDiscovery: FunctionComponent<
         showRefreshButton={true}
         refreshToggle={refreshToggle}
         name="Network Device Discovery Scans"
-        filters={[]}
+        /*
+         * Both halves of a scan's identity are searchable, because either one
+         * can be the thing the operator remembers: the purpose they gave it,
+         * or the range they know it covers.
+         */
+        filters={[
+          {
+            field: {
+              name: true,
+            },
+            title: "Name",
+            type: FieldType.Text,
+          },
+          {
+            field: {
+              cidr: true,
+            },
+            title: "Scan Target",
+            type: FieldType.Text,
+          },
+        ]}
         cardProps={{
           title: "Discovery Scans",
           description:
@@ -411,6 +476,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
           { title: "Schedule", id: "schedule" },
         ]}
         formFields={[
+          SCAN_NAME_FORM_FIELD,
           {
             field: {
               cidr: true,
@@ -544,12 +610,36 @@ const NetworkDeviceDiscovery: FunctionComponent<
           },
         ]}
         columns={[
+          /*
+           * The scan's identity, in one column: its name if it has one, with
+           * the address range it sweeps underneath. A scan with no name reads
+           * exactly as it did before names existed — the target alone, on the
+           * first line — so this replaces the old Scan Target column rather
+           * than sitting beside it and leaving half the rows with an empty
+           * cell where their name would be (issue #3391).
+           */
           {
             field: {
-              cidr: true,
+              name: true,
             },
-            title: "Scan Target",
-            type: FieldType.Text,
+            title: "Scan",
+            type: FieldType.Element,
+            getElement: (item: NetworkDeviceDiscoveryScan): ReactElement => {
+              const name: string | null = ScanNameUtil.getDisplayName(item);
+
+              return (
+                <div>
+                  <div className="text-sm font-medium text-gray-900">
+                    {name || item.cidr || "—"}
+                  </div>
+                  {name && item.cidr ? (
+                    <div className="text-xs text-gray-500">{item.cidr}</div>
+                  ) : (
+                    <></>
+                  )}
+                </div>
+              );
+            },
           },
           {
             field: {
@@ -707,6 +797,11 @@ const NetworkDeviceDiscovery: FunctionComponent<
           },
         ]}
         selectMoreFields={{
+          /*
+           * Rendered as the second line of the Scan column, and as the
+           * fallback first line for a scan with no name.
+           */
+          cidr: true,
           scannedHostCount: true,
           discoveredDevices: true,
           // Recurrence details rendered inside the "Recurrence" column.
@@ -727,6 +822,31 @@ const NetworkDeviceDiscovery: FunctionComponent<
         }}
         actionButtons={[
           {
+            title: "Rename",
+            buttonStyleType: ButtonStyleType.NORMAL,
+            icon: IconProp.Pencil,
+            /*
+             * Hidden for anyone who could not save the rename anyway. The
+             * table sets isEditable={false}, so this button is the only edit
+             * affordance on the page and nothing else is gating it — a viewer
+             * would otherwise open a dialog whose one field ModelForm has
+             * already dropped for want of the update permission.
+             */
+            isVisible: (): boolean => {
+              return PermissionGate.check(
+                new NetworkDeviceDiscoveryScan(),
+                ModelAction.Update,
+              ).isAllowed;
+            },
+            onClick: async (
+              item: NetworkDeviceDiscoveryScan,
+              onCompleteAction: VoidFunction,
+            ) => {
+              setScanToRename(item);
+              onCompleteAction();
+            },
+          },
+          {
             title: "Review Results",
             buttonStyleType: ButtonStyleType.NORMAL,
             icon: IconProp.List,
@@ -744,6 +864,40 @@ const NetworkDeviceDiscovery: FunctionComponent<
         ]}
       />
 
+      {scanToRename && (
+        /*
+         * One field, no steps. ModelFormModal fetches the scan, prefills the
+         * box and PATCHes just this column — the only column on the model
+         * whose ColumnAccessControl grants update, so nothing else about a
+         * sweep that has already run can be edited from here.
+         */
+        <ModelFormModal<NetworkDeviceDiscoveryScan>
+          modelType={NetworkDeviceDiscoveryScan}
+          modelIdToEdit={scanToRename.id!}
+          name="Rename Discovery Scan"
+          title="Rename Discovery Scan"
+          description={`Give this scan a name you will recognise in the list. It sweeps ${
+            scanToRename.cidr || "the address range it was created with"
+          }.`}
+          submitButtonText="Save Changes"
+          onClose={() => {
+            setScanToRename(null);
+          }}
+          onSuccess={() => {
+            setScanToRename(null);
+            // Same refresh the import path uses, so the list shows the new name.
+            setRefreshToggle(Date.now().toString());
+          }}
+          formProps={{
+            name: "Rename Discovery Scan",
+            modelType: NetworkDeviceDiscoveryScan,
+            id: "rename-network-device-discovery-scan-form",
+            fields: [SCAN_NAME_FORM_FIELD],
+            formType: FormType.Update,
+          }}
+        />
+      )}
+
       {showReviewModal && scanToReview && (
         <Modal
           title="Review Discovered Devices"
@@ -754,7 +908,8 @@ const NetworkDeviceDiscovery: FunctionComponent<
            * a No SNMP filter that exists precisely to import them as a batch.
            */
           description={`Hosts that responded in ${
-            scanToReview.cidr || "the scanned address range"
+            ScanNameUtil.getScanLabel(scanToReview) ||
+            "the scanned address range"
           }. Filter to a group, pick the hosts you want, and import — SNMP hosts arrive as polled devices, hosts without SNMP as monitor-backed ones.${
             /*
              * The probe's summary of the sweep. Most valuable precisely when

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -619,8 +619,18 @@ const NetworkDeviceDiscovery: FunctionComponent<
            * cell where their name would be (issue #3391).
            */
           {
+            /*
+             * BOTH fields are declared, not just the one the column is keyed
+             * on: getExportKeysFromColumn builds the CSV row out of a column's
+             * declared fields alone (selectMoreFields never reaches it), so a
+             * column that reached `cidr` through selectMoreFields would export
+             * an EMPTY cell for every scan without a name - which is every
+             * scan that predates the column. The cell on screen would still
+             * show the target, so the loss would be silent and export-only.
+             */
             field: {
               name: true,
+              cidr: true,
             },
             title: "Scan",
             type: FieldType.Element,
@@ -797,11 +807,6 @@ const NetworkDeviceDiscovery: FunctionComponent<
           },
         ]}
         selectMoreFields={{
-          /*
-           * Rendered as the second line of the Scan column, and as the
-           * fallback first line for a scan with no name.
-           */
-          cidr: true,
           scannedHostCount: true,
           discoveredDevices: true,
           // Recurrence details rendered inside the "Recurrence" column.
@@ -867,9 +872,10 @@ const NetworkDeviceDiscovery: FunctionComponent<
       {scanToRename && (
         /*
          * One field, no steps. ModelFormModal fetches the scan, prefills the
-         * box and PATCHes just this column — the only column on the model
-         * whose ColumnAccessControl grants update, so nothing else about a
-         * sweep that has already run can be edited from here.
+         * box and PATCHes just this column. The schedule pair (isRecurring,
+         * rescanIntervalInMinutes) is updatable on the model too, but it is
+         * deliberately not offered here: this dialog answers "what is this
+         * scan called", and nothing about the sweep itself.
          */
         <ModelFormModal<NetworkDeviceDiscoveryScan>
           modelType={NetworkDeviceDiscoveryScan}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation.ts
@@ -1,6 +1,7 @@
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
+import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
 
 /*
  * Client-side validators for the "Create New Network Device Discovery Scan"
@@ -105,6 +106,35 @@ export const validateScanTarget: ScanTargetValidatorFunction = (
   }
 
   return ScanTargetUtil.getValidationError(raw.trim());
+};
+
+export type ScanNameValidatorFunction = (
+  values: FormValues<NetworkDeviceDiscoveryScan>,
+) => string | null;
+
+/*
+ * The scan's optional name (issue #3391). Delegates to the same
+ * ScanNameUtil.getValidationError the server throws with
+ * (NetworkDeviceDiscoveryScanService.onBeforeCreate / onBeforeUpdate), so the
+ * two messages are identical by construction.
+ *
+ * It exists at all for one case: length. ModelForm infers a maxLength of 100
+ * from the ShortText column and validates it — but customValidation runs LAST
+ * in Validation.validate, so whatever this returns replaces that message. A
+ * field with a custom validator and an inferred length rule that disagree is a
+ * field whose error text depends on which rule ran last, so this one owns both
+ * and says the same thing the server would.
+ *
+ * The length is measured after normalization, exactly as the server measures
+ * it — a name that is 100 characters plus a trailing newline is saved, not
+ * rejected, because the newline is about to be removed. Nothing else here is
+ * an error: the field is optional, so an empty box and a blank one are both
+ * simply "no name", and neither the form nor the server complains.
+ */
+export const validateScanName: ScanNameValidatorFunction = (
+  values: FormValues<NetworkDeviceDiscoveryScan>,
+): string | null => {
+  return ScanNameUtil.getValidationError(values.name);
 };
 
 export type RescanIntervalValidatorFunction = (

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation.ts
@@ -118,18 +118,27 @@ export type ScanNameValidatorFunction = (
  * (NetworkDeviceDiscoveryScanService.onBeforeCreate / onBeforeUpdate), so the
  * two messages are identical by construction.
  *
- * It exists at all for one case: length. ModelForm infers a maxLength of 100
- * from the ShortText column and validates it — but customValidation runs LAST
- * in Validation.validate, so whatever this returns replaces that message. A
- * field with a custom validator and an inferred length rule that disagree is a
- * field whose error text depends on which rule ran last, so this one owns both
- * and says the same thing the server would.
+ * It covers two cases the field's own rules cannot:
  *
- * The length is measured after normalization, exactly as the server measures
- * it — a name that is 100 characters plus a trailing newline is saved, not
- * rejected, because the newline is about to be removed. Nothing else here is
- * an error: the field is optional, so an empty box and a blank one are both
- * simply "no name", and neither the form nor the server complains.
+ *   - a value that is not text at all, which the server rejects and no form
+ *     rule looks at;
+ *   - a name whose length is only acceptable AFTER normalization. Length is
+ *     measured here exactly as the server measures it — on the value that
+ *     would be stored — so a name of 100 characters plus a trailing newline
+ *     is saved rather than rejected.
+ *
+ * ModelForm also infers a maxLength of 100 from the ShortText column, and that
+ * rule keeps its own message: customValidation runs last but only OVERWRITES
+ * when it returns something, so a box holding more than 100 characters is
+ * refused by the inferred rule even in the narrow case where collapsing its
+ * internal whitespace would have brought it under the cap. That errs toward
+ * the operator shortening a name they can see is too long, which is the safe
+ * direction — the form never accepts a name the server would refuse, which is
+ * the failure shape issue #3377 was about.
+ *
+ * Nothing else here is an error: the field is optional, so an empty box and a
+ * blank one are both simply "no name", and neither the form nor the server
+ * complains.
  */
 export const validateScanName: ScanNameValidatorFunction = (
   values: FormValues<NetworkDeviceDiscoveryScan>,

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Overview.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Overview.tsx
@@ -26,6 +26,7 @@ import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
 import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
 import NetworkEndpoint from "Common/Models/DatabaseModels/NetworkEndpoint";
 import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
@@ -130,6 +131,7 @@ const NetworkOverview: FunctionComponent<
           skip: 0,
           select: {
             _id: true,
+            name: true,
             cidr: true,
             status: true,
             respondedHostCount: true,
@@ -531,6 +533,28 @@ const NetworkOverview: FunctionComponent<
                 (scan: NetworkDeviceDiscoveryScan): ReactElement => {
                   const status: string = (scan.status as string) || "Pending";
 
+                  /*
+                   * A named scan leads with its name — the identity the
+                   * Discovery Scans list shows — and moves the range it sweeps
+                   * down beside the timestamp. An unnamed scan is still just
+                   * its range (issue #3391).
+                   */
+                  const scanName: string | null =
+                    ScanNameUtil.getDisplayName(scan);
+
+                  const secondaryLine: string = [
+                    scanName ? scan.cidr : null,
+                    scan.createdAt
+                      ? OneUptimeDate.fromNow(
+                          OneUptimeDate.fromString(scan.createdAt),
+                        )
+                      : null,
+                  ]
+                    .filter((part: string | null | undefined): boolean => {
+                      return Boolean(part);
+                    })
+                    .join(" · ");
+
                   let statusClassName: string = "text-gray-500";
                   if (status === "In Progress") {
                     statusClassName = "text-blue-600";
@@ -547,13 +571,11 @@ const NetworkOverview: FunctionComponent<
                     >
                       <div className="min-w-0">
                         <div className="truncate text-sm font-medium text-gray-900">
-                          {scan.cidr || "—"}
+                          {scanName || scan.cidr || "—"}
                         </div>
-                        {scan.createdAt && (
-                          <div className="text-xs text-gray-500">
-                            {OneUptimeDate.fromNow(
-                              OneUptimeDate.fromString(scan.createdAt),
-                            )}
+                        {secondaryLine && (
+                          <div className="truncate text-xs text-gray-500">
+                            {secondaryLine}
                           </div>
                         )}
                       </div>

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -75,6 +75,12 @@ router.post(
           select: {
             _id: true,
             projectId: true,
+            /*
+             * Not used to run the sweep — the probe logs it, so a probe's own
+             * log names the scan the way the operator named it rather than by
+             * address range alone.
+             */
+            name: true,
             cidr: true,
             snmpVersion: true,
             snmpCommunityString: true,

--- a/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
+++ b/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
@@ -4,6 +4,7 @@ import OneUptimeDate from "Common/Types/Date";
 import QueryDeepPartialEntity from "Common/Types/Database/PartialEntity";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
+import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
 import Probe, {
   ProbeConnectionStatus,
 } from "Common/Models/DatabaseModels/Probe";
@@ -76,6 +77,7 @@ RunCron(
         },
         select: {
           _id: true,
+          name: true,
           cidr: true,
         },
         props: {
@@ -85,7 +87,7 @@ RunCron(
 
     for (const scan of staleScans) {
       logger.warn(
-        `Discovery scan ${scan.id?.toString()} (${scan.cidr}) has been In Progress for over ${STALE_IN_PROGRESS_HOURS} hour(s); marking it Failed (probe likely went offline mid-scan).`,
+        `Discovery scan ${scan.id?.toString()} (${ScanNameUtil.getScanLabel(scan)}) has been In Progress for over ${STALE_IN_PROGRESS_HOURS} hour(s); marking it Failed (probe likely went offline mid-scan).`,
       );
 
       await NetworkDeviceDiscoveryScanService.updateOneById({
@@ -115,6 +117,7 @@ RunCron(
         },
         select: {
           _id: true,
+          name: true,
           cidr: true,
         },
         props: {
@@ -124,7 +127,7 @@ RunCron(
 
     for (const scan of dueScans) {
       logger.debug(
-        `Re-queueing recurring discovery scan ${scan.id?.toString()} (${scan.cidr}).`,
+        `Re-queueing recurring discovery scan ${scan.id?.toString()} (${ScanNameUtil.getScanLabel(scan)}).`,
       );
 
       await NetworkDeviceDiscoveryScanService.updateOneById({
@@ -185,6 +188,7 @@ export async function explainUnclaimedScans(): Promise<void> {
       },
       select: {
         _id: true,
+        name: true,
         cidr: true,
         probeId: true,
         statusMessage: true,
@@ -286,7 +290,7 @@ export async function explainUnclaimedScans(): Promise<void> {
     }
 
     logger.warn(
-      `Discovery scan ${scan.id?.toString()} (${scan.cidr}) has been Pending for over ${UNCLAIMED_PENDING_MINUTES} minutes with no probe claiming it: ${statusMessage}`,
+      `Discovery scan ${scan.id?.toString()} (${ScanNameUtil.getScanLabel(scan)}) has been Pending for over ${UNCLAIMED_PENDING_MINUTES} minutes with no probe claiming it: ${statusMessage}`,
     );
 
     await NetworkDeviceDiscoveryScanService.updateOneById({

--- a/App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts
+++ b/App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts
@@ -266,12 +266,41 @@ describe("Network automation rule run endpoints", () => {
     });
 
     /*
-     * Only a literal true turns it on. A "true" string or a stray 1 - what a
-     * hand-written client or a form encoder sends - must not be enough to
-     * move devices somebody placed by hand.
+     * Only a literal boolean is accepted. A "true" string or a stray 1 - what
+     * a hand-written client or a form encoder sends - is a 400, and the rule
+     * does not run at all.
+     *
+     * Rejecting rather than coercing is what fails safe in BOTH directions
+     * these flags are used in: read as false, a "true" string would silently
+     * skip the reassignment the caller asked for; read as true, it would move
+     * devices somebody placed by hand. The endpoint refuses to guess which
+     * (App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts readBooleanFlag).
      */
     test.each([["true"], [1], ["yes"], [{}]])(
-      "treats a non-boolean overwrite flag (%p) as off",
+      "refuses a non-boolean overwrite flag (%p) rather than guessing",
+      async (value: unknown) => {
+        const next: NextFunction = await callRoute({
+          uri: SITE_RULE_URI,
+          body: { reassignDevicesAlreadyInASite: value } as JSONObject,
+        });
+
+        expect(errorFrom(next).message).toContain(
+          "reassignDevicesAlreadyInASite must be a boolean",
+        );
+
+        // Nothing was moved: the run never started.
+        expect(
+          deviceService.applySiteAssignmentRuleToExistingDevices,
+        ).not.toHaveBeenCalled();
+      },
+    );
+
+    /*
+     * The absent case is the one that IS allowed to mean false - a caller that
+     * says nothing about reassignment is asking for the safe half.
+     */
+    test.each([[undefined], [null]])(
+      "treats an omitted overwrite flag (%p) as off",
       async (value: unknown) => {
         await callRoute({
           uri: SITE_RULE_URI,

--- a/App/Tests/Dashboard/BackupCodesCardWiring.test.ts
+++ b/App/Tests/Dashboard/BackupCodesCardWiring.test.ts
@@ -797,6 +797,17 @@ describe("the destructive path cannot be reached by accident", () => {
    * regeneration; the two interleave their delete-then-insert, and the set the
    * user is shown stops matching the set the database keeps.
    */
+  /*
+   * Hoisted out of the `.test()` calls below rather than written inline:
+   * wrap-regex wants an inline literal in parens and prettier removes them
+   * again, so an inline regex here is a lint error whichever way it is
+   * written. A named constant satisfies both.
+   */
+  const DISABLED_INCLUDES_GENERATING: RegExp =
+    /disabled:\s*isStatusLoading \|\| isGenerating/;
+
+  const REPORTS_GENERATING_AS_LOADING: RegExp = /isLoading:\s*isGenerating/;
+
   test("the button is disabled while a generation is in flight", () => {
     const buttonBlock: string = backupCodesSource.slice(
       backupCodesSource.indexOf("buttons={["),
@@ -805,13 +816,13 @@ describe("the destructive path cannot be reached by accident", () => {
 
     const violations: Array<string> = [];
 
-    if (!(/disabled:\s*isStatusLoading \|\| isGenerating/).test(buttonBlock)) {
+    if (!DISABLED_INCLUDES_GENERATING.test(buttonBlock)) {
       violations.push(
         "the button's disabled prop does not include isGenerating",
       );
     }
 
-    if (!(/isLoading:\s*isGenerating/).test(buttonBlock)) {
+    if (!REPORTS_GENERATING_AS_LOADING.test(buttonBlock)) {
       violations.push("the button does not report isGenerating as isLoading");
     }
 

--- a/App/Tests/Dashboard/DiscoveryScanFormValidation.test.ts
+++ b/App/Tests/Dashboard/DiscoveryScanFormValidation.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "@jest/globals";
 import {
   MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
   validateRescanInterval,
+  validateScanName,
   validateScanTarget,
 } from "../../FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
+import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
 
 /*
  * The client-side half of the Create Network Device Discovery Scan wizard's
@@ -36,6 +38,10 @@ type ScanTargetValues = FormValues<NetworkDeviceDiscoveryScan>;
 
 function scanTarget(value: unknown): ScanTargetValues {
   return { cidr: value } as ScanTargetValues;
+}
+
+function scanName(value: unknown): ScanTargetValues {
+  return { name: value } as ScanTargetValues;
 }
 
 function schedule(
@@ -469,5 +475,114 @@ describe("the minimum rescan interval is the one the form advertises", () => {
   test("is a whole number of minutes and at least a quarter hour", () => {
     expect(Number.isInteger(MINIMUM_RESCAN_INTERVAL_IN_MINUTES)).toBe(true);
     expect(MINIMUM_RESCAN_INTERVAL_IN_MINUTES).toBeGreaterThanOrEqual(15);
+  });
+});
+
+/*
+ * The scan's optional name (issue #3391).
+ *
+ * The field is not required and the column is nullable, so almost everything
+ * typed into it is legal — which makes the two things this validator DOES
+ * refuse worth pinning, along with the much longer list it deliberately stays
+ * silent about. Silence matters here: a validator that complained about an
+ * empty optional box would block "Next" on a step the operator has no reason
+ * to fill in.
+ */
+describe("validateScanName — says nothing about a name the operator may legitimately leave out", () => {
+  test.each([
+    ["an untouched field", undefined],
+    ["an explicitly empty field", ""],
+    ["a single space", " "],
+    ["several spaces", "     "],
+    ["a tab", "\t"],
+    ["a newline", "\n"],
+  ])("%s is accepted in silence", (_label: string, value: unknown) => {
+    expect(validateScanName(scanName(value))).toBeNull();
+  });
+
+  test("a field the operator never reached is accepted", () => {
+    expect(validateScanName({} as ScanTargetValues)).toBeNull();
+  });
+
+  test.each([
+    ["a purpose", "Router Discovery - Region 1100"],
+    ["a site name", "Switch Discovery — WB Units"],
+    ["punctuation and digits", "Region 1100 / floor 3 (v2)"],
+    ["accents", "Zürich core switches"],
+    ["a name with inner spacing", "Router    Discovery"],
+    ["a name that needs trimming", "  Router Discovery  "],
+  ])("%s is accepted", (_label: string, value: unknown) => {
+    expect(validateScanName(scanName(value))).toBeNull();
+  });
+});
+
+describe("validateScanName — refuses only what could not be stored", () => {
+  test("a name at the column width is accepted", () => {
+    expect(
+      validateScanName(scanName("a".repeat(ScanNameUtil.MAX_SCAN_NAME_LENGTH))),
+    ).toBeNull();
+  });
+
+  test("a name past the column width is refused on its own step", () => {
+    const error: string | null = validateScanName(
+      scanName("a".repeat(ScanNameUtil.MAX_SCAN_NAME_LENGTH + 1)),
+    );
+
+    expect(error).not.toBeNull();
+    expect(error).toContain(String(ScanNameUtil.MAX_SCAN_NAME_LENGTH));
+  });
+
+  /*
+   * The length is measured on what would actually be stored. A value that only
+   * exceeds the cap because of whitespace this validator's own normalization
+   * is about to remove is not an error.
+   */
+  test("a name that only exceeds the cap before trimming is accepted", () => {
+    expect(
+      validateScanName(
+        scanName(` ${"a".repeat(ScanNameUtil.MAX_SCAN_NAME_LENGTH)}  `),
+      ),
+    ).toBeNull();
+  });
+
+  /*
+   * Form values are JSONValues, so a text box is not a guarantee of a string —
+   * and this validator is shared with the server hook, which really can be
+   * handed one of these by an API client.
+   */
+  test.each([
+    ["a number", 1100],
+    ["a boolean", true],
+    ["an object", {}],
+    ["an array", []],
+  ])("%s is refused rather than coerced", (_label: string, value: unknown) => {
+    expect(validateScanName(scanName(value))).not.toBeNull();
+  });
+
+  test("nothing here throws, whatever the value", () => {
+    for (const value of [{}, [], true, 0, Symbol.iterator.toString()]) {
+      expect(() => {
+        return validateScanName(scanName(value));
+      }).not.toThrow();
+    }
+  });
+});
+
+/*
+ * The same identity assertion the scan-target validator carries: the form and
+ * the server share ONE function, so the inline error under the box and the 400
+ * from the API cannot drift into disagreeing about which names are legal.
+ */
+describe("validateScanName delegates to the rule the server enforces", () => {
+  test.each([
+    ["a legal name", "Router Discovery"],
+    ["an empty box", ""],
+    ["a blank box", "   "],
+    ["an over-long name", "a".repeat(ScanNameUtil.MAX_SCAN_NAME_LENGTH + 1)],
+    ["a non-string", 1100],
+  ])("agrees with ScanNameUtil about %s", (_label: string, value: unknown) => {
+    expect(validateScanName(scanName(value))).toBe(
+      ScanNameUtil.getValidationError(value),
+    );
   });
 });

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -413,6 +413,12 @@ describe("POST /probe/discovery-scan/result", () => {
 
     const data: JSONObject = lastUpdateData();
     expect(Object.keys(data).sort()).toEqual([
+      /*
+       * Cleared on every result: a NULL marker is how the auto-import worker
+       * knows the results now on this row have not been processed yet
+       * (Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules.ts).
+       */
+      "autoImportProcessedAt",
       "completedAt",
       "discoveredDevices",
       "respondedHostCount",
@@ -420,6 +426,7 @@ describe("POST /probe/discovery-scan/result", () => {
       "status",
       "statusMessage",
     ]);
+    expect(data["autoImportProcessedAt"]).toBeNull();
     expect(data["status"]).toBe("Completed");
     expect(data["statusMessage"]).toBe("Swept 254 hosts.");
     expect(data["scannedHostCount"]).toBe(254);

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -176,6 +176,25 @@ describe("POST /probe/discovery-scan/list", () => {
     jest.clearAllMocks();
   });
 
+  /*
+   * The probe logs the scan it is sweeping, and since scans can be named
+   * (issue #3391) that log line names it the way its operator did. The name is
+   * of no use to the sweep itself — it has to be asked for here or it never
+   * reaches the probe at all.
+   */
+  test("hands the scan's name to the probe alongside its target", async () => {
+    scanService.findBy.mockResolvedValue([] as never);
+
+    await callListEndpoint(makeRequest({ probeId }));
+
+    const findArgs: JSONObject = scanService.findBy.mock
+      .calls[0]![0] as JSONObject;
+    const select: JSONObject = findArgs["select"] as JSONObject;
+
+    expect(select["name"]).toBe(true);
+    expect(select["cidr"]).toBe(true);
+  });
+
   test("hands out the probe's pending scans and marks each In Progress with plain column data", async () => {
     const scanId: ObjectID = ObjectID.generate();
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(

--- a/App/Tests/Workers/Jobs/NetworkDeviceDiscovery/UnclaimedScans.test.ts
+++ b/App/Tests/Workers/Jobs/NetworkDeviceDiscovery/UnclaimedScans.test.ts
@@ -8,6 +8,7 @@ import OneUptimeDate from "Common/Types/Date";
 import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import { UNCLAIMED_PENDING_MINUTES } from "Common/Utils/NetworkDiscovery/UnclaimedScanDiagnosis";
+import logger from "Common/Server/Utils/Logger";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 
 jest.mock(
@@ -79,6 +80,16 @@ const scanService: MockedScanService =
 const probeService: { findOneById: jest.Mock } = ProbeService as unknown as {
   findOneById: jest.Mock;
 };
+
+const mockedLogger: { warn: jest.Mock } = logger as unknown as {
+  warn: jest.Mock;
+};
+
+function warnings(): Array<string> {
+  return mockedLogger.warn.mock.calls.map((call: Array<unknown>): string => {
+    return String(call[0]);
+  });
+}
 
 const probeId: ObjectID = ObjectID.generate();
 const otherProbeId: ObjectID = ObjectID.generate();
@@ -380,5 +391,53 @@ describe("explainUnclaimedScans — it runs every minute, so it must not churn",
       .join("\n");
     expect(messages).toContain("Probe A");
     expect(messages).toContain("Probe B");
+  });
+});
+
+/*
+ * Which scan the operator is being told about (issue #3391).
+ *
+ * This pass exists because a stuck scan used to say nothing at all. Now that
+ * scans can be named, the warning it writes to the log has to carry that name
+ * — a fleet with a hundred pending sweeps is exactly the situation where
+ * "10.240-249.0-254.220-226" is not an answer to "which one?".
+ */
+describe("explainUnclaimedScans — naming the scan it complains about", () => {
+  test("asks for the name along with the target", async () => {
+    respondWith({ unclaimed: [] });
+
+    await explainUnclaimedScans();
+
+    const args: JSONObject = scanService.findAllBy.mock
+      .calls[0]![0] as JSONObject;
+    const select: JSONObject = args["select"] as JSONObject;
+
+    expect(select["name"]).toBe(true);
+    expect(select["cidr"]).toBe(true);
+  });
+
+  test("names a named scan by name, and still says what it sweeps", async () => {
+    respondWith({
+      unclaimed: [makeScan({ name: "Switch Discovery - WB Units" })],
+    });
+
+    await explainUnclaimedScans();
+
+    const logged: string = warnings().join("\n");
+
+    expect(logged).toContain("Switch Discovery - WB Units");
+    expect(logged).toContain("10.240-249.0-254.220-226");
+  });
+
+  // Unnamed scans read exactly as they did before the column existed.
+  test("falls back to the target for an unnamed scan", async () => {
+    respondWith({ unclaimed: [makeScan()] });
+
+    await explainUnclaimedScans();
+
+    const logged: string = warnings().join("\n");
+
+    expect(logged).toContain("10.240-249.0-254.220-226");
+    expect(logged).not.toContain("undefined");
   });
 });

--- a/Common/Models/DatabaseModels/NetworkDeviceAutoImportRule.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceAutoImportRule.ts
@@ -78,6 +78,17 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Automatically import matching hosts from network device discovery scan results as Network Devices, with no manual review step",
 })
+/*
+ * The index and foreign-key names below are written out rather than left to
+ * TypeORM's generated hashes, because this table's migration
+ * (1789100000000-AddNetworkDeviceAutoImportRule) was hand-written and created
+ * them with readable names. TypeORM compares constraint NAMES when it diffs a
+ * database against these entities, so an entity that does not spell them out
+ * reports the whole table as schema drift on every run of the Postgres Schema
+ * Drift check — which is what it did until these were added. Naming them here
+ * keeps the readable names and costs no migration; the alternative was an
+ * ALTER that renamed seven objects on every installation to hashes.
+ */
 export default class NetworkDeviceAutoImportRule extends BaseModel {
   @ColumnAccessControl({
     create: [
@@ -112,7 +123,10 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
       orphanedRowAction: "nullify",
     },
   )
-  @JoinColumn({ name: "projectId" })
+  @JoinColumn({
+    name: "projectId",
+    foreignKeyConstraintName: "FK_nd_auto_import_rule_projectId",
+  })
   public project?: Project = undefined;
 
   @ColumnAccessControl({
@@ -130,7 +144,7 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
     ],
     update: [],
   })
-  @Index()
+  @Index("IDX_network_device_auto_import_rule_projectId")
   @TableColumn({
     type: TableColumnType.ObjectID,
     required: true,
@@ -164,7 +178,7 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
       Permission.EditNetworkDeviceAutoImportRule,
     ],
   })
-  @Index()
+  @Index("IDX_network_device_auto_import_rule_name")
   @TableColumn({
     required: true,
     type: TableColumnType.ShortText,
@@ -230,7 +244,7 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
       Permission.EditNetworkDeviceAutoImportRule,
     ],
   })
-  @Index()
+  @Index("IDX_network_device_auto_import_rule_isEnabled")
   @TableColumn({
     required: true,
     type: TableColumnType.Boolean,
@@ -434,7 +448,7 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
       Permission.EditNetworkDeviceAutoImportRule,
     ],
   })
-  @Index()
+  @Index("IDX_network_device_auto_import_rule_isExclusion")
   @TableColumn({
     required: true,
     type: TableColumnType.Boolean,
@@ -485,7 +499,10 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
       orphanedRowAction: "nullify",
     },
   )
-  @JoinColumn({ name: "createdByUserId" })
+  @JoinColumn({
+    name: "createdByUserId",
+    foreignKeyConstraintName: "FK_nd_auto_import_rule_createdByUserId",
+  })
   public createdByUser?: User = undefined;
 
   @ColumnAccessControl({
@@ -541,7 +558,10 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
       orphanedRowAction: "nullify",
     },
   )
-  @JoinColumn({ name: "deletedByUserId" })
+  @JoinColumn({
+    name: "deletedByUserId",
+    foreignKeyConstraintName: "FK_nd_auto_import_rule_deletedByUserId",
+  })
   public deletedByUser?: User = undefined;
 
   @ColumnAccessControl({

--- a/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
@@ -269,6 +269,70 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
+    /*
+     * The only updatable column on this model. Everything else describes a
+     * sweep that has already been handed to a probe — changing the target or
+     * the credentials of a scan mid-flight would mean the stored row no longer
+     * described the sweep that ran. A name describes nothing but itself, and
+     * the whole point of it is to be fixed after the fact: a scan mislabelled
+     * "Region 1100" is worse than an unnamed one, and deleting a scan to
+     * rename it would throw away its results.
+     */
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
+  })
+  /*
+   * What this scan is FOR, in the operator's own words — "Router Discovery —
+   * Region 1100", "Switch Discovery — WB Units". Optional, not unique, and
+   * never used to look a scan up: it exists so the Discovery Scans list can be
+   * read at a glance instead of by matching octet ranges against a subnet plan
+   * kept somewhere else (OneUptime issue #3391).
+   *
+   * Nullable, and every scan created before this column existed is null — so
+   * every surface that renders it falls back to the scan target. See
+   * Common/Utils/NetworkDiscovery/ScanNameUtil.
+   */
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "Name",
+    description:
+      "Optional name for this scan, so it can be told apart from other scans at a glance. Falls back to the scan target when empty.",
+    example: "Router Discovery - Region 1100",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public name?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.CreateNetworkDeviceDiscoveryScan,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.SettingsViewer,
+      Permission.ReadNetworkDeviceDiscoveryScan,
+    ],
     update: [],
   })
   /*

--- a/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
@@ -270,13 +270,16 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
     /*
-     * The only updatable column on this model. Everything else describes a
-     * sweep that has already been handed to a probe — changing the target or
-     * the credentials of a scan mid-flight would mean the stored row no longer
-     * described the sweep that ran. A name describes nothing but itself, and
-     * the whole point of it is to be fixed after the fact: a scan mislabelled
-     * "Region 1100" is worse than an unnamed one, and deleting a scan to
-     * rename it would throw away its results.
+     * Updatable, unlike everything that describes the sweep itself: changing
+     * the target or the credentials of a scan mid-flight would mean the stored
+     * row no longer described the sweep that ran, so those grant no update at
+     * all. (The recurrence pair is updatable too — it describes the NEXT run
+     * rather than the one that happened.)
+     *
+     * A name describes nothing but itself, and the whole point of it is to be
+     * fixable after the fact: a scan mislabelled "Region 1100" is worse than
+     * an unnamed one, and deleting a scan to rename it would throw away its
+     * results.
      */
     update: [
       Permission.ProjectOwner,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1789400000000-AddNameToNetworkDeviceDiscoveryScan.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1789400000000-AddNameToNetworkDeviceDiscoveryScan.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * An optional operator-supplied name on a discovery scan (issue #3391), so the
+ * Discovery Scans list can be read by purpose — "Router Discovery — Region
+ * 1100" — instead of only by the raw address range it sweeps.
+ *
+ * Nullable with no default and no backfill: every scan that already exists
+ * stays unnamed, and every surface that renders the name falls back to the
+ * scan target exactly as it did before this column existed.
+ */
+export class AddNameToNetworkDeviceDiscoveryScan1789400000000
+  implements MigrationInterface
+{
+  public name: string = "AddNameToNetworkDeviceDiscoveryScan1789400000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceDiscoveryScan" ADD "name" character varying(100)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceDiscoveryScan" DROP COLUMN "name"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -547,6 +547,7 @@ import { AddNetworkDeviceAutoImportRule1789100000000 } from "./1789100000000-Add
 import { AddSysObjectIdPatternToAutoImportRule1789200000000 } from "./1789200000000-AddSysObjectIdPatternToAutoImportRule";
 import { AddAutoApplyVendorHealthTemplate1789300000000 } from "./1789300000000-AddAutoApplyVendorHealthTemplate";
 import { AddUserTwoFactorBackupCode1789100000000 } from "./1789100000000-AddUserTwoFactorBackupCode";
+import { AddNameToNetworkDeviceDiscoveryScan1789400000000 } from "./1789400000000-AddNameToNetworkDeviceDiscoveryScan";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1102,4 +1103,5 @@ export default [
   AddSysObjectIdPatternToAutoImportRule1789200000000,
   AddAutoApplyVendorHealthTemplate1789300000000,
   AddUserTwoFactorBackupCode1789100000000,
+  AddNameToNetworkDeviceDiscoveryScan1789400000000,
 ];

--- a/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
+++ b/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
@@ -6,6 +6,7 @@ import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ScanTargetUtil from "../../Utils/NetworkDiscovery/ScanTargetUtil";
+import ScanNameUtil from "../../Utils/NetworkDiscovery/ScanNameUtil";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -33,6 +34,25 @@ export class Service extends DatabaseService<Model> {
   ): Promise<OnCreate<Model>> {
     this.validateScanTarget(createBy.data.cidr);
 
+    /*
+     * The name is normalized as well as validated — collapsed onto one line,
+     * trimmed, and a blank one dropped entirely — so the column holds either a
+     * name or nothing. An empty string stored here would read as a name to
+     * every `scan.name ?` in the product and render as a blank line above the
+     * scan target. See ScanNameUtil.
+     */
+    this.validateScanName(createBy.data.name);
+
+    /*
+     * Written through a cast because `exactOptionalPropertyTypes` forbids
+     * assigning `undefined` to an optional property — and dropping a blank
+     * name is exactly that assignment. Undefined rather than null: a model
+     * instance starts with every column undefined, so this leaves the row in
+     * the state a scan created without a name would already have been in.
+     */
+    (createBy.data as unknown as Record<string, unknown>)["name"] =
+      ScanNameUtil.normalize(createBy.data.name) ?? undefined;
+
     return { createBy, carryForward: null };
   }
 
@@ -54,6 +74,27 @@ export class Service extends DatabaseService<Model> {
       );
     }
 
+    /*
+     * The name IS user-updatable — renaming a scan is the whole point of
+     * letting it be named — so this path is the one the form actually takes,
+     * not just a guard against root writers.
+     *
+     * Cleared with null rather than left as "": the form sends back an empty
+     * box as an empty string, and the operator who emptied it meant "this scan
+     * has no name", which is what NULL says. `undefined` would not do — the
+     * key is present in the update, and an undefined value is a column TypeORM
+     * would try to write.
+     */
+    if (dataKeys.includes("name")) {
+      const data: Record<string, unknown> = updateBy.data as Record<
+        string,
+        unknown
+      >;
+
+      this.validateScanName(data["name"]);
+      data["name"] = ScanNameUtil.normalize(data["name"]);
+    }
+
     return { updateBy, carryForward: null };
   }
 
@@ -70,6 +111,24 @@ export class Service extends DatabaseService<Model> {
     const validationError: string | null = ScanTargetUtil.getValidationError(
       target as string,
     );
+
+    if (validationError) {
+      throw new BadDataException(validationError);
+    }
+  }
+
+  /*
+   * Same contract as validateScanTarget above: the value is passed through
+   * untouched, because it arrives straight from the request JSON and may be a
+   * number, an object or an array rather than a string. ScanNameUtil type-
+   * guards internally and reports a non-string as such.
+   *
+   * An ABSENT or blank name is not an error — the column is optional, and a
+   * scan with no name reads as it always did, by its target.
+   */
+  private validateScanName(name: unknown): void {
+    const validationError: string | null =
+      ScanNameUtil.getValidationError(name);
 
     if (validationError) {
       throw new BadDataException(validationError);

--- a/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
@@ -52,9 +52,37 @@ type CapturedFormStep = {
   title: string;
 };
 
+/*
+ * The list half of the table's configuration, captured for the same reason the
+ * form half is: the Scan column, the filters and the row actions are all plain
+ * props, so a refactor can drop one without breaking a type or a render.
+ */
+type CapturedColumn = {
+  field?: Record<string, unknown> | undefined;
+  title?: string | undefined;
+  getElement?:
+    | ((item: NetworkDeviceDiscoveryScan) => React.ReactElement)
+    | undefined;
+};
+
+type CapturedFilter = {
+  field?: Record<string, unknown> | undefined;
+  title?: string | undefined;
+};
+
+type CapturedActionButton = {
+  title?: string | undefined;
+  isVisible?: ((item: NetworkDeviceDiscoveryScan) => boolean) | undefined;
+};
+
 type CapturedTableProps = {
   formFields?: Array<CapturedFormField>;
   formSteps?: Array<CapturedFormStep>;
+  columns?: Array<CapturedColumn>;
+  filters?: Array<CapturedFilter>;
+  actionButtons?: Array<CapturedActionButton>;
+  selectMoreFields?: Record<string, boolean>;
+  isEditable?: boolean | undefined;
 };
 
 let capturedTableProps: CapturedTableProps | null = null;
@@ -74,7 +102,11 @@ import ProbeUtil from "../../../../App/FeatureSet/Dashboard/src/Utils/Probe";
 import Project from "../../../Models/DatabaseModels/Project";
 import Probe from "../../../Models/DatabaseModels/Probe";
 import ProjectUtil from "../../../UI/Utils/Project";
+import PermissionUtil from "../../../UI/Utils/Permission";
+import Permission from "../../../Types/Permission";
 import ScanTargetUtil from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
+import ScanNameUtil from "../../../Utils/NetworkDiscovery/ScanNameUtil";
+import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import ObjectID from "../../../Types/ObjectID";
 import Route from "../../../Types/API/Route";
 
@@ -103,6 +135,43 @@ function fieldNamed(key: string): CapturedFormField {
   }
 
   return field;
+}
+
+function columnNamed(key: string): CapturedColumn {
+  const column: CapturedColumn | undefined = capturedTableProps?.columns?.find(
+    (tableColumn: CapturedColumn): boolean => {
+      return Object.keys(tableColumn.field || {})[0] === key;
+    },
+  );
+
+  if (!column) {
+    throw new Error(`Discovery scans table column "${key}" not found`);
+  }
+
+  return column;
+}
+
+/*
+ * What the Scan column actually puts on screen for a given row. Rendered
+ * rather than inspected: the fallback that matters here is a rendering
+ * decision (name on the first line, target underneath, target ALONE when there
+ * is no name), and reading it off the element tree would pin the markup rather
+ * than what an operator sees.
+ */
+function renderScanCell(scan: Partial<NetworkDeviceDiscoveryScan>): string {
+  const column: CapturedColumn = columnNamed("name");
+
+  if (!column.getElement) {
+    throw new Error("The Scan column renders no element");
+  }
+
+  const { container } = render(
+    <MemoryRouter>
+      {column.getElement(scan as NetworkDeviceDiscoveryScan)}
+    </MemoryRouter>,
+  );
+
+  return container.textContent || "";
 }
 
 function validate(key: string, values: Record<string, unknown>): string | null {
@@ -404,5 +473,211 @@ describe("SNMP Port is bounded on the SNMP Credentials step", () => {
     expect(validate("snmpPort", { snmpPort: 161 })).toBeNull();
     expect(validate("snmpPort", { snmpPort: "" })).toBeNull();
     expect(validate("snmpPort", {})).toBeNull();
+  });
+});
+
+/*
+ * The name (issue #3391).
+ *
+ * A discovery scan was identified everywhere by its target alone, so a list of
+ * them read as a column of octet ranges with no way to tell the router sweep
+ * from the switch range. These tests pin the three places the name has to
+ * appear for that to be fixed — the wizard that collects it, the list column
+ * that shows it, and the filters that find it — plus the fallback that keeps
+ * every scan created before the column existed looking exactly as it did.
+ */
+describe("Name is collected by the wizard", () => {
+  beforeEach(() => {
+    capturedTableProps = null;
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+    jest.spyOn(ProbeUtil, "getAllProbes").mockResolvedValue([] as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    capturedTableProps = null;
+  });
+
+  test("is the first thing the wizard asks for, on the first step", async () => {
+    await renderPage();
+
+    const fields: Array<CapturedFormField> =
+      capturedTableProps?.formFields || [];
+
+    expect(fieldKeyOf(fields[0] as CapturedFormField)).toBe("name");
+    expect(fieldNamed("name").stepId).toBe(STEP_SCAN_TARGET);
+  });
+
+  /*
+   * Optional on purpose. Requiring it would put a wall in front of the
+   * operator sweeping one subnet once, which is the case the page was built
+   * for.
+   */
+  test("is optional", async () => {
+    await renderPage();
+
+    expect(fieldNamed("name").required).toBeFalsy();
+  });
+
+  test("carries the shared validator, so the form and the server agree", async () => {
+    await renderPage();
+
+    expect(typeof fieldNamed("name").customValidation).toBe("function");
+
+    for (const value of [
+      "Router Discovery - Region 1100",
+      "",
+      "   ",
+      "a".repeat(ScanNameUtil.MAX_SCAN_NAME_LENGTH + 1),
+      1100,
+    ]) {
+      expect(validate("name", { name: value })).toBe(
+        ScanNameUtil.getValidationError(value),
+      );
+    }
+  });
+
+  test("says nothing about an empty box, so Next is never blocked by it", async () => {
+    await renderPage();
+
+    expect(validate("name", {})).toBeNull();
+    expect(validate("name", { name: "" })).toBeNull();
+  });
+});
+
+describe("Name identifies the scan in the list", () => {
+  beforeEach(() => {
+    capturedTableProps = null;
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+    jest.spyOn(ProbeUtil, "getAllProbes").mockResolvedValue([] as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    capturedTableProps = null;
+  });
+
+  test("a named scan leads with its name and still shows its target", async () => {
+    await renderPage();
+
+    const cell: string = renderScanCell({
+      name: "Router Discovery - Region 1100",
+      cidr: "10.15.128.0-255",
+    });
+
+    expect(cell).toContain("Router Discovery - Region 1100");
+    expect(cell).toContain("10.15.128.0-255");
+  });
+
+  /*
+   * The case that has to keep working: every scan that existed before this
+   * column did. It reads exactly as it did before — the target, on the first
+   * line, with nothing above it.
+   */
+  test("an unnamed scan reads exactly as it did before names existed", async () => {
+    await renderPage();
+
+    expect(renderScanCell({ cidr: "10.114.167.11-38" })).toBe(
+      "10.114.167.11-38",
+    );
+    expect(renderScanCell({ name: "", cidr: "10.114.167.11-38" })).toBe(
+      "10.114.167.11-38",
+    );
+    expect(renderScanCell({ name: "   ", cidr: "10.114.167.11-38" })).toBe(
+      "10.114.167.11-38",
+    );
+  });
+
+  test("a blank name never renders as an empty line above the target", async () => {
+    await renderPage();
+
+    const cell: string = renderScanCell({
+      name: "  ",
+      cidr: "192.168.1.0/24",
+    });
+
+    expect(cell.trim()).toBe("192.168.1.0/24");
+  });
+
+  test("a stored name is tidied up on the way out, not rendered raw", async () => {
+    await renderPage();
+
+    expect(
+      renderScanCell({ name: "Router\nDiscovery", cidr: "10.0.0.0/24" }),
+    ).toContain("Router Discovery");
+  });
+
+  /*
+   * The column renders `cidr` but is keyed on `name`, so the target has to be
+   * asked for explicitly or the second line silently disappears.
+   */
+  test("the target is still fetched, because the column renders it", async () => {
+    await renderPage();
+
+    expect(capturedTableProps?.selectMoreFields?.["cidr"]).toBe(true);
+  });
+
+  test("both halves of the identity are searchable", async () => {
+    await renderPage();
+
+    const filtered: Array<string> = (capturedTableProps?.filters || []).map(
+      (filter: CapturedFilter): string => {
+        return Object.keys(filter.field || {})[0] as string;
+      },
+    );
+
+    expect(filtered).toContain("name");
+    expect(filtered).toContain("cidr");
+  });
+
+  /*
+   * A name that cannot be corrected is worse than no name: "Region 1100" on
+   * the wrong range misleads everyone who reads the list afterwards, and the
+   * only other way to fix it would be deleting the scan and its results.
+   */
+  test("a scan can be renamed after it was created", async () => {
+    await renderPage();
+
+    const actions: Array<string> = (
+      capturedTableProps?.actionButtons || []
+    ).map((button: CapturedActionButton): string => {
+      return button.title || "";
+    });
+
+    expect(actions).toContain("Rename");
+  });
+
+  /*
+   * The table is not editable, so this button is the page's only edit
+   * affordance and nothing else gates it. Offered to a reader, it would open a
+   * dialog whose one field ModelForm has already dropped for want of the
+   * update permission — a box that cannot be saved and does not say why.
+   */
+  test("renaming is offered only to someone who could save it", async () => {
+    await renderPage();
+
+    const rename: CapturedActionButton | undefined = (
+      capturedTableProps?.actionButtons || []
+    ).find((button: CapturedActionButton): boolean => {
+      return button.title === "Rename";
+    });
+
+    const scan: NetworkDeviceDiscoveryScan = {
+      cidr: "10.0.0.0/24",
+    } as NetworkDeviceDiscoveryScan;
+
+    jest
+      .spyOn(PermissionUtil, "getAllPermissions")
+      .mockReturnValue([Permission.Viewer]);
+
+    expect(rename?.isVisible?.(scan)).toBe(false);
+
+    jest
+      .spyOn(PermissionUtil, "getAllPermissions")
+      .mockReturnValue([Permission.ProjectAdmin]);
+
+    expect(rename?.isVisible?.(scan)).toBe(true);
   });
 });

--- a/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
@@ -610,13 +610,21 @@ describe("Name identifies the scan in the list", () => {
   });
 
   /*
-   * The column renders `cidr` but is keyed on `name`, so the target has to be
-   * asked for explicitly or the second line silently disappears.
+   * The column renders `cidr` while being keyed on `name`, so the target has
+   * to be DECLARED on the column — not merely selected alongside it. Declaring
+   * it is what fetches it for the second line AND what puts it in the CSV
+   * export, which builds its row out of a column's declared fields alone
+   * (Common/UI/Components/ModelTable/ExportFromColumns.ts). Reaching the
+   * target through selectMoreFields instead exported an empty cell for every
+   * scan without a name.
    */
-  test("the target is still fetched, because the column renders it", async () => {
+  test("the target is declared on the column, so it is fetched and exported", async () => {
     await renderPage();
 
-    expect(capturedTableProps?.selectMoreFields?.["cidr"]).toBe(true);
+    expect(Object.keys(columnNamed("name").field || {})).toEqual([
+      "name",
+      "cidr",
+    ]);
   });
 
   test("both halves of the identity are searchable", async () => {

--- a/Common/Tests/Models/DiscoveryScanNameColumn.test.ts
+++ b/Common/Tests/Models/DiscoveryScanNameColumn.test.ts
@@ -12,9 +12,10 @@
  *   - OPTIONAL and un-backfilled. Every scan that already existed has no name,
  *     and a NOT NULL column (or a backfilled one) would either fail the
  *     migration or invent a name nobody wrote.
- *   - UPDATABLE, alone on this model. Every other column describes a sweep
- *     that has already been handed to a probe; a name describes nothing but
- *     itself, and a mislabelled scan is worse than an unlabelled one.
+ *   - UPDATABLE. Almost nothing on this model is: the target and the
+ *     credentials describe a sweep already handed to a probe. A name describes
+ *     nothing but itself, and a mislabelled scan is worse than an unlabelled
+ *     one, so it joins the recurrence pair as the third editable column.
  *   - NOT unique and NOT slugged. It is a label for humans, never a key: two
  *     scans of the same range may legitimately be called the same thing.
  */
@@ -207,21 +208,69 @@ describe("NetworkDeviceDiscoveryScan.name access control", () => {
   });
 
   /*
-   * The one updatable column on the model. The Rename dialog on the Discovery
-   * page depends on this list being non-empty — ModelForm drops a field whose
-   * column grants no update permission, so an empty list here would silently
-   * turn the dialog into a permission error.
+   * The Rename dialog on the Discovery page depends on this list being
+   * non-empty — ModelForm drops a field whose column grants no update
+   * permission, so an empty list here would turn the dialog into a permission
+   * error rather than a text box.
    */
-  test("is the one column a scan can be edited through", () => {
+  test("can be edited by whoever may edit the scan", () => {
     expect(
       new NetworkDeviceDiscoveryScan().getColumnAccessControlFor(COLUMN)
         ?.update,
     ).toEqual(EDITORS);
+  });
 
-    expect(
-      new NetworkDeviceDiscoveryScan().getColumnAccessControlFor("cidr")
-        ?.update,
-    ).toEqual([]);
+  /*
+   * And the sweep itself stays read-only. This is the claim worth pinning:
+   * adding an editable column must not have made anything that DESCRIBES a
+   * sweep editable with it. A target or a credential changed after a probe
+   * took the scan would leave the stored row describing a sweep that never
+   * ran, and a status or a result changed by hand would be a lie about one
+   * that did.
+   *
+   * (The recurrence pair is editable, and always was — it describes the NEXT
+   * run rather than the one that happened.)
+   */
+  test("does not make any part of the sweep editable", () => {
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+
+    const sweepColumns: Array<string> = [
+      "cidr",
+      "probeId",
+      "snmpVersion",
+      "snmpCommunityString",
+      "snmpPort",
+      "snmpV3SecurityLevel",
+      "snmpV3Username",
+      "snmpV3AuthProtocol",
+      "snmpV3AuthKey",
+      "snmpV3PrivProtocol",
+      "snmpV3PrivKey",
+      "status",
+      "statusMessage",
+      "discoveredDevices",
+      "scannedHostCount",
+      "respondedHostCount",
+      "startedAt",
+      "completedAt",
+      "nextScanAt",
+    ];
+
+    for (const column of sweepColumns) {
+      expect({
+        column: column,
+        update: scan.getColumnAccessControlFor(column)?.update,
+      }).toEqual({ column: column, update: [] });
+    }
+  });
+
+  // ...while the two columns that describe a future run stay editable.
+  test("leaves the recurrence pair editable, as it already was", () => {
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+
+    for (const column of ["isRecurring", "rescanIntervalInMinutes"]) {
+      expect(scan.getColumnAccessControlFor(column)?.update).toEqual(EDITORS);
+    }
   });
 
   /*

--- a/Common/Tests/Models/DiscoveryScanNameColumn.test.ts
+++ b/Common/Tests/Models/DiscoveryScanNameColumn.test.ts
@@ -1,0 +1,244 @@
+/**
+ * NetworkDeviceDiscoveryScan.name column contract (issue #3391).
+ *
+ * A discovery scan used to be identified in the product by its target alone,
+ * so a list of them read as a column of octet ranges. This column is the
+ * operator's own sentence about what the scan is FOR, and everything below
+ * pins a property that, quietly changed, either loses that sentence or turns
+ * an optional label into something that can refuse a write.
+ *
+ * Three properties matter more than the rest:
+ *
+ *   - OPTIONAL and un-backfilled. Every scan that already existed has no name,
+ *     and a NOT NULL column (or a backfilled one) would either fail the
+ *     migration or invent a name nobody wrote.
+ *   - UPDATABLE, alone on this model. Every other column describes a sweep
+ *     that has already been handed to a probe; a name describes nothing but
+ *     itself, and a mislabelled scan is worse than an unlabelled one.
+ *   - NOT unique and NOT slugged. It is a label for humans, never a key: two
+ *     scans of the same range may legitimately be called the same thing.
+ */
+
+import NetworkDeviceDiscoveryScan from "../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { TableColumnMetadata } from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import ColumnLength from "../../Types/Database/ColumnLength";
+import Columns from "../../Types/Database/Columns";
+import Permission from "../../Types/Permission";
+import { describe, expect, test } from "@jest/globals";
+import { getMetadataArgsStorage } from "typeorm";
+import { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+import fs from "fs";
+import path from "path";
+
+const COLUMN: string = "name";
+
+const MIGRATIONS_DIR: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "Server",
+  "Infrastructure",
+  "Postgres",
+  "SchemaMigrations",
+);
+
+const MIGRATION_CLASS: string =
+  "AddNameToNetworkDeviceDiscoveryScan1789400000000";
+
+const MIGRATION_PATH: string = path.join(
+  MIGRATIONS_DIR,
+  "1789400000000-AddNameToNetworkDeviceDiscoveryScan.ts",
+);
+
+function metadata(): TableColumnMetadata {
+  return new NetworkDeviceDiscoveryScan().getTableColumnMetadata(COLUMN);
+}
+
+function typeOrmColumn(): ColumnMetadataArgs | undefined {
+  return getMetadataArgsStorage().columns.find((column: ColumnMetadataArgs) => {
+    return (
+      column.target === NetworkDeviceDiscoveryScan &&
+      column.propertyName === COLUMN
+    );
+  });
+}
+
+describe("NetworkDeviceDiscoveryScan.name", () => {
+  test("exists as a ShortText column", () => {
+    expect(metadata()).toBeDefined();
+    expect(metadata().type).toBe(TableColumnType.ShortText);
+    expect(metadata().title).toBe("Name");
+  });
+
+  /*
+   * The whole point of the field. A required name would put a wall in front of
+   * the operator sweeping one subnet once, which is the case the Discovery
+   * page was built for in the first place.
+   */
+  test("is optional, so a scan can still be created without one", () => {
+    expect(metadata().required).toBeFalsy();
+    expect(typeOrmColumn()).toBeDefined();
+    expect(typeOrmColumn()?.options.nullable).toBe(true);
+  });
+
+  test("is stored at the width the shared validator caps names at", () => {
+    expect(typeOrmColumn()?.options.length).toBe(ColumnLength.ShortText);
+  });
+
+  /*
+   * A default would name every unnamed scan the same thing, which is exactly
+   * the state the issue describes as unreadable.
+   */
+  test("has no default value", () => {
+    expect(typeOrmColumn()?.options.default).toBeUndefined();
+    expect(new NetworkDeviceDiscoveryScan().isDefaultValueColumn(COLUMN)).toBe(
+      false,
+    );
+  });
+
+  test("is not unique, because a name is a label and not a key", () => {
+    expect(typeOrmColumn()?.options.unique).toBeFalsy();
+
+    const uniqueColumns: Columns =
+      new NetworkDeviceDiscoveryScan().getUniqueColumns();
+
+    expect(uniqueColumns.columns).not.toContain(COLUMN);
+  });
+
+  /*
+   * Slugs are opt-in through @SlugifyColumn. A scan is never addressed by
+   * name, and slugging one would add a second column to keep in step with a
+   * value the operator is expected to rewrite.
+   */
+  test("is not slugified", () => {
+    expect(new NetworkDeviceDiscoveryScan().getSlugifyColumn()).toBeFalsy();
+  });
+});
+
+describe("NetworkDeviceDiscoveryScan.name migration", () => {
+  test("adds a nullable varchar without backfilling existing scans", () => {
+    const migration: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+    expect(migration).toContain('ALTER TABLE "NetworkDeviceDiscoveryScan"');
+    expect(migration).toContain(`ADD "${COLUMN}" character varying(100)`);
+    /*
+     * No NOT NULL, no DEFAULT and no UPDATE: scans created before this column
+     * existed stay unnamed, and every surface falls back to their target.
+     */
+    expect(migration).not.toContain("NOT NULL");
+    expect(migration).not.toContain("DEFAULT");
+    expect(migration).not.toContain("UPDATE");
+  });
+
+  test("its down() removes the column", () => {
+    const migration: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+    expect(migration).toContain(
+      `ALTER TABLE "NetworkDeviceDiscoveryScan" DROP COLUMN "${COLUMN}"`,
+    );
+  });
+
+  /*
+   * TypeORM records a migration under its `public name` property, not its
+   * class name, and nothing else in the suite compares the two. A rename that
+   * updates the class and forgets the literal leaves the deployed identity on
+   * the old value.
+   */
+  test("its class name, file name and recorded name all agree", () => {
+    const migration: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+    expect(migration).toContain(`export class ${MIGRATION_CLASS}`);
+    expect(migration).toContain(`public name: string = "${MIGRATION_CLASS}"`);
+  });
+
+  test("is registered, so the column actually exists at runtime", () => {
+    const index: string = fs.readFileSync(
+      path.join(MIGRATIONS_DIR, "Index.ts"),
+      "utf8",
+    );
+
+    // Imported AND listed in the exported array - the import alone does nothing.
+    expect(index.match(new RegExp(MIGRATION_CLASS, "g"))?.length).toBe(2);
+  });
+});
+
+describe("NetworkDeviceDiscoveryScan.name access control", () => {
+  const CREATORS: Array<Permission> = [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.SettingsAdmin,
+    Permission.SettingsMember,
+    Permission.CreateNetworkDeviceDiscoveryScan,
+  ];
+
+  const READERS: Array<Permission> = [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.Viewer,
+    Permission.SettingsAdmin,
+    Permission.SettingsMember,
+    Permission.SettingsViewer,
+    Permission.ReadNetworkDeviceDiscoveryScan,
+  ];
+
+  const EDITORS: Array<Permission> = [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.SettingsAdmin,
+    Permission.SettingsMember,
+    Permission.EditNetworkDeviceDiscoveryScan,
+  ];
+
+  test("is set by whoever may create a scan", () => {
+    expect(
+      new NetworkDeviceDiscoveryScan().getColumnAccessControlFor(COLUMN)
+        ?.create,
+    ).toEqual(CREATORS);
+  });
+
+  test("is read by everyone who may read a scan, viewers included", () => {
+    expect(
+      new NetworkDeviceDiscoveryScan().getColumnAccessControlFor(COLUMN)?.read,
+    ).toEqual(READERS);
+  });
+
+  /*
+   * The one updatable column on the model. The Rename dialog on the Discovery
+   * page depends on this list being non-empty — ModelForm drops a field whose
+   * column grants no update permission, so an empty list here would silently
+   * turn the dialog into a permission error.
+   */
+  test("is the one column a scan can be edited through", () => {
+    expect(
+      new NetworkDeviceDiscoveryScan().getColumnAccessControlFor(COLUMN)
+        ?.update,
+    ).toEqual(EDITORS);
+
+    expect(
+      new NetworkDeviceDiscoveryScan().getColumnAccessControlFor("cidr")
+        ?.update,
+    ).toEqual([]);
+  });
+
+  /*
+   * Everything the operator can edit has to be something the table itself
+   * accepts an update for, or the row-level check refuses the write before the
+   * column-level one is ever consulted.
+   */
+  test("its editors are editors of the table too", () => {
+    const tableUpdatePermissions: Array<Permission> =
+      new NetworkDeviceDiscoveryScan().getUpdatePermissions();
+
+    for (const permission of EDITORS) {
+      expect(tableUpdatePermissions).toContain(permission);
+    }
+  });
+
+  test("is readable from a relation query, like the target beside it", () => {
+    expect(metadata().canReadOnRelationQuery).toBe(true);
+  });
+});

--- a/Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts
@@ -65,15 +65,36 @@ const INITIAL_MIGRATION_TIMESTAMP: number = 1717605043663;
  * history, not a fixable defect, and the assertions below step around it while
  * still failing for a NEW one.
  *
- * The list may only shrink: the test at the end of this describe fails if an
- * entry here is not actually duplicated in the registry, so removing one of
- * these migrations removes its entry too.
+ * The exception names the two classes, so it cannot quietly grow: a third
+ * migration on the same stamp is not one of them and fails the duplicate
+ * guard, and dropping either migration leaves the exception naming a class
+ * that is no longer registered, which fails too.
  */
-const SHIPPED_DUPLICATE_TIMESTAMPS: ReadonlyArray<number> = [1789100000000];
+const SHIPPED_DUPLICATE_MIGRATIONS: ReadonlyArray<{
+  timestamp: number;
+  classNames: ReadonlyArray<string>;
+}> = [
+  {
+    timestamp: 1789100000000,
+    classNames: [
+      "AddNetworkDeviceAutoImportRule1789100000000",
+      "AddUserTwoFactorBackupCode1789100000000",
+    ],
+  },
+];
 
-type TimestampCountsFunction = (
-  migrationClasses: Array<MigrationClass>,
-) => Map<number, number>;
+/*
+ * The exception is written as the exact pair of classes that share the stamp,
+ * not as the bare number, so it excuses those two and nothing else. Excusing
+ * the number would have excused a THIRD migration landing on it — a brand new
+ * collision, waved through by the exception made for the old one.
+ */
+const SHIPPED_DUPLICATE_TIMESTAMPS: ReadonlyArray<number> =
+  SHIPPED_DUPLICATE_MIGRATIONS.map(
+    (duplicate: { timestamp: number }): number => {
+      return duplicate.timestamp;
+    },
+  );
 
 const TIMESTAMPED_FILE: RegExp = new RegExp("^\\d+-");
 
@@ -90,24 +111,6 @@ const timestampOf: TimestampOfFunction = (
 
 const registered: Array<MigrationClass> =
   SchemaMigrations as Array<MigrationClass>;
-
-const timestampCounts: TimestampCountsFunction = (
-  migrationClasses: Array<MigrationClass>,
-): Map<number, number> => {
-  const counts: Map<number, number> = new Map<number, number>();
-
-  for (const migrationClass of migrationClasses) {
-    const timestamp: number | null = timestampOf(migrationClass);
-
-    if (timestamp === null) {
-      continue;
-    }
-
-    counts.set(timestamp, (counts.get(timestamp) || 0) + 1);
-  }
-
-  return counts;
-};
 
 describe("the migration registry", () => {
   /*
@@ -190,11 +193,35 @@ describe("the migration registry", () => {
      * entry goes with it — and nobody can quietly widen the list to wave a new
      * collision through, because a wrong entry fails right here.
      */
-    test("grandfathers only collisions that actually exist", () => {
-      const counts: Map<number, number> = timestampCounts(registered);
+    test("grandfathers exactly the collisions that exist, and no more", () => {
+      const names: Array<string> = registered.map(
+        (migrationClass: MigrationClass): string => {
+          return migrationClass.name;
+        },
+      );
 
-      for (const timestamp of SHIPPED_DUPLICATE_TIMESTAMPS) {
-        expect(counts.get(timestamp)).toBeGreaterThan(1);
+      for (const duplicate of SHIPPED_DUPLICATE_MIGRATIONS) {
+        const onThisTimestamp: Array<string> = registered
+          .filter((migrationClass: MigrationClass): boolean => {
+            return timestampOf(migrationClass) === duplicate.timestamp;
+          })
+          .map((migrationClass: MigrationClass): string => {
+            return migrationClass.name;
+          })
+          .sort();
+
+        /*
+         * Both halves matter. Naming a class that is no longer registered
+         * means the exception has outlived the collision and must go; finding
+         * a class the exception does not name means a NEW migration has
+         * landed on the shipped stamp, which is the very thing the duplicate
+         * guard exists to catch.
+         */
+        expect(onThisTimestamp).toEqual([...duplicate.classNames].sort());
+
+        for (const className of duplicate.classNames) {
+          expect(names).toContain(className);
+        }
       }
     });
 
@@ -224,8 +251,6 @@ describe("the migration registry", () => {
   test("backs every registered migration with exactly one file on disk", () => {
     const files: Array<string> = fs.readdirSync(MIGRATION_DIRECTORY);
 
-    const counts: Map<number, number> = timestampCounts(registered);
-
     const unbacked: Array<string> = registered
       .filter((migrationClass: MigrationClass): boolean => {
         const timestamp: number | null = timestampOf(migrationClass);
@@ -240,10 +265,23 @@ describe("the migration registry", () => {
          * means two — both classes are real, both have a file, and neither can
          * be renamed. See SHIPPED_DUPLICATE_TIMESTAMPS.
          */
-        const expectedFileCount: number = SHIPPED_DUPLICATE_TIMESTAMPS.includes(
-          timestamp,
-        )
-          ? counts.get(timestamp) || 1
+        const grandfathered:
+          | { timestamp: number; classNames: ReadonlyArray<string> }
+          | undefined = SHIPPED_DUPLICATE_MIGRATIONS.find(
+          (duplicate: { timestamp: number }): boolean => {
+            return duplicate.timestamp === timestamp;
+          },
+        );
+
+        /*
+         * One file per registered class, which for every timestamp but the
+         * grandfathered collision means exactly one file. For that one it
+         * means exactly as many files as the exception names — a fixed
+         * number, never the live count, so an unexpected third file on that
+         * stamp fails here rather than being counted and excused.
+         */
+        const expectedFileCount: number = grandfathered
+          ? grandfathered.classNames.length
           : 1;
 
         return (

--- a/Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/SchemaMigrationsOrdering.test.ts
@@ -50,6 +50,31 @@ const UNTIMESTAMPED_MIGRATION_NAME: string = "InitialMigration";
 
 const INITIAL_MIGRATION_TIMESTAMP: number = 1717605043663;
 
+/*
+ * Timestamps that two migrations already share, and always will.
+ *
+ * `AddNetworkDeviceAutoImportRule1789100000000` and
+ * `AddUserTwoFactorBackupCode1789100000000` were authored in parallel, both
+ * picked the same round slot (the hazard the timestamps in this directory are
+ * hand-picked rather than wall-clock), and both shipped before anyone noticed.
+ *
+ * Renaming either one now would re-run it. TypeORM records a migration by
+ * name, so a renamed class reads as one that has never executed — and both of
+ * these CREATE a table with no IF NOT EXISTS, so the re-run fails against
+ * every database that already has it. The collision is therefore permanent
+ * history, not a fixable defect, and the assertions below step around it while
+ * still failing for a NEW one.
+ *
+ * The list may only shrink: the test at the end of this describe fails if an
+ * entry here is not actually duplicated in the registry, so removing one of
+ * these migrations removes its entry too.
+ */
+const SHIPPED_DUPLICATE_TIMESTAMPS: ReadonlyArray<number> = [1789100000000];
+
+type TimestampCountsFunction = (
+  migrationClasses: Array<MigrationClass>,
+) => Map<number, number>;
+
 const TIMESTAMPED_FILE: RegExp = new RegExp("^\\d+-");
 
 type MigrationClass = new () => MigrationInterface;
@@ -65,6 +90,24 @@ const timestampOf: TimestampOfFunction = (
 
 const registered: Array<MigrationClass> =
   SchemaMigrations as Array<MigrationClass>;
+
+const timestampCounts: TimestampCountsFunction = (
+  migrationClasses: Array<MigrationClass>,
+): Map<number, number> => {
+  const counts: Map<number, number> = new Map<number, number>();
+
+  for (const migrationClass of migrationClasses) {
+    const timestamp: number | null = timestampOf(migrationClass);
+
+    if (timestamp === null) {
+      continue;
+    }
+
+    counts.set(timestamp, (counts.get(timestamp) || 0) + 1);
+  }
+
+  return counts;
+};
 
 describe("the migration registry", () => {
   /*
@@ -125,13 +168,34 @@ describe("the migration registry", () => {
           return timestamp !== null;
         });
 
-      const duplicates: Array<number> = timestamps.filter(
-        (timestamp: number, index: number): boolean => {
+      const duplicates: Array<number> = timestamps
+        .filter((timestamp: number, index: number): boolean => {
           return timestamps.indexOf(timestamp) !== index;
-        },
-      );
+        })
+        /*
+         * A collision that has already shipped cannot be undone — see
+         * SHIPPED_DUPLICATE_TIMESTAMPS. A new one still fails here, which is
+         * the only case this assertion can actually do anything about.
+         */
+        .filter((timestamp: number): boolean => {
+          return !SHIPPED_DUPLICATE_TIMESTAMPS.includes(timestamp);
+        });
 
       expect(duplicates).toEqual([]);
+    });
+
+    /*
+     * Keeps the exception list honest. Every entry has to name a collision
+     * that is really there, so the day one of those migrations is deleted its
+     * entry goes with it — and nobody can quietly widen the list to wave a new
+     * collision through, because a wrong entry fails right here.
+     */
+    test("grandfathers only collisions that actually exist", () => {
+      const counts: Map<number, number> = timestampCounts(registered);
+
+      for (const timestamp of SHIPPED_DUPLICATE_TIMESTAMPS) {
+        expect(counts.get(timestamp)).toBeGreaterThan(1);
+      }
     });
 
     test("never registers the same migration class twice", () => {
@@ -160,6 +224,8 @@ describe("the migration registry", () => {
   test("backs every registered migration with exactly one file on disk", () => {
     const files: Array<string> = fs.readdirSync(MIGRATION_DIRECTORY);
 
+    const counts: Map<number, number> = timestampCounts(registered);
+
     const unbacked: Array<string> = registered
       .filter((migrationClass: MigrationClass): boolean => {
         const timestamp: number | null = timestampOf(migrationClass);
@@ -168,10 +234,22 @@ describe("the migration registry", () => {
           return false;
         }
 
+        /*
+         * One file per registered class, which for every timestamp but the
+         * grandfathered collision means exactly one file. For that one it
+         * means two — both classes are real, both have a file, and neither can
+         * be renamed. See SHIPPED_DUPLICATE_TIMESTAMPS.
+         */
+        const expectedFileCount: number = SHIPPED_DUPLICATE_TIMESTAMPS.includes(
+          timestamp,
+        )
+          ? counts.get(timestamp) || 1
+          : 1;
+
         return (
           files.filter((file: string): boolean => {
             return file.startsWith(`${timestamp}-`);
-          }).length !== 1
+          }).length !== expectedFileCount
         );
       })
       .map((migrationClass: MigrationClass): string => {

--- a/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+++ b/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
@@ -140,7 +140,13 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
         "startedAt",
         "statusMessage",
       ];
-      const columnsValidatedByHook: Array<string> = ["cidr"];
+      /*
+       * `name` joined `cidr` here when discovery scans became nameable
+       * (issue #3391): the hook validates and normalizes it on any update that
+       * carries it. The claim payload does not, which is what keeps the
+       * hookless write honest.
+       */
+      const columnsValidatedByHook: Array<string> = ["cidr", "name"];
 
       for (const column of claimWriteColumns) {
         expect(columnsValidatedByHook).not.toContain(column);

--- a/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
@@ -3,6 +3,7 @@ import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDe
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
 import ScanTargetUtil from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
+import ScanNameUtil from "../../../Utils/NetworkDiscovery/ScanNameUtil";
 import CreateBy from "../../../Server/Types/Database/CreateBy";
 import UpdateBy from "../../../Server/Types/Database/UpdateBy";
 import { describe, expect, it } from "@jest/globals";
@@ -39,6 +40,41 @@ function makeCreateBy(cidr?: unknown): CreateBy<NetworkDeviceDiscoveryScan> {
     props: { isRoot: true },
   };
 }
+
+/*
+ * A scan with a valid target and whatever `name` the caller wants to try. The
+ * name is written through a Record cast for the same reason the target is: the
+ * hook runs before the model's own type checks, so a client really can send a
+ * number or an object here.
+ */
+function makeCreateByWithName(
+  name?: unknown,
+): CreateBy<NetworkDeviceDiscoveryScan> {
+  const createBy: CreateBy<NetworkDeviceDiscoveryScan> =
+    makeCreateBy("192.168.1.0/24");
+
+  if (name !== undefined) {
+    (createBy.data as unknown as Record<string, unknown>)["name"] = name;
+  }
+
+  return createBy;
+}
+
+type CreatedNameFunction = (name?: unknown) => Promise<unknown>;
+
+/*
+ * What the hook would actually store in the column, for a given input.
+ */
+const createdName: CreatedNameFunction = async (
+  name?: unknown,
+): Promise<unknown> => {
+  const createBy: CreateBy<NetworkDeviceDiscoveryScan> =
+    makeCreateByWithName(name);
+
+  await onBeforeCreate(createBy);
+
+  return (createBy.data as unknown as Record<string, unknown>)["name"];
+};
 
 function makeUpdateBy(
   data: Record<string, unknown>,
@@ -257,6 +293,164 @@ describe("NetworkDeviceDiscoveryScanService.onBeforeUpdate", () => {
     );
     await expect(onBeforeUpdate(makeUpdateBy({ cidr: "" }))).rejects.toThrow(
       BadDataException,
+    );
+  });
+});
+
+/*
+ * The optional name (issue #3391). The hook does two things with it, and the
+ * tests below separate them deliberately: it REJECTS what could never be
+ * stored (a non-string, a value past the column width), and it NORMALIZES what
+ * can be (trimming, folding onto one line, and turning a blank name into no
+ * name at all). The messages are ScanNameUtil's, so the wizard's inline error
+ * and the API's 400 are the same sentence.
+ */
+describe("NetworkDeviceDiscoveryScanService name validation on create", () => {
+  it("accepts a scan with no name, because the field is optional", async () => {
+    await expect(onBeforeCreate(makeCreateByWithName())).resolves.toBeDefined();
+    await expect(createdName()).resolves.toBeUndefined();
+  });
+
+  it("accepts an ordinary name and stores it as typed", async () => {
+    await expect(createdName("Router Discovery - Region 1100")).resolves.toBe(
+      "Router Discovery - Region 1100",
+    );
+  });
+
+  it("trims the name before storing it", async () => {
+    await expect(createdName("  Switch Discovery  ")).resolves.toBe(
+      "Switch Discovery",
+    );
+  });
+
+  /*
+   * A name pasted out of a spreadsheet cell arrives with a newline in it. The
+   * list renders one line per scan and the probe inlines the name into log
+   * messages, so the fold happens once, here, rather than at each reader.
+   */
+  it("folds a multi-line name onto one line", async () => {
+    await expect(createdName("Router\nDiscovery   1100")).resolves.toBe(
+      "Router Discovery 1100",
+    );
+  });
+
+  /*
+   * The distinction the column depends on: a blank box and an empty box are
+   * the same statement, and both store nothing. An empty string would read as
+   * a name to every caller that asks `scan.name ?`.
+   */
+  it("stores nothing at all for a blank name", async () => {
+    await expect(createdName("")).resolves.toBeUndefined();
+    await expect(createdName("   ")).resolves.toBeUndefined();
+    await expect(createdName("\n\t")).resolves.toBeUndefined();
+  });
+
+  it("rejects a name that would not fit the column", async () => {
+    await expect(
+      onBeforeCreate(makeCreateByWithName("a".repeat(101))),
+    ).rejects.toThrow(BadDataException);
+
+    await expect(
+      onBeforeCreate(makeCreateByWithName("a".repeat(100))),
+    ).resolves.toBeDefined();
+  });
+
+  /*
+   * The hook runs before the model's type checks, so this is the first thing
+   * to see a client that sent the wrong shape. It must be a 400 rather than
+   * the 500 an unguarded `.trim()` would produce.
+   */
+  it("rejects a name that is not text", async () => {
+    for (const value of [1100, true, { name: "Router" }, ["Router"]]) {
+      await expect(onBeforeCreate(makeCreateByWithName(value))).rejects.toThrow(
+        BadDataException,
+      );
+    }
+  });
+
+  it("reports the same message the shared validator does", async () => {
+    const tooLong: string = "a".repeat(101);
+
+    await expect(onBeforeCreate(makeCreateByWithName(tooLong))).rejects.toThrow(
+      ScanNameUtil.getValidationError(tooLong) as string,
+    );
+  });
+
+  // The target is still validated when a name is present.
+  it("still rejects a bad target on a named scan", async () => {
+    const createBy: CreateBy<NetworkDeviceDiscoveryScan> =
+      makeCreateBy("10.22-16.0.1");
+    (createBy.data as unknown as Record<string, unknown>)["name"] =
+      "Router Discovery";
+
+    await expect(onBeforeCreate(createBy)).rejects.toThrow(BadDataException);
+  });
+});
+
+describe("NetworkDeviceDiscoveryScanService name validation on update", () => {
+  type UpdatedNameFunction = (name: unknown) => Promise<unknown>;
+
+  const updatedName: UpdatedNameFunction = async (
+    name: unknown,
+  ): Promise<unknown> => {
+    const updateBy: UpdateBy<NetworkDeviceDiscoveryScan> = makeUpdateBy({
+      name: name,
+    });
+
+    await onBeforeUpdate(updateBy);
+
+    return (updateBy.data as unknown as Record<string, unknown>)["name"];
+  };
+
+  /*
+   * Renaming is the one edit a scan accepts, so this path is the product's,
+   * not just a guard against root writers.
+   */
+  it("accepts and normalizes a rename", async () => {
+    await expect(updatedName("  Switch Discovery — WB Units  ")).resolves.toBe(
+      "Switch Discovery — WB Units",
+    );
+  });
+
+  /*
+   * The form posts an emptied box as an empty string. That means "this scan
+   * has no name", which is NULL — not "", and not `undefined`, which TypeORM
+   * would still try to write.
+   */
+  it("clears the name with null when the box is emptied", async () => {
+    await expect(updatedName("")).resolves.toBeNull();
+    await expect(updatedName("   ")).resolves.toBeNull();
+    await expect(updatedName(null)).resolves.toBeNull();
+  });
+
+  it("rejects a rename that would not fit the column", async () => {
+    await expect(
+      onBeforeUpdate(makeUpdateBy({ name: "a".repeat(101) })),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a rename that is not text", async () => {
+    await expect(onBeforeUpdate(makeUpdateBy({ name: 1100 }))).rejects.toThrow(
+      BadDataException,
+    );
+  });
+
+  /*
+   * The probe claim path writes status/startedAt/statusMessage through the
+   * hookless fast path, and every other run-state write goes through here
+   * without a name. Touching the column on those updates would rewrite a name
+   * nobody asked to change.
+   */
+  it("leaves an update that does not carry a name completely alone", async () => {
+    const updateBy: UpdateBy<NetworkDeviceDiscoveryScan> = makeUpdateBy({
+      status: "Completed",
+      respondedHostCount: 3,
+    });
+
+    await onBeforeUpdate(updateBy);
+
+    expect(Object.prototype.hasOwnProperty.call(updateBy.data, "name")).toBe(
+      false,
     );
   });
 });

--- a/Common/Tests/Utils/NetworkDiscovery/ScanNameUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/ScanNameUtil.test.ts
@@ -1,0 +1,312 @@
+import ScanNameUtil, {
+  DiscoveryScanIdentity,
+} from "../../../Utils/NetworkDiscovery/ScanNameUtil";
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test: the optional name on a Network Device Discovery Scan
+ * (issue #3391).
+ *
+ * Three rules are pinned here, because four different layers depend on all
+ * three agreeing — the create form, the server's write hooks, the Discovery
+ * Scans list, and the probe's own log lines:
+ *
+ *   1. what gets STORED (normalize): one line, trimmed, and nothing at all
+ *      rather than an empty string. A scan is either named or it is not;
+ *      "" is a third state that every `name ?` in the product would read as
+ *      the first one and render as a blank line above the scan target.
+ *   2. what is REJECTED (getValidationError): only two things — a value that
+ *      is not text, and one that would not fit the varchar(100) column. The
+ *      field is optional, so absence and blankness are not errors anywhere.
+ *   3. what a scan is CALLED (getScanLabel): its name and its target
+ *      together, falling back to whichever one it has. Every scan that
+ *      existed before this column did has no name, so the fallback is the
+ *      common case, not the edge case.
+ */
+
+function scan(name?: unknown, cidr?: unknown): DiscoveryScanIdentity {
+  return {
+    name: name as string | null | undefined,
+    cidr: cidr as string | null | undefined,
+  };
+}
+
+const MAX: number = ScanNameUtil.MAX_SCAN_NAME_LENGTH;
+
+describe("ScanNameUtil", () => {
+  /*
+   * The ceiling is the column, not a number this module invented. A name that
+   * passes validation and then fails the INSERT would be the worst of both.
+   */
+  it("caps names at the width of the ShortText column they are stored in", () => {
+    expect(MAX).toBe(ColumnLength.ShortText);
+    expect(MAX).toBe(100);
+  });
+
+  describe("normalize", () => {
+    it("returns null when there is no name", () => {
+      expect(ScanNameUtil.normalize(undefined)).toBeNull();
+      expect(ScanNameUtil.normalize(null)).toBeNull();
+    });
+
+    /*
+     * The distinction that matters most: an operator who typed nothing and one
+     * who typed a space have said the same thing, and the column stores the
+     * same thing for both.
+     */
+    it("returns null for a blank name rather than an empty string", () => {
+      expect(ScanNameUtil.normalize("")).toBeNull();
+      expect(ScanNameUtil.normalize(" ")).toBeNull();
+      expect(ScanNameUtil.normalize("   ")).toBeNull();
+      expect(ScanNameUtil.normalize("\t")).toBeNull();
+      expect(ScanNameUtil.normalize("\n\n")).toBeNull();
+      // A non-breaking space pasted out of a document is still a blank box.
+      expect(ScanNameUtil.normalize("\u00A0")).toBeNull();
+    });
+
+    it("keeps an ordinary name exactly as it was typed", () => {
+      expect(ScanNameUtil.normalize("Router Discovery - Region 1100")).toBe(
+        "Router Discovery - Region 1100",
+      );
+    });
+
+    it("trims the ends", () => {
+      expect(ScanNameUtil.normalize("  Switch Discovery  ")).toBe(
+        "Switch Discovery",
+      );
+    });
+
+    /*
+     * A name is rendered in one table cell and inlined into log lines. A value
+     * pasted out of a spreadsheet cell arrives with a newline in it, and
+     * nothing downstream would ever repair that.
+     */
+    it("folds a multi-line name onto one line", () => {
+      expect(ScanNameUtil.normalize("Router\nDiscovery")).toBe(
+        "Router Discovery",
+      );
+      expect(ScanNameUtil.normalize("Router\r\nDiscovery")).toBe(
+        "Router Discovery",
+      );
+      expect(ScanNameUtil.normalize("Router\tDiscovery")).toBe(
+        "Router Discovery",
+      );
+    });
+
+    it("collapses every run of whitespace to a single space", () => {
+      expect(ScanNameUtil.normalize("Router     Discovery")).toBe(
+        "Router Discovery",
+      );
+      expect(ScanNameUtil.normalize(" WB \n\t  Units ")).toBe("WB Units");
+    });
+
+    it("strips control characters, including ones with no whitespace meaning", () => {
+      expect(ScanNameUtil.normalize("Router\u0000Discovery")).toBe(
+        "Router Discovery",
+      );
+      expect(ScanNameUtil.normalize("Router\u007FDiscovery")).toBe(
+        "Router Discovery",
+      );
+      expect(ScanNameUtil.normalize("\u0001\u0002")).toBeNull();
+    });
+
+    it("leaves punctuation, accents and symbols alone", () => {
+      expect(ScanNameUtil.normalize("Switch Discovery — WB Units (v2)")).toBe(
+        "Switch Discovery — WB Units (v2)",
+      );
+      expect(ScanNameUtil.normalize("Zürich / Køge · 10%")).toBe(
+        "Zürich / Køge · 10%",
+      );
+    });
+
+    /*
+     * The value arrives straight from request JSON, so it is genuinely not
+     * guaranteed to be a string. normalize() answers "what would be stored",
+     * and the answer for a non-string is "nothing" — rejecting it is
+     * getValidationError's job, not this one's.
+     */
+    it("returns null for anything that is not a string", () => {
+      expect(ScanNameUtil.normalize(1100)).toBeNull();
+      expect(ScanNameUtil.normalize(0)).toBeNull();
+      expect(ScanNameUtil.normalize(true)).toBeNull();
+      expect(ScanNameUtil.normalize({ name: "Router" })).toBeNull();
+      expect(ScanNameUtil.normalize(["Router"])).toBeNull();
+      expect(ScanNameUtil.normalize(NaN)).toBeNull();
+    });
+
+    // Normalizing is what gets STORED, so it must not also be a length gate.
+    it("does not truncate a name that is too long to store", () => {
+      const tooLong: string = "a".repeat(MAX + 50);
+
+      expect(ScanNameUtil.normalize(tooLong)).toBe(tooLong);
+    });
+
+    it("is idempotent, so a stored name re-read is left alone", () => {
+      const messy: string = "  Router \n Discovery — Region 1100  ";
+      const once: string | null = ScanNameUtil.normalize(messy);
+
+      expect(ScanNameUtil.normalize(once)).toBe(once);
+    });
+  });
+
+  describe("getValidationError", () => {
+    it("says nothing about a missing name, because the field is optional", () => {
+      expect(ScanNameUtil.getValidationError(undefined)).toBeNull();
+      expect(ScanNameUtil.getValidationError(null)).toBeNull();
+    });
+
+    it("says nothing about a blank name either", () => {
+      expect(ScanNameUtil.getValidationError("")).toBeNull();
+      expect(ScanNameUtil.getValidationError("   ")).toBeNull();
+      expect(ScanNameUtil.getValidationError("\n\t")).toBeNull();
+    });
+
+    it("accepts an ordinary name", () => {
+      expect(
+        ScanNameUtil.getValidationError("Router Discovery - Region 1100"),
+      ).toBeNull();
+    });
+
+    it("accepts a name of exactly the column width", () => {
+      expect(ScanNameUtil.getValidationError("a".repeat(MAX))).toBeNull();
+    });
+
+    it("rejects a name one character past the column width", () => {
+      const error: string | null = ScanNameUtil.getValidationError(
+        "a".repeat(MAX + 1),
+      );
+
+      expect(error).not.toBeNull();
+      expect(error).toContain(String(MAX));
+      expect(error).toContain(String(MAX + 1));
+    });
+
+    /*
+     * Length is measured on what would be STORED. Rejecting a value this
+     * module was about to shorten by trimming would be refusing to save
+     * something perfectly storable.
+     */
+    it("measures the normalized name, not the raw one", () => {
+      expect(
+        ScanNameUtil.getValidationError(` ${"a".repeat(MAX)} \n`),
+      ).toBeNull();
+
+      const collapsible: string = `${"a".repeat(MAX - 2)}     b`;
+
+      expect(collapsible.length).toBeGreaterThan(MAX);
+      expect(ScanNameUtil.getValidationError(collapsible)).toBeNull();
+    });
+
+    it("rejects a value that is not text at all", () => {
+      for (const value of [1100, true, { name: "Router" }, ["Router"]]) {
+        const error: string | null = ScanNameUtil.getValidationError(value);
+
+        expect(error).not.toBeNull();
+        expect(error).toContain("text");
+      }
+    });
+
+    /*
+     * A non-string is reported rather than silently dropped: a client sending
+     * `{"name": 1100}` has made a type error, and quietly storing no name at
+     * all would hide it until someone noticed the scan was unnamed.
+     */
+    it("does not accept a non-string merely because it normalizes to nothing", () => {
+      expect(ScanNameUtil.normalize(1100)).toBeNull();
+      expect(ScanNameUtil.getValidationError(1100)).not.toBeNull();
+    });
+  });
+
+  describe("getDisplayName", () => {
+    it("is the normalized name", () => {
+      expect(ScanNameUtil.getDisplayName(scan("  Router Discovery  "))).toBe(
+        "Router Discovery",
+      );
+    });
+
+    /*
+     * Normalized on the way OUT as well as in, because rows written before the
+     * column existed — and any writer that bypasses the hooks — are not
+     * guaranteed to have been through normalize().
+     */
+    it("is null for a scan with no usable name, whatever the row holds", () => {
+      expect(ScanNameUtil.getDisplayName(scan(undefined))).toBeNull();
+      expect(ScanNameUtil.getDisplayName(scan(null))).toBeNull();
+      expect(ScanNameUtil.getDisplayName(scan(""))).toBeNull();
+      expect(ScanNameUtil.getDisplayName(scan("   "))).toBeNull();
+      expect(ScanNameUtil.getDisplayName(scan(1100))).toBeNull();
+    });
+
+    it("ignores the scan target entirely", () => {
+      expect(
+        ScanNameUtil.getDisplayName(scan(undefined, "10.15.128.0-255")),
+      ).toBeNull();
+    });
+
+    it("reads a row that selected no name column at all", () => {
+      expect(ScanNameUtil.getDisplayName({})).toBeNull();
+    });
+  });
+
+  describe("getScanLabel", () => {
+    it("names a named scan and says what it sweeps", () => {
+      expect(
+        ScanNameUtil.getScanLabel(
+          scan("Router Discovery - Region 1100", "10.15.128.0-255"),
+        ),
+      ).toBe("Router Discovery - Region 1100 (10.15.128.0-255)");
+    });
+
+    // Exactly what every log line and modal said before names existed.
+    it("falls back to the target for an unnamed scan", () => {
+      expect(
+        ScanNameUtil.getScanLabel(scan(undefined, "10.15.128.0-255")),
+      ).toBe("10.15.128.0-255");
+      expect(ScanNameUtil.getScanLabel(scan("", "192.168.1.0/24"))).toBe(
+        "192.168.1.0/24",
+      );
+      expect(ScanNameUtil.getScanLabel(scan("  ", "192.168.1.0/24"))).toBe(
+        "192.168.1.0/24",
+      );
+    });
+
+    it("uses the name alone when the target was not selected", () => {
+      expect(ScanNameUtil.getScanLabel(scan("Router Discovery"))).toBe(
+        "Router Discovery",
+      );
+    });
+
+    /*
+     * Returned empty rather than invented: the only caller that can see this
+     * is one that selected neither column, and each of them appends its own
+     * fallback (the scan id).
+     */
+    it("is empty when the row carries neither", () => {
+      expect(ScanNameUtil.getScanLabel({})).toBe("");
+      expect(ScanNameUtil.getScanLabel(scan(null, null))).toBe("");
+      expect(ScanNameUtil.getScanLabel(scan("  ", "   "))).toBe("");
+    });
+
+    it("normalizes both halves", () => {
+      expect(
+        ScanNameUtil.getScanLabel(scan(" Router\nDiscovery ", " 10.0.0.0/24 ")),
+      ).toBe("Router Discovery (10.0.0.0/24)");
+    });
+
+    it("ignores a target that is not text", () => {
+      expect(ScanNameUtil.getScanLabel(scan("Router Discovery", 10))).toBe(
+        "Router Discovery",
+      );
+      expect(ScanNameUtil.getScanLabel(scan(undefined, 10))).toBe("");
+    });
+
+    it("does not truncate, so a log line always names the whole scan", () => {
+      const long: string = "a".repeat(MAX);
+
+      expect(ScanNameUtil.getScanLabel(scan(long, "10.0.0.0/24"))).toBe(
+        `${long} (10.0.0.0/24)`,
+      );
+    });
+  });
+});

--- a/Common/Utils/NetworkDiscovery/ScanNameUtil.ts
+++ b/Common/Utils/NetworkDiscovery/ScanNameUtil.ts
@@ -1,0 +1,181 @@
+import ColumnLength from "../../Types/Database/ColumnLength";
+
+/*
+ * The optional operator-supplied name on a Network Device Discovery Scan.
+ *
+ * WHY IT EXISTS
+ *
+ * A scan used to be identified by its target alone — `10.15.128.0-255`,
+ * `10.240-249.0-254.220-226`. Half a dozen rows in, nothing on the Discovery
+ * Scans list says which one was the router sweep and which one was the switch
+ * range for a region; the only way to find out is to open each scan and read
+ * the range back against a subnet plan kept somewhere else (OneUptime issue
+ * #3391). A name is that missing sentence, stored with the scan rather than in
+ * a spreadsheet beside it.
+ *
+ * It is deliberately OPTIONAL and deliberately NOT unique: it is a label for
+ * humans, not an identifier. Every scan that existed before this column did
+ * has none, and every surface that shows a name therefore has to keep working
+ * when it is absent — which is what getScanLabel() below is for.
+ *
+ * WHY IT LIVES IN Common
+ *
+ * The same two questions — "is this name storable?" and "what do I call this
+ * scan?" — are asked by the create form (App Dashboard), the write hooks
+ * (Common server service), the recurring-scan worker (App Workers) and the
+ * sweep itself (Probe). Answering them in one module is what keeps the form's
+ * error message identical to the server's, and the probe's log line readable
+ * against the row the operator is looking at. Same reason ScanTargetUtil sits
+ * next door.
+ */
+
+/*
+ * The parts of a scan that answer "which scan is this?". Structural rather
+ * than the model type, so a partially-selected row — the workers and the probe
+ * both select two or three columns — satisfies it, and so this module stays
+ * importable from the Probe without dragging a database model behind it.
+ *
+ * Both are nullable: `cidr` is NOT NULL in the database, but a caller that did
+ * not select it hands over a row where it is simply missing.
+ */
+export interface DiscoveryScanIdentity {
+  name?: string | null | undefined;
+  cidr?: string | null | undefined;
+}
+
+export class ScanNameUtil {
+  /*
+   * Matches the column: NetworkDeviceDiscoveryScan.name is a ShortText, so a
+   * longer value does not truncate in Postgres — it throws, failing the whole
+   * INSERT. Read off ColumnLength rather than written as 100 so the two cannot
+   * drift apart if the column type ever changes.
+   */
+  public static readonly MAX_SCAN_NAME_LENGTH: number = ColumnLength.ShortText;
+
+  /*
+   * ASCII control characters, including DEL. Written as escapes rather than as
+   * a literal range so the characters this guards against cannot end up inside
+   * the guard itself, and so the file stays readable in a diff.
+   *
+   * no-control-regex is disabled deliberately, the same way
+   * MetricResourceAttributeUtil disables it: a control character inside a
+   * user-typed name is precisely what this has to match in order to remove it.
+   */
+  // eslint-disable-next-line no-control-regex
+  private static readonly CONTROL_CHARACTERS: RegExp = /[\u0000-\u001F\u007F]/g;
+
+  /*
+   * The name as it should be stored, or null when the operator supplied none.
+   *
+   * Three things happen here, in this order:
+   *
+   *   - anything that is not a string becomes null. The value arrives straight
+   *     from request JSON (BaseAPI assigns ShortText columns verbatim), so a
+   *     client really can hand over a number, an object or an array. Callers
+   *     that want to REJECT those call getValidationError() first; this
+   *     function's job is only to say what would be stored.
+   *   - control characters — a newline pasted out of a spreadsheet cell, a
+   *     stray tab — become spaces, and every run of whitespace collapses to a
+   *     single space. A name is rendered on one line in a table cell and
+   *     inlined into log messages; a multi-line one breaks both, and nothing
+   *     downstream would ever repair it.
+   *   - the result is trimmed, and an empty result is null rather than "".
+   *     "Not named" is one state, not two: an empty string in the column would
+   *     read as a name everywhere `name ?` is asked, and render as a blank
+   *     first line above the scan target.
+   */
+  public static normalize(name: unknown): string | null {
+    if (typeof name !== "string") {
+      return null;
+    }
+
+    const collapsed: string = name
+      .replace(ScanNameUtil.CONTROL_CHARACTERS, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    return collapsed.length > 0 ? collapsed : null;
+  }
+
+  /*
+   * The single validation entry point for a scan name, shared by the create
+   * form and both write hooks. Returns null when the name is storable —
+   * INCLUDING when there is no name at all, because the field is optional and
+   * "" is a perfectly good way to say so.
+   *
+   * `name` is typed unknown for the same reason ScanTargetUtil's target is:
+   * the server hook runs before the model's own type and length checks, so it
+   * is the first thing to see whatever the client actually sent.
+   */
+  public static getValidationError(name: unknown): string | null {
+    if (name === undefined || name === null) {
+      return null;
+    }
+
+    if (typeof name !== "string") {
+      return "A scan name must be text.";
+    }
+
+    const normalized: string | null = ScanNameUtil.normalize(name);
+
+    if (normalized === null) {
+      return null;
+    }
+
+    /*
+     * Measured against the NORMALIZED value, which is what would be stored:
+     * rejecting a 101-character value that is 100 characters plus a trailing
+     * newline would be refusing to save something this module was about to fix
+     * anyway.
+     */
+    if (normalized.length > ScanNameUtil.MAX_SCAN_NAME_LENGTH) {
+      return (
+        `A scan name cannot be longer than ${ScanNameUtil.MAX_SCAN_NAME_LENGTH} characters. ` +
+        `This one is ${normalized.length}.`
+      );
+    }
+
+    return null;
+  }
+
+  /*
+   * The name to show for a scan, or null when it has none — so a caller can
+   * render the scan target instead rather than an empty line.
+   *
+   * Normalized on the way out as well as on the way in, because rows written
+   * before this column existed, and rows written by any writer that bypasses
+   * the hooks (migrations, the probe-ingest endpoints), are not guaranteed to
+   * have been through normalize().
+   */
+  public static getDisplayName(scan: DiscoveryScanIdentity): string | null {
+    return ScanNameUtil.normalize(scan.name);
+  }
+
+  /*
+   * How to refer to a scan in one line of running text — a log message, a
+   * modal's description, a status note.
+   *
+   * A named scan carries its target along with it (`Router Discovery — Region
+   * 1100 (10.15.128.0-255)`): the name says which scan, the target says what
+   * it sweeps, and an operator reading a log line usually wants both. An
+   * unnamed one is exactly what it was before this column existed — the target
+   * alone.
+   *
+   * Returns "" when the row has neither, which happens only when the caller
+   * selected neither column. Callers append their own fallback (the scan id)
+   * rather than having one invented for them here.
+   */
+  public static getScanLabel(scan: DiscoveryScanIdentity): string {
+    const name: string | null = ScanNameUtil.getDisplayName(scan);
+    const target: string =
+      typeof scan.cidr === "string" ? scan.cidr.trim() : "";
+
+    if (name && target) {
+      return `${name} (${target})`;
+    }
+
+    return name || target || "";
+  }
+}
+
+export default ScanNameUtil;

--- a/Probe/Jobs/Discovery/FetchScans.ts
+++ b/Probe/Jobs/Discovery/FetchScans.ts
@@ -17,6 +17,7 @@ import { JSONArray } from "Common/Types/JSON";
 import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
 import SnmpV3Auth from "Common/Types/Monitor/SnmpMonitor/SnmpV3Auth";
 import SnmpSecurityLevel, {
   SnmpSecurityLevelUtil,
@@ -54,7 +55,8 @@ export function buildSnmpV3Auth(
    * One credential set is built per scan and reused for every host, so a
    * single unreadable value silently blanks the entire sweep.
    */
-  const scanLabel: string = scan.cidr || scan.id?.toString() || "scan";
+  const scanLabel: string =
+    ScanNameUtil.getScanLabel(scan) || scan.id?.toString() || "scan";
 
   if (SnmpSecurityLevelUtil.isUnrecognized(scan.snmpV3SecurityLevel)) {
     throw new Error(
@@ -364,7 +366,9 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
 
   try {
     logger.debug(
-      `Running discovery scan ${scan.id?.toString()} on ${scan.cidr}`,
+      `Running discovery scan ${scan.id?.toString()} on ${
+        ScanNameUtil.getScanLabel(scan) || scan.cidr
+      }`,
     );
 
     scanResult = await scanWithDeadline(

--- a/Probe/Tests/Jobs/Discovery/FetchScans.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScans.test.ts
@@ -152,3 +152,52 @@ describe("FetchScans.buildSnmpV3Auth — recognized values, including drift", ()
     ).toBe(SnmpSecurityLevel.NoAuthNoPriv);
   });
 });
+
+/*
+ * Which scan a probe-side failure is about (issue #3391).
+ *
+ * One credential set is built per scan and reused for every host, so this
+ * message is the operator's whole explanation of a sweep that found nothing.
+ * A probe runs scans for many address ranges, and since scans can be named,
+ * naming the failing one by the name its operator gave it is the difference
+ * between a log line they recognise and one they have to look up.
+ */
+describe("FetchScans.buildSnmpV3Auth — which scan the failure names", () => {
+  test("a named scan is named, with the range it sweeps", () => {
+    expect(() => {
+      return buildSnmpV3Auth(
+        buildScan({
+          name: "Router Discovery - Region 1100",
+          snmpV3PrivProtocol: "nonsense",
+        }),
+      );
+    }).toThrow("Router Discovery - Region 1100 (10.0.0.0/24)");
+  });
+
+  // Exactly what the message said before scans could be named.
+  test("an unnamed scan is named by its target", () => {
+    expect(() => {
+      return buildSnmpV3Auth(buildScan({ snmpV3PrivProtocol: "nonsense" }));
+    }).toThrow("10.0.0.0/24");
+  });
+
+  test("a blank name does not blank out the label", () => {
+    expect(() => {
+      return buildSnmpV3Auth(
+        buildScan({ name: "   ", snmpV3PrivProtocol: "nonsense" }),
+      );
+    }).toThrow("10.0.0.0/24");
+  });
+
+  /*
+   * The last-resort fallback. A row that carries neither still has to produce
+   * a sentence, rather than one with a hole in it.
+   */
+  test("a scan with neither still produces a readable message", () => {
+    expect(() => {
+      return buildSnmpV3Auth(
+        buildScan({ cidr: undefined, snmpV3PrivProtocol: "nonsense" }),
+      );
+    }).toThrow("discovery scan scan");
+  });
+});


### PR DESCRIPTION
Closes #3391.

## The problem

A discovery scan was identified everywhere by the address space it sweeps, so the Discovery Scans list read as a column of octet ranges — `10.15.128.0-255`, `10.114.167.11-38`, `10.240-249.0-254.220-226` — with nothing to say which one was the router sweep and which was the switch range for a region. The issue reports operators tracking that in a spreadsheet beside the product.

## What this does

Scans now carry an **optional** name. Nothing is required and nothing is backfilled: a scan without one reads exactly as it did before.

| | |
|---|---|
| **Model** | `NetworkDeviceDiscoveryScan.name` — nullable ShortText, migration `1789400000000`. Updatable, unlike everything that describes the sweep itself: the target and the credentials describe a sweep already handed to a probe, and a scan mislabelled "Region 1100" is worse than an unnamed one. |
| **Shared rule** | `Common/Utils/NetworkDiscovery/ScanNameUtil` answers "is this storable?" and "what do I call this scan?" for the form, the write hooks, the workers and the probe — the same reason `ScanTargetUtil` sits beside it. Names are normalized on write: folded onto one line, trimmed, and a blank one stored as *no* name rather than as `""`. |
| **Wizard** | Asks for the name first, on the Scan Target step, carrying the very validator the server throws with, so the inline error and the API's 400 are the same sentence. |
| **List** | One identity column: the name, with the target underneath — and the target *alone*, exactly as before, for a scan with no name. Both fields are declared on the column, so both reach the CSV export. Both are filterable. |
| **Rename** | A row action gated on the update permission, so a typo can be fixed without deleting the scan and its results. |
| **Everywhere else** | The Overview card, the review dialog, the recurring-scan worker's log lines and the probe's own sweep logs all name the scan the way its operator named it, falling back to the target. |

## Also in this PR: master was red before it

`master@4c13026b` fails **five** checks — Common Test, App Test, Postgres Schema Drift and js-lint — each from a different change that landed the same day. They are fixed in their own commits so this feature could be verified at all:

1. **Migration registry** — `1789100000000` is claimed by two migrations (`AddNetworkDeviceAutoImportRule`, `AddUserTwoFactorBackupCode`), authored in parallel, both shipped. Neither can be renumbered: TypeORM records a migration by name, so a renamed class reads as one that never ran, and both `CREATE` a table with no `IF NOT EXISTS`. The guard now grandfathers **those two classes by name** — so a third migration on the same stamp is still a new collision — and fails if either class stops existing.
2. **ProbeIngestDiscoveryScan** — the result endpoint started clearing `autoImportProcessedAt` on every upload; the test pinning the exact update payload was never updated with it.
3. **Schema drift** — `NetworkDeviceAutoImportRule`'s hand-written migration used readable index and constraint names, while TypeORM diffs by constraint *name* and expects its own hashes, so every drift run reported the whole table. Fixed on the entity (`@Index("…")`, `@JoinColumn({ foreignKeyConstraintName })`) rather than with an ALTER: keeps the readable names, renames nothing on any installation.
4. **NetworkRuleRunAPI** — the "Run now" endpoints used to coerce a non-boolean body flag to false; the hardening pass made them reject it with a 400 and left four tests pinning the old contract. The tests now say why refusing is right: read as false, a `"true"` string silently skips the reassignment the caller asked for; read as true, it moves devices somebody placed by hand.
5. **js-lint** — two inline regex literals where `wrap-regex` wants parens and `prettier` removes them, so the expression is an error written either way. Hoisted to named constants, with a comment so the next person does not rediscover the loop.

## Verification

- `Common`: 343 suites / 8611 tests green (Models, Utils/NetworkDiscovery, Server/Services, Server/Infrastructure, App/Dashboard)
- `App`: 389 suites / 10,570 tests — green but for two SSO suites that fail only on this machine (a stale `@types/node` in the local install; they pass in CI)
- `Probe`: 1143 tests green
- `npm run check-postgres-schema-drift` against a throwaway Postgres: *"No schema drift. The database matches the entities."*
- `npx eslint` clean on every changed file; `tsc` clean for Common, App, Dashboard and Probe

A five-lens adversarial review raised 13 findings; 11 were refuted on inspection and **2 confirmed and fixed**: the CSV export dropped the scan target (a column exports only the fields it *declares*, and `cidr` was reaching the cell through `selectMoreFields`), and the migration-collision exception was keyed on the timestamp rather than on the two classes sharing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBj4FRa3L9BYnwHbkAy9wA
