### PR TITLE
fix(monitor): a second breaching host gets its own alert instead of being silenced

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
@@ -280,10 +280,13 @@ const CriteriaFilterElement: FunctionComponent<ComponentProps> = (
         {criteriaFilter?.checkOn &&
           criteriaFilter?.checkOn === CheckOn.DiskUsagePercent && (
             <div className="mt-1">
-              <FieldLabelElement title="Disk Path" />
+              <FieldLabelElement
+                title="Disk Path"
+                description="The mount point or device to check. Enter * to check every disk the agent reports and raise a separate alert for each one — otherwise a second disk filling up is silenced while the first disk's alert is open."
+              />
 
               <Input
-                placeholder={"C:\\ or /mnt/data or /dev/sda1"}
+                placeholder={"* or C:\\ or /mnt/data or /dev/sda1"}
                 value={criteriaFilter?.serverMonitorOptions?.diskPath?.toString()}
                 onChange={(value: string) => {
                   props.onChange?.({
@@ -359,11 +362,11 @@ const CriteriaFilterElement: FunctionComponent<ComponentProps> = (
             <div className="mt-1">
               <FieldLabelElement
                 title="Interface (Optional)"
-                description="Scope this criteria to one interface, matched by name or alias (e.g. Gi0/1 or 'Uplink to core'). Leave empty to evaluate every monitored interface on the device."
+                description="Scope this criteria to one interface, matched by name or alias (e.g. Gi0/1 or 'Uplink to core'). Leave empty to evaluate every monitored interface as one combined alert, or enter * to evaluate every interface and raise a separate alert for each one."
               />
               <Input
                 value={criteriaFilter?.snmpMonitorOptions?.interfaceName || ""}
-                placeholder="Gi0/1"
+                placeholder="* or Gi0/1"
                 onChange={(value: string) => {
                   props.onChange?.({
                     ...criteriaFilter,

--- a/App/FeatureSet/Docs/Content/en/monitor/metrics-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/metrics-monitor.md
@@ -32,7 +32,7 @@ Define one or more metric queries. Each query includes:
 | Metric Name      | The name of the metric to query                                | Yes      |
 | Aggregation Type | How to aggregate raw metric values (sum, avg, min, max, count) | Yes      |
 | Attributes       | Key-value filters to narrow the metric data                    | No       |
-| Aggregate By     | Dimensions to group the metric by                              | No       |
+| Group By         | Attributes to split the query into one series per unique value | No       |
 
 Each query is assigned an alias (e.g., `a`, `b`, `c`) for use in formulas.
 
@@ -107,6 +107,33 @@ Anomaly conditions stay in a "Learning" state and produce no alerts until at lea
 - **Query**: `request_queue_size`, aggregation: Maximum Value
 - **Condition**: Greater Than
 - **Threshold**: 1000
+
+## Per-Series Alerting (Group By)
+
+**Group By** on a metric query splits that query into one series per unique attribute value — one per host, one per container, one per mountpoint — and a monitor with Group By set evaluates every series independently. That single setting is the difference between "the fleet is unhealthy" and "`prod-db-01` is unhealthy".
+
+### One alert per group
+
+With Group By set to `host.name`, a disk-usage monitor watching fifty hosts raises **one alert (or incident) per breaching host**. Host A filling up opens its own alert; host B filling up ten minutes later opens a second, separate alert alongside it.
+
+Without Group By, the same monitor is a single scalar: the query collapses every host into one number and the monitor raises **one alert for the whole monitor**. While that alert is open, a second host breaching produces nothing — the monitor is already alerting, so there is nothing new to raise, and the on-call engineer never learns about host B. **Setting Group By is how you get per-host alerts.** If you want to be paged per host, per container, or per mountpoint, set it.
+
+### Independent resolution
+
+Each per-group alert tracks its own group. When host A drops back under the threshold its alert resolves on its own, and host B's alert stays open until host B recovers. One group recovering never closes another group's alert.
+
+### Criteria evaluation differs
+
+- **Grouped monitors evaluate every criteria.** Severity bands can therefore fire on different groups at the same time: with "Critical — greater than 95" above "Warning — greater than 80", a host at 96% opens a critical alert while a host at 85% opens a warning alert on the same check. A host that breaches both bands still gets exactly one alert — from the first matching criteria, so **order the criteria most severe first**.
+- **Ungrouped monitors stop at the first matching criteria.** Only that one criteria fires, which is another reason to put the alerting criteria above the healthy one: a broad healthy criteria placed first matches on nearly every check and prevents the alerting criteria below it from ever being evaluated.
+
+### Choosing an attribute to group by
+
+Group by an attribute that genuinely identifies a distinct thing you would page someone about: the host attribute for a fleet-wide host metric, the container or pod attribute for a container metric, the mountpoint or device attribute for a filesystem or disk-I/O metric, the interface attribute for a network metric. The **Group by** dropdown is populated from the attributes your collector actually sends, so pick from the list rather than typing a key by hand.
+
+Do not group a metric that is already a single scalar for the whole system — a cluster-wide leader flag, a scheduler backlog, or a single host's CPU on a single-host monitor. Grouping those produces exactly one series and changes nothing except the alert titles.
+
+The grouping attribute values are also available as [template variables](/docs/monitor/incident-alert-templating) in the alert or incident title, description, and remediation notes — grouping by `host.name` lets the title read `Disk almost full on {{host.name}}`.
 
 ## Setup Requirements
 

--- a/App/FeatureSet/Docs/Content/en/terraform/monitor-steps.md
+++ b/App/FeatureSet/Docs/Content/en/terraform/monitor-steps.md
@@ -73,7 +73,23 @@ resource "oneuptime_monitor" "website" {
     monitor_destination_type = "URL"                 # URL | Hostname | IP
     request_type             = "GET"                 # HTTP method for Website/API monitors
 
-    criteria = [ # evaluated in order; first match wins
+    criteria = [ # evaluated in order; first match wins, so alerting first and healthy last
+      {
+        name                  = "Offline"
+        description           = "Check if website is offline"
+        filter_condition      = "Any"
+        change_monitor_status = true
+        create_incidents      = false
+        create_alerts         = false
+        monitor_status_id     = oneuptime_monitor_status.offline.id
+
+        filters = [
+          {
+            check_on    = "Is Online"
+            filter_type = "False"
+          }
+        ]
+      },
       {
         name                  = "Online"
         description           = "Check if website is online"
@@ -92,22 +108,6 @@ resource "oneuptime_monitor" "website" {
             check_on    = "Response Status Code"
             filter_type = "Equal To"
             value       = "200" # comparison values are strings
-          }
-        ]
-      },
-      {
-        name                  = "Offline"
-        description           = "Check if website is offline"
-        filter_condition      = "Any"
-        change_monitor_status = true
-        create_incidents      = false
-        create_alerts         = false
-        monitor_status_id     = oneuptime_monitor_status.offline.id
-
-        filters = [
-          {
-            check_on    = "Is Online"
-            filter_type = "False"
           }
         ]
       }
@@ -175,7 +175,13 @@ These escape hatches mirror the dashboard's JSON for each monitor type — an es
 
 ## Criteria attributes
 
-Each entry of `criteria` is one rule: *if these filters match, do these things.* Criteria are evaluated in order and the first matching one wins, so put your "healthy" criteria first and your "down" criteria after it.
+Each entry of `criteria` is one rule: *if these filters match, do these things.*
+
+**Order matters, and the order is alerting first.** Criteria are evaluated top to bottom and the first one that matches wins — evaluation stops there, and every criteria below it is never looked at on that check. So list your alerting criteria first, most severe first (critical, then warning), and put the "healthy" / recovery criteria **last**.
+
+Putting a "healthy" criteria first is the most common way to build a monitor that never alerts. A broad healthy rule — `Is Online` is `True`, or a metric value `Greater Than` `0` — matches on almost every check, claims the evaluation, and the "down" criteria underneath it never runs. Ordered the other way round, the down criteria gets its chance first and the healthy criteria only matches when nothing above it did, which is exactly what you want.
+
+**Grouped metric monitors are the one exception to first-match-wins.** When a metric monitor's query is grouped — `groupByAttributeKeys` set inside the escape-hatch JSON, at `metricViewConfig.queryConfigs[].metricQueryData.groupByAttributeKeys` — the monitor raises one alert/incident *per group* (per host, per container, per mountpoint) and every criteria is evaluated, so a "critical" and a "warning" criteria can fire on different hosts on the same check. A host that breaches both still pages once, from the first matching criteria, so most-severe-first still applies. See [Metrics Monitor](/docs/monitor/metrics-monitor).
 
 | Attribute | Type | Meaning |
 |-----------|------|---------|

--- a/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
@@ -417,29 +417,20 @@ const loadNativeUnitsByMetricName: (input: {
 
 /**
  * Collect the union of attribute keys the user asked to group by
- * across every queryConfig on the monitor step. Per-series
- * alerting needs a consistent key set across queries so formula
- * series line up (otherwise `a + b` would split differently for a
- * and b and the per-series formula evaluation wouldn't align).
+ * across every queryConfig on the monitor step.
+ *
+ * Delegates to MonitorStep so that "is this monitor grouped?" has
+ * exactly one answer. The criteria evaluator asks the same question to
+ * decide whether a criteria must fan out per series, and the two
+ * answers disagreeing is what let a grouped monitor quietly open a
+ * single whole-monitor alert that then blocked every other host.
  */
 const collectGroupByAttributeKeys: (
   queryConfigs: Array<MetricQueryConfigData>,
 ) => Array<string> = (
   queryConfigs: Array<MetricQueryConfigData>,
 ): Array<string> => {
-  const keys: Set<string> = new Set<string>();
-  for (const queryConfig of queryConfigs) {
-    const groupKeys: Array<string> | undefined =
-      queryConfig.metricQueryData?.groupByAttributeKeys;
-    if (groupKeys) {
-      for (const key of groupKeys) {
-        if (key) {
-          keys.add(key);
-        }
-      }
-    }
-  }
-  return Array.from(keys);
+  return MonitorStep.getGroupByAttributeKeysFromQueryConfigs(queryConfigs);
 };
 
 /**

--- a/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
@@ -1,5 +1,6 @@
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
+import PerEntityCriteriaFanOut from "../PerEntityCriteriaFanOut";
 import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
 import OneUptimeDate from "../../../../Types/Date";
 import { BasicDiskMetrics } from "../../../../Types/Infrastructure/BasicMetrics";
@@ -211,9 +212,39 @@ export default class ServerMonitorCriteria {
 
       const normalizedDiskPath: string = normalizeDiskPath(diskPath);
 
-      const diskMetric: BasicDiskMetrics | undefined = (
-        input.dataToProcess as ServerMonitorResponse
-      ).basicInfrastructureMetrics?.diskMetrics?.find(
+      const allDiskMetrics: Array<BasicDiskMetrics> =
+        (input.dataToProcess as ServerMonitorResponse)
+          .basicInfrastructureMetrics?.diskMetrics || [];
+
+      /*
+       * "*" means every disk the agent reported. The criteria is met
+       * when ANY of them breaches, mirroring how a grouped metric
+       * monitor's criteria is met when any series breaches. The
+       * per-entity pass then re-runs this filter once per disk to work
+       * out which ones, so each full mount gets its own alert instead
+       * of the first one silencing the rest.
+       */
+      if (PerEntityCriteriaFanOut.isWildcard(diskPath)) {
+        for (const candidateDisk of allDiskMetrics) {
+          const candidateUsage: number =
+            candidateDisk.percentUsed ?? candidateDisk.percentFree ?? 0;
+
+          const candidateResult: string | null =
+            CompareCriteria.compareCriteriaNumbers({
+              value: candidateUsage,
+              threshold: threshold as number,
+              criteriaFilter: input.criteriaFilter,
+            });
+
+          if (candidateResult) {
+            return `Disk ${candidateDisk.diskPath} - ${candidateResult}`;
+          }
+        }
+
+        return null;
+      }
+
+      const diskMetric: BasicDiskMetrics | undefined = allDiskMetrics.find(
         (item: BasicDiskMetrics) => {
           return normalizeDiskPath(item.diskPath) === normalizedDiskPath;
         },

--- a/Common/Server/Utils/Monitor/Criteria/SnmpMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SnmpMonitorCriteria.ts
@@ -1,5 +1,6 @@
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
+import PerEntityCriteriaFanOut from "../PerEntityCriteriaFanOut";
 import {
   AnomalyDetectionSensitivity,
   CheckOn,
@@ -43,7 +44,14 @@ export default class SnmpMonitorCriteria {
       .trim()
       .toLowerCase();
 
-    if (!scope) {
+    /*
+     * Empty has always meant "every interface". "*" means the same
+     * thing, and additionally opts the criteria into raising one alert
+     * per interface — see PerEntityCriteriaFanOut. Scoping treats them
+     * identically; only the fan-out tells them apart, so existing
+     * monitors that leave this blank keep their single combined alert.
+     */
+    if (!scope || PerEntityCriteriaFanOut.isWildcard(scope)) {
       return interfaces;
     }
 

--- a/Common/Server/Utils/Monitor/Criteria/SyntheticMonitor.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SyntheticMonitor.ts
@@ -30,20 +30,38 @@ export default class SyntheticMonitoringCriteria {
 
       // check browser type and screen type.
 
+      /*
+       * A synthetic monitor run produces one response per browser / screen size
+       * combination. Each branch below must only return when it actually found a
+       * match, otherwise the loop has to keep going so the remaining responses
+       * are compared too. Returning the (possibly null) comparison result
+       * directly would mean only the first response is ever evaluated.
+       */
+
       if (CheckOn.ScreenSizeType === input.criteriaFilter.checkOn) {
-        return CompareCriteria.checkEqualToOrNotEqualTo({
-          value: syntheticMonitorResponse.screenSizeType,
-          threshold: threshold as number,
-          criteriaFilter: input.criteriaFilter,
-        });
+        const screenSizeResult: string | null =
+          CompareCriteria.checkEqualToOrNotEqualTo({
+            value: syntheticMonitorResponse.screenSizeType,
+            threshold: threshold as number,
+            criteriaFilter: input.criteriaFilter,
+          });
+
+        if (screenSizeResult) {
+          return screenSizeResult;
+        }
       }
 
       if (CheckOn.BrowserType === input.criteriaFilter.checkOn) {
-        return CompareCriteria.checkEqualToOrNotEqualTo({
-          value: syntheticMonitorResponse.browserType,
-          threshold: threshold as number,
-          criteriaFilter: input.criteriaFilter,
-        });
+        const browserTypeResult: string | null =
+          CompareCriteria.checkEqualToOrNotEqualTo({
+            value: syntheticMonitorResponse.browserType,
+            threshold: threshold as number,
+            criteriaFilter: input.criteriaFilter,
+          });
+
+        if (browserTypeResult) {
+          return browserTypeResult;
+        }
       }
     }
 

--- a/Common/Server/Utils/Monitor/MonitorAlert.ts
+++ b/Common/Server/Utils/Monitor/MonitorAlert.ts
@@ -50,6 +50,20 @@ export default class MonitorAlert {
     evaluationSummary?: MonitorEvaluationSummary | undefined;
     breachingSeriesFingerprints?: Set<string> | undefined;
     /**
+     * The breaching fingerprints of EACH criteria evaluated on this
+     * tick, keyed by criteria id — a criteria that ran and matched
+     * nothing maps to an empty set.
+     *
+     * Without this, "is this series still breaching?" was answered from
+     * the winning criteria's set alone, so a host held critical by
+     * criteria A silently auto-resolved another host's still-valid alert
+     * from criteria B. A criteria absent from this dictionary was not
+     * evaluated at all, and its open alerts are left untouched.
+     */
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
+    /**
      * Event-driven (incoming-request / webhook) mode. When true, an open
      * alert carrying a seriesFingerprint is never auto-resolved here —
      * webhooks resolve per-key only via resolveSeriesAlertsByFingerprint,
@@ -86,6 +100,8 @@ export default class MonitorAlert {
 
     // check if should close the alert.
 
+    const resolvedAlertIds: Set<string> = new Set<string>();
+
     for (const openAlert of openAlerts) {
       const shouldClose: boolean = this.shouldCloseAlert({
         openAlert,
@@ -93,10 +109,14 @@ export default class MonitorAlert {
           input.autoResolveCriteriaInstanceIdAlertIdsDictionary,
         criteriaInstance: input.criteriaInstance,
         breachingSeriesFingerprints: input.breachingSeriesFingerprints,
+        breachingSeriesFingerprintsByCriteriaId:
+          input.breachingSeriesFingerprintsByCriteriaId,
         disableSeriesAbsenceResolution: input.disableSeriesAbsenceResolution,
       });
 
       if (shouldClose) {
+        resolvedAlertIds.add(openAlert.id!.toString());
+
         // then resolve alert.
         await this.resolveOpenAlert({
           openAlert: openAlert,
@@ -118,7 +138,20 @@ export default class MonitorAlert {
       }
     }
 
-    return openAlerts;
+    /*
+     * Return the alerts that are still open AFTER this pass. The create
+     * path dedupes against this list, and an alert this pass just
+     * resolved must not count as "already active" — that combination
+     * resolved a stale whole-monitor alert and then refused to create
+     * the per-series alerts meant to replace it.
+     */
+    if (resolvedAlertIds.size === 0) {
+      return openAlerts;
+    }
+
+    return openAlerts.filter((openAlert: Alert) => {
+      return !resolvedAlertIds.has(openAlert.id!.toString());
+    });
   }
 
   /**
@@ -230,6 +263,26 @@ export default class MonitorAlert {
     };
     matchesPerSeries?: Array<PerSeriesCriteriaMatch> | undefined;
     /**
+     * The still-open alerts, when the caller has already run the
+     * resolve pass itself.
+     *
+     * A single evaluation can fan out across several matching criteria
+     * (host A critical while host B is only warning). The resolve pass
+     * has to run exactly once, with every criteria's breaching set in
+     * hand — running it once per criteria would let each criteria
+     * absence-resolve the others' alerts. So MonitorResource runs it up
+     * front and hands the survivors here.
+     */
+    openAlerts?: Array<Alert> | undefined;
+    /**
+     * Per-criteria breaching fingerprints, forwarded to the resolve pass
+     * when this method runs it itself. See
+     * checkOpenAlertsAndCloseIfResolved.
+     */
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
+    /**
      * Series fingerprints whose underlying resource is inside an
      * ongoing scheduled maintenance window. Alerts for these series are
      * suppressed at creation time even though the monitor keeps
@@ -276,19 +329,42 @@ export default class MonitorAlert {
 
     // check active alerts and if there are open alerts, do not cretae anothr alert.
     const openAlerts: Array<Alert> =
-      await this.checkOpenAlertsAndCloseIfResolved({
-        monitorId: input.monitor.id!,
-        autoResolveCriteriaInstanceIdAlertIdsDictionary:
-          input.autoResolveCriteriaInstanceIdAlertIdsDictionary,
-        rootCause: input.rootCause,
-        criteriaInstance: input.criteriaInstance,
-        dataToProcess: input.dataToProcess,
-        evaluationSummary: input.evaluationSummary,
-        breachingSeriesFingerprints,
-        disableSeriesAbsenceResolution: input.disableSeriesAbsenceResolution,
-      });
+      input.openAlerts !== undefined
+        ? input.openAlerts
+        : await this.checkOpenAlertsAndCloseIfResolved({
+            monitorId: input.monitor.id!,
+            autoResolveCriteriaInstanceIdAlertIdsDictionary:
+              input.autoResolveCriteriaInstanceIdAlertIdsDictionary,
+            rootCause: input.rootCause,
+            criteriaInstance: input.criteriaInstance,
+            dataToProcess: input.dataToProcess,
+            evaluationSummary: input.evaluationSummary,
+            breachingSeriesFingerprints,
+            breachingSeriesFingerprintsByCriteriaId:
+              input.breachingSeriesFingerprintsByCriteriaId,
+            disableSeriesAbsenceResolution:
+              input.disableSeriesAbsenceResolution,
+          });
 
     if (!input.criteriaInstance.data?.createAlerts) {
+      return;
+    }
+
+    /*
+     * Checked once, up front. It used to be tested deep inside the
+     * template x series loops with a `return`, which on a grouped
+     * monitor abandoned every series after the first.
+     */
+    if (DisableAutomaticAlertCreation) {
+      input.evaluationSummary?.events.push({
+        type: "alert-skipped",
+        title: "Alert creation skipped",
+        message:
+          "Automatic alert creation is disabled by environment configuration.",
+        relatedCriteriaId: input.criteriaInstance.data?.id,
+        at: OneUptimeDate.getCurrentDate(),
+      });
+
       return;
     }
 
@@ -359,332 +435,376 @@ export default class MonitorAlert {
 
     for (const criteriaAlert of input.criteriaInstance.data?.alerts || []) {
       for (const seriesMatch of seriesToProcess) {
-        const seriesFingerprint: string | undefined = seriesMatch?.fingerprint;
-        const seriesLabels: JSONObject | undefined = seriesMatch?.labels;
-        const seriesRootCause: string =
-          seriesMatch?.rootCause || input.rootCause;
+        try {
+          const seriesFingerprint: string | undefined =
+            seriesMatch?.fingerprint;
+          const seriesLabels: JSONObject | undefined = seriesMatch?.labels;
+          const seriesRootCause: string =
+            seriesMatch?.rootCause || input.rootCause;
 
-        /*
-         * Per-series scheduled-maintenance suppression: skip creating an
-         * alert for a series whose resource is inside an ongoing
-         * maintenance window. Other series on the same monitor are
-         * unaffected. Only *new* creation is suppressed — existing open
-         * alerts follow the normal resolve path.
-         */
-        if (
-          seriesFingerprint &&
-          input.suppressedSeriesFingerprints?.has(seriesFingerprint)
-        ) {
+          /*
+           * Per-series scheduled-maintenance suppression: skip creating an
+           * alert for a series whose resource is inside an ongoing
+           * maintenance window. Other series on the same monitor are
+           * unaffected. Only *new* creation is suppressed — existing open
+           * alerts follow the normal resolve path.
+           */
+          if (
+            seriesFingerprint &&
+            input.suppressedSeriesFingerprints?.has(seriesFingerprint)
+          ) {
+            logger.debug(
+              `${input.monitor.id?.toString()} - Skipping alert for series ${seriesFingerprint}: its resource is under an active scheduled maintenance window.`,
+              alertLogAttributes,
+            );
+
+            input.evaluationSummary?.events.push({
+              type: "alert-skipped",
+              title: "Alert suppressed by scheduled maintenance",
+              message:
+                "Skipped creating an alert because the resource for this series is under an active scheduled maintenance window.",
+              relatedCriteriaId: input.criteriaInstance.data?.id,
+              at: OneUptimeDate.getCurrentDate(),
+            });
+            continue;
+          }
+
+          /*
+           * Mirror the create path: `createdCriteriaId` is only set when the
+           * criteria has an `id`. Guard the `.toString()` with `?.` (a criteria
+           * with a missing id otherwise threw "Cannot read properties of
+           * undefined (reading 'toString')" and failed the queue job every
+           * cycle) and normalise both sides to `undefined` on missing so dedupe
+           * stays correct instead of creating a duplicate alert each cycle.
+           */
+          const alreadyOpenAlert: Alert | undefined = openAlerts.find(
+            (alert: Alert) => {
+              return (
+                (alert.createdCriteriaId || undefined) ===
+                  (input.criteriaInstance.data?.id?.toString() || undefined) &&
+                (alert.seriesFingerprint || undefined) === seriesFingerprint
+              );
+            },
+          );
+
+          const hasAlreadyOpenAlert: boolean = Boolean(alreadyOpenAlert);
+
           logger.debug(
-            `${input.monitor.id?.toString()} - Skipping alert for series ${seriesFingerprint}: its resource is under an active scheduled maintenance window.`,
+            `${input.monitor.id?.toString()} - Open Alert ${alreadyOpenAlert?.id?.toString()}`,
             alertLogAttributes,
           );
 
-          input.evaluationSummary?.events.push({
-            type: "alert-skipped",
-            title: "Alert suppressed by scheduled maintenance",
-            message:
-              "Skipped creating an alert because the resource for this series is under an active scheduled maintenance window.",
-            relatedCriteriaId: input.criteriaInstance.data?.id,
-            at: OneUptimeDate.getCurrentDate(),
-          });
-          continue;
-        }
-
-        /*
-         * Mirror the create path: `createdCriteriaId` is only set when the
-         * criteria has an `id`. Guard the `.toString()` with `?.` (a criteria
-         * with a missing id otherwise threw "Cannot read properties of
-         * undefined (reading 'toString')" and failed the queue job every
-         * cycle) and normalise both sides to `undefined` on missing so dedupe
-         * stays correct instead of creating a duplicate alert each cycle.
-         */
-        const alreadyOpenAlert: Alert | undefined = openAlerts.find(
-          (alert: Alert) => {
-            return (
-              (alert.createdCriteriaId || undefined) ===
-                (input.criteriaInstance.data?.id?.toString() || undefined) &&
-              (alert.seriesFingerprint || undefined) === seriesFingerprint
-            );
-          },
-        );
-
-        const hasAlreadyOpenAlert: boolean = Boolean(alreadyOpenAlert);
-
-        logger.debug(
-          `${input.monitor.id?.toString()} - Open Alert ${alreadyOpenAlert?.id?.toString()}`,
-          alertLogAttributes,
-        );
-
-        logger.debug(
-          `${input.monitor.id?.toString()} - Has open alert ${hasAlreadyOpenAlert}`,
-          alertLogAttributes,
-        );
-
-        if (hasAlreadyOpenAlert) {
-          const renderedAlertTitle: string =
-            alreadyOpenAlert?.title || criteriaAlert.title;
-
-          input.evaluationSummary?.events.push({
-            type: "alert-skipped",
-            title: `Alert already active: ${renderedAlertTitle}`,
-            message:
-              "Skipped creating a new alert because an active alert exists for this criteria.",
-            relatedCriteriaId: input.criteriaInstance.data?.id,
-            relatedAlertId: alreadyOpenAlert?.id?.toString(),
-            relatedAlertNumber: alreadyOpenAlert?.alertNumber,
-            relatedAlertNumberWithPrefix:
-              alreadyOpenAlert?.alertNumberWithPrefix,
-            at: OneUptimeDate.getCurrentDate(),
-          });
-          continue;
-        }
-
-        // create alert here.
-
-        logger.debug(
-          `${input.monitor.id?.toString()} - Create alert.`,
-          alertLogAttributes,
-        );
-
-        const alert: Alert = new Alert();
-        const storageMap: JSONObject =
-          MonitorTemplateUtil.buildTemplateStorageMap({
-            monitorType: input.monitor.monitorType!,
-            dataToProcess: input.dataToProcess,
-            monitor: input.monitor,
-            seriesLabels,
-          });
-
-        alert.title = MonitorTemplateUtil.processTemplateString({
-          value: criteriaAlert.title,
-          storageMap,
-        });
-        alert.description = MonitorTemplateUtil.processTemplateString({
-          value: criteriaAlert.description,
-          storageMap,
-        });
-
-        /*
-         * A criteria severity belonging to *another* project is rejected by
-         * AlertService on create. Throwing here would fail the whole
-         * probe/telemetry ingest job for this monitor, so treat it as
-         * "missing" and fall back to this project's own default — which is
-         * also what stops the bad id spreading onto new alerts. See the same
-         * fallback in MonitorIncident.
-         */
-        const isCriteriaSeverityUsable: boolean =
-          await ProjectScopedReferenceValidator.isUsableInProject({
-            projectId: input.monitor.projectId!,
-            id: criteriaAlert.alertSeverityId,
-            service: AlertSeverityService,
-          });
-
-        if (
-          criteriaAlert.alertSeverityId?.toString() &&
-          !isCriteriaSeverityUsable
-        ) {
-          logger.error(
-            `${input.monitor.id?.toString()} - Criteria "${
-              input.criteriaInstance.data?.name
-            }" references alert severity ${criteriaAlert.alertSeverityId.toString()}, which does not belong to project ${input.monitor.projectId?.toString()}. Falling back to this project's default severity.`,
+          logger.debug(
+            `${input.monitor.id?.toString()} - Has open alert ${hasAlreadyOpenAlert}`,
+            alertLogAttributes,
           );
-        }
 
-        if (!isCriteriaSeverityUsable) {
-          // pick the critical criteria.
+          if (hasAlreadyOpenAlert) {
+            const renderedAlertTitle: string =
+              alreadyOpenAlert?.title || criteriaAlert.title;
 
-          const severity: AlertSeverity | null =
-            await AlertSeverityService.findOneBy({
-              query: {
-                projectId: input.monitor.projectId!,
-              },
-              sort: {
-                order: SortOrder.Ascending,
-              },
-              props: {
-                isRoot: true,
-              },
-              select: {
-                _id: true,
-              },
+            input.evaluationSummary?.events.push({
+              type: "alert-skipped",
+              title: `Alert already active: ${renderedAlertTitle}`,
+              message:
+                "Skipped creating a new alert because an active alert exists for this criteria.",
+              relatedCriteriaId: input.criteriaInstance.data?.id,
+              relatedAlertId: alreadyOpenAlert?.id?.toString(),
+              relatedAlertNumber: alreadyOpenAlert?.alertNumber,
+              relatedAlertNumberWithPrefix:
+                alreadyOpenAlert?.alertNumberWithPrefix,
+              at: OneUptimeDate.getCurrentDate(),
+            });
+            continue;
+          }
+
+          // create alert here.
+
+          logger.debug(
+            `${input.monitor.id?.toString()} - Create alert.`,
+            alertLogAttributes,
+          );
+
+          const alert: Alert = new Alert();
+          const storageMap: JSONObject =
+            MonitorTemplateUtil.buildTemplateStorageMap({
+              monitorType: input.monitor.monitorType!,
+              dataToProcess: input.dataToProcess,
+              monitor: input.monitor,
+              seriesLabels,
             });
 
-          if (!severity) {
-            throw new BadDataException("Project does not have alert severity");
-          } else {
-            alert.alertSeverityId = severity.id!;
-          }
-        } else {
-          alert.alertSeverityId = criteriaAlert.alertSeverityId!;
-        }
-
-        alert.monitor = input.monitor;
-        alert.projectId = input.monitor.projectId!;
-        alert.rootCause = seriesRootCause;
-        alert.createdStateLog = JSON.parse(
-          JSON.stringify(input.dataToProcess, null, 2),
-        );
-
-        /*
-         * Same capture on every alert this evaluation opens - they all
-         * came from the one check.
-         */
-        const serializedMonitorSummary: JSONObject | null =
-          MonitorSummarySnapshotUtil.serialize(input.monitorSummary);
-
-        if (serializedMonitorSummary) {
-          alert.monitorSummary = serializedMonitorSummary;
-        }
-
-        if (input.criteriaInstance.data?.id) {
-          alert.createdCriteriaId = input.criteriaInstance.data.id.toString();
-        }
-
-        if (seriesFingerprint) {
-          alert.seriesFingerprint = seriesFingerprint;
-        }
-        if (seriesLabels && Object.keys(seriesLabels).length > 0) {
-          alert.seriesLabels = seriesLabels;
-
-          /*
-           * Attach every resource this series identifies — host, docker
-           * host, podman host, k8s cluster, service, and the Proxmox /
-           * Ceph / Swarm / IoT clusters — resolved from the shared label
-           * key map. Same call the incident path makes, so the two can't
-           * drift apart again.
-           */
-          await SeriesResourceLinker.linkSeriesResourcesToModel({
-            model: alert,
-            seriesLabels,
-            projectId: input.monitor.projectId!,
-            monitorType: input.monitor.monitorType,
-          });
-        }
-
-        /*
-         * Deterministic resource link from the monitor's step config
-         * (resolved once above). For most monitor types this — not the
-         * label path above — is what makes the per-resource Activity
-         * tabs and badge counts see monitor-created alerts, because
-         * their criteria are ungrouped and emit no series labels at
-         * all. Runs for both grouped and ungrouped alerts, and merges
-         * with whatever the labels resolved.
-         */
-        SeriesResourceLinker.attachResolvedResources({
-          model: alert,
-          resolved: resourceContext,
-        });
-
-        alert.onCallDutyPolicies =
-          criteriaAlert.onCallPolicyIds?.map((id: ObjectID) => {
-            const onCallPolicy: OnCallDutyPolicy = new OnCallDutyPolicy();
-            onCallPolicy._id = id.toString();
-            return onCallPolicy;
-          }) || [];
-
-        // Set labels from criteria
-        alert.labels =
-          criteriaAlert.labelIds?.map((id: ObjectID) => {
-            const label: Label = new Label();
-            label._id = id.toString();
-            return label;
-          }) || [];
-
-        alert.isCreatedAutomatically = true;
-
-        if (criteriaAlert.isPrivate === true) {
-          alert.isPrivate = true;
-        }
-
-        if (input.props.telemetryQuery) {
-          alert.telemetryQuery = input.props.telemetryQuery;
-        }
-
-        if (
-          input.dataToProcess &&
-          (input.dataToProcess as ProbeMonitorResponse).probeId
-        ) {
-          alert.createdByProbeId = (
-            input.dataToProcess as ProbeMonitorResponse
-          ).probeId;
-        }
-
-        if (criteriaAlert.remediationNotes) {
-          alert.remediationNotes = MonitorTemplateUtil.processTemplateString({
-            value: criteriaAlert.remediationNotes,
+          alert.title = MonitorTemplateUtil.processTemplateString({
+            value: criteriaAlert.title,
             storageMap,
           });
-        }
+          alert.description = MonitorTemplateUtil.processTemplateString({
+            value: criteriaAlert.description,
+            storageMap,
+          });
 
-        if (DisableAutomaticAlertCreation) {
+          /*
+           * A criteria severity belonging to *another* project is rejected by
+           * AlertService on create. Throwing here would fail the whole
+           * probe/telemetry ingest job for this monitor, so treat it as
+           * "missing" and fall back to this project's own default — which is
+           * also what stops the bad id spreading onto new alerts. See the same
+           * fallback in MonitorIncident.
+           */
+          const isCriteriaSeverityUsable: boolean =
+            await ProjectScopedReferenceValidator.isUsableInProject({
+              projectId: input.monitor.projectId!,
+              id: criteriaAlert.alertSeverityId,
+              service: AlertSeverityService,
+            });
+
+          if (
+            criteriaAlert.alertSeverityId?.toString() &&
+            !isCriteriaSeverityUsable
+          ) {
+            logger.error(
+              `${input.monitor.id?.toString()} - Criteria "${
+                input.criteriaInstance.data?.name
+              }" references alert severity ${criteriaAlert.alertSeverityId.toString()}, which does not belong to project ${input.monitor.projectId?.toString()}. Falling back to this project's default severity.`,
+            );
+          }
+
+          if (!isCriteriaSeverityUsable) {
+            // pick the critical criteria.
+
+            const severity: AlertSeverity | null =
+              await AlertSeverityService.findOneBy({
+                query: {
+                  projectId: input.monitor.projectId!,
+                },
+                sort: {
+                  order: SortOrder.Ascending,
+                },
+                props: {
+                  isRoot: true,
+                },
+                select: {
+                  _id: true,
+                },
+              });
+
+            if (!severity?.id?.toString()) {
+              /*
+               * The project has no alert severity configured. Throwing here
+               * would fail the entire probe/telemetry ingest job — which
+               * then retries forever over a misconfiguration the worker
+               * cannot fix, and takes every other series on this monitor
+               * down with it. Skip this alert and log instead, exactly as
+               * the incident path does.
+               */
+              logger.error(
+                `${input.monitor.id?.toString()} - Cannot create alert: project ${input.monitor.projectId?.toString()} has no alert severity configured. Skipping alert creation for criteria "${
+                  input.criteriaInstance.data?.name
+                }".`,
+              );
+
+              input.evaluationSummary?.events.push({
+                type: "alert-skipped",
+                title: "Alert creation skipped",
+                message:
+                  "Skipped creating an alert because the project has no alert severity configured.",
+                relatedCriteriaId: input.criteriaInstance.data?.id,
+                at: OneUptimeDate.getCurrentDate(),
+              });
+              continue;
+            }
+
+            alert.alertSeverityId = severity.id!;
+          } else {
+            alert.alertSeverityId = criteriaAlert.alertSeverityId!;
+          }
+
+          alert.monitor = input.monitor;
+          alert.projectId = input.monitor.projectId!;
+          alert.rootCause = seriesRootCause;
+          alert.createdStateLog = JSON.parse(
+            JSON.stringify(input.dataToProcess, null, 2),
+          );
+
+          /*
+           * Same capture on every alert this evaluation opens - they all
+           * came from the one check.
+           */
+          const serializedMonitorSummary: JSONObject | null =
+            MonitorSummarySnapshotUtil.serialize(input.monitorSummary);
+
+          if (serializedMonitorSummary) {
+            alert.monitorSummary = serializedMonitorSummary;
+          }
+
+          if (input.criteriaInstance.data?.id) {
+            alert.createdCriteriaId = input.criteriaInstance.data.id.toString();
+          }
+
+          if (seriesFingerprint) {
+            alert.seriesFingerprint = seriesFingerprint;
+          }
+          if (seriesLabels && Object.keys(seriesLabels).length > 0) {
+            alert.seriesLabels = seriesLabels;
+
+            /*
+             * Attach every resource this series identifies — host, docker
+             * host, podman host, k8s cluster, service, and the Proxmox /
+             * Ceph / Swarm / IoT clusters — resolved from the shared label
+             * key map. Same call the incident path makes, so the two can't
+             * drift apart again.
+             */
+            await SeriesResourceLinker.linkSeriesResourcesToModel({
+              model: alert,
+              seriesLabels,
+              projectId: input.monitor.projectId!,
+              monitorType: input.monitor.monitorType,
+            });
+          }
+
+          /*
+           * Deterministic resource link from the monitor's step config
+           * (resolved once above). For most monitor types this — not the
+           * label path above — is what makes the per-resource Activity
+           * tabs and badge counts see monitor-created alerts, because
+           * their criteria are ungrouped and emit no series labels at
+           * all. Runs for both grouped and ungrouped alerts, and merges
+           * with whatever the labels resolved.
+           */
+          SeriesResourceLinker.attachResolvedResources({
+            model: alert,
+            resolved: resourceContext,
+          });
+
+          alert.onCallDutyPolicies =
+            criteriaAlert.onCallPolicyIds?.map((id: ObjectID) => {
+              const onCallPolicy: OnCallDutyPolicy = new OnCallDutyPolicy();
+              onCallPolicy._id = id.toString();
+              return onCallPolicy;
+            }) || [];
+
+          // Set labels from criteria
+          alert.labels =
+            criteriaAlert.labelIds?.map((id: ObjectID) => {
+              const label: Label = new Label();
+              label._id = id.toString();
+              return label;
+            }) || [];
+
+          alert.isCreatedAutomatically = true;
+
+          if (criteriaAlert.isPrivate === true) {
+            alert.isPrivate = true;
+          }
+
+          if (input.props.telemetryQuery) {
+            alert.telemetryQuery = input.props.telemetryQuery;
+          }
+
+          if (
+            input.dataToProcess &&
+            (input.dataToProcess as ProbeMonitorResponse).probeId
+          ) {
+            alert.createdByProbeId = (
+              input.dataToProcess as ProbeMonitorResponse
+            ).probeId;
+          }
+
+          if (criteriaAlert.remediationNotes) {
+            alert.remediationNotes = MonitorTemplateUtil.processTemplateString({
+              value: criteriaAlert.remediationNotes,
+              storageMap,
+            });
+          }
+
+          const createdAlert: Alert = await AlertService.create({
+            data: alert,
+            props: {
+              isRoot: true,
+            },
+          });
+
+          /*
+           * Add owner teams and users after alert creation. Owners configured
+           * on the criteria template are merged (deduped) with the owners of
+           * the network device this monitor watches, so device ownership flows
+           * into the alerts its monitor raises.
+           */
+          if (networkDeviceOwners === null) {
+            networkDeviceOwners =
+              await NetworkDeviceOwnerUserService.getDeviceOwnersForMonitor({
+                monitor: input.monitor,
+                monitorStepId: (
+                  input.dataToProcess as ProbeMonitorResponse
+                ).monitorStepId?.toString(),
+              });
+          }
+
+          const ownerUserIds: Array<ObjectID> = this.mergeOwnerIds(
+            criteriaAlert.ownerUserIds || [],
+            networkDeviceOwners.ownerUserIds,
+          );
+
+          const ownerTeamIds: Array<ObjectID> = this.mergeOwnerIds(
+            criteriaAlert.ownerTeamIds || [],
+            networkDeviceOwners.ownerTeamIds,
+          );
+
+          if (ownerTeamIds.length || ownerUserIds.length) {
+            await AlertService.addOwners(
+              input.monitor.projectId!,
+              createdAlert.id!,
+              ownerUserIds,
+              ownerTeamIds,
+              true, // notify owners
+              {
+                isRoot: true,
+              },
+            );
+          }
+
+          input.evaluationSummary?.events.push({
+            type: "alert-created",
+            title: `Alert created: ${createdAlert.title || criteriaAlert.title}`,
+            message: `Alert triggered from criteria "${input.criteriaInstance.data?.name || "Unnamed criteria"}".`,
+            relatedCriteriaId: input.criteriaInstance.data?.id,
+            relatedAlertId: createdAlert.id?.toString(),
+            relatedAlertNumber: createdAlert.alertNumber,
+            relatedAlertNumberWithPrefix: createdAlert.alertNumberWithPrefix,
+            at: OneUptimeDate.getCurrentDate(),
+          });
+        } catch (err) {
+          /*
+           * One series must not take the rest of the fleet down with it.
+           * Everything below this loop happens per host/container/key and
+           * touches the database; an error thrown from here used to
+           * propagate out of MonitorResource (which has no catch, only a
+           * `finally` that releases the lock) and abandon every series
+           * after the failing one, plus the monitor log for the tick.
+           */
+          logger.error(
+            `${input.monitor.id?.toString()} - Failed to create alert${
+              seriesMatch?.fingerprint
+                ? ` for series ${seriesMatch.fingerprint}`
+                : ""
+            }.`,
+          );
+          logger.error(err);
+
           input.evaluationSummary?.events.push({
             type: "alert-skipped",
-            title: "Alert creation skipped",
-            message:
-              "Automatic alert creation is disabled by environment configuration.",
+            title: "Alert creation failed",
+            message: `Could not create an alert${
+              seriesMatch?.fingerprint
+                ? ` for series ${seriesMatch.fingerprint}`
+                : ""
+            }: ${err instanceof Error ? err.message : String(err)}`,
             relatedCriteriaId: input.criteriaInstance.data?.id,
             at: OneUptimeDate.getCurrentDate(),
           });
-          return;
+
+          continue;
         }
-
-        const createdAlert: Alert = await AlertService.create({
-          data: alert,
-          props: {
-            isRoot: true,
-          },
-        });
-
-        /*
-         * Add owner teams and users after alert creation. Owners configured
-         * on the criteria template are merged (deduped) with the owners of
-         * the network device this monitor watches, so device ownership flows
-         * into the alerts its monitor raises.
-         */
-        if (networkDeviceOwners === null) {
-          networkDeviceOwners =
-            await NetworkDeviceOwnerUserService.getDeviceOwnersForMonitor({
-              monitor: input.monitor,
-              monitorStepId: (
-                input.dataToProcess as ProbeMonitorResponse
-              ).monitorStepId?.toString(),
-            });
-        }
-
-        const ownerUserIds: Array<ObjectID> = this.mergeOwnerIds(
-          criteriaAlert.ownerUserIds || [],
-          networkDeviceOwners.ownerUserIds,
-        );
-
-        const ownerTeamIds: Array<ObjectID> = this.mergeOwnerIds(
-          criteriaAlert.ownerTeamIds || [],
-          networkDeviceOwners.ownerTeamIds,
-        );
-
-        if (ownerTeamIds.length || ownerUserIds.length) {
-          await AlertService.addOwners(
-            input.monitor.projectId!,
-            createdAlert.id!,
-            ownerUserIds,
-            ownerTeamIds,
-            true, // notify owners
-            {
-              isRoot: true,
-            },
-          );
-        }
-
-        input.evaluationSummary?.events.push({
-          type: "alert-created",
-          title: `Alert created: ${createdAlert.title || criteriaAlert.title}`,
-          message: `Alert triggered from criteria "${input.criteriaInstance.data?.name || "Unnamed criteria"}".`,
-          relatedCriteriaId: input.criteriaInstance.data?.id,
-          relatedAlertId: createdAlert.id?.toString(),
-          relatedAlertNumber: createdAlert.alertNumber,
-          relatedAlertNumberWithPrefix: createdAlert.alertNumberWithPrefix,
-          at: OneUptimeDate.getCurrentDate(),
-        });
       }
     }
   }
@@ -778,11 +898,92 @@ export default class MonitorAlert {
     }
   }
 
+  /**
+   * Is `openAlert`'s series still breaching the criteria that raised it?
+   *
+   * Prefers the per-criteria dictionary, which answers the question for
+   * the criteria that actually owns this alert. The single-set fallback
+   * only knows the winning criteria's breaches, so it has to approximate
+   * with `createAlerts` — a criteria that creates no alerts is a
+   * recovery criteria whose "matches" are healthy series, and counting
+   * those as breaches would pin an offline alert open forever.
+   */
+  private static isSeriesStillBreaching(input: {
+    openAlert: Alert;
+    criteriaInstance: MonitorCriteriaInstance | null;
+    openSeriesFingerprint: string;
+    breachingSeriesFingerprints: Set<string>;
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
+  }): boolean {
+    const owningCriteriaId: string | undefined =
+      input.openAlert.createdCriteriaId?.toString() || undefined;
+
+    if (input.breachingSeriesFingerprintsByCriteriaId && owningCriteriaId) {
+      return Boolean(
+        input.breachingSeriesFingerprintsByCriteriaId[owningCriteriaId]?.has(
+          input.openSeriesFingerprint,
+        ),
+      );
+    }
+
+    const matchedCriteriaCreatesAlerts: boolean =
+      input.criteriaInstance?.data?.createAlerts === true;
+
+    return (
+      matchedCriteriaCreatesAlerts &&
+      input.breachingSeriesFingerprints.has(input.openSeriesFingerprint)
+    );
+  }
+
+  private static wasCriteriaEvaluated(input: {
+    openAlert: Alert;
+    breachingSeriesFingerprintsByCriteriaId: Dictionary<Set<string>>;
+  }): boolean {
+    const owningCriteriaId: string | undefined =
+      input.openAlert.createdCriteriaId?.toString() || undefined;
+
+    if (!owningCriteriaId) {
+      return true;
+    }
+
+    return (
+      input.breachingSeriesFingerprintsByCriteriaId[owningCriteriaId] !==
+      undefined
+    );
+  }
+
+  /**
+   * Alert auto-resolve lists templates by criteria; the presence of any
+   * template for a criteria means "this criteria's alerts are configured
+   * to auto-resolve".
+   */
+  private static isAutoResolveConfiguredForAlert(input: {
+    openAlert: Alert;
+    autoResolveCriteriaInstanceIdAlertIdsDictionary: Dictionary<Array<string>>;
+  }): boolean {
+    const createdCriteriaId: string | undefined =
+      input.openAlert.createdCriteriaId?.toString() || undefined;
+
+    if (!createdCriteriaId) {
+      return false;
+    }
+
+    const autoResolveTemplates: Array<string> | undefined =
+      input.autoResolveCriteriaInstanceIdAlertIdsDictionary[createdCriteriaId];
+
+    return Boolean(autoResolveTemplates && autoResolveTemplates.length > 0);
+  }
+
   private static shouldCloseAlert(input: {
     openAlert: Alert;
     autoResolveCriteriaInstanceIdAlertIdsDictionary: Dictionary<Array<string>>;
     criteriaInstance: MonitorCriteriaInstance | null; // null if no criteia met.
     breachingSeriesFingerprints?: Set<string> | undefined;
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
     disableSeriesAbsenceResolution?: boolean | undefined;
   }): boolean {
     const openSeriesFingerprint: string | undefined =
@@ -800,55 +1001,63 @@ export default class MonitorAlert {
       return false;
     }
 
-    /*
-     * Per-series auto-resolve: when a breaching-series set is given and
-     * this alert has a fingerprint, resolve whenever the fingerprint is
-     * no longer in the set, independent of whether other series on the
-     * same monitor are still breaching.
-     */
-    if (
-      input.breachingSeriesFingerprints !== undefined &&
-      openSeriesFingerprint
-    ) {
+    // Per-series mode: this evaluation knows which series are breaching.
+    if (input.breachingSeriesFingerprints !== undefined) {
       /*
-       * The breaching set is the matched criteria's per-series matches.
-       * On a recovery tick the matched criteria is the RECOVERY criteria
-       * and its matches are healthy series, not breaches; counting them
-       * would pin the open offline alert open forever. Membership only
-       * counts as still-breaching when the matched criteria actually
-       * creates alerts (createAlerts=false recovery criteria contributes
-       * no breaches, letting the per-series alert auto-resolve).
+       * A whole-monitor alert (no fingerprint) on a monitor that now
+       * alerts per series. It was raised before the monitor was grouped,
+       * and nothing can ever dedupe against it again — every alert from
+       * here on carries a fingerprint. Left alone it stays open forever
+       * while its replacements come and go. Resolve it, on the same
+       * auto-resolve terms as any other alert from its criteria.
        */
-      const matchedCriteriaCreatesAlerts: boolean =
-        input.criteriaInstance?.data?.createAlerts === true;
+      if (!openSeriesFingerprint) {
+        if (input.disableSeriesAbsenceResolution) {
+          return false;
+        }
 
-      const stillBreaching: boolean =
-        matchedCriteriaCreatesAlerts &&
-        input.breachingSeriesFingerprints.has(openSeriesFingerprint);
+        return MonitorAlert.isAutoResolveConfiguredForAlert({
+          openAlert: input.openAlert,
+          autoResolveCriteriaInstanceIdAlertIdsDictionary:
+            input.autoResolveCriteriaInstanceIdAlertIdsDictionary,
+        });
+      }
 
-      if (stillBreaching) {
+      if (
+        MonitorAlert.isSeriesStillBreaching({
+          openAlert: input.openAlert,
+          criteriaInstance: input.criteriaInstance,
+          openSeriesFingerprint,
+          breachingSeriesFingerprints: input.breachingSeriesFingerprints,
+          breachingSeriesFingerprintsByCriteriaId:
+            input.breachingSeriesFingerprintsByCriteriaId,
+        })
+      ) {
         return false;
       }
 
-      if (!input.openAlert.createdCriteriaId?.toString()) {
+      /*
+       * The criteria that raised this alert was not evaluated on this
+       * tick at all (disabled, deleted, or the monitor stops at its
+       * first match). Absence of a breaching set for it is not evidence
+       * of recovery, so leave the alert alone.
+       */
+      if (
+        input.breachingSeriesFingerprintsByCriteriaId &&
+        !MonitorAlert.wasCriteriaEvaluated({
+          openAlert: input.openAlert,
+          breachingSeriesFingerprintsByCriteriaId:
+            input.breachingSeriesFingerprintsByCriteriaId,
+        })
+      ) {
         return false;
       }
 
-      const autoResolveTemplates: Array<string> | undefined =
-        input.autoResolveCriteriaInstanceIdAlertIdsDictionary[
-          input.openAlert.createdCriteriaId.toString()
-        ];
-
-      /*
-       * Alert auto-resolve lists templates by criteria; presence of any
-       * template for this criteria means "this criteria's alerts are
-       * configured to auto-resolve", so resolve this series.
-       */
-      if (autoResolveTemplates && autoResolveTemplates.length > 0) {
-        return true;
-      }
-
-      return false;
+      return MonitorAlert.isAutoResolveConfiguredForAlert({
+        openAlert: input.openAlert,
+        autoResolveCriteriaInstanceIdAlertIdsDictionary:
+          input.autoResolveCriteriaInstanceIdAlertIdsDictionary,
+      });
     }
 
     if (

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -6,6 +6,9 @@ import CustomCodeMonitoringCriteria from "./Criteria/CustomCodeMonitorCriteria";
 import IncomingEmailCriteria from "./Criteria/IncomingEmailCriteria";
 import IncomingRequestCriteria from "./Criteria/IncomingRequestCriteria";
 import IncomingRequestIncidentGrouping from "./IncomingRequestIncidentGrouping";
+import PerEntityCriteriaFanOut, {
+  FanOutEntity,
+} from "./PerEntityCriteriaFanOut";
 import SSLMonitorCriteria from "./Criteria/SSLMonitorCriteria";
 import ServerMonitorCriteria from "./Criteria/ServerMonitorCriteria";
 import SyntheticMonitoringCriteria from "./Criteria/SyntheticMonitor";
@@ -411,6 +414,31 @@ ${contextBlock}
       return MonitorStep.getGroupByAttributeKeys(input.monitorStep).length > 0;
     }
 
+    /*
+     * Monitor types with no group-by concept, whose criteria name one
+     * entity each. They opt into per-entity alerting by naming "*"
+     * instead of a specific disk / interface.
+     */
+    if (monitorType === MonitorType.Server) {
+      return input.criteriaInstances.some(
+        (criteriaInstance: MonitorCriteriaInstance) => {
+          return PerEntityCriteriaFanOut.isServerDiskFanOutConfigured(
+            criteriaInstance,
+          );
+        },
+      );
+    }
+
+    if (monitorType === MonitorType.NetworkDevice) {
+      return input.criteriaInstances.some(
+        (criteriaInstance: MonitorCriteriaInstance) => {
+          return PerEntityCriteriaFanOut.isSnmpInterfaceFanOutConfigured(
+            criteriaInstance,
+          );
+        },
+      );
+    }
+
     return false;
   }
 
@@ -465,6 +493,65 @@ ${contextBlock}
       return IncomingRequestIncidentGrouping.collectFiringMatches({
         dataToProcess: input.dataToProcess,
         criteriaInstance: input.criteriaInstance,
+      });
+    }
+
+    /*
+     * Server and SNMP monitors observe several independent entities in a
+     * single check — every mounted filesystem, every port on a switch —
+     * but their criteria address one at a time. When a criteria opts in
+     * with the "*" wildcard, evaluate it once per entity so a second
+     * full disk or a second dead port raises its own alert instead of
+     * being swallowed by the first one's.
+     */
+    if (
+      input.monitor.monitorType === MonitorType.Server ||
+      input.monitor.monitorType === MonitorType.NetworkDevice
+    ) {
+      const entities: Array<FanOutEntity> =
+        input.monitor.monitorType === MonitorType.Server
+          ? PerEntityCriteriaFanOut.getServerDiskEntities({
+              dataToProcess: input.dataToProcess,
+              criteriaInstance: input.criteriaInstance,
+            })
+          : PerEntityCriteriaFanOut.getSnmpInterfaceEntities({
+              dataToProcess: input.dataToProcess,
+              criteriaInstance: input.criteriaInstance,
+            });
+
+      return PerEntityCriteriaFanOut.collectMatches({
+        criteriaInstance: input.criteriaInstance,
+        entities: entities,
+        monitorId: input.monitor.id?.toString(),
+        evaluateNarrowedCriteria: (
+          narrowedCriteriaInstance: MonitorCriteriaInstance,
+        ): Promise<string | null> => {
+          return MonitorCriteriaEvaluator.isMonitorInstanceCriteriaFiltersMet({
+            dataToProcess: input.dataToProcess,
+            monitorStep: input.monitorStep,
+            monitor: input.monitor,
+            probeApiIngestResponse: {
+              monitorId: input.dataToProcess.monitorId,
+              rootCause: null,
+            },
+            criteriaInstance: narrowedCriteriaInstance,
+            /*
+             * A throwaway result: the per-entity pass must not overwrite
+             * the summary row the whole-criteria evaluation already
+             * wrote for this criteria.
+             */
+            criteriaResult: {
+              criteriaId: narrowedCriteriaInstance.data?.id,
+              criteriaName: narrowedCriteriaInstance.data?.name,
+              filterCondition:
+                narrowedCriteriaInstance.data?.filterCondition ||
+                FilterCondition.All,
+              met: false,
+              message: "",
+              filters: [],
+            },
+          });
+        },
       });
     }
 

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -38,6 +38,7 @@ import MonitorEvaluationSummary, {
   MonitorEvaluationFilterResult,
 } from "../../../Types/Monitor/MonitorEvaluationSummary";
 import ProbeApiIngestResponse, {
+  MatchedCriteriaResult,
   PerSeriesCriteriaMatch,
 } from "../../../Types/Probe/ProbeApiIngestResponse";
 import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
@@ -114,7 +115,62 @@ export default class MonitorCriteriaEvaluator {
       return input.probeApiIngestResponse;
     }
 
+    /*
+     * Is this monitor configured to raise one alert/incident per series
+     * (per host, per container, per key) rather than one for the whole
+     * monitor? Answered from the monitor's own configuration, NOT from
+     * whether this tick happened to produce per-series matches — that
+     * distinction is the entire fix for "the second host never alerts".
+     *
+     * When a grouped monitor produced no per-series match, the old code
+     * left `perSeriesMatches` undefined, which the creators read as
+     * "legacy whole-monitor mode" and deduped on criteria id alone. The
+     * first breaching host opened an alert with no series attached and
+     * every host that started breaching afterwards was skipped with
+     * "an active alert exists for this criteria" for as long as that
+     * first alert stayed open.
+     */
+    const isPerSeriesMonitor: boolean =
+      MonitorCriteriaEvaluator.isPerSeriesMonitor({
+        monitor: input.monitor,
+        monitorStep: input.monitorStep,
+        criteriaInstances: criteria.data.monitorCriteriaInstanceArray,
+      });
+
+    /*
+     * Grouped metric monitors additionally evaluate EVERY criteria
+     * rather than stopping at the first match, because their series can
+     * sit in different bands simultaneously.
+     *
+     * Incoming-request grouping is deliberately excluded: a webhook is
+     * event-driven and its criteria pick one interpretation of one
+     * payload, so first-match-wins is the correct reading there and
+     * changing it would alter established webhook behaviour.
+     */
+    const fanOutAcrossCriteria: boolean =
+      isPerSeriesMonitor &&
+      input.monitor.monitorType !== MonitorType.IncomingRequest;
+
+    const matchedCriteria: Array<MatchedCriteriaResult> = [];
+    const evaluatedCriteriaIds: Array<string> = [];
+
     for (const criteriaInstance of criteria.data.monitorCriteriaInstanceArray) {
+      /*
+       * Ungrouped monitors keep the historical semantics exactly: the
+       * first criteria that matches wins and nothing after it is even
+       * looked at. Grouped monitors evaluate every criteria, because
+       * different series can legitimately sit in different bands at the
+       * same time (host A critical, host B warning) and stopping at the
+       * first match silently drops every other band.
+       */
+      if (matchedCriteria.length > 0 && !fanOutAcrossCriteria) {
+        MonitorCriteriaEvaluator.pushNotEvaluatedCriteriaResult({
+          criteriaInstance,
+          evaluationSummary: input.evaluationSummary,
+        });
+        continue;
+      }
+
       /*
        * Record disabled criteria in the summary (so the user can see why
        * nothing happened) but skip evaluation, status changes, incidents,
@@ -177,87 +233,211 @@ export default class MonitorCriteriaEvaluator {
 
       input.evaluationSummary.events.push(criteriaEvent);
 
-      if (rootCause) {
-        input.probeApiIngestResponse.criteriaMetId = criteriaInstance.data?.id;
-        input.probeApiIngestResponse.rootCause = `
+      if (criteriaInstance.data?.id) {
+        evaluatedCriteriaIds.push(criteriaInstance.data.id.toString());
+      }
+
+      if (!rootCause) {
+        continue;
+      }
+
+      /*
+       * When this is a monitor with per-series results, compute the
+       * per-series match list so MonitorResource can fan out one
+       * incident + one alert per affected series.
+       */
+      const perSeriesMatches: Array<PerSeriesCriteriaMatch> =
+        await MonitorCriteriaEvaluator.collectPerSeriesMatches({
+          dataToProcess: input.dataToProcess,
+          monitor: input.monitor,
+          monitorStep: input.monitorStep,
+          criteriaInstance,
+        });
+
+      /*
+       * A grouped monitor whose scalar verdict says "met" but which
+       * cannot name a single breaching series is NOT a match.
+       *
+       * The scalar verdict evaluates each filter independently and each
+       * one collapses to its own first breaching series, so under
+       * FilterCondition.All two filters can be satisfied by two
+       * different hosts and report the criteria met even though no
+       * single host satisfies all of them. Honouring that verdict opened
+       * one unattributed whole-monitor alert that then blocked every
+       * real per-host alert. Skip the criteria instead and let the next
+       * one decide.
+       */
+      if (fanOutAcrossCriteria && perSeriesMatches.length === 0) {
+        criteriaResult.met = false;
+        criteriaResult.message =
+          "Criteria was not met: no single series satisfied it. " +
+          "This monitor raises one alert per series, so a criteria that " +
+          "only holds across different series combined does not fire.";
+
+        input.evaluationSummary.events.push({
+          type: "criteria-not-met",
+          title: `Criteria not met: ${criteriaResult.criteriaName || "Unnamed criteria"}`,
+          message: criteriaResult.message,
+          relatedCriteriaId: criteriaResult.criteriaId,
+          at: OneUptimeDate.getCurrentDate(),
+        });
+
+        continue;
+      }
+
+      const isFirstMatch: boolean = matchedCriteria.length === 0;
+
+      const contextBlock: string | null =
+        await MonitorCriteriaEvaluator.buildRootCauseContext({
+          dataToProcess: input.dataToProcess,
+          monitorStep: input.monitorStep,
+          monitor: input.monitor,
+          criteriaInstance: criteriaInstance,
+        });
+
+      /*
+       * For metric monitors, render the metric identity (name, unit,
+       * filter attrs, breaching series) before the comparison line so
+       * the reader has context when they reach "Filter Conditions Met".
+       */
+      const isMetricMonitor: boolean =
+        input.monitor.monitorType === MonitorType.Metrics;
+
+      let renderedRootCause: string = `
 **Created because the following criteria was met**:
 
 **Criteria Name**: ${criteriaInstance.data?.name}
 `;
 
-        const contextBlock: string | null =
-          await MonitorCriteriaEvaluator.buildRootCauseContext({
-            dataToProcess: input.dataToProcess,
-            monitorStep: input.monitorStep,
-            monitor: input.monitor,
-            criteriaInstance: criteriaInstance,
-          });
-
-        /*
-         * For metric monitors, render the metric identity (name, unit,
-         * filter attrs, breaching series) before the comparison line so
-         * the reader has context when they reach "Filter Conditions Met".
-         */
-        const isMetricMonitor: boolean =
-          input.monitor.monitorType === MonitorType.Metrics;
-
-        if (contextBlock && isMetricMonitor) {
-          input.probeApiIngestResponse.rootCause += `
+      if (contextBlock && isMetricMonitor) {
+        renderedRootCause += `
 ${contextBlock}
 `;
-        }
+      }
 
-        input.probeApiIngestResponse.rootCause += `
+      renderedRootCause += `
 **Filter Conditions Met**: ${rootCause}
 `;
 
-        if (contextBlock && !isMetricMonitor) {
-          input.probeApiIngestResponse.rootCause += `
+      if (contextBlock && !isMetricMonitor) {
+        renderedRootCause += `
 ${contextBlock}
 `;
-        }
+      }
 
-        if ((input.dataToProcess as ProbeMonitorResponse).failureCause) {
-          input.probeApiIngestResponse.rootCause += `
+      if ((input.dataToProcess as ProbeMonitorResponse).failureCause) {
+        renderedRootCause += `
 **Cause**: ${(input.dataToProcess as ProbeMonitorResponse).failureCause || ""}
 `;
-        }
+      }
 
-        /*
-         * When this is a metric-style monitor with per-series results,
-         * compute the per-series match list so MonitorResource can fan
-         * out one incident per affected series. We do this *after* the
-         * scalar criteriaMetId/rootCause is populated so legacy readers
-         * still see a usable response if perSeriesMatches is ignored.
-         */
-        const perSeriesMatches: Array<PerSeriesCriteriaMatch> =
-          await MonitorCriteriaEvaluator.collectPerSeriesMatches({
-            dataToProcess: input.dataToProcess,
-            monitor: input.monitor,
-            monitorStep: input.monitorStep,
-            criteriaInstance,
-          });
+      /*
+       * The monitor has exactly one status, and the FIRST matching
+       * criteria owns it — unchanged from before this became a list.
+       * `perSeriesMatches` likewise keeps pointing at the first match so
+       * any reader that only knows the scalar fields still behaves the
+       * way it always did.
+       */
+      if (isFirstMatch) {
+        input.probeApiIngestResponse.criteriaMetId = criteriaInstance.data?.id;
+        input.probeApiIngestResponse.rootCause = renderedRootCause;
 
-        if (perSeriesMatches.length > 0) {
-          input.probeApiIngestResponse.perSeriesMatches = perSeriesMatches;
-        } else if (
-          input.monitor.monitorType === MonitorType.IncomingRequest &&
-          IncomingRequestIncidentGrouping.isGroupingConfigured(criteriaInstance)
-        ) {
+        if (perSeriesMatches.length > 0 || isPerSeriesMonitor) {
           /*
-           * Grouped incoming-request criteria that produced no firing key
-           * (e.g. a pure "resolved" webhook). Force per-series mode with an
-           * empty set so the create path does NOT fall back to opening a
-           * single whole-monitor incident.
+           * A per-series monitor always publishes an array, even an
+           * empty one: a defined array is what tells the creators
+           * "per-series mode — dedupe on (criteria, series)" instead of
+           * silently degrading to one alert for the whole monitor.
            */
-          input.probeApiIngestResponse.perSeriesMatches = [];
+          input.probeApiIngestResponse.perSeriesMatches = perSeriesMatches;
         }
+      }
 
-        break;
+      if (criteriaInstance.data?.id) {
+        matchedCriteria.push({
+          criteriaId: criteriaInstance.data.id.toString(),
+          rootCause: renderedRootCause,
+          perSeriesMatches: perSeriesMatches,
+        });
       }
     }
 
+    /*
+     * Only grouped monitors fan out across several criteria. Leaving
+     * this undefined for everything else keeps MonitorResource on the
+     * single-criteria path it has always taken.
+     */
+    if (fanOutAcrossCriteria) {
+      input.probeApiIngestResponse.matchedCriteria = matchedCriteria;
+      input.probeApiIngestResponse.evaluatedCriteriaIds = evaluatedCriteriaIds;
+    }
+
     return input.probeApiIngestResponse;
+  }
+
+  /**
+   * Does this monitor raise one alert/incident per series rather than
+   * one for the whole monitor?
+   *
+   * Answered from configuration only — group-by attributes on a
+   * metric-backed step, or incident grouping on an incoming-request
+   * criteria — never from whether this particular tick produced
+   * matches. A tick that produces none must still be treated as
+   * per-series, otherwise the creators fall back to whole-monitor
+   * dedupe and swallow every series after the first.
+   */
+  private static isPerSeriesMonitor(input: {
+    monitor: Monitor;
+    monitorStep: MonitorStep;
+    criteriaInstances: Array<MonitorCriteriaInstance>;
+  }): boolean {
+    const monitorType: MonitorType | undefined = input.monitor.monitorType;
+
+    if (!monitorType) {
+      return false;
+    }
+
+    if (monitorType === MonitorType.IncomingRequest) {
+      return input.criteriaInstances.some(
+        (criteriaInstance: MonitorCriteriaInstance) => {
+          return IncomingRequestIncidentGrouping.isGroupingConfigured(
+            criteriaInstance,
+          );
+        },
+      );
+    }
+
+    if (MonitorCriteriaInstance.isMetricBackedMonitorType(monitorType)) {
+      return MonitorStep.getGroupByAttributeKeys(input.monitorStep).length > 0;
+    }
+
+    return false;
+  }
+
+  /**
+   * Record a criteria that the evaluator never got to, so "why did
+   * nothing happen for host B" is answerable from the monitor log
+   * instead of being an unexplained gap in the summary.
+   */
+  private static pushNotEvaluatedCriteriaResult(input: {
+    criteriaInstance: MonitorCriteriaInstance;
+    evaluationSummary: MonitorEvaluationSummary;
+  }): void {
+    const skipReason: string =
+      "An earlier criteria already matched. This monitor raises a single " +
+      "alert for the whole monitor, so evaluation stops at the first match.";
+
+    input.evaluationSummary.criteriaResults.push({
+      criteriaId: input.criteriaInstance.data?.id,
+      criteriaName: input.criteriaInstance.data?.name,
+      filterCondition:
+        input.criteriaInstance.data?.filterCondition || FilterCondition.All,
+      met: false,
+      message: skipReason,
+      filters: [],
+      skipped: true,
+      skipReason: skipReason,
+    });
   }
 
   /**
@@ -288,16 +468,15 @@ ${contextBlock}
       });
     }
 
+    /*
+     * Same list as MonitorCriteriaInstance.isMetricBackedMonitorType,
+     * which is where it now lives so the two cannot drift apart.
+     */
     if (
-      input.monitor.monitorType !== MonitorType.Metrics &&
-      input.monitor.monitorType !== MonitorType.Kubernetes &&
-      input.monitor.monitorType !== MonitorType.Docker &&
-      input.monitor.monitorType !== MonitorType.Host &&
-      input.monitor.monitorType !== MonitorType.Podman &&
-      input.monitor.monitorType !== MonitorType.DockerSwarm &&
-      input.monitor.monitorType !== MonitorType.Proxmox &&
-      input.monitor.monitorType !== MonitorType.Ceph &&
-      input.monitor.monitorType !== MonitorType.IoTDevice
+      !input.monitor.monitorType ||
+      !MonitorCriteriaInstance.isMetricBackedMonitorType(
+        input.monitor.monitorType,
+      )
     ) {
       return [];
     }

--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -63,6 +63,20 @@ export default class MonitorIncident {
      */
     breachingSeriesFingerprints?: Set<string> | undefined;
     /**
+     * The breaching fingerprints of EACH criteria evaluated on this
+     * tick, keyed by criteria id — a criteria that ran and matched
+     * nothing maps to an empty set.
+     *
+     * Without this, "is this series still breaching?" was answered from
+     * the winning criteria's set alone, so a host held critical by
+     * criteria A silently auto-resolved another host's still-valid
+     * incident from criteria B. A criteria absent from this dictionary
+     * was not evaluated at all, and its open incidents are left alone.
+     */
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
+    /**
      * Event-driven (incoming-request / webhook) mode. When true, an open
      * incident carrying a seriesFingerprint is never auto-resolved here —
      * webhooks resolve per-key only via resolveSeriesIncidentsByFingerprint,
@@ -100,6 +114,8 @@ export default class MonitorIncident {
 
     // check if should close the incident.
 
+    const resolvedIncidentIds: Set<string> = new Set<string>();
+
     for (const openIncident of openIncidents) {
       const shouldClose: boolean = this.shouldCloseIncident({
         openIncident,
@@ -107,10 +123,14 @@ export default class MonitorIncident {
           input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
         criteriaInstance: input.criteriaInstance,
         breachingSeriesFingerprints: input.breachingSeriesFingerprints,
+        breachingSeriesFingerprintsByCriteriaId:
+          input.breachingSeriesFingerprintsByCriteriaId,
         disableSeriesAbsenceResolution: input.disableSeriesAbsenceResolution,
       });
 
       if (shouldClose) {
+        resolvedIncidentIds.add(openIncident.id!.toString());
+
         // then resolve incident.
         await this.resolveOpenIncident({
           openIncident: openIncident,
@@ -133,7 +153,20 @@ export default class MonitorIncident {
       }
     }
 
-    return openIncidents;
+    /*
+     * Return the incidents still open AFTER this pass. The create path
+     * dedupes against this list, and an incident this pass just resolved
+     * must not count as "already active" — that combination resolved a
+     * stale whole-monitor incident and then refused to create the
+     * per-series incidents meant to replace it.
+     */
+    if (resolvedIncidentIds.size === 0) {
+      return openIncidents;
+    }
+
+    return openIncidents.filter((openIncident: Incident) => {
+      return !resolvedIncidentIds.has(openIncident.id!.toString());
+    });
   }
 
   /**
@@ -265,6 +298,26 @@ export default class MonitorIncident {
      */
     matchesPerSeries?: Array<PerSeriesCriteriaMatch> | undefined;
     /**
+     * The still-open incidents, when the caller has already run the
+     * resolve pass itself.
+     *
+     * A single evaluation can fan out across several matching criteria
+     * (host A critical while host B is only warning). The resolve pass
+     * has to run exactly once, with every criteria's breaching set in
+     * hand — running it once per criteria would let each criteria
+     * absence-resolve the others' incidents. So MonitorResource runs it
+     * up front and hands the survivors here.
+     */
+    openIncidents?: Array<Incident> | undefined;
+    /**
+     * Per-criteria breaching fingerprints, forwarded to the resolve pass
+     * when this method runs it itself. See
+     * checkOpenIncidentsAndCloseIfResolved.
+     */
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
+    /**
      * Series fingerprints whose underlying resource (host, docker host,
      * kubernetes cluster, or service) is inside an ongoing scheduled
      * maintenance window. The monitor itself keeps evaluating — it is
@@ -318,19 +371,42 @@ export default class MonitorIncident {
 
     // check active incidents and if there are open incidents, do not cretae anothr incident.
     const openIncidents: Array<Incident> =
-      await this.checkOpenIncidentsAndCloseIfResolved({
-        monitorId: input.monitor.id!,
-        autoResolveCriteriaInstanceIdIncidentIdsDictionary:
-          input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
-        rootCause: input.rootCause,
-        criteriaInstance: input.criteriaInstance,
-        dataToProcess: input.dataToProcess,
-        evaluationSummary: input.evaluationSummary,
-        breachingSeriesFingerprints,
-        disableSeriesAbsenceResolution: input.disableSeriesAbsenceResolution,
-      });
+      input.openIncidents !== undefined
+        ? input.openIncidents
+        : await this.checkOpenIncidentsAndCloseIfResolved({
+            monitorId: input.monitor.id!,
+            autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+              input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+            rootCause: input.rootCause,
+            criteriaInstance: input.criteriaInstance,
+            dataToProcess: input.dataToProcess,
+            evaluationSummary: input.evaluationSummary,
+            breachingSeriesFingerprints,
+            breachingSeriesFingerprintsByCriteriaId:
+              input.breachingSeriesFingerprintsByCriteriaId,
+            disableSeriesAbsenceResolution:
+              input.disableSeriesAbsenceResolution,
+          });
 
     if (!input.criteriaInstance.data?.createIncidents) {
+      return;
+    }
+
+    /*
+     * Checked once, up front. It used to be tested deep inside the
+     * template x series loops with a `return`, which on a grouped
+     * monitor abandoned every series after the first.
+     */
+    if (DisableAutomaticIncidentCreation) {
+      input.evaluationSummary?.events.push({
+        type: "incident-skipped",
+        title: "Incident creation skipped",
+        message:
+          "Automatic incident creation is disabled by environment configuration.",
+        relatedCriteriaId: input.criteriaInstance.data?.id,
+        at: OneUptimeDate.getCurrentDate(),
+      });
+
       return;
     }
 
@@ -406,434 +482,455 @@ export default class MonitorIncident {
     for (const criteriaIncident of input.criteriaInstance.data?.incidents ||
       []) {
       for (const seriesMatch of seriesToProcess) {
-        const seriesFingerprint: string | undefined = seriesMatch?.fingerprint;
-        const seriesLabels: JSONObject | undefined = seriesMatch?.labels;
-        const seriesRootCause: string =
-          seriesMatch?.rootCause || input.rootCause;
+        try {
+          const seriesFingerprint: string | undefined =
+            seriesMatch?.fingerprint;
+          const seriesLabels: JSONObject | undefined = seriesMatch?.labels;
+          const seriesRootCause: string =
+            seriesMatch?.rootCause || input.rootCause;
 
-        /*
-         * Per-series scheduled-maintenance suppression: this series'
-         * resource is inside an ongoing maintenance window, so skip
-         * creating an incident for it. Other series on the same monitor
-         * whose resources are not under maintenance still get incidents.
-         * Note: we only suppress *new* creation — any incident already
-         * open for this series is left to the normal resolve path
-         * (checkOpenIncidentsAndCloseIfResolved still sees the full
-         * breaching set), so a real incident raised before maintenance
-         * is not silently closed.
-         */
-        if (
-          seriesFingerprint &&
-          input.suppressedSeriesFingerprints?.has(seriesFingerprint)
-        ) {
-          logger.debug(
-            `${input.monitor.id?.toString()} - Skipping incident for series ${seriesFingerprint}: its resource is under an active scheduled maintenance window.`,
-            incidentLogAttributes,
-          );
-
-          input.evaluationSummary?.events.push({
-            type: "incident-skipped",
-            title: "Incident suppressed by scheduled maintenance",
-            message:
-              "Skipped creating an incident because the resource for this series is under an active scheduled maintenance window.",
-            relatedCriteriaId: input.criteriaInstance.data?.id,
-            at: OneUptimeDate.getCurrentDate(),
-          });
-          continue;
-        }
-
-        /*
-         * Dedupe match must mirror the create path below (which sets
-         * `createdCriteriaId` / `createdIncidentTemplateId` only when the
-         * corresponding id is present). A criteria incident template can be
-         * missing its `id` (legacy/API-authored criteria), so guard the
-         * `.toString()` with `?.` — an unguarded call previously threw
-         * "Cannot read properties of undefined (reading 'toString')" here and
-         * failed the probe/telemetry queue job on every cycle for the affected
-         * monitor. Normalise both sides to `undefined` on missing so a created
-         * incident (whose template id was left NULL) still matches itself next
-         * cycle instead of being recreated as a duplicate.
-         */
-        const alreadyOpenIncident: Incident | undefined = openIncidents.find(
-          (incident: Incident) => {
-            return (
-              (incident.createdCriteriaId || undefined) ===
-                (input.criteriaInstance.data?.id?.toString() || undefined) &&
-              (incident.createdIncidentTemplateId || undefined) ===
-                (criteriaIncident.id?.toString() || undefined) &&
-              (incident.seriesFingerprint || undefined) === seriesFingerprint
-            );
-          },
-        );
-
-        const hasAlreadyOpenIncident: boolean = Boolean(alreadyOpenIncident);
-
-        logger.debug(
-          `${input.monitor.id?.toString()} - Open Incident ${alreadyOpenIncident?.id?.toString()}`,
-          incidentLogAttributes,
-        );
-
-        logger.debug(
-          `${input.monitor.id?.toString()} - Has open incident ${hasAlreadyOpenIncident}`,
-          incidentLogAttributes,
-        );
-
-        if (hasAlreadyOpenIncident) {
           /*
-           * Use the open incident's already-rendered title when
-           * available — the template (`criteriaIncident.title`) still
-           * contains unresolved `{{…}}` placeholders because it's the
-           * criterion's template string, not the instance's rendered
-           * output. Falling back to the template only when the open
-           * incident somehow has no title.
+           * Per-series scheduled-maintenance suppression: this series'
+           * resource is inside an ongoing maintenance window, so skip
+           * creating an incident for it. Other series on the same monitor
+           * whose resources are not under maintenance still get incidents.
+           * Note: we only suppress *new* creation — any incident already
+           * open for this series is left to the normal resolve path
+           * (checkOpenIncidentsAndCloseIfResolved still sees the full
+           * breaching set), so a real incident raised before maintenance
+           * is not silently closed.
            */
-          const renderedTitle: string =
-            alreadyOpenIncident?.title || criteriaIncident.title;
-
-          input.evaluationSummary?.events.push({
-            type: "incident-skipped",
-            title: `Incident already active: ${renderedTitle}`,
-            message:
-              "Skipped creating a new incident because an active incident exists for this criteria.",
-            relatedCriteriaId: input.criteriaInstance.data?.id,
-            relatedIncidentId: alreadyOpenIncident?.id?.toString(),
-            relatedIncidentNumber: alreadyOpenIncident?.incidentNumber,
-            relatedIncidentNumberWithPrefix:
-              alreadyOpenIncident?.incidentNumberWithPrefix,
-            at: OneUptimeDate.getCurrentDate(),
-          });
-          continue;
-        }
-
-        logger.debug(
-          `${input.monitor.id?.toString()} - Create incident.`,
-          incidentLogAttributes,
-        );
-
-        const incident: Incident = new Incident();
-        const storageMap: JSONObject =
-          MonitorTemplateUtil.buildTemplateStorageMap({
-            monitorType: input.monitor.monitorType!,
-            dataToProcess: input.dataToProcess,
-            monitor: input.monitor,
-            seriesLabels,
-          });
-
-        incident.title = MonitorTemplateUtil.processTemplateString({
-          value: criteriaIncident.title,
-          storageMap,
-        });
-        incident.description = MonitorTemplateUtil.processTemplateString({
-          value: criteriaIncident.description,
-          storageMap,
-        });
-
-        /*
-         * Resolve the incident severity. `criteriaIncident.incidentSeverityId`
-         * can be a truthy-but-EMPTY ObjectID (id === "") — a stored
-         * `{"_type":"ObjectID","value":""}` deserializes to `new ObjectID("")`,
-         * which is an object so `!incidentSeverityId` is false. That empty id
-         * serializes to "" for the `uuid` (not-null) column and lands as NULL,
-         * throwing 23502 inside the probe-ingest worker and retrying forever.
-         * Use `?.toString()` truthiness so an empty/blank ObjectID is treated
-         * the same as "missing" and falls through to the project-default lookup.
-         */
-        /*
-         * A criteria severity that belongs to *another* project is rejected by
-         * IncidentService on create. Throwing here would fail the whole
-         * probe/telemetry ingest job for this monitor — no incident, and no
-         * payload or monitor log persisted either, because those run after the
-         * create. Treat it as "missing" and fall back to this project's own
-         * default, which is also what stops the bad id spreading onto new
-         * incidents. monitorSteps can still hold one: the 1785240000000
-         * repair skipped ids it could not resolve.
-         */
-        const isCriteriaSeverityUsable: boolean =
-          await ProjectScopedReferenceValidator.isUsableInProject({
-            projectId: input.monitor.projectId!,
-            id: criteriaIncident.incidentSeverityId,
-            service: IncidentSeverityService,
-          });
-
-        if (
-          criteriaIncident.incidentSeverityId?.toString() &&
-          !isCriteriaSeverityUsable
-        ) {
-          logger.error(
-            `${input.monitor.id?.toString()} - Criteria "${
-              input.criteriaInstance.data?.name
-            }" references incident severity ${criteriaIncident.incidentSeverityId.toString()}, which does not belong to project ${input.monitor.projectId?.toString()}. Falling back to this project's default severity.`,
-          );
-        }
-
-        if (!isCriteriaSeverityUsable) {
-          // pick the critical (first/lowest-order root) severity.
-
-          const severity: IncidentSeverity | null =
-            await IncidentSeverityService.findOneBy({
-              query: {
-                projectId: input.monitor.projectId!,
-              },
-              sort: {
-                order: SortOrder.Ascending,
-              },
-              props: {
-                isRoot: true,
-              },
-              select: {
-                _id: true,
-              },
-            });
-
-          if (!severity?.id?.toString()) {
-            /*
-             * The project has no incident severity configured. Throwing here
-             * would fail the entire probe/telemetry ingest job, which then
-             * retries forever for a misconfiguration the worker cannot fix.
-             * Skip incident creation gracefully and log instead.
-             */
-            logger.error(
-              `${input.monitor.id?.toString()} - Cannot create incident: project ${input.monitor.projectId?.toString()} has no incident severity configured. Skipping incident creation for criteria "${
-                input.criteriaInstance.data?.name
-              }".`,
+          if (
+            seriesFingerprint &&
+            input.suppressedSeriesFingerprints?.has(seriesFingerprint)
+          ) {
+            logger.debug(
+              `${input.monitor.id?.toString()} - Skipping incident for series ${seriesFingerprint}: its resource is under an active scheduled maintenance window.`,
+              incidentLogAttributes,
             );
 
             input.evaluationSummary?.events.push({
               type: "incident-skipped",
-              title: "Incident creation skipped",
+              title: "Incident suppressed by scheduled maintenance",
               message:
-                "Skipped creating an incident because the project has no incident severity configured.",
+                "Skipped creating an incident because the resource for this series is under an active scheduled maintenance window.",
               relatedCriteriaId: input.criteriaInstance.data?.id,
               at: OneUptimeDate.getCurrentDate(),
             });
             continue;
           }
 
-          incident.incidentSeverityId = severity.id!;
-        } else {
-          incident.incidentSeverityId = criteriaIncident.incidentSeverityId!;
-        }
-
-        incident.monitors = [input.monitor];
-        incident.projectId = input.monitor.projectId!;
-        incident.rootCause = seriesRootCause;
-        incident.createdStateLog = JSON.parse(
-          JSON.stringify(input.dataToProcess, null, 2),
-        );
-
-        /*
-         * Same capture on every incident this evaluation opens - they all
-         * came from the one check.
-         */
-        const serializedMonitorSummary: JSONObject | null =
-          MonitorSummarySnapshotUtil.serialize(input.monitorSummary);
-
-        if (serializedMonitorSummary) {
-          incident.monitorSummary = serializedMonitorSummary;
-        }
-
-        /*
-         * Guard against missing ids — these are optional reference fields and
-         * must not crash incident creation (which runs inside the probe /
-         * telemetry queue workers). A missing id previously threw
-         * "Cannot read properties of undefined (reading 'toString')" and failed
-         * the job on every cycle for the affected monitor.
-         */
-        if (input.criteriaInstance.data?.id) {
-          incident.createdCriteriaId =
-            input.criteriaInstance.data.id.toString();
-        }
-
-        if (criteriaIncident.id) {
-          incident.createdIncidentTemplateId = criteriaIncident.id.toString();
-        }
-
-        if (seriesFingerprint) {
-          incident.seriesFingerprint = seriesFingerprint;
-        }
-        if (seriesLabels && Object.keys(seriesLabels).length > 0) {
-          incident.seriesLabels = seriesLabels;
-
-          await SeriesResourceLinker.linkSeriesResourcesToModel({
-            model: incident,
-            seriesLabels,
-            projectId: input.monitor.projectId!,
-            monitorType: input.monitor.monitorType,
-          });
-        }
-
-        /*
-         * Deterministic resource link from the monitor's step config
-         * (resolved once above). Runs for both grouped and ungrouped
-         * incidents and merges with anything the series-label path
-         * resolved, so the per-resource Activity tabs always see
-         * monitor-created incidents.
-         */
-        SeriesResourceLinker.attachResolvedResources({
-          model: incident,
-          resolved: resourceContext,
-        });
-
-        incident.onCallDutyPolicies =
-          criteriaIncident.onCallPolicyIds?.map((id: ObjectID) => {
-            const onCallPolicy: OnCallDutyPolicy = new OnCallDutyPolicy();
-            onCallPolicy._id = id.toString();
-            return onCallPolicy;
-          }) || [];
-
-        // Set labels from criteria
-        incident.labels =
-          criteriaIncident.labelIds?.map((id: ObjectID) => {
-            const label: Label = new Label();
-            label._id = id.toString();
-            return label;
-          }) || [];
-
-        incident.isCreatedAutomatically = true;
-
-        // Set status page visibility (defaults to true if not specified)
-        if (criteriaIncident.showIncidentOnStatusPage !== undefined) {
-          incident.isVisibleOnStatusPage =
-            criteriaIncident.showIncidentOnStatusPage;
-        }
-
-        if (criteriaIncident.isPrivate === true) {
-          incident.isPrivate = true;
-        }
-
-        if (input.props.telemetryQuery) {
-          incident.telemetryQuery = input.props.telemetryQuery;
-        }
-
-        if (
-          input.dataToProcess &&
-          (input.dataToProcess as ProbeMonitorResponse).probeId
-        ) {
-          incident.createdByProbeId = (
-            input.dataToProcess as ProbeMonitorResponse
-          ).probeId;
-        }
-
-        if (criteriaIncident.remediationNotes) {
-          incident.remediationNotes = MonitorTemplateUtil.processTemplateString(
-            {
-              value: criteriaIncident.remediationNotes,
-              storageMap,
+          /*
+           * Dedupe match must mirror the create path below (which sets
+           * `createdCriteriaId` / `createdIncidentTemplateId` only when the
+           * corresponding id is present). A criteria incident template can be
+           * missing its `id` (legacy/API-authored criteria), so guard the
+           * `.toString()` with `?.` — an unguarded call previously threw
+           * "Cannot read properties of undefined (reading 'toString')" here and
+           * failed the probe/telemetry queue job on every cycle for the affected
+           * monitor. Normalise both sides to `undefined` on missing so a created
+           * incident (whose template id was left NULL) still matches itself next
+           * cycle instead of being recreated as a duplicate.
+           */
+          const alreadyOpenIncident: Incident | undefined = openIncidents.find(
+            (incident: Incident) => {
+              return (
+                (incident.createdCriteriaId || undefined) ===
+                  (input.criteriaInstance.data?.id?.toString() || undefined) &&
+                (incident.createdIncidentTemplateId || undefined) ===
+                  (criteriaIncident.id?.toString() || undefined) &&
+                (incident.seriesFingerprint || undefined) === seriesFingerprint
+              );
             },
           );
-        }
 
-        if (DisableAutomaticIncidentCreation) {
-          input.evaluationSummary?.events.push({
-            type: "incident-skipped",
-            title: "Incident creation skipped",
-            message:
-              "Automatic incident creation is disabled by environment configuration.",
-            relatedCriteriaId: input.criteriaInstance.data?.id,
-            at: OneUptimeDate.getCurrentDate(),
-          });
-          return;
-        }
+          const hasAlreadyOpenIncident: boolean = Boolean(alreadyOpenIncident);
 
-        const createdIncident: Incident = await IncidentService.create({
-          data: incident,
-          props: {
-            isRoot: true,
-          },
-        });
+          logger.debug(
+            `${input.monitor.id?.toString()} - Open Incident ${alreadyOpenIncident?.id?.toString()}`,
+            incidentLogAttributes,
+          );
 
-        /*
-         * Add owner teams and users after incident creation. Owners
-         * configured on the criteria template are merged (deduped) with the
-         * owners of the network device this monitor watches, so device
-         * ownership flows into the incidents its monitor raises.
-         */
-        if (networkDeviceOwners === null) {
-          networkDeviceOwners =
-            await NetworkDeviceOwnerUserService.getDeviceOwnersForMonitor({
-              monitor: input.monitor,
-              monitorStepId: (
-                input.dataToProcess as ProbeMonitorResponse
-              ).monitorStepId?.toString(),
+          logger.debug(
+            `${input.monitor.id?.toString()} - Has open incident ${hasAlreadyOpenIncident}`,
+            incidentLogAttributes,
+          );
+
+          if (hasAlreadyOpenIncident) {
+            /*
+             * Use the open incident's already-rendered title when
+             * available — the template (`criteriaIncident.title`) still
+             * contains unresolved `{{…}}` placeholders because it's the
+             * criterion's template string, not the instance's rendered
+             * output. Falling back to the template only when the open
+             * incident somehow has no title.
+             */
+            const renderedTitle: string =
+              alreadyOpenIncident?.title || criteriaIncident.title;
+
+            input.evaluationSummary?.events.push({
+              type: "incident-skipped",
+              title: `Incident already active: ${renderedTitle}`,
+              message:
+                "Skipped creating a new incident because an active incident exists for this criteria.",
+              relatedCriteriaId: input.criteriaInstance.data?.id,
+              relatedIncidentId: alreadyOpenIncident?.id?.toString(),
+              relatedIncidentNumber: alreadyOpenIncident?.incidentNumber,
+              relatedIncidentNumberWithPrefix:
+                alreadyOpenIncident?.incidentNumberWithPrefix,
+              at: OneUptimeDate.getCurrentDate(),
             });
-        }
+            continue;
+          }
 
-        const ownerUserIds: Array<ObjectID> = this.mergeOwnerIds(
-          criteriaIncident.ownerUserIds || [],
-          networkDeviceOwners.ownerUserIds,
-        );
+          logger.debug(
+            `${input.monitor.id?.toString()} - Create incident.`,
+            incidentLogAttributes,
+          );
 
-        const ownerTeamIds: Array<ObjectID> = this.mergeOwnerIds(
-          criteriaIncident.ownerTeamIds || [],
-          networkDeviceOwners.ownerTeamIds,
-        );
+          const incident: Incident = new Incident();
+          const storageMap: JSONObject =
+            MonitorTemplateUtil.buildTemplateStorageMap({
+              monitorType: input.monitor.monitorType!,
+              dataToProcess: input.dataToProcess,
+              monitor: input.monitor,
+              seriesLabels,
+            });
 
-        if (ownerTeamIds.length || ownerUserIds.length) {
-          await IncidentService.addOwners(
-            input.monitor.projectId!,
-            createdIncident.id!,
-            ownerUserIds,
-            ownerTeamIds,
-            true, // notify owners
-            {
+          incident.title = MonitorTemplateUtil.processTemplateString({
+            value: criteriaIncident.title,
+            storageMap,
+          });
+          incident.description = MonitorTemplateUtil.processTemplateString({
+            value: criteriaIncident.description,
+            storageMap,
+          });
+
+          /*
+           * Resolve the incident severity. `criteriaIncident.incidentSeverityId`
+           * can be a truthy-but-EMPTY ObjectID (id === "") — a stored
+           * `{"_type":"ObjectID","value":""}` deserializes to `new ObjectID("")`,
+           * which is an object so `!incidentSeverityId` is false. That empty id
+           * serializes to "" for the `uuid` (not-null) column and lands as NULL,
+           * throwing 23502 inside the probe-ingest worker and retrying forever.
+           * Use `?.toString()` truthiness so an empty/blank ObjectID is treated
+           * the same as "missing" and falls through to the project-default lookup.
+           */
+          /*
+           * A criteria severity that belongs to *another* project is rejected by
+           * IncidentService on create. Throwing here would fail the whole
+           * probe/telemetry ingest job for this monitor — no incident, and no
+           * payload or monitor log persisted either, because those run after the
+           * create. Treat it as "missing" and fall back to this project's own
+           * default, which is also what stops the bad id spreading onto new
+           * incidents. monitorSteps can still hold one: the 1785240000000
+           * repair skipped ids it could not resolve.
+           */
+          const isCriteriaSeverityUsable: boolean =
+            await ProjectScopedReferenceValidator.isUsableInProject({
+              projectId: input.monitor.projectId!,
+              id: criteriaIncident.incidentSeverityId,
+              service: IncidentSeverityService,
+            });
+
+          if (
+            criteriaIncident.incidentSeverityId?.toString() &&
+            !isCriteriaSeverityUsable
+          ) {
+            logger.error(
+              `${input.monitor.id?.toString()} - Criteria "${
+                input.criteriaInstance.data?.name
+              }" references incident severity ${criteriaIncident.incidentSeverityId.toString()}, which does not belong to project ${input.monitor.projectId?.toString()}. Falling back to this project's default severity.`,
+            );
+          }
+
+          if (!isCriteriaSeverityUsable) {
+            // pick the critical (first/lowest-order root) severity.
+
+            const severity: IncidentSeverity | null =
+              await IncidentSeverityService.findOneBy({
+                query: {
+                  projectId: input.monitor.projectId!,
+                },
+                sort: {
+                  order: SortOrder.Ascending,
+                },
+                props: {
+                  isRoot: true,
+                },
+                select: {
+                  _id: true,
+                },
+              });
+
+            if (!severity?.id?.toString()) {
+              /*
+               * The project has no incident severity configured. Throwing here
+               * would fail the entire probe/telemetry ingest job, which then
+               * retries forever for a misconfiguration the worker cannot fix.
+               * Skip incident creation gracefully and log instead.
+               */
+              logger.error(
+                `${input.monitor.id?.toString()} - Cannot create incident: project ${input.monitor.projectId?.toString()} has no incident severity configured. Skipping incident creation for criteria "${
+                  input.criteriaInstance.data?.name
+                }".`,
+              );
+
+              input.evaluationSummary?.events.push({
+                type: "incident-skipped",
+                title: "Incident creation skipped",
+                message:
+                  "Skipped creating an incident because the project has no incident severity configured.",
+                relatedCriteriaId: input.criteriaInstance.data?.id,
+                at: OneUptimeDate.getCurrentDate(),
+              });
+              continue;
+            }
+
+            incident.incidentSeverityId = severity.id!;
+          } else {
+            incident.incidentSeverityId = criteriaIncident.incidentSeverityId!;
+          }
+
+          incident.monitors = [input.monitor];
+          incident.projectId = input.monitor.projectId!;
+          incident.rootCause = seriesRootCause;
+          incident.createdStateLog = JSON.parse(
+            JSON.stringify(input.dataToProcess, null, 2),
+          );
+
+          /*
+           * Same capture on every incident this evaluation opens - they all
+           * came from the one check.
+           */
+          const serializedMonitorSummary: JSONObject | null =
+            MonitorSummarySnapshotUtil.serialize(input.monitorSummary);
+
+          if (serializedMonitorSummary) {
+            incident.monitorSummary = serializedMonitorSummary;
+          }
+
+          /*
+           * Guard against missing ids — these are optional reference fields and
+           * must not crash incident creation (which runs inside the probe /
+           * telemetry queue workers). A missing id previously threw
+           * "Cannot read properties of undefined (reading 'toString')" and failed
+           * the job on every cycle for the affected monitor.
+           */
+          if (input.criteriaInstance.data?.id) {
+            incident.createdCriteriaId =
+              input.criteriaInstance.data.id.toString();
+          }
+
+          if (criteriaIncident.id) {
+            incident.createdIncidentTemplateId = criteriaIncident.id.toString();
+          }
+
+          if (seriesFingerprint) {
+            incident.seriesFingerprint = seriesFingerprint;
+          }
+          if (seriesLabels && Object.keys(seriesLabels).length > 0) {
+            incident.seriesLabels = seriesLabels;
+
+            await SeriesResourceLinker.linkSeriesResourcesToModel({
+              model: incident,
+              seriesLabels,
+              projectId: input.monitor.projectId!,
+              monitorType: input.monitor.monitorType,
+            });
+          }
+
+          /*
+           * Deterministic resource link from the monitor's step config
+           * (resolved once above). Runs for both grouped and ungrouped
+           * incidents and merges with anything the series-label path
+           * resolved, so the per-resource Activity tabs always see
+           * monitor-created incidents.
+           */
+          SeriesResourceLinker.attachResolvedResources({
+            model: incident,
+            resolved: resourceContext,
+          });
+
+          incident.onCallDutyPolicies =
+            criteriaIncident.onCallPolicyIds?.map((id: ObjectID) => {
+              const onCallPolicy: OnCallDutyPolicy = new OnCallDutyPolicy();
+              onCallPolicy._id = id.toString();
+              return onCallPolicy;
+            }) || [];
+
+          // Set labels from criteria
+          incident.labels =
+            criteriaIncident.labelIds?.map((id: ObjectID) => {
+              const label: Label = new Label();
+              label._id = id.toString();
+              return label;
+            }) || [];
+
+          incident.isCreatedAutomatically = true;
+
+          // Set status page visibility (defaults to true if not specified)
+          if (criteriaIncident.showIncidentOnStatusPage !== undefined) {
+            incident.isVisibleOnStatusPage =
+              criteriaIncident.showIncidentOnStatusPage;
+          }
+
+          if (criteriaIncident.isPrivate === true) {
+            incident.isPrivate = true;
+          }
+
+          if (input.props.telemetryQuery) {
+            incident.telemetryQuery = input.props.telemetryQuery;
+          }
+
+          if (
+            input.dataToProcess &&
+            (input.dataToProcess as ProbeMonitorResponse).probeId
+          ) {
+            incident.createdByProbeId = (
+              input.dataToProcess as ProbeMonitorResponse
+            ).probeId;
+          }
+
+          if (criteriaIncident.remediationNotes) {
+            incident.remediationNotes =
+              MonitorTemplateUtil.processTemplateString({
+                value: criteriaIncident.remediationNotes,
+                storageMap,
+              });
+          }
+
+          const createdIncident: Incident = await IncidentService.create({
+            data: incident,
+            props: {
               isRoot: true,
             },
+          });
+
+          /*
+           * Add owner teams and users after incident creation. Owners
+           * configured on the criteria template are merged (deduped) with the
+           * owners of the network device this monitor watches, so device
+           * ownership flows into the incidents its monitor raises.
+           */
+          if (networkDeviceOwners === null) {
+            networkDeviceOwners =
+              await NetworkDeviceOwnerUserService.getDeviceOwnersForMonitor({
+                monitor: input.monitor,
+                monitorStepId: (
+                  input.dataToProcess as ProbeMonitorResponse
+                ).monitorStepId?.toString(),
+              });
+          }
+
+          const ownerUserIds: Array<ObjectID> = this.mergeOwnerIds(
+            criteriaIncident.ownerUserIds || [],
+            networkDeviceOwners.ownerUserIds,
           );
-        }
 
-        // Add incident member role assignments after incident creation
-        if (
-          criteriaIncident.incidentMemberRoles &&
-          criteriaIncident.incidentMemberRoles.length > 0
-        ) {
-          for (const roleAssignment of criteriaIncident.incidentMemberRoles) {
-            try {
-              const assignment: IncidentMemberRoleAssignment =
-                roleAssignment as IncidentMemberRoleAssignment;
+          const ownerTeamIds: Array<ObjectID> = this.mergeOwnerIds(
+            criteriaIncident.ownerTeamIds || [],
+            networkDeviceOwners.ownerTeamIds,
+          );
 
-              if (assignment.roleId && assignment.userId) {
-                const incidentMember: IncidentMember = new IncidentMember();
-                incidentMember.incidentId = createdIncident.id!;
-                incidentMember.projectId = input.monitor.projectId!;
-                incidentMember.userId = new ObjectID(
-                  assignment.userId.toString(),
-                );
-                incidentMember.incidentRoleId = new ObjectID(
-                  assignment.roleId.toString(),
-                );
+          if (ownerTeamIds.length || ownerUserIds.length) {
+            await IncidentService.addOwners(
+              input.monitor.projectId!,
+              createdIncident.id!,
+              ownerUserIds,
+              ownerTeamIds,
+              true, // notify owners
+              {
+                isRoot: true,
+              },
+            );
+          }
 
-                await IncidentMemberService.create({
-                  data: incidentMember,
-                  props: {
-                    isRoot: true,
-                  },
-                });
+          // Add incident member role assignments after incident creation
+          if (
+            criteriaIncident.incidentMemberRoles &&
+            criteriaIncident.incidentMemberRoles.length > 0
+          ) {
+            for (const roleAssignment of criteriaIncident.incidentMemberRoles) {
+              try {
+                const assignment: IncidentMemberRoleAssignment =
+                  roleAssignment as IncidentMemberRoleAssignment;
 
-                logger.debug(
-                  `${input.monitor.id?.toString()} - Assigned incident member role ${assignment.roleId.toString()} to user ${assignment.userId.toString()}`,
+                if (assignment.roleId && assignment.userId) {
+                  const incidentMember: IncidentMember = new IncidentMember();
+                  incidentMember.incidentId = createdIncident.id!;
+                  incidentMember.projectId = input.monitor.projectId!;
+                  incidentMember.userId = new ObjectID(
+                    assignment.userId.toString(),
+                  );
+                  incidentMember.incidentRoleId = new ObjectID(
+                    assignment.roleId.toString(),
+                  );
+
+                  await IncidentMemberService.create({
+                    data: incidentMember,
+                    props: {
+                      isRoot: true,
+                    },
+                  });
+
+                  logger.debug(
+                    `${input.monitor.id?.toString()} - Assigned incident member role ${assignment.roleId.toString()} to user ${assignment.userId.toString()}`,
+                    incidentLogAttributes,
+                  );
+                }
+              } catch (memberError) {
+                logger.error(
+                  `${input.monitor.id?.toString()} - Failed to assign incident member role: ${memberError}`,
                   incidentLogAttributes,
                 );
               }
-            } catch (memberError) {
-              logger.error(
-                `${input.monitor.id?.toString()} - Failed to assign incident member role: ${memberError}`,
-                incidentLogAttributes,
-              );
             }
           }
-        }
 
-        input.evaluationSummary?.events.push({
-          type: "incident-created",
-          title: `Incident created: ${createdIncident.title || criteriaIncident.title}`,
-          message: `Incident triggered from criteria "${input.criteriaInstance.data?.name || "Unnamed criteria"}".`,
-          relatedCriteriaId: input.criteriaInstance.data?.id,
-          relatedIncidentId: createdIncident.id?.toString(),
-          relatedIncidentNumber: createdIncident.incidentNumber,
-          relatedIncidentNumberWithPrefix:
-            createdIncident.incidentNumberWithPrefix,
-          at: OneUptimeDate.getCurrentDate(),
-        });
+          input.evaluationSummary?.events.push({
+            type: "incident-created",
+            title: `Incident created: ${createdIncident.title || criteriaIncident.title}`,
+            message: `Incident triggered from criteria "${input.criteriaInstance.data?.name || "Unnamed criteria"}".`,
+            relatedCriteriaId: input.criteriaInstance.data?.id,
+            relatedIncidentId: createdIncident.id?.toString(),
+            relatedIncidentNumber: createdIncident.incidentNumber,
+            relatedIncidentNumberWithPrefix:
+              createdIncident.incidentNumberWithPrefix,
+            at: OneUptimeDate.getCurrentDate(),
+          });
+        } catch (err) {
+          /*
+           * One series must not take the rest of the fleet down with it.
+           * Everything in this loop happens per host/container/key and
+           * touches the database; an error thrown from here used to
+           * propagate out of MonitorResource (which has no catch, only a
+           * `finally` that releases the lock) and abandon every series
+           * after the failing one, plus the monitor log for the tick.
+           */
+          logger.error(
+            `${input.monitor.id?.toString()} - Failed to create incident${
+              seriesMatch?.fingerprint
+                ? ` for series ${seriesMatch.fingerprint}`
+                : ""
+            }.`,
+          );
+          logger.error(err);
+
+          input.evaluationSummary?.events.push({
+            type: "incident-skipped",
+            title: "Incident creation failed",
+            message: `Could not create an incident${
+              seriesMatch?.fingerprint
+                ? ` for series ${seriesMatch.fingerprint}`
+                : ""
+            }: ${err instanceof Error ? err.message : String(err)}`,
+            relatedCriteriaId: input.criteriaInstance.data?.id,
+            at: OneUptimeDate.getCurrentDate(),
+          });
+
+          continue;
+        }
       }
     }
   }
@@ -929,6 +1026,106 @@ export default class MonitorIncident {
     }
   }
 
+  /**
+   * Is `openIncident`'s series still breaching the criteria that raised
+   * it?
+   *
+   * Prefers the per-criteria dictionary, which answers the question for
+   * the criteria that actually owns this incident. The single-set
+   * fallback only knows the winning criteria's breaches, so it has to
+   * approximate with `createIncidents` — a criteria that creates no
+   * incidents is a recovery criteria whose "matches" are healthy series,
+   * and counting those as breaches would pin an offline incident open
+   * forever.
+   */
+  private static isSeriesStillBreaching(input: {
+    openIncident: Incident;
+    criteriaInstance: MonitorCriteriaInstance | null;
+    openSeriesFingerprint: string;
+    breachingSeriesFingerprints: Set<string>;
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
+  }): boolean {
+    const owningCriteriaId: string | undefined =
+      input.openIncident.createdCriteriaId?.toString() || undefined;
+
+    if (input.breachingSeriesFingerprintsByCriteriaId && owningCriteriaId) {
+      return Boolean(
+        input.breachingSeriesFingerprintsByCriteriaId[owningCriteriaId]?.has(
+          input.openSeriesFingerprint,
+        ),
+      );
+    }
+
+    const matchedCriteriaCreatesIncidents: boolean =
+      input.criteriaInstance?.data?.createIncidents === true;
+
+    return (
+      matchedCriteriaCreatesIncidents &&
+      input.breachingSeriesFingerprints.has(input.openSeriesFingerprint)
+    );
+  }
+
+  private static wasCriteriaEvaluated(input: {
+    openIncident: Incident;
+    breachingSeriesFingerprintsByCriteriaId: Dictionary<Set<string>>;
+  }): boolean {
+    const owningCriteriaId: string | undefined =
+      input.openIncident.createdCriteriaId?.toString() || undefined;
+
+    if (!owningCriteriaId) {
+      return true;
+    }
+
+    return (
+      input.breachingSeriesFingerprintsByCriteriaId[owningCriteriaId] !==
+      undefined
+    );
+  }
+
+  /**
+   * Did the criteria that raised this incident opt into auto-resolve for
+   * the template that raised it?
+   *
+   * An incident whose `createdIncidentTemplateId` is missing (legacy or
+   * API-authored criteria whose template carries no id) is matched
+   * against the criteria as a whole. Requiring an exact template id
+   * there meant such an incident could never auto-resolve — and, because
+   * it stayed open, its criteria could never raise a new one either.
+   */
+  private static isAutoResolveConfiguredForIncident(input: {
+    openIncident: Incident;
+    autoResolveCriteriaInstanceIdIncidentIdsDictionary: Dictionary<
+      Array<string>
+    >;
+  }): boolean {
+    const createdCriteriaId: string | undefined =
+      input.openIncident.createdCriteriaId?.toString() || undefined;
+
+    if (!createdCriteriaId) {
+      return false;
+    }
+
+    const autoResolveTemplates: Array<string> | undefined =
+      input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
+        createdCriteriaId
+      ];
+
+    if (!autoResolveTemplates || autoResolveTemplates.length === 0) {
+      return false;
+    }
+
+    const createdTemplateId: string | undefined =
+      input.openIncident.createdIncidentTemplateId?.toString() || undefined;
+
+    if (!createdTemplateId) {
+      return true;
+    }
+
+    return autoResolveTemplates.includes(createdTemplateId);
+  }
+
   private static shouldCloseIncident(input: {
     openIncident: Incident;
     autoResolveCriteriaInstanceIdIncidentIdsDictionary: Dictionary<
@@ -936,6 +1133,9 @@ export default class MonitorIncident {
     >;
     criteriaInstance: MonitorCriteriaInstance | null; // null if no criteia met.
     breachingSeriesFingerprints?: Set<string> | undefined;
+    breachingSeriesFingerprintsByCriteriaId?:
+      | Dictionary<Set<string>>
+      | undefined;
     disableSeriesAbsenceResolution?: boolean | undefined;
   }): boolean {
     const openSeriesFingerprint: string | undefined =
@@ -956,69 +1156,75 @@ export default class MonitorIncident {
       return false;
     }
 
-    /*
-     * Per-series auto-resolve: when the monitor emits a breaching-
-     * series set and this open incident has a fingerprint, resolve
-     * whenever the fingerprint is no longer in the set — regardless
-     * of whether some *other* series is still breaching the same
-     * criteria. This is the whole point of per-host incidents.
-     */
-    if (
-      input.breachingSeriesFingerprints !== undefined &&
-      openSeriesFingerprint
-    ) {
+    // Per-series mode: this evaluation knows which series are breaching.
+    if (input.breachingSeriesFingerprints !== undefined) {
       /*
-       * The breaching set is the matched criteria's per-series matches.
-       * Only ONE criteria wins per evaluation tick, so on a recovery
-       * tick the matched criteria is the RECOVERY criteria (e.g.
-       * Min(iot_device_up) >= 1) and its "matches" are healthy series —
-       * NOT breaches. Treating them as breaching would leave the open
-       * offline incident's fingerprint in the set and pin it open
-       * forever once no other series is down. So membership only counts
-       * as still-breaching when the matched criteria actually creates
-       * incidents (an offline/breach criteria); a recovery criteria
-       * (createIncidents=false) contributes no breaches and lets the
-       * per-series incident auto-resolve.
+       * A whole-monitor incident (no fingerprint) on a monitor that now
+       * raises incidents per series. It was raised before the monitor
+       * was grouped, and nothing can ever dedupe against it again —
+       * every incident from here on carries a fingerprint. Left alone it
+       * stays open forever while its replacements come and go. Resolve
+       * it, on the same auto-resolve terms as any other incident from
+       * its criteria.
        */
-      const matchedCriteriaCreatesIncidents: boolean =
-        input.criteriaInstance?.data?.createIncidents === true;
+      if (!openSeriesFingerprint) {
+        if (input.disableSeriesAbsenceResolution) {
+          return false;
+        }
 
-      const stillBreaching: boolean =
-        matchedCriteriaCreatesIncidents &&
-        input.breachingSeriesFingerprints.has(openSeriesFingerprint);
-
-      if (stillBreaching) {
-        return false;
+        return MonitorIncident.isAutoResolveConfiguredForIncident({
+          openIncident: input.openIncident,
+          autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+            input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+        });
       }
 
       /*
-       * Series no longer breaching. Only auto-close if the criteria
-       * was configured to auto-resolve in the first place; otherwise
-       * stay open so a human can acknowledge.
+       * Per-series auto-resolve: resolve whenever this fingerprint is no
+       * longer breaching the criteria that raised it — regardless of
+       * whether some *other* series is still breaching. That is the
+       * whole point of per-host incidents.
        */
-      if (!input.openIncident.createdCriteriaId?.toString()) {
-        return false;
-      }
-
-      if (!input.openIncident.createdIncidentTemplateId?.toString()) {
-        return false;
-      }
-
-      const autoResolveTemplates: Array<string> | undefined =
-        input.autoResolveCriteriaInstanceIdIncidentIdsDictionary[
-          input.openIncident.createdCriteriaId.toString()
-        ];
-
       if (
-        autoResolveTemplates &&
-        autoResolveTemplates.includes(
-          input.openIncident.createdIncidentTemplateId.toString(),
-        )
+        MonitorIncident.isSeriesStillBreaching({
+          openIncident: input.openIncident,
+          criteriaInstance: input.criteriaInstance,
+          openSeriesFingerprint,
+          breachingSeriesFingerprints: input.breachingSeriesFingerprints,
+          breachingSeriesFingerprintsByCriteriaId:
+            input.breachingSeriesFingerprintsByCriteriaId,
+        })
       ) {
-        return true;
+        return false;
       }
 
-      return false;
+      /*
+       * The criteria that raised this incident was not evaluated on this
+       * tick at all (disabled, deleted, or the monitor stops at its
+       * first match). Absence of a breaching set for it is not evidence
+       * of recovery, so leave the incident alone.
+       */
+      if (
+        input.breachingSeriesFingerprintsByCriteriaId &&
+        !MonitorIncident.wasCriteriaEvaluated({
+          openIncident: input.openIncident,
+          breachingSeriesFingerprintsByCriteriaId:
+            input.breachingSeriesFingerprintsByCriteriaId,
+        })
+      ) {
+        return false;
+      }
+
+      /*
+       * Series no longer breaching. Only auto-close if the criteria was
+       * configured to auto-resolve in the first place; otherwise stay
+       * open so a human can acknowledge.
+       */
+      return MonitorIncident.isAutoResolveConfiguredForIncident({
+        openIncident: input.openIncident,
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+          input.autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+      });
     }
 
     if (

--- a/Common/Server/Utils/Monitor/MonitorResource.ts
+++ b/Common/Server/Utils/Monitor/MonitorResource.ts
@@ -25,7 +25,12 @@ import MonitorType, {
 import ServerMonitorResponse from "../../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
 import ObjectID from "../../../Types/ObjectID";
 import { JSONObject } from "../../../Types/JSON";
-import ProbeApiIngestResponse from "../../../Types/Probe/ProbeApiIngestResponse";
+import ProbeApiIngestResponse, {
+  MatchedCriteriaResult,
+  PerSeriesCriteriaMatch,
+} from "../../../Types/Probe/ProbeApiIngestResponse";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import Alert from "../../../Models/DatabaseModels/Alert";
 import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import MonitorProbe, {
@@ -966,6 +971,67 @@ export default class MonitorResourceUtil {
         }
 
         /*
+         * The criteria this evaluation is going to act on.
+         *
+         * Grouped monitors evaluate every criteria and can match several
+         * at once — host A critical while host B is only warning — so
+         * they hand back a list. Everything else keeps the historical
+         * single-winner shape, reconstructed here so both cases go down
+         * exactly the same code path below.
+         */
+        const criteriaFanOut: Array<MatchedCriteriaResult> =
+          response.matchedCriteria ?? [
+            {
+              criteriaId: response.criteriaMetId!,
+              rootCause: response.rootCause,
+              perSeriesMatches: response.perSeriesMatches ?? [],
+            },
+          ];
+
+        const isPerSeriesEvaluation: boolean =
+          response.perSeriesMatches !== undefined;
+
+        /*
+         * Every series breaching anything on this tick, and the same
+         * broken out per criteria.
+         *
+         * The resolve pass needs the per-criteria view: "is host B still
+         * breaching?" has to be answered against the criteria that
+         * raised host B's alert, not against whichever criteria happened
+         * to win the tick. Answering it against the winner resolved a
+         * still-valid warning alert the moment another host went
+         * critical. A criteria that ran and matched nothing maps to an
+         * empty set — that is what lets a recovered series resolve —
+         * while a criteria that never ran is absent, and its records are
+         * left alone.
+         */
+        const breachingSeriesFingerprintsByCriteriaId: Dictionary<Set<string>> =
+          {};
+
+        if (response.evaluatedCriteriaIds) {
+          for (const evaluatedCriteriaId of response.evaluatedCriteriaIds) {
+            breachingSeriesFingerprintsByCriteriaId[evaluatedCriteriaId] =
+              new Set<string>();
+          }
+        }
+
+        const allBreachingSeriesFingerprints: Set<string> = new Set<string>();
+
+        for (const matched of criteriaFanOut) {
+          const forCriteria: Set<string> =
+            breachingSeriesFingerprintsByCriteriaId[matched.criteriaId] ||
+            new Set<string>();
+
+          breachingSeriesFingerprintsByCriteriaId[matched.criteriaId] =
+            forCriteria;
+
+          for (const seriesMatch of matched.perSeriesMatches) {
+            forCriteria.add(seriesMatch.fingerprint);
+            allBreachingSeriesFingerprints.add(seriesMatch.fingerprint);
+          }
+        }
+
+        /*
          * For grouped metric monitors, work out which breaching series
          * belong to a resource that is currently inside an ongoing
          * scheduled maintenance window. Those series are suppressed
@@ -977,7 +1043,11 @@ export default class MonitorResourceUtil {
         const suppressedSeriesFingerprints: Set<string> =
           await MonitorMaintenanceSuppression.getSuppressedSeriesFingerprints({
             projectId: monitor.projectId!,
-            matchesPerSeries: response.perSeriesMatches,
+            matchesPerSeries: isPerSeriesEvaluation
+              ? criteriaFanOut.flatMap((matched: MatchedCriteriaResult) => {
+                  return matched.perSeriesMatches;
+                })
+              : undefined,
           });
 
         /*
@@ -1011,54 +1081,130 @@ export default class MonitorResourceUtil {
             probeName: probeName,
           });
 
-        await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
-          monitor: monitor,
-          rootCause: response.rootCause,
-          dataToProcess: dataToProcess,
-          autoResolveCriteriaInstanceIdIncidentIdsDictionary,
-          criteriaInstance: matchedCriteriaInstance,
-          evaluationSummary: evaluationSummary,
-          monitorSummary: monitorSummary,
-          props: {
-            telemetryQuery: telemetryQuery,
-          },
-          matchesPerSeries: response.perSeriesMatches,
-          suppressedSeriesFingerprints,
-          dependencySuppression,
-          /*
-           * Incoming-request grouping is event-driven: a webhook describes
-           * only the keys in its payload, so absence from this tick is not
-           * recovery. Skip the snapshot absence-resolve pass; grouped
-           * incidents are resolved explicitly via the resolution block
-           * above. Per-key create + dedupe still run from matchesPerSeries.
-           */
-          disableSeriesAbsenceResolution:
-            monitor.monitorType === MonitorType.IncomingRequest,
-        });
+        /*
+         * Incoming-request grouping is event-driven: a webhook describes
+         * only the keys in its payload, so absence from this tick is not
+         * recovery. Skip the snapshot absence-resolve pass; grouped
+         * incidents/alerts are resolved explicitly via the resolution
+         * block above. Per-key create + dedupe still run from
+         * matchesPerSeries.
+         */
+        const disableSeriesAbsenceResolution: boolean =
+          monitor.monitorType === MonitorType.IncomingRequest;
 
-        await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
-          monitor: monitor,
-          rootCause: response.rootCause,
-          dataToProcess: dataToProcess,
-          autoResolveCriteriaInstanceIdAlertIdsDictionary,
-          criteriaInstance: criteriaInstanceAlertMap[response.criteriaMetId!]!,
-          evaluationSummary: evaluationSummary,
-          monitorSummary: monitorSummary,
-          props: {
-            telemetryQuery: telemetryQuery,
-          },
-          matchesPerSeries: response.perSeriesMatches,
-          suppressedSeriesFingerprints,
-          dependencySuppression,
-          /*
-           * Incoming-request grouping is event-driven (see the incident
-           * create call above): skip the snapshot absence-resolve pass for
-           * webhooks; grouped alerts are resolved explicitly via the
-           * resolution block above. Per-key create + dedupe still run.
-           */
-          disableSeriesAbsenceResolution:
-            monitor.monitorType === MonitorType.IncomingRequest,
-        });
+        const breachingSeriesFingerprints: Set<string> | undefined =
+          isPerSeriesEvaluation && !disableSeriesAbsenceResolution
+            ? allBreachingSeriesFingerprints
+            : undefined;
+
+        /*
+         * Resolve first, once, for the whole evaluation — then create.
+         *
+         * The resolve pass has to see every criteria's breaching set at
+         * the same time. Running it once per matching criteria would let
+         * each criteria absence-resolve the records the others just
+         * justified. The creators are handed the survivors so they never
+         * dedupe a new alert against one this pass has already closed.
+         */
+        const openIncidents: Array<Incident> =
+          await MonitorIncident.checkOpenIncidentsAndCloseIfResolved({
+            monitorId: monitor.id!,
+            autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+            rootCause: response.rootCause,
+            criteriaInstance: matchedCriteriaInstance,
+            dataToProcess: dataToProcess,
+            evaluationSummary: evaluationSummary,
+            breachingSeriesFingerprints,
+            breachingSeriesFingerprintsByCriteriaId: response.matchedCriteria
+              ? breachingSeriesFingerprintsByCriteriaId
+              : undefined,
+            disableSeriesAbsenceResolution,
+          });
+
+        const openAlerts: Array<Alert> =
+          await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+            monitorId: monitor.id!,
+            autoResolveCriteriaInstanceIdAlertIdsDictionary,
+            rootCause: response.rootCause,
+            criteriaInstance: matchedCriteriaInstance,
+            dataToProcess: dataToProcess,
+            evaluationSummary: evaluationSummary,
+            breachingSeriesFingerprints,
+            breachingSeriesFingerprintsByCriteriaId: response.matchedCriteria
+              ? breachingSeriesFingerprintsByCriteriaId
+              : undefined,
+            disableSeriesAbsenceResolution,
+          });
+
+        /*
+         * De-escalation: a host that breaches both "critical" and
+         * "warning" gets one record, from the first (highest priority)
+         * criteria that claims it — criteria are in user-defined order
+         * and the first match is the one that also sets the monitor's
+         * status. Tracked separately for incidents and alerts because a
+         * criteria can create one without the other.
+         */
+        const seriesClaimedByIncidentCriteria: Set<string> = new Set<string>();
+        const seriesClaimedByAlertCriteria: Set<string> = new Set<string>();
+
+        for (const matched of criteriaFanOut) {
+          const criteriaInstance: MonitorCriteriaInstance | undefined =
+            criteriaInstanceMap[matched.criteriaId];
+
+          if (!criteriaInstance) {
+            continue;
+          }
+
+          await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus(
+            {
+              monitor: monitor,
+              rootCause: matched.rootCause,
+              dataToProcess: dataToProcess,
+              autoResolveCriteriaInstanceIdIncidentIdsDictionary,
+              criteriaInstance: criteriaInstance,
+              evaluationSummary: evaluationSummary,
+              monitorSummary: monitorSummary,
+              props: {
+                telemetryQuery: telemetryQuery,
+              },
+              matchesPerSeries: isPerSeriesEvaluation
+                ? MonitorResourceUtil.claimUnclaimedSeries({
+                    matches: matched.perSeriesMatches,
+                    claimed: seriesClaimedByIncidentCriteria,
+                    isClaiming: criteriaInstance.data?.createIncidents === true,
+                  })
+                : undefined,
+              openIncidents,
+              suppressedSeriesFingerprints,
+              dependencySuppression,
+              disableSeriesAbsenceResolution,
+            },
+          );
+
+          await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+            monitor: monitor,
+            rootCause: matched.rootCause,
+            dataToProcess: dataToProcess,
+            autoResolveCriteriaInstanceIdAlertIdsDictionary,
+            criteriaInstance: criteriaInstanceAlertMap[matched.criteriaId]!,
+            evaluationSummary: evaluationSummary,
+            monitorSummary: monitorSummary,
+            props: {
+              telemetryQuery: telemetryQuery,
+            },
+            matchesPerSeries: isPerSeriesEvaluation
+              ? MonitorResourceUtil.claimUnclaimedSeries({
+                  matches: matched.perSeriesMatches,
+                  claimed: seriesClaimedByAlertCriteria,
+                  isClaiming: criteriaInstance.data?.createAlerts === true,
+                })
+              : undefined,
+            openAlerts,
+            suppressedSeriesFingerprints,
+            dependencySuppression,
+            disableSeriesAbsenceResolution,
+          });
+        }
       } else if (
         !response.criteriaMetId &&
         /*
@@ -1361,6 +1507,37 @@ export default class MonitorResourceUtil {
   }
 
   @CaptureSpan()
+  /**
+   * Take the series this criteria may act on, given what earlier
+   * (higher-priority) criteria have already claimed.
+   *
+   * A host breaching both "critical" and "warning" should page once,
+   * from the more severe band. Criteria that create nothing claim
+   * nothing, so a passive recovery criteria never steals a series from
+   * the criteria that would have alerted on it.
+   */
+  private static claimUnclaimedSeries(input: {
+    matches: Array<PerSeriesCriteriaMatch>;
+    claimed: Set<string>;
+    isClaiming: boolean;
+  }): Array<PerSeriesCriteriaMatch> {
+    if (!input.isClaiming) {
+      return input.matches;
+    }
+
+    const unclaimed: Array<PerSeriesCriteriaMatch> = input.matches.filter(
+      (match: PerSeriesCriteriaMatch) => {
+        return !input.claimed.has(match.fingerprint);
+      },
+    );
+
+    for (const match of unclaimed) {
+      input.claimed.add(match.fingerprint);
+    }
+
+    return unclaimed;
+  }
+
   private static async checkProbeAgreement(input: {
     monitor: Monitor;
     monitorStep: MonitorStep;

--- a/Common/Server/Utils/Monitor/PerEntityCriteriaFanOut.ts
+++ b/Common/Server/Utils/Monitor/PerEntityCriteriaFanOut.ts
@@ -1,0 +1,329 @@
+import { CheckOn, CriteriaFilter } from "../../../Types/Monitor/CriteriaFilter";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
+import ServerMonitorResponse from "../../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
+import SnmpMonitorResponse from "../../../Types/Monitor/SnmpMonitor/SnmpMonitorResponse";
+import SnmpInterface from "../../../Types/Monitor/SnmpMonitor/SnmpInterface";
+import { BasicDiskMetrics } from "../../../Types/Infrastructure/BasicMetrics";
+import MetricSeriesFingerprint from "../../../Utils/Metrics/MetricSeriesFingerprint";
+import { PerSeriesCriteriaMatch } from "../../../Types/Probe/ProbeApiIngestResponse";
+import DataToProcess from "./DataToProcess";
+import logger from "../Logger";
+
+/**
+ * The value a user types into "Disk Path" or "Interface Name" to mean
+ * "every one of them, and raise a separate alert for each".
+ *
+ * Metric-backed monitors express the same idea with a Group By
+ * attribute. The non-metric monitor types have no group-by concept —
+ * their criteria name ONE entity — so this is how they opt in. Leaving
+ * the field at its existing value keeps today's behaviour exactly: one
+ * alert for the whole monitor, naming whichever entity the criteria was
+ * pinned to.
+ */
+export const AllEntitiesWildcard: string = "*";
+
+/**
+ * A hard ceiling on how many entities one criteria may fan out to.
+ *
+ * Each entity is a full criteria re-evaluation, and an
+ * "evaluate over time" filter makes each of those a query. A switch
+ * with hundreds of ports would otherwise turn one monitor tick into
+ * hundreds of round trips and hundreds of alerts. Truncation is logged
+ * rather than silent — a monitor that quietly covers only part of its
+ * fleet reads exactly like one that covers all of it.
+ */
+export const MaxEntitiesPerCriteria: number = 100;
+
+/**
+ * One entity a criteria can be narrowed down to — a mountpoint, a
+ * network interface — together with the labels that identify it on the
+ * alert it raises.
+ */
+export interface FanOutEntity {
+  /**
+   * Identity of this entity, stored on the alert/incident as
+   * seriesLabels and hashed into its seriesFingerprint. Also reachable
+   * from the alert title template.
+   */
+  labels: JSONObject;
+  /**
+   * Rewrite one criteria filter so it names this entity and nothing
+   * else. Filters that do not address an entity are returned unchanged,
+   * so a criteria mixing "CPU > 90%" with "any disk > 90%" still means
+   * what it says for each disk.
+   */
+  narrowFilter: (filter: CriteriaFilter) => CriteriaFilter;
+}
+
+export default class PerEntityCriteriaFanOut {
+  public static isWildcard(value: string | undefined | null): boolean {
+    return (value || "").trim() === AllEntitiesWildcard;
+  }
+
+  /**
+   * Re-evaluate one criteria once per entity and return a match for
+   * every entity that satisfies it on its own.
+   *
+   * Deliberately reuses the caller's full criteria evaluation rather
+   * than reimplementing threshold comparison per entity: filter
+   * conditions (All/Any), evaluate-over-time windows, no-data policies
+   * and every filter type keep meaning exactly what they mean on the
+   * whole-monitor path.
+   */
+  public static async collectMatches(input: {
+    criteriaInstance: MonitorCriteriaInstance;
+    entities: Array<FanOutEntity>;
+    evaluateNarrowedCriteria: (
+      narrowedCriteriaInstance: MonitorCriteriaInstance,
+    ) => Promise<string | null>;
+    monitorId: string | undefined;
+  }): Promise<Array<PerSeriesCriteriaMatch>> {
+    const criteriaId: string | undefined = input.criteriaInstance.data?.id;
+
+    if (!criteriaId || input.entities.length === 0) {
+      return [];
+    }
+
+    let entities: Array<FanOutEntity> = input.entities;
+
+    if (entities.length > MaxEntitiesPerCriteria) {
+      logger.warn(
+        `${input.monitorId} - Criteria "${input.criteriaInstance.data?.name}" matched ${entities.length} entities, which is above the ${MaxEntitiesPerCriteria} per-criteria cap. Only the first ${MaxEntitiesPerCriteria} are evaluated; narrow the criteria to cover the rest.`,
+      );
+      entities = entities.slice(0, MaxEntitiesPerCriteria);
+    }
+
+    const matches: Array<PerSeriesCriteriaMatch> = [];
+
+    for (const entity of entities) {
+      const narrowed: MonitorCriteriaInstance =
+        PerEntityCriteriaFanOut.narrowCriteriaInstance({
+          criteriaInstance: input.criteriaInstance,
+          entity,
+        });
+
+      const rootCause: string | null =
+        await input.evaluateNarrowedCriteria(narrowed);
+
+      if (!rootCause) {
+        continue;
+      }
+
+      matches.push({
+        criteriaMetId: criteriaId,
+        fingerprint: MetricSeriesFingerprint.computeFingerprint(entity.labels),
+        labels: entity.labels,
+        rootCause: rootCause,
+      });
+    }
+
+    return matches;
+  }
+
+  /**
+   * A copy of the criteria whose filters address exactly one entity.
+   *
+   * The copy is deliberately shallow-per-filter: the evaluator writes
+   * transient state onto the filter objects it evaluates (metric
+   * context, resolved thresholds), and that must not leak back onto the
+   * monitor's stored criteria or bleed between entities.
+   */
+  private static narrowCriteriaInstance(input: {
+    criteriaInstance: MonitorCriteriaInstance;
+    entity: FanOutEntity;
+  }): MonitorCriteriaInstance {
+    const narrowed: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+
+    narrowed.data = {
+      ...input.criteriaInstance.data,
+      filters: (input.criteriaInstance.data?.filters || []).map(
+        (filter: CriteriaFilter) => {
+          return input.entity.narrowFilter(filter);
+        },
+      ),
+    } as MonitorCriteriaInstance["data"];
+
+    return narrowed;
+  }
+
+  /**
+   * The disks a Server monitor's criteria should fan out over: every
+   * disk the agent reported, but only when the criteria actually asks
+   * for all of them.
+   *
+   * Returns an empty array — meaning "not a per-disk criteria, take the
+   * whole-monitor path" — when no filter uses the wildcard.
+   */
+  public static getServerDiskEntities(input: {
+    dataToProcess: DataToProcess;
+    criteriaInstance: MonitorCriteriaInstance;
+  }): Array<FanOutEntity> {
+    if (
+      !PerEntityCriteriaFanOut.isServerDiskFanOutConfigured(
+        input.criteriaInstance,
+      )
+    ) {
+      return [];
+    }
+
+    const serverResponse: ServerMonitorResponse =
+      input.dataToProcess as ServerMonitorResponse;
+
+    const diskMetrics: Array<BasicDiskMetrics> =
+      serverResponse.basicInfrastructureMetrics?.diskMetrics || [];
+
+    const seenDiskPaths: Set<string> = new Set<string>();
+    const entities: Array<FanOutEntity> = [];
+
+    for (const diskMetric of diskMetrics) {
+      const diskPath: string = (diskMetric.diskPath || "").trim();
+
+      if (!diskPath || seenDiskPaths.has(diskPath)) {
+        continue;
+      }
+
+      seenDiskPaths.add(diskPath);
+
+      entities.push({
+        labels: { diskPath: diskPath },
+        narrowFilter: (filter: CriteriaFilter): CriteriaFilter => {
+          if (
+            filter.checkOn !== CheckOn.DiskUsagePercent ||
+            !PerEntityCriteriaFanOut.isWildcard(
+              filter.serverMonitorOptions?.diskPath,
+            )
+          ) {
+            return filter;
+          }
+
+          return {
+            ...filter,
+            serverMonitorOptions: {
+              ...filter.serverMonitorOptions,
+              diskPath: diskPath,
+            },
+          };
+        },
+      });
+    }
+
+    return entities;
+  }
+
+  public static isServerDiskFanOutConfigured(
+    criteriaInstance: MonitorCriteriaInstance,
+  ): boolean {
+    return (criteriaInstance.data?.filters || []).some(
+      (filter: CriteriaFilter) => {
+        return (
+          filter.checkOn === CheckOn.DiskUsagePercent &&
+          PerEntityCriteriaFanOut.isWildcard(
+            filter.serverMonitorOptions?.diskPath,
+          )
+        );
+      },
+    );
+  }
+
+  /**
+   * The interfaces an SNMP monitor's criteria should fan out over.
+   *
+   * Note the asymmetry with the disk case: an EMPTY interface name
+   * already means "all interfaces" to the existing scoping code, and
+   * has done since before per-entity alerting existed. Treating empty
+   * as opt-in would turn one "3 interfaces down" alert into three
+   * alerts on every existing SNMP monitor at upgrade time, so the
+   * wildcard has to be explicit here too.
+   */
+  public static getSnmpInterfaceEntities(input: {
+    dataToProcess: DataToProcess;
+    criteriaInstance: MonitorCriteriaInstance;
+  }): Array<FanOutEntity> {
+    if (
+      !PerEntityCriteriaFanOut.isSnmpInterfaceFanOutConfigured(
+        input.criteriaInstance,
+      )
+    ) {
+      return [];
+    }
+
+    const snmpResponse: SnmpMonitorResponse =
+      input.dataToProcess as unknown as SnmpMonitorResponse;
+
+    const interfaces: Array<SnmpInterface> = snmpResponse?.interfaces || [];
+
+    const seenInterfaceNames: Set<string> = new Set<string>();
+    const entities: Array<FanOutEntity> = [];
+
+    for (const snmpInterface of interfaces) {
+      /*
+       * Scoping matches on name OR alias, so the name is what a
+       * narrowed filter has to carry. An interface with neither cannot
+       * be addressed individually and stays on the whole-monitor path.
+       */
+      const interfaceName: string = (snmpInterface.name || "").trim();
+
+      if (!interfaceName || seenInterfaceNames.has(interfaceName)) {
+        continue;
+      }
+
+      seenInterfaceNames.add(interfaceName);
+
+      const labels: JSONObject = { interfaceName: interfaceName };
+
+      if (snmpInterface.alias) {
+        labels["interfaceAlias"] = snmpInterface.alias;
+      }
+
+      entities.push({
+        labels,
+        narrowFilter: (filter: CriteriaFilter): CriteriaFilter => {
+          if (
+            !PerEntityCriteriaFanOut.isInterfaceScopedCheckOn(filter.checkOn) ||
+            !PerEntityCriteriaFanOut.isWildcard(
+              filter.snmpMonitorOptions?.interfaceName,
+            )
+          ) {
+            return filter;
+          }
+
+          return {
+            ...filter,
+            snmpMonitorOptions: {
+              ...filter.snmpMonitorOptions,
+              interfaceName: interfaceName,
+            },
+          };
+        },
+      });
+    }
+
+    return entities;
+  }
+
+  public static isSnmpInterfaceFanOutConfigured(
+    criteriaInstance: MonitorCriteriaInstance,
+  ): boolean {
+    return (criteriaInstance.data?.filters || []).some(
+      (filter: CriteriaFilter) => {
+        return (
+          PerEntityCriteriaFanOut.isInterfaceScopedCheckOn(filter.checkOn) &&
+          PerEntityCriteriaFanOut.isWildcard(
+            filter.snmpMonitorOptions?.interfaceName,
+          )
+        );
+      },
+    );
+  }
+
+  private static isInterfaceScopedCheckOn(
+    checkOn: CheckOn | undefined,
+  ): boolean {
+    return (
+      checkOn === CheckOn.SnmpInterfaceIsDown ||
+      checkOn === CheckOn.SnmpInterfaceUtilizationPercent ||
+      checkOn === CheckOn.SnmpInterfaceErrorsPerSecond
+    );
+  }
+}

--- a/Common/Tests/Server/Utils/Monitor/Criteria/SyntheticMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/SyntheticMonitorCriteria.test.ts
@@ -1,0 +1,259 @@
+import SyntheticMonitoringCriteria from "../../../../../Server/Utils/Monitor/Criteria/SyntheticMonitor";
+import CustomCodeMonitoringCriteria from "../../../../../Server/Utils/Monitor/Criteria/CustomCodeMonitorCriteria";
+import BrowserType from "../../../../../Types/BrowserType";
+import ScreenSizeType from "../../../../../Types/ScreenSizeType";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import SyntheticMonitorResponse from "../../../../../Types/Monitor/SyntheticMonitors/SyntheticMonitorResponse";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The repo mixes @types/jest and @jest/globals typings, so the concrete spy
+ * type returned by jest.spyOn is not portable between them. This structural
+ * alias is the same workaround used elsewhere in Common/Tests and is all these
+ * tests need: a call count.
+ */
+type SpyLike = {
+  mock: { calls: Array<unknown> };
+};
+
+/*
+ * A synthetic monitor run produces one SyntheticMonitorResponse per
+ * browser / screen-size combination it was configured with (Chromium + Firefox,
+ * Mobile + Desktop, ...). SyntheticMonitoringCriteria.isMonitorInstanceCriteriaFilterMet
+ * has to evaluate EVERY response in that array and return the first one that
+ * breaches the filter; a non-matching response must not end the evaluation.
+ *
+ * These tests pin that contract down for the BrowserType / ScreenSizeType
+ * branches (which previously returned the raw, possibly-null, comparison result
+ * from inside the loop and therefore only ever looked at the first response),
+ * and confirm the custom-code branch keeps its short-circuit behaviour.
+ */
+
+function buildResponse(input: {
+  browserType: BrowserType;
+  screenSizeType: ScreenSizeType;
+  executionTimeInMS?: number | undefined;
+  scriptError?: string | undefined;
+}): SyntheticMonitorResponse {
+  return {
+    result: "ok",
+    scriptError: input.scriptError,
+    logMessages: [],
+    capturedMetrics: [],
+    executionTimeInMS: input.executionTimeInMS ?? 100,
+    browserType: input.browserType,
+    screenSizeType: input.screenSizeType,
+  };
+}
+
+function evaluate(
+  monitorResponse: Array<SyntheticMonitorResponse>,
+  criteriaFilter: CriteriaFilter,
+): Promise<string | null> {
+  return SyntheticMonitoringCriteria.isMonitorInstanceCriteriaFilterMet({
+    monitorResponse,
+    criteriaFilter,
+  });
+}
+
+describe("SyntheticMonitoringCriteria.isMonitorInstanceCriteriaFilterMet", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("every response in the run is evaluated", () => {
+    test("CheckOn.BrowserType matches on the SECOND response", async () => {
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Desktop,
+        }),
+        buildResponse({
+          browserType: BrowserType.Firefox,
+          screenSizeType: ScreenSizeType.Desktop,
+        }),
+      ];
+
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.BrowserType,
+        filterType: FilterType.EqualTo,
+        value: BrowserType.Firefox,
+      });
+
+      expect(result).toBe(`${CheckOn.BrowserType} is equal to Firefox.`);
+    });
+
+    test("CheckOn.ScreenSizeType matches on the LAST response", async () => {
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Mobile,
+        }),
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Tablet,
+        }),
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Desktop,
+        }),
+      ];
+
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.ScreenSizeType,
+        filterType: FilterType.EqualTo,
+        value: ScreenSizeType.Desktop,
+      });
+
+      expect(result).toBe(`${CheckOn.ScreenSizeType} is equal to Desktop.`);
+    });
+
+    test("the first MATCHING response still wins", async () => {
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Mobile,
+        }),
+        buildResponse({
+          browserType: BrowserType.Firefox,
+          screenSizeType: ScreenSizeType.Desktop,
+        }),
+      ];
+
+      /*
+       * NotEqualTo matches BOTH responses; the message must describe the first
+       * one that matched rather than the last one seen.
+       */
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.ScreenSizeType,
+        filterType: FilterType.NotEqualTo,
+        value: ScreenSizeType.Desktop,
+      });
+
+      expect(result).toBe(`${CheckOn.ScreenSizeType} is not equal to Desktop.`);
+    });
+  });
+
+  describe("no match", () => {
+    test("no response matches the browser type → null", async () => {
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Desktop,
+        }),
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Mobile,
+        }),
+      ];
+
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.BrowserType,
+        filterType: FilterType.EqualTo,
+        value: BrowserType.Firefox,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("no response matches the screen size → null, and all responses were visited", async () => {
+      const customCodeSpy: SpyLike = jest.spyOn(
+        CustomCodeMonitoringCriteria,
+        "isMonitorInstanceCriteriaFilterMet",
+      ) as unknown as SpyLike;
+
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Mobile,
+        }),
+        buildResponse({
+          browserType: BrowserType.Firefox,
+          screenSizeType: ScreenSizeType.Tablet,
+        }),
+        buildResponse({
+          browserType: BrowserType.Firefox,
+          screenSizeType: ScreenSizeType.Mobile,
+        }),
+      ];
+
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.ScreenSizeType,
+        filterType: FilterType.EqualTo,
+        value: ScreenSizeType.Desktop,
+      });
+
+      expect(result).toBeNull();
+      // one custom-code evaluation per response proves the loop ran to the end.
+      expect(customCodeSpy.mock.calls.length).toBe(responses.length);
+    });
+
+    test("empty response array → null", async () => {
+      const result: string | null = await evaluate([], {
+        checkOn: CheckOn.BrowserType,
+        filterType: FilterType.EqualTo,
+        value: BrowserType.Chromium,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("custom code criteria", () => {
+    test("a custom-code breach on the first response short-circuits the loop", async () => {
+      const customCodeSpy: SpyLike = jest.spyOn(
+        CustomCodeMonitoringCriteria,
+        "isMonitorInstanceCriteriaFilterMet",
+      ) as unknown as SpyLike;
+
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Desktop,
+          executionTimeInMS: 5000,
+        }),
+        buildResponse({
+          browserType: BrowserType.Firefox,
+          screenSizeType: ScreenSizeType.Desktop,
+          executionTimeInMS: 6000,
+        }),
+      ];
+
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.ExecutionTime,
+        filterType: FilterType.GreaterThan,
+        value: 1000,
+      });
+
+      expect(result).toBeTruthy();
+      expect(customCodeSpy.mock.calls.length).toBe(1);
+    });
+
+    test("a custom-code breach on a LATER response is still reported", async () => {
+      const responses: Array<SyntheticMonitorResponse> = [
+        buildResponse({
+          browserType: BrowserType.Chromium,
+          screenSizeType: ScreenSizeType.Desktop,
+          executionTimeInMS: 100,
+        }),
+        buildResponse({
+          browserType: BrowserType.Firefox,
+          screenSizeType: ScreenSizeType.Desktop,
+          executionTimeInMS: 9000,
+        }),
+      ];
+
+      const result: string | null = await evaluate(responses, {
+        checkOn: CheckOn.ExecutionTime,
+        filterType: FilterType.GreaterThan,
+        value: 1000,
+      });
+
+      expect(result).toBeTruthy();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEvaluatorPerSeriesFanout.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCriteriaEvaluatorPerSeriesFanout.test.ts
@@ -1,0 +1,557 @@
+/*
+ * MonitorCriteriaEvaluator reaches the template renderer, which loads the
+ * native isolated-vm addon. Nothing here uses the sandbox and the
+ * prebuilt binary cannot always dlopen in the test environment.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorCriteriaEvaluator from "../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator";
+import MonitorResourceUtil from "../../../../Server/Utils/Monitor/MonitorResource";
+import AggregateModel from "../../../../Types/BaseDatabase/AggregatedModel";
+import AggregatedResult from "../../../../Types/BaseDatabase/AggregatedResult";
+import FilterCondition from "../../../../Types/Filter/FilterCondition";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import MetricMonitorResponse from "../../../../Types/Monitor/MetricMonitor/MetricMonitorResponse";
+import MonitorCriteria from "../../../../Types/Monitor/MonitorCriteria";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import MetricAliasData from "../../../../Types/Metrics/MetricAliasData";
+import MetricQueryConfigData from "../../../../Types/Metrics/MetricQueryConfigData";
+import MetricQueryData from "../../../../Types/Metrics/MetricQueryData";
+import MetricsViewConfig from "../../../../Types/Metrics/MetricsViewConfig";
+import RollingTime from "../../../../Types/RollingTime/RollingTime";
+import MonitorEvaluationSummary from "../../../../Types/Monitor/MonitorEvaluationSummary";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeApiIngestResponse, {
+  MatchedCriteriaResult,
+  PerSeriesCriteriaMatch,
+} from "../../../../Types/Probe/ProbeApiIngestResponse";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Two questions used to share one variable: "which criteria sets the
+ * monitor's status" and "which criteria gets to raise records". Because
+ * evaluation stopped at the first match, a grouped monitor with
+ * `critical > 95%` above `warning > 80%` never evaluated the warning
+ * band at all — a host at 85% got nothing for as long as another host
+ * held the monitor critical.
+ *
+ * Grouped monitors now evaluate every criteria and report all of them;
+ * `criteriaMetId` still names the first match, because the monitor still
+ * has exactly one status. Ungrouped monitors keep first-match-wins.
+ */
+
+const HOST_KEY: string = "host.name";
+
+type SeriesSample = {
+  host: string;
+  // One value per query alias, in alias order (a, then b).
+  valuesByAlias: Array<number>;
+};
+
+function buildStep(input: {
+  aliases: Array<string>;
+  grouped: boolean;
+  criteriaInstances: Array<MonitorCriteriaInstance>;
+}): MonitorStep {
+  const queryConfigs: Array<MetricQueryConfigData> = input.aliases.map(
+    (alias: string): MetricQueryConfigData => {
+      const metricAliasData: MetricAliasData = {
+        metricVariable: alias,
+        title: `Metric ${alias}`,
+        description: undefined,
+        legend: undefined,
+        legendUnit: "%",
+      };
+
+      const metricQueryData: MetricQueryData = {
+        filterData: { metricName: `metric.${alias}` },
+        ...(input.grouped ? { groupByAttributeKeys: [HOST_KEY] } : {}),
+      } as unknown as MetricQueryData;
+
+      return { metricAliasData, metricQueryData };
+    },
+  );
+
+  const metricViewConfig: MetricsViewConfig = {
+    queryConfigs,
+    formulaConfigs: [],
+  };
+
+  const criteria: MonitorCriteria = new MonitorCriteria();
+  criteria.data = {
+    monitorCriteriaInstanceArray: input.criteriaInstances,
+  };
+
+  const monitorStep: MonitorStep = new MonitorStep();
+  monitorStep.data = {
+    id: ObjectID.generate().toString(),
+    monitorCriteria: criteria,
+  } as unknown as MonitorStep["data"];
+  monitorStep.data!.metricMonitor = {
+    metricViewConfig,
+    rollingTime: RollingTime.Past1Minute,
+  };
+
+  return monitorStep;
+}
+
+function buildResponse(input: {
+  aliases: Array<string>;
+  series: Array<SeriesSample>;
+  withSeriesBreakdown: boolean;
+}): MetricMonitorResponse {
+  function sample(value: number, host: string): AggregateModel {
+    return {
+      timestamp: new Date("2026-08-27T00:00:00.000Z"),
+      value,
+      attributes: { [HOST_KEY]: host },
+    } as unknown as AggregateModel;
+  }
+
+  // One AggregatedResult per alias, holding every host's row.
+  const metricResult: Array<AggregatedResult> = input.aliases.map(
+    (_alias: string, aliasIndex: number): AggregatedResult => {
+      return {
+        data: input.series.map((s: SeriesSample) => {
+          return sample(s.valuesByAlias[aliasIndex]!, s.host);
+        }),
+      } as AggregatedResult;
+    },
+  );
+
+  const seriesBreakdown: Array<{
+    fingerprint: string;
+    labels: Record<string, string>;
+    aggregatedResults: Array<AggregatedResult>;
+  }> = input.series.map((s: SeriesSample) => {
+    return {
+      fingerprint: `fp-${s.host}`,
+      labels: { [HOST_KEY]: s.host },
+      aggregatedResults: input.aliases.map(
+        (_alias: string, aliasIndex: number): AggregatedResult => {
+          return {
+            data: [sample(s.valuesByAlias[aliasIndex]!, s.host)],
+          } as AggregatedResult;
+        },
+      ),
+    };
+  });
+
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    metricResult,
+    metricViewConfig: { queryConfigs: [], formulaConfigs: [] },
+    ...(input.withSeriesBreakdown
+      ? {
+          seriesBreakdown:
+            seriesBreakdown as unknown as MetricMonitorResponse["seriesBreakdown"],
+        }
+      : {}),
+  } as unknown as MetricMonitorResponse;
+}
+
+function thresholdFilter(input: {
+  alias: string;
+  greaterThan: number;
+}): CriteriaFilter {
+  return {
+    checkOn: CheckOn.MetricValue,
+    filterType: FilterType.GreaterThan,
+    value: String(input.greaterThan),
+    metricMonitorOptions: {
+      metricAlias: input.alias,
+      metricAggregationType: EvaluateOverTimeType.AnyValue,
+    },
+  };
+}
+
+function criteriaInstance(input: {
+  id: string;
+  name: string;
+  filters: Array<CriteriaFilter>;
+  filterCondition?: FilterCondition | undefined;
+  createAlerts?: boolean | undefined;
+}): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data = {
+    id: input.id,
+    name: input.name,
+    description: "",
+    monitorStatusId: undefined,
+    filterCondition: input.filterCondition || FilterCondition.All,
+    filters: input.filters,
+    incidents: [],
+    alerts: [],
+    createAlerts: input.createAlerts !== false,
+    createIncidents: input.createAlerts !== false,
+  } as unknown as MonitorCriteriaInstance["data"];
+  return instance;
+}
+
+function monitorModel(): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor._id = ObjectID.generate().toString();
+  monitor.projectId = ObjectID.generate();
+  monitor.monitorType = MonitorType.Metrics;
+  monitor.name = "Disk usage by host";
+  return monitor;
+}
+
+function emptySummary(): MonitorEvaluationSummary {
+  return {
+    criteriaResults: [],
+    events: [],
+  } as unknown as MonitorEvaluationSummary;
+}
+
+async function evaluate(input: {
+  grouped: boolean;
+  aliases: Array<string>;
+  criteriaInstances: Array<MonitorCriteriaInstance>;
+  series: Array<SeriesSample>;
+}): Promise<{
+  response: ProbeApiIngestResponse;
+  summary: MonitorEvaluationSummary;
+}> {
+  const monitor: Monitor = monitorModel();
+  const monitorStep: MonitorStep = buildStep({
+    aliases: input.aliases,
+    grouped: input.grouped,
+    criteriaInstances: input.criteriaInstances,
+  });
+  const dataToProcess: MetricMonitorResponse = buildResponse({
+    aliases: input.aliases,
+    series: input.series,
+    // Ungrouped monitors get no breakdown, exactly as the worker does it.
+    withSeriesBreakdown: input.grouped,
+  });
+  const summary: MonitorEvaluationSummary = emptySummary();
+
+  const response: ProbeApiIngestResponse =
+    await MonitorCriteriaEvaluator.processMonitorStep({
+      dataToProcess: dataToProcess,
+      monitorStep: monitorStep,
+      monitor: monitor,
+      probeApiIngestResponse: {
+        monitorId: monitor.id!,
+        rootCause: null,
+      },
+      evaluationSummary: summary,
+    });
+
+  return { response, summary };
+}
+
+function fingerprintsOf(matched: MatchedCriteriaResult): Array<string> {
+  return matched.perSeriesMatches.map((match: PerSeriesCriteriaMatch) => {
+    return match.fingerprint;
+  });
+}
+
+describe("MonitorCriteriaEvaluator per-series fan-out", () => {
+  describe("grouped monitors evaluate every criteria", () => {
+    it("critical on one host and warning on another both fan out", async () => {
+      const { response, summary } = await evaluate({
+        grouped: true,
+        aliases: ["a"],
+        criteriaInstances: [
+          criteriaInstance({
+            id: "critical",
+            name: "Disk > 95%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 95 })],
+          }),
+          criteriaInstance({
+            id: "warning",
+            name: "Disk > 80%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 80 })],
+          }),
+        ],
+        series: [
+          { host: "host-a", valuesByAlias: [96] },
+          { host: "host-b", valuesByAlias: [85] },
+        ],
+      });
+
+      // The monitor still has one status, owned by the first match.
+      expect(response.criteriaMetId).toBe("critical");
+
+      expect(response.matchedCriteria).toHaveLength(2);
+      expect(response.matchedCriteria![0]!.criteriaId).toBe("critical");
+      expect(fingerprintsOf(response.matchedCriteria![0]!)).toEqual([
+        "fp-host-a",
+      ]);
+
+      expect(response.matchedCriteria![1]!.criteriaId).toBe("warning");
+      // host-a breaches 80 too; de-escalation happens downstream.
+      expect(fingerprintsOf(response.matchedCriteria![1]!).sort()).toEqual([
+        "fp-host-a",
+        "fp-host-b",
+      ]);
+
+      expect(response.evaluatedCriteriaIds).toEqual(["critical", "warning"]);
+
+      // Both criteria are reported, so the log explains what happened.
+      expect(summary.criteriaResults).toHaveLength(2);
+      expect(
+        summary.criteriaResults.every(
+          (result: { skipped?: boolean | undefined }) => {
+            return result.skipped !== true;
+          },
+        ),
+      ).toBe(true);
+    });
+
+    it("records an unmatched criteria with an empty breaching set, not as absent", async () => {
+      const { response } = await evaluate({
+        grouped: true,
+        aliases: ["a"],
+        criteriaInstances: [
+          criteriaInstance({
+            id: "critical",
+            name: "Disk > 95%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 95 })],
+          }),
+          criteriaInstance({
+            id: "warning",
+            name: "Disk > 80%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 80 })],
+          }),
+        ],
+        series: [
+          { host: "host-a", valuesByAlias: [96] },
+          { host: "host-b", valuesByAlias: [10] },
+        ],
+      });
+
+      /*
+       * Both criteria ran. "warning" matched host-a only. The resolve
+       * pass needs `evaluatedCriteriaIds` to tell an evaluated-and-clean
+       * criteria (resolve its records) from one that never ran at all
+       * (leave them alone).
+       */
+      expect(response.evaluatedCriteriaIds).toEqual(["critical", "warning"]);
+      expect(response.matchedCriteria).toHaveLength(2);
+    });
+
+    it("a grouped monitor always publishes a per-series array", async () => {
+      const { response } = await evaluate({
+        grouped: true,
+        aliases: ["a"],
+        criteriaInstances: [
+          criteriaInstance({
+            id: "critical",
+            name: "Disk > 95%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 95 })],
+          }),
+        ],
+        series: [{ host: "host-a", valuesByAlias: [96] }],
+      });
+
+      /*
+       * A defined array is what tells the creators to dedupe on
+       * (criteria, series). Leaving it undefined is what made the first
+       * host's alert block every other host.
+       */
+      expect(response.perSeriesMatches).toBeDefined();
+      expect(response.perSeriesMatches).toHaveLength(1);
+      expect(response.perSeriesMatches![0]!.fingerprint).toBe("fp-host-a");
+    });
+  });
+
+  describe("a criteria no single series satisfies does not fire", () => {
+    it("two filters met by two different hosts is not a match", async () => {
+      /*
+       * Under FilterCondition.All the scalar verdict evaluates each
+       * filter independently and each collapses to its own first
+       * breaching series, so filter "a" can be satisfied by host-a while
+       * filter "b" is satisfied by host-b and the criteria reports met.
+       * Honouring that opened one unattributed whole-monitor alert that
+       * then blocked every real per-host alert.
+       */
+      const { response, summary } = await evaluate({
+        grouped: true,
+        aliases: ["a", "b"],
+        criteriaInstances: [
+          criteriaInstance({
+            id: "both-metrics",
+            name: "a and b both high",
+            filterCondition: FilterCondition.All,
+            filters: [
+              thresholdFilter({ alias: "a", greaterThan: 90 }),
+              thresholdFilter({ alias: "b", greaterThan: 90 }),
+            ],
+          }),
+        ],
+        series: [
+          { host: "host-a", valuesByAlias: [95, 10] },
+          { host: "host-b", valuesByAlias: [10, 95] },
+        ],
+      });
+
+      expect(response.criteriaMetId).toBeUndefined();
+      expect(response.matchedCriteria).toEqual([]);
+      expect(summary.criteriaResults[0]!.met).toBe(false);
+    });
+
+    it("the same two filters DO fire when one host satisfies both", async () => {
+      const { response } = await evaluate({
+        grouped: true,
+        aliases: ["a", "b"],
+        criteriaInstances: [
+          criteriaInstance({
+            id: "both-metrics",
+            name: "a and b both high",
+            filterCondition: FilterCondition.All,
+            filters: [
+              thresholdFilter({ alias: "a", greaterThan: 90 }),
+              thresholdFilter({ alias: "b", greaterThan: 90 }),
+            ],
+          }),
+        ],
+        series: [
+          { host: "host-a", valuesByAlias: [95, 95] },
+          { host: "host-b", valuesByAlias: [10, 10] },
+        ],
+      });
+
+      expect(response.criteriaMetId).toBe("both-metrics");
+      expect(fingerprintsOf(response.matchedCriteria![0]!)).toEqual([
+        "fp-host-a",
+      ]);
+    });
+  });
+
+  describe("ungrouped monitors keep first-match-wins", () => {
+    it("stops at the first matching criteria and reports the rest as skipped", async () => {
+      const { response, summary } = await evaluate({
+        grouped: false,
+        aliases: ["a"],
+        criteriaInstances: [
+          criteriaInstance({
+            id: "critical",
+            name: "Disk > 95%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 95 })],
+          }),
+          criteriaInstance({
+            id: "warning",
+            name: "Disk > 80%",
+            filters: [thresholdFilter({ alias: "a", greaterThan: 80 })],
+          }),
+        ],
+        series: [{ host: "host-a", valuesByAlias: [96] }],
+      });
+
+      expect(response.criteriaMetId).toBe("critical");
+      // Nothing new is published for an ungrouped monitor.
+      expect(response.matchedCriteria).toBeUndefined();
+      expect(response.evaluatedCriteriaIds).toBeUndefined();
+      expect(response.perSeriesMatches).toBeUndefined();
+
+      /*
+       * The criteria that never ran is now named in the summary rather
+       * than being an unexplained gap in it.
+       */
+      expect(summary.criteriaResults).toHaveLength(2);
+      expect(summary.criteriaResults[1]!.criteriaId).toBe("warning");
+      expect(summary.criteriaResults[1]!.skipped).toBe(true);
+      expect(summary.criteriaResults[1]!.skipReason).toContain(
+        "already matched",
+      );
+    });
+  });
+});
+
+describe("MonitorResourceUtil de-escalation", () => {
+  /*
+   * claimUnclaimedSeries is private; exercised through the documented
+   * escape hatch, the same way HostAbsenceSeriesIntegration reaches
+   * collectPerSeriesMatches.
+   */
+  const claimUnclaimedSeries: (input: {
+    matches: Array<PerSeriesCriteriaMatch>;
+    claimed: Set<string>;
+    isClaiming: boolean;
+  }) => Array<PerSeriesCriteriaMatch> = (
+    MonitorResourceUtil as unknown as {
+      claimUnclaimedSeries: (input: {
+        matches: Array<PerSeriesCriteriaMatch>;
+        claimed: Set<string>;
+        isClaiming: boolean;
+      }) => Array<PerSeriesCriteriaMatch>;
+    }
+  ).claimUnclaimedSeries;
+
+  function match(fingerprint: string): PerSeriesCriteriaMatch {
+    return {
+      criteriaMetId: "c",
+      fingerprint,
+      labels: {},
+      rootCause: "breached",
+    };
+  }
+
+  it("a host claimed by the critical band is not claimed again by warning", () => {
+    const claimed: Set<string> = new Set<string>();
+
+    const critical: Array<PerSeriesCriteriaMatch> = claimUnclaimedSeries({
+      matches: [match("fp-host-a")],
+      claimed,
+      isClaiming: true,
+    });
+
+    const warning: Array<PerSeriesCriteriaMatch> = claimUnclaimedSeries({
+      matches: [match("fp-host-a"), match("fp-host-b")],
+      claimed,
+      isClaiming: true,
+    });
+
+    expect(
+      critical.map((m: PerSeriesCriteriaMatch) => {
+        return m.fingerprint;
+      }),
+    ).toEqual(["fp-host-a"]);
+    // host-a already pages at critical; only host-b gets the warning.
+    expect(
+      warning.map((m: PerSeriesCriteriaMatch) => {
+        return m.fingerprint;
+      }),
+    ).toEqual(["fp-host-b"]);
+  });
+
+  it("a criteria that creates nothing claims nothing", () => {
+    const claimed: Set<string> = new Set<string>();
+
+    claimUnclaimedSeries({
+      matches: [match("fp-host-a")],
+      claimed,
+      isClaiming: false,
+    });
+
+    const alerting: Array<PerSeriesCriteriaMatch> = claimUnclaimedSeries({
+      matches: [match("fp-host-a")],
+      claimed,
+      isClaiming: true,
+    });
+
+    /*
+     * A passive recovery criteria must never steal a series from the
+     * criteria that would have alerted on it.
+     */
+    expect(
+      alerting.map((m: PerSeriesCriteriaMatch) => {
+        return m.fingerprint;
+      }),
+    ).toEqual(["fp-host-a"]);
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorDependencySuppressionCreatorSkip.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorDependencySuppressionCreatorSkip.test.ts
@@ -459,7 +459,12 @@ describe("Dependency-suppression skip block in the alert / incident creators", (
           evaluationSummary: summary,
         });
 
-      expect(openAlerts).toHaveLength(1);
+      /*
+       * The return value is the set still open AFTER the pass, which the
+       * create path dedupes against — an alert this pass just resolved
+       * must not count as "already active" there.
+       */
+      expect(openAlerts).toHaveLength(0);
       expect(createdAlertStateTimelines).toHaveLength(1);
       expect(createdAlertStateTimelines[0]!.alertId?.toString()).toBe(
         openAlert.id!.toString(),
@@ -595,7 +600,12 @@ describe("Dependency-suppression skip block in the alert / incident creators", (
           evaluationSummary: summary,
         });
 
-      expect(openIncidents).toHaveLength(1);
+      /*
+       * The return value is the set still open AFTER the pass, which the
+       * create path dedupes against — an incident this pass just resolved
+       * must not count as "already active" there.
+       */
+      expect(openIncidents).toHaveLength(0);
       expect(createdIncidentStateTimelines).toHaveLength(1);
       expect(createdIncidentStateTimelines[0]!.incidentId?.toString()).toBe(
         openIncident.id!.toString(),

--- a/Common/Tests/Server/Utils/Monitor/PerEntityCriteriaFanOut.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/PerEntityCriteriaFanOut.test.ts
@@ -1,0 +1,444 @@
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorCriteriaEvaluator from "../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator";
+import PerEntityCriteriaFanOut, {
+  FanOutEntity,
+} from "../../../../Server/Utils/Monitor/PerEntityCriteriaFanOut";
+import ServerMonitorCriteria from "../../../../Server/Utils/Monitor/Criteria/ServerMonitorCriteria";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import FilterCondition from "../../../../Types/Filter/FilterCondition";
+import { BasicDiskMetrics } from "../../../../Types/Infrastructure/BasicMetrics";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../../Types/ObjectID";
+import { PerSeriesCriteriaMatch } from "../../../../Types/Probe/ProbeApiIngestResponse";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Server and SNMP monitors see several independent entities per check —
+ * every mounted filesystem, every port on a switch — but their criteria
+ * name one at a time. Two full mountpoints therefore produced ONE alert,
+ * and the second one to fill up was silenced for as long as the first
+ * one's alert stayed open: exactly the reported bug, on a monitor type
+ * with no Group By to turn on.
+ *
+ * "*" is how those criteria opt in. Anything else keeps today's
+ * behaviour byte for byte.
+ */
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+function diskFilter(input: {
+  diskPath: string;
+  greaterThan: number;
+}): CriteriaFilter {
+  return {
+    checkOn: CheckOn.DiskUsagePercent,
+    filterType: FilterType.GreaterThan,
+    value: String(input.greaterThan),
+    serverMonitorOptions: { diskPath: input.diskPath },
+  };
+}
+
+function cpuFilter(greaterThan: number): CriteriaFilter {
+  return {
+    checkOn: CheckOn.CPUUsagePercent,
+    filterType: FilterType.GreaterThan,
+    value: String(greaterThan),
+  };
+}
+
+function criteriaWith(input: {
+  filters: Array<CriteriaFilter>;
+  filterCondition?: FilterCondition | undefined;
+}): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data = {
+    id: "criteria-1",
+    name: "Disk is filling up",
+    description: "",
+    monitorStatusId: undefined,
+    filterCondition: input.filterCondition || FilterCondition.All,
+    filters: input.filters,
+    incidents: [],
+    alerts: [],
+    createAlerts: true,
+    createIncidents: true,
+  } as unknown as MonitorCriteriaInstance["data"];
+  return instance;
+}
+
+function serverResponse(
+  disks: Array<{ diskPath: string; percentUsed: number }>,
+  cpuPercent: number = 5,
+): DataToProcess {
+  const diskMetrics: Array<BasicDiskMetrics> = disks.map(
+    (disk: { diskPath: string; percentUsed: number }): BasicDiskMetrics => {
+      return {
+        total: 100,
+        free: 100 - disk.percentUsed,
+        used: disk.percentUsed,
+        diskPath: disk.diskPath,
+        percentUsed: disk.percentUsed,
+        percentFree: 100 - disk.percentUsed,
+      };
+    },
+  );
+
+  return {
+    projectId: new ObjectID("11111111-1111-4111-8111-111111111111"),
+    monitorId: MONITOR_ID,
+    requestReceivedAt: new Date("2026-08-27T00:00:00.000Z"),
+    basicInfrastructureMetrics: {
+      cpuMetrics: { percentUsed: cpuPercent, cores: 4 },
+      memoryMetrics: {
+        total: 100,
+        free: 90,
+        used: 10,
+        percentFree: 90,
+        percentUsed: 10,
+      },
+      diskMetrics,
+    },
+  } as unknown as DataToProcess;
+}
+
+function serverMonitor(): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor._id = MONITOR_ID.toString();
+  monitor.projectId = new ObjectID("11111111-1111-4111-8111-111111111111");
+  monitor.monitorType = MonitorType.Server;
+  monitor.name = "prod-db-01";
+  return monitor;
+}
+
+type CollectPerSeriesMatches = (input: {
+  dataToProcess: DataToProcess;
+  monitor: Monitor;
+  monitorStep: MonitorStep;
+  criteriaInstance: MonitorCriteriaInstance;
+}) => Promise<Array<PerSeriesCriteriaMatch>>;
+
+const collectPerSeriesMatches: CollectPerSeriesMatches = (
+  MonitorCriteriaEvaluator as unknown as {
+    collectPerSeriesMatches: CollectPerSeriesMatches;
+  }
+).collectPerSeriesMatches.bind(MonitorCriteriaEvaluator);
+
+async function collectForServer(input: {
+  criteriaInstance: MonitorCriteriaInstance;
+  dataToProcess: DataToProcess;
+}): Promise<Array<PerSeriesCriteriaMatch>> {
+  return collectPerSeriesMatches({
+    dataToProcess: input.dataToProcess,
+    monitor: serverMonitor(),
+    monitorStep: new MonitorStep(),
+    criteriaInstance: input.criteriaInstance,
+  });
+}
+
+function labelsOf(matches: Array<PerSeriesCriteriaMatch>): Array<unknown> {
+  return matches.map((match: PerSeriesCriteriaMatch) => {
+    return match.labels["diskPath"];
+  });
+}
+
+describe("PerEntityCriteriaFanOut — Server disks", () => {
+  describe("the wildcard opts a criteria into per-disk alerting", () => {
+    it("produces one match per breaching disk and skips the healthy ones", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filters: [diskFilter({ diskPath: "*", greaterThan: 90 })],
+        }),
+        dataToProcess: serverResponse([
+          { diskPath: "/", percentUsed: 95 },
+          { diskPath: "/var", percentUsed: 97 },
+          { diskPath: "/home", percentUsed: 20 },
+        ]),
+      });
+
+      expect(labelsOf(matches)).toEqual(["/", "/var"]);
+    });
+
+    it("gives each disk a distinct fingerprint so they dedupe independently", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filters: [diskFilter({ diskPath: "*", greaterThan: 90 })],
+        }),
+        dataToProcess: serverResponse([
+          { diskPath: "/", percentUsed: 95 },
+          { diskPath: "/var", percentUsed: 97 },
+        ]),
+      });
+
+      expect(matches[0]!.fingerprint).not.toBe(matches[1]!.fingerprint);
+      expect(matches[0]!.fingerprint).toBeTruthy();
+    });
+
+    it("names the disk in the root cause so the alert says which one", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filters: [diskFilter({ diskPath: "*", greaterThan: 90 })],
+        }),
+        dataToProcess: serverResponse([{ diskPath: "/var", percentUsed: 97 }]),
+      });
+
+      expect(matches[0]!.rootCause).toContain("/var");
+    });
+
+    it("returns nothing when no disk breaches", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filters: [diskFilter({ diskPath: "*", greaterThan: 90 })],
+        }),
+        dataToProcess: serverResponse([
+          { diskPath: "/", percentUsed: 10 },
+          { diskPath: "/var", percentUsed: 20 },
+        ]),
+      });
+
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe("filters that do not address a disk still apply per disk", () => {
+    it("under All, a failing host-wide filter suppresses every disk", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filterCondition: FilterCondition.All,
+          filters: [
+            diskFilter({ diskPath: "*", greaterThan: 90 }),
+            // CPU is quiet, so "disk full AND cpu busy" holds for nobody.
+            cpuFilter(90),
+          ],
+        }),
+        dataToProcess: serverResponse(
+          [
+            { diskPath: "/", percentUsed: 95 },
+            { diskPath: "/var", percentUsed: 97 },
+          ],
+          5,
+        ),
+      });
+
+      expect(matches).toEqual([]);
+    });
+
+    it("under All, a passing host-wide filter lets each breaching disk through", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filterCondition: FilterCondition.All,
+          filters: [
+            diskFilter({ diskPath: "*", greaterThan: 90 }),
+            cpuFilter(50),
+          ],
+        }),
+        dataToProcess: serverResponse(
+          [
+            { diskPath: "/", percentUsed: 95 },
+            { diskPath: "/home", percentUsed: 20 },
+          ],
+          80,
+        ),
+      });
+
+      expect(labelsOf(matches)).toEqual(["/"]);
+    });
+  });
+
+  describe("existing configurations are untouched", () => {
+    it("a criteria pinned to one disk does not fan out", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({
+          filters: [diskFilter({ diskPath: "/var", greaterThan: 90 })],
+        }),
+        dataToProcess: serverResponse([
+          { diskPath: "/", percentUsed: 95 },
+          { diskPath: "/var", percentUsed: 97 },
+        ]),
+      });
+
+      // No per-entity matches -> the whole-monitor path, exactly as before.
+      expect(matches).toEqual([]);
+    });
+
+    it("a criteria with no disk filter at all does not fan out", async () => {
+      const matches: Array<PerSeriesCriteriaMatch> = await collectForServer({
+        criteriaInstance: criteriaWith({ filters: [cpuFilter(50)] }),
+        dataToProcess: serverResponse([{ diskPath: "/", percentUsed: 95 }], 80),
+      });
+
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe("the scalar verdict agrees with the fan-out", () => {
+    /*
+     * collectPerSeriesMatches only runs once the whole-criteria
+     * evaluation has already said "met". If the scalar path did not
+     * understand the wildcard it would resolve "*" to no disk at all,
+     * score 0%, and the criteria would never fire — so the fan-out
+     * would never be reached either.
+     */
+    it("a wildcard disk filter is met when any disk breaches", async () => {
+      const rootCause: string | null =
+        await ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: serverResponse([
+            { diskPath: "/", percentUsed: 10 },
+            { diskPath: "/var", percentUsed: 97 },
+          ]),
+          criteriaFilter: diskFilter({ diskPath: "*", greaterThan: 90 }),
+        });
+
+      expect(rootCause).toBeTruthy();
+      expect(rootCause).toContain("/var");
+    });
+
+    it("a wildcard disk filter is not met when every disk is healthy", async () => {
+      const rootCause: string | null =
+        await ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: serverResponse([
+            { diskPath: "/", percentUsed: 10 },
+            { diskPath: "/var", percentUsed: 20 },
+          ]),
+          criteriaFilter: diskFilter({ diskPath: "*", greaterThan: 90 }),
+        });
+
+      expect(rootCause).toBeNull();
+    });
+
+    it("an unset disk path still means the root filesystem", async () => {
+      const rootCause: string | null =
+        await ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: serverResponse([
+            { diskPath: "/", percentUsed: 10 },
+            { diskPath: "/var", percentUsed: 97 },
+          ]),
+          criteriaFilter: {
+            checkOn: CheckOn.DiskUsagePercent,
+            filterType: FilterType.GreaterThan,
+            value: "90",
+          },
+        });
+
+      expect(rootCause).toBeNull();
+    });
+  });
+});
+
+describe("PerEntityCriteriaFanOut — configuration detection", () => {
+  it("recognises the wildcard, and only the wildcard", () => {
+    expect(PerEntityCriteriaFanOut.isWildcard("*")).toBe(true);
+    expect(PerEntityCriteriaFanOut.isWildcard(" * ")).toBe(true);
+    expect(PerEntityCriteriaFanOut.isWildcard("")).toBe(false);
+    expect(PerEntityCriteriaFanOut.isWildcard(undefined)).toBe(false);
+    expect(PerEntityCriteriaFanOut.isWildcard("/var")).toBe(false);
+    expect(PerEntityCriteriaFanOut.isWildcard("*.log")).toBe(false);
+  });
+
+  it("an SNMP criteria with a blank interface name does not fan out", () => {
+    /*
+     * Blank has always meant "every interface, one combined alert".
+     * Treating it as opt-in would turn a single "3 interfaces down"
+     * alert into three on every existing SNMP monitor at upgrade time.
+     */
+    const instance: MonitorCriteriaInstance = criteriaWith({
+      filters: [
+        {
+          checkOn: CheckOn.SnmpInterfaceIsDown,
+          filterType: FilterType.True,
+          value: undefined,
+          snmpMonitorOptions: { interfaceName: "" },
+        },
+      ],
+    });
+
+    expect(
+      PerEntityCriteriaFanOut.isSnmpInterfaceFanOutConfigured(instance),
+    ).toBe(false);
+  });
+
+  it("an SNMP criteria with the wildcard fans out over named interfaces", () => {
+    const instance: MonitorCriteriaInstance = criteriaWith({
+      filters: [
+        {
+          checkOn: CheckOn.SnmpInterfaceUtilizationPercent,
+          filterType: FilterType.GreaterThan,
+          value: "80",
+          snmpMonitorOptions: { interfaceName: "*" },
+        },
+      ],
+    });
+
+    expect(
+      PerEntityCriteriaFanOut.isSnmpInterfaceFanOutConfigured(instance),
+    ).toBe(true);
+
+    const entities: Array<FanOutEntity> =
+      PerEntityCriteriaFanOut.getSnmpInterfaceEntities({
+        criteriaInstance: instance,
+        dataToProcess: {
+          monitorId: MONITOR_ID,
+          interfaces: [
+            { name: "Gi0/1", alias: "Uplink" },
+            { name: "Gi0/2" },
+            // No name: cannot be addressed individually, so it is skipped.
+            { alias: "unnamed" },
+            // Duplicate name: counted once.
+            { name: "Gi0/1" },
+          ],
+        } as unknown as DataToProcess,
+      });
+
+    expect(
+      entities.map((entity: FanOutEntity) => {
+        return entity.labels["interfaceName"];
+      }),
+    ).toEqual(["Gi0/1", "Gi0/2"]);
+    expect(entities[0]!.labels["interfaceAlias"]).toBe("Uplink");
+  });
+
+  it("narrowing rewrites only the wildcard filter, leaving the others alone", () => {
+    const instance: MonitorCriteriaInstance = criteriaWith({
+      filters: [
+        diskFilter({ diskPath: "*", greaterThan: 90 }),
+        diskFilter({ diskPath: "/boot", greaterThan: 50 }),
+        cpuFilter(80),
+      ],
+    });
+
+    const entities: Array<FanOutEntity> =
+      PerEntityCriteriaFanOut.getServerDiskEntities({
+        criteriaInstance: instance,
+        dataToProcess: serverResponse([{ diskPath: "/var", percentUsed: 97 }]),
+      });
+
+    const narrowed: Array<CriteriaFilter> = (
+      instance.data!.filters as Array<CriteriaFilter>
+    ).map((filter: CriteriaFilter) => {
+      return entities[0]!.narrowFilter(filter);
+    });
+
+    expect(narrowed[0]!.serverMonitorOptions?.diskPath).toBe("/var");
+    // A criteria that explicitly names another disk keeps naming it.
+    expect(narrowed[1]!.serverMonitorOptions?.diskPath).toBe("/boot");
+    expect(narrowed[2]!.checkOn).toBe(CheckOn.CPUUsagePercent);
+
+    // The monitor's stored criteria is not mutated.
+    expect(
+      (instance.data!.filters as Array<CriteriaFilter>)[0]!.serverMonitorOptions
+        ?.diskPath,
+    ).toBe("*");
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/PerSeriesSecondEntityAlerting.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/PerSeriesSecondEntityAlerting.test.ts
@@ -1,0 +1,1112 @@
+/*
+ * The alert/incident creation paths pull the native isolated-vm addon
+ * through their template renderer (MonitorAlert → MonitorTemplateUtil →
+ * VMAPI → VMRunner). Nothing here touches the sandbox and the prebuilt
+ * binary cannot always dlopen in the test environment, so stub it out
+ * before anything imports it.
+ */
+jest.mock("isolated-vm", () => {
+  return {};
+});
+
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import AlertService from "../../../../Server/Services/AlertService";
+import AlertSeverityService from "../../../../Server/Services/AlertSeverityService";
+import AlertStateTimelineService from "../../../../Server/Services/AlertStateTimelineService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import IncidentStateTimelineService from "../../../../Server/Services/IncidentStateTimelineService";
+import HostService from "../../../../Server/Services/HostService";
+import NetworkDeviceOwnerUserService from "../../../../Server/Services/NetworkDeviceOwnerUserService";
+import ProjectScopedReferenceValidator from "../../../../Server/Utils/Database/ProjectScopedReferenceValidator";
+import MonitorAlert from "../../../../Server/Utils/Monitor/MonitorAlert";
+import MonitorIncident from "../../../../Server/Utils/Monitor/MonitorIncident";
+import MonitorResourceContextUtil from "../../../../Server/Utils/Monitor/MonitorResourceContext";
+import { SeriesResolvedResourceIds } from "../../../../Server/Utils/Monitor/SeriesResourceLinker";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorEvaluationSummary from "../../../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../../Types/ObjectID";
+import { PerSeriesCriteriaMatch } from "../../../../Types/Probe/ProbeApiIngestResponse";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * The reported bug, pinned at the layer that produced it.
+ *
+ * A metric monitor grouped by host alerts per host. Host A's disk filled
+ * up and got an alert. While that alert was still open, Host B's disk
+ * filled up and NOTHING happened — the evaluation logged "an active
+ * alert exists for this criteria" and moved on, because the creators
+ * decided between per-series and whole-monitor dedupe from whether that
+ * tick happened to produce matches rather than from how the monitor is
+ * configured.
+ *
+ * These tests drive the real creators and the real resolve pass with
+ * every surrounding service stubbed, and mirror every case across alerts
+ * and incidents so the two paths cannot drift apart again.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SEVERITY_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const RESOLVED_STATE_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+
+const CRITICAL_CRITERIA_ID: string = "criteria-critical";
+const WARNING_CRITERIA_ID: string = "criteria-warning";
+
+const FP_HOST_A: string = "fp-host-a";
+const FP_HOST_B: string = "fp-host-b";
+const FP_HOST_C: string = "fp-host-c";
+
+function monitorModel(): Monitor {
+  const model: Monitor = new Monitor();
+  model._id = MONITOR_ID.toString();
+  model.projectId = PROJECT_ID;
+  model.monitorType = MonitorType.Metrics;
+  model.name = "Disk usage by host";
+  return model;
+}
+
+function criteria(options: {
+  id: string;
+  name: string;
+  createAlerts?: boolean | undefined;
+  createIncidents?: boolean | undefined;
+  autoResolve?: boolean | undefined;
+}): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data!.id = options.id;
+  instance.data!.name = options.name;
+  instance.data!.createAlerts = options.createAlerts !== false;
+  instance.data!.createIncidents = options.createIncidents !== false;
+  instance.data!.alerts = [
+    {
+      id: `${options.id}-alert-template`,
+      title: "Disk usage on {{host.name}} is above threshold",
+      description: "{{host.name}} is running out of disk.",
+      alertSeverityId: SEVERITY_ID,
+      autoResolveAlert: options.autoResolve === true,
+    },
+  ];
+  instance.data!.incidents = [
+    {
+      id: `${options.id}-incident-template`,
+      title: "Disk usage on {{host.name}} is above threshold",
+      description: "{{host.name}} is running out of disk.",
+      incidentSeverityId: SEVERITY_ID,
+      autoResolveIncident: options.autoResolve === true,
+    },
+  ];
+  return instance;
+}
+
+const dataToProcess: ProbeMonitorResponse = {
+  projectId: PROJECT_ID,
+  monitorId: MONITOR_ID,
+  monitoredAt: new Date("2026-08-27T03:33:00.000Z"),
+} as unknown as ProbeMonitorResponse;
+
+const NO_AUTO_RESOLVE: Dictionary<Array<string>> = {};
+
+function seriesMatch(
+  criteriaId: string,
+  fingerprint: string,
+  hostName: string,
+): PerSeriesCriteriaMatch {
+  const labels: JSONObject = { "host.name": hostName };
+  return {
+    criteriaMetId: criteriaId,
+    fingerprint: fingerprint,
+    labels: labels,
+    rootCause: `Disk usage on ${hostName} is above 90%`,
+  };
+}
+
+function openAlertModel(options: {
+  id: string;
+  criteriaId: string;
+  fingerprint?: string | undefined;
+}): Alert {
+  const alert: Alert = new Alert();
+  alert._id = options.id;
+  alert.projectId = PROJECT_ID;
+  alert.title = "Disk usage is above threshold";
+  alert.createdCriteriaId = options.criteriaId;
+  if (options.fingerprint) {
+    alert.seriesFingerprint = options.fingerprint;
+  }
+  return alert;
+}
+
+function openIncidentModel(options: {
+  id: string;
+  criteriaId: string;
+  fingerprint?: string | undefined;
+  templateId?: string | undefined;
+}): Incident {
+  const incident: Incident = new Incident();
+  incident._id = options.id;
+  incident.projectId = PROJECT_ID;
+  incident.title = "Disk usage is above threshold";
+  incident.createdCriteriaId = options.criteriaId;
+  incident.createdIncidentTemplateId =
+    options.templateId === undefined
+      ? `${options.criteriaId}-incident-template`
+      : options.templateId;
+  if (options.fingerprint) {
+    incident.seriesFingerprint = options.fingerprint;
+  }
+  return incident;
+}
+
+function emptyResourceContext(): SeriesResolvedResourceIds {
+  return {
+    hostIds: [],
+    dockerHostIds: [],
+    podmanHostIds: [],
+    kubernetesClusterIds: [],
+    serviceIds: [],
+    proxmoxClusterIds: [],
+    cephClusterIds: [],
+    dockerSwarmClusterIds: [],
+    iotFleetIds: [],
+  };
+}
+
+function emptyEvaluationSummary(): MonitorEvaluationSummary {
+  return {
+    criteriaResults: [],
+    events: [],
+  } as unknown as MonitorEvaluationSummary;
+}
+
+describe("A second breaching series alerts even while the first is open", () => {
+  let createdAlerts: Array<Alert> = [];
+  let createdIncidents: Array<Incident> = [];
+  let resolvedAlertIds: Array<string> = [];
+  let resolvedIncidentIds: Array<string> = [];
+  let openAlerts: Array<Alert> = [];
+  let openIncidents: Array<Incident> = [];
+
+  beforeEach(() => {
+    createdAlerts = [];
+    createdIncidents = [];
+    resolvedAlertIds = [];
+    resolvedIncidentIds = [];
+    openAlerts = [];
+    openIncidents = [];
+
+    jest.spyOn(AlertService, "findBy").mockImplementation(async () => {
+      return openAlerts as never;
+    });
+    jest.spyOn(IncidentService, "findBy").mockImplementation(async () => {
+      return openIncidents as never;
+    });
+
+    jest
+      .spyOn(ProjectScopedReferenceValidator, "isUsableInProject")
+      .mockResolvedValue(true);
+
+    jest
+      .spyOn(MonitorResourceContextUtil, "resolveResourceContextForMonitor")
+      .mockResolvedValue(emptyResourceContext());
+
+    jest
+      .spyOn(NetworkDeviceOwnerUserService, "getDeviceOwnersForMonitor")
+      .mockResolvedValue({ ownerUserIds: [], ownerTeamIds: [] });
+
+    // The series labels name a host, so the linker looks the host up.
+    jest.spyOn(HostService, "findBy").mockResolvedValue([] as never);
+
+    jest
+      .spyOn(AlertService, "create")
+      .mockImplementation(async (createBy: unknown): Promise<Alert> => {
+        const alert: Alert = (createBy as { data: Alert }).data;
+        alert._id = `created-alert-${createdAlerts.length + 1}`;
+        createdAlerts.push(alert);
+        return alert;
+      });
+
+    jest
+      .spyOn(IncidentService, "create")
+      .mockImplementation(async (createBy: unknown): Promise<Incident> => {
+        const incident: Incident = (createBy as { data: Incident }).data;
+        incident._id = `created-incident-${createdIncidents.length + 1}`;
+        createdIncidents.push(incident);
+        return incident;
+      });
+
+    jest.spyOn(AlertService, "addOwners").mockResolvedValue(undefined);
+    jest.spyOn(IncidentService, "addOwners").mockResolvedValue(undefined);
+
+    jest
+      .spyOn(AlertStateTimelineService, "getResolvedStateIdForProject")
+      .mockResolvedValue(RESOLVED_STATE_ID);
+    jest
+      .spyOn(IncidentStateTimelineService, "getResolvedStateIdForProject")
+      .mockResolvedValue(RESOLVED_STATE_ID);
+
+    jest
+      .spyOn(AlertStateTimelineService, "create")
+      .mockImplementation(async (createBy: unknown): Promise<never> => {
+        const timeline: { alertId?: ObjectID } = (
+          createBy as { data: { alertId?: ObjectID } }
+        ).data;
+        resolvedAlertIds.push(String(timeline.alertId));
+        return undefined as never;
+      });
+
+    jest
+      .spyOn(IncidentStateTimelineService, "create")
+      .mockImplementation(async (createBy: unknown): Promise<never> => {
+        const timeline: { incidentId?: ObjectID } = (
+          createBy as { data: { incidentId?: ObjectID } }
+        ).data;
+        resolvedIncidentIds.push(String(timeline.incidentId));
+        return undefined as never;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("the reported bug", () => {
+    it("alerts: host B gets its own alert while host A's alert is open", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "open-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+      ];
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        props: {},
+      });
+
+      expect(createdAlerts).toHaveLength(1);
+      expect(createdAlerts[0]!.seriesFingerprint).toBe(FP_HOST_B);
+      expect(createdAlerts[0]!.seriesLabels).toEqual({
+        "host.name": "host-b",
+      });
+      // Host A's alert is untouched — it is still breaching.
+      expect(resolvedAlertIds).toEqual([]);
+    });
+
+    it("incidents: host B gets its own incident while host A's incident is open", async () => {
+      openIncidents = [
+        openIncidentModel({
+          id: "open-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+      ];
+
+      await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        props: {},
+      });
+
+      expect(createdIncidents).toHaveLength(1);
+      expect(createdIncidents[0]!.seriesFingerprint).toBe(FP_HOST_B);
+      expect(resolvedIncidentIds).toEqual([]);
+    });
+
+    it("alerts: a third host joins later without disturbing the first two", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "open-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+        openAlertModel({
+          id: "open-b",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_B,
+        }),
+      ];
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_C, "host-c"),
+        ],
+        props: {},
+      });
+
+      expect(createdAlerts).toHaveLength(1);
+      expect(createdAlerts[0]!.seriesFingerprint).toBe(FP_HOST_C);
+    });
+
+    it("alerts: nothing is created when the only breaching host already has its alert", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "open-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+      ];
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+          autoResolve: true,
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-alert-template`],
+        },
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+        ],
+        props: {},
+      });
+
+      expect(createdAlerts).toHaveLength(0);
+      expect(resolvedAlertIds).toEqual([]);
+    });
+  });
+
+  describe("ungrouped monitors keep the whole-monitor contract", () => {
+    /*
+     * A monitor with no group-by raises one alert for the monitor. The
+     * evaluator signals that by leaving matchesPerSeries undefined, and
+     * the second breach must NOT open a second alert — there is no
+     * second entity to distinguish in the data.
+     */
+    it("alerts: an open whole-monitor alert blocks another one", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "open-monitor",
+          criteriaId: CRITICAL_CRITERIA_ID,
+        }),
+      ];
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        props: {},
+      });
+
+      expect(createdAlerts).toHaveLength(0);
+      expect(resolvedAlertIds).toEqual([]);
+    });
+
+    it("incidents: an open whole-monitor incident blocks another one", async () => {
+      openIncidents = [
+        openIncidentModel({
+          id: "open-monitor",
+          criteriaId: CRITICAL_CRITERIA_ID,
+        }),
+      ];
+
+      await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+        props: {},
+      });
+
+      expect(createdIncidents).toHaveLength(0);
+    });
+  });
+
+  describe("a monitor that has just been grouped", () => {
+    /*
+     * The alert raised before the group-by was added carries no
+     * fingerprint, so nothing can ever dedupe against it again. Left
+     * alone it would sit open forever beside its per-series
+     * replacements.
+     */
+    it("alerts: resolves the stale whole-monitor alert and still creates the per-series ones", async () => {
+      openAlerts = [
+        openAlertModel({ id: "stale", criteriaId: CRITICAL_CRITERIA_ID }),
+      ];
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+          autoResolve: true,
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-alert-template`],
+        },
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        props: {},
+      });
+
+      expect(resolvedAlertIds).toEqual(["stale"]);
+      expect(
+        createdAlerts.map((alert: Alert) => {
+          return alert.seriesFingerprint;
+        }),
+      ).toEqual([FP_HOST_A, FP_HOST_B]);
+    });
+
+    it("incidents: resolves the stale whole-monitor incident and still creates the per-series ones", async () => {
+      openIncidents = [
+        openIncidentModel({ id: "stale", criteriaId: CRITICAL_CRITERIA_ID }),
+      ];
+
+      await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+          autoResolve: true,
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-incident-template`],
+        },
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        props: {},
+      });
+
+      expect(resolvedIncidentIds).toEqual(["stale"]);
+      expect(
+        createdIncidents.map((incident: Incident) => {
+          return incident.seriesFingerprint;
+        }),
+      ).toEqual([FP_HOST_A, FP_HOST_B]);
+    });
+
+    it("alerts: leaves the stale whole-monitor alert open when its criteria does not auto-resolve", async () => {
+      openAlerts = [
+        openAlertModel({ id: "stale", criteriaId: CRITICAL_CRITERIA_ID }),
+      ];
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+        ],
+        props: {},
+      });
+
+      expect(resolvedAlertIds).toEqual([]);
+      expect(createdAlerts).toHaveLength(1);
+      expect(createdAlerts[0]!.seriesFingerprint).toBe(FP_HOST_A);
+    });
+  });
+
+  describe("severity bands do not resolve each other's alerts", () => {
+    const AUTO_RESOLVE_BOTH: Dictionary<Array<string>> = {
+      [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-alert-template`],
+      [WARNING_CRITERIA_ID]: [`${WARNING_CRITERIA_ID}-alert-template`],
+    };
+
+    const AUTO_RESOLVE_BOTH_INCIDENTS: Dictionary<Array<string>> = {
+      [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-incident-template`],
+      [WARNING_CRITERIA_ID]: [`${WARNING_CRITERIA_ID}-incident-template`],
+    };
+
+    it("alerts: host B's warning alert survives host A going critical", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "warning-b",
+          criteriaId: WARNING_CRITERIA_ID,
+          fingerprint: FP_HOST_B,
+        }),
+      ];
+
+      await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: AUTO_RESOLVE_BOTH,
+        rootCause: "Disk usage is above 95% on host-a",
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 95%",
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A, FP_HOST_B]),
+        breachingSeriesFingerprintsByCriteriaId: {
+          [CRITICAL_CRITERIA_ID]: new Set<string>([FP_HOST_A]),
+          [WARNING_CRITERIA_ID]: new Set<string>([FP_HOST_B]),
+        },
+      });
+
+      expect(resolvedAlertIds).toEqual([]);
+    });
+
+    it("incidents: host B's warning incident survives host A going critical", async () => {
+      openIncidents = [
+        openIncidentModel({
+          id: "warning-b",
+          criteriaId: WARNING_CRITERIA_ID,
+          fingerprint: FP_HOST_B,
+        }),
+      ];
+
+      await MonitorIncident.checkOpenIncidentsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+          AUTO_RESOLVE_BOTH_INCIDENTS,
+        rootCause: "Disk usage is above 95% on host-a",
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 95%",
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A, FP_HOST_B]),
+        breachingSeriesFingerprintsByCriteriaId: {
+          [CRITICAL_CRITERIA_ID]: new Set<string>([FP_HOST_A]),
+          [WARNING_CRITERIA_ID]: new Set<string>([FP_HOST_B]),
+        },
+      });
+
+      expect(resolvedIncidentIds).toEqual([]);
+    });
+
+    it("alerts: host B's warning alert resolves once host B stops breaching the warning band", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "warning-b",
+          criteriaId: WARNING_CRITERIA_ID,
+          fingerprint: FP_HOST_B,
+        }),
+      ];
+
+      const survivors: Array<Alert> =
+        await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+          monitorId: MONITOR_ID,
+          autoResolveCriteriaInstanceIdAlertIdsDictionary: AUTO_RESOLVE_BOTH,
+          rootCause: "host-b recovered",
+          criteriaInstance: criteria({
+            id: CRITICAL_CRITERIA_ID,
+            name: "Disk > 95%",
+          }),
+          dataToProcess: dataToProcess,
+          evaluationSummary: emptyEvaluationSummary(),
+          breachingSeriesFingerprints: new Set<string>([FP_HOST_A]),
+          breachingSeriesFingerprintsByCriteriaId: {
+            [CRITICAL_CRITERIA_ID]: new Set<string>([FP_HOST_A]),
+            // Warning ran this tick and matched nothing.
+            [WARNING_CRITERIA_ID]: new Set<string>(),
+          },
+        });
+
+      expect(resolvedAlertIds).toEqual(["warning-b"]);
+      // The resolved alert must not be handed to the create path.
+      expect(survivors).toHaveLength(0);
+    });
+
+    it("alerts: an alert whose criteria was not evaluated at all is left alone", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "warning-b",
+          criteriaId: WARNING_CRITERIA_ID,
+          fingerprint: FP_HOST_B,
+        }),
+      ];
+
+      await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: AUTO_RESOLVE_BOTH,
+        rootCause: "Disk usage is above 95% on host-a",
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 95%",
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A]),
+        breachingSeriesFingerprintsByCriteriaId: {
+          // The warning criteria is absent: it never ran (disabled/deleted).
+          [CRITICAL_CRITERIA_ID]: new Set<string>([FP_HOST_A]),
+        },
+      });
+
+      expect(resolvedAlertIds).toEqual([]);
+    });
+
+    it("incidents: an incident whose criteria was not evaluated at all is left alone", async () => {
+      openIncidents = [
+        openIncidentModel({
+          id: "warning-b",
+          criteriaId: WARNING_CRITERIA_ID,
+          fingerprint: FP_HOST_B,
+        }),
+      ];
+
+      await MonitorIncident.checkOpenIncidentsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary:
+          AUTO_RESOLVE_BOTH_INCIDENTS,
+        rootCause: "Disk usage is above 95% on host-a",
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 95%",
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A]),
+        breachingSeriesFingerprintsByCriteriaId: {
+          [CRITICAL_CRITERIA_ID]: new Set<string>([FP_HOST_A]),
+        },
+      });
+
+      expect(resolvedIncidentIds).toEqual([]);
+    });
+  });
+
+  describe("recovery ticks still resolve (no per-criteria map available)", () => {
+    /*
+     * Regression guard for PerSeriesRecoveryResolution: when only the
+     * single-set form is available, a matched criteria that creates
+     * nothing is a recovery criteria and its "matches" are healthy
+     * series, so the open per-series record must resolve.
+     */
+    it("alerts: resolves on a recovery tick even though the fingerprint is in the matched set", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "offline-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+      ];
+
+      await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-alert-template`],
+        },
+        rootCause: "host-a is back",
+        criteriaInstance: criteria({
+          id: "criteria-recovery",
+          name: "Disk is healthy",
+          createAlerts: false,
+          createIncidents: false,
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A]),
+      });
+
+      expect(resolvedAlertIds).toEqual(["offline-a"]);
+    });
+
+    it("incidents: resolves on a recovery tick even though the fingerprint is in the matched set", async () => {
+      openIncidents = [
+        openIncidentModel({
+          id: "offline-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+      ];
+
+      await MonitorIncident.checkOpenIncidentsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-incident-template`],
+        },
+        rootCause: "host-a is back",
+        criteriaInstance: criteria({
+          id: "criteria-recovery",
+          name: "Disk is healthy",
+          createAlerts: false,
+          createIncidents: false,
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A]),
+      });
+
+      expect(resolvedIncidentIds).toEqual(["offline-a"]);
+    });
+
+    it("incidents: an incident whose template carries no id can still auto-resolve", async () => {
+      /*
+       * Criteria authored through the API can ship an incident template
+       * with no id, so the created incident stores no
+       * createdIncidentTemplateId. Requiring an exact template match
+       * meant such an incident could never resolve — and, staying open,
+       * its criteria could never raise a new one either.
+       */
+      openIncidents = [
+        openIncidentModel({
+          id: "template-less",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+          templateId: "",
+        }),
+      ];
+
+      await MonitorIncident.checkOpenIncidentsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-incident-template`],
+        },
+        rootCause: "host-a is back",
+        criteriaInstance: criteria({
+          id: "criteria-recovery",
+          name: "Disk is healthy",
+          createAlerts: false,
+          createIncidents: false,
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>(),
+      });
+
+      expect(resolvedIncidentIds).toEqual(["template-less"]);
+    });
+  });
+
+  describe("event-driven (incoming request) grouping is untouched", () => {
+    it("alerts: a per-key alert is never resolved by absence", async () => {
+      openAlerts = [
+        openAlertModel({
+          id: "key-a",
+          criteriaId: CRITICAL_CRITERIA_ID,
+          fingerprint: FP_HOST_A,
+        }),
+      ];
+
+      await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-alert-template`],
+        },
+        rootCause: "another key fired",
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Grafana alert",
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_B]),
+        disableSeriesAbsenceResolution: true,
+      });
+
+      expect(resolvedAlertIds).toEqual([]);
+    });
+
+    it("alerts: a whole-monitor alert is not resolved as 'stale' on a webhook tick", async () => {
+      openAlerts = [
+        openAlertModel({ id: "whole", criteriaId: CRITICAL_CRITERIA_ID }),
+      ];
+
+      await MonitorAlert.checkOpenAlertsAndCloseIfResolved({
+        monitorId: MONITOR_ID,
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: {
+          [CRITICAL_CRITERIA_ID]: [`${CRITICAL_CRITERIA_ID}-alert-template`],
+        },
+        rootCause: "a key fired",
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Grafana alert",
+        }),
+        dataToProcess: dataToProcess,
+        evaluationSummary: emptyEvaluationSummary(),
+        breachingSeriesFingerprints: new Set<string>([FP_HOST_A]),
+        disableSeriesAbsenceResolution: true,
+      });
+
+      expect(resolvedAlertIds).toEqual([]);
+    });
+  });
+
+  describe("one series' failure does not silence the rest of the fleet", () => {
+    it("alerts: a project with no severity configured skips instead of failing the whole evaluation", async () => {
+      jest
+        .spyOn(ProjectScopedReferenceValidator, "isUsableInProject")
+        .mockResolvedValue(false);
+      jest.spyOn(AlertSeverityService, "findOneBy").mockResolvedValue(null);
+
+      const summary: MonitorEvaluationSummary = emptyEvaluationSummary();
+
+      await expect(
+        MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+          criteriaInstance: criteria({
+            id: CRITICAL_CRITERIA_ID,
+            name: "Disk > 90%",
+          }),
+          monitor: monitorModel(),
+          dataToProcess: dataToProcess,
+          rootCause: "Disk usage is above 90%",
+          autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+          matchesPerSeries: [
+            seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+            seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+          ],
+          evaluationSummary: summary,
+          props: {},
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(createdAlerts).toHaveLength(0);
+      expect(
+        summary.events.filter((event: { type: string }) => {
+          return event.type === "alert-skipped";
+        }),
+      ).toHaveLength(2);
+    });
+
+    it("alerts: a create that throws for one host still lets the others through", async () => {
+      jest
+        .spyOn(AlertService, "create")
+        .mockImplementation(async (createBy: unknown): Promise<Alert> => {
+          const alert: Alert = (createBy as { data: Alert }).data;
+
+          if (alert.seriesFingerprint === FP_HOST_A) {
+            throw new Error("row could not be written");
+          }
+
+          alert._id = `created-alert-${createdAlerts.length + 1}`;
+          createdAlerts.push(alert);
+          return alert;
+        });
+
+      const summary: MonitorEvaluationSummary = emptyEvaluationSummary();
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_C, "host-c"),
+        ],
+        evaluationSummary: summary,
+        props: {},
+      });
+
+      expect(
+        createdAlerts.map((alert: Alert) => {
+          return alert.seriesFingerprint;
+        }),
+      ).toEqual([FP_HOST_B, FP_HOST_C]);
+    });
+
+    it("incidents: a create that throws for one host still lets the others through", async () => {
+      jest
+        .spyOn(IncidentService, "create")
+        .mockImplementation(async (createBy: unknown): Promise<Incident> => {
+          const incident: Incident = (createBy as { data: Incident }).data;
+
+          if (incident.seriesFingerprint === FP_HOST_A) {
+            throw new Error("row could not be written");
+          }
+
+          incident._id = `created-incident-${createdIncidents.length + 1}`;
+          createdIncidents.push(incident);
+          return incident;
+        });
+
+      await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_C, "host-c"),
+        ],
+        evaluationSummary: emptyEvaluationSummary(),
+        props: {},
+      });
+
+      expect(
+        createdIncidents.map((incident: Incident) => {
+          return incident.seriesFingerprint;
+        }),
+      ).toEqual([FP_HOST_B, FP_HOST_C]);
+    });
+  });
+
+  describe("the caller can own the resolve pass", () => {
+    it("alerts: a supplied open set is used and no query is issued", async () => {
+      const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        AlertService,
+        "findBy",
+      );
+
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        openAlerts: [
+          openAlertModel({
+            id: "open-a",
+            criteriaId: CRITICAL_CRITERIA_ID,
+            fingerprint: FP_HOST_A,
+          }),
+        ],
+        props: {},
+      });
+
+      expect(findBySpy.mock.calls).toHaveLength(0);
+      expect(createdAlerts).toHaveLength(1);
+      expect(createdAlerts[0]!.seriesFingerprint).toBe(FP_HOST_B);
+    });
+
+    it("incidents: a supplied open set is used and no query is issued", async () => {
+      const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        IncidentService,
+        "findBy",
+      );
+
+      await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        openIncidents: [
+          openIncidentModel({
+            id: "open-a",
+            criteriaId: CRITICAL_CRITERIA_ID,
+            fingerprint: FP_HOST_A,
+          }),
+        ],
+        props: {},
+      });
+
+      expect(findBySpy.mock.calls).toHaveLength(0);
+      expect(createdIncidents).toHaveLength(1);
+      expect(createdIncidents[0]!.seriesFingerprint).toBe(FP_HOST_B);
+    });
+  });
+
+  describe("maintenance suppression is per series", () => {
+    it("alerts: suppressing one host's resource still alerts on the others", async () => {
+      await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+        criteriaInstance: criteria({
+          id: CRITICAL_CRITERIA_ID,
+          name: "Disk > 90%",
+        }),
+        monitor: monitorModel(),
+        dataToProcess: dataToProcess,
+        rootCause: "Disk usage is above 90%",
+        autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+        matchesPerSeries: [
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_A, "host-a"),
+          seriesMatch(CRITICAL_CRITERIA_ID, FP_HOST_B, "host-b"),
+        ],
+        suppressedSeriesFingerprints: new Set<string>([FP_HOST_A]),
+        evaluationSummary: emptyEvaluationSummary(),
+        props: {},
+      });
+
+      expect(
+        createdAlerts.map((alert: Alert) => {
+          return alert.seriesFingerprint;
+        }),
+      ).toEqual([FP_HOST_B]);
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/KubernetesTemplateGroupByKeys.test.ts
+++ b/Common/Tests/Types/Monitor/KubernetesTemplateGroupByKeys.test.ts
@@ -1,0 +1,225 @@
+import {
+  KubernetesAlertTemplate,
+  KubernetesAlertTemplateArgs,
+  getAllKubernetesAlertTemplates,
+} from "../../../Types/Monitor/KubernetesAlertTemplates";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Guard test for per-series alerting on the SHIPPED Kubernetes templates.
+ *
+ * A monitor is treated as per-series purely from configuration —
+ * MonitorStep.getGroupByAttributeKeys(step).length > 0, the same answer
+ * the telemetry worker uses to build the series breakdown. So a template
+ * that forgets its group-by key is not a cosmetic miss: the monitor
+ * created from it raises ONE alert for the whole cluster, and every other
+ * unhealthy node/pod/deployment after the first dedupes silently behind
+ * that alert for as long as it stays open.
+ *
+ * The expectation below is therefore an explicit, per-template decision
+ * rather than a rule, and both directions matter:
+ *
+ *   - Grouped templates must carry the RIGHT key. It is the
+ *     ClickHouse-stored attribute name, so it carries the `resource.`
+ *     prefix that OtelMetricsIngestService stamps on OTel resource
+ *     attributes. A bare `k8s.node.name` matches nothing and collapses
+ *     the fleet into one mislabeled series that still renders and still
+ *     alerts — a silent failure, not a loud one.
+ *
+ *   - Cluster-scalar templates must stay UNGROUPED. etcd leadership, API
+ *     server throttling and scheduler queue depth are one value for the
+ *     cluster; splitting them invents series that do not exist.
+ */
+
+interface TemplateGroupByCase {
+  id: string;
+  // [] means "deliberately whole-cluster".
+  groupByKeys: Array<string>;
+  why: string;
+}
+
+const EXPECTED_GROUP_BY: Array<TemplateGroupByCase> = [
+  {
+    id: "k8s-crashloopbackoff",
+    groupByKeys: ["resource.k8s.pod.name"],
+    why: "restarts belong to one pod's containers",
+  },
+  {
+    id: "k8s-pod-pending",
+    groupByKeys: [],
+    why: "cluster-wide count of unschedulable pods; pending pod names are ephemeral",
+  },
+  {
+    id: "k8s-node-not-ready",
+    groupByKeys: ["resource.k8s.node.name"],
+    why: "one incident per NotReady node",
+  },
+  {
+    id: "k8s-high-cpu",
+    groupByKeys: ["resource.k8s.node.name"],
+    why: "per-node CPU utilization ratio",
+  },
+  {
+    id: "k8s-high-memory",
+    groupByKeys: ["resource.k8s.node.name"],
+    why: "per-node memory utilization ratio",
+  },
+  {
+    id: "k8s-deployment-replica-mismatch",
+    groupByKeys: ["resource.k8s.deployment.name"],
+    why: "a stuck rollout belongs to one Deployment object",
+  },
+  {
+    id: "k8s-job-failures",
+    groupByKeys: ["resource.k8s.job.name"],
+    why: "one failing Job must not hide the next",
+  },
+  {
+    id: "k8s-etcd-no-leader",
+    groupByKeys: [],
+    why: "etcd leadership is a cluster-scalar fact",
+  },
+  {
+    id: "k8s-apiserver-throttling",
+    groupByKeys: [],
+    why: "control-plane aggregate; no per-instance identity on this metric",
+  },
+  {
+    id: "k8s-scheduler-backlog",
+    groupByKeys: [],
+    why: "scheduler queue depth is one number for the cluster",
+  },
+  {
+    id: "k8s-high-disk-usage",
+    groupByKeys: ["resource.k8s.node.name"],
+    why: "disk fills one node at a time; the fleet Avg would dilute it away",
+  },
+  {
+    id: "k8s-daemonset-unavailable",
+    groupByKeys: ["resource.k8s.daemonset.name"],
+    why: "the incident names one DaemonSet",
+  },
+  {
+    id: "k8s-node-cpu-request-utilization",
+    groupByKeys: ["resource.k8s.node.name"],
+    why: "per-node scheduling commitment",
+  },
+  {
+    id: "k8s-node-memory-request-utilization",
+    groupByKeys: ["resource.k8s.node.name"],
+    why: "per-node scheduling commitment",
+  },
+  {
+    id: "k8s-hpa-at-max-replicas",
+    groupByKeys: ["resource.k8s.hpa.name"],
+    why: "saturation belongs to one HPA object",
+  },
+  {
+    id: "k8s-pod-memory-limit-saturation",
+    groupByKeys: ["resource.k8s.pod.name"],
+    why: "the pod about to be OOMKilled is the one to page on",
+  },
+  {
+    id: "k8s-pod-cpu-limit-saturation",
+    groupByKeys: ["resource.k8s.pod.name"],
+    why: "the throttled pod is the one to page on",
+  },
+];
+
+function buildArgs(): KubernetesAlertTemplateArgs {
+  return {
+    clusterIdentifier: "prod-cluster",
+    onlineMonitorStatusId: ObjectID.generate(),
+    offlineMonitorStatusId: ObjectID.generate(),
+    defaultIncidentSeverityId: ObjectID.generate(),
+    defaultAlertSeverityId: ObjectID.generate(),
+    monitorName: "Test Monitor",
+  };
+}
+
+describe("KubernetesAlertTemplates - per-series group-by keys", () => {
+  test("every shipped template has a declared group-by expectation", () => {
+    const shippedIds: Array<string> = getAllKubernetesAlertTemplates()
+      .map((t: KubernetesAlertTemplate) => {
+        return t.id;
+      })
+      .sort();
+
+    const expectedIds: Array<string> = EXPECTED_GROUP_BY.map(
+      (tc: TemplateGroupByCase) => {
+        return tc.id;
+      },
+    ).sort();
+
+    /*
+     * A new template added without a decision here would otherwise ship
+     * ungrouped by default and quietly alert once for a whole fleet.
+     */
+    expect(shippedIds).toEqual(expectedIds);
+  });
+
+  test.each(EXPECTED_GROUP_BY)(
+    "$id groups by $groupByKeys ($why)",
+    (tc: TemplateGroupByCase) => {
+      const template: KubernetesAlertTemplate | undefined =
+        getAllKubernetesAlertTemplates().find((t: KubernetesAlertTemplate) => {
+          return t.id === tc.id;
+        });
+      expect(template).toBeDefined();
+
+      const step: MonitorStep = template!.getMonitorStep(buildArgs());
+
+      expect(MonitorStep.getGroupByAttributeKeys(step)).toEqual(tc.groupByKeys);
+
+      /*
+       * getGroupByAttributeKeys unions across queryConfigs, so a ratio
+       * template whose two queries disagreed would still look grouped
+       * here while its formula series failed to join. Assert the key set
+       * on EVERY query instead.
+       */
+      for (const queryConfig of (step.data?.kubernetesMonitor?.metricViewConfig
+        ?.queryConfigs || []) as Array<any>) {
+        expect(queryConfig.metricQueryData.groupByAttributeKeys || []).toEqual(
+          tc.groupByKeys,
+        );
+      }
+    },
+  );
+
+  test.each(
+    EXPECTED_GROUP_BY.filter((tc: TemplateGroupByCase) => {
+      return tc.groupByKeys.length > 0;
+    }),
+  )(
+    "$id groups by a resource-prefixed attribute key",
+    (tc: TemplateGroupByCase) => {
+      for (const key of tc.groupByKeys) {
+        /*
+         * The `resource.` prefix is load-bearing: OTel resource
+         * attributes are stored prefixed, so a bare `k8s.pod.name` would
+         * match nothing and every pod would collapse into one series.
+         */
+        expect(key.startsWith("resource.k8s.")).toBe(true);
+      }
+    },
+  );
+
+  test("grouped templates are the majority of the shipped set", () => {
+    const grouped: number = EXPECTED_GROUP_BY.filter(
+      (tc: TemplateGroupByCase) => {
+        return tc.groupByKeys.length > 0;
+      },
+    ).length;
+
+    /*
+     * Not a style rule — a regression tripwire. This file shipped with
+     * only the four ratio templates grouped; if a refactor drops the
+     * group-by plumbing from buildKubernetesMonitorConfig, every
+     * single-query template silently reverts to whole-cluster alerting
+     * and this count falls back toward four.
+     */
+    expect(grouped).toBe(13);
+    expect(EXPECTED_GROUP_BY.length - grouped).toBe(4);
+  });
+});

--- a/Common/Tests/Types/Monitor/TemplateGroupByKeys.test.ts
+++ b/Common/Tests/Types/Monitor/TemplateGroupByKeys.test.ts
@@ -1,0 +1,296 @@
+import {
+  DockerAlertTemplate,
+  DockerAlertTemplateArgs,
+  getAllDockerAlertTemplates,
+} from "../../../Types/Monitor/DockerAlertTemplates";
+import {
+  HostAlertTemplate,
+  HostAlertTemplateArgs,
+  getAllHostAlertTemplates,
+} from "../../../Types/Monitor/HostAlertTemplates";
+import {
+  PodmanAlertTemplate,
+  PodmanAlertTemplateArgs,
+  getAllPodmanAlertTemplates,
+} from "../../../Types/Monitor/PodmanAlertTemplates";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Guard: a shipped template must never silently lose (or silently gain) its
+ * per-series group-by.
+ *
+ * `MonitorStep.getGroupByAttributeKeys` is the single source of truth for "is
+ * this monitor grouped?" — the telemetry worker uses it to build the
+ * per-series breakdown and the criteria evaluator uses it to decide whether a
+ * criteria fans out one alert/incident per series. An ungrouped template over
+ * a fleet raises ONE alert for the whole fleet: the first container/mount to
+ * breach opens an incident whose dedupe key carries no series, and every other
+ * container/mount that breaches afterwards is silenced for as long as that
+ * incident stays open. That is the exact bug this table exists to prevent from
+ * coming back.
+ *
+ * The decision recorded per template:
+ *
+ *   - Docker / Podman: EVERY template groups by `resource.container.name`.
+ *     Both agents stamp container identity as OTLP RESOURCE attributes, so
+ *     ClickHouse stores them `resource.`-prefixed — the same key the worker
+ *     uses for `containerFilters.containerName`
+ *     (App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts)
+ *     and the same key the Docker/Podman dashboards query by
+ *     (`CONTAINER_NAME_ATTR` in App/FeatureSet/Dashboard/src/Pages/{Docker,
+ *     Podman}/View/Overview.tsx). NOTE this differs from Docker Swarm, whose
+ *     docker_stats receiver keeps container identity in DATAPOINT labels
+ *     (plain `container.name`).
+ *
+ *   - Host: a host monitor is already scoped to ONE host (the worker injects
+ *     `resource.host.name` from hostIdentifier), so host-scalar metrics — CPU
+ *     utilization, memory utilization, load average, process count — stay
+ *     UNGROUPED: there is exactly one series per host and grouping buys
+ *     nothing. Filesystem utilization is per-mountpoint, so it groups by the
+ *     unprefixed `mountpoint` datapoint label the hostmetrics receiver sets
+ *     (read the same way in App/FeatureSet/Dashboard/src/Pages/Host/View/
+ *     Overview.tsx). Host templates for per-device disk I/O or network
+ *     interfaces do not exist yet; when one is added it groups by `device`.
+ *
+ * Each table is exhaustive both ways — a new template with no row here fails
+ * loudly, which forces the group-by decision to be made deliberately.
+ */
+
+interface GroupByExpectation {
+  id: string;
+  // The exact group-by keys, or [] for a deliberately ungrouped template.
+  groupByAttributeKeys: Array<string>;
+}
+
+const CONTAINER_NAME_ATTRIBUTE: string = "resource.container.name";
+
+const EXPECTED_DOCKER_GROUP_BY: Array<GroupByExpectation> = [
+  { id: "docker-high-cpu", groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE] },
+  {
+    id: "docker-high-memory",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+  {
+    id: "docker-restart-loop",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+  {
+    id: "docker-cpu-throttling",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+  { id: "docker-high-pids", groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE] },
+  {
+    id: "docker-container-down",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+];
+
+const EXPECTED_PODMAN_GROUP_BY: Array<GroupByExpectation> = [
+  { id: "podman-high-cpu", groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE] },
+  {
+    id: "podman-high-memory",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+  {
+    id: "podman-restart-loop",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+  {
+    id: "podman-cpu-throttling",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+  { id: "podman-high-pids", groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE] },
+  {
+    id: "podman-container-down",
+    groupByAttributeKeys: [CONTAINER_NAME_ATTRIBUTE],
+  },
+];
+
+const EXPECTED_HOST_GROUP_BY: Array<GroupByExpectation> = [
+  // Host-scalar: one series per host, nothing to fan out over.
+  { id: "host-high-cpu", groupByAttributeKeys: [] },
+  { id: "host-high-memory", groupByAttributeKeys: [] },
+  { id: "host-high-load-average", groupByAttributeKeys: [] },
+  { id: "host-high-processes", groupByAttributeKeys: [] },
+  // Per-entity within the host: one series (and one incident) per mount.
+  { id: "host-high-filesystem", groupByAttributeKeys: ["mountpoint"] },
+];
+
+function buildDockerArgs(): DockerAlertTemplateArgs {
+  return {
+    hostIdentifier: "host-01",
+    onlineMonitorStatusId: ObjectID.generate(),
+    offlineMonitorStatusId: ObjectID.generate(),
+    defaultIncidentSeverityId: ObjectID.generate(),
+    defaultAlertSeverityId: ObjectID.generate(),
+    monitorName: "Test Monitor",
+  };
+}
+
+function buildPodmanArgs(): PodmanAlertTemplateArgs {
+  return buildDockerArgs();
+}
+
+function buildHostArgs(): HostAlertTemplateArgs {
+  return buildDockerArgs();
+}
+
+function idsOf(expectations: Array<GroupByExpectation>): Array<string> {
+  return expectations
+    .map((expectation: GroupByExpectation) => {
+      return expectation.id;
+    })
+    .sort();
+}
+
+function expectationFor(
+  expectations: Array<GroupByExpectation>,
+  id: string,
+): GroupByExpectation {
+  const expectation: GroupByExpectation | undefined = expectations.find(
+    (candidate: GroupByExpectation) => {
+      return candidate.id === id;
+    },
+  );
+
+  if (!expectation) {
+    throw new Error(
+      `No group-by expectation for template "${id}". Add a row to this table and decide, deliberately, whether the template is per-series.`,
+    );
+  }
+
+  return expectation;
+}
+
+const DOCKER_TEMPLATES: Array<DockerAlertTemplate> =
+  getAllDockerAlertTemplates();
+const PODMAN_TEMPLATES: Array<PodmanAlertTemplate> =
+  getAllPodmanAlertTemplates();
+const HOST_TEMPLATES: Array<HostAlertTemplate> = getAllHostAlertTemplates();
+
+describe("Alert template group-by keys", () => {
+  describe("DockerAlertTemplates", () => {
+    test("every template has a group-by expectation (exhaustive both ways)", () => {
+      expect(
+        DOCKER_TEMPLATES.map((template: DockerAlertTemplate) => {
+          return template.id;
+        }).sort(),
+      ).toEqual(idsOf(EXPECTED_DOCKER_GROUP_BY));
+    });
+
+    test.each(
+      DOCKER_TEMPLATES.map((template: DockerAlertTemplate) => {
+        return [template.id, template];
+      }),
+    )(
+      "%s groups by the expected attribute keys",
+      (id: unknown, template: unknown) => {
+        const step: MonitorStep = (
+          template as DockerAlertTemplate
+        ).getMonitorStep(buildDockerArgs());
+
+        expect(MonitorStep.getGroupByAttributeKeys(step)).toEqual(
+          expectationFor(EXPECTED_DOCKER_GROUP_BY, id as string)
+            .groupByAttributeKeys,
+        );
+      },
+    );
+  });
+
+  describe("PodmanAlertTemplates", () => {
+    test("every template has a group-by expectation (exhaustive both ways)", () => {
+      expect(
+        PODMAN_TEMPLATES.map((template: PodmanAlertTemplate) => {
+          return template.id;
+        }).sort(),
+      ).toEqual(idsOf(EXPECTED_PODMAN_GROUP_BY));
+    });
+
+    test.each(
+      PODMAN_TEMPLATES.map((template: PodmanAlertTemplate) => {
+        return [template.id, template];
+      }),
+    )(
+      "%s groups by the expected attribute keys",
+      (id: unknown, template: unknown) => {
+        const step: MonitorStep = (
+          template as PodmanAlertTemplate
+        ).getMonitorStep(buildPodmanArgs());
+
+        expect(MonitorStep.getGroupByAttributeKeys(step)).toEqual(
+          expectationFor(EXPECTED_PODMAN_GROUP_BY, id as string)
+            .groupByAttributeKeys,
+        );
+      },
+    );
+  });
+
+  describe("HostAlertTemplates", () => {
+    test("every template has a group-by expectation (exhaustive both ways)", () => {
+      expect(
+        HOST_TEMPLATES.map((template: HostAlertTemplate) => {
+          return template.id;
+        }).sort(),
+      ).toEqual(idsOf(EXPECTED_HOST_GROUP_BY));
+    });
+
+    test.each(
+      HOST_TEMPLATES.map((template: HostAlertTemplate) => {
+        return [template.id, template];
+      }),
+    )(
+      "%s groups by the expected attribute keys",
+      (id: unknown, template: unknown) => {
+        const step: MonitorStep = (
+          template as HostAlertTemplate
+        ).getMonitorStep(buildHostArgs());
+
+        expect(MonitorStep.getGroupByAttributeKeys(step)).toEqual(
+          expectationFor(EXPECTED_HOST_GROUP_BY, id as string)
+            .groupByAttributeKeys,
+        );
+      },
+    );
+  });
+
+  /*
+   * The fleet templates are the whole point of the fix: a container monitor
+   * covers every container on the host and a filesystem monitor covers every
+   * mount, so both MUST be grouped. Asserted separately from the tables so a
+   * bulk edit that blanks every expectation still fails.
+   */
+  test("every Docker and Podman template is grouped, and by a resource-prefixed key", () => {
+    const containerTemplates: Array<DockerAlertTemplate | PodmanAlertTemplate> =
+      [...DOCKER_TEMPLATES, ...PODMAN_TEMPLATES];
+
+    expect(containerTemplates.length).toBeGreaterThan(0);
+
+    for (const template of containerTemplates) {
+      const step: MonitorStep = template.getMonitorStep(buildDockerArgs());
+      const keys: Array<string> = MonitorStep.getGroupByAttributeKeys(step);
+
+      expect(keys).toEqual([CONTAINER_NAME_ATTRIBUTE]);
+      /*
+       * Docker/Podman container identity is a RESOURCE attribute. Dropping the
+       * prefix (the Docker Swarm spelling) would group every datapoint into a
+       * single "" series and quietly restore the fleet-wide single alert.
+       */
+      expect(keys[0]!.startsWith("resource.")).toBe(true);
+    }
+  });
+
+  test("the host filesystem template is grouped per mountpoint", () => {
+    const filesystemTemplate: HostAlertTemplate | undefined =
+      HOST_TEMPLATES.find((template: HostAlertTemplate) => {
+        return template.id === "host-high-filesystem";
+      });
+
+    expect(filesystemTemplate).toBeDefined();
+
+    const step: MonitorStep =
+      filesystemTemplate!.getMonitorStep(buildHostArgs());
+
+    expect(MonitorStep.getGroupByAttributeKeys(step)).toEqual(["mountpoint"]);
+  });
+});

--- a/Common/Types/Monitor/DockerAlertTemplates.ts
+++ b/Common/Types/Monitor/DockerAlertTemplates.ts
@@ -30,6 +30,22 @@ export interface DockerAlertTemplate {
   getMonitorStep: (args: DockerAlertTemplateArgs) => MonitorStep;
 }
 
+/*
+ * Filter contract: the Docker agent stamps container identity as OTLP
+ * RESOURCE attributes, so ClickHouse stores them `resource.`-prefixed:
+ * `resource.container.name`, `resource.container.image.name`,
+ * `resource.container.runtime` ("docker") and `resource.host.name`. The
+ * worker adds the host scope (`resource.host.name` from hostIdentifier)
+ * and the runtime filter itself. Every template groups by
+ * `resource.container.name` so each container on the host is evaluated
+ * independently — one incident per container instead of one incident for
+ * the whole host, where the busiest container silences every other one.
+ *
+ * NOTE: this is `resource.`-prefixed, unlike Docker Swarm, whose
+ * docker_stats receiver keeps container identity in DATAPOINT labels
+ * (plain `container.name`).
+ */
+
 export function buildDockerMonitorStep(args: {
   dockerMonitor: MonitorStepDockerMonitor;
   offlineCriteriaInstance: MonitorCriteriaInstance;
@@ -184,6 +200,7 @@ export function buildDockerMonitorConfig(args: {
   rollingTime: RollingTime;
   aggregationType: MetricsAggregationType;
   attributes?: Record<string, string>;
+  groupByAttributeKey?: string | undefined;
 }): MonitorStepDockerMonitor {
   return {
     hostIdentifier: args.hostIdentifier,
@@ -205,6 +222,9 @@ export function buildDockerMonitorConfig(args: {
               aggegationType: args.aggregationType,
               aggregateBy: {},
             },
+            ...(args.groupByAttributeKey
+              ? { groupByAttributeKeys: [args.groupByAttributeKey] }
+              : {}),
           },
         },
       ],
@@ -219,7 +239,8 @@ export function buildDockerMonitorConfig(args: {
 const highCpuTemplate: DockerAlertTemplate = {
   id: "docker-high-cpu",
   name: "High Container CPU Usage",
-  description: "Alert when container CPU usage exceeds 80% sustained.",
+  description:
+    "Alert when container CPU usage exceeds 80% sustained. One alert per container.",
   category: "Resource",
   severity: "Warning",
   getMonitorStep: (args: DockerAlertTemplateArgs): MonitorStep => {
@@ -232,10 +253,12 @@ const highCpuTemplate: DockerAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single hot container trips the threshold instead of
-         * being diluted by idle containers on the host.
+         * Max WITHIN each container's series: any scrape in the window over
+         * the threshold trips that container. Grouping by container name
+         * already keeps a hot container from being diluted by idle ones.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildDockerOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -264,7 +287,8 @@ const highCpuTemplate: DockerAlertTemplate = {
 const highMemoryTemplate: DockerAlertTemplate = {
   id: "docker-high-memory",
   name: "High Container Memory Usage",
-  description: "Alert when container memory usage exceeds 85% of its limit.",
+  description:
+    "Alert when container memory usage exceeds 85% of its limit. One alert per container.",
   category: "Resource",
   severity: "Warning",
   getMonitorStep: (args: DockerAlertTemplateArgs): MonitorStep => {
@@ -277,10 +301,12 @@ const highMemoryTemplate: DockerAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single container breaching its limit trips the
-         * threshold instead of being diluted by idle containers.
+         * Max WITHIN each container's series: any scrape in the window over
+         * the limit trips that container. Grouping by container name already
+         * keeps a container at its limit from being diluted by idle ones.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildDockerOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -310,7 +336,7 @@ const containerRestartLoopTemplate: DockerAlertTemplate = {
   id: "docker-restart-loop",
   name: "Container Restart Loop",
   description:
-    "Alert when a container has restarted more than 5 times, indicating a crash loop.",
+    "Alert when a container has restarted more than 5 times, indicating a crash loop. One alert per container.",
   category: "Container",
   severity: "Critical",
   getMonitorStep: (args: DockerAlertTemplateArgs): MonitorStep => {
@@ -323,6 +349,7 @@ const containerRestartLoopTemplate: DockerAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildDockerOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -352,7 +379,7 @@ const highCpuThrottlingTemplate: DockerAlertTemplate = {
   id: "docker-cpu-throttling",
   name: "Container CPU Throttling",
   description:
-    "Alert when a container is being CPU-throttled, indicating it needs more CPU resources.",
+    "Alert when a container is being CPU-throttled, indicating it needs more CPU resources. One alert per container.",
   category: "Resource",
   severity: "Warning",
   getMonitorStep: (args: DockerAlertTemplateArgs): MonitorStep => {
@@ -365,10 +392,12 @@ const highCpuThrottlingTemplate: DockerAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single throttled container trips the threshold,
-         * rather than summing throttled time across all containers.
+         * Max WITHIN each container's series, so throttled time is never
+         * summed across containers — grouping by container name attributes
+         * the throttling to the container that actually suffered it.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildDockerOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -398,7 +427,7 @@ const highProcessCountTemplate: DockerAlertTemplate = {
   id: "docker-high-pids",
   name: "High Container Process Count",
   description:
-    "Alert when a container has an unusually high number of processes, which may indicate a fork bomb or resource leak.",
+    "Alert when a container has an unusually high number of processes, which may indicate a fork bomb or resource leak. One alert per container.",
   category: "Container",
   severity: "Warning",
   getMonitorStep: (args: DockerAlertTemplateArgs): MonitorStep => {
@@ -411,6 +440,7 @@ const highProcessCountTemplate: DockerAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildDockerOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -440,7 +470,7 @@ const containerUptimeTemplate: DockerAlertTemplate = {
   id: "docker-container-down",
   name: "Container Down (Low Uptime)",
   description:
-    "Alert when a container's uptime drops to zero, indicating it has stopped or crashed.",
+    "Alert when a container's uptime drops to zero, indicating it has stopped or crashed. One alert per container.",
   category: "Container",
   severity: "Critical",
   getMonitorStep: (args: DockerAlertTemplateArgs): MonitorStep => {
@@ -453,6 +483,7 @@ const containerUptimeTemplate: DockerAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past1Minute,
         aggregationType: MetricsAggregationType.Min,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildDockerOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,

--- a/Common/Types/Monitor/HostAlertTemplates.ts
+++ b/Common/Types/Monitor/HostAlertTemplates.ts
@@ -30,6 +30,25 @@ export interface HostAlertTemplate {
   getMonitorStep: (args: HostAlertTemplateArgs) => MonitorStep;
 }
 
+/*
+ * Filter contract: a host monitor is already scoped to ONE host — the
+ * worker adds `resource.host.name` from the step's hostIdentifier — so
+ * host-scalar metrics (CPU utilization, memory utilization, load average,
+ * process count) stay UNGROUPED: there is exactly one series per host and
+ * grouping would buy nothing.
+ *
+ * Metrics that are per-entity WITHIN the host are grouped, because the
+ * hostmetrics receiver partitions them by unprefixed DATAPOINT labels
+ * (never `resource.`-prefixed):
+ *
+ *   - `system.filesystem.*` -> `mountpoint` (also `device`, `state`)
+ *   - `system.disk.*` / `system.network.*` -> `device` (also `direction`)
+ *
+ * Without a group-by, one full mount raises a single incident for the
+ * whole host and every other mount that fills up afterwards is silenced
+ * for as long as that incident stays open.
+ */
+
 export function buildHostMonitorStep(args: {
   hostMonitor: MonitorStepHostMonitor;
   offlineCriteriaInstance: MonitorCriteriaInstance;
@@ -184,6 +203,7 @@ export function buildHostMonitorConfig(args: {
   rollingTime: RollingTime;
   aggregationType: MetricsAggregationType;
   attributes?: Record<string, string>;
+  groupByAttributeKey?: string | undefined;
 }): MonitorStepHostMonitor {
   return {
     hostIdentifier: args.hostIdentifier,
@@ -204,6 +224,9 @@ export function buildHostMonitorConfig(args: {
               aggegationType: args.aggregationType,
               aggregateBy: {},
             },
+            ...(args.groupByAttributeKey
+              ? { groupByAttributeKeys: [args.groupByAttributeKey] }
+              : {}),
           },
         },
       ],
@@ -302,7 +325,8 @@ const highMemoryTemplate: HostAlertTemplate = {
 const highFilesystemUsageTemplate: HostAlertTemplate = {
   id: "host-high-filesystem",
   name: "High Filesystem Usage",
-  description: "Alert when host filesystem utilization exceeds 90%.",
+  description:
+    "Alert when host filesystem utilization exceeds 90%. One alert per mountpoint.",
   category: "Resource",
   severity: "Critical",
   getMonitorStep: (args: HostAlertTemplateArgs): MonitorStep => {
@@ -315,10 +339,14 @@ const highFilesystemUsageTemplate: HostAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single full filesystem trips the threshold instead of
-         * being diluted by averaging across multiple mounted filesystems.
+         * Max WITHIN each mountpoint's series: the peak utilization that
+         * mount reached during the window. Grouping by `mountpoint` already
+         * keeps mounts from being averaged together, and gives one incident
+         * per mount so a second mount filling up is not silenced by the
+         * first one's open incident.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "mountpoint",
       }),
       offlineCriteriaInstance: buildHostOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,

--- a/Common/Types/Monitor/KubernetesAlertTemplates.ts
+++ b/Common/Types/Monitor/KubernetesAlertTemplates.ts
@@ -182,6 +182,29 @@ export function buildOnlineCriteriaInstance(args: {
   return instance;
 }
 
+/**
+ * Build a single-query monitor config.
+ *
+ * `groupByAttributeKey` makes the monitor PER-SERIES: the worker splits
+ * the metric by that attribute and every group is evaluated — and paged —
+ * on its own, so a cluster of 200 pods raises one incident per unhealthy
+ * pod rather than one incident for the whole cluster that then dedupes
+ * every later pod away. Omitting it keeps the monitor whole-cluster.
+ *
+ * Group by an object's own name whenever the metric is genuinely
+ * PER-OBJECT (per node, per pod, per deployment, ...). Leave it off for
+ * cluster-scalar signals — etcd leadership, API server throttling,
+ * scheduler backlog — where there is exactly one value for the cluster
+ * and splitting it would invent series that do not exist.
+ *
+ * The key is the ClickHouse-stored attribute name, which carries the
+ * `resource.` prefix for OTel resource attributes (see
+ * OtelMetricsIngestService — resource attributes are stamped with
+ * `prefixKeysWithString: "resource"`). So node grouping is
+ * `resource.k8s.node.name`, not the bare `k8s.node.name`; the bare key
+ * matches nothing and collapses the whole fleet into one mislabeled
+ * series that still renders and still alerts.
+ */
 export function buildKubernetesMonitorConfig(args: {
   clusterIdentifier: string;
   metricName: string;
@@ -190,6 +213,7 @@ export function buildKubernetesMonitorConfig(args: {
   rollingTime: RollingTime;
   aggregationType: MetricsAggregationType;
   attributes?: Record<string, string>;
+  groupByAttributeKey?: string | undefined;
 }): MonitorStepKubernetesMonitor {
   return {
     clusterIdentifier: args.clusterIdentifier,
@@ -212,6 +236,9 @@ export function buildKubernetesMonitorConfig(args: {
               aggegationType: args.aggregationType,
               aggregateBy: {},
             },
+            ...(args.groupByAttributeKey
+              ? { groupByAttributeKeys: [args.groupByAttributeKey] }
+              : {}),
           },
         },
       ],
@@ -346,6 +373,13 @@ const crashLoopBackOffTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Cluster,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        /*
+         * Per pod: restarts are a property of one pod's containers, so a
+         * crash-looping pod must page on its own rather than dedupe behind
+         * whichever pod in the cluster crashed first. Max over the window
+         * therefore becomes "the worst container in THIS pod".
+         */
+        groupByAttributeKey: "resource.k8s.pod.name",
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -390,6 +424,22 @@ const podPendingTemplate: KubernetesAlertTemplate = {
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Sum,
         attributes: { "resource.k8s.pod.phase": "Pending" },
+        /*
+         * Deliberately NOT grouped, unlike the other pod-level templates.
+         *
+         * This is a cluster-wide COUNT of unschedulable pods (Cluster
+         * scope, Sum, "Count > 0"), i.e. a statement about the cluster's
+         * scheduling capacity rather than about any one pod's health — the
+         * same signal as k8s-scheduler-backlog, seen from the pod side.
+         *
+         * Grouping it by `resource.k8s.pod.name` would fan out per pod
+         * name, and pending pod names are ephemeral: a stuck rollout burns
+         * a new replicaset-hash-suffixed name per attempt, so every retry
+         * would open a fresh incident and resolve it again the moment the
+         * name changed. That is an alert storm keyed on an identity that
+         * does not persist, which is the opposite of what per-series
+         * grouping is for (durable entities: nodes, deployments, jobs).
+         */
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -433,6 +483,12 @@ const nodeNotReadyTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Node,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Min,
+        /*
+         * Per node: one incident per NotReady node. Ungrouped, the Min
+         * across the fleet is 0 as soon as ANY node is down, and the
+         * second node to fail dedupes behind the first one's incident.
+         */
+        groupByAttributeKey: "resource.k8s.node.name",
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -584,6 +640,14 @@ const deploymentReplicaMismatchTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Workload,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        /*
+         * Per deployment: a stuck rollout is a property of one Deployment
+         * object, and the incident copy already names the deployment. The
+         * k8s_cluster receiver stamps `k8s.deployment.name` on this metric
+         * (the worker reads `resource.k8s.deployment.name` back off these
+         * rows to build the affected-resource breakdown).
+         */
+        groupByAttributeKey: "resource.k8s.deployment.name",
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -626,6 +690,13 @@ const jobFailuresTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Workload,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        /*
+         * Per Job object — one failing Job must not hide the next one.
+         * Jobs are short-lived: when a Job is cleaned up its series stops
+         * arriving and the per-series pass auto-resolves that Job's alert
+         * by absence, which is the behaviour we want here.
+         */
+        groupByAttributeKey: "resource.k8s.job.name",
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -669,6 +740,11 @@ const etcdNoLeaderTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Cluster,
         rollingTime: RollingTime.Past1Minute,
         aggregationType: MetricsAggregationType.Min,
+        /*
+         * Ungrouped: leadership is a property of the etcd cluster as a
+         * whole, not of any one object. "No leader" is one cluster-scalar
+         * fact and belongs in one incident.
+         */
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -712,6 +788,11 @@ const apiServerThrottlingTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Cluster,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Sum,
+        /*
+         * Ungrouped: this is the control plane's aggregate throttling
+         * rate. Splitting it would need a per-apiserver-instance identity
+         * that this metric does not carry in the shipped agent config.
+         */
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -755,6 +836,10 @@ const schedulerBacklogTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Cluster,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Avg,
+        /*
+         * Ungrouped: a scheduler queue depth is one number for the
+         * cluster. There is no per-object series to split it into.
+         */
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -797,6 +882,13 @@ const highDiskUsageTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Node,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Avg,
+        /*
+         * Per node: filesystem usage is per node (kubeletstats reports the
+         * node's filesystem), and disk fills one node at a time. Ungrouped,
+         * the Avg across the fleet dilutes a single full node into the
+         * fleet mean and the alert never fires.
+         */
+        groupByAttributeKey: "resource.k8s.node.name",
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -840,6 +932,12 @@ const daemonSetUnavailableTemplate: KubernetesAlertTemplate = {
         resourceScope: KubernetesResourceScope.Workload,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        /*
+         * Per DaemonSet object: the incident names the DaemonSet, so each
+         * one has to own its own alert instead of dedupeing behind
+         * whichever DaemonSet in the cluster misscheduled first.
+         */
+        groupByAttributeKey: "resource.k8s.daemonset.name",
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -79,6 +79,7 @@ import MonitorStepIoTMonitor, {
   MonitorStepIoTMonitorUtil,
 } from "./MonitorStepIoTMonitor";
 import MetricsViewConfig from "../Metrics/MetricsViewConfig";
+import MetricQueryConfigData from "../Metrics/MetricQueryConfigData";
 import Zod, { ZodSchema } from "../../Utils/Schema/Zod";
 
 /*
@@ -387,6 +388,54 @@ export default class MonitorStep extends DatabaseProperty {
       data.proxmoxMonitor?.metricViewConfig ||
       data.cephMonitor?.metricViewConfig
     );
+  }
+
+  /**
+   * The union of `groupByAttributeKeys` across every metric query config
+   * on this step — i.e. the attributes the monitor is grouped by.
+   *
+   * This is the single source of truth for "is this monitor grouped?".
+   * The telemetry worker uses it to decide whether to build a
+   * `seriesBreakdown`, and the criteria evaluator uses it to decide
+   * whether a criteria is *meant* to fan out one alert/incident per
+   * series. Those two answers must never disagree: when they did, a
+   * grouped monitor that produced no per-series match silently fell
+   * back to a single whole-monitor alert whose dedupe key carries no
+   * series, and every host after the first was skipped for as long as
+   * that alert stayed open.
+   */
+  public static getGroupByAttributeKeys(
+    monitorStep: MonitorStep | undefined,
+  ): Array<string> {
+    return MonitorStep.getGroupByAttributeKeysFromQueryConfigs(
+      MonitorStep.getMetricsViewConfig(monitorStep)?.queryConfigs || [],
+    );
+  }
+
+  /**
+   * The query-config-level half of `getGroupByAttributeKeys`, for the
+   * telemetry worker which already holds the configs and never
+   * reconstructs the step. Per-series alerting needs a consistent key
+   * set across queries so formula series line up — otherwise `a + b`
+   * would split differently for `a` and for `b` and the per-series
+   * formula evaluation would not align — hence the union rather than
+   * per-query keys.
+   */
+  public static getGroupByAttributeKeysFromQueryConfigs(
+    queryConfigs: Array<MetricQueryConfigData>,
+  ): Array<string> {
+    const keys: Set<string> = new Set<string>();
+
+    for (const queryConfig of queryConfigs) {
+      for (const key of queryConfig?.metricQueryData?.groupByAttributeKeys ||
+        []) {
+        if (key) {
+          keys.add(key);
+        }
+      }
+    }
+
+    return Array.from(keys);
   }
 
   public get id(): ObjectID {

--- a/Common/Types/Monitor/PodmanAlertTemplates.ts
+++ b/Common/Types/Monitor/PodmanAlertTemplates.ts
@@ -30,6 +30,18 @@ export interface PodmanAlertTemplate {
   getMonitorStep: (args: PodmanAlertTemplateArgs) => MonitorStep;
 }
 
+/*
+ * Filter contract: the Podman agent stamps container identity as OTLP
+ * RESOURCE attributes, so ClickHouse stores them `resource.`-prefixed:
+ * `resource.container.name`, `resource.container.image.name`,
+ * `resource.container.runtime` ("podman") and `resource.host.name`. The
+ * worker adds the host scope (`resource.host.name` from hostIdentifier)
+ * and the runtime filter itself. Every template groups by
+ * `resource.container.name` so each container on the host is evaluated
+ * independently — one incident per container instead of one incident for
+ * the whole host, where the busiest container silences every other one.
+ */
+
 export function buildPodmanMonitorStep(args: {
   podmanMonitor: MonitorStepPodmanMonitor;
   offlineCriteriaInstance: MonitorCriteriaInstance;
@@ -184,6 +196,7 @@ export function buildPodmanMonitorConfig(args: {
   rollingTime: RollingTime;
   aggregationType: MetricsAggregationType;
   attributes?: Record<string, string>;
+  groupByAttributeKey?: string | undefined;
 }): MonitorStepPodmanMonitor {
   return {
     hostIdentifier: args.hostIdentifier,
@@ -205,6 +218,9 @@ export function buildPodmanMonitorConfig(args: {
               aggegationType: args.aggregationType,
               aggregateBy: {},
             },
+            ...(args.groupByAttributeKey
+              ? { groupByAttributeKeys: [args.groupByAttributeKey] }
+              : {}),
           },
         },
       ],
@@ -219,7 +235,8 @@ export function buildPodmanMonitorConfig(args: {
 const highCpuTemplate: PodmanAlertTemplate = {
   id: "podman-high-cpu",
   name: "High Container CPU Usage",
-  description: "Alert when container CPU usage exceeds 80% sustained.",
+  description:
+    "Alert when container CPU usage exceeds 80% sustained. One alert per container.",
   category: "Resource",
   severity: "Warning",
   getMonitorStep: (args: PodmanAlertTemplateArgs): MonitorStep => {
@@ -232,10 +249,12 @@ const highCpuTemplate: PodmanAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single hot container trips the threshold instead of
-         * being diluted by idle containers on the host.
+         * Max WITHIN each container's series: any scrape in the window over
+         * the threshold trips that container. Grouping by container name
+         * already keeps a hot container from being diluted by idle ones.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildPodmanOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -264,7 +283,8 @@ const highCpuTemplate: PodmanAlertTemplate = {
 const highMemoryTemplate: PodmanAlertTemplate = {
   id: "podman-high-memory",
   name: "High Container Memory Usage",
-  description: "Alert when container memory usage exceeds 85% of its limit.",
+  description:
+    "Alert when container memory usage exceeds 85% of its limit. One alert per container.",
   category: "Resource",
   severity: "Warning",
   getMonitorStep: (args: PodmanAlertTemplateArgs): MonitorStep => {
@@ -277,10 +297,12 @@ const highMemoryTemplate: PodmanAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single container breaching its limit trips the
-         * threshold instead of being diluted by idle containers.
+         * Max WITHIN each container's series: any scrape in the window over
+         * the limit trips that container. Grouping by container name already
+         * keeps a container at its limit from being diluted by idle ones.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildPodmanOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -310,7 +332,7 @@ const containerRestartLoopTemplate: PodmanAlertTemplate = {
   id: "podman-restart-loop",
   name: "Container Restart Loop",
   description:
-    "Alert when a container has restarted more than 5 times, indicating a crash loop.",
+    "Alert when a container has restarted more than 5 times, indicating a crash loop. One alert per container.",
   category: "Container",
   severity: "Critical",
   getMonitorStep: (args: PodmanAlertTemplateArgs): MonitorStep => {
@@ -323,6 +345,7 @@ const containerRestartLoopTemplate: PodmanAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildPodmanOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -352,7 +375,7 @@ const highCpuThrottlingTemplate: PodmanAlertTemplate = {
   id: "podman-cpu-throttling",
   name: "Container CPU Throttling",
   description:
-    "Alert when a container is being CPU-throttled, indicating it needs more CPU resources.",
+    "Alert when a container is being CPU-throttled, indicating it needs more CPU resources. One alert per container.",
   category: "Resource",
   severity: "Warning",
   getMonitorStep: (args: PodmanAlertTemplateArgs): MonitorStep => {
@@ -365,10 +388,12 @@ const highCpuThrottlingTemplate: PodmanAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         /*
-         * Use Max so a single throttled container trips the threshold,
-         * rather than summing throttled time across all containers.
+         * Max WITHIN each container's series, so throttled time is never
+         * summed across containers — grouping by container name attributes
+         * the throttling to the container that actually suffered it.
          */
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildPodmanOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -398,7 +423,7 @@ const highProcessCountTemplate: PodmanAlertTemplate = {
   id: "podman-high-pids",
   name: "High Container Process Count",
   description:
-    "Alert when a container has an unusually high number of processes, which may indicate a fork bomb or resource leak.",
+    "Alert when a container has an unusually high number of processes, which may indicate a fork bomb or resource leak. One alert per container.",
   category: "Container",
   severity: "Warning",
   getMonitorStep: (args: PodmanAlertTemplateArgs): MonitorStep => {
@@ -411,6 +436,7 @@ const highProcessCountTemplate: PodmanAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past5Minutes,
         aggregationType: MetricsAggregationType.Max,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildPodmanOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -440,7 +466,7 @@ const containerUptimeTemplate: PodmanAlertTemplate = {
   id: "podman-container-down",
   name: "Container Down (Low Uptime)",
   description:
-    "Alert when a container's uptime drops to zero, indicating it has stopped or crashed.",
+    "Alert when a container's uptime drops to zero, indicating it has stopped or crashed. One alert per container.",
   category: "Container",
   severity: "Critical",
   getMonitorStep: (args: PodmanAlertTemplateArgs): MonitorStep => {
@@ -453,6 +479,7 @@ const containerUptimeTemplate: PodmanAlertTemplate = {
         metricAlias,
         rollingTime: RollingTime.Past1Minute,
         aggregationType: MetricsAggregationType.Min,
+        groupByAttributeKey: "resource.container.name",
       }),
       offlineCriteriaInstance: buildPodmanOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,

--- a/Common/Types/Probe/ProbeApiIngestResponse.ts
+++ b/Common/Types/Probe/ProbeApiIngestResponse.ts
@@ -18,6 +18,24 @@ export interface PerSeriesCriteriaMatch {
   metricContext?: MetricCriteriaContext | undefined;
 }
 
+/**
+ * One criteria that matched on this evaluation, together with the
+ * series it matched. Grouped (per-series) monitors accumulate one entry
+ * per matching criteria instead of stopping at the first one, so a host
+ * breaching the "warning" band still gets its alert while another host
+ * holds the monitor in "critical".
+ */
+export interface MatchedCriteriaResult {
+  criteriaId: string;
+  rootCause: string;
+  /**
+   * The series this criteria matched. Empty is impossible here — a
+   * criteria with no matching series is not recorded as matched for a
+   * grouped monitor.
+   */
+  perSeriesMatches: Array<PerSeriesCriteriaMatch>;
+}
+
 export default interface ProbeApiIngestResponse {
   monitorId: ObjectID;
   ingestedMonitorStepId?: ObjectID | undefined;
@@ -33,4 +51,28 @@ export default interface ProbeApiIngestResponse {
    * + `rootCause` still drive the legacy single-incident path.
    */
   perSeriesMatches?: Array<PerSeriesCriteriaMatch> | undefined;
+  /**
+   * Every criteria that matched on this evaluation, in criteria order.
+   *
+   * Only populated for monitors that fan out per series (grouped metric
+   * monitors and grouped incoming-request monitors). Ungrouped monitors
+   * keep the historical "first matching criteria wins, stop there"
+   * semantics and leave this undefined, in which case `criteriaMetId` +
+   * `rootCause` + `perSeriesMatches` are the whole story.
+   *
+   * `criteriaMetId` always stays the FIRST match — the monitor has a
+   * single status and that is what sets it.
+   */
+  matchedCriteria?: Array<MatchedCriteriaResult> | undefined;
+  /**
+   * The ids of every criteria that was actually evaluated on this tick
+   * (matched or not, excluding disabled ones and — for ungrouped
+   * monitors — everything after the winner).
+   *
+   * The resolve pass needs this to tell "this criteria was evaluated and
+   * this series is no longer breaching it" (resolve) apart from "this
+   * criteria never ran, so its open records are none of my business"
+   * (leave alone).
+   */
+  evaluatedCriteriaIds?: Array<string> | undefined;
 }


### PR DESCRIPTION
## The report

> A metric monitor grouped by host watches disk space and alerts per host. Host A's disk fills up and gets an alert. While that alert is still open, Host B's disk fills up — and there is no alert for Host B. It just ignores it.

**Confirmed.** Reproduced, and it turned out to be three separate defects that combine, plus a fourth reason most users never had per-host alerting in the first place.

## Why it happened

**1. Grouped monitors silently degraded to whole-monitor mode.**
`MonitorAlert` / `MonitorIncident` chose between "one alert per series" and "one alert for the whole monitor" by looking at whether *this tick* produced per-series matches — not at whether the monitor is grouped. Any tick that produced none fell back to whole-monitor dedupe, which keys on the criteria alone. The first host's alert then blocked every other host with *"an active alert exists for this criteria"* for as long as it stayed open. Five different configurations reach that fallback, including the common one where two filters under `Match All` are satisfied by two different hosts.

**2. Only one criteria ever fanned out.**
Evaluation stopped at the first matching criteria. With `critical > 95%` above `warning > 80%`, a host at 96% claimed the monitor and a host at 85% was never evaluated against anything — and did not even appear in the evaluation summary.

**3. Severity bands auto-resolved each other's alerts.**
The per-series resolve pass tested *every* open record against the *winning* criteria's breaching set. The moment one host went critical, another host's still-valid warning alert was auto-resolved with "Alert autoresolved…" while that host was still breaching.

**4. Most shipped templates set no group-by at all.**
Docker, Podman, Host and Kubernetes per-object templates shipped ungrouped, so monitors created from them were in permanent whole-monitor mode. The ungrouped disk templates use `Max` on purpose, so one hot host trips the threshold and the alert *reads* like a per-host alert. It isn't.

And the Terraform docs actively taught the ordering that bricks alerting: *"put your 'healthy' criteria first and your 'down' criteria after it."* Since evaluation stops at the first match and the default online criteria matches any positive metric, a user following that guidance builds a monitor that never alerts.

## What changed

**Engine** — per-series mode is now decided from configuration (`MonitorStep.getGroupByAttributeKeys`, the same answer the telemetry worker uses to build the series breakdown), so a grouped monitor can never fall back to an unattributed whole-monitor alert. Grouped monitors evaluate **every** criteria and fan out each one that matches, with the first criteria to claim a series owning it so a host breaching two bands still pages once. Resolution is scoped to the criteria that raised the record, and the resolve pass runs once per evaluation with every criteria's breaching set in hand instead of once per criteria with a partial one. **Ungrouped monitors keep first-match-wins byte for byte.**

**Templates** — Docker/Podman group by `resource.container.name`, Host filesystem by `mountpoint`, per-object Kubernetes templates by their object-name attribute. Cluster- and host-scalar templates (CPU, memory, load, etcd leader, apiserver throttling, scheduler backlog) stay ungrouped on purpose. Guard tests pin every template's decision **both ways**, so a new template cannot ship without one.

**Other monitor types with the same bug** — Server and SNMP monitors observe many entities per check (every mountpoint, every port) but their criteria name one at a time, so a second full disk was silenced exactly the same way. They have no Group By to turn on, so `*` in **Disk Path** / **Interface Name** is the opt-in: the criteria is evaluated once per entity, reusing the normal whole-criteria path with the filter narrowed, so filter conditions, evaluate-over-time and no-data policies keep their meaning. Capped at 100 entities per criteria, with truncation logged rather than silent.

**Synthetic monitors** — the `ScreenSizeType` / `BrowserType` branches returned from *inside* the loop over responses, so a non-matching first response ended the check and no other browser or screen size was ever compared.

**Robustness, all the same failure mode** — a missing alert severity threw from inside the series loop and killed the whole ingest job (no alerts, no monitor log, retried forever); it now skips like the incident path already did. Per-series creation is isolated so one host's failure cannot abandon the fleet. A whole-monitor record raised *before* the monitor was grouped is now resolved instead of hanging open forever beside its replacements. `checkOpen*AndCloseIfResolved` returns the records still open *after* the pass — it used to return the pre-resolve set, so a record it had just resolved still suppressed the create meant to replace it.

## Tests

**+69 new tests**, all mirrored across alerts and incidents.

- `PerSeriesSecondEntityAlerting.test.ts` (25) — the reported bug end to end, plus stale-record migration, cross-criteria non-resolution, the recovery-tick regression guard, severity-missing, per-series error isolation, and maintenance suppression.
- `MonitorCriteriaEvaluatorPerSeriesFanout.test.ts` (8) — multi-criteria fan-out, de-escalation, the "no single series satisfies it" case, and the ungrouped backward-compat gate.
- `PerEntityCriteriaFanOut.test.ts` (15) — Server disks and SNMP interfaces, including that non-wildcard configs do not change.
- `SyntheticMonitorCriteria.test.ts` (8), `TemplateGroupByKeys.test.ts` (22) and `KubernetesTemplateGroupByKeys.test.ts`.

Full monitor suite locally: **138 suites / 3458 tests passing.** `tsc` clean in `Common`; `App` has only pre-existing failures in `SSO.ts` and `MqttServer.ts`, untouched here.

## Things a reviewer should weigh

- **Attribute-key spelling is the load-bearing decision.** A key absent from the rows collapses every datapoint into one `""` series — which looks grouped but reproduces the original bug. Docker/Podman use `resource.container.name` (the worker filters on that exact string); Swarm keeps plain `container.name` and is the documented exception.
- **Existing monitors are not migrated.** Templates only affect newly created monitors; monitors created earlier keep their stored ungrouped step and must be edited or recreated.
- **Grouping the Host filesystem template surfaces a pre-existing false positive per mount.** Read-only mounts (`devfs`, snap/squashfs loops) sit at 100% by design. That monitor was *already* alerting permanently on such hosts via `Max`; grouping turns one permanent unattributed alert into one per pseudo-mount. More noise, but now attributable and — crucially — a genuinely full `/var` is no longer silenced by it. Worth a mount-exclusion follow-up.
- **First deploy may be noisy** on fleets where previously-masked hosts and mounts all alert at once.

## Deliberately out of scope

- `Alert.createdAlertTemplateId` (a criteria with two alert templates permanently loses one after a manual resolve) — needs a migration, separate PR.
- `k8s-high-disk-usage` compares a raw **bytes** gauge against `90` and so fires permanently on every cluster. A real bug, but a units bug, unrelated to this one.
- Ceph per-OSD templates route through `ceph_health_detail`, whose only label is the check name — adding a key would not help; they need re-pointing at per-daemon metrics.
- Logs / Traces / Exceptions / Security Events / Profiles monitors evaluate one aggregate count and have no group-by control. That is a feature gap, not this defect.
- Grouped queries disable materialized-view routing and are capped at 10k rows; large fleets should get loud truncation detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLRQ6rRoHe5ivyr62TktbG
