### PR TITLE
feat(security-events): column per event field, plus attribute columns

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventAttributeUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventAttributeUtil.ts
@@ -1,0 +1,48 @@
+import AnalyticsModelAPI from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
+import API from "Common/UI/Utils/API/API";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import URL from "Common/Types/API/URL";
+import { APP_API_URL } from "Common/UI/Config";
+import { JSONObject } from "Common/Types/JSON";
+
+/*
+ * The attribute keys a project's security events actually carry.
+ *
+ * Every source field OCSF has no typed column for is flattened into the
+ * event's `attributes` map (activity_name, device.hostname,
+ * finding_info.title, metadata.product.name, ...), and which keys exist
+ * differs per event class and per source. So the security events table cannot
+ * ship them as columns; it asks for the list and lets the viewer pick.
+ *
+ * Same endpoint shape as the log / trace / metric attribute pickers, served by
+ * TelemetryAttributeService over the `attributeKeys` sidecar column.
+ */
+export default class SecurityEventAttributeUtil {
+  public static async getAttributeKeys(): Promise<Array<string>> {
+    const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await API.post({
+        url: URL.fromString(APP_API_URL.toString()).addRoute(
+          "/telemetry/security-events/get-attributes",
+        ),
+        data: {},
+        headers: {
+          ...AnalyticsModelAPI.getCommonHeaders(),
+        },
+      });
+
+    if (response instanceof HTTPErrorResponse) {
+      throw response;
+    }
+
+    const attributes: unknown = response.data["attributes"];
+
+    if (!Array.isArray(attributes)) {
+      return [];
+    }
+
+    return attributes.filter((attribute: unknown): attribute is string => {
+      return typeof attribute === "string";
+    });
+  }
+}

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTable.tsx
@@ -14,10 +14,10 @@ import IconProp from "Common/Types/Icon/IconProp";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 import ProjectUtil from "Common/UI/Utils/Project";
-import OneUptimeDate from "Common/Types/Date";
 import { VoidFunction } from "Common/Types/FunctionTypes";
-import SecurityEventSeverityPill from "./SecurityEventSeverityPill";
 import SecurityEventDetail from "./SecurityEventDetail";
+import securityEventColumns from "./SecurityEventsTableColumns";
+import SecurityEventAttributeUtil from "./SecurityEventAttributeUtil";
 import EmptyState from "Common/UI/Components/EmptyState/EmptyState";
 import Navigation from "Common/UI/Utils/Navigation";
 import Route from "Common/Types/API/Route";
@@ -36,6 +36,11 @@ const severityDropdownOptions: Array<DropdownOption> = Object.values(
 const SecurityEventsTable: FunctionComponent = (): ReactElement => {
   const [detailEvent, setDetailEvent] = useState<SecurityEvent | null>(null);
 
+  /*
+   * The detail side-over renders straight off the row it was handed, so every
+   * field it shows has to be on the wire whether or not a column for it is on
+   * screen.
+   */
   const extraSelect: Select<SecurityEvent> = {
     eventUid: true,
     categoryName: true,
@@ -81,6 +86,24 @@ const SecurityEventsTable: FunctionComponent = (): ReactElement => {
         sortBy="time"
         sortOrder={SortOrder.Descending}
         selectMoreFields={extraSelect}
+        /*
+         * The keys inside `attributes` are whatever the source sent, so they
+         * cannot ship as columns. The picker offers them through a search box
+         * instead, and whatever is added from it becomes an ordinary column -
+         * hideable, re-orderable, exported, and remembered for next time.
+         */
+        attributeColumnsProps={{
+          columnKey: "attributes",
+          title: "Add Attribute Column",
+          description:
+            "Source fields that OCSF has no column for. These differ per event class, so search for the one you want.",
+          placeholder: "Search attributes...",
+          emptyMessage:
+            "No attributes seen on recent events. Attribute columns become available once events carrying them are ingested.",
+          fetchAttributeKeys: (): Promise<Array<string>> => {
+            return SecurityEventAttributeUtil.getAttributeKeys();
+          },
+        }}
         /*
          * An empty table here means "nothing is sending yet" far more often
          * than "nothing happened", and the answer to that is a page away.
@@ -143,73 +166,7 @@ const SecurityEventsTable: FunctionComponent = (): ReactElement => {
             title: "Time",
           },
         ]}
-        columns={[
-          {
-            field: { time: true },
-            title: "Time",
-            type: FieldType.Element,
-            getElement: (item: SecurityEvent): ReactElement => {
-              const time: Date | undefined = item.time;
-              if (!time) {
-                return <span className="text-gray-400">-</span>;
-              }
-              const timeDate: Date = new Date(time);
-              return (
-                <div
-                  className="flex flex-col leading-tight"
-                  title={OneUptimeDate.getDateAsLocalFormattedString(timeDate)}
-                >
-                  <span className="text-sm font-medium text-gray-900">
-                    {OneUptimeDate.fromNow(timeDate)}
-                  </span>
-                  <span className="text-[11px] text-gray-500">
-                    {OneUptimeDate.getDateAsLocalFormattedString(timeDate)}
-                  </span>
-                </div>
-              );
-            },
-          },
-          {
-            field: { severityName: true },
-            title: "Severity",
-            type: FieldType.Element,
-            getElement: (item: SecurityEvent): ReactElement => {
-              return (
-                <SecurityEventSeverityPill severityName={item.severityName} />
-              );
-            },
-          },
-          {
-            field: { className: true },
-            title: "Event Class",
-            type: FieldType.Text,
-            noValueMessage: "-",
-          },
-          {
-            field: { message: true },
-            title: "Message",
-            type: FieldType.LongText,
-            noValueMessage: "-",
-          },
-          {
-            field: { principalUser: true },
-            title: "Principal User",
-            type: FieldType.Text,
-            noValueMessage: "-",
-          },
-          {
-            field: { principalHost: true },
-            title: "Principal Host",
-            type: FieldType.Text,
-            noValueMessage: "-",
-          },
-          {
-            field: { vendorName: true },
-            title: "Vendor",
-            type: FieldType.Text,
-            noValueMessage: "-",
-          },
-        ]}
+        columns={securityEventColumns}
         actionButtons={[
           {
             title: "View Details",

--- a/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTableColumns.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTableColumns.tsx
@@ -1,0 +1,238 @@
+import React, { ReactElement } from "react";
+import SecurityEvent from "Common/Models/AnalyticsModels/SecurityEvent";
+import Column from "Common/UI/Components/ModelTable/Column";
+import Columns from "Common/UI/Components/ModelTable/Columns";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import OneUptimeDate from "Common/Types/Date";
+import SecurityEventSeverityPill from "./SecurityEventSeverityPill";
+
+/*
+ * Array columns (observables, MITRE ids) render as one comma-joined line with
+ * the full list on hover: a row is one line tall, and an event that mentions
+ * thirty observables would otherwise push every other row off the screen.
+ */
+type JoinArrayFunction = (values: Array<string> | undefined) => string;
+
+const joinArray: JoinArrayFunction = (
+  values: Array<string> | undefined,
+): string => {
+  return (values || [])
+    .filter((value: string) => {
+      return Boolean(value);
+    })
+    .join(", ");
+};
+
+type NoValueFunction = () => ReactElement;
+
+const noValue: NoValueFunction = (): ReactElement => {
+  return <span className="text-gray-400">-</span>;
+};
+
+type ArrayColumnFunction = (data: {
+  field: Column<SecurityEvent>["field"];
+  title: string;
+  getValues: (item: SecurityEvent) => Array<string> | undefined;
+}) => Column<SecurityEvent>;
+
+const arrayColumn: ArrayColumnFunction = (data: {
+  field: Column<SecurityEvent>["field"];
+  title: string;
+  getValues: (item: SecurityEvent) => Array<string> | undefined;
+}): Column<SecurityEvent> => {
+  return {
+    field: data.field,
+    title: data.title,
+    type: FieldType.Element,
+    isHiddenByDefault: true,
+    // ClickHouse can order by an Array(String), but the ordering is meaningless.
+    disableSort: true,
+    getExportValue: (item: SecurityEvent): string => {
+      return joinArray(data.getValues(item));
+    },
+    getElement: (item: SecurityEvent): ReactElement => {
+      const text: string = joinArray(data.getValues(item));
+
+      if (!text) {
+        return noValue();
+      }
+
+      return (
+        <span className="break-words" title={text}>
+          {text}
+        </span>
+      );
+    },
+  };
+};
+
+type TextColumnFunction = (data: {
+  field: Column<SecurityEvent>["field"];
+  title: string;
+  type?: FieldType | undefined;
+}) => Column<SecurityEvent>;
+
+const hiddenTextColumn: TextColumnFunction = (data: {
+  field: Column<SecurityEvent>["field"];
+  title: string;
+  type?: FieldType | undefined;
+}): Column<SecurityEvent> => {
+  return {
+    field: data.field,
+    title: data.title,
+    type: data.type || FieldType.Text,
+    noValueMessage: "-",
+    isHiddenByDefault: true,
+  };
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * Columns
+ * ---------------------------------------------------------------------------
+ *
+ * Every field the detail side-over shows is a column here, so that anything
+ * worth reading on one event is also something you can scan down the table -
+ * "which vendor produced all of these", "group these by rule name". The seven
+ * that were the whole table before are still the seven that show by default;
+ * the rest ship hidden and are one click away in "Customize Columns".
+ *
+ * They are appended rather than interleaved on purpose: inserting them in
+ * detail-panel order would silently reshuffle the default layout for everyone
+ * who has never opened the picker.
+ *
+ * The OCSF *typed* columns stop here. Everything else a source sent lands in
+ * the `attributes` map, whose keys differ per event class - those are offered
+ * through the picker's "Add Attribute Column" search instead (see
+ * attributeColumnsProps below).
+ */
+const securityEventColumns: Columns<SecurityEvent> = [
+  {
+    field: { time: true },
+    title: "Time",
+    type: FieldType.Element,
+    getElement: (item: SecurityEvent): ReactElement => {
+      const time: Date | undefined = item.time;
+      if (!time) {
+        return noValue();
+      }
+      const timeDate: Date = new Date(time);
+      return (
+        <div
+          className="flex flex-col leading-tight"
+          title={OneUptimeDate.getDateAsLocalFormattedString(timeDate)}
+        >
+          <span className="text-sm font-medium text-gray-900">
+            {OneUptimeDate.fromNow(timeDate)}
+          </span>
+          <span className="text-[11px] text-gray-500">
+            {OneUptimeDate.getDateAsLocalFormattedString(timeDate)}
+          </span>
+        </div>
+      );
+    },
+  },
+  {
+    field: { severityName: true },
+    title: "Severity",
+    type: FieldType.Element,
+    getElement: (item: SecurityEvent): ReactElement => {
+      return <SecurityEventSeverityPill severityName={item.severityName} />;
+    },
+  },
+  {
+    field: { className: true },
+    title: "Event Class",
+    type: FieldType.Text,
+    noValueMessage: "-",
+  },
+  {
+    field: { message: true },
+    title: "Message",
+    type: FieldType.LongText,
+    noValueMessage: "-",
+  },
+  {
+    field: { principalUser: true },
+    title: "Principal User",
+    type: FieldType.Text,
+    noValueMessage: "-",
+  },
+  {
+    field: { principalHost: true },
+    title: "Principal Host",
+    type: FieldType.Text,
+    noValueMessage: "-",
+  },
+  {
+    field: { vendorName: true },
+    title: "Vendor",
+    type: FieldType.Text,
+    noValueMessage: "-",
+  },
+  hiddenTextColumn({ field: { categoryName: true }, title: "Category" }),
+  hiddenTextColumn({ field: { activityName: true }, title: "Activity" }),
+  hiddenTextColumn({ field: { statusName: true }, title: "Status" }),
+  hiddenTextColumn({ field: { productName: true }, title: "Product" }),
+  hiddenTextColumn({ field: { ruleId: true }, title: "Rule ID" }),
+  hiddenTextColumn({ field: { ruleName: true }, title: "Rule Name" }),
+  arrayColumn({
+    field: { mitreTactics: true },
+    title: "MITRE Tactics",
+    getValues: (item: SecurityEvent): Array<string> | undefined => {
+      return item.mitreTactics;
+    },
+  }),
+  arrayColumn({
+    field: { mitreTechniques: true },
+    title: "MITRE Techniques",
+    getValues: (item: SecurityEvent): Array<string> | undefined => {
+      return item.mitreTechniques;
+    },
+  }),
+  hiddenTextColumn({ field: { principalIp: true }, title: "Principal IP" }),
+  hiddenTextColumn({
+    field: { principalProcess: true },
+    title: "Principal Process",
+    type: FieldType.LongText,
+  }),
+  hiddenTextColumn({ field: { targetUser: true }, title: "Target User" }),
+  hiddenTextColumn({ field: { targetHost: true }, title: "Target Host" }),
+  hiddenTextColumn({ field: { targetIp: true }, title: "Target IP" }),
+  {
+    field: { targetPort: true },
+    title: "Target Port",
+    type: FieldType.Element,
+    isHiddenByDefault: true,
+    /*
+     * The column is non-nullable with a 0 default, so 0 means "the source did
+     * not say" far more often than it means port zero. Rendering it as a
+     * literal 0 reads as data the event does not have.
+     */
+    getExportValue: (item: SecurityEvent): string => {
+      return item.targetPort ? item.targetPort.toString() : "";
+    },
+    getElement: (item: SecurityEvent): ReactElement => {
+      if (!item.targetPort) {
+        return noValue();
+      }
+
+      return <span>{item.targetPort.toString()}</span>;
+    },
+  },
+  hiddenTextColumn({
+    field: { targetResource: true },
+    title: "Target Resource",
+    type: FieldType.LongText,
+  }),
+  arrayColumn({
+    field: { observables: true },
+    title: "Observables",
+    getValues: (item: SecurityEvent): Array<string> | undefined => {
+      return item.observables;
+    },
+  }),
+  hiddenTextColumn({ field: { eventUid: true }, title: "Event UID" }),
+];
+
+export default securityEventColumns;

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -204,6 +204,13 @@ const requireExceptionReadAccess: Array<RequestHandler> =
 const requireProfileReadAccess: Array<RequestHandler> =
   createTelemetryReadAccessGuard(Permission.ReadTelemetryServiceProfiles);
 
+/*
+ * Mirrors the read access control declared on the SecurityEvent analytics
+ * model.
+ */
+const requireSecurityEventReadAccess: Array<RequestHandler> =
+  createTelemetryReadAccessGuard(Permission.ReadSecurityEvent);
+
 router.post(
   "/telemetry/metrics/get-attributes",
   ...requireMetricReadAccess,
@@ -265,6 +272,28 @@ router.post(
   ...requireExceptionReadAccess,
   async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
     return getAttributeValues(req, res, next, TelemetryType.Exception);
+  },
+);
+
+/*
+ * Security events flatten their whole source payload into `attributes`, so
+ * these are what backs the "add an attribute column" picker on the security
+ * events table — the keys differ per event class and per source, so there is
+ * no fixed list the UI could ship.
+ */
+router.post(
+  "/telemetry/security-events/get-attributes",
+  ...requireSecurityEventReadAccess,
+  async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+    return getAttributes(req, res, next, TelemetryType.SecurityEvent);
+  },
+);
+
+router.post(
+  "/telemetry/security-events/get-attribute-values",
+  ...requireSecurityEventReadAccess,
+  async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+    return getAttributeValues(req, res, next, TelemetryType.SecurityEvent);
   },
 );
 

--- a/Common/Server/Services/TelemetryAttributeService.ts
+++ b/Common/Server/Services/TelemetryAttributeService.ts
@@ -4,6 +4,7 @@ import LogDatabaseService from "./LogService";
 import MetricDatabaseService from "./MetricService";
 import SpanDatabaseService from "./SpanService";
 import ExceptionInstanceService from "./ExceptionInstanceService";
+import SecurityEventService from "./SecurityEventService";
 import MutableMetricDatabaseService, {
   MutableMetricService as MutableMetricServiceClass,
 } from "./MutableMetricService";
@@ -97,6 +98,22 @@ export class TelemetryAttributeService {
         return {
           service: ExceptionInstanceService,
           tableName: ExceptionInstanceService.model.tableName,
+          attributesColumn: "attributes",
+          attributeKeysColumn: "attributeKeys",
+          timeColumn: "time",
+        };
+      /*
+       * Security events carry the whole source payload flattened into
+       * `attributes`, which is where every field the OCSF schema does not
+       * have a typed column for ends up (device.hostname,
+       * finding_info.title, metadata.product.name, ...). The security
+       * events table offers those as optional columns, and this is the
+       * list it offers.
+       */
+      case TelemetryType.SecurityEvent:
+        return {
+          service: SecurityEventService,
+          tableName: SecurityEventService.model.tableName,
           attributesColumn: "attributes",
           attributeKeysColumn: "attributeKeys",
           timeColumn: "time",

--- a/Common/Tests/App/Dashboard/SecurityEventAttributeUtil.test.ts
+++ b/Common/Tests/App/Dashboard/SecurityEventAttributeUtil.test.ts
@@ -1,0 +1,171 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+import SecurityEventAttributeUtil from "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventAttributeUtil";
+import API from "../../../UI/Utils/API/API";
+import AnalyticsModelAPI from "../../../UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import URL from "../../../Types/API/URL";
+import { JSONObject } from "../../../Types/JSON";
+import Dictionary from "../../../Types/Dictionary";
+
+/*
+ * The security events table's "Add Attribute Column" search is fed from this
+ * one request. Three things about it are worth pinning, because each fails
+ * quietly rather than loudly:
+ *
+ *  - the route. A wrong path 404s, which the picker renders as an error the
+ *    user cannot act on.
+ *  - the tenant headers. AnalyticsModelAPI.getCommonHeaders carries the
+ *    project id these bespoke telemetry routes read the tenant from; without
+ *    it the request is rejected as having no project.
+ *  - the shape of what comes back. It is JSON off the wire, so a non-array
+ *    (or an array with junk in it) has to degrade to "no attributes" rather
+ *    than generating columns titled "null" that read nothing off any row.
+ */
+
+type PostArgs = {
+  url: URL;
+  data: JSONObject;
+  headers?: Dictionary<string> | undefined;
+};
+
+type MockPostFunction = (
+  response: HTTPResponse<JSONObject> | HTTPErrorResponse,
+) => jest.SpiedFunction<typeof API.post>;
+
+const mockPost: MockPostFunction = (
+  response: HTTPResponse<JSONObject> | HTTPErrorResponse,
+): jest.SpiedFunction<typeof API.post> => {
+  return jest
+    .spyOn(API, "post")
+    .mockResolvedValue(response as never) as unknown as jest.SpiedFunction<
+    typeof API.post
+  >;
+};
+
+type FirstPostArgsFunction = (
+  spy: jest.SpiedFunction<typeof API.post>,
+) => PostArgs;
+
+const firstPostArgs: FirstPostArgsFunction = (
+  spy: jest.SpiedFunction<typeof API.post>,
+): PostArgs => {
+  return (spy.mock.calls[0] as Array<unknown>)[0] as PostArgs;
+};
+
+type OkFunction = (data: JSONObject) => HTTPResponse<JSONObject>;
+
+const ok: OkFunction = (data: JSONObject): HTTPResponse<JSONObject> => {
+  return new HTTPResponse<JSONObject>(200, data, {});
+};
+
+describe("SecurityEventAttributeUtil.getAttributeKeys", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(AnalyticsModelAPI, "getCommonHeaders")
+      .mockReturnValue({ tenantid: "project-1" } as Dictionary<string>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("posts to the security events attribute route", async () => {
+    const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+      ok({ attributes: [] }),
+    );
+
+    await SecurityEventAttributeUtil.getAttributeKeys();
+
+    expect(firstPostArgs(spy).url.toString()).toContain(
+      "/telemetry/security-events/get-attributes",
+    );
+  });
+
+  test("carries the tenant headers the route reads the project from", async () => {
+    const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+      ok({ attributes: [] }),
+    );
+
+    await SecurityEventAttributeUtil.getAttributeKeys();
+
+    expect(firstPostArgs(spy).headers).toMatchObject({
+      tenantid: "project-1",
+    });
+  });
+
+  test("returns the keys the server sent", async () => {
+    mockPost(
+      ok({
+        attributes: ["device.hostname", "class_uid", "finding_info.title"],
+      }),
+    );
+
+    await expect(
+      SecurityEventAttributeUtil.getAttributeKeys(),
+    ).resolves.toEqual(["device.hostname", "class_uid", "finding_info.title"]);
+  });
+
+  test("an empty list is an empty list, not an error", async () => {
+    mockPost(ok({ attributes: [] }));
+
+    await expect(
+      SecurityEventAttributeUtil.getAttributeKeys(),
+    ).resolves.toEqual([]);
+  });
+
+  test("a missing attributes field degrades to no attributes", async () => {
+    mockPost(ok({ someOtherField: true }));
+
+    await expect(
+      SecurityEventAttributeUtil.getAttributeKeys(),
+    ).resolves.toEqual([]);
+  });
+
+  test("a non-array attributes field degrades to no attributes", async () => {
+    mockPost(ok({ attributes: "device.hostname" }));
+
+    await expect(
+      SecurityEventAttributeUtil.getAttributeKeys(),
+    ).resolves.toEqual([]);
+  });
+
+  test("non-string entries are dropped rather than turned into columns", async () => {
+    mockPost(
+      ok({
+        attributes: ["device.hostname", null, 42, { a: 1 }, "class_uid"],
+      } as unknown as JSONObject),
+    );
+
+    await expect(
+      SecurityEventAttributeUtil.getAttributeKeys(),
+    ).resolves.toEqual(["device.hostname", "class_uid"]);
+  });
+
+  /*
+   * The caller turns a rejection into the picker's error message. Swallowing
+   * it here would show an empty search box instead, which reads as "this
+   * project has no attributes".
+   */
+  test("an error response is thrown, not swallowed", async () => {
+    const error: HTTPErrorResponse = new HTTPErrorResponse(
+      500,
+      { message: "clickhouse said no" },
+      {},
+    );
+
+    mockPost(error);
+
+    await expect(SecurityEventAttributeUtil.getAttributeKeys()).rejects.toBe(
+      error,
+    );
+  });
+});

--- a/Common/Tests/App/Dashboard/SecurityEventsTableColumns.test.tsx
+++ b/Common/Tests/App/Dashboard/SecurityEventsTableColumns.test.tsx
@@ -1,0 +1,382 @@
+import "@testing-library/jest-dom";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+import securityEventColumns from "../../../../App/FeatureSet/Dashboard/src/Components/SecurityEvents/SecurityEventsTableColumns";
+import Column from "../../../UI/Components/ModelTable/Column";
+import { getColumnIds } from "../../../UI/Components/ModelTable/ColumnPreference";
+import { getSelectFromColumns } from "../../../UI/Components/ModelTable/SelectFromColumns";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import SecurityEvent from "../../../Models/AnalyticsModels/SecurityEvent";
+import OcsfSeverity from "../../../Types/SecurityEvent/OcsfSeverity";
+import Select from "../../../Types/BaseDatabase/Select";
+import { JSONObject } from "../../../Types/JSON";
+
+/*
+ * ---------------------------------------------------------------------------
+ * The security events table's column set
+ * ---------------------------------------------------------------------------
+ *
+ * The table used to offer seven columns while the detail panel showed twelve
+ * fields, so answering "which vendor produced all of these?" meant opening
+ * every event one at a time (OneUptime/oneuptime#3399). Every field the detail
+ * panel shows is now a column; the seven that were the whole table are still
+ * the seven that show by default, and the rest are one click away in the
+ * picker.
+ *
+ * Three classes of mistake are invisible on screen and each is pinned below:
+ *
+ *  - a field name that is not a column on the model. getSelectFromColumns
+ *    throws a BadDataException for the primary field, which blanks the entire
+ *    table rather than one cell.
+ *  - a hidden column marked isNotCustomizable, which would put it in neither
+ *    the table nor the picker: unreachable.
+ *  - a column that silently changes the DEFAULT layout, which would reshuffle
+ *    the table for every viewer who has never opened the picker.
+ */
+
+afterEach(() => {
+  cleanup();
+});
+
+type TitlesOfFunction = (
+  columns: Array<Column<SecurityEvent>>,
+) => Array<string>;
+
+const titlesOf: TitlesOfFunction = (
+  columns: Array<Column<SecurityEvent>>,
+): Array<string> => {
+  return columns.map((column: Column<SecurityEvent>) => {
+    return column.title;
+  });
+};
+
+const visibleColumns: Array<Column<SecurityEvent>> =
+  securityEventColumns.filter((column: Column<SecurityEvent>) => {
+    return !column.isHiddenByDefault;
+  });
+
+type ColumnByTitleFunction = (title: string) => Column<SecurityEvent>;
+
+const columnByTitle: ColumnByTitleFunction = (
+  title: string,
+): Column<SecurityEvent> => {
+  const column: Column<SecurityEvent> | undefined = securityEventColumns.find(
+    (candidate: Column<SecurityEvent>) => {
+      return candidate.title === title;
+    },
+  );
+
+  if (!column) {
+    throw new Error(`No security event column titled "${title}"`);
+  }
+
+  return column;
+};
+
+type MakeEventFunction = (data: JSONObject) => SecurityEvent;
+
+const makeEvent: MakeEventFunction = (data: JSONObject): SecurityEvent => {
+  const event: SecurityEvent = new SecurityEvent();
+
+  for (const key of Object.keys(data)) {
+    (event as unknown as JSONObject)[key] = data[key];
+  }
+
+  return event;
+};
+
+describe("SecurityEventsTable columns - the default layout", () => {
+  /*
+   * These seven, in this order, are what the table showed before the rest were
+   * added. Anything new has to ship hidden, or every existing viewer's table
+   * silently rearranges itself.
+   */
+  test("shows exactly the seven columns it always did, in the same order", () => {
+    expect(titlesOf(visibleColumns)).toEqual([
+      "Time",
+      "Severity",
+      "Event Class",
+      "Message",
+      "Principal User",
+      "Principal Host",
+      "Vendor",
+    ]);
+  });
+
+  test("everything else ships hidden", () => {
+    const hidden: Array<Column<SecurityEvent>> = securityEventColumns.filter(
+      (column: Column<SecurityEvent>) => {
+        return Boolean(column.isHiddenByDefault);
+      },
+    );
+
+    expect(hidden.length).toBe(securityEventColumns.length - 7);
+    expect(hidden.length).toBeGreaterThan(0);
+  });
+});
+
+describe("SecurityEventsTable columns - coverage of the detail panel", () => {
+  /*
+   * The issue's actual complaint: these are the fields the detail panel showed
+   * but the picker did not offer. Named one by one rather than counted, so a
+   * regression says which one went missing.
+   */
+  const requestedInIssue: Array<string> = [
+    "Category",
+    "Activity",
+    "Vendor",
+    "Product",
+    "Rule Name",
+    "Observables",
+    "Event UID",
+  ];
+
+  test.each(requestedInIssue)("offers a %s column", (title: string) => {
+    expect(titlesOf(securityEventColumns)).toContain(title);
+  });
+
+  /*
+   * The rest of what the detail panel renders. Parity is the point: anything
+   * worth reading on one event is worth scanning down the table.
+   */
+  const restOfTheDetailPanel: Array<string> = [
+    "Time",
+    "Severity",
+    "Event Class",
+    "Status",
+    "Message",
+    "Rule ID",
+    "MITRE Tactics",
+    "MITRE Techniques",
+    "Principal User",
+    "Principal Host",
+    "Principal IP",
+    "Principal Process",
+    "Target User",
+    "Target Host",
+    "Target IP",
+    "Target Port",
+    "Target Resource",
+  ];
+
+  test.each(restOfTheDetailPanel)(
+    "also offers a %s column",
+    (title: string) => {
+      expect(titlesOf(securityEventColumns)).toContain(title);
+    },
+  );
+
+  test("the picker offers materially more than the seven it used to", () => {
+    expect(securityEventColumns.length).toBe(
+      requestedInIssue.length + restOfTheDetailPanel.length,
+    );
+  });
+});
+
+describe("SecurityEventsTable columns - shape", () => {
+  test("every declared field is a real column on the model", () => {
+    const model: SecurityEvent = new SecurityEvent();
+
+    for (const column of securityEventColumns) {
+      for (const field of Object.keys(column.field as JSONObject)) {
+        expect({
+          title: column.title,
+          field,
+          exists: model.hasColumn(field),
+        }).toEqual({ title: column.title, field, exists: true });
+      }
+    }
+  });
+
+  /*
+   * The real check that the above is enough: this is the call the table makes
+   * on every fetch, and it throws rather than degrading.
+   */
+  test("building the API select does not throw", () => {
+    const select: Select<SecurityEvent> = getSelectFromColumns<SecurityEvent>({
+      columns: securityEventColumns,
+      model: new SecurityEvent(),
+    });
+
+    expect((select as JSONObject)["categoryName"]).toBe(true);
+    expect((select as JSONObject)["observables"]).toBe(true);
+    expect((select as JSONObject)["eventUid"]).toBe(true);
+  });
+
+  test("column ids are unique, so a stored layout cannot confuse two of them", () => {
+    const ids: Array<string> =
+      getColumnIds<SecurityEvent>(securityEventColumns);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("titles are unique, so the picker's search is unambiguous", () => {
+    const titles: Array<string> = titlesOf(securityEventColumns);
+
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  /*
+   * A hidden AND non-customizable column would be in neither the table nor the
+   * picker.
+   */
+  test("no column is both hidden by default and kept out of the picker", () => {
+    for (const column of securityEventColumns) {
+      expect({
+        title: column.title,
+        unreachable: Boolean(
+          column.isHiddenByDefault && column.isNotCustomizable,
+        ),
+      }).toEqual({ title: column.title, unreachable: false });
+    }
+  });
+
+  /*
+   * These columns are the table's own, not the viewer's - "remove" is only for
+   * attribute columns, which are added from the picker in the first place.
+   */
+  test("no declared column is removable", () => {
+    for (const column of securityEventColumns) {
+      expect({
+        title: column.title,
+        removable: Boolean(column.isRemovable),
+      }).toEqual({ title: column.title, removable: false });
+    }
+  });
+});
+
+describe("SecurityEventsTable columns - cells", () => {
+  test("a text column with no value renders a dash rather than blank", () => {
+    expect(columnByTitle("Category").noValueMessage).toBe("-");
+    expect(columnByTitle("Rule Name").noValueMessage).toBe("-");
+    expect(columnByTitle("Event UID").noValueMessage).toBe("-");
+  });
+
+  test("Observables joins the list into one scannable line", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Observables");
+
+    const { container } = render(
+      column.getElement!(
+        makeEvent({ observables: ["web-1", "10.0.0.4", "bob@example.com"] }),
+      ),
+    );
+
+    expect(container.textContent).toBe("web-1, 10.0.0.4, bob@example.com");
+  });
+
+  test("Observables keeps the full list available on hover", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Observables");
+
+    const { container } = render(
+      column.getElement!(makeEvent({ observables: ["web-1", "10.0.0.4"] })),
+    );
+
+    expect(container.querySelector("span")).toHaveAttribute(
+      "title",
+      "web-1, 10.0.0.4",
+    );
+  });
+
+  test("an empty array column renders the placeholder, not an empty cell", () => {
+    const column: Column<SecurityEvent> = columnByTitle("MITRE Tactics");
+
+    const { container } = render(
+      column.getElement!(makeEvent({ mitreTactics: [] })),
+    );
+
+    expect(container.textContent).toBe("-");
+  });
+
+  test("blank entries inside an array are dropped rather than joined as commas", () => {
+    const column: Column<SecurityEvent> = columnByTitle("MITRE Techniques");
+
+    const { container } = render(
+      column.getElement!(
+        makeEvent({ mitreTechniques: ["T1110", "", "T1078"] }),
+      ),
+    );
+
+    expect(container.textContent).toBe("T1110, T1078");
+  });
+
+  test("array columns export the same joined text they render", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Observables");
+
+    expect(
+      column.getExportValue!(makeEvent({ observables: ["web-1", "10.0.0.4"] })),
+    ).toBe("web-1, 10.0.0.4");
+
+    expect(column.getExportValue!(makeEvent({ observables: [] }))).toBe("");
+  });
+
+  /*
+   * ClickHouse cannot meaningfully order by an Array(String), and nothing
+   * between the header and the query builder would reject the attempt.
+   */
+  test("array columns are not sortable", () => {
+    expect(columnByTitle("Observables").disableSort).toBe(true);
+    expect(columnByTitle("MITRE Tactics").disableSort).toBe(true);
+    expect(columnByTitle("MITRE Techniques").disableSort).toBe(true);
+  });
+
+  /*
+   * targetPort is non-nullable with a 0 default, so 0 means "the source did
+   * not say" far more often than it means port zero.
+   */
+  test("Target Port renders a dash when the source did not say", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Target Port");
+
+    const { container } = render(
+      column.getElement!(makeEvent({ targetPort: 0 })),
+    );
+
+    expect(container.textContent).toBe("-");
+    expect(column.getExportValue!(makeEvent({ targetPort: 0 }))).toBe("");
+  });
+
+  test("Target Port renders a real port", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Target Port");
+
+    const { container } = render(
+      column.getElement!(makeEvent({ targetPort: 443 })),
+    );
+
+    expect(container.textContent).toBe("443");
+    expect(column.getExportValue!(makeEvent({ targetPort: 443 }))).toBe("443");
+  });
+
+  test("Severity still renders its pill", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Severity");
+
+    const { container } = render(
+      column.getElement!(makeEvent({ severityName: OcsfSeverity.Critical })),
+    );
+
+    expect(container.textContent).toContain("Critical");
+  });
+
+  test("Time renders a relative and an absolute reading", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Time");
+
+    const { container } = render(
+      column.getElement!(makeEvent({ time: new Date("2024-03-01T10:00:00Z") })),
+    );
+
+    expect(container.textContent).toContain("2024");
+  });
+
+  test("Time with nothing to show renders the placeholder", () => {
+    const column: Column<SecurityEvent> = columnByTitle("Time");
+
+    const { container } = render(column.getElement!(makeEvent({})));
+
+    expect(container.textContent).toBe("-");
+  });
+
+  test("long free-text columns are typed as long text so they wrap", () => {
+    expect(columnByTitle("Message").type).toBe(FieldType.LongText);
+    expect(columnByTitle("Principal Process").type).toBe(FieldType.LongText);
+    expect(columnByTitle("Target Resource").type).toBe(FieldType.LongText);
+  });
+});

