### PR TITLE
fix(ui): give YAML fields a YAML editor instead of the Markdown one

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/SecurityEvents/DetectionRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/SecurityEvents/DetectionRules.tsx
@@ -154,8 +154,15 @@ const DetectionRulesPage: FunctionComponent<
           stepId: "sigma-rule",
           description:
             "The Sigma rule to evaluate against incoming security events, in YAML.",
-          fieldType: FormFieldSchemaType.Markdown,
+          /*
+           * YAML, not Markdown. Markdown put a rich-text toolbar (Bold, H1)
+           * over a Sigma rule, and the editor behind it round-trips its value
+           * through HTML - which indentation-sensitive YAML does not survive.
+           */
+          fieldType: FormFieldSchemaType.YAML,
           required: true,
+          placeholder:
+            "Sigma rule YAML — title, logsource, detection and condition.",
         },
         {
           field: {

--- a/Common/Tests/App/Dashboard/SecurityEventsDetectionRulesPage.test.tsx
+++ b/Common/Tests/App/Dashboard/SecurityEventsDetectionRulesPage.test.tsx
@@ -24,6 +24,7 @@ import { MemoryRouter } from "react-router-dom";
 type CapturedFormField = {
   field: Record<string, boolean>;
   title: string;
+  fieldType?: unknown;
   showIf?: ((model: Record<string, unknown>) => boolean) | undefined;
   dropdownModal?: { type: unknown } | undefined;
 };
@@ -58,6 +59,7 @@ jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
 });
 
 import DetectionRulesPage from "../../../../App/FeatureSet/Dashboard/src/Pages/SecurityEvents/DetectionRules";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
 import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
 import IncidentSeverity from "../../../Models/DatabaseModels/IncidentSeverity";
 import Project from "../../../Models/DatabaseModels/Project";
@@ -169,6 +171,59 @@ describe("Detection Rules page", () => {
         shouldWriteDetectionFinding: true,
         shouldCreateIncident: false,
       });
+    });
+  });
+
+  describe("the Sigma rule field is a YAML editor", () => {
+    /*
+     * The rule is YAML — SigmaRuleParser runs js-yaml over it and
+     * DetectionRuleService rejects a create or update whose rule does not
+     * compile. It was declared as Markdown, which put a rich-text toolbar
+     * (Bold, H1) over a Sigma rule and, worse, routed the value through an
+     * editor that round-trips through HTML. Indentation-sensitive YAML does
+     * not survive that.
+     */
+    test("it is declared as YAML", () => {
+      renderPage();
+
+      expect(fieldTitled("Sigma Rule (YAML)").fieldType).toBe(
+        FormFieldSchemaType.YAML,
+      );
+    });
+
+    test("it is not the Markdown editor", () => {
+      renderPage();
+
+      expect(fieldTitled("Sigma Rule (YAML)").fieldType).not.toBe(
+        FormFieldSchemaType.Markdown,
+      );
+    });
+
+    test("it still binds to sigmaRuleYaml on its own form step", () => {
+      renderPage();
+
+      const field: CapturedFormField = fieldTitled("Sigma Rule (YAML)");
+
+      expect(field.field).toEqual({ sigmaRuleYaml: true });
+      expect((field as unknown as { stepId?: string | undefined }).stepId).toBe(
+        "sigma-rule",
+      );
+      expect(
+        (field as unknown as { required?: boolean | undefined }).required,
+      ).toBe(true);
+    });
+
+    test("no other field on the page was switched to YAML by accident", () => {
+      renderPage();
+
+      const yamlFields: Array<CapturedFormField> = (
+        capturedTableProps?.formFields || []
+      ).filter((field: CapturedFormField): boolean => {
+        return field.fieldType === FormFieldSchemaType.YAML;
+      });
+
+      expect(yamlFields).toHaveLength(1);
+      expect(yamlFields[0]?.title).toBe("Sigma Rule (YAML)");
     });
   });
 

--- a/Common/Tests/Types/Code/YamlSyntax.test.ts
+++ b/Common/Tests/Types/Code/YamlSyntax.test.ts
@@ -1,0 +1,295 @@
+import {
+  YamlSyntaxCheckResult,
+  checkYamlSyntax,
+  describeYamlSyntaxError,
+} from "../../../Types/Code/YamlSyntax";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * checkYamlSyntax answers one question — "would a YAML parser accept this
+ * text?" — and is the single source of truth behind both the form-level
+ * validator and the YAML editor's status bar. It is pure: same string in,
+ * same verdict out, no time, network or randomness.
+ *
+ * Its contract deliberately mirrors checkJSONSyntax's: permissive about
+ * anything it cannot decide (non-strings, empty boxes, handlebars loops),
+ * definite about anything it can.
+ */
+
+const VALID_SIGMA_RULE: string = `title: Failed logon burst
+logsource:
+  category: authentication
+detection:
+  selection:
+    className: Authentication
+    statusName: Failure
+  condition: selection
+level: high
+`;
+
+describe("checkYamlSyntax — accepts what a YAML parser accepts", () => {
+  test("a real Sigma rule", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(VALID_SIGMA_RULE);
+
+    expect(result.isValid).toBe(true);
+    expect(result.wasSkipped).toBe(false);
+    expect(result.errorMessage).toBeNull();
+    expect(result.line).toBeNull();
+    expect(result.column).toBeNull();
+  });
+
+  test("a flat mapping", () => {
+    expect(checkYamlSyntax("a: 1\nb: two\n").isValid).toBe(true);
+  });
+
+  test("a sequence", () => {
+    expect(checkYamlSyntax("- one\n- two\n- three\n").isValid).toBe(true);
+  });
+
+  test("flow style, which is also legal JSON", () => {
+    expect(checkYamlSyntax('{"a": 1, "b": [1, 2]}').isValid).toBe(true);
+  });
+
+  test("a bare scalar — a lone word is a valid YAML document", () => {
+    expect(checkYamlSyntax("hello").isValid).toBe(true);
+  });
+
+  test("comments, which the editor must never strip", () => {
+    expect(
+      checkYamlSyntax("# what this rule catches\ntitle: Something\n").isValid,
+    ).toBe(true);
+  });
+
+  test("anchors and aliases", () => {
+    expect(
+      checkYamlSyntax("base: &base\n  a: 1\nderived:\n  <<: *base\n").isValid,
+    ).toBe(true);
+  });
+
+  test("a block scalar", () => {
+    expect(
+      checkYamlSyntax("description: |\n  line one\n  line two\n").isValid,
+    ).toBe(true);
+  });
+
+  /*
+   * A YAML stream can hold several documents separated by `---`. load() throws
+   * on the second one, loadAll() does not — this pins that the implementation
+   * uses loadAll.
+   */
+  test("a multi-document stream", () => {
+    expect(checkYamlSyntax("---\na: 1\n---\nb: 2\n").isValid).toBe(true);
+  });
+
+  test("a document that is only a comment", () => {
+    expect(checkYamlSyntax("# nothing but a note\n").isValid).toBe(true);
+  });
+});
+
+describe("checkYamlSyntax — catches the real mistakes", () => {
+  test("an unclosed flow sequence", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax("title: [unclosed");
+
+    expect(result.isValid).toBe(false);
+    expect(result.wasSkipped).toBe(false);
+    expect(result.errorMessage).toBeTruthy();
+  });
+
+  test("an unclosed flow mapping", () => {
+    expect(checkYamlSyntax("detection: {selection: 1").isValid).toBe(false);
+  });
+
+  test("a tab used for indentation — illegal in YAML, invisible on screen", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(
+      "detection:\n\tselection: 1\n",
+    );
+
+    expect(result.isValid).toBe(false);
+  });
+
+  test("two mapping keys at odds about their indentation", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(
+      "detection:\n  selection: 1\n   condition: selection\n",
+    );
+
+    expect(result.isValid).toBe(false);
+  });
+
+  test("a duplicated mapping key", () => {
+    expect(checkYamlSyntax("title: one\ntitle: two\n").isValid).toBe(false);
+  });
+
+  test("an unclosed quote", () => {
+    expect(checkYamlSyntax('title: "never closed\n').isValid).toBe(false);
+  });
+});
+
+describe("checkYamlSyntax — reports where the failure is", () => {
+  /*
+   * The line and column are the whole point of the message: the editor turns
+   * the gutter on for YAML precisely so the reader can go there.
+   */
+  test("a 1-based line and column, not js-yaml's 0-based mark", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(
+      "title: fine\ndetection:\n  selection: 1\n   condition: selection\n",
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.line).not.toBeNull();
+    expect(result.line).toBeGreaterThanOrEqual(1);
+    expect(result.column).not.toBeNull();
+    expect(result.column).toBeGreaterThanOrEqual(1);
+  });
+
+  test("a single-line reason, not js-yaml's multi-line source excerpt", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax("title: [unclosed");
+
+    expect(result.errorMessage).not.toContain("\n");
+  });
+
+  test("the reason does not repeat the coordinates the caller adds", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(
+      "detection:\n  selection: 1\n   condition: selection\n",
+    );
+
+    // js-yaml's `message` ends with "(3:4)"; its `reason` does not.
+    expect(result.errorMessage).not.toMatch(/\(\d+:\d+\)/);
+  });
+});
+
+describe("checkYamlSyntax — declines to judge what it cannot know", () => {
+  /*
+   * Every one of these is reported valid AND flagged as skipped, so a caller
+   * that wants to explain itself can tell "passed" from "not checked".
+   */
+  test("a non-string, because nothing was typed", () => {
+    for (const value of [undefined, null, 42, true, { a: 1 }, ["a"]]) {
+      const result: YamlSyntaxCheckResult = checkYamlSyntax(value);
+
+      expect(result.isValid).toBe(true);
+      expect(result.wasSkipped).toBe(true);
+    }
+  });
+
+  test("empty and whitespace-only, which is the required check's job", () => {
+    for (const value of ["", "   ", "\n\n", "\t"]) {
+      const result: YamlSyntaxCheckResult = checkYamlSyntax(value);
+
+      expect(result.isValid).toBe(true);
+      expect(result.wasSkipped).toBe(true);
+    }
+  });
+
+  test("a handlebars loop, whose shape is only known at run time", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(
+      "items:\n{{#each local.variables.hosts}}\n  - {{this}}\n{{/each}}\n",
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.wasSkipped).toBe(true);
+  });
+});
+
+describe("checkYamlSyntax — tolerates handlebars the way the JSON check does", () => {
+  test("a template standing in for a value", () => {
+    expect(
+      checkYamlSyntax("threshold: {{local.variables.count}}").isValid,
+    ).toBe(true);
+  });
+
+  test("a template inside a quoted string", () => {
+    expect(
+      checkYamlSyntax('auth: "Bearer {{local.variables.token}}"').isValid,
+    ).toBe(true);
+  });
+
+  test("a whole-field template", () => {
+    expect(
+      checkYamlSyntax("{{local.components.a.returnValues.body}}").isValid,
+    ).toBe(true);
+  });
+
+  test("masking does not paper over a genuine error elsewhere", () => {
+    expect(
+      checkYamlSyntax("threshold: {{local.variables.count}}\nbad: [unclosed")
+        .isValid,
+    ).toBe(false);
+  });
+});
+
+describe("checkYamlSyntax — purity", () => {
+  test("the same input yields the same verdict every time", () => {
+    for (const value of [VALID_SIGMA_RULE, "title: [unclosed", "", "a: 1"]) {
+      expect(checkYamlSyntax(value)).toEqual(checkYamlSyntax(value));
+    }
+  });
+
+  test("does not mutate or consume its input", () => {
+    const original: string = VALID_SIGMA_RULE;
+
+    checkYamlSyntax(original);
+
+    expect(original).toBe(VALID_SIGMA_RULE);
+  });
+});
+
+describe("describeYamlSyntaxError — one readable sentence", () => {
+  test("reason, line and column when all three are known", () => {
+    expect(
+      describeYamlSyntaxError({
+        isValid: false,
+        errorMessage: "bad indentation of a mapping entry",
+        wasSkipped: false,
+        line: 4,
+        column: 3,
+      }),
+    ).toBe("bad indentation of a mapping entry (line 4, column 3)");
+  });
+
+  test("drops the column when the parser did not report one", () => {
+    expect(
+      describeYamlSyntaxError({
+        isValid: false,
+        errorMessage: "unexpected end of the stream",
+        wasSkipped: false,
+        line: 9,
+        column: null,
+      }),
+    ).toBe("unexpected end of the stream (line 9)");
+  });
+
+  test("the bare reason when there is no position at all", () => {
+    expect(
+      describeYamlSyntaxError({
+        isValid: false,
+        errorMessage: "something went wrong",
+        wasSkipped: false,
+        line: null,
+        column: null,
+      }),
+    ).toBe("something went wrong");
+  });
+
+  test("never renders an empty sentence", () => {
+    expect(
+      describeYamlSyntaxError({
+        isValid: false,
+        errorMessage: null,
+        wasSkipped: false,
+        line: null,
+        column: null,
+      }),
+    ).toBe("Invalid YAML.");
+  });
+
+  test("describes a real parse failure end to end", () => {
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(
+      "detection:\n  selection: 1\n   condition: selection\n",
+    );
+
+    const sentence: string = describeYamlSyntaxError(result);
+
+    expect(sentence).toContain("line ");
+    expect(sentence).not.toContain("\n");
+  });
+});

