### PR TITLE
feat(security-events): multi-condition AND/OR correlation query builder

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterBuilder.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterBuilder.tsx
@@ -1,0 +1,309 @@
+import React, { FunctionComponent, ReactElement } from "react";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
+import Input from "Common/UI/Components/Input/Input";
+import AutocompleteTextInput from "Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput";
+import IconProp from "Common/Types/Icon/IconProp";
+import {
+  CorrelationCondition,
+  CorrelationConnector,
+  CorrelationFieldDefinition,
+  CorrelationFieldDefinitions,
+  CorrelationFieldKey,
+  CorrelationOperator,
+  CorrelationOperatorLabels,
+  getCorrelationFieldDefinition,
+} from "../../Utils/SecurityEventCorrelation";
+
+/*
+ * The chainable condition rows for Security Events → Correlate: field +
+ * operator + value per row, one AND/OR connector for the whole chain,
+ * add/remove. Fully controlled — the parent owns the draft conditions and
+ * applies them when the user hits Correlate.
+ */
+
+export interface ComponentProps {
+  conditions: Array<CorrelationCondition>;
+  connector: CorrelationConnector;
+  onChange: (
+    conditions: Array<CorrelationCondition>,
+    connector: CorrelationConnector,
+  ) => void;
+}
+
+const fieldDropdownOptions: Array<DropdownOption> =
+  CorrelationFieldDefinitions.map(
+    (definition: CorrelationFieldDefinition): DropdownOption => {
+      return {
+        label: definition.label,
+        value: definition.key,
+      };
+    },
+  );
+
+function operatorDropdownOptions(
+  definition: CorrelationFieldDefinition,
+): Array<DropdownOption> {
+  return definition.operators.map(
+    (operator: CorrelationOperator): DropdownOption => {
+      return {
+        label: CorrelationOperatorLabels[operator],
+        value: operator,
+      };
+    },
+  );
+}
+
+export function getDefaultCorrelationCondition(): CorrelationCondition {
+  return {
+    field: CorrelationFieldKey.Observable,
+    operator: CorrelationOperator.Equals,
+    value: "",
+  };
+}
+
+const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const updateCondition: (
+    index: number,
+    condition: CorrelationCondition,
+  ) => void = (index: number, condition: CorrelationCondition): void => {
+    const next: Array<CorrelationCondition> = [...props.conditions];
+    next[index] = condition;
+    props.onChange(next, props.connector);
+  };
+
+  const renderValueInput: (
+    condition: CorrelationCondition,
+    index: number,
+  ) => ReactElement = (
+    condition: CorrelationCondition,
+    index: number,
+  ): ReactElement => {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(condition.field);
+
+    if (definition.valueOptions && definition.valueOptions.length > 0) {
+      const valueOptions: Array<DropdownOption> = definition.valueOptions.map(
+        (option: string): DropdownOption => {
+          return { label: option, value: option };
+        },
+      );
+      return (
+        <Dropdown
+          dataTestId={`correlate-condition-value-${index}`}
+          options={valueOptions}
+          value={valueOptions.find((option: DropdownOption) => {
+            return option.value === condition.value;
+          })}
+          placeholder={definition.placeholder || "Select a value"}
+          onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+            updateCondition(index, {
+              ...condition,
+              value: typeof value === "string" ? value : "",
+            });
+          }}
+        />
+      );
+    }
+
+    if (definition.valueSuggestions && definition.valueSuggestions.length > 0) {
+      return (
+        <AutocompleteTextInput
+          dataTestId={`correlate-condition-value-${index}`}
+          value={condition.value}
+          suggestions={definition.valueSuggestions}
+          placeholder={definition.placeholder}
+          onChange={(value: string) => {
+            updateCondition(index, { ...condition, value });
+          }}
+        />
+      );
+    }
+
+    return (
+      <Input
+        dataTestId={`correlate-condition-value-${index}`}
+        value={condition.value}
+        placeholder={definition.placeholder}
+        onChange={(value: string) => {
+          updateCondition(index, { ...condition, value });
+        }}
+      />
+    );
+  };
+
+  return (
+    <div
+      data-testid="correlate-filter-builder"
+      className="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-3"
+    >
+      {props.conditions.length > 1 && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-gray-500">Match</span>
+          <div className="inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-0.5">
+            <button
+              type="button"
+              data-testid="correlate-connector-and"
+              className={`rounded-md px-2.5 py-1 text-xs font-semibold ${
+                props.connector === "and"
+                  ? "bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-200"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+              onClick={() => {
+                props.onChange(props.conditions, "and");
+              }}
+            >
+              All conditions
+            </button>
+            <button
+              type="button"
+              data-testid="correlate-connector-or"
+              className={`rounded-md px-2.5 py-1 text-xs font-semibold ${
+                props.connector === "or"
+                  ? "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+              onClick={() => {
+                props.onChange(props.conditions, "or");
+              }}
+            >
+              Any condition
+            </button>
+          </div>
+        </div>
+      )}
+
+      {props.conditions.map(
+        (condition: CorrelationCondition, index: number): ReactElement => {
+          const definition: CorrelationFieldDefinition =
+            getCorrelationFieldDefinition(condition.field);
+          const operatorOptions: Array<DropdownOption> =
+            operatorDropdownOptions(definition);
+
+          return (
+            <div
+              key={index}
+              data-testid={`correlate-condition-row-${index}`}
+              className="flex flex-col md:flex-row md:items-center gap-2"
+            >
+              {index > 0 && (
+                <span
+                  className={`inline-flex w-fit shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-bold border ${
+                    props.connector === "or"
+                      ? "bg-amber-50 text-amber-600 border-amber-200"
+                      : "bg-indigo-50 text-indigo-600 border-indigo-200"
+                  }`}
+                >
+                  {props.connector === "or" ? "OR" : "AND"}
+                </span>
+              )}
+              <div className="md:w-44">
+                <Dropdown
+                  dataTestId={`correlate-condition-field-${index}`}
+                  options={fieldDropdownOptions}
+                  value={fieldDropdownOptions.find((option: DropdownOption) => {
+                    return option.value === condition.field;
+                  })}
+                  onChange={(
+                    value: DropdownValue | Array<DropdownValue> | null,
+                  ) => {
+                    if (typeof value !== "string") {
+                      return;
+                    }
+                    const nextField: CorrelationFieldKey =
+                      value as CorrelationFieldKey;
+                    const nextDefinition: CorrelationFieldDefinition =
+                      getCorrelationFieldDefinition(nextField);
+                    /*
+                     * Keep the operator when the new field offers it too;
+                     * fall back to the field's first operator otherwise.
+                     * The value resets — a hostname makes no sense as a
+                     * severity.
+                     */
+                    const nextOperator: CorrelationOperator =
+                      nextDefinition.operators.includes(condition.operator)
+                        ? condition.operator
+                        : (nextDefinition.operators[0] as CorrelationOperator);
+                    updateCondition(index, {
+                      field: nextField,
+                      operator: nextOperator,
+                      value: "",
+                    });
+                  }}
+                />
+              </div>
+              <div className="md:w-40">
+                <Dropdown
+                  dataTestId={`correlate-condition-operator-${index}`}
+                  options={operatorOptions}
+                  value={operatorOptions.find((option: DropdownOption) => {
+                    return option.value === condition.operator;
+                  })}
+                  onChange={(
+                    value: DropdownValue | Array<DropdownValue> | null,
+                  ) => {
+                    if (typeof value !== "string") {
+                      return;
+                    }
+                    updateCondition(index, {
+                      ...condition,
+                      operator: value as CorrelationOperator,
+                    });
+                  }}
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                {renderValueInput(condition, index)}
+              </div>
+              <Button
+                dataTestId={`correlate-condition-delete-${index}`}
+                icon={IconProp.Trash}
+                buttonStyle={ButtonStyleType.ICON}
+                buttonSize={ButtonSize.Small}
+                tooltip="Remove condition"
+                onClick={() => {
+                  const next: Array<CorrelationCondition> =
+                    props.conditions.filter(
+                      (
+                        _condition: CorrelationCondition,
+                        conditionIndex: number,
+                      ) => {
+                        return conditionIndex !== index;
+                      },
+                    );
+                  props.onChange(next, props.connector);
+                }}
+              />
+            </div>
+          );
+        },
+      )}
+
+      <div>
+        <Button
+          dataTestId="correlate-add-condition"
+          title="Add condition"
+          icon={IconProp.Add}
+          buttonStyle={ButtonStyleType.OUTLINE}
+          buttonSize={ButtonSize.Small}
+          onClick={() => {
+            props.onChange(
+              [...props.conditions, getDefaultCorrelationCondition()],
+              props.connector,
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CorrelateFilterBuilder;

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterBuilder.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterBuilder.tsx
@@ -99,6 +99,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
       return (
         <Dropdown
           dataTestId={`correlate-condition-value-${index}`}
+          ariaLabel={`Condition ${index + 1} value`}
           options={valueOptions}
           value={valueOptions.find((option: DropdownOption) => {
             return option.value === condition.value;
@@ -118,6 +119,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
       return (
         <AutocompleteTextInput
           dataTestId={`correlate-condition-value-${index}`}
+          ariaLabel={`Condition ${index + 1} value`}
           value={condition.value}
           suggestions={definition.valueSuggestions}
           placeholder={definition.placeholder}
@@ -131,6 +133,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
     return (
       <Input
         dataTestId={`correlate-condition-value-${index}`}
+        ariaLabel={`Condition ${index + 1} value`}
         value={condition.value}
         placeholder={definition.placeholder}
         onChange={(value: string) => {
@@ -152,6 +155,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
             <button
               type="button"
               data-testid="correlate-connector-and"
+              aria-pressed={props.connector === "and"}
               className={`rounded-md px-2.5 py-1 text-xs font-semibold ${
                 props.connector === "and"
                   ? "bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-200"
@@ -166,6 +170,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
             <button
               type="button"
               data-testid="correlate-connector-or"
+              aria-pressed={props.connector === "or"}
               className={`rounded-md px-2.5 py-1 text-xs font-semibold ${
                 props.connector === "or"
                   ? "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200"
@@ -208,6 +213,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
               <div className="md:w-44">
                 <Dropdown
                   dataTestId={`correlate-condition-field-${index}`}
+                  ariaLabel={`Condition ${index + 1} field`}
                   options={fieldDropdownOptions}
                   value={fieldDropdownOptions.find((option: DropdownOption) => {
                     return option.value === condition.field;
@@ -243,6 +249,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
               <div className="md:w-40">
                 <Dropdown
                   dataTestId={`correlate-condition-operator-${index}`}
+                  ariaLabel={`Condition ${index + 1} operator`}
                   options={operatorOptions}
                   value={operatorOptions.find((option: DropdownOption) => {
                     return option.value === condition.operator;
@@ -265,6 +272,7 @@ const CorrelateFilterBuilder: FunctionComponent<ComponentProps> = (
               </div>
               <Button
                 dataTestId={`correlate-condition-delete-${index}`}
+                ariaLabel={`Remove condition ${index + 1}`}
                 icon={IconProp.Trash}
                 buttonStyle={ButtonStyleType.ICON}
                 buttonSize={ButtonSize.Small}

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterChips.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterChips.tsx
@@ -1,0 +1,96 @@
+import React, { Fragment, FunctionComponent, ReactElement } from "react";
+import Icon from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
+import {
+  CorrelationCondition,
+  CorrelationFilter,
+  CorrelationOperatorLabels,
+  getCorrelationFieldDefinition,
+} from "../../Utils/SecurityEventCorrelation";
+
+/*
+ * The applied filter, rendered as removable chips above the graph — the
+ * always-visible answer to "what exactly is this graph showing?", with the
+ * AND/OR connector spelled out between chips. Removing a chip re-runs the
+ * correlation with the remaining conditions.
+ */
+
+export interface ComponentProps {
+  filter: CorrelationFilter;
+  onRemoveCondition: (index: number) => void;
+  onClearAll: () => void;
+}
+
+const CorrelateFilterChips: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  if (props.filter.conditions.length === 0) {
+    return <Fragment />;
+  }
+
+  const connectorLabel: string = props.filter.connector === "or" ? "OR" : "AND";
+
+  return (
+    <div
+      data-testid="correlate-filter-chips"
+      className="flex flex-wrap items-center gap-1.5"
+    >
+      {props.filter.conditions.map(
+        (condition: CorrelationCondition, index: number): ReactElement => {
+          return (
+            <Fragment key={index}>
+              {index > 0 && (
+                <span
+                  className={`text-[10px] font-bold ${
+                    props.filter.connector === "or"
+                      ? "text-amber-600"
+                      : "text-indigo-600"
+                  }`}
+                >
+                  {connectorLabel}
+                </span>
+              )}
+              <span
+                data-testid={`correlate-filter-chip-${index}`}
+                className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-indigo-50 py-0.5 pl-2 pr-1 text-xs text-indigo-700"
+              >
+                <span className="font-medium text-indigo-500">
+                  {getCorrelationFieldDefinition(condition.field).label}
+                </span>
+                <span className="italic">
+                  {CorrelationOperatorLabels[condition.operator]}
+                </span>
+                <span className="font-mono">{condition.value}</span>
+                <button
+                  type="button"
+                  data-testid={`correlate-filter-chip-remove-${index}`}
+                  aria-label={`Remove condition ${index + 1}`}
+                  className="flex h-4 w-4 items-center justify-center rounded text-indigo-400 hover:bg-indigo-100 hover:text-indigo-600"
+                  onClick={() => {
+                    props.onRemoveCondition(index);
+                  }}
+                >
+                  <Icon icon={IconProp.Close} className="h-2.5 w-2.5" />
+                </button>
+              </span>
+            </Fragment>
+          );
+        },
+      )}
+      {props.filter.conditions.length > 1 && (
+        <button
+          type="button"
+          data-testid="correlate-filter-clear-all"
+          className="text-xs text-gray-500 hover:text-gray-700 underline ml-1"
+          onClick={() => {
+            props.onClearAll();
+          }}
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default CorrelateFilterChips;

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateGraph.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateGraph.tsx
@@ -24,13 +24,17 @@ import AnalyticsModelAPI, {
 } from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
 import API from "Common/UI/Utils/API/API";
 import Query from "Common/Types/BaseDatabase/Query";
+import Select from "Common/Types/BaseDatabase/Select";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import Includes from "Common/Types/BaseDatabase/Includes";
-import InBetween from "Common/Types/BaseDatabase/InBetween";
+import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
+import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
 import IconProp from "Common/Types/Icon/IconProp";
 import Input from "Common/UI/Components/Input/Input";
-import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
 import Dropdown, {
   DropdownOption,
   DropdownValue,
@@ -38,31 +42,98 @@ import Dropdown, {
 import EmptyState from "Common/UI/Components/EmptyState/EmptyState";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import Navigation from "Common/UI/Utils/Navigation";
+import ProjectUtil from "Common/UI/Utils/Project";
 import computeLayeredLayout, {
   LayoutPoint,
 } from "../../Utils/LayeredGraphLayout";
+import {
+  CompiledCorrelationQueries,
+  CorrelationCondition,
+  CorrelationConnector,
+  CorrelationFieldKey,
+  CorrelationFilter,
+  CorrelationOperator,
+  compileCorrelationFilter,
+  describeCorrelationCondition,
+  getEqualityObservables,
+  parseCorrelationFilter,
+  serializeCorrelationFilter,
+} from "../../Utils/SecurityEventCorrelation";
+import {
+  CLASS_NODE_PREFIX,
+  CorrelationGraphData,
+  CorrelationGraphNode,
+  OBSERVABLE_NODE_PREFIX,
+  buildCorrelationGraph,
+  dedupeSecurityEvents,
+} from "../../Utils/CorrelationGraph";
+import CorrelateFilterBuilder, {
+  getDefaultCorrelationCondition,
+} from "./CorrelateFilterBuilder";
+import CorrelateFilterChips from "./CorrelateFilterChips";
+import SecurityEventSeverityPill from "./SecurityEventSeverityPill";
+import SecurityEventDetail from "./SecurityEventDetail";
 
 /*
- * Entity-neighborhood graph: the searched observable in the middle, one node
- * per event class that mentioned it, and one node per co-occurring observable
- * (capped at the most frequent 30). Clicking an observable node re-centers
- * the graph on it.
+ * Entity-neighborhood graph over security events: the applied filter in the
+ * middle, one node per event class that matched it, one node per
+ * co-occurring observable (capped at the most frequent 30).
+ *
+ * The filter is either the quick single-observable search (the original
+ * UX, kept as a shorthand) or a chain of field/operator/value conditions
+ * with one AND/OR connector. AND compiles to a single server query; OR runs
+ * one query per condition and unions the results by event id (the analytics
+ * query API has no cross-column OR). Filter + time range live in the URL
+ * (`q`, `hours` — plus `observable` as a simple deep-link param other pages
+ * use), so a correlation is shareable and pivots survive reloads.
+ *
+ * Clicking a class node opens the matching events below the graph (each row
+ * opens the full event detail); clicking an observable node offers pivot
+ * actions (focus / add condition / exclude).
  */
 
 const X_GAP: number = 240;
 const Y_GAP: number = 140;
-const MAX_CO_OBSERVABLES: number = 30;
 const EVENT_LIMIT: number = 200;
-
-const OBSERVABLE_NODE_PREFIX: string = "observable:";
-const CLASS_NODE_PREFIX: string = "class:";
+const DRILL_DOWN_ROW_LIMIT: number = 50;
 
 const timeRangeOptions: Array<DropdownOption> = [
   { label: "Last 1 hour", value: 1 },
   { label: "Last 6 hours", value: 6 },
   { label: "Last 24 hours", value: 24 },
   { label: "Last 7 days", value: 168 },
+  { label: "Last 30 days", value: 720 },
 ];
+
+const eventSelect: Select<SecurityEvent> = {
+  _id: true,
+  time: true,
+  eventUid: true,
+  categoryName: true,
+  className: true,
+  activityName: true,
+  severityName: true,
+  statusName: true,
+  message: true,
+  vendorName: true,
+  productName: true,
+  ruleId: true,
+  ruleName: true,
+  mitreTactics: true,
+  mitreTechniques: true,
+  principalUser: true,
+  principalHost: true,
+  principalIp: true,
+  principalProcess: true,
+  targetUser: true,
+  targetHost: true,
+  targetIp: true,
+  targetPort: true,
+  targetResource: true,
+  observables: true,
+  attributes: true,
+} as Select<SecurityEvent>;
 
 const centerNodeStyle: React.CSSProperties = {
   background: "#4f46e5",
@@ -72,16 +143,6 @@ const centerNodeStyle: React.CSSProperties = {
   padding: 10,
   fontSize: 12,
   fontWeight: 600,
-  maxWidth: 220,
-};
-
-const classNodeStyle: React.CSSProperties = {
-  background: "#fff7ed",
-  color: "#9a3412",
-  border: "1px solid #fdba74",
-  borderRadius: 8,
-  padding: 8,
-  fontSize: 12,
   maxWidth: 220,
 };
 
@@ -95,229 +156,357 @@ const coObservableNodeStyle: React.CSSProperties = {
   maxWidth: 220,
 };
 
+const baseClassNodeStyle: React.CSSProperties = {
+  borderRadius: 8,
+  padding: 8,
+  fontSize: 12,
+  maxWidth: 220,
+};
+
+/*
+ * Class nodes are tinted by the worst severity among their events so the
+ * dangerous classes stand out before anyone reads a single count.
+ */
+function classNodeStyle(
+  worstSeverity: OcsfSeverity | undefined,
+): React.CSSProperties {
+  switch (worstSeverity) {
+    case OcsfSeverity.Fatal:
+    case OcsfSeverity.Critical:
+      return {
+        ...baseClassNodeStyle,
+        background: "#fef2f2",
+        color: "#7f1d1d",
+        border: "1px solid #f87171",
+      };
+    case OcsfSeverity.High:
+      return {
+        ...baseClassNodeStyle,
+        background: "#fff7ed",
+        color: "#9a3412",
+        border: "1px solid #fdba74",
+      };
+    case OcsfSeverity.Medium:
+      return {
+        ...baseClassNodeStyle,
+        background: "#fefce8",
+        color: "#854d0e",
+        border: "1px solid #fde047",
+      };
+    case OcsfSeverity.Low:
+      return {
+        ...baseClassNodeStyle,
+        background: "#eff6ff",
+        color: "#1e40af",
+        border: "1px solid #93c5fd",
+      };
+    default:
+      return {
+        ...baseClassNodeStyle,
+        background: "#f9fafb",
+        color: "#374151",
+        border: "1px solid #cbd5e1",
+      };
+  }
+}
+
+function singleObservableFilter(observable: string): CorrelationFilter {
+  return {
+    conditions: [
+      {
+        field: CorrelationFieldKey.Observable,
+        operator: CorrelationOperator.Equals,
+        value: observable,
+      },
+    ],
+    connector: "and",
+  };
+}
+
+/*
+ * The quick input mirrors the applied filter only when the filter is
+ * exactly one "Observable is X" condition — anything richer belongs to the
+ * builder.
+ */
+function quickValueForFilter(filter: CorrelationFilter | null): string {
+  if (
+    filter &&
+    filter.conditions.length === 1 &&
+    filter.conditions[0]!.field === CorrelationFieldKey.Observable &&
+    filter.conditions[0]!.operator === CorrelationOperator.Equals
+  ) {
+    return filter.conditions[0]!.value;
+  }
+  return "";
+}
+
 const CorrelateGraph: FunctionComponent = (): ReactElement => {
-  const [inputValue, setInputValue] = useState<string>("");
-  const [searchedObservable, setSearchedObservable] = useState<string>("");
+  const [quickValue, setQuickValue] = useState<string>("");
+  const [draftConditions, setDraftConditions] = useState<
+    Array<CorrelationCondition>
+  >([]);
+  const [draftConnector, setDraftConnector] =
+    useState<CorrelationConnector>("and");
+  const [isBuilderOpen, setIsBuilderOpen] = useState<boolean>(false);
+  const [appliedFilter, setAppliedFilter] = useState<CorrelationFilter | null>(
+    null,
+  );
   const [timeRangeInHours, setTimeRangeInHours] = useState<number>(24);
   const [events, setEvents] = useState<Array<SecurityEvent>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
+  const [isTruncated, setIsTruncated] = useState<boolean>(false);
+  const [selectedObservable, setSelectedObservable] = useState<string>("");
+  const [drillDownClassName, setDrillDownClassName] = useState<string>("");
+  const [detailEvent, setDetailEvent] = useState<SecurityEvent | null>(null);
 
   const flowInstance: React.MutableRefObject<ReactFlowInstance | null> =
     useRef<ReactFlowInstance | null>(null);
+  const fetchRequestId: React.MutableRefObject<number> = useRef<number>(0);
 
-  const fetchEvents: (observable: string, hours: number) => Promise<void> =
-    useCallback(async (observable: string, hours: number): Promise<void> => {
-      if (!observable) {
-        return;
-      }
-
-      setIsLoading(true);
-      setError("");
-
-      try {
-        const endDate: Date = OneUptimeDate.getCurrentDate();
-        const startDate: Date = OneUptimeDate.getSomeHoursAgo(hours);
-
-        const query: Query<SecurityEvent> = {
-          observables: new Includes([observable]),
-          time: new InBetween<Date>(startDate, endDate),
-        } as Query<SecurityEvent>;
-
-        const listResult: ListResult<SecurityEvent> =
-          await AnalyticsModelAPI.getList<SecurityEvent>({
-            modelType: SecurityEvent,
-            query: query,
-            limit: EVENT_LIMIT,
-            skip: 0,
-            select: {
-              className: true,
-              severityName: true,
-              message: true,
-              principalUser: true,
-              principalHost: true,
-              principalIp: true,
-              targetUser: true,
-              targetHost: true,
-              targetIp: true,
-              observables: true,
-              time: true,
-            },
-            sort: {
-              time: SortOrder.Descending,
-            },
-            requestOptions: {},
-          });
-
-        setEvents(listResult.data);
-      } catch (err) {
-        setError(API.getFriendlyMessage(err));
-      } finally {
-        setIsLoading(false);
-      }
+  const syncUrl: (filter: CorrelationFilter | null, hours: number) => void =
+    useCallback((filter: CorrelationFilter | null, hours: number): void => {
+      Navigation.setQueryString({
+        q: filter ? serializeCorrelationFilter(filter) : null,
+        hours: filter ? String(hours) : null,
+        observable: null,
+      });
     }, []);
 
-  const searchObservable: (observable: string) => void = useCallback(
-    (observable: string): void => {
-      const trimmed: string = observable.trim();
-      if (!trimmed) {
-        return;
-      }
-      setInputValue(trimmed);
-      setSearchedObservable(trimmed);
+  const applyFilter: (filter: CorrelationFilter | null) => void = useCallback(
+    (filter: CorrelationFilter | null): void => {
+      setAppliedFilter(filter);
+      setQuickValue(quickValueForFilter(filter));
+      setDraftConditions(filter ? [...filter.conditions] : []);
+      setDraftConnector(filter ? filter.connector : "and");
+      setSelectedObservable("");
+      setDrillDownClassName("");
+      setDetailEvent(null);
+      syncUrl(filter, timeRangeInHours);
     },
-    [],
+    [syncUrl, timeRangeInHours],
   );
 
+  // Seed from the URL — deep links from the events table and shared views.
   useEffect(() => {
-    if (searchedObservable) {
-      fetchEvents(searchedObservable, timeRangeInHours).catch(
-        (err: unknown) => {
-          setError(API.getFriendlyMessage(err));
-        },
-      );
+    const rawHours: string | null = Navigation.getQueryStringByName("hours");
+    let initialHours: number = 24;
+    if (rawHours) {
+      const parsedHours: number = parseInt(rawHours, 10);
+      if (
+        timeRangeOptions.some((option: DropdownOption) => {
+          return option.value === parsedHours;
+        })
+      ) {
+        initialHours = parsedHours;
+        setTimeRangeInHours(parsedHours);
+      }
     }
-  }, [searchedObservable, timeRangeInHours, fetchEvents]);
+
+    const parsedFilter: CorrelationFilter | null = parseCorrelationFilter(
+      Navigation.getQueryStringByName("q"),
+    );
+    const rawObservable: string | null =
+      Navigation.getQueryStringByName("observable");
+
+    const initialFilter: CorrelationFilter | null =
+      parsedFilter ||
+      (rawObservable && rawObservable.trim()
+        ? singleObservableFilter(rawObservable.trim())
+        : null);
+
+    if (initialFilter) {
+      setAppliedFilter(initialFilter);
+      setQuickValue(quickValueForFilter(initialFilter));
+      setDraftConditions([...initialFilter.conditions]);
+      setDraftConnector(initialFilter.connector);
+      if (initialFilter.conditions.length > 1) {
+        setIsBuilderOpen(true);
+      }
+      syncUrl(initialFilter, initialHours);
+    }
+    // Mount-only: the URL is an input here, not a subscription.
+  }, []);
+
+  useEffect(() => {
+    if (!appliedFilter) {
+      setEvents([]);
+      setError("");
+      setIsTruncated(false);
+      return;
+    }
+
+    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+    if (!projectId) {
+      return;
+    }
+
+    const endDate: Date = OneUptimeDate.getCurrentDate();
+    const startDate: Date = OneUptimeDate.getSomeHoursAgo(timeRangeInHours);
+
+    const compiled: CompiledCorrelationQueries = compileCorrelationFilter(
+      appliedFilter,
+      {
+        projectId: projectId,
+        startDate: startDate,
+        endDate: endDate,
+      },
+    );
+
+    if (compiled.error) {
+      setError(compiled.error);
+      setEvents([]);
+      setIsTruncated(false);
+      return;
+    }
+
+    if (compiled.queries.length === 0) {
+      setEvents([]);
+      setError("");
+      setIsTruncated(false);
+      return;
+    }
+
+    const requestId: number = ++fetchRequestId.current;
+    setIsLoading(true);
+    setError("");
+
+    const fetchAll: () => Promise<void> = async (): Promise<void> => {
+      try {
+        const listResults: Array<ListResult<SecurityEvent>> = await Promise.all(
+          compiled.queries.map(
+            (
+              query: Query<SecurityEvent>,
+            ): Promise<ListResult<SecurityEvent>> => {
+              return AnalyticsModelAPI.getList<SecurityEvent>({
+                modelType: SecurityEvent,
+                query: query,
+                limit: EVENT_LIMIT,
+                skip: 0,
+                select: eventSelect,
+                sort: {
+                  time: SortOrder.Descending,
+                },
+                requestOptions: {},
+              });
+            },
+          ),
+        );
+
+        if (requestId !== fetchRequestId.current) {
+          return; // A newer correlation superseded this one.
+        }
+
+        setEvents(
+          dedupeSecurityEvents(
+            listResults.map((listResult: ListResult<SecurityEvent>) => {
+              return listResult.data;
+            }),
+          ),
+        );
+        setIsTruncated(
+          listResults.some((listResult: ListResult<SecurityEvent>) => {
+            return listResult.data.length >= EVENT_LIMIT;
+          }),
+        );
+      } catch (err) {
+        if (requestId === fetchRequestId.current) {
+          setError(API.getFriendlyMessage(err));
+        }
+      } finally {
+        if (requestId === fetchRequestId.current) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchAll().catch((err: unknown) => {
+      setError(API.getFriendlyMessage(err));
+      setIsLoading(false);
+    });
+  }, [appliedFilter, timeRangeInHours]);
+
+  const graphData: CorrelationGraphData = useMemo((): CorrelationGraphData => {
+    if (!appliedFilter || events.length === 0) {
+      return { nodes: [], edges: [], droppedCoObservableCount: 0 };
+    }
+
+    const centerLabel: string =
+      appliedFilter.conditions.length === 1
+        ? describeCorrelationCondition(appliedFilter.conditions[0]!)
+        : `${appliedFilter.conditions.length} conditions (${
+            appliedFilter.connector === "or" ? "ANY" : "ALL"
+          })`;
+
+    return buildCorrelationGraph({
+      events: events,
+      centerLabel: centerLabel,
+      excludedObservables: getEqualityObservables(appliedFilter),
+    });
+  }, [events, appliedFilter]);
 
   const { nodes, edges } = useMemo((): {
     nodes: Array<Node>;
     edges: Array<Edge>;
   } => {
-    if (!searchedObservable || events.length === 0) {
+    if (graphData.nodes.length === 0) {
       return { nodes: [], edges: [] };
     }
 
-    const centerId: string = `${OBSERVABLE_NODE_PREFIX}${searchedObservable}`;
-
-    // Events per class, and co-occurring observables per class.
-    const classCounts: Map<string, number> = new Map<string, number>();
-    const coObservableCounts: Map<string, number> = new Map<string, number>();
-    const classToCoObservable: Map<string, Map<string, number>> = new Map<
-      string,
-      Map<string, number>
-    >();
-
-    for (const event of events) {
-      const className: string = event.className || "Unclassified";
-      classCounts.set(className, (classCounts.get(className) || 0) + 1);
-
-      const seenInEvent: Set<string> = new Set<string>();
-      for (const observable of event.observables || []) {
-        if (
-          !observable ||
-          observable === searchedObservable ||
-          seenInEvent.has(observable)
-        ) {
-          continue;
-        }
-        seenInEvent.add(observable);
-        coObservableCounts.set(
-          observable,
-          (coObservableCounts.get(observable) || 0) + 1,
-        );
-        const observableCounts: Map<string, number> =
-          classToCoObservable.get(className) || new Map<string, number>();
-        observableCounts.set(
-          observable,
-          (observableCounts.get(observable) || 0) + 1,
-        );
-        classToCoObservable.set(className, observableCounts);
-      }
-    }
-
-    // Cap co-observables at the most frequent ones.
-    const topCoObservables: Set<string> = new Set<string>(
-      Array.from(coObservableCounts.entries())
-        .sort((a: [string, number], b: [string, number]): number => {
-          if (b[1] !== a[1]) {
-            return b[1] - a[1];
-          }
-          return a[0].localeCompare(b[0]);
-        })
-        .slice(0, MAX_CO_OBSERVABLES)
-        .map((entry: [string, number]) => {
-          return entry[0];
-        }),
-    );
-
-    const nodeIds: Array<string> = [centerId];
-    const layoutEdges: Array<{ from: string; to: string }> = [];
-    const builtEdges: Array<Edge> = [];
-
-    for (const [className, count] of classCounts) {
-      const classId: string = `${CLASS_NODE_PREFIX}${className}`;
-      nodeIds.push(classId);
-      layoutEdges.push({ from: centerId, to: classId });
-      builtEdges.push({
-        id: `${centerId}->${classId}`,
-        source: centerId,
-        target: classId,
-        type: "smoothstep",
-        animated: true,
-        label: count.toString(),
-        labelStyle: { fontSize: 10, fill: "#6b7280" },
-        markerEnd: { type: MarkerType.ArrowClosed, color: "#94a3b8" },
-        style: { stroke: "#94a3b8" },
-      });
-    }
-
-    for (const [className, observableCounts] of classToCoObservable) {
-      for (const [observable, count] of observableCounts) {
-        if (!topCoObservables.has(observable)) {
-          continue;
-        }
-        const classId: string = `${CLASS_NODE_PREFIX}${className}`;
-        const coId: string = `${OBSERVABLE_NODE_PREFIX}${observable}`;
-        if (!nodeIds.includes(coId)) {
-          nodeIds.push(coId);
-        }
-        layoutEdges.push({ from: classId, to: coId });
-        builtEdges.push({
-          id: `${classId}->${coId}`,
-          source: classId,
-          target: coId,
-          type: "smoothstep",
-          label: count.toString(),
-          labelStyle: { fontSize: 10, fill: "#6b7280" },
-          markerEnd: { type: MarkerType.ArrowClosed, color: "#cbd5e1" },
-          style: { stroke: "#cbd5e1" },
-        });
-      }
-    }
-
     const layout: Map<string, LayoutPoint> = computeLayeredLayout(
-      nodeIds,
-      layoutEdges,
+      graphData.nodes.map((node: CorrelationGraphNode) => {
+        return node.id;
+      }),
+      graphData.edges.map((edge: { from: string; to: string }) => {
+        return { from: edge.from, to: edge.to };
+      }),
       { xGap: X_GAP, yGap: Y_GAP },
     );
 
-    const builtNodes: Array<Node> = nodeIds.map((nodeId: string): Node => {
-      const point: LayoutPoint = layout.get(nodeId) || { x: 0, y: 0 };
-      const isCenter: boolean = nodeId === centerId;
-      const isClass: boolean = nodeId.startsWith(CLASS_NODE_PREFIX);
-      const label: string = isClass
-        ? `${nodeId.substring(CLASS_NODE_PREFIX.length)} (${
-            classCounts.get(nodeId.substring(CLASS_NODE_PREFIX.length)) || 0
-          })`
-        : nodeId.substring(OBSERVABLE_NODE_PREFIX.length);
+    const builtNodes: Array<Node> = graphData.nodes.map(
+      (node: CorrelationGraphNode): Node => {
+        const point: LayoutPoint = layout.get(node.id) || { x: 0, y: 0 };
 
-      let style: React.CSSProperties = coObservableNodeStyle;
-      if (isCenter) {
-        style = centerNodeStyle;
-      } else if (isClass) {
-        style = classNodeStyle;
-      }
+        let style: React.CSSProperties = coObservableNodeStyle;
+        let label: string = node.label;
+        if (node.kind === "center") {
+          style = centerNodeStyle;
+        } else if (node.kind === "class") {
+          style = classNodeStyle(node.worstSeverity);
+          label = `${node.label} (${node.count || 0})`;
+        }
 
-      return {
-        id: nodeId,
-        position: point,
-        data: { label },
-        style,
-      };
-    });
+        return {
+          id: node.id,
+          position: point,
+          data: { label },
+          style,
+        };
+      },
+    );
+
+    const builtEdges: Array<Edge> = graphData.edges.map(
+      (edge: { id: string; from: string; to: string; count: number }): Edge => {
+        const isCenterEdge: boolean = edge.from === "center";
+        return {
+          id: edge.id,
+          source: edge.from,
+          target: edge.to,
+          type: "smoothstep",
+          animated: isCenterEdge,
+          label: edge.count.toString(),
+          labelStyle: { fontSize: 10, fill: "#6b7280" },
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: isCenterEdge ? "#94a3b8" : "#cbd5e1",
+          },
+          style: { stroke: isCenterEdge ? "#94a3b8" : "#cbd5e1" },
+        };
+      },
+    );
 
     return { nodes: builtNodes, edges: builtEdges };
-  }, [events, searchedObservable]);
+  }, [graphData]);
 
   /*
    * Re-fit when the graph changes. A new controlled `nodes` array wipes
@@ -342,7 +531,211 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
     return () => {
       cancelAnimationFrame(raf);
     };
-  }, [nodes.length, searchedObservable]);
+  }, [nodes.length, appliedFilter]);
+
+  const appendCondition: (condition: CorrelationCondition) => void =
+    useCallback(
+      (condition: CorrelationCondition): void => {
+        if (!appliedFilter) {
+          applyFilter({ conditions: [condition], connector: "and" });
+          return;
+        }
+        applyFilter({
+          conditions: [...appliedFilter.conditions, condition],
+          connector: appliedFilter.connector,
+        });
+      },
+      [appliedFilter, applyFilter],
+    );
+
+  const drillDownEvents: Array<SecurityEvent> =
+    useMemo((): Array<SecurityEvent> => {
+      if (!drillDownClassName) {
+        return [];
+      }
+      return events.filter((event: SecurityEvent) => {
+        return (event.className || "Unclassified") === drillDownClassName;
+      });
+    }, [events, drillDownClassName]);
+
+  /*
+   * Excluding in OR mode would just add a near-match-everything branch —
+   * "is not X" only narrows when it ANDs with the rest of the filter.
+   */
+  const canExclude: boolean =
+    !appliedFilter ||
+    appliedFilter.connector === "and" ||
+    appliedFilter.conditions.length === 0;
+
+  const getObservableActionBar: () => ReactElement = (): ReactElement => {
+    if (!selectedObservable) {
+      return <Fragment />;
+    }
+
+    return (
+      <div
+        data-testid="correlate-observable-actions"
+        className="mb-3 flex flex-wrap items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50/60 px-3 py-2"
+      >
+        <span className="text-xs text-gray-600">
+          Selected observable:{" "}
+          <span className="font-mono font-medium text-gray-900">
+            {selectedObservable}
+          </span>
+        </span>
+        <Button
+          dataTestId="correlate-action-focus"
+          title="Focus"
+          tooltip="Start a new correlation on this observable"
+          buttonStyle={ButtonStyleType.OUTLINE}
+          buttonSize={ButtonSize.Small}
+          icon={IconProp.Graph}
+          onClick={() => {
+            applyFilter(singleObservableFilter(selectedObservable));
+          }}
+        />
+        <Button
+          dataTestId="correlate-action-add"
+          title={
+            appliedFilter && appliedFilter.connector === "or"
+              ? "Add OR condition"
+              : "Add AND condition"
+          }
+          tooltip="Narrow or widen the current correlation with this observable"
+          buttonStyle={ButtonStyleType.OUTLINE}
+          buttonSize={ButtonSize.Small}
+          icon={IconProp.Add}
+          onClick={() => {
+            appendCondition({
+              field: CorrelationFieldKey.Observable,
+              operator: CorrelationOperator.Equals,
+              value: selectedObservable,
+            });
+          }}
+        />
+        {canExclude && (
+          <Button
+            dataTestId="correlate-action-exclude"
+            title="Exclude"
+            tooltip="Hide events that mention this observable"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            buttonSize={ButtonSize.Small}
+            icon={IconProp.Minus}
+            onClick={() => {
+              appendCondition({
+                field: CorrelationFieldKey.Observable,
+                operator: CorrelationOperator.NotEquals,
+                value: selectedObservable,
+              });
+            }}
+          />
+        )}
+        <Button
+          dataTestId="correlate-action-dismiss"
+          title="Dismiss"
+          buttonStyle={ButtonStyleType.SECONDARY_LINK}
+          buttonSize={ButtonSize.Small}
+          onClick={() => {
+            setSelectedObservable("");
+          }}
+        />
+      </div>
+    );
+  };
+
+  const getDrillDownPanel: () => ReactElement = (): ReactElement => {
+    if (!drillDownClassName) {
+      return <Fragment />;
+    }
+
+    const visibleEvents: Array<SecurityEvent> = drillDownEvents.slice(
+      0,
+      DRILL_DOWN_ROW_LIMIT,
+    );
+
+    return (
+      <div
+        data-testid="correlate-drilldown"
+        className="mt-3 rounded-lg border border-gray-200 bg-white"
+      >
+        <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2">
+          <p className="text-sm font-medium text-gray-900">
+            {drillDownClassName}{" "}
+            <span className="text-gray-500 font-normal">
+              — {drillDownEvents.length} matching event
+              {drillDownEvents.length === 1 ? "" : "s"}
+            </span>
+          </p>
+          <div className="flex items-center gap-2">
+            {(!appliedFilter || appliedFilter.connector === "and") && (
+              <Button
+                dataTestId="correlate-drilldown-filter-class"
+                title="Filter to this class"
+                buttonStyle={ButtonStyleType.OUTLINE}
+                buttonSize={ButtonSize.Small}
+                icon={IconProp.Filter}
+                onClick={() => {
+                  appendCondition({
+                    field: CorrelationFieldKey.EventClass,
+                    operator: CorrelationOperator.Equals,
+                    value: drillDownClassName,
+                  });
+                }}
+              />
+            )}
+            <Button
+              dataTestId="correlate-drilldown-close"
+              title="Close"
+              buttonStyle={ButtonStyleType.SECONDARY_LINK}
+              buttonSize={ButtonSize.Small}
+              onClick={() => {
+                setDrillDownClassName("");
+              }}
+            />
+          </div>
+        </div>
+        <ul className="divide-y divide-gray-100 max-h-72 overflow-y-auto">
+          {visibleEvents.map(
+            (event: SecurityEvent, index: number): ReactElement => {
+              return (
+                <li key={index}>
+                  <button
+                    type="button"
+                    data-testid={`correlate-drilldown-event-${index}`}
+                    className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-gray-50"
+                    onClick={() => {
+                      setDetailEvent(event);
+                    }}
+                  >
+                    <span className="w-24 shrink-0 text-xs text-gray-500">
+                      {event.time
+                        ? OneUptimeDate.fromNow(new Date(event.time))
+                        : "-"}
+                    </span>
+                    <SecurityEventSeverityPill
+                      severityName={event.severityName}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-sm text-gray-900">
+                      {event.message || "-"}
+                    </span>
+                    <span className="hidden md:block w-40 shrink-0 truncate text-xs text-gray-500">
+                      {event.principalUser || event.principalHost || ""}
+                    </span>
+                  </button>
+                </li>
+              );
+            },
+          )}
+        </ul>
+        {drillDownEvents.length > DRILL_DOWN_ROW_LIMIT && (
+          <p className="border-t border-gray-100 px-3 py-2 text-xs text-gray-500">
+            Showing the {DRILL_DOWN_ROW_LIMIT} most recent — narrow the filter
+            or time range to see the rest.
+          </p>
+        )}
+      </div>
+    );
+  };
 
   const getGraphContent: () => ReactElement = (): ReactElement => {
     if (isLoading) {
@@ -353,13 +746,13 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
       return <ErrorMessage message={error} />;
     }
 
-    if (!searchedObservable) {
+    if (!appliedFilter) {
       return (
         <EmptyState
           id="security-events-correlate-empty"
           icon={IconProp.Graph}
-          title="Correlate an observable"
-          description="Enter a hostname, user, or IP address above to see every event class that mentioned it and the observables it co-occurred with."
+          title="Correlate security events"
+          description="Enter a hostname, user, or IP address above — or build a multi-condition filter (host AND ip, user OR user) with Add filters — to see every event class that matched and the observables they co-occurred with."
         />
       );
     }
@@ -370,7 +763,7 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
           id="security-events-correlate-no-results"
           icon={IconProp.Search}
           title="No events found"
-          description={`No security events mention "${searchedObservable}" in the selected time range. Try a longer range or a different observable.`}
+          description="No security events match this filter in the selected time range. Try a longer range or fewer conditions."
         />
       );
     }
@@ -390,8 +783,14 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
           }}
           onNodeClick={(_event: React.MouseEvent, node: Node) => {
             if (node.id.startsWith(OBSERVABLE_NODE_PREFIX)) {
-              searchObservable(
+              setSelectedObservable(
                 node.id.substring(OBSERVABLE_NODE_PREFIX.length),
+              );
+              return;
+            }
+            if (node.id.startsWith(CLASS_NODE_PREFIX)) {
+              setDrillDownClassName(
+                node.id.substring(CLASS_NODE_PREFIX.length),
               );
             }
           }}
@@ -408,32 +807,40 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
     );
   };
 
+  const hasDraftToApply: boolean = isBuilderOpen
+    ? draftConditions.length > 0
+    : Boolean(quickValue.trim());
+
   return (
     <Fragment>
       <div className="mb-3 flex flex-col md:flex-row md:items-end gap-3">
-        <div className="md:w-80">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Observable
-          </label>
-          <Input
-            dataTestId="security-events-correlate-observable"
-            placeholder="hostname, user, or IP address"
-            value={inputValue}
-            onChange={(value: string) => {
-              setInputValue(value);
-            }}
-            onEnterPress={() => {
-              searchObservable(inputValue);
-            }}
-          />
-        </div>
+        {!isBuilderOpen && (
+          <div className="md:w-80">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Observable
+            </label>
+            <Input
+              dataTestId="security-events-correlate-observable"
+              placeholder="hostname, user, or IP address"
+              value={quickValue}
+              onChange={(value: string) => {
+                setQuickValue(value);
+              }}
+              onEnterPress={() => {
+                if (quickValue.trim()) {
+                  applyFilter(singleObservableFilter(quickValue.trim()));
+                }
+              }}
+            />
+          </div>
+        )}
         <div className="md:w-48">
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Time Range
           </label>
           <Dropdown
             options={timeRangeOptions}
-            initialValue={
+            value={
               timeRangeOptions.find((option: DropdownOption) => {
                 return option.value === timeRangeInHours;
               }) || timeRangeOptions[2]
@@ -441,34 +848,135 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
             onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
               if (typeof value === "number") {
                 setTimeRangeInHours(value);
+                if (appliedFilter) {
+                  syncUrl(appliedFilter, value);
+                }
               }
             }}
           />
         </div>
-        <div>
+        <div className="flex items-end gap-2">
           <Button
             title="Correlate"
+            dataTestId="security-events-correlate-button"
             buttonStyle={ButtonStyleType.PRIMARY}
             icon={IconProp.Graph}
-            disabled={!inputValue.trim() || isLoading}
+            disabled={!hasDraftToApply || isLoading}
             onClick={() => {
-              searchObservable(inputValue);
+              if (isBuilderOpen) {
+                applyFilter({
+                  conditions: draftConditions,
+                  connector: draftConnector,
+                });
+                return;
+              }
+              if (quickValue.trim()) {
+                applyFilter(singleObservableFilter(quickValue.trim()));
+              }
+            }}
+          />
+          <Button
+            title={isBuilderOpen ? "Simple search" : "Add filters"}
+            dataTestId="security-events-correlate-toggle-builder"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            icon={IconProp.Filter}
+            onClick={() => {
+              if (isBuilderOpen) {
+                setIsBuilderOpen(false);
+                setQuickValue(quickValueForFilter(appliedFilter));
+                return;
+              }
+              // Seed the builder from what is already on screen.
+              if (draftConditions.length === 0) {
+                if (quickValue.trim()) {
+                  setDraftConditions(
+                    singleObservableFilter(quickValue.trim()).conditions,
+                  );
+                } else {
+                  setDraftConditions([getDefaultCorrelationCondition()]);
+                }
+              }
+              setIsBuilderOpen(true);
             }}
           />
         </div>
-        {searchedObservable && !isLoading && !error && events.length > 0 && (
+        {appliedFilter && !isLoading && !error && events.length > 0 && (
           <p className="text-xs text-gray-500 md:ml-auto">
-            {events.length === EVENT_LIMIT
-              ? `Showing the ${EVENT_LIMIT} most recent matching events.`
-              : `${events.length} matching event${
-                  events.length === 1 ? "" : "s"
-                }.`}{" "}
-            Click an observable node to re-center the graph on it.
+            {events.length} matching event{events.length === 1 ? "" : "s"}.
+            {isTruncated
+              ? ` At least one search hit the ${EVENT_LIMIT}-event cap — treat counts as lower bounds.`
+              : ""}{" "}
+            Click a class node to inspect its events, or an observable node to
+            pivot.
           </p>
         )}
       </div>
 
+      {isBuilderOpen && (
+        <div className="mb-3">
+          <CorrelateFilterBuilder
+            conditions={draftConditions}
+            connector={draftConnector}
+            onChange={(
+              conditions: Array<CorrelationCondition>,
+              connector: CorrelationConnector,
+            ) => {
+              setDraftConditions(conditions);
+              setDraftConnector(connector);
+            }}
+          />
+        </div>
+      )}
+
+      {appliedFilter && (
+        <div className="mb-3">
+          <CorrelateFilterChips
+            filter={appliedFilter}
+            onRemoveCondition={(index: number) => {
+              const remaining: Array<CorrelationCondition> =
+                appliedFilter.conditions.filter(
+                  (
+                    _condition: CorrelationCondition,
+                    conditionIndex: number,
+                  ) => {
+                    return conditionIndex !== index;
+                  },
+                );
+              applyFilter(
+                remaining.length > 0
+                  ? {
+                      conditions: remaining,
+                      connector: appliedFilter.connector,
+                    }
+                  : null,
+              );
+            }}
+            onClearAll={() => {
+              applyFilter(null);
+            }}
+          />
+        </div>
+      )}
+
+      {getObservableActionBar()}
+
       {getGraphContent()}
+
+      {getDrillDownPanel()}
+
+      {detailEvent && (
+        <SecurityEventDetail
+          securityEvent={detailEvent}
+          onClose={() => {
+            setDetailEvent(null);
+          }}
+          onCorrelateObservable={(observable: string) => {
+            setDetailEvent(null);
+            setDrillDownClassName("");
+            applyFilter(singleObservableFilter(observable));
+          }}
+        />
+      )}
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateGraph.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateGraph.tsx
@@ -329,15 +329,24 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
   }, []);
 
   useEffect(() => {
+    /*
+     * Every effect run supersedes whatever fetch is in flight — including
+     * the early-return branches below, which would otherwise let a stale
+     * response pass the requestId guard and overwrite the cleared state.
+     */
+    const requestId: number = ++fetchRequestId.current;
+
     if (!appliedFilter) {
       setEvents([]);
       setError("");
       setIsTruncated(false);
+      setIsLoading(false);
       return;
     }
 
     const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
     if (!projectId) {
+      setIsLoading(false);
       return;
     }
 
@@ -357,6 +366,7 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
       setError(compiled.error);
       setEvents([]);
       setIsTruncated(false);
+      setIsLoading(false);
       return;
     }
 
@@ -364,10 +374,10 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
       setEvents([]);
       setError("");
       setIsTruncated(false);
+      setIsLoading(false);
       return;
     }
 
-    const requestId: number = ++fetchRequestId.current;
     setIsLoading(true);
     setError("");
 
@@ -568,7 +578,12 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
     appliedFilter.conditions.length === 0;
 
   const getObservableActionBar: () => ReactElement = (): ReactElement => {
-    if (!selectedObservable) {
+    /*
+     * Selections belong to the CURRENT result set — while a new fetch is in
+     * flight (or after it failed) the underlying events are stale, so the
+     * pivot bar and the drill-down below both hide until fresh data lands.
+     */
+    if (!selectedObservable || isLoading || error) {
       return <Fragment />;
     }
 
@@ -644,7 +659,8 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
   };
 
   const getDrillDownPanel: () => ReactElement = (): ReactElement => {
-    if (!drillDownClassName) {
+    // Same staleness rule as the action bar above.
+    if (!drillDownClassName || isLoading || error) {
       return <Fragment />;
     }
 
@@ -807,8 +823,17 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
     );
   };
 
+  /*
+   * Correlate stays disabled until every builder row has a value —
+   * matching the quick-search path, and keeping an all-empty default row
+   * from ever becoming an error state, a blank chip, and a q URL param
+   * that degrades to "no filter" when the link is shared.
+   */
   const hasDraftToApply: boolean = isBuilderOpen
-    ? draftConditions.length > 0
+    ? draftConditions.length > 0 &&
+      draftConditions.every((draftCondition: CorrelationCondition) => {
+        return Boolean(draftCondition.value.trim());
+      })
     : Boolean(quickValue.trim());
 
   return (
@@ -816,11 +841,15 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
       <div className="mb-3 flex flex-col md:flex-row md:items-end gap-3">
         {!isBuilderOpen && (
           <div className="md:w-80">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              id="security-events-correlate-observable-label"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Observable
             </label>
             <Input
               dataTestId="security-events-correlate-observable"
+              ariaLabelledby="security-events-correlate-observable-label"
               placeholder="hostname, user, or IP address"
               value={quickValue}
               onChange={(value: string) => {
@@ -834,11 +863,18 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
             />
           </div>
         )}
-        <div className="md:w-48">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+        <div
+          className="md:w-48"
+          data-testid="security-events-correlate-time-range"
+        >
+          <label
+            id="security-events-correlate-time-range-label"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
             Time Range
           </label>
           <Dropdown
+            ariaLabelledby="security-events-correlate-time-range-label"
             options={timeRangeOptions}
             value={
               timeRangeOptions.find((option: DropdownOption) => {
@@ -886,11 +922,24 @@ const CorrelateGraph: FunctionComponent = (): ReactElement => {
                 setQuickValue(quickValueForFilter(appliedFilter));
                 return;
               }
-              // Seed the builder from what is already on screen.
-              if (draftConditions.length === 0) {
-                if (quickValue.trim()) {
+              /*
+               * Seed the builder from what is on screen. Freshly typed
+               * (unapplied) quick text wins over a stale draft — the user
+               * just told us what they want to correlate on.
+               */
+              const trimmedQuickValue: string = quickValue.trim();
+              if (
+                trimmedQuickValue &&
+                trimmedQuickValue !== quickValueForFilter(appliedFilter)
+              ) {
+                setDraftConditions(
+                  singleObservableFilter(trimmedQuickValue).conditions,
+                );
+                setDraftConnector("and");
+              } else if (draftConditions.length === 0) {
+                if (trimmedQuickValue) {
                   setDraftConditions(
-                    singleObservableFilter(quickValue.trim()).conditions,
+                    singleObservableFilter(trimmedQuickValue).conditions,
                   );
                 } else {
                   setDraftConditions([getDefaultCorrelationCondition()]);

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventDetail.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventDetail.tsx
@@ -4,10 +4,21 @@ import SecurityEvent from "Common/Models/AnalyticsModels/SecurityEvent";
 import SecurityEventSeverityPill from "./SecurityEventSeverityPill";
 import OneUptimeDate from "Common/Types/Date";
 import { JSONObject } from "Common/Types/JSON";
+import Navigation from "Common/UI/Utils/Navigation";
+import Route from "Common/Types/API/Route";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import PageMap from "../../Utils/PageMap";
 
 export interface ComponentProps {
   securityEvent: SecurityEvent;
   onClose: () => void;
+  /*
+   * Pivot handler for the observable chips. When the detail panel is
+   * already on the Correlate page the pivot happens in place; everywhere
+   * else (omit the prop) a chip deep-links to the Correlate page seeded
+   * with that observable.
+   */
+  onCorrelateObservable?: ((observable: string) => void) | undefined;
 }
 
 interface DetailRow {
@@ -29,6 +40,57 @@ const SecurityEventDetail: FunctionComponent<ComponentProps> = (
       })
       .join(", ");
   };
+
+  const correlateObservable: (observable: string) => void = (
+    observable: string,
+  ): void => {
+    if (props.onCorrelateObservable) {
+      props.onCorrelateObservable(observable);
+      return;
+    }
+    Navigation.navigate(
+      (
+        RouteUtil.populateRouteParams(
+          RouteMap[PageMap.SECURITY_EVENTS_CORRELATE] as Route,
+        ) as Route
+      ).addQueryParams({
+        observable: encodeURIComponent(observable),
+      }),
+    );
+  };
+
+  const observables: Array<string> = (event.observables || []).filter(
+    (observable: string) => {
+      return Boolean(observable);
+    },
+  );
+
+  /*
+   * Observables are the pivot points of the whole product — every one of
+   * them is a valid Correlate query, so render them as chips that start
+   * (or refocus) a correlation instead of a comma-joined string.
+   */
+  const observableChips: ReactElement | undefined =
+    observables.length > 0 ? (
+      <span className="flex flex-wrap gap-1.5">
+        {observables.map((observable: string, index: number): ReactElement => {
+          return (
+            <button
+              key={index}
+              type="button"
+              data-testid={`security-event-observable-chip-${index}`}
+              title={`Correlate "${observable}"`}
+              className="inline-flex items-center rounded-md border border-indigo-200 bg-indigo-50 px-2 py-0.5 font-mono text-xs text-indigo-700 hover:bg-indigo-100"
+              onClick={() => {
+                correlateObservable(observable);
+              }}
+            >
+              {observable}
+            </button>
+          );
+        })}
+      </span>
+    ) : undefined;
 
   const rows: Array<DetailRow> = [
     {
@@ -64,7 +126,7 @@ const SecurityEventDetail: FunctionComponent<ComponentProps> = (
       value: event.targetPort ? event.targetPort.toString() : undefined,
     },
     { label: "Target Resource", value: event.targetResource },
-    { label: "Observables", value: formatArray(event.observables) },
+    { label: "Observables", value: observableChips },
     { label: "Event UID", value: event.eventUid },
   ];
 

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTable.tsx
@@ -122,6 +122,16 @@ const SecurityEventsTable: FunctionComponent = (): ReactElement => {
             type: FieldType.Text,
             title: "Event Class",
           },
+          /*
+           * Substring match over the bloom-indexed observables array —
+           * "every event that mentions this host/user/IP", the same
+           * vocabulary the Correlate tab pivots on.
+           */
+          {
+            field: { observables: true },
+            type: FieldType.Text,
+            title: "Observable",
+          },
           {
             field: { message: true },
             type: FieldType.Text,

--- a/App/FeatureSet/Dashboard/src/Pages/SecurityEvents/DetectionRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/SecurityEvents/DetectionRules.tsx
@@ -23,6 +23,7 @@ import PermissionGate, {
   PermissionGateResult,
 } from "Common/UI/Utils/PermissionGate";
 import ProjectUtil from "Common/UI/Utils/Project";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import React, { FunctionComponent, ReactElement } from "react";
 
 const documentationMarkdown: string = `
@@ -53,9 +54,23 @@ level: high
 Fields referenced in the rule match the normalized OCSF columns of security events (\`className\`, \`severityName\`, \`statusName\`, \`principalUser\`, \`principalHost\`, \`attributes.<key>\`, ...).
 `;
 
-const DetectionRulesPage: FunctionComponent<
-  PageComponentProps
-> = (): ReactElement => {
+const DetectionRulesPage: FunctionComponent<PageComponentProps> = (
+  props: PageComponentProps,
+): ReactElement => {
+  /*
+   * Same reseller-telemetry gate as every other Security Events tab —
+   * detection rules run over telemetry-billed security events, so a plan
+   * without telemetry features has nothing for them to evaluate.
+   */
+  const disableTelemetryForThisProject: boolean =
+    props.currentProject?.reseller?.enableTelemetryFeatures === false;
+
+  if (disableTelemetryForThisProject) {
+    return (
+      <ErrorMessage message="Looks like you have bought this plan from a reseller. It did not include telemetry features in your plan. Telemetry features are disabled for this project." />
+    );
+  }
+
   /*
    * The row action deep-links into the monitor create wizard, which
    * ModelTable's own permission gating never sees — so gate it here the

--- a/App/FeatureSet/Dashboard/src/Utils/CorrelationGraph.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/CorrelationGraph.ts
@@ -1,0 +1,255 @@
+import SecurityEvent from "Common/Models/AnalyticsModels/SecurityEvent";
+import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
+
+/*
+ * Pure graph construction for Security Events → Correlate: the applied
+ * filter in the middle, one node per event class that matched it, and one
+ * node per co-occurring observable (capped at the most frequent N). The
+ * component maps this data onto React Flow nodes/edges and a layout — kept
+ * out of here so counting, capping, exclusion, dedupe, and severity ranking
+ * are unit-testable without rendering anything.
+ */
+
+export const CENTER_NODE_ID: string = "center";
+export const OBSERVABLE_NODE_PREFIX: string = "observable:";
+export const CLASS_NODE_PREFIX: string = "class:";
+
+export const DEFAULT_MAX_CO_OBSERVABLES: number = 30;
+
+export type CorrelationGraphNodeKind = "center" | "class" | "observable";
+
+export interface CorrelationGraphNode {
+  id: string;
+  label: string;
+  kind: CorrelationGraphNodeKind;
+  // Number of matching events (class nodes) — undefined otherwise.
+  count?: number | undefined;
+  // Worst severity among the node's events (class nodes) — undefined otherwise.
+  worstSeverity?: OcsfSeverity | undefined;
+}
+
+export interface CorrelationGraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  count: number;
+}
+
+export interface CorrelationGraphData {
+  nodes: Array<CorrelationGraphNode>;
+  edges: Array<CorrelationGraphEdge>;
+  // How many distinct co-observables were dropped by the cap (0 = none).
+  droppedCoObservableCount: number;
+}
+
+export interface CorrelationGraphInput {
+  events: Array<SecurityEvent>;
+  centerLabel: string;
+  /*
+   * Observable values pinned by the filter with equality — they would
+   * trivially co-occur with every matched event, so they are not shown as
+   * co-occurring nodes.
+   */
+  excludedObservables: Array<string>;
+  maxCoObservables?: number | undefined;
+}
+
+/*
+ * "Worst" ranking for the class-node coloring. This is deliberately NOT
+ * OcsfSeverityId: there `Other` is 99 and would beat `Fatal`, which is
+ * wrong for a "how bad is it" ordering — Unknown/Other rank below
+ * everything real.
+ */
+const SEVERITY_RANK: Record<string, number> = {
+  [OcsfSeverity.Fatal]: 6,
+  [OcsfSeverity.Critical]: 5,
+  [OcsfSeverity.High]: 4,
+  [OcsfSeverity.Medium]: 3,
+  [OcsfSeverity.Low]: 2,
+  [OcsfSeverity.Informational]: 1,
+};
+
+export function severityRank(severityName: string | undefined): number {
+  if (!severityName) {
+    return 0;
+  }
+  return SEVERITY_RANK[severityName] || 0;
+}
+
+/*
+ * Union of several per-query result sets. OR-mode correlation runs one
+ * query per condition; an event matching two conditions comes back twice
+ * and must count once. Keyed by the row id, with eventUid+time as the
+ * fallback identity for callers that did not select _id.
+ */
+export function dedupeSecurityEvents(
+  eventLists: Array<Array<SecurityEvent>>,
+): Array<SecurityEvent> {
+  const deduped: Array<SecurityEvent> = [];
+  const seen: Set<string> = new Set<string>();
+
+  for (const eventList of eventLists) {
+    for (const event of eventList) {
+      const id: string = event._id
+        ? event._id.toString()
+        : `${event.eventUid || ""}|${event.time ? new Date(event.time).toISOString() : ""}`;
+
+      if (seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      deduped.push(event);
+    }
+  }
+
+  return deduped;
+}
+
+export function buildCorrelationGraph(
+  input: CorrelationGraphInput,
+): CorrelationGraphData {
+  const maxCoObservables: number =
+    input.maxCoObservables ?? DEFAULT_MAX_CO_OBSERVABLES;
+  const excluded: Set<string> = new Set<string>(input.excludedObservables);
+
+  if (input.events.length === 0) {
+    return { nodes: [], edges: [], droppedCoObservableCount: 0 };
+  }
+
+  // Events per class, worst severity per class, co-observables per class.
+  const classCounts: Map<string, number> = new Map<string, number>();
+  const classWorstSeverity: Map<string, string> = new Map<string, string>();
+  const coObservableCounts: Map<string, number> = new Map<string, number>();
+  const classToCoObservable: Map<string, Map<string, number>> = new Map<
+    string,
+    Map<string, number>
+  >();
+
+  for (const event of input.events) {
+    const className: string = event.className || "Unclassified";
+    classCounts.set(className, (classCounts.get(className) || 0) + 1);
+
+    const currentWorst: string | undefined = classWorstSeverity.get(className);
+    if (
+      severityRank(event.severityName) > severityRank(currentWorst) ||
+      currentWorst === undefined
+    ) {
+      classWorstSeverity.set(className, event.severityName || "");
+    }
+
+    const seenInEvent: Set<string> = new Set<string>();
+    for (const observable of event.observables || []) {
+      if (
+        !observable ||
+        excluded.has(observable) ||
+        seenInEvent.has(observable)
+      ) {
+        continue;
+      }
+      seenInEvent.add(observable);
+      coObservableCounts.set(
+        observable,
+        (coObservableCounts.get(observable) || 0) + 1,
+      );
+      const observableCounts: Map<string, number> =
+        classToCoObservable.get(className) || new Map<string, number>();
+      observableCounts.set(
+        observable,
+        (observableCounts.get(observable) || 0) + 1,
+      );
+      classToCoObservable.set(className, observableCounts);
+    }
+  }
+
+  // Cap co-observables at the most frequent ones; ties break alphabetically.
+  const sortedCoObservables: Array<[string, number]> = Array.from(
+    coObservableCounts.entries(),
+  ).sort((a: [string, number], b: [string, number]): number => {
+    if (b[1] !== a[1]) {
+      return b[1] - a[1];
+    }
+    return a[0].localeCompare(b[0]);
+  });
+
+  const topCoObservables: Set<string> = new Set<string>(
+    sortedCoObservables
+      .slice(0, maxCoObservables)
+      .map((entry: [string, number]) => {
+        return entry[0];
+      }),
+  );
+
+  const droppedCoObservableCount: number = Math.max(
+    0,
+    sortedCoObservables.length - maxCoObservables,
+  );
+
+  const nodes: Array<CorrelationGraphNode> = [
+    { id: CENTER_NODE_ID, label: input.centerLabel, kind: "center" },
+  ];
+  const edges: Array<CorrelationGraphEdge> = [];
+
+  const sortedClassNames: Array<string> = Array.from(classCounts.keys()).sort(
+    (a: string, b: string): number => {
+      return a.localeCompare(b);
+    },
+  );
+
+  for (const className of sortedClassNames) {
+    const classId: string = `${CLASS_NODE_PREFIX}${className}`;
+    const count: number = classCounts.get(className) || 0;
+    const worstSeverityName: string = classWorstSeverity.get(className) || "";
+
+    nodes.push({
+      id: classId,
+      label: className,
+      kind: "class",
+      count: count,
+      worstSeverity: severityRank(worstSeverityName)
+        ? (worstSeverityName as OcsfSeverity)
+        : undefined,
+    });
+    edges.push({
+      id: `${CENTER_NODE_ID}->${classId}`,
+      from: CENTER_NODE_ID,
+      to: classId,
+      count: count,
+    });
+  }
+
+  const addedObservableNodes: Set<string> = new Set<string>();
+
+  for (const className of sortedClassNames) {
+    const observableCounts: Map<string, number> | undefined =
+      classToCoObservable.get(className);
+    if (!observableCounts) {
+      continue;
+    }
+
+    const classId: string = `${CLASS_NODE_PREFIX}${className}`;
+    const sortedObservables: Array<string> = Array.from(
+      observableCounts.keys(),
+    ).sort((a: string, b: string): number => {
+      return a.localeCompare(b);
+    });
+
+    for (const observable of sortedObservables) {
+      if (!topCoObservables.has(observable)) {
+        continue;
+      }
+      const coId: string = `${OBSERVABLE_NODE_PREFIX}${observable}`;
+      if (!addedObservableNodes.has(coId)) {
+        addedObservableNodes.add(coId);
+        nodes.push({ id: coId, label: observable, kind: "observable" });
+      }
+      edges.push({
+        id: `${classId}->${coId}`,
+        from: classId,
+        to: coId,
+        count: observableCounts.get(observable) || 0,
+      });
+    }
+  }
+
+  return { nodes, edges, droppedCoObservableCount };
+}

--- a/App/FeatureSet/Dashboard/src/Utils/SecurityEventCorrelation.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/SecurityEventCorrelation.ts
@@ -1,0 +1,690 @@
+import SecurityEvent from "Common/Models/AnalyticsModels/SecurityEvent";
+import Query from "Common/Types/BaseDatabase/Query";
+import EqualTo from "Common/Types/BaseDatabase/EqualTo";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import IncludesAll from "Common/Types/BaseDatabase/IncludesAll";
+import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
+import NotContains from "Common/Types/BaseDatabase/NotContains";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
+import Search from "Common/Types/BaseDatabase/Search";
+import StartsWith from "Common/Types/BaseDatabase/StartsWith";
+import EndsWith from "Common/Types/BaseDatabase/EndsWith";
+import ObjectID from "Common/Types/ObjectID";
+import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
+import {
+  OcsfEventClasses,
+  OcsfEventClassProps,
+} from "Common/Types/SecurityEvent/OcsfEventClass";
+
+/*
+ * The correlation filter model behind Security Events → Correlate: rows of
+ * field + operator + value chained with a single AND/OR connector, compiled
+ * into one or more server-side Query<SecurityEvent> objects.
+ *
+ * The analytics query API is a flat map — every key ANDs with every other
+ * key, one operator per column, no OR between columns. That shapes the
+ * compilation strategy:
+ *
+ *  - "All conditions" (AND) compiles to ONE query. Conditions on different
+ *    columns land on different keys. Conditions on the SAME column merge
+ *    where an equivalent single operator exists (two observable equalities →
+ *    IncludesAll/hasAll; several "is not" → IncludesNone) and are rejected
+ *    with a friendly error where none does, instead of silently returning
+ *    wrong results.
+ *
+ *  - "Any condition" (OR) compiles to one query PER condition; the caller
+ *    runs them in parallel and unions the result sets by event id. Equality
+ *    conditions on the same field collapse into a single Includes (hasAny /
+ *    IN) query first, since that IS an OR.
+ *
+ * Everything here is pure so the whole contract is unit-testable without a
+ * component render.
+ */
+
+export enum CorrelationFieldKey {
+  Observable = "observable",
+  PrincipalUser = "principalUser",
+  PrincipalHost = "principalHost",
+  PrincipalIp = "principalIp",
+  TargetUser = "targetUser",
+  TargetHost = "targetHost",
+  TargetIp = "targetIp",
+  EventClass = "className",
+  Severity = "severityName",
+  Message = "message",
+  RuleName = "ruleName",
+  Vendor = "vendorName",
+}
+
+export enum CorrelationOperator {
+  Equals = "equals",
+  NotEquals = "not-equals",
+  Contains = "contains",
+  NotContains = "not-contains",
+  StartsWith = "starts-with",
+  EndsWith = "ends-with",
+}
+
+export type CorrelationConnector = "and" | "or";
+
+export interface CorrelationCondition {
+  field: CorrelationFieldKey;
+  operator: CorrelationOperator;
+  value: string;
+}
+
+export interface CorrelationFilter {
+  conditions: Array<CorrelationCondition>;
+  connector: CorrelationConnector;
+}
+
+export interface CorrelationFieldDefinition {
+  key: CorrelationFieldKey;
+  label: string;
+  // The SecurityEvent column this field filters on.
+  columnKey: string;
+  isArrayColumn: boolean;
+  operators: Array<CorrelationOperator>;
+  // Fixed value vocabulary — render a dropdown instead of a text input.
+  valueOptions?: Array<string> | undefined;
+  /*
+   * Known values worth suggesting, but free text stays allowed (event
+   * classes outside the curated OCSF table keep their source-derived
+   * names, so a strict dropdown would make them unreachable).
+   */
+  valueSuggestions?: Array<string> | undefined;
+  placeholder?: string | undefined;
+}
+
+const ALL_TEXT_OPERATORS: Array<CorrelationOperator> = [
+  CorrelationOperator.Equals,
+  CorrelationOperator.NotEquals,
+  CorrelationOperator.Contains,
+  CorrelationOperator.NotContains,
+  CorrelationOperator.StartsWith,
+  CorrelationOperator.EndsWith,
+];
+
+export const CorrelationFieldDefinitions: Array<CorrelationFieldDefinition> = [
+  {
+    key: CorrelationFieldKey.Observable,
+    label: "Observable",
+    columnKey: "observables",
+    isArrayColumn: true,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "hostname, user, or IP address",
+  },
+  {
+    key: CorrelationFieldKey.PrincipalUser,
+    label: "Principal User",
+    columnKey: "principalUser",
+    isArrayColumn: false,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "alice@example.com",
+  },
+  {
+    key: CorrelationFieldKey.PrincipalHost,
+    label: "Principal Host",
+    columnKey: "principalHost",
+    isArrayColumn: false,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "wb-ubuntu-03",
+  },
+  {
+    key: CorrelationFieldKey.PrincipalIp,
+    label: "Principal IP",
+    columnKey: "principalIp",
+    isArrayColumn: false,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "192.168.1.20",
+  },
+  {
+    key: CorrelationFieldKey.TargetUser,
+    label: "Target User",
+    columnKey: "targetUser",
+    isArrayColumn: false,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "svc-backup",
+  },
+  {
+    key: CorrelationFieldKey.TargetHost,
+    label: "Target Host",
+    columnKey: "targetHost",
+    isArrayColumn: false,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "db-primary",
+  },
+  {
+    key: CorrelationFieldKey.TargetIp,
+    label: "Target IP",
+    columnKey: "targetIp",
+    isArrayColumn: false,
+    operators: ALL_TEXT_OPERATORS,
+    placeholder: "10.0.0.5",
+  },
+  {
+    key: CorrelationFieldKey.EventClass,
+    label: "Event Class",
+    columnKey: "className",
+    isArrayColumn: false,
+    operators: [
+      CorrelationOperator.Equals,
+      CorrelationOperator.NotEquals,
+      CorrelationOperator.Contains,
+    ],
+    valueSuggestions: OcsfEventClasses.map(
+      (eventClass: OcsfEventClassProps) => {
+        return eventClass.name;
+      },
+    ),
+    placeholder: "Authentication",
+  },
+  {
+    key: CorrelationFieldKey.Severity,
+    label: "Severity",
+    columnKey: "severityName",
+    isArrayColumn: false,
+    operators: [CorrelationOperator.Equals, CorrelationOperator.NotEquals],
+    valueOptions: Object.values(OcsfSeverity),
+    placeholder: "High",
+  },
+  {
+    key: CorrelationFieldKey.Message,
+    label: "Message",
+    columnKey: "message",
+    isArrayColumn: false,
+    operators: [
+      CorrelationOperator.Contains,
+      CorrelationOperator.NotContains,
+      CorrelationOperator.StartsWith,
+      CorrelationOperator.EndsWith,
+    ],
+    placeholder: "failed password",
+  },
+  {
+    key: CorrelationFieldKey.RuleName,
+    label: "Rule Name",
+    columnKey: "ruleName",
+    isArrayColumn: false,
+    operators: [
+      CorrelationOperator.Equals,
+      CorrelationOperator.NotEquals,
+      CorrelationOperator.Contains,
+    ],
+    placeholder: "Brute force detected",
+  },
+  {
+    key: CorrelationFieldKey.Vendor,
+    label: "Vendor",
+    columnKey: "vendorName",
+    isArrayColumn: false,
+    operators: [
+      CorrelationOperator.Equals,
+      CorrelationOperator.NotEquals,
+      CorrelationOperator.Contains,
+    ],
+    placeholder: "CrowdStrike",
+  },
+];
+
+export function getCorrelationFieldDefinition(
+  key: CorrelationFieldKey,
+): CorrelationFieldDefinition {
+  const definition: CorrelationFieldDefinition | undefined =
+    CorrelationFieldDefinitions.find(
+      (fieldDefinition: CorrelationFieldDefinition) => {
+        return fieldDefinition.key === key;
+      },
+    );
+
+  if (!definition) {
+    throw new Error(`Unknown correlation field: ${key}`);
+  }
+
+  return definition;
+}
+
+export const CorrelationOperatorLabels: Record<CorrelationOperator, string> = {
+  [CorrelationOperator.Equals]: "is",
+  [CorrelationOperator.NotEquals]: "is not",
+  [CorrelationOperator.Contains]: "contains",
+  [CorrelationOperator.NotContains]: "does not contain",
+  [CorrelationOperator.StartsWith]: "starts with",
+  [CorrelationOperator.EndsWith]: "ends with",
+};
+
+export function describeCorrelationCondition(
+  condition: CorrelationCondition,
+): string {
+  const definition: CorrelationFieldDefinition = getCorrelationFieldDefinition(
+    condition.field,
+  );
+  return `${definition.label} ${
+    CorrelationOperatorLabels[condition.operator]
+  } "${condition.value}"`;
+}
+
+export function describeCorrelationFilter(filter: CorrelationFilter): string {
+  const connectorWord: string = filter.connector === "or" ? " OR " : " AND ";
+  return filter.conditions
+    .map((condition: CorrelationCondition) => {
+      return describeCorrelationCondition(condition);
+    })
+    .join(connectorWord);
+}
+
+export interface CompiledCorrelationQueries {
+  queries: Array<Query<SecurityEvent>>;
+  // Human-friendly reason compilation failed; queries is empty when set.
+  error: string | null;
+}
+
+export interface CorrelationQueryOptions {
+  projectId: ObjectID;
+  startDate: Date;
+  endDate: Date;
+}
+
+type ConditionValue =
+  | string
+  | EqualTo<string>
+  | Includes
+  | IncludesAll
+  | IncludesNone
+  | NotEqual<string>
+  | Search<string>
+  | NotContains<string>
+  | StartsWith<string>
+  | EndsWith<string>;
+
+function operatorValueForScalarColumn(
+  condition: CorrelationCondition,
+): ConditionValue {
+  switch (condition.operator) {
+    case CorrelationOperator.Equals:
+      return condition.value;
+    case CorrelationOperator.NotEquals:
+      return new NotEqual<string>(condition.value);
+    case CorrelationOperator.Contains:
+      return new Search<string>(condition.value);
+    case CorrelationOperator.NotContains:
+      return new NotContains<string>(condition.value);
+    case CorrelationOperator.StartsWith:
+      return new StartsWith<string>(condition.value);
+    case CorrelationOperator.EndsWith:
+      return new EndsWith<string>(condition.value);
+    default:
+      throw new Error(`Unknown correlation operator: ${condition.operator}`);
+  }
+}
+
+function operatorValueForArrayColumn(
+  condition: CorrelationCondition,
+): ConditionValue {
+  switch (condition.operator) {
+    case CorrelationOperator.Equals:
+      // hasAny(col, [v]) — the row's array mentions this exact value.
+      return new Includes([condition.value]);
+    case CorrelationOperator.NotEquals:
+      return new IncludesNone([condition.value]);
+    default:
+      /*
+       * Contains / NotContains / StartsWith / EndsWith compile to
+       * (NOT) arrayExists ILIKE on the server — the operator wrappers are
+       * the same as for scalars.
+       */
+      return operatorValueForScalarColumn(condition);
+  }
+}
+
+function baseQuery(options: CorrelationQueryOptions): Query<SecurityEvent> {
+  return {
+    projectId: options.projectId,
+    time: new InBetween<Date>(options.startDate, options.endDate),
+  } as Query<SecurityEvent>;
+}
+
+function normalizeConditions(
+  conditions: Array<CorrelationCondition>,
+): Array<CorrelationCondition> | { error: string } {
+  const normalized: Array<CorrelationCondition> = [];
+  const seen: Set<string> = new Set<string>();
+
+  for (const condition of conditions) {
+    const value: string = (condition.value || "").trim();
+
+    if (!value) {
+      const definition: CorrelationFieldDefinition =
+        getCorrelationFieldDefinition(condition.field);
+      return {
+        error: `The "${definition.label}" condition needs a value.`,
+      };
+    }
+
+    // Identical rows are redundant under both AND and OR — drop them.
+    const dedupeKey: string = `${condition.field} ${condition.operator} ${value}`;
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+
+    normalized.push({
+      field: condition.field,
+      operator: condition.operator,
+      value: value,
+    });
+  }
+
+  return normalized;
+}
+
+function compileAndFilter(
+  conditions: Array<CorrelationCondition>,
+  options: CorrelationQueryOptions,
+): CompiledCorrelationQueries {
+  const query: Query<SecurityEvent> = baseQuery(options);
+
+  // Group by target column — the flat query map has one slot per column.
+  const conditionsByColumn: Map<string, Array<CorrelationCondition>> = new Map<
+    string,
+    Array<CorrelationCondition>
+  >();
+
+  for (const condition of conditions) {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(condition.field);
+    const existing: Array<CorrelationCondition> =
+      conditionsByColumn.get(definition.columnKey) || [];
+    existing.push(condition);
+    conditionsByColumn.set(definition.columnKey, existing);
+  }
+
+  for (const [columnKey, columnConditions] of conditionsByColumn) {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(columnConditions[0]!.field);
+
+    if (columnConditions.length === 1) {
+      const condition: CorrelationCondition = columnConditions[0]!;
+      (query as Record<string, ConditionValue>)[columnKey] =
+        definition.isArrayColumn
+          ? operatorValueForArrayColumn(condition)
+          : operatorValueForScalarColumn(condition);
+      continue;
+    }
+
+    const equalsValues: Array<string> = columnConditions
+      .filter((condition: CorrelationCondition) => {
+        return condition.operator === CorrelationOperator.Equals;
+      })
+      .map((condition: CorrelationCondition) => {
+        return condition.value;
+      });
+    const notEqualsValues: Array<string> = columnConditions
+      .filter((condition: CorrelationCondition) => {
+        return condition.operator === CorrelationOperator.NotEquals;
+      })
+      .map((condition: CorrelationCondition) => {
+        return condition.value;
+      });
+    const otherConditions: Array<CorrelationCondition> =
+      columnConditions.filter((condition: CorrelationCondition) => {
+        return (
+          condition.operator !== CorrelationOperator.Equals &&
+          condition.operator !== CorrelationOperator.NotEquals
+        );
+      });
+
+    if (!definition.isArrayColumn && equalsValues.length > 1) {
+      /*
+       * A scalar can't equal two different values at once. (Identical
+       * duplicates were already removed, so reaching here means the values
+       * differ.)
+       */
+      return {
+        queries: [],
+        error: `"All conditions" with two different "${definition.label} is ..." values can never match. Switch the connector to "Any condition" to search for either value.`,
+      };
+    }
+
+    /*
+     * Everything else merges into per-operator predicates on this column.
+     * Where more than one predicate remains, the query carries an ARRAY of
+     * operators under the key — the statement generator ANDs them (e.g.
+     * "mentions X AND does not mention Y" → hasAll + NOT hasAny).
+     */
+    const operatorValues: Array<ConditionValue> = [];
+
+    if (equalsValues.length > 0) {
+      if (definition.isArrayColumn) {
+        operatorValues.push(
+          equalsValues.length > 1
+            ? new IncludesAll(equalsValues)
+            : new Includes([equalsValues[0] as string]),
+        );
+      } else {
+        operatorValues.push(new EqualTo<string>(equalsValues[0] as string));
+      }
+    }
+
+    if (notEqualsValues.length > 0) {
+      if (definition.isArrayColumn || notEqualsValues.length > 1) {
+        operatorValues.push(new IncludesNone(notEqualsValues));
+      } else {
+        operatorValues.push(new NotEqual<string>(notEqualsValues[0] as string));
+      }
+    }
+
+    for (const otherCondition of otherConditions) {
+      operatorValues.push(operatorValueForScalarColumn(otherCondition));
+    }
+
+    (query as Record<string, ConditionValue | Array<ConditionValue>>)[
+      columnKey
+    ] =
+      operatorValues.length === 1
+        ? (operatorValues[0] as ConditionValue)
+        : operatorValues;
+  }
+
+  return { queries: [query], error: null };
+}
+
+function compileOrFilter(
+  conditions: Array<CorrelationCondition>,
+  options: CorrelationQueryOptions,
+): CompiledCorrelationQueries {
+  const queries: Array<Query<SecurityEvent>> = [];
+
+  /*
+   * Equality conditions on the same field collapse into one Includes query —
+   * hasAny / IN already IS an OR across values, and one round-trip beats N.
+   */
+  const equalsValuesByField: Map<CorrelationFieldKey, Array<string>> = new Map<
+    CorrelationFieldKey,
+    Array<string>
+  >();
+  const standaloneConditions: Array<CorrelationCondition> = [];
+
+  for (const condition of conditions) {
+    if (condition.operator === CorrelationOperator.Equals) {
+      const existing: Array<string> =
+        equalsValuesByField.get(condition.field) || [];
+      existing.push(condition.value);
+      equalsValuesByField.set(condition.field, existing);
+    } else {
+      standaloneConditions.push(condition);
+    }
+  }
+
+  for (const [fieldKey, values] of equalsValuesByField) {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(fieldKey);
+    const query: Query<SecurityEvent> = baseQuery(options);
+    (query as Record<string, ConditionValue>)[definition.columnKey] =
+      new Includes(values);
+    queries.push(query);
+  }
+
+  for (const condition of standaloneConditions) {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(condition.field);
+    const query: Query<SecurityEvent> = baseQuery(options);
+    (query as Record<string, ConditionValue>)[definition.columnKey] =
+      definition.isArrayColumn
+        ? operatorValueForArrayColumn(condition)
+        : operatorValueForScalarColumn(condition);
+    queries.push(query);
+  }
+
+  return { queries, error: null };
+}
+
+export function compileCorrelationFilter(
+  filter: CorrelationFilter,
+  options: CorrelationQueryOptions,
+): CompiledCorrelationQueries {
+  const normalized: Array<CorrelationCondition> | { error: string } =
+    normalizeConditions(filter.conditions);
+
+  if (!Array.isArray(normalized)) {
+    return { queries: [], error: normalized.error };
+  }
+
+  if (normalized.length === 0) {
+    return { queries: [], error: null };
+  }
+
+  if (filter.connector === "or") {
+    return compileOrFilter(normalized, options);
+  }
+
+  return compileAndFilter(normalized, options);
+}
+
+/*
+ * The observable values the filter pins with equality. The graph excludes
+ * these from the co-occurring layer (they would trivially co-occur with
+ * everything matched) and uses them for the center label.
+ */
+export function getEqualityObservables(
+  filter: CorrelationFilter,
+): Array<string> {
+  return filter.conditions
+    .filter((condition: CorrelationCondition) => {
+      return (
+        condition.field === CorrelationFieldKey.Observable &&
+        condition.operator === CorrelationOperator.Equals &&
+        Boolean(condition.value.trim())
+      );
+    })
+    .map((condition: CorrelationCondition) => {
+      return condition.value.trim();
+    });
+}
+
+/*
+ * URL round-trip. The filter serializes into a single `q` query-string
+ * param as compact JSON tuples: {"v":1,"j":"and","c":[["field","op","value"],...]}.
+ * Parsing is tolerant — unknown fields/operators and malformed rows are
+ * dropped, malformed JSON yields null — so a stale or hand-edited link
+ * degrades to "no filter" instead of a crash.
+ */
+
+interface SerializedCorrelationFilter {
+  v: number;
+  j: CorrelationConnector;
+  c: Array<[string, string, string]>;
+}
+
+export function serializeCorrelationFilter(filter: CorrelationFilter): string {
+  const serialized: SerializedCorrelationFilter = {
+    v: 1,
+    j: filter.connector,
+    c: filter.conditions.map(
+      (condition: CorrelationCondition): [string, string, string] => {
+        return [condition.field, condition.operator, condition.value];
+      },
+    ),
+  };
+
+  return JSON.stringify(serialized);
+}
+
+export function parseCorrelationFilter(
+  raw: string | null,
+): CorrelationFilter | null {
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+
+  const candidate: Partial<SerializedCorrelationFilter> =
+    parsed as Partial<SerializedCorrelationFilter>;
+
+  const connector: CorrelationConnector = candidate.j === "or" ? "or" : "and";
+
+  const validFieldKeys: Set<string> = new Set<string>(
+    CorrelationFieldDefinitions.map(
+      (definition: CorrelationFieldDefinition) => {
+        return definition.key as string;
+      },
+    ),
+  );
+  const validOperators: Set<string> = new Set<string>(
+    Object.values(CorrelationOperator),
+  );
+
+  const conditions: Array<CorrelationCondition> = [];
+
+  for (const row of candidate.c || []) {
+    if (!Array.isArray(row) || row.length < 3) {
+      continue;
+    }
+
+    const [field, operator, value] = row as [unknown, unknown, unknown];
+
+    if (
+      typeof field !== "string" ||
+      typeof operator !== "string" ||
+      typeof value !== "string" ||
+      !validFieldKeys.has(field) ||
+      !validOperators.has(operator) ||
+      !value.trim()
+    ) {
+      continue;
+    }
+
+    const fieldKey: CorrelationFieldKey = field as CorrelationFieldKey;
+    const operatorKey: CorrelationOperator = operator as CorrelationOperator;
+
+    // The operator must actually be offered for that field.
+    if (
+      !getCorrelationFieldDefinition(fieldKey).operators.includes(operatorKey)
+    ) {
+      continue;
+    }
+
+    conditions.push({
+      field: fieldKey,
+      operator: operatorKey,
+      value: value.trim(),
+    });
+  }
+
+  if (conditions.length === 0) {
+    return null;
+  }
+
+  return { conditions, connector };
+}

--- a/Common/Server/Utils/AnalyticsDatabase/Statement.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/Statement.ts
@@ -26,6 +26,18 @@ export type StatementParameter = {
   value: RecordValue;
 };
 
+/*
+ * Escape LIKE/ILIKE metacharacters so a user-supplied value matches
+ * literally. Without this, "svc_" matches svcX (a false positive) and a
+ * value containing "%" silently corrupts the whole pattern — the worst
+ * possible failure mode for a security-events filter. ClickHouse honors
+ * backslash escapes inside (I)LIKE patterns; backslash itself must be
+ * escaped first.
+ */
+export function escapeIlikePattern(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
 /**
  * A table-qualified column reference (`table.column`) bound as TWO
  * Identifier parameters. ClickHouse treats a dotted string bound as a
@@ -133,7 +145,7 @@ export class Statement implements BaseQueryParams {
     } else if (v.value instanceof ObjectID) {
       finalValue = v.value.toString();
     } else if (v.value instanceof Search) {
-      finalValue = `%${v.value.toString()}%`;
+      finalValue = `%${escapeIlikePattern(v.value.toString())}%`;
     } else if (
       v.value instanceof LessThan ||
       v.value instanceof LessThanOrEqual ||

--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -25,10 +25,12 @@ import AnalyticsTableColumn, {
 } from "../../../Types/AnalyticsDatabase/TableColumn";
 import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
 import EqualTo from "../../../Types/BaseDatabase/EqualTo";
+import EqualToOrNull from "../../../Types/BaseDatabase/EqualToOrNull";
 import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "../../../Types/BaseDatabase/GreaterThanOrEqual";
 import InBetween from "../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesAll from "../../../Types/BaseDatabase/IncludesAll";
 import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
 import ObjectID from "../../../Types/ObjectID";
 import IsNull from "../../../Types/BaseDatabase/IsNull";
@@ -39,6 +41,7 @@ import LessThanOrNull from "../../../Types/BaseDatabase/LessThanOrNull";
 import NotEqual from "../../../Types/BaseDatabase/NotEqual";
 import NotContains from "../../../Types/BaseDatabase/NotContains";
 import NotNull from "../../../Types/BaseDatabase/NotNull";
+import QueryOperator from "../../../Types/BaseDatabase/QueryOperator";
 import Search from "../../../Types/BaseDatabase/Search";
 import MultiSearch from "../../../Types/BaseDatabase/MultiSearch";
 import StartsWith from "../../../Types/BaseDatabase/StartsWith";
@@ -755,7 +758,64 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
         whereStatement.append(SQL` `);
       }
 
-      if (value instanceof Search) {
+      /*
+       * Several operators AND-ed onto ONE column — e.g.
+       * `observables: [Includes([x]), IncludesNone([y])]` for "mentions x
+       * AND does not mention y". The flat query map has a single slot per
+       * column, so without this an AND of two predicates on the same column
+       * is inexpressible (the Security Events correlation builder needs
+       * it). Each element compiles through a single-key recursive call, so
+       * every per-operator branch below applies unchanged; elements whose
+       * branch drops the predicate (e.g. an empty Includes) contribute
+       * nothing. A bare value array (exact-array equality on ArrayText)
+       * has non-operator elements and falls through untouched.
+       */
+      if (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((element: unknown) => {
+          return element instanceof QueryOperator;
+        })
+      ) {
+        let isFirstFragment: boolean = true;
+        for (const operator of value) {
+          const fragment: Statement = this.toWhereStatement(
+            { [key]: operator } as Query<TBaseModel>,
+            options,
+          );
+          if (!fragment.query) {
+            continue;
+          }
+          if (isFirstFragment) {
+            isFirstFragment = false;
+          } else {
+            whereStatement.append(SQL` `);
+          }
+          whereStatement.append(fragment);
+        }
+        continue;
+      }
+
+      if (
+        value instanceof Search &&
+        tableColumn.type === TableColumnType.ArrayText
+      ) {
+        /*
+         * Substring search over an Array(String) column ("any element
+         * contains v"): `arrayExists(x -> x ILIKE '%v%', col)`. The scalar
+         * `col ILIKE ...` form below would declare the bound parameter as
+         * Array(String) while carrying a single pattern string, which
+         * ClickHouse rejects at parameter-parse time — so array columns get
+         * their own per-element form. This is what makes a plain text filter
+         * on `observables` (Security Events) work at all.
+         */
+        whereStatement.append(
+          SQL`AND arrayExists(x -> x ILIKE ${{
+            value: value,
+            type: TableColumnType.Text,
+          }}, ${columnRef(key)})`,
+        );
+      } else if (value instanceof Search) {
         whereStatement.append(
           SQL`AND ${columnRef(key)} ILIKE ${{
             value: value,
@@ -893,6 +953,135 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           );
         } else {
           whereStatement.append(SQL`AND ${columnRef(key)} IS NULL`);
+        }
+      } else if (value instanceof NotNull) {
+        /*
+         * Mirror of IsNull above: Text columns store '' as their "not set"
+         * default (they are non-nullable Strings unless optional), so a
+         * present-value check must reject the empty string too.
+         */
+        if (tableColumn.type === TableColumnType.Text) {
+          whereStatement.append(
+            SQL`AND (${columnRef(key)} IS NOT NULL AND ${columnRef(key)} != '')`,
+          );
+        } else {
+          whereStatement.append(SQL`AND ${columnRef(key)} IS NOT NULL`);
+        }
+      } else if (value instanceof EqualTo) {
+        /*
+         * Explicit equality wrapper. Before this branch existed an EqualTo
+         * instance fell through to the bare-value fallback, which bound the
+         * operator OBJECT as the parameter — a silent match-nothing filter.
+         * Bind the wrapped value instead, exactly like a bare value.
+         */
+        whereStatement.append(
+          SQL`AND ${columnRef(key)} = ${{
+            value: (value as EqualTo<string>).value,
+            type: tableColumn.type,
+          }}`,
+        );
+      } else if (value instanceof EqualToOrNull) {
+        if (tableColumn.type === TableColumnType.Text) {
+          whereStatement.append(
+            SQL`AND (${columnRef(key)} = ${{
+              value: (value as EqualToOrNull<string>).value,
+              type: tableColumn.type,
+            }} OR ${columnRef(key)} IS NULL OR ${columnRef(key)} = '')`,
+          );
+        } else {
+          whereStatement.append(
+            SQL`AND (${columnRef(key)} = ${{
+              value: (value as EqualToOrNull<string>).value,
+              type: tableColumn.type,
+            }} OR ${columnRef(key)} IS NULL)`,
+          );
+        }
+      } else if (value instanceof StartsWith) {
+        /*
+         * Prefix / suffix / negated-substring matching, previously only
+         * implemented for map (attributes) sub-keys. Array(String) columns
+         * get the per-element arrayExists form (see the Search branch
+         * above); scalars get a plain ILIKE. Patterns bind as Text because
+         * the pattern itself is a string whatever the column type is.
+         */
+        const startsWithPattern: string = `${(value.value as string) || ""}%`;
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          whereStatement.append(
+            SQL`AND arrayExists(x -> x ILIKE ${{
+              value: startsWithPattern,
+              type: TableColumnType.Text,
+            }}, ${columnRef(key)})`,
+          );
+        } else {
+          whereStatement.append(
+            SQL`AND ${columnRef(key)} ILIKE ${{
+              value: startsWithPattern,
+              type: TableColumnType.Text,
+            }}`,
+          );
+        }
+      } else if (value instanceof EndsWith) {
+        const endsWithPattern: string = `%${(value.value as string) || ""}`;
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          whereStatement.append(
+            SQL`AND arrayExists(x -> x ILIKE ${{
+              value: endsWithPattern,
+              type: TableColumnType.Text,
+            }}, ${columnRef(key)})`,
+          );
+        } else {
+          whereStatement.append(
+            SQL`AND ${columnRef(key)} ILIKE ${{
+              value: endsWithPattern,
+              type: TableColumnType.Text,
+            }}`,
+          );
+        }
+      } else if (value instanceof NotContains) {
+        /*
+         * On a nullable scalar, `NOT (NULL ILIKE ...)` is NULL and would
+         * filter the row out — but a row with no value at all trivially
+         * "does not contain" the needle, so NULL rows are let through
+         * explicitly (mirrors how missing map keys pass the map-branch
+         * NotContains).
+         */
+        const notContainsPattern: string = `%${(value.value as string) || ""}%`;
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          whereStatement.append(
+            SQL`AND NOT arrayExists(x -> x ILIKE ${{
+              value: notContainsPattern,
+              type: TableColumnType.Text,
+            }}, ${columnRef(key)})`,
+          );
+        } else {
+          whereStatement.append(
+            SQL`AND (NOT (${columnRef(key)} ILIKE ${{
+              value: notContainsPattern,
+              type: TableColumnType.Text,
+            }}) OR ${columnRef(key)} IS NULL)`,
+          );
+        }
+      } else if (
+        value instanceof IncludesAll &&
+        tableColumn.type === TableColumnType.ArrayText
+      ) {
+        /*
+         * Array(String) conjunction ("mentions ALL of these"): `hasAll`,
+         * the AND-counterpart of the Includes/hasAny branch above. This is
+         * what a correlation like "events naming host X AND ip Y" compiles
+         * to on the `observables` column. An empty IncludesAll constrains
+         * nothing — drop the predicate (hasAll(col, []) is vacuously true
+         * anyway, but skipping keeps parity with the empty-Includes path).
+         */
+        const arrayAllValues: Array<string> =
+          ((value as IncludesAll).values as Array<string>) || [];
+        if (arrayAllValues.length > 0) {
+          whereStatement.append(
+            SQL`AND hasAll(${columnRef(key)}, ${{
+              value: arrayAllValues,
+              type: TableColumnType.ArrayText,
+            }})`,
+          );
         }
       } else if (
         tableColumn.type === TableColumnType.MapStringString &&
@@ -1290,6 +1479,17 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           }
         }
       } else {
+        /*
+         * Bare-value equality. A query operator that reaches this point has
+         * no branch for this column type (e.g. IncludesAll on a scalar) —
+         * binding the operator object itself would produce a silent
+         * match-nothing filter, so fail loudly instead.
+         */
+        if (value instanceof QueryOperator) {
+          throw new BadDataException(
+            `Unsupported query operator ${value.constructor.name} on column: ${key}`,
+          );
+        }
         whereStatement.append(
           SQL`AND ${columnRef(key)} = ${{ value, type: tableColumn.type }}`,
         );

--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -5,7 +5,12 @@ import Select from "../../Types/AnalyticsDatabase/Select";
 import Sort from "../../Types/AnalyticsDatabase/Sort";
 import UpdateBy from "../../Types/AnalyticsDatabase/UpdateBy";
 import logger from "../Logger";
-import { QualifiedColumn, SQL, Statement } from "./Statement";
+import {
+  QualifiedColumn,
+  SQL,
+  Statement,
+  escapeIlikePattern,
+} from "./Statement";
 import {
   adaptTableSettingsForStorage,
   getDistributedEngine,
@@ -42,6 +47,7 @@ import NotEqual from "../../../Types/BaseDatabase/NotEqual";
 import NotContains from "../../../Types/BaseDatabase/NotContains";
 import NotNull from "../../../Types/BaseDatabase/NotNull";
 import QueryOperator from "../../../Types/BaseDatabase/QueryOperator";
+import GenericObject from "../../../Types/GenericObject";
 import Search from "../../../Types/BaseDatabase/Search";
 import MultiSearch from "../../../Types/BaseDatabase/MultiSearch";
 import StartsWith from "../../../Types/BaseDatabase/StartsWith";
@@ -109,6 +115,28 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
     this.modelType = data.modelType;
     this.model = new this.modelType();
     this.database = data.database;
+  }
+
+  /*
+   * Map(String,String) and JSON columns have per-sub-key handling further
+   * down the operator chain; a scalar operator applied to the whole column
+   * would compile to SQL ClickHouse rejects with a cryptic type error.
+   * Fail with the same loud BadDataException the fallback uses.
+   */
+  private throwIfMapOrJsonColumn(input: {
+    operator: QueryOperator<GenericObject | number | string>;
+    tableColumn: AnalyticsTableColumn;
+    key: string;
+  }): void {
+    if (
+      input.tableColumn.type === TableColumnType.MapStringString ||
+      input.tableColumn.type === TableColumnType.JSON ||
+      input.tableColumn.type === TableColumnType.JSONArray
+    ) {
+      throw new BadDataException(
+        `Unsupported query operator ${input.operator.constructor.name} on column: ${input.key}`,
+      );
+    }
   }
 
   private appendMapKeyPresenceFilter(input: {
@@ -822,6 +850,22 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
             type: tableColumn.type,
           }}`,
         );
+      } else if (
+        value instanceof NotEqual &&
+        tableColumn.type === TableColumnType.ArrayText
+      ) {
+        /*
+         * "not equal to v" on an Array(String) column means "does not
+         * mention v" — the scalar `col != v` form would bind a single
+         * string against an Array(String) parameter and fail at
+         * ClickHouse parameter-parse time.
+         */
+        whereStatement.append(
+          SQL`AND NOT has(${columnRef(key)}, ${{
+            value: String((value as NotEqual<string>).value ?? ""),
+            type: TableColumnType.Text,
+          }})`,
+        );
       } else if (value instanceof NotEqual) {
         whereStatement.append(
           SQL`AND ${columnRef(key)} != ${{
@@ -947,7 +991,13 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           );
         }
       } else if (value instanceof IsNull) {
-        if (tableColumn.type === TableColumnType.Text) {
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          /*
+           * Array(String) columns are non-Nullable — `IS NULL` would be
+           * constant-false. "Not set" for an array is the empty array.
+           */
+          whereStatement.append(SQL`AND empty(${columnRef(key)})`);
+        } else if (tableColumn.type === TableColumnType.Text) {
           whereStatement.append(
             SQL`AND (${columnRef(key)} IS NULL OR ${columnRef(key)} = '')`,
           );
@@ -958,9 +1008,13 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
         /*
          * Mirror of IsNull above: Text columns store '' as their "not set"
          * default (they are non-nullable Strings unless optional), so a
-         * present-value check must reject the empty string too.
+         * present-value check must reject the empty string too; Array
+         * columns are non-Nullable, so `IS NOT NULL` would be constant-true
+         * — presence for an array means "has at least one element".
          */
-        if (tableColumn.type === TableColumnType.Text) {
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          whereStatement.append(SQL`AND notEmpty(${columnRef(key)})`);
+        } else if (tableColumn.type === TableColumnType.Text) {
           whereStatement.append(
             SQL`AND (${columnRef(key)} IS NOT NULL AND ${columnRef(key)} != '')`,
           );
@@ -972,15 +1026,35 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
          * Explicit equality wrapper. Before this branch existed an EqualTo
          * instance fell through to the bare-value fallback, which bound the
          * operator OBJECT as the parameter — a silent match-nothing filter.
-         * Bind the wrapped value instead, exactly like a bare value.
+         * Scalars bind the wrapped value exactly like a bare value; on an
+         * Array(String) column "equals v" means membership (`has`), which
+         * is what a table filter's Equal To on `observables` intends. Map
+         * and JSON columns have no scalar equality — fail loudly instead
+         * of emitting SQL ClickHouse will reject with a cryptic error.
          */
-        whereStatement.append(
-          SQL`AND ${columnRef(key)} = ${{
-            value: (value as EqualTo<string>).value,
-            type: tableColumn.type,
-          }}`,
-        );
+        this.throwIfMapOrJsonColumn({ operator: value, tableColumn, key });
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          whereStatement.append(
+            SQL`AND has(${columnRef(key)}, ${{
+              value: String((value as EqualTo<string>).value ?? ""),
+              type: TableColumnType.Text,
+            }})`,
+          );
+        } else {
+          whereStatement.append(
+            SQL`AND ${columnRef(key)} = ${{
+              value: (value as EqualTo<string>).value,
+              type: tableColumn.type,
+            }}`,
+          );
+        }
       } else if (value instanceof EqualToOrNull) {
+        this.throwIfMapOrJsonColumn({ operator: value, tableColumn, key });
+        if (tableColumn.type === TableColumnType.ArrayText) {
+          throw new BadDataException(
+            `Unsupported query operator EqualToOrNull on column: ${key}`,
+          );
+        }
         if (tableColumn.type === TableColumnType.Text) {
           whereStatement.append(
             SQL`AND (${columnRef(key)} = ${{
@@ -1002,9 +1076,14 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
          * implemented for map (attributes) sub-keys. Array(String) columns
          * get the per-element arrayExists form (see the Search branch
          * above); scalars get a plain ILIKE. Patterns bind as Text because
-         * the pattern itself is a string whatever the column type is.
+         * the pattern itself is a string whatever the column type is, and
+         * the user value is escaped so it matches literally rather than as
+         * wildcard syntax.
          */
-        const startsWithPattern: string = `${(value.value as string) || ""}%`;
+        this.throwIfMapOrJsonColumn({ operator: value, tableColumn, key });
+        const startsWithPattern: string = `${escapeIlikePattern(
+          (value.value as string) || "",
+        )}%`;
         if (tableColumn.type === TableColumnType.ArrayText) {
           whereStatement.append(
             SQL`AND arrayExists(x -> x ILIKE ${{
@@ -1021,7 +1100,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           );
         }
       } else if (value instanceof EndsWith) {
-        const endsWithPattern: string = `%${(value.value as string) || ""}`;
+        this.throwIfMapOrJsonColumn({ operator: value, tableColumn, key });
+        const endsWithPattern: string = `%${escapeIlikePattern(
+          (value.value as string) || "",
+        )}`;
         if (tableColumn.type === TableColumnType.ArrayText) {
           whereStatement.append(
             SQL`AND arrayExists(x -> x ILIKE ${{
@@ -1045,7 +1127,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
          * explicitly (mirrors how missing map keys pass the map-branch
          * NotContains).
          */
-        const notContainsPattern: string = `%${(value.value as string) || ""}%`;
+        this.throwIfMapOrJsonColumn({ operator: value, tableColumn, key });
+        const notContainsPattern: string = `%${escapeIlikePattern(
+          (value.value as string) || "",
+        )}%`;
         if (tableColumn.type === TableColumnType.ArrayText) {
           whereStatement.append(
             SQL`AND NOT arrayExists(x -> x ILIKE ${{
@@ -1174,7 +1259,9 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           }
 
           if (mapEntry instanceof NotContains) {
-            const literalValue: string = `%${(mapEntry.value as string) || ""}%`;
+            const literalValue: string = `%${escapeIlikePattern(
+              (mapEntry.value as string) || "",
+            )}%`;
             whereStatement.append(
               SQL`AND NOT arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(${{
                 value: mapKey,
@@ -1188,7 +1275,9 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           }
 
           if (mapEntry instanceof StartsWith) {
-            const literalValue: string = `${(mapEntry.value as string) || ""}%`;
+            const literalValue: string = `${escapeIlikePattern(
+              (mapEntry.value as string) || "",
+            )}%`;
             whereStatement.append(
               SQL`AND arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(${{
                 value: mapKey,
@@ -1202,7 +1291,9 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           }
 
           if (mapEntry instanceof EndsWith) {
-            const literalValue: string = `%${(mapEntry.value as string) || ""}`;
+            const literalValue: string = `%${escapeIlikePattern(
+              (mapEntry.value as string) || "",
+            )}`;
             whereStatement.append(
               SQL`AND arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(${{
                 value: mapKey,

--- a/Common/Tests/App/Dashboard/CorrelateFilterBuilder.test.tsx
+++ b/Common/Tests/App/Dashboard/CorrelateFilterBuilder.test.tsx
@@ -1,0 +1,319 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import CorrelateFilterBuilder, {
+  getDefaultCorrelationCondition,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateFilterBuilder";
+import {
+  CorrelationCondition,
+  CorrelationConnector,
+  CorrelationFieldKey,
+  CorrelationOperator,
+} from "../../../../App/FeatureSet/Dashboard/src/Utils/SecurityEventCorrelation";
+import OcsfSeverity from "../../../Types/SecurityEvent/OcsfSeverity";
+
+/*
+ * The correlate filter builder rows (issue #3395): field + operator + value
+ * per row, add/remove, one AND/OR connector. Pinned here: the default row,
+ * append/delete, the operator vocabulary following the field, value reset
+ * on field change, the connector toggle appearing only for chains, and the
+ * value editor switching between text input and fixed dropdown per field.
+ */
+
+interface HarnessProps {
+  initialConditions: Array<CorrelationCondition>;
+  initialConnector: CorrelationConnector;
+  onChangeSpy: (
+    conditions: Array<CorrelationCondition>,
+    connector: CorrelationConnector,
+  ) => void;
+}
+
+const Harness: FunctionComponent<HarnessProps> = (
+  props: HarnessProps,
+): ReactElement => {
+  const [conditions, setConditions] = useState<Array<CorrelationCondition>>(
+    props.initialConditions,
+  );
+  const [connector, setConnector] = useState<CorrelationConnector>(
+    props.initialConnector,
+  );
+
+  return (
+    <CorrelateFilterBuilder
+      conditions={conditions}
+      connector={connector}
+      onChange={(
+        nextConditions: Array<CorrelationCondition>,
+        nextConnector: CorrelationConnector,
+      ) => {
+        setConditions(nextConditions);
+        setConnector(nextConnector);
+        props.onChangeSpy(nextConditions, nextConnector);
+      }}
+    />
+  );
+};
+
+type RenderHarnessFunction = (
+  initialConditions?: Array<CorrelationCondition>,
+  initialConnector?: CorrelationConnector,
+) => MockFunction;
+
+const renderHarness: RenderHarnessFunction = (
+  initialConditions?: Array<CorrelationCondition>,
+  initialConnector?: CorrelationConnector,
+): MockFunction => {
+  const onChangeSpy: MockFunction = getJestMockFunction();
+  render(
+    <Harness
+      initialConditions={
+        initialConditions || [getDefaultCorrelationCondition()]
+      }
+      initialConnector={initialConnector || "and"}
+      onChangeSpy={
+        onChangeSpy as (
+          conditions: Array<CorrelationCondition>,
+          connector: CorrelationConnector,
+        ) => void
+      }
+    />,
+  );
+  return onChangeSpy;
+};
+
+type SelectOptionFunction = (combobox: HTMLElement, optionText: string) => void;
+
+/*
+ * react-select renders its menu on ArrowDown; the option text is unique on
+ * the page at that moment, so a global text lookup finds it.
+ */
+const selectOption: SelectOptionFunction = (
+  combobox: HTMLElement,
+  optionText: string,
+): void => {
+  fireEvent.keyDown(combobox, { key: "ArrowDown" });
+  const option: HTMLElement = screen.getByText(optionText);
+  fireEvent.mouseDown(option);
+  fireEvent.click(option);
+};
+
+function rowComboboxes(rowIndex: number): Array<HTMLElement> {
+  return within(
+    screen.getByTestId(`correlate-condition-row-${rowIndex}`),
+  ).getAllByRole("combobox");
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  cleanup();
+});
+
+describe("CorrelateFilterBuilder", () => {
+  test("renders the default observable row with a text value input", () => {
+    renderHarness();
+    expect(screen.getByTestId("correlate-condition-row-0")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("correlate-condition-value-0"),
+    ).toBeInTheDocument();
+    // Single row → no connector toggle yet.
+    expect(screen.queryByTestId("correlate-connector-and")).toBeNull();
+  });
+
+  test("typing a value emits the updated condition", () => {
+    const onChangeSpy: MockFunction = renderHarness();
+    fireEvent.change(screen.getByTestId("correlate-condition-value-0"), {
+      target: { value: "wb-ubuntu-03" },
+    });
+    expect(onChangeSpy).toHaveBeenCalledWith(
+      [
+        {
+          field: CorrelationFieldKey.Observable,
+          operator: CorrelationOperator.Equals,
+          value: "wb-ubuntu-03",
+        },
+      ],
+      "and",
+    );
+  });
+
+  test("Add condition appends a default row and reveals the connector toggle", () => {
+    const onChangeSpy: MockFunction = renderHarness();
+    fireEvent.click(screen.getByTestId("correlate-add-condition"));
+
+    expect(screen.getByTestId("correlate-condition-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("correlate-connector-and")).toBeInTheDocument();
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [getDefaultCorrelationCondition(), getDefaultCorrelationCondition()],
+      "and",
+    );
+  });
+
+  test("deleting a row removes exactly that row", () => {
+    const onChangeSpy: MockFunction = renderHarness([
+      {
+        field: CorrelationFieldKey.Observable,
+        operator: CorrelationOperator.Equals,
+        value: "keep-me",
+      },
+      {
+        field: CorrelationFieldKey.PrincipalUser,
+        operator: CorrelationOperator.Equals,
+        value: "delete-me",
+      },
+    ]);
+
+    fireEvent.click(screen.getByTestId("correlate-condition-delete-1"));
+
+    expect(screen.queryByTestId("correlate-condition-row-1")).toBeNull();
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [
+        {
+          field: CorrelationFieldKey.Observable,
+          operator: CorrelationOperator.Equals,
+          value: "keep-me",
+        },
+      ],
+      "and",
+    );
+  });
+
+  test("switching the connector to OR emits and restyles the badge", () => {
+    const onChangeSpy: MockFunction = renderHarness([
+      getDefaultCorrelationCondition(),
+      getDefaultCorrelationCondition(),
+    ]);
+
+    fireEvent.click(screen.getByTestId("correlate-connector-or"));
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [getDefaultCorrelationCondition(), getDefaultCorrelationCondition()],
+      "or",
+    );
+    // The between-row badge now reads OR.
+    expect(
+      within(screen.getByTestId("correlate-condition-row-1")).getByText("OR"),
+    ).toBeInTheDocument();
+  });
+
+  test("switching the field resets the value and keeps a compatible operator", () => {
+    const onChangeSpy: MockFunction = renderHarness([
+      {
+        field: CorrelationFieldKey.Observable,
+        operator: CorrelationOperator.Contains,
+        value: "ubuntu",
+      },
+    ]);
+
+    const fieldCombobox: HTMLElement = rowComboboxes(0)[0] as HTMLElement;
+    selectOption(fieldCombobox, "Principal Host");
+
+    // "contains" is offered on Principal Host too, so it survives.
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [
+        {
+          field: CorrelationFieldKey.PrincipalHost,
+          operator: CorrelationOperator.Contains,
+          value: "",
+        },
+      ],
+      "and",
+    );
+  });
+
+  test("switching to a field that lacks the operator falls back to the field's first operator", () => {
+    const onChangeSpy: MockFunction = renderHarness([
+      {
+        field: CorrelationFieldKey.Observable,
+        operator: CorrelationOperator.StartsWith,
+        value: "192.168.",
+      },
+    ]);
+
+    const fieldCombobox: HTMLElement = rowComboboxes(0)[0] as HTMLElement;
+    selectOption(fieldCombobox, "Severity");
+
+    // Severity only offers is / is not.
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [
+        {
+          field: CorrelationFieldKey.Severity,
+          operator: CorrelationOperator.Equals,
+          value: "",
+        },
+      ],
+      "and",
+    );
+  });
+
+  test("severity value renders a dropdown with the OCSF vocabulary", () => {
+    const onChangeSpy: MockFunction = renderHarness([
+      {
+        field: CorrelationFieldKey.Severity,
+        operator: CorrelationOperator.Equals,
+        value: "",
+      },
+    ]);
+
+    /*
+     * The value editor is a react-select dropdown (not a text input): the
+     * row has three comboboxes — field, operator, value.
+     */
+    const comboboxes: Array<HTMLElement> = rowComboboxes(0);
+    expect(comboboxes).toHaveLength(3);
+
+    selectOption(comboboxes[2] as HTMLElement, OcsfSeverity.Critical);
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [
+        {
+          field: CorrelationFieldKey.Severity,
+          operator: CorrelationOperator.Equals,
+          value: OcsfSeverity.Critical,
+        },
+      ],
+      "and",
+    );
+  });
+
+  test("operator dropdown only offers the field's vocabulary", () => {
+    renderHarness([
+      {
+        field: CorrelationFieldKey.Severity,
+        operator: CorrelationOperator.Equals,
+        value: "",
+      },
+    ]);
+
+    const operatorCombobox: HTMLElement = rowComboboxes(0)[1] as HTMLElement;
+    fireEvent.keyDown(operatorCombobox, { key: "ArrowDown" });
+
+    expect(screen.getByText("is not")).toBeInTheDocument();
+    expect(screen.queryByText("contains")).toBeNull();
+    expect(screen.queryByText("starts with")).toBeNull();
+  });
+
+  test("message field starts on its first operator (contains) and offers no equality", () => {
+    renderHarness([
+      {
+        field: CorrelationFieldKey.Message,
+        operator: CorrelationOperator.Contains,
+        value: "",
+      },
+    ]);
+
+    const operatorCombobox: HTMLElement = rowComboboxes(0)[1] as HTMLElement;
+    fireEvent.keyDown(operatorCombobox, { key: "ArrowDown" });
+
+    expect(screen.getByText("does not contain")).toBeInTheDocument();
+    expect(screen.queryByText(/^is$/)).toBeNull();
+  });
+});

--- a/Common/Tests/App/Dashboard/CorrelateFilterBuilder.test.tsx
+++ b/Common/Tests/App/Dashboard/CorrelateFilterBuilder.test.tsx
@@ -301,6 +301,46 @@ describe("CorrelateFilterBuilder", () => {
     expect(screen.queryByText("starts with")).toBeNull();
   });
 
+  test("event class renders a free-text autocomplete seeded with the OCSF class names", () => {
+    const onChangeSpy: MockFunction = renderHarness([
+      {
+        field: CorrelationFieldKey.EventClass,
+        operator: CorrelationOperator.Equals,
+        value: "",
+      },
+    ]);
+
+    /*
+     * Event Class is suggestions-not-dropdown on purpose: classes outside
+     * the curated OCSF table keep source-derived names, so the value must
+     * stay free text — an AutocompleteTextInput (a real INPUT that types
+     * freely; it also exposes role=combobox for its suggestion menu, so
+     * the row carries three comboboxes).
+     */
+    expect(rowComboboxes(0)).toHaveLength(3);
+    const valueInput: HTMLElement = screen.getByTestId(
+      "correlate-condition-value-0",
+    );
+    expect(valueInput.tagName).toBe("INPUT");
+    expect(valueInput).toHaveAttribute("placeholder", "Authentication");
+
+    fireEvent.change(valueInput, { target: { value: "Auth" } });
+    expect(onChangeSpy).toHaveBeenLastCalledWith(
+      [
+        {
+          field: CorrelationFieldKey.EventClass,
+          operator: CorrelationOperator.Equals,
+          value: "Auth",
+        },
+      ],
+      "and",
+    );
+
+    // Typing surfaces the matching curated suggestion.
+    fireEvent.focus(valueInput);
+    expect(screen.getByText("Authentication")).toBeInTheDocument();
+  });
+
   test("message field starts on its first operator (contains) and offers no equality", () => {
     renderHarness([
       {

--- a/Common/Tests/App/Dashboard/CorrelateGraph.test.tsx
+++ b/Common/Tests/App/Dashboard/CorrelateGraph.test.tsx
@@ -1,0 +1,691 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Security Events → Correlate (issue #3395): the quick single-observable
+ * search stays as shorthand, a condition builder adds AND/OR chains, the
+ * applied filter shows as removable chips and lives in the URL, AND chains
+ * compile into ONE query, OR chains fan out and union by event id, class
+ * nodes drill down into their events, and observable nodes offer
+ * focus/add/exclude pivots. Everything the component promises the issue is
+ * pinned here against a mocked AnalyticsModelAPI and a recording ReactFlow
+ * stand-in.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+const mockQueryParams: Record<string, string | null> = {};
+const setQueryStringMock: MockFunction = getJestMockFunction();
+const navigateMock: MockFunction = getJestMockFunction();
+
+const PROJECT_ID_STRING: string = "11111111-1111-4111-8111-111111111111";
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the
+ * compiled requires, so naming the mocks directly would capture them before
+ * their initializers have run.
+ */
+jest.mock("../../../UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return new ObjectID("11111111-1111-4111-8111-111111111111");
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Navigation", () => {
+  return {
+    __esModule: true,
+    default: {
+      getQueryStringByName: (name: string) => {
+        return mockQueryParams[name] ?? null;
+      },
+      setQueryString: (...args: Array<any>) => {
+        return setQueryStringMock(...args);
+      },
+      navigate: (...args: Array<any>) => {
+        return navigateMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string): string => {
+          return key;
+        },
+      };
+    },
+  };
+});
+
+/*
+ * ReactFlow renders nothing measurable in jsdom — replace it with a stand-in
+ * that lists every node as a clickable button so node-click pivots are
+ * testable, and forwards onNodeClick exactly like the real component.
+ */
+jest.mock("reactflow", () => {
+  return {
+    __esModule: true,
+    default: (props: any) => {
+      return React.createElement(
+        "div",
+        { "data-testid": "mock-react-flow" },
+        (props.nodes || []).map((node: any) => {
+          return React.createElement(
+            "button",
+            {
+              key: node.id,
+              type: "button",
+              "data-testid": `flow-node-${node.id}`,
+              onClick: (event: any) => {
+                if (props.onNodeClick) {
+                  props.onNodeClick(event, node);
+                }
+              },
+            },
+            typeof node.data?.label === "string" ? node.data.label : node.id,
+          );
+        }),
+      );
+    },
+    Background: () => {
+      return null;
+    },
+    Controls: () => {
+      return null;
+    },
+    BackgroundVariant: { Dots: "dots" },
+    MarkerType: { ArrowClosed: "arrowclosed" },
+  };
+});
+
+const detailPivotObservable: string = "pivot-observable";
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventDetail",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: any) => {
+        return React.createElement(
+          "div",
+          { "data-testid": "mock-event-detail" },
+          React.createElement(
+            "span",
+            { "data-testid": "mock-event-detail-message" },
+            props.securityEvent?.message || "",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "mock-event-detail-pivot",
+              onClick: () => {
+                if (props.onCorrelateObservable) {
+                  props.onCorrelateObservable("pivot-observable");
+                }
+              },
+            },
+            "pivot",
+          ),
+        );
+      },
+    };
+  },
+);
+
+/*
+ * The component import comes LAST: requiring it is what instantiates the
+ * mock factories above, and those factories reference these imports (e.g.
+ * ObjectID) — so everything else must be initialized first.
+ */
+import SecurityEvent from "../../../Models/AnalyticsModels/SecurityEvent";
+import ObjectID from "../../../Types/ObjectID";
+import OcsfSeverity from "../../../Types/SecurityEvent/OcsfSeverity";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import Search from "../../../Types/BaseDatabase/Search";
+import {
+  CorrelationFilter,
+  serializeCorrelationFilter,
+} from "../../../../App/FeatureSet/Dashboard/src/Utils/SecurityEventCorrelation";
+import CorrelateGraph from "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/CorrelateGraph";
+
+interface EventInput {
+  id: string;
+  className?: string;
+  severityName?: OcsfSeverity;
+  message?: string;
+  observables?: Array<string>;
+  principalUser?: string;
+}
+
+function buildEvent(input: EventInput): SecurityEvent {
+  const event: SecurityEvent = new SecurityEvent();
+  event._id = new ObjectID(input.id);
+  event.time = new Date("2026-08-25T10:00:00.000Z");
+  if (input.className) {
+    event.className = input.className;
+  }
+  if (input.severityName) {
+    event.severityName = input.severityName;
+  }
+  if (input.message) {
+    event.message = input.message;
+  }
+  if (input.principalUser) {
+    event.principalUser = input.principalUser;
+  }
+  event.observables = input.observables || [];
+  return event;
+}
+
+function listResult(events: Array<SecurityEvent>): {
+  data: Array<SecurityEvent>;
+  count: number;
+  skip: number;
+  limit: number;
+} {
+  return { data: events, count: events.length, skip: 0, limit: 200 };
+}
+
+type QueryRecord = Record<string, unknown>;
+
+function queryOfCall(callIndex: number): QueryRecord {
+  const callArg: { query: QueryRecord } = getListMock.mock.calls[
+    callIndex
+  ]?.[0] as { query: QueryRecord };
+  return callArg.query;
+}
+
+function runQuickSearch(observable: string): void {
+  fireEvent.change(screen.getByTestId("security-events-correlate-observable"), {
+    target: { value: observable },
+  });
+  fireEvent.click(screen.getByTestId("security-events-correlate-button"));
+}
+
+beforeEach(() => {
+  getListMock.mockReset();
+  getListMock.mockResolvedValue(listResult([]));
+  setQueryStringMock.mockReset();
+  navigateMock.mockReset();
+  for (const key of Object.keys(mockQueryParams)) {
+    delete mockQueryParams[key];
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CorrelateGraph", () => {
+  test("starts on the empty state without fetching", () => {
+    render(<CorrelateGraph />);
+    expect(screen.getByText("Correlate security events")).toBeInTheDocument();
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("quick search compiles to ONE hasAny query with project and time scope", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03", "alice"],
+        }),
+        buildEvent({
+          id: "33333333-3333-4333-8333-333333333333",
+          className: "Process Activity",
+          observables: ["wb-ubuntu-03"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+
+    const query: QueryRecord = queryOfCall(0);
+    expect((query["projectId"] as ObjectID).toString()).toBe(PROJECT_ID_STRING);
+    expect(query["time"]).toBeInstanceOf(InBetween);
+    expect(query["observables"]).toBeInstanceOf(Includes);
+    expect((query["observables"] as Includes).values).toEqual(["wb-ubuntu-03"]);
+
+    const callArg: { limit: number; sort: Record<string, unknown> } =
+      getListMock.mock.calls[0]?.[0] as {
+        limit: number;
+        sort: Record<string, unknown>;
+      };
+    expect(callArg.limit).toBe(200);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 matching events\./)).toBeInTheDocument();
+    });
+
+    // The applied filter shows as a chip and lands in the URL.
+    expect(screen.getByTestId("correlate-filter-chip-0")).toHaveTextContent(
+      "wb-ubuntu-03",
+    );
+    expect(setQueryStringMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: expect.stringContaining("wb-ubuntu-03"),
+        observable: null,
+      }),
+    );
+
+    // Class nodes made it into the graph.
+    expect(
+      screen.getByTestId("flow-node-class:Authentication"),
+    ).toHaveTextContent("Authentication (1)");
+  });
+
+  test("a ?observable= deep link auto-correlates on mount", async () => {
+    mockQueryParams["observable"] = "wb-ubuntu-03";
+    render(<CorrelateGraph />);
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+    expect((queryOfCall(0)["observables"] as Includes).values).toEqual([
+      "wb-ubuntu-03",
+    ]);
+  });
+
+  test("a ?q= deep link restores a multi-condition AND filter into one query and opens the builder", async () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        { field: "principalIp", operator: "equals", value: "192.168.1.20" },
+        { field: "principalHost", operator: "equals", value: "wb-ubuntu-03" },
+      ],
+      connector: "and",
+    } as CorrelationFilter;
+    mockQueryParams["q"] = serializeCorrelationFilter(filter);
+    mockQueryParams["hours"] = "168";
+
+    render(<CorrelateGraph />);
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+    const query: QueryRecord = queryOfCall(0);
+    expect(query["principalIp"]).toBe("192.168.1.20");
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+
+    // Both chips visible, builder auto-opened for the chain.
+    expect(screen.getByTestId("correlate-filter-chip-1")).toBeInTheDocument();
+    expect(screen.getByTestId("correlate-filter-builder")).toBeInTheDocument();
+
+    // The seeded time range makes it into the query window (168h ≈ 7 days).
+    const timeWindow: InBetween<Date> = query["time"] as InBetween<Date>;
+    const windowMs: number =
+      new Date(timeWindow.endValue).getTime() -
+      new Date(timeWindow.startValue).getTime();
+    expect(Math.round(windowMs / (1000 * 60 * 60))).toBe(168);
+  });
+
+  test("OR filters fan out into one query per condition and union by event id", async () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        { field: "observable", operator: "equals", value: "wb-ubuntu-03" },
+        { field: "message", operator: "contains", value: "failed" },
+      ],
+      connector: "or",
+    } as CorrelationFilter;
+    mockQueryParams["q"] = serializeCorrelationFilter(filter);
+
+    const sharedEvent: SecurityEvent = buildEvent({
+      id: "44444444-4444-4444-8444-444444444444",
+      className: "Authentication",
+      message: "failed password for alice",
+      observables: ["wb-ubuntu-03"],
+    });
+
+    getListMock.mockImplementation((args: any) => {
+      const query: QueryRecord = args.query as QueryRecord;
+      if (query["observables"]) {
+        return Promise.resolve(
+          listResult([
+            sharedEvent,
+            buildEvent({
+              id: "55555555-5555-4555-8555-555555555555",
+              className: "Authentication",
+              observables: ["wb-ubuntu-03"],
+            }),
+          ]),
+        );
+      }
+      return Promise.resolve(
+        listResult([
+          sharedEvent,
+          buildEvent({
+            id: "66666666-6666-4666-8666-666666666666",
+            className: "Detection Finding",
+            message: "failed logon burst",
+            observables: [],
+          }),
+        ]),
+      );
+    });
+
+    render(<CorrelateGraph />);
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+
+    // 2 + 2 rows with one shared id → 3 unique events.
+    await waitFor(() => {
+      expect(screen.getByText(/3 matching events\./)).toBeInTheDocument();
+    });
+
+    const queries: Array<QueryRecord> = [queryOfCall(0), queryOfCall(1)];
+    const observableQuery: QueryRecord | undefined = queries.find(
+      (query: QueryRecord) => {
+        return Boolean(query["observables"]);
+      },
+    );
+    const messageQuery: QueryRecord | undefined = queries.find(
+      (query: QueryRecord) => {
+        return Boolean(query["message"]);
+      },
+    );
+    expect(observableQuery).toBeTruthy();
+    expect(messageQuery?.["message"]).toBeInstanceOf(Search);
+  });
+
+  test("an impossible AND chain surfaces the friendly compiler error and fetches nothing", async () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        { field: "principalHost", operator: "equals", value: "host-a" },
+        { field: "principalHost", operator: "equals", value: "host-b" },
+      ],
+      connector: "and",
+    } as CorrelationFilter;
+    mockQueryParams["q"] = serializeCorrelationFilter(filter);
+
+    render(<CorrelateGraph />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/can never match/)).toBeInTheDocument();
+    });
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("hitting the per-query cap marks counts as lower bounds", async () => {
+    const manyEvents: Array<SecurityEvent> = [];
+    for (let eventIndex: number = 0; eventIndex < 200; eventIndex++) {
+      manyEvents.push(
+        buildEvent({
+          id: `77777777-7777-4777-8777-${String(eventIndex).padStart(12, "0")}`,
+          className: "Authentication",
+          observables: ["wb-ubuntu-03"],
+        }),
+      );
+    }
+    getListMock.mockResolvedValue(listResult(manyEvents));
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/treat counts as lower bounds/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("removing a chip re-correlates with the remaining conditions", async () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        { field: "principalIp", operator: "equals", value: "192.168.1.20" },
+        { field: "principalHost", operator: "equals", value: "wb-ubuntu-03" },
+      ],
+      connector: "and",
+    } as CorrelationFilter;
+    mockQueryParams["q"] = serializeCorrelationFilter(filter);
+
+    render(<CorrelateGraph />);
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByTestId("correlate-filter-chip-remove-0"));
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    const query: QueryRecord = queryOfCall(1);
+    expect(query["principalIp"]).toBeUndefined();
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+    expect(screen.queryByTestId("correlate-filter-chip-1")).toBeNull();
+  });
+
+  test("clearing every condition returns to the empty state and clears the URL", async () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        { field: "observable", operator: "equals", value: "wb-ubuntu-03" },
+        { field: "observable", operator: "equals", value: "192.168.1.20" },
+      ],
+      connector: "or",
+    } as CorrelationFilter;
+    mockQueryParams["q"] = serializeCorrelationFilter(filter);
+
+    render(<CorrelateGraph />);
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByTestId("correlate-filter-clear-all"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Correlate security events")).toBeInTheDocument();
+    });
+    expect(setQueryStringMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ q: null, hours: null }),
+    );
+  });
+
+  test("clicking a class node opens the drill-down and a row opens the event detail; the detail pivot re-correlates", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "88888888-8888-4888-8888-888888888888",
+          className: "Authentication",
+          severityName: OcsfSeverity.High,
+          message: "failed password for alice",
+          principalUser: "alice",
+          observables: ["wb-ubuntu-03", "alice"],
+        }),
+        buildEvent({
+          id: "99999999-9999-4999-8999-999999999999",
+          className: "Process Activity",
+          message: "suspicious process",
+          observables: ["wb-ubuntu-03"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flow-node-class:Authentication"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("flow-node-class:Authentication"));
+
+    const drillDown: HTMLElement = screen.getByTestId("correlate-drilldown");
+    expect(within(drillDown).getByText(/1 matching event/)).toBeInTheDocument();
+    expect(
+      within(drillDown).getByText("failed password for alice"),
+    ).toBeInTheDocument();
+    // Only Authentication events — not the Process Activity row.
+    expect(within(drillDown).queryByText("suspicious process")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("correlate-drilldown-event-0"));
+    expect(screen.getByTestId("mock-event-detail")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-event-detail-message")).toHaveTextContent(
+      "failed password for alice",
+    );
+
+    fireEvent.click(screen.getByTestId("mock-event-detail-pivot"));
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    expect((queryOfCall(1)["observables"] as Includes).values).toEqual([
+      detailPivotObservable,
+    ]);
+  });
+
+  test("clicking an observable node offers Focus / Add / Exclude pivots", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03", "alice"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flow-node-observable:alice"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("flow-node-observable:alice"));
+    const actionBar: HTMLElement = screen.getByTestId(
+      "correlate-observable-actions",
+    );
+    expect(within(actionBar).getByText("alice")).toBeInTheDocument();
+
+    // Exclude appends "Observable is not alice" alongside the equality.
+    fireEvent.click(screen.getByTestId("correlate-action-exclude"));
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    const operators: Array<unknown> = queryOfCall(1)[
+      "observables"
+    ] as Array<unknown>;
+    expect(Array.isArray(operators)).toBe(true);
+    expect(operators[0]).toBeInstanceOf(Includes);
+    expect((operators[0] as Includes).values).toEqual(["wb-ubuntu-03"]);
+    expect(operators[1]).toBeInstanceOf(IncludesNone);
+    expect((operators[1] as IncludesNone).values).toEqual(["alice"]);
+  });
+
+  test("Focus replaces the whole filter with the selected observable", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03", "alice"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flow-node-observable:alice"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("flow-node-observable:alice"));
+    fireEvent.click(screen.getByTestId("correlate-action-focus"));
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    expect((queryOfCall(1)["observables"] as Includes).values).toEqual([
+      "alice",
+    ]);
+    // The quick input follows a single-observable filter.
+    expect(
+      screen.getByTestId("security-events-correlate-observable"),
+    ).toHaveValue("alice");
+  });
+
+  test("searched observables never appear as co-occurring nodes", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03", "alice"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flow-node-observable:alice"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("flow-node-observable:wb-ubuntu-03"),
+    ).toBeNull();
+  });
+
+  test("an API failure surfaces as an error message", async () => {
+    getListMock.mockRejectedValue(new Error("ClickHouse is down"));
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+
+    await waitFor(() => {
+      expect(screen.getByText(/ClickHouse is down/)).toBeInTheDocument();
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/CorrelateGraph.test.tsx
+++ b/Common/Tests/App/Dashboard/CorrelateGraph.test.tsx
@@ -688,4 +688,178 @@ describe("CorrelateGraph", () => {
       expect(screen.getByText(/ClickHouse is down/)).toBeInTheDocument();
     });
   });
+
+  test("changing the time range refetches with the new window and syncs the URL", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+
+    const timeRangeCombobox: HTMLElement = within(
+      screen.getByTestId("security-events-correlate-time-range"),
+    ).getByRole("combobox");
+    fireEvent.keyDown(timeRangeCombobox, { key: "ArrowDown" });
+    const option: HTMLElement = screen.getByText("Last 7 days");
+    fireEvent.mouseDown(option);
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    const timeWindow: InBetween<Date> = queryOfCall(1)[
+      "time"
+    ] as InBetween<Date>;
+    const windowMs: number =
+      new Date(timeWindow.endValue).getTime() -
+      new Date(timeWindow.startValue).getTime();
+    expect(Math.round(windowMs / (1000 * 60 * 60))).toBe(168);
+    expect(setQueryStringMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ hours: "168" }),
+    );
+  });
+
+  test.each<[string]>([["999"], ["abc"], ["-5"]])(
+    "an invalid ?hours=%s falls back to the 24-hour default",
+    async (rawHours: string) => {
+      mockQueryParams["observable"] = "wb-ubuntu-03";
+      mockQueryParams["hours"] = rawHours;
+
+      render(<CorrelateGraph />);
+      await waitFor(() => {
+        expect(getListMock).toHaveBeenCalledTimes(1);
+      });
+
+      const timeWindow: InBetween<Date> = queryOfCall(0)[
+        "time"
+      ] as InBetween<Date>;
+      const windowMs: number =
+        new Date(timeWindow.endValue).getTime() -
+        new Date(timeWindow.startValue).getTime();
+      expect(Math.round(windowMs / (1000 * 60 * 60))).toBe(24);
+    },
+  );
+
+  test("OR mode hides the Exclude pivot and the drill-down class filter", async () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        { field: "observable", operator: "equals", value: "wb-ubuntu-03" },
+        { field: "observable", operator: "equals", value: "192.168.1.20" },
+      ],
+      connector: "or",
+    } as CorrelationFilter;
+    mockQueryParams["q"] = serializeCorrelationFilter(filter);
+
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03", "alice"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flow-node-observable:alice"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("flow-node-observable:alice"));
+    expect(
+      screen.getByTestId("correlate-observable-actions"),
+    ).toBeInTheDocument();
+    // "is not X" only narrows under AND — the pivot hides in OR mode.
+    expect(screen.queryByTestId("correlate-action-exclude")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("flow-node-class:Authentication"));
+    expect(screen.getByTestId("correlate-drilldown")).toBeInTheDocument();
+    expect(screen.queryByTestId("correlate-drilldown-filter-class")).toBeNull();
+  });
+
+  test("the drill-down's Filter-to-this-class appends a className condition in AND mode", async () => {
+    getListMock.mockResolvedValue(
+      listResult([
+        buildEvent({
+          id: "22222222-2222-4222-8222-222222222222",
+          className: "Authentication",
+          observables: ["wb-ubuntu-03"],
+        }),
+      ]),
+    );
+
+    render(<CorrelateGraph />);
+    runQuickSearch("wb-ubuntu-03");
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flow-node-class:Authentication"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("flow-node-class:Authentication"));
+    fireEvent.click(screen.getByTestId("correlate-drilldown-filter-class"));
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+    const query: QueryRecord = queryOfCall(1);
+    expect((query["observables"] as Includes).values).toEqual(["wb-ubuntu-03"]);
+    expect(query["className"]).toBe("Authentication");
+  });
+
+  test("Correlate stays disabled while a builder row has no value", () => {
+    render(<CorrelateGraph />);
+
+    // Open the builder — it seeds one default (empty-valued) row.
+    fireEvent.click(
+      screen.getByTestId("security-events-correlate-toggle-builder"),
+    );
+    expect(screen.getByTestId("correlate-filter-builder")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("security-events-correlate-button"),
+    ).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("correlate-condition-value-0"), {
+      target: { value: "wb-ubuntu-03" },
+    });
+    expect(
+      screen.getByTestId("security-events-correlate-button"),
+    ).not.toBeDisabled();
+  });
+
+  test("opening the builder seeds it from freshly typed (unapplied) quick text", async () => {
+    getListMock.mockResolvedValue(listResult([]));
+
+    render(<CorrelateGraph />);
+    // Apply one search, then type something NEW without applying it.
+    runQuickSearch("wb-ubuntu-03");
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.change(
+      screen.getByTestId("security-events-correlate-observable"),
+      { target: { value: "freshly-typed" } },
+    );
+
+    fireEvent.click(
+      screen.getByTestId("security-events-correlate-toggle-builder"),
+    );
+
+    // The new text wins over the stale draft from the applied search.
+    expect(screen.getByTestId("correlate-condition-value-0")).toHaveValue(
+      "freshly-typed",
+    );
+  });
 });

--- a/Common/Tests/App/Dashboard/CorrelationGraph.test.ts
+++ b/Common/Tests/App/Dashboard/CorrelationGraph.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from "@jest/globals";
+import SecurityEvent from "../../../Models/AnalyticsModels/SecurityEvent";
+import ObjectID from "../../../Types/ObjectID";
+import OcsfSeverity from "../../../Types/SecurityEvent/OcsfSeverity";
+import {
+  CENTER_NODE_ID,
+  CLASS_NODE_PREFIX,
+  CorrelationGraphData,
+  CorrelationGraphEdge,
+  CorrelationGraphNode,
+  OBSERVABLE_NODE_PREFIX,
+  buildCorrelationGraph,
+  dedupeSecurityEvents,
+  severityRank,
+} from "../../../../App/FeatureSet/Dashboard/src/Utils/CorrelationGraph";
+
+/*
+ * The correlate graph builder aggregates fetched events into the
+ * center/class/observable neighborhood: event counts per class, worst
+ * severity per class (for node tinting), co-observable counting with
+ * per-event dedupe, exclusion of the searched values, the top-N cap with
+ * honest drop accounting, and the union-dedupe used when OR mode runs one
+ * query per condition. All pinned here as pure data — no React, no
+ * ReactFlow.
+ */
+
+interface EventInput {
+  id?: string;
+  eventUid?: string;
+  className?: string;
+  severityName?: OcsfSeverity;
+  observables?: Array<string>;
+  time?: Date;
+}
+
+function buildEvent(input: EventInput): SecurityEvent {
+  const event: SecurityEvent = new SecurityEvent();
+  if (input.id) {
+    event._id = new ObjectID(input.id);
+  }
+  if (input.eventUid) {
+    event.eventUid = input.eventUid;
+  }
+  if (input.className) {
+    event.className = input.className;
+  }
+  if (input.severityName) {
+    event.severityName = input.severityName;
+  }
+  event.observables = input.observables || [];
+  if (input.time) {
+    event.time = input.time;
+  }
+  return event;
+}
+
+function nodeById(
+  graph: CorrelationGraphData,
+  id: string,
+): CorrelationGraphNode | undefined {
+  return graph.nodes.find((node: CorrelationGraphNode) => {
+    return node.id === id;
+  });
+}
+
+function edgeById(
+  graph: CorrelationGraphData,
+  id: string,
+): CorrelationGraphEdge | undefined {
+  return graph.edges.find((edge: CorrelationGraphEdge) => {
+    return edge.id === id;
+  });
+}
+
+describe("severityRank", () => {
+  test("orders real severities and puts Unknown/Other/blank at the bottom", () => {
+    expect(severityRank(OcsfSeverity.Fatal)).toBeGreaterThan(
+      severityRank(OcsfSeverity.Critical),
+    );
+    expect(severityRank(OcsfSeverity.Critical)).toBeGreaterThan(
+      severityRank(OcsfSeverity.High),
+    );
+    expect(severityRank(OcsfSeverity.High)).toBeGreaterThan(
+      severityRank(OcsfSeverity.Medium),
+    );
+    expect(severityRank(OcsfSeverity.Medium)).toBeGreaterThan(
+      severityRank(OcsfSeverity.Low),
+    );
+    expect(severityRank(OcsfSeverity.Low)).toBeGreaterThan(
+      severityRank(OcsfSeverity.Informational),
+    );
+    expect(severityRank(OcsfSeverity.Unknown)).toBe(0);
+    expect(severityRank(OcsfSeverity.Other)).toBe(0);
+    expect(severityRank(undefined)).toBe(0);
+    expect(severityRank("")).toBe(0);
+  });
+});
+
+describe("buildCorrelationGraph", () => {
+  test("no events → empty graph", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [],
+      centerLabel: 'Observable is "x"',
+      excludedObservables: ["x"],
+    });
+    expect(graph.nodes).toHaveLength(0);
+    expect(graph.edges).toHaveLength(0);
+    expect(graph.droppedCoObservableCount).toBe(0);
+  });
+
+  test("one node per class with event counts on the center edges", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [
+        buildEvent({ className: "Authentication", observables: ["host-1"] }),
+        buildEvent({ className: "Authentication", observables: ["host-1"] }),
+        buildEvent({ className: "Process Activity", observables: ["host-1"] }),
+        buildEvent({ observables: ["host-1"] }), // no class → Unclassified
+      ],
+      centerLabel: "center-label",
+      excludedObservables: ["host-1"],
+    });
+
+    const center: CorrelationGraphNode | undefined = nodeById(
+      graph,
+      CENTER_NODE_ID,
+    );
+    expect(center).toBeTruthy();
+    expect(center?.label).toBe("center-label");
+    expect(center?.kind).toBe("center");
+
+    const authClass: CorrelationGraphNode | undefined = nodeById(
+      graph,
+      `${CLASS_NODE_PREFIX}Authentication`,
+    );
+    expect(authClass?.count).toBe(2);
+    expect(
+      edgeById(graph, `${CENTER_NODE_ID}->${CLASS_NODE_PREFIX}Authentication`)
+        ?.count,
+    ).toBe(2);
+
+    expect(nodeById(graph, `${CLASS_NODE_PREFIX}Unclassified`)?.count).toBe(1);
+    expect(nodeById(graph, `${CLASS_NODE_PREFIX}Process Activity`)?.count).toBe(
+      1,
+    );
+
+    // Excluded observable never becomes a node.
+    expect(nodeById(graph, `${OBSERVABLE_NODE_PREFIX}host-1`)).toBeUndefined();
+  });
+
+  test("class nodes carry the WORST severity among their events", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [
+        buildEvent({
+          className: "Authentication",
+          severityName: OcsfSeverity.Low,
+        }),
+        buildEvent({
+          className: "Authentication",
+          severityName: OcsfSeverity.Critical,
+        }),
+        buildEvent({
+          className: "Authentication",
+          severityName: OcsfSeverity.Medium,
+        }),
+        buildEvent({
+          className: "Compliance Finding",
+          severityName: OcsfSeverity.Unknown,
+        }),
+      ],
+      centerLabel: "c",
+      excludedObservables: [],
+    });
+
+    expect(
+      nodeById(graph, `${CLASS_NODE_PREFIX}Authentication`)?.worstSeverity,
+    ).toBe(OcsfSeverity.Critical);
+    /*
+     * Unknown ranks zero — the node gets NO severity rather than
+     * pretending "Unknown" is a color-worthy signal.
+     */
+    expect(
+      nodeById(graph, `${CLASS_NODE_PREFIX}Compliance Finding`)?.worstSeverity,
+    ).toBeUndefined();
+  });
+
+  test("co-observables count once per event even when repeated in one row", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [
+        buildEvent({
+          className: "Authentication",
+          observables: ["searched", "alice", "alice", "alice"],
+        }),
+        buildEvent({
+          className: "Authentication",
+          observables: ["searched", "alice"],
+        }),
+      ],
+      centerLabel: "c",
+      excludedObservables: ["searched"],
+    });
+
+    expect(
+      edgeById(
+        graph,
+        `${CLASS_NODE_PREFIX}Authentication->${OBSERVABLE_NODE_PREFIX}alice`,
+      )?.count,
+    ).toBe(2);
+  });
+
+  test("empty observable strings are ignored", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [
+        buildEvent({ className: "Authentication", observables: ["", "alice"] }),
+      ],
+      centerLabel: "c",
+      excludedObservables: [],
+    });
+    expect(nodeById(graph, `${OBSERVABLE_NODE_PREFIX}alice`)).toBeTruthy();
+    expect(nodeById(graph, `${OBSERVABLE_NODE_PREFIX}`)).toBeUndefined();
+  });
+
+  test("an observable shared by two classes gets ONE node and two edges", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [
+        buildEvent({ className: "Authentication", observables: ["alice"] }),
+        buildEvent({ className: "Process Activity", observables: ["alice"] }),
+      ],
+      centerLabel: "c",
+      excludedObservables: [],
+    });
+
+    const observableNodes: Array<CorrelationGraphNode> = graph.nodes.filter(
+      (node: CorrelationGraphNode) => {
+        return node.kind === "observable";
+      },
+    );
+    expect(observableNodes).toHaveLength(1);
+    expect(
+      edgeById(
+        graph,
+        `${CLASS_NODE_PREFIX}Authentication->${OBSERVABLE_NODE_PREFIX}alice`,
+      ),
+    ).toBeTruthy();
+    expect(
+      edgeById(
+        graph,
+        `${CLASS_NODE_PREFIX}Process Activity->${OBSERVABLE_NODE_PREFIX}alice`,
+      ),
+    ).toBeTruthy();
+  });
+
+  test("caps co-observables at the most frequent N and reports the drop count", () => {
+    const events: Array<SecurityEvent> = [];
+    // "popular" appears in 3 events, every "rare-N" in exactly one.
+    for (let eventIndex: number = 0; eventIndex < 3; eventIndex++) {
+      events.push(
+        buildEvent({
+          className: "Authentication",
+          observables: ["popular", `rare-${eventIndex}`],
+        }),
+      );
+    }
+    events.push(
+      buildEvent({ className: "Authentication", observables: ["rare-3"] }),
+    );
+
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: events,
+      centerLabel: "c",
+      excludedObservables: [],
+      maxCoObservables: 2,
+    });
+
+    const observableNodes: Array<CorrelationGraphNode> = graph.nodes.filter(
+      (node: CorrelationGraphNode) => {
+        return node.kind === "observable";
+      },
+    );
+    expect(observableNodes).toHaveLength(2);
+    // Highest count first, then alphabetical among the tied rares.
+    expect(nodeById(graph, `${OBSERVABLE_NODE_PREFIX}popular`)).toBeTruthy();
+    expect(nodeById(graph, `${OBSERVABLE_NODE_PREFIX}rare-0`)).toBeTruthy();
+    expect(graph.droppedCoObservableCount).toBe(3);
+  });
+
+  test("cap exactly met → nothing reported dropped", () => {
+    const graph: CorrelationGraphData = buildCorrelationGraph({
+      events: [
+        buildEvent({ className: "Authentication", observables: ["a", "b"] }),
+      ],
+      centerLabel: "c",
+      excludedObservables: [],
+      maxCoObservables: 2,
+    });
+    expect(graph.droppedCoObservableCount).toBe(0);
+  });
+});
+
+describe("dedupeSecurityEvents", () => {
+  test("unions result sets by row id", () => {
+    const shared: SecurityEvent = buildEvent({
+      id: "11111111-1111-4111-8111-111111111111",
+      className: "Authentication",
+    });
+    const onlyFirst: SecurityEvent = buildEvent({
+      id: "22222222-2222-4222-8222-222222222222",
+    });
+    const onlySecond: SecurityEvent = buildEvent({
+      id: "33333333-3333-4333-8333-333333333333",
+    });
+
+    const deduped: Array<SecurityEvent> = dedupeSecurityEvents([
+      [onlyFirst, shared],
+      [shared, onlySecond],
+    ]);
+
+    expect(deduped).toHaveLength(3);
+    expect(deduped[0]).toBe(onlyFirst);
+    expect(deduped[1]).toBe(shared);
+    expect(deduped[2]).toBe(onlySecond);
+  });
+
+  test("two model instances with the SAME id count once", () => {
+    const first: SecurityEvent = buildEvent({
+      id: "11111111-1111-4111-8111-111111111111",
+    });
+    const second: SecurityEvent = buildEvent({
+      id: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(dedupeSecurityEvents([[first], [second]])).toHaveLength(1);
+  });
+
+  test("falls back to eventUid + time when _id was not selected", () => {
+    const time: Date = new Date("2026-08-25T10:00:00.000Z");
+    const first: SecurityEvent = buildEvent({ eventUid: "uid-1", time });
+    const duplicate: SecurityEvent = buildEvent({ eventUid: "uid-1", time });
+    const differentTime: SecurityEvent = buildEvent({
+      eventUid: "uid-1",
+      time: new Date("2026-08-25T11:00:00.000Z"),
+    });
+
+    expect(
+      dedupeSecurityEvents([[first], [duplicate], [differentTime]]),
+    ).toHaveLength(2);
+  });
+});

--- a/Common/Tests/App/Dashboard/SecurityEventCorrelation.test.ts
+++ b/Common/Tests/App/Dashboard/SecurityEventCorrelation.test.ts
@@ -1,0 +1,857 @@
+import { describe, expect, test } from "@jest/globals";
+import EqualTo from "../../../Types/BaseDatabase/EqualTo";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesAll from "../../../Types/BaseDatabase/IncludesAll";
+import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import NotContains from "../../../Types/BaseDatabase/NotContains";
+import NotEqual from "../../../Types/BaseDatabase/NotEqual";
+import Search from "../../../Types/BaseDatabase/Search";
+import StartsWith from "../../../Types/BaseDatabase/StartsWith";
+import EndsWith from "../../../Types/BaseDatabase/EndsWith";
+import ObjectID from "../../../Types/ObjectID";
+import OcsfSeverity from "../../../Types/SecurityEvent/OcsfSeverity";
+import {
+  CompiledCorrelationQueries,
+  CorrelationCondition,
+  CorrelationFieldDefinition,
+  CorrelationFieldDefinitions,
+  CorrelationFieldKey,
+  CorrelationFilter,
+  CorrelationOperator,
+  CorrelationOperatorLabels,
+  CorrelationQueryOptions,
+  compileCorrelationFilter,
+  describeCorrelationCondition,
+  describeCorrelationFilter,
+  getCorrelationFieldDefinition,
+  getEqualityObservables,
+  parseCorrelationFilter,
+  serializeCorrelationFilter,
+} from "../../../../App/FeatureSet/Dashboard/src/Utils/SecurityEventCorrelation";
+
+/*
+ * The correlation filter compiler is the contract between the Correlate
+ * query-builder UI (issue #3395) and the flat analytics query API: AND
+ * chains must land in ONE query (with same-column conditions merged into an
+ * equivalent single operator or rejected with a friendly error — never
+ * silently wrong), OR chains must fan out into one query per condition with
+ * same-field equalities collapsed into a single Includes. These tests pin
+ * every compilation rule, the URL round-trip, and the tolerance of the
+ * parser against malformed input.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const START_DATE: Date = new Date("2026-08-24T00:00:00.000Z");
+const END_DATE: Date = new Date("2026-08-25T00:00:00.000Z");
+
+const options: CorrelationQueryOptions = {
+  projectId: PROJECT_ID,
+  startDate: START_DATE,
+  endDate: END_DATE,
+};
+
+function condition(
+  field: CorrelationFieldKey,
+  operator: CorrelationOperator,
+  value: string,
+): CorrelationCondition {
+  return { field, operator, value };
+}
+
+function compile(
+  conditions: Array<CorrelationCondition>,
+  connector: "and" | "or",
+): CompiledCorrelationQueries {
+  return compileCorrelationFilter({ conditions, connector }, options);
+}
+
+type QueryRecord = Record<string, unknown>;
+
+function expectBaseQuery(query: QueryRecord): void {
+  expect(query["projectId"]).toBe(PROJECT_ID);
+  expect(query["time"]).toBeInstanceOf(InBetween);
+  expect((query["time"] as InBetween<Date>).startValue).toBe(START_DATE);
+  expect((query["time"] as InBetween<Date>).endValue).toBe(END_DATE);
+}
+
+describe("field catalog", () => {
+  test("every field offers at least one operator, and only labeled operators", () => {
+    for (const definition of CorrelationFieldDefinitions) {
+      expect(definition.operators.length).toBeGreaterThan(0);
+      for (const operator of definition.operators) {
+        expect(CorrelationOperatorLabels[operator]).toBeTruthy();
+      }
+    }
+  });
+
+  test("the observable field targets the observables array column", () => {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(CorrelationFieldKey.Observable);
+    expect(definition.columnKey).toBe("observables");
+    expect(definition.isArrayColumn).toBe(true);
+  });
+
+  test("severity offers a fixed value vocabulary", () => {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(CorrelationFieldKey.Severity);
+    expect(definition.valueOptions).toEqual(Object.values(OcsfSeverity));
+    expect(definition.operators).toEqual([
+      CorrelationOperator.Equals,
+      CorrelationOperator.NotEquals,
+    ]);
+  });
+
+  test("event class suggests the curated OCSF names but stays free-text", () => {
+    const definition: CorrelationFieldDefinition =
+      getCorrelationFieldDefinition(CorrelationFieldKey.EventClass);
+    expect(definition.valueOptions).toBeUndefined();
+    expect(definition.valueSuggestions).toContain("Authentication");
+    expect(definition.valueSuggestions).toContain("Detection Finding");
+  });
+
+  test("getCorrelationFieldDefinition throws for an unknown field", () => {
+    expect(() => {
+      return getCorrelationFieldDefinition("nope" as CorrelationFieldKey);
+    }).toThrow("Unknown correlation field: nope");
+  });
+});
+
+describe("AND compilation — single conditions", () => {
+  test.each<[CorrelationOperator, (value: unknown) => void]>([
+    [
+      CorrelationOperator.Equals,
+      (value: unknown): void => {
+        expect(value).toBeInstanceOf(Includes);
+        expect((value as Includes).values).toEqual(["wb-ubuntu-03"]);
+      },
+    ],
+    [
+      CorrelationOperator.NotEquals,
+      (value: unknown): void => {
+        expect(value).toBeInstanceOf(IncludesNone);
+        expect((value as IncludesNone).values).toEqual(["wb-ubuntu-03"]);
+      },
+    ],
+    [
+      CorrelationOperator.Contains,
+      (value: unknown): void => {
+        expect(value).toBeInstanceOf(Search);
+        expect((value as Search<string>).toString()).toBe("wb-ubuntu-03");
+      },
+    ],
+    [
+      CorrelationOperator.NotContains,
+      (value: unknown): void => {
+        expect(value).toBeInstanceOf(NotContains);
+      },
+    ],
+    [
+      CorrelationOperator.StartsWith,
+      (value: unknown): void => {
+        expect(value).toBeInstanceOf(StartsWith);
+      },
+    ],
+    [
+      CorrelationOperator.EndsWith,
+      (value: unknown): void => {
+        expect(value).toBeInstanceOf(EndsWith);
+      },
+    ],
+  ])(
+    "observable %s compiles onto the observables column",
+    (operator: CorrelationOperator, assertValue: (value: unknown) => void) => {
+      const compiled: CompiledCorrelationQueries = compile(
+        [condition(CorrelationFieldKey.Observable, operator, "wb-ubuntu-03")],
+        "and",
+      );
+      expect(compiled.error).toBeNull();
+      expect(compiled.queries).toHaveLength(1);
+      const query: QueryRecord = compiled.queries[0] as QueryRecord;
+      expectBaseQuery(query);
+      assertValue(query["observables"]);
+    },
+  );
+
+  test("scalar equals compiles to a bare value (the fast equality path)", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+  });
+
+  test("scalar not-equals compiles to NotEqual", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+      ],
+      "and",
+    );
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalUser"]).toBeInstanceOf(NotEqual);
+    expect((query["principalUser"] as NotEqual<string>).value).toBe("baduser1");
+  });
+
+  test("scalar contains compiles to Search", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Message,
+          CorrelationOperator.Contains,
+          "failed password",
+        ),
+      ],
+      "and",
+    );
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["message"]).toBeInstanceOf(Search);
+  });
+});
+
+describe("AND compilation — the issue #3395 shapes", () => {
+  test("IP = X AND Hostname = Y (different fields) lands in one query", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalIp,
+          CorrelationOperator.Equals,
+          "192.168.1.20",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expectBaseQuery(query);
+    expect(query["principalIp"]).toBe("192.168.1.20");
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+  });
+
+  test("Hostname = X AND User != Y mixes equality and exclusion across fields", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+    expect(query["principalUser"]).toBeInstanceOf(NotEqual);
+  });
+
+  test("Observable = X AND Observable = Y merges into IncludesAll (hasAll)", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "192.168.1.20",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["observables"]).toBeInstanceOf(IncludesAll);
+    expect((query["observables"] as IncludesAll).values).toEqual([
+      "wb-ubuntu-03",
+      "192.168.1.20",
+    ]);
+  });
+
+  test("Observable != X AND Observable != Y merges into IncludesNone", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.NotEquals,
+          "known-scanner",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.NotEquals,
+          "10.0.0.99",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["observables"]).toBeInstanceOf(IncludesNone);
+    expect((query["observables"] as IncludesNone).values).toEqual([
+      "known-scanner",
+      "10.0.0.99",
+    ]);
+  });
+
+  test("scalar != X AND != Y merges into IncludesNone (NOT IN)", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "baduser2",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalUser"]).toBeInstanceOf(IncludesNone);
+    expect((query["principalUser"] as IncludesNone).values).toEqual([
+      "baduser1",
+      "baduser2",
+    ]);
+  });
+});
+
+describe("AND compilation — impossible or inexpressible chains fail with a friendly error", () => {
+  test("two different equalities on a scalar can never match", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "host-a",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "host-b",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.queries).toHaveLength(0);
+    expect(compiled.error).toContain("can never match");
+    expect(compiled.error).toContain("Principal Host");
+  });
+
+  test("Observable = X AND Observable != Y compiles to an operator ARRAY (hasAll + NOT hasAny)", () => {
+    /*
+     * Two predicates on one column don't fit the flat query map's single
+     * slot — the compiler emits an array of operators under the key, which
+     * the statement generator ANDs. This is the graph's "Exclude" pivot.
+     */
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    const operators: Array<unknown> = query["observables"] as Array<unknown>;
+    expect(Array.isArray(operators)).toBe(true);
+    expect(operators).toHaveLength(2);
+    expect(operators[0]).toBeInstanceOf(Includes);
+    expect((operators[0] as Includes).values).toEqual(["wb-ubuntu-03"]);
+    expect(operators[1]).toBeInstanceOf(IncludesNone);
+    expect((operators[1] as IncludesNone).values).toEqual(["baduser1"]);
+  });
+
+  test("two equals AND one not-equals on observables → [IncludesAll, IncludesNone]", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "192.168.1.20",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    const operators: Array<unknown> = query["observables"] as Array<unknown>;
+    expect(operators).toHaveLength(2);
+    expect(operators[0]).toBeInstanceOf(IncludesAll);
+    expect((operators[0] as IncludesAll).values).toEqual([
+      "wb-ubuntu-03",
+      "192.168.1.20",
+    ]);
+    expect(operators[1]).toBeInstanceOf(IncludesNone);
+  });
+
+  test("two contains conditions on the same field compile to two Search operators ANDed", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Message,
+          CorrelationOperator.Contains,
+          "failed",
+        ),
+        condition(
+          CorrelationFieldKey.Message,
+          CorrelationOperator.Contains,
+          "password",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    const operators: Array<unknown> = query["message"] as Array<unknown>;
+    expect(operators).toHaveLength(2);
+    expect(operators[0]).toBeInstanceOf(Search);
+    expect(operators[1]).toBeInstanceOf(Search);
+  });
+
+  test("scalar equals AND not-equals on the same field → [EqualTo, NotEqual] array", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.Equals,
+          "alice",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "bob",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    const operators: Array<unknown> = query["principalUser"] as Array<unknown>;
+    expect(operators).toHaveLength(2);
+    expect(operators[0]).toBeInstanceOf(EqualTo);
+    expect((operators[0] as EqualTo<string>).value).toBe("alice");
+    expect(operators[1]).toBeInstanceOf(NotEqual);
+    expect((operators[1] as NotEqual<string>).value).toBe("bob");
+  });
+
+  test("an empty condition value is rejected with the field named", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "   ",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.queries).toHaveLength(0);
+    expect(compiled.error).toContain("Observable");
+    expect(compiled.error).toContain("needs a value");
+  });
+});
+
+describe("AND compilation — normalization", () => {
+  test("values are trimmed", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "  wb-ubuntu-03  ",
+        ),
+      ],
+      "and",
+    );
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+  });
+
+  test("identical duplicate rows collapse instead of erroring", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+      ],
+      "and",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalHost"]).toBe("wb-ubuntu-03");
+  });
+
+  test("no conditions compile to no queries and no error", () => {
+    const compiled: CompiledCorrelationQueries = compile([], "and");
+    expect(compiled.queries).toHaveLength(0);
+    expect(compiled.error).toBeNull();
+  });
+});
+
+describe("OR compilation", () => {
+  test("IP = X OR IP = Y collapses into ONE Includes query (hasAny already is an OR)", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "192.168.1.20",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "192.168.1.21",
+        ),
+      ],
+      "or",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expectBaseQuery(query);
+    expect(query["observables"]).toBeInstanceOf(Includes);
+    expect((query["observables"] as Includes).values).toEqual([
+      "192.168.1.20",
+      "192.168.1.21",
+    ]);
+  });
+
+  test("scalar equalities on the same field collapse into one IN query", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.Equals,
+          "alice",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.Equals,
+          "bob",
+        ),
+      ],
+      "or",
+    );
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect(query["principalUser"]).toBeInstanceOf(Includes);
+    expect((query["principalUser"] as Includes).values).toEqual([
+      "alice",
+      "bob",
+    ]);
+  });
+
+  test("equalities on DIFFERENT fields fan out into one query each", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.TargetHost,
+          CorrelationOperator.Equals,
+          "db-primary",
+        ),
+      ],
+      "or",
+    );
+    expect(compiled.error).toBeNull();
+    expect(compiled.queries).toHaveLength(2);
+    for (const query of compiled.queries as Array<QueryRecord>) {
+      expectBaseQuery(query);
+    }
+    const keys: Array<string> = (compiled.queries as Array<QueryRecord>).map(
+      (query: QueryRecord) => {
+        return Object.keys(query)
+          .filter((key: string) => {
+            return key !== "projectId" && key !== "time";
+          })
+          .join(",");
+      },
+    );
+    expect(keys.sort()).toEqual(["principalHost", "targetHost"]);
+  });
+
+  test("non-equality conditions always get their own query", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.Message,
+          CorrelationOperator.Contains,
+          "failed password",
+        ),
+        condition(
+          CorrelationFieldKey.Severity,
+          CorrelationOperator.Equals,
+          "Critical",
+        ),
+      ],
+      "or",
+    );
+    expect(compiled.error).toBeNull();
+    // observable= and severity= are equality groups; contains stands alone.
+    expect(compiled.queries).toHaveLength(3);
+  });
+
+  test("same-field same-value duplicates collapse before fan-out", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+      ],
+      "or",
+    );
+    expect(compiled.queries).toHaveLength(1);
+    const query: QueryRecord = compiled.queries[0] as QueryRecord;
+    expect((query["observables"] as Includes).values).toEqual(["wb-ubuntu-03"]);
+  });
+
+  test("empty value fails in OR mode too", () => {
+    const compiled: CompiledCorrelationQueries = compile(
+      [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "",
+        ),
+      ],
+      "or",
+    );
+    expect(compiled.queries).toHaveLength(0);
+    expect(compiled.error).toContain("needs a value");
+  });
+});
+
+describe("descriptions", () => {
+  test("describeCorrelationCondition spells out field, operator, and value", () => {
+    expect(
+      describeCorrelationCondition(
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+      ),
+    ).toBe('Observable is "wb-ubuntu-03"');
+  });
+
+  test("describeCorrelationFilter joins with the connector", () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        condition(
+          CorrelationFieldKey.PrincipalIp,
+          CorrelationOperator.Equals,
+          "192.168.1.20",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+      ],
+      connector: "and",
+    };
+    expect(describeCorrelationFilter(filter)).toBe(
+      'Principal IP is "192.168.1.20" AND Principal User is not "baduser1"',
+    );
+  });
+});
+
+describe("getEqualityObservables", () => {
+  test("returns only observable equality values", () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.NotEquals,
+          "excluded",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalHost,
+          CorrelationOperator.Equals,
+          "not-an-observable-condition",
+        ),
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          " 192.168.1.20 ",
+        ),
+      ],
+      connector: "or",
+    };
+    expect(getEqualityObservables(filter)).toEqual([
+      "wb-ubuntu-03",
+      "192.168.1.20",
+    ]);
+  });
+});
+
+describe("URL round-trip", () => {
+  test("serialize → parse preserves conditions and connector", () => {
+    const filter: CorrelationFilter = {
+      conditions: [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+        condition(
+          CorrelationFieldKey.PrincipalUser,
+          CorrelationOperator.NotEquals,
+          "baduser1",
+        ),
+        condition(
+          CorrelationFieldKey.Message,
+          CorrelationOperator.Contains,
+          "failed password",
+        ),
+      ],
+      connector: "or",
+    };
+    const parsed: CorrelationFilter | null = parseCorrelationFilter(
+      serializeCorrelationFilter(filter),
+    );
+    expect(parsed).toEqual(filter);
+  });
+
+  test.each<[string, string | null]>([
+    ["null input", null],
+    ["empty string", ""],
+    ["not JSON", "{{{{"],
+    ["JSON scalar", "42"],
+    ["JSON null", "null"],
+    ["no conditions", JSON.stringify({ v: 1, j: "and", c: [] })],
+    [
+      "conditions is not an array",
+      JSON.stringify({ v: 1, j: "and", c: "nope" }),
+    ],
+  ])("tolerates %s by returning null", (_label: string, raw: string | null) => {
+    expect(parseCorrelationFilter(raw)).toBeNull();
+  });
+
+  test("drops malformed rows but keeps valid ones", () => {
+    const raw: string = JSON.stringify({
+      v: 1,
+      j: "or",
+      c: [
+        ["observable", "equals", "wb-ubuntu-03"],
+        ["unknownField", "equals", "x"],
+        ["observable", "unknown-operator", "x"],
+        ["observable", "equals", "   "],
+        ["observable", "equals"],
+        "not-an-array",
+        [42, "equals", "x"],
+      ],
+    });
+    const parsed: CorrelationFilter | null = parseCorrelationFilter(raw);
+    expect(parsed).toEqual({
+      conditions: [
+        condition(
+          CorrelationFieldKey.Observable,
+          CorrelationOperator.Equals,
+          "wb-ubuntu-03",
+        ),
+      ],
+      connector: "or",
+    });
+  });
+
+  test("drops rows whose operator exists but is not offered for that field", () => {
+    // Severity only offers equals / not-equals.
+    const raw: string = JSON.stringify({
+      v: 1,
+      j: "and",
+      c: [["severityName", "contains", "Crit"]],
+    });
+    expect(parseCorrelationFilter(raw)).toBeNull();
+  });
+
+  test("any connector other than 'or' becomes 'and'", () => {
+    const raw: string = JSON.stringify({
+      v: 1,
+      j: "garbage",
+      c: [["observable", "equals", "x"]],
+    });
+    expect(parseCorrelationFilter(raw)?.connector).toBe("and");
+  });
+});

