### PR TITLE
fix(monitor): auto-resolve incidents created from id-less criteria incident templates

### DIFF
--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -196,24 +196,15 @@ export default class MonitorIncident {
         continue;
       }
 
-      const createdCriteriaId: string | undefined =
-        openIncident.createdCriteriaId?.toString();
-      const createdIncidentTemplateId: string | undefined =
-        openIncident.createdIncidentTemplateId?.toString();
-
       // Only auto-resolve when the creating criteria opted into it.
-      if (!createdCriteriaId || !createdIncidentTemplateId) {
-        continue;
-      }
-
-      const autoResolveTemplates: Array<string> | undefined =
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          createdCriteriaId
-        ];
-
       if (
-        !autoResolveTemplates ||
-        !autoResolveTemplates.includes(createdIncidentTemplateId)
+        !this.isAutoResolveIncidentTemplate({
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+          createdCriteriaId: openIncident.createdCriteriaId?.toString(),
+          createdIncidentTemplateId:
+            openIncident.createdIncidentTemplateId?.toString(),
+        })
       ) {
         continue;
       }
@@ -929,6 +920,56 @@ export default class MonitorIncident {
     }
   }
 
+  /**
+   * True when the criteria that created this incident opted that incident
+   * template into auto-resolve.
+   *
+   * Mirrors the create path (and the dedupe match above), which sets
+   * `createdIncidentTemplateId` only when the criteria's incident template
+   * carries an `id`. API- and Terraform-authored criteria routinely omit it
+   * and the write path accepts them, so the stored id is NULL for those
+   * incidents while the auto-resolve dictionary holds a matching `undefined`
+   * entry (MonitorResource pushes `incidentTemplate.id` verbatim). Gating
+   * hard on a non-empty id therefore made those incidents unresolvable
+   * forever, by payload or by absence, with nothing logged to say why.
+   *
+   * Normalising both sides to `undefined` lets them resolve while staying
+   * exact: an incident whose template id is NULL matches only an id-less
+   * auto-resolve template on the same criteria, never an unrelated one that
+   * does carry an id.
+   */
+  private static isAutoResolveIncidentTemplate(input: {
+    autoResolveCriteriaInstanceIdIncidentIdsDictionary: Dictionary<
+      Array<string>
+    >;
+    createdCriteriaId: string | undefined;
+    createdIncidentTemplateId: string | undefined;
+  }): boolean {
+    if (!input.createdCriteriaId) {
+      return false;
+    }
+
+    const autoResolveTemplateIds: Array<string> | undefined =
+      input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
+        input.createdCriteriaId
+      ];
+
+    if (!autoResolveTemplateIds) {
+      return false;
+    }
+
+    const createdIncidentTemplateId: string | undefined =
+      input.createdIncidentTemplateId || undefined;
+
+    return autoResolveTemplateIds.some(
+      (autoResolveTemplateId: string | undefined) => {
+        return (
+          (autoResolveTemplateId || undefined) === createdIncidentTemplateId
+        );
+      },
+    );
+  }
+
   private static shouldCloseIncident(input: {
     openIncident: Incident;
     autoResolveCriteriaInstanceIdIncidentIdsDictionary: Dictionary<
@@ -996,29 +1037,13 @@ export default class MonitorIncident {
        * was configured to auto-resolve in the first place; otherwise
        * stay open so a human can acknowledge.
        */
-      if (!input.openIncident.createdCriteriaId?.toString()) {
-        return false;
-      }
-
-      if (!input.openIncident.createdIncidentTemplateId?.toString()) {
-        return false;
-      }
-
-      const autoResolveTemplates: Array<string> | undefined =
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          input.openIncident.createdCriteriaId.toString()
-        ];
-
-      if (
-        autoResolveTemplates &&
-        autoResolveTemplates.includes(
-          input.openIncident.createdIncidentTemplateId.toString(),
-        )
-      ) {
-        return true;
-      }
-
-      return false;
+      return this.isAutoResolveIncidentTemplate({
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+          input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+        createdCriteriaId: input.openIncident.createdCriteriaId?.toString(),
+        createdIncidentTemplateId:
+          input.openIncident.createdIncidentTemplateId?.toString(),
+      });
     }
 
     if (
@@ -1031,28 +1056,12 @@ export default class MonitorIncident {
 
     // If antoher criteria is active then, check if the incident id is present in the map.
 
-    if (!input.openIncident.createdCriteriaId?.toString()) {
-      return false;
-    }
-
-    if (!input.openIncident.createdIncidentTemplateId?.toString()) {
-      return false;
-    }
-
-    if (
-      input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-        input.openIncident.createdCriteriaId?.toString()
-      ]
-    ) {
-      if (
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          input.openIncident.createdCriteriaId?.toString()
-        ]?.includes(input.openIncident.createdIncidentTemplateId?.toString())
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.isAutoResolveIncidentTemplate({
+      autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+      createdCriteriaId: input.openIncident.createdCriteriaId?.toString(),
+      createdIncidentTemplateId:
+        input.openIncident.createdIncidentTemplateId?.toString(),
+    });
   }
 }

--- a/Common/Tests/Server/Utils/Monitor/IdLessIncidentTemplateAutoResolve.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/IdLessIncidentTemplateAutoResolve.test.ts
@@ -1,0 +1,294 @@
+/*
+ * MonitorIncident reaches the native isolated-vm addon through its template
+ * renderer (MonitorTemplateUtil -> VMAPI -> VMRunner). Nothing under test
+ * here touches the sandbox and the prebuilt binary cannot always dlopen in
+ * the test environment, so stub it out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import MonitorIncident from "../../../../Server/Utils/Monitor/MonitorIncident";
+import OneUptimeDate from "../../../../Types/Date";
+import Dictionary from "../../../../Types/Dictionary";
+import IncomingMonitorRequest from "../../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Regression tests for incidents created from criteria incident templates
+ * that carry no `id`.
+ *
+ * `CriteriaIncident.id` is declared required, but the write path accepts
+ * templates without one — the API and the Terraform provider both author
+ * criteria that way. The create path already handles it (it sets
+ * `createdIncidentTemplateId` only when the id is present) and so does the
+ * dedupe match, which normalises both sides to `undefined` so a created
+ * incident still matches itself on the next cycle.
+ *
+ * Both resolution paths did not: they returned early whenever
+ * `createdIncidentTemplateId` was NULL. So an incident created from an
+ * id-less template was created correctly, deduplicated correctly, carried a
+ * correct `seriesFingerprint` — and could never be auto-resolved, neither by
+ * an incoming payload reporting the key recovered nor by series absence,
+ * with nothing logged to say why.
+ *
+ * The tests below fail on the pre-fix code and pin the exactness the fix
+ * must keep: a NULL template id matches only an id-less auto-resolve
+ * template on the same criteria, never an unrelated one that has an id.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const CRITERIA_ID: string = "aafe2669-1a2b-4c3d-8e4f-5a6b7c8d9e0f";
+const TEMPLATE_ID: string = "template-1";
+const SERIES_FINGERPRINT: string = "0eb39d7970a4f69a";
+
+/*
+ * MonitorResource builds the auto-resolve dictionary by pushing
+ * `incidentTemplate.id` verbatim for every template with
+ * `autoResolveIncident: true`. The declared element type is `string` because
+ * `CriteriaIncident.id` is declared required — but for an id-less template
+ * the array really does hold `undefined` at runtime. This reproduces that
+ * exact shape rather than a tidied-up version of it.
+ */
+const ID_LESS_TEMPLATE: string = undefined as unknown as string;
+
+const AUTO_RESOLVE_ID_LESS_TEMPLATE: Dictionary<Array<string>> = {
+  [CRITERIA_ID]: [ID_LESS_TEMPLATE],
+};
+
+const AUTO_RESOLVE_TEMPLATE_WITH_ID: Dictionary<Array<string>> = {
+  [CRITERIA_ID]: [TEMPLATE_ID],
+};
+
+type ResolveOpenIncident = (input: {
+  openIncident: Incident;
+  rootCause: string;
+  dataToProcess: IncomingMonitorRequest;
+}) => Promise<void>;
+
+const monitorIncidentInternals: {
+  resolveOpenIncident: ResolveOpenIncident;
+  shouldCloseIncident: (input: Record<string, unknown>) => boolean;
+} = MonitorIncident as unknown as {
+  resolveOpenIncident: ResolveOpenIncident;
+  shouldCloseIncident: (input: Record<string, unknown>) => boolean;
+};
+
+/** Builds an open incident the way the create path would have stored it. */
+function openIncident(templateId: string | undefined): Incident {
+  const model: Incident = new Incident();
+  model._id = INCIDENT_ID.toString();
+  model.projectId = PROJECT_ID;
+  model.createdCriteriaId = CRITERIA_ID;
+  model.seriesFingerprint = SERIES_FINGERPRINT;
+
+  // Mirrors the create path: only set when the template actually has an id.
+  if (templateId) {
+    model.createdIncidentTemplateId = templateId;
+  }
+
+  return model;
+}
+
+function criteria(
+  id: string,
+  createsIncidents: boolean,
+): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data!.id = id;
+  instance.data!.createIncidents = createsIncidents;
+  return instance;
+}
+
+function monitor(): Monitor {
+  const model: Monitor = new Monitor();
+  model._id = MONITOR_ID.toString();
+  model.projectId = PROJECT_ID;
+  return model;
+}
+
+/** The Alertmanager-style recovery payload from the issue reproduction. */
+function resolvedPayload(): IncomingMonitorRequest {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    requestBody: {
+      groupKey: "alertmanager-group-1",
+      status: "resolved",
+    },
+    incomingRequestReceivedAt: OneUptimeDate.getCurrentDate(),
+    checkedAt: OneUptimeDate.getCurrentDate(),
+  };
+}
+
+/*
+ * Arranges a single open incident and drives the event-driven resolution
+ * path over it. Asserting on the mocked `resolveOpenIncident` keeps the test
+ * on the decision under test rather than on incident-state persistence.
+ */
+async function runPayloadResolution(input: {
+  incident: Incident;
+  autoResolveTemplates: Dictionary<Array<string>>;
+}): Promise<void> {
+  jest.spyOn(IncidentService, "findBy").mockResolvedValue([input.incident]);
+  jest
+    .spyOn(monitorIncidentInternals, "resolveOpenIncident")
+    .mockResolvedValue(undefined);
+
+  await MonitorIncident.resolveSeriesIncidentsByFingerprint({
+    monitor: monitor(),
+    fingerprints: [SERIES_FINGERPRINT],
+    rootCause: "Payload reported this key as resolved.",
+    dataToProcess: resolvedPayload(),
+    autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+      input.autoResolveTemplates,
+  });
+}
+
+describe("Auto-resolve for id-less criteria incident templates", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("resolveSeriesIncidentsByFingerprint (payload reports the key resolved)", () => {
+    it("resolves an incident whose template id is NULL when the criteria opted in with an id-less template", async () => {
+      await runPayloadResolution({
+        incident: openIncident(undefined),
+        autoResolveTemplates: AUTO_RESOLVE_ID_LESS_TEMPLATE,
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("still resolves an incident created from a template that does have an id", async () => {
+      await runPayloadResolution({
+        incident: openIncident(TEMPLATE_ID),
+        autoResolveTemplates: AUTO_RESOLVE_TEMPLATE_WITH_ID,
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not resolve a NULL-template incident when every auto-resolve template on that criteria carries an id", async () => {
+      await runPayloadResolution({
+        incident: openIncident(undefined),
+        autoResolveTemplates: AUTO_RESOLVE_TEMPLATE_WITH_ID,
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("does not resolve when the creating criteria did not opt into auto-resolve at all", async () => {
+      await runPayloadResolution({
+        incident: openIncident(undefined),
+        autoResolveTemplates: {},
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("shouldCloseIncident, per-series absence path", () => {
+    it("closes a NULL-template incident once its series stops breaching", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>(["some-other-series"]),
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("keeps a NULL-template incident open while its series is still breaching", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>([SERIES_FINGERPRINT]),
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("does not close a NULL-template incident when the opted-in template carries an id", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_TEMPLATE_WITH_ID,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>(["some-other-series"]),
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("still honours the event-driven guard for NULL-template incidents", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>(["some-other-series"]),
+          disableSeriesAbsenceResolution: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("shouldCloseIncident, cross-criteria path", () => {
+    it("closes a NULL-template incident when another criteria is now active", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria("another-criteria", true),
+          breachingSeriesFingerprints: undefined,
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not close a NULL-template incident when its own criteria is still active", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: undefined,
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/Common/Tests/Types/Code/YamlSyntax.test.ts
+++ b/Common/Tests/Types/Code/YamlSyntax.test.ts
@@ -322,9 +322,17 @@ describe("checkYamlSyntax — tabs used for indentation", () => {
   test.each([
     ["a tab indenting a sequence entry", "a:\n\t- 1\n", 2],
     ["spaces followed by a tab", "a:\n  \tb: 1\n", 2],
-    ["a tab on a line after a block scalar closes", "a: |\n  body\nb:\n\tc: 1\n", 4],
+    [
+      "a tab on a line after a block scalar closes",
+      "a: |\n  body\nb:\n\tc: 1\n",
+      4,
+    ],
     ["a CRLF document", "a:\r\n\tb: 1\r\n", 2],
-    ["a tab several levels into the document", "a:\n  b:\n    c: 1\n\td: 2\n", 4],
+    [
+      "a tab several levels into the document",
+      "a:\n  b:\n    c: 1\n\td: 2\n",
+      4,
+    ],
   ])("rejects %s", (_label: string, document: string, line: number) => {
     const result: YamlSyntaxCheckResult = checkYamlSyntax(document);
 
@@ -339,16 +347,31 @@ describe("checkYamlSyntax — tabs used for indentation", () => {
    */
   test.each([
     ["a tab inside block scalar content", "a: |\n  line\twith tab\n"],
-    ["a block scalar line that starts with a tab", "a: |\n  first\n  \tindented more\n"],
-    ["a block scalar with an explicit indent indicator", "a: |2\n  \tcontent\n"],
+    [
+      "a block scalar line that starts with a tab",
+      "a: |\n  first\n  \tindented more\n",
+    ],
+    [
+      "a block scalar with an explicit indent indicator",
+      "a: |2\n  \tcontent\n",
+    ],
     ["a block scalar with chomping indicators", "a: |-\n  \tx\nb: >+\n  \ty\n"],
-    ["a block scalar containing a blank line", "a: |\n  one\n\n  \ttwo\nb: 2\n"],
+    [
+      "a block scalar containing a blank line",
+      "a: |\n  one\n\n  \ttwo\nb: 2\n",
+    ],
     ["a block scalar inside a sequence", "- |\n  \tx\n- 2\n"],
-    ["YAML embedded in a block scalar, as a ConfigMap does", "data:\n  app.yaml: |\n    outer:\n    \tinner: 1\n"],
+    [
+      "YAML embedded in a block scalar, as a ConfigMap does",
+      "data:\n  app.yaml: |\n    outer:\n    \tinner: 1\n",
+    ],
     ["a block scalar line shaped like a mapping key", "a: |\n  x:\n  \ty: 1\n"],
     ["a double-quoted scalar continued on a tabbed line", 'a: "one\n\ttwo"\n'],
     ["a single-quoted scalar continued on a tabbed line", "a: 'one\n\ttwo'\n"],
-    ["a quoted continuation that looks like a mapping key", 'a: "one\n\ttwo: three"\n'],
+    [
+      "a quoted continuation that looks like a mapping key",
+      'a: "one\n\ttwo: three"\n',
+    ],
     ["a flow mapping spanning lines", "a: {\n\tb: 1 }\n"],
     ["a tab inside a quoted value", 'a: "x\ty"\n'],
     ["a tab inside a comment", "a: 1 #\tcomment\n"],

--- a/Common/Types/Code/YamlSyntax.ts
+++ b/Common/Types/Code/YamlSyntax.ts
@@ -192,11 +192,17 @@ const scanLine: ScanLineFunction = (
 
     const previous: string = line[index - 1] || "";
 
-    if (character === "#" && (index === 0 || previous === " " || previous === "\t")) {
+    if (
+      character === "#" &&
+      (index === 0 || previous === " " || previous === "\t")
+    ) {
       return line.slice(0, index);
     }
 
-    if ((character === '"' || character === "'") && isScalarOpeningQuote(line, index)) {
+    if (
+      (character === '"' || character === "'") &&
+      isScalarOpeningQuote(line, index)
+    ) {
       state.openQuote = character as QuoteCharacter;
       index++;
       continue;


### PR DESCRIPTION
### Title of this pull request?

fix(monitor): auto-resolve incidents created from id-less criteria incident templates

### Small Description?

An incident created from a criteria whose incident template has no `id` can **never** be auto-resolved — not by an incoming `status: resolved` payload, and not by series absence. Both resolution paths hard-gate on `createdIncidentTemplateId`, which the creation path leaves NULL when the template has no id.

`CriteriaIncident.id` is declared required, but the write path accepts templates without one, and API- and Terraform-authored criteria routinely omit it. The **create** path already handles that — it sets `createdIncidentTemplateId` only when the id is present — and so does the **dedupe** match, which normalises both sides to `undefined` so a created incident still matches itself on the next cycle.

The **resolution** paths were never given the same treatment:

- `resolveSeriesIncidentsByFingerprint` — `if (!createdCriteriaId || !createdIncidentTemplateId) { continue; }`
- `shouldCloseIncident` — the same gate, in both of its branches

So a state the write path accepts and the dedupe path explicitly supports is silently unresolvable. This is the worst failure shape: incidents are created correctly, deduplicated correctly, carry a correct `seriesFingerprint` — and stay open forever, with nothing in any log to say why.

**The fix.** The three hard gates become one `isAutoResolveIncidentTemplate()` helper that normalises both sides to `undefined`, mirroring what the dedupe path already does. It stays exact: an incident whose template id is NULL matches only an **id-less** auto-resolve template on the same criteria, never an unrelated one that does carry an id.

This also heals monitors already in this state, which a provider-side fix alone cannot do.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

closes #3390

### Tests

New: `Common/Tests/Server/Utils/Monitor/IdLessIncidentTemplateAutoResolve.test.ts` (10 tests).

Verified against the pre-fix code — 3 tests fail without the change, one per broken path:

| Test | Pre-fix | Post-fix |
|---|---|---|
| resolves a NULL-template incident when the payload reports the key resolved | ✕ | ✓ |
| closes a NULL-template incident once its series stops breaching | ✕ | ✓ |
| closes a NULL-template incident when another criteria is now active | ✕ | ✓ |

The other 7 pin the exactness and pass both before and after, so they demonstrate the fix does not over-resolve: a NULL-template incident is **not** resolved when the criteria's auto-resolve template carries an id, when the criteria never opted in, or while its series is still breaching; and the event-driven absence guard still holds.

Full `Common/Tests/Server/Utils/Monitor` suite: **67 suites / 1378 tests pass**. `tsc --noEmit` and `eslint` clean.