--- a/Common/Tests/Server/API/SecurityEventAttributesAPI.test.ts
+++ b/Common/Tests/Server/API/SecurityEventAttributesAPI.test.ts
@@ -1,0 +1,550 @@
+import TelemetryAttributeService from "../../../Server/Services/TelemetryAttributeService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import Dictionary from "../../../Types/Dictionary";
+import Exception from "../../../Types/Exception/Exception";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import TelemetryType from "../../../Types/Telemetry/TelemetryType";
+import SecurityEvent from "../../../Models/AnalyticsModels/SecurityEvent";
+import UserType from "../../../Types/UserType";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * /telemetry/security-events/get-attributes[-values]
+ * ---------------------------------------------------------------------------
+ *
+ * These back the "Add Attribute Column" search on the security events table:
+ * the keys inside an event's `attributes` map differ per event class and per
+ * source, so the UI has to ask which ones exist.
+ *
+ * They do not go through BaseAnalyticsAPI, so nothing downstream re-checks
+ * authorization - the tenantId arrives in a caller-controlled header and
+ * UserMiddleware lets tokenless requests through as Public. The guard on the
+ * route IS the access control, and it has to stay exactly as permissive as
+ * the SecurityEvent model's own read list, no more. That parity is the main
+ * thing pinned here.
+ */
+
+type RouterFunction = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+type RecordedRoute = {
+  method: string;
+  uri: string;
+  handlers: Array<RouterFunction>;
+};
+
+const recordedRoutes: Array<RecordedRoute> = [];
+
+type RecordRouteFunction = (
+  method: string,
+) => (uri: string, ...handlers: Array<RouterFunction>) => void;
+
+const recordRoute: RecordRouteFunction = (method: string) => {
+  return (uri: string, ...handlers: Array<RouterFunction>): void => {
+    recordedRoutes.push({
+      method: method.toUpperCase(),
+      uri: uri,
+      handlers: handlers,
+    });
+  };
+};
+
+const telemetryRouter: JSONObject = {
+  get: recordRoute("get"),
+  post: recordRoute("post"),
+  put: recordRoute("put"),
+  delete: recordRoute("delete"),
+} as unknown as JSONObject;
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return telemetryRouter;
+    },
+    getClientIp: () => {
+      return "203.0.113.7";
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+  };
+});
+
+const KEYS_ROUTE: string = "/telemetry/security-events/get-attributes";
+const VALUES_ROUTE: string = "/telemetry/security-events/get-attribute-values";
+
+type FindRouteFunction = (uri: string) => RecordedRoute;
+
+const findRoute: FindRouteFunction = (uri: string): RecordedRoute => {
+  const route: RecordedRoute | undefined = recordedRoutes.find(
+    (candidate: RecordedRoute): boolean => {
+      return candidate.method === "POST" && candidate.uri === uri;
+    },
+  );
+
+  if (!route) {
+    throw new Error(`Route not registered: ${uri}`);
+  }
+
+  return route;
+};
+
+type CallResult = {
+  deniedWith: Exception | undefined;
+  thrownToNext: unknown;
+  reachedHandler: boolean;
+  jsonBody: JSONObject | undefined;
+};
+
+/*
+ * Runs a recorded route's middleware chain for real, starting at
+ * requireUserAuthentication. Index 0 is getUserMiddleware, whose only job is
+ * to populate the session fields these fixtures set directly - running it
+ * would need a live session store and prove nothing about authorization.
+ */
+type CallRouteFunction = (data: {
+  uri: string;
+  request: JSONObject;
+  body: JSONObject;
+}) => Promise<CallResult>;
+
+const callRoute: CallRouteFunction = async (data: {
+  uri: string;
+  request: JSONObject;
+  body: JSONObject;
+}): Promise<CallResult> => {
+  const route: RecordedRoute = findRoute(data.uri);
+
+  const req: ExpressRequest = {
+    ...data.request,
+    body: data.body,
+    params: {},
+    query: {},
+    headers: { "user-agent": "jest-agent" },
+  } as unknown as ExpressRequest;
+
+  const res: ExpressResponse = {
+    setHeader: (): void => {
+      // no-op
+    },
+    send: (): void => {
+      // no-op
+    },
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as ExpressResponse;
+
+  const outcome: { thrownToNext: unknown; reachedHandler: boolean } = {
+    thrownToNext: undefined,
+    reachedHandler: false,
+  };
+
+  for (let index: number = 1; index < route.handlers.length; index++) {
+    const handler: RouterFunction | undefined = route.handlers[index];
+
+    if (!handler) {
+      break;
+    }
+
+    if (index === route.handlers.length - 1) {
+      outcome.reachedHandler = true;
+    }
+
+    const step: { calledNext: boolean } = { calledNext: false };
+
+    const next: NextFunction = ((error?: unknown): void => {
+      step.calledNext = true;
+
+      if (error) {
+        outcome.thrownToNext = error;
+      }
+    }) as unknown as NextFunction;
+
+    await handler(req, res, next);
+
+    // A guard that answered the request itself never calls next.
+    if (!step.calledNext) {
+      break;
+    }
+  }
+
+  const sendErrorResponse: jest.Mock =
+    Response.sendErrorResponse as unknown as jest.Mock;
+  const sendJsonObjectResponse: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+
+  const errorCall: Array<unknown> | undefined = sendErrorResponse.mock
+    .calls[0] as Array<unknown> | undefined;
+  const jsonCall: Array<unknown> | undefined = sendJsonObjectResponse.mock
+    .calls[0] as Array<unknown> | undefined;
+
+  return {
+    deniedWith: errorCall ? (errorCall[2] as Exception) : undefined,
+    thrownToNext: outcome.thrownToNext,
+    reachedHandler: outcome.reachedHandler,
+    jsonBody: jsonCall ? (jsonCall[2] as JSONObject) : undefined,
+  };
+};
+
+type BuildPrincipalFunction = (data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+  permissions: Array<Permission>;
+}) => JSONObject;
+
+const buildPrincipal: BuildPrincipalFunction = (data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+  permissions: Array<Permission>;
+}): JSONObject => {
+  /*
+   * isBlockPermission must be an explicit false: getUserPermissions filters
+   * tenant permissions with a strict `=== false`, so undefined would silently
+   * drop every permission the fixture grants.
+   */
+  const userPermissions: Array<UserPermission> = data.permissions.map(
+    (permission: Permission): UserPermission => {
+      return {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+        isBlockPermission: false,
+      };
+    },
+  );
+
+  const tenantPermission: UserTenantAccessPermission = {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: userPermissions,
+  };
+
+  const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+  permissionMap[data.projectId.toString()] = tenantPermission;
+
+  return {
+    userType: UserType.User,
+    tenantId: data.projectId,
+    userTenantAccessPermission: permissionMap,
+    userAuthorization: { userId: data.userId },
+  } as unknown as JSONObject;
+};
+
+describe("Security event attribute API", () => {
+  let projectId: ObjectID;
+  let userId: ObjectID;
+
+  interface ServiceSpy {
+    mock: { calls: Array<Array<unknown>> };
+    mockResolvedValue: (value: Array<string>) => unknown;
+    mockRejectedValue: (value: unknown) => unknown;
+  }
+
+  let fetchAttributes: ServiceSpy;
+  let fetchAttributeValues: ServiceSpy;
+
+  beforeAll(() => {
+    recordedRoutes.length = 0;
+    /*
+     * Loaded lazily rather than with a top-level import: TelemetryAPI calls
+     * Express.getRouter() at module scope, so a static import would run the
+     * mock factory before `telemetryRouter` is initialised and die in the
+     * temporal dead zone.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../../../Server/API/TelemetryAPI");
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    projectId = ObjectID.generate();
+    userId = ObjectID.generate();
+
+    fetchAttributes = jest.spyOn(
+      TelemetryAttributeService,
+      "fetchAttributes" as never,
+    ) as unknown as ServiceSpy;
+    fetchAttributes.mockResolvedValue([]);
+
+    fetchAttributeValues = jest.spyOn(
+      TelemetryAttributeService,
+      "fetchAttributeValues" as never,
+    ) as unknown as ServiceSpy;
+    fetchAttributeValues.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("route registration", () => {
+    test("both routes exist as POST", () => {
+      expect(findRoute(KEYS_ROUTE).uri).toBe(KEYS_ROUTE);
+      expect(findRoute(VALUES_ROUTE).uri).toBe(VALUES_ROUTE);
+    });
+
+    /*
+     * getUserMiddleware, requireUserAuthentication, requirePermission, then
+     * the handler. A route registered without the guard chain would still
+     * "work" for the UI and be wide open.
+     */
+    test("both routes carry a guard chain in front of the handler", () => {
+      expect(findRoute(KEYS_ROUTE).handlers.length).toBe(4);
+      expect(findRoute(VALUES_ROUTE).handlers.length).toBe(4);
+    });
+  });
+
+  describe("access control", () => {
+    test("an unauthenticated caller is refused", async () => {
+      const result: CallResult = await callRoute({
+        uri: KEYS_ROUTE,
+        request: { userType: UserType.Public, tenantId: projectId },
+        body: {},
+      });
+
+      expect(result.reachedHandler).toBe(false);
+      expect(result.deniedWith).toBeDefined();
+      expect(fetchAttributes.mock.calls).toHaveLength(0);
+    });
+
+    test("a project member without any telemetry read permission is refused", async () => {
+      const result: CallResult = await callRoute({
+        uri: KEYS_ROUTE,
+        request: buildPrincipal({
+          projectId,
+          userId,
+          permissions: [Permission.ReadProject],
+        }),
+        body: {},
+      });
+
+      expect(result.reachedHandler).toBe(false);
+      expect(result.deniedWith).toBeDefined();
+      expect(fetchAttributes.mock.calls).toHaveLength(0);
+    });
+
+    test("ReadSecurityEvent alone is enough", async () => {
+      const result: CallResult = await callRoute({
+        uri: KEYS_ROUTE,
+        request: buildPrincipal({
+          projectId,
+          userId,
+          permissions: [Permission.ReadSecurityEvent],
+        }),
+        body: {},
+      });
+
+      expect(result.reachedHandler).toBe(true);
+      expect(result.deniedWith).toBeUndefined();
+    });
+
+    /*
+     * The guard has to mirror the model's table-level read list exactly, or
+     * these routes end up either stricter or looser than the CRUD API for the
+     * same rows. Every permission the model grants a read to is exercised.
+     */
+    test.each([
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.ReadSecurityEvent,
+    ])("%s can read attribute keys", async (permission: Permission) => {
+      const result: CallResult = await callRoute({
+        uri: KEYS_ROUTE,
+        request: buildPrincipal({
+          projectId,
+          userId,
+          permissions: [permission],
+        }),
+        body: {},
+      });
+
+      expect(result.reachedHandler).toBe(true);
+    });
+
+    test("the model's read list and the guard have not drifted apart", () => {
+      const modelReadPermissions: Array<Permission> =
+        new SecurityEvent().getReadPermissions();
+
+      expect(modelReadPermissions).toEqual(
+        expect.arrayContaining([Permission.ReadSecurityEvent]),
+      );
+      expect(modelReadPermissions).toHaveLength(8);
+    });
+
+    test("the values route is guarded the same way", async () => {
+      const result: CallResult = await callRoute({
+        uri: VALUES_ROUTE,
+        request: { userType: UserType.Public, tenantId: projectId },
+        body: { attributeKey: "device.hostname" },
+      });
+
+      expect(result.reachedHandler).toBe(false);
+      expect(result.deniedWith).toBeDefined();
+    });
+  });
+
+  describe("attribute keys", () => {
+    type CallKeysFunction = (body?: JSONObject) => Promise<CallResult>;
+
+    const callKeys: CallKeysFunction = (
+      body: JSONObject = {},
+    ): Promise<CallResult> => {
+      return callRoute({
+        uri: KEYS_ROUTE,
+        request: buildPrincipal({
+          projectId,
+          userId,
+          permissions: [Permission.ReadSecurityEvent],
+        }),
+        body: body,
+      });
+    };
+
+    /*
+     * The whole point of the new source: asking for Log attributes here would
+     * return the wrong project's-worth of keys from the wrong table, and look
+     * entirely plausible in the picker.
+     */
+    test("asks the attribute service for SECURITY EVENT attributes", async () => {
+      await callKeys();
+
+      expect(fetchAttributes.mock.calls[0]![0]).toMatchObject({
+        telemetryType: TelemetryType.SecurityEvent,
+      });
+    });
+
+    test("scopes the lookup to the caller's project", async () => {
+      await callKeys();
+
+      const request: JSONObject = fetchAttributes.mock
+        .calls[0]![0] as JSONObject;
+
+      expect((request["projectId"] as ObjectID).toString()).toBe(
+        projectId.toString(),
+      );
+    });
+
+    test("returns the keys under an `attributes` field", async () => {
+      fetchAttributes.mockResolvedValue(["class_uid", "device.hostname"]);
+
+      const result: CallResult = await callKeys();
+
+      expect(result.jsonBody).toEqual({
+        attributes: ["class_uid", "device.hostname"],
+      });
+    });
+
+    test("no keys is an empty list, not an error", async () => {
+      const result: CallResult = await callKeys();
+
+      expect(result.jsonBody).toEqual({ attributes: [] });
+    });
+
+    test("a service failure goes to the error handler rather than a 200", async () => {
+      fetchAttributes.mockRejectedValue(new Error("clickhouse said no"));
+
+      const result: CallResult = await callKeys();
+
+      expect(result.thrownToNext).toBeDefined();
+      expect(result.jsonBody).toBeUndefined();
+    });
+  });
+
+  describe("attribute values", () => {
+    type CallValuesFunction = (body: JSONObject) => Promise<CallResult>;
+
+    const callValues: CallValuesFunction = (
+      body: JSONObject,
+    ): Promise<CallResult> => {
+      return callRoute({
+        uri: VALUES_ROUTE,
+        request: buildPrincipal({
+          projectId,
+          userId,
+          permissions: [Permission.ReadSecurityEvent],
+        }),
+        body: body,
+      });
+    };
+
+    test("asks for SECURITY EVENT values for the requested key", async () => {
+      await callValues({ attributeKey: "device.hostname" });
+
+      expect(fetchAttributeValues.mock.calls[0]![0]).toMatchObject({
+        telemetryType: TelemetryType.SecurityEvent,
+        attributeKey: "device.hostname",
+      });
+    });
+
+    test("passes the search text through so the narrowing happens server-side", async () => {
+      await callValues({ attributeKey: "device.hostname", searchText: "web" });
+
+      expect(fetchAttributeValues.mock.calls[0]![0]).toMatchObject({
+        searchText: "web",
+      });
+    });
+
+    test("a missing attribute key is a bad request, not an unbounded scan", async () => {
+      const result: CallResult = await callValues({});
+
+      expect(result.deniedWith).toBeDefined();
+      expect(fetchAttributeValues.mock.calls).toHaveLength(0);
+    });
+
+    /*
+     * The body is caller-controlled JSON, so a non-string is not a key.
+     * Reading it as one would put a non-string into the SQL parameter.
+     */
+    test("a non-string attribute key is rejected", async () => {
+      const result: CallResult = await callValues({ attributeKey: 42 });
+
+      expect(result.deniedWith).toBeDefined();
+      expect(fetchAttributeValues.mock.calls).toHaveLength(0);
+    });
+
+    test("returns the values under a `values` field", async () => {
+      fetchAttributeValues.mockResolvedValue(["web-1", "web-2"]);
+
+      const result: CallResult = await callValues({
+        attributeKey: "device.hostname",
+      });
+
+      expect(result.jsonBody).toEqual({ values: ["web-1", "web-2"] });
+    });
+  });
+});

