### PR TITLE
fix(telemetry): bound decompression and multipart on the ingest paths

### DIFF
--- a/App/FeatureSet/Telemetry/Middleware/OtelRequestMiddleware.ts
+++ b/App/FeatureSet/Telemetry/Middleware/OtelRequestMiddleware.ts
@@ -12,6 +12,20 @@ import logger, {
   getLogAttributesFromRequest,
 } from "Common/Server/Utils/Logger";
 
+/*
+ * Byte ceiling for one OTLP ingest request, measured on the wire (so on
+ * the COMPRESSED body when the client sends gzip).
+ *
+ * This middleware reads the socket itself, which means none of the global
+ * body-parser limits in StartServer apply to it - before this constant
+ * existed the only bound was whatever nginx happened to allow, and a
+ * deployment fronted by something else, or reached directly, had none at
+ * all. 50 MiB is the same number body-parser is given everywhere else in
+ * the app, and nginx cuts it to 1-4 MiB in the shipped config, so no
+ * legitimate exporter is affected.
+ */
+export const MAX_OTLP_REQUEST_BYTES: number = 50 * 1024 * 1024;
+
 export default class OpenTelemetryRequestMiddleware {
   /*
    * Read the OTel HTTP request body into a raw Buffer. We deliberately
@@ -21,11 +35,16 @@ export default class OpenTelemetryRequestMiddleware {
    * sent). The handler now base64-encodes this raw buffer and queues
    * it; the BullMQ worker performs gunzip + protobuf decode off the
    * HTTP path.
+   *
+   * It does enforce a byte cap. The worker's inflate has its own ceiling
+   * (MAX_DECOMPRESSED_OTLP_BODY_BYTES), but that one only fires after the
+   * body has already been read into this process and written to Redis, so
+   * both ends need bounding.
    */
   @CaptureSpan()
   public static async parseBody(
     req: ExpressRequest,
-    _res: ExpressResponse,
+    res: ExpressResponse,
     next: NextFunction,
   ): Promise<void> {
     try {
@@ -33,27 +52,94 @@ export default class OpenTelemetryRequestMiddleware {
         return next();
       }
 
-      const requestBuffer: Buffer = await new Promise<Buffer>(
-        (resolve: (value: Buffer) => void, reject: (err: Error) => void) => {
-          const chunks: Array<Uint8Array> = [];
+      /*
+       * Cheap pre-check before a byte is read. Content-Length is advisory
+       * - a chunked request carries none - but when it is present and
+       * already over the cap there is no reason to accept the body.
+       */
+      const contentLengthHeader: string | undefined = headerValueToString(
+        req.headers["content-length"],
+      );
 
-          req.on("data", (chunk: Buffer | string) => {
-            chunks.push(
-              new Uint8Array(
-                Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf-8"),
-              ),
-            );
-          });
+      if (contentLengthHeader) {
+        const declaredLength: number = parseInt(contentLengthHeader, 10);
+
+        if (!isNaN(declaredLength) && declaredLength > MAX_OTLP_REQUEST_BYTES) {
+          OpenTelemetryRequestMiddleware.rejectTooLarge(res, declaredLength);
+          return;
+        }
+      }
+
+      const requestBuffer: Buffer | null = await new Promise<Buffer | null>(
+        (
+          resolve: (value: Buffer | null) => void,
+          reject: (err: Error) => void,
+        ) => {
+          const chunks: Array<Uint8Array> = [];
+          let receivedBytes: number = 0;
+          let rejected: boolean = false;
+
+          const onData: (chunk: Buffer | string) => void = (
+            chunk: Buffer | string,
+          ): void => {
+            if (rejected) {
+              return;
+            }
+
+            const asBuffer: Buffer = Buffer.isBuffer(chunk)
+              ? chunk
+              : Buffer.from(chunk, "utf-8");
+
+            receivedBytes += asBuffer.length;
+
+            if (receivedBytes > MAX_OTLP_REQUEST_BYTES) {
+              rejected = true;
+
+              /*
+               * Answer FIRST, then stop accumulating. The OTel spec tells
+               * exporters to treat 4xx as non-retryable, so a 413 makes a
+               * misconfigured batch size stop rather than loop; tearing
+               * the socket down instead would read as a network error and
+               * be retried forever.
+               */
+              OpenTelemetryRequestMiddleware.rejectTooLarge(res, receivedBytes);
+
+              chunks.length = 0;
+
+              req.removeListener("data", onData);
+              req.resume();
+
+              resolve(null);
+              return;
+            }
+
+            chunks.push(new Uint8Array(asBuffer));
+          };
+
+          req.on("data", onData);
 
           req.on("end", () => {
+            if (rejected) {
+              return;
+            }
+
             resolve(Buffer.concat(chunks));
           });
 
           req.on("error", (err: Error) => {
+            if (rejected) {
+              return;
+            }
+
             reject(err);
           });
         },
       );
+
+      if (requestBuffer === null) {
+        // Already answered with 413. Do not continue down the stack.
+        return;
+      }
 
       req.body = requestBuffer;
 
@@ -61,6 +147,17 @@ export default class OpenTelemetryRequestMiddleware {
     } catch (err) {
       return next(err);
     }
+  }
+
+  private static rejectTooLarge(res: ExpressResponse, bytes: number): void {
+    if (res.headersSent) {
+      return;
+    }
+
+    res.status(413).json({
+      error: "payload-too-large",
+      message: `An OTLP ingest request may not exceed ${MAX_OTLP_REQUEST_BYTES} bytes. Received at least ${bytes}.`,
+    });
   }
 
   /*

--- a/App/FeatureSet/Telemetry/Services/PyroscopeIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/PyroscopeIngestService.ts
@@ -9,6 +9,7 @@ import CaptureSpan from "Common/Server/Utils/Telemetry/CaptureSpan";
 import EventLoop from "Common/Server/Utils/EventLoop";
 import logger from "Common/Server/Utils/Logger";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
+import PayloadTooLargeException from "Common/Types/Exception/PayloadTooLargeException";
 import Dictionary from "Common/Types/Dictionary";
 import { JSONObject } from "Common/Types/JSON";
 import OneUptimeDate from "Common/Types/Date";
@@ -17,6 +18,7 @@ import ObjectID from "Common/Types/ObjectID";
 import protobuf from "protobufjs";
 import path from "path";
 import zlib from "zlib";
+import { promisify } from "util";
 import {
   SPAN_ID_KEYS,
   TRACE_ID_KEYS,
@@ -37,6 +39,42 @@ const PushProto: protobuf.Root = protobuf.loadSync(
   path.resolve(__dirname, "..", "ProtoFiles", "pyroscope", "push.proto"),
 );
 const PushRequest: protobuf.Type = PushProto.lookupType("push.v1.PushRequest");
+
+/*
+ * Decompressed-payload ceiling for ONE gzip member on this path.
+ *
+ * pprof is protobuf wrapped in gzip and a real profile is tens to a few
+ * hundred KB; 32 MiB is orders of magnitude above anything a profiler
+ * emits, so a legitimate client never approaches it. It exists because
+ * `zlib.gunzip` with no ceiling turns the ~1 MiB nginx lets through into
+ * however much the sender wants - a measured 1,029x on repeated bytes is
+ * about a gigabyte of resident Buffer per request.
+ */
+export const MAX_DECOMPRESSED_PROFILE_BYTES: number = 32 * 1024 * 1024;
+
+/*
+ * Decompressed-payload ceiling for the WHOLE request, which is the number
+ * that actually bounds the process.
+ *
+ * ingestPyroscopePush walks series[].samples[] and inflates every sample,
+ * so a per-payload cap alone just multiplies by the sample count: 64
+ * samples one byte under the per-profile cap is 2 GB. The budget below is
+ * spent across every inflate in one request, the same shape
+ * SessionReplayIngestService uses for its per-job allowance.
+ */
+export const MAX_DECOMPRESSED_REQUEST_BYTES: number = 64 * 1024 * 1024;
+
+/*
+ * Async, not gunzipSync: a multi-MB synchronous inflate pins the event
+ * loop, which is the same reason the push loop yields between samples.
+ */
+const gunzipAsync: (
+  buffer: Uint8Array,
+  options: zlib.ZlibOptions,
+) => Promise<Buffer> = promisify(zlib.gunzip) as unknown as (
+  buffer: Uint8Array,
+  options: zlib.ZlibOptions,
+) => Promise<Buffer>;
 
 // Interfaces for parsed Pyroscope push data
 interface PyroscopeLabelPair {
@@ -110,6 +148,15 @@ const JFR_UNSUPPORTED_MESSAGE: string =
   "pushes pprof to /pyroscope/push.v1.PusherService/Push.";
 
 /*
+ * Deliberately says nothing about how much was received or how much is
+ * left of the budget. A caller probing for the exact ceiling learns
+ * nothing from the response.
+ */
+const PYROSCOPE_TOO_LARGE_MESSAGE: string =
+  "Profile payload is too large once decompressed. Reduce the profile " +
+  "size or the number of samples per request.";
+
+/*
  * Label keys that are PROMOTED to the link table rather than stored as
  * sample attributes: a valid id becomes a first-class traceId/spanId
  * column downstream, and an invalid one must be dropped entirely —
@@ -173,8 +220,14 @@ export default class PyroscopeIngestService {
         throw new BadRequestException("No profile data found in request body.");
       }
 
-      // Decompress if gzipped
-      const decompressed: Buffer = await this.decompressIfNeeded(pprofBuffer);
+      /*
+       * One payload per request on this route, so it may spend the whole
+       * request allowance (the per-profile ceiling still applies inside).
+       */
+      const decompressed: Buffer = await this.decompressIfNeeded(
+        pprofBuffer,
+        MAX_DECOMPRESSED_REQUEST_BYTES,
+      );
 
       /*
        * pyroscope-java omits format=jfr on some versions — catch the
@@ -288,8 +341,23 @@ export default class PyroscopeIngestService {
         throw new BadRequestException("No push data found in request body.");
       }
 
-      // Decompress if gzipped
-      const decompressed: Buffer = await this.decompressIfNeeded(rawBody);
+      /*
+       * Running request-wide decompression allowance, spent by the outer
+       * envelope and then sample by sample below. This is what bounds the
+       * process: every decompressed sample stays resident until the merged
+       * OTLP body is built at the end, so the ceiling has to be per
+       * REQUEST, not per payload.
+       */
+      let decompressionBudgetRemaining: number = MAX_DECOMPRESSED_REQUEST_BYTES;
+
+      const decompressed: Buffer = await this.decompressIfNeeded(
+        rawBody,
+        decompressionBudgetRemaining,
+      );
+
+      if (decompressed !== rawBody) {
+        decompressionBudgetRemaining -= decompressed.length;
+      }
 
       // Decode the PushRequest protobuf
       const pushMessage: protobuf.Message = PushRequest.decode(
@@ -346,8 +414,14 @@ export default class PyroscopeIngestService {
             : Buffer.from(sample.rawProfile);
 
           // Decompress if the embedded profile is gzipped
-          const decompressedProfile: Buffer =
-            await this.decompressIfNeeded(profileBuffer);
+          const decompressedProfile: Buffer = await this.decompressIfNeeded(
+            profileBuffer,
+            decompressionBudgetRemaining,
+          );
+
+          if (decompressedProfile !== profileBuffer) {
+            decompressionBudgetRemaining -= decompressedProfile.length;
+          }
 
           // Parse the embedded pprof
           const pprofData: PprofProfileData =
@@ -496,23 +570,52 @@ export default class PyroscopeIngestService {
     return null;
   }
 
-  private static async decompressIfNeeded(data: Buffer): Promise<Buffer> {
+  /*
+   * gunzip under a hard output ceiling, or pass identity bytes through.
+   *
+   * `budgetBytes` is what is left of the request-wide allowance. It is
+   * folded into `maxOutputLength` rather than checked afterwards so the
+   * inflate ABORTS at the ceiling instead of completing and being rejected
+   * once the memory has already been allocated - the whole point of the
+   * limit.
+   *
+   * `maxOutputLength` works here because this is zlib's CONVENIENCE api.
+   * Node honours the option on `gunzip`/`gunzipSync` only; on a
+   * `createGunzip` stream it is accepted and silently ignored, so do not
+   * "simplify" this into a stream without replacing the ceiling with a
+   * manual byte count.
+   */
+  private static async decompressIfNeeded(
+    data: Buffer,
+    budgetBytes: number,
+  ): Promise<Buffer> {
     // Check for gzip magic bytes (0x1f, 0x8b)
     if (data.length >= 2 && data[0] === 0x1f && data[1] === 0x8b) {
-      return new Promise<Buffer>(
-        (resolve: (value: Buffer) => void, reject: (reason: Error) => void) => {
-          zlib.gunzip(
-            data as unknown as Uint8Array,
-            (err: Error | null, result: Buffer) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve(result);
-              }
-            },
-          );
-        },
+      const ceiling: number = Math.max(
+        0,
+        Math.min(MAX_DECOMPRESSED_PROFILE_BYTES, budgetBytes),
       );
+
+      /*
+       * A spent budget cannot inflate anything, and zlib treats
+       * maxOutputLength: 0 as "no limit" rather than "nothing allowed", so
+       * refuse before calling it.
+       */
+      if (ceiling === 0) {
+        throw new PayloadTooLargeException(PYROSCOPE_TOO_LARGE_MESSAGE);
+      }
+
+      try {
+        return await gunzipAsync(data as unknown as Uint8Array, {
+          maxOutputLength: ceiling,
+        });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code === "ERR_BUFFER_TOO_LARGE") {
+          throw new PayloadTooLargeException(PYROSCOPE_TOO_LARGE_MESSAGE);
+        }
+
+        throw err;
+      }
     }
     return data;
   }

--- a/App/FeatureSet/Telemetry/Utils/OtelPayloadDecoder.ts
+++ b/App/FeatureSet/Telemetry/Utils/OtelPayloadDecoder.ts
@@ -56,10 +56,30 @@ const ProfilesData: protobuf.Type = ProfilesProto.lookupType("ProfilesData");
  * at the type level even though it is valid at runtime (same workaround
  * as the promisified gunzip in SessionReplayIngestService).
  */
-export const gunzipAsync: (buffer: Buffer | Uint8Array) => Promise<Buffer> =
-  promisify(zlib.gunzip) as unknown as (
-    buffer: Buffer | Uint8Array,
-  ) => Promise<Buffer>;
+export const gunzipAsync: (
+  buffer: Buffer | Uint8Array,
+  options?: zlib.ZlibOptions,
+) => Promise<Buffer> = promisify(zlib.gunzip) as unknown as (
+  buffer: Buffer | Uint8Array,
+  options?: zlib.ZlibOptions,
+) => Promise<Buffer>;
+
+/*
+ * Decompressed-payload ceiling for ONE queued OTLP body.
+ *
+ * The inflate runs in the BullMQ worker, where TELEMETRY_CONCURRENCY (100
+ * by default) jobs can be in flight on one pod, so an unbounded gunzip is
+ * unbounded a hundred times over. Nginx caps the COMPRESSED body at its
+ * 1 MB default on /otlp and at 4 MB on /telemetry, and gzip on OTLP
+ * protobuf runs about 5-15x, so a legitimate batch has an order of
+ * magnitude of headroom under this. A hostile one reaches four figures of
+ * amplification and would otherwise take the pod out.
+ *
+ * `maxOutputLength` is honoured because this is zlib's CONVENIENCE api.
+ * Node applies it on `gunzip`/`gunzipSync` only; on a `createGunzip`
+ * stream it is accepted and silently ignored.
+ */
+export const MAX_DECOMPRESSED_OTLP_BODY_BYTES: number = 64 * 1024 * 1024;
 
 export enum OtelPayloadFormat {
   Protobuf = "protobuf",
@@ -116,7 +136,9 @@ export default class OtelPayloadDecoder {
     }
 
     if (input.encoding === "gzip") {
-      raw = await gunzipAsync(raw);
+      raw = await gunzipAsync(raw, {
+        maxOutputLength: MAX_DECOMPRESSED_OTLP_BODY_BYTES,
+      });
     }
 
     if (input.format === OtelPayloadFormat.Json) {

--- a/App/Tests/Telemetry/OtelPayloadDecoderBufferPassthrough.test.ts
+++ b/App/Tests/Telemetry/OtelPayloadDecoderBufferPassthrough.test.ts
@@ -36,17 +36,38 @@ import zlib from "zlib";
  * `promisify(zlib.gunzip)` picks up the recording wrapper.
  */
 const mockGunzipReceivedInputs: Array<unknown> = [];
+const mockGunzipReceivedOptions: Array<unknown> = [];
 
 jest.mock("zlib", () => {
   const actualZlib: typeof import("zlib") = jest.requireActual("zlib");
   return {
     ...actualZlib,
+    /*
+     * zlib.gunzip is overloaded: (buf, cb) and (buf, options, cb). The
+     * decoder passes options (a decompression ceiling), so the wrapper has
+     * to handle BOTH shapes and forward them - a two-argument wrapper
+     * silently drops the options into the callback slot and every gzip
+     * test fails with "callback must be of type function".
+     */
     gunzip: (
       buffer: unknown,
-      callback: (error: Error | null, result: Buffer) => void,
+      optionsOrCallback: unknown,
+      maybeCallback?: (error: Error | null, result: Buffer) => void,
     ): void => {
       mockGunzipReceivedInputs.push(buffer);
-      actualZlib.gunzip(buffer as never, callback);
+
+      if (typeof optionsOrCallback === "function") {
+        mockGunzipReceivedOptions.push(undefined);
+        actualZlib.gunzip(buffer as never, optionsOrCallback as never);
+        return;
+      }
+
+      mockGunzipReceivedOptions.push(optionsOrCallback);
+      actualZlib.gunzip(
+        buffer as never,
+        optionsOrCallback as never,
+        maybeCallback as never,
+      );
     },
   };
 });
@@ -72,6 +93,7 @@ jest.mock("../../FeatureSet/Telemetry/Utils/TelemetryBodyStore", () => {
 });
 
 import OtelPayloadDecoder, {
+  MAX_DECOMPRESSED_OTLP_BODY_BYTES,
   OtelPayloadFormat,
   gunzipAsync,
 } from "../../FeatureSet/Telemetry/Utils/OtelPayloadDecoder";
@@ -291,6 +313,7 @@ beforeAll(() => {
 beforeEach(() => {
   mockBodyStoreBackingMap.clear();
   mockGunzipReceivedInputs.length = 0;
+  mockGunzipReceivedOptions.length = 0;
 });
 
 describe("OtelPayloadDecoder.decodeFromQueue — decoding correctness per format/encoding", () => {
@@ -430,6 +453,17 @@ describe("OtelPayloadDecoder.decodeFromQueue — Buffer passthrough (no copies)"
      */
     expect(mockGunzipReceivedInputs[0]).toBe(gzippedBuffer);
     expect(Buffer.isBuffer(mockGunzipReceivedInputs[0])).toBe(true);
+
+    /*
+     * The decompression ceiling has to actually REACH zlib. It is the only
+     * thing bounding this inflate, and the worker runs
+     * TELEMETRY_CONCURRENCY (100 by default) of them at once, so an
+     * option that quietly stopped being passed would be invisible until a
+     * pod died.
+     */
+    expect(mockGunzipReceivedOptions[0]).toEqual({
+      maxOutputLength: MAX_DECOMPRESSED_OTLP_BODY_BYTES,
+    });
   });
 
   test("json + gzip path: zlib.gunzip also receives the EXACT stored Buffer", async () => {

--- a/App/Tests/Telemetry/OtelPayloadDecoderDecompressionLimit.test.ts
+++ b/App/Tests/Telemetry/OtelPayloadDecoderDecompressionLimit.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The OTLP body is inflated in the BullMQ worker, not on the HTTP path -
+ * which is why an unbounded `gunzip` here was worse than it looked.
+ * TELEMETRY_CONCURRENCY defaults to 100, so one pod can have a hundred of
+ * these in flight; unbounded once is unbounded a hundred times over.
+ *
+ * The body arrives from Redis (TelemetryBodyStore), so these tests mock
+ * the store and drive decodeFromQueue directly - no infrastructure, and
+ * the assertion is about what the decoder does with the bytes.
+ */
+
+const storedBodies: Map<string, Buffer | null> = new Map<
+  string,
+  Buffer | null
+>();
+
+jest.mock("../../FeatureSet/Telemetry/Utils/TelemetryBodyStore", () => {
+  return {
+    __esModule: true,
+    default: {
+      readBody: jest.fn(async (key: unknown): Promise<Buffer | null> => {
+        return storedBodies.get(key as string) ?? null;
+      }),
+      storeBody: jest.fn(),
+      deleteBody: jest.fn(),
+    },
+  };
+});
+
+import OtelPayloadDecoder, {
+  MAX_DECOMPRESSED_OTLP_BODY_BYTES,
+  OtelPayloadFormat,
+  gunzipAsync,
+} from "../../FeatureSet/Telemetry/Utils/OtelPayloadDecoder";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+import { JSONObject } from "Common/Types/JSON";
+import zlib from "zlib";
+
+function gzip(buffer: Buffer): Buffer {
+  return zlib.gzipSync(buffer as unknown as Uint8Array);
+}
+
+let keySeq: number = 0;
+
+function store(body: Buffer): string {
+  const key: string = `telemetry:body:test-${++keySeq}`;
+  storedBodies.set(key, body);
+  return key;
+}
+
+async function decodeJson(body: Buffer): Promise<JSONObject> {
+  return await OtelPayloadDecoder.decodeFromQueue({
+    productType: ProductType.Logs,
+    format: OtelPayloadFormat.Json,
+    encoding: "gzip",
+    bodyKey: store(body),
+  });
+}
+
+beforeEach(() => {
+  storedBodies.clear();
+});
+
+describe("OtelPayloadDecoder - the ceiling", () => {
+  test("the ceiling is 64 MiB", () => {
+    expect(MAX_DECOMPRESSED_OTLP_BODY_BYTES).toBe(64 * 1024 * 1024);
+  });
+
+  test("a body over the ceiling is refused rather than inflated", async () => {
+    /*
+     * ~65 KB on the wire, 64 MiB + 1 once inflated. Before the ceiling
+     * this allocated all of it, per job, up to a hundred at a time.
+     */
+    const bomb: Buffer = gzip(
+      Buffer.alloc(MAX_DECOMPRESSED_OTLP_BODY_BYTES + 1),
+    );
+
+    expect(bomb.length).toBeLessThan(MAX_DECOMPRESSED_OTLP_BODY_BYTES / 500);
+
+    await expect(decodeJson(bomb)).rejects.toMatchObject({
+      code: "ERR_BUFFER_TOO_LARGE",
+    });
+  });
+
+  test("a real OTLP JSON body still decodes", async () => {
+    const payload: JSONObject = {
+      resourceLogs: [
+        {
+          resource: { attributes: [] },
+          scopeLogs: [{ logRecords: [{ body: { stringValue: "hello" } }] }],
+        },
+      ],
+    };
+
+    const decoded: JSONObject = await decodeJson(
+      gzip(Buffer.from(JSON.stringify(payload))),
+    );
+
+    expect(decoded).toEqual(payload);
+  });
+
+  test("a body just under the ceiling is accepted", async () => {
+    /*
+     * Deliberately built as valid JSON so this exercises the whole
+     * decode, not just the inflate: a 32 MiB string of one repeated
+     * character.
+     */
+    const filler: string = "a".repeat(32 * 1024 * 1024);
+    const json: string = JSON.stringify({
+      resourceLogs: [{ resource: { attributes: [] }, scopeLogs: [] }],
+      filler: filler,
+    });
+
+    expect(Buffer.byteLength(json)).toBeLessThan(
+      MAX_DECOMPRESSED_OTLP_BODY_BYTES,
+    );
+
+    const decoded: JSONObject = await decodeJson(gzip(Buffer.from(json)));
+
+    expect((decoded["filler"] as string).length).toBe(filler.length);
+  });
+
+  test("an identity-encoded body never touches the inflate", async () => {
+    const payload: JSONObject = { resourceLogs: [] };
+
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: store(Buffer.from(JSON.stringify(payload))),
+    });
+
+    expect(decoded).toEqual(payload);
+  });
+
+  test("a lost body (expired TTL) is still an empty object, not an error", async () => {
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "gzip",
+      bodyKey: "telemetry:body:gone",
+    });
+
+    expect(decoded).toEqual({});
+  });
+});
+
+describe("OtelPayloadDecoder.gunzipAsync - the exported helper", () => {
+  test("still accepts a bare buffer with no options (old signature)", async () => {
+    const inflated: Buffer = await gunzipAsync(gzip(Buffer.from("plain")));
+
+    expect(inflated.toString()).toBe("plain");
+  });
+
+  test("still accepts a plain Uint8Array", async () => {
+    const compressed: Buffer = gzip(Buffer.from("plain"));
+
+    const inflated: Buffer = await gunzipAsync(new Uint8Array(compressed));
+
+    expect(inflated.toString()).toBe("plain");
+  });
+
+  test("honours maxOutputLength when it is passed", async () => {
+    const compressed: Buffer = gzip(Buffer.alloc(4 * 1024 * 1024));
+
+    await expect(
+      gunzipAsync(compressed, { maxOutputLength: 1024 }),
+    ).rejects.toMatchObject({ code: "ERR_BUFFER_TOO_LARGE" });
+  });
+
+  test("a payload exactly at maxOutputLength is allowed through", async () => {
+    const compressed: Buffer = gzip(Buffer.alloc(1024));
+
+    const inflated: Buffer = await gunzipAsync(compressed, {
+      maxOutputLength: 1024,
+    });
+
+    expect(inflated.length).toBe(1024);
+  });
+});

--- a/App/Tests/Telemetry/OtelRequestMiddlewareByteCap.test.ts
+++ b/App/Tests/Telemetry/OtelRequestMiddlewareByteCap.test.ts
@@ -1,0 +1,360 @@
+import OpenTelemetryRequestMiddleware, {
+  MAX_OTLP_REQUEST_BYTES,
+} from "../../FeatureSet/Telemetry/Middleware/OtelRequestMiddleware";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import { describe, expect, test } from "@jest/globals";
+import { EventEmitter } from "events";
+
+/*
+ * OtelRequestMiddleware.parseBody reads the socket itself, which means
+ * none of StartServer's global body-parser limits apply to it - it is
+ * mounted on routes that StartServer's dispatcher deliberately bypasses.
+ * Until this cap existed the only bound on an OTLP ingest body was
+ * whatever the ingress happened to allow, and a deployment reached
+ * directly had none at all.
+ *
+ * SessionReplayRequestMiddleware's header comment called this out
+ * explicitly ("the byte cap the OTLP equivalent does not have"); these
+ * tests are that comment turned into an assertion.
+ */
+
+interface FakeRequest extends EventEmitter {
+  body?: unknown;
+  headers: Record<string, string>;
+  destroy: () => void;
+  resume: () => void;
+  destroyed: boolean;
+  resumed: boolean;
+}
+
+interface FakeResponse {
+  statusCode: number;
+  headersSent: boolean;
+  jsonBody: unknown;
+  status: (code: number) => FakeResponse;
+  json: (body: unknown) => FakeResponse;
+}
+
+function buildRequest(headers?: Record<string, string>): FakeRequest {
+  const req: FakeRequest = new EventEmitter() as FakeRequest;
+
+  req.headers = headers || {};
+  req.destroyed = false;
+  req.resumed = false;
+  req.destroy = (): void => {
+    req.destroyed = true;
+  };
+  req.resume = (): void => {
+    req.resumed = true;
+  };
+
+  return req;
+}
+
+function buildResponse(): FakeResponse {
+  const res: FakeResponse = {
+    statusCode: 0,
+    headersSent: false,
+    jsonBody: undefined,
+    status: (code: number): FakeResponse => {
+      res.statusCode = code;
+      return res;
+    },
+    json: (body: unknown): FakeResponse => {
+      res.jsonBody = body;
+      res.headersSent = true;
+      return res;
+    },
+  };
+
+  return res;
+}
+
+interface Harness {
+  req: FakeRequest;
+  res: FakeResponse;
+  nextCalls: Array<unknown>;
+  done: Promise<void>;
+}
+
+function start(headers?: Record<string, string>): Harness {
+  const req: FakeRequest = buildRequest(headers);
+  const res: FakeResponse = buildResponse();
+  const nextCalls: Array<unknown> = [];
+
+  const done: Promise<void> = OpenTelemetryRequestMiddleware.parseBody(
+    req as unknown as ExpressRequest,
+    res as unknown as ExpressResponse,
+    ((err?: unknown): void => {
+      nextCalls.push(err);
+    }) as NextFunction,
+  );
+
+  return { req: req, res: res, nextCalls: nextCalls, done: done };
+}
+
+describe("OtelRequestMiddleware.parseBody - the body still gets through", () => {
+  test("a normal body is handed on as a Buffer", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.from("hello "));
+    harness.req.emit("data", Buffer.from("otlp"));
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect(harness.nextCalls).toEqual([undefined]);
+    expect(Buffer.isBuffer(harness.req.body)).toBe(true);
+    expect((harness.req.body as Buffer).toString()).toBe("hello otlp");
+    expect(harness.res.statusCode).toBe(0);
+  });
+
+  test("string chunks are decoded as utf-8, as before", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", "héllo");
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect((harness.req.body as Buffer).toString("utf-8")).toBe("héllo");
+  });
+
+  test("an empty body is an empty Buffer, not a rejection", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect(harness.nextCalls).toEqual([undefined]);
+    expect((harness.req.body as Buffer).length).toBe(0);
+  });
+
+  test("a body one byte UNDER the cap is accepted", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.alloc(MAX_OTLP_REQUEST_BYTES - 1));
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(0);
+    expect((harness.req.body as Buffer).length).toBe(
+      MAX_OTLP_REQUEST_BYTES - 1,
+    );
+  });
+
+  test("a body exactly ON the cap is accepted", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.alloc(MAX_OTLP_REQUEST_BYTES));
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(0);
+    expect((harness.req.body as Buffer).length).toBe(MAX_OTLP_REQUEST_BYTES);
+  });
+
+  test("an already-parsed body short-circuits rather than double-reading", async () => {
+    const harness: Harness = start();
+    harness.req.body = Buffer.from("set upstream");
+
+    /* parseBody was already called by start(); call again on the same req. */
+    const nextCalls: Array<unknown> = [];
+
+    await OpenTelemetryRequestMiddleware.parseBody(
+      harness.req as unknown as ExpressRequest,
+      harness.res as unknown as ExpressResponse,
+      ((err?: unknown): void => {
+        nextCalls.push(err);
+      }) as NextFunction,
+    );
+
+    expect(nextCalls).toEqual([undefined]);
+    expect((harness.req.body as Buffer).toString()).toBe("set upstream");
+
+    harness.req.emit("end");
+    await harness.done;
+  });
+});
+
+describe("OtelRequestMiddleware.parseBody - the cap", () => {
+  test("one byte OVER the cap is a 413 and next() never runs", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.alloc(MAX_OTLP_REQUEST_BYTES + 1));
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(413);
+    expect(harness.nextCalls).toHaveLength(0);
+    expect(harness.req.body).toBeUndefined();
+    expect(
+      (harness.res.jsonBody as { error: string; message: string }).error,
+    ).toBe("payload-too-large");
+  });
+
+  test("the cap counts ACROSS chunks, not per chunk", async () => {
+    const harness: Harness = start();
+
+    /* Three chunks, each comfortably legal, together over the line. */
+    const third: number = Math.ceil(MAX_OTLP_REQUEST_BYTES / 3) + 1;
+
+    harness.req.emit("data", Buffer.alloc(third));
+    expect(harness.res.statusCode).toBe(0);
+
+    harness.req.emit("data", Buffer.alloc(third));
+    expect(harness.res.statusCode).toBe(0);
+
+    harness.req.emit("data", Buffer.alloc(third));
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(413);
+    expect(harness.nextCalls).toHaveLength(0);
+  });
+
+  test("an over-cap Content-Length is refused before a byte is read", async () => {
+    const harness: Harness = start({
+      "content-length": String(MAX_OTLP_REQUEST_BYTES + 1),
+    });
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(413);
+    expect(harness.nextCalls).toHaveLength(0);
+
+    /* Nothing was ever wired to the stream - the cheapest possible refusal. */
+    expect(harness.req.listenerCount("data")).toBe(0);
+    expect(harness.req.listenerCount("end")).toBe(0);
+  });
+
+  test("a Content-Length at the cap is not refused", async () => {
+    const harness: Harness = start({
+      "content-length": String(MAX_OTLP_REQUEST_BYTES),
+    });
+
+    harness.req.emit("data", Buffer.from("small"));
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(0);
+    expect(harness.nextCalls).toEqual([undefined]);
+  });
+
+  test("a garbage Content-Length is ignored rather than trusted", async () => {
+    const harness: Harness = start({ "content-length": "not-a-number" });
+
+    harness.req.emit("data", Buffer.from("ok"));
+    harness.req.emit("end");
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(0);
+    expect(harness.nextCalls).toEqual([undefined]);
+  });
+
+  test("the 413 is answered, the socket is not destroyed, and the rest is drained", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.alloc(MAX_OTLP_REQUEST_BYTES + 1));
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(413);
+    /*
+     * A destroyed socket reads as a network error, and OTel exporters
+     * retry those. 413 is a 4xx, which the spec tells them not to retry -
+     * so a misconfigured batch size stops instead of looping.
+     */
+    expect(harness.req.destroyed).toBe(false);
+    expect(harness.req.resumed).toBe(true);
+  });
+
+  test("data arriving after the 413 does not produce a second response", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.alloc(MAX_OTLP_REQUEST_BYTES + 1));
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(413);
+
+    const firstBody: unknown = harness.res.jsonBody;
+
+    harness.res.statusCode = 0;
+    harness.req.emit("data", Buffer.alloc(1024));
+    harness.req.emit("end");
+
+    expect(harness.res.statusCode).toBe(0);
+    expect(harness.res.jsonBody).toBe(firstBody);
+    expect(harness.nextCalls).toHaveLength(0);
+  });
+
+  test("a response that already has headers is not written to again", async () => {
+    const harness: Harness = start({
+      "content-length": String(MAX_OTLP_REQUEST_BYTES + 1),
+    });
+
+    await harness.done;
+    expect(harness.res.statusCode).toBe(413);
+
+    /* Second request, response already committed by something upstream. */
+    const req: FakeRequest = buildRequest({
+      "content-length": String(MAX_OTLP_REQUEST_BYTES + 1),
+    });
+    const res: FakeResponse = buildResponse();
+    res.headersSent = true;
+
+    await OpenTelemetryRequestMiddleware.parseBody(
+      req as unknown as ExpressRequest,
+      res as unknown as ExpressResponse,
+      ((): void => {}) as NextFunction,
+    );
+
+    expect(res.statusCode).toBe(0);
+    expect(res.jsonBody).toBeUndefined();
+  });
+
+  test("the cap is the app-wide 50 MiB body-parser number", () => {
+    expect(MAX_OTLP_REQUEST_BYTES).toBe(50 * 1024 * 1024);
+  });
+});
+
+describe("OtelRequestMiddleware.parseBody - stream errors", () => {
+  test("a request error reaches Express instead of hanging", async () => {
+    const harness: Harness = start();
+
+    const failure: Error = new Error("ECONNRESET");
+
+    harness.req.emit("data", Buffer.from("partial"));
+    harness.req.emit("error", failure);
+
+    await harness.done;
+
+    expect(harness.nextCalls).toEqual([failure]);
+    expect(harness.res.statusCode).toBe(0);
+    expect(harness.req.body).toBeUndefined();
+  });
+
+  test("an error AFTER a 413 does not turn into a second outcome", async () => {
+    const harness: Harness = start();
+
+    harness.req.emit("data", Buffer.alloc(MAX_OTLP_REQUEST_BYTES + 1));
+
+    await harness.done;
+
+    expect(harness.res.statusCode).toBe(413);
+
+    harness.req.emit("error", new Error("late"));
+
+    expect(harness.nextCalls).toHaveLength(0);
+  });
+});

