### PR TITLE
fix(network): stamp a monitor-backed device's status when its monitor is bound

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Network/NetworkOverviewUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Network/NetworkOverviewUtil.ts
@@ -13,13 +13,26 @@ export interface OverviewDeviceRow {
   name?: string | undefined;
   /*
    * The reachability inputs the shared rule reads. `isReachable` is the
-   * verdict; the rest only size the "polling has stopped" backstop. See
-   * DeviceStatusUtil.DEVICE_STATUS_SELECT — the page must select all four.
+   * verdict for a polled device; the two timestamps and the interval only
+   * size the "polling has stopped" backstop. See
+   * DeviceStatusUtil.DEVICE_STATUS_SELECT — the page must select them all.
    */
   isReachable?: boolean | undefined;
   lastPolledAt?: Date | undefined;
   lastSeenAt?: Date | undefined;
   pollingIntervalInMinutes?: number | undefined;
+  /*
+   * ...and the two a monitor-backed device is judged by instead. Without
+   * them every ping-only device counts as Pending in the fleet strip while
+   * the device list next to it renders its monitor's real status.
+   */
+  monitoringMethod?: string | undefined;
+  currentMonitorStatus?:
+    | {
+        isOfflineState?: boolean | null | undefined;
+      }
+    | null
+    | undefined;
   interfacesDown?: number | undefined;
   vendor?: string | undefined;
 }

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusHero.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusHero.tsx
@@ -28,7 +28,8 @@ export interface ComponentProps {
 
 /*
  * Status hero for the device Overview: answers "is this device OK right
- * now?" in one glance — SNMP reachability, monitor-evaluated status,
+ * now?" in one glance — reachability (from the SNMP walk, or from the bound
+ * Monitor for a device nothing polls), monitor-evaluated status,
  * interface up/down bar, hardware uptime, and where the device lives
  * (site + probe) — before the user reads anything else on the page.
  */
@@ -53,10 +54,6 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
           interfacesTotal: true,
           interfacesUp: true,
           interfacesDown: true,
-          currentMonitorStatus: {
-            name: true,
-            color: true,
-          },
           site: {
             name: true,
             _id: true,
@@ -114,6 +111,14 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
 
   type GetReachabilityPillFunction = () => ReactElement;
 
+  /*
+   * Nothing polls a monitor-backed device, so every sentence this tile can
+   * say about a poll is false for one — including the "check that this
+   * device's probe is online" staleness note, which the shared rule already
+   * suppresses for them.
+   */
+  const isMonitorBacked: boolean = reachabilityResult.isMonitorBacked;
+
   const getReachabilityPill: GetReachabilityPillFunction = (): ReactElement => {
     if (reachability === NetworkDeviceStatus.Up) {
       return (
@@ -121,7 +126,11 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
           text="Up"
           color={Green}
           size={PillSize.Normal}
-          tooltip="The last SNMP poll reached this device."
+          tooltip={
+            isMonitorBacked
+              ? "The monitor bound to this device reports it healthy."
+              : "The last SNMP poll reached this device."
+          }
         />
       );
     }
@@ -132,7 +141,11 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
           text="Down"
           color={Red500}
           size={PillSize.Normal}
-          tooltip="The last SNMP poll could not reach this device."
+          tooltip={
+            isMonitorBacked
+              ? "The monitor bound to this device reports it offline."
+              : "The last SNMP poll could not reach this device."
+          }
         />
       );
     }
@@ -142,7 +155,11 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
         text="Pending"
         color={Gray500}
         size={PillSize.Normal}
-        tooltip="This device has not been polled yet."
+        tooltip={
+          isMonitorBacked
+            ? "No monitor is bound to this device yet, or the one that is has not reported a status."
+            : "This device has not been polled yet."
+        }
       />
     );
   };
@@ -212,11 +229,13 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
             )}
           </div>
           <div className="mt-1.5 text-xs text-gray-500">
-            {lastSeenAt
-              ? `Last seen ${OneUptimeDate.fromNow(lastSeenAt)}`
-              : "Never answered a poll"}
+            {isMonitorBacked
+              ? "Reported by the monitor bound to this device"
+              : lastSeenAt
+                ? `Last seen ${OneUptimeDate.fromNow(lastSeenAt)}`
+                : "Never answered a poll"}
           </div>