--- a/Common/Tests/Server/Services/TelemetryAttributeServiceSecurityEvent.test.ts
+++ b/Common/Tests/Server/Services/TelemetryAttributeServiceSecurityEvent.test.ts
@@ -1,0 +1,256 @@
+import { TelemetryAttributeService } from "../../../Server/Services/TelemetryAttributeService";
+import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import SecurityEvent from "../../../Models/AnalyticsModels/SecurityEvent";
+import AnalyticsTableName from "../../../Types/AnalyticsDatabase/AnalyticsTableName";
+import TelemetryType from "../../../Types/Telemetry/TelemetryType";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Security events are the fourth signal to grow an attribute picker, and the
+ * one where it matters most: the OCSF schema only has typed columns for the
+ * common fields, so everything else a SIEM sent - device.hostname,
+ * finding_info.title, metadata.product.name - lives in the `attributes` map.
+ * The security events table offers those as columns, and this is the query
+ * that tells it which ones exist.
+ *
+ * TelemetryType.SecurityEvent was in the enum long before there was a source
+ * for it, and getTelemetrySource returns null for anything it does not
+ * recognise - which makes a missing case a silently empty picker rather than
+ * an error. That is what the first test here exists to catch.
+ */
+
+type SourceShape = {
+  tableName: string;
+  attributesColumn: string;
+  attributeKeysColumn?: string | undefined;
+  timeColumn: string;
+  isMutableMetricSource?: boolean | undefined;
+};
+
+type GetSourceFunction = (telemetryType: TelemetryType) => SourceShape | null;
+
+const getSource: GetSourceFunction = (
+  telemetryType: TelemetryType,
+): SourceShape | null => {
+  return (
+    new TelemetryAttributeService() as unknown as {
+      getTelemetrySource: (type: TelemetryType) => SourceShape | null;
+    }
+  ).getTelemetrySource(telemetryType);
+};
+
+describe("TelemetryAttributeService - security event source", () => {
+  test("security events resolve to a source at all", () => {
+    expect(getSource(TelemetryType.SecurityEvent)).not.toBeNull();
+  });
+
+  test("points at the security event table", () => {
+    const source: SourceShape = getSource(
+      TelemetryType.SecurityEvent,
+    ) as SourceShape;
+
+    expect(source.tableName).toBe(AnalyticsTableName.SecurityEvent);
+    expect(source.tableName).toBe(new SecurityEvent().tableName);
+  });
+
+  /*
+   * The names are bound into the statement as identifiers, so a typo here is
+   * not a type error anywhere - it is a query that fails at runtime against a
+   * table that does exist.
+   */
+  test("names columns that are actually on the model", () => {
+    const source: SourceShape = getSource(
+      TelemetryType.SecurityEvent,
+    ) as SourceShape;
+
+    const model: SecurityEvent = new SecurityEvent();
+
+    expect(model.hasColumn(source.attributesColumn)).toBe(true);
+    expect(model.hasColumn(source.attributeKeysColumn as string)).toBe(true);
+    expect(model.hasColumn(source.timeColumn)).toBe(true);
+  });
+
+  /*
+   * The sidecar array column is what keeps this cheap: without it the SQL
+   * falls back to mapKeys(attributes), which reads the whole map off every
+   * row instead of an already-denormalized array.
+   */
+  test("uses the attributeKeys sidecar rather than expanding the map", () => {
+    const source: SourceShape = getSource(
+      TelemetryType.SecurityEvent,
+    ) as SourceShape;
+
+    expect(source.attributeKeysColumn).toBe("attributeKeys");
+    expect(source.attributesColumn).toBe("attributes");
+    expect(source.timeColumn).toBe("time");
+  });
+
+  test("is not treated as a mutable metric source", () => {
+    const source: SourceShape = getSource(
+      TelemetryType.SecurityEvent,
+    ) as SourceShape;
+
+    expect(source.isMutableMetricSource).toBeFalsy();
+  });
+
+  // A signal with no source still degrades to "no attributes", not an error.
+  test("a telemetry type with no source is still null", () => {
+    expect(getSource(TelemetryType.Profile)).toBeNull();
+  });
+});
+
+describe("TelemetryAttributeService - security event attribute keys query", () => {
+  type BuildAttributesInput = {
+    projectId: ObjectID;
+    tableName: string;
+    attributesColumn: string;
+    attributeKeysColumn?: string | undefined;
+    timeColumn: string;
+    metricName?: string | undefined;
+    isMutableMetricSource?: boolean | undefined;
+  };
+
+  type BuildStatementFunction = () => Statement;
+
+  const buildStatement: BuildStatementFunction = (): Statement => {
+    const source: SourceShape = getSource(
+      TelemetryType.SecurityEvent,
+    ) as SourceShape;
+
+    return (
+      TelemetryAttributeService as unknown as {
+        buildAttributesStatement: (data: BuildAttributesInput) => Statement;
+      }
+    ).buildAttributesStatement({
+      projectId: ObjectID.generate(),
+      tableName: source.tableName,
+      attributesColumn: source.attributesColumn,
+      attributeKeysColumn: source.attributeKeysColumn,
+      timeColumn: source.timeColumn,
+    });
+  };
+
+  /*
+   * Table and column names ride in as {pN:Identifier} bindings rather than as
+   * SQL text, so everything below asserts against the bound parameters. That
+   * is the point of the check as much as a quirk of it: nothing
+   * caller-influenced is ever concatenated into these statements.
+   */
+  test("aggregates the sidecar array over the security event table", () => {
+    const statement: Statement = buildStatement();
+
+    expect(Object.values(statement.query_params)).toContain(
+      AnalyticsTableName.SecurityEvent,
+    );
+    expect(statement.query).toContain("groupUniqArrayArray(");
+    expect(Object.values(statement.query_params)).toContain("attributeKeys");
+
+    /*
+     * The mapKeys() branch is the fallback for tables with no sidecar column;
+     * taking it here would read the whole map off every row.
+     */
+    expect(statement.query).not.toContain("mapKeys(");
+  });
+
+  test("scopes to one project, as a bound parameter", () => {
+    const statement: Statement = buildStatement();
+
+    expect(statement.query).toContain("projectId = ");
+    /*
+     * A tenant id interpolated into SQL would be both an injection surface
+     * and a cache-buster; every value in these statements is parameterized.
+     */
+    expect(statement.query).toMatch(/projectId = \{p\d+:String\}/);
+  });
+
+  test("bounds the scan by time and by execution budget", () => {
+    const statement: Statement = buildStatement();
+
+    expect(Object.values(statement.query_params)).toContain("time");
+    expect(statement.query).toMatch(/>= \{p\d+:DateTime\}/);
+    expect(statement.query).toContain("max_execution_time = 45");
+    expect(statement.query).toContain("timeout_overflow_mode = 'break'");
+  });
+
+  test("skips rows with no attributes at all", () => {
+    const statement: Statement = buildStatement();
+
+    expect(statement.query).toMatch(/NOT empty\(\{p\d+:Identifier\}\)/);
+  });
+
+  // metricName is a Metric-only filter; nothing here should mention `name`.
+  test("does not filter by metric name", () => {
+    const statement: Statement = buildStatement();
+
+    expect(statement.query).not.toContain("AND name = ");
+  });
+});
+
+describe("TelemetryAttributeService - security event attribute values query", () => {
+  type BuildValuesInput = {
+    projectId: ObjectID;
+    source: SourceShape;
+    metricName?: string | undefined;
+    attributeKey: string;
+    searchText?: string | undefined;
+  };
+
+  type BuildValuesFunction = (searchText?: string | undefined) => Statement;
+
+  const buildValues: BuildValuesFunction = (
+    searchText?: string | undefined,
+  ): Statement => {
+    return (
+      TelemetryAttributeService as unknown as {
+        buildAttributeValuesStatement: (data: BuildValuesInput) => Statement;
+      }
+    ).buildAttributeValuesStatement({
+      projectId: ObjectID.generate(),
+      source: getSource(TelemetryType.SecurityEvent) as SourceShape,
+      attributeKey: "device.hostname",
+      ...(searchText === undefined ? {} : { searchText }),
+    });
+  };
+
+  test("reads the requested key out of the map on the security event table", () => {
+    const statement: Statement = buildValues();
+
+    const params: Array<unknown> = Object.values(statement.query_params);
+
+    expect(params).toContain(AnalyticsTableName.SecurityEvent);
+    expect(params).toContain("attributes");
+    expect(params).toContain("device.hostname");
+    expect(statement.query).toContain("mapContains(");
+  });
+
+  /*
+   * The key is caller-supplied, so it must never reach the SQL text - an
+   * attribute key can contain quotes, brackets, anything a payload had.
+   */
+  test("never inlines the attribute key into the SQL text", () => {
+    const statement: Statement = buildValues();
+
+    expect(statement.query).not.toContain("device.hostname");
+  });
+
+  test("narrows server-side when the picker sends search text", () => {
+    const statement: Statement = buildValues("web");
+
+    expect(statement.query).toContain("ILIKE");
+    expect(Object.values(statement.query_params)).toContain("%web%");
+  });
+
+  test("whitespace-only search text is not a filter", () => {
+    const statement: Statement = buildValues("   ");
+
+    expect(statement.query).not.toContain("ILIKE");
+  });
+
+  test("caps the number of values returned", () => {
+    const statement: Statement = buildValues();
+
+    expect(statement.query).toContain("ORDER BY attributeValue ASC");
+    expect(statement.query).toContain("LIMIT ");
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/AttributeColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/AttributeColumns.test.tsx
@@ -1,0 +1,573 @@
+import Column from "../../../../UI/Components/ModelTable/Column";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import {
+  getAttributeColumnId,
+  getAttributeColumns,
+  getAttributeExportValue,
+  getAttributeKeyFromColumnId,
+  getAttributeKeysFromColumnPreference,
+  getAttributeValue,
+  normalizeAttributeKeys,
+  renderAttributeValue,
+} from "../../../../UI/Components/ModelTable/AttributeColumns";
+import {
+  ColumnPreference,
+  getColumnBaseId,
+  getColumnIds,
+  getCustomizableColumns,
+  CustomizableColumn,
+} from "../../../../UI/Components/ModelTable/ColumnPreference";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import SecurityEvent from "../../../../Models/AnalyticsModels/SecurityEvent";
+import { JSONObject } from "../../../../Types/JSON";
+import "@testing-library/jest-dom";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Attribute columns are generated from keys inside a row's Map(String,String)
+ * column, which is where every source field the OCSF schema has no typed
+ * column for ends up. Almost everything about their shape is load-bearing in a
+ * way that fails quietly rather than loudly:
+ *
+ *  - the declared `field` has to be the REAL map column. A synthetic
+ *    `field: { "attributes.x": true }` fails the model's column check in
+ *    getSelectFromColumns and throws the whole table away.
+ *  - the id has to match what ColumnPreference would derive on its own, or a
+ *    stored layout and a live column disagree about which column is which.
+ *  - sorting has to stay off: a dotted pseudo-column reaching the query
+ *    builder is not something ClickHouse can order by.
+ *  - the cell has to render through getElement, because the typed renderers
+ *    index item[column.key] and would look for a literal
+ *    "attributes.device.hostname" property no row has.
+ *
+ * And the whole "which columns did the viewer add" question is answered by
+ * reading the stored layout back, so that round trip is pinned here too.
+ */
+
+const ATTRIBUTES: string = "attributes";
+
+afterEach(() => {
+  cleanup();
+});
+
+type MakeEventFunction = (attributes: JSONObject | undefined) => SecurityEvent;
+
+const makeEvent: MakeEventFunction = (
+  attributes: JSONObject | undefined,
+): SecurityEvent => {
+  const event: SecurityEvent = new SecurityEvent();
+  event.attributes = attributes;
+  return event;
+};
+
+describe("AttributeColumns - ids", () => {
+  test("the id is the map column and the key, joined with a dot", () => {
+    expect(
+      getAttributeColumnId({
+        attributesColumnKey: ATTRIBUTES,
+        attributeKey: "device.hostname",
+      }),
+    ).toBe("attributes.device.hostname");
+  });
+
+  test("the id round-trips back to the key", () => {
+    const columnId: string = getAttributeColumnId({
+      attributesColumnKey: ATTRIBUTES,
+      attributeKey: "metadata.product.name",
+    });
+
+    expect(
+      getAttributeKeyFromColumnId({
+        attributesColumnKey: ATTRIBUTES,
+        columnId: columnId,
+      }),
+    ).toBe("metadata.product.name");
+  });
+
+  test("an id under a different column, or with no key at all, is not an attribute id", () => {
+    expect(
+      getAttributeKeyFromColumnId({
+        attributesColumnKey: ATTRIBUTES,
+        columnId: "customFields.Severity",
+      }),
+    ).toBeNull();
+
+    // The map column itself is a column, not a column-per-key.
+    expect(
+      getAttributeKeyFromColumnId({
+        attributesColumnKey: ATTRIBUTES,
+        columnId: "attributes",
+      }),
+    ).toBeNull();
+
+    expect(
+      getAttributeKeyFromColumnId({
+        attributesColumnKey: ATTRIBUTES,
+        columnId: "attributes.",
+      }),
+    ).toBeNull();
+  });
+
+  /*
+   * The explicit id and the one ColumnPreference derives from field +
+   * selectedProperty have to be the same string. If they ever drift, a layout
+   * saved by one release stops matching the column in the next.
+   */
+  test("the explicit id matches what ColumnPreference would derive on its own", () => {
+    const [column] = getAttributeColumns<SecurityEvent>({
+      attributesColumnKey: ATTRIBUTES,
+      attributeKeys: ["device.hostname"],
+    });
+
+    const derivedId: string = getColumnBaseId<SecurityEvent>({
+      ...(column as Column<SecurityEvent>),
+      id: undefined,
+    });
+
+    expect(column!.id).toBe(derivedId);
+  });
+
+  test("ids stay unique across a generated set", () => {
+    const columns: Columns<SecurityEvent> = getAttributeColumns<SecurityEvent>({
+      attributesColumnKey: ATTRIBUTES,
+      attributeKeys: ["a", "b", "a.b", "c"],
+    });
+
+    const ids: Array<string> = getColumnIds<SecurityEvent>(columns);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("AttributeColumns - normalizeAttributeKeys", () => {
+  test("trims, de-duplicates and sorts", () => {
+    expect(
+      normalizeAttributeKeys([
+        "  user.name  ",
+        "device.hostname",
+        "user.name",
+        "class_uid",
+      ]),
+    ).toEqual(["class_uid", "device.hostname", "user.name"]);
+  });
+
+  test("drops empties and non-strings rather than rendering them as columns", () => {
+    expect(
+      normalizeAttributeKeys(["", "   ", null, undefined, 42, {}, "ok"]),
+    ).toEqual(["ok"]);
+  });
+
+  test("anything that is not an array degrades to an empty list", () => {
+    expect(normalizeAttributeKeys(null)).toEqual([]);
+    expect(normalizeAttributeKeys(undefined)).toEqual([]);
+    expect(
+      normalizeAttributeKeys("device.hostname" as unknown as Array<unknown>),
+    ).toEqual([]);
+  });
+
+  test("the same input always produces the same order", () => {
+    const first: Array<string> = normalizeAttributeKeys(["b", "a", "c"]);
+    const second: Array<string> = normalizeAttributeKeys(["c", "a", "b"]);
+
+    expect(first).toEqual(second);
+  });
+});
+
+describe("AttributeColumns - reading a value off a row", () => {
+  test("reads the key out of the map column", () => {
+    expect(
+      getAttributeValue({
+        item: makeEvent({ "device.hostname": "web-1" }),
+        attributesColumnKey: ATTRIBUTES,
+        attributeKey: "device.hostname",
+      }),
+    ).toBe("web-1");
+  });
+
+  test("a row with no map, or no such key, has no value", () => {
+    expect(
+      getAttributeValue({
+        item: makeEvent(undefined),
+        attributesColumnKey: ATTRIBUTES,
+        attributeKey: "device.hostname",
+      }),
+    ).toBeUndefined();
+
+    expect(
+      getAttributeValue({
+        item: makeEvent({ "user.name": "bob" }),
+        attributesColumnKey: ATTRIBUTES,
+        attributeKey: "device.hostname",
+      }),
+    ).toBeUndefined();
+
+    expect(
+      getAttributeValue({
+        item: undefined,
+        attributesColumnKey: ATTRIBUTES,
+        attributeKey: "device.hostname",
+      }),
+    ).toBeUndefined();
+  });
+
+  /*
+   * The map is typed Map(String,String) in ClickHouse, but rows also reach
+   * this code straight from JSON the API returned, and a project can PUT
+   * anything over the ingest API - so a non-string must not throw.
+   */
+  test("a non-object under the map column is treated as absent", () => {
+    expect(
+      getAttributeValue({
+        item: { attributes: "not-a-map" },
+        attributesColumnKey: ATTRIBUTES,
+        attributeKey: "device.hostname",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("AttributeColumns - export values", () => {
+  test("scalars stringify", () => {
+    expect(getAttributeExportValue("web-1")).toBe("web-1");
+    expect(getAttributeExportValue(3002)).toBe("3002");
+    expect(getAttributeExportValue(false)).toBe("false");
+  });
+
+  test("null and undefined export as an empty cell, not as the word", () => {
+    expect(getAttributeExportValue(null)).toBe("");
+    expect(getAttributeExportValue(undefined)).toBe("");
+  });
+
+  test("arrays join, objects serialize", () => {
+    expect(getAttributeExportValue(["a", "b"])).toBe("a, b");
+    expect(getAttributeExportValue({ a: 1 })).toBe('{"a":1}');
+  });
+
+  /*
+   * An empty string is a real stored value; it just has nothing to show. It
+   * must not become the literal text "" in a CSV.
+   */
+  test("an empty string exports as an empty cell", () => {
+    expect(getAttributeExportValue("")).toBe("");
+  });
+});
+
+describe("AttributeColumns - rendering", () => {
+  test("renders the value, with the full text available on hover", () => {
+    const { container } = render(
+      renderAttributeValue({ value: "web-1.prod.internal" }),
+    );
+
+    expect(container.textContent).toBe("web-1.prod.internal");
+    expect(container.querySelector("span")).toHaveAttribute(
+      "title",
+      "web-1.prod.internal",
+    );
+  });
+
+  test("a missing value renders the placeholder rather than nothing", () => {
+    const { container } = render(renderAttributeValue({ value: undefined }));
+
+    expect(container.textContent).toBe("-");
+  });
+
+  test("the placeholder is configurable", () => {
+    const { container } = render(
+      renderAttributeValue({ value: null, noValueMessage: "not set" }),
+    );
+
+    expect(container.textContent).toBe("not set");
+  });
+
+  test("a nested value renders rather than showing [object Object]", () => {
+    const { container } = render(
+      renderAttributeValue({ value: { product: "SecOps" } }),
+    );
+
+    expect(container.textContent).toBe('{"product":"SecOps"}');
+  });
+});
+
+describe("AttributeColumns - generated column shape", () => {
+  const columns: Columns<SecurityEvent> = getAttributeColumns<SecurityEvent>({
+    attributesColumnKey: ATTRIBUTES,
+    attributeKeys: ["device.hostname"],
+  });
+
+  const column: Column<SecurityEvent> = columns[0] as Column<SecurityEvent>;
+
+  test("declares the real map column as its field", () => {
+    /*
+     * getSelectFromColumns throws a BadDataException for a field the model
+     * does not have, which takes the entire table down - so this has to be a
+     * column that exists.
+     */
+    expect(Object.keys(column.field as JSONObject)).toEqual([ATTRIBUTES]);
+    expect(new SecurityEvent().hasColumn(ATTRIBUTES)).toBe(true);
+  });
+
+  test("names the key through selectedProperty, not through the field", () => {
+    expect(column.selectedProperty).toBe("device.hostname");
+  });
+
+  test("titles itself with the raw key, so searching for the key finds it", () => {
+    expect(column.title).toBe("device.hostname");
+  });
+
+  test("is not sortable", () => {
+    expect(column.disableSort).toBe(true);
+  });
+
+  test("renders through getElement", () => {
+    expect(column.type).toBe(FieldType.Element);
+    expect(typeof column.getElement).toBe("function");
+  });
+
+  test("is removable, so the picker can take it away again", () => {
+    expect(column.isRemovable).toBe(true);
+  });
+
+  test("defaults to visible - a column you just added should be on screen", () => {
+    expect(column.isHiddenByDefault).toBe(false);
+  });
+
+  test("can be generated hidden when a caller wants a checklist instead", () => {
+    const [hidden] = getAttributeColumns<SecurityEvent>({
+      attributesColumnKey: ATTRIBUTES,
+      attributeKeys: ["device.hostname"],
+      isHiddenByDefault: true,
+    });
+
+    expect(hidden!.isHiddenByDefault).toBe(true);
+  });
+
+  test("the cell reads its own key off the row", () => {
+    const { container } = render(
+      column.getElement!(makeEvent({ "device.hostname": "web-1" })),
+    );
+
+    expect(container.textContent).toBe("web-1");
+  });
+
+  test("the cell renders the placeholder for a row that lacks the key", () => {
+    const { container } = render(
+      column.getElement!(makeEvent({ "user.name": "bob" })),
+    );
+
+    expect(container.textContent).toBe("-");
+  });
+
+  test("the export cell reads the same key the rendered cell does", () => {
+    expect(
+      column.getExportValue!(makeEvent({ "device.hostname": "web-1" })),
+    ).toBe("web-1");
+
+    expect(column.getExportValue!(makeEvent({}))).toBe("");
+  });
+
+  test("generates one column per key, in the order given", () => {
+    const many: Columns<SecurityEvent> = getAttributeColumns<SecurityEvent>({
+      attributesColumnKey: ATTRIBUTES,
+      attributeKeys: ["b", "a", "c"],
+    });
+
+    expect(
+      many.map((entry: Column<SecurityEvent>) => {
+        return entry.title;
+      }),
+    ).toEqual(["b", "a", "c"]);
+  });
+
+  test("an empty key list generates nothing", () => {
+    expect(
+      getAttributeColumns<SecurityEvent>({
+        attributesColumnKey: ATTRIBUTES,
+        attributeKeys: [],
+      }),
+    ).toEqual([]);
+  });
+
+  /*
+   * `isRemovable` has to survive the trip into the picker's model, because
+   * that is the only thing that tells the modal to offer a remove button.
+   */
+  test("isRemovable reaches the picker entry", () => {
+    const entries: Array<CustomizableColumn<SecurityEvent>> =
+      getCustomizableColumns<SecurityEvent>({ columns, preference: null });
+
+    expect(entries[0]!.isRemovable).toBe(true);
+  });
+
+  test("a pinned column is never removable, whatever it declares", () => {
+    const entries: Array<CustomizableColumn<SecurityEvent>> =
+      getCustomizableColumns<SecurityEvent>({
+        columns: [
+          {
+            ...(column as Column<SecurityEvent>),
+            isNotCustomizable: true,
+          },
+        ],
+        preference: null,
+      });
+
+    expect(entries[0]!.isPinned).toBe(true);
+    expect(entries[0]!.isRemovable).toBe(false);
+  });
+
+  test("an ordinary column is not removable", () => {
+    const entries: Array<CustomizableColumn<SecurityEvent>> =
+      getCustomizableColumns<SecurityEvent>({
+        columns: [
+          {
+            field: { message: true },
+            title: "Message",
+            type: FieldType.Text,
+          },
+        ],
+        preference: null,
+      });
+
+    expect(entries[0]!.isRemovable).toBe(false);
+  });
+});
+
+describe("AttributeColumns - recovering the viewer's keys from a stored layout", () => {
+  /*
+   * There is no second store for "which attribute columns did they add": a
+   * column exists precisely when its id is in the layout. Everything below
+   * pins that recovery, because a bug here silently loses columns someone
+   * chose, or invents ones they did not.
+   */
+  test("no stored layout means no attribute columns", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: null,
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual([]);
+
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: undefined,
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual([]);
+  });
+
+  test("picks the attribute ids out of the order list, in order", () => {
+    const preference: ColumnPreference = {
+      order: [
+        "time",
+        "attributes.device.hostname",
+        "severityName",
+        "attributes.class_uid",
+      ],
+      hidden: [],
+    };
+
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference,
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual(["device.hostname", "class_uid"]);
+  });
+
+  /*
+   * A viewer who switched an attribute column off still chose it. Losing it
+   * here would make "hide" behave like "remove", but only after a reload.
+   */
+  test("a hidden attribute column is still a column", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: {
+          order: ["time", "attributes.device.hostname"],
+          hidden: ["attributes.device.hostname"],
+        },
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual(["device.hostname"]);
+  });
+
+  /*
+   * buildColumnPreference always writes both lists, but a payload from an
+   * older release - or one hand-edited in devtools - may only carry `hidden`.
+   */
+  test("an id that appears only in hidden is still recovered", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: { order: [], hidden: ["attributes.device.hostname"] },
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual(["device.hostname"]);
+  });
+
+  test("the same key listed twice produces one column", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: {
+          order: ["attributes.a", "attributes.a"],
+          hidden: ["attributes.a"],
+        },
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual(["a"]);
+  });
+
+  test("ids belonging to declared columns are left alone", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: { order: ["attributes.device.hostname"], hidden: [] },
+        attributesColumnKey: ATTRIBUTES,
+        reservedColumnIds: ["attributes.device.hostname"],
+      }),
+    ).toEqual([]);
+  });
+
+  test("custom field ids are not mistaken for attribute ids", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: {
+          order: ["customFields.Severity", "attributes.user.name"],
+          hidden: [],
+        },
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual(["user.name"]);
+  });
+
+  test("a different map column name is honoured", () => {
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference: { order: ["resourceAttributes.host.name"], hidden: [] },
+        attributesColumnKey: "resourceAttributes",
+      }),
+    ).toEqual(["host.name"]);
+  });
+
+  /*
+   * The full round trip: keys -> columns -> ids -> a stored layout -> keys.
+   * This is the loop the feature actually runs every page load.
+   */
+  test("keys survive the round trip through generated columns and back", () => {
+    const keys: Array<string> = ["device.hostname", "finding_info.title"];
+
+    const columns: Columns<SecurityEvent> = getAttributeColumns<SecurityEvent>({
+      attributesColumnKey: ATTRIBUTES,
+      attributeKeys: keys,
+    });
+
+    const preference: ColumnPreference = {
+      order: getColumnIds<SecurityEvent>(columns),
+      hidden: [],
+    };
+
+    expect(
+      getAttributeKeysFromColumnPreference({
+        preference,
+        attributesColumnKey: ATTRIBUTES,
+      }),
+    ).toEqual(keys);
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableAttributeColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableAttributeColumns.test.tsx
@@ -1,0 +1,824 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  configure,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+/*
+ * A real BaseModelTable mounts a card, a header, a full table and (in the
+ * picker tests) a modal on top of that. That comfortably outruns the 1s
+ * default when the whole Common suite is competing for the same box.
+ */
+configure({ asyncUtilTimeout: 15000 });
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * BaseModelTable pulls in permissions, the current project and the i18n
+ * provider. None of those are what this suite is about.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return true;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined) => {
+          return value;
+        },
+        translateValue: (value: unknown) => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import SecurityEvent from "../../../../Models/AnalyticsModels/SecurityEvent";
+import Query from "../../../../Types/BaseDatabase/Query";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import UserPreferences, {
+  UserPreferenceType,
+} from "../../../../Utils/UserPreferences";
+import { JSONObject } from "../../../../Types/JSON";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Attribute columns, end to end through a real table
+ * ---------------------------------------------------------------------------
+ *
+ * A security event's typed OCSF columns are only half of what it carries; the
+ * rest of the source payload is flattened into an `attributes` map whose keys
+ * differ per event class. Those cannot ship as columns, so the picker offers
+ * them through a search box and whatever the viewer adds becomes an ordinary
+ * column.
+ *
+ * What is pinned here is everything that only shows up once the pieces are
+ * wired together:
+ *
+ *  - a column added from the picker actually renders a <th> and a cell;
+ *  - it survives a reload, because the layout it lives in is the same layout
+ *    every other column choice lives in;
+ *  - removing it, or resetting the layout, takes it away;
+ *  - the map column is on the wire from the FIRST request, since the table
+ *    does not refetch when its column set changes - get that wrong and a
+ *    freshly added column renders blank until something else reloads the page;
+ *  - the key pool is fetched lazily, when the picker opens, not on mount.
+ */
+
+const PREFS_KEY: string = "security-events-table";
+
+const ATTRIBUTE_KEYS: Array<string> = [
+  "activity_name",
+  "class_uid",
+  "device.hostname",
+  "finding_info.title",
+  "metadata.product.name",
+];
+
+type GetListCall = {
+  query: Query<SecurityEvent>;
+  select: JSONObject;
+};
+
+type MakeColumnsFunction = () => Columns<SecurityEvent>;
+
+const makeColumns: MakeColumnsFunction = (): Columns<SecurityEvent> => {
+  return [
+    { field: { message: true }, title: "Message", type: FieldType.Text },
+    { field: { severityName: true }, title: "Severity", type: FieldType.Text },
+    {
+      field: { eventUid: true },
+      title: "Event UID",
+      type: FieldType.Text,
+      isHiddenByDefault: true,
+    },
+  ] as unknown as Columns<SecurityEvent>;
+};
+
+type SeedPreferenceFunction = (data: {
+  order: Array<string>;
+  hidden: Array<string>;
+}) => void;
+
+const seedPreference: SeedPreferenceFunction = (data: {
+  order: Array<string>;
+  hidden: Array<string>;
+}): void => {
+  UserPreferences.saveUserPreferenceByTypeAsJSON({
+    key: PREFS_KEY,
+    userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+    value: { order: data.order, hidden: data.hidden },
+  });
+};
+
+type ReadPreferenceFunction = () => JSONObject | null;
+
+const readPreference: ReadPreferenceFunction = (): JSONObject | null => {
+  return UserPreferences.getUserPreferenceByTypeAsJSON({
+    key: PREFS_KEY,
+    userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+  });
+};
+
+type GetHeadersFunction = () => Array<string>;
+
+const getHeaders: GetHeadersFunction = (): Array<string> => {
+  return screen.getAllByRole("columnheader").map((header: HTMLElement) => {
+    return (header.textContent || "").trim();
+  });
+};
+
+describe("BaseModelTable attribute columns", () => {
+  let calls: Array<GetListCall> = [];
+  let rows: Array<JSONObject> = [];
+  let fetchCallCount: number = 0;
+  let fetchResult: () => Promise<Array<string>> = async () => {
+    return ATTRIBUTE_KEYS;
+  };
+
+  type MakeCallbacksFunction = () => BaseTableCallbacks<SecurityEvent>;
+
+  const makeCallbacks: MakeCallbacksFunction =
+    (): BaseTableCallbacks<SecurityEvent> => {
+      return {
+        deleteItem: async () => {
+          return undefined;
+        },
+        getModelFromJSON: (item: JSONObject) => {
+          return item as unknown as SecurityEvent;
+        },
+        getJSONFromModel: (item: SecurityEvent) => {
+          return item as unknown as JSONObject;
+        },
+        addSlugToSelect: (select: unknown) => {
+          return select;
+        },
+        getList: async (data: {
+          query: Query<SecurityEvent>;
+          limit: number;
+          select: JSONObject;
+        }): Promise<ListResult<SecurityEvent>> => {
+          calls.push({
+            query: data.query,
+            select: (data.select || {}) as unknown as JSONObject,
+          });
+          return {
+            data: rows as unknown as Array<SecurityEvent>,
+            count: rows.length,
+            skip: 0,
+            limit: data.limit,
+          };
+        },
+        toJSONArray: () => {
+          return rows;
+        },
+        updateById: async () => {
+          return undefined;
+        },
+        showCreateEditModal: () => {
+          return <></>;
+        },
+      } as unknown as BaseTableCallbacks<SecurityEvent>;
+    };
+
+  type RenderTableOptions = {
+    columns?: Columns<SecurityEvent> | undefined;
+    attributeColumnKey?: string | undefined;
+    withoutAttributeColumns?: boolean | undefined;
+  };
+
+  type RenderTableFunction = (
+    options?: RenderTableOptions,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    options: RenderTableOptions = {},
+  ): ReturnType<typeof render> => {
+    const props: BaseModelTableProps<SecurityEvent> = {
+      modelType: SecurityEvent,
+      id: "security-events-table",
+      name: "Security Events",
+      userPreferencesKey: PREFS_KEY,
+      cardProps: { title: "Security Events" },
+      columns: options.columns || makeColumns(),
+      filters: [],
+      isDeleteable: false,
+      isCreateable: false,
+      isViewable: false,
+      isEditable: false,
+      disableUrlState: true,
+      callbacks: makeCallbacks(),
+      ...(options.withoutAttributeColumns
+        ? {}
+        : {
+            attributeColumnsProps: {
+              columnKey: options.attributeColumnKey || "attributes",
+              title: "Add Attribute Column",
+              emptyMessage: "No attributes seen on recent events.",
+              fetchAttributeKeys: (): Promise<Array<string>> => {
+                fetchCallCount++;
+                return fetchResult();
+              },
+            },
+          }),
+    } as unknown as BaseModelTableProps<SecurityEvent>;
+
+    return render(<BaseModelTable<SecurityEvent> {...props} />);
+  };
+
+  type WaitForTableFunction = () => Promise<void>;
+
+  const waitForTable: WaitForTableFunction = async (): Promise<void> => {
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("columnheader").length).toBeGreaterThan(0);
+    });
+  };
+
+  type ClickFunction = (element: HTMLElement) => Promise<void>;
+
+  const click: ClickFunction = async (element: HTMLElement): Promise<void> => {
+    await act(async () => {
+      fireEvent.click(element);
+    });
+  };
+
+  type OpenPickerFunction = () => Promise<void>;
+
+  const openPicker: OpenPickerFunction = async (): Promise<void> => {
+    await click(screen.getByRole("button", { name: "More options" }));
+    await click(screen.getByText("Columns"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("column-customization-modal")).not.toBeNull();
+    });
+  };
+
+  type SavePickerFunction = () => Promise<void>;
+
+  const savePicker: SavePickerFunction = async (): Promise<void> => {
+    await click(screen.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("column-customization-modal")).toBeNull();
+    });
+  };
+
+  type WaitForPoolFunction = () => Promise<void>;
+
+  const waitForPool: WaitForPoolFunction = async (): Promise<void> => {
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("add-column-attributes.device.hostname"),
+      ).not.toBeNull();
+    });
+  };
+
+  beforeEach(() => {
+    calls = [];
+    rows = [];
+    fetchCallCount = 0;
+    fetchResult = async () => {
+      return ATTRIBUTE_KEYS;
+    };
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/dashboard/security-events",
+    );
+    TableFilterUrlState.resetClaimedKeys();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("the map column is always requested", () => {
+    /*
+     * The table does not refetch when its column set changes, so a column the
+     * viewer adds from the picker appears against rows that were fetched
+     * before it existed. If the map were only selected because a column reads
+     * it, every freshly added attribute column would render blank until
+     * something else happened to reload the page.
+     */
+    test("the very first request selects the map column, with no attribute columns yet", async () => {
+      renderTable();
+
+      await waitForTable();
+
+      expect(calls[0]!.select["attributes"]).toBe(true);
+    });
+
+    test("a table that did not opt in does not select the map column", async () => {
+      renderTable({ withoutAttributeColumns: true });
+
+      await waitForTable();
+
+      expect(calls[0]!.select["attributes"]).toBeUndefined();
+    });
+
+    /*
+     * A misconfigured columnKey must cost the feature, not the page:
+     * getSelectFromColumns throws a BadDataException for a field the model
+     * does not have, which would blank the whole table.
+     */
+    test("a column key that is not on the model is ignored rather than fatal", async () => {
+      renderTable({ attributeColumnKey: "notAColumn" });
+
+      await waitForTable();
+
+      expect(getHeaders()).toContain("Message");
+      expect(calls[0]!.select["notAColumn"]).toBeUndefined();
+    });
+  });
+
+  describe("the key pool", () => {
+    test("is not fetched on mount", async () => {
+      renderTable();
+
+      await waitForTable();
+
+      expect(fetchCallCount).toBe(0);
+    });
+
+    test("is fetched when the picker opens, and offered as searchable rows", async () => {
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+      await waitForPool();
+
+      expect(fetchCallCount).toBe(1);
+      expect(screen.getAllByTestId(/^add-column-attributes\./)).toHaveLength(
+        ATTRIBUTE_KEYS.length,
+      );
+    });
+
+    test("is fetched once, not again on every open", async () => {
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+      await waitForPool();
+      await click(screen.getByTestId("modal-footer-close-button"));
+      await openPicker();
+      await waitForPool();
+
+      expect(fetchCallCount).toBe(1);
+    });
+
+    test("is normalized: blanks dropped, duplicates collapsed, sorted", async () => {
+      fetchResult = async () => {
+        return ["zeta", "  alpha  ", "", "alpha"] as Array<string>;
+      };
+
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("add-column-attributes.alpha"),
+        ).not.toBeNull();
+      });
+
+      const offered: Array<string> = screen
+        .getAllByTestId(/^add-column-attributes\./)
+        .map((element: HTMLElement) => {
+          return (element.getAttribute("data-testid") || "").replace(
+            "add-column-attributes.",
+            "",
+          );
+        });
+
+      expect(offered).toEqual(["alpha", "zeta"]);
+    });
+
+    /*
+     * A failed pool costs the search box and nothing else. It must not take
+     * the picker, or the columns already added, down with it.
+     */
+    test("a failure is surfaced without breaking the rest of the picker", async () => {
+      fetchResult = async () => {
+        throw new Error("clickhouse said no");
+      };
+
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("add-column-error")).not.toBeNull();
+      });
+
+      expect(screen.getByTestId("add-column-error")).toHaveTextContent(
+        "clickhouse said no",
+      );
+      // The ordinary checklist is untouched.
+      expect(screen.getByTestId("column-toggle-message")).toBeInTheDocument();
+    });
+
+    test("a failed fetch is retried the next time the picker opens", async () => {
+      fetchResult = async () => {
+        throw new Error("clickhouse said no");
+      };
+
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("add-column-error")).not.toBeNull();
+      });
+
+      fetchResult = async () => {
+        return ATTRIBUTE_KEYS;
+      };
+
+      await click(screen.getByTestId("modal-footer-close-button"));
+      await openPicker();
+      await waitForPool();
+
+      expect(fetchCallCount).toBe(2);
+    });
+
+    test("an empty pool says so in the caller's words", async () => {
+      fetchResult = async () => {
+        return [];
+      };
+
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("add-column-empty")).not.toBeNull();
+      });
+
+      expect(screen.getByTestId("add-column-empty")).toHaveTextContent(
+        "No attributes seen on recent events.",
+      );
+    });
+  });
+
+  describe("adding a column from the picker", () => {
+    test("renders it as a new header once saved", async () => {
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toEqual(["Message", "Severity"]);
+
+      await openPicker();
+      await waitForPool();
+      await click(screen.getByTestId("add-column-attributes.device.hostname"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toContain("device.hostname");
+      });
+
+      expect(getHeaders()).toEqual(["Message", "Severity", "device.hostname"]);
+    });
+
+    test("renders the value out of the row's map", async () => {
+      rows = [
+        {
+          _id: "1",
+          message: "Suspicious logon",
+          severityName: "High",
+          attributes: { "device.hostname": "web-1", class_uid: "3002" },
+        },
+      ];
+
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+      await waitForPool();
+      await click(screen.getByTestId("add-column-attributes.device.hostname"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(screen.queryByText("web-1")).not.toBeNull();
+      });
+    });
+
+    test("stores the choice so it survives a reload", async () => {
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+      await waitForPool();
+      await click(screen.getByTestId("add-column-attributes.device.hostname"));
+      await savePicker();
+
+      const stored: JSONObject | null = readPreference();
+
+      expect(stored).not.toBeNull();
+      expect(stored!["order"]).toContain("attributes.device.hostname");
+    });
+
+    test("a stored attribute column is rebuilt on the next mount", async () => {
+      seedPreference({
+        order: ["message", "severityName", "attributes.device.hostname"],
+        hidden: [],
+      });
+
+      rows = [
+        {
+          _id: "1",
+          message: "Suspicious logon",
+          severityName: "High",
+          attributes: { "device.hostname": "web-1" },
+        },
+      ];
+
+      renderTable();
+
+      await waitForTable();
+
+      /*
+       * Rebuilt during render off the stored layout - not after an effect, and
+       * without waiting on the key pool, which is not even fetched yet.
+       */
+      expect(getHeaders()).toEqual(["Message", "Severity", "device.hostname"]);
+      expect(fetchCallCount).toBe(0);
+
+      // Headers render off the column set; the cells wait on the first page.
+      await waitFor(() => {
+        expect(screen.queryByText("web-1")).not.toBeNull();
+      });
+    });
+
+    test("a stored attribute column that is also hidden stays a column", async () => {
+      seedPreference({
+        order: ["message", "severityName", "attributes.device.hostname"],
+        hidden: ["attributes.device.hostname"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toEqual(["Message", "Severity"]);
+
+      await openPicker();
+
+      // Still in the picker, so switching it back on is one click.
+      expect(
+        screen.getByTestId("column-toggle-attributes.device.hostname"),
+      ).not.toBeChecked();
+    });
+
+    test("adding several keeps them in the order they were added", async () => {
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+      await waitForPool();
+      await click(screen.getByTestId("add-column-attributes.device.hostname"));
+      await click(screen.getByTestId("add-column-attributes.class_uid"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toContain("class_uid");
+      });
+
+      expect(getHeaders()).toEqual([
+        "Message",
+        "Severity",
+        "device.hostname",
+        "class_uid",
+      ]);
+    });
+
+    test("an added column can be reordered like any other", async () => {
+      renderTable();
+
+      await waitForTable();
+      await openPicker();
+      await waitForPool();
+      await click(screen.getByTestId("add-column-attributes.device.hostname"));
+      await click(
+        screen.getByTestId("column-move-up-attributes.device.hostname"),
+      );
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toContain("device.hostname");
+      });
+
+      /*
+       * "Event UID" is hidden by default, so it sits between Severity and the
+       * added column in the picker but never reaches the header row.
+       */
+      expect(getHeaders()).toEqual(["Message", "Severity", "device.hostname"]);
+
+      expect(readPreference()!["order"]).toEqual([
+        "message",
+        "severityName",
+        "attributes.device.hostname",
+        "eventUid",
+      ]);
+    });
+  });
+
+  describe("removing an attribute column", () => {
+    type SeedAndRenderFunction = () => Promise<void>;
+
+    const seedAndRender: SeedAndRenderFunction = async (): Promise<void> => {
+      seedPreference({
+        order: ["message", "severityName", "attributes.device.hostname"],
+        hidden: [],
+      });
+
+      renderTable();
+
+      await waitForTable();
+    };
+
+    test("takes the header away", async () => {
+      await seedAndRender();
+
+      expect(getHeaders()).toContain("device.hostname");
+
+      await openPicker();
+      await click(
+        screen.getByTestId("column-remove-attributes.device.hostname"),
+      );
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).not.toContain("device.hostname");
+      });
+    });
+
+    test("takes it out of the stored layout, not just out of view", async () => {
+      await seedAndRender();
+
+      await openPicker();
+      await click(
+        screen.getByTestId("column-remove-attributes.device.hostname"),
+      );
+      await savePicker();
+
+      /*
+       * With nothing left that differs from the table's own layout, the stored
+       * preference is cleared entirely rather than pinning this release's
+       * column set forever.
+       */
+      expect(readPreference()).toBeNull();
+    });
+
+    test("a removed column goes back into the pool it came from", async () => {
+      await seedAndRender();
+
+      await openPicker();
+
+      /*
+       * Waits on a DIFFERENT key: device.hostname is already a column, so it
+       * is precisely the one the pool must not be offering yet.
+       */
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("add-column-attributes.class_uid"),
+        ).not.toBeNull();
+      });
+
+      expect(
+        screen.queryByTestId("add-column-attributes.device.hostname"),
+      ).toBeNull();
+
+      await click(
+        screen.getByTestId("column-remove-attributes.device.hostname"),
+      );
+
+      expect(
+        screen.getByTestId("add-column-attributes.device.hostname"),
+      ).toBeInTheDocument();
+    });
+
+    test("declared columns have no remove button at all", async () => {
+      await seedAndRender();
+
+      await openPicker();
+
+      expect(screen.queryByTestId("column-remove-message")).toBeNull();
+      expect(screen.queryByTestId("column-remove-severityName")).toBeNull();
+    });
+
+    test("Reset to default drops every attribute column", async () => {
+      await seedAndRender();
+
+      await openPicker();
+      await click(screen.getByTestId("column-customization-reset"));
+
+      await waitFor(() => {
+        expect(getHeaders()).not.toContain("device.hostname");
+      });
+
+      expect(readPreference()).toBeNull();
+      expect(getHeaders()).toEqual(["Message", "Severity"]);
+    });
+  });
+
+  describe("stored layouts that name things this table does not have", () => {
+    /*
+     * Attribute keys are recovered from the RAW stored layout rather than the
+     * sanitized one, which is the only way a column can exist because its id
+     * is in there. The flip side is that a key nobody has ingested for a while
+     * still rebuilds - deliberately: it renders empty cells the viewer can see
+     * and remove, rather than silently discarding a column they chose.
+     */
+    test("a key the pool no longer knows about still rebuilds its column", async () => {
+      fetchResult = async () => {
+        return ["class_uid"];
+      };
+
+      seedPreference({
+        order: ["message", "severityName", "attributes.long.gone"],
+        hidden: [],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toContain("long.gone");
+    });
+
+    test("an unknown non-attribute id is still dropped", async () => {
+      seedPreference({
+        order: ["message", "severityName", "someColumnWeRemoved"],
+        hidden: ["someColumnWeRemoved"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toEqual(["Message", "Severity"]);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/ColumnCustomizationModalAddableColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/ColumnCustomizationModalAddableColumns.test.tsx
@@ -1,0 +1,707 @@
+import ColumnCustomizationModal, {
+  AddableColumnsConfig,
+} from "../../../../UI/Components/ModelTable/ColumnCustomizationModal";
+import {
+  CustomizableColumn,
+  ModelTableColumn,
+} from "../../../../UI/Components/ModelTable/ColumnPreference";
+import { getAttributeColumns } from "../../../../UI/Components/ModelTable/AttributeColumns";
+import Column from "../../../../UI/Components/ModelTable/Column";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import SecurityEvent from "../../../../Models/AnalyticsModels/SecurityEvent";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+import "@testing-library/jest-dom";
+import {
+  RenderResult,
+  cleanup,
+  fireEvent,
+  render,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The "add a column" half of the picker.
+ *
+ * It exists because some columns cannot be a checklist: the keys inside a
+ * security event's `attributes` map are whatever the source sent, differ per
+ * event class, and there can be several hundred of them. A checkbox each would
+ * bury the columns the table was designed around and hand "Show all" a way to
+ * put 500 columns on screen. So they are offered through a search box, and
+ * only what someone asks for is materialized.
+ *
+ * The invariants that carry weight, all pinned below:
+ *
+ *  1. Adding is still staging. Nothing leaves the modal before Save, exactly
+ *     like every checkbox and every reorder.
+ *  2. A column already in the list is not offered again - otherwise adding it
+ *     twice would put two columns with the same id into the layout.
+ *  3. Removing is hiding plus forgetting, so it is bound by the same rule:
+ *     the last column standing cannot go.
+ *  4. Only columns that say they are removable get a remove button. A column
+ *     the table ships must never be removable, because nothing would put it
+ *     back.
+ */
+
+type MakeEntryFunction = (data: {
+  id: string;
+  title: string;
+  isVisible: boolean;
+  isRemovable?: boolean | undefined;
+}) => CustomizableColumn<SecurityEvent>;
+
+const makeEntry: MakeEntryFunction = (data: {
+  id: string;
+  title: string;
+  isVisible: boolean;
+  isRemovable?: boolean | undefined;
+}): CustomizableColumn<SecurityEvent> => {
+  const column: ModelTableColumn<SecurityEvent> = {
+    field: { message: true },
+    title: data.title,
+    type: FieldType.Text,
+  };
+
+  return {
+    id: data.id,
+    column: column,
+    isVisible: data.isVisible,
+    isPinned: false,
+    isRemovable: data.isRemovable,
+  };
+};
+
+type GetDeclaredColumnsFunction = () => Array<
+  CustomizableColumn<SecurityEvent>
+>;
+
+const getDeclaredColumns: GetDeclaredColumnsFunction = (): Array<
+  CustomizableColumn<SecurityEvent>
+> => {
+  return [
+    makeEntry({ id: "time", title: "Time", isVisible: true }),
+    makeEntry({ id: "severityName", title: "Severity", isVisible: true }),
+    makeEntry({ id: "eventUid", title: "Event UID", isVisible: false }),
+  ];
+};
+
+/*
+ * Real generated attribute columns rather than placeholders: the ids the
+ * layout is keyed on come out of that generator, so a pool of fake entries
+ * would not exercise the same identity the app uses.
+ */
+type MakePoolFunction = (
+  attributeKeys: Array<string>,
+) => Array<CustomizableColumn<SecurityEvent>>;
+
+const makePool: MakePoolFunction = (
+  attributeKeys: Array<string>,
+): Array<CustomizableColumn<SecurityEvent>> => {
+  const columns: Columns<SecurityEvent> = getAttributeColumns<SecurityEvent>({
+    attributesColumnKey: "attributes",
+    attributeKeys: attributeKeys,
+  });
+
+  return columns.map(
+    (column: Column<SecurityEvent>): CustomizableColumn<SecurityEvent> => {
+      return {
+        id: column.id as string,
+        column: column,
+        isVisible: true,
+        isPinned: false,
+        isRemovable: true,
+      };
+    },
+  );
+};
+
+const POOL_KEYS: Array<string> = [
+  "activity_name",
+  "class_uid",
+  "device.hostname",
+  "finding_info.title",
+  "metadata.product.name",
+];
+
+interface RenderedModal {
+  view: RenderResult;
+  onSave: MockFunction;
+  onClose: MockFunction;
+  onReset: MockFunction;
+}
+
+type RenderModalFunction = (data?: {
+  columns?: Array<CustomizableColumn<SecurityEvent>> | undefined;
+  addableColumns?: AddableColumnsConfig<SecurityEvent> | undefined | null;
+}) => RenderedModal;
+
+const renderModal: RenderModalFunction = (data?: {
+  columns?: Array<CustomizableColumn<SecurityEvent>> | undefined;
+  addableColumns?: AddableColumnsConfig<SecurityEvent> | undefined | null;
+}): RenderedModal => {
+  const onSave: MockFunction = getJestMockFunction();
+  const onClose: MockFunction = getJestMockFunction();
+  const onReset: MockFunction = getJestMockFunction();
+
+  const addableColumns: AddableColumnsConfig<SecurityEvent> | undefined =
+    data?.addableColumns === null
+      ? undefined
+      : data?.addableColumns || {
+          title: "Add Attribute Column",
+          description: "Attributes differ per event.",
+          placeholder: "Search attributes...",
+          columns: makePool(POOL_KEYS),
+        };
+
+  const view: RenderResult = render(
+    <ColumnCustomizationModal<SecurityEvent>
+      columns={data?.columns || getDeclaredColumns()}
+      addableColumns={addableColumns}
+      onSave={onSave}
+      onClose={onClose}
+      onReset={onReset}
+    />,
+  );
+
+  return { view, onSave, onClose, onReset };
+};
+
+type GetSavedIdsFunction = (onSave: MockFunction) => Array<string>;
+
+const getSavedIds: GetSavedIdsFunction = (
+  onSave: MockFunction,
+): Array<string> => {
+  return (
+    onSave.mock.calls[0]![0] as Array<CustomizableColumn<SecurityEvent>>
+  ).map((entry: CustomizableColumn<SecurityEvent>) => {
+    return entry.id;
+  });
+};
+
+type TypeAddSearchFunction = (view: RenderResult, text: string) => void;
+
+const typeAddSearch: TypeAddSearchFunction = (
+  view: RenderResult,
+  text: string,
+): void => {
+  fireEvent.change(view.getByTestId("add-column-search"), {
+    target: { value: text },
+  });
+};
+
+describe("ColumnCustomizationModal - addable columns", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("the section is absent entirely when no pool is configured", () => {
+    const { view }: RenderedModal = renderModal({ addableColumns: null });
+
+    expect(view.queryByTestId("add-column-section")).not.toBeInTheDocument();
+    expect(view.queryByTestId("add-column-search")).not.toBeInTheDocument();
+  });
+
+  test("renders its own title, description and search box", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("add-column-section")).toBeInTheDocument();
+    expect(view.getByText("Add Attribute Column")).toBeInTheDocument();
+    expect(view.getByText("Attributes differ per event.")).toBeInTheDocument();
+    expect(view.getByTestId("add-column-search")).toHaveAttribute(
+      "placeholder",
+      "Search attributes...",
+    );
+  });
+
+  test("offers every key in the pool", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(
+      POOL_KEYS.length,
+    );
+    expect(view.getByText("device.hostname")).toBeInTheDocument();
+  });
+
+  /*
+   * The pool is offered against the column TITLE, which for an attribute
+   * column is the raw key - so searching for the key someone read in the
+   * detail panel is what finds it.
+   */
+  test("searching narrows the pool by key", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeAddSearch(view, "device");
+
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(1);
+    expect(
+      view.getByTestId("add-column-attributes.device.hostname"),
+    ).toBeInTheDocument();
+  });
+
+  test("the search is case-insensitive and matches anywhere in the key", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeAddSearch(view, "PRODUCT");
+
+    expect(
+      view.getByTestId("add-column-attributes.metadata.product.name"),
+    ).toBeInTheDocument();
+  });
+
+  test("surrounding whitespace in the search is ignored", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeAddSearch(view, "   class_uid   ");
+
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(1);
+  });
+
+  test("a search that matches nothing says so", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeAddSearch(view, "no-such-key");
+
+    expect(view.getByTestId("add-column-no-results")).toHaveTextContent(
+      'No matches for "no-such-key"',
+    );
+    expect(view.queryAllByTestId(/^add-column-attributes\./)).toHaveLength(0);
+  });
+
+  test("the search can be cleared, which brings the whole pool back", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeAddSearch(view, "device");
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(1);
+
+    fireEvent.click(view.getByTestId("add-column-search-clear"));
+
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(
+      POOL_KEYS.length,
+    );
+  });
+
+  test("adding puts the column in the list, visible, at the end", () => {
+    const { view }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+
+    expect(
+      view.getByTestId("column-toggle-attributes.device.hostname"),
+    ).toBeChecked();
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "3 of 4 columns shown",
+    );
+  });
+
+  test("an added column is no longer offered in the pool", () => {
+    const { view }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+
+    expect(
+      view.queryByTestId("add-column-attributes.device.hostname"),
+    ).not.toBeInTheDocument();
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(
+      POOL_KEYS.length - 1,
+    );
+  });
+
+  test("adding stages: nothing is handed back before Save", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test("Save hands back the added column alongside the declared ones", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(view.getByTestId("add-column-attributes.class_uid"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "time",
+      "severityName",
+      "eventUid",
+      "attributes.device.hostname",
+      "attributes.class_uid",
+    ]);
+  });
+
+  test("Cancel discards an added column", () => {
+    const { view, onSave, onClose }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(view.getByTestId("modal-footer-close-button"));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("an added column can be reordered like any other", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(
+      view.getByTestId("column-move-up-attributes.device.hostname"),
+    );
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "time",
+      "severityName",
+      "attributes.device.hostname",
+      "eventUid",
+    ]);
+  });
+
+  test("an added column can be switched off without being removed", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(
+      view.getByTestId("column-toggle-attributes.device.hostname"),
+    );
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    const saved: Array<CustomizableColumn<SecurityEvent>> = onSave.mock
+      .calls[0]![0] as Array<CustomizableColumn<SecurityEvent>>;
+
+    const added: CustomizableColumn<SecurityEvent> | undefined = saved.find(
+      (entry: CustomizableColumn<SecurityEvent>) => {
+        return entry.id === "attributes.device.hostname";
+      },
+    );
+
+    expect(added).toBeDefined();
+    expect(added!.isVisible).toBe(false);
+  });
+
+  test("the same pool entry cannot be added twice", () => {
+    /*
+     * Not reachable through the UI (an added column leaves the pool), but the
+     * guard is what keeps two columns with one id out of the stored layout if
+     * a double click ever races the re-render.
+     */
+    const pool: Array<CustomizableColumn<SecurityEvent>> = makePool([
+      "device.hostname",
+    ]);
+
+    const { view, onSave }: RenderedModal = renderModal({
+      columns: [
+        ...getDeclaredColumns(),
+        { ...(pool[0] as CustomizableColumn<SecurityEvent>) },
+      ],
+      addableColumns: {
+        title: "Add Attribute Column",
+        columns: pool,
+      },
+    });
+
+    // Already staged, so the pool has nothing left to offer.
+    expect(view.getByTestId("add-column-empty")).toBeInTheDocument();
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSavedIds(onSave).filter((id: string) => {
+        return id === "attributes.device.hostname";
+      }),
+    ).toHaveLength(1);
+  });
+});
+
+describe("ColumnCustomizationModal - removing a column", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("only removable columns get a remove button", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.queryByTestId("column-remove-time")).not.toBeInTheDocument();
+    expect(
+      view.queryByTestId("column-remove-severityName"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+
+    expect(
+      view.getByTestId("column-remove-attributes.device.hostname"),
+    ).toBeInTheDocument();
+  });
+
+  test("removing takes the column out of the list", () => {
+    const { view }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(
+      view.getByTestId("column-remove-attributes.device.hostname"),
+    );
+
+    expect(
+      view.queryByTestId("column-toggle-attributes.device.hostname"),
+    ).not.toBeInTheDocument();
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "2 of 3 columns shown",
+    );
+  });
+
+  test("a removed column goes back into the pool", () => {
+    const { view }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(
+      view.getByTestId("column-remove-attributes.device.hostname"),
+    );
+
+    expect(
+      view.getByTestId("add-column-attributes.device.hostname"),
+    ).toBeInTheDocument();
+  });
+
+  test("Save without the removed column is what drops it for good", () => {
+    const { view, onSave }: RenderedModal = renderModal({
+      columns: [
+        ...getDeclaredColumns(),
+        ...makePool(["device.hostname"]).map(
+          (entry: CustomizableColumn<SecurityEvent>) => {
+            return { ...entry, isVisible: true };
+          },
+        ),
+      ],
+    });
+
+    fireEvent.click(
+      view.getByTestId("column-remove-attributes.device.hostname"),
+    );
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual(["time", "severityName", "eventUid"]);
+  });
+
+  /*
+   * Removing is hiding plus forgetting, so it inherits the rule that keeps a
+   * table from becoming an empty shell with no header row and no way back.
+   */
+  test("the last visible column cannot be removed", () => {
+    const only: Array<CustomizableColumn<SecurityEvent>> = makePool([
+      "device.hostname",
+    ]);
+
+    const { view }: RenderedModal = renderModal({
+      columns: only,
+      addableColumns: { title: "Add Attribute Column", columns: [] },
+    });
+
+    const removeButton: HTMLElement = view.getByTestId(
+      "column-remove-attributes.device.hostname",
+    );
+
+    expect(removeButton).toBeDisabled();
+
+    fireEvent.click(removeButton);
+
+    expect(
+      view.getByTestId("column-toggle-attributes.device.hostname"),
+    ).toBeInTheDocument();
+  });
+
+  test("a hidden removable column can still be removed while another is on", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("add-column-attributes.device.hostname"));
+    fireEvent.click(
+      view.getByTestId("column-toggle-attributes.device.hostname"),
+    );
+    fireEvent.click(
+      view.getByTestId("column-remove-attributes.device.hostname"),
+    );
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual(["time", "severityName", "eventUid"]);
+  });
+});
+
+describe("ColumnCustomizationModal - pool states", () => {
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("says it is loading rather than reading as empty", () => {
+    const { view }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        isLoading: true,
+        columns: [],
+      },
+    });
+
+    expect(view.getByTestId("add-column-loading")).toBeInTheDocument();
+    expect(view.queryByTestId("add-column-empty")).not.toBeInTheDocument();
+  });
+
+  test("surfaces a failure instead of pretending there is nothing to add", () => {
+    const { view }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        errorMessage: "Could not load attributes.",
+        columns: [],
+      },
+    });
+
+    expect(view.getByTestId("add-column-error")).toHaveTextContent(
+      "Could not load attributes.",
+    );
+  });
+
+  /*
+   * An error takes precedence over the loading state: a retry that fails
+   * again must not flash back to "Loading..." and hide why.
+   */
+  test("an error wins over a concurrent loading flag", () => {
+    const { view }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        isLoading: true,
+        errorMessage: "Could not load attributes.",
+        columns: [],
+      },
+    });
+
+    expect(view.getByTestId("add-column-error")).toBeInTheDocument();
+    expect(view.queryByTestId("add-column-loading")).not.toBeInTheDocument();
+  });
+
+  test("an empty pool shows the caller's message", () => {
+    const { view }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        emptyMessage: "No attributes seen on recent events.",
+        columns: [],
+      },
+    });
+
+    expect(view.getByTestId("add-column-empty")).toHaveTextContent(
+      "No attributes seen on recent events.",
+    );
+  });
+
+  test("a pool whose entries are all already added says something different", () => {
+    const pool: Array<CustomizableColumn<SecurityEvent>> = makePool([
+      "device.hostname",
+    ]);
+
+    const { view }: RenderedModal = renderModal({
+      columns: [...getDeclaredColumns(), ...pool],
+      addableColumns: {
+        title: "Add Attribute Column",
+        emptyMessage: "No attributes seen on recent events.",
+        columns: pool,
+      },
+    });
+
+    expect(view.getByTestId("add-column-empty")).toHaveTextContent(
+      "already in the list above",
+    );
+  });
+
+  /*
+   * A project can carry thousands of attribute keys. Rendering all of them
+   * would put the whole list in the DOM and make the picker crawl, so the
+   * list is capped and the cap is said out loud - otherwise someone whose key
+   * is not shown has no reason to believe typing more would find it.
+   */
+  test("caps how many matches are rendered at once", () => {
+    const keys: Array<string> = Array.from(
+      { length: 40 },
+      (_unused: unknown, index: number) => {
+        return `attr.key${String(index).padStart(2, "0")}`;
+      },
+    );
+
+    const { view }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        columns: makePool(keys),
+        maxResults: 10,
+      },
+    });
+
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(10);
+    expect(view.getByTestId("add-column-hint")).toHaveTextContent(
+      "Showing 10 of 40",
+    );
+  });
+
+  test("the cap notice disappears once the search fits inside it", () => {
+    const keys: Array<string> = Array.from(
+      { length: 40 },
+      (_unused: unknown, index: number) => {
+        return `attr.key${String(index).padStart(2, "0")}`;
+      },
+    );
+
+    const { view }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        columns: makePool(keys),
+        maxResults: 10,
+      },
+    });
+
+    typeAddSearch(view, "key07");
+
+    expect(view.getAllByTestId(/^add-column-attributes\./)).toHaveLength(1);
+    expect(view.queryByTestId("add-column-hint")).not.toBeInTheDocument();
+  });
+
+  test("a key beyond the cap is still reachable by searching for it", () => {
+    const keys: Array<string> = Array.from(
+      { length: 40 },
+      (_unused: unknown, index: number) => {
+        return `attr.key${String(index).padStart(2, "0")}`;
+      },
+    );
+
+    const { view, onSave }: RenderedModal = renderModal({
+      addableColumns: {
+        title: "Add Attribute Column",
+        columns: makePool(keys),
+        maxResults: 10,
+      },
+    });
+
+    expect(
+      view.queryByTestId("add-column-attributes.attr.key39"),
+    ).not.toBeInTheDocument();
+
+    typeAddSearch(view, "key39");
+    fireEvent.click(view.getByTestId("add-column-attributes.attr.key39"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toContain("attributes.attr.key39");
+  });
+});