--- a/Common/Tests/UI/Components/CodeEditor.test.tsx
+++ b/Common/Tests/UI/Components/CodeEditor.test.tsx
@@ -28,6 +28,14 @@ interface RecordedEditorProps {
 
 const mockEditorRenders: Array<RecordedEditorProps> = [];
 
+/*
+ * Everything the component pushes onto the MODEL rather than into the options
+ * bag. tabSize/insertSpaces live here on purpose - they are global config in
+ * monaco's standalone build, so setting them per-editor would have the last
+ * editor to mount dictate indentation for every other one on the page.
+ */
+const mockModelOptionUpdates: Array<Record<string, unknown>> = [];
+
 jest.mock("@monaco-editor/react", () => {
   return {
     __esModule: true,
@@ -42,6 +50,7 @@ jest.mock("@monaco-editor/react", () => {
       height?: string | undefined;
       options?: Record<string, unknown> | undefined;
       onChange?: ((value: string | undefined) => void) | undefined;
+      onMount?: ((editor: unknown, monaco: unknown) => void) | undefined;
     }) => {
       mockEditorRenders.push({
         value: editorProps.value,
@@ -52,16 +61,49 @@ jest.mock("@monaco-editor/react", () => {
         options: editorProps.options,
       });
 
+      const hostRef: React.MutableRefObject<HTMLDivElement | null> =
+        React.useRef<HTMLDivElement | null>(null);
+
+      /*
+       * Monaco calls onMount once the editor and its model exist. Child
+       * effects run before the parent's, which is the same order the real
+       * editor mounts in.
+       */
+      React.useEffect(() => {
+        if (!editorProps.onMount) {
+          return;
+        }
+
+        editorProps.onMount(
+          {
+            getDomNode: () => {
+              return hostRef.current;
+            },
+            getModel: () => {
+              return {
+                updateOptions: (options: Record<string, unknown>) => {
+                  mockModelOptionUpdates.push(options);
+                },
+              };
+            },
+          },
+          {},
+        );
+        // eslint-disable-next-line
+      }, []);
+
       return (
-        <textarea
-          data-testid="monaco"
-          value={editorProps.value || ""}
-          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-            if (editorProps.onChange) {
-              editorProps.onChange(event.target.value);
-            }
-          }}
-        />
+        <div ref={hostRef}>
+          <textarea
+            data-testid="monaco"
+            value={editorProps.value || ""}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+              if (editorProps.onChange) {
+                editorProps.onChange(event.target.value);
+              }
+            }}
+          />
+        </div>
       );
     },
   };
@@ -248,17 +290,62 @@ describe("CodeEditor — YAML gets YAML-safe editing options", () => {
   };
 
   /*
-   * A literal tab is illegal as YAML indentation, and Monaco's defaults are
-   * four spaces with detectIndentation ON - so pasting a tab-indented blob
-   * silently reconfigures the editor to emit tabs and the document the user
-   * saves is rejected by the parser.
+   * A literal tab is illegal as YAML indentation, and Monaco's model defaults
+   * are four spaces with the indentation detected from the initial content -
+   * so a rule pasted in tab-indented would keep emitting tabs the parser
+   * rejects.
    */
-  test("two spaces, always spaces, never re-detected", () => {
-    const options: Record<string, unknown> = yamlOptions();
+  test("two spaces, always spaces - set on this editor's own model", () => {
+    mockModelOptionUpdates.length = 0;
 
-    expect(options["tabSize"]).toBe(2);
-    expect(options["insertSpaces"]).toBe(true);
-    expect(options["detectIndentation"]).toBe(false);
+    render(<CodeEditor type={CodeType.YAML} value={"a:\n  b: 1"} />);
+
+    expect(mockModelOptionUpdates).toContainEqual({
+      tabSize: 2,
+      insertSpaces: true,
+    });
+  });
+
+  /*
+   * The regression guard for the reason those three live on the model.
+   * tabSize, insertSpaces and detectIndentation are IGlobalEditorOptions:
+   * monaco's standalone editor writes every registered `editor.*` key it is
+   * constructed with into a PROCESS-WIDE configuration service, and those
+   * three are exactly the ones ModelService reads back and pushes onto every
+   * model on the page. Put them in the options bag and the last editor to
+   * mount silently re-indents all the others.
+   */
+  test.each(["tabSize", "insertSpaces", "detectIndentation"])(
+    "%s is never passed as an editor option - it is global config",
+    (key: string) => {
+      for (const type of [
+        CodeType.YAML,
+        CodeType.JSON,
+        CodeType.JavaScript,
+        CodeType.Markdown,
+        CodeType.Text,
+      ]) {
+        mockEditorRenders.length = 0;
+
+        render(<CodeEditor type={type} value="x" />);
+
+        expect(
+          Object.keys((lastRender().options || {}) as Record<string, unknown>),
+        ).not.toContain(key);
+      }
+    },
+  );
+
+  test("a non-YAML editor touches no model options at all", () => {
+    mockModelOptionUpdates.length = 0;
+
+    render(<CodeEditor type={CodeType.JSON} value="{}" />);
+
+    expect(mockModelOptionUpdates).toHaveLength(0);
+  });
+
+  test("the YAML chrome's padding is supplied by the editor", () => {
+    expect(yamlOptions()["padding"]).toEqual({ top: 10, bottom: 10 });
   });
 
   test("the gutter is on, because every parse error names a line", () => {
@@ -315,9 +402,28 @@ describe("CodeEditor — the other languages are left exactly as they were", () 
   ])("%s keeps Monaco's own indentation behaviour", (type: CodeType) => {
     const options: Record<string, unknown> = optionsFor(type);
 
-    expect(options["tabSize"]).toBe(4);
-    expect(options["detectIndentation"]).toBe(true);
+    expect(options["tabSize"]).toBeUndefined();
+    expect(options["insertSpaces"]).toBeUndefined();
+    expect(options["detectIndentation"]).toBeUndefined();
   });
+
+  test.each([
+    CodeType.JSON,
+    CodeType.JavaScript,
+    CodeType.CSS,
+    CodeType.HTML,
+    CodeType.Markdown,
+    CodeType.Text,
+  ])(
+    "%s keeps its scrolling and padding exactly as before",
+    (type: CodeType) => {
+      const options: Record<string, unknown> = optionsFor(type);
+
+      expect(options["scrollbar"]).toEqual({ horizontal: "hidden" });
+      expect(options["scrollBeyondLastLine"]).toBe(true);
+      expect(options["padding"]).toBeUndefined();
+    },
+  );
 
   test.each([
     CodeType.JSON,
@@ -402,5 +508,131 @@ describe("CodeEditor — a YAML placeholder never becomes document text", () => 
     render(<CodeEditor type={CodeType.YAML} value="" />);
 
     expect(lastRender().defaultValue).toBe("");
+  });
+});
+describe("CodeEditor — accessibility lands on Monaco's input, not the wrapper", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  type InputAreaFunction = () => HTMLTextAreaElement;
+
+  const inputArea: InputAreaFunction = (): HTMLTextAreaElement => {
+    return screen.getByTestId("monaco") as HTMLTextAreaElement;
+  };
+
+  /*
+   * The wrapper this component returns is a bare <div>, i.e. role=generic,
+   * and ARIA forbids naming one - browsers compute no name for it and
+   * assistive technology ignores it. The element that actually takes focus is
+   * Monaco's own textarea, whose default name is the string "Editor content".
+   */
+  test("the field's label names the editor's textarea", () => {
+    render(
+      <CodeEditor
+        type={CodeType.YAML}
+        value="a: 1"
+        ariaLabelledby="the-field-label"
+      />,
+    );
+
+    expect(inputArea().getAttribute("aria-labelledby")).toBe("the-field-label");
+  });
+
+  test("descriptions are associated with the textarea", () => {
+    render(
+      <CodeEditor
+        type={CodeType.YAML}
+        value="a: 1"
+        ariaDescribedby="hint-id status-id"
+      />,
+    );
+
+    expect(inputArea().getAttribute("aria-describedby")).toBe(
+      "hint-id status-id",
+    );
+  });
+
+  test("an invalid document is announced as invalid", () => {
+    render(<CodeEditor type={CodeType.YAML} value="a: [" ariaInvalid={true} />);
+
+    expect(inputArea().getAttribute("aria-invalid")).toBe("true");
+  });
+
+  test("a valid document carries no aria-invalid at all", () => {
+    render(<CodeEditor type={CodeType.YAML} value="a: 1" />);
+
+    expect(inputArea().hasAttribute("aria-invalid")).toBe(false);
+  });
+
+  test("the attributes follow their props after mount", () => {
+    const { rerender } = render(
+      <CodeEditor type={CodeType.YAML} value="a: 1" ariaInvalid={false} />,
+    );
+
+    expect(inputArea().hasAttribute("aria-invalid")).toBe(false);
+
+    rerender(
+      <CodeEditor type={CodeType.YAML} value="a: [" ariaInvalid={true} />,
+    );
+
+    expect(inputArea().getAttribute("aria-invalid")).toBe("true");
+  });
+
+  test("no aria attributes are invented when the caller passes none", () => {
+    render(<CodeEditor type={CodeType.JSON} value="{}" />);
+
+    expect(inputArea().hasAttribute("aria-labelledby")).toBe(false);
+    expect(inputArea().hasAttribute("aria-describedby")).toBe(false);
+  });
+});
+
+describe("CodeEditor — spell check", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  type SpellCheckFunction = () => boolean;
+
+  const spellCheck: SpellCheckFunction = (): boolean => {
+    return (screen.getByTestId("monaco") as HTMLTextAreaElement).spellcheck;
+  };
+
+  // YAML is code: squiggles under every Sigma key name are pure noise.
+  test("is always off for YAML, whatever the caller asked for", () => {
+    render(<CodeEditor type={CodeType.YAML} value="a: 1" />);
+
+    expect(spellCheck()).toBe(false);
+  });
+
+  test("is still off for YAML when the caller explicitly enables it", () => {
+    render(
+      <CodeEditor
+        type={CodeType.YAML}
+        value="a: 1"
+        disableSpellCheck={false}
+      />,
+    );
+
+    expect(spellCheck()).toBe(false);
+  });
+
+  // Markdown is prose, and keeps following the caller exactly as it did.
+  test("follows the caller for Markdown", () => {
+    render(<CodeEditor type={CodeType.Markdown} value="# hi" />);
+
+    expect(spellCheck()).toBe(true);
+  });
+
+  test("is off for Markdown when the caller disables it", () => {
+    render(
+      <CodeEditor
+        type={CodeType.Markdown}
+        value="# hi"
+        disableSpellCheck={true}
+      />,
+    );
+
+    expect(spellCheck()).toBe(false);
   });
 });

--- a/Common/Tests/UI/Components/CodeEditor.test.tsx
+++ b/Common/Tests/UI/Components/CodeEditor.test.tsx
@@ -1,6 +1,7 @@
+import "@testing-library/jest-dom";
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, test } from "@jest/globals";
+import { beforeEach, describe, expect, test } from "@jest/globals";
 import CodeType from "../../../Types/Code/CodeType";
 
 /*
@@ -13,6 +14,16 @@ import CodeType from "../../../Types/Code/CodeType";
 interface RecordedEditorProps {
   value?: string | undefined;
   defaultValue?: string | undefined;
+  /*
+   * The grammar Monaco would tokenise with, and the option bag it would be
+   * configured from. Both are recorded because for YAML they are the feature:
+   * the wrong grammar highlights a Sigma rule as HTML, and the wrong
+   * indentation options emit tabs the parser rejects.
+   */
+  defaultLanguage?: string | undefined;
+  language?: string | undefined;
+  height?: string | undefined;
+  options?: Record<string, unknown> | undefined;
 }
 
 const mockEditorRenders: Array<RecordedEditorProps> = [];
