### PR TITLE
fix(security): bound the global gzip request reader (GHSA-cp58-wc9q-qv53)

### DIFF
--- a/Common/Server/Middleware/GzipRequestBody.ts
+++ b/Common/Server/Middleware/GzipRequestBody.ts
@@ -1,0 +1,311 @@
+import ServerException from "../../Types/Exception/ServerException";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+  OneUptimeRequest,
+  headerValueToString,
+} from "../Utils/Express";
+import logger, { getLogAttributesFromRequest } from "../Utils/Logger";
+import Response from "../Utils/Response";
+import zlib from "zlib";
+
+/*
+ * Ceilings for the global `Content-Encoding: gzip` request path.
+ *
+ * Both are 50 MiB, which is exactly what body-parser is given for the
+ * identity path (`jsonBodyParserOptions.limit` / `urlEncodedBodyParserOptions.limit`,
+ * and `bytes("50mb")` is 1024-based too). Announcing gzip must not buy a
+ * caller more room than sending the same body uncompressed.
+ *
+ * They are two constants because they bound two different things and
+ * neither alone is sufficient:
+ *
+ *   - COMPRESSED bounds what arrives on the socket, so a client cannot
+ *     stream unbounded bytes into the process.
+ *   - DECOMPRESSED bounds what the inflate produces. gzip of repeated
+ *     bytes reaches four figures of amplification: 130,479 bytes of gzip
+ *     inflates to 134,217,728 bytes (1,029x, measured), so the compressed
+ *     cap on its own leaves ~50 GB of expansion on the table.
+ */
+export const MAX_COMPRESSED_REQUEST_BODY_BYTES: number = 50 * 1024 * 1024;
+export const MAX_DECOMPRESSED_REQUEST_BODY_BYTES: number = 50 * 1024 * 1024;
+
+/*
+ * Inflate a `Content-Encoding: gzip` request body under hard limits, and
+ * hand the decompressed bytes on as `req.body` (a Buffer, which is what
+ * this path has always produced).
+ *
+ * This middleware runs BEFORE routing and therefore before authentication,
+ * so every limit here is an unauthenticated-attacker limit.
+ *
+ * Two implementation notes that are easy to get wrong:
+ *
+ *   1. It streams. Buffering the whole compressed body and then calling
+ *      `zlib.gunzip` would hold the compressed cap AND the decompressed cap
+ *      at once, and would not notice a bomb until the last byte arrived.
+ *      Feeding a `createGunzip` stream instead trips the cap after ~64 KiB
+ *      of a 128 MiB bomb (measured), before most of the body is even sent.
+ *
+ *   2. It counts the output itself. `maxOutputLength` looks like the right
+ *      knob but Node only honours it on the convenience methods
+ *      (`zlib.gunzip` / `gunzipSync`); on a `createGunzip` STREAM it is
+ *      silently ignored - a stream with `maxOutputLength: 1 MiB` happily
+ *      emits 128 MiB. Verified against Node 24. Setting it here would read
+ *      as protection while providing none, so the running total below is
+ *      what actually enforces the ceiling.
+ */
+export default class GzipRequestBodyMiddleware {
+  public static parseBody(
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): void {
+    /*
+     * Cheap pre-check before a byte is read. Content-Length is advisory (a
+     * chunked request carries none) but when it is present and already over
+     * the cap there is no reason to accept the body at all.
+     */
+    const contentLengthHeader: string | undefined = headerValueToString(
+      req.headers["content-length"],
+    );
+
+    if (contentLengthHeader) {
+      const declaredLength: number = parseInt(contentLengthHeader, 10);
+
+      if (
+        !isNaN(declaredLength) &&
+        declaredLength > MAX_COMPRESSED_REQUEST_BODY_BYTES
+      ) {
+        GzipRequestBodyMiddleware.rejectTooLarge(
+          req,
+          res,
+          "compressed",
+          declaredLength,
+          MAX_COMPRESSED_REQUEST_BODY_BYTES,
+        );
+        return;
+      }
+    }
+
+    const inflate: zlib.Gunzip = zlib.createGunzip();
+
+    const decoded: Array<Buffer> = [];
+
+    let compressedBytes: number = 0;
+    let decompressedBytes: number = 0;
+    let requestEnded: boolean = false;
+    let awaitingDrain: boolean = false;
+    let settled: boolean = false;
+
+    const settle: (finish: () => void) => void = (finish: () => void): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+
+      req.removeListener("data", onData);
+      req.removeListener("end", onEnd);
+      req.removeListener("error", onRequestError);
+      req.removeListener("close", onClose);
+
+      inflate.removeAllListeners();
+
+      /*
+       * A stream that emits "error" with no listener throws, and an
+       * uncaught throw here would turn a memory-exhaustion fix into a
+       * process-exit one. Nothing can consume a post-teardown error, so
+       * swallow it explicitly rather than leaving the stream bare.
+       */
+      inflate.on("error", (): void => {});
+      inflate.destroy();
+
+      decoded.length = 0;
+
+      finish();
+    };
+
+    /*
+     * Stop reading rather than draining. The session replay middleware
+     * deliberately drains its oversized bodies to keep the keep-alive
+     * connection usable for the next chunk, but that is a cooperative
+     * first-party client sending a 4 MiB cap's worth of bytes. Here the
+     * body we are refusing may be gigabytes from someone who wants us to
+     * read them, so we pause: Node flushes the response we already wrote
+     * and then closes the connection because the request was never
+     * consumed, which is precisely the outcome we want.
+     */
+    const stopReading: () => void = (): void => {
+      if (typeof req.pause === "function") {
+        req.pause();
+      }
+    };
+
+    const onData: (chunk: Buffer | string) => void = (
+      chunk: Buffer | string,
+    ): void => {
+      const asBuffer: Buffer = Buffer.isBuffer(chunk)
+        ? chunk
+        : Buffer.from(chunk, "utf-8");
+
+      compressedBytes += asBuffer.length;
+
+      if (compressedBytes > MAX_COMPRESSED_REQUEST_BODY_BYTES) {
+        settle((): void => {
+          stopReading();
+          GzipRequestBodyMiddleware.rejectTooLarge(
+            req,
+            res,
+            "compressed",
+            compressedBytes,
+            MAX_COMPRESSED_REQUEST_BODY_BYTES,
+          );
+        });
+        return;
+      }
+
+      /*
+       * Honour the inflate's backpressure. zlib does its work on the
+       * threadpool, so a socket that is faster than the inflate will
+       * otherwise pile the whole compressed body into the writable queue -
+       * which is the unbounded buffering this middleware exists to remove,
+       * just one object further down. Pausing also means the caps below get
+       * to see the output before we accept the next chunk, so a bomb is
+       * refused while most of it is still on the wire.
+       */
+      if (!inflate.write(asBuffer) && !awaitingDrain) {
+        awaitingDrain = true;
+
+        if (typeof req.pause === "function") {
+          req.pause();
+        }
+
+        inflate.once("drain", (): void => {
+          awaitingDrain = false;
+
+          if (!settled && typeof req.resume === "function") {
+            req.resume();
+          }
+        });
+      }
+    };
+
+    const onEnd: () => void = (): void => {
+      requestEnded = true;
+
+      /*
+       * A request that announced gzip and then sent nothing. `inflate.end()`
+       * on an empty stream raises "unexpected end of file", which used to
+       * turn every such request - including a bare GET carrying the header -
+       * into a 500 plus an error-level log line. Treat it as the empty body
+       * it is and let the route decide.
+       */
+      if (compressedBytes === 0) {
+        settle((): void => {
+          req.body = Buffer.alloc(0);
+          next();
+        });
+        return;
+      }
+
+      inflate.end();
+    };
+
+    const onRequestError: (err: Error) => void = (err: Error): void => {
+      settle((): void => {
+        next(err);
+      });
+    };
+
+    /*
+     * The client hung up mid-body. There is nobody left to answer, so drop
+     * the inflate and everything it is holding instead of waiting for a
+     * `end` that will never come. `close` also fires on the happy path,
+     * after `end`, which is what `requestEnded` guards.
+     */
+    const onClose: () => void = (): void => {
+      if (requestEnded) {
+        return;
+      }
+
+      settle((): void => {});
+    };
+
+    inflate.on("data", (chunk: Buffer): void => {
+      decompressedBytes += chunk.length;
+
+      if (decompressedBytes > MAX_DECOMPRESSED_REQUEST_BODY_BYTES) {
+        settle((): void => {
+          stopReading();
+          GzipRequestBodyMiddleware.rejectTooLarge(
+            req,
+            res,
+            "decompressed",
+            decompressedBytes,
+            MAX_DECOMPRESSED_REQUEST_BODY_BYTES,
+          );
+        });
+        return;
+      }
+
+      decoded.push(chunk);
+    });
+
+    inflate.on("end", (): void => {
+      const body: Buffer = Buffer.concat(
+        decoded as unknown as Array<Uint8Array>,
+      );
+
+      settle((): void => {
+        req.body = body;
+        next();
+      });
+    });
+
+    inflate.on("error", (err: Error): void => {
+      settle((): void => {
+        logger.error(err, getLogAttributesFromRequest(req as OneUptimeRequest));
+
+        Response.sendErrorResponse(
+          req,
+          res,
+          new ServerException("Error decompressing data"),
+        );
+      });
+    });
+
+    req.on("data", onData);
+    req.on("end", onEnd);
+    req.on("error", onRequestError);
+    req.on("close", onClose);
+  }
+
+  private static rejectTooLarge(
+    req: ExpressRequest,
+    res: ExpressResponse,
+    stage: "compressed" | "decompressed",
+    bytes: number,
+    limit: number,
+  ): void {
+    if (res.headersSent) {
+      return;
+    }
+
+    /*
+     * debug, not warn or error. This path is unauthenticated, so a level
+     * that reaches the log sink by default would hand the same attacker a
+     * log-amplification vector in place of the memory one - while still
+     * leaving an operator something to turn on when a legitimate client
+     * starts getting 413s.
+     */
+    logger.debug(
+      `Rejected a gzip request body: ${stage} size reached ${bytes} bytes, limit is ${limit}.`,
+      getLogAttributesFromRequest(req as OneUptimeRequest),
+    );
+
+    res.status(413).json({
+      message: `Request body too large. The ${stage} body of a gzip-encoded request may not exceed ${limit} bytes.`,
+    });
+  }
+}