--- a/App/Tests/Telemetry/PyroscopeDecompressionLimits.test.ts
+++ b/App/Tests/Telemetry/PyroscopeDecompressionLimits.test.ts
@@ -1,0 +1,562 @@
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Pyroscope ingest used to hand the request payload to a bare
+ * `zlib.gunzip` with no output ceiling - the same decompression-bomb
+ * shape GHSA-cp58-wc9q-qv53 fixed in the global request reader, one
+ * layer in. It sits behind TelemetryIngest.isAuthorizedServiceMiddleware,
+ * so it needs a valid project ingest key, but any holder of one could
+ * turn the ~1 MiB nginx allows on /pyroscope into roughly a gigabyte of
+ * resident Buffer.
+ *
+ * Two ceilings, because on the push route neither one alone is enough:
+ *
+ *   - the PER-PROFILE ceiling bounds one gzip member;
+ *   - the PER-REQUEST budget bounds the sum, because
+ *     ingestPyroscopePush walks series[].samples[] and inflates each one,
+ *     so a per-profile cap on its own just multiplies by the sample
+ *     count.
+ */
+
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/Queue/ProfilesQueueService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        addProfileIngestJob: jest.fn(async (): Promise<void> => {
+          return undefined;
+        }),
+      },
+    };
+  },
+);
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    getLogAttributesFromRequest: jest.fn().mockReturnValue({}),
+  };
+});
+
+import PyroscopeIngestService, {
+  MAX_DECOMPRESSED_PROFILE_BYTES,
+  MAX_DECOMPRESSED_REQUEST_BYTES,
+} from "../../FeatureSet/Telemetry/Services/PyroscopeIngestService";
+import { TelemetryRequest } from "Common/Server/Middleware/TelemetryIngest";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import Exception from "Common/Types/Exception/Exception";
+import ExceptionCode from "Common/Types/Exception/ExceptionCode";
+import ObjectID from "Common/Types/ObjectID";
+import protobuf from "protobufjs";
+import path from "path";
+import zlib from "zlib";
+
+/*
+ * The ceilings under test are 32 and 64 MiB, so the fixtures that probe
+ * them are tens of MiB of real gzip and real inflation, and an ACCEPTED
+ * large sample is then pprof-parsed (protobufjs spends ~4s per 24 MiB).
+ * None of that fits in the 30s App default.
+ */
+jest.setTimeout(180_000);
+
+const PushProto: protobuf.Root = protobuf.loadSync(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "FeatureSet",
+    "Telemetry",
+    "ProtoFiles",
+    "pyroscope",
+    "push.proto",
+  ),
+);
+const PushRequestType: protobuf.Type = PushProto.lookupType(
+  "push.v1.PushRequest",
+);
+
+function gzip(buffer: Buffer): Buffer {
+  return zlib.gzipSync(buffer as unknown as Uint8Array);
+}
+
+/*
+ * A gzip member that inflates to `bytes`. Zero-filled, so it compresses at
+ * roughly a thousand to one - which is the whole point: the fixtures below
+ * are tens of kilobytes and the payloads they stand for are hundreds of
+ * megabytes.
+ */
+function bombOf(bytes: number): Buffer {
+  return gzip(Buffer.alloc(bytes));
+}
+
+/* Folded/collapsed profile text, which the ingest path parses without pprof. */
+function foldedText(): Buffer {
+  return Buffer.from("main;work;inner 12\nmain;idle 3\n");
+}
+
+interface Outcome {
+  req: TelemetryRequest;
+  nextCalls: Array<unknown>;
+  responded: boolean;
+}
+
+function buildResponse(onSend: () => void): ExpressResponse {
+  return {
+    status: (): unknown => {
+      return { send: onSend, json: onSend };
+    },
+    send: onSend,
+    json: onSend,
+    end: onSend,
+    setHeader: (): void => {},
+    headersSent: false,
+  } as unknown as ExpressResponse;
+}
+
+async function ingestProfile(options: {
+  body?: unknown;
+  files?: Array<{ fieldname: string; buffer: Buffer }>;
+  query?: Record<string, string>;
+}): Promise<Outcome> {
+  const nextCalls: Array<unknown> = [];
+  let responded: boolean = false;
+
+  const req: TelemetryRequest = {
+    projectId: ObjectID.generate(),
+    query: options.query || {},
+    headers: {},
+    body: options.body,
+    files: options.files,
+  } as unknown as TelemetryRequest;
+
+  await PyroscopeIngestService.ingestPyroscopeProfile(
+    req as unknown as ExpressRequest,
+    buildResponse((): void => {
+      responded = true;
+    }),
+    ((err?: unknown): void => {
+      nextCalls.push(err);
+    }) as NextFunction,
+  );
+
+  return { req: req, nextCalls: nextCalls, responded: responded };
+}
+
+async function ingestPush(rawBody: Buffer): Promise<Outcome> {
+  const nextCalls: Array<unknown> = [];
+  let responded: boolean = false;
+
+  const req: TelemetryRequest = {
+    projectId: ObjectID.generate(),
+    query: {},
+    headers: {},
+    body: rawBody,
+  } as unknown as TelemetryRequest;
+
+  await PyroscopeIngestService.ingestPyroscopePush(
+    req as unknown as ExpressRequest,
+    buildResponse((): void => {
+      responded = true;
+    }),
+    ((err?: unknown): void => {
+      nextCalls.push(err);
+    }) as NextFunction,
+  );
+
+  return { req: req, nextCalls: nextCalls, responded: responded };
+}
+
+function encodePush(
+  samples: Array<Buffer>,
+  options?: { padBytes?: number },
+): Buffer {
+  /*
+   * `padBytes` inflates the ENVELOPE without adding samples, by parking
+   * the bytes in a label value the ingest path never reads (__name__ is
+   * the only label it looks at). Used to spend the request budget before
+   * the sample loop starts.
+   */
+  const labels: Array<{ name: string; value: string }> = [
+    { name: "__name__", value: "myapp.cpu" },
+  ];
+
+  if (options?.padBytes) {
+    labels.push({ name: "pad", value: "a".repeat(options.padBytes) });
+  }
+
+  const message: protobuf.Message = PushRequestType.create({
+    series: [
+      {
+        labels: labels,
+        samples: samples.map((s: Buffer) => {
+          return { rawProfile: new Uint8Array(s), id: "" };
+        }),
+      },
+    ],
+  });
+
+  return Buffer.from(PushRequestType.encode(message).finish());
+}
+
+function thrownException(outcome: Outcome): Exception | undefined {
+  return outcome.nextCalls[0] as Exception | undefined;
+}
+
+describe("Pyroscope ingest - the ceilings are set where they were measured", () => {
+  test("the per-profile ceiling is 32 MiB and the per-request budget is 64 MiB", () => {
+    expect(MAX_DECOMPRESSED_PROFILE_BYTES).toBe(32 * 1024 * 1024);
+    expect(MAX_DECOMPRESSED_REQUEST_BYTES).toBe(64 * 1024 * 1024);
+  });
+
+  test("the budget is larger than one profile, so a single profile is never budget-limited", () => {
+    expect(MAX_DECOMPRESSED_REQUEST_BYTES).toBeGreaterThan(
+      MAX_DECOMPRESSED_PROFILE_BYTES,
+    );
+  });
+});
+
+describe("Pyroscope /ingest - decompression bombs", () => {
+  test("a profile over the per-profile ceiling is refused with 413", async () => {
+    const outcome: Outcome = await ingestProfile({
+      body: bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1),
+      query: { format: "folded" },
+    });
+
+    const err: Exception | undefined = thrownException(outcome);
+
+    expect(err).toBeInstanceOf(Exception);
+    expect(err!.code).toBe(ExceptionCode.PayloadTooLargeException);
+    expect(err!.code).toBe(413);
+    expect(outcome.responded).toBe(false);
+  });
+
+  test("the bomb fixture really is a bomb - four figures of amplification", () => {
+    const compressed: Buffer = bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1);
+
+    expect(compressed.length).toBeLessThan(
+      MAX_DECOMPRESSED_PROFILE_BYTES / 500,
+    );
+  });
+
+  test("the refusal does not leak how much was received or how much is left", async () => {
+    const outcome: Outcome = await ingestProfile({
+      body: bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1),
+    });
+
+    const message: string = thrownException(outcome)!.message;
+
+    expect(message).not.toMatch(/\d{4,}/);
+    expect(message.toLowerCase()).toContain("too large");
+  });
+
+  test("a bomb arriving as a multipart file is refused too", async () => {
+    const outcome: Outcome = await ingestProfile({
+      files: [
+        {
+          fieldname: "profile",
+          buffer: bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1),
+        },
+      ],
+      query: { format: "folded" },
+    });
+
+    expect(thrownException(outcome)!.code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+  });
+
+  test("a legitimate gzipped profile still goes through", async () => {
+    const outcome: Outcome = await ingestProfile({
+      body: gzip(foldedText()),
+      query: { format: "folded", name: "myapp.cpu" },
+    });
+
+    expect(outcome.nextCalls).toHaveLength(0);
+    expect(outcome.responded).toBe(true);
+    expect(
+      (outcome.req.body as Record<string, unknown>)["resourceProfiles"],
+    ).toBeDefined();
+  });
+
+  test("an uncompressed profile is untouched by the ceiling", async () => {
+    const outcome: Outcome = await ingestProfile({
+      body: foldedText(),
+      query: { format: "folded", name: "myapp.cpu" },
+    });
+
+    expect(outcome.nextCalls).toHaveLength(0);
+    expect(outcome.responded).toBe(true);
+  });
+
+  test("a gzipped profile comfortably under the ceiling is accepted", async () => {
+    /* 5 MiB of real folded text - well within the ceiling, far past a chunk. */
+    const big: Buffer = Buffer.from("main;work;inner 12\n".repeat(300_000));
+
+    expect(big.length).toBeGreaterThan(5 * 1024 * 1024);
+    expect(big.length).toBeLessThan(MAX_DECOMPRESSED_PROFILE_BYTES);
+
+    const outcome: Outcome = await ingestProfile({
+      body: gzip(big),
+      query: { format: "folded", name: "myapp.cpu" },
+    });
+
+    expect(outcome.nextCalls).toHaveLength(0);
+    expect(outcome.responded).toBe(true);
+  });
+
+  test("a corrupt gzip payload is still a decode error, not a size error", async () => {
+    const corrupt: Buffer = Buffer.concat([
+      Buffer.from([0x1f, 0x8b]) as unknown as Uint8Array,
+      Buffer.from("this is not a gzip stream") as unknown as Uint8Array,
+    ]);
+
+    const outcome: Outcome = await ingestProfile({ body: corrupt });
+
+    const err: unknown = outcome.nextCalls[0];
+
+    expect(err).toBeDefined();
+    expect((err as Exception).code).not.toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+  });
+});
+
+describe("Pyroscope /push - the per-request budget", () => {
+  test("one oversized embedded sample is refused with 413", async () => {
+    const outcome: Outcome = await ingestPush(
+      encodePush([bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1)]),
+    );
+
+    expect(thrownException(outcome)!.code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect(outcome.responded).toBe(false);
+  });
+
+  test("the budget is SHARED - an envelope that ate most of it makes an otherwise-legal sample illegal", async () => {
+    /*
+     * The case a per-payload cap can never catch. The sample below is
+     * 30 MiB inflated, comfortably inside the 32 MiB per-profile ceiling,
+     * and the control test underneath proves it is accepted on its own.
+     * It is refused here only because the gzipped ENVELOPE already spent
+     * ~40 MiB of the 64 MiB request budget.
+     *
+     * Padding the envelope rather than sending several large samples is
+     * deliberate: every sample that IS accepted then gets pprof-parsed,
+     * and protobufjs takes ~4s per 24 MiB of it. This shape proves the
+     * same property - the allowance is per request, not per payload -
+     * without paying for parses the assertion does not care about.
+     */
+    const envelope: Buffer = encodePush([bombOf(30 * 1024 * 1024)], {
+      padBytes: 40 * 1024 * 1024,
+    });
+
+    const outcome: Outcome = await ingestPush(gzip(envelope));
+
+    expect(thrownException(outcome)!.code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect(outcome.responded).toBe(false);
+  });
+
+  test("control: the SAME sample is accepted when the envelope did not eat the budget", async () => {
+    /*
+     * Same 30 MiB sample, identity-encoded envelope. If this were refused
+     * too, the test above would be measuring the per-profile ceiling
+     * rather than the shared budget and would prove nothing.
+     */
+    const outcome: Outcome = await ingestPush(
+      encodePush([bombOf(30 * 1024 * 1024)]),
+    );
+
+    expect(outcome.nextCalls).toHaveLength(0);
+    expect(outcome.responded).toBe(true);
+  });
+
+  test("a gzipped push ENVELOPE over the ceiling is refused before any protobuf decode", async () => {
+    const outcome: Outcome = await ingestPush(
+      bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1),
+    );
+
+    expect(thrownException(outcome)!.code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+  });
+
+  test("an empty push body is a 400, not a 413", async () => {
+    const outcome: Outcome = await ingestPush(Buffer.alloc(0));
+
+    const err: Exception | undefined = thrownException(outcome);
+
+    expect(err!.code).toBe(ExceptionCode.BadDataException);
+  });
+
+  test("a push with no series responds OK and enqueues nothing", async () => {
+    const outcome: Outcome = await ingestPush(encodePush([]));
+
+    expect(outcome.nextCalls).toHaveLength(0);
+    expect(outcome.responded).toBe(true);
+  });
+});
+
+/*
+ * The budget arithmetic itself, exercised directly.
+ *
+ * `decompressIfNeeded` is private, so this reaches it through a cast. That
+ * is deliberate: the arithmetic is what an attacker actually plays
+ * against, the boundaries are exact, and driving them through the HTTP
+ * entry points would cost tens of seconds of inflation per assertion to
+ * prove the same four facts.
+ */
+type DecompressFunction = (
+  data: Buffer,
+  budgetBytes: number,
+) => Promise<Buffer>;
+
+const decompressIfNeeded: DecompressFunction = (
+  PyroscopeIngestService as unknown as {
+    decompressIfNeeded: DecompressFunction;
+  }
+).decompressIfNeeded.bind(PyroscopeIngestService) as DecompressFunction;
+
+describe("decompressIfNeeded - the ceiling arithmetic", () => {
+  test("inflates normally when the budget is ample", async () => {
+    const out: Buffer = await decompressIfNeeded(
+      gzip(Buffer.from("profile bytes")),
+      MAX_DECOMPRESSED_REQUEST_BYTES,
+    );
+
+    expect(out.toString()).toBe("profile bytes");
+  });
+
+  test("a payload exactly AT the remaining budget is allowed", async () => {
+    const out: Buffer = await decompressIfNeeded(bombOf(1024), 1024);
+
+    expect(out.length).toBe(1024);
+  });
+
+  test("one byte over the remaining budget is refused", async () => {
+    await expect(decompressIfNeeded(bombOf(1025), 1024)).rejects.toMatchObject({
+      code: ExceptionCode.PayloadTooLargeException,
+    });
+  });
+
+  test("the per-profile ceiling still applies when the budget is larger", async () => {
+    await expect(
+      decompressIfNeeded(
+        bombOf(MAX_DECOMPRESSED_PROFILE_BYTES + 1),
+        MAX_DECOMPRESSED_REQUEST_BYTES,
+      ),
+    ).rejects.toMatchObject({
+      code: ExceptionCode.PayloadTooLargeException,
+    });
+  });
+
+  test("an EXHAUSTED budget refuses instead of meaning 'unlimited'", async () => {
+    /*
+     * zlib reads maxOutputLength: 0 as "no limit", not "nothing allowed",
+     * so a spent budget would otherwise reopen the hole completely - the
+     * exact moment the guard matters most.
+     */
+    await expect(
+      decompressIfNeeded(bombOf(64 * 1024 * 1024), 0),
+    ).rejects.toMatchObject({ code: ExceptionCode.PayloadTooLargeException });
+  });
+
+  test("a negative budget is treated as exhausted, not as unlimited", async () => {
+    await expect(
+      decompressIfNeeded(bombOf(1024 * 1024), -1),
+    ).rejects.toMatchObject({
+      code: ExceptionCode.PayloadTooLargeException,
+    });
+  });
+
+  test("identity bytes pass through untouched, whatever the budget", async () => {
+    const plain: Buffer = Buffer.from("not gzip at all");
+
+    const out: Buffer = await decompressIfNeeded(plain, 0);
+
+    /* Same object: no copy, no inflate, no budget spent. */
+    expect(out).toBe(plain);
+  });
+
+  test("a payload whose first two bytes are not the gzip magic is not inflated", async () => {
+    const plain: Buffer = Buffer.from([0x1f, 0x00, 0x01, 0x02]);
+
+    const out: Buffer = await decompressIfNeeded(plain, 0);
+
+    expect(out).toBe(plain);
+  });
+
+  test("a corrupt gzip stream surfaces as a decode error, not a size error", async () => {
+    const corrupt: Buffer = Buffer.concat([
+      Buffer.from([0x1f, 0x8b]) as unknown as Uint8Array,
+      Buffer.from("garbage") as unknown as Uint8Array,
+    ]);
+
+    await expect(
+      decompressIfNeeded(corrupt, MAX_DECOMPRESSED_REQUEST_BYTES),
+    ).rejects.not.toMatchObject({
+      code: ExceptionCode.PayloadTooLargeException,
+    });
+  });
+});
+
+/*
+ * The reason `decompressIfNeeded` uses zlib's CONVENIENCE api rather than a
+ * stream. Node honours `maxOutputLength` on gunzip/gunzipSync only; on a
+ * createGunzip STREAM it is accepted and silently ignored, so "simplifying"
+ * this into a stream would remove the ceiling while looking like it kept
+ * it. If a future Node starts honouring it, this test fails and the choice
+ * can be revisited.
+ */
+describe("maxOutputLength only works on the convenience api", () => {
+  test("gunzipSync honours it", () => {
+    const compressed: Buffer = bombOf(8 * 1024 * 1024);
+
+    expect(() => {
+      zlib.gunzipSync(compressed as unknown as Uint8Array, {
+        maxOutputLength: 1024 * 1024,
+      });
+    }).toThrow();
+  });
+
+  test("createGunzip does not", async () => {
+    const compressed: Buffer = bombOf(8 * 1024 * 1024);
+
+    const emitted: number = await new Promise<number>(
+      (resolve: (value: number) => void): void => {
+        const stream: zlib.Gunzip = zlib.createGunzip({
+          maxOutputLength: 1024 * 1024,
+        });
+
+        let out: number = 0;
+
+        stream.on("data", (chunk: Buffer): void => {
+          out += chunk.length;
+        });
+        stream.on("error", (): void => {
+          resolve(-1);
+        });
+        stream.on("end", (): void => {
+          resolve(out);
+        });
+
+        stream.end(compressed as unknown as Uint8Array);
+      },
+    );
+
+    expect(emitted).toBe(8 * 1024 * 1024);
+  });
+});

--- a/Common/Server/Middleware/MultipartFormData.ts
+++ b/Common/Server/Middleware/MultipartFormData.ts
@@ -1,17 +1,101 @@
+import BadRequestException from "../../Types/Exception/BadRequestException";
+import PayloadTooLargeException from "../../Types/Exception/PayloadTooLargeException";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../Utils/Express";
 import multer from "multer";
 import { RequestHandler } from "express";
+
+/*
+ * Ceilings for multipart bodies.
+ *
+ * memoryStorage means every part is buffered in the process, and both
+ * routes that mount this middleware run it BEFORE their auth check -
+ * Pyroscope ingest before isAuthorizedServiceMiddleware, SendGrid inbound
+ * before the webhook secret is verified. So these are the limits an
+ * unauthenticated caller is held to, and multer's defaults leave most of
+ * them at Infinity: file size, file count, field count and part count are
+ * all unbounded out of the box (only fieldSize has a default, 1 MB).
+ *
+ * The sizes match the 50 MiB body-parser limit the rest of the app uses,
+ * and nginx cuts the shipped deployment lower still (50M on
+ * /incoming-email, its 1M default on /pyroscope). The COUNTS are the part
+ * that was genuinely missing: without them a body of ten thousand
+ * one-byte parts costs ten thousand allocations and passes every size
+ * check.
+ */
+export const MAX_MULTIPART_FILE_BYTES: number = 50 * 1024 * 1024;
+export const MAX_MULTIPART_FIELD_BYTES: number = 25 * 1024 * 1024;
+export const MAX_MULTIPART_FILES: number = 50;
+export const MAX_MULTIPART_FIELDS: number = 200;
 
 /*
  * Configure multer for handling multipart/form-data
  * Uses memory storage to store files in memory as Buffer objects
  */
-const upload: multer.Multer = multer({ storage: multer.memoryStorage() });
+const upload: multer.Multer = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_MULTIPART_FILE_BYTES,
+    fieldSize: MAX_MULTIPART_FIELD_BYTES,
+    files: MAX_MULTIPART_FILES,
+    fields: MAX_MULTIPART_FIELDS,
+    /*
+     * Parts are files + fields, so this has to allow both in full or it
+     * would be the effective limit and the two above would never fire.
+     */
+    parts: MAX_MULTIPART_FILES + MAX_MULTIPART_FIELDS,
+  },
+});
+
+const uploadAny: RequestHandler = upload.any() as unknown as RequestHandler;
+
+/*
+ * The LIMIT_* codes that mean "you sent too much". LIMIT_UNEXPECTED_FILE
+ * is deliberately absent: it means the body named a field the route did
+ * not ask for, which is a malformed request rather than an oversized one.
+ * (`.any()` accepts every field name, so it should not arise here - the
+ * distinction is kept so this stays correct if the mount ever narrows.)
+ */
+const TOO_LARGE_CODES: Set<string> = new Set<string>([
+  "LIMIT_PART_COUNT",
+  "LIMIT_FILE_SIZE",
+  "LIMIT_FILE_COUNT",
+  "LIMIT_FIELD_KEY",
+  "LIMIT_FIELD_VALUE",
+  "LIMIT_FIELD_COUNT",
+]);
 
 /*
  * Middleware for handling any file uploads (multipart/form-data)
  * This is useful for webhooks that send data as multipart/form-data (e.g., SendGrid inbound email)
+ *
+ * Wrapped so a limit breach answers 413 rather than 500. multer signals
+ * every limit with a MulterError whose `code` is one of the LIMIT_*
+ * values, and nothing downstream knows what those mean - the generic
+ * error handler would turn a caller's oversized upload into a server
+ * error and page whoever is on call for it.
  */