--- a/Common/UI/Components/ModelTable/AttributeColumns.tsx
+++ b/Common/UI/Components/ModelTable/AttributeColumns.tsx
@@ -1,0 +1,321 @@
+import Column from "./Column";
+import Columns from "./Columns";
+import { ColumnPreference } from "./ColumnPreference";
+import FieldType from "../Types/FieldType";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import { JSONObject } from "../../../Types/JSON";
+import React, { ReactElement } from "react";
+
+/*
+ * ---------------------------------------------------------------------------
+ * One table column per key inside a Map(String, String) attributes column
+ * ---------------------------------------------------------------------------
+ *
+ * Analytics rows (logs, spans, security events) carry the whole source
+ * payload flattened into a single map column - `attributes` - so that
+ * arbitrary vendor fields stay queryable without a schema change. Those keys
+ * differ per event class and per source, so there is no fixed list to ship as
+ * columns: the viewer picks the ones they care about and the table grows a
+ * column for each.
+ *
+ * The shape mirrors CustomFieldColumns, and for the same reasons:
+ *
+ *     field:            { attributes: true }     <- a real model column
+ *     selectedProperty: "device.hostname"        <- the key inside it
+ *
+ * which BaseModelTable turns into the column key "attributes.device.hostname".
+ *
+ *  - the declared field has to be the real map column. A synthetic
+ *    `field: { "attributes.device.hostname": true }` would fail the model's
+ *    column check in getSelectFromColumns and throw the whole table away.
+ *
+ *  - sorting is off. Nothing between the header and the query builder
+ *    validates `sort`, so a clickable header here would send a dotted
+ *    pseudo-column into ClickHouse, which can only order by a map key through
+ *    an explicit `attributes['key']` subscript the sort path cannot express.
+ *
+ *  - cells render through `getElement`, because the typed cell renderers index
+ *    `item[column.key]` directly and would look for a literal
+ *    "attributes.device.hostname" property that no row has.
+ *
+ * WHERE THE VIEWER'S CHOICE LIVES
+ *
+ * Nowhere new. A column exists iff its id appears in the stored
+ * ColumnPreference, and the id encodes the key, so the list of chosen
+ * attribute columns is recovered from the layout the viewer already saves
+ * (see getAttributeKeysFromColumnPreference). That keeps "Reset to default"
+ * honest, makes a saved TableView carry its attribute columns with it, and
+ * means there is no second store that can drift out of sync with the first.
+ */
+
+export type GetAttributeColumnIdFunction = (data: {
+  attributesColumnKey: string;
+  attributeKey: string;
+}) => string;
+
+/*
+ * Deliberately the same shape ColumnPreference.getColumnBaseId would derive
+ * from `field` + `selectedProperty` on its own ("attributes.device.hostname"),
+ * so an explicitly-set id and a derived one can never disagree.
+ */
+export const getAttributeColumnId: GetAttributeColumnIdFunction = (data: {
+  attributesColumnKey: string;
+  attributeKey: string;
+}): string => {
+  return `${data.attributesColumnKey}.${data.attributeKey}`;
+};
+
+export type GetAttributeKeyFromColumnIdFunction = (data: {
+  attributesColumnKey: string;
+  columnId: string;
+}) => string | null;
+
+export const getAttributeKeyFromColumnId: GetAttributeKeyFromColumnIdFunction =
+  (data: { attributesColumnKey: string; columnId: string }): string | null => {
+    const prefix: string = `${data.attributesColumnKey}.`;
+
+    if (!data.columnId.startsWith(prefix)) {
+      return null;
+    }
+
+    const attributeKey: string = data.columnId.slice(prefix.length);
+
+    return attributeKey.length > 0 ? attributeKey : null;
+  };
+
+export type NormalizeAttributeKeysFunction = (
+  keys: Array<unknown> | null | undefined,
+) => Array<string>;
+
+/*
+ * Whatever the server said, turned into a stable list: trimmed, de-duplicated,
+ * and sorted. The sort is load-bearing rather than cosmetic - the picker shows
+ * these in order, and an unsorted list from ClickHouse would reshuffle itself
+ * between requests.
+ */
+export const normalizeAttributeKeys: NormalizeAttributeKeysFunction = (
+  keys: Array<unknown> | null | undefined,
+): Array<string> => {
+  if (!Array.isArray(keys)) {
+    return [];
+  }
+
+  const seen: Set<string> = new Set();
+  const normalized: Array<string> = [];
+
+  for (const key of keys) {
+    if (typeof key !== "string") {
+      continue;
+    }
+
+    const trimmed: string = key.trim();
+
+    if (trimmed.length === 0 || seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized.sort((a: string, b: string): number => {
+    return a.localeCompare(b);
+  });
+};
+
+export type GetAttributeValueFunction = (data: {
+  item: unknown;
+  attributesColumnKey: string;
+  attributeKey: string;
+}) => unknown;
+
+export const getAttributeValue: GetAttributeValueFunction = (data: {
+  item: unknown;
+  attributesColumnKey: string;
+  attributeKey: string;
+}): unknown => {
+  const attributes: unknown = (data.item as JSONObject | undefined)?.[
+    data.attributesColumnKey
+  ];
+
+  if (!attributes || typeof attributes !== "object") {
+    return undefined;
+  }
+
+  return (attributes as JSONObject)[data.attributeKey];
+};
+
+export type GetAttributeExportValueFunction = (value: unknown) => string;
+
+export const getAttributeExportValue: GetAttributeExportValueFunction = (
+  value: unknown,
+): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry: unknown): string => {
+        return getAttributeExportValue(entry);
+      })
+      .join(", ");
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+};
+
+export type RenderAttributeValueFunction = (data: {
+  value: unknown;
+  noValueMessage?: string | undefined;
+}) => ReactElement;
+
+/*
+ * Map values arrive as strings, but the ingest side is free to write a
+ * flattened object or an array under a key, and a project can PUT anything
+ * over the API - so this renders whatever it is handed rather than assuming.
+ */
+export const renderAttributeValue: RenderAttributeValueFunction = (data: {
+  value: unknown;
+  noValueMessage?: string | undefined;
+}): ReactElement => {
+  const noValueMessage: string = data.noValueMessage ?? "-";
+  const text: string = getAttributeExportValue(data.value);
+
+  if (text.length === 0) {
+    return <span className="text-gray-400">{noValueMessage}</span>;
+  }
+
+  return (
+    <span className="break-words" title={text}>
+      {text}
+    </span>
+  );
+};
+
+export type GetAttributeColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  attributeKeys: Array<string>;
+  attributesColumnKey: string;
+  isHiddenByDefault?: boolean | undefined;
+  noValueMessage?: string | undefined;
+}) => Columns<TBaseModel>;
+
+/*
+ * `isRemovable` is what separates these from every other optional column: a
+ * viewer who switches an attribute column off still has it sitting in the
+ * picker forever, and a table whose source writes a few hundred keys would
+ * accumulate an unusable list. Removing drops the id from the stored layout,
+ * which is the same thing as the column never having been added.
+ */
+export const getAttributeColumns: GetAttributeColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  attributeKeys: Array<string>;
+  attributesColumnKey: string;
+  isHiddenByDefault?: boolean | undefined;
+  noValueMessage?: string | undefined;
+}): Columns<TBaseModel> => {
+  const { attributesColumnKey } = data;
+
+  return (data.attributeKeys || []).map(
+    (attributeKey: string): Column<TBaseModel> => {
+      return {
+        id: getAttributeColumnId({ attributesColumnKey, attributeKey }),
+        field: {
+          [attributesColumnKey]: true,
+        } as Column<TBaseModel>["field"],
+        selectedProperty: attributeKey,
+        title: attributeKey,
+        type: FieldType.Element,
+        // See the file header: a map key is not something the sort path can express.
+        disableSort: true,
+        isHiddenByDefault: Boolean(data.isHiddenByDefault),
+        isRemovable: true,
+        getExportValue: (item: TBaseModel): string => {
+          return getAttributeExportValue(
+            getAttributeValue({ item, attributesColumnKey, attributeKey }),
+          );
+        },
+        getElement: (item: TBaseModel): ReactElement => {
+          return renderAttributeValue({
+            value: getAttributeValue({
+              item,
+              attributesColumnKey,
+              attributeKey,
+            }),
+            noValueMessage: data.noValueMessage,
+          });
+        },
+      };
+    },
+  );
+};
+
+export type GetAttributeKeysFromColumnPreferenceFunction = (data: {
+  preference: ColumnPreference | null | undefined;
+  attributesColumnKey: string;
+  /*
+   * Ids of the columns the table declares for itself. A declared column that
+   * happens to sit under the same prefix is not an attribute column, and
+   * regenerating one for it would put two columns with the same id in the
+   * picker.
+   */
+  reservedColumnIds?: Array<string> | undefined;
+}) => Array<string>;
+
+/*
+ * The attribute columns a stored layout implies.
+ *
+ * Read from the RAW preference rather than the sanitized one: sanitizing drops
+ * ids that name no current column, and an attribute column is only ever a
+ * current column *because* its id is in here. `hidden` is scanned as well as
+ * `order` - buildColumnPreference always writes both, but a payload from an
+ * older release (or one hand-edited in devtools) may carry only the one, and
+ * losing the column would silently discard the viewer's choice.
+ */
+export const getAttributeKeysFromColumnPreference: GetAttributeKeysFromColumnPreferenceFunction =
+  (data: {
+    preference: ColumnPreference | null | undefined;
+    attributesColumnKey: string;
+    reservedColumnIds?: Array<string> | undefined;
+  }): Array<string> => {
+    if (!data.preference) {
+      return [];
+    }
+
+    const reserved: Set<string> = new Set(data.reservedColumnIds || []);
+    const seen: Set<string> = new Set();
+    const attributeKeys: Array<string> = [];
+
+    const columnIds: Array<string> = [
+      ...(data.preference.order || []),
+      ...(data.preference.hidden || []),
+    ];
+
+    for (const columnId of columnIds) {
+      if (reserved.has(columnId)) {
+        continue;
+      }
+
+      const attributeKey: string | null = getAttributeKeyFromColumnId({
+        attributesColumnKey: data.attributesColumnKey,
+        columnId: columnId,
+      });
+
+      if (!attributeKey || seen.has(attributeKey)) {
+        continue;
+      }
+
+      seen.add(attributeKey);
+      attributeKeys.push(attributeKey);
+    }
+
+    return attributeKeys;
+  };

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -62,7 +62,14 @@ import TableColumn from "../Table/Types/Column";
 import FieldType from "../Types/FieldType";
 import ModelTableColumn from "./Column";
 import Columns from "./Columns";
