### PR TITLE
fix(terraform-provider): recognize the "column does not exist" select-clause error too

### DIFF
--- a/Scripts/TerraformProvider/Core/ProviderGenerator.ts
+++ b/Scripts/TerraformProvider/Core/ProviderGenerator.ts
@@ -334,6 +334,10 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 // "You do not have permissions to select on - serviceLanguage."
 var rejectedSelectColumn = regexp.MustCompile(\`select on - ([A-Za-z0-9_]+)\`)
 
+// unknownSelectColumn matches the server's unknown-column error, e.g.
+// \`Cannot select on "serviceLanguage". This column does not exist on Status Page.\`
+var unknownSelectColumn = regexp.MustCompile(\`Cannot select on "([A-Za-z0-9_]+)"\`)
+
 // PostWithSelect performs a POST request with a select parameter. When the
 // server rejects a column in the select (permission-gated columns, or
 // columns this server version does not know about yet), that column is
@@ -364,6 +368,9 @@ func (c *Client) PostWithSelect(ctx context.Context, path string, selectParam in
         }
 
         match := rejectedSelectColumn.FindSubmatch(body)
+        if match == nil {
+            match = unknownSelectColumn.FindSubmatch(body)
+        }
         rebuilt := func() *http.Response {
             resp.Body = io.NopCloser(bytes.NewReader(body))
             return resp


### PR DESCRIPTION
PostWithSelect's column-drop-and-retry only matched the permission-denied error format ("select on - X"). The server also returns a differently worded error when a column doesn't exist yet on its side ("Cannot select on \"X\". This column does not exist..."), which happens whenever the generated Terraform provider is ahead of the API schema it's talking to (e.g. a field added to a model right before a provider release, before that release is deployed everywhere). That format wasn't recognized, so instead of dropping the column and retrying, the whole read failed - blocking any read of the affected resource, new or existing.

This edits the embedded Go source in the provider generator (Scripts/TerraformProvider/Core/ProviderGenerator.ts), since terraform-provider-oneuptime is a generated, read-only mirror.

We previously opened this against the mirror repo directly (OneUptime/terraform-provider-oneuptime#14 / #15) before realizing that repo has no CI and isn't where changes should land per its own README.

### Title of this pull request?

fix(terraform-provider): recognize the "column does not exist" select-clause error too

### Small Description?

Adds a second regex to `PostWithSelect`'s column-drop-and-retry logic so it also recognizes the "column does not exist" error format, not just the permission-denied one. Matches the same fix already proposed against the (wrong, read-only) mirror repo, now applied at the actual generator source.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

closes #3414

### Screenshots (if appropriate):

N/A - Go source change only, verified with `go build`/`go vet`/`go test` against the generated output, plus the generator's own Jest test suite (6/7 suites pass, 78/78 tests; the 1 failing suite fails on a pre-existing unrelated dependency resolution issue).