-const MultipartFormDataMiddleware: RequestHandler =
-  upload.any() as unknown as RequestHandler;
+const MultipartFormDataMiddleware: RequestHandler = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+): void => {
+  uploadAny(req, res, (err: unknown): void => {
+    if (err instanceof multer.MulterError) {
+      const message: string = `Multipart request rejected: ${err.code}.`;
+
+      return next(
+        TOO_LARGE_CODES.has(err.code)
+          ? new PayloadTooLargeException(message)
+          : new BadRequestException(message),
+      );
+    }
+
+    return next(err);
+  });
+};
 
 export default MultipartFormDataMiddleware;

--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -16,8 +16,9 @@ import UpdateBy from "../Types/Database/UpdateBy";
 import logger, { LogAttributes } from "../Utils/Logger";
 import Errors from "../Utils/Errors";
 import ProductAnalytics from "../Utils/ProductAnalytics";
-import MarketingEventUtil from "../Utils/Marketing/MarketingEventUtil";
-import { utmAnalyticsProperties } from "../Utils/Marketing/MarketingEventUtil";
+import MarketingEventUtil, {
+  utmAnalyticsProperties,
+} from "../Utils/Marketing/MarketingEventUtil";
 import { MarketingEventType } from "../../Types/Marketing/MarketingEvent";
 import {
   UtmPropertyKeys,

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -42,8 +42,9 @@ import TeamMember from "../../Models/DatabaseModels/TeamMember";
 import Model from "../../Models/DatabaseModels/User";
 import SlackUtil from "../Utils/Workspace/Slack/Slack";
 import ProductAnalytics from "../Utils/ProductAnalytics";
-import MarketingEventUtil from "../Utils/Marketing/MarketingEventUtil";
-import { utmAnalyticsProperties } from "../Utils/Marketing/MarketingEventUtil";
+import MarketingEventUtil, {
+  utmAnalyticsProperties,
+} from "../Utils/Marketing/MarketingEventUtil";
 import { MarketingEventType } from "../../Types/Marketing/MarketingEvent";
 import UserTotpAuthService from "./UserTotpAuthService";
 import UserTwoFactorBackupCodeService from "./UserTwoFactorBackupCodeService";

--- a/Common/Tests/Server/Middleware/MultipartFormData.test.ts
+++ b/Common/Tests/Server/Middleware/MultipartFormData.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import timers from "timers";
+
+/*
+ * multer calls `setImmediate` internally (make-middleware.js and
+ * remove-uploaded-files.js), and Common's jest environment is jsdom, which
+ * does not expose it. A `@jest-environment node` docblock is not an option
+ * here - Common's shared jest.setup.ts touches `window`, which is why
+ * EsbuildConfig.test.ts spawns a subprocess instead - so lend jsdom the
+ * real one from Node.
+ */
+if (
+  typeof (globalThis as unknown as { setImmediate?: unknown }).setImmediate !==
+  "function"
+) {
+  (globalThis as unknown as { setImmediate: unknown }).setImmediate =
+    timers.setImmediate;
+}
+
+/*
+ * The limits under test are 25 and 50 MiB, so the fixtures that probe them
+ * are 25 and 50 MiB of real multipart body parsed by the real busboy.
+ * That does not fit in jest's 5s default.
+ */
+jest.setTimeout(180_000);
+
+/*
+ * The multipart reader used by Pyroscope ingest and the SendGrid inbound
+ * email webhook.
+ *
+ * Both routes mount it BEFORE their auth check - Pyroscope before
+ * isAuthorizedServiceMiddleware, SendGrid before the webhook secret is
+ * verified - and it uses multer's memoryStorage, so every part it accepts
+ * is buffered in the process on behalf of a caller who has not proved
+ * anything yet.
+ *
+ * multer's defaults leave almost all of that unbounded: fileSize, files,
+ * fields and parts are all Infinity out of the box, and only fieldSize
+ * has a default at all. These tests pin the limits and the status code a
+ * breach produces, because the failure mode of getting this wrong is
+ * silent - an unbounded upload looks exactly like a working one until the
+ * pod dies.
+ */
+
+import MultipartFormDataMiddleware, {
+  MAX_MULTIPART_FIELDS,
+  MAX_MULTIPART_FIELD_BYTES,
+  MAX_MULTIPART_FILES,
+  MAX_MULTIPART_FILE_BYTES,
+} from "../../../Server/Middleware/MultipartFormData";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Exception from "../../../Types/Exception/Exception";
+import ExceptionCode from "../../../Types/Exception/ExceptionCode";
+import { Readable } from "stream";
+
+const BOUNDARY: string = "----oneuptimetestboundary";
+
+interface MultipartPart {
+  name: string;
+  value: Buffer;
+  filename?: string;
+}
+
+function buildMultipartBody(parts: Array<MultipartPart>): Buffer {
+  const chunks: Array<Buffer> = [];
+
+  for (const part of parts) {
+    const disposition: string = part.filename
+      ? `form-data; name="${part.name}"; filename="${part.filename}"`
+      : `form-data; name="${part.name}"`;
+
+    const header: string =
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: ${disposition}\r\n` +
+      (part.filename ? "Content-Type: application/octet-stream\r\n" : "") +
+      "\r\n";
+
+    chunks.push(Buffer.from(header));
+    chunks.push(part.value);
+    chunks.push(Buffer.from("\r\n"));
+  }
+
+  chunks.push(Buffer.from(`--${BOUNDARY}--\r\n`));
+
+  return Buffer.concat(chunks as unknown as Array<Uint8Array>);
+}
+
+interface Outcome {
+  req: ExpressRequest;
+  error: unknown;
+  nextCalls: number;
+}
+
+/*
+ * Drive the middleware with a real multipart body over a real Readable, so
+ * busboy does the parsing it does in production rather than being faked.
+ */
+function run(parts: Array<MultipartPart>): Promise<Outcome> {
+  const body: Buffer = buildMultipartBody(parts);
+
+  const req: Readable & {
+    headers: Record<string, string>;
+    body?: unknown;
+    files?: unknown;
+  } = Readable.from([body]) as never;
+
+  req.headers = {
+    "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+    "content-length": String(body.length),
+  };
+
+  const res: ExpressResponse = {
+    status: (): unknown => {
+      return { send: (): void => {}, json: (): void => {} };
+    },
+    headersSent: false,
+  } as unknown as ExpressResponse;
+
+  return new Promise<Outcome>((resolve: (value: Outcome) => void): void => {
+    let nextCalls: number = 0;
+
+    MultipartFormDataMiddleware(req as unknown as ExpressRequest, res, ((
+      err?: unknown,
+    ): void => {
+      nextCalls++;
+      resolve({
+        req: req as unknown as ExpressRequest,
+        error: err,
+        nextCalls: nextCalls,
+      });
+    }) as NextFunction);
+  });
+}
+
+function files(outcome: Outcome): Array<{ fieldname: string; buffer: Buffer }> {
+  return (outcome.req.files || []) as Array<{
+    fieldname: string;
+    buffer: Buffer;
+  }>;
+}
+
+describe("MultipartFormData - the limits are set where they were reasoned about", () => {
+  test("sizes match the app-wide 50 MiB body-parser number", () => {
+    expect(MAX_MULTIPART_FILE_BYTES).toBe(50 * 1024 * 1024);
+    expect(MAX_MULTIPART_FIELD_BYTES).toBe(25 * 1024 * 1024);
+  });
+
+  test("counts are bounded at all, which is the part multer leaves at Infinity", () => {
+    expect(MAX_MULTIPART_FILES).toBe(50);
+    expect(MAX_MULTIPART_FIELDS).toBe(200);
+    expect(Number.isFinite(MAX_MULTIPART_FILES)).toBe(true);
+    expect(Number.isFinite(MAX_MULTIPART_FIELDS)).toBe(true);
+  });
+});
+
+describe("MultipartFormData - normal bodies still parse", () => {
+  test("a single file arrives as a Buffer on req.files", async () => {
+    const outcome: Outcome = await run([
+      { name: "profile", value: Buffer.from("pprof-bytes"), filename: "p.pb" },
+    ]);
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(1);
+    expect(files(outcome)[0]!.fieldname).toBe("profile");
+    expect(files(outcome)[0]!.buffer.toString()).toBe("pprof-bytes");
+  });
+
+  test("fields and files together, the SendGrid shape", async () => {
+    const outcome: Outcome = await run([
+      { name: "from", value: Buffer.from("someone@example.com") },
+      { name: "subject", value: Buffer.from("hello") },
+      { name: "attachment1", value: Buffer.from("PDF"), filename: "a.pdf" },
+    ]);
+
+    expect(outcome.error).toBeUndefined();
+    expect((outcome.req.body as Record<string, string>)["from"]).toBe(
+      "someone@example.com",
+    );
+    expect(files(outcome)).toHaveLength(1);
+  });
+
+  test("a body with no parts at all is fine", async () => {
+    const outcome: Outcome = await run([]);
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(0);
+  });
+
+  test("a file right at the count limit is accepted", async () => {
+    const outcome: Outcome = await run(
+      Array.from({ length: MAX_MULTIPART_FILES }, (_v: unknown, i: number) => {
+        return {
+          name: `f${i}`,
+          value: Buffer.from("x"),
+          filename: `f${i}.bin`,
+        };
+      }),
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(MAX_MULTIPART_FILES);
+  });
+
+  test("fields right at the count limit are accepted", async () => {
+    const outcome: Outcome = await run(
+      Array.from({ length: MAX_MULTIPART_FIELDS }, (_v: unknown, i: number) => {
+        return { name: `k${i}`, value: Buffer.from("v") };
+      }),
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(
+      Object.keys(outcome.req.body as Record<string, unknown>),
+    ).toHaveLength(MAX_MULTIPART_FIELDS);
+  });
+});
+
+describe("MultipartFormData - breaches answer 413, not 500", () => {
+  test("one file over the size limit", async () => {
+    const outcome: Outcome = await run([
+      {
+        name: "big",
+        value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES + 1),
+        filename: "big.bin",
+      },
+    ]);
+
+    expect(outcome.error).toBeInstanceOf(Exception);
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).code).toBe(413);
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_SIZE");
+  });
+
+  test("one file too many", async () => {
+    const outcome: Outcome = await run(
+      Array.from(
+        { length: MAX_MULTIPART_FILES + 1 },
+        (_v: unknown, i: number) => {
+          return {
+            name: `f${i}`,
+            value: Buffer.from("x"),
+            filename: `f${i}.bin`,
+          };
+        },
+      ),
+    );
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+
+  test("one field too many - thousands of tiny parts is the cheap version of this attack", async () => {
+    const outcome: Outcome = await run(
+      Array.from(
+        { length: MAX_MULTIPART_FIELDS + 1 },
+        (_v: unknown, i: number) => {
+          return { name: `k${i}`, value: Buffer.from("v") };
+        },
+      ),
+    );
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FIELD_COUNT");
+  });
+
+  test("one field value over the size limit", async () => {
+    const outcome: Outcome = await run([
+      { name: "html", value: Buffer.alloc(MAX_MULTIPART_FIELD_BYTES + 1) },
+    ]);
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FIELD_VALUE");
+  });
+
+  test("next() is called exactly once on a breach", async () => {
+    const outcome: Outcome = await run([
+      {
+        name: "big",
+        value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES + 1),
+        filename: "big.bin",
+      },
+    ]);
+
+    expect(outcome.nextCalls).toBe(1);
+  });
+});

--- a/Common/Tests/Server/Views/AnalyticsConsentPartial.test.ts
+++ b/Common/Tests/Server/Views/AnalyticsConsentPartial.test.ts
@@ -277,6 +277,8 @@ describe("consent can be withdrawn", () => {
 
     expect(policy).not.toContain("governed by the same consent choice");
     expect(policy).not.toContain("they are not set in the product either");
-    expect(policy).toContain("regardless of the answer given on the cookie banner");
+    expect(policy).toContain(
+      "regardless of the answer given on the cookie banner",
+    );
   });
 });

--- a/Common/Types/Exception/ExceptionCode.ts
+++ b/Common/Types/Exception/ExceptionCode.ts
@@ -15,6 +15,7 @@ enum ExceptionCode {
   PaymentRequiredException = 402,
   NotFoundException = 404,
   TimeoutException = 408,
+  PayloadTooLargeException = 413,
   TenantNotFoundException = 405,
   SsoAuthorizationException = 406,
   TooManyRequestsException = 429,

--- a/Common/Types/Exception/PayloadTooLargeException.ts
+++ b/Common/Types/Exception/PayloadTooLargeException.ts
@@ -1,0 +1,8 @@
+import Exception from "./Exception";
+import ExceptionCode from "./ExceptionCode";
+
+export default class PayloadTooLargeException extends Exception {
+  public constructor(message: string) {
+    super(ExceptionCode.PayloadTooLargeException, message);
+  }
+}

--- a/Home/Tests/AttributionCapture.test.ts
+++ b/Home/Tests/AttributionCapture.test.ts
@@ -1114,11 +1114,9 @@ describe("attribution capture and consent", () => {
 
       const innerNames: Array<string> = Object.keys(
         harness.calMetadata("enterprise_demo"),
-      ).map(
-        (key: string) => {
-          return key.slice("metadata[".length, -1);
-        },
-      );
+      ).map((key: string) => {
+        return key.slice("metadata[".length, -1);
+      });
 
       // The fixture has to actually exercise the keys for this to mean anything.
       expect(innerNames.length).toBeGreaterThanOrEqual(readableKeys.size);
@@ -1212,9 +1210,10 @@ describe("attribution capture and consent", () => {
       expect(blocked["metadata[gclid]"]).toBe("abc123");
       expect(blocked["metadata[utm_source]"]).toBe("google");
       expect(blocked["metadata[utm_url]"]).toBe(AD_URL);
-      expect(
-        JSON.parse(blocked["metadata[ou_first_touch]"]!),
-      ).toMatchObject({ utmSource: "google", clickIds: { gclid: "abc123" } });
+      expect(JSON.parse(blocked["metadata[ou_first_touch]"]!)).toMatchObject({
+        utmSource: "google",
+        clickIds: { gclid: "abc123" },
+      });
 
       /*
        * Nothing about a working store should change what is sent. The first


### PR DESCRIPTION
Follow-up to #3404 (GHSA-cp58-wc9q-qv53), which bounded the global gzip request reader. Three ingest paths still had the same shape one layer in.

## 1. Pyroscope — unbounded `zlib.gunzip`

`PyroscopeIngestService.decompressIfNeeded` inflated the payload with no output ceiling. It sits behind `TelemetryIngest.isAuthorizedServiceMiddleware`, so it needs a valid project ingest key — but any holder of one could turn the ~1 MiB nginx allows on `/pyroscope` into about a gigabyte of resident Buffer (a measured 1,029x on repeated bytes).

Now two ceilings:

| ceiling | value | bounds |
|---|---|---|
| `MAX_DECOMPRESSED_PROFILE_BYTES` | 32 MiB | one gzip member |
| `MAX_DECOMPRESSED_REQUEST_BYTES` | 64 MiB | the whole request |

**Both are needed.** `ingestPyroscopePush` walks `series[].samples[]` and inflates every sample, so a per-payload cap alone just multiplies by the sample count — 64 samples one byte under the per-profile cap is 2 GB. The budget is spent across every inflate in one request, the same per-frame / per-job split `SessionReplayIngestService` already uses.

There is a test for exactly that, with a control: a 30 MiB sample is **accepted** on its own and **refused** when the gzipped envelope already spent ~40 MiB of the budget. Without the control the test would be measuring the per-profile ceiling and proving nothing.

## 2. OTLP — unbounded in the worker, uncapped on the wire

`OtelPayloadDecoder.gunzipAsync` inflates the queued body inside the BullMQ worker, where `TELEMETRY_CONCURRENCY` (**100** by default) jobs can be in flight on one pod — unbounded once is unbounded a hundred times over. Capped at 64 MiB.

`OtelRequestMiddleware.parseBody` reads the socket itself, so it gets **none** of StartServer's body-parser limits — the routes it serves are exactly the ones StartServer's dispatcher bypasses. Before this the only bound was whatever the ingress happened to allow, and a deployment reached directly had none. It now has a 50 MiB cap with a Content-Length pre-check and a 413.

`SessionReplayRequestMiddleware`'s header comment has said *"the byte cap the OTLP equivalent (`OtelRequestMiddleware.parseBody`) does not have"* for a while. It now does.

## 3. Multipart — multer with no `limits` at all, before auth

`Common/Server/Middleware/MultipartFormData` used `memoryStorage` with no `limits`, and **both** routes that mount it run it before their auth check — Pyroscope before `isAuthorizedServiceMiddleware`, SendGrid inbound before the webhook secret is verified. multer's defaults leave `fileSize`, `files`, `fields` and `parts` at Infinity; only `fieldSize` has a default.

The **counts** were the real gap. A body of ten thousand one-byte parts costs ten thousand allocations and passes every size check.

## `maxOutputLength` vs a manual counter

These use `maxOutputLength` where the global reader counts bytes by hand, and that is deliberate — the difference is which zlib API is in play:

| call | `maxOutputLength: 1 MiB` on an 8 MiB payload |
|---|---|
| `zlib.gunzip` / `gunzipSync` (convenience) | throws `ERR_BUFFER_TOO_LARGE` |
| `zlib.createGunzip` (stream) | **emits all 8 MiB** |

Node honours it on the convenience methods only. These paths already hold the whole payload in memory, so the convenience call is the right one and the option works; the global reader streams, so it counts manually. Tests in both suites pin the difference so neither gets "simplified" into the other.

Also guarded: zlib reads `maxOutputLength: 0` as **"no limit"**, not "nothing allowed" — so an exhausted budget would silently reopen the hole. There is a test for that specific moment.

## 413, not 500

Breaches raise a new `PayloadTooLargeException` (`ExceptionCode` 413). A caller sending too much is not a server error, it should not page anyone, and OTel exporters treat 4xx as non-retryable — so a misconfigured batch size stops instead of looping. Multer's `LIMIT_*` codes map to 413 except `LIMIT_UNEXPECTED_FILE`, which is a malformed request rather than an oversized one.

## Headroom

No ceiling here is reachable by a legitimate client. nginx caps these locations at 1–4 MiB **compressed**, real pprof profiles are tens to hundreds of KB, and OTLP protobuf gzips at roughly 5–15x — an order of magnitude of headroom under every number above.

## Tests

**73 new tests**, all passing:

| suite | tests |
|---|---|
| `PyroscopeDecompressionLimits` | 27 |
| `OtelRequestMiddlewareByteCap` | 24 |
| `MultipartFormData` | 12 |
| `OtelPayloadDecoderDecompressionLimit` | 10 |

They cover both directions — under, exactly on, and one byte over every ceiling — plus the shared-budget control described above, the `maxOutputLength: 0` trap, negative budgets, identity passthrough, corrupt and truncated gzip (which must stay a decode error, not a size error), stream errors, and single-outcome-per-request.

The multipart suite drives the real busboy over a real `Readable` with hand-built multipart bodies rather than faking the parse.

`tsc --noEmit` clean in App and Common; `eslint` clean.

## Note on the first commit

`chore(lint)` reformats two files unrelated to this change. b9504f88e9 landed them with prettier violations and went red on master; every PR opened since has inherited the same five errors through the `pull_request` merge-commit checkout. It was pushed to #3404 but landed after that PR was merged, so it is carried here instead. Whitespace only.