-import ColumnCustomizationModal from "./ColumnCustomizationModal";
+import ColumnCustomizationModal, {
+  AddableColumnsConfig,
+} from "./ColumnCustomizationModal";
+import {
+  getAttributeColumns,
+  getAttributeKeysFromColumnPreference,
+  normalizeAttributeKeys,
+} from "./AttributeColumns";
 import {
   ColumnPreference,
   CustomizableColumn,
@@ -364,6 +371,40 @@ export interface BaseTableProps<
    * Only meaningful for resources with a `customFields` column of their own.
    */
   customFieldsModelType?: { new (): BaseModel } | undefined;
+
+  /**
+   * Let the viewer add a column for any key inside a Map(String, String)
+   * column on the model — `attributes` on logs, spans and security events.
+   *
+   * Those keys are per-payload rather than per-schema, so they cannot ship as
+   * columns and there can be hundreds of them. Instead the picker grows an
+   * "add a column" search box fed by `fetchAttributeKeys`, and whatever the
+   * viewer adds becomes an ordinary column: hideable, re-orderable, exported,
+   * and remembered in the same stored layout as every other column.
+   *
+   * Requires `userPreferencesKey` and column customization to be on, since the
+   * chosen keys are recovered from the stored layout.
+   */
+  attributeColumnsProps?:
+    | {
+        /*
+         * The map column the generated columns read from. Must be a real
+         * column on the model; anything else is ignored rather than throwing
+         * the table away.
+         */
+        columnKey: string;
+        /*
+         * Every key the viewer may pick from. Called the first time the picker
+         * opens rather than on mount — it is typically a wide scan, and a
+         * table nobody customizes should not pay for it.
+         */
+        fetchAttributeKeys: () => Promise<Array<string>>;
+        title?: string | undefined;
+        description?: string | undefined;
+        placeholder?: string | undefined;
+        emptyMessage?: string | undefined;
+      }
+    | undefined;
 }
 
 export interface ComponentProps<
