### PR TITLE
fix: harden Slack request verification

### DIFF
--- a/Common/Server/API/SlackAPI.ts
+++ b/Common/Server/API/SlackAPI.ts
@@ -592,7 +592,6 @@ export default class SlackAPI {
           "Slack Interactive Auth Result: ",
           getLogAttributesFromRequest(req as any),
         );
-        logger.debug(authResult, getLogAttributesFromRequest(req as any));
 
         // if slack uninstall app then,
         if (authResult.payloadType === "app_uninstall") {
@@ -886,7 +885,6 @@ export default class SlackAPI {
           "Slack Events API Request received",
           getLogAttributesFromRequest(req as any),
         );
-        logger.debug(req.body, getLogAttributesFromRequest(req as any));
 
         const payload: JSONObject = req.body;
 

--- a/Common/Server/Middleware/SlackAuthorization.ts
+++ b/Common/Server/Middleware/SlackAuthorization.ts
@@ -1,10 +1,13 @@
 import {
   ExpressResponse,
+  headerValueToString,
   NextFunction,
   OneUptimeRequest,
 } from "../Utils/Express";
+import GlobalCache from "../Infrastructure/GlobalCache";
 import Response from "../Utils/Response";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ServiceUnavailableException from "../../Types/Exception/ServiceUnavailableException";
 import { SlackAppSigningSecret } from "../EnvironmentConfig";
 import crypto from "crypto";
 import logger, { getLogAttributesFromRequest } from "../Utils/Logger";
@@ -21,6 +24,9 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
  */
 const SIGNATURE_PREFIX: string = "v0=";
 const HEX_DIGEST_REGEX: RegExp = /^[a-f0-9]{64}$/i;
+const UNIX_TIMESTAMP_REGEX: RegExp = /^\d+$/;
+const MAX_REQUEST_AGE_IN_SECONDS: number = 5 * 60;
+const REPLAY_CACHE_NAMESPACE: string = "slack-request-replay";
 
 export default class SlackAuthorization {
   @CaptureSpan()
@@ -51,25 +57,41 @@ export default class SlackAuthorization {
     // validate slack signing secret
     const slackSigningSecret: string = SlackAppSigningSecret.toString();
 
-    const slackSignature: string | undefined = req.headers[
-      "x-slack-signature"
-    ] as string | undefined;
-    const timestamp: string = req.headers[
-      "x-slack-request-timestamp"
-    ] as string;
+    const slackSignature: string | undefined = headerValueToString(
+      req.headers["x-slack-signature"],
+    );
+    const timestamp: string =
+      headerValueToString(req.headers["x-slack-request-timestamp"]) || "";
     // Use rawBody for both JSON and URL-encoded requests, fallback to rawFormUrlEncodedBody for backward compatibility
     const requestBody: string =
       (req as OneUptimeRequest).rawBody ||
       (req as OneUptimeRequest).rawFormUrlEncodedBody ||
       "";
 
-    logger.debug(
-      `slackSignature: ${slackSignature}`,
-      getLogAttributesFromRequest(req),
-    );
-    logger.debug(`timestamp: ${timestamp}`, getLogAttributesFromRequest(req));
-    logger.debug(`requestBody: `, getLogAttributesFromRequest(req));
-    logger.debug(requestBody, getLogAttributesFromRequest(req));
+    /*
+     * Slack signs the timestamp specifically so a captured request cannot be
+     * replayed indefinitely. Verify the documented five-minute freshness
+     * window before doing any signature work. The strict decimal check keeps
+     * Number parsing from accepting partial values such as "123abc".
+     */
+    const timestampInSeconds: number = Number(timestamp);
+    const nowInSeconds: number = Math.floor(Date.now() / 1000);
+
+    if (
+      !UNIX_TIMESTAMP_REGEX.test(timestamp) ||
+      !Number.isSafeInteger(timestampInSeconds) ||
+      Math.abs(nowInSeconds - timestampInSeconds) > MAX_REQUEST_AGE_IN_SECONDS
+    ) {
+      logger.error(
+        "Slack request has a missing, malformed, or stale X-Slack-Request-Timestamp header.",
+        getLogAttributesFromRequest(req),
+      );
+      return Response.sendErrorResponse(
+        req,
+        res,
+        new BadDataException("Slack Signature Verification Failed."),
+      );
+    }
 
     const providedDigest: string =
       slackSignature && slackSignature.startsWith(SIGNATURE_PREFIX)
@@ -94,11 +116,6 @@ export default class SlackAuthorization {
       .update(baseString)
       .digest("hex");
 
-    logger.debug(
-      `Generated signature: ${SIGNATURE_PREFIX}${expectedDigest}`,
-      getLogAttributesFromRequest(req),
-    );
-
     /*
      * Both sides are decoded from 64 validated hex characters, so both
      * buffers are 32 bytes and timingSafeEqual cannot throw here.
@@ -118,6 +135,67 @@ export default class SlackAuthorization {
         res,
         new BadDataException("Slack Signature Verification Failed."),
       );
+    }
+
+    /*
+     * URL verification and options loading have no side effects and need their
+     * normal response on every valid delivery. All other signed Slack routes
+     * are processed at most once.
+     */
+    const isNaturallyIdempotentRequest: boolean =
+      req.route?.path === "/slack/options-load" ||
+      req.body?.["type"] === "url_verification";
+
+    if (isNaturallyIdempotentRequest) {
+      next();
+      return;
+    }
+
+    /*
+     * Freshness bounds replay to a small window; this atomic cache claim closes
+     * that remaining window across every application replica. The expiry lasts
+     * until this timestamp can no longer pass the freshness check. That can be
+     * almost ten minutes when a sender clock is five minutes ahead.
+     */
+    const replayCacheTtlInSeconds: number = Math.max(
+      timestampInSeconds + MAX_REQUEST_AGE_IN_SECONDS - nowInSeconds + 1,
+      1,
+    );
+
+    let isFirstDelivery: boolean;
+
+    try {
+      isFirstDelivery = await GlobalCache.setStringIfNotExists(
+        REPLAY_CACHE_NAMESPACE,
+        expectedDigest,
+        timestamp,
+        { expiresInSeconds: replayCacheTtlInSeconds },
+      );
+    } catch {
+      /*
+       * Replay protection is part of authentication, so cache failure must
+       * fail closed. Letting the request through would silently restore the
+       * vulnerability whenever Redis is unavailable.
+       */
+      logger.error(
+        "Slack replay protection is unavailable.",
+        getLogAttributesFromRequest(req),
+      );
+      return Response.sendErrorResponse(
+        req,
+        res,
+        new ServiceUnavailableException(
+          "Slack request verification is temporarily unavailable.",
+        ),
+      );
+    }
+
+    if (!isFirstDelivery) {
+      logger.debug(
+        "Duplicate Slack request acknowledged without reprocessing.",
+        getLogAttributesFromRequest(req),
+      );
+      return Response.sendTextResponse(req, res, "");
     }
 
     logger.debug(

--- a/Common/Server/Utils/Workspace/Slack/Actions/Auth.ts
+++ b/Common/Server/Utils/Workspace/Slack/Actions/Auth.ts
@@ -65,17 +65,12 @@ export default class SlackAuthAction {
     const { req } = data;
 
     logger.debug("Starting Slack request authorization");
-    logger.debug(`Request body: `);
-    logger.debug(req.body);
 
     let payload: JSONObject = req.body;
 
     if (payload["payload"] && typeof payload["payload"] === "string") {
       payload = JSON.parse(payload["payload"]);
     }
-
-    logger.debug(`Payload: `);
-    logger.debug(payload);
 
     let slackUserId: string | undefined = (
       (payload as JSONObject)["user"] as JSONObject
@@ -216,11 +211,6 @@ export default class SlackAuthAction {
       };
 
       actions.push(action);
-      logger.debug("View values: ");
-      logger.debug(viewValues);
-
-      logger.debug("Actions: ");
-      logger.debug(actions);
     }
 
     if (payload["callback_id"]) {
@@ -296,8 +286,6 @@ export default class SlackAuthAction {
     logger.debug("Slack request authorized successfully", {
       projectId: projectId.toString(),
     });
-    logger.debug("Slack request: ");
-    logger.debug(slackRequest);
 
     return slackRequest;
   }

--- a/Common/Tests/Server/Middleware/SlackAuthorization.test.ts
+++ b/Common/Tests/Server/Middleware/SlackAuthorization.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test, beforeEach } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 import crypto from "crypto";
+import GlobalCache from "../../../Server/Infrastructure/GlobalCache";
 import SlackAuthorization from "../../../Server/Middleware/SlackAuthorization";
 import Response from "../../../Server/Utils/Response";
 import {
@@ -8,6 +9,7 @@ import {
   OneUptimeRequest,
 } from "../../../Server/Utils/Express";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import ServiceUnavailableException from "../../../Types/Exception/ServiceUnavailableException";
 
 const SIGNING_SECRET: string = "slack-app-signing-secret";
 
@@ -28,6 +30,16 @@ jest.mock("../../../Server/Utils/Response", () => {
     __esModule: true,
     default: {
       sendErrorResponse: jest.fn(),
+      sendTextResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Infrastructure/GlobalCache", () => {
+  return {
+    __esModule: true,
+    default: {
+      setStringIfNotExists: jest.fn(),
     },
   };
 });
@@ -41,11 +53,16 @@ jest.mock("../../../Server/Utils/Response", () => {
  * have to come back as the intended 400.
  */
 describe("SlackAuthorization.isAuthorizedSlackRequest", () => {
-  const TIMESTAMP: string = "1700000000";
+  const NOW_IN_SECONDS: number = 1_800_000_000;
+  const TIMESTAMP: string = NOW_IN_SECONDS.toString();
   const RAW_BODY: string = "token=abc&team_id=T123&command=%2Foneuptime";
 
   const sendErrorResponse: jest.Mock =
     Response.sendErrorResponse as unknown as jest.Mock;
+  const sendTextResponse: jest.Mock =
+    Response.sendTextResponse as unknown as jest.Mock;
+  const setStringIfNotExists: jest.Mock =
+    GlobalCache.setStringIfNotExists as unknown as jest.Mock;
 
   const res: ExpressResponse = {} as ExpressResponse;
   let next: NextFunction;
@@ -62,15 +79,19 @@ describe("SlackAuthorization.isAuthorizedSlackRequest", () => {
   type BuildRequestFunction = (
     signature: string | undefined,
     body?: string,
+    timestamp?: string | null,
   ) => OneUptimeRequest;
 
   const buildRequest: BuildRequestFunction = (
     signature: string | undefined,
     body: string = RAW_BODY,
+    timestamp: string | null = TIMESTAMP,
   ): OneUptimeRequest => {
-    const headers: Record<string, string> = {
-      "x-slack-request-timestamp": TIMESTAMP,
-    };
+    const headers: Record<string, string> = {};
+
+    if (timestamp !== null) {
+      headers["x-slack-request-timestamp"] = timestamp;
+    }
 
     if (signature !== undefined) {
       headers["x-slack-signature"] = signature;
@@ -81,7 +102,13 @@ describe("SlackAuthorization.isAuthorizedSlackRequest", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(NOW_IN_SECONDS * 1000);
+    setStringIfNotExists.mockResolvedValue(true);
     next = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test("calls next when the signature matches the timestamp and body", async () => {
@@ -91,6 +118,12 @@ describe("SlackAuthorization.isAuthorizedSlackRequest", () => {
 
     expect(next).toHaveBeenCalled();
     expect(sendErrorResponse).not.toHaveBeenCalled();
+    expect(setStringIfNotExists).toHaveBeenCalledWith(
+      "slack-request-replay",
+      sign(TIMESTAMP, RAW_BODY).slice("v0=".length),
+      TIMESTAMP,
+      { expiresInSeconds: 5 * 60 + 1 },
+    );
   });
 
   test("rejects a well-formed signature computed over a different body", async () => {
@@ -106,6 +139,212 @@ describe("SlackAuthorization.isAuthorizedSlackRequest", () => {
       req,
       res,
       new BadDataException("Slack Signature Verification Failed."),
+    );
+    expect(setStringIfNotExists).not.toHaveBeenCalled();
+  });
+
+  test("accepts a request exactly five minutes old", async () => {
+    const timestamp: string = (NOW_IN_SECONDS - 5 * 60).toString();
+    const req: OneUptimeRequest = buildRequest(
+      sign(timestamp, RAW_BODY),
+      RAW_BODY,
+      timestamp,
+    );
+
+    await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(sendErrorResponse).not.toHaveBeenCalled();
+  });
+
+  test("accepts a request exactly five minutes in the future and covers the full replay window", async () => {
+    const timestamp: string = (NOW_IN_SECONDS + 5 * 60).toString();
+    const req: OneUptimeRequest = buildRequest(
+      sign(timestamp, RAW_BODY),
+      RAW_BODY,
+      timestamp,
+    );
+
+    await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(setStringIfNotExists).toHaveBeenCalledWith(
+      "slack-request-replay",
+      sign(timestamp, RAW_BODY).slice("v0=".length),
+      timestamp,
+      { expiresInSeconds: 10 * 60 + 1 },
+    );
+  });
+
+  test("rejects a correctly signed request older than five minutes", async () => {
+    const timestamp: string = (NOW_IN_SECONDS - 5 * 60 - 1).toString();
+    const req: OneUptimeRequest = buildRequest(
+      sign(timestamp, RAW_BODY),
+      RAW_BODY,
+      timestamp,
+    );
+
+    await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      req,
+      res,
+      new BadDataException("Slack Signature Verification Failed."),
+    );
+    expect(setStringIfNotExists).not.toHaveBeenCalled();
+  });
+
+  test("rejects a correctly signed request more than five minutes in the future", async () => {
+    const timestamp: string = (NOW_IN_SECONDS + 5 * 60 + 1).toString();
+    const req: OneUptimeRequest = buildRequest(
+      sign(timestamp, RAW_BODY),
+      RAW_BODY,
+      timestamp,
+    );
+
+    await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      req,
+      res,
+      new BadDataException("Slack Signature Verification Failed."),
+    );
+  });
+
+  test("acknowledges a duplicate without invoking the Slack handler", async () => {
+    setStringIfNotExists.mockResolvedValue(false);
+    const req: OneUptimeRequest = buildRequest(sign(TIMESTAMP, RAW_BODY));
+
+    await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(sendErrorResponse).not.toHaveBeenCalled();
+    expect(sendTextResponse).toHaveBeenCalledWith(req, res, "");
+  });
+
+  test("uses the canonical digest so signature casing cannot bypass replay detection", async () => {
+    const lowercaseSignature: string = sign(TIMESTAMP, RAW_BODY);
+    const uppercaseSignature: string = `v0=${lowercaseSignature
+      .slice("v0=".length)
+      .toUpperCase()}`;
+    const firstRequest: OneUptimeRequest = buildRequest(lowercaseSignature);
+    const replayRequest: OneUptimeRequest = buildRequest(uppercaseSignature);
+
+    setStringIfNotExists
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await SlackAuthorization.isAuthorizedSlackRequest(firstRequest, res, next);
+    await SlackAuthorization.isAuthorizedSlackRequest(replayRequest, res, next);
+
+    const canonicalDigest: string = lowercaseSignature.slice("v0=".length);
+    expect(setStringIfNotExists).toHaveBeenNthCalledWith(
+      1,
+      "slack-request-replay",
+      canonicalDigest,
+      TIMESTAMP,
+      { expiresInSeconds: 5 * 60 + 1 },
+    );
+    expect(setStringIfNotExists).toHaveBeenNthCalledWith(
+      2,
+      "slack-request-replay",
+      canonicalDigest,
+      TIMESTAMP,
+      { expiresInSeconds: 5 * 60 + 1 },
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(sendTextResponse).toHaveBeenCalledWith(replayRequest, res, "");
+  });
+
+  test("allows repeated URL verification requests to reach their idempotent handler", async () => {
+    const signature: string = sign(TIMESTAMP, RAW_BODY);
+    const firstRequest: OneUptimeRequest = buildRequest(signature);
+    const secondRequest: OneUptimeRequest = buildRequest(signature);
+
+    Object.assign(firstRequest, {
+      route: { path: "/slack/events" },
+      body: { type: "url_verification" },
+    });
+    Object.assign(secondRequest, {
+      route: { path: "/slack/events" },
+      body: { type: "url_verification" },
+    });
+
+    await SlackAuthorization.isAuthorizedSlackRequest(firstRequest, res, next);
+    await SlackAuthorization.isAuthorizedSlackRequest(secondRequest, res, next);
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(setStringIfNotExists).not.toHaveBeenCalled();
+  });
+
+  test("allows repeated options loads to reach their idempotent handler", async () => {
+    const signature: string = sign(TIMESTAMP, RAW_BODY);
+    const firstRequest: OneUptimeRequest = buildRequest(signature);
+    const secondRequest: OneUptimeRequest = buildRequest(signature);
+
+    Object.assign(firstRequest, {
+      route: { path: "/slack/options-load" },
+    });
+    Object.assign(secondRequest, {
+      route: { path: "/slack/options-load" },
+    });
+
+    await SlackAuthorization.isAuthorizedSlackRequest(firstRequest, res, next);
+    await SlackAuthorization.isAuthorizedSlackRequest(secondRequest, res, next);
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(setStringIfNotExists).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when distributed replay protection is unavailable", async () => {
+    setStringIfNotExists.mockRejectedValue(new Error("cache unavailable"));
+    const req: OneUptimeRequest = buildRequest(sign(TIMESTAMP, RAW_BODY));
+
+    await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      req,
+      res,
+      new ServiceUnavailableException(
+        "Slack request verification is temporarily unavailable.",
+      ),
+    );
+  });
+
+  const malformedTimestamps: Array<[string, string | null]> = [
+    ["absent", null],
+    ["empty", ""],
+    ["non-numeric", "not-a-timestamp"],
+    ["partially numeric", `${TIMESTAMP}abc`],
+    ["fractional", `${TIMESTAMP}.5`],
+    ["negative", "-1"],
+    ["outside the safe integer range", "999999999999999999999"],
+  ];
+
+  describe("rejects a malformed timestamp", () => {
+    test.each(malformedTimestamps)(
+      "%s",
+      async (_label: string, timestamp: string | null) => {
+        const signedTimestamp: string = timestamp || TIMESTAMP;
+        const req: OneUptimeRequest = buildRequest(
+          sign(signedTimestamp, RAW_BODY),
+          RAW_BODY,
+          timestamp,
+        );
+
+        await SlackAuthorization.isAuthorizedSlackRequest(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(sendErrorResponse).toHaveBeenCalledWith(
+          req,
+          res,
+          new BadDataException("Slack Signature Verification Failed."),
+        );
+        expect(setStringIfNotExists).not.toHaveBeenCalled();
+      },
     );
   });
 
@@ -143,7 +382,25 @@ describe("SlackAuthorization.isAuthorizedSlackRequest", () => {
           res,
           new BadDataException("Slack Signature Verification Failed."),
         );
+        expect(setStringIfNotExists).not.toHaveBeenCalled();
       },
     );
+  });
+
+  test("normalizes an array signature header without throwing", async () => {
+    const req: OneUptimeRequest = buildRequest(undefined);
+    req.headers["x-slack-signature"] = ["not-a-signature"];
+
+    await expect(
+      SlackAuthorization.isAuthorizedSlackRequest(req, res, next),
+    ).resolves.toBeUndefined();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      req,
+      res,
+      new BadDataException("Slack Signature Verification Failed."),
+    );
+    expect(setStringIfNotExists).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- validate signed Slack request timestamps within five minutes
- atomically deduplicate authenticated deliveries across replicas while preserving Slack-compatible acknowledgements
- remove sensitive Slack request and authorization-result logging
- cover malformed headers, freshness boundaries, replay variants, cache outages, and idempotent routes

## Verification

- `npm run fix`
- `cd Common && npm run compile`
- focused Slack authorization tests: 28 passed
- local Docker API hot-reloaded and returned HTTP 200