--- a/Common/Server/Utils/StartServer.ts
+++ b/Common/Server/Utils/StartServer.ts
@@ -9,6 +9,7 @@ import {
 } from "../EnvironmentConfig";
 import LocalCache from "../Infrastructure/LocalCache";
 import HttpMetricsMiddleware from "../Middleware/HttpMetricsMiddleware";
+import GzipRequestBodyMiddleware from "../Middleware/GzipRequestBody";
 import CorsOptions, {
   CORS_EXPOSED_HEADERS,
   CORS_PREFLIGHT_MAX_AGE_SECONDS,
@@ -41,7 +42,6 @@ import StatusCode from "../../Types/API/StatusCode";
 import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
 import Exception from "../../Types/Exception/Exception";
 import NotFoundException from "../../Types/Exception/NotFoundException";
-import ServerException from "../../Types/Exception/ServerException";
 import { PromiseVoidFunction } from "../../Types/FunctionTypes";
 import { JSONObject } from "../../Types/JSON";
 import JSONFunctions from "../../Types/JSONFunctions";
@@ -49,7 +49,6 @@ import Port from "../../Types/Port";
 import Typeof from "../../Types/Typeof";
 import CookieParser from "cookie-parser";
 import cors from "cors";
-import zlib from "zlib";
 import crypto from "crypto";
 import path from "path";
 import "ejs";
@@ -206,10 +205,11 @@ app.use((req: OneUptimeRequest, res: ExpressResponse, next: NextFunction) => {
    * several prefixes, so /telemetry/otlp/v1/... and
    * /telemetry/session-replay/v1/... are equally live. A prefix-anchored
    * test would let the prefixed path fall into the gzip fast-path below,
-   * which has NO size limit and no content-length pre-check (a zip-bomb
-   * vector on a public browser endpoint) and which sets req.body to the
-   * DECOMPRESSED buffer — that in turn trips the ingest middleware's
-   * "already parsed" early-out, so its byte cap would never run at all.
+   * which sets req.body to the DECOMPRESSED buffer — that in turn trips
+   * the ingest middleware's "already parsed" early-out, so its own,
+   * tighter, byte cap would never run at all. (The fast path has its own
+   * limits since GHSA-cp58-wc9q-qv53, but they are the generic 50 MiB
+   * body-parser numbers, not the 4 MiB these routes are sized for.)
    */
   if (
     req.path.includes("/otlp/v1/") ||
@@ -226,32 +226,12 @@ app.use((req: OneUptimeRequest, res: ExpressResponse, next: NextFunction) => {
   );
 
   if (contentEncoding?.includes("gzip")) {
-    const buffers: any = [];
-
-    req.on("data", (chunk: any) => {
-      buffers.push(chunk);
-    });
-
-    req.on("end", () => {
-      const buffer: Buffer = Buffer.concat(buffers);
-      zlib.gunzip(buffer as Uint8Array, (err: unknown, decoded: Buffer) => {
-        if (err) {
-          logger.error(
-            err,
-            getLogAttributesFromRequest(req as OneUptimeRequest),
-          );
-          return Response.sendErrorResponse(
-            req,
-            res,
-            new ServerException("Error decompressing data"),
-          );
-        }
-
-        req.body = decoded;
-
-        next();
-      });
-    });
+    /*
+     * Bounded on both sides - see GzipRequestBody. This used to buffer the
+     * whole compressed body and hand it to an unbounded zlib.gunzip, which
+     * turned 130 KB of anonymous request into 128 MiB of resident Buffer.
+     */
+    GzipRequestBodyMiddleware.parseBody(req, res, next);
   } else if (
     contentType &&
     (contentType.includes("application/x-protobuf") ||

--- a/Common/Tests/Server/Middleware/GzipRequestBody.test.ts
+++ b/Common/Tests/Server/Middleware/GzipRequestBody.test.ts
@@ -1,0 +1,725 @@
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The global `Content-Encoding: gzip` request reader (GHSA-cp58-wc9q-qv53).
+ *
+ * This middleware runs in StartServer BEFORE routing, so it sees every
+ * request to every service on every path, authenticated or not. It used to
+ * accumulate the whole compressed body in an unbounded array and hand it to
+ * an unbounded `zlib.gunzip` - a decompression bomb requiring no work at all
+ * from the attacker: the fixture below turns ~51 KB of anonymous request
+ * into 50 MiB of resident Buffer, and the trick scales linearly.
+ *
+ * There are two ceilings, and most of the tests here exist to show that
+ * neither one subsumes the other:
+ *
+ *   - Drop the DECOMPRESSED cap and 51 KB buys 50 MiB.
+ *   - Drop the COMPRESSED cap and 51 MiB of concatenated EMPTY gzip members -
+ *     which inflate to exactly zero bytes, so the decompressed cap can never
+ *     fire - streams straight into the process.
+ */
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    getLogAttributesFromRequest: jest.fn().mockReturnValue({}),
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: jest.fn(),
+    },
+  };
+});
+
+import GzipRequestBodyMiddleware, {
+  MAX_COMPRESSED_REQUEST_BODY_BYTES,
+  MAX_DECOMPRESSED_REQUEST_BODY_BYTES,
+} from "../../../Server/Middleware/GzipRequestBody";
+import Response from "../../../Server/Utils/Response";
+import logger from "../../../Server/Utils/Logger";
+import Exception from "../../../Types/Exception/Exception";
+import ExceptionCode from "../../../Types/Exception/ExceptionCode";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import { EventEmitter } from "events";
+import fs from "fs";
+import path from "path";
+import zlib from "zlib";
+
+/*
+ * The caps under test are 50 MiB, so the fixtures that probe them are 50 MiB
+ * of real gzip and real inflation. That does not fit in jest's 5s default.
+ */
+jest.setTimeout(300_000);
+
+type JestMock = {
+  mock: { calls: Array<Array<unknown>> };
+  mockClear: () => void;
+};
+
+const sendErrorResponseMock: JestMock =
+  Response.sendErrorResponse as unknown as JestMock;
+
+function loggerMock(level: "debug" | "warn" | "error"): JestMock {
+  return logger[level] as unknown as JestMock;
+}
+
+/*
+ * Response.sendErrorResponse is a module mock, so the drivers below cannot
+ * each attach to it. One shared implementation fans out to whichever driver
+ * is currently waiting.
+ */
+const errorResponseListeners: Set<() => void> = new Set();
+
+(
+  Response.sendErrorResponse as unknown as {
+    mockImplementation: (fn: () => void) => void;
+  }
+).mockImplementation((): void => {
+  for (const listener of Array.from(errorResponseListeners)) {
+    listener();
+  }
+});
+
+/*
+ * A request that models the one property this middleware depends on: a
+ * paused socket stops delivering. The driver waits while `paused` is set, so
+ * backpressure is exercised rather than ignored.
+ */
+interface FakeRequest extends EventEmitter {
+  body?: unknown;
+  headers: Record<string, string>;
+  destroy: () => void;
+  pause: () => void;
+  resume: () => void;
+  destroyed: boolean;
+  paused: boolean;
+}
+
+interface FakeResponse {
+  statusCode: number;
+  headersSent: boolean;
+  jsonBody: unknown;
+  status: (code: number) => FakeResponse;
+  json: (body: unknown) => FakeResponse;
+}
+
+function buildResponse(onJson?: () => void): FakeResponse {
+  const res: FakeResponse = {
+    statusCode: 0,
+    headersSent: false,
+    jsonBody: undefined,
+    status: (code: number): FakeResponse => {
+      res.statusCode = code;
+      return res;
+    },
+    json: (body: unknown): FakeResponse => {
+      res.jsonBody = body;
+      res.headersSent = true;
+
+      if (onJson) {
+        onJson();
+      }
+
+      return res;
+    },
+  };
+
+  return res;
+}
+
+/* Let anything that WOULD have happened, happen, before asserting it did not. */
+function quietPeriod(): Promise<void> {
+  return new Promise<void>((resolve: () => void): void => {
+    setTimeout(resolve, 100);
+  });
+}
+
+/*
+ * Deliberately event-driven rather than a poll loop. The inflate runs on the
+ * threadpool, and under jsdom a `setTimeout(0)` poll competes with its
+ * callbacks for the event loop - polling turned a 50 MiB inflate into half a
+ * minute. The 250 ms timer is only a safety net for a wake-up that never
+ * arrives.
+ */
+class Driver {
+  public req: FakeRequest;
+  public res: FakeResponse;
+  public nextCalls: Array<unknown> = [];
+  public fedBytes: number = 0;
+
+  private waiters: Array<() => void> = [];
+  private errorResponsesAtStart: number;
+
+  private wake: () => void = (): void => {
+    for (const waiter of this.waiters.splice(0)) {
+      waiter();
+    }
+  };
+
+  public constructor(headers?: Record<string, string>) {
+    const req: FakeRequest = new EventEmitter() as FakeRequest;
+
+    req.headers = headers || {};
+    req.destroyed = false;
+    req.paused = false;
+    req.destroy = (): void => {
+      req.destroyed = true;
+    };
+    req.pause = (): void => {
+      req.paused = true;
+    };
+    req.resume = (): void => {
+      req.paused = false;
+      this.wake();
+    };
+
+    this.req = req;
+    this.res = buildResponse(this.wake);
+    this.errorResponsesAtStart = sendErrorResponseMock.mock.calls.length;
+
+    errorResponseListeners.add(this.wake);
+
+    GzipRequestBodyMiddleware.parseBody(
+      this.req as unknown as ExpressRequest,
+      this.res as unknown as ExpressResponse,
+      ((err?: unknown): void => {
+        this.nextCalls.push(err);
+        this.wake();
+      }) as NextFunction,
+    );
+  }
+
+  public isSettled(): boolean {
+    return (
+      this.nextCalls.length > 0 ||
+      this.res.statusCode !== 0 ||
+      sendErrorResponseMock.mock.calls.length > this.errorResponsesAtStart
+    );
+  }
+
+  public errorResponse(): Exception | undefined {
+    const calls: Array<Array<unknown>> = sendErrorResponseMock.mock.calls.slice(
+      this.errorResponsesAtStart,
+    );
+
+    return calls.length > 0 ? (calls[0]![2] as Exception) : undefined;
+  }
+
+  public async waitForOutcome(timeoutMs: number = 120000): Promise<boolean> {
+    const startedAt: number = Date.now();
+
+    while (!this.isSettled()) {
+      if (Date.now() - startedAt > timeoutMs) {
+        return false;
+      }
+
+      await this.waitForWake();
+    }
+
+    errorResponseListeners.delete(this.wake);
+
+    return true;
+  }
+
+  /* Feed chunks the way a socket would: stop while paused, stop once answered. */
+  public async feed(chunks: Array<Buffer>): Promise<void> {
+    for (const chunk of chunks) {
+      while (this.req.paused && !this.isSettled()) {
+        await this.waitForWake();
+      }
+
+      if (this.isSettled()) {
+        return;
+      }
+
+      this.req.emit("data", chunk);
+      this.fedBytes += chunk.length;
+    }
+  }
+
+  public end(): void {
+    this.req.emit("end");
+  }
+
+  private waitForWake(): Promise<void> {
+    return new Promise<void>((resolve: () => void): void => {
+      this.waiters.push(resolve);
+      setTimeout(resolve, 250);
+    });
+  }
+}
+
+function gzip(buffer: Buffer): Buffer {
+  return zlib.gzipSync(buffer as unknown as Uint8Array);
+}
+
+function chunked(buffer: Buffer, size: number): Array<Buffer> {
+  const out: Array<Buffer> = [];
+
+  for (let offset: number = 0; offset < buffer.length; offset += size) {
+    out.push(buffer.subarray(offset, offset + size));
+  }
+
+  return out;
+}
+
+/*
+ * A block of concatenated EMPTY gzip members. Each member is 20 valid bytes
+ * that inflate to nothing, so a stream of these is arbitrarily large on the
+ * wire and exactly zero bytes of output - the shape that makes a
+ * decompressed-only cap useless.
+ */
+function emptyMemberBlock(approximateBytes: number): Buffer {
+  const member: Buffer = gzip(Buffer.alloc(0));
+  const count: number = Math.floor(approximateBytes / member.length);
+
+  return Buffer.concat(
+    Array.from({ length: count }, (): Uint8Array => {
+      return member as unknown as Uint8Array;
+    }),
+  );
+}
+
+/* Built once - the 50 MiB fixtures are the slow part of this suite. */
+const oneMiBOfEmptyMembers: Buffer = emptyMemberBlock(1024 * 1024);
+
+describe("GzipRequestBodyMiddleware - the happy path still works", () => {
+  test("inflates a gzip body and hands it on as a Buffer", async () => {
+    const payload: Buffer = Buffer.from(
+      JSON.stringify({ hello: "world", n: 42 }),
+    );
+
+    const driver: Driver = new Driver();
+
+    await driver.feed([gzip(payload)]);
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toEqual([undefined]);
+    expect(Buffer.isBuffer(driver.req.body)).toBe(true);
+    expect((driver.req.body as Buffer).toString()).toBe(payload.toString());
+    expect(driver.res.statusCode).toBe(0);
+  });
+
+  test("reassembles a body split across many socket-sized chunks", async () => {
+    const payload: Buffer = Buffer.from("x".repeat(300_000));
+
+    const driver: Driver = new Driver();
+
+    await driver.feed(chunked(gzip(payload), 512));
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toHaveLength(1);
+    expect((driver.req.body as Buffer).length).toBe(payload.length);
+    expect((driver.req.body as Buffer).equals(payload as never)).toBe(true);
+  });
+
+  test("a body exactly ON the decompressed limit is accepted", async () => {
+    const payload: Buffer = Buffer.alloc(MAX_DECOMPRESSED_REQUEST_BODY_BYTES);
+
+    const driver: Driver = new Driver();
+
+    await driver.feed(chunked(gzip(payload), 16 * 1024));
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.res.statusCode).toBe(0);
+    expect(driver.nextCalls).toHaveLength(1);
+    expect((driver.req.body as Buffer).length).toBe(
+      MAX_DECOMPRESSED_REQUEST_BODY_BYTES,
+    );
+  });
+
+  test("a declared Content-Length under the cap is not treated as a rejection", async () => {
+    const compressed: Buffer = gzip(Buffer.from("small"));
+
+    const driver: Driver = new Driver({
+      "content-length": String(compressed.length),
+    });
+
+    await driver.feed([compressed]);
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.res.statusCode).toBe(0);
+    expect(driver.nextCalls).toHaveLength(1);
+  });
+
+  test("a garbage Content-Length is ignored rather than trusted", async () => {
+    const driver: Driver = new Driver({ "content-length": "not-a-number" });
+
+    await driver.feed([gzip(Buffer.from("ok"))]);
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.res.statusCode).toBe(0);
+    expect(driver.nextCalls).toHaveLength(1);
+  });
+});
+
+describe("GzipRequestBodyMiddleware - decompression bombs (GHSA-cp58-wc9q-qv53)", () => {
+  test("one byte over the decompressed cap is a 413, and next() never runs", async () => {
+    const payload: Buffer = Buffer.alloc(
+      MAX_DECOMPRESSED_REQUEST_BODY_BYTES + 1,
+    );
+    const compressed: Buffer = gzip(payload);
+
+    /* The amplification the advisory is about, measured on the fixture. */
+    expect(compressed.length).toBeLessThan(payload.length / 500);
+
+    const driver: Driver = new Driver();
+
+    await driver.feed(chunked(compressed, 16 * 1024));
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.res.statusCode).toBe(413);
+    expect(driver.nextCalls).toHaveLength(0);
+    expect(driver.req.body).toBeUndefined();
+    expect(
+      String((driver.res.jsonBody as { message: string }).message),
+    ).toContain("decompressed");
+  });
+
+  test("the bomb is refused mid-stream, not after the last byte arrives", async () => {
+    /*
+     * 64 MiB of output hidden in ~65 KB, followed by 4 MiB of padding that
+     * inflates to nothing. The 50 MiB ceiling is therefore crossed inside
+     * the first fraction of the request, and everything after it should
+     * never be read. The old code read all of it and then allocated the
+     * whole 64 MiB.
+     */
+    const bomb: Buffer = gzip(Buffer.alloc(64 * 1024 * 1024));
+    const padding: Buffer = Buffer.concat(
+      Array.from({ length: 4 }, (): Uint8Array => {
+        return oneMiBOfEmptyMembers as unknown as Uint8Array;
+      }),
+    );
+    const compressed: Buffer = Buffer.concat([
+      bomb as unknown as Uint8Array,
+      padding as unknown as Uint8Array,
+    ]);
+
+    expect(compressed.length).toBeGreaterThan(4 * 1024 * 1024);
+
+    const driver: Driver = new Driver();
+
+    await driver.feed(chunked(compressed, 16 * 1024));
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.res.statusCode).toBe(413);
+    expect(driver.nextCalls).toHaveLength(0);
+
+    /*
+     * How much INPUT we had to accept before answering is the number that
+     * decides whether this is still a denial of service. 512 KiB of a 4 MiB
+     * request is a generous bound; the observed figure is far under it.
+     */
+    expect(driver.fedBytes).toBeLessThan(512 * 1024);
+
+    /* It stopped reading rather than draining, and left the socket alone. */
+    expect(driver.req.paused).toBe(true);
+    expect(driver.req.destroyed).toBe(false);
+  });
+
+  test("51 MiB of EMPTY gzip members is refused even though it inflates to nothing", async () => {
+    /*
+     * Zero output, so the decompressed cap can never fire. Without the
+     * compressed cap this request is unbounded.
+     */
+    const driver: Driver = new Driver();
+
+    await driver.feed(
+      Array.from({ length: 52 }, (): Buffer => {
+        return oneMiBOfEmptyMembers;
+      }),
+    );
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.res.statusCode).toBe(413);
+    expect(driver.nextCalls).toHaveLength(0);
+    expect(
+      String((driver.res.jsonBody as { message: string }).message),
+    ).toContain("compressed");
+    expect(driver.req.paused).toBe(true);
+  });
+
+  test("an over-cap Content-Length is refused before a single byte is read", async () => {
+    const driver: Driver = new Driver({
+      "content-length": String(MAX_COMPRESSED_REQUEST_BODY_BYTES + 1),
+    });
+
+    expect(driver.res.statusCode).toBe(413);
+    expect(driver.nextCalls).toHaveLength(0);
+
+    /*
+     * No listeners were attached at all, so the body is never consumed -
+     * the cheapest possible refusal.
+     */
+    expect(driver.req.listenerCount("data")).toBe(0);
+    expect(driver.req.listenerCount("end")).toBe(0);
+  });
+
+  test("both caps are pinned to the identity path's 50 MiB body-parser limit", () => {
+    expect(MAX_COMPRESSED_REQUEST_BODY_BYTES).toBe(50 * 1024 * 1024);
+    expect(MAX_DECOMPRESSED_REQUEST_BODY_BYTES).toBe(50 * 1024 * 1024);
+  });
+});
+
+describe("GzipRequestBodyMiddleware - one outcome per request", () => {
+  test("data arriving after a 413 does not produce a second response", async () => {
+    const driver: Driver = new Driver();
+
+    await driver.feed(
+      Array.from({ length: 52 }, (): Buffer => {
+        return oneMiBOfEmptyMembers;
+      }),
+    );
+
+    expect(await driver.waitForOutcome()).toBe(true);
+    expect(driver.res.statusCode).toBe(413);
+
+    const firstBody: unknown = driver.res.jsonBody;
+
+    /* Keep shouting at a middleware that has already answered. */
+    driver.res.statusCode = 0;
+    driver.req.emit("data", oneMiBOfEmptyMembers);
+    driver.req.emit("end");
+    driver.req.emit("close");
+
+    await quietPeriod();
+
+    expect(driver.res.statusCode).toBe(0);
+    expect(driver.res.jsonBody).toBe(firstBody);
+    expect(driver.nextCalls).toHaveLength(0);
+  });
+
+  test("a response that already has headers is not written to again", () => {
+    const req: EventEmitter = new EventEmitter();
+    (req as unknown as { headers: Record<string, string> }).headers = {
+      "content-length": String(MAX_COMPRESSED_REQUEST_BODY_BYTES + 1),
+    };
+
+    const res: FakeResponse = buildResponse();
+
+    res.headersSent = true;
+
+    GzipRequestBodyMiddleware.parseBody(
+      req as unknown as ExpressRequest,
+      res as unknown as ExpressResponse,
+      ((): void => {}) as NextFunction,
+    );
+
+    expect(res.statusCode).toBe(0);
+    expect(res.jsonBody).toBeUndefined();
+  });
+});
+
+describe("GzipRequestBodyMiddleware - malformed and truncated input", () => {
+  test("a body that is not gzip at all is a 500, exactly as before", async () => {
+    const driver: Driver = new Driver();
+
+    await driver.feed([Buffer.from("this is not gzip")]);
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toHaveLength(0);
+
+    const error: Exception | undefined = driver.errorResponse();
+
+    expect(error).toBeDefined();
+    expect(error!.code).toBe(ExceptionCode.ServerException);
+    expect(error!.message).toBe("Error decompressing data");
+  });
+
+  test("a truncated gzip body is a 500 and never reaches the route", async () => {
+    const compressed: Buffer = gzip(Buffer.from("x".repeat(100_000)));
+
+    const driver: Driver = new Driver();
+
+    await driver.feed([
+      compressed.subarray(0, Math.floor(compressed.length / 2)),
+    ]);
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toHaveLength(0);
+    expect(driver.req.body).toBeUndefined();
+    expect(driver.errorResponse()).toBeDefined();
+  });
+
+  test("an empty body is an empty body, not a 500", async () => {
+    /*
+     * A bare `Content-Encoding: gzip` header with no body - which any client
+     * can put on a GET - used to reach zlib as an empty stream, fail with
+     * "unexpected end of file", and cost a 500 plus an error-level log line
+     * on every request.
+     */
+    const driver: Driver = new Driver();
+
+    driver.end();
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toEqual([undefined]);
+    expect(Buffer.isBuffer(driver.req.body)).toBe(true);
+    expect((driver.req.body as Buffer).length).toBe(0);
+    expect(driver.errorResponse()).toBeUndefined();
+  });
+
+  test("a request error is handed to Express rather than swallowed", async () => {
+    const driver: Driver = new Driver();
+
+    const failure: Error = new Error("ECONNRESET");
+
+    await driver.feed([gzip(Buffer.from("partial")).subarray(0, 4)]);
+    driver.req.emit("error", failure);
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toEqual([failure]);
+    expect(driver.res.statusCode).toBe(0);
+  });
+
+  test("a client that hangs up mid-body gets no response and no next()", async () => {
+    const compressed: Buffer = gzip(Buffer.alloc(2 * 1024 * 1024));
+
+    const driver: Driver = new Driver();
+
+    await driver.feed(chunked(compressed, 512).slice(0, 2));
+    driver.req.emit("close");
+
+    await quietPeriod();
+
+    expect(driver.nextCalls).toHaveLength(0);
+    expect(driver.res.statusCode).toBe(0);
+    expect(driver.req.body).toBeUndefined();
+    expect(driver.errorResponse()).toBeUndefined();
+  });
+
+  test("the normal close that follows a completed request is not treated as an abort", async () => {
+    const driver: Driver = new Driver();
+
+    await driver.feed([gzip(Buffer.from("done"))]);
+    driver.end();
+    /* Node emits this straight after "end" on a completed request. */
+    driver.req.emit("close");
+
+    expect(await driver.waitForOutcome()).toBe(true);
+
+    expect(driver.nextCalls).toHaveLength(1);
+    expect((driver.req.body as Buffer).toString()).toBe("done");
+  });
+});
+
+describe("GzipRequestBodyMiddleware - rejections do not become a log flood", () => {
+  test("a 413 is logged at debug, never at warn or error", () => {
+    loggerMock("debug").mockClear();
+    loggerMock("warn").mockClear();
+    loggerMock("error").mockClear();
+
+    /* eslint-disable-next-line no-new */
+    new Driver({
+      "content-length": String(MAX_COMPRESSED_REQUEST_BODY_BYTES + 1),
+    });
+
+    expect(loggerMock("error").mock.calls).toHaveLength(0);
+    expect(loggerMock("warn").mock.calls).toHaveLength(0);
+    expect(loggerMock("debug").mock.calls).toHaveLength(1);
+  });
+});
+
+/*
+ * The reason the middleware counts output bytes by hand instead of handing
+ * zlib a `maxOutputLength`. If a future Node starts honouring the option on
+ * streams this test fails and the manual counter can be reconsidered - until
+ * then, setting the option would look like a limit while being none.
+ */
+describe("zlib.createGunzip ignores maxOutputLength (why the counter is manual)", () => {
+  test("a stream capped at 1 MiB still emits 8 MiB", async () => {
+    const compressed: Buffer = gzip(Buffer.alloc(8 * 1024 * 1024));
+
+    const emitted: number = await new Promise<number>(
+      (resolve: (value: number) => void): void => {
+        const stream: zlib.Gunzip = zlib.createGunzip({
+          maxOutputLength: 1024 * 1024,
+        });
+
+        let out: number = 0;
+
+        stream.on("data", (chunk: Buffer): void => {
+          out += chunk.length;
+        });
+        stream.on("error", (): void => {
+          resolve(-1);
+        });
+        stream.on("end", (): void => {
+          resolve(out);
+        });
+
+        stream.end(compressed as unknown as Uint8Array);
+      },
+    );
+
+    expect(emitted).toBe(8 * 1024 * 1024);
+  });
+
+  test("the same option on the convenience method DOES fire", () => {
+    const compressed: Buffer = gzip(Buffer.alloc(8 * 1024 * 1024));
+
+    expect(() => {
+      zlib.gunzipSync(compressed as unknown as Uint8Array, {
+        maxOutputLength: 1024 * 1024,
+      });
+    }).toThrow();
+  });
+});
+
+/*
+ * Source-level assertion, for the same reason the session replay suite has
+ * one: a jest test cannot stand up the real Express stack, and this failure
+ * mode is silent. If StartServer ever goes back to inflating inline, every
+ * limit in this file stops running with no visible symptom.
+ */
+describe("StartServer routes the gzip branch through this middleware", () => {
+  const startServerSource: string = fs.readFileSync(
+    path.join(__dirname, "../../../Server/Utils/StartServer.ts"),
+    "utf-8",
+  );
+
+  test("the gzip branch calls GzipRequestBodyMiddleware.parseBody", () => {
+    expect(startServerSource).toContain(
+      "GzipRequestBodyMiddleware.parseBody(req, res, next)",
+    );
+  });
+
+  test("StartServer no longer inflates a request body itself", () => {
+    expect(startServerSource).not.toContain("zlib.gunzip(");
+    expect(startServerSource).not.toMatch(/^import zlib from "zlib";$/m);
+  });
+});