@@ -501,14 +542,6 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       showAs !== ShowAs.OrderedStatesList,
   );
 
-  const allColumns: Columns<TBaseModel> = useMemo(() => {
-    if (customFieldColumns.columns.length === 0) {
-      return props.columns || [];
-    }
-
-    return [...(props.columns || []), ...customFieldColumns.columns];
-  }, [props.columns, customFieldColumns.columns]);
-
   type ReadStoredColumnPreferenceFunction = () => ColumnPreference | null;
 
   const readStoredColumnPreference: ReadStoredColumnPreferenceFunction =
@@ -530,6 +563,68 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
   const [showColumnCustomizationModal, setShowColumnCustomizationModal] =
     useState<boolean>(false);
+
+  /*
+   * ---------------------------------------------------------------------
+   * Attribute columns
+   * ---------------------------------------------------------------------
+   *
+   * A column per viewer-chosen key inside the model's map column. There is no
+   * second store for "which keys did they pick": a column exists precisely
+   * when its id is in the stored layout, and the id encodes the key. That is
+   * what makes "Reset to default" take them away, a saved TableView bring its
+   * own, and the two halves of a layout impossible to desynchronize.
+   *
+   * Derived from the RAW preference, before sanitizing: sanitizing drops ids
+   * that name no current column, and these are only current columns *because*
+   * their ids are in there.
+   */
+  const attributeColumnKey: string | null = useMemo(() => {
+    const columnKey: string | undefined =
+      props.attributeColumnsProps?.columnKey;
+
+    if (!columnKey || !isColumnCustomizationEnabled) {
+      return null;
+    }
+
+    /*
+     * A key that is not a column on the model would make getSelectFromColumns
+     * throw and blank the whole table. A misconfigured prop should cost the
+     * feature, not the page.
+     */
+    return model.hasColumn(columnKey) ? columnKey : null;
+  }, [props.attributeColumnsProps?.columnKey, isColumnCustomizationEnabled]);
+
+  const declaredColumns: Columns<TBaseModel> = useMemo(() => {
+    if (customFieldColumns.columns.length === 0) {
+      return props.columns || [];
+    }
+
+    return [...(props.columns || []), ...customFieldColumns.columns];
+  }, [props.columns, customFieldColumns.columns]);
+
+  const attributeColumns: Columns<TBaseModel> = useMemo(() => {
+    if (!attributeColumnKey) {
+      return [];
+    }
+
+    return getAttributeColumns<TBaseModel>({
+      attributesColumnKey: attributeColumnKey,
+      attributeKeys: getAttributeKeysFromColumnPreference({
+        preference: columnPreference,
+        attributesColumnKey: attributeColumnKey,
+        reservedColumnIds: getColumnIds<TBaseModel>(declaredColumns),
+      }),
+    });
+  }, [attributeColumnKey, columnPreference, declaredColumns]);
+
+  const allColumns: Columns<TBaseModel> = useMemo(() => {
+    if (attributeColumns.length === 0) {
+      return declaredColumns;
+    }
+
+    return [...declaredColumns, ...attributeColumns];
+  }, [declaredColumns, attributeColumns]);
 
   /*
    * Ids are derived over the *whole* declared set, so a column dropping out
@@ -583,6 +678,18 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       value: json,
     });
   };
+
+  /*
+   * The pool of keys the picker offers. Fetched the first time the picker
+   * opens, never on mount: it is a wide scan over the analytics table, and a
+   * table nobody customizes should not pay for it on every page load.
+   */
+  const [attributeKeyPool, setAttributeKeyPool] = useState<{
+    keys: Array<string>;
+    isLoading: boolean;
+    error: string;
+    hasLoaded: boolean;
+  }>({ keys: [], isLoading: false, error: "", hasLoaded: false });
 
   const [classicTableFilters, setClassicTableFilters] = useState<
     Array<ClassicFilterType<TBaseModel>>
