### PR TITLE
feat(chart): support extraEnv and extraVolumes/extraVolumeMounts on every service

### DIFF
--- a/HelmChart/Public/oneuptime/docs/configuration.md
+++ b/HelmChart/Public/oneuptime/docs/configuration.md
@@ -205,6 +205,101 @@ Bitnami charts — you will need to set the security context for those as well.
 | `tolerations`              | Tolerations.               | `[]`    |
 | `affinity`                 | Affinity.                  | `{}`    |
 
+## Extra environment variables and volumes
+
+Every workload the chart runs takes `extraEnv`, `extraVolumes` and
+`extraVolumeMounts`. They are passed through to the pod spec verbatim, so
+anything Kubernetes accepts in an `EnvVar`, `Volume` or `VolumeMount` works.
+They are empty by default and render nothing at all, so an install that does not
+set them is unaffected.
+
+Set them at the top level to apply to every workload, or under a single service
+to apply to just that one:
+
+| Parameter                        | Description                                                                      | Default |
+|----------------------------------|----------------------------------------------------------------------------------|---------|
+| `extraEnv`                       | Extra environment variables added to every workload.                             | `[]`    |
+| `extraVolumes`                   | Extra pod volumes added to every workload.                                       | `[]`    |
+| `extraVolumeMounts`              | Extra container volume mounts added to every workload.                           | `[]`    |
+| `<service>.extraEnv`             | Extra environment variables for one service. Replaces the chart-wide list.        | `[]`    |
+| `<service>.extraVolumes`         | Extra pod volumes for one service. Replaces the chart-wide list.                  | `[]`    |
+| `<service>.extraVolumeMounts`    | Extra container volume mounts for one service. Replaces the chart-wide list.      | `[]`    |
+
+`<service>` is any of `app`, `worker`, `probes.<name>`, `runner`, `home`,
+`telemetryWriter`, `nginx`, `pgbouncer`, `testServer`, `migrate`, `vllm` or
+`cronJobs.e2e`.
+
+A service's list **replaces** the chart-wide one — the two are not merged. That
+is the precedence the chart already uses for `hostAliases`, `nodeSelector` and
+the security contexts, and for volumes it is the only safe one: concatenating
+would produce two volumes with the same `name` as soon as you narrowed a
+chart-wide volume for one service, and the API server rejects that pod outright.
+Setting a service's list to `[]` inherits the chart-wide list rather than
+clearing it, so a service cannot opt out of a chart-wide entry — scope the entry
+per-service instead of chart-wide when only some services should get it.
+
+`extraEnv` entries are appended after the variables the chart sets itself, so
+Kubernetes — which applies the last entry for a repeated name — uses yours. Two
+names are worth not repeating: `DISABLE_QUEUE_WORKERS` is what makes a pod a
+`worker` rather than an API pod (and the reverse on `telemetryWriter`), so
+setting it chart-wide silently changes what those tiers do.
+
+
+The bundled databases (`postgresql`, `redis`, `clickhouse` and the ClickHouse
+Keeper) and the `cronJobs.cleanup` jobs deliberately do not take these. The
+databases are servers rather than clients, already expose their TLS and tuning
+settings as first-class values, and have operator-managed twins whose pods come
+from a CR rather than from these templates — so the setting would apply to only
+half of an install. The cleanup jobs run `bitnami/kubectl` against the
+in-cluster API server, which is trusted through the ServiceAccount CA.
+
+### Example: trust an internal CA
+
+The case these exist for. OneUptime's services are Node.js, so pointing
+`NODE_EXTRA_CA_CERTS` at a mounted bundle is enough for every outbound TLS call
+— webhooks, SMTP, custom monitors, an internal container registry, an
+OIDC provider with a private issuer.
+
+Put the bundle in a ConfigMap first:
+
+```console
+kubectl create configmap internal-ca-bundle -n oneuptime --from-file=ca.crt=/path/to/internal-ca.crt
+```
+
+Then, in your `values.yaml`:
+
+```yaml
+extraVolumes:
+  - name: internal-ca
+    configMap:
+      name: internal-ca-bundle
+extraVolumeMounts:
+  - name: internal-ca
+    mountPath: /etc/ssl/internal
+    readOnly: true
+extraEnv:
+  - name: NODE_EXTRA_CA_CERTS
+    value: /etc/ssl/internal/ca.crt
+```
+
+That reaches app, worker, every probe, runner, home, telemetry-writer, nginx,
+pgbouncer, test-server, the migrate Job and the e2e cron in one setting. The
+migrate Job matters here: it talks to Postgres and ClickHouse before any app pod
+does, so a CA it cannot see fails the install rather than degrading it.
+
+`NODE_EXTRA_CA_CERTS` covers Node.js, which is every outbound call OneUptime's
+own code makes. It does **not** reach the Chromium that probes drive for
+synthetic browser monitors, or the one the e2e cron uses: Chromium reads the OS
+trust store instead. Synthetic monitors against an internally-signed site need
+the certificate baked into the image's `/usr/local/share/ca-certificates` and
+`update-ca-certificates` run at build time.
+
+Confirm what an upgrade would actually change before you run it:
+
+```console
+helm template my-oneuptime oneuptime/oneuptime -f values.yaml | grep -c NODE_EXTRA_CA_CERTS
+```
+
 ## Local AI (vLLM)
 
 Run a local, OpenAI-compatible LLM server in-cluster for OneUptime's AI

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -964,12 +964,15 @@ spec:
       {{- end }}
       nodeSelector:
         {{- include "oneuptime.nodeSelector" ($.NodeSelector | default $.Values.nodeSelector) | nindent 8 }}
-      {{- if $.Volumes }}
+      {{- if or $.Volumes $.ExtraVolumes }}
       volumes:
       {{- range $key, $val := $.Volumes }}
         - name: {{ $key }}
           emptyDir:
             sizeLimit: {{ $val.SizeLimit }}
+      {{- end }}
+      {{- with $.ExtraVolumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
       containers:
@@ -996,11 +999,17 @@ spec:
               value: {{ $val | squote }}
             {{- end }}
             {{- end }}
-          {{- if $.Volumes }}
+            {{- with $.ExtraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or $.Volumes $.ExtraVolumeMounts }}
           volumeMounts:
             {{- range $key, $val := $.Volumes }}
             - name: {{ $key }}
               mountPath: {{ $val.MountPath }}
+            {{- end }}
+            {{- with $.ExtraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- if $.Ports }}

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -62,6 +62,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- include "oneuptime.nodeSelector" ($.Values.app.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
+      {{- with (default $.Values.extraVolumes $.Values.app.extraVolumes) }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "app") }}
           name: {{ printf "%s-%s" $.Release.Name "app"  }}
@@ -163,6 +167,13 @@ spec:
             - name: DISABLE_QUEUE_WORKERS
               value: {{ $.Values.worker.enabled | default false | quote }}
             {{- include "oneuptime.env.registerProbeKey" (dict "Values" $.Values "Release" $.Release) | nindent 12 }}
+            {{- with (default $.Values.extraEnv $.Values.app.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumeMounts $.Values.app.extraVolumeMounts) }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ $.Values.app.ports.http }}
               protocol: TCP

--- a/HelmChart/Public/oneuptime/templates/e2e-cron.yml
+++ b/HelmChart/Public/oneuptime/templates/e2e-cron.yml
@@ -37,6 +37,17 @@ spec:
                 value: {{ $.Values.cronJobs.e2e.statusPageUrl | quote }}
               - name: E2E_TESTS_FAILED_WEBHOOK_URL
                 value: {{ $.Values.cronJobs.e2e.failedWebhookUrl | quote }}
+              {{- with (default $.Values.extraEnv $.Values.cronJobs.e2e.extraEnv) }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+            {{- with (default $.Values.extraVolumeMounts $.Values.cronJobs.e2e.extraVolumeMounts) }}
+            volumeMounts:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumes $.Values.cronJobs.e2e.extraVolumes) }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
 
 {{- end }}

--- a/HelmChart/Public/oneuptime/templates/home.yaml
+++ b/HelmChart/Public/oneuptime/templates/home.yaml
@@ -60,6 +60,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- include "oneuptime.nodeSelector" ($.Values.home.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
+      {{- with (default $.Values.extraVolumes $.Values.home.extraVolumes) }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "home") }}
           name: {{ printf "%s-%s" $.Release.Name "home"  }}
@@ -111,6 +115,13 @@ spec:
               value: {{ $.Values.home.disableTelemetryCollection | quote }}
             - name: ENABLE_PROFILING
               value: {{ $.Values.home.enableProfiling | quote }}