### PR DESCRIPTION
Fixes **GHSA-cp58-wc9q-qv53** (draft advisory, High) — *Unauthenticated gzip decompression bomb bypasses request size limits*. CWE-409, data amplification.

## The bug

`Common/Server/Utils/StartServer.ts` inflated any request carrying `Content-Encoding: gzip`. It is an `app.use` with no path, registered before `CommonAPI` mounts anything, so it ran **before routing and therefore before authentication**, on every path of every service — including paths that do not exist.

```ts
req.on("data", (chunk: any) => { buffers.push(chunk); });   // no input limit
req.on("end", () => {
  zlib.gunzip(Buffer.concat(buffers), (err, decoded) => {   // no output limit
    req.body = decoded;
    next();
  });
});
```

No compressed limit, no expanded limit, no ratio limit. The 50 MB body-parser limit never applies here because this middleware consumes the stream itself and the parsers are in the `else` branch.

Reproduced locally, and it is exactly the advisory's number:

```
plain bytes    : 134217728
gzipped bytes  : 130479
ratio          : 1028.7x
rss delta      : 264.4 MiB
```

**130 KB of anonymous request → 128 MiB resident.** A handful of concurrent requests exhausts the App/API container and forces a restart.

nginx does not save you: `client_max_body_size` bounds the **compressed** body. At nginx's 1 MB default that is still ~1 GB of expansion per request, and `location /api`, `/ingestor`, `/probe-ingest`, `/analytics-api` and friends are all set to `50M` — ~50 GB.