-          {isPollNewerThanContact && lastPolledAt && (
+          {!isMonitorBacked && isPollNewerThanContact && lastPolledAt && (
             <div className="mt-0.5 text-xs text-gray-400">
               {`Last polled ${OneUptimeDate.fromNow(lastPolledAt)}`}
             </div>

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusUtil.ts
@@ -18,6 +18,11 @@ import DeviceReachabilityUtil, {
  * cadence is a function of fleet size) showed healthy devices as Down while
  * their own Interfaces tab, written by the same successful walk, showed
  * them Up.
+ *
+ * ...unless nothing polls the device at all. A monitor-backed device is
+ * judged by the Monitor bound to it, and this door is where the nested
+ * `currentMonitorStatus` relation the API returns is turned into the flag
+ * the shared rule reads.
  */
 
 export {
@@ -30,31 +35,82 @@ export type { DeviceReachabilityInput, DeviceReachabilityResult };
 /*
  * The columns every caller of this util has to select. Exported so a page
  * cannot add a status pill and forget one of them — a missing `isReachable`
- * silently falls back to the legacy freshness rule and reintroduces the bug.
+ * silently falls back to the legacy freshness rule and reintroduces the bug,
+ * and a missing `monitoringMethod` / `currentMonitorStatus` leaves every
+ * monitor-backed device on "Pending" whatever its monitor says
+ * (OneUptime/oneuptime#3392).
  */
 export const DEVICE_STATUS_SELECT: {
   isReachable: boolean;
   lastPolledAt: boolean;
   lastSeenAt: boolean;
   pollingIntervalInMinutes: boolean;
+  monitoringMethod: boolean;
+  currentMonitorStatus: {
+    name: boolean;
+    color: boolean;
+    isOfflineState: boolean;
+  };
 } = {
   isReachable: true,
   lastPolledAt: true,
   lastSeenAt: true,
   pollingIntervalInMinutes: true,
+  monitoringMethod: true,
+  /*
+   * `name` and `color` so a surface can render the operator's own status
+   * word ("Operational", "Degraded") instead of flattening it to Up/Down;
+   * `isOfflineState` because that is the end of the ladder the rule reads.
+   */
+  currentMonitorStatus: {
+    name: true,
+    color: true,
+    isOfflineState: true,
+  },
 };
 
+/*
+ * A NetworkDevice row as the API returns it: the monitor's verdict arrives
+ * as the nested `currentMonitorStatus` relation, while the shared rule takes
+ * the one flag it reads. Accepting both spellings is what lets every page go
+ * on passing the model straight through.
+ */
+export interface DeviceStatusRow extends DeviceReachabilityInput {
+  currentMonitorStatus?:
+    | {
+        isOfflineState?: boolean | null | undefined;
+      }
+    | null
+    | undefined;
+}
+
+function toReachabilityInput(device: DeviceStatusRow): DeviceReachabilityInput {
+  if (device.monitorStatusIsOffline !== undefined) {
+    return device;
+  }
+
+  return {
+    ...device,
+    /*
+     * No stamped status stays `undefined` rather than becoming `false` — the
+     * rule reads that as "no monitor has reported yet" (Pending), and
+     * defaulting it to "not offline" would paint an unbound device green.
+     */
+    monitorStatusIsOffline: device.currentMonitorStatus
+      ? Boolean(device.currentMonitorStatus.isOfflineState)
+      : undefined,
+  };
+}
+
 export default class DeviceStatusUtil {
-  public static getStatus(
-    device: DeviceReachabilityInput,
-  ): NetworkDeviceReachability {
-    return DeviceReachabilityUtil.getStatus(device);
+  public static getStatus(device: DeviceStatusRow): NetworkDeviceReachability {
+    return DeviceReachabilityUtil.getStatus(toReachabilityInput(device));
   }
 
   public static getReachability(
-    device: DeviceReachabilityInput,
+    device: DeviceStatusRow,
   ): DeviceReachabilityResult {
-    return DeviceReachabilityUtil.getReachability(device);
+    return DeviceReachabilityUtil.getReachability(toReachabilityInput(device));
   }
 
   public static getStaleWindowInMinutes(

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
@@ -843,21 +843,17 @@ const NetworkDevices: FunctionComponent<
           },
         ]}
         selectMoreFields={{
+          /*
+           * Carries `monitoringMethod` and `currentMonitorStatus` as well as
+           * the poll columns: the status pill reads a monitor-backed
+           * device's health from its monitor, not from an SNMP walk —
+           * nothing polls those, so the poll columns alone would leave every
+           * one of them stuck on "Pending".
+           */
           ...DEVICE_STATUS_SELECT,
           interfacesDown: true,
           sysName: true,
           deviceModel: true,
-          /*
-           * The status pill reads a monitor-backed device's health from its
-           * monitor, not from an SNMP walk — nothing polls those, so the poll
-           * columns would leave every one of them stuck on "Pending".
-           */
-          monitoringMethod: true,
-          currentMonitorStatus: {
-            name: true,
-            color: true,
-            isOfflineState: true,
-          },
         }}
         onViewPage={(item: NetworkDevice): Promise<Route> => {
           return Promise.resolve(

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Overview.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Overview.tsx
@@ -224,6 +224,8 @@ const NetworkOverview: FunctionComponent<
         lastPolledAt: device.lastPolledAt,
         lastSeenAt: device.lastSeenAt,
         pollingIntervalInMinutes: device.pollingIntervalInMinutes,
+        monitoringMethod: device.monitoringMethod,
+        currentMonitorStatus: device.currentMonitorStatus,
         interfacesDown: device.interfacesDown,
         vendor: device.vendor,
       };

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Devices.tsx
@@ -21,7 +21,8 @@ import React, { Fragment, FunctionComponent, ReactElement } from "react";
 /*
  * Every device assigned to this site — same status language as the main
  * device list (Up / Down / Pending, decided by the outcome of the last
- * SNMP poll rather than by how long ago it happened).
+ * SNMP poll rather than by how long ago it happened, or by the bound
+ * Monitor for a device nothing polls).
  */
 const NetworkSiteDevices: FunctionComponent<
   PageComponentProps
@@ -78,13 +79,25 @@ const NetworkSiteDevices: FunctionComponent<
               const reachability: DeviceReachabilityResult =
                 DeviceStatusUtil.getReachability(item);
 
+              /*
+               * Same verdict either way, but never the same sentence: a
+               * device nothing polls has no "last SNMP poll" to talk
+               * about, and telling its operator to go and check a probe it
+               * does not have is how a real ping outage gets missed.
+               */
+              const isMonitorBacked: boolean = reachability.isMonitorBacked;
+
               if (reachability.status === NetworkDeviceStatus.Up) {
                 return (
                   <Pill
                     text="Up"
                     color={Green}
                     size={PillSize.Small}
-                    tooltip="The last SNMP poll reached this device."
+                    tooltip={
+                      isMonitorBacked
+                        ? "The monitor bound to this device reports it healthy."
+                        : "The last SNMP poll reached this device."
+                    }
                   />
                 );
               }
@@ -95,7 +108,11 @@ const NetworkSiteDevices: FunctionComponent<
                     text="Down"
                     color={Red500}
                     size={PillSize.Small}
-                    tooltip="The last SNMP poll could not reach this device."
+                    tooltip={
+                      isMonitorBacked
+                        ? "The monitor bound to this device reports it offline."
+                        : "The last SNMP poll could not reach this device."
+                    }
                   />
                 );
               }
@@ -105,7 +122,11 @@ const NetworkSiteDevices: FunctionComponent<
                   text="Pending"
                   color={Gray500}
                   size={PillSize.Small}
-                  tooltip="This device has not been polled yet."
+                  tooltip={
+                    isMonitorBacked
+                      ? "No monitor is bound to this device yet, or the one that is has not reported a status."
+                      : "This device has not been polled yet."
+                  }
                 />
               );
             },

--- a/App/FeatureSet/Workers/DataMigrations/BackfillMonitorBackedDeviceStatus.ts
+++ b/App/FeatureSet/Workers/DataMigrations/BackfillMonitorBackedDeviceStatus.ts
@@ -1,0 +1,104 @@
+import DataMigrationBase from "./DataMigrationBase";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import { NetworkDeviceMonitoringMethodUtil } from "Common/Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import logger from "Common/Server/Utils/Logger";
+
+/*
+ * Stamps the bound monitor's CURRENT status onto every monitor-backed
+ * NetworkDevice that never got one.
+ *
+ * A monitor-backed device (monitoringMethod "Monitor") is never polled, so
+ * `currentMonitorStatusId` is the only thing that can say whether it is up —
+ * the device list pill, the site rollup and the topology node all read it.
+ * Until NetworkDeviceService.refreshStampedMonitorStatus existed, the ONLY
+ * writer of that column was NetworkSiteService.onMonitorStatusChanged, which
+ * fires on a monitor's next status CHANGE. Bind a device to a Ping monitor
+ * that is already Up and stays Up and nothing ever writes it, so the device
+ * reads "Pending" indefinitely — OneUptime/oneuptime#3392.
+ *
+ * The service fix stamps at bind time, which repairs every future binding
+ * but not the ones already saved: those devices are waiting on a status
+ * change that may be weeks away, on a healthy network may never come, and
+ * would in any case mean the operator only learns the device exists at the
+ * moment it breaks. This walks them once on upgrade.
+ *
+ * Idempotent, and safe to run twice CONCURRENTLY as this runner requires
+ * (see Workers/Utils/DataMigration.ts): refreshStampedMonitorStatus derives
+ * the stamp from the binding rather than from anything it just wrote, and
+ * writes nothing when it already agrees. Two runners racing therefore
+ * compute the same value, and the loser writes what the winner already
+ * wrote. A device whose monitor has since moved on is simply brought up to
+ * date.
+ */
+export default class BackfillMonitorBackedDeviceStatus extends DataMigrationBase {
+  public constructor() {
+    super("BackfillMonitorBackedDeviceStatus");
+  }
+
+  public override async migrate(): Promise<void> {
+    /*
+     * Only devices that actually point at a monitor. A monitor-backed
+     * device with nothing bound has no status to adopt (discovery import
+     * creates them that way on purpose) and "Pending" is the true answer
+     * for it, so it is left alone rather than walked.
+     */
+    const devices: Array<NetworkDevice> = await NetworkDeviceService.findBy({
+      query: {
+        monitorId: QueryHelper.notNull(),
+      },
+      select: {
+        _id: true,
+        monitoringMethod: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    for (const device of devices) {
+      if (!device.id) {
+        continue;
+      }
+
+      /*
+       * Filtered here rather than in the query because monitoringMethod is
+       * free text: NULL, "" and anything unrecognised all read as SNMP (see
+       * NetworkDeviceMonitoringMethodUtil.parse), and an SNMP device's
+       * stamp comes from the Network Device monitor watching it — which is
+       * not this column, and must not be rewritten from it.
+       */
+      if (
+        !NetworkDeviceMonitoringMethodUtil.isMonitorBacked(
+          device.monitoringMethod,
+        )
+      ) {
+        continue;
+      }
+
+      try {
+        await NetworkDeviceService.refreshStampedMonitorStatus({
+          deviceId: device.id,
+          clearWhenNotMonitorBacked: false,
+        });
+      } catch (err) {
+        /*
+         * One unreadable device must not cost the rest of the fleet its
+         * status, nor halt every migration queued behind this one.
+         */
+        logger.error(
+          `Failed to backfill the monitor status of network device ${device.id.toString()}:`,
+        );
+        logger.error(err);
+      }
+    }
+  }
+
+  public override async rollback(): Promise<void> {
+    return;
+  }
+}

--- a/App/FeatureSet/Workers/DataMigrations/Index.ts
+++ b/App/FeatureSet/Workers/DataMigrations/Index.ts
@@ -102,6 +102,7 @@ import BackfillNetworkSiteTypes from "./BackfillNetworkSiteTypes";
 import AddSessionIdToTelemetryTables from "./AddSessionIdToTelemetryTables";
 import AddScheduledMaintenanceTemplateOwnerPermissions from "./AddScheduledMaintenanceTemplateOwnerPermissions";
 import RepairEpisodeNotificationRuleSeverity from "./RepairEpisodeNotificationRuleSeverity";
+import BackfillMonitorBackedDeviceStatus from "./BackfillMonitorBackedDeviceStatus";
 
 // This is the order in which the migrations will be run. Add new migrations to the end of the array.
 
@@ -343,6 +344,15 @@ const DataMigrations: Array<DataMigrationBase> = [
    * rule pages. Idempotent and restartable, so a re-run is a clean no-op.
    */
   new RepairEpisodeNotificationRuleSeverity(),
+  /*
+   * Stamps the bound monitor's current status onto monitor-backed network
+   * devices that never got one. Until the binding itself started stamping,
+   * the column was only ever written by a monitor's next status CHANGE — so
+   * a ping-only device bound to a monitor that was already Up sat on
+   * "Pending" indefinitely (OneUptime/oneuptime#3392). Idempotent: the stamp
+   * is re-derived from the binding and only written when it disagrees.
+   */
+  new BackfillMonitorBackedDeviceStatus(),
 ];
 
 export default DataMigrations;

--- a/App/Tests/Dashboard/DeviceStatusSurfaceInvariants.test.ts
+++ b/App/Tests/Dashboard/DeviceStatusSurfaceInvariants.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "@jest/globals";
+import { DEVICE_STATUS_SELECT } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusUtil";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Every screen that prints a NetworkDevice's status, held to one rule.
+ *
+ * Issue #3392 was not a wrong rule, it was a partial one applied unevenly.
+ * A monitor-backed device — a phone, a camera, an access point, anything
+ * that cannot be walked over SNMP — is judged by the Monitor bound to it,
+ * and the poll columns that decide every other device are NULL on its row
+ * forever. A surface that selects only those columns therefore renders
+ * "Pending" for it no matter what its monitor says, and does so silently:
+ * the code compiles, the pill draws, and the answer is simply wrong.
+ *
+ * The shared rule (DeviceReachabilityUtil, via DeviceStatusUtil) now knows
+ * about both kinds of device, and DEVICE_STATUS_SELECT names every column
+ * it reads. What is left to enforce is that the surfaces actually go
+ * through the pair — which is wiring, and the App suite runs in a plain
+ * Node environment with no renderer, so it is asserted against the sources
+ * the way NetworkSitePageInvariants and SummaryTileFilteringInvariants are.
+ *
+ * Sources are whitespace-squashed first so prettier re-wrapping a line
+ * cannot turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readRawSource(...relativeParts: Array<string>): string {
+  return fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(readRawSource(...relativeParts));
+}
+
+/**
+ * The object literal the DEVICE_STATUS_SELECT spread sits inside — i.e. the
+ * device select itself, and nothing else in the file.
+ *
+ * Position alone is not enough to tell one select from another here: a
+ * NetworkSite has a `currentMonitorStatus` of its own (its rollup), and the
+ * Network Overview page selects devices and sites side by side. So the
+ * enclosing literal is found by brace matching from the spread outwards,
+ * and every assertion about "the device select" is made against that slice.
+ */
+function deviceSelectLiteral(...relativeParts: Array<string>): string {
+  const source: string = readRawSource(...relativeParts);
+  const spreadAt: number = source.indexOf("...DEVICE_STATUS_SELECT");
+
+  expect(spreadAt).toBeGreaterThanOrEqual(0);
+
+  let start: number = -1;
+  let depth: number = 0;
+
+  for (let index: number = spreadAt; index >= 0; index--) {
+    const character: string = source[index]!;
+
+    if (character === "}") {
+      depth++;
+    } else if (character === "{") {
+      if (depth === 0) {
+        start = index;
+        break;
+      }
+      depth--;
+    }
+  }
+
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  depth = 0;
+
+  for (let index: number = start; index < source.length; index++) {
+    const character: string = source[index]!;
+
+    if (character === "{") {
+      depth++;
+    } else if (character === "}") {
+      depth--;
+
+      if (depth === 0) {
+        return squash(source.substring(start, index + 1));
+      }
+    }
+  }
+
+  throw new Error("The device select literal is not brace-balanced.");
+}
+
+/*
+ * The surfaces that turn a NetworkDevice row into an up/down verdict. Each
+ * fetches its own devices, so each has to ask for the columns the rule
+ * reads; none of them can borrow another's select.
+ */
+const DEVICE_STATUS_SURFACES: Array<{ name: string; parts: Array<string> }> = [
+  {
+    name: "the device list",
+    parts: ["Pages", "NetworkDevice", "Devices.tsx"],
+  },
+  {
+    name: "the device Overview hero",
+    parts: ["Components", "NetworkDevice", "DeviceStatusHero.tsx"],
+  },
+  {
+    name: "a site's Devices tab",
+    parts: ["Pages", "NetworkSite", "View", "Devices.tsx"],
+  },
+  {
+    name: "the site status hero",
+    parts: ["Components", "NetworkSite", "SiteStatusHero.tsx"],
+  },
+  {
+    name: "the Network Overview fleet strip",
+    parts: ["Pages", "NetworkDevice", "Overview.tsx"],
+  },
+];
+
+describe("every device-status surface selects the whole rule", () => {
+  test.each(DEVICE_STATUS_SURFACES)(
+    "$name spreads DEVICE_STATUS_SELECT",
+    ({ parts }: { parts: Array<string> }) => {
+      const source: string = readSource(...parts);
+
+      expect(source).toContain(squash("...DEVICE_STATUS_SELECT,"));
+    },
+  );
+
+  /*
+   * Spreading it is not enough on its own. A key repeated after a spread
+   * REPLACES what the spread put there, so an explicit `currentMonitorStatus:
+   * { name, color }` — which is all a "Monitor Status" tile needs to print —
+   * silently drops `isOfflineState`, the single field the verdict turns on.
+   * That is a one-line edit away at any time, it leaves the page compiling
+   * and rendering, and nothing else in the repo would go red for it. The
+   * device Overview hero had exactly that shape before this fix.
+   */
+  test.each(DEVICE_STATUS_SURFACES)(
+    "$name does not narrow currentMonitorStatus back down",
+    ({ parts }: { parts: Array<string> }) => {
+      const select: string = deviceSelectLiteral(...parts);
+
+      if (select.includes("currentMonitorStatus:")) {
+        expect(select).toContain("isOfflineState: true");
+      }
+    },
+  );
+
+  /*
+   * The same trap for the poll half: a repeated `isReachable` or
+   * `monitoringMethod` after the spread could quietly turn either off.
+   */
+  test.each(DEVICE_STATUS_SURFACES)(
+    "$name does not override the columns the spread provides",
+    ({ parts }: { parts: Array<string> }) => {
+      const select: string = deviceSelectLiteral(...parts);
+
+      expect(select).not.toContain("isReachable: false");
+      expect(select).not.toContain("monitoringMethod: false");
+    },
+  );
+
+  /*
+   * The regression in one assertion: the select the surfaces share has to
+   * carry the monitor columns, not just the poll ones. Without these two a
+   * correctly bound ping-only device reads "Pending" on every screen above.
+   */
+  test("the shared select carries both halves of the rule", () => {
+    expect(DEVICE_STATUS_SELECT.isReachable).toBe(true);
+    expect(DEVICE_STATUS_SELECT.monitoringMethod).toBe(true);
+    expect(DEVICE_STATUS_SELECT.currentMonitorStatus.isOfflineState).toBe(true);
+  });
+});
+
+/*
+ * Wording, not verdicts. The two kinds of device reach the same three
+ * pills by different routes, and a tooltip that talks about an SNMP poll
+ * on a device nothing polls sends its operator to check a probe that does
+ * not exist — which is how a real ping outage gets read as a
+ * misconfiguration and ignored.
+ */
+describe("the pills explain the verdict they actually reached", () => {
+  const MONITOR_BACKED_SURFACES: Array<{ name: string; parts: Array<string> }> =
+    [
+      {
+        name: "a site's Devices tab",
+        parts: ["Pages", "NetworkSite", "View", "Devices.tsx"],
+      },
+      {
+        name: "the device Overview hero",
+        parts: ["Components", "NetworkDevice", "DeviceStatusHero.tsx"],
+      },
+    ];
+
+  test.each(MONITOR_BACKED_SURFACES)(
+    "$name branches its tooltips on isMonitorBacked",
+    ({ parts }: { parts: Array<string> }) => {
+      const source: string = readSource(...parts);
+
+      expect(source).toContain("isMonitorBacked");
+      expect(source).toContain("The monitor bound to this device reports it");
+    },
+  );
+
+  /*
+   * The device list is the surface in the issue's screenshot, and it says
+   * more than Up/Down: it prints the operator's own status word for a
+   * monitor-backed device ("Operational", "Degraded"), which is why it
+   * reads the stamped status by name rather than through the shared rule.
+   */
+  test("the device list renders a monitor-backed device's status by name", () => {
+    const source: string = readSource("Pages", "NetworkDevice", "Devices.tsx");
+
+    expect(source).toContain(
+      squash(
+        "NetworkDeviceMonitoringMethodUtil.isMonitorBacked( item.monitoringMethod,",
+      ),
+    );
+    expect(source).toContain("item.currentMonitorStatus.name");
+  });
+});

--- a/App/Tests/Dashboard/DeviceStatusUtil.test.ts
+++ b/App/Tests/Dashboard/DeviceStatusUtil.test.ts
@@ -39,7 +39,34 @@ describe("DEVICE_STATUS_SELECT", () => {
       lastPolledAt: true,
       lastSeenAt: true,
       pollingIntervalInMinutes: true,
+      monitoringMethod: true,
+      currentMonitorStatus: {
+        name: true,
+        color: true,
+        isOfflineState: true,
+      },
     });
+  });
+
+  /*
+   * Issue #3392 was a select as much as it was a rule: the poll columns
+   * alone can only ever answer "Pending" for a device nothing polls, so a
+   * page that selects them and nothing else paints every correctly bound
+   * ping-only device grey forever.
+   */
+  test("names the two columns a monitor-backed device is judged by", () => {
+    expect(DEVICE_STATUS_SELECT.monitoringMethod).toBe(true);
+    expect(DEVICE_STATUS_SELECT.currentMonitorStatus.isOfflineState).toBe(true);
+  });
+
+  /*
+   * `name` and `color` come with it so a surface can print the operator's
+   * own status word ("Operational", "Degraded") rather than flattening
+   * every ladder rung to Up or Down.
+   */
+  test("carries the monitor status label the pills render", () => {
+    expect(DEVICE_STATUS_SELECT.currentMonitorStatus.name).toBe(true);
+    expect(DEVICE_STATUS_SELECT.currentMonitorStatus.color).toBe(true);
   });
 
   test("spreads into a ModelAPI select without nesting", () => {
@@ -203,5 +230,140 @@ describe("DeviceStatusUtil.getStaleWindowInMinutes", () => {
     expect(DeviceStatusUtil.getStaleWindowInMinutes(5)).toBe(60);
     expect(DeviceStatusUtil.getStaleWindowInMinutes(undefined)).toBe(60);
     expect(DeviceStatusUtil.getStaleWindowInMinutes(30)).toBe(300);
+  });
+});
+
+/*
+ * Issue #3392, at the dashboard door.
+ *
+ * The shared rule takes one flag — "is the device's stamped MonitorStatus
+ * at the OFFLINE end of the ladder" — while the API hands every page the
+ * nested `currentMonitorStatus` relation instead. This door is where the
+ * one becomes the other, and it is the only place that mapping happens, so
+ * a page can go on passing a NetworkDevice row straight through.
+ */
+describe("a monitor-backed device, as a page actually receives it", () => {
+  const MONITOR_BACKED: string = "Monitor";
+
+  test("reads an operational monitor off the nested relation as Up", () => {
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: MONITOR_BACKED,
+        currentMonitorStatus: { isOfflineState: false },
+      }),
+    ).toBe(NetworkDeviceStatus.Up);
+  });
+
+  test("reads an offline monitor off the nested relation as Down", () => {
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: MONITOR_BACKED,
+        currentMonitorStatus: { isOfflineState: true },
+      }),
+    ).toBe(NetworkDeviceStatus.Down);
+  });
+
+  /*
+   * The regression. Every poll column NULL — because nothing polls it —
+   * plus a bound Ping monitor reporting healthy, which is exactly the row
+   * the issue screenshots show sitting on "Pending".
+   */
+  test("issue #3392: a bound ping monitor beats the empty poll columns", () => {
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: MONITOR_BACKED,
+        currentMonitorStatus: { isOfflineState: false },
+        isReachable: null,
+        lastPolledAt: null,
+        lastSeenAt: null,
+        pollingIntervalInMinutes: null,
+      }),
+    ).toBe(NetworkDeviceStatus.Up);
+  });
+
+  /*
+   * A relation the API left out (nothing bound, or bound and never
+   * evaluated) must not collapse into "not offline" — that would paint an
+   * unbound device green, which is a worse lie than the grey one this
+   * change is fixing.
+   */
+  test("a missing relation is Pending, not a healthy default", () => {
+    expect(
+      DeviceStatusUtil.getStatus({ monitoringMethod: MONITOR_BACKED }),
+    ).toBe(NetworkDeviceStatus.Pending);
+
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: MONITOR_BACKED,
+        currentMonitorStatus: null,
+      }),
+    ).toBe(NetworkDeviceStatus.Pending);
+  });
+
+  /*
+   * A MonitorStatus row whose isOfflineState the select did not ask for
+   * still means "a monitor has reported" — the middle rungs of the ladder
+   * ("Degraded") are not offline, which is how the topology map reads them.
+   */
+  test("a relation with no isOfflineState reads as not-offline", () => {
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: MONITOR_BACKED,
+        currentMonitorStatus: {},
+      }),
+    ).toBe(NetworkDeviceStatus.Up);
+  });
+
+  test("flags the verdict as monitor-backed so a tooltip can say so", () => {
+    const monitorBacked: DeviceReachabilityResult =
+      DeviceStatusUtil.getReachability({
+        monitoringMethod: MONITOR_BACKED,
+        currentMonitorStatus: { isOfflineState: false },
+      });
+
+    expect(monitorBacked.isMonitorBacked).toBe(true);
+    // Nothing polls it, so it can never be "nobody has polled this lately".
+    expect(monitorBacked.isStale).toBe(false);
+
+    const polled: DeviceReachabilityResult = DeviceStatusUtil.getReachability({
+      isReachable: true,
+      lastPolledAt: minutesAgo(1),
+      lastSeenAt: minutesAgo(1),
+    });
+
+    expect(polled.isMonitorBacked).toBe(false);
+  });
+
+  /*
+   * An SNMP device can also carry a stamped monitor status — a Network
+   * Device monitor watching its walk puts one there. That must not start
+   * deciding its pill: the walk does, and the two disagreeing is how a
+   * device reads Up on its own Interfaces tab and Down on the list above it.
+   */
+  test("an SNMP device with a stamped status is still judged by its walk", () => {
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: "SNMP",
+        currentMonitorStatus: { isOfflineState: true },
+        isReachable: true,
+        lastPolledAt: minutesAgo(1),
+        lastSeenAt: minutesAgo(1),
+      }),
+    ).toBe(NetworkDeviceStatus.Up);
+  });
+
+  /*
+   * Server-side callers (the site rollup, the topology builder) already
+   * hand the shared rule the flat flag. Passing it through unchanged is
+   * what lets the same door serve both.
+   */
+  test("an explicit flat flag is passed through rather than remapped", () => {
+    expect(
+      DeviceStatusUtil.getStatus({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: true,
+        currentMonitorStatus: { isOfflineState: false },
+      }),
+    ).toBe(NetworkDeviceStatus.Down);
   });
 });