--- a/Common/Tests/App/Dashboard/SecurityEventDetailObservables.test.tsx
+++ b/Common/Tests/App/Dashboard/SecurityEventDetailObservables.test.tsx
@@ -33,9 +33,14 @@ jest.mock("../../../UI/Utils/Navigation", () => {
 });
 
 jest.mock("../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap", () => {
+  /*
+   * The mocked route keeps its :projectId placeholder and only the mocked
+   * populateRouteParams substitutes it — so the exact-URL assertions below
+   * fail if the component ever skips populateRouteParams.
+   */
   const routeMap: Record<string, unknown> = {};
   routeMap[PageMap.SECURITY_EVENTS_CORRELATE] = new Route(
-    "/dashboard/mock-project/security-events/correlate",
+    "/dashboard/:projectId/security-events/correlate",
   );
   return {
     __esModule: true,
@@ -46,7 +51,9 @@ jest.mock("../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap", () => {
        * shared one would leak query params across tests.
        */
       populateRouteParams: (route: { toString: () => string }) => {
-        return new Route(route.toString());
+        return new Route(
+          route.toString().replace(":projectId", "mock-project"),
+        );
       },
     },
   };

--- a/Common/Tests/App/Dashboard/SecurityEventDetailObservables.test.tsx
+++ b/Common/Tests/App/Dashboard/SecurityEventDetailObservables.test.tsx
@@ -1,0 +1,187 @@
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The security event detail panel renders observables as pivot chips: with
+ * an onCorrelateObservable handler (the Correlate page embeds it that way)
+ * a chip pivots in place; without one (the events table) a chip deep-links
+ * to the Correlate page with the observable pre-seeded — URL-encoded, since
+ * Route.addQueryParams does not encode.
+ */
+
+const navigateMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/Navigation", () => {
+  return {
+    __esModule: true,
+    default: {
+      navigate: (...args: Array<any>) => {
+        return navigateMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap", () => {
+  const routeMap: Record<string, unknown> = {};
+  routeMap[PageMap.SECURITY_EVENTS_CORRELATE] = new Route(
+    "/dashboard/mock-project/security-events/correlate",
+  );
+  return {
+    __esModule: true,
+    default: routeMap,
+    RouteUtil: {
+      /*
+       * Fresh Route per call — addQueryParams mutates the instance, and a
+       * shared one would leak query params across tests.
+       */
+      populateRouteParams: (route: { toString: () => string }) => {
+        return new Route(route.toString());
+      },
+    },
+  };
+});
+
+/*
+ * The component import comes LAST: requiring it instantiates the mock
+ * factories above, which reference Route and PageMap — so those must be
+ * initialized first.
+ */
+import SecurityEvent from "../../../Models/AnalyticsModels/SecurityEvent";
+import Route from "../../../Types/API/Route";
+import OcsfSeverity from "../../../Types/SecurityEvent/OcsfSeverity";
+import PageMap from "../../../../App/FeatureSet/Dashboard/src/Utils/PageMap";
+import SecurityEventDetail from "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventDetail";
+
+function buildEvent(observables: Array<string>): SecurityEvent {
+  const event: SecurityEvent = new SecurityEvent();
+  event.className = "Authentication";
+  event.severityName = OcsfSeverity.High;
+  event.message = "failed password for alice";
+  event.observables = observables;
+  return event;
+}
+
+beforeEach(() => {
+  navigateMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SecurityEventDetail observables", () => {
+  test("renders one chip per observable", () => {
+    render(
+      <SecurityEventDetail
+        securityEvent={buildEvent(["wb-ubuntu-03", "alice", "192.168.1.20"])}
+        onClose={() => {
+          return;
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("security-event-observable-chip-0"),
+    ).toHaveTextContent("wb-ubuntu-03");
+    expect(
+      screen.getByTestId("security-event-observable-chip-1"),
+    ).toHaveTextContent("alice");
+    expect(
+      screen.getByTestId("security-event-observable-chip-2"),
+    ).toHaveTextContent("192.168.1.20");
+  });
+
+  test("empty observable strings render no chip, and no observables hides the row", () => {
+    render(
+      <SecurityEventDetail
+        securityEvent={buildEvent(["", "alice"])}
+        onClose={() => {
+          return;
+        }}
+      />,
+    );
+    expect(
+      screen.getByTestId("security-event-observable-chip-0"),
+    ).toHaveTextContent("alice");
+    expect(screen.queryByTestId("security-event-observable-chip-1")).toBeNull();
+
+    cleanup();
+
+    render(
+      <SecurityEventDetail
+        securityEvent={buildEvent([])}
+        onClose={() => {
+          return;
+        }}
+      />,
+    );
+    expect(screen.queryByText("Observables")).toBeNull();
+  });
+
+  test("with an onCorrelateObservable handler, a chip pivots in place instead of navigating", () => {
+    const onCorrelateMock: MockFunction = getJestMockFunction();
+
+    render(
+      <SecurityEventDetail
+        securityEvent={buildEvent(["wb-ubuntu-03"])}
+        onClose={() => {
+          return;
+        }}
+        onCorrelateObservable={onCorrelateMock as (observable: string) => void}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("security-event-observable-chip-0"));
+
+    expect(onCorrelateMock).toHaveBeenCalledWith("wb-ubuntu-03");
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("without a handler, a chip deep-links to Correlate with the observable pre-seeded", () => {
+    render(
+      <SecurityEventDetail
+        securityEvent={buildEvent(["wb-ubuntu-03"])}
+        onClose={() => {
+          return;
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("security-event-observable-chip-0"));
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const route: Route = navigateMock.mock.calls[0]?.[0] as Route;
+    expect(route.toString()).toBe(
+      "/dashboard/mock-project/security-events/correlate?observable=wb-ubuntu-03",
+    );
+  });
+
+  test("observable values are URL-encoded into the deep link", () => {
+    render(
+      <SecurityEventDetail
+        securityEvent={buildEvent(["svc account&admin"])}
+        onClose={() => {
+          return;
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("security-event-observable-chip-0"));
+
+    const route: Route = navigateMock.mock.calls[0]?.[0] as Route;
+    expect(route.toString()).toContain(
+      `observable=${encodeURIComponent("svc account&admin")}`,
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGeneratorWhereOperators.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGeneratorWhereOperators.test.ts
@@ -12,6 +12,7 @@ import EqualToOrNull from "../../../../Types/BaseDatabase/EqualToOrNull";
 import EndsWith from "../../../../Types/BaseDatabase/EndsWith";
 import IncludesAll from "../../../../Types/BaseDatabase/IncludesAll";
 import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../../Types/BaseDatabase/IsNull";
 import NotContains from "../../../../Types/BaseDatabase/NotContains";
 import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
 import NotNull from "../../../../Types/BaseDatabase/NotNull";
@@ -72,6 +73,14 @@ describe("StatementGenerator toWhereStatement operator branches", () => {
             required: true,
             defaultValue: [],
             type: TableColumnType.ArrayText,
+          }),
+          new AnalyticsTableColumn({
+            key: "attributes",
+            title: "<title>",
+            description: "<description>",
+            required: true,
+            defaultValue: {},
+            type: TableColumnType.MapStringString,
           }),
         ],
         crudApiPath: new Route("route"),
@@ -307,6 +316,163 @@ describe("StatementGenerator toWhereStatement operator branches", () => {
     });
   });
 
+  describe("ILIKE metacharacter escaping", () => {
+    /*
+     * User values must match literally: "svc_" is a service-account prefix,
+     * not "svc followed by any character". The relational (Postgres) query
+     * path has escaped LIKE metacharacters for a while — these pin the
+     * ClickHouse path to the same contract.
+     */
+    test("StartsWith escapes _ so it cannot act as a single-char wildcard", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new StartsWith("svc_"),
+      } as any);
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "svc\\_%",
+      });
+    });
+
+    test("EndsWith escapes % so a literal percent stays literal", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new EndsWith("50%"),
+      } as any);
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "%50\\%",
+      });
+    });
+
+    test("NotContains escapes % — '100%' must not exclude every '100'", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new NotContains("100%"),
+      } as any);
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "%100\\%%",
+        p2: "principalHost",
+      });
+    });
+
+    test("Search escapes % _ and backslash in the bound pattern", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new Search("a_b%"),
+      } as any);
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "%a\\_b\\%%",
+      });
+    });
+
+    test("Search over Array(String) escapes a Windows-path backslash", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new Search("C:\\"),
+      } as any);
+      expect(statement.query_params).toStrictEqual({
+        p0: "%C:\\\\%",
+        p1: "observables",
+      });
+    });
+  });
+
+  describe("array-aware equality and presence", () => {
+    test("EqualTo on an Array(String) column means membership (has)", () => {
+      /*
+       * This is the events-table Observable filter's 'Equal To' operator —
+       * the scalar `col = v` form would bind a single string against an
+       * Array(String) parameter and fail at ClickHouse parse time.
+       */
+      const statement: Statement = generator.toWhereStatement({
+        observables: new EqualTo("wb-ubuntu-03"),
+      } as any);
+      expect(statement.query).toBe("AND has({p0:Identifier}, {p1:String})");
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: "wb-ubuntu-03",
+      });
+    });
+
+    test("NotEqual on an Array(String) column means does-not-mention (NOT has)", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new NotEqual("baduser1"),
+      } as any);
+      expect(statement.query).toBe("AND NOT has({p0:Identifier}, {p1:String})");
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: "baduser1",
+      });
+    });
+
+    test("IsNull on an Array(String) column means the empty array", () => {
+      // Arrays are non-Nullable — `IS NULL` would be constant-false.
+      const statement: Statement = generator.toWhereStatement({
+        observables: new IsNull(),
+      } as any);
+      expect(statement.query).toBe("AND empty({p0:Identifier})");
+      expect(statement.query_params).toStrictEqual({ p0: "observables" });
+    });
+
+    test("NotNull on an Array(String) column means at-least-one-element", () => {
+      // `IS NOT NULL` would be constant-true — a silent match-everything.
+      const statement: Statement = generator.toWhereStatement({
+        observables: new NotNull(),
+      } as any);
+      expect(statement.query).toBe("AND notEmpty({p0:Identifier})");
+      expect(statement.query_params).toStrictEqual({ p0: "observables" });
+    });
+
+    test("EqualToOrNull on an Array(String) column throws", () => {
+      expect(() => {
+        return generator.toWhereStatement({
+          observables: new EqualToOrNull("x"),
+        } as any);
+      }).toThrow(
+        "Unsupported query operator EqualToOrNull on column: observables",
+      );
+    });
+  });
+
+  describe("map/JSON column guards", () => {
+    /*
+     * Scalar operators applied to a whole Map column have per-sub-key
+     * forms instead; applying them to the column itself must fail with a
+     * BadDataException, not a cryptic ClickHouse type error.
+     */
+    test.each<[string, () => Statement]>([
+      [
+        "StartsWith",
+        (): Statement => {
+          return generator.toWhereStatement({
+            attributes: new StartsWith("a"),
+          } as any);
+        },
+      ],
+      [
+        "EqualTo",
+        (): Statement => {
+          return generator.toWhereStatement({
+            attributes: new EqualTo("a"),
+          } as any);
+        },
+      ],
+      [
+        "NotContains",
+        (): Statement => {
+          return generator.toWhereStatement({
+            attributes: new NotContains("a"),
+          } as any);
+        },
+      ],
+    ])(
+      "%s on a Map(String,String) column throws BadDataException",
+      (operatorName: string, compile: () => Statement) => {
+        expect(compile).toThrow(
+          `Unsupported query operator ${operatorName} on column: attributes`,
+        );
+      },
+    );
+  });
+
   describe("unsupported operator instances fail loudly", () => {
     test("IncludesAll on a scalar column throws instead of binding the operator object", () => {
       expect(() => {
@@ -423,6 +589,32 @@ describe("StatementGenerator toWhereStatement operator branches", () => {
       expect(statement.query_params).toStrictEqual({
         p0: "observables",
         p1: ["a", "b"],
+      });
+    });
+
+    test("operator arrays qualify every column reference under a table alias", () => {
+      /*
+       * The recursion forwards options, so an Exclude-pivot query embedded
+       * in an aggregate statement (which aliases the table) must qualify
+       * every fragment's column refs — no bare {pN:Identifier} columns.
+       */
+      const statement: Statement = generator.toWhereStatement(
+        {
+          observables: [new IncludesAll(["a"]), new IncludesNone(["b"])],
+        } as any,
+        { tableAlias: "<operator-table>" },
+      );
+      expect(statement.query).toBe(
+        "AND hasAll({p0_t:Identifier}.{p0_c:Identifier}, {p1:Array(String)}) " +
+          "AND NOT hasAny({p2_t:Identifier}.{p2_c:Identifier}, {p3:Array(String)})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0_t: "<operator-table>",
+        p0_c: "observables",
+        p1: ["a"],
+        p2_t: "<operator-table>",
+        p2_c: "observables",
+        p3: ["b"],
       });
     });
 

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGeneratorWhereOperators.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGeneratorWhereOperators.test.ts
@@ -1,0 +1,485 @@
+import { ClickhouseAppInstance } from "../../../../Server/Infrastructure/ClickhouseDatabase";
+import { Statement } from "../../../../Server/Utils/AnalyticsDatabase/Statement";
+import StatementGenerator from "../../../../Server/Utils/AnalyticsDatabase/StatementGenerator";
+import "../../TestingUtils/Init";
+import AnalyticsBaseModel from "../../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../../../Types/API/Route";
+import AnalyticsTableEngine from "../../../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableColumn from "../../../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../../../Types/AnalyticsDatabase/TableColumnType";
+import EqualTo from "../../../../Types/BaseDatabase/EqualTo";
+import EqualToOrNull from "../../../../Types/BaseDatabase/EqualToOrNull";
+import EndsWith from "../../../../Types/BaseDatabase/EndsWith";
+import IncludesAll from "../../../../Types/BaseDatabase/IncludesAll";
+import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
+import NotContains from "../../../../Types/BaseDatabase/NotContains";
+import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../../Types/BaseDatabase/NotNull";
+import Search from "../../../../Types/BaseDatabase/Search";
+import StartsWith from "../../../../Types/BaseDatabase/StartsWith";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * WHERE-clause coverage for the operator branches added for the Security
+ * Events correlation query builder (issue #3395): explicit EqualTo /
+ * EqualToOrNull / NotNull, prefix/suffix/negated-substring matching on
+ * scalar AND Array(String) columns, substring Search over Array(String)
+ * (previously bound a single pattern against an Array(String) parameter —
+ * a guaranteed ClickHouse parse error), hasAll conjunction, and the loud
+ * failure for operators that have no branch for a column type (previously
+ * the operator OBJECT was bound as an equality value — a silent
+ * match-nothing filter).
+ *
+ * The shape of the model mirrors SecurityEvent where it matters: Text
+ * scalars like principalHost, an Array(String) observables column, and a
+ * Number column to pin non-Text NotNull/EqualToOrNull behavior.
+ */
+
+describe("StatementGenerator toWhereStatement operator branches", () => {
+  class OperatorModel extends AnalyticsBaseModel {
+    public constructor() {
+      super({
+        tableName: "<operator-table>",
+        singularName: "<singular>",
+        pluralName: "<plural>",
+        tableColumns: [
+          new AnalyticsTableColumn({
+            key: "_id",
+            title: "<title>",
+            description: "<description>",
+            required: true,
+            type: TableColumnType.ObjectID,
+          }),
+          new AnalyticsTableColumn({
+            key: "principalHost",
+            title: "<title>",
+            description: "<description>",
+            required: false,
+            type: TableColumnType.Text,
+          }),
+          new AnalyticsTableColumn({
+            key: "targetPort",
+            title: "<title>",
+            description: "<description>",
+            required: false,
+            type: TableColumnType.Number,
+          }),
+          new AnalyticsTableColumn({
+            key: "observables",
+            title: "<title>",
+            description: "<description>",
+            required: true,
+            defaultValue: [],
+            type: TableColumnType.ArrayText,
+          }),
+        ],
+        crudApiPath: new Route("route"),
+        primaryKeys: ["_id"],
+        sortKeys: ["_id"],
+        partitionKey: "_id",
+        tableEngine: AnalyticsTableEngine.MergeTree,
+      });
+    }
+  }
+
+  let generator: StatementGenerator<OperatorModel>;
+  beforeEach(() => {
+    generator = new StatementGenerator<OperatorModel>({
+      modelType: OperatorModel,
+      database: ClickhouseAppInstance,
+    });
+  });
+
+  describe("EqualTo wrapper on scalar columns", () => {
+    test("binds the WRAPPED value, exactly like bare equality", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new EqualTo("wb-ubuntu-03"),
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} = {p1:String}");
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "wb-ubuntu-03",
+      });
+    });
+
+    test("matches the SQL produced by a bare value", () => {
+      const wrapped: Statement = generator.toWhereStatement({
+        principalHost: new EqualTo("wb-ubuntu-03"),
+      } as any);
+      const bare: Statement = generator.toWhereStatement({
+        principalHost: "wb-ubuntu-03",
+      } as any);
+      expect(wrapped.query).toBe(bare.query);
+      expect(wrapped.query_params).toStrictEqual(bare.query_params);
+    });
+
+    test("binds a numeric EqualTo against a Number column", () => {
+      const statement: Statement = generator.toWhereStatement({
+        targetPort: new EqualTo(443),
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} = {p1:Int32}");
+      expect(statement.query_params).toStrictEqual({
+        p0: "targetPort",
+        p1: 443,
+      });
+    });
+  });
+
+  describe("EqualToOrNull wrapper", () => {
+    test("Text column also accepts the empty-string 'not set' default", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new EqualToOrNull("wb-ubuntu-03"),
+      } as any);
+      expect(statement.query).toBe(
+        "AND ({p0:Identifier} = {p1:String} OR {p2:Identifier} IS NULL OR {p3:Identifier} = '')",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "wb-ubuntu-03",
+        p2: "principalHost",
+        p3: "principalHost",
+      });
+    });
+
+    test("non-Text column only accepts NULL as 'not set'", () => {
+      const statement: Statement = generator.toWhereStatement({
+        targetPort: new EqualToOrNull(443),
+      } as any);
+      expect(statement.query).toBe(
+        "AND ({p0:Identifier} = {p1:Int32} OR {p2:Identifier} IS NULL)",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "targetPort",
+        p1: 443,
+        p2: "targetPort",
+      });
+    });
+  });
+
+  describe("NotNull wrapper", () => {
+    test("Text column rejects both NULL and the empty-string default (mirror of IsNull)", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new NotNull(),
+      } as any);
+      expect(statement.query).toBe(
+        "AND ({p0:Identifier} IS NOT NULL AND {p1:Identifier} != '')",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "principalHost",
+      });
+    });
+
+    test("non-Text column checks NULL only", () => {
+      const statement: Statement = generator.toWhereStatement({
+        targetPort: new NotNull(),
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} IS NOT NULL");
+      expect(statement.query_params).toStrictEqual({
+        p0: "targetPort",
+      });
+    });
+  });
+
+  describe("StartsWith / EndsWith / NotContains on scalar columns", () => {
+    test("StartsWith compiles to ILIKE 'v%'", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new StartsWith("wb-"),
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} ILIKE {p1:String}");
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "wb-%",
+      });
+    });
+
+    test("EndsWith compiles to ILIKE '%v'", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new EndsWith("-03"),
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} ILIKE {p1:String}");
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "%-03",
+      });
+    });
+
+    test("NotContains compiles to NOT ILIKE with a NULL passthrough", () => {
+      /*
+       * A row with no value at all trivially "does not contain" the
+       * needle — without the IS NULL disjunct, `NOT (NULL ILIKE ...)`
+       * evaluates to NULL and drops the row.
+       */
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: new NotContains("ubuntu"),
+      } as any);
+      expect(statement.query).toBe(
+        "AND (NOT ({p0:Identifier} ILIKE {p1:String}) OR {p2:Identifier} IS NULL)",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "%ubuntu%",
+        p2: "principalHost",
+      });
+    });
+  });
+
+  describe("Array(String) columns — per-element matching", () => {
+    test("Search compiles to arrayExists ILIKE, binding the pattern as String (not Array(String))", () => {
+      /*
+       * Before this branch the generic Search path declared the bound
+       * parameter with the COLUMN's type — Array(String) — while carrying
+       * a single '%v%' pattern string, which ClickHouse rejects at
+       * parameter-parse time. This is what makes a plain text filter on
+       * `observables` work.
+       */
+      const statement: Statement = generator.toWhereStatement({
+        observables: new Search("ubuntu"),
+      } as any);
+      expect(statement.query).toBe(
+        "AND arrayExists(x -> x ILIKE {p0:String}, {p1:Identifier})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "%ubuntu%",
+        p1: "observables",
+      });
+    });
+
+    test("StartsWith compiles to arrayExists ILIKE 'v%'", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new StartsWith("192.168."),
+      } as any);
+      expect(statement.query).toBe(
+        "AND arrayExists(x -> x ILIKE {p0:String}, {p1:Identifier})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "192.168.%",
+        p1: "observables",
+      });
+    });
+
+    test("EndsWith compiles to arrayExists ILIKE '%v'", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new EndsWith(".example.com"),
+      } as any);
+      expect(statement.query).toBe(
+        "AND arrayExists(x -> x ILIKE {p0:String}, {p1:Identifier})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "%.example.com",
+        p1: "observables",
+      });
+    });
+
+    test("NotContains compiles to NOT arrayExists", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new NotContains("baduser"),
+      } as any);
+      expect(statement.query).toBe(
+        "AND NOT arrayExists(x -> x ILIKE {p0:String}, {p1:Identifier})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "%baduser%",
+        p1: "observables",
+      });
+    });
+
+    test("IncludesAll compiles to hasAll — the 'mentions X AND Y' conjunction", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new IncludesAll(["wb-ubuntu-03", "192.168.1.20"]),
+      } as any);
+      expect(statement.query).toBe(
+        "AND hasAll({p0:Identifier}, {p1:Array(String)})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: ["wb-ubuntu-03", "192.168.1.20"],
+      });
+    });
+
+    test("empty IncludesAll drops the predicate instead of hasAll(col, [])", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new IncludesAll([]),
+      } as any);
+      expect(statement.query).toBe("");
+      expect(statement.query_params).toStrictEqual({});
+    });
+  });
+
+  describe("unsupported operator instances fail loudly", () => {
+    test("IncludesAll on a scalar column throws instead of binding the operator object", () => {
+      expect(() => {
+        return generator.toWhereStatement({
+          principalHost: new IncludesAll(["a", "b"]),
+        } as any);
+      }).toThrow(BadDataException);
+      expect(() => {
+        return generator.toWhereStatement({
+          principalHost: new IncludesAll(["a", "b"]),
+        } as any);
+      }).toThrow(
+        "Unsupported query operator IncludesAll on column: principalHost",
+      );
+    });
+
+    test("bare values still compile to equality through the fallback", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: "wb-ubuntu-03",
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} = {p1:String}");
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "wb-ubuntu-03",
+      });
+    });
+  });
+
+  describe("operator arrays — several predicates AND-ed on ONE column", () => {
+    test("Includes + IncludesNone on an Array(String) column → hasAll-style conjunction", () => {
+      /*
+       * "mentions wb-ubuntu-03 AND does not mention baduser1" — the
+       * correlate builder's Exclude pivot. One column, two predicates,
+       * expressed as an array of operators under the key.
+       */
+      const statement: Statement = generator.toWhereStatement({
+        observables: [
+          new IncludesAll(["wb-ubuntu-03", "192.168.1.20"]),
+          new IncludesNone(["baduser1"]),
+        ],
+      } as any);
+      expect(statement.query).toBe(
+        "AND hasAll({p0:Identifier}, {p1:Array(String)}) " +
+          "AND NOT hasAny({p2:Identifier}, {p3:Array(String)})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: ["wb-ubuntu-03", "192.168.1.20"],
+        p2: "observables",
+        p3: ["baduser1"],
+      });
+    });
+
+    test("EqualTo + NotEqual on a scalar column", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: [new EqualTo("wb-ubuntu-03"), new NotEqual("db-01")],
+      } as any);
+      expect(statement.query).toBe(
+        "AND {p0:Identifier} = {p1:String} AND {p2:Identifier} != {p3:String}",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "wb-ubuntu-03",
+        p2: "principalHost",
+        p3: "db-01",
+      });
+    });
+
+    test("two Search operators AND two ILIKEs", () => {
+      const statement: Statement = generator.toWhereStatement({
+        principalHost: [new Search("wb"), new Search("ubuntu")],
+      } as any);
+      expect(statement.query).toBe(
+        "AND {p0:Identifier} ILIKE {p1:String} AND {p2:Identifier} ILIKE {p3:String}",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "principalHost",
+        p1: "%wb%",
+        p2: "principalHost",
+        p3: "%ubuntu%",
+      });
+    });
+
+    test("elements whose predicate drops (empty Includes) contribute nothing", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: [new IncludesAll([]), new IncludesNone(["baduser1"])],
+      } as any);
+      expect(statement.query).toBe(
+        "AND NOT hasAny({p0:Identifier}, {p1:Array(String)})",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: ["baduser1"],
+      });
+    });
+
+    test("operator array composes with other columns", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: [new IncludesAll(["a", "b"]), new IncludesNone(["c"])],
+        principalHost: "wb-ubuntu-03",
+      } as any);
+      expect(statement.query).toBe(
+        "AND hasAll({p0:Identifier}, {p1:Array(String)}) " +
+          "AND NOT hasAny({p2:Identifier}, {p3:Array(String)}) " +
+          "AND {p4:Identifier} = {p5:String}",
+      );
+    });
+
+    test("a bare string array still means exact-array equality (not operator dispatch)", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: ["a", "b"],
+      } as any);
+      expect(statement.query).toBe("AND {p0:Identifier} = {p1:Array(String)}");
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: ["a", "b"],
+      });
+    });
+
+    test("an unsupported operator inside the array still throws", () => {
+      expect(() => {
+        return generator.toWhereStatement({
+          principalHost: [new EqualTo("x"), new IncludesAll(["a"])],
+        } as any);
+      }).toThrow(
+        "Unsupported query operator IncludesAll on column: principalHost",
+      );
+    });
+  });
+
+  describe("composition — the shapes the correlation builder emits", () => {
+    test("AND across different columns, mixing new and old branches", () => {
+      const statement: Statement = generator.toWhereStatement({
+        observables: new IncludesAll(["wb-ubuntu-03", "192.168.1.20"]),
+        principalHost: new StartsWith("wb-"),
+        targetPort: new NotEqual(22),
+      } as any);
+      expect(statement.query).toBe(
+        "AND hasAll({p0:Identifier}, {p1:Array(String)}) " +
+          "AND {p2:Identifier} ILIKE {p3:String} " +
+          "AND {p4:Identifier} != {p5:Int32}",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "observables",
+        p1: ["wb-ubuntu-03", "192.168.1.20"],
+        p2: "principalHost",
+        p3: "wb-%",
+        p4: "targetPort",
+        p5: 22,
+      });
+    });
+
+    test("table alias qualifies the new branches too", () => {
+      const statement: Statement = generator.toWhereStatement(
+        {
+          observables: new Search("ubuntu"),
+          principalHost: new NotNull(),
+        } as any,
+        { tableAlias: "<operator-table>" },
+      );
+      expect(statement.query).toBe(
+        "AND arrayExists(x -> x ILIKE {p0:String}, {p1_t:Identifier}.{p1_c:Identifier}) " +
+          "AND ({p2_t:Identifier}.{p2_c:Identifier} IS NOT NULL AND {p3_t:Identifier}.{p3_c:Identifier} != '')",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "%ubuntu%",
+        p1_t: "<operator-table>",
+        p1_c: "observables",
+        p2_t: "<operator-table>",
+        p2_c: "principalHost",
+        p3_t: "<operator-table>",
+        p3_c: "principalHost",
+      });
+    });
+  });
+});