## The fix

The reader moved to `Common/Server/Middleware/GzipRequestBody.ts` with two ceilings, both **50 MiB** — exactly `bytes("50mb")`, what body-parser is given for the identity path. Announcing gzip must not buy a caller more room than sending the same bytes uncompressed.

### Both ceilings are load-bearing

A decompressed-only cap is trivially defeated. `zlib.gzipSync(Buffer.alloc(0))` is a **valid 20-byte gzip member that inflates to nothing**, and gzip is a multi-member format:

```
fed 51 blocks = 53476560 compressed bytes -> output bytes: 0
```

51 MiB streamed into the process, output counter never leaves zero, decompressed cap never fires. There is a test for it.

### It streams

Buffering the compressed body and *then* inflating would hold both caps at once and would not notice a bomb until the last byte arrived. Feeding a `createGunzip` stream refuses it while most of the request is still on the wire — **under 512 KiB of a 4 MiB request** in the test.

It also honours the inflate's backpressure. zlib works on the threadpool, so an unpaused socket would pile the whole compressed body into the writable queue: the same unbounded buffering, one object further down.

### `maxOutputLength` is a trap

The advisory's remediation says to set it. I did not, because it does not work here:

| call | `maxOutputLength: 1 MiB` on an 8 MiB payload |
|---|---|
| `zlib.gunzipSync(buf, opts)` | throws `ERR_BUFFER_TOO_LARGE` |
| `zlib.createGunzip(opts)` stream | **emits all 8 MiB** |