--- a/App/Tests/Dashboard/NetworkOverviewUtil.test.ts
+++ b/App/Tests/Dashboard/NetworkOverviewUtil.test.ts
@@ -62,6 +62,21 @@ const DOWN: Partial<OverviewDeviceRow> = unreachable(1, 20);
 // Failed its last poll a minute ago; has not answered for hours.
 const LONGER_DOWN: Partial<OverviewDeviceRow> = unreachable(1, 300);
 
+/*
+ * A ping-only device: nothing polls it, so every poll column is NULL and
+ * only the bound monitor knows anything (issue #3392). The page selects
+ * both of these columns for exactly this reason.
+ */
+function monitorBacked(
+  isOffline: boolean | undefined,
+): Partial<OverviewDeviceRow> {
+  return {
+    monitoringMethod: "Monitor",
+    currentMonitorStatus:
+      isOffline === undefined ? undefined : { isOfflineState: isOffline },
+  };
+}
+
 beforeEach(() => {
   jest.useFakeTimers({
     doNotFake: [
@@ -111,6 +126,31 @@ describe("summarizeDeviceFleet", () => {
       up: 0,
       down: 0,
       pending: 0,
+      interfacesDown: 0,
+    });
+  });
+
+  /*
+   * A mixed estate — switches walked over SNMP alongside the IP phones and
+   * access points that cannot be. Before #3392 every one of the latter
+   * counted as Pending here while the device list beside it rendered the
+   * monitor's real status, so the strip and the table disagreed about the
+   * same fleet.
+   */
+  test("counts monitor-backed devices by their monitor, not as pending", () => {
+    const devices: Array<OverviewDeviceRow> = [
+      { _id: "switch", ...HEALTHY },
+      { _id: "phone", ...monitorBacked(false) },
+      { _id: "camera", ...monitorBacked(true) },
+      // Imported by a discovery sweep, nothing bound to it yet.
+      { _id: "unbound-ap", ...monitorBacked(undefined) },
+    ];
+
+    expect(summarizeDeviceFleet(devices)).toEqual({
+      total: 4,
+      up: 2,
+      down: 1,
+      pending: 1,
       interfacesDown: 0,
     });
   });
@@ -172,6 +212,28 @@ describe("pickDevicesNeedingAttention", () => {
     ];
 
     expect(pickDevicesNeedingAttention(devices, 2)).toHaveLength(2);
+  });
+
+  /*
+   * The list an operator opens the page to read. A phone whose ping
+   * monitor is offline belongs on it — before #3392 it was invisible here,
+   * counted as never-polled onboarding, because nothing polls it by
+   * design.
+   */
+  test("a monitor-backed device its monitor calls offline needs attention", () => {
+    const devices: Array<OverviewDeviceRow> = [
+      { _id: "phone", ...monitorBacked(true) },
+      { _id: "camera", ...monitorBacked(false) },
+      { _id: "unbound-ap", ...monitorBacked(undefined) },
+    ];
+
+    expect(
+      pickDevicesNeedingAttention(devices, 10).map(
+        (device: OverviewDeviceRow) => {
+          return device._id;
+        },
+      ),
+    ).toEqual(["phone"]);
   });
 });
 