+            {{- with (default $.Values.extraEnv $.Values.home.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumeMounts $.Values.home.extraVolumeMounts) }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ $.Values.home.ports.http }}
               protocol: TCP

--- a/HelmChart/Public/oneuptime/templates/migrate-job.yaml
+++ b/HelmChart/Public/oneuptime/templates/migrate-job.yaml
@@ -81,6 +81,10 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- with (default $.Values.extraVolumes $.Values.migrate.extraVolumes) }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         # Wait for Postgres to accept TCP connections before migrating. As a
         # post-install hook this Job can start before the bundled Postgres /
@@ -123,6 +127,13 @@ spec:
             - name: CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS
               value: {{ .Values.migrate.clickhouseDistributedDdlTaskTimeoutSeconds | squote }}
             {{- end }}
+            {{- with (default $.Values.extraEnv $.Values.migrate.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumeMounts $.Values.migrate.extraVolumeMounts) }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.migrate.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -51,6 +51,9 @@ spec:
         - name: run
           emptyDir:
             sizeLimit: "1Gi"
+        {{- with (default $.Values.extraVolumes $.Values.nginx.extraVolumes) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if $.Values.nginx.podSecurityContext }}
       securityContext:
         {{- toYaml $.Values.nginx.podSecurityContext | nindent 8 }}
@@ -155,6 +158,9 @@ spec:
               mountPath: /etc/nginx/conf.d
             - name: run
               mountPath: /var/run
+            {{- with (default $.Values.extraVolumeMounts $.Values.nginx.extraVolumeMounts) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if $.Values.nginx.containerSecurityContext }}
           securityContext:
             {{- toYaml $.Values.nginx.containerSecurityContext | nindent 12 }}
@@ -195,6 +201,9 @@ spec:
               value: "7851" # Port for the nodejs server for live and ready status
             - name: DISABLE_TELEMETRY
               value: {{ $.Values.nginx.disableTelemetryCollection | quote }}
+            {{- with (default $.Values.extraEnv $.Values.nginx.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 7849
               protocol: TCP

--- a/HelmChart/Public/oneuptime/templates/pgbouncer.yaml
+++ b/HelmChart/Public/oneuptime/templates/pgbouncer.yaml
@@ -94,7 +94,12 @@ spec:
         appname: oneuptime
       annotations:
         # Roll the pods when the rendered pgbouncer.ini (its inputs) changes.
-        checksum/config: {{ printf "%s|%s|%s|%s" (toYaml .Values.pgbouncer) (include "oneuptime.postgres.backendHost" .) (include "oneuptime.postgres.backendPort" .) (include "oneuptime.postgres.backendUser" .) | sha256sum }}
+        {{- /* extraEnv/extraVolumes/extraVolumeMounts are omitted on purpose: they are
+               pod-spec inputs, not pgbouncer.ini inputs, so setting one already changes the
+               pod template and rolls the pods on its own. Leaving them in the hash would
+               instead roll the pooler on the upgrade that merely INTRODUCED the keys, for
+               every install, without the ini changing. */}}
+        checksum/config: {{ printf "%s|%s|%s|%s" (toYaml (omit .Values.pgbouncer "extraEnv" "extraVolumes" "extraVolumeMounts")) (include "oneuptime.postgres.backendHost" .) (include "oneuptime.postgres.backendPort" .) (include "oneuptime.postgres.backendUser" .) | sha256sum }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -150,6 +155,9 @@ spec:
         - name: PGB_DB_USER
           value: {{ include "oneuptime.postgres.backendUser" . | quote }}
         {{- include "oneuptime.postgres.backendPasswordEnv" . | nindent 8 }}
+        {{- with (default $.Values.extraEnv $.Values.pgbouncer.extraEnv) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         ports:
         - name: pgbouncer
           containerPort: {{ .Values.pgbouncer.service.port | int }}
@@ -183,6 +191,9 @@ spec:
           mountPath: /etc/pgbouncer/tls
           readOnly: true
         {{- end }}
+        {{- with (default $.Values.extraVolumeMounts $.Values.pgbouncer.extraVolumeMounts) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:
@@ -196,6 +207,9 @@ spec:
           items:
           - key: ssl-ca
             path: server-ca.crt
+      {{- end }}
+      {{- with (default $.Values.extraVolumes $.Values.pgbouncer.extraVolumes) }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 ---
 apiVersion: v1

--- a/HelmChart/Public/oneuptime/templates/probe.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe.yaml
@@ -106,6 +106,9 @@ spec:
           volumeMounts:
             - name: synthetic-runtime-tmp
               mountPath: /tmp
+            {{- with (default $.Values.extraVolumeMounts $val.extraVolumeMounts) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: BILLING_ENABLED
               value: {{ $.Values.billing.enabled | squote }}
@@ -185,6 +188,9 @@ spec:
               value: {{ $val.proxy.noProxy | squote }}
             {{- end }}
             {{- include "oneuptime.env.registerProbeKey" (dict "Values" $.Values "Release" $.Release) | nindent 12 }}
+            {{- with (default $.Values.extraEnv $val.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: {{ if and $val.ports $val.ports.http }}{{ $val.ports.http }}{{ else }}3874{{ end }}
               protocol: TCP
@@ -200,6 +206,9 @@ spec:
         - name: synthetic-runtime-tmp
           emptyDir:
             sizeLimit: {{ default "2Gi" $val.syntheticMonitorTempStorageSizeLimit | quote }}
+        {{- with (default $.Values.extraVolumes $val.extraVolumes) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       restartPolicy: {{ $.Values.image.restartPolicy }}
 ---
 

--- a/HelmChart/Public/oneuptime/templates/runner.yaml
+++ b/HelmChart/Public/oneuptime/templates/runner.yaml
@@ -59,6 +59,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- include "oneuptime.nodeSelector" ($.Values.runner.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
+      {{- with (default $.Values.extraVolumes $.Values.runner.extraVolumes) }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "runner") }}
           name: {{ printf "%s-%s" $.Release.Name "runner" }}
@@ -101,6 +105,13 @@ spec:
               value: {{ $.Values.runner.enableProfiling | quote }}
             {{- end }}
             {{- include "oneuptime.env.runtime" (dict "Values" $.Values "Release" $.Release) | nindent 12 }}
+            {{- with (default $.Values.extraEnv $.Values.runner.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumeMounts $.Values.runner.extraVolumeMounts) }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ $.Values.runner.ports.http }}
               protocol: TCP

--- a/HelmChart/Public/oneuptime/templates/telemetry-writer.yaml
+++ b/HelmChart/Public/oneuptime/templates/telemetry-writer.yaml
@@ -82,6 +82,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- include "oneuptime.nodeSelector" ($.Values.telemetryWriter.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
+      {{- with (default $.Values.extraVolumes $.Values.telemetryWriter.extraVolumes) }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "telemetry-writer" "ImageName" "app") }}
           name: {{ printf "%s-%s" $.Release.Name "telemetry-writer"  }}
@@ -167,6 +171,13 @@ spec:
               value: {{ $.Values.telemetryWriter.clickhouseMaxOpenConnections | default 100 | squote }}
             - name: CLICKHOUSE_INGEST_MAX_OPEN_CONNECTIONS
               value: {{ $.Values.telemetryWriter.clickhouseIngestMaxOpenConnections | default ($.Values.telemetryWriter.clickhouseMaxOpenConnections | default 100) | squote }}
+            {{- with (default $.Values.extraEnv $.Values.telemetryWriter.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumeMounts $.Values.telemetryWriter.extraVolumeMounts) }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ $.Values.telemetryWriter.ports.http }}
               protocol: TCP

--- a/HelmChart/Public/oneuptime/templates/test-server.yaml
+++ b/HelmChart/Public/oneuptime/templates/test-server.yaml
@@ -3,7 +3,7 @@
 # OneUptime test-server Deployment
 {{- $testServerPorts := $.Values.testServer.ports -}}
 {{- $testServerEnv := dict "PORT"  $.Values.testServer.ports.http  "DISABLE_TELEMETRY" $.Values.testServer.disableTelemetryCollection  "ENABLE_PROFILING" $.Values.testServer.enableProfiling -}}
-{{- $testServerDeploymentArgs :=dict "IsUI" true "ServiceName" "test-server" "Ports" $testServerPorts "Release" $.Release "Values" $.Values "Env" $testServerEnv "Resources" $.Values.testServer.resources "NodeSelector" $.Values.testServer.nodeSelector "PodSecurityContext" $.Values.testServer.podSecurityContext "ContainerSecurityContext" $.Values.testServer.containerSecurityContext "DisableAutoscaler" $.Values.testServer.disableAutoscaler "AutoscalingOverride" $.Values.testServer.autoscaling "ReplicaCount" $.Values.testServer.replicaCount -}}
+{{- $testServerDeploymentArgs :=dict "IsUI" true "ServiceName" "test-server" "Ports" $testServerPorts "Release" $.Release "Values" $.Values "Env" $testServerEnv "Resources" $.Values.testServer.resources "NodeSelector" $.Values.testServer.nodeSelector "PodSecurityContext" $.Values.testServer.podSecurityContext "ContainerSecurityContext" $.Values.testServer.containerSecurityContext "DisableAutoscaler" $.Values.testServer.disableAutoscaler "AutoscalingOverride" $.Values.testServer.autoscaling "ReplicaCount" $.Values.testServer.replicaCount "ExtraEnv" (default $.Values.extraEnv $.Values.testServer.extraEnv) "ExtraVolumes" (default $.Values.extraVolumes $.Values.testServer.extraVolumes) "ExtraVolumeMounts" (default $.Values.extraVolumeMounts $.Values.testServer.extraVolumeMounts) -}}
 {{- include "oneuptime.deployment" $testServerDeploymentArgs }}
 ---
 

--- a/HelmChart/Public/oneuptime/templates/vllm.yaml
+++ b/HelmChart/Public/oneuptime/templates/vllm.yaml
@@ -165,7 +165,7 @@ spec:
               key: api-key
               {{- end }}
         {{- end }}
-        {{- with .Values.vllm.extraEnv }}
+        {{- with (default $.Values.extraEnv $.Values.vllm.extraEnv) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.vllm.startupProbe.enabled }}
@@ -216,6 +216,9 @@ spec:
           mountPath: /data
         - name: shm
           mountPath: /dev/shm
+        {{- with (default $.Values.extraVolumeMounts $.Values.vllm.extraVolumeMounts) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
       # vLLM's multiprocess engine uses /dev/shm for shared-memory IPC (and
       # NCCL needs it for tensor parallelism); the Kubernetes default of 64Mi
@@ -228,6 +231,9 @@ spec:
       - name: data
         emptyDir:
           sizeLimit: {{ .Values.vllm.persistence.size }}
+      {{- end }}
+      {{- with (default $.Values.extraVolumes $.Values.vllm.extraVolumes) }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
   {{- if .Values.vllm.persistence.enabled }}
   volumeClaimTemplates:

--- a/HelmChart/Public/oneuptime/templates/worker.yaml
+++ b/HelmChart/Public/oneuptime/templates/worker.yaml
@@ -70,6 +70,10 @@ spec:
       {{- end }}
       nodeSelector:
         {{- include "oneuptime.nodeSelector" ($.Values.worker.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
+      {{- with (default $.Values.extraVolumes $.Values.worker.extraVolumes) }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "worker" "ImageName" "app") }}
           name: {{ printf "%s-%s" $.Release.Name "worker"  }}
@@ -159,6 +163,13 @@ spec:
               value: {{ $.Values.worker.clickhouseIngestMaxOpenConnections | default ($.Values.worker.clickhouseMaxOpenConnections | default 100) | squote }}
             {{- include "oneuptime.env.telemetryWriterUrl" . | nindent 12 }}
             {{- include "oneuptime.env.registerProbeKey" (dict "Values" $.Values "Release" $.Release) | nindent 12 }}
+            {{- with (default $.Values.extraEnv $.Values.worker.extraEnv) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (default $.Values.extraVolumeMounts $.Values.worker.extraVolumeMounts) }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ $.Values.worker.ports.http }}
               protocol: TCP

--- a/HelmChart/Public/oneuptime/tests/extra-env-volumes-precedence_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/extra-env-volumes-precedence_test.yaml
@@ -1,0 +1,431 @@
+# Precedence between the chart-wide extraEnv / extraVolumes / extraVolumeMounts
+# and a service's own copy of them.
+#
+# A service's list REPLACES the chart-wide one; the two are not merged. That is
+# the precedence the chart already uses for hostAliases, nodeSelector and the
+# security contexts, and for volumes it is the only safe one: concatenating the
+# two lists would emit two entries with the same `name` the moment an operator
+# narrowed a chart-wide volume for one service, and the API server rejects a pod
+# with duplicate volume names outright.
+#
+# The cost of that choice is the case in "falls back ... when the service's list
+# is empty": a service cannot opt OUT of a chart-wide list by setting `[]`,
+# because Helm's `default` treats an empty list as absent. Nothing here depends
+# on being able to, but the behaviour is pinned so it cannot change silently.
+suite: extra env and volume precedence
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  - it: uses the service's own list instead of the chart-wide one
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      app:
+        extraEnv:
+          - name: SOURCE
+            value: app-only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: app-only
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: chart-wide
+
+  - it: leaves the other services on the chart-wide list in the same render
+    templates:
+      - templates/worker.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      worker:
+        enabled: true
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      app:
+        extraEnv:
+          - name: SOURCE
+            value: app-only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: chart-wide
+
+  - it: replaces the chart-wide volumes and mounts, rather than adding to them
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraVolumes:
+        - name: chart-wide-ca
+          configMap:
+            name: chart-wide-ca
+      extraVolumeMounts:
+        - name: chart-wide-ca
+          mountPath: /etc/ssl/chart-wide
+      app:
+        extraVolumes:
+          - name: app-ca
+            configMap:
+              name: app-ca
+        extraVolumeMounts:
+          - name: app-ca
+            mountPath: /etc/ssl/app
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 1
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: app-ca
+            configMap:
+              name: app-ca
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: chart-wide-ca
+            configMap:
+              name: chart-wide-ca
+
+  - it: falls back to the chart-wide list when the service's list is empty
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      app:
+        extraEnv: []
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: chart-wide
+
+  - it: takes a service's list with no chart-wide default set at all
+    templates:
+      - templates/runner.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      runner:
+        extraEnv:
+          - name: RUNNER_ONLY
+            value: "1"
+        extraVolumes:
+          - name: runner-scratch
+            emptyDir: {}
+        extraVolumeMounts:
+          - name: runner-scratch
+            mountPath: /scratch
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNNER_ONLY
+            value: "1"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: runner-scratch
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: runner-scratch
+            mountPath: /scratch
+
+  # Probes are a map, so the override is read off the individual probe rather
+  # than off a fixed key.
+  - it: honours a single probe's own list over the chart-wide one
+    templates:
+      - templates/probe.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      probes:
+        one:
+          extraEnv:
+            - name: SOURCE
+              value: probe-one-only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: probe-one-only
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: chart-wide
+
+  - it: honours the e2e cron's own list over the chart-wide one
+    templates:
+      - templates/e2e-cron.yml
+    set:
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      cronJobs:
+        e2e:
+          enabled: true
+          extraEnv:
+            - name: SOURCE
+              value: e2e-only
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: e2e-only
+
+  # vllm.extraEnv predates the chart-wide list. It keeps winning, and it now
+  # inherits the chart-wide list when it is left unset.
+  - it: keeps vllm.extraEnv winning over the chart-wide list
+    templates:
+      - templates/vllm.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      vllm:
+        enabled: true
+        extraEnv:
+          - name: SOURCE
+            value: vllm-only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: vllm-only
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: chart-wide
+
+  - it: gives vllm the chart-wide list when vllm.extraEnv is unset
+    templates:
+      - templates/vllm.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      extraEnv:
+        - name: SOURCE
+          value: chart-wide
+      vllm:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE
+            value: chart-wide
+
+  # ---------------------------------------------------------------------------
+  # The lists are passed through verbatim, so anything Kubernetes accepts in an
+  # EnvVar / Volume / VolumeMount has to survive the round trip.
+  # ---------------------------------------------------------------------------
+  - it: passes a valueFrom env entry through untouched
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraEnv:
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: my-smtp
+              key: password
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-smtp
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+
+  - it: passes secret, hostPath and projected volume shapes through untouched
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraVolumes:
+        - name: keytab
+          secret:
+            secretName: kerberos-keytab
+            defaultMode: 384
+        - name: host-certs
+          hostPath:
+            path: /etc/pki/tls/certs
+            type: Directory
+        - name: bundle
+          projected:
+            sources:
+              - configMap:
+                  name: internal-ca-bundle
+              - secret:
+                  name: partner-ca
+      extraVolumeMounts:
+        - name: keytab
+          mountPath: /etc/krb5.keytab
+          subPath: krb5.keytab
+          readOnly: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 3
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: keytab
+            secret:
+              secretName: kerberos-keytab
+              defaultMode: 384
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-certs
+            hostPath:
+              path: /etc/pki/tls/certs
+              type: Directory
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: bundle
+            projected:
+              sources:
+                - configMap:
+                    name: internal-ca-bundle
+                - secret:
+                    name: partner-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: keytab
+            mountPath: /etc/krb5.keytab
+            subPath: krb5.keytab
+            readOnly: true
+
+  # Extras are appended AFTER the chart's own variables. Kubernetes applies the
+  # last entry for a duplicated name, so this ordering is what lets an operator
+  # override a variable the chart already sets.
+  - it: appends extra env after the variables the chart sets itself
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraEnv:
+        - name: LOG_LEVEL
+          value: DEBUG
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[-1]
+          value:
+            name: LOG_LEVEL
+            value: DEBUG
+
+  - it: renders every entry of a multi-entry list, in order
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraEnv:
+        - name: FIRST
+          value: "1"
+        - name: SECOND
+          value: "2"
+        - name: THIRD
+          value: "3"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[-3]
+          value:
+            name: FIRST
+            value: "1"
+      - equal:
+          path: spec.template.spec.containers[0].env[-2]
+          value:
+            name: SECOND
+            value: "2"
+      - equal:
+          path: spec.template.spec.containers[0].env[-1]
+          value:
+            name: THIRD
+            value: "3"
+
+  # A volume with no matching mount is legal Kubernetes (a sidecar injected by a
+  # webhook may claim it), so the chart must not invent a mount for it.
+  - it: emits the volume without inventing a mount for it
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      extraVolumes:
+        - name: injected
+          emptyDir: {}
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts

--- a/HelmChart/Public/oneuptime/tests/extra-env-volumes_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/extra-env-volumes_test.yaml
@@ -1,0 +1,522 @@
+# extraEnv / extraVolumes / extraVolumeMounts are the chart's escape hatch for
+# the things it cannot enumerate. Trusting an internal CA — a bundle mounted
+# from a ConfigMap plus NODE_EXTRA_CA_CERTS pointing at it — is the case that
+# motivated them, and it is the one this suite renders end to end.
+#
+# Three properties have to hold, and none of them is visible from reading a
+# single template:
+#
+#   - They are a NO-OP when unset. Every workload has to render the manifest it
+#     rendered before, with no empty `volumes:` / `volumeMounts:` key left
+#     behind. A stray key is not cosmetic: it shows up as a change in
+#     `helm diff` for every existing install on the upgrade that ships this.
+#   - The chart-wide list has to reach EVERY workload. The whole point is that
+#     an operator sets the CA once; a service the wiring was forgotten on is a
+#     partial TLS failure that surfaces at runtime, not at install time. So
+#     there is one case per workload here rather than one case for `app`.
+#   - Services that already mount something of their own — probe, nginx,
+#     pgbouncer, vllm — must APPEND. Clobbering probe's synthetic-runtime-tmp
+#     or nginx's conf volume would break the pod outright.
+suite: extra env, volumes and volume mounts
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  # ---------------------------------------------------------------------------
+  # Unset is a no-op: no key, not an empty one.
+  # ---------------------------------------------------------------------------
+  - it: leaves app untouched when nothing is set
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves worker untouched when nothing is set
+    templates:
+      - templates/worker.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      worker:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves runner untouched when nothing is set
+    templates:
+      - templates/runner.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves home untouched when nothing is set
+    templates:
+      - templates/home.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      home:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves telemetry-writer untouched when nothing is set
+    templates:
+      - templates/telemetry-writer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      telemetryWriter:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves test-server untouched when nothing is set
+    templates:
+      - templates/test-server.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      testServer:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves the migrate Job untouched when nothing is set
+    templates:
+      - templates/migrate-job.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: leaves the e2e cron untouched when nothing is set
+    templates:
+      - templates/e2e-cron.yml
+    set:
+      cronJobs:
+        e2e:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.volumes
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+
+  # The four workloads that already carry volumes keep exactly the ones they
+  # shipped with — a count, so an accidental extra entry fails too.
+  - it: leaves the probe's own volumes alone when nothing is set
+    templates:
+      - templates/probe.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 1
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: synthetic-runtime-tmp
+            emptyDir:
+              sizeLimit: "2Gi"
+
+  - it: leaves nginx's own volumes alone when nothing is set
+    templates:
+      - templates/nginx.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 5
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 5
+
+  - it: leaves pgbouncer's own volumes alone when nothing is set
+    templates:
+      - templates/pgbouncer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      pgbouncer:
+        enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 2
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 2
+
+  - it: leaves vllm's own volumes alone when nothing is set
+    templates:
+      - templates/vllm.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      vllm:
+        enabled: true
+    asserts:
+      # `data` is a volumeClaimTemplate while persistence is on, so only `shm`
+      # is a pod volume here; both are mounted.
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 2
+
+  # ---------------------------------------------------------------------------
+  # One chart-wide setting has to reach every workload — the CA-bundle case.
+  # ---------------------------------------------------------------------------
+  - it: mounts the chart-wide CA bundle on app
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: &ca
+      extraEnv:
+        - name: NODE_EXTRA_CA_CERTS
+          value: /etc/ssl/internal/ca.crt
+      extraVolumes:
+        - name: internal-ca
+          configMap:
+            name: internal-ca-bundle
+      extraVolumeMounts:
+        - name: internal-ca
+          mountPath: /etc/ssl/internal
+          readOnly: true
+    asserts: &caAsserts
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_EXTRA_CA_CERTS
+            value: /etc/ssl/internal/ca.crt
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: internal-ca
+            configMap:
+              name: internal-ca-bundle
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: internal-ca
+            mountPath: /etc/ssl/internal
+            readOnly: true
+
+  - it: mounts the chart-wide CA bundle on worker
+    templates:
+      - templates/worker.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      worker:
+        enabled: true
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on every probe
+    templates:
+      - templates/probe.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: *ca
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on runner
+    templates:
+      - templates/runner.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: *ca
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on home
+    templates:
+      - templates/home.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      home:
+        enabled: true
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on telemetry-writer
+    templates:
+      - templates/telemetry-writer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      telemetryWriter:
+        enabled: true
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on nginx
+    templates:
+      - templates/nginx.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: *ca
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on test-server
+    templates:
+      - templates/test-server.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      testServer:
+        enabled: true
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on pgbouncer
+    templates:
+      - templates/pgbouncer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      pgbouncer:
+        enabled: true
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on vllm
+    templates:
+      - templates/vllm.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      <<: *ca
+      vllm:
+        enabled: true
+    asserts: *caAsserts
+
+  # The migrate Job talks to Postgres and ClickHouse before any app pod does,
+  # so a CA it cannot see fails the install rather than degrading it.
+  - it: mounts the chart-wide CA bundle on the migrate Job
+    templates:
+      - templates/migrate-job.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    set: *ca
+    asserts: *caAsserts
+
+  - it: mounts the chart-wide CA bundle on the e2e cron
+    templates:
+      - templates/e2e-cron.yml
+    set:
+      <<: *ca
+      cronJobs:
+        e2e:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: NODE_EXTRA_CA_CERTS
+            value: /etc/ssl/internal/ca.crt
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: internal-ca
+            configMap:
+              name: internal-ca-bundle
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: internal-ca
+            mountPath: /etc/ssl/internal
+            readOnly: true
+
+  # ---------------------------------------------------------------------------
+  # Append, never clobber.
+  # ---------------------------------------------------------------------------
+  - it: keeps the probe's synthetic-monitor scratch volume alongside the extra
+    templates:
+      - templates/probe.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: *ca
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: synthetic-runtime-tmp
+            emptyDir:
+              sizeLimit: "2Gi"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: synthetic-runtime-tmp
+            mountPath: /tmp
+
+  - it: keeps all five of nginx's own volumes alongside the extra
+    templates:
+      - templates/nginx.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: *ca
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 6
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 6
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: conf
+            mountPath: /etc/nginx/conf.d
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: run
+            mountPath: /var/run
+
+  - it: keeps pgbouncer's config and tmp volumes alongside the extra
+    templates:
+      - templates/pgbouncer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      pgbouncer:
+        enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 3
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/pgbouncer
+            readOnly: true
+
+  # pgbouncer already mounts a CA of its own when externalPostgres uses TLS;
+  # the extra has to land next to it, not instead of it.
+  - it: keeps pgbouncer's external-postgres CA alongside the extra
+    templates:
+      - templates/pgbouncer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      <<: *ca
+      pgbouncer:
+        enabled: true
+      postgresql:
+        enabled: false
+      postgresOperator:
+        cnpg:
+          enabled: false
+      externalPostgres:
+        host: postgres.example.com
+        ssl:
+          enabled: true
+          ca: |
+            -----BEGIN CERTIFICATE-----
+            -----END CERTIFICATE-----
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 4
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: server-tls
+            mountPath: /etc/pgbouncer/tls
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: internal-ca
+            mountPath: /etc/ssl/internal
+            readOnly: true
+
+  - it: keeps vllm's shm and data volumes alongside the extra
+    templates:
+      - templates/vllm.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      <<: *ca
+      vllm:
+        enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 2
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 3
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 2Gi

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -419,6 +419,24 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -1012,6 +1030,24 @@
                 },
                 "priorityClassName": {
                     "type": "string"
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -1140,6 +1176,24 @@
                 },
                 "containerSecurityContext": {
                     "type": "object"
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -1999,6 +2053,24 @@
                                 }
                             },
                             "additionalProperties": false
+                        },
+                        "extraEnv": {
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "extraVolumes": {
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "extraVolumeMounts": {
+                            "type": [
+                                "array",
+                                "null"
+                            ]
                         }
                     },
                     "additionalProperties": false
@@ -2068,6 +2140,24 @@
                 },
                 "enableProfiling": {
                     "type": "boolean"
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -2181,6 +2271,24 @@
                         "failedWebhookUrl": {
                             "type": [
                                 "string",
+                                "null"
+                            ]
+                        },
+                        "extraEnv": {
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "extraVolumes": {
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "extraVolumeMounts": {
+                            "type": [
+                                "array",
                                 "null"
                             ]
                         }
@@ -2674,6 +2782,24 @@
                 },
                 "enableProfiling": {
                     "type": "boolean"
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -2944,6 +3070,24 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -3144,6 +3288,24 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -3345,6 +3507,24 @@
                 },
                 "containerSecurityContext": {
                     "type": "object"
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -3674,6 +3854,24 @@
                 },
                 "enableProfiling": {
                     "type": "boolean"
+                },
+                "extraEnv": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -3952,6 +4150,18 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "extraVolumes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false
@@ -4008,6 +4218,24 @@
                 }
             },
             "additionalProperties": false
+        },
+        "extraEnv": {
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "extraVolumes": {
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "extraVolumeMounts": {
+            "type": [
+                "array",
+                "null"
+            ]
         }
     },
     "additionalProperties": false

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -134,6 +134,11 @@ nginx:
   podSecurityContext: {}
   hostAliases: []
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
   # Kernel networking tuning for the ingress gateway. The ingress proxies a very
   # high volume of short-lived upstream connections (OTLP/telemetry ingest, API,
   # dashboard) out to a single backend Service IP. Without tuning, a pod can
@@ -754,6 +759,11 @@ migrate:
   affinity: {}
   # Optional PriorityClass so the migration run isn't preempted under pressure.
   priorityClassName: ""
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 # =============================================================================
 # PgBouncer connection pooler (opt-in). Orthogonal to the Postgres backend:
@@ -846,6 +856,11 @@ pgbouncer:
   # Optional: override global security contexts just for the pgbouncer pod/container
   podSecurityContext: {}
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 redis:
   enabled: true
@@ -1228,6 +1243,11 @@ probes:
     podSecurityContext: {}
     hostAliases: []
     containerSecurityContext: {}
+    # Extra env / volumes for this service only. A non-empty list REPLACES the
+    # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+    extraEnv: []
+    extraVolumes: []
+    extraVolumeMounts: []
 #   additionalContainers:
 # two:
 #   name: "Probe 2"
@@ -1310,6 +1330,11 @@ testServer:
   nodeSelector: {}
   podSecurityContext: {}
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 openTelemetryExporter:
   endpoint:
@@ -1322,6 +1347,33 @@ affinity:
 tolerations:
 nodeSelector:
 hostAliases:
+
+# Chart-wide escape hatches, applied to every OneUptime workload the chart runs:
+# app, worker, every probe, runner, home, telemetry-writer, nginx, pgbouncer,
+# the migrate Job, test-server, the e2e cron, and vLLM. Empty by default, so an
+# install that leaves them alone renders exactly the manifests it always did.
+#
+# A service that sets its own extraEnv / extraVolumes / extraVolumeMounts
+# REPLACES the chart-wide list for that service — the two are NOT merged. That
+# is the same precedence the chart already uses for hostAliases, nodeSelector
+# and the security contexts above.
+#
+# The usual reason to reach for these: make every service trust an internal CA.
+#
+# extraVolumes:
+#   - name: internal-ca
+#     configMap:
+#       name: internal-ca-bundle   # kubectl create configmap internal-ca-bundle --from-file=ca.crt
+# extraVolumeMounts:
+#   - name: internal-ca
+#     mountPath: /etc/ssl/internal
+#     readOnly: true
+# extraEnv:
+#   - name: NODE_EXTRA_CA_CERTS
+#     value: /etc/ssl/internal/ca.crt
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
 
 # Chart-wide fallback DNS settings. Services that support DNS overrides (currently
 # the probes) use their per-service dnsConfig/dnsPolicy if set, otherwise these.
@@ -1380,6 +1432,11 @@ cronJobs:
     # This is the URL of the status page you want to test. This is used to check if the status page is up and running.
     statusPageUrl:
     failedWebhookUrl:
+    # Extra env / volumes for this service only. A non-empty list REPLACES the
+    # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+    extraEnv: []
+    extraVolumes: []
+    extraVolumeMounts: []
 
 # Please add this information if you want to generate SSL certificates for your status page custom domains.
 # This is only required if you're using custom domains for status pages.
@@ -1538,6 +1595,11 @@ home:
   podSecurityContext: {}
   hostAliases: []
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 app:
   enabled: true
@@ -1608,6 +1670,11 @@ app:
   podSecurityContext: {}
   hostAliases: []
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
   # KEDA autoscaling configuration based on combined queue metrics (worker + workflow + telemetry + runbook)
   keda:
     enabled: false
@@ -1698,6 +1765,11 @@ worker:
   podSecurityContext: {}
   hostAliases: []
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
   # KEDA autoscaling based on combined queue depth (worker + workflow + telemetry + runbook)
   keda:
     enabled: false
@@ -1830,6 +1902,11 @@ telemetryWriter:
   podSecurityContext: {}
   hostAliases: []
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 # AI Agent Configuration
 # Runs the OneUptime AI Agent within your Kubernetes cluster.
@@ -1867,6 +1944,11 @@ runner:
   podSecurityContext: {}
   hostAliases: []
   containerSecurityContext: {}
+  # Extra env / volumes for this service only. A non-empty list REPLACES the
+  # chart-wide extraEnv/extraVolumes/extraVolumeMounts (they are not merged).
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
   # KEDA autoscaling configuration based on queue metrics
   keda:
     enabled: false
@@ -1943,6 +2025,10 @@ vllm:
   extraArgs: []
   # Extra environment variables, e.g. [{name: VLLM_LOGGING_LEVEL, value: DEBUG}]
   extraEnv: []
+  # Extra volumes / mounts for the vLLM pod only. A non-empty list REPLACES the
+  # chart-wide extraVolumes/extraVolumeMounts (they are not merged).
+  extraVolumes: []
+  extraVolumeMounts: []
   ports:
     http: 8000
   service:

--- a/HelmChart/README.md
+++ b/HelmChart/README.md
@@ -21,6 +21,7 @@ not stop the others, so one run tells you everything that is broken.
 | ------------------- | --------------- | ------------------------------------------------------------------------------------ |
 | `lint`              | no              | `helm lint` over the `oneuptime` and `kubernetes-agent` charts                        |
 | `unit`              | no              | the helm-unittest suites in [`Public/oneuptime/tests`](Public/oneuptime/tests)        |
+| `extra-values`      | no              | `extraEnv`/`extraVolumes`/`extraVolumeMounts` reach every workload the chart renders, and no more |
 | `secrets-lifecycle` | yes             | installs and upgrades the chart for real, to cover Secret handling across an upgrade  |
 | `keda-bootstrap`    | yes             | the KEDA CRD bootstrap and the `keda.install` / `keda.enabled` split, against a real API server |
 

--- a/HelmChart/Tests/run.sh
+++ b/HelmChart/Tests/run.sh
@@ -20,7 +20,7 @@ SUITES_DIR="${TESTS_DIR}/suites"
 
 # Ordered cheapest-first. Every file in ./suites has to appear here, which is
 # checked below: a new suite cannot be added and then silently never run.
-ALL_SUITES=(lint unit secrets-lifecycle keda-bootstrap)
+ALL_SUITES=(lint unit extra-values secrets-lifecycle keda-bootstrap)
 
 usage() {
     echo "usage: $(basename "${BASH_SOURCE[0]}") [suite ...]"

--- a/HelmChart/Tests/suites/extra-values.sh
+++ b/HelmChart/Tests/suites/extra-values.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+#
+# Cluster-free coverage for extraEnv / extraVolumes / extraVolumeMounts -- the
+# escape hatch that lets an operator hand every OneUptime workload an internal
+# CA bundle (or anything else the chart cannot enumerate) without forking it.
+# https://github.com/OneUptime/oneuptime/issues/3423
+#
+# The helm-unittest suites already assert the wiring template by template. This
+# suite exists for the thing they structurally cannot check: that no workload
+# was MISSED. helm-unittest asserts only on the templates a test names, so a
+# service added later -- or an existing one whose include is dropped in a
+# refactor -- fails nothing there. Here the whole chart is rendered with every
+# workload switched on, and every Deployment/StatefulSet/Job/CronJob/DaemonSet
+# that comes out of the chart's OWN templates has to either carry the extras or
+# be named in SKIP_WORKLOADS below with a reason. A new workload is in neither
+# list, so it fails until someone decides which it is.
+#
+# It renders twice, because which workloads exist depends on the database
+# backend: the standalone StatefulSets and the operator-managed pair (CNPG +
+# Altinity, which is what brings the ClickHouse Keeper into the render).
+#
+# Everything here is `helm template`: no cluster, no images, no API server.
+
+# shellcheck source=../lib/harness.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/harness.sh"
+
+harness_install_helm
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Workloads that deliberately do NOT take the extras, matched on metadata.name.
+#
+#   the standalone database StatefulSets -- postgresql, redis, clickhouse and
+#   the ClickHouse Keeper are servers, not clients: NODE_EXTRA_CA_CERTS means
+#   nothing to them, and their TLS and tuning surfaces are already first-class
+#   values. They also have operator-managed twins (CloudNativePG, Altinity)
+#   whose pods are shaped by a CR rather than by these templates, so an extraEnv
+#   here would reach only whichever half of an install happened to be
+#   standalone -- a knob that works half the time is worse than no knob.
+#
+#   the cleanup CronJobs run bitnami/kubectl against the in-cluster API server,
+#   which is trusted through the ServiceAccount CA the kubelet projects. There
+#   is no external endpoint for an operator's CA to apply to.
+SKIP_WORKLOADS=(
+    oneuptime-postgresql
+    oneuptime-redis
+    oneuptime-clickhouse-shard0
+    oneuptime-clickhouse-keeper
+    cleanup-crashloopbackoff-pods
+    cleanup-completed-pods
+)
+
+# Every workload the chart runs, switched on at once.
+cat >"${WORK_DIR}/all-on.yaml" <<'YAML'
+worker:
+  enabled: true
+home:
+  enabled: true
+telemetryWriter:
+  enabled: true
+testServer:
+  enabled: true
+pgbouncer:
+  enabled: true
+vllm:
+  enabled: true
+cronJobs:
+  cleanup:
+    enabled: true
+  e2e:
+    enabled: true
+YAML
+
+# The operator-managed database backend, which renders a different set of
+# workloads (no standalone Postgres/ClickHouse StatefulSet; a Keeper instead).
+cat >"${WORK_DIR}/operators.yaml" <<'YAML'
+postgresql:
+  enabled: false
+postgresOperator:
+  cnpg:
+    enabled: true
+clickhouse:
+  enabled: false
+clickhouseOperator:
+  altinity:
+    enabled: true
+YAML
+
+cat >"${WORK_DIR}/extras.yaml" <<'YAML'
+extraEnv:
+  - name: NODE_EXTRA_CA_CERTS
+    value: /etc/ssl/internal/ca.crt
+extraVolumes:
+  - name: internal-ca
+    configMap:
+      name: internal-ca-bundle
+extraVolumeMounts:
+  - name: internal-ca
+    mountPath: /etc/ssl/internal
+    readOnly: true
+YAML
+
+render() {
+    # render <output-file> [extra -f arguments...]
+    local out="$1"
+    shift
+    if ! helm template oneuptime "$HELM_CHART_DIR" -f "${WORK_DIR}/all-on.yaml" "$@" >"$out" 2>"${out}.err"; then
+        fail "helm template failed for $(basename "$out")"
+        sed 's/^/        /' "${out}.err"
+        harness_report
+        exit 1
+    fi
+}
+
+# Splits a rendered manifest into one file per workload under <dir>, named
+# "<kind>@<metadata.name>". Subchart output is dropped: helm stamps every
+# document with a "# Source:" line, and only "oneuptime/templates/..." is this
+# chart's own -- cloudnative-pg and the Altinity operator ship their own values
+# for this and are not ours to wire.
+split_workloads() {
+    # split_workloads <manifest> <dir>
+    mkdir -p "$2"
+    awk -v dir="$2" '
+        /^---[[:space:]]*$/ { flush(); next }
+        { doc = doc $0 "\n" }
+        END { flush() }
+        function flush(   kind, name, own, n, i, lines, line) {
+            if (doc == "") { return }
+            kind = ""; name = ""; own = 0
+            n = split(doc, lines, "\n")
+            for (i = 1; i <= n; i++) {
+                line = lines[i]
+                if (line ~ /^# Source: oneuptime\/templates\//) { own = 1 }
+                else if (kind == "" && line ~ /^kind:[[:space:]]/) {
+                    sub(/^kind:[[:space:]]*/, "", line); kind = line
+                }
+                # metadata.name is the first two-space-indented "name:";
+                # containers, ports and volumes all sit deeper than that.
+                else if (name == "" && line ~ /^  name:[[:space:]]/) {
+                    sub(/^  name:[[:space:]]*/, "", line); name = line
+                }
+            }
+            if (own && name != "" && (kind == "Deployment" || kind == "StatefulSet" || \
+                    kind == "Job" || kind == "CronJob" || kind == "DaemonSet")) {
+                gsub(/["\047]/, "", name)
+                print doc > (dir "/" kind "@" name)
+                close(dir "/" kind "@" name)
+            }
+            doc = ""
+        }
+    ' "$1"
+}
+
+# The pod-level volume names in a rendered workload, one per line.
+pod_volume_names() {
+    # pod_volume_names <workload-file>
+    awk '
+        /^[[:space:]]*volumes:[[:space:]]*$/ { inblock = 1; indent = match($0, /[^ ]/); next }
+        inblock && /^[[:space:]]*-[[:space:]]*name:/ { sub(/^[^:]*:[[:space:]]*/, ""); print; next }
+        inblock && /^[[:space:]]*[a-zA-Z]/ { if (match($0, /[^ ]/) <= indent) { inblock = 0 } }
+    ' "$1"
+}
+
+# The volume names every container mounts, deduplicated.
+mounted_volume_names() {
+    # mounted_volume_names <workload-file>
+    awk '
+        /^[[:space:]]*volumeMounts:[[:space:]]*$/ { inblock = 1; indent = match($0, /[^ ]/); next }
+        inblock && /^[[:space:]]*-[[:space:]]*name:/ { sub(/^[^:]*:[[:space:]]*/, ""); print; next }
+        inblock && /^[[:space:]]*[a-zA-Z]/ { if (match($0, /[^ ]/) <= indent) { inblock = 0 } }
+    ' "$1" | sort -u
+}
+
+# A StatefulSet may mount a volumeClaimTemplate, which is not a pod volume.
+claim_template_names() {
+    # claim_template_names <workload-file>
+    awk '
+        /^[[:space:]]*volumeClaimTemplates:[[:space:]]*$/ { inblock = 1; next }
+        inblock && /^[[:space:]]*name:/ { sub(/^[^:]*:[[:space:]]*/, ""); print }
+    ' "$1" | sort -u
+}
+
+is_skipped() {
+    local name="$1" skip
+    for skip in "${SKIP_WORKLOADS[@]}"; do
+        [ "$skip" = "$name" ] && return 0
+    done
+    return 1
+}
+
+# Chart-generated secrets and the optional timestamp label are random per
+# render; everything else has to match byte for byte.
+normalise() {
+    sed -E 's/^( *[a-zA-Z-]+): "[A-Za-z0-9]{32}"$/\1: "<random>"/; s/date: "[0-9]+"/date: "<ts>"/' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Unset is a no-op. This is what makes the upgrade that ships this feature a
+#    no-diff upgrade for every install that does not want it.
+# ---------------------------------------------------------------------------
+render "${WORK_DIR}/plain.yaml"
+cat >"${WORK_DIR}/empty-extras.yaml" <<'YAML'
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+app:
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+YAML
+render "${WORK_DIR}/empty.yaml" -f "${WORK_DIR}/empty-extras.yaml"
+
+if diff -q <(normalise "${WORK_DIR}/plain.yaml") <(normalise "${WORK_DIR}/empty.yaml") >/dev/null; then
+    pass "empty extraEnv/extraVolumes/extraVolumeMounts render exactly as if unset"
+else
+    fail "declaring the extras empty changed the render"
+    diff <(normalise "${WORK_DIR}/plain.yaml") <(normalise "${WORK_DIR}/empty.yaml") | head -40 | sed 's/^/        /'
+fi
+
+split_workloads "${WORK_DIR}/plain.yaml" "${WORK_DIR}/plain.d"
+plain_count="$(find "${WORK_DIR}/plain.d" -type f | wc -l | tr -d ' ')"
+if [ "$plain_count" -gt 0 ]; then
+    pass "rendered ${plain_count} of the chart's own workloads to check"
+else
+    fail "rendered no workloads -- the values file or the splitter is wrong"
+    harness_report
+    exit 1
+fi
+
+# An empty `volumes:` key is not the same as no key, and would show up as a
+# change in `helm diff` for every existing install.
+stray=""
+for file in "${WORK_DIR}"/plain.d/*; do
+    grep -qE '^[[:space:]]*volumes:' "$file" || continue
+    if [ -z "$(pod_volume_names "$file")" ]; then
+        stray="${stray} $(basename "$file")"
+    fi
+done
+assert_eq "no workload is left with a volumes: key holding nothing" "" "$stray"
+
+# ---------------------------------------------------------------------------
+# 2. One chart-wide setting reaches every workload -- in both database layouts.
+# ---------------------------------------------------------------------------
+check_render() {
+    # check_render <label> <split-dir>
+    local label="$1" dir="$2"
+    local missing_env="" missing_volume="" missing_mount="" skipped_but_wired="" seen=0
+    local file entry name
+
+    for file in "${dir}"/*; do
+        entry="$(basename "$file")"
+        name="${entry#*@}"
+        seen=$((seen + 1))
+
+        if is_skipped "$name"; then
+            if grep -qF 'NODE_EXTRA_CA_CERTS' "$file"; then
+                skipped_but_wired="${skipped_but_wired} ${name}"
+            fi
+            continue
+        fi
+
+        grep -qF 'NODE_EXTRA_CA_CERTS' "$file" || missing_env="${missing_env} ${name}"
+        grep -qF 'name: internal-ca-bundle' "$file" || missing_volume="${missing_volume} ${name}"
+        grep -qF 'mountPath: /etc/ssl/internal' "$file" || missing_mount="${missing_mount} ${name}"
+    done
+
+    assert_eq "[${label}] every workload got the chart-wide extraEnv" "" "$missing_env"
+    assert_eq "[${label}] every workload got the chart-wide extraVolumes" "" "$missing_volume"
+    assert_eq "[${label}] every workload got the chart-wide extraVolumeMounts" "" "$missing_mount"
+    # A skipped workload that starts carrying the extras means SKIP_WORKLOADS is
+    # stale, and is quietly under-reporting coverage.
+    assert_eq "[${label}] SKIP_WORKLOADS holds no workload that is in fact wired up" "" "$skipped_but_wired"
+    echo "  (${label}: checked ${seen} workloads)"
+}
+
+# The API server rejects a pod that mounts a volume it never declares, or that
+# declares two volumes under one name -- the failure mode a merging (rather than
+# overriding) precedence would have introduced.
+check_manifest_validity() {
+    # check_manifest_validity <label> <split-dir>
+    local label="$1" dir="$2"
+    local bad_ref="" dup_name="" file name volumes mounts claims declared mount dups
+
+    for file in "${dir}"/*; do
+        name="$(basename "$file")"
+        name="${name#*@}"
+
+        volumes="$(pod_volume_names "$file" | sort)"
+        mounts="$(mounted_volume_names "$file")"
+        claims="$(claim_template_names "$file")"
+
+        declared="$(printf '%s\n%s\n' "$volumes" "$claims" | sed '/^$/d' | sort -u)"
+        while read -r mount; do
+            [ -z "$mount" ] && continue
+            grep -qxF -- "$mount" <<<"$declared" || bad_ref="${bad_ref} ${name}:${mount}"
+        done <<<"$mounts"
+
+        dups="$(sed '/^$/d' <<<"$volumes" | uniq -d)"
+        if [ -n "$dups" ]; then
+            dup_name="${dup_name} ${name}:$(tr '\n' ',' <<<"$dups")"
+        fi
+    done
+
+    assert_eq "[${label}] no container mounts a volume its pod never declares" "" "$bad_ref"
+    assert_eq "[${label}] no pod declares two volumes with the same name" "" "$dup_name"
+}
+
+render "${WORK_DIR}/standalone.yaml" -f "${WORK_DIR}/extras.yaml"
+split_workloads "${WORK_DIR}/standalone.yaml" "${WORK_DIR}/standalone.d"
+check_render "standalone db" "${WORK_DIR}/standalone.d"
+check_manifest_validity "standalone db" "${WORK_DIR}/standalone.d"
+
+render "${WORK_DIR}/operator.yaml" -f "${WORK_DIR}/operators.yaml" -f "${WORK_DIR}/extras.yaml"
+split_workloads "${WORK_DIR}/operator.yaml" "${WORK_DIR}/operator.d"
+check_render "operator db" "${WORK_DIR}/operator.d"
+check_manifest_validity "operator db" "${WORK_DIR}/operator.d"
+
+# An entry in SKIP_WORKLOADS that neither layout renders is dead weight, and
+# hides a workload that was renamed out from under it.
+gone=""
+for skip in "${SKIP_WORKLOADS[@]}"; do
+    if ! find "${WORK_DIR}/standalone.d" "${WORK_DIR}/operator.d" -name "*@${skip}" 2>/dev/null | grep -q .; then
+        gone="${gone} ${skip}"
+    fi
+done
+assert_eq "SKIP_WORKLOADS holds no workload the chart no longer renders" "" "$gone"
+
+# ---------------------------------------------------------------------------
+# 3. A per-service list overrides the chart-wide one rather than merging with
+#    it -- across a whole render, not just the one template a unit test names.
+# ---------------------------------------------------------------------------
+cat >"${WORK_DIR}/override.yaml" <<'YAML'
+app:
+  extraEnv:
+    - name: NODE_EXTRA_CA_CERTS
+      value: /etc/ssl/app-only/ca.crt
+  extraVolumes:
+    - name: app-ca
+      configMap:
+        name: app-ca-bundle
+  extraVolumeMounts:
+    - name: app-ca
+      mountPath: /etc/ssl/app-only
+      readOnly: true
+YAML
+render "${WORK_DIR}/override-render.yaml" -f "${WORK_DIR}/extras.yaml" -f "${WORK_DIR}/override.yaml"
+split_workloads "${WORK_DIR}/override-render.yaml" "${WORK_DIR}/override.d"
+
+app_doc="${WORK_DIR}/override.d/Deployment@oneuptime-app"
+if [ -f "$app_doc" ]; then
+    assert_present "app took its own CA path" "$(cat "$app_doc")" "/etc/ssl/app-only/ca.crt"
+    assert_absent "app did not also keep the chart-wide one" "$(cat "$app_doc")" "/etc/ssl/internal/ca.crt"
+    assert_absent "app did not also keep the chart-wide volume" "$(cat "$app_doc")" "name: internal-ca-bundle"
+else
+    fail "app Deployment did not render"
+fi
+
+worker_doc="${WORK_DIR}/override.d/Deployment@oneuptime-worker"
+if [ -f "$worker_doc" ]; then
+    assert_present "worker still has the chart-wide CA path" "$(cat "$worker_doc")" "/etc/ssl/internal/ca.crt"
+    assert_absent "worker did not pick up app's override" "$(cat "$worker_doc")" "/etc/ssl/app-only/ca.crt"
+else
+    fail "worker Deployment did not render"
+fi
+
+check_manifest_validity "per-service override" "${WORK_DIR}/override.d"
+
+# ---------------------------------------------------------------------------
+# 4. pgbouncer hashes its whole values block into a pod annotation to roll the
+#    pooler when pgbouncer.ini changes. The three new keys are pod-spec inputs,
+#    not ini inputs, so they are omitted from that hash -- otherwise every
+#    install would have rolled its pooler on the upgrade that merely introduced
+#    the keys. Setting one still rolls the pod, through the pod template itself.
+# ---------------------------------------------------------------------------
+PGBOUNCER_DOC="Deployment@oneuptime-pgbouncer"
+
+pgbouncer_checksum() {
+    # pgbouncer_checksum <split-dir>
+    local doc="$1/${PGBOUNCER_DOC}"
+    [ -f "$doc" ] || return 0
+    awk '/checksum\/config:/ { print $2; exit }' "$doc"
+}
+
+cat >"${WORK_DIR}/pgb-extras.yaml" <<'YAML'
+pgbouncer:
+  extraEnv:
+    - name: PGB_EXTRA
+      value: "1"
+  extraVolumes:
+    - name: pgb-scratch
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: pgb-scratch
+      mountPath: /scratch
+YAML
+render "${WORK_DIR}/pgb-extras-render.yaml" -f "${WORK_DIR}/pgb-extras.yaml"
+split_workloads "${WORK_DIR}/pgb-extras-render.yaml" "${WORK_DIR}/pgb-extras.d"
+
+cat >"${WORK_DIR}/pgb-ini.yaml" <<'YAML'
+pgbouncer:
+  poolMode: session
+YAML
+render "${WORK_DIR}/pgb-ini-render.yaml" -f "${WORK_DIR}/pgb-ini.yaml"
+split_workloads "${WORK_DIR}/pgb-ini-render.yaml" "${WORK_DIR}/pgb-ini.d"
+
+base_sum="$(pgbouncer_checksum "${WORK_DIR}/plain.d")"
+extras_sum="$(pgbouncer_checksum "${WORK_DIR}/pgb-extras.d")"
+ini_sum="$(pgbouncer_checksum "${WORK_DIR}/pgb-ini.d")"
+
+if [ -z "$base_sum" ]; then
+    fail "could not read pgbouncer's checksum/config -- the annotation moved or the pooler did not render"
+else
+    assert_eq "pgbouncer's config checksum ignores the extra* keys" "$base_sum" "$extras_sum"
+    if [ "$base_sum" != "$ini_sum" ]; then
+        pass "pgbouncer's config checksum still tracks a real pgbouncer.ini input"
+    else
+        fail "pgbouncer's config checksum no longer changes when pgbouncer.ini does (poolMode)"
+    fi
+fi
+
+# The pod still rolls when the extras change -- through the pod template, which
+# is what actually carries them.
+if diff -q "${WORK_DIR}/plain.d/${PGBOUNCER_DOC}" "${WORK_DIR}/pgb-extras.d/${PGBOUNCER_DOC}" >/dev/null; then
+    fail "setting pgbouncer's extras changed nothing in its Deployment"
+else
+    pass "setting pgbouncer's extras still changes its pod template (so the pods roll)"
+fi
+
+harness_report


### PR DESCRIPTION
Closes #3423.

## The gap

`extraEnv` existed on `vllm` and nowhere else; `extraVolumes` / `extraVolumeMounts` existed nowhere at all. And `values.schema.json` carries `additionalProperties: false` on every service object *and* at the root, so an operator could not even set an unknown key and have it ignored. The reporter's workarounds are accurate: `kubectl patch` is reverted by the next `helm upgrade`, and everything else means a fork or a post-renderer.

The case that surfaced it is an internal CA. OneUptime's services are Node, so a private root needs a PEM mounted and `NODE_EXTRA_CA_CERTS` pointing at it — and there was no place to say either. The same hole blocks a mounted keytab, a vendor agent's config, an OIDC provider with a private issuer, `NODE_OPTIONS` tuning, and a registry the image pull secret doesn't cover.

## What this adds

All three keys, chart-wide and per-service, on **app, worker, every probe, runner, home, telemetry-writer, nginx, pgbouncer, test-server, the migrate Job, the e2e cron, and vLLM** (which keeps its existing `extraEnv`, now falling back to the chart-wide list when unset). Lists are passed to the pod spec verbatim, so `valueFrom`, projected sources, `subPath` and the rest all work.

```yaml
extraVolumes:
  - name: internal-ca
    configMap:
      name: internal-ca-bundle
extraVolumeMounts:
  - name: internal-ca
    mountPath: /etc/ssl/internal
    readOnly: true
extraEnv:
  - name: NODE_EXTRA_CA_CERTS
    value: /etc/ssl/internal/ca.crt
```

The issue asks for per-service keys only. I added the chart-wide tier on top because the CA case needs one setting, not twelve — and a service you forget is a partial TLS failure that shows up at runtime, not at install time. The **migrate Job** is the one that matters most: it opens TLS to Postgres and ClickHouse before any app pod does, so a CA it can't see fails the install rather than degrading it.

## Precedence

A service's list **replaces** the chart-wide one; they are not merged. That's the precedence the chart already uses for `hostAliases`, `nodeSelector` and the security contexts. For volumes it's also the only safe rule — concatenating emits two volumes under one name the moment someone narrows a chart-wide volume for a single service, and the API server rejects that pod outright.

The cost: `[]` inherits rather than clears, so a service can't opt out of a chart-wide entry. That's documented, and it's the behaviour `hostAliases` already has.

## No-op by default — verified byte-for-byte

With every workload enabled, `helm template` against this branch and against `master` produce **identical** output once the randomly generated secrets are normalised. Services that already mount things (probe's `synthetic-runtime-tmp`, nginx's five, pgbouncer's `config`/`tmp`/`server-tls`, vLLM's `shm`) append; the rest emit the `volumes:` / `volumeMounts:` key only when there's something to put in it, so nobody picks up an empty key they didn't have.

**One change was needed for that to actually hold.** `pgbouncer` hashes `toYaml .Values.pgbouncer` into a pod annotation to roll the pooler when `pgbouncer.ini` changes — so declaring three empty keys under `pgbouncer:` would have moved that hash and rolled every install's pooler on this upgrade, for nothing. The three are now omitted from that hash: they're pod-spec inputs, not ini inputs, and setting one already rolls the pod through the pod template itself. There's a test for both halves of that.

## Deliberately not wired

Listing these so they don't read as oversights:

- **The standalone `postgresql` / `redis` / `clickhouse` StatefulSets and the ClickHouse Keeper.** Servers, not clients — `NODE_EXTRA_CA_CERTS` means nothing to them, their TLS and tuning surfaces are already first-class values, and each has an operator-managed twin (CloudNativePG, Altinity) whose pods come from a CR rather than these templates. The knob would work for whichever half of an install happened to be standalone.
- **The `cronJobs.cleanup` jobs.** `bitnami/kubectl` against the in-cluster API server, trusted through the projected ServiceAccount CA.
- **Two init containers:** migrate's `wait-for-postgres` (a raw `/dev/tcp` dial, no TLS handshake) and nginx's `sysctl-tuning` (no network, no mounts).

Happy to wire any of these if you'd rather have the symmetry.

## Tests

**43 new helm-unittest cases** across two suites (171 total, up from 128): the no-op default per workload, the chart-wide list reaching each workload, append-not-clobber for the four that already mount things, per-service-beats-chart-wide, empty-list inheritance, `valueFrom`/secret/hostPath/projected shapes, and ordering.

**A new cluster-free `extra-values` suite** covers what helm-unittest structurally cannot: that no workload was *missed*. helm-unittest only asserts on templates a test names, so a service added later fails nothing there. This one renders the whole chart twice — standalone and operator-managed databases — and requires every `Deployment`/`StatefulSet`/`Job`/`CronJob` from the chart's own templates to either carry the extras or be named in `SKIP_WORKLOADS` with a reason. **A new workload is in neither list, so it fails until someone decides which it is.** It also fails on a stale skip entry in either direction, on a mount referencing a volume its pod never declares, and on duplicate volume names. It's registered in `ALL_SUITES`, so the existing `helm-test` CI job picks it up with no workflow change.

**The tests were checked for vacuity rather than assumed.** 17 mutations — dropped includes on eight workloads, a clobbered probe volume, an unconditional `volumes:` key, `concat` instead of override, `default`'s arguments swapped so the chart-wide list silently always wins, and the pgbouncer hash left un-narrowed — were each caught by at least one suite. That last pair matter: swapping `default`'s arguments leaves every no-op and every chart-wide assertion passing, and is caught only by the precedence cases. Writing the mutation harness also caught a check of my own that was vacuous (a `grep` that matched every pod through its env list); it's fixed and now uses the real parse.

```console
bash HelmChart/Tests/run.sh lint unit extra-values
  PASS   lint                 2 passed
  PASS   unit                 1 passed
  PASS   extra-values         26 passed
```

## Docs

New **Extra environment variables and volumes** section in `docs/configuration.md` with the CA-bundle worked example, the precedence rule and its `[]` caveat, and two things that would otherwise bite:

- `extraEnv` is appended after the chart's own variables, so a repeated name wins — which means `DISABLE_QUEUE_WORKERS` set chart-wide would silently change what the `worker` and `telemetryWriter` tiers *do*.
- `NODE_EXTRA_CA_CERTS` does **not** reach the Chromium that probes drive for synthetic browser monitors; Chromium reads the OS trust store, so that case needs the cert baked into the image.

No upgrade note: the change is additive and the render is unchanged, so there's nothing an existing install has to do.