Node's own docs say it "limits output size when using convenience methods" — on a stream it is accepted and silently ignored. Measured on Node 24.1. Two tests pin both halves of that table, so if a future Node starts honouring it the manual counter can be revisited, and until then nobody "restores" the option believing it is a limit.

The stream is left on zlib's default 16 KB `chunkSize` deliberately. A larger one would cut threadpool round-trips, but it is also a per-in-flight-request allocation, and trading concurrent-request memory for throughput is the wrong direction in this particular PR.

### Other content encodings were already fine

The advisory also asks to reject unsupported content encodings. Checked, and nothing needed changing: `deflate` reaches body-parser, which pipes it through `createInflate` into `raw-body` with the 50 MB limit applied to the **decompressed** stream (`opts.length` is only set for `identity`, so the limit counts inflated bytes). Anything else either gets body-parser's 415 or is never read at all, because the parser only engages on a matching content-type. The gzip fast path was the only unbounded decompressor in the dispatcher.

## Three smaller things on the same path

- **Aborted requests leaked.** No `close` handling, so a client hanging up mid-body left the middleware waiting for an `end` that never came, holding everything it had buffered. It settles on `close` now (guarded by an `end` flag, since Node emits `close` after `end` on completed requests too).
- **Request stream errors were unhandled.** The request hung rather than reaching Express's error handler. Now `next(err)`.
- **`Content-Encoding: gzip` with no body was a 500.** Anyone can put that header on a GET. It reached zlib as an empty stream, failed with "unexpected end of file", and cost a 500 plus an error-level log line per request — an unauthenticated log-flood in its own right. Treated as the empty body it is.