--- a/Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput.tsx
+++ b/Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput.tsx
@@ -27,6 +27,8 @@ export interface ComponentProps {
   isLoadingSuggestions?: boolean | undefined;
   loadingMessage?: string | undefined;
   noSuggestionsMessage?: string | undefined;
+  // For inputs with no visible label element to point ariaLabelledby at.
+  ariaLabel?: string | undefined;
   /*
    * The id of the element that names this input. Without it a picker that draws
    * its own label - the workflow record editor, where the field's name sits in
@@ -464,6 +466,7 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
         className={getInputClassName()}
         data-testid={props.dataTestId}
         disabled={props.disabled}
+        aria-label={props.ariaLabel}
         aria-labelledby={props.ariaLabelledby}
         aria-autocomplete="list"
         aria-controls={listboxIdRef.current}

--- a/Common/UI/Components/Input/Input.tsx
+++ b/Common/UI/Components/Input/Input.tsx
@@ -30,6 +30,8 @@ export interface ComponentProps {
   ariaHasPopup?: "dialog" | "listbox" | "menu" | "grid" | "tree" | undefined;
   ariaExpanded?: boolean | undefined;
   ariaControls?: string | undefined;
+  // For inputs with no visible label element to point ariaLabelledby at.
+  ariaLabel?: string | undefined;
   /*
    * For fields that render their own error text - a picker whose message sits
    * below the whole control rather than below this input.
@@ -177,6 +179,7 @@ const Input: FunctionComponent<ComponentProps> = (
           data-testid={props.dataTestId}
           spellCheck={!props.disableSpellCheck}
           autoComplete={props.autoComplete}
+          aria-label={props.ariaLabel}
           aria-labelledby={props.ariaLabelledby}
           aria-haspopup={props.ariaHasPopup}
           aria-expanded={props.ariaExpanded}

--- a/Common/jest.config.json
+++ b/Common/jest.config.json
@@ -31,6 +31,7 @@
     "^react-i18next$": "<rootDir>/node_modules/react-i18next",
     "^i18next$": "<rootDir>/node_modules/i18next",
     "^use-async-effect$": "<rootDir>/node_modules/use-async-effect",
+    "^reactflow$": "<rootDir>/node_modules/reactflow",
     "^i18next-browser-languagedetector$": "<rootDir>/Tests/__mocks__/i18next-browser-languagedetector.js",
     "^react-markdown$": "<rootDir>/Tests/__mocks__/react-markdown.js",
     "^remark-gfm$": "<rootDir>/Tests/__mocks__/remark-gfm.js",

--- a/Common/tsconfig.json
+++ b/Common/tsconfig.json
@@ -68,7 +68,8 @@
       "react-router-dom": ["./node_modules/react-router-dom"],
       "react-i18next": ["./node_modules/react-i18next"],
       "i18next": ["./node_modules/i18next"],
-      "use-async-effect": ["./node_modules/use-async-effect"]
+      "use-async-effect": ["./node_modules/use-async-effect"],
+      "reactflow": ["./node_modules/reactflow"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": [


### PR DESCRIPTION
Fixes #3395.

The Security Events → Correlate view accepted exactly one Observable value — no way to combine fields (`IP = X AND Hostname = Y`), search alternatives (`IP = X OR IP = Y`), or exclude values (`User != baduser1`). This PR adds a structured, operator-based query builder and improves the correlation product around it.

## What the issue asked for → what shipped

1. **Query builder UI** — an *Add filters* panel with chainable field + operator + value rows under one AND/OR connector (All conditions / Any condition).
2. **Operators per field** — `is`, `is not`, `contains`, `does not contain`, `starts with`, `ends with` across Observable, Principal/Target User/Host/IP, Event Class (with OCSF name suggestions), Severity (fixed vocabulary), Message, Rule Name, and Vendor.
3. **Single-field input stays a shorthand** — the quick Observable input is unchanged and additive; Enter or Correlate still runs a one-observable search.
4. **Visible filter chain** — the applied filter renders as removable chips with the connector spelled out between them; removing a chip re-runs the correlation.

## How compound filters compile

The analytics query API is a flat AND-ed map (one operator slot per column, no cross-column OR), so:

- **AND** chains compile into **one** ClickHouse query. Same-column conditions merge into an equivalent operator (`= AND =` on observables → `hasAll`; `!= AND !=` → `NOT IN` / `NOT hasAny`), and a new server capability lets an **array of operators under one key** AND several predicates on one column (`mentions X AND does not mention Y` — the graph's *Exclude* pivot). Contradictions (`Host = a AND Host = b`) are rejected with a friendly explanation instead of silently returning nothing.
- **OR** chains fan out into one query per condition (same-field equalities collapse into a single `IN`/`hasAny` query first) and union client-side by event id.

## Server-side operator support (benefits every analytics model)

`StatementGenerator.toWhereStatement` previously bound unhandled operator instances **as the equality value** — a silent match-nothing filter. Now:

- New branches: `EqualTo`, `EqualToOrNull`, `NotNull`, `StartsWith`, `EndsWith`, `NotContains` on scalars; `Search`/`StartsWith`/`EndsWith`/`NotContains` as per-element `arrayExists ILIKE` on `Array(String)` columns (a plain text filter on `observables` previously produced a ClickHouse parameter-parse error); `IncludesAll` → `hasAll`; array-aware `EqualTo`/`NotEqual` (`has` / `NOT has`); `IsNull`/`NotNull` on arrays → `empty()`/`notEmpty()`.
- ILIKE patterns **escape `%`, `_`, `\`** so user values match literally (parity with the relational query path).
- Operators with no branch for a column type throw a `BadDataException` instead of emitting broken SQL.

## Correlate UX improvements

- **URL state** (`q`, `hours`, `observable` params): correlations are shareable, and other pages deep-link in.
- **Event detail pivots**: observables in the detail side-over render as chips that start (or refocus) a correlation.
- **Graph → events**: clicking a class node opens its matching events below the graph, each row opening the full event detail; class nodes are tinted by their worst severity.
- **Observable node pivots**: Focus / Add condition / Exclude (Exclude and class-filter hide in OR mode where they would not narrow).
- **Honest counts**: when any branch hits the 200-event cap, counts are labeled as lower bounds.
- Events table gains an **Observable** substring filter; Detection Rules gets the same reseller-telemetry gate as the other tabs.

## Tests

~150 new cases: WHERE-operator branches incl. operator arrays, escaping, and table-alias qualification; the filter compiler (AND merging, OR fan-out, contradiction errors, URL round-trip tolerance against malformed input); the graph builder (counts, caps, severity ranking, union dedupe); and component suites for the builder, the Correlate page (quick search, deep links, chips, pivots, drill-down, OR-mode guards, error/cap states), and the detail chips. A six-lens adversarial review workflow (ClickHouse SQL, compiler semantics, React state, UX-vs-issue, test quality, security) ran over the diff; all 17 confirmed findings are fixed in the second commit.

All 71 dashboard suites (1,722 tests) and every statement-generator-adjacent suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqBCJYvyrqgE2orGqsYxjv