--- a/App/Tests/Workers/DataMigrations/BackfillMonitorBackedDeviceStatus.test.ts
+++ b/App/Tests/Workers/DataMigrations/BackfillMonitorBackedDeviceStatus.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceMonitoringMethod from "Common/Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import logger from "Common/Server/Utils/Logger";
+import BackfillMonitorBackedDeviceStatus from "../../../FeatureSet/Workers/DataMigrations/BackfillMonitorBackedDeviceStatus";
+
+/*
+ * The upgrade half of OneUptime/oneuptime#3392.
+ *
+ * The service fix stamps a monitor-backed device with its monitor's
+ * current status at bind time, which repairs every binding made from now
+ * on. It does nothing for the bindings already saved — those devices are
+ * waiting on a status CHANGE that, on a monitor that is healthy and stays
+ * healthy, never comes. Their operators would only ever see the device
+ * leave "Pending" at the moment it broke.
+ *
+ * So this walks them once, on upgrade. What is pinned here is the shape of
+ * that walk: which rows it touches, which it deliberately does not, and
+ * that one bad device cannot take the rest of the fleet — or the
+ * migrations queued behind it — down with it.
+ */
+jest.mock("Common/Server/Services/NetworkDeviceService", () => {
+  return {
+    __esModule: true,
+    default: { findBy: jest.fn(), refreshStampedMonitorStatus: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+const deviceService: {
+  findBy: jest.Mock;
+  refreshStampedMonitorStatus: jest.Mock;
+} = NetworkDeviceService as unknown as {
+  findBy: jest.Mock;
+  refreshStampedMonitorStatus: jest.Mock;
+};
+
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+function makeDevice(data: {
+  deviceId: ObjectID;
+  monitoringMethod?: string | undefined;
+}): NetworkDevice {
+  const device: NetworkDevice = new NetworkDevice(data.deviceId);
+  device.monitoringMethod = data.monitoringMethod;
+  return device;
+}
+
+function refreshedDeviceIds(): Array<string> {
+  return deviceService.refreshStampedMonitorStatus.mock.calls.map(
+    (callArgs: Array<unknown>) => {
+      return ((callArgs[0] as JSONObject)["deviceId"] as ObjectID).toString();
+    },
+  );
+}
+
+describe("BackfillMonitorBackedDeviceStatus", () => {
+  const migration: BackfillMonitorBackedDeviceStatus =
+    new BackfillMonitorBackedDeviceStatus();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    deviceService.findBy.mockResolvedValue([] as never);
+    deviceService.refreshStampedMonitorStatus.mockResolvedValue(
+      undefined as never,
+    );
+  });
+
+  /*
+   * A device with nothing bound has no status to adopt — discovery import
+   * creates ping-only hosts that way on purpose — so "Pending" is its true
+   * answer and the query never fetches it.
+   */
+  test("asks only for devices that actually point at a monitor", async () => {
+    await migration.migrate();
+
+    expect(deviceService.findBy).toHaveBeenCalledTimes(1);
+    const findArgs: JSONObject = deviceService.findBy.mock
+      .calls[0]![0] as JSONObject;
+
+    expect((findArgs["query"] as JSONObject)["monitorId"]).toBeDefined();
+    expect((findArgs["props"] as JSONObject)["isRoot"]).toBe(true);
+    expect(findArgs["limit"]).toBe(LIMIT_MAX);
+    expect(findArgs["skip"]).toBe(0);
+  });
+
+  /*
+   * monitoringMethod decides whether a row is walked at all, so a select
+   * that dropped it would send every SNMP device through the monitor path.
+   */
+  test("selects the column it filters on", async () => {
+    await migration.migrate();
+
+    const select: JSONObject = deviceService.findBy.mock.calls[0]![0][
+      "select"
+    ] as JSONObject;
+
+    expect(select["_id"]).toBe(true);
+    expect(select["monitoringMethod"]).toBe(true);
+  });
+
+  // The devices in the issue: bound, monitor-backed, and stuck on Pending.
+  test("re-stamps every monitor-backed device", async () => {
+    const first: ObjectID = ObjectID.generate();
+    const second: ObjectID = ObjectID.generate();
+
+    deviceService.findBy.mockResolvedValue([
+      makeDevice({
+        deviceId: first,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+      makeDevice({
+        deviceId: second,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+    ] as never);
+
+    await migration.migrate();
+
+    expect(refreshedDeviceIds()).toEqual([first.toString(), second.toString()]);
+  });
+
+  /*
+   * It never clears: a backfill exists to fill in a stamp that is missing,
+   * not to take a decision about one that is there.
+   */
+  test("never asks to clear a stamp", async () => {
+    deviceService.findBy.mockResolvedValue([
+      makeDevice({
+        deviceId: ObjectID.generate(),
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+    ] as never);
+
+    await migration.migrate();
+
+    expect(
+      deviceService.refreshStampedMonitorStatus.mock.calls[0]![0][
+        "clearWhenNotMonitorBacked"
+      ],
+    ).toBe(false);
+  });
+
+  /*
+   * An SNMP device can carry a monitorId and a stamped status both — the
+   * status comes from the Network Device monitor watching its walk. Sending
+   * it through here would re-derive that stamp from the wrong binding and
+   * wipe it.
+   */
+  test("skips SNMP devices that happen to carry a monitor", async () => {
+    const snmp: ObjectID = ObjectID.generate();
+    const monitorBacked: ObjectID = ObjectID.generate();
+
+    deviceService.findBy.mockResolvedValue([
+      makeDevice({
+        deviceId: snmp,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Snmp,
+      }),
+      makeDevice({
+        deviceId: monitorBacked,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+    ] as never);
+
+    await migration.migrate();
+
+    expect(refreshedDeviceIds()).toEqual([monitorBacked.toString()]);
+  });
+
+  /*
+   * The column is free text and nullable. Everything that is not the
+   * literal "monitor" is an SNMP device — including a row written before
+   * the column existed, and including a typo.
+   */
+  test.each([
+    ["a NULL method, from before the column existed", undefined],
+    ["an empty string", ""],
+    ["a typo", "Monitorr"],
+  ])("leaves a device with %s alone", async (_label: string, method) => {
+    deviceService.findBy.mockResolvedValue([
+      makeDevice({
+        deviceId: ObjectID.generate(),
+        monitoringMethod: method as string | undefined,
+      }),
+    ] as never);
+
+    await migration.migrate();
+
+    expect(deviceService.refreshStampedMonitorStatus).not.toHaveBeenCalled();
+  });
+
+  test.each(["Monitor", "monitor", "  MONITOR  "])(
+    "walks a device whose method reads as %p",
+    async (method: string) => {
+      deviceService.findBy.mockResolvedValue([
+        makeDevice({
+          deviceId: ObjectID.generate(),
+          monitoringMethod: method,
+        }),
+      ] as never);
+
+      await migration.migrate();
+
+      expect(deviceService.refreshStampedMonitorStatus).toHaveBeenCalledTimes(
+        1,
+      );
+    },
+  );
+
+  /*
+   * Migrations run in sequence at boot, so an unhandled throw here does not
+   * just lose one device's status — it halts every migration queued after
+   * it.
+   */
+  test("keeps going when one device fails, and says which", async () => {
+    const broken: ObjectID = ObjectID.generate();
+    const healthy: ObjectID = ObjectID.generate();
+
+    deviceService.findBy.mockResolvedValue([
+      makeDevice({
+        deviceId: broken,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+      makeDevice({
+        deviceId: healthy,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+    ] as never);
+
+    deviceService.refreshStampedMonitorStatus.mockImplementation(
+      (...callArgs: Array<unknown>) => {
+        const deviceId: string = (
+          (callArgs[0] as JSONObject)["deviceId"] as ObjectID
+        ).toString();
+
+        if (deviceId === broken.toString()) {
+          return Promise.reject(new Error("monitor lookup exploded"));
+        }
+
+        return Promise.resolve();
+      },
+    );
+
+    await expect(migration.migrate()).resolves.toBeUndefined();
+
+    expect(refreshedDeviceIds()).toEqual([
+      broken.toString(),
+      healthy.toString(),
+    ]);
+    expect(mockedLogger.error).toHaveBeenCalled();
+    expect(String(mockedLogger.error.mock.calls[0]![0])).toContain(
+      broken.toString(),
+    );
+  });
+
+  test("does nothing at all on an installation with no bound devices", async () => {
+    await migration.migrate();
+
+    expect(deviceService.refreshStampedMonitorStatus).not.toHaveBeenCalled();
+  });
+
+  // Nothing to undo: the stamp is derived state, re-derived on every save.
+  test("rolls back to a no-op", async () => {
+    await expect(migration.rollback()).resolves.toBeUndefined();
+  });
+});

--- a/Common/Server/Services/NetworkDeviceService.ts
+++ b/Common/Server/Services/NetworkDeviceService.ts
@@ -303,6 +303,24 @@ export class Service extends DatabaseService<Model> {
             await this.applySiteAssignmentRulesToDevice(createdItem.id!);
           }
         })
+        .then(async () => {
+          /*
+           * A device created monitor-backed adopts its monitor's CURRENT
+           * status right away rather than waiting for that monitor's next
+           * status CHANGE. Skipped for SNMP devices, which are judged by
+           * their own walk.
+           */
+          if (
+            NetworkDeviceMonitoringMethodUtil.isMonitorBacked(
+              createdItem.monitoringMethod,
+            )
+          ) {
+            await this.refreshStampedMonitorStatus({
+              deviceId: createdItem.id!,
+              clearWhenNotMonitorBacked: false,
+            });
+          }
+        })
         .catch((error: Error) => {
           logger.error(
             `Error applying network device rules in NetworkDeviceService.onCreateSuccess: ${error}`,
@@ -454,6 +472,109 @@ export class Service extends DatabaseService<Model> {
   }
 
   /*
+   * Re-derives one device's stamped `currentMonitorStatusId` from its
+   * binding, and refreshes its site chain if the stamp moved.
+   *
+   * The stamp is what every monitor-backed surface reads — the device list
+   * pill, the site rollup, the topology node — and until this existed the
+   * ONLY thing that ever wrote it was
+   * `NetworkSiteService.onMonitorStatusChanged`, which fires on a monitor's
+   * next status CHANGE. Bind a device to a Ping monitor that is already Up
+   * and staying Up and nothing writes the stamp at all, so the device sits
+   * on "Pending" until the monitor happens to go down — which is
+   * OneUptime/oneuptime#3392. Binding is itself an event that decides the
+   * device's status, so it stamps here.
+   *
+   * `clearWhenNotMonitorBacked` is for the write that moves a device OFF
+   * monitor-backed: the ping monitor's verdict must not outlive the binding
+   * (DeviceHealthStateUtil lets a stamped status beat reachability, so a
+   * stale one would poison the site rollup of a device that is now walked).
+   * It is deliberately NOT set when a write only touches the monitor
+   * binding of an SNMP device, because an SNMP device's stamp comes from
+   * the Network Device monitor that watches it, and that binding lives in
+   * the monitor's step data rather than in this column.
+   */
+  @CaptureSpan()
+  public async refreshStampedMonitorStatus(data: {
+    deviceId: ObjectID;
+    clearWhenNotMonitorBacked: boolean;
+  }): Promise<void> {
+    const device: Model | null = await this.findOneById({
+      id: data.deviceId,
+      select: {
+        _id: true,
+        projectId: true,
+        siteId: true,
+        monitoringMethod: true,
+        monitorId: true,
+        currentMonitorStatusId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!device || !device.projectId) {
+      return;
+    }
+
+    const isMonitorBacked: boolean =
+      NetworkDeviceMonitoringMethodUtil.isMonitorBacked(
+        device.monitoringMethod,
+      );
+
+    if (!isMonitorBacked && !data.clearWhenNotMonitorBacked) {
+      return;
+    }
+
+    let monitorStatusId: ObjectID | null = null;
+
+    if (isMonitorBacked && device.monitorId) {
+      /*
+       * Scoped to the device's project on the read as well as on the write
+       * path in onBeforeCreate/onBeforeUpdate: a monitor from another
+       * tenant must never be able to stamp a status here.
+       */
+      const monitor: Monitor | null = await MonitorService.findOneBy({
+        query: {
+          _id: device.monitorId,
+          projectId: device.projectId,
+        },
+        select: {
+          _id: true,
+          currentMonitorStatusId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      monitorStatusId = monitor?.currentMonitorStatusId || null;
+    }
+
+    const currentStampId: string | null =
+      device.currentMonitorStatusId?.toString() || null;
+    const nextStampId: string | null = monitorStatusId?.toString() || null;
+
+    if (currentStampId === nextStampId) {
+      return;
+    }
+
+    await this.updateColumnsByIdWithoutHooks({
+      id: data.deviceId,
+      data: {
+        currentMonitorStatusId: monitorStatusId,
+      },
+    });
+
+    if (device.siteId) {
+      await NetworkSiteService.recomputeRollupForSiteAndAncestors(
+        device.siteId,
+      );
+    }
+  }
+
+  /*
    * Site maintenance after device updates. Resilient by design: a rollup
    * or rule-engine failure must never fail the device update itself.
    */
@@ -462,6 +583,33 @@ export class Service extends DatabaseService<Model> {
     onUpdate: OnUpdate<Model>,
     updatedItemIds: Array<ObjectID>,
   ): Promise<OnUpdate<Model>> {
+    /*
+     * Re-stamp before the site maintenance below, and in its own try: the
+     * two are independent, and a rollup failure must not cost the device
+     * its status (nor the other way round).
+     */
+    try {
+      const dataKeys: Array<string> = Object.keys(onUpdate.updateBy.data || {});
+      const isMethodWrite: boolean = dataKeys.includes("monitoringMethod");
+      const isMonitorWrite: boolean = RelationIdUtil.isWritten(
+        dataKeys,
+        MONITOR_KEYS,
+      );
+
+      if (isMethodWrite || isMonitorWrite) {
+        for (const deviceId of updatedItemIds) {
+          await this.refreshStampedMonitorStatus({
+            deviceId: deviceId,
+            clearWhenNotMonitorBacked: isMethodWrite,
+          });
+        }
+      }
+    } catch (error) {
+      logger.error(
+        `Error in NetworkDeviceService.onUpdateSuccess monitor status refresh: ${error}`,
+      );
+    }
+
     try {
       const dataKeys: Array<string> = Object.keys(onUpdate.updateBy.data || {});
 

--- a/Common/Tests/Server/Services/NetworkDeviceMonitorStatusStamp.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceMonitorStatusStamp.test.ts
@@ -1,0 +1,800 @@
+import MonitorService from "../../../Server/Services/MonitorService";
+import NetworkDeviceLabelRuleEngineService from "../../../Server/Services/NetworkDeviceLabelRuleEngineService";
+import NetworkDeviceOwnerRuleEngineService from "../../../Server/Services/NetworkDeviceOwnerRuleEngineService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import NetworkSiteService from "../../../Server/Services/NetworkSiteService";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceMonitoringMethod from "../../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import ObjectID from "../../../Types/ObjectID";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { OnUpdate } from "../../../Server/Types/Database/Hooks";
+import { afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — OneUptime/oneuptime#3392, "a correctly bound
+ * ping-only device is stuck on Pending".
+ *
+ * A monitor-backed NetworkDevice is never polled: no probe, no
+ * credentials, no walk. Its ONLY source of health is the Monitor bound to
+ * it, stamped onto `currentMonitorStatusId`, which the device list pill,
+ * the site rollup and the topology node all read.
+ *
+ * Before this fix the only writer of that column was
+ * `NetworkSiteService.onMonitorStatusChanged`, which runs when a monitor's
+ * status CHANGES. So the documented workflow — create a Ping monitor, set
+ * Monitoring Method to Monitor, bind the monitor — produced a device with
+ * an empty stamp, and it stayed empty until the monitor happened to go
+ * down. On a healthy device that is never, which is why the reporter's
+ * phone stayed on "Pending" while it answered every ping.
+ *
+ * What is pinned here:
+ *
+ *   - binding stamps the monitor's CURRENT status immediately, on create
+ *     and on update, rather than waiting for its next change,
+ *   - the site chain is recomputed when the stamp moves, and only then,
+ *   - unbinding (or switching the device back to SNMP) clears the stamp,
+ *     so a ping monitor's verdict cannot outlive the binding,
+ *   - an SNMP device's stamp — which comes from the Network Device monitor
+ *     watching its walk, not from this column — is never touched,
+ *   - the monitor lookup is scoped to the device's own project,
+ *   - and a failure in any of it never escapes into the device update.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const DEVICE_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const SECOND_DEVICE_ID: ObjectID = new ObjectID(
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+);
+const SITE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const MONITOR_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OPERATIONAL_STATUS_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+
+function fakeDevice(overrides: Record<string, unknown>): NetworkDevice {
+  return {
+    id: DEVICE_ID,
+    _id: DEVICE_ID.toString(),
+    projectId: PROJECT_ID,
+    ...overrides,
+  } as unknown as NetworkDevice;
+}
+
+function fakeMonitor(currentMonitorStatusId: ObjectID | undefined): Monitor {
+  return {
+    id: MONITOR_ID,
+    _id: MONITOR_ID.toString(),
+    currentMonitorStatusId: currentMonitorStatusId,
+  } as unknown as Monitor;
+}
+
+/*
+ * The whole write path this method owns, mocked at the three seams it
+ * touches: read the device, read its monitor, write the stamp (plus the
+ * rollup it triggers).
+ */
+function mockDeviceAndMonitor(data: {
+  device: NetworkDevice | null;
+  monitor?: Monitor | null;
+}): {
+  update: jest.SpyInstance;
+  rollup: jest.SpyInstance;
+  findMonitor: jest.SpyInstance;
+} {
+  jest
+    .spyOn(NetworkDeviceService, "findOneById")
+    .mockResolvedValue(data.device);
+
+  const findMonitor: jest.SpyInstance = jest
+    .spyOn(MonitorService, "findOneBy")
+    .mockResolvedValue(data.monitor === undefined ? null : data.monitor);
+
+  const update: jest.SpyInstance = jest
+    .spyOn(NetworkDeviceService, "updateColumnsByIdWithoutHooks")
+    .mockResolvedValue(undefined as never);
+
+  const rollup: jest.SpyInstance = jest
+    .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+    .mockResolvedValue(undefined as never);
+
+  return { update, rollup, findMonitor };
+}
+
+describe("NetworkDeviceService.refreshStampedMonitorStatus", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The fix, stated once: the device in the issue, bound to a Ping monitor
+   * that is Operational and has been for weeks.
+   */
+  it("stamps the bound monitor's current status onto a monitor-backed device", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+        currentMonitorStatusId: undefined,
+      }),
+      monitor: fakeMonitor(OPERATIONAL_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    const args: any = update.mock.calls[0]![0];
+    expect(args.id.toString()).toBe(DEVICE_ID.toString());
+    expect(args.data.currentMonitorStatusId.toString()).toBe(
+      OPERATIONAL_STATUS_ID.toString(),
+    );
+  });
+
+  it("stamps an offline monitor just the same, so the device reads Down", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: fakeMonitor(OFFLINE_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(
+      update.mock.calls[0]![0].data.currentMonitorStatusId.toString(),
+    ).toBe(OFFLINE_STATUS_ID.toString());
+  });
+
+  /*
+   * The site card above the device shows a worst-of rollup over its
+   * devices' stamps, so a stamp that moves without recomputing it leaves
+   * the site and the device contradicting each other on screen.
+   */
+  it("refreshes the device's site chain when the stamp moves", async () => {
+    const { rollup } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+        siteId: SITE_ID,
+      }),
+      monitor: fakeMonitor(OPERATIONAL_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(rollup).toHaveBeenCalledTimes(1);
+    expect(rollup.mock.calls[0]![0].toString()).toBe(SITE_ID.toString());
+  });
+
+  it("skips the rollup for a device that belongs to no site", async () => {
+    const { update, rollup } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+      }),
+      monitor: fakeMonitor(OPERATIONAL_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(rollup).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Idempotence is what makes this safe to call from every save and from
+   * the upgrade backfill: re-deriving a stamp that already agrees must
+   * cost nothing and, more importantly, must not churn the site rollups of
+   * a whole estate on every unrelated device edit.
+   */
+  it("writes nothing when the stamp already agrees", async () => {
+    const { update, rollup } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+        siteId: SITE_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: fakeMonitor(OPERATIONAL_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(rollup).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Discovery import creates ping-only hosts with no monitor on purpose —
+   * a subnet sweep has nothing to bind them to yet. "Pending" is the true
+   * answer for those, so nothing is invented for them.
+   */
+  it("leaves an already-empty stamp alone when no monitor is bound", async () => {
+    const { update, findMonitor } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: undefined,
+      }),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(findMonitor).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  /*
+   * ...and the same device once its monitor is unbound. The old verdict
+   * must not survive the binding that produced it.
+   */
+  it("clears the stamp when the monitor is unbound", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: undefined,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0]![0].data.currentMonitorStatusId).toBeNull();
+  });
+
+  /*
+   * A bound monitor that has somehow never had a status is the same case:
+   * there is nothing to adopt, and a stale stamp is worse than none.
+   */
+  it("clears the stamp when the bound monitor has no status of its own", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: fakeMonitor(undefined),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update.mock.calls[0]![0].data.currentMonitorStatusId).toBeNull();
+  });
+
+  it("clears the stamp when the bound monitor is gone", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: null,
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update.mock.calls[0]![0].data.currentMonitorStatusId).toBeNull();
+  });
+
+  /*
+   * The monitorId FK only requires the Monitor row to exist, not that it
+   * belongs to the device's project — the same hole the create/update
+   * guards close. Reading it back through a project-scoped query is what
+   * stops another tenant's status being stamped here.
+   */
+  it("looks the monitor up inside the device's own project", async () => {
+    const { findMonitor } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+      }),
+      monitor: fakeMonitor(OPERATIONAL_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    const query: any = findMonitor.mock.calls[0]![0].query;
+    expect(query._id.toString()).toBe(MONITOR_ID.toString());
+    expect(query.projectId.toString()).toBe(PROJECT_ID.toString());
+    expect(query.projectId.toString()).not.toBe(OTHER_PROJECT_ID.toString());
+  });
+
+  /*
+   * An SNMP device's stamp comes from the Network Device monitor watching
+   * its walk, and that binding lives in the monitor's step data rather
+   * than in this column. Re-deriving it from `monitorId` would wipe a
+   * legitimate status the walk pipeline put there.
+   */
+  it("does not touch an SNMP device by default", async () => {
+    const { update, findMonitor } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Snmp,
+        monitorId: MONITOR_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: fakeMonitor(OFFLINE_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(findMonitor).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A device created before the column existed holds NULL, which reads as
+   * SNMP — and must behave as one.
+   */
+  it("treats a device with no monitoring method as SNMP", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: undefined,
+        monitorId: MONITOR_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: fakeMonitor(OFFLINE_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The one write that DOES clear an SNMP device: the one that just moved
+   * it off monitor-backed. The ping monitor's verdict outliving the
+   * binding matters because a stamped status beats reachability in
+   * DeviceHealthStateUtil — it would keep deciding the site rollup of a
+   * device that is now being walked.
+   */
+  it("clears the stamp when a device is switched back to SNMP", async () => {
+    const { update, rollup } = mockDeviceAndMonitor({
+      device: fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Snmp,
+        monitorId: MONITOR_ID,
+        siteId: SITE_ID,
+        currentMonitorStatusId: OPERATIONAL_STATUS_ID,
+      }),
+      monitor: fakeMonitor(OPERATIONAL_STATUS_ID),
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: true,
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0]![0].data.currentMonitorStatusId).toBeNull();
+    expect(rollup).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing for a device the update never actually matched", async () => {
+    const { update } = mockDeviceAndMonitor({ device: null });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: true,
+    });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a device row carrying no project", async () => {
+    const { update } = mockDeviceAndMonitor({
+      device: {
+        id: DEVICE_ID,
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+      } as unknown as NetworkDevice,
+    });
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: true,
+    });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The columns the method reads. A select that drops one of them makes
+   * this silently wrong rather than loudly broken — a missing
+   * `monitoringMethod` reads as SNMP and skips every monitor-backed
+   * device, which is the bug all over again.
+   */
+  it("selects every column its decision depends on", async () => {
+    const findDevice: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(null);
+
+    await NetworkDeviceService.refreshStampedMonitorStatus({
+      deviceId: DEVICE_ID,
+      clearWhenNotMonitorBacked: false,
+    });
+
+    const select: any = findDevice.mock.calls[0]![0].select;
+    expect(select.monitoringMethod).toBe(true);
+    expect(select.monitorId).toBe(true);
+    expect(select.currentMonitorStatusId).toBe(true);
+    expect(select.projectId).toBe(true);
+    expect(select.siteId).toBe(true);
+  });
+});
+
+/*
+ * The hook that turns "the operator pressed Save" into a re-stamp. The
+ * dashboard's Device Details card posts `monitoringMethod` and the
+ * `monitor` RELATION together; server-side callers write the `monitorId`
+ * COLUMN. Both spellings have to fire, or the fix reaches only half the
+ * writes (OneUptime/oneuptime#2940 is the same lesson for sites).
+ */
+describe("NetworkDeviceService.onUpdateSuccess re-stamps a changed binding", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function runOnUpdateSuccess(
+    data: Record<string, unknown>,
+    updatedItemIds: Array<ObjectID> = [DEVICE_ID],
+  ): Promise<OnUpdate<NetworkDevice>> {
+    const onUpdate: OnUpdate<NetworkDevice> = {
+      updateBy: {
+        query: {},
+        data: data,
+        props: { isRoot: true },
+      } as unknown as UpdateBy<NetworkDevice>,
+      carryForward: null,
+    };
+
+    return (NetworkDeviceService as any).onUpdateSuccess(
+      onUpdate,
+      updatedItemIds,
+    );
+  }
+
+  it("re-stamps when the monitoring method is written", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess({
+      monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh.mock.calls[0]![0].deviceId.toString()).toBe(
+      DEVICE_ID.toString(),
+    );
+  });
+
+  it("re-stamps when the monitor RELATION is written, as the dashboard posts it", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess({ monitor: { _id: MONITOR_ID.toString() } });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-stamps when the monitorId COLUMN is written", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess({ monitorId: MONITOR_ID });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * The exact save from the issue: Monitoring Method and Monitor set in one
+   * submit, which is how the Device Details card posts them.
+   */
+  it("re-stamps the reported save, which writes both at once", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess({
+      monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      monitor: { _id: MONITOR_ID.toString() },
+      deviceRole: "IP phone",
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh.mock.calls[0]![0].clearWhenNotMonitorBacked).toBe(true);
+  });
+
+  /*
+   * A method write is the only thing allowed to clear an SNMP device's
+   * stamp, because it is the only write that can have just moved the
+   * device off monitor-backed. Binding alone must not.
+   */
+  it("only asks to clear on a method write", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess({ monitorId: MONITOR_ID });
+
+    expect(refresh.mock.calls[0]![0].clearWhenNotMonitorBacked).toBe(false);
+  });
+
+  it("re-stamps every device a bulk update touched", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess(
+      { monitoringMethod: NetworkDeviceMonitoringMethod.Monitor },
+      [DEVICE_ID, SECOND_DEVICE_ID],
+    );
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(
+      refresh.mock.calls.map((call: Array<any>) => {
+        return call[0].deviceId.toString();
+      }),
+    ).toEqual([DEVICE_ID.toString(), SECOND_DEVICE_ID.toString()]);
+  });
+
+  /*
+   * onUpdateSuccess runs even when the permission-scoped UPDATE matched
+   * nothing, and a re-stamp of a device the caller could not touch would
+   * be a write they were not allowed to make.
+   */
+  it("re-stamps nothing when the update matched no rows", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess(
+      { monitoringMethod: NetworkDeviceMonitoringMethod.Monitor },
+      [],
+    );
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The SNMP walk rewrites sysName, lastSeenAt and the interface counts on
+   * every single poll of every single device. Re-deriving a stamp on those
+   * would put a device read and a monitor read into the hot ingest path
+   * for an entire fleet.
+   */
+  it("does not re-stamp on a write that leaves the binding alone", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnUpdateSuccess({ sysName: "un0661voipcp01", interfacesDown: 2 });
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Status maintenance is best-effort, exactly like the site maintenance
+   * beside it: the device update has already committed, and failing the
+   * caller's request over a stamp would turn a cosmetic problem into a
+   * failed save.
+   */
+  it("never lets a re-stamp failure escape into the update", async () => {
+    jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockRejectedValue(new Error("monitor lookup exploded") as never);
+
+    await expect(
+      runOnUpdateSuccess({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  /*
+   * ...and the two halves are independent. A rollup failure in the site
+   * maintenance below must not cost the device its stamp, which is why
+   * they sit in separate try blocks.
+   */
+  it("still re-stamps when the site maintenance beside it fails", async () => {
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+      .mockRejectedValue(new Error("rollup exploded") as never);
+
+    await expect(
+      runOnUpdateSuccess({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        siteId: SITE_ID,
+      }),
+    ).resolves.toBeDefined();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * The create side. A device can arrive monitor-backed and already bound —
+ * the "Add Device" form asks for the monitor in the same submit, and the
+ * discovery review screen imports ping-only hosts in bulk — so waiting for
+ * a later edit to stamp it would leave a freshly created device on
+ * "Pending" for exactly the same reason the reported one was.
+ *
+ * The chain is detached from the create response on purpose (a rule
+ * failure must never fail the device write), so these drain the microtask
+ * queue the way the rule-chain suite does.
+ */
+describe("NetworkDeviceService.onCreateSuccess stamps a device created bound", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockRuleChain(): void {
+    jest
+      .spyOn(NetworkDeviceLabelRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(NetworkDeviceOwnerRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+      .mockResolvedValue(undefined as never);
+  }
+
+  async function runOnCreateSuccess(createdItem: NetworkDevice): Promise<void> {
+    await (NetworkDeviceService as any).onCreateSuccess(
+      { createBy: { data: {}, props: {} }, carryForward: null },
+      createdItem,
+    );
+
+    await new Promise((resolve: (value: unknown) => void) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  it("stamps a device created monitor-backed", async () => {
+    mockRuleChain();
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnCreateSuccess(
+      fakeDevice({
+        monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+        monitorId: MONITOR_ID,
+      }),
+    );
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh.mock.calls[0]![0].deviceId.toString()).toBe(
+      DEVICE_ID.toString(),
+    );
+    // Nothing to clear on a row that has only just been written.
+    expect(refresh.mock.calls[0]![0].clearWhenNotMonitorBacked).toBe(false);
+  });
+
+  /*
+   * Discovery import creates ping-only hosts with no monitor bound. Those
+   * still go through, and the method itself decides there is nothing to
+   * stamp — which keeps the "did we call it" decision in one place.
+   */
+  it("stamps a monitor-backed device created with nothing bound", async () => {
+    mockRuleChain();
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnCreateSuccess(
+      fakeDevice({ monitoringMethod: NetworkDeviceMonitoringMethod.Monitor }),
+    );
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * Every SNMP device ever created goes through this hook, including a
+   * whole subnet at a time on discovery import. None of them has anything
+   * to stamp, so none of them pays for a device read and a monitor read.
+   */
+  it("does not touch an SNMP device", async () => {
+    mockRuleChain();
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnCreateSuccess(
+      fakeDevice({ monitoringMethod: NetworkDeviceMonitoringMethod.Snmp }),
+    );
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not touch a device created with no monitoring method", async () => {
+    mockRuleChain();
+    const refresh: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockResolvedValue(undefined as never);
+
+    await runOnCreateSuccess(fakeDevice({}));
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Detached, and it has to stay that way: the device row is already
+   * committed and its id already returned to the caller by the time this
+   * runs, so a monitor lookup that throws must not surface as a failed
+   * create.
+   */
+  it("never lets a stamp failure escape the create", async () => {
+    mockRuleChain();
+    jest
+      .spyOn(NetworkDeviceService, "refreshStampedMonitorStatus")
+      .mockRejectedValue(new Error("monitor lookup exploded") as never);
+
+    await expect(
+      runOnCreateSuccess(
+        fakeDevice({
+          monitoringMethod: NetworkDeviceMonitoringMethod.Monitor,
+          monitorId: MONITOR_ID,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/Common/Tests/Utils/NetworkDevice/DeviceReachabilityUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDevice/DeviceReachabilityUtil.test.ts
@@ -608,3 +608,252 @@ describe("issue #3220 at fleet scale", () => {
     expect(stale).toBe(50);
   });
 });
+
+/*
+ * Issue #3392: a device nothing polls.
+ *
+ * The whole rule above is about the OUTCOME of a poll, and a monitor-backed
+ * device never gets one — no probe, no credentials, no walk. Its poll
+ * columns are NULL forever, so the rule could only ever answer "Pending"
+ * for it: an operator who followed the documented workflow to the letter
+ * (Monitoring Method = Monitor, a Ping monitor bound, polling off) watched
+ * a device that answers every ping sit on "Pending" indefinitely.
+ *
+ * These pin the second rule: for such a device the bound Monitor's verdict
+ * IS the answer, and every poll column on the row is irrelevant to it.
+ */
+describe("monitor-backed devices are judged by their monitor, not by a poll", () => {
+  const MONITOR_BACKED: string = "Monitor";
+
+  test("a bound monitor reporting healthy makes the device Up", () => {
+    expect(
+      statusOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: false,
+      }),
+    ).toBe(NetworkDeviceReachability.Up);
+  });
+
+  test("a bound monitor reporting offline makes the device Down", () => {
+    expect(
+      statusOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: true,
+      }),
+    ).toBe(NetworkDeviceReachability.Down);
+  });
+
+  /*
+   * MonitorStatus is a ladder, not a pair: a "Degraded" row is neither
+   * operational nor offline. Reading the OFFLINE end is what keeps this
+   * verdict identical to the one the topology map draws for the same
+   * device, which resolves the ladder the same way.
+   */
+  test("a degraded-but-not-offline status is Up, exactly as the map draws it", () => {
+    expect(
+      statusOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: false,
+      }),
+    ).toBe(NetworkDeviceReachability.Up);
+  });
+
+  /*
+   * The two ways a monitor-backed device legitimately has no verdict:
+   * nothing is bound to it yet (discovery import creates ping-only hosts
+   * that way on purpose), or something is bound and has not been evaluated
+   * yet. Both are Pending, and neither may default to healthy.
+   */
+  test("no stamped status is Pending, not a healthy default", () => {
+    expect(statusOf({ monitoringMethod: MONITOR_BACKED })).toBe(
+      NetworkDeviceReachability.Pending,
+    );
+
+    expect(
+      statusOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: null,
+      }),
+    ).toBe(NetworkDeviceReachability.Pending);
+  });
+
+  /*
+   * The regression itself. This is the exact row shape the issue reports:
+   * an ICMP-only host imported by a discovery scan, switched to Monitor,
+   * bound to a Ping monitor that is reporting healthy, and polled by
+   * nothing — so every poll column is NULL.
+   */
+  test("the reported row shape reads Up rather than Pending", () => {
+    const un0661voipcp01: DeviceReachabilityInput = {
+      monitoringMethod: MONITOR_BACKED,
+      monitorStatusIsOffline: false,
+      isReachable: null,
+      lastPolledAt: null,
+      lastSeenAt: null,
+      pollingIntervalInMinutes: null,
+    };
+
+    expect(statusOf(un0661voipcp01)).toBe(NetworkDeviceReachability.Up);
+  });
+
+  /*
+   * Poll columns on a monitor-backed row are not merely absent — on a
+   * device switched over from SNMP they hold whatever a probe last found
+   * before it stopped asking, which is worse than nothing. The monitor
+   * wins outright, in both directions.
+   */
+  test("a stale successful walk does not override a monitor reporting offline", () => {
+    expect(
+      statusOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: true,
+        isReachable: true,
+        lastPolledAt: minutesAgo(2),
+        lastSeenAt: minutesAgo(2),
+      }),
+    ).toBe(NetworkDeviceReachability.Down);
+  });
+
+  test("a failed walk from its SNMP days does not override a healthy monitor", () => {
+    expect(
+      statusOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: false,
+        isReachable: false,
+        lastPolledAt: minutesAgo(4000),
+        lastSeenAt: minutesAgo(9000),
+      }),
+    ).toBe(NetworkDeviceReachability.Up);
+  });
+
+  /*
+   * Staleness says "nothing has polled this device lately, go and check its
+   * probe". For a device that has no probe BY DESIGN that is both false and
+   * actively misleading, so it can never be raised here.
+   */
+  test("is never flagged stale, however old the poll columns are", () => {
+    const result: DeviceReachabilityResult = reachabilityOf({
+      monitoringMethod: MONITOR_BACKED,
+      monitorStatusIsOffline: false,
+      lastPolledAt: minutesAgo(60 * 24 * 30),
+      lastSeenAt: minutesAgo(60 * 24 * 30),
+      pollingIntervalInMinutes: 5,
+    });
+
+    expect(result.status).toBe(NetworkDeviceReachability.Up);
+    expect(result.isStale).toBe(false);
+  });
+
+  test("is never flagged stale even when it has no poll columns at all", () => {
+    expect(
+      reachabilityOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: true,
+      }).isStale,
+    ).toBe(false);
+  });
+
+  /*
+   * lastContactAt is still reported honestly — it is "the newest thing a
+   * probe wrote", and for a device converted from SNMP that is a real
+   * historical fact the device page prints. It just does not decide
+   * anything here.
+   */
+  test("still reports lastContactAt from the poll columns when there is one", () => {
+    expect(
+      reachabilityOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: false,
+        lastPolledAt: minutesAgo(90),
+      }).lastContactAt?.getTime(),
+    ).toBe(minutesAgo(90).getTime());
+
+    expect(
+      reachabilityOf({
+        monitoringMethod: MONITOR_BACKED,
+        monitorStatusIsOffline: false,
+      }).lastContactAt,
+    ).toBeNull();
+  });
+});
+
+/*
+ * The column is free text (the SnmpVersion precedent), so what counts as
+ * "monitor-backed" is whatever NetworkDeviceMonitoringMethodUtil.parse says
+ * — and every other value has to keep the poll rule, because reading a
+ * typo as monitor-backed would silently stop a switch being judged by its
+ * walk.
+ */
+describe("which rows count as monitor-backed", () => {
+  test.each(["Monitor", "monitor", "MONITOR", "  Monitor  "])(
+    "%p reads as monitor-backed",
+    (monitoringMethod: string) => {
+      const result: DeviceReachabilityResult = reachabilityOf({
+        monitoringMethod: monitoringMethod,
+        monitorStatusIsOffline: false,
+      });
+
+      expect(result.isMonitorBacked).toBe(true);
+      expect(result.status).toBe(NetworkDeviceReachability.Up);
+    },
+  );
+
+  test.each([
+    ["SNMP", "the explicit SNMP value"],
+    ["", "an empty string"],
+    ["Monitorr", "a typo"],
+    ["ping", "an unrecognised word"],
+  ])("%p (%s) keeps the poll rule", (monitoringMethod: string) => {
+    const device: DeviceReachabilityInput = {
+      monitoringMethod: monitoringMethod,
+      // A monitor status the poll rule must ignore for these rows.
+      monitorStatusIsOffline: true,
+      isReachable: true,
+      lastPolledAt: minutesAgo(1),
+      lastSeenAt: minutesAgo(1),
+    };
+
+    const result: DeviceReachabilityResult = reachabilityOf(device);
+
+    expect(result.isMonitorBacked).toBe(false);
+    expect(result.status).toBe(NetworkDeviceReachability.Up);
+  });
+
+  /*
+   * Every row written before the column existed, and every caller that
+   * does not select it. Both have to keep behaving exactly as they did.
+   */
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+  ])("a %s method is a polled device, unchanged", (_label: string, value) => {
+    const result: DeviceReachabilityResult = reachabilityOf({
+      monitoringMethod: value as string | null | undefined,
+      monitorStatusIsOffline: true,
+      isReachable: true,
+      lastPolledAt: minutesAgo(1),
+      lastSeenAt: minutesAgo(1),
+    });
+
+    expect(result.isMonitorBacked).toBe(false);
+    expect(result.status).toBe(NetworkDeviceReachability.Up);
+  });
+
+  /*
+   * A caller that selects neither new column gets precisely the old
+   * behaviour, including staleness — which is what lets the topology
+   * builder and the site rollup keep passing their existing projections.
+   */
+  test("an input carrying neither new column behaves exactly as before", () => {
+    const result: DeviceReachabilityResult = reachabilityOf({
+      isReachable: true,
+      lastPolledAt: minutesAgo(180),
+      lastSeenAt: minutesAgo(180),
+      pollingIntervalInMinutes: 5,
+    });
+
+    expect(result.status).toBe(NetworkDeviceReachability.Up);
+    expect(result.isStale).toBe(true);
+    expect(result.isMonitorBacked).toBe(false);
+  });
+});

--- a/Common/Utils/NetworkDevice/DeviceReachabilityUtil.ts
+++ b/Common/Utils/NetworkDevice/DeviceReachabilityUtil.ts
@@ -1,4 +1,5 @@
 import OneUptimeDate from "../../Types/Date";
+import { NetworkDeviceMonitoringMethodUtil } from "../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
 
 /*
  * The one place that decides whether a NetworkDevice is reachable.
@@ -23,6 +24,14 @@ import OneUptimeDate from "../../Types/Date";
  * NetworkDevice.isReachable, stamped by the walk pipeline on every ingested
  * walk — and freshness is only a backstop for "the polling pipeline itself
  * stopped", measured generously against the device's own interval.
+ *
+ * All of which is about a device that gets POLLED. A monitor-backed device
+ * (monitoringMethod "Monitor") is never polled at all: no probe, no
+ * credentials, no walk. Every poll column on such a row is NULL forever, so
+ * the rule above can only ever answer "Pending" for it — which is
+ * OneUptime/oneuptime#3392, a correctly bound ping-only device stuck on
+ * Pending. Its health comes from the Monitor bound to it, stamped onto
+ * NetworkDevice.currentMonitorStatusId, and that is the branch below.
  */
 
 export enum NetworkDeviceReachability {
@@ -71,6 +80,28 @@ export interface DeviceReachabilityInput {
   lastSeenAt?: Date | string | null | undefined;
   // The device's own schedule; sizes the staleness backstop.
   pollingIntervalInMinutes?: number | null | undefined;
+  /*
+   * How this device's health is established. NULL, empty and anything
+   * unrecognised read as SNMP — see NetworkDeviceMonitoringMethodUtil.parse,
+   * which is why an omitted value keeps every existing caller on the poll
+   * rule unchanged.
+   */
+  monitoringMethod?: string | null | undefined;
+  /*
+   * The OFFLINE end of the device's stamped MonitorStatus row, and only
+   * consulted for a monitor-backed device. `undefined` means no monitor has
+   * reported yet (nothing bound, or bound and never evaluated), which is a
+   * real "Pending" rather than a healthy default.
+   *
+   * The offline end and not the operational end, because MonitorStatus is a
+   * ladder rather than a pair: a "Degraded" row is NEITHER operational nor
+   * offline, and the device map already resolves that ladder with
+   * `isOfflineState ? down : up`. Reading the operational flag here instead
+   * would paint every degraded-but-reachable device red on one surface and
+   * green on the other. See DeviceHealthStateUtil, which reads it the same
+   * way for the same reason.
+   */
+  monitorStatusIsOffline?: boolean | null | undefined;
 }
 
 export interface DeviceReachabilityResult {
@@ -87,6 +118,13 @@ export interface DeviceReachabilityResult {
   staleWindowInMinutes: number;
   // Latest of lastPolledAt / lastSeenAt; null when neither is set.
   lastContactAt: Date | null;
+  /*
+   * True when this verdict came from the bound Monitor rather than from an
+   * SNMP poll. Carried so a surface can word its pill and its tooltip for
+   * what actually decided the answer — "the last SNMP poll reached this
+   * device" is a lie on a device nothing polls.
+   */
+  isMonitorBacked: boolean;
 }
 
 const MS_PER_MINUTE: number = 60 * 1000;
@@ -153,6 +191,11 @@ export default class DeviceReachabilityUtil {
         staleWindowInMinutes * MS_PER_MINUTE
       : false;
 
+    const isMonitorBacked: boolean =
+      NetworkDeviceMonitoringMethodUtil.isMonitorBacked(
+        device.monitoringMethod,
+      );
+
     const result: (
       status: NetworkDeviceReachability,
     ) => DeviceReachabilityResult = (
@@ -160,11 +203,40 @@ export default class DeviceReachabilityUtil {
     ): DeviceReachabilityResult => {
       return {
         status: status,
-        isStale: isStale,
+        /*
+         * Staleness is "nothing has polled this device lately", so it can
+         * only ever be false for a device nothing polls BY DESIGN. Letting
+         * it through would put an amber "check this device's probe" pill on
+         * every monitor-backed device forever — and it has no probe.
+         */
+        isStale: isMonitorBacked ? false : isStale,
         staleWindowInMinutes: staleWindowInMinutes,
         lastContactAt: lastContactAt,
+        isMonitorBacked: isMonitorBacked,
       };
     };
+
+    /*
+     * Monitor-backed: the bound Monitor's verdict IS the device's, and the
+     * poll columns below are meaningless for it (they are NULL forever, and
+     * on a device switched over from SNMP they are worse than meaningless —
+     * they are the last thing a probe found before it stopped asking).
+     *
+     * No stamped status means Pending, and it is honest in both of the ways
+     * it happens: no monitor is bound yet (discovery import creates devices
+     * that way on purpose), or one is bound and has not been evaluated yet.
+     */
+    if (isMonitorBacked) {
+      if (device.monitorStatusIsOffline === true) {
+        return result(NetworkDeviceReachability.Down);
+      }
+
+      if (device.monitorStatusIsOffline === false) {
+        return result(NetworkDeviceReachability.Up);
+      }
+
+      return result(NetworkDeviceReachability.Pending);
+    }
 
     /*
      * The probe asked and got nothing. Authoritative however long ago it


### PR DESCRIPTION
### Title of this pull request?

fix(network): stamp a monitor-backed device's status when its monitor is bound

### Small Description?

A network device whose Monitoring Method is **Monitor** is never polled — no probe, no
credentials, no SNMP walk — so `isReachable`, `lastPolledAt` and `lastSeenAt` are NULL on its
row forever. Its health comes from one column, `NetworkDevice.currentMonitorStatusId`, which
the device list pill, the site rollup and the topology map all read.

**The only thing that ever wrote that column was `NetworkSiteService.onMonitorStatusChanged`,
which fires when a bound monitor's status *changes*.** Bind a device to a Ping monitor that is
already Operational and stays Operational and nothing writes the stamp at all — so the device
sits on "Pending" until the monitor first goes down. On a device that answers every ping, that
is never. That is exactly the report: the documented workflow was followed correctly and the
device stayed grey.

Binding is itself an event that decides the device's status, so it now stamps:

- **`NetworkDeviceService.refreshStampedMonitorStatus`** re-derives the stamp from the binding,
  writes only when it actually moved, and recomputes the device's site rollup chain when it
  does. Called from `onCreateSuccess` for a device created monitor-backed, and from
  `onUpdateSuccess` for any write that touches `monitoringMethod`, `monitor` or `monitorId`
  (both spellings — the dashboard posts the relation, server-side callers post the column).
- It **clears** the stamp when the monitor is unbound or the device is switched back to SNMP:
  a stamped status beats reachability in `DeviceHealthStateUtil`, so a ping monitor's verdict
  outliving its binding would keep deciding the site rollup of a device that is now walked.
- It never touches an ordinary SNMP device — that device's stamp comes from the Network Device
  monitor watching its walk, and that binding lives in the monitor's step data, not this column.

Two secondary faults produced the same symptom and are fixed with it:

- **Only the main device list understood monitor-backed devices.** A site's Devices tab, the
  device Overview hero, the site status hero and the Network Overview fleet strip all decided
  status from the poll columns alone, so even a correctly stamped device read "Pending" there.
  `DeviceReachabilityUtil` — the one place that decides this — now knows both kinds of device,
  suppresses the "nothing has polled this lately" staleness flag for devices nothing polls by
  design, and returns `isMonitorBacked` so a pill can say *why* rather than talking about an
  SNMP poll that never happened. `DEVICE_STATUS_SELECT` gained the two columns the new branch
  reads, which fixes every surface that spreads it at once.
- **The device Overview hero narrowed `currentMonitorStatus` back down to `{ name, color }`**
  after spreading the shared select, dropping the one field the verdict turns on. A new
  source-invariant suite pins that no status surface can do that again.

Finally, the fix above repairs every binding made from now on but not the ones already saved —
those devices are still waiting on a status change that may never come. **`BackfillMonitorBackedDeviceStatus`**
walks them once on upgrade. It is idempotent and safe to run twice concurrently, as this
runner requires.

**Known limitation, unchanged by this PR:** the device list's summary tiles and its Status
filter chip are SQL counts over `isReachable`, which is NULL for a monitor-backed device — so
those devices still fall in the "Pending" bucket of the strip and the chip while their pill now
reads Up or Down. That divergence has existed since the monitor-backed feature shipped (the
device list has always had its own branch), and closing it means changing what `isReachable`
means for a device nothing polls, which is a larger design decision than this fix.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

closes #3392

### Related Issue?

closes #3392

### Screenshots (if appropriate):

Not applicable — the change is in what the pill reads, not how it is drawn. The behaviour is
covered by tests instead:

| Suite | What it pins |
| --- | --- |
| `Common/Tests/Server/Services/NetworkDeviceMonitorStatusStamp.test.ts` (new) | Binding stamps the monitor's current status on create and on update, under both the relation and the column spelling; the site chain is recomputed only when the stamp moves; unbinding and switching back to SNMP clear it; an SNMP device is never touched; the monitor lookup is project-scoped; no failure escapes into the device write. |
| `Common/Tests/Utils/NetworkDevice/DeviceReachabilityUtil.test.ts` | The monitor-backed branch of the shared rule, including the exact row shape from the issue, that the poll columns cannot override the monitor in either direction, that staleness never applies, and that every non-`monitor` method value (NULL, `""`, a typo) keeps the poll rule exactly as before. |
| `App/Tests/Dashboard/DeviceStatusUtil.test.ts` | The dashboard door maps the nested `currentMonitorStatus` relation onto the flag the rule reads; a missing relation is Pending rather than a healthy default; an SNMP device with a stamped status is still judged by its walk. |
| `App/Tests/Dashboard/DeviceStatusSurfaceInvariants.test.ts` (new) | Every screen that prints a device status spreads `DEVICE_STATUS_SELECT` and none of them narrows `currentMonitorStatus` back down over the spread. |
| `App/Tests/Dashboard/NetworkOverviewUtil.test.ts` | The fleet strip counts a mixed estate by each device's own rule, and a phone whose ping monitor is offline reaches the attention list. |
| `App/Tests/Workers/DataMigrations/BackfillMonitorBackedDeviceStatus.test.ts` (new) | The backfill walks only bound, monitor-backed rows, never clears, and one bad device cannot halt the migration chain. |