Size rejections log at `debug`, not `error`: this path is unauthenticated and a default-visible line per rejection just trades the memory vector for a logging one.

## Tests

`Common/Tests/Server/Middleware/GzipRequestBody.test.ts` — 23 tests over the happy path, both caps, the empty-member bypass, mid-stream refusal, single-outcome-per-request, malformed/truncated/empty/aborted input, the log level, and the two `maxOutputLength` behaviour pins.

The request fake models the one property that matters: **a paused socket stops delivering**, so backpressure is exercised rather than ignored.

There is also a source-level assertion that StartServer routes through the middleware and no longer calls `zlib.gunzip` itself — the same technique the session replay suite uses, because this failure mode is silent: if the inflate moves back inline, every limit here stops running with no visible symptom.

## Not in this PR

Two telemetry paths still gunzip without an output limit — `PyroscopeIngestService.decompressIfNeeded` and `OtelPayloadDecoder.gunzipAsync` (the latter in the BullMQ worker, and `OtelRequestMiddleware.parseBody` has no byte cap at all). Both sit **behind** `TelemetryIngest.isAuthorizedServiceMiddleware`, so they need a valid project ingest key and are a different severity class than an anonymous request to any path. Worth their own change rather than widening this one; `SessionReplayIngestService` already shows the shape.
