### PR TITLE
fix: auto-resolve incidents from id-less criteria incident templates

### DIFF
--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -196,24 +196,15 @@ export default class MonitorIncident {
         continue;
       }
 
-      const createdCriteriaId: string | undefined =
-        openIncident.createdCriteriaId?.toString();
-      const createdIncidentTemplateId: string | undefined =
-        openIncident.createdIncidentTemplateId?.toString();
-
       // Only auto-resolve when the creating criteria opted into it.
-      if (!createdCriteriaId || !createdIncidentTemplateId) {
-        continue;
-      }
-
-      const autoResolveTemplates: Array<string> | undefined =
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          createdCriteriaId
-        ];
-
       if (
-        !autoResolveTemplates ||
-        !autoResolveTemplates.includes(createdIncidentTemplateId)
+        !this.isAutoResolveIncidentTemplate({
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+          createdCriteriaId: openIncident.createdCriteriaId?.toString(),
+          createdIncidentTemplateId:
+            openIncident.createdIncidentTemplateId?.toString(),
+        })
       ) {
         continue;
       }
@@ -929,6 +920,56 @@ export default class MonitorIncident {
     }
   }
 
+  /**
+   * True when the criteria that created this incident opted that incident
+   * template into auto-resolve.
+   *
+   * Mirrors the create path (and the dedupe match above), which sets
+   * `createdIncidentTemplateId` only when the criteria's incident template
+   * carries an `id`. API- and Terraform-authored criteria routinely omit it
+   * and the write path accepts them, so the stored id is NULL for those
+   * incidents while the auto-resolve dictionary holds a matching `undefined`
+   * entry (MonitorResource pushes `incidentTemplate.id` verbatim). Gating
+   * hard on a non-empty id therefore made those incidents unresolvable
+   * forever, by payload or by absence, with nothing logged to say why.
+   *
+   * Normalising both sides to `undefined` lets them resolve while staying
+   * exact: an incident whose template id is NULL matches only an id-less
+   * auto-resolve template on the same criteria, never an unrelated one that
+   * does carry an id.
+   */
+  private static isAutoResolveIncidentTemplate(input: {
+    autoResolveCriteriaInstanceIdIncidentIdsDictionary: Dictionary<
+      Array<string>
+    >;
+    createdCriteriaId: string | undefined;
+    createdIncidentTemplateId: string | undefined;
+  }): boolean {
+    if (!input.createdCriteriaId) {
+      return false;
+    }
+
+    const autoResolveTemplateIds: Array<string> | undefined =
+      input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
+        input.createdCriteriaId
+      ];
+
+    if (!autoResolveTemplateIds) {
+      return false;
+    }
+
+    const createdIncidentTemplateId: string | undefined =
+      input.createdIncidentTemplateId || undefined;
+
+    return autoResolveTemplateIds.some(
+      (autoResolveTemplateId: string | undefined) => {
+        return (
+          (autoResolveTemplateId || undefined) === createdIncidentTemplateId
+        );
+      },
+    );
+  }
+
   private static shouldCloseIncident(input: {
     openIncident: Incident;
     autoResolveCriteriaInstanceIdIncidentIdsDictionary: Dictionary<
@@ -996,29 +1037,13 @@ export default class MonitorIncident {
        * was configured to auto-resolve in the first place; otherwise
        * stay open so a human can acknowledge.
        */
-      if (!input.openIncident.createdCriteriaId?.toString()) {
-        return false;
-      }
-
-      if (!input.openIncident.createdIncidentTemplateId?.toString()) {
-        return false;
-      }
-
-      const autoResolveTemplates: Array<string> | undefined =
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          input.openIncident.createdCriteriaId.toString()
-        ];
-
-      if (
-        autoResolveTemplates &&
-        autoResolveTemplates.includes(
-          input.openIncident.createdIncidentTemplateId.toString(),
-        )
-      ) {
-        return true;
-      }
-
-      return false;
+      return this.isAutoResolveIncidentTemplate({
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+          input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+        createdCriteriaId: input.openIncident.createdCriteriaId?.toString(),
+        createdIncidentTemplateId:
+          input.openIncident.createdIncidentTemplateId?.toString(),
+      });
     }
 
     if (
@@ -1031,28 +1056,12 @@ export default class MonitorIncident {
 
     // If antoher criteria is active then, check if the incident id is present in the map.
 
-    if (!input.openIncident.createdCriteriaId?.toString()) {
-      return false;
-    }
-
-    if (!input.openIncident.createdIncidentTemplateId?.toString()) {
-      return false;
-    }
-
-    if (
-      input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-        input.openIncident.createdCriteriaId?.toString()
-      ]
-    ) {
-      if (
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          input.openIncident.createdCriteriaId?.toString()
-        ]?.includes(input.openIncident.createdIncidentTemplateId?.toString())
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.isAutoResolveIncidentTemplate({
+      autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+      createdCriteriaId: input.openIncident.createdCriteriaId?.toString(),
+      createdIncidentTemplateId:
+        input.openIncident.createdIncidentTemplateId?.toString(),
+    });
   }
 }

--- a/Common/Tests/Server/Utils/Monitor/IdLessIncidentTemplateAutoResolve.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/IdLessIncidentTemplateAutoResolve.test.ts
@@ -1,0 +1,294 @@
+/*
+ * MonitorIncident reaches the native isolated-vm addon through its template
+ * renderer (MonitorTemplateUtil -> VMAPI -> VMRunner). Nothing under test
+ * here touches the sandbox and the prebuilt binary cannot always dlopen in
+ * the test environment, so stub it out before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import MonitorIncident from "../../../../Server/Utils/Monitor/MonitorIncident";
+import OneUptimeDate from "../../../../Types/Date";
+import Dictionary from "../../../../Types/Dictionary";
+import IncomingMonitorRequest from "../../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Regression tests for incidents created from criteria incident templates
+ * that carry no `id`.
+ *
+ * `CriteriaIncident.id` is declared required, but the write path accepts
+ * templates without one — the API and the Terraform provider both author
+ * criteria that way. The create path already handles it (it sets
+ * `createdIncidentTemplateId` only when the id is present) and so does the
+ * dedupe match, which normalises both sides to `undefined` so a created
+ * incident still matches itself on the next cycle.
+ *
+ * Both resolution paths did not: they returned early whenever
+ * `createdIncidentTemplateId` was NULL. So an incident created from an
+ * id-less template was created correctly, deduplicated correctly, carried a
+ * correct `seriesFingerprint` — and could never be auto-resolved, neither by
+ * an incoming payload reporting the key recovered nor by series absence,
+ * with nothing logged to say why.
+ *
+ * The tests below fail on the pre-fix code and pin the exactness the fix
+ * must keep: a NULL template id matches only an id-less auto-resolve
+ * template on the same criteria, never an unrelated one that has an id.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const CRITERIA_ID: string = "aafe2669-1a2b-4c3d-8e4f-5a6b7c8d9e0f";
+const TEMPLATE_ID: string = "template-1";
+const SERIES_FINGERPRINT: string = "0eb39d7970a4f69a";
+
+/*
+ * MonitorResource builds the auto-resolve dictionary by pushing
+ * `incidentTemplate.id` verbatim for every template with
+ * `autoResolveIncident: true`. The declared element type is `string` because
+ * `CriteriaIncident.id` is declared required — but for an id-less template
+ * the array really does hold `undefined` at runtime. This reproduces that
+ * exact shape rather than a tidied-up version of it.
+ */
+const ID_LESS_TEMPLATE: string = undefined as unknown as string;
+
+const AUTO_RESOLVE_ID_LESS_TEMPLATE: Dictionary<Array<string>> = {
+  [CRITERIA_ID]: [ID_LESS_TEMPLATE],
+};
+
+const AUTO_RESOLVE_TEMPLATE_WITH_ID: Dictionary<Array<string>> = {
+  [CRITERIA_ID]: [TEMPLATE_ID],
+};
+
+type ResolveOpenIncident = (input: {
+  openIncident: Incident;
+  rootCause: string;
+  dataToProcess: IncomingMonitorRequest;
+}) => Promise<void>;
+
+const monitorIncidentInternals: {
+  resolveOpenIncident: ResolveOpenIncident;
+  shouldCloseIncident: (input: Record<string, unknown>) => boolean;
+} = MonitorIncident as unknown as {
+  resolveOpenIncident: ResolveOpenIncident;
+  shouldCloseIncident: (input: Record<string, unknown>) => boolean;
+};
+
+/** Builds an open incident the way the create path would have stored it. */
+function openIncident(templateId: string | undefined): Incident {
+  const model: Incident = new Incident();
+  model._id = INCIDENT_ID.toString();
+  model.projectId = PROJECT_ID;
+  model.createdCriteriaId = CRITERIA_ID;
+  model.seriesFingerprint = SERIES_FINGERPRINT;
+
+  // Mirrors the create path: only set when the template actually has an id.
+  if (templateId) {
+    model.createdIncidentTemplateId = templateId;
+  }
+
+  return model;
+}
+
+function criteria(
+  id: string,
+  createsIncidents: boolean,
+): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data!.id = id;
+  instance.data!.createIncidents = createsIncidents;
+  return instance;
+}
+
+function monitor(): Monitor {
+  const model: Monitor = new Monitor();
+  model._id = MONITOR_ID.toString();
+  model.projectId = PROJECT_ID;
+  return model;
+}
+
+/** The Alertmanager-style recovery payload from the issue reproduction. */
+function resolvedPayload(): IncomingMonitorRequest {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    requestBody: {
+      groupKey: "alertmanager-group-1",
+      status: "resolved",
+    },
+    incomingRequestReceivedAt: OneUptimeDate.getCurrentDate(),
+    checkedAt: OneUptimeDate.getCurrentDate(),
+  };
+}
+
+/*
+ * Arranges a single open incident and drives the event-driven resolution
+ * path over it. Asserting on the mocked `resolveOpenIncident` keeps the test
+ * on the decision under test rather than on incident-state persistence.
+ */
+async function runPayloadResolution(input: {
+  incident: Incident;
+  autoResolveTemplates: Dictionary<Array<string>>;
+}): Promise<void> {
+  jest.spyOn(IncidentService, "findBy").mockResolvedValue([input.incident]);
+  jest
+    .spyOn(monitorIncidentInternals, "resolveOpenIncident")
+    .mockResolvedValue(undefined);
+
+  await MonitorIncident.resolveSeriesIncidentsByFingerprint({
+    monitor: monitor(),
+    fingerprints: [SERIES_FINGERPRINT],
+    rootCause: "Payload reported this key as resolved.",
+    dataToProcess: resolvedPayload(),
+    autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+      input.autoResolveTemplates,
+  });
+}
+
+describe("Auto-resolve for id-less criteria incident templates", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("resolveSeriesIncidentsByFingerprint (payload reports the key resolved)", () => {
+    it("resolves an incident whose template id is NULL when the criteria opted in with an id-less template", async () => {
+      await runPayloadResolution({
+        incident: openIncident(undefined),
+        autoResolveTemplates: AUTO_RESOLVE_ID_LESS_TEMPLATE,
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("still resolves an incident created from a template that does have an id", async () => {
+      await runPayloadResolution({
+        incident: openIncident(TEMPLATE_ID),
+        autoResolveTemplates: AUTO_RESOLVE_TEMPLATE_WITH_ID,
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not resolve a NULL-template incident when every auto-resolve template on that criteria carries an id", async () => {
+      await runPayloadResolution({
+        incident: openIncident(undefined),
+        autoResolveTemplates: AUTO_RESOLVE_TEMPLATE_WITH_ID,
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("does not resolve when the creating criteria did not opt into auto-resolve at all", async () => {
+      await runPayloadResolution({
+        incident: openIncident(undefined),
+        autoResolveTemplates: {},
+      });
+
+      expect(
+        monitorIncidentInternals.resolveOpenIncident,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("shouldCloseIncident, per-series absence path", () => {
+    it("closes a NULL-template incident once its series stops breaching", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>(["some-other-series"]),
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("keeps a NULL-template incident open while its series is still breaching", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>([SERIES_FINGERPRINT]),
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("does not close a NULL-template incident when the opted-in template carries an id", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_TEMPLATE_WITH_ID,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>(["some-other-series"]),
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("still honours the event-driven guard for NULL-template incidents", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: new Set<string>(["some-other-series"]),
+          disableSeriesAbsenceResolution: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("shouldCloseIncident, cross-criteria path", () => {
+    it("closes a NULL-template incident when another criteria is now active", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria("another-criteria", true),
+          breachingSeriesFingerprints: undefined,
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not close a NULL-template incident when its own criteria is still active", () => {
+      expect(
+        monitorIncidentInternals.shouldCloseIncident({
+          openIncident: openIncident(undefined),
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            AUTO_RESOLVE_ID_LESS_TEMPLATE,
+          criteriaInstance: criteria(CRITERIA_ID, true),
+          breachingSeriesFingerprints: undefined,
+          disableSeriesAbsenceResolution: false,
+        }),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix: auto-resolve incidents from id-less criteria incident templates

### Small Description?

Incidents created from id-less criteria incident templates can never auto-resolve (#3390). Both resolution paths hard-gate on `createdIncidentTemplateId`, which the create path leaves NULL when the template has no `id` — a state the write path accepts and the dedupe path explicitly supports, yet which was silently unresolvable forever.

This was previously submitted together with #3394 as one PR; it has been split so each fix can be reviewed and merged on its own. This half touches two files and carries no migration.

---

`CriteriaIncident.id` is declared required, but the write path accepts templates without one, and API- and Terraform-authored criteria routinely omit it. The **create** path already handles that (sets `createdIncidentTemplateId` only when the id is present) and so does the **dedupe** match, which normalises both sides to `undefined`. The **resolution** paths did not:

- `resolveSeriesIncidentsByFingerprint` — `if (!createdCriteriaId || !createdIncidentTemplateId) { continue; }`
- `shouldCloseIncident` — the same gate, in both of its branches

So incidents were created correctly, deduplicated correctly, carried a correct `seriesFingerprint` — and stayed open forever with nothing logged to say why.

The three hard gates become one `isAutoResolveIncidentTemplate()` helper that normalises both sides to `undefined`, mirroring the dedupe path. It stays exact: an incident whose template id is NULL matches only an **id-less** auto-resolve template on the same criteria, never an unrelated one that carries an id. This also heals monitors already in this state, which a provider-side fix alone cannot do.

---

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

closes #3390

### Tests

`IdLessIncidentTemplateAutoResolve.test.ts` — **10 tests, all passing**. Three of them fail on the pre-fix code, one per broken resolution path; the other seven pin that the fix does not over-resolve:

- resolves an incident whose template id is NULL when the criteria opted in with an id-less template
- still resolves an incident created from a template that does have an id
- does not resolve a NULL-template incident when every auto-resolve template on that criteria carries an id
- does not resolve when the creating criteria did not opt into auto-resolve at all
- closes a NULL-template incident once its series stops breaching
- keeps a NULL-template incident open while its series is still breaching
- does not close a NULL-template incident when the opted-in template carries an id
- still honours the event-driven guard for NULL-template incidents
- closes a NULL-template incident when another criteria is now active
- does not close a NULL-template incident when its own criteria is still active

The full `Tests/Server/Utils/Monitor` directory (67 suites / 1378 tests) also passes.

### Scope

Two files: `Common/Server/Utils/Monitor/MonitorIncident.ts` and the new test. No schema change, no migration, no API surface change.