@@ -1972,6 +2079,20 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       (selectFields as Dictionary<boolean>)[CustomFieldsColumnKey] = true;
     }
 
+    /*
+     * Same reasoning for the attribute map column: a column added from the
+     * picker appears without a refetch, so the map it reads has to have been
+     * on the wire since the first request or the new column renders blank
+     * until something else happens to reload the page.
+     */
+    if (
+      attributeColumnKey &&
+      (hasPermissionToReadField(attributeColumnKey as keyof TBaseModel) ||
+        User.isMasterAdmin())
+    ) {
+      (selectFields as Dictionary<boolean>)[attributeColumnKey] = true;
+    }
+
     const selectMoreFields: Array<keyof TBaseModel> = props.selectMoreFields
       ? (Object.keys(props.selectMoreFields) as Array<keyof TBaseModel>)
       : [];
@@ -2431,12 +2552,77 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   }, [props.columns]);
 
   /*
-   * The viewer changed their layout, or the project's custom field
-   * definitions finally arrived.
+   * The viewer changed their layout, the project's custom field definitions
+   * finally arrived, or an attribute column was added or removed.
    */
   useEffect(() => {
     serializeToTableColumns();
-  }, [effectiveColumnPreference, customFieldColumns.columns]);
+  }, [effectiveColumnPreference, customFieldColumns.columns, attributeColumns]);
+
+  /*
+   * The attribute key pool is only ever needed by the picker, so it is fetched
+   * when the picker first opens and kept for the rest of the page's life.
+   * A failure costs the "add a column" search box and nothing else — the
+   * columns the viewer already added are rebuilt from their stored layout and
+   * do not depend on this at all.
+   */
+  useEffect(() => {
+    if (
+      !showColumnCustomizationModal ||
+      !attributeColumnKey ||
+      !props.attributeColumnsProps ||
+      attributeKeyPool.hasLoaded ||
+      attributeKeyPool.isLoading
+    ) {
+      return;
+    }
+
+    const fetchAttributeKeys: () => Promise<Array<string>> =
+      props.attributeColumnsProps.fetchAttributeKeys;
+
+    let isCancelled: boolean = false;
+
+    setAttributeKeyPool({
+      keys: [],
+      isLoading: true,
+      error: "",
+      hasLoaded: false,
+    });
+
+    fetchAttributeKeys()
+      .then((keys: Array<string>) => {
+        if (isCancelled) {
+          return;
+        }
+
+        setAttributeKeyPool({
+          keys: normalizeAttributeKeys(keys),
+          isLoading: false,
+          error: "",
+          hasLoaded: true,
+        });
+      })
+      .catch((err: Error) => {
+        if (isCancelled) {
+          return;
+        }
+
+        setAttributeKeyPool({
+          keys: [],
+          isLoading: false,
+          error: API.getFriendlyMessage(err),
+          /*
+           * Not "loaded": closing and reopening the picker is the only retry
+           * anyone would think to try, so let it be one.
+           */
+          hasLoaded: false,
+        });
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [showColumnCustomizationModal, attributeColumnKey]);
 
   const setActionSchema: VoidFunction = () => {
     const permissions: Array<Permission> = PermissionUtil.getAllPermissions();
@@ -4007,13 +4193,15 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
   type GetPickerEntriesFunction = (
     preference: ColumnPreference | null,
+    columns?: Columns<TBaseModel> | undefined,
   ) => Array<CustomizableColumn<TBaseModel>>;
 
   const getPickerEntries: GetPickerEntriesFunction = (
     preference: ColumnPreference | null,
+    columns?: Columns<TBaseModel> | undefined,
   ): Array<CustomizableColumn<TBaseModel>> => {
     return getCustomizableColumns<TBaseModel>({
-      columns: allColumns,
+      columns: columns || allColumns,
       preference: preference,
     }).filter((entry: CustomizableColumn<TBaseModel>) => {
       return isPickableColumn(entry.column);
@@ -4055,8 +4243,16 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
      * would be pinned to the column set of the release they opened it in, and
      * columns added later would arrive already stale.
      */
+    /*
+     * Over the DECLARED columns only. An attribute column exists because the
+     * viewer added it, so the layout that has none of them is the default one
+     * — otherwise adding a column and then removing it again would leave the
+     * table pinned to a stored layout it no longer differs from.
+     */
     const defaultPreference: ColumnPreference =
-      buildColumnPreference<TBaseModel>(getPickerEntries(null));
+      buildColumnPreference<TBaseModel>(
+        getPickerEntries(null, declaredColumns),
+      );
 
     const isBackToDefault: boolean =
       JSON.stringify(preference) === JSON.stringify(defaultPreference);
@@ -4089,6 +4285,58 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     setShowColumnCustomizationModal(false);
   };
 
+  /*
+   * The pool the picker offers, as picker entries rather than model columns,
+   * so the modal can stage one straight into its list. Every one starts
+   * removable — the whole point is that the viewer can take it away again.
+   */
+  const addableAttributeColumns: Array<CustomizableColumn<TBaseModel>> =
+    useMemo(() => {
+      if (!attributeColumnKey || attributeKeyPool.keys.length === 0) {
+        return [];
+      }
+
+      return getAttributeColumns<TBaseModel>({
+        attributesColumnKey: attributeColumnKey,
+        attributeKeys: attributeKeyPool.keys,
+      }).map(
+        (
+          column: ModelTableColumn<TBaseModel>,
+          index: number,
+        ): CustomizableColumn<TBaseModel> => {
+          return {
+            id: column.id || `${attributeColumnKey}.${index}`,
+            column: column,
+            isVisible: true,
+            isPinned: false,
+            isRemovable: true,
+          };
+        },
+      );
+    }, [attributeColumnKey, attributeKeyPool.keys]);
+
+  const getAddableColumnsConfig: () =>
+    | AddableColumnsConfig<TBaseModel>
+    | undefined = (): AddableColumnsConfig<TBaseModel> | undefined => {
+    if (!attributeColumnKey || !props.attributeColumnsProps) {
+      return undefined;
+    }
+
+    return {
+      title: props.attributeColumnsProps.title || tx("Add Attribute Column"),
+      description:
+        props.attributeColumnsProps.description ||
+        tx(
+          "Attributes vary per event, so they are not listed above. Search for one to add it as a column.",
+        ),
+      placeholder: props.attributeColumnsProps.placeholder || "Search...",
+      emptyMessage: props.attributeColumnsProps.emptyMessage,
+      isLoading: attributeKeyPool.isLoading,
+      errorMessage: attributeKeyPool.error,
+      columns: addableAttributeColumns,
+    };
+  };
+
   const getColumnCustomizationModal: () => ReactElement | null =
     (): ReactElement | null => {
       if (!showColumnCustomizationModal || !isColumnCustomizationEnabled) {
@@ -4098,6 +4346,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       return (
         <ColumnCustomizationModal<TBaseModel>
           columns={getPickerEntries(effectiveColumnPreference)}
+          addableColumns={getAddableColumnsConfig()}
           isDefaultLayout={isEmptyColumnPreference(effectiveColumnPreference)}
           title={tx("Customize Columns")}
           onSave={onColumnCustomizationSave}

--- a/Common/UI/Components/ModelTable/Column.ts
+++ b/Common/UI/Components/ModelTable/Column.ts
@@ -36,6 +36,14 @@ export default interface Columns<
   isNotCustomizable?: boolean | undefined;
   // Start hidden. The viewer can still switch it on from the picker.
   isHiddenByDefault?: boolean | undefined;
+  /*
+   * This column exists only because the viewer added it, so the picker offers
+   * to take it away again rather than only switching it off. Set it on columns
+   * generated from viewer-chosen keys (see AttributeColumns) - a table that
+   * ships a column should never be removable, because nothing would put it
+   * back.
+   */
+  isRemovable?: boolean | undefined;
   contentClassName?: string | undefined;
   colSpan?: number | undefined;
   disableSort?: boolean;

--- a/Common/UI/Components/ModelTable/ColumnCustomizationModal.tsx
+++ b/Common/UI/Components/ModelTable/ColumnCustomizationModal.tsx
@@ -18,11 +18,49 @@ import {
   DropResult,
 } from "react-beautiful-dnd";
 
+/*
+ * A pool of columns the viewer can bring INTO the picker, rather than one
+ * checklist entry per possibility.
+ *
+ * Attribute columns are the motivating case: the keys inside a row's
+ * `attributes` map differ per event class and per source, so a project can
+ * easily have several hundred of them. Listing every one as a checkbox turns
+ * "which columns do I want?" into a scroll through noise (and hands "Show all"
+ * a way to put 500 columns on screen), so they are offered through a search
+ * box that only materializes what was asked for.
+ */
+export interface AddableColumnsConfig<
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+> {
+  title: string;
+  description?: string | undefined;
+  placeholder?: string | undefined;
+  // Still fetching the pool. The section says so rather than reading as empty.
+  isLoading?: boolean | undefined;
+  errorMessage?: string | undefined;
+  // Shown when the pool itself is empty, e.g. nothing has been ingested yet.
+  emptyMessage?: string | undefined;
+  /*
+   * Every column that could be added, in the order they should be offered.
+   * Ones already in the picker are filtered out here rather than by the
+   * caller, so a column added and then removed reappears in the pool.
+   */
+  columns: Array<CustomizableColumn<TBaseModel>>;
+  /*
+   * How many matches to render at once. The pool can be in the thousands and
+   * an unbounded list would put all of it in the DOM; the search box is what
+   * gets you to the rest.
+   */
+  maxResults?: number | undefined;
+}
+
 export interface ComponentProps<
   TBaseModel extends BaseModel | AnalyticsBaseModel,
 > {
   // Every customizable column, already in the order the table renders them.
   columns: Array<CustomizableColumn<TBaseModel>>;
+  // Optional pool of columns the viewer can add. Omit to hide the whole section.
+  addableColumns?: AddableColumnsConfig<TBaseModel> | undefined;
   onSave: (columns: Array<CustomizableColumn<TBaseModel>>) => void;
   onClose: () => void;
   // Drop the stored layout and go back to what the table ships with.
@@ -96,6 +134,109 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
    */
   const isEverythingVisible: boolean = visibleCount === entries.length;
   const isOnlyOneVisible: boolean = visibleCount <= 1;
+
+  /*
+   * ---------------------------------------------------------------------
+   * The "add a column" pool
+   * ---------------------------------------------------------------------
+   */
+  const [addSearchText, setAddSearchText] = useState<string>("");
+
+  const stagedIds: Set<string> = useMemo(() => {
+    return new Set(
+      entries.map((entry: CustomizableColumn<TBaseModel>) => {
+        return entry.id;
+      }),
+    );
+  }, [entries]);
+
+  // Everything in the pool that is not already sitting in the list above.
+  const addableColumns: Array<CustomizableColumn<TBaseModel>> = useMemo(() => {
+    return (props.addableColumns?.columns || []).filter(
+      (entry: CustomizableColumn<TBaseModel>) => {
+        return !stagedIds.has(entry.id);
+      },
+    );
+  }, [props.addableColumns?.columns, stagedIds]);
+
+  const normalizedAddSearch: string = addSearchText.trim().toLowerCase();
+
+  const matchingAddableColumns: Array<CustomizableColumn<TBaseModel>> =
+    useMemo(() => {
+      if (normalizedAddSearch.length === 0) {
+        return addableColumns;
+      }
+
+      return addableColumns.filter((entry: CustomizableColumn<TBaseModel>) => {
+        return (entry.column.title || "")
+          .toLowerCase()
+          .includes(normalizedAddSearch);
+      });
+    }, [addableColumns, normalizedAddSearch]);
+
+  const addableResultLimit: number = props.addableColumns?.maxResults ?? 25;
+
+  const shownAddableColumns: Array<CustomizableColumn<TBaseModel>> =
+    useMemo(() => {
+      return matchingAddableColumns.slice(0, addableResultLimit);
+    }, [matchingAddableColumns, addableResultLimit]);
+
+  type AddColumnFunction = (entry: CustomizableColumn<TBaseModel>) => void;
+
+  /*
+   * An added column goes on the end and starts visible. Adding a column you
+   * then have to go and switch on would be a strange thing to ask of someone
+   * who just searched for it by name.
+   */
+  const addColumn: AddColumnFunction = (
+    entry: CustomizableColumn<TBaseModel>,
+  ): void => {
+    setEntries((current: Array<CustomizableColumn<TBaseModel>>) => {
+      if (
+        current.some((existing: CustomizableColumn<TBaseModel>) => {
+          return existing.id === entry.id;
+        })
+      ) {
+        return current;
+      }
+
+      return [...current, { ...entry, isVisible: true, isPinned: false }];
+    });
+  };
+
+  type RemoveColumnFunction = (id: string) => void;
+
+  const removeColumn: RemoveColumnFunction = (id: string): void => {
+    setEntries((current: Array<CustomizableColumn<TBaseModel>>) => {
+      const target: CustomizableColumn<TBaseModel> | undefined = current.find(
+        (entry: CustomizableColumn<TBaseModel>) => {
+          return entry.id === id;
+        },
+      );
+
+      if (!target || !target.isRemovable) {
+        return current;
+      }
+
+      /*
+       * Removing is hiding plus forgetting, so it is bound by the same rule:
+       * the last column standing cannot go.
+       */
+      const isLastVisible: boolean =
+        target.isVisible &&
+        current.filter((entry: CustomizableColumn<TBaseModel>) => {
+          return entry.isVisible;
+        }).length <= 1;
+
+      if (isLastVisible) {
+        return current;
+      }
+
+      return current.filter((entry: CustomizableColumn<TBaseModel>) => {
+        return entry.id !== id;
+      });
+    });
+  };
 
   type ToggleFunction = (id: string, isVisible: boolean) => void;
 
@@ -303,6 +444,22 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
               moveColumn(index, index + 1);
             }}
           />
+          {entry.isRemovable && (
+            <Button
+              buttonSize={ButtonSize.Small}
+              buttonStyle={ButtonStyleType.ICON}
+              icon={IconProp.Close}
+              title=""
+              tooltip="Remove column"
+              ariaLabel={`Remove ${entry.column.title}`}
+              className="text-gray-400 hover:bg-red-100 hover:text-red-600 disabled:text-gray-200 disabled:hover:bg-transparent"
+              dataTestId={`column-remove-${entry.id}`}
+              disabled={isOnlyVisibleColumn}
+              onClick={() => {
+                removeColumn(entry.id);
+              }}
+            />
+          )}
         </div>
       </div>
     );
@@ -413,6 +570,157 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
     );
   };
 
+  type GetAddColumnSectionFunction = () => ReactElement;
+
+  const getAddColumnSection: GetAddColumnSectionFunction = (): ReactElement => {
+    const config: AddableColumnsConfig<TBaseModel> | undefined =
+      props.addableColumns;
+
+    if (!config) {
+      return <></>;
+    }
+
+    type GetBodyFunction = () => ReactElement;
+
+    const getBody: GetBodyFunction = (): ReactElement => {
+      if (config.errorMessage) {
+        return (
+          <p
+            className="px-3 py-4 text-sm text-red-500"
+            data-testid="add-column-error"
+          >
+            {config.errorMessage}
+          </p>
+        );
+      }
+
+      if (config.isLoading) {
+        return (
+          <p
+            className="px-3 py-4 text-sm text-gray-500"
+            data-testid="add-column-loading"
+          >
+            Loading...
+          </p>
+        );
+      }
+
+      if (addableColumns.length === 0) {
+        return (
+          <p
+            className="px-3 py-4 text-sm text-gray-500"
+            data-testid="add-column-empty"
+          >
+            {(config.columns || []).length === 0
+              ? config.emptyMessage || "Nothing to add."
+              : "Every one of these is already in the list above."}
+          </p>
+        );
+      }
+
+      if (shownAddableColumns.length === 0) {
+        return (
+          <p
+            className="px-3 py-4 text-sm text-gray-500"
+            data-testid="add-column-no-results"
+          >
+            No matches for &quot;{addSearchText}&quot;.
+          </p>
+        );
+      }
+
+      return (
+        <div className="divide-y divide-gray-100">
+          {shownAddableColumns.map((entry: CustomizableColumn<TBaseModel>) => {
+            return (
+              <div
+                key={entry.id}
+                className="flex items-center gap-2 px-3 py-2 transition-colors hover:bg-gray-50"
+              >
+                <span className="min-w-0 flex-1 break-words text-sm text-gray-700">
+                  {entry.column.title}
+                </span>
+                <Button
+                  buttonSize={ButtonSize.Small}
+                  buttonStyle={ButtonStyleType.ICON}
+                  icon={IconProp.Add}
+                  title=""
+                  tooltip="Add column"
+                  ariaLabel={`Add ${entry.column.title}`}
+                  className="flex-none text-gray-400 hover:bg-gray-200 hover:text-gray-700"
+                  dataTestId={`add-column-${entry.id}`}
+                  onClick={() => {
+                    addColumn(entry);
+                  }}
+                />
+              </div>
+            );
+          })}
+        </div>
+      );
+    };
+
+    return (
+      <div className="space-y-2 pt-1" data-testid="add-column-section">
+        <div>
+          <h4 className="text-sm font-medium text-gray-900">{config.title}</h4>
+          {config.description ? (
+            <p className="text-xs text-gray-500">{config.description}</p>
+          ) : (
+            <></>
+          )}
+        </div>
+
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <Icon icon={IconProp.Search} className="h-4 w-4 text-gray-400" />
+          </div>
+          <Input
+            type={InputType.TEXT}
+            placeholder={config.placeholder || "Search..."}
+            value={addSearchText}
+            dataTestId="add-column-search"
+            outerDivClassName="w-full"
+            className="block w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-9 text-sm placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            onChange={(value: string) => {
+              setAddSearchText(value);
+            }}
+          />
+          {addSearchText.length > 0 && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              title="Clear search"
+              data-testid="add-column-search-clear"
+              onClick={() => {
+                setAddSearchText("");
+              }}
+              className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 transition-colors hover:text-gray-600 focus:outline-none focus-visible:text-gray-600"
+            >
+              <Icon icon={IconProp.Close} className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        <div className="max-h-48 overflow-y-auto overscroll-contain rounded-md border border-gray-200 bg-white">
+          {getBody()}
+        </div>
+
+        {/*
+         * Said out loud rather than silently truncating: a viewer who cannot
+         * see their key otherwise has no way to know that typing more of it
+         * would find it.
+         */}
+        {matchingAddableColumns.length > shownAddableColumns.length && (
+          <p className="text-xs text-gray-400" data-testid="add-column-hint">
+            Showing {shownAddableColumns.length} of{" "}
+            {matchingAddableColumns.length}. Search to narrow this down.
+          </p>
+        )}
+      </div>
+    );
+  };
+
   return (
     <Modal
       title={props.title || "Customize Columns"}
@@ -515,6 +823,8 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
             ? "Clear the search to reorder columns."
             : "Drag a row, or use the arrows, to change the column order."}
         </p>
+
+        {getAddColumnSection()}
       </div>
     </Modal>
   );

--- a/Common/UI/Components/ModelTable/ColumnPreference.ts
+++ b/Common/UI/Components/ModelTable/ColumnPreference.ts
@@ -153,6 +153,12 @@ export interface CustomizableColumn<
   isVisible: boolean;
   // Pinned columns are always shown and cannot be moved.
   isPinned: boolean;
+  /*
+   * The picker may drop this column entirely, not just switch it off. True
+   * only for columns the viewer added themselves (attribute columns); a
+   * pinned column is never removable, since it is not the viewer's to touch.
+   */
+  isRemovable?: boolean | undefined;
 }
 
 export type IsDefaultHiddenFunction = <
@@ -214,7 +220,13 @@ export const getCustomizableColumns: GetCustomizableColumnsFunction = <
         }
       }
 