@@ -26,11 +37,19 @@ jest.mock("@monaco-editor/react", () => {
     default: (editorProps: {
       value?: string | undefined;
       defaultValue?: string | undefined;
+      defaultLanguage?: string | undefined;
+      language?: string | undefined;
+      height?: string | undefined;
+      options?: Record<string, unknown> | undefined;
       onChange?: ((value: string | undefined) => void) | undefined;
     }) => {
       mockEditorRenders.push({
         value: editorProps.value,
         defaultValue: editorProps.defaultValue,
+        defaultLanguage: editorProps.defaultLanguage,
+        language: editorProps.language,
+        height: editorProps.height,
+        options: editorProps.options,
       });
 
       return (
@@ -170,5 +189,218 @@ describe("CodeEditor", () => {
     );
 
     expect(getEditor().value).toBe(JSON.stringify({ hello: "world" }, null, 4));
+  });
+});
+
+type LastRenderFunction = () => RecordedEditorProps;
+
+const lastRender: LastRenderFunction = (): RecordedEditorProps => {
+  expect(mockEditorRenders.length).toBeGreaterThan(0);
+
+  return mockEditorRenders[mockEditorRenders.length - 1] as RecordedEditorProps;
+};
+
+describe("CodeEditor — the grammar Monaco is given", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  test.each([
+    [CodeType.YAML, "yaml"],
+    [CodeType.JSON, "json"],
+    [CodeType.JavaScript, "javascript"],
+    [CodeType.CSS, "css"],
+    [CodeType.HTML, "html"],
+    [CodeType.Markdown, "markdown"],
+  ])("%s is handed to Monaco as %s", (type: CodeType, expected: string) => {
+    render(<CodeEditor type={type} value="" />);
+
+    expect(lastRender().defaultLanguage).toBe(expected);
+  });
+
+  /*
+   * `defaultLanguage` is only read when the model is created, so a caller that
+   * swaps CodeType after mount keeps the old grammar unless `language` is also
+   * passed - the prop that drives setModelLanguage.
+   */
+  test("the language prop is passed too, so a type change after mount lands", () => {
+    const { rerender } = render(<CodeEditor type={CodeType.Text} value="" />);
+
+    expect(lastRender().language).toBe("text");
+
+    rerender(<CodeEditor type={CodeType.YAML} value="" />);
+
+    expect(lastRender().language).toBe("yaml");
+  });
+});
+
+describe("CodeEditor — YAML gets YAML-safe editing options", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  type YamlOptionsFunction = () => Record<string, unknown>;
+
+  const yamlOptions: YamlOptionsFunction = (): Record<string, unknown> => {
+    render(<CodeEditor type={CodeType.YAML} value="title: x" />);
+
+    return (lastRender().options || {}) as Record<string, unknown>;
+  };
+
+  /*
+   * A literal tab is illegal as YAML indentation, and Monaco's defaults are
+   * four spaces with detectIndentation ON - so pasting a tab-indented blob
+   * silently reconfigures the editor to emit tabs and the document the user
+   * saves is rejected by the parser.
+   */
+  test("two spaces, always spaces, never re-detected", () => {
+    const options: Record<string, unknown> = yamlOptions();
+
+    expect(options["tabSize"]).toBe(2);
+    expect(options["insertSpaces"]).toBe(true);
+    expect(options["detectIndentation"]).toBe(false);
+  });
+
+  test("the gutter is on, because every parse error names a line", () => {
+    expect(yamlOptions()["lineNumbers"]).toBe("on");
+  });
+
+  /*
+   * Wrapping YAML is not an option - the indentation IS the syntax and a
+   * wrapped line reads as a deeper one - so the horizontal scrollbar is the
+   * only way to reach a long scalar.
+   */
+  test("long lines stay reachable: no wrapping, but a real scrollbar", () => {
+    const options: Record<string, unknown> = yamlOptions();
+
+    expect(options["wordWrap"]).toBe("off");
+    expect(options["scrollbar"]).toEqual({ horizontal: "auto" });
+  });
+
+  test("whitespace is rendered, because in YAML it is the syntax", () => {
+    expect(yamlOptions()["renderWhitespace"]).toBe("boundary");
+  });
+
+  test("no blank runway below the last line in a short form field", () => {
+    expect(yamlOptions()["scrollBeyondLastLine"]).toBe(false);
+  });
+
+  test("folding is on, which YAML's offside rule makes work", () => {
+    expect(yamlOptions()["folding"]).toBe(true);
+  });
+});
+
+describe("CodeEditor — the other languages are left exactly as they were", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  type OptionsForFunction = (type: CodeType) => Record<string, unknown>;
+
+  const optionsFor: OptionsForFunction = (
+    type: CodeType,
+  ): Record<string, unknown> => {
+    render(<CodeEditor type={type} value="x" />);
+
+    return (lastRender().options || {}) as Record<string, unknown>;
+  };
+
+  test.each([
+    CodeType.JSON,
+    CodeType.JavaScript,
+    CodeType.CSS,
+    CodeType.HTML,
+    CodeType.Markdown,
+    CodeType.Text,
+  ])("%s keeps Monaco's own indentation behaviour", (type: CodeType) => {
+    const options: Record<string, unknown> = optionsFor(type);
+
+    expect(options["tabSize"]).toBe(4);
+    expect(options["detectIndentation"]).toBe(true);
+  });
+
+  test.each([
+    CodeType.JSON,
+    CodeType.JavaScript,
+    CodeType.CSS,
+    CodeType.HTML,
+    CodeType.Text,
+  ])("%s keeps its gutter off unless asked", (type: CodeType) => {
+    expect(optionsFor(type)["lineNumbers"]).toBe("off");
+  });
+
+  test("showLineNumbers still turns the gutter on for any type", () => {
+    render(
+      <CodeEditor type={CodeType.JSON} value="{}" showLineNumbers={true} />,
+    );
+
+    expect(
+      ((lastRender().options || {}) as Record<string, unknown>)["lineNumbers"],
+    ).toBe("on");
+  });
+
+  test.each([
+    CodeType.JSON,
+    CodeType.JavaScript,
+    CodeType.CSS,
+    CodeType.HTML,
+    CodeType.Markdown,
+  ])("%s keeps rendering no whitespace", (type: CodeType) => {
+    expect(optionsFor(type)["renderWhitespace"]).toBe("none");
+  });
+
+  test("Markdown still wraps", () => {
+    expect(optionsFor(CodeType.Markdown)["wordWrap"]).toBe("on");
+  });
+});
+
+describe("CodeEditor — height", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  test("defaults to 30vh, as every existing caller expects", () => {
+    render(<CodeEditor type={CodeType.JSON} value="{}" />);
+
+    expect(lastRender().height).toBe("30vh");
+  });
+
+  test("a caller can ask for its own", () => {
+    render(<CodeEditor type={CodeType.YAML} value="a: 1" height="22rem" />);
+
+    expect(lastRender().height).toBe("22rem");
+  });
+});
+
+describe("CodeEditor — a YAML placeholder never becomes document text", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  /*
+   * `defaultValue` seeds the Monaco model, so anything routed there is real
+   * content the user can accidentally save. The JS and CSS arms get away with
+   * it by wrapping the hint in a comment; YAML has no such wrapper, so its
+   * hint has to go to the help text instead.
+   */
+  test("the hint is shown as help text, not seeded into the editor", () => {
+    render(
+      <CodeEditor
+        type={CodeType.YAML}
+        value=""
+        placeholder="Sigma rule YAML — title, logsource, detection and condition."
+      />,
+    );
+
+    expect(lastRender().defaultValue).toBe("");
+    expect(
+      screen.getByText(/Sigma rule YAML/, { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  test("an empty YAML editor still starts empty when no hint is given", () => {
+    render(<CodeEditor type={CodeType.YAML} value="" />);
+
+    expect(lastRender().defaultValue).toBe("");
   });
 });

--- a/Common/Tests/UI/Components/Detail/YamlField.test.tsx
+++ b/Common/Tests/UI/Components/Detail/YamlField.test.tsx
@@ -1,0 +1,105 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+
+import Detail from "../../../../UI/Components/Detail/Detail";
+import Field from "../../../../UI/Components/Detail/Field";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+
+/*
+ * The read-only half of the YAML field type. A YAML value must render as a
+ * highlighted code block - never as prose, and never re-emitted through a
+ * parser: dumping YAML back out drops the comments, anchors and key ordering
+ * a hand-written document (a Sigma rule, a collector config) is written with.
+ */
+
+interface TestItem {
+  sigmaRuleYaml: string;
+  description: string;
+}
+
+const SIGMA_RULE_WITH_COMMENT: string = `# catches password spraying
+title: Failed logon burst
+logsource:
+  category: authentication
+detection:
+  selection:
+    className: Authentication
+  condition: selection
+`;
+
+type RenderDetailFunction = (fieldType: FieldType, value: string) => void;
+
+const renderDetail: RenderDetailFunction = (
+  fieldType: FieldType,
+  value: string,
+): void => {
+  const fields: Array<Field<TestItem>> = [
+    {
+      key: "sigmaRuleYaml",
+      title: "Sigma Rule (YAML)",
+      fieldType,
+    },
+  ];
+
+  render(
+    <Detail<TestItem>
+      item={{ sigmaRuleYaml: value, description: "unused" }}
+      fields={fields}
+    />,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Detail — a YAML field renders as highlighted YAML", () => {
+  test("the value reaches the page", () => {
+    renderDetail(FieldType.YAML, SIGMA_RULE_WITH_COMMENT);
+
+    expect(document.body.textContent).toContain("title: Failed logon burst");
+  });
+
+  test("it renders inside a code block, not as prose", () => {
+    renderDetail(FieldType.YAML, SIGMA_RULE_WITH_COMMENT);
+
+    expect(document.querySelector("pre code")).not.toBeNull();
+  });
+
+  test("it is tagged as the yaml language for the highlighter", () => {
+    renderDetail(FieldType.YAML, SIGMA_RULE_WITH_COMMENT);
+
+    expect(document.querySelector("code.language-yaml")).not.toBeNull();
+  });
+
+  /*
+   * The JSON arm of the same branch pretty-prints by round-tripping through
+   * JSON.parse/stringify. Doing that to YAML would silently rewrite the user's
+   * document; comments are the most visible casualty.
+   */
+  test("comments survive - the document is rendered verbatim", () => {
+    renderDetail(FieldType.YAML, SIGMA_RULE_WITH_COMMENT);
+
+    expect(document.body.textContent).toContain("# catches password spraying");
+  });
+
+  test("indentation survives verbatim", () => {
+    renderDetail(FieldType.YAML, SIGMA_RULE_WITH_COMMENT);
+
+    expect(document.body.textContent).toContain("  condition: selection");
+  });
+
+  test("the field title is still rendered", () => {
+    renderDetail(FieldType.YAML, SIGMA_RULE_WITH_COMMENT);
+
+    expect(screen.getByText("Sigma Rule (YAML)")).toBeInTheDocument();
+  });
+
+  test("a syntactically broken document is still displayed, not swallowed", () => {
+    renderDetail(FieldType.YAML, "title: [unclosed");
+
+    expect(document.body.textContent).toContain("title: [unclosed");
+  });
+});

--- a/Common/Tests/UI/Components/Forms/FormFieldYaml.test.tsx
+++ b/Common/Tests/UI/Components/Forms/FormFieldYaml.test.tsx
@@ -1,0 +1,188 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Monaco stand-in. Needed because FormField reaches CodeEditor through
+ * YamlEditor, and CodeEditor calls configureMonacoLoader() at module scope.
+ */
+jest.mock("@monaco-editor/react", () => {
+  return {
+    __esModule: true,
+    loader: { config: jest.fn() },
+    default: (editorProps: {
+      value?: string | undefined;
+      defaultLanguage?: string | undefined;
+      onChange?: ((value: string | undefined) => void) | undefined;
+    }) => {
+      return (
+        <textarea
+          data-testid="monaco"
+          data-language={editorProps.defaultLanguage}
+          value={editorProps.value || ""}
+          readOnly={true}
+        />
+      );
+    },
+  };
+});
+
+import FormField from "../../../../UI/Components/Forms/Fields/FormField";
+import Field from "../../../../UI/Components/Forms/Types/Field";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import { JSONObject } from "../../../../Types/JSON";
+
+/*
+ * A FormFieldSchemaType member with no render branch in FormField.tsx is a
+ * silent failure: the field draws its label and description above empty
+ * space, and neither the compiler nor the linter says a word. (Query is in
+ * the enum today and does exactly that.) These tests are the guard for YAML.
+ */
+
+interface TestEntity extends JSONObject {
+  sigmaRuleYaml?: string;
+}
+
+const VALID_SIGMA_RULE: string = "title: Failed logon burst\nlevel: high\n";
+
+type RenderFieldFunction = (
+  overrides?: Partial<Field<TestEntity>>,
+  values?: FormValues<TestEntity>,
+) => void;
+
+const renderField: RenderFieldFunction = (
+  overrides?: Partial<Field<TestEntity>>,
+  values?: FormValues<TestEntity>,
+): void => {
+  const field: Field<TestEntity> = {
+    title: "Sigma Rule (YAML)",
+    description: "The Sigma rule to evaluate, in YAML.",
+    name: "sigmaRuleYaml",
+    field: { sigmaRuleYaml: true },
+    fieldType: FormFieldSchemaType.YAML,
+    required: true,
+    ...overrides,
+  } as Field<TestEntity>;
+
+  render(
+    <FormField<TestEntity>
+      field={field}
+      fieldName="sigmaRuleYaml"
+      index={0}
+      isDisabled={false}
+      error=""
+      touched={false}
+      currentValues={
+        (values || {
+          sigmaRuleYaml: VALID_SIGMA_RULE,
+        }) as FormValues<TestEntity>
+      }
+      setFieldTouched={() => {}}
+      setFieldValue={() => {}}
+    />,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FormField — a YAML field renders a YAML editor", () => {
+  test("an editor is rendered at all, not a label above empty space", () => {
+    renderField();
+
+    expect(screen.getByTestId("yaml-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("monaco")).toBeInTheDocument();
+  });
+
+  test("Monaco is given the yaml grammar, not html or markdown", () => {
+    renderField();
+
+    expect(screen.getByTestId("monaco")).toHaveAttribute(
+      "data-language",
+      "yaml",
+    );
+  });
+
+  /*
+   * The bug: a Sigma rule field rendered the rich-text Markdown editor, so it
+   * carried a Bold button and an H1 button.
+   */
+  test("no rich-text toolbar comes with it", () => {
+    renderField();
+
+    for (const label of ["Bold", "Italic", "Heading 1", "Heading 2"]) {
+      expect(screen.queryByTitle(label)).toBeNull();
+    }
+  });
+
+  test("the current value is shown in the editor", () => {
+    renderField();
+
+    expect((screen.getByTestId("monaco") as HTMLTextAreaElement).value).toBe(
+      VALID_SIGMA_RULE,
+    );
+  });
+
+  test("an empty field renders an empty editor rather than crashing", () => {
+    renderField(undefined, {} as FormValues<TestEntity>);
+
+    expect((screen.getByTestId("monaco") as HTMLTextAreaElement).value).toBe(
+      "",
+    );
+  });
+
+  test("the field's label is still rendered above it", () => {
+    renderField();
+
+    expect(screen.getByText("Sigma Rule (YAML)")).toBeInTheDocument();
+  });
+
+  /*
+   * Monaco renders nothing carrying the generated field id, so the label must
+   * name the editor through aria-labelledby instead of a dangling htmlFor
+   * (WCAG 1.3.1). This mirrors what the JSON/HTML/CSS/JavaScript branches do.
+   */
+  test("the label names the editor through aria-labelledby", () => {
+    renderField();
+
+    const labelled: Element | null =
+      document.querySelector("[aria-labelledby]");
+
+    expect(labelled).not.toBeNull();
+
+    const labelId: string = labelled!.getAttribute("aria-labelledby") || "";
+
+    expect(document.getElementById(labelId)).not.toBeNull();
+  });
+
+  test("no <label for> points at an element that does not exist", () => {
+    renderField();
+
+    const labels: Array<HTMLLabelElement> = Array.from(
+      document.querySelectorAll("label[for]"),
+    );
+
+    for (const label of labels) {
+      expect(document.getElementById(label.htmlFor)).not.toBeNull();
+    }
+  });
+
+  test("the dataTestId the page sets reaches the editor", () => {
+    renderField({ dataTestId: "sigma-rule-yaml" });
+
+    expect(screen.getByTestId("sigma-rule-yaml")).toBeInTheDocument();
+  });
+
+  test("a hidden field (showIf false) renders nothing", () => {
+    renderField({
+      showIf: (): boolean => {
+        return false;
+      },
+    });
+
+    expect(screen.queryByTestId("yaml-editor")).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Forms/FormFieldYaml.test.tsx
+++ b/Common/Tests/UI/Components/Forms/FormFieldYaml.test.tsx
@@ -15,14 +15,43 @@ jest.mock("@monaco-editor/react", () => {
       value?: string | undefined;
       defaultLanguage?: string | undefined;
       onChange?: ((value: string | undefined) => void) | undefined;
+      onMount?: ((editor: unknown, monaco: unknown) => void) | undefined;
     }) => {
+      const hostRef: React.MutableRefObject<HTMLDivElement | null> =
+        React.useRef<HTMLDivElement | null>(null);
+
+      React.useEffect(() => {
+        if (!editorProps.onMount) {
+          return;
+        }
+
+        editorProps.onMount(
+          {
+            getDomNode: () => {
+              return hostRef.current;
+            },
+            getModel: () => {
+              return {
+                updateOptions: () => {
+                  return undefined;
+                },
+              };
+            },
+          },
+          {},
+        );
+        // eslint-disable-next-line
+      }, []);
+
       return (
-        <textarea
-          data-testid="monaco"
-          data-language={editorProps.defaultLanguage}
-          value={editorProps.value || ""}
-          readOnly={true}
-        />
+        <div ref={hostRef}>
+          <textarea
+            data-testid="monaco"
+            data-language={editorProps.defaultLanguage}
+            value={editorProps.value || ""}
+            readOnly={true}
+          />
+        </div>
       );
     },
   };
@@ -141,21 +170,35 @@ describe("FormField — a YAML field renders a YAML editor", () => {
   });
 
   /*
-   * Monaco renders nothing carrying the generated field id, so the label must
-   * name the editor through aria-labelledby instead of a dangling htmlFor
-   * (WCAG 1.3.1). This mirrors what the JSON/HTML/CSS/JavaScript branches do.
+   * Monaco renders nothing carrying the generated field id, so the label
+   * cannot use htmlFor without dangling (WCAG 1.3.1). It names the editor
+   * through aria-labelledby instead — and that has to land on Monaco's own
+   * focusable textarea, because the wrapper around it is a bare <div> and
+   * ARIA does not name a role=generic element.
    */
-  test("the label names the editor through aria-labelledby", () => {
+  test("the field's label names Monaco's textarea", () => {
     renderField();
 
-    const labelled: Element | null =
-      document.querySelector("[aria-labelledby]");
+    const labelId: string =
+      screen.getByTestId("monaco").getAttribute("aria-labelledby") || "";
 
-    expect(labelled).not.toBeNull();
+    expect(labelId).not.toBe("");
+    expect(document.getElementById(labelId)?.textContent).toContain(
+      "Sigma Rule (YAML)",
+    );
+  });
 
-    const labelId: string = labelled!.getAttribute("aria-labelledby") || "";
+  test("the editor is described by the hint and the status bar", () => {
+    renderField();
 
-    expect(document.getElementById(labelId)).not.toBeNull();
+    const describedBy: string =
+      screen.getByTestId("monaco").getAttribute("aria-describedby") || "";
+
+    expect(describedBy.split(" ").length).toBeGreaterThanOrEqual(2);
+
+    for (const id of describedBy.split(" ")) {
+      expect(document.getElementById(id)).not.toBeNull();
+    }
   });
 
   test("no <label for> points at an element that does not exist", () => {

--- a/Common/Tests/UI/Components/Forms/Utils/FormFieldSchemaTypeUtil.test.ts
+++ b/Common/Tests/UI/Components/Forms/Utils/FormFieldSchemaTypeUtil.test.ts
@@ -69,6 +69,7 @@ const expectations: Array<SchemaToFieldExpectation> = [
   { schemaType: FormFieldSchemaType.HTML, expected: FieldType.HTML },
   { schemaType: FormFieldSchemaType.RadioButton, expected: FieldType.Text },
   { schemaType: FormFieldSchemaType.JSON, expected: FieldType.JSON },
+  { schemaType: FormFieldSchemaType.YAML, expected: FieldType.YAML },
   { schemaType: FormFieldSchemaType.Query, expected: FieldType.Element },
   {
     schemaType: FormFieldSchemaType.CustomComponent,

--- a/Common/Tests/UI/Components/Forms/ValidationYAML.test.ts
+++ b/Common/Tests/UI/Components/Forms/ValidationYAML.test.ts
@@ -1,0 +1,234 @@
+import Validation from "../../../../UI/Components/Forms/Validation";
+import Field from "../../../../UI/Components/Forms/Types/Field";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The YAML twin of ValidationJSON.test.ts. Its job is the same: block Save on
+ * a document the parser will refuse, and never block on one it will accept.
+ *
+ * The field this exists for is the Detection Rules page's "Sigma Rule (YAML)",
+ * which used to render the Markdown editor. The server compiles the rule on
+ * save either way, so everything here is about hearing the error before the
+ * round trip rather than after it.
+ */
+
+interface TestEntity extends JSONObject {
+  sigmaRuleYaml?: JSONValue;
+  name?: JSONValue;
+}
+
+const VALID_SIGMA_RULE: string = `title: Failed logon burst
+logsource:
+  category: authentication
+detection:
+  selection:
+    className: Authentication
+    statusName: Failure
+  condition: selection
+level: high
+`;
+
+type MakeFieldFunction = (
+  overrides?: Partial<Field<TestEntity>>,
+) => Field<TestEntity>;
+
+const makeYAMLField: MakeFieldFunction = (
+  overrides?: Partial<Field<TestEntity>>,
+): Field<TestEntity> => {
+  return {
+    title: "Sigma Rule (YAML)",
+    name: "sigmaRuleYaml",
+    field: { sigmaRuleYaml: true },
+    fieldType: FormFieldSchemaType.YAML,
+    ...overrides,
+  } as Field<TestEntity>;
+};
+
+type ValidateValueFunction = (
+  value: unknown,
+  field?: Field<TestEntity> | undefined,
+) => string | null;
+
+const validateValue: ValidateValueFunction = (
+  value: unknown,
+  field?: Field<TestEntity> | undefined,
+): string | null => {
+  return Validation.validateYAMLSyntax(
+    value as never,
+    field || makeYAMLField(),
+  );
+};
+
+describe("Validation.validateYAMLSyntax — only acts on YAML fields", () => {
+  test("ignores every other field type", () => {
+    for (const fieldType of [
+      FormFieldSchemaType.Text,
+      FormFieldSchemaType.LongText,
+      FormFieldSchemaType.Markdown,
+      FormFieldSchemaType.JSON,
+      FormFieldSchemaType.JavaScript,
+    ]) {
+      const otherField: Field<TestEntity> = makeYAMLField({ fieldType });
+
+      expect(
+        validateValue("title: [definitely not yaml", otherField),
+      ).toBeNull();
+    }
+  });
+
+  test("names the field in the message", () => {
+    const message: string | null = validateValue("title: [unclosed");
+
+    expect(message).toMatch(/^Sigma Rule \(YAML\) is not valid YAML\./);
+  });
+
+  test("falls back to the field name when it has no title", () => {
+    const untitled: Field<TestEntity> = makeYAMLField();
+    delete (untitled as { title?: string }).title;
+
+    const message: string | null = validateValue("title: [unclosed", untitled);
+
+    expect(message).toMatch(/^sigmaRuleYaml is not valid YAML\./);
+  });
+
+  test("the message carries the parser's reason and position", () => {
+    const message: string | null = validateValue(
+      "detection:\n  selection: 1\n   condition: selection\n",
+    );
+
+    expect(message).toContain("line ");
+    expect(message).toContain("column ");
+  });
+
+  test("the message is one line — it is rendered under a form field", () => {
+    expect(validateValue("title: [unclosed")).not.toContain("\n");
+  });
+});
+
+describe("Validation.validateYAMLSyntax — catches the real mistakes", () => {
+  test("an unclosed flow sequence", () => {
+    expect(validateValue("title: [unclosed")).toBeTruthy();
+  });
+
+  test("a tab used for indentation", () => {
+    expect(validateValue("detection:\n\tselection: 1\n")).toBeTruthy();
+  });
+
+  test("indentation that does not line up", () => {
+    expect(
+      validateValue("detection:\n  selection: 1\n   condition: selection\n"),
+    ).toBeTruthy();
+  });
+
+  test("a duplicated key", () => {
+    expect(validateValue("title: one\ntitle: two\n")).toBeTruthy();
+  });
+});
+
+describe("Validation.validateYAMLSyntax — never fires on a working value", () => {
+  test("a real Sigma rule", () => {
+    expect(validateValue(VALID_SIGMA_RULE)).toBeNull();
+  });
+
+  test("a rule carrying comments", () => {
+    expect(
+      validateValue(`# catches password spraying\n${VALID_SIGMA_RULE}`),
+    ).toBeNull();
+  });
+
+  test("flow style, which is also legal JSON", () => {
+    expect(validateValue('{"title": "x"}')).toBeNull();
+  });
+
+  /*
+   * The raw value is handed in rather than the stringified `content` for the
+   * same reason the JSON validator takes it: String(anObject) is
+   * "[object Object]", which is not the document the user typed.
+   */
+  test("an already-parsed object is not judged as text", () => {
+    expect(validateValue({ title: "x" })).toBeNull();
+    expect(validateValue(["a", "b"])).toBeNull();
+  });
+
+  test("empty, so the required-field message stands instead", () => {
+    expect(validateValue("")).toBeNull();
+    expect(validateValue("   ")).toBeNull();
+    expect(validateValue(undefined)).toBeNull();
+    expect(validateValue(null)).toBeNull();
+  });
+
+  test("handlebars templates, which resolve at run time", () => {
+    expect(validateValue("threshold: {{local.variables.count}}")).toBeNull();
+    expect(
+      validateValue(
+        "items:\n{{#each local.variables.hosts}}\n  - {{this}}\n{{/each}}\n",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("Validation.validate — a YAML field inside a whole form", () => {
+  type ValidateFormFunction = (
+    values: FormValues<TestEntity>,
+    fields?: Array<Field<TestEntity>> | undefined,
+  ) => Dictionary<string>;
+
+  const validateForm: ValidateFormFunction = (
+    values: FormValues<TestEntity>,
+    fields?: Array<Field<TestEntity>> | undefined,
+  ): Dictionary<string> => {
+    return Validation.validate<TestEntity>({
+      formFields: fields || [makeYAMLField({ required: true })],
+      values,
+      onValidate: undefined,
+    });
+  };
+
+  test("a malformed rule stops the form", () => {
+    const errors: Dictionary<string> = validateForm({
+      sigmaRuleYaml: "title: [unclosed",
+    } as FormValues<TestEntity>);
+
+    expect(errors["sigmaRuleYaml"]).toMatch(/is not valid YAML/);
+  });
+
+  test("a well-formed rule leaves the form clean", () => {
+    const errors: Dictionary<string> = validateForm({
+      sigmaRuleYaml: VALID_SIGMA_RULE,
+    } as FormValues<TestEntity>);
+
+    expect(errors["sigmaRuleYaml"]).toBeUndefined();
+  });
+
+  /*
+   * An empty box must read as "required", not as a parse failure — the syntax
+   * check skips empty precisely so this message is the one that survives.
+   */
+  test("an empty required field reports required, not invalid YAML", () => {
+    const errors: Dictionary<string> = validateForm({
+      sigmaRuleYaml: "",
+    } as FormValues<TestEntity>);
+
+    expect(errors["sigmaRuleYaml"]).toBeDefined();
+    expect(errors["sigmaRuleYaml"]).not.toMatch(/is not valid YAML/);
+  });
+
+  test("a hidden field (showIf false) is not validated", () => {
+    const errors: Dictionary<string> = validateForm(
+      { sigmaRuleYaml: "title: [unclosed" } as FormValues<TestEntity>,
+      [
+        makeYAMLField({
+          showIf: (): boolean => {
+            return false;
+          },
+        }),
+      ],
+    );
+
+    expect(errors["sigmaRuleYaml"]).toBeUndefined();
+  });
+});

--- a/Common/Tests/UI/Components/YamlEditor.test.tsx
+++ b/Common/Tests/UI/Components/YamlEditor.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -21,9 +22,24 @@ interface RecordedEditorProps {
   defaultLanguage?: string | undefined;
   options?: Record<string, unknown> | undefined;
   readOnly?: boolean | undefined;
+  height?: string | undefined;
+  /*
+   * Recorded so a test can prove what YamlEditor deliberately WITHHOLDS: the
+   * chrome owns the border and prints the error once, so neither may reach
+   * CodeEditor and be painted a second time.
+   */
+  className?: string | undefined;
+  error?: string | undefined;
 }
 
 const mockEditorRenders: Array<RecordedEditorProps> = [];
+
+/*
+ * tabSize/insertSpaces are set on the MODEL, not in the options bag: in
+ * monaco's standalone build they are global config, so an editor that set
+ * them per-instance would re-indent every other editor on the page.
+ */
+const mockModelOptionUpdates: Array<Record<string, unknown>> = [];
 
 jest.mock("@monaco-editor/react", () => {
   return {
@@ -35,32 +51,69 @@ jest.mock("@monaco-editor/react", () => {
       value?: string | undefined;
       defaultLanguage?: string | undefined;
       options?: Record<string, unknown> | undefined;
+      height?: string | undefined;
+      className?: string | undefined;
+      error?: string | undefined;
       onChange?: ((value: string | undefined) => void) | undefined;
+      onMount?: ((editor: unknown, monaco: unknown) => void) | undefined;
     }) => {
       mockEditorRenders.push({
         value: editorProps.value,
         defaultLanguage: editorProps.defaultLanguage,
         options: editorProps.options,
         readOnly: editorProps.options?.["readOnly"] as boolean | undefined,
+        height: editorProps.height,
+        className: editorProps.className,
+        error: editorProps.error,
       });
 
+      const hostRef: React.MutableRefObject<HTMLDivElement | null> =
+        React.useRef<HTMLDivElement | null>(null);
+
+      React.useEffect(() => {
+        if (!editorProps.onMount) {
+          return;
+        }
+
+        editorProps.onMount(
+          {
+            getDomNode: () => {
+              return hostRef.current;
+            },
+            getModel: () => {
+              return {
+                updateOptions: (modelOptions: Record<string, unknown>) => {
+                  mockModelOptionUpdates.push(modelOptions);
+                },
+              };
+            },
+          },
+          {},
+        );
+        // eslint-disable-next-line
+      }, []);
+
       return (
-        <textarea
-          data-testid="monaco"
-          value={editorProps.value || ""}
-          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-            if (editorProps.onChange) {
-              editorProps.onChange(event.target.value);
-            }
-          }}
-        />
+        <div ref={hostRef}>
+          <textarea
+            data-testid="monaco"
+            value={editorProps.value || ""}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+              if (editorProps.onChange) {
+                editorProps.onChange(event.target.value);
+              }
+            }}
+          />
+        </div>
       );
     },
   };
 });
 
 // Imported after the mock so the module picks up the stand-in editor.
-import YamlEditor from "../../../UI/Components/CodeEditor/YamlEditor";
+import YamlEditor, {
+  YAML_VALIDATION_DEBOUNCE_MS,
+} from "../../../UI/Components/CodeEditor/YamlEditor";
 
 const VALID_SIGMA_RULE: string = `title: Failed logon burst
 logsource:
@@ -132,16 +185,25 @@ describe("YamlEditor — it is a YAML editor, not a rich text editor", () => {
     expect(screen.getByText("YAML")).toBeInTheDocument();
   });
 
-  test("YAML-safe indentation reaches Monaco", () => {
+  test("YAML-safe indentation reaches Monaco's model", () => {
+    mockModelOptionUpdates.length = 0;
+
+    render(<YamlEditor value="a: 1" />);
+
+    expect(mockModelOptionUpdates).toContainEqual({
+      tabSize: 2,
+      insertSpaces: true,
+    });
+  });
+
+  test("the gutter is on, because every parse error names a line", () => {
     render(<YamlEditor value="a: 1" />);
 
     const options: Record<string, unknown> = (mockEditorRenders[0]?.options ||
       {}) as Record<string, unknown>;
 
-    expect(options["tabSize"]).toBe(2);
-    expect(options["insertSpaces"]).toBe(true);
-    expect(options["detectIndentation"]).toBe(false);
     expect(options["lineNumbers"]).toBe("on");
+    expect(options["renderWhitespace"]).toBe("boundary");
   });
 });
 
@@ -230,22 +292,26 @@ describe("YamlEditor — the status bar tells you whether it parses", () => {
     await expectStatus(/1 line(?!s)/);
   });
 
+  /*
+   * The parser's own words, not a generic "Invalid YAML." - the reason is the
+   * only part of the message that tells the reader what to change.
+   */
   test("a broken rule is reported with the parser's reason", async () => {
     render(<YamlEditor value="title: [unclosed" />);
 
-    await waitFor(() => {
-      expect(statusText()).not.toMatch(/Valid YAML/);
-    });
+    await expectStatus(/unexpected end of the stream/i);
+  });
 
-    expect(statusText().length).toBeGreaterThan(0);
+  test("a misindented rule names the indentation as the problem", async () => {
+    render(<YamlEditor value={"a: 1\nb:\n  c: 1\n   d: 2\n"} />);
+
+    await expectStatus(/bad indentation/i);
   });
 
   test("a tab used for indentation is caught", async () => {
     render(<YamlEditor value={"detection:\n\tselection: 1\n"} />);
 
-    await waitFor(() => {
-      expect(statusText()).not.toMatch(/Valid YAML/);
-    });
+    await expectStatus(/tab/i);
   });
 
   test("the failure names a line, which is why the gutter is on", async () => {
@@ -266,7 +332,22 @@ describe("YamlEditor — the status bar tells you whether it parses", () => {
     await expectStatus(/Valid YAML/);
   });
 
-  test("handlebars are not reported as broken", async () => {
+  /*
+   * checkYamlSyntax declines to judge a document whose shape is only known at
+   * run time. Claiming it is valid would be a claim about text nobody parsed.
+   */
+  test("handlebars are reported as unchecked, not as broken and not as valid", async () => {
+    render(
+      <YamlEditor
+        value={"items:\n{{#each hosts}}\n  - {{this}}\n{{/each}}\n"}
+      />,
+    );
+
+    await expectStatus(/syntax not checked/);
+    expect(statusText()).not.toMatch(/Valid YAML/);
+  });
+
+  test("a template standing in for a single value still parses", async () => {
     render(<YamlEditor value="threshold: {{local.variables.count}}" />);
 
     await expectStatus(/Valid YAML/);
@@ -476,5 +557,291 @@ describe("YamlEditor — accessibility and pass-through", () => {
     fireEvent.change(getEditor(), { target: { value: "a: 2" } });
 
     expect(onBlur).toHaveBeenCalled();
+  });
+});
+
+describe("YamlEditor — the parse is debounced", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  type AdvanceFunction = (ms: number) => void;
+
+  const advance: AdvanceFunction = (ms: number): void => {
+    act(() => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+
+  /*
+   * Without the debounce the document is judged on every keystroke, so a rule
+   * flashes an error the instant a line is half typed. This pins that the
+   * status waits for the typing to stop.
+   */
+  test("a keystroke does not immediately re-judge the document", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    advance(YAML_VALIDATION_DEBOUNCE_MS);
+    expect(statusText()).toMatch(/Valid YAML/);
+
+    fireEvent.change(getEditor(), { target: { value: "a: [" } });
+
+    // One tick short of the debounce: the old verdict still stands.
+    advance(YAML_VALIDATION_DEBOUNCE_MS - 1);
+    expect(statusText()).toMatch(/Valid YAML/);
+
+    advance(1);
+    expect(statusText()).not.toMatch(/Valid YAML/);
+  });
+
+  test("only the settled text is judged, not every intermediate one", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    advance(YAML_VALIDATION_DEBOUNCE_MS);
+
+    fireEvent.change(getEditor(), { target: { value: "a: [" } });
+    advance(50);
+    fireEvent.change(getEditor(), { target: { value: "a: [1" } });
+    advance(50);
+    fireEvent.change(getEditor(), { target: { value: "a: [1]" } });
+
+    // The two broken intermediates never made it to the status bar.
+    expect(statusText()).toMatch(/Valid YAML/);
+
+    advance(YAML_VALIDATION_DEBOUNCE_MS);
+    expect(statusText()).toMatch(/Valid YAML/);
+  });
+
+  /*
+   * The form re-validates synchronously on every keystroke and marks the field
+   * touched from the first one, so props.error is undebounced. Letting it win
+   * immediately would put a red message under a half-typed line and defeat the
+   * debounce entirely.
+   */
+  test("an undebounced form error does not overtake the debounced status", () => {
+    const { rerender } = render(<YamlEditor value="a: 1" />);
+
+    advance(YAML_VALIDATION_DEBOUNCE_MS);
+    expect(statusText()).toMatch(/Valid YAML/);
+
+    rerender(<YamlEditor value="a: [" error="Config is not valid YAML." />);
+
+    expect(statusText()).not.toMatch(/Config is not valid YAML/);
+
+    advance(YAML_VALIDATION_DEBOUNCE_MS);
+    expect(statusText()).toMatch(/Config is not valid YAML/);
+  });
+
+  test("the copy confirmation goes back to Copy on its own", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: () => {
+          return Promise.resolve();
+        },
+      },
+      configurable: true,
+    });
+
+    fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+    expect(screen.getByTestId("yaml-editor-copy-button")).toHaveTextContent(
+      "Copied",
+    );
+
+    advance(2000);
+
+    expect(screen.getByTestId("yaml-editor-copy-button")).toHaveTextContent(
+      "Copy",
+    );
+    expect(screen.getByTestId("yaml-editor-copy-button")).not.toHaveTextContent(
+      "Copied",
+    );
+  });
+});
+
+describe("YamlEditor — what it withholds from CodeEditor", () => {
+  beforeEach(() => {
+    mockEditorRenders.length = 0;
+  });
+
+  type LastRenderFunction = () => RecordedEditorProps;
+
+  const lastRender: LastRenderFunction = (): RecordedEditorProps => {
+    expect(mockEditorRenders.length).toBeGreaterThan(0);
+
+    return mockEditorRenders[
+      mockEditorRenders.length - 1
+    ] as RecordedEditorProps;
+  };
+
+  /*
+   * CodeEditor renders its own red border and its own copy of the error under
+   * the box. The chrome already says it once in the status bar, so forwarding
+   * the error would say it twice and outline it twice.
+   */
+  test("the error is not forwarded — the status bar is the single voice", () => {
+    render(<YamlEditor value="a: [" error="Config is not valid YAML." />);
+
+    expect(lastRender().error).toBeUndefined();
+  });
+
+  test("the editor is given a chrome-free className", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    const className: string = lastRender().className || "";
+
+    expect(className).not.toContain("border");
+    expect(className).not.toContain("rounded");
+    expect(className).not.toContain("shadow");
+  });
+
+  test("it is tall enough to author a rule in", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    expect(lastRender().height).toBe("22rem");
+  });
+
+  test("a caller can still choose the height", () => {
+    render(<YamlEditor value="a: 1" height="40rem" />);
+
+    expect(lastRender().height).toBe("40rem");
+  });
+});
+
+describe("YamlEditor — the editor's own accessible description", () => {
+  /*
+   * Monaco takes Tab to indent, so Tab cannot leave the editor. WCAG 2.1.2 is
+   * met only if the user is told the way out — which means the advisory has to
+   * reach them on the way IN, not as trailing text they meet on the way past.
+   */
+  test("the escape hatch and the status are described to Monaco's input", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    const describedBy: string =
+      getEditor().getAttribute("aria-describedby") || "";
+
+    expect(describedBy.split(" ")).toHaveLength(3);
+
+    for (const id of describedBy.split(" ")) {
+      expect(document.getElementById(id)).not.toBeNull();
+    }
+  });
+
+  test("the escape hint comes before the editor in reading order", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    const hint: HTMLElement = screen.getByText(/toggle whether the Tab key/);
+    const editor: HTMLElement = getEditor();
+
+    expect(
+      hint.compareDocumentPosition(editor) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test("a broken document is announced as invalid to assistive technology", async () => {
+    render(<YamlEditor value="a: [" error="Config is not valid YAML." />);
+
+    await waitFor(() => {
+      expect(getEditor().getAttribute("aria-invalid")).toBe("true");
+    });
+  });
+
+  test("a clean document carries no aria-invalid", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    expect(getEditor().hasAttribute("aria-invalid")).toBe(false);
+  });
+
+  test("the copy confirmation is announced, not just drawn", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: () => {
+          return Promise.resolve();
+        },
+      },
+      configurable: true,
+    });
+
+    render(<YamlEditor value="a: 1" />);
+
+    fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+
+    const liveRegions: Array<HTMLElement> = screen.getAllByRole("status");
+
+    expect(
+      liveRegions.some((region: HTMLElement): boolean => {
+        return (region.textContent || "").includes("YAML copied to clipboard");
+      }),
+    ).toBe(true);
+  });
+
+  test("the copy button's own name tracks its state", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: () => {
+          return Promise.resolve();
+        },
+      },
+      configurable: true,
+    });
+
+    render(<YamlEditor value="a: 1" />);
+
+    const button: HTMLElement = screen.getByTestId("yaml-editor-copy-button");
+
+    expect(button.getAttribute("aria-label")).toBe("Copy YAML to clipboard");
+
+    fireEvent.click(button);
+
+    /*
+     * WCAG 2.5.3: while the visible label reads "Copied", the accessible name
+     * has to contain it, or speech input users cannot address the control.
+     */
+    expect(button.getAttribute("aria-label")).toContain("copied");
+    expect(button).toHaveTextContent("Copied");
+  });
+});
+
+describe("YamlEditor — the tab-trap escape hint names the right key", () => {
+  type SetPlatformFunction = (platform: string) => void;
+
+  const setPlatform: SetPlatformFunction = (platform: string): void => {
+    Object.defineProperty(navigator, "platform", {
+      value: platform,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    setPlatform("Linux x86_64");
+  });
+
+  /*
+   * Monaco binds toggleTabFocusMode to Ctrl+M everywhere except macOS, whose
+   * `mac` override makes it Ctrl+Shift+M. Naming the wrong key turns the
+   * keyboard-trap advisory (WCAG 2.1.2) into a false one — the user presses a
+   * combination bound to nothing and stays trapped.
+   */
+  test("Ctrl+M off macOS", () => {
+    setPlatform("Linux x86_64");
+
+    render(<YamlEditor value="a: 1" />);
+
+    expect(screen.getByText(/Press Control plus M to toggle/)).toBeTruthy();
+  });
+
+  test("Ctrl+Shift+M on macOS", () => {
+    setPlatform("MacIntel");
+
+    render(<YamlEditor value="a: 1" />);
+
+    expect(
+      screen.getByText(/Press Control plus Shift plus M to toggle/),
+    ).toBeTruthy();
   });
 });

--- a/Common/Tests/UI/Components/YamlEditor.test.tsx
+++ b/Common/Tests/UI/Components/YamlEditor.test.tsx
@@ -1,0 +1,480 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Monaco cannot run in jsdom, so it is replaced with a textarea that echoes
+ * the props <Editor> was given. Every suite that mounts CodeEditor has to
+ * declare its own copy of this mock - there is no shared __mocks__ entry - and
+ * it must export `loader`, because CodeEditor calls configureMonacoLoader() at
+ * module scope.
+ */
+interface RecordedEditorProps {
+  value?: string | undefined;
+  defaultLanguage?: string | undefined;
+  options?: Record<string, unknown> | undefined;
+  readOnly?: boolean | undefined;
+}
+
+const mockEditorRenders: Array<RecordedEditorProps> = [];
+
+jest.mock("@monaco-editor/react", () => {
+  return {
+    __esModule: true,
+    loader: {
+      config: jest.fn(),
+    },
+    default: (editorProps: {
+      value?: string | undefined;
+      defaultLanguage?: string | undefined;
+      options?: Record<string, unknown> | undefined;
+      onChange?: ((value: string | undefined) => void) | undefined;
+    }) => {
+      mockEditorRenders.push({
+        value: editorProps.value,
+        defaultLanguage: editorProps.defaultLanguage,
+        options: editorProps.options,
+        readOnly: editorProps.options?.["readOnly"] as boolean | undefined,
+      });
+
+      return (
+        <textarea
+          data-testid="monaco"
+          value={editorProps.value || ""}
+          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+            if (editorProps.onChange) {
+              editorProps.onChange(event.target.value);
+            }
+          }}
+        />
+      );
+    },
+  };
+});
+
+// Imported after the mock so the module picks up the stand-in editor.
+import YamlEditor from "../../../UI/Components/CodeEditor/YamlEditor";
+
+const VALID_SIGMA_RULE: string = `title: Failed logon burst
+logsource:
+  category: authentication
+detection:
+  selection:
+    className: Authentication
+  condition: selection
+`;
+
+type GetEditorFunction = () => HTMLTextAreaElement;
+
+const getEditor: GetEditorFunction = (): HTMLTextAreaElement => {
+  return screen.getByTestId("monaco") as HTMLTextAreaElement;
+};
+
+type StatusTextFunction = () => string;
+
+const statusText: StatusTextFunction = (): string => {
+  return screen.getByTestId("yaml-editor-status").textContent || "";
+};
+
+type ExpectStatusFunction = (matcher: RegExp) => Promise<void>;
+
+/*
+ * The parse is debounced, so the status bar is always asserted through
+ * waitFor rather than read synchronously after a keystroke.
+ */
+const expectStatus: ExpectStatusFunction = async (
+  matcher: RegExp,
+): Promise<void> => {
+  await waitFor(() => {
+    expect(statusText()).toMatch(matcher);
+  });
+};
+
+beforeEach(() => {
+  mockEditorRenders.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("YamlEditor — it is a YAML editor, not a rich text editor", () => {
+  /*
+   * The bug this component exists for: the "Sigma Rule (YAML)" field rendered
+   * the Markdown editor, so a Sigma rule got a Bold button and an H1 button
+   * over it - and the value was round-tripped through HTML, which
+   * indentation-sensitive YAML does not survive.
+   */
+  test("Monaco is given the yaml grammar", () => {
+    render(<YamlEditor value={VALID_SIGMA_RULE} />);
+
+    expect(mockEditorRenders[0]?.defaultLanguage).toBe("yaml");
+  });
+
+  test("there is no rich-text toolbar anywhere in it", () => {
+    render(<YamlEditor value={VALID_SIGMA_RULE} />);
+
+    for (const label of ["Bold", "Italic", "Heading 1", "Heading 2", "Link"]) {
+      expect(screen.queryByTitle(label)).toBeNull();
+    }
+  });
+
+  test("the header names the language", () => {
+    render(<YamlEditor value="" />);
+
+    expect(screen.getByText("YAML")).toBeInTheDocument();
+  });
+
+  test("YAML-safe indentation reaches Monaco", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    const options: Record<string, unknown> = (mockEditorRenders[0]?.options ||
+      {}) as Record<string, unknown>;
+
+    expect(options["tabSize"]).toBe(2);
+    expect(options["insertSpaces"]).toBe(true);
+    expect(options["detectIndentation"]).toBe(false);
+    expect(options["lineNumbers"]).toBe("on");
+  });
+});
+
+describe("YamlEditor — the value it shows", () => {
+  test("renders the value prop", () => {
+    render(<YamlEditor value={VALID_SIGMA_RULE} />);
+
+    expect(getEditor().value).toBe(VALID_SIGMA_RULE);
+  });
+
+  test("renders initialValue when no value is given", () => {
+    render(<YamlEditor initialValue="a: 1" />);
+
+    expect(getEditor().value).toBe("a: 1");
+  });
+
+  test("prefers value over initialValue", () => {
+    render(<YamlEditor initialValue="stale: true" value="current: true" />);
+
+    expect(getEditor().value).toBe("current: true");
+  });
+
+  test("follows the value prop after mount", () => {
+    const { rerender } = render(<YamlEditor value="a: 1" />);
+
+    expect(getEditor().value).toBe("a: 1");
+
+    rerender(<YamlEditor value="a: 2" />);
+
+    expect(getEditor().value).toBe("a: 2");
+  });
+
+  test("picks up a value that only arrives later", () => {
+    const { rerender } = render(<YamlEditor />);
+
+    expect(getEditor().value).toBe("");
+
+    rerender(<YamlEditor value={VALID_SIGMA_RULE} />);
+
+    expect(getEditor().value).toBe(VALID_SIGMA_RULE);
+  });
+
+  test("a non-string value is stringified rather than crashing", () => {
+    render(<YamlEditor value={{ a: 1 } as unknown as string} />);
+
+    expect(getEditor().value).toBe(JSON.stringify({ a: 1 }, null, 4));
+  });
+
+  test("reports edits to onChange", () => {
+    const onChange: jest.Mock = jest.fn();
+
+    render(<YamlEditor value="before: 1" onChange={onChange} />);
+
+    fireEvent.change(getEditor(), { target: { value: "after: 2" } });
+
+    expect(onChange).toHaveBeenCalledWith("after: 2");
+  });
+
+  test("typing is reflected even when the parent does not feed the value back", () => {
+    // The form field is controlled, but a bare caller may not be.
+    render(<YamlEditor />);
+
+    fireEvent.change(getEditor(), { target: { value: "typed: yes" } });
+
+    expect(getEditor().value).toBe("typed: yes");
+  });
+});
+
+describe("YamlEditor — the status bar tells you whether it parses", () => {
+  test("an empty editor says so instead of claiming an error", async () => {
+    render(<YamlEditor value="" />);
+
+    await expectStatus(/Nothing entered yet/);
+  });
+
+  test("a valid rule is confirmed, with a line count", async () => {
+    render(<YamlEditor value={"a: 1\nb: 2\n"} />);
+
+    await expectStatus(/Valid YAML/);
+    await expectStatus(/3 lines/);
+  });
+
+  test("a one-line document says line, not lines", async () => {
+    render(<YamlEditor value="a: 1" />);
+
+    await expectStatus(/1 line(?!s)/);
+  });
+
+  test("a broken rule is reported with the parser's reason", async () => {
+    render(<YamlEditor value="title: [unclosed" />);
+
+    await waitFor(() => {
+      expect(statusText()).not.toMatch(/Valid YAML/);
+    });
+
+    expect(statusText().length).toBeGreaterThan(0);
+  });
+
+  test("a tab used for indentation is caught", async () => {
+    render(<YamlEditor value={"detection:\n\tselection: 1\n"} />);
+
+    await waitFor(() => {
+      expect(statusText()).not.toMatch(/Valid YAML/);
+    });
+  });
+
+  test("the failure names a line, which is why the gutter is on", async () => {
+    render(<YamlEditor value={"a: 1\nb:\n  c: 1\n   d: 2\n"} />);
+
+    await expectStatus(/line \d+/);
+  });
+
+  test("it re-checks as the document is edited", async () => {
+    render(<YamlEditor value="title: [unclosed" />);
+
+    await waitFor(() => {
+      expect(statusText()).not.toMatch(/Valid YAML/);
+    });
+
+    fireEvent.change(getEditor(), { target: { value: "title: fixed" } });
+
+    await expectStatus(/Valid YAML/);
+  });
+
+  test("handlebars are not reported as broken", async () => {
+    render(<YamlEditor value="threshold: {{local.variables.count}}" />);
+
+    await expectStatus(/Valid YAML/);
+  });
+
+  test("it is announced politely rather than interrupting", () => {
+    render(<YamlEditor value="a: 1" />);
+
+    const status: HTMLElement = screen.getByTestId("yaml-editor-status");
+
+    expect(status).toHaveAttribute("role", "status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+});
+
+describe("YamlEditor — a form error is shown once, not twice", () => {
+  /*
+   * The form's own message wins whenever there is one, because it is the
+   * sentence blocking Save. It must also not reach CodeEditor, which would
+   * paint a second red border and print the text a second time under the box.
+   */
+  test("the form error replaces the live status", async () => {
+    render(
+      <YamlEditor
+        value="title: [unclosed"
+        error="Sigma Rule (YAML) is not valid YAML. unexpected end of the stream"
+      />,
+    );
+
+    await expectStatus(/unexpected end of the stream/);
+  });
+
+  test("the error text appears exactly once in the whole component", () => {
+    const message: string = "Sigma Rule (YAML) is required.";
+
+    render(<YamlEditor value="" error={message} />);
+
+    expect(screen.getAllByText(message)).toHaveLength(1);
+  });
+
+  test("a valid document with a form error still shows the error", async () => {
+    render(<YamlEditor value="a: 1" error="Something else is wrong." />);
+
+    await expectStatus(/Something else is wrong/);
+    expect(statusText()).not.toMatch(/Valid YAML/);
+  });
+
+  test("clearing the error hands the status bar back to the parser", async () => {
+    const { rerender } = render(
+      <YamlEditor value="a: 1" error="Something else is wrong." />,
+    );
+
+    await expectStatus(/Something else is wrong/);
+
+    rerender(<YamlEditor value="a: 1" />);
+
+    await expectStatus(/Valid YAML/);
+  });
+});
+
+describe("YamlEditor — copying the document", () => {
+  type WriteTextMock = jest.Mock;
+
+  let writeText: WriteTextMock;
+
+  beforeEach(() => {
+    writeText = jest.fn(() => {
+      return Promise.resolve();
+    });
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  test("copies exactly what is in the editor", () => {
+    render(<YamlEditor value={VALID_SIGMA_RULE} />);
+
+    fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+
+    expect(writeText).toHaveBeenCalledWith(VALID_SIGMA_RULE);
+  });
+
+  test("copies the edited text, not the text it mounted with", () => {
+    render(<YamlEditor initialValue="old: 1" />);
+
+    fireEvent.change(getEditor(), { target: { value: "new: 2" } });
+    fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+
+    expect(writeText).toHaveBeenCalledWith("new: 2");
+  });
+
+  test("confirms the copy", async () => {
+    render(<YamlEditor value="a: 1" />);
+
+    fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("yaml-editor-copy-button")).toHaveTextContent(
+        "Copied",
+      );
+    });
+  });
+
+  test("there is nothing to copy from an empty editor", () => {
+    render(<YamlEditor value="" />);
+
+    expect(screen.getByTestId("yaml-editor-copy-button")).toBeDisabled();
+  });
+
+  test("a browser with no clipboard API does not throw", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+
+    render(<YamlEditor value="a: 1" />);
+
+    expect(() => {
+      fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+    }).not.toThrow();
+  });
+
+  test("a denied clipboard permission does not throw", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: jest.fn(() => {
+          return Promise.reject(new Error("denied"));
+        }),
+      },
+      configurable: true,
+    });
+
+    render(<YamlEditor value="a: 1" />);
+
+    expect(() => {
+      fireEvent.click(screen.getByTestId("yaml-editor-copy-button"));
+    }).not.toThrow();
+  });
+});
+
+describe("YamlEditor — the hint above the editor", () => {
+  test("says how YAML indentation works when the caller has nothing to add", () => {
+    render(<YamlEditor value="" />);
+
+    expect(screen.getByTestId("yaml-editor-hint").textContent).toMatch(
+      /2 spaces/,
+    );
+    expect(screen.getByTestId("yaml-editor-hint").textContent).toMatch(
+      /[Tt]abs/,
+    );
+  });
+
+  test("a caller's placeholder replaces it", () => {
+    render(<YamlEditor value="" placeholder="Sigma rule YAML." />);
+
+    expect(screen.getByTestId("yaml-editor-hint")).toHaveTextContent(
+      "Sigma rule YAML.",
+    );
+  });
+
+  /*
+   * The hint must never be seeded into the document: whatever Monaco is given
+   * as its initial content is text the user can accidentally save, and the
+   * server would reject a prose sentence as a Sigma rule.
+   */
+  test("the hint is never written into the editor", () => {
+    render(<YamlEditor value="" placeholder="Sigma rule YAML." />);
+
+    expect(getEditor().value).toBe("");
+  });
+});
+
+describe("YamlEditor — accessibility and pass-through", () => {
+  test("the field label names the editor", () => {
+    render(<YamlEditor value="" ariaLabelledby="field-label-id" />);
+
+    expect(
+      document.querySelector('[aria-labelledby="field-label-id"]'),
+    ).not.toBeNull();
+  });
+
+  test("the caller's dataTestId reaches the editor itself", () => {
+    render(<YamlEditor value="" dataTestId="sigma-rule-yaml" />);
+
+    expect(screen.getByTestId("sigma-rule-yaml")).toBeInTheDocument();
+  });
+
+  test("readOnly reaches Monaco", () => {
+    render(<YamlEditor value="a: 1" readOnly={true} />);
+
+    expect(mockEditorRenders[0]?.readOnly).toBe(true);
+  });
+
+  test("a keyboard user is told how to get out of the editor", () => {
+    render(<YamlEditor value="" />);
+
+    expect(screen.getByText(/Control plus M/)).toBeInTheDocument();
+  });
+
+  test("blur is reported so the form can mark the field touched", () => {
+    const onBlur: jest.Mock = jest.fn();
+
+    render(<YamlEditor value="a: 1" onBlur={onBlur} />);
+
+    fireEvent.change(getEditor(), { target: { value: "a: 2" } });
+
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/Common/Types/Code/YamlSyntax.ts
+++ b/Common/Types/Code/YamlSyntax.ts
@@ -1,0 +1,180 @@
+import {
+  hasEachBlock,
+  maskTemplateExpressions,
+} from "../Workflow/TemplateSyntax";
+import yaml from "js-yaml";
+
+/*
+ * Is this text parseable as YAML?
+ *
+ * The JSON twin of this module lives in Types/Workflow/TemplateSyntax.ts
+ * (checkJSONSyntax) and this deliberately mirrors its contract, because the
+ * two are used side by side by Forms/Validation.ts and a caller should not
+ * have to remember which one skips what.
+ *
+ * Deliberately permissive, for the same reason checkJSONSyntax is: a false
+ * positive blocks Save on a document that actually works. Anything this
+ * module cannot decide about is reported valid and flagged as skipped.
+ */
+
+export interface YamlSyntaxCheckResult {
+  /**
+   * False only when the document is definitely malformed. A value this module
+   * cannot decide about (a handlebars loop, a non-string, an empty box) is
+   * reported valid.
+   */
+  isValid: boolean;
+  /**
+   * The parser's own reason ("bad indentation of a mapping entry"), with no
+   * framing around it and no source snippet - callers phrase the sentence,
+   * since a form error and an editor status bar word it differently. Null
+   * when valid.
+   */
+  errorMessage: string | null;
+  /** True when the check was skipped rather than passed. */
+  wasSkipped: boolean;
+  /** 1-based line of the failure, when the parser reported one. */
+  line: number | null;
+  /** 1-based column of the failure, when the parser reported one. */
+  column: number | null;
+}
+
+/*
+ * js-yaml throws a YAMLException carrying `reason` (the message without the
+ * source snippet) and `mark` (0-based line/column). Neither is on the public
+ * type, and both are absent on a non-YAMLException, so read them defensively.
+ */
+interface YamlExceptionShape {
+  reason?: string | undefined;
+  mark?: { line?: number | undefined; column?: number | undefined } | undefined;
+}
+
+type ReadMarkFunction = (error: unknown) => {
+  line: number | null;
+  column: number | null;
+};
+
+const readMark: ReadMarkFunction = (
+  error: unknown,
+): { line: number | null; column: number | null } => {
+  const mark: YamlExceptionShape["mark"] = (error as YamlExceptionShape | null)
+    ?.mark;
+
+  if (!mark) {
+    return { line: null, column: null };
+  }
+
+  return {
+    line: typeof mark.line === "number" ? mark.line + 1 : null,
+    column: typeof mark.column === "number" ? mark.column + 1 : null,
+  };
+};
+
+type ReadReasonFunction = (error: unknown) => string;
+
+const readReason: ReadReasonFunction = (error: unknown): string => {
+  const reason: string | undefined = (error as YamlExceptionShape | null)
+    ?.reason;
+
+  if (reason) {
+    return reason;
+  }
+
+  /*
+   * Fall back to the first line of the message: js-yaml appends a multi-line
+   * source excerpt to `message`, which is far too much for a form error.
+   */
+  if (error instanceof Error && error.message) {
+    return error.message.split("\n")[0] || "Invalid YAML.";
+  }
+
+  return "Invalid YAML.";
+};
+
+export type CheckYamlSyntaxFunction = (value: unknown) => YamlSyntaxCheckResult;
+
+/**
+ * Parse `value` as YAML and report whether it is well formed.
+ */
+export const checkYamlSyntax: CheckYamlSyntaxFunction = (
+  value: unknown,
+): YamlSyntaxCheckResult => {
+  const skipped: YamlSyntaxCheckResult = {
+    isValid: true,
+    errorMessage: null,
+    wasSkipped: true,
+    line: null,
+    column: null,
+  };
+
+  // Not a string: nothing was typed into an editor, so there is no text to parse.
+  if (typeof value !== "string") {
+    return skipped;
+  }
+
+  // Empty is the job of the required-field check, not this one.
+  if (value.trim() === "") {
+    return skipped;
+  }
+
+  /*
+   * A handlebars loop emits its body once per array element, so the document's
+   * indentation depends on data that only exists at run time.
+   */
+  if (hasEachBlock(value)) {
+    return skipped;
+  }
+
+  const masked: string = maskTemplateExpressions(value);
+
+  try {
+    /*
+     * loadAll, not load: a YAML stream may hold several `---` separated
+     * documents and load() rejects the second one. The parsed values are
+     * discarded - only the syntax is being judged here.
+     */
+    yaml.loadAll(masked);
+
+    return {
+      isValid: true,
+      errorMessage: null,
+      wasSkipped: false,
+      line: null,
+      column: null,
+    };
+  } catch (err: unknown) {
+    const { line, column } = readMark(err);
+
+    return {
+      isValid: false,
+      errorMessage: readReason(err),
+      wasSkipped: false,
+      line,
+      column,
+    };
+  }
+};
+
+export type DescribeYamlSyntaxErrorFunction = (
+  result: YamlSyntaxCheckResult,
+) => string;
+
+/**
+ * "bad indentation of a mapping entry (line 4, column 3)" - the one-line
+ * sentence both the form error and the editor status bar are built from.
+ */
+export const describeYamlSyntaxError: DescribeYamlSyntaxErrorFunction = (
+  result: YamlSyntaxCheckResult,
+): string => {
+  const reason: string = result.errorMessage || "Invalid YAML.";
+
+  if (result.line === null) {
+    return reason;
+  }
+
+  if (result.column === null) {
+    return `${reason} (line ${result.line})`;
+  }
+
+  return `${reason} (line ${result.line}, column ${result.column})`;
+};

--- a/Common/UI/Components/CodeEditor/CodeEditor.tsx
+++ b/Common/UI/Components/CodeEditor/CodeEditor.tsx
@@ -31,6 +31,10 @@ export interface ComponentProps {
   showLineNumbers?: boolean | undefined;
   disableSpellCheck?: boolean | undefined;
   ariaLabelledby?: string | undefined;
+  /** Ids of the elements describing this control (hint, status, error). */
+  ariaDescribedby?: string | undefined;
+  /** Marks the control invalid to assistive technology. */
+  ariaInvalid?: boolean | undefined;
   /** CSS height handed to Monaco. Defaults to "30vh". */
   height?: string | undefined;
 }
@@ -137,6 +141,79 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
 
   const isYaml: boolean = props.type === CodeType.YAML;
 
+  type GetInputAreaFunction = (editor: any) => HTMLTextAreaElement | null;
+
+  /*
+   * Monaco's real focusable control. The wrapper <div> this component returns
+   * has no role, and ARIA forbids naming a role=generic element - so every
+   * accessibility attribute has to land here instead.
+   */
+  const getInputArea: GetInputAreaFunction = (
+    editor: any,
+  ): HTMLTextAreaElement | null => {
+    const domNode: HTMLElement | null = editor?.getDomNode?.() || null;
+
+    if (!domNode) {
+      return null;
+    }
+
+    return domNode.querySelector("textarea");
+  };
+
+  type ApplyAriaFunction = (editor: any) => void;
+
+  const applyAria: ApplyAriaFunction = (editor: any): void => {
+    const inputArea: HTMLTextAreaElement | null = getInputArea(editor);
+
+    if (!inputArea) {
+      return;
+    }
+
+    /*
+     * aria-labelledby wins over the aria-label Monaco puts here itself
+     * ("Editor content"), so the field's own label names the editor.
+     */
+    if (props.ariaLabelledby) {
+      inputArea.setAttribute("aria-labelledby", props.ariaLabelledby);
+    } else {
+      inputArea.removeAttribute("aria-labelledby");
+    }
+
+    if (props.ariaDescribedby) {
+      inputArea.setAttribute("aria-describedby", props.ariaDescribedby);
+    } else {
+      inputArea.removeAttribute("aria-describedby");
+    }
+
+    if (props.ariaInvalid) {
+      inputArea.setAttribute("aria-invalid", "true");
+    } else {
+      inputArea.removeAttribute("aria-invalid");
+    }
+  };
+
+  type ApplyModelOptionsFunction = (editor: any) => void;
+
+  /*
+   * Per-model, not per-editor and emphatically not global: a literal tab is
+   * illegal as YAML indentation, and Monaco's model defaults are four spaces
+   * with indentation detected from the initial content - so a rule pasted in
+   * tab-indented would keep emitting tabs the parser rejects.
+   */
+  const applyModelOptions: ApplyModelOptionsFunction = (editor: any): void => {
+    if (!isYaml) {
+      return;
+    }
+
+    const model: any = editor?.getModel?.();
+
+    if (!model || typeof model.updateOptions !== "function") {
+      return;
+    }
+
+    model.updateOptions({ tabSize: 2, insertSpaces: true });
+  };
+
   /*
    * Markdown is prose, so it follows the caller's preference. YAML is code:
    * red squiggles under every key name in a Sigma rule are pure noise, so
@@ -169,7 +246,14 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
   // Handle spell check configuration for Monaco Editor
   useEffect(() => {
     applySpellCheck(editorRef.current);
+    applyModelOptions(editorRef.current);
+    // eslint-disable-next-line
   }, [props.disableSpellCheck, props.type]);
+
+  useEffect(() => {
+    applyAria(editorRef.current);
+    // eslint-disable-next-line
+  }, [props.ariaLabelledby, props.ariaDescribedby, props.ariaInvalid]);
 
   /*
    * Memoised: @monaco-editor/react calls editor.updateOptions() whenever this
@@ -249,17 +333,19 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
       wordBasedSuggestions: "off",
       wordWrap: props.type === CodeType.Markdown ? "on" : "off",
       tabCompletion: "off",
-      /*
-       * YAML forbids tabs for indentation, and Monaco's defaults are 4 spaces
-       * with detectIndentation ON - so pasting a tab-indented blob silently
-       * reconfigures the editor to emit tabs, and the document the user saves
-       * is rejected by the parser. Pin two spaces and never re-detect.
-       */
-      tabSize: isYaml ? 2 : 4,
-      insertSpaces: true,
-      detectIndentation: !isYaml,
       // The YAML chrome owns the padding, so the editor supplies its own.
       padding: isYaml ? { top: 10, bottom: 10 } : undefined,
+      /*
+       * tabSize / insertSpaces / detectIndentation deliberately do NOT belong
+       * here. They are IGlobalEditorOptions: monaco's standalone editor pipes
+       * whatever it is constructed with through updateConfigurationService,
+       * which writes every registered `editor.*` key into a PROCESS-WIDE
+       * config service - and those three are exactly the ones ModelService
+       * reads back, pushing them onto every model on the page. Setting them
+       * here would mean the last editor to mount dictates the indentation of
+       * all the others. They are applied to this editor's own model instead,
+       * in applyModelOptions below.
+       */
     };
   }, [
     props.tabIndex,
@@ -316,6 +402,8 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
         onMount={(editor: any, _monaco: any) => {
           editorRef.current = editor;
           applySpellCheck(editor);
+          applyModelOptions(editor);
+          applyAria(editor);
         }}
         defaultValue={value || placeholder || ""}
         className={className}

--- a/Common/UI/Components/CodeEditor/CodeEditor.tsx
+++ b/Common/UI/Components/CodeEditor/CodeEditor.tsx
@@ -7,6 +7,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -30,6 +31,8 @@ export interface ComponentProps {
   showLineNumbers?: boolean | undefined;
   disableSpellCheck?: boolean | undefined;
   ariaLabelledby?: string | undefined;
+  /** CSS height handed to Monaco. Defaults to "30vh". */
+  height?: string | undefined;
 }
 
 /*
@@ -106,6 +109,17 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
       if (props.type === CodeType.CSS) {
         setPlaceholder(`/* ${props.placeholder}. This is in CSS. */`);
       }
+
+      /*
+       * Help text, never `setPlaceholder`: whatever setPlaceholder holds is
+       * rendered into `defaultValue` below, i.e. it becomes real document
+       * text. The JS and CSS arms above get away with it because they wrap
+       * the hint in a comment; an unwrapped YAML hint would be content the
+       * user can accidentally save, and the server would reject it.
+       */
+      if (props.type === CodeType.YAML) {
+        setHelpText(`${props.placeholder}`);
+      }
     }
   }, [props.placeholder, props.type]);
 
@@ -121,20 +135,139 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
       "block w-full rounded-md border bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-red-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500 sm:text-sm border-red-300 pr-10 text-red-900 placeholder-red-300 focus:border-red-500 focus:outline-none focus:ring-red-500";
   }
 
+  const isYaml: boolean = props.type === CodeType.YAML;
+
+  /*
+   * Markdown is prose, so it follows the caller's preference. YAML is code:
+   * red squiggles under every key name in a Sigma rule are pure noise, so
+   * spell check is off for it regardless of what the caller asked for.
+   */
+  const shouldSpellCheck: boolean = isYaml ? false : !props.disableSpellCheck;
+  const managesSpellCheck: boolean = props.type === CodeType.Markdown || isYaml;
+
+  type ApplySpellCheckFunction = (editor: any) => void;
+
+  const applySpellCheck: ApplySpellCheckFunction = (editor: any): void => {
+    if (!editor || !managesSpellCheck) {
+      return;
+    }
+
+    const domNode: HTMLElement | null = editor.getDomNode();
+
+    if (!domNode) {
+      return;
+    }
+
+    const textareaElement: HTMLTextAreaElement | null =
+      domNode.querySelector("textarea");
+
+    if (textareaElement) {
+      textareaElement.spellcheck = shouldSpellCheck;
+    }
+  };
+
   // Handle spell check configuration for Monaco Editor
   useEffect(() => {
-    if (editorRef.current && props.type === CodeType.Markdown) {
-      const editor: any = editorRef.current;
-      const domNode: HTMLElement | null = editor.getDomNode();
-      if (domNode) {
-        const textareaElement: HTMLTextAreaElement | null =
-          domNode.querySelector("textarea");
-        if (textareaElement) {
-          textareaElement.spellcheck = !props.disableSpellCheck;
-        }
-      }
-    }
+    applySpellCheck(editorRef.current);
   }, [props.disableSpellCheck, props.type]);
+
+  /*
+   * Memoised: @monaco-editor/react calls editor.updateOptions() whenever this
+   * object's identity changes, so an inline literal reconfigured the editor on
+   * every parent re-render - which for the indentation options below would
+   * reset them mid-keystroke.
+   */
+  const editorOptions: Record<string, unknown> = useMemo(() => {
+    return {
+      acceptSuggestionOnCommitCharacter: false,
+      acceptSuggestionOnEnter: "off",
+      accessibilitySupport: "auto",
+      fontSize: 14,
+      automaticLayout: true,
+      codeLens: false,
+      colorDecorators: true,
+      contextmenu: false,
+      cursorBlinking: "blink",
+      tabIndex: props.tabIndex || 0,
+      minimap: { enabled: false },
+      cursorStyle: "line",
+      disableLayerHinting: false,
+      disableMonospaceOptimizations: false,
+      dragAndDrop: false,
+      fixedOverflowWidgets: false,
+      folding: true,
+      foldingStrategy: "auto",
+      fontLigatures: false,
+      formatOnPaste: false,
+      formatOnType: false,
+
+      hideCursorInOverviewRuler: false,
+      links: true,
+      mouseWheelZoom: false,
+      multiCursorMergeOverlapping: true,
+      multiCursorModifier: "alt",
+      overviewRulerBorder: true,
+      overviewRulerLanes: 2,
+      quickSuggestions: false,
+      quickSuggestionsDelay: 100,
+      readOnly: props.readOnly || false,
+      renderControlCharacters: false,
+      /*
+       * Long scalars - a URL, a base64 blob, a Sigma `condition:` line - run
+       * off the right edge, and with wordWrap off for code there is no other
+       * way to reach them. Wrapping YAML instead is not an option: the
+       * indentation IS the syntax, and a wrapped line reads as a deeper one.
+       */
+      scrollbar: {
+        horizontal: isYaml ? "auto" : "hidden",
+      },
+      renderLineHighlight: "all",
+      suggestOnTriggerCharacters: false,
+      /*
+       * In YAML whitespace is the syntax. Rendering it at the boundaries makes
+       * the indentation depth countable and, more importantly, makes a literal
+       * tab visible - tabs are illegal as YAML indentation and are otherwise
+       * indistinguishable from spaces.
+       */
+      renderWhitespace: isYaml ? "boundary" : "none",
+      revealHorizontalRightPadding: 30,
+      roundedSelection: true,
+      rulers: [],
+      scrollBeyondLastColumn: 5,
+      // Half a short editor as blank runway is wasted space in a form field.
+      scrollBeyondLastLine: !isYaml,
+      selectOnLineNumbers: true,
+      /*
+       * Every YAML parse error - ours and the server's - is reported as a
+       * line and column, so the gutter is what makes the message actionable.
+       */
+      lineNumbers: props.showLineNumbers || isYaml ? "on" : "off",
+      selectionClipboard: true,
+      selectionHighlight: true,
+      showFoldingControls: "mouseover",
+      smoothScrolling: false,
+      wordBasedSuggestions: "off",
+      wordWrap: props.type === CodeType.Markdown ? "on" : "off",
+      tabCompletion: "off",
+      /*
+       * YAML forbids tabs for indentation, and Monaco's defaults are 4 spaces
+       * with detectIndentation ON - so pasting a tab-indented blob silently
+       * reconfigures the editor to emit tabs, and the document the user saves
+       * is rejected by the parser. Pin two spaces and never re-detect.
+       */
+      tabSize: isYaml ? 2 : 4,
+      insertSpaces: true,
+      detectIndentation: !isYaml,
+      // The YAML chrome owns the padding, so the editor supplies its own.
+      padding: isYaml ? { top: 10, bottom: 10 } : undefined,
+    };
+  }, [
+    props.tabIndex,
+    props.readOnly,
+    props.showLineNumbers,
+    props.type,
+    isYaml,
+  ]);
 
   return (
     <div
@@ -159,7 +292,13 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
       <Editor
         theme={theme === Theme.Dark ? "vs-dark" : "light"}
         defaultLanguage={props.type}
-        height="30vh"
+        /*
+         * `defaultLanguage` is applied only when the model is created, so a
+         * caller that swaps CodeType after mount keeps the old grammar.
+         * `language` is the prop that drives setModelLanguage afterwards.
+         */
+        language={props.type}
+        height={props.height || "30vh"}
         value={value}
         onChange={(code: string | undefined) => {
           if (code === undefined) {
@@ -176,76 +315,11 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
         }}
         onMount={(editor: any, _monaco: any) => {
           editorRef.current = editor;
-
-          // Configure spell check for Markdown
-          if (props.type === CodeType.Markdown) {
-            const domNode: HTMLElement | null = editor.getDomNode();
-            if (domNode) {
-              const textareaElement: HTMLTextAreaElement | null =
-                domNode.querySelector("textarea");
-              if (textareaElement) {
-                textareaElement.spellcheck = !props.disableSpellCheck;
-              }
-            }
-          }
+          applySpellCheck(editor);
         }}
         defaultValue={value || placeholder || ""}
         className={className}
-        options={{
-          acceptSuggestionOnCommitCharacter: false,
-          acceptSuggestionOnEnter: "off",
-          accessibilitySupport: "auto",
-          fontSize: 14,
-          automaticLayout: true,
-          codeLens: false,
-          colorDecorators: true,
-          contextmenu: false,
-          cursorBlinking: "blink",
-          tabIndex: props.tabIndex || 0,
-          minimap: { enabled: false },
-          cursorStyle: "line",
-          disableLayerHinting: false,
-          disableMonospaceOptimizations: false,
-          dragAndDrop: false,
-          fixedOverflowWidgets: false,
-          folding: true,
-          foldingStrategy: "auto",
-          fontLigatures: false,
-          formatOnPaste: false,
-          formatOnType: false,
-
-          hideCursorInOverviewRuler: false,
-          links: true,
-          mouseWheelZoom: false,
-          multiCursorMergeOverlapping: true,
-          multiCursorModifier: "alt",
-          overviewRulerBorder: true,
-          overviewRulerLanes: 2,
-          quickSuggestions: false,
-          quickSuggestionsDelay: 100,
-          readOnly: props.readOnly || false,
-          renderControlCharacters: false,
-          scrollbar: {
-            horizontal: "hidden",
-          },
-          renderLineHighlight: "all",
-          suggestOnTriggerCharacters: false,
-          renderWhitespace: "none",
-          revealHorizontalRightPadding: 30,
-          roundedSelection: true,
-          rulers: [],
-          scrollBeyondLastColumn: 5,
-          scrollBeyondLastLine: true,
-          selectOnLineNumbers: true,
-          lineNumbers: props.showLineNumbers ? "on" : "off",
-          selectionClipboard: true,
-          selectionHighlight: true,
-          showFoldingControls: "mouseover",
-          smoothScrolling: false,
-          wordBasedSuggestions: "off",
-          wordWrap: props.type === CodeType.Markdown ? "on" : "off",
-          tabCompletion: "off",
-        }}
+        options={editorOptions}
       />
       {props.error && (
         <p className="mt-1 text-sm text-red-400">{props.error}</p>

--- a/Common/UI/Components/CodeEditor/YamlEditor.tsx
+++ b/Common/UI/Components/CodeEditor/YamlEditor.tsx
@@ -11,6 +11,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -38,6 +39,26 @@ export const YAML_VALIDATION_DEBOUNCE_MS: number = 250;
 
 const DEFAULT_HINT: string =
   "Indentation is significant — use 2 spaces per level. Tabs are not valid YAML.";
+
+const MAC_PLATFORM_PATTERN: RegExp = /Mac|iPhone|iPad|iPod/i;
+
+type IsMacFunction = () => boolean;
+
+/*
+ * Monaco binds toggleTabFocusMode to Ctrl+M everywhere except macOS, where the
+ * `mac` override in its keybinding makes it Ctrl+Shift+M. Naming the wrong key
+ * turns the keyboard-trap advisory (WCAG 2.1.2) into a false one.
+ */
+const isMac: IsMacFunction = (): boolean => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const platform: string =
+    (navigator as { platform?: string }).platform || navigator.userAgent || "";
+
+  return MAC_PLATFORM_PATTERN.test(platform);
+};
 
 /*
  * Callers reach us through Form's currentValues, which is `any`, so a
@@ -89,6 +110,11 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
   const [checkedText, setCheckedText] = useState<string>(() => {
     return toText(props.value ?? props.initialValue);
   });
+
+  const instanceId: string = useId();
+  const hintId: string = `${instanceId}-yaml-hint`;
+  const statusId: string = `${instanceId}-yaml-status`;
+  const escapeHintId: string = `${instanceId}-yaml-escape`;
 
   const [copied, setCopied] = useState<boolean>(false);
   const copyResetTimer: React.MutableRefObject<ReturnType<
@@ -153,8 +179,9 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
   };
 
   /*
-   * One line, one message. The form error wins when there is one, because it
-   * is the sentence that is blocking Save; otherwise the live parse speaks.
+   * One line, one message, five states. Whichever arm wins, the status bar is
+   * the only place the field says anything - the editor below is not given
+   * the error, so nothing is printed twice.
    */
   type StatusShape = {
     tone: "error" | "valid" | "invalid" | "empty";
@@ -163,7 +190,14 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
   };
 
   const status: StatusShape = useMemo(() => {
-    if (props.error) {
+    /*
+     * The form re-validates synchronously on every keystroke and the field is
+     * marked touched from the first one, so props.error arrives undebounced.
+     * Deferring to it only once the parse has caught up with the text keeps a
+     * red message off a half-typed line - and the moment they agree, the
+     * form's sentence wins, because it is the one blocking Save.
+     */
+    if (props.error && checkedText === text) {
       return {
         tone: "error",
         icon: IconProp.Error,
@@ -176,6 +210,19 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
         tone: "empty",
         icon: IconProp.Info,
         message: "Nothing entered yet.",
+      };
+    }
+
+    /*
+     * checkYamlSyntax declines to judge a document whose shape is only known
+     * at run time. Saying "Valid YAML" about text nobody parsed would be a
+     * claim this component cannot make.
+     */
+    if (syntax.wasSkipped) {
+      return {
+        tone: "empty",
+        icon: IconProp.Info,
+        message: "Contains template expressions — syntax not checked.",
       };
     }
 
@@ -194,35 +241,47 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
       icon: IconProp.Alert,
       message: describeYamlSyntaxError(syntax),
     };
-  }, [props.error, isEmpty, syntax, text]);
+  }, [props.error, isEmpty, syntax, text, checkedText]);
 
+  /*
+   * Light-theme values only, one step darker than the obvious choice so the
+   * 12px status text clears 4.5:1 on bg-gray-50 (WCAG 1.4.3). Dark mode is
+   * not written here: Styles/Theme.css remaps these very classes globally
+   * under html.dark, at a specificity that beats any dark: variant a
+   * component could add - which is why no sibling component uses them.
+   */
   const statusToneClassName: string = {
-    error: "text-red-600 dark:text-red-400",
-    invalid: "text-amber-600 dark:text-amber-400",
-    valid: "text-green-600 dark:text-green-400",
-    empty: "text-gray-400 dark:text-slate-500",
+    error: "text-red-700",
+    invalid: "text-amber-700",
+    valid: "text-green-700",
+    empty: "text-gray-500",
   }[status.tone];
 
   const borderClassName: string = props.error
-    ? "border-red-300 dark:border-red-500/60 focus-within:border-red-500 focus-within:ring-red-500"
-    : "border-gray-300 dark:border-slate-700 focus-within:border-indigo-500 focus-within:ring-indigo-500";
+    ? "border-red-300 focus-within:border-red-500 focus-within:ring-red-500"
+    : "border-gray-300 focus-within:border-indigo-500 focus-within:ring-indigo-500";
+
+  const escapeHint: string = isMac()
+    ? "Press Control plus Shift plus M to toggle whether the Tab key indents or moves focus out of this editor."
+    : "Press Control plus M to toggle whether the Tab key indents or moves focus out of this editor.";
 
   return (
     <div
       data-testid="yaml-editor"
       className={
         props.className ||
-        `overflow-hidden rounded-md border bg-white shadow-sm transition-shadow focus-within:ring-1 dark:bg-slate-900 ${borderClassName}`
+        `overflow-hidden rounded-md border bg-white shadow-sm transition-shadow focus-within:ring-1 ${borderClassName}`
       }
     >
-      <div className="flex items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-slate-700 dark:bg-slate-800">
+      <div className="flex items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-3 py-1">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="inline-flex shrink-0 items-center rounded border border-indigo-100 bg-indigo-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300">
+          <span className="inline-flex shrink-0 items-center rounded border border-indigo-100 bg-indigo-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700">
             YAML
           </span>
           <span
+            id={hintId}
             data-testid="yaml-editor-hint"
-            className="truncate text-xs text-gray-500 dark:text-slate-400"
+            className="truncate text-xs text-gray-500"
           >
             {props.placeholder || DEFAULT_HINT}
           </span>
@@ -231,10 +290,12 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
         <button
           type="button"
           data-testid="yaml-editor-copy-button"
-          aria-label="Copy YAML to clipboard"
+          aria-label={
+            copied ? "YAML copied to clipboard" : "Copy YAML to clipboard"
+          }
           disabled={isEmpty}
           onClick={handleCopy}
-          className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-500 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+          className="inline-flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-500"
         >
           <Icon
             icon={copied ? IconProp.Check : IconProp.Copy}
@@ -244,9 +305,21 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
         </button>
       </div>
 
+      {/*
+       * Ahead of the editor in reading order, and referenced from Monaco's own
+       * input through aria-describedby - Monaco takes Tab to indent, so this
+       * is the only way out, and it has to be heard on the way in rather than
+       * discovered on the way past.
+       */}
+      <span id={escapeHintId} className="sr-only">
+        {escapeHint}
+      </span>
+
       <CodeEditor
         type={CodeType.YAML}
         ariaLabelledby={props.ariaLabelledby}
+        ariaDescribedby={`${escapeHintId} ${hintId} ${statusId}`}
+        ariaInvalid={Boolean(props.error)}
         dataTestId={props.dataTestId}
         tabIndex={props.tabIndex}
         readOnly={props.readOnly}
@@ -272,23 +345,22 @@ const YamlEditor: FunctionComponent<ComponentProps> = (
       />
 
       <div
+        id={statusId}
         data-testid="yaml-editor-status"
         role="status"
         aria-live="polite"
-        className={`flex items-center gap-1.5 border-t border-gray-200 bg-gray-50 px-3 py-1.5 text-xs dark:border-slate-700 dark:bg-slate-800 ${statusToneClassName}`}
+        className={`flex items-center gap-1.5 border-t border-gray-200 bg-gray-50 px-3 py-1.5 text-xs ${statusToneClassName}`}
       >
         <Icon icon={status.icon} className="h-3.5 w-3.5 shrink-0" />
         <span className="min-w-0 break-words">{status.message}</span>
       </div>
 
       {/*
-       * Monaco takes the Tab key to indent, so Tab cannot leave the editor.
-       * Monaco's own escape hatch is Ctrl+M; a keyboard-only user has no way
-       * to discover it unless something says so.
+       * The copy button's own name changes, but a button name is not a live
+       * region - nothing would speak the confirmation. This does.
        */}
-      <span className="sr-only">
-        Press Control plus M to toggle whether the Tab key indents or moves
-        focus out of this editor.
+      <span role="status" aria-live="polite" className="sr-only">
+        {copied ? "YAML copied to clipboard" : ""}
       </span>
     </div>
   );

--- a/Common/UI/Components/CodeEditor/YamlEditor.tsx
+++ b/Common/UI/Components/CodeEditor/YamlEditor.tsx
@@ -1,0 +1,297 @@
+import CodeEditor from "./CodeEditor";
+import Icon from "../Icon/Icon";
+import CodeType from "../../../Types/Code/CodeType";
+import IconProp from "../../../Types/Icon/IconProp";
+import {
+  YamlSyntaxCheckResult,
+  checkYamlSyntax,
+  describeYamlSyntaxError,
+} from "../../../Types/Code/YamlSyntax";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export interface ComponentProps {
+  initialValue?: string | undefined;
+  value?: string | undefined;
+  onChange?: ((value: string) => void) | undefined;
+  onBlur?: (() => void) | undefined;
+  onFocus?: (() => void) | undefined;
+  /** Shown in the header bar as a hint. Never written into the document. */
+  placeholder?: string | undefined;
+  error?: string | undefined;
+  readOnly?: boolean | undefined;
+  tabIndex?: number | undefined;
+  dataTestId?: string | undefined;
+  ariaLabelledby?: string | undefined;
+  height?: string | undefined;
+  className?: string | undefined;
+}
+
+/** How long the document sits still before it is parsed again. */
+export const YAML_VALIDATION_DEBOUNCE_MS: number = 250;
+
+const DEFAULT_HINT: string =
+  "Indentation is significant — use 2 spaces per level. Tabs are not valid YAML.";
+
+/*
+ * Callers reach us through Form's currentValues, which is `any`, so a
+ * non-string can arrive on a prop typed as string. CodeEditor stringifies for
+ * display; we mirror that so the status bar judges the same text the user
+ * sees.
+ */
+type ToTextFunction = (value: string | undefined) => string;
+
+const toText: ToTextFunction = (value: string | undefined): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    return JSON.stringify(value, null, 4);
+  }
+
+  return value;
+};
+
+type CountLinesFunction = (text: string) => number;
+
+const countLines: CountLinesFunction = (text: string): number => {
+  return text.split("\n").length;
+};
+
+/**
+ * A YAML document editor: Monaco with the YAML grammar and YAML-safe
+ * indentation, wrapped in chrome that names the language, copies the document
+ * and reports - as you type - whether what is in the box actually parses.
+ *
+ * Exists because YAML fields used to render the rich-text Markdown editor.
+ * That was not only the wrong affordance (a Bold button over a Sigma rule);
+ * the Markdown editor round-trips its value through HTML and back, and
+ * indentation-sensitive YAML does not survive that intact.
+ */
+const YamlEditor: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [text, setText] = useState<string>(() => {
+    return toText(props.value ?? props.initialValue);
+  });
+
+  /*
+   * The parse runs on a timer so it does not re-run on every keystroke, and
+   * so a half-typed line is not judged the instant it is typed.
+   */
+  const [checkedText, setCheckedText] = useState<string>(() => {
+    return toText(props.value ?? props.initialValue);
+  });
+
+  const [copied, setCopied] = useState<boolean>(false);
+  const copyResetTimer: React.MutableRefObject<ReturnType<
+    typeof setTimeout
+  > | null> = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // `value` is the controlled prop; `initialValue` only seeds it.
+  useEffect(() => {
+    setText(
+      toText(props.value === undefined ? props.initialValue : props.value),
+    );
+  }, [props.value, props.initialValue]);
+
+  useEffect(() => {
+    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+      setCheckedText(text);
+    }, YAML_VALIDATION_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [text]);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimer.current) {
+        clearTimeout(copyResetTimer.current);
+      }
+    };
+  }, []);
+
+  const syntax: YamlSyntaxCheckResult = useMemo(() => {
+    return checkYamlSyntax(checkedText);
+  }, [checkedText]);
+
+  const isEmpty: boolean = text.trim() === "";
+
+  type HandleCopyFunction = () => void;
+
+  const handleCopy: HandleCopyFunction = (): void => {
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.clipboard ||
+      typeof navigator.clipboard.writeText !== "function"
+    ) {
+      return;
+    }
+
+    void Promise.resolve(navigator.clipboard.writeText(text)).catch(() => {
+      /* A denied clipboard permission is not worth an error state. */
+    });
+
+    setCopied(true);
+
+    if (copyResetTimer.current) {
+      clearTimeout(copyResetTimer.current);
+    }
+
+    copyResetTimer.current = setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  /*
+   * One line, one message. The form error wins when there is one, because it
+   * is the sentence that is blocking Save; otherwise the live parse speaks.
+   */
+  type StatusShape = {
+    tone: "error" | "valid" | "invalid" | "empty";
+    icon: IconProp;
+    message: string;
+  };
+
+  const status: StatusShape = useMemo(() => {
+    if (props.error) {
+      return {
+        tone: "error",
+        icon: IconProp.Error,
+        message: props.error,
+      };
+    }
+
+    if (isEmpty) {
+      return {
+        tone: "empty",
+        icon: IconProp.Info,
+        message: "Nothing entered yet.",
+      };
+    }
+
+    if (syntax.isValid) {
+      const lines: number = countLines(text);
+
+      return {
+        tone: "valid",
+        icon: IconProp.CheckCircle,
+        message: `Valid YAML · ${lines} ${lines === 1 ? "line" : "lines"}`,
+      };
+    }
+
+    return {
+      tone: "invalid",
+      icon: IconProp.Alert,
+      message: describeYamlSyntaxError(syntax),
+    };
+  }, [props.error, isEmpty, syntax, text]);
+
+  const statusToneClassName: string = {
+    error: "text-red-600 dark:text-red-400",
+    invalid: "text-amber-600 dark:text-amber-400",
+    valid: "text-green-600 dark:text-green-400",
+    empty: "text-gray-400 dark:text-slate-500",
+  }[status.tone];
+
+  const borderClassName: string = props.error
+    ? "border-red-300 dark:border-red-500/60 focus-within:border-red-500 focus-within:ring-red-500"
+    : "border-gray-300 dark:border-slate-700 focus-within:border-indigo-500 focus-within:ring-indigo-500";
+
+  return (
+    <div
+      data-testid="yaml-editor"
+      className={
+        props.className ||
+        `overflow-hidden rounded-md border bg-white shadow-sm transition-shadow focus-within:ring-1 dark:bg-slate-900 ${borderClassName}`
+      }
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-slate-700 dark:bg-slate-800">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="inline-flex shrink-0 items-center rounded border border-indigo-100 bg-indigo-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300">
+            YAML
+          </span>
+          <span
+            data-testid="yaml-editor-hint"
+            className="truncate text-xs text-gray-500 dark:text-slate-400"
+          >
+            {props.placeholder || DEFAULT_HINT}
+          </span>
+        </div>
+
+        <button
+          type="button"
+          data-testid="yaml-editor-copy-button"
+          aria-label="Copy YAML to clipboard"
+          disabled={isEmpty}
+          onClick={handleCopy}
+          className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-gray-500 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        >
+          <Icon
+            icon={copied ? IconProp.Check : IconProp.Copy}
+            className="h-3.5 w-3.5"
+          />
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+
+      <CodeEditor
+        type={CodeType.YAML}
+        ariaLabelledby={props.ariaLabelledby}
+        dataTestId={props.dataTestId}
+        tabIndex={props.tabIndex}
+        readOnly={props.readOnly}
+        height={props.height || "22rem"}
+        /*
+         * The chrome above owns the border, the background and the focus ring,
+         * so the editor contributes none of its own. `error` is deliberately
+         * not forwarded either - it would paint a second red border and print
+         * the message a second time under the box; the status bar below says
+         * it once.
+         */
+        className="block w-full text-sm"
+        value={text}
+        onChange={(value: string) => {
+          setText(value);
+
+          if (props.onChange) {
+            props.onChange(value);
+          }
+        }}
+        onBlur={props.onBlur}
+        onFocus={props.onFocus}
+      />
+
+      <div
+        data-testid="yaml-editor-status"
+        role="status"
+        aria-live="polite"
+        className={`flex items-center gap-1.5 border-t border-gray-200 bg-gray-50 px-3 py-1.5 text-xs dark:border-slate-700 dark:bg-slate-800 ${statusToneClassName}`}
+      >
+        <Icon icon={status.icon} className="h-3.5 w-3.5 shrink-0" />
+        <span className="min-w-0 break-words">{status.message}</span>
+      </div>
+
+      {/*
+       * Monaco takes the Tab key to indent, so Tab cannot leave the editor.
+       * Monaco's own escape hatch is Ctrl+M; a keyboard-only user has no way
+       * to discover it unless something says so.
+       */}
+      <span className="sr-only">
+        Press Control plus M to toggle whether the Tab key indents or moves
+        focus out of this editor.
+      </span>
+    </div>
+  );
+};
+
+export default YamlEditor;

--- a/Common/UI/Components/Detail/Detail.tsx
+++ b/Common/UI/Components/Detail/Detail.tsx
@@ -631,6 +631,7 @@ const Detail: DetailFunction = <T extends GenericObject>(
         field.fieldType === FieldType.CSS ||
         field.fieldType === FieldType.JSON ||
         field.fieldType === FieldType.JavaScript ||
+        field.fieldType === FieldType.YAML ||
         field.fieldType === FieldType.Code)
     ) {
       let language: string = "html";
@@ -680,6 +681,15 @@ const Detail: DetailFunction = <T extends GenericObject>(
 
       if (field.fieldType === FieldType.Code) {
         language = "plaintext";
+      }
+
+      /*
+       * Rendered verbatim, unlike the JSON arm above: re-emitting YAML through
+       * a parser would drop the comments, anchors and key ordering that a hand
+       * written document (a Sigma rule, a collector config) is written with.
+       */
+      if (field.fieldType === FieldType.YAML) {
+        language = "yaml";
       }
 
       data = (

--- a/Common/UI/Components/Forms/Fields/FormField.tsx
+++ b/Common/UI/Components/Forms/Fields/FormField.tsx
@@ -40,6 +40,7 @@ import Radio, { RadioValue } from "../../Radio/Radio";
 import { BasicRadioButtonOption } from "../../RadioButtons/BasicRadioButtons";
 import HorizontalRule from "../../HorizontalRule/HorizontalRule";
 import MarkdownEditor from "../../Markdown.tsx/MarkdownEditor";
+import YamlEditor from "../../CodeEditor/YamlEditor";
 import useTranslateValue from "../../../Utils/Translation";
 
 export interface ComponentProps<T extends GenericObject> {
@@ -663,6 +664,35 @@ const FormField: <T extends GenericObject>(
               ariaLabelledby={fieldLabelId}
               error={props.touched && props.error ? props.error : undefined}
               type={CodeType.JSON}
+              tabIndex={0}
+              dataTestId={props.field.dataTestId}
+              onChange={async (value: string) => {
+                onChange(value);
+                props.setFieldValue(props.fieldName, value);
+              }}
+              onBlur={async () => {
+                props.setFieldTouched(props.fieldName, true);
+              }}
+              initialValue={
+                props.currentValues &&
+                (props.currentValues as any)[props.fieldName]
+                  ? (props.currentValues as any)[props.fieldName]
+                  : ""
+              }
+              value={
+                props.currentValues &&
+                (props.currentValues as any)[props.fieldName]
+                  ? (props.currentValues as any)[props.fieldName]
+                  : ""
+              }
+              placeholder={translatedPlaceholder || ""}
+            />
+          )}
+
+          {props.field.fieldType === FormFieldSchemaType.YAML && (
+            <YamlEditor
+              ariaLabelledby={fieldLabelId}
+              error={props.touched && props.error ? props.error : undefined}
               tabIndex={0}
               dataTestId={props.field.dataTestId}
               onChange={async (value: string) => {

--- a/Common/UI/Components/Forms/Types/FormFieldSchemaType.ts
+++ b/Common/UI/Components/Forms/Types/FormFieldSchemaType.ts
@@ -31,6 +31,7 @@ enum FormFieldSchemaType {
   HTML = "HTML",
   RadioButton = "RadioButton",
   JSON = "JSON",
+  YAML = "YAML",
   Query = "Query",
   CustomComponent = "CustomComponent",
   Checkbox = "Checkbox",

--- a/Common/UI/Components/Forms/Utils/FormFieldSchemaTypeUtil.ts
+++ b/Common/UI/Components/Forms/Utils/FormFieldSchemaTypeUtil.ts
@@ -68,6 +68,8 @@ export default class FormFieldSchemaTypeUtil {
         return FieldType.Element;
       case FormFieldSchemaType.JSON:
         return FieldType.JSON;
+      case FormFieldSchemaType.YAML:
+        return FieldType.YAML;
       case FormFieldSchemaType.Query:
         return FieldType.Element;
       case FormFieldSchemaType.CustomComponent:

--- a/Common/UI/Components/Forms/Validation.ts
+++ b/Common/UI/Components/Forms/Validation.ts
@@ -18,6 +18,11 @@ import {
   JSONSyntaxCheckResult,
   checkJSONSyntax,
 } from "../../../Types/Workflow/TemplateSyntax";
+import {
+  YamlSyntaxCheckResult,
+  checkYamlSyntax,
+  describeYamlSyntaxError,
+} from "../../../Types/Code/YamlSyntax";
 import { Logger } from "../../Utils/Logger";
 import Port from "../../../Types/Port";
 import Typeof from "../../../Types/Typeof";
@@ -368,6 +373,37 @@ export default class Validation {
     );
   }
 
+  /**
+   * Reject a YAML-typed field whose text does not parse.
+   *
+   * The server validates too (a Sigma rule is compiled on save), but a round
+   * trip to hear "bad indentation on line 4" is a poor way to find out. Like
+   * validateJSONSyntax this takes the raw value rather than the stringified
+   * `content`, and defers to checkYamlSyntax for what it declines to judge.
+   */
+  public static validateYAMLSyntax<T extends GenericObject>(
+    value: JSONValue | undefined,
+    field: Field<T>,
+  ): string | null {
+    if (field.fieldType !== FormFieldSchemaType.YAML) {
+      return null;
+    }
+
+    const result: YamlSyntaxCheckResult = checkYamlSyntax(value);
+
+    if (result.isValid) {
+      return null;
+    }
+
+    return translateValidationMessage(
+      "{{field}} is not valid YAML. {{parserMessage}}",
+      {
+        field: field.title || field.name || "",
+        parserMessage: describeYamlSyntaxError(result),
+      },
+    );
+  }
+
   public static validate<T extends GenericObject>(args: {
     formFields: Array<Field<T>>;
     values: FormValues<T>;
@@ -435,6 +471,16 @@ export default class Validation {
 
         if (resultJSONSyntax) {
           errors[name] = resultJSONSyntax;
+        }
+
+        // Fed the raw value for the same reason validateJSONSyntax is.
+        const resultYAMLSyntax: string | null = this.validateYAMLSyntax(
+          (entries as JSONObject)[name] as JSONValue | undefined,
+          field,
+        );
+
+        if (resultYAMLSyntax) {
+          errors[name] = resultYAMLSyntax;
         }
 
         const resultMatch: string | null = this.validateMatchField(

--- a/Common/UI/Components/Types/FieldType.ts
+++ b/Common/UI/Components/Types/FieldType.ts
@@ -31,6 +31,7 @@ enum FieldType {
   JavaScript = "JavaScript",
   DictionaryOfStrings = "DictionaryOfStrings",
   JSON = "JSON",
+  YAML = "YAML",
   USDCents = "USDCents",
   Element = "Element",
   Minutes = "Minutes",


### PR DESCRIPTION
## The bug

The **Sigma Rule (YAML)** field on *Security Events → Detection Rules* was declared as `FormFieldSchemaType.Markdown`, so authoring a Sigma rule meant typing into the rich-text editor — Bold, Italic and H1–H3 over a YAML document.

Worse than the wrong affordance: `MarkdownEditor` defaults to WYSIWYG and round-trips its value through `markdownToHtml` / `htmlToMarkdown` + DOMPurify. Indentation-sensitive YAML does not survive that trip intact.

There was no YAML field type to declare instead, so this adds one.

## What's in it

- **`FormFieldSchemaType.YAML` + `FieldType.YAML`**, mapped between by `FormFieldSchemaTypeUtil`.
- **`YamlEditor`** — Monaco with the YAML grammar, wrapped in chrome that names the language, copies the document, and reports *as you type* whether what is in the box actually parses, with the failing line and column.
- **Monaco tuned for YAML**: two spaces, always spaces (set on the editor's own **model** — `tabSize`/`insertSpaces`/`detectIndentation` are process-wide config in Monaco's standalone build, so setting them per-editor would have the last editor to mount re-indent every other one on the page); the gutter on, because every parse error names a line; whitespace rendered, because in YAML whitespace *is* the syntax and a literal tab is illegal indentation that is otherwise invisible; and a real horizontal scrollbar, because a long scalar is otherwise unreachable and wrapping would misrepresent the indentation. **Every other `CodeType` keeps exactly the options it had** — pinned by test.
- **`Validation.validateYAMLSyntax`** blocks Save on a document the parser will refuse, so the error arrives before the round trip to the server rather than after it. Mirrors `validateJSONSyntax`: raw value in, permissive about anything it cannot decide (non-strings, empty boxes, handlebars loops).
- **`Detail`** renders a YAML field as a highlighted code block, *verbatim* — unlike the JSON arm, which pretty-prints through a parser. Re-emitting YAML would drop the comments, anchors and key ordering a hand-written Sigma rule carries.

The syntax check uses **`js-yaml`, not the `yaml` package**: `Common/jest.config.json` maps `^yaml$` to a mock whose `parse()` never throws, which would make every "invalid YAML is rejected" test pass a lie.

## Accessibility

`aria-labelledby` used to land on CodeEditor's wrapper `<div>` — role=generic, which ARIA does not name — so the editor had no accessible name at all (Monaco's textarea fell back to its default `"Editor content"`). Name, description and `aria-invalid` now go on Monaco's own input. Monaco takes Tab to indent, so the WCAG 2.1.2 escape-hatch advisory leads the editor in reading order, is wired through `aria-describedby` so it is spoken on the way *in*, and names the right key per platform (macOS binds `toggleTabFocusMode` to Ctrl+Shift+M, not Ctrl+M). Status tones clear 4.5:1 on their own background.

## Tests

~200 tests across seven suites — including a `FormField` render test, because a schema type with no render branch draws its label above empty space and neither the compiler nor the linter says a word (`FormFieldSchemaType.Query` does exactly that today).

Full `Tests/UI` + `Tests/Types` + `Tests/App` sweep: **600 suites / 14,117 tests green**.

Both commits were put through an adversarial multi-agent review; the second commit is the confirmed findings from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ngv6jvUJiNnoHk41fSd1o5