-      return { id, column, isVisible, isPinned };
+      return {
+        id,
+        column,
+        isVisible,
+        isPinned,
+        isRemovable: Boolean(column.isRemovable) && !isPinned,
+      };
     },
   );
 


### PR DESCRIPTION
Closes #3399

## The problem

The Security Events table's **Customize Columns** dialog offered seven columns ("7 of 7 columns shown") while the detail side-over showed twelve fields. Answering "which vendor produced all of these?" or "group these by rule name" meant opening every event one at a time. The `Attributes` section of the detail panel — the OCSF-style nested fields like `device.hostname`, `finding_info.title`, `metadata.product.name` — wasn't reachable as a column at all.

## What this does

**1. Every event field is a column.** All seventeen remaining detail-panel fields — Category, Activity, Status, Product, Rule ID, Rule Name, MITRE Tactics, MITRE Techniques, Principal IP/Process, Target User/Host/IP/Port/Resource, Observables, Event UID — are now columns, shipped hidden and one click away in the picker. The seven that were the whole table are still the seven that show by default, and the new ones are **appended** rather than interleaved so nobody's existing layout silently reshuffles.

**2. "Add Attribute Column".** The keys inside an event's `attributes` map differ per event class and per source and there can be hundreds of them, so a checkbox each would bury the columns the table was designed around (and hand "Show all" a way to put 500 columns on screen). The picker grows a separate searchable section instead — search `device.hostname`, click add. Whatever is added becomes an ordinary column: hideable, re-orderable, exported to CSV, and *removable*, which no table-declared column is.

**3. Persistence, with no new store.** An attribute column exists precisely when its id is in the `ColumnPreference` the viewer already saves, and the id encodes the key. So "Reset to default" takes them away, a saved TableView carries its own, and there is no second store that can drift out of sync with the first.

The feature is generic to `BaseModelTable` (opt in with `attributeColumnsProps`), so any table over a `Map(String, String)` column can use it. Security events are the first caller.

## How the keys are fetched

`TelemetryType.SecurityEvent` was already in the enum but had no source in `TelemetryAttributeService`, so it silently returned no attributes. This adds the source (over the `attributeKeys` sidecar column, same as logs/traces/metrics) and two routes:

- `POST /telemetry/security-events/get-attributes`
- `POST /telemetry/security-events/get-attribute-values`

Both are guarded by a read guard that mirrors the `SecurityEvent` model's own table-level read list exactly. The key pool is fetched lazily — the first time the picker opens, never on mount — so a table nobody customizes doesn't pay for the scan.

## Tests

**604 tests across 7 new suites**, plus the existing ModelTable suites re-run green (19 suites / 580 tests).

| Suite | What it pins |
|---|---|
| `AttributeColumns.test.tsx` (45) | Column shape — the declared field has to be the *real* map column or `getSelectFromColumns` throws the whole table away; the explicit id has to equal what `ColumnPreference` derives on its own; sorting off; cells through `getElement`. Plus the keys → columns → ids → stored layout → keys round trip. |
| `ColumnCustomizationModalAddableColumns.test.tsx` (40) | Search/add/remove staging, the pool excluding what's already staged, the last-visible-column guard applied to removal, loading/error/empty states, and the result cap being announced rather than silently truncating. |
| `BaseModelTableAttributeColumns.test.tsx` (24) | End to end through a real table: an added column renders a `<th>` and a cell, survives a reload, is removed by Reset, and the map column is on the wire from the **first** request (the table doesn't refetch when its column set changes). |
| `SecurityEventsTableColumns.test.tsx` (49) | Default layout is byte-for-byte the old seven, every issue-requested field has a column, every declared field is real on the model, array cells join, `targetPort: 0` renders `-`. |
| `SecurityEventAttributesAPI.test.ts` (25) | Both routes registered with a guard chain; every permission on the model's read list gets through and an unrelated one doesn't; the service is asked for `SecurityEvent` attributes and not some other signal. |
| `TelemetryAttributeServiceSecurityEvent.test.ts` (22) | The source resolves at all (a missing `case` here is a silently empty picker, not an error), points at the right table, and every identifier/value is a bound parameter. |
| `SecurityEventAttributeUtil.test.ts` (8) | Route, tenant headers, and junk in the response degrading to "no attributes" rather than columns titled `null`. |

`tsc --noEmit` is clean for both `Common` and `App`; eslint is clean on every touched file.

> One unrelated pre-existing failure exists on `master`: `SecurityEventsSetupGuide.test.tsx` → "interpolates the selected key's secret, not the placeholder". Verified failing at `4c13026b21` before any of these changes; untouched here.