### PR TITLE
feat(network-device): auto-provision monitors from import rules

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts
@@ -25,7 +25,11 @@ import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import NetworkDeviceAutoImportRule from "Common/Models/DatabaseModels/NetworkDeviceAutoImportRule";
 import NetworkDeviceLabelRule from "Common/Models/DatabaseModels/NetworkDeviceLabelRule";
 import NetworkSiteAssignmentRule from "Common/Models/DatabaseModels/NetworkSiteAssignmentRule";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorTemplate from "Common/Models/DatabaseModels/MonitorTemplate";
+import MonitorTemplateService from "Common/Server/Services/MonitorTemplateService";
 import NetworkDeviceAutoImportRuleEngineService from "Common/Server/Services/NetworkDeviceAutoImportRuleEngineService";
+import NetworkDeviceAutoImportRuleService from "Common/Server/Services/NetworkDeviceAutoImportRuleService";
 import NetworkDeviceLabelRuleEngineService from "Common/Server/Services/NetworkDeviceLabelRuleEngineService";
 import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
 import {
@@ -165,6 +169,46 @@ function assertCanRunRule(data: {
 }
 
 /*
+ * A rule with a Monitor Template performs a second kind of create: after the
+ * inventory record is available it creates an active Network Device monitor.
+ * The worker runs that operation as root, but a human pressing Run Now must
+ * not gain Monitor-create access through a rule when their role explicitly
+ * lacks it. Kept separate from assertCanRunRule because device-only import
+ * rules retain their existing permission contract.
+ */
+function assertCanCreateMonitor(props: DatabaseCommonInteractionProps): void {
+  if (props.isMasterAdmin) {
+    return;
+  }
+
+  const held: Array<Permission> = callerPermissions(props);
+  const createPermissions: Array<Permission> =
+    new Monitor().getCreatePermissions() || [];
+
+  if (
+    !held.some((permission: Permission): boolean => {
+      return createPermissions.includes(permission);
+    })
+  ) {
+    throw new NotAuthorizedException(
+      `You do not have permission to create monitors, which running this auto-import rule does. Missing permission: ${PermissionHelper.getTitle(
+        Permission.CreateProjectMonitor,
+      )}.`,
+    );
+  }
+
+  /*
+   * Match BaseAPI's create path in both directions: a broad ProjectAdmin
+   * grant does not override a team's explicit block on Monitor creation.
+   */
+  TablePermission.checkTableLevelBlockPermissions(
+    Monitor,
+    props,
+    DatabaseRequestType.Create,
+  );
+}
+
+/*
  * ":ruleId" as an ObjectID, or a message the caller can act on. The format
  * check is explicit: ObjectID's constructor takes any string, so an id that
  * is not a UUID would otherwise reach the query layer and come back as a
@@ -277,14 +321,66 @@ export default class NetworkRuleRunAPI {
             deviceWriteKind: "create",
           });
 
+          const ruleId: ObjectID = readRuleId(req);
+
+          /*
+           * Resolve the rule inside the caller's project before deciding
+           * whether Monitor-create permission is needed. Requiring it for
+           * every auto-import rule would break the existing device-only
+           * operation; trusting an id without the project predicate would let
+           * one tenant use another tenant's rule to influence authorization.
+           */
+          const rule: NetworkDeviceAutoImportRule | null =
+            await NetworkDeviceAutoImportRuleService.findOneBy({
+              query: {
+                _id: ruleId,
+                projectId: projectId,
+              },
+              select: {
+                _id: true,
+                monitorTemplateId: true,
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          if (!rule) {
+            throw new BadDataException("Auto-import rule not found.");
+          }
+
+          if (rule.monitorTemplateId) {
+            assertCanCreateMonitor(props);
+
+            /*
+             * Run Now is a fresh human-triggered use of the template, not an
+             * unattended continuation of the rule's persisted capability.
+             * Re-authorize the template under the current caller's tenant,
+             * ownership and label scope before the root engine can clone it.
+             */
+            const readableTemplate: MonitorTemplate | null =
+              await MonitorTemplateService.findOneById({
+                id: rule.monitorTemplateId,
+                select: { _id: true },
+                props,
+              });
+
+            if (!readableTemplate) {
+              throw new NotAuthorizedException(
+                "You do not have permission to read the Monitor Template selected by this auto-import rule.",
+              );
+            }
+          }
+
           const body: JSONObject = (req.body || {}) as JSONObject;
 
           const result: AutoImportRuleRunResult =
             await NetworkDeviceAutoImportRuleEngineService.applyRuleToCompletedScans(
               {
-                ruleId: readRuleId(req),
+                ruleId: ruleId,
                 projectId: projectId,
                 isDryRun: readBooleanFlag(body, "dryRun"),
+                expectedMonitorTemplateId: rule.monitorTemplateId || null,
               },
             );
 

--- a/App/FeatureSet/Dashboard/src/Components/NetworkAutomation/RunAutoImportRuleModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkAutomation/RunAutoImportRuleModal.tsx
@@ -33,13 +33,19 @@ function hosts(count: number): string {
   return `${count} ${count === 1 ? "host" : "hosts"}`;
 }
 
+function activeMonitors(count: number): string {
+  return `${count} active Network Device ${
+    count === 1 ? "monitor" : "monitors"
+  }`;
+}
+
 /*
  * The sentences the report shows, in the style of RuleRunSummary: a run
  * that imported nothing is the common case once a rule has been run, and
  * "0 imported" with no reason reads as a broken button. Every bucket the
  * server counted is reported only when it happened.
  */
-function describeAutoImportRun(result: AutoImportRuleRunResult): string {
+export function describeAutoImportRun(result: AutoImportRuleRunResult): string {
   const lines: Array<string> = [];
 
   if (result.isDryRun) {
@@ -80,6 +86,54 @@ function describeAutoImportRun(result: AutoImportRuleRunResult): string {
     );
   }
 
+  /*
+   * Device import and active-monitor provisioning are separate outcomes. A
+   * monitor can fail after its inventory record was safely created, and a dry
+   * run predicts monitor work without claiming anything was written.
+   */
+  if (result.isDryRun && result.monitorsWouldCreate > 0) {
+    lines.push(
+      `It would also create ${activeMonitors(
+        result.monitorsWouldCreate,
+      )} from the selected Monitor Template.`,
+    );
+  } else if (!result.isDryRun && result.monitorsCreated > 0) {
+    lines.push(
+      `Created ${activeMonitors(
+        result.monitorsCreated,
+      )} from the selected Monitor Template.`,
+    );
+  }
+
+  if (result.monitorsSkippedAlreadyExisting > 0) {
+    const skippedRequestedMonitors: string = `${
+      result.monitorsSkippedAlreadyExisting
+    } requested active Network Device ${
+      result.monitorsSkippedAlreadyExisting === 1 ? "monitor" : "monitors"
+    }`;
+    lines.push(
+      `${skippedRequestedMonitors} ${
+        result.monitorsSkippedAlreadyExisting === 1 ? "was" : "were"
+      } skipped because the device already had the requested automatic monitor or a manually configured Network Device monitor.`,
+    );
+  }
+
+  if (result.monitorsSkippedUnsupportedHost > 0) {
+    lines.push(
+      `${activeMonitors(
+        result.monitorsSkippedUnsupportedHost,
+      )} could not be provisioned because the discovery result was not SNMP-capable (for example, a ping-only host).`,
+    );
+  }
+
+  if (result.monitorsFailed > 0) {
+    lines.push(
+      `${activeMonitors(
+        result.monitorsFailed,
+      )} could not be created. Their network devices remain imported; check the server logs for the reason.`,
+    );
+  }
+
   if (result.hostsExcluded > 0) {
     lines.push(`An exclusion rule vetoed ${hosts(result.hostsExcluded)}.`);
   }
@@ -88,7 +142,7 @@ function describeAutoImportRun(result: AutoImportRuleRunResult): string {
     lines.push(
       `${hosts(
         result.hostsSkippedAlreadyRegistered,
-      )} skipped because a device with that address already exists.`,
+      )} already had network devices at those addresses, so no duplicate device records were imported.`,
     );
   }
 
@@ -112,7 +166,7 @@ function describeAutoImportRun(result: AutoImportRuleRunResult): string {
     );
   } else if (result.isTruncated) {
     lines.push(
-      "Stopped counting at the run cap — a real run imports this many at most per run.",
+      "Stopped counting at the run cap — a real run is bounded by the same device-import and active-monitor creation limits.",
     );
   }
 
@@ -225,8 +279,8 @@ const RunAutoImportRuleModal: FunctionComponent<ComponentProps> = (
   }
 
   const description: string = props.isDryRun
-    ? 'Evaluate this rule against every completed discovery scan in the project and report what it would import. Nothing is written — no devices are created — so this is the safe way to answer "what would this rule import" before trusting it against live scans.\n\nHosts that already have a registered device are skipped, and exclusion rules still veto.'
-    : "Evaluate this rule against every completed discovery scan in the project and import every host it matches as a network device. This creates devices from ALL completed scans in the project, not just the most recent one — a broad rule can import a lot at once, so consider a Dry Run first.\n\nHosts that already have a registered device are skipped and exclusion rules still veto, so running this more than once is safe. Site assignment, owner, and label rules apply to the imported devices automatically.";
+    ? 'Evaluate this rule against every completed discovery scan in the project and report what it would import. Nothing is written — no devices or active monitors are created — so this is the safe way to answer "what would this rule import" before trusting it against live scans.\n\nIf the rule has a Monitor Template selected, the preview also reports how many eligible devices would receive an active Network Device monitor. Existing monitors are never duplicated, and exclusion rules still veto.'
+    : "Evaluate this rule against every completed discovery scan in the project and import every host it matches as a network device. This creates devices from ALL completed scans in the project, not just the most recent one — a broad rule can import a lot at once, so consider a Dry Run first.\n\nIf the rule has a Monitor Template selected, eligible devices also receive an active Network Device monitor. Existing monitors are never duplicated and exclusion rules still veto. Site assignment, owner, and label rules apply automatically.";
 
   return (
     <ConfirmModal

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRuleFormUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRuleFormUtil.ts
@@ -1,0 +1,66 @@
+import NetworkDeviceAutoImportRule from "Common/Models/DatabaseModels/NetworkDeviceAutoImportRule";
+import Permission from "Common/Types/Permission";
+import Column from "Common/UI/Components/ModelTable/Column";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import PermissionGate from "Common/UI/Utils/PermissionGate";
+
+export type MonitorIncompatibleBehaviorField =
+  | "isExclusion"
+  | "includePingOnlyHosts";
+
+export function canSelectAutoImportMonitorTemplate(
+  values: FormValues<NetworkDeviceAutoImportRule>,
+): boolean {
+  return !values.isExclusion && !values.includePingOnlyHosts;
+}
+
+/*
+ * Selecting an unreadable relation column fails the whole rule list request;
+ * return no column for a granular rule-reader so the inventory-only page
+ * remains usable. The optional permission set is a deterministic test seam.
+ */
+export function getReadableMonitorTemplateColumn(
+  permissions?: Array<Permission>,
+): Column<NetworkDeviceAutoImportRule> | null {
+  if (
+    !PermissionGate.canReadColumn(
+      new NetworkDeviceAutoImportRule(),
+      "monitorTemplate",
+      permissions ? { permissions } : undefined,
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    field: { monitorTemplate: { templateName: true } },
+    title: "Monitor Template",
+    type: FieldType.Entity,
+  };
+}
+
+/*
+ * Hidden form fields remain part of BasicForm's submitted value. Clear the
+ * relation under both writable spellings when a behavior toggle makes
+ * monitor provisioning invalid, including on edits where null (rather than
+ * undefined) is what tells the API to remove a persisted relation.
+ */
+export function updateMonitorIncompatibleBehavior(
+  currentValues: FormValues<NetworkDeviceAutoImportRule>,
+  field: MonitorIncompatibleBehaviorField,
+  value: boolean,
+): FormValues<NetworkDeviceAutoImportRule> {
+  const nextValues: FormValues<NetworkDeviceAutoImportRule> = {
+    ...currentValues,
+    [field]: value,
+  };
+
+  if (value) {
+    nextValues.monitorTemplate = null;
+    (nextValues as unknown as Record<string, unknown>)["monitorTemplateId"] =
+      null;
+  }
+
+  return nextValues;
+}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRules.tsx
@@ -1,16 +1,25 @@
 import PageComponentProps from "../../PageComponentProps";
 import RunAutoImportRuleModal from "../../../Components/NetworkAutomation/RunAutoImportRuleModal";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import { ErrorFunction, VoidFunction } from "Common/Types/FunctionTypes";
 import IconProp from "Common/Types/Icon/IconProp";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
+import Column from "Common/UI/Components/ModelTable/Column";
 import { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import Pill from "Common/UI/Components/Pill/Pill";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
 import NetworkDeviceAutoImportRule from "Common/Models/DatabaseModels/NetworkDeviceAutoImportRule";
+import MonitorTemplate from "Common/Models/DatabaseModels/MonitorTemplate";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
 import React, {
   Fragment,
   FunctionComponent,
@@ -18,11 +27,18 @@ import React, {
   useState,
 } from "react";
 import { Blue, Green, Red } from "Common/Types/BrandColors";
+import {
+  canSelectAutoImportMonitorTemplate,
+  getReadableMonitorTemplateColumn,
+  updateMonitorIncompatibleBehavior,
+} from "./AutoImportRuleFormUtil";
 
 const networkDeviceAutoImportDocumentation: string = `
 ### How Auto Import Rules Work
 
-Auto Import Rules turn discovery scan results into Network Devices automatically — matching hosts are imported the moment a scan completes, with no manual "Review Results → Import" step. Site assignment, owner, and label rules then apply to the imported devices automatically, so a rule here is the first link in a fully automatic pipeline from scan to labelled, owned, site-assigned device.
+Auto Import Rules turn discovery scan results into Network Devices automatically — matching hosts are imported the moment a scan completes, with no manual "Review Results → Import" step. Site assignment, owner, and label rules then apply to the imported devices automatically.
+
+An import rule can also select a **Network Device Monitor Template**. That opt-in completes the alerting pipeline: OneUptime creates an active monitor for each matching SNMP device, copies the template's criteria, interval, minimum probe agreement, custom fields and monitor labels, and then applies the normal Monitor Label and Owner Rules. Existing rules with no template remain inventory-only.
 
 ### Match Criteria
 
@@ -34,18 +50,65 @@ A rule imports a discovered host only when **all** specified criteria pass — c
 
 By default only hosts that answered SNMP are imported. Enable **Include Ping-Only Hosts** to also import hosts that only answered ping — but beware: a wrong SNMP credential makes every host on a subnet report as ping-only.
 
+### Monitor Provisioning
+
+Selecting a monitor template creates active monitors and may affect plan usage or billing. The template must belong to this project and have the **Network Device** monitor type. Ping-only hosts cannot use this operation because they do not produce the SNMP walks a Network Device monitor evaluates.
+
+The monitor template is the alerting layer: it supplies evaluation criteria and monitor settings. SNMP Health OIDs, interface walking, and endpoint collection remain polling settings on the Network Device itself; auto-imported devices continue to use the existing vendor-health-template seeding behavior for those fields.
+
+Provisioning is reconciled and safe to repeat: a missing template monitor is added even when the Network Device was registered by an earlier scan, while an existing automatic or manually configured Network Device monitor is left alone. If several matching rules select the same template, OneUptime creates one monitor. If they deliberately select different templates, it creates one monitor per distinct template.
+
+Changing a rule's template does not delete or rewrite monitors created from its old template. This avoids destructive surprises; delete the old automatic monitor and let the intended rule recreate it, or replace it with a manual monitor if you are migrating templates.
+
 ### Exclusion Rules
 
 An exclusion rule inverts the match: hosts it matches are **never** auto-imported, even when another rule matches them. Use one to carve printers, phones, or other unwanted hosts out of a broader import rule. An exclusion rule cannot be run directly — it vetoes other rules instead of importing anything.
 
 ### Dry Run and Run Now
 
-Rules fire automatically when a discovery scan completes, so a rule written after your scans ran does not reach them. **Run Now** applies a rule to every completed scan already in the project. **Dry Run** does the same evaluation but writes nothing — it answers "what would this rule import" before you trust the rule, and it works on a **disabled** rule too, so you can preview a rule before the automatic path can ever see it. Hosts that already have a registered device are always skipped, so running a rule more than once is safe.
+Rules fire automatically when a discovery scan completes. **Run Now** applies a rule to completed scans already in the project, including backfilling a selected template monitor for an already-registered matching device. **Dry Run** performs the same reconciliation but writes nothing — it answers what would be imported and which monitors would be created before you trust the rule. It also works on a **disabled** rule. Device and monitor creation are idempotent, so running a rule more than once is safe.
 `;
 
 const NetworkDeviceAutoImportRulesPage: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
+  const monitorTemplateColumn: Column<NetworkDeviceAutoImportRule> | null =
+    getReadableMonitorTemplateColumn();
+  const canReadMonitorTemplate: boolean = Boolean(monitorTemplateColumn);
+
+  const fetchNetworkDeviceMonitorTemplates: () => Promise<
+    Array<DropdownOption>
+  > = async (): Promise<Array<DropdownOption>> => {
+    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+
+    if (!projectId) {
+      return [];
+    }
+
+    const result: ListResult<MonitorTemplate> =
+      await ModelAPI.getList<MonitorTemplate>({
+        modelType: MonitorTemplate,
+        query: {
+          projectId: projectId,
+          monitorType: MonitorType.NetworkDevice,
+        },
+        select: {
+          _id: true,
+          templateName: true,
+        },
+        sort: { templateName: SortOrder.Ascending },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+      });
+
+    return result.data.map((template: MonitorTemplate): DropdownOption => {
+      return {
+        value: template.id?.toString() || "",
+        label: template.templateName || "Unnamed Network Device template",
+      };
+    });
+  };
+
   // The rule a run is open for, by id, plus its name and which kind of run.
   const [ruleBeingRun, setRuleBeingRun] = useState<{
     id: string;
@@ -189,12 +252,22 @@ const NetworkDeviceAutoImportRulesPage: FunctionComponent<
             title: "Host IP Is In",
             type: FieldType.Text,
           },
+          ...(monitorTemplateColumn ? [monitorTemplateColumn] : []),
         ]}
         viewPageRoute={Navigation.getCurrentRoute()}
         formSteps={[
           { title: "Basic Info", id: "basic-info" },
           { title: "Match Criteria", id: "match-criteria", columns: 2 },
           { title: "Behavior", id: "behavior" },
+          ...(canReadMonitorTemplate
+            ? [
+                {
+                  title: "Monitor",
+                  id: "monitor",
+                  showIf: canSelectAutoImportMonitorTemplate,
+                },
+              ]
+            : []),
         ]}
         formFields={[
           {
@@ -276,6 +349,21 @@ const NetworkDeviceAutoImportRulesPage: FunctionComponent<
             required: false,
             description:
               "Also import hosts that answered ping but not SNMP. Off by default: a wrong SNMP credential makes every host on a subnet report as ping-only, and this rule would then import all of them as half-identified devices.",
+            onChange: (
+              value: unknown,
+              currentValues: FormValues<NetworkDeviceAutoImportRule>,
+              setNewFormValues: (
+                values: FormValues<NetworkDeviceAutoImportRule>,
+              ) => void,
+            ): void => {
+              setNewFormValues(
+                updateMonitorIncompatibleBehavior(
+                  currentValues,
+                  "includePingOnlyHosts",
+                  value === true,
+                ),
+              );
+            },
           },
           {
             field: { isExclusion: true },
@@ -285,7 +373,41 @@ const NetworkDeviceAutoImportRulesPage: FunctionComponent<
             required: false,
             description:
               "Invert this rule: matching hosts are NEVER auto-imported, even when another rule matches them. Use it to carve printers, phones, or other unwanted hosts out of a broader rule.",
+            onChange: (
+              value: unknown,
+              currentValues: FormValues<NetworkDeviceAutoImportRule>,
+              setNewFormValues: (
+                values: FormValues<NetworkDeviceAutoImportRule>,
+              ) => void,
+            ): void => {
+              setNewFormValues(
+                updateMonitorIncompatibleBehavior(
+                  currentValues,
+                  "isExclusion",
+                  value === true,
+                ),
+              );
+            },
           },
+          ...(canReadMonitorTemplate
+            ? [
+                {
+                  field: { monitorTemplate: true },
+                  title: "Network Device Monitor Template",
+                  stepId: "monitor",
+                  sectionTitle: "Optional Alerting",
+                  sectionDescription:
+                    "Leave this empty for inventory-only import. Selecting a template creates active, potentially billable monitors and runs the normal Monitor Label and Owner Rules after creation.",
+                  fieldType: FormFieldSchemaType.Dropdown,
+                  fetchDropdownOptions: fetchNetworkDeviceMonitorTemplates,
+                  required: false,
+                  placeholder: "Import device only (no monitor)",
+                  description:
+                    "Alert criteria, interval, minimum probe agreement, custom fields and monitor labels are copied from this template. Health OIDs and other polling settings remain on the Network Device. Matching rules that select different templates can create multiple monitors per device.",
+                  showIf: canSelectAutoImportMonitorTemplate,
+                },
+              ]
+            : []),
         ]}
         showRefreshButton={true}
       />

--- a/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules.ts
+++ b/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules.ts
@@ -10,6 +10,8 @@ import NetworkDeviceAutoImportRuleEngineService, {
   AUTO_IMPORT_SWEEP_LOCK_NAMESPACE,
   AUTO_IMPORT_SWEEP_LOCK_TIMEOUT_MS,
   ExistingHostnamesByProjectId,
+  ExistingMonitorsByProjectId,
+  ImportAttemptBudgetsByProjectId,
 } from "Common/Server/Services/NetworkDeviceAutoImportRuleEngineService";
 import Semaphore, {
   SemaphoreMutex,
@@ -136,27 +138,64 @@ RunCron(
        */
       const existingHostnamesByProjectId: ExistingHostnamesByProjectId =
         new Map();
+      const existingMonitorsByProjectId: ExistingMonitorsByProjectId =
+        new Map();
+      const attemptBudgetsByProjectId: ImportAttemptBudgetsByProjectId =
+        new Map();
+      const cappedProjectIds: Set<string> = new Set();
 
       for (const scan of unprocessedScans) {
+        const projectId: string = scan.projectId?.toString() || "";
+
+        /*
+         * Device and active-monitor caps are per project per sweep, not per
+         * scan. Once one scan reaches either cap, leave the rest of that
+         * project's markers untouched for the next tick while still serving
+         * other projects in this sweep.
+         */
+        if (projectId && cappedProjectIds.has(projectId)) {
+          continue;
+        }
+
         try {
           const result: AutoImportRuleRunResult | null =
             await NetworkDeviceAutoImportRuleEngineService.processCompletedScan(
               {
                 scanId: scan.id!,
                 existingHostnamesByProjectId: existingHostnamesByProjectId,
+                existingMonitorsByProjectId: existingMonitorsByProjectId,
+                attemptBudgetsByProjectId: attemptBudgetsByProjectId,
               },
             );
 
+          if (result?.isTruncated && projectId) {
+            cappedProjectIds.add(projectId);
+          }
+
           if (
             result &&
-            (result.devicesCreated > 0 || result.devicesFailed > 0)
+            (result.devicesCreated > 0 ||
+              result.devicesFailed > 0 ||
+              result.monitorsCreated > 0 ||
+              result.monitorsFailed > 0)
           ) {
             logger.info(
-              `NetworkDeviceDiscovery:ProcessAutoImportRules - scan ${scan.id?.toString()}: ${result.devicesCreated} device(s) auto-imported, ${result.hostsSkippedAlreadyRegistered} already registered, ${result.hostsExcluded} excluded, ${result.devicesFailed} failed${
+              `NetworkDeviceDiscovery:ProcessAutoImportRules - scan ${scan.id?.toString()}: ${result.devicesCreated} device(s) auto-imported, ${result.hostsSkippedAlreadyRegistered} already registered, ${result.hostsExcluded} excluded, ${result.devicesFailed} device import(s) failed; ${result.monitorsCreated} active Network Device monitor(s) created, ${result.monitorsSkippedAlreadyExisting} requested monitor(s) skipped because monitoring already existed, ${result.monitorsSkippedUnsupportedHost} requested monitor(s) unsupported, ${result.monitorsFailed} monitor create(s) failed${
                 result.isTruncated
                   ? "; capped — the next tick will resume this scan"
                   : ""
               }.`,
+              { projectId: scan.projectId?.toString() } as LogAttributes,
+            );
+          } else if (
+            result &&
+            (result.hostsSkippedAlreadyRegistered > 0 ||
+              result.hostsExcluded > 0 ||
+              result.monitorsSkippedAlreadyExisting > 0 ||
+              result.monitorsSkippedUnsupportedHost > 0)
+          ) {
+            logger.debug(
+              `NetworkDeviceDiscovery:ProcessAutoImportRules - scan ${scan.id?.toString()} required no writes: ${result.hostsSkippedAlreadyRegistered} host(s) already registered, ${result.hostsExcluded} excluded, ${result.monitorsSkippedAlreadyExisting} requested monitor(s) already covered, ${result.monitorsSkippedUnsupportedHost} requested monitor(s) unsupported.`,
               { projectId: scan.projectId?.toString() } as LogAttributes,
             );
           }

--- a/App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts
+++ b/App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts
@@ -1,7 +1,10 @@
 import { mockRouter } from "Common/Tests/Server/API/Helpers";
 import CommonAPI from "Common/Server/API/CommonAPI";
+import NetworkDeviceAutoImportRuleEngineService from "Common/Server/Services/NetworkDeviceAutoImportRuleEngineService";
+import NetworkDeviceAutoImportRuleService from "Common/Server/Services/NetworkDeviceAutoImportRuleService";
 import NetworkDeviceLabelRuleEngineService from "Common/Server/Services/NetworkDeviceLabelRuleEngineService";
 import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
+import MonitorTemplateService from "Common/Server/Services/MonitorTemplateService";
 import Response from "Common/Server/Utils/Response";
 import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
 import { JSONObject } from "Common/Types/JSON";
@@ -57,6 +60,30 @@ jest.mock("Common/Server/Services/NetworkDeviceLabelRuleEngineService", () => {
   };
 });
 
+jest.mock("Common/Server/Services/NetworkDeviceAutoImportRuleService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorTemplateService", () => {
+  return {
+    __esModule: true,
+    default: { findOneById: jest.fn() },
+  };
+});
+
+jest.mock(
+  "Common/Server/Services/NetworkDeviceAutoImportRuleEngineService",
+  () => {
+    return {
+      __esModule: true,
+      default: { applyRuleToCompletedScans: jest.fn() },
+    };
+  },
+);
+
 /*
  * Importing the API module registers both routes on the mocked router, so
  * each handler can be invoked directly with every service call observable.
@@ -81,6 +108,17 @@ const deviceService: {
 const labelRuleEngine: { applyRuleToExistingNetworkDevices: jest.Mock } =
   NetworkDeviceLabelRuleEngineService as unknown as {
     applyRuleToExistingNetworkDevices: jest.Mock;
+  };
+
+const autoImportRuleService: { findOneBy: jest.Mock } =
+  NetworkDeviceAutoImportRuleService as unknown as { findOneBy: jest.Mock };
+
+const monitorTemplateService: { findOneById: jest.Mock } =
+  MonitorTemplateService as unknown as { findOneById: jest.Mock };
+
+const autoImportRuleEngine: { applyRuleToCompletedScans: jest.Mock } =
+  NetworkDeviceAutoImportRuleEngineService as unknown as {
+    applyRuleToCompletedScans: jest.Mock;
   };
 
 const responseUtil: { sendJsonObjectResponse: jest.Mock } =
@@ -167,6 +205,8 @@ async function callRoute(data: {
 
 const SITE_RULE_URI: string = "/network-site-assignment-rule/:ruleId/run";
 const LABEL_RULE_URI: string = "/network-device-label-rule/:ruleId/run";
+const AUTO_IMPORT_RULE_URI: string =
+  "/network-device-auto-import-rule/:ruleId/run";
 
 function errorFrom(next: NextFunction): Error {
   const calls: Array<Array<unknown>> = (next as unknown as jest.Mock).mock
@@ -204,11 +244,35 @@ describe("Network automation rule run endpoints", () => {
       labelsFailed: 0,
       isTruncated: false,
     } as never);
+    autoImportRuleService.findOneBy.mockResolvedValue({
+      id: RULE_ID,
+      monitorTemplateId: undefined,
+    });
+    monitorTemplateService.findOneById.mockResolvedValue({
+      id: ObjectID.generate(),
+    });
+    autoImportRuleEngine.applyRuleToCompletedScans.mockResolvedValue({
+      hostsEvaluated: 3,
+      hostsMatched: 2,
+      hostsExcluded: 0,
+      hostsSkippedAlreadyRegistered: 0,
+      devicesCreated: 2,
+      devicesFailed: 0,
+      monitorsWouldCreate: 0,
+      monitorsCreated: 0,
+      monitorsSkippedAlreadyExisting: 0,
+      monitorsSkippedUnsupportedHost: 0,
+      monitorsFailed: 0,
+      isTruncated: false,
+      hasMoreScans: false,
+      isDryRun: false,
+      matchedIpAddressSample: ["10.0.0.1", "10.0.0.2"],
+    });
   });
 
   describe("route registration", () => {
-    test("both routes are registered behind the user middleware", () => {
-      for (const uri of [SITE_RULE_URI, LABEL_RULE_URI]) {
+    test("all routes are registered behind the user middleware", () => {
+      for (const uri of [SITE_RULE_URI, LABEL_RULE_URI, AUTO_IMPORT_RULE_URI]) {
         const route: { middlewares: Array<unknown> } = mockRouter.match(
           "post",
           uri,
@@ -348,6 +412,275 @@ describe("Network automation rule run endpoints", () => {
 
       expect(errorFrom(next).message).toBe("Assignment rule not found.");
       expect(responseUtil.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /network-device-auto-import-rule/:ruleId/run", () => {
+    test("resolves the selected rule in the caller's project and returns every counter", async () => {
+      autoImportRuleEngine.applyRuleToCompletedScans.mockResolvedValue({
+        hostsEvaluated: 4,
+        hostsMatched: 3,
+        hostsExcluded: 1,
+        hostsSkippedAlreadyRegistered: 1,
+        devicesCreated: 2,
+        devicesFailed: 0,
+        monitorsWouldCreate: 0,
+        monitorsCreated: 1,
+        monitorsSkippedAlreadyExisting: 1,
+        monitorsSkippedUnsupportedHost: 0,
+        monitorsFailed: 0,
+        isTruncated: false,
+        hasMoreScans: false,
+        isDryRun: false,
+        matchedIpAddressSample: ["10.0.0.1"],
+      });
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(next).not.toHaveBeenCalled();
+      expect(autoImportRuleService.findOneBy).toHaveBeenCalledTimes(1);
+
+      const lookup: JSONObject = autoImportRuleService.findOneBy.mock
+        .calls[0]![0] as JSONObject;
+      const lookupQuery: JSONObject = lookup["query"] as JSONObject;
+      expect((lookupQuery["_id"] as ObjectID).toString()).toBe(
+        RULE_ID.toString(),
+      );
+      expect((lookupQuery["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(lookup["select"]).toEqual({
+        _id: true,
+        monitorTemplateId: true,
+      });
+
+      const run: JSONObject = autoImportRuleEngine.applyRuleToCompletedScans
+        .mock.calls[0]![0] as JSONObject;
+      expect((run["ruleId"] as ObjectID).toString()).toBe(RULE_ID.toString());
+      expect((run["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(run["isDryRun"]).toBe(false);
+      expect(run["expectedMonitorTemplateId"]).toBeNull();
+
+      expect(
+        (responseUtil.sendJsonObjectResponse.mock.calls[0]![2] as JSONObject)[
+          "monitorsCreated"
+        ],
+      ).toBe(1);
+    });
+
+    test("passes a literal dryRun through after applying the existing create-permission policy", async () => {
+      await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+        body: { dryRun: true },
+      });
+
+      const run: JSONObject = autoImportRuleEngine.applyRuleToCompletedScans
+        .mock.calls[0]![0] as JSONObject;
+      expect(run["isDryRun"]).toBe(true);
+    });
+
+    test.each([["true"], [1], ["yes"], [{}]])(
+      "refuses malformed dryRun (%p) rather than accidentally writing",
+      async (value: unknown) => {
+        const next: NextFunction = await callRoute({
+          uri: AUTO_IMPORT_RULE_URI,
+          body: { dryRun: value } as JSONObject,
+        });
+
+        expect(errorFrom(next).message).toContain("dryRun must be a boolean");
+        expect(
+          autoImportRuleEngine.applyRuleToCompletedScans,
+        ).not.toHaveBeenCalled();
+      },
+    );
+
+    test("rejects a rule that does not resolve inside the project", async () => {
+      autoImportRuleService.findOneBy.mockResolvedValue(null);
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(errorFrom(next).message).toBe("Auto-import rule not found.");
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("retains the device-only permission contract when no template is selected", async () => {
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceAutoImportRule,
+            Permission.CreateNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(next).not.toHaveBeenCalled();
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    test("requires Monitor create permission when the rule selects a template", async () => {
+      autoImportRuleService.findOneBy.mockResolvedValue({
+        id: RULE_ID,
+        monitorTemplateId: ObjectID.generate(),
+      });
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceAutoImportRule,
+            Permission.CreateNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(errorFrom(next).message).toContain(
+        "permission to create monitors",
+      );
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("passes the authorized Monitor Template snapshot to the engine", async () => {
+      const monitorTemplateId: ObjectID = ObjectID.generate();
+      autoImportRuleService.findOneBy.mockResolvedValue({
+        id: RULE_ID,
+        monitorTemplateId: monitorTemplateId,
+      });
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceAutoImportRule,
+            Permission.CreateNetworkDevice,
+            Permission.CreateProjectMonitor,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(next).not.toHaveBeenCalled();
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).toHaveBeenCalledTimes(1);
+
+      const run: JSONObject = autoImportRuleEngine.applyRuleToCompletedScans
+        .mock.calls[0]![0] as JSONObject;
+      expect((run["expectedMonitorTemplateId"] as ObjectID).toString()).toBe(
+        monitorTemplateId.toString(),
+      );
+      expect(monitorTemplateService.findOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: monitorTemplateId,
+          props: expect.objectContaining({ tenantId: PROJECT_ID }),
+        }),
+      );
+    });
+
+    test("refuses Run Now when the selected Monitor Template is outside the caller's read scope", async () => {
+      const monitorTemplateId: ObjectID = ObjectID.generate();
+      autoImportRuleService.findOneBy.mockResolvedValue({
+        id: RULE_ID,
+        monitorTemplateId,
+      });
+      monitorTemplateService.findOneById.mockResolvedValue(null);
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceAutoImportRule,
+            Permission.CreateNetworkDevice,
+            Permission.CreateProjectMonitor,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(errorFrom(next).message).toContain(
+        "permission to read the Monitor Template",
+      );
+      expect(monitorTemplateService.findOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: monitorTemplateId,
+          props: expect.objectContaining({ tenantId: PROJECT_ID }),
+        }),
+      );
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("honours an explicit block on Monitor creation", async () => {
+      autoImportRuleService.findOneBy.mockResolvedValue({
+        id: RULE_ID,
+        monitorTemplateId: ObjectID.generate(),
+      });
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceAutoImportRule,
+            Permission.CreateNetworkDevice,
+            Permission.CreateProjectMonitor,
+          ],
+          blockedPermissions: [Permission.CreateProjectMonitor],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+      });
+
+      expect(errorFrom(next).message).toContain("block list");
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("keeps Monitor create permission checks on a dry run", async () => {
+      autoImportRuleService.findOneBy.mockResolvedValue({
+        id: RULE_ID,
+        monitorTemplateId: ObjectID.generate(),
+      });
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceAutoImportRule,
+            Permission.CreateNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({
+        uri: AUTO_IMPORT_RULE_URI,
+        body: { dryRun: true },
+      });
+
+      expect(errorFrom(next).message).toContain(
+        "permission to create monitors",
+      );
+      expect(
+        autoImportRuleEngine.applyRuleToCompletedScans,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/App/Tests/Dashboard/NetworkDeviceAutoImportRuleFormUtil.test.ts
+++ b/App/Tests/Dashboard/NetworkDeviceAutoImportRuleFormUtil.test.ts
@@ -1,0 +1,90 @@
+/*
+ * PermissionGate normally reads the signed-in browser user before checking a
+ * supplied permission snapshot. App tests run under Jest's Node environment,
+ * so use the same user seam as the neighboring permission-gating suites.
+ */
+jest.mock("Common/UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return false;
+      },
+    },
+  };
+});
+
+import NetworkDeviceAutoImportRule from "Common/Models/DatabaseModels/NetworkDeviceAutoImportRule";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import ObjectID from "Common/Types/ObjectID";
+import Permission from "Common/Types/Permission";
+import {
+  canSelectAutoImportMonitorTemplate,
+  getReadableMonitorTemplateColumn,
+  updateMonitorIncompatibleBehavior,
+} from "../../FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/AutoImportRuleFormUtil";
+import { describe, expect, it } from "@jest/globals";
+
+describe("Network Device auto-import rule monitor form state", () => {
+  it("omits the Monitor Template column for a granular inventory-rule reader", () => {
+    expect(
+      getReadableMonitorTemplateColumn([
+        Permission.ReadNetworkDeviceAutoImportRule,
+      ]),
+    ).toBeNull();
+  });
+
+  it("includes the Monitor Template column for a caller allowed to read it", () => {
+    expect(
+      getReadableMonitorTemplateColumn([Permission.ReadMonitorTemplate]),
+    ).toEqual(
+      expect.objectContaining({
+        field: { monitorTemplate: { templateName: true } },
+      }),
+    );
+  });
+
+  it("shows the monitor step for an ordinary import rule", () => {
+    expect(canSelectAutoImportMonitorTemplate({})).toBe(true);
+  });
+
+  it.each(["isExclusion", "includePingOnlyHosts"] as const)(
+    "hides the monitor step when %s is enabled",
+    (field: "isExclusion" | "includePingOnlyHosts") => {
+      expect(canSelectAutoImportMonitorTemplate({ [field]: true })).toBe(false);
+    },
+  );
+
+  it.each(["isExclusion", "includePingOnlyHosts"] as const)(
+    "clears a persisted monitor template when %s is enabled",
+    (field: "isExclusion" | "includePingOnlyHosts") => {
+      const current: FormValues<NetworkDeviceAutoImportRule> = {
+        monitorTemplate: "template-id",
+        monitorTemplateId: ObjectID.generate(),
+        name: "Rule",
+      };
+
+      const updated: FormValues<NetworkDeviceAutoImportRule> =
+        updateMonitorIncompatibleBehavior(current, field, true);
+
+      expect(updated).toEqual({
+        monitorTemplate: null,
+        monitorTemplateId: null,
+        name: "Rule",
+        [field]: true,
+      });
+      expect(current.monitorTemplate).toBe("template-id");
+      expect(current.monitorTemplateId).toBeInstanceOf(ObjectID);
+    },
+  );
+
+  it("preserves a selected template when an incompatible toggle is turned off", () => {
+    expect(
+      updateMonitorIncompatibleBehavior(
+        { monitorTemplate: "template-id", isExclusion: true },
+        "isExclusion",
+        false,
+      ),
+    ).toEqual({ monitorTemplate: "template-id", isExclusion: false });
+  });
+});

--- a/App/Tests/Dashboard/RunAutoImportRuleModal.test.ts
+++ b/App/Tests/Dashboard/RunAutoImportRuleModal.test.ts
@@ -1,0 +1,70 @@
+import { describeAutoImportRun } from "../../FeatureSet/Dashboard/src/Components/NetworkAutomation/RunAutoImportRuleModal";
+import { AutoImportRuleRunResult } from "Common/Types/NetworkAutomation/RuleRunResult";
+import { describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * The summary helper lives beside the browser component, whose import graph
+ * reads APP_API_URL. Keep this pure text test in Node by replacing only that
+ * browser-time configuration value.
+ */
+jest.mock("Common/UI/Config", () => {
+  const { default: MockURL } = jest.requireActual("Common/Types/API/URL") as {
+    default: { fromString: (value: string) => unknown };
+  };
+
+  return {
+    __esModule: true,
+    APP_API_URL: MockURL.fromString("http://localhost/api"),
+  };
+});
+
+function result(
+  overrides: Partial<AutoImportRuleRunResult>,
+): AutoImportRuleRunResult {
+  return {
+    hostsEvaluated: 1,
+    hostsMatched: 1,
+    hostsExcluded: 0,
+    hostsSkippedAlreadyRegistered: 1,
+    devicesCreated: 0,
+    devicesFailed: 0,
+    monitorsWouldCreate: 0,
+    monitorsCreated: 0,
+    monitorsSkippedAlreadyExisting: 0,
+    monitorsSkippedUnsupportedHost: 0,
+    monitorsFailed: 0,
+    isTruncated: false,
+    hasMoreScans: false,
+    isDryRun: false,
+    matchedIpAddressSample: [],
+    ...overrides,
+  };
+}
+
+describe("auto-import rule run summary", () => {
+  it("uses singular grammar for one skipped monitor request", () => {
+    const summary: string = describeAutoImportRun(
+      result({ monitorsSkippedAlreadyExisting: 1 }),
+    );
+
+    expect(summary).toContain(
+      "1 requested active Network Device monitor was skipped",
+    );
+    expect(summary).not.toContain("monitor were");
+  });
+
+  it("describes multiple skipped requests without claiming that many monitors exist", () => {
+    expect(
+      describeAutoImportRun(result({ monitorsSkippedAlreadyExisting: 3 })),
+    ).toContain("3 requested active Network Device monitors were skipped");
+  });
+
+  it("explains that a dry-run cap can come from device or monitor work", () => {
+    const summary: string = describeAutoImportRun(
+      result({ isDryRun: true, isTruncated: true }),
+    );
+
+    expect(summary).toContain("device-import and active-monitor creation");
+    expect(summary).not.toContain("imports this many");
+  });
+});

--- a/App/Tests/Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules.test.ts
+++ b/App/Tests/Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules.test.ts
@@ -1,0 +1,244 @@
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import Semaphore, {
+  SemaphoreMutex,
+} from "Common/Server/Infrastructure/Semaphore";
+import NetworkDeviceAutoImportRuleEngineService from "Common/Server/Services/NetworkDeviceAutoImportRuleEngineService";
+import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
+import logger from "Common/Server/Utils/Logger";
+import ObjectID from "Common/Types/ObjectID";
+import { AutoImportRuleRunResult } from "Common/Types/NetworkAutomation/RuleRunResult";
+
+/*
+ * The job exports no handler: it registers one at module load. Capture that
+ * callback so each test can exercise a complete worker sweep without creating
+ * a BullMQ repeatable job.
+ */
+type CronHandler = () => Promise<void>;
+
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    default: {
+      lock: jest.fn(),
+      release: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/NetworkDeviceDiscoveryScanService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock(
+  "Common/Server/Services/NetworkDeviceAutoImportRuleEngineService",
+  () => {
+    return {
+      __esModule: true,
+      AUTO_IMPORT_SWEEP_LOCK_KEY:
+        "NetworkDeviceDiscovery:ProcessAutoImportRules",
+      AUTO_IMPORT_SWEEP_LOCK_NAMESPACE: "Workers.Cron",
+      AUTO_IMPORT_SWEEP_LOCK_TIMEOUT_MS: 11 * 60 * 1000,
+      default: {
+        processCompletedScan: jest.fn(),
+      },
+    };
+  },
+);
+
+// Imported for its side effect: the RunCron mock above records the handler.
+import "../../../../FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/ProcessAutoImportRules";
+
+interface ProcessCompletedScanArgs {
+  scanId: ObjectID;
+  existingHostnamesByProjectId: Map<string, unknown>;
+  existingMonitorsByProjectId: Map<string, unknown>;
+  attemptBudgetsByProjectId: Map<string, unknown>;
+}
+
+const scanService: { findBy: jest.Mock } =
+  NetworkDeviceDiscoveryScanService as unknown as { findBy: jest.Mock };
+const engineService: { processCompletedScan: jest.Mock } =
+  NetworkDeviceAutoImportRuleEngineService as unknown as {
+    processCompletedScan: jest.Mock;
+  };
+const semaphore: { lock: jest.Mock; release: jest.Mock } =
+  Semaphore as unknown as { lock: jest.Mock; release: jest.Mock };
+const mockedLogger: {
+  debug: jest.Mock;
+  info: jest.Mock;
+  error: jest.Mock;
+} = logger as unknown as {
+  debug: jest.Mock;
+  info: jest.Mock;
+  error: jest.Mock;
+};
+
+const SWEEP_MUTEX: SemaphoreMutex = {
+  identifier: "network-auto-import-sweep",
+} as unknown as SemaphoreMutex;
+
+const PROJECT_A_ID: ObjectID = new ObjectID("project-a");
+const PROJECT_B_ID: ObjectID = new ObjectID("project-b");
+const PROJECT_A_SCAN_1_ID: ObjectID = new ObjectID("project-a-scan-1");
+const PROJECT_A_SCAN_2_ID: ObjectID = new ObjectID("project-a-scan-2");
+const PROJECT_B_SCAN_ID: ObjectID = new ObjectID("project-b-scan-1");
+
+function makeScan(data: {
+  id: ObjectID;
+  projectId: ObjectID;
+}): NetworkDeviceDiscoveryScan {
+  return {
+    id: data.id,
+    projectId: data.projectId,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+function makeResult(
+  overrides: Partial<AutoImportRuleRunResult> = {},
+): AutoImportRuleRunResult {
+  return {
+    hostsEvaluated: 0,
+    hostsMatched: 0,
+    hostsExcluded: 0,
+    hostsSkippedAlreadyRegistered: 0,
+    devicesCreated: 0,
+    devicesFailed: 0,
+    monitorsWouldCreate: 0,
+    monitorsCreated: 0,
+    monitorsSkippedAlreadyExisting: 0,
+    monitorsSkippedUnsupportedHost: 0,
+    monitorsFailed: 0,
+    isTruncated: false,
+    hasMoreScans: false,
+    isDryRun: false,
+    matchedIpAddressSample: [],
+    ...overrides,
+  };
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["NetworkDeviceDiscovery:ProcessAutoImportRules"];
+
+  if (!handler) {
+    throw new Error(
+      "NetworkDeviceDiscovery:ProcessAutoImportRules did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("NetworkDeviceDiscovery:ProcessAutoImportRules worker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    semaphore.lock.mockResolvedValue(SWEEP_MUTEX);
+    semaphore.release.mockResolvedValue(undefined);
+    scanService.findBy.mockResolvedValue([]);
+    engineService.processCompletedScan.mockResolvedValue(makeResult());
+  });
+
+  test("a capped project defers its later scans without starving another project and shares all sweep caches", async () => {
+    scanService.findBy.mockResolvedValue([
+      makeScan({ id: PROJECT_A_SCAN_1_ID, projectId: PROJECT_A_ID }),
+      makeScan({ id: PROJECT_A_SCAN_2_ID, projectId: PROJECT_A_ID }),
+      makeScan({ id: PROJECT_B_SCAN_ID, projectId: PROJECT_B_ID }),
+    ]);
+    engineService.processCompletedScan
+      .mockResolvedValueOnce(makeResult({ isTruncated: true }))
+      .mockResolvedValueOnce(makeResult());
+
+    await runWorkerTick();
+
+    expect(engineService.processCompletedScan).toHaveBeenCalledTimes(2);
+
+    const firstCall: ProcessCompletedScanArgs = engineService
+      .processCompletedScan.mock.calls[0]![0] as ProcessCompletedScanArgs;
+    const secondCall: ProcessCompletedScanArgs = engineService
+      .processCompletedScan.mock.calls[1]![0] as ProcessCompletedScanArgs;
+
+    expect(firstCall.scanId).toBe(PROJECT_A_SCAN_1_ID);
+    expect(secondCall.scanId).toBe(PROJECT_B_SCAN_ID);
+    expect(
+      engineService.processCompletedScan.mock.calls.some(
+        (call: Array<unknown>) => {
+          return (
+            (call[0] as ProcessCompletedScanArgs).scanId === PROJECT_A_SCAN_2_ID
+          );
+        },
+      ),
+    ).toBe(false);
+
+    expect(firstCall.existingHostnamesByProjectId).toBeInstanceOf(Map);
+    expect(firstCall.existingMonitorsByProjectId).toBeInstanceOf(Map);
+    expect(firstCall.attemptBudgetsByProjectId).toBeInstanceOf(Map);
+    expect(secondCall.existingHostnamesByProjectId).toBe(
+      firstCall.existingHostnamesByProjectId,
+    );
+    expect(secondCall.existingMonitorsByProjectId).toBe(
+      firstCall.existingMonitorsByProjectId,
+    );
+    expect(secondCall.attemptBudgetsByProjectId).toBe(
+      firstCall.attemptBudgetsByProjectId,
+    );
+    expect(semaphore.release).toHaveBeenCalledWith(SWEEP_MUTEX);
+  });
+
+  test("skip-only outcomes are diagnostic debug logs rather than write-summary info logs", async () => {
+    scanService.findBy.mockResolvedValue([
+      makeScan({ id: PROJECT_A_SCAN_1_ID, projectId: PROJECT_A_ID }),
+    ]);
+    engineService.processCompletedScan.mockResolvedValue(
+      makeResult({
+        hostsSkippedAlreadyRegistered: 3,
+        hostsExcluded: 2,
+        monitorsSkippedAlreadyExisting: 4,
+        monitorsSkippedUnsupportedHost: 1,
+      }),
+    );
+
+    await runWorkerTick();
+
+    expect(mockedLogger.info).not.toHaveBeenCalled();
+    expect(mockedLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("required no writes"),
+      { projectId: PROJECT_A_ID.toString() },
+    );
+    expect(mockedLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("4 requested monitor(s) already covered"),
+      { projectId: PROJECT_A_ID.toString() },
+    );
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Models/DatabaseModels/Monitor.ts
+++ b/Common/Models/DatabaseModels/Monitor.ts
@@ -1,6 +1,7 @@
 import Label from "./Label";
 import MonitorStatus from "./MonitorStatus";
 import MonitorTemplate from "./MonitorTemplate";
+import NetworkDevice from "./NetworkDevice";
 import Project from "./Project";
 import User from "./User";
 import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
@@ -91,6 +92,15 @@ import NotificationRuleWorkspaceChannel from "../../Types/Workspace/Notification
 @EnableAuditLog()
 @CrudApiEndpoint(new Route("/monitor"))
 @SlugifyColumn("name", "slug")
+@Index(
+  "IDX_monitor_auto_provisioned_device_template_unique",
+  ["autoProvisionedNetworkDeviceId", "monitorTemplateId"],
+  {
+    unique: true,
+    where:
+      '"deletedAt" IS NULL AND "autoProvisionedNetworkDeviceId" IS NOT NULL AND "monitorTemplateId" IS NOT NULL',
+  },
+)
 @Entity({
   name: "Monitor",
 })
@@ -676,6 +686,80 @@ export default class Monitor extends BaseModel {
     transformer: ObjectID.getDatabaseTransformer(),
   })
   public monitorTemplateId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.MonitorViewer,
+      Permission.ReadProjectMonitor,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "autoProvisionedNetworkDeviceId",
+    type: TableColumnType.Entity,
+    modelType: NetworkDevice,
+    title: "Auto-Provisioned Network Device",
+    description:
+      "Network Device that caused this monitor to be provisioned automatically",
+  })
+  @ManyToOne(
+    () => {
+      return NetworkDevice;
+    },
+    {
+      eager: false,
+      nullable: true,
+      /*
+       * Service deletion removes automatic monitors through MonitorService.
+       * RESTRICT is the final race backstop: a monitor inserted after that
+       * preflight makes the device delete fail instead of being silently
+       * cascade-deleted without authorization or lifecycle hooks.
+       */
+      onDelete: "RESTRICT",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({
+    name: "autoProvisionedNetworkDeviceId",
+    foreignKeyConstraintName: "FK_monitor_auto_provisioned_network_device",
+  })
+  public autoProvisionedNetworkDevice?: NetworkDevice = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.MonitorViewer,
+      Permission.ReadProjectMonitor,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Auto-Provisioned Network Device ID",
+    description:
+      "ID of the Network Device that caused this monitor to be provisioned automatically",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public autoProvisionedNetworkDeviceId?: ObjectID = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/NetworkDeviceAutoImportRule.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceAutoImportRule.ts
@@ -1,3 +1,4 @@
+import MonitorTemplate from "./MonitorTemplate";
 import Project from "./Project";
 import User from "./User";
 import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
@@ -23,13 +24,13 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
  * manual "Review Results -> Import" step — the OneUptime shape of Zabbix's
  * autoregistration actions (issue #3378).
  *
- * The rule is deliberately a pure CREATION GATE: conditions decide WHICH
- * discovered hosts import, and the import itself goes through the same
- * builder as the manual dialog. Everything downstream of creation — site
- * assignment, owners, labels — already fires automatically from
+ * Conditions decide WHICH discovered hosts import, and the optional monitor
+ * template decides whether each imported SNMP device also gets a Network
+ * Device monitor. Everything else downstream of creation — site assignment,
+ * owners, labels — already fires automatically from
  * NetworkDeviceService.onCreateSuccess through the existing
  * NetworkSiteAssignmentRule / NetworkDeviceOwnerRule / NetworkDeviceLabelRule
- * engines, so this model carries no operation columns to fight them with.
+ * engines, so this model carries no competing operation columns.
  *
  * Conditions on one rule are ANDed; OR is more rules. An exclusion rule
  * (isExclusion) vetoes matching import rules — "never auto-import X".
@@ -76,7 +77,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   pluralName: "Network Device Auto Import Rules",
   icon: IconProp.Automation,
   tableDescription:
-    "Automatically import matching hosts from network device discovery scan results as Network Devices, with no manual review step",
+    "Automatically import matching hosts from network device discovery scan results as Network Devices and optionally provision a monitor from a template",
 })
 /*
  * The index and foreign-key names below are written out rather than left to
@@ -464,6 +465,103 @@ export default class NetworkDeviceAutoImportRule extends BaseModel {
     default: false,
   })
   public isExclusion?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.CreateProjectMonitor,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.MonitorViewer,
+      Permission.ReadMonitorTemplate,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.CreateProjectMonitor,
+    ],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "monitorTemplateId",
+    type: TableColumnType.Entity,
+    modelType: MonitorTemplate,
+    title: "Monitor Template",
+    description:
+      "Optional Network Device monitor template to apply to devices imported by this rule",
+  })
+  @ManyToOne(
+    () => {
+      return MonitorTemplate;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({
+    name: "monitorTemplateId",
+    foreignKeyConstraintName: "FK_nd_auto_import_rule_monitorTemplateId",
+  })
+  public monitorTemplate?: MonitorTemplate = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.CreateProjectMonitor,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.MonitorViewer,
+      Permission.ReadMonitorTemplate,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.MonitorAdmin,
+      Permission.MonitorMember,
+      Permission.CreateProjectMonitor,
+    ],
+  })
+  @Index("IDX_network_device_auto_import_rule_monitorTemplateId")
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Monitor Template ID",
+    description:
+      "ID of the optional Network Device monitor template to apply to devices imported by this rule",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public monitorTemplateId?: ObjectID = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1789600000000-AddAutoProvisionedNetworkDeviceMonitors.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1789600000000-AddAutoProvisionedNetworkDeviceMonitors.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAutoProvisionedNetworkDeviceMonitors1789600000000
+  implements MigrationInterface
+{
+  public name: string = "AddAutoProvisionedNetworkDeviceMonitors1789600000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Monitor" ADD "autoProvisionedNetworkDeviceId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceAutoImportRule" ADD "monitorTemplateId" uuid`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_monitor_auto_provisioned_device_template_unique" ON "Monitor" ("autoProvisionedNetworkDeviceId", "monitorTemplateId") WHERE "deletedAt" IS NULL AND "autoProvisionedNetworkDeviceId" IS NOT NULL AND "monitorTemplateId" IS NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_network_device_auto_import_rule_monitorTemplateId" ON "NetworkDeviceAutoImportRule" ("monitorTemplateId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Monitor" ADD CONSTRAINT "FK_monitor_auto_provisioned_network_device" FOREIGN KEY ("autoProvisionedNetworkDeviceId") REFERENCES "NetworkDevice"("_id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceAutoImportRule" ADD CONSTRAINT "FK_nd_auto_import_rule_monitorTemplateId" FOREIGN KEY ("monitorTemplateId") REFERENCES "MonitorTemplate"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceAutoImportRule" DROP CONSTRAINT "FK_nd_auto_import_rule_monitorTemplateId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Monitor" DROP CONSTRAINT "FK_monitor_auto_provisioned_network_device"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_network_device_auto_import_rule_monitorTemplateId"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_monitor_auto_provisioned_device_template_unique"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceAutoImportRule" DROP COLUMN "monitorTemplateId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Monitor" DROP COLUMN "autoProvisionedNetworkDeviceId"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -550,6 +550,7 @@ import { AddCampaignUtmFields1789500000000 } from "./1789500000000-AddCampaignUt
 import { AddUserTwoFactorBackupCode1789100000000 } from "./1789100000000-AddUserTwoFactorBackupCode";
 import { AddNameToNetworkDeviceDiscoveryScan1789400000000 } from "./1789400000000-AddNameToNetworkDeviceDiscoveryScan";
 import { AddDetectionRuleDistinctCountColumns1789512000000 } from "./1789512000000-AddDetectionRuleDistinctCountColumns";
+import { AddAutoProvisionedNetworkDeviceMonitors1789600000000 } from "./1789600000000-AddAutoProvisionedNetworkDeviceMonitors";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
 import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
@@ -1108,4 +1109,5 @@ export default [
   AddNameToNetworkDeviceDiscoveryScan1789400000000,
   AddCampaignUtmFields1789500000000,
   AddDetectionRuleDistinctCountColumns1789512000000,
+  AddAutoProvisionedNetworkDeviceMonitors1789600000000,
 ];

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -44,6 +44,7 @@ import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import Typeof from "../../Types/Typeof";
 import Model from "../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../Models/DatabaseModels/MonitorTemplate";
 import MonitorOwnerTeam from "../../Models/DatabaseModels/MonitorOwnerTeam";
 import MonitorOwnerUser from "../../Models/DatabaseModels/MonitorOwnerUser";
 import MonitorProbe from "../../Models/DatabaseModels/MonitorProbe";
@@ -89,6 +90,14 @@ import ExceptionMessages from "../../Types/Exception/ExceptionMessages";
 import Project from "../../Models/DatabaseModels/Project";
 import { createWhatsAppMessageFromTemplate } from "../Utils/WhatsAppTemplateUtil";
 import { WhatsAppMessagePayload } from "../../Types/WhatsApp/WhatsAppMessage";
+import MonitorTemplateService from "./MonitorTemplateService";
+import RelationIdUtil from "../Utils/Database/RelationIdUtil";
+import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
+
+const MONITOR_TEMPLATE_RELATION_KEYS: Array<string> = [
+  "monitorTemplateId",
+  "monitorTemplate",
+];
 
 export interface MonitorDestinationInfo {
   monitorDestination: string;
@@ -99,6 +108,55 @@ export interface MonitorDestinationInfo {
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  private async validateMonitorTemplateReference(data: {
+    monitorTemplateId: ObjectID;
+    projectId: ObjectID | undefined;
+    monitorType: MonitorType | undefined;
+    props: DatabaseCommonInteractionProps;
+  }): Promise<void> {
+    if (!data.projectId) {
+      throw new BadDataException(
+        "Project ID is required when linking a monitor template.",
+      );
+    }
+
+    const monitorTemplate: MonitorTemplate | null =
+      await MonitorTemplateService.findOneById({
+        id: data.monitorTemplateId,
+        select: {
+          _id: true,
+          projectId: true,
+          monitorType: true,
+        },
+        /*
+         * Linking is also a read of the template. Keep the caller's tenant,
+         * ownership and label scopes so a generic Monitor write cannot attach
+         * a hidden template and expose its configuration through a later sync.
+         * Internal callers already use root props and retain that behavior.
+         */
+        props: data.props,
+      });
+
+    if (!monitorTemplate) {
+      throw new BadDataException("Monitor template not found.");
+    }
+
+    if (
+      !monitorTemplate.projectId ||
+      monitorTemplate.projectId.toString() !== data.projectId.toString()
+    ) {
+      throw new BadDataException(
+        "Monitor template must belong to the same project as the monitor.",
+      );
+    }
+
+    if (!data.monitorType || monitorTemplate.monitorType !== data.monitorType) {
+      throw new BadDataException(
+        "Monitor template type must match the monitor type.",
+      );
+    }
   }
 
   public getMonitorDestinationInfo(monitor: Model): MonitorDestinationInfo {
@@ -407,7 +465,15 @@ export class Service extends DatabaseService<Model> {
       resolveReferenceId(updateBy.data.currentMonitorStatusId) ||
       resolveReferenceId(updateBy.data.currentMonitorStatus);
 
-    if (updateBy.data.monitorSteps) {
+    const updateDataKeys: Array<string> = Object.keys(updateBy.data || {});
+    const isMonitorStepsWritten: boolean =
+      updateDataKeys.includes("monitorSteps");
+    const isMonitorTemplateWritten: boolean = RelationIdUtil.isWritten(
+      updateDataKeys,
+      MONITOR_TEMPLATE_RELATION_KEYS,
+    );
+
+    if (isMonitorStepsWritten || isMonitorTemplateWritten) {
       /*
        * Validated per matched monitor rather than per distinct project, because
        * the check needs that monitor's CURRENT monitorSteps: a reference id it
@@ -416,10 +482,16 @@ export class Service extends DatabaseService<Model> {
        * MonitorStepsProjectValidator.
        */
       const monitors: Array<Model> = await this.findBy({
-        query: updateBy.query,
+        query:
+          !updateBy.props.isRoot && updateBy.props.tenantId
+            ? { ...updateBy.query, projectId: updateBy.props.tenantId }
+            : updateBy.query,
         select: {
           projectId: true,
+          monitorType: true,
           monitorSteps: true,
+          monitorTemplateId: true,
+          autoProvisionedNetworkDeviceId: true,
         },
         limit: LIMIT_MAX,
         skip: 0,
@@ -429,16 +501,66 @@ export class Service extends DatabaseService<Model> {
         },
       });
 
+      const writtenMonitorTemplateId: ObjectID | null =
+        RelationIdUtil.readConsistent(
+          updateBy.data as unknown as Record<string, unknown>,
+          MONITOR_TEMPLATE_RELATION_KEYS,
+          "Monitor Template",
+        );
+
       for (const monitor of monitors) {
-        await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
-          monitorSteps: updateBy.data.monitorSteps as MonitorSteps | JSONObject,
-          /*
-           * Root/API updates do not always carry a tenantId, so fall back to
-           * the project of the monitor being updated.
-           */
-          projectId: updateBy.props.tenantId || monitor.projectId,
-          alreadyStoredMonitorSteps: monitor.monitorSteps,
-        });
+        if (isMonitorStepsWritten) {
+          if (updateBy.data.monitorSteps) {
+            await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject(
+              {
+                monitorSteps: updateBy.data.monitorSteps as
+                  | MonitorSteps
+                  | JSONObject,
+                /*
+                 * Root/API updates do not always carry a tenantId, so fall back
+                 * to the project of the monitor being updated.
+                 */
+                projectId: updateBy.props.tenantId || monitor.projectId,
+                alreadyStoredMonitorSteps: monitor.monitorSteps,
+              },
+            );
+          }
+
+          if (monitor.autoProvisionedNetworkDeviceId) {
+            NetworkDeviceMonitorTemplateUtil.assertMonitorStepsBoundToNetworkDevice(
+              {
+                monitorSteps: updateBy.data.monitorSteps as
+                  | MonitorSteps
+                  | JSONObject,
+                networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
+              },
+            );
+          }
+        }
+
+        if (isMonitorTemplateWritten) {
+          if (monitor.autoProvisionedNetworkDeviceId) {
+            const storedTemplateId: string =
+              monitor.monitorTemplateId?.toString() || "";
+            const writtenTemplateId: string =
+              writtenMonitorTemplateId?.toString() || "";
+
+            if (storedTemplateId !== writtenTemplateId) {
+              throw new BadDataException(
+                "An auto-provisioned monitor cannot be relinked or unlinked from its template. Delete it and let the intended rule recreate it, or create a manual monitor instead.",
+              );
+            }
+          }
+
+          if (writtenMonitorTemplateId) {
+            await this.validateMonitorTemplateReference({
+              monitorTemplateId: writtenMonitorTemplateId,
+              projectId: updateBy.props.tenantId || monitor.projectId,
+              monitorType: monitor.monitorType,
+              props: updateBy.props,
+            });
+          }
+        }
       }
     }
 
@@ -1072,6 +1194,40 @@ export class Service extends DatabaseService<Model> {
 
     if (!createBy.props.tenantId) {
       throw new BadDataException("ProjectId required to create monitor.");
+    }
+
+    const monitorTemplateId: ObjectID | null = RelationIdUtil.readConsistent(
+      createBy.data as unknown as Record<string, unknown>,
+      MONITOR_TEMPLATE_RELATION_KEYS,
+      "Monitor Template",
+    );
+
+    if (monitorTemplateId) {
+      await this.validateMonitorTemplateReference({
+        monitorTemplateId: monitorTemplateId,
+        projectId: createBy.props.tenantId,
+        monitorType: createBy.data.monitorType,
+        props: createBy.props,
+      });
+    }
+
+    if (createBy.data.autoProvisionedNetworkDeviceId) {
+      if (!monitorTemplateId) {
+        throw new BadDataException(
+          "An auto-provisioned Network Device monitor must be linked to a monitor template.",
+        );
+      }
+
+      if (createBy.data.monitorType !== MonitorType.NetworkDevice) {
+        throw new BadDataException(
+          "Only Network Device monitors can carry auto-provisioning provenance.",
+        );
+      }
+
+      NetworkDeviceMonitorTemplateUtil.assertMonitorStepsBoundToNetworkDevice({
+        monitorSteps: createBy.data.monitorSteps,
+        networkDeviceId: createBy.data.autoProvisionedNetworkDeviceId,
+      });
     }
 
     await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({

--- a/Common/Server/Services/MonitorTemplateService.ts
+++ b/Common/Server/Services/MonitorTemplateService.ts
@@ -9,11 +9,16 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import { JSONObject } from "../../Types/JSON";
 import MonitorSteps from "../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../Types/Monitor/MonitorType";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import Model from "../../Models/DatabaseModels/MonitorTemplate";
 import Monitor from "../../Models/DatabaseModels/Monitor";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
+import ModelPermission from "../Types/Database/Permissions/Index";
+import Query from "../Types/Database/Query";
 
 export interface SyncLinkedMonitorsResult {
   totalLinkedMonitors: number;
@@ -189,6 +194,7 @@ export class Service extends DatabaseService<Model> {
       select: {
         _id: true,
         projectId: true,
+        monitorType: true,
         monitorSteps: true,
         monitoringInterval: true,
         minimumProbeAgreement: true,
@@ -226,6 +232,93 @@ export class Service extends DatabaseService<Model> {
         totalLinkedMonitors,
         syncedMonitors: 0,
       };
+    }
+
+    /*
+     * A Network Device template contains a design-time device reference,
+     * while each linked monitor has its own device. A bulk JSON assignment
+     * would retarget the entire fleet to the template editor's device. Sync
+     * those rows individually and rebind cloned template steps to each
+     * monitor's current (or provenance-backed) device instead.
+     */
+    if (
+      template.monitorType === MonitorType.NetworkDevice &&
+      fields.includes("monitorSteps")
+    ) {
+      let syncedMonitors: number = 0;
+      const linkedMonitorQuery: Query<Monitor> = {
+        monitorTemplateId: template.id!,
+        projectId: template.projectId,
+      };
+
+      /*
+       * Resolve the caller's complete update-authorized set before the first
+       * per-monitor write. Root-enumerating every linked row made a mixed
+       * label scope order-dependent: accessible rows could update before a
+       * later hidden row threw. This is the same permission-narrowed subset
+       * the ordinary bulk update path applies atomically.
+       */
+      const authorizedMonitorQuery: Query<Monitor> =
+        await ModelPermission.checkUpdateQueryPermissions(
+          Monitor,
+          linkedMonitorQuery,
+          updateData as any,
+          data.props,
+        );
+      const monitorsToSync: Array<Monitor> = [];
+
+      for (let skip: number = 0; ; skip += LIMIT_MAX) {
+        const monitors: Array<Monitor> = await MonitorService.findBy({
+          query: authorizedMonitorQuery,
+          select: {
+            _id: true,
+            monitorSteps: true,
+            autoProvisionedNetworkDeviceId: true,
+          },
+          sort: { createdAt: SortOrder.Ascending },
+          limit: LIMIT_MAX,
+          skip: skip,
+          props: { isRoot: true },
+        });
+
+        monitorsToSync.push(...monitors);
+
+        if (monitors.length < LIMIT_MAX) {
+          break;
+        }
+      }
+
+      /* Validate and materialize every instance-specific rebind first. */
+      const updates: Array<{
+        monitor: Monitor;
+        data: Partial<Monitor>;
+      }> = monitorsToSync.map((monitor: Monitor) => {
+        return {
+          monitor,
+          data: {
+            ...updateData,
+            monitorSteps: monitor.autoProvisionedNetworkDeviceId
+              ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+                  monitorSteps: template.monitorSteps,
+                  networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
+                })
+              : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+                  templateMonitorSteps: template.monitorSteps,
+                  currentMonitorSteps: monitor.monitorSteps,
+                }),
+          },
+        };
+      });
+
+      for (const update of updates) {
+        syncedMonitors += await MonitorService.updateOneById({
+          id: update.monitor.id!,
+          data: update.data as any,
+          props: data.props,
+        });
+      }
+
+      return { totalLinkedMonitors, syncedMonitors };
     }
 
     const syncedMonitors: number = await MonitorService.updateBy({
@@ -270,6 +363,7 @@ export class Service extends DatabaseService<Model> {
       select: {
         _id: true,
         projectId: true,
+        monitorType: true,
         monitorSteps: true,
         monitoringInterval: true,
         minimumProbeAgreement: true,
@@ -294,6 +388,8 @@ export class Service extends DatabaseService<Model> {
         _id: true,
         projectId: true,
         monitorTemplateId: true,
+        monitorSteps: true,
+        autoProvisionedNetworkDeviceId: true,
       },
       props: { isRoot: true },
     });
@@ -319,6 +415,21 @@ export class Service extends DatabaseService<Model> {
     }
 
     const updateData: Partial<Monitor> = this.buildUpdateData(template, fields);
+
+    if (
+      template.monitorType === MonitorType.NetworkDevice &&
+      fields.includes("monitorSteps")
+    ) {
+      updateData.monitorSteps = monitor.autoProvisionedNetworkDeviceId
+        ? NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+            monitorSteps: template.monitorSteps,
+            networkDeviceId: monitor.autoProvisionedNetworkDeviceId,
+          })
+        : NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+            templateMonitorSteps: template.monitorSteps,
+            currentMonitorSteps: monitor.monitorSteps,
+          });
+    }
 
     if (Object.keys(updateData).length === 0) {
       return;

--- a/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceAutoImportRuleEngineService.ts
@@ -3,9 +3,13 @@ import NetworkDeviceAutoImportRule from "../../Models/DatabaseModels/NetworkDevi
 import NetworkDeviceDiscoveryScan, {
   DiscoveredNetworkDevice,
 } from "../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import Monitor from "../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../Models/DatabaseModels/MonitorTemplate";
 import NetworkDeviceAutoImportRuleService from "./NetworkDeviceAutoImportRuleService";
 import NetworkDeviceDiscoveryScanService from "./NetworkDeviceDiscoveryScanService";
 import NetworkDeviceService from "./NetworkDeviceService";
+import MonitorService from "./MonitorService";
+import MonitorTemplateService from "./MonitorTemplateService";
 import BadDataException from "../../Types/Exception/BadDataException";
 import { JSONObject } from "../../Types/JSON";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
@@ -13,19 +17,28 @@ import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
+import MonitorType from "../../Types/Monitor/MonitorType";
 import {
   AutoImportRuleRunResult,
   MAX_MATCHED_IP_SAMPLE,
 } from "../../Types/NetworkAutomation/RuleRunResult";
 import AutoImportRuleMatcher, {
   AutoImportHostEvaluation,
+  AutoImportRuleCandidate,
 } from "../../Utils/NetworkDiscovery/AutoImportRuleMatcher";
 import {
   buildFallbackDeviceName,
   buildNetworkDeviceFromDiscoveredHost,
 } from "../../Utils/NetworkDiscovery/DiscoveredDeviceBuilder";
 import { normalizeDiscoveredHosts } from "../../Utils/NetworkDiscovery/DiscoveredHostUtil";
+import { monitoringMethodForDiscoveredHost } from "../../Utils/NetworkDiscovery/DiscoveryImportEligibility";
+import NetworkDeviceMonitoringMethod, {
+  NetworkDeviceMonitoringMethodUtil,
+} from "../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
+import QueryHelper from "../Types/Database/QueryHelper";
+import NetworkDeviceHydrationUtil from "../Utils/Monitor/NetworkDeviceHydrationUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 
@@ -48,8 +61,9 @@ import logger, { LogAttributes } from "../Utils/Logger";
  *
  * Everything here is idempotent by construction: a device exists per
  * (project, address), recurring scans re-report the same hosts every
- * interval, and both paths skip hosts whose address is already registered —
- * so seeing the same results twice creates nothing twice.
+ * interval, and both paths reuse hosts whose address is already registered.
+ * Existing devices are still reconciled for a selected template monitor,
+ * while provenance keys prevent the same monitor from being created twice.
  */
 
 /*
@@ -84,6 +98,16 @@ export const AUTO_IMPORT_SCAN_CREDENTIAL_SELECT: {
  * /16" from an outage into a few paced ticks an operator can catch.
  */
 export const MAX_DEVICES_PER_AUTO_IMPORT_RUN: number = 500;
+
+/*
+ * Monitor creates run an even broader service pipeline than device creates:
+ * plan limits, operational status, labels, owners, SLOs and status pages all
+ * participate. Keep a separate cap so reconciling an existing /16 cannot
+ * bypass the device cap merely because all devices are already registered.
+ * A truncated automatic pass leaves its marker NULL whenever it made
+ * progress, and the next sweep resumes from the queryable provenance keys.
+ */
+export const MAX_MONITORS_PER_AUTO_IMPORT_RUN: number = 500;
 
 // Scans one manual "Run Now" will read, oldest results last.
 export const MAX_SCANS_PER_AUTO_IMPORT_RULE_RUN: number = 100;
@@ -122,7 +146,21 @@ export const AUTO_IMPORT_SWEEP_LOCK_TIMEOUT_MS: number = 11 * 60 * 1000;
  * read as registered when scan B reports the same address seconds later —
  * before any re-read of the device table would show it.
  */
-export type ExistingHostnamesByProjectId = Map<string, Set<string>>;
+export type ExistingHostnamesByProjectId = Map<
+  string,
+  Map<string, NetworkDevice>
+>;
+
+export interface ExistingMonitorProvisioningState {
+  autoProvisionedKeys: Set<string>;
+  manuallyMonitoredDeviceIds: Set<string>;
+  attemptedProvisioningKeys: Set<string>;
+}
+
+export type ExistingMonitorsByProjectId = Map<
+  string,
+  ExistingMonitorProvisioningState
+>;
 
 /*
  * How many imports one run has attempted, shared across every scan the run
@@ -131,9 +169,12 @@ export type ExistingHostnamesByProjectId = Map<string, Set<string>>;
  * cap as the real run it predicts, instead of walking unbounded work inside
  * an API request.
  */
-interface ImportAttemptBudget {
-  count: number;
+export interface ImportAttemptBudget {
+  deviceCount: number;
+  monitorCount: number;
 }
+
+export type ImportAttemptBudgetsByProjectId = Map<string, ImportAttemptBudget>;
 
 class NetworkDeviceAutoImportRuleEngineServiceClass {
   /**
@@ -161,6 +202,8 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
   public async processCompletedScan(data: {
     scanId: ObjectID;
     existingHostnamesByProjectId: ExistingHostnamesByProjectId;
+    existingMonitorsByProjectId?: ExistingMonitorsByProjectId;
+    attemptBudgetsByProjectId?: ImportAttemptBudgetsByProjectId;
   }): Promise<AutoImportRuleRunResult | null> {
     const scan: NetworkDeviceDiscoveryScan | null =
       await NetworkDeviceDiscoveryScanService.findOneBy({
@@ -218,18 +261,57 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
       return null;
     }
 
-    const existingHostnames: Set<string> = await this.getExistingHostnames({
-      projectId: projectId,
-      cache: data.existingHostnamesByProjectId,
-    });
+    const existingDevices: Map<string, NetworkDevice> =
+      await this.getExistingDevices({
+        projectId: projectId,
+        cache: data.existingHostnamesByProjectId,
+      });
+
+    const hasMonitorProvisioningRules: boolean = rules.some(
+      (rule: NetworkDeviceAutoImportRule): boolean => {
+        return !rule.isExclusion && Boolean(rule.monitorTemplateId);
+      },
+    );
+
+    const existingMonitors: ExistingMonitorProvisioningState =
+      hasMonitorProvisioningRules
+        ? await this.getExistingMonitors({
+            projectId: projectId,
+            cache: data.existingMonitorsByProjectId || new Map(),
+          })
+        : this.emptyExistingMonitorProvisioningState();
+
+    const monitorTemplates: Map<string, MonitorTemplate> =
+      hasMonitorProvisioningRules
+        ? await this.loadMonitorTemplates({ projectId, rules })
+        : new Map();
 
     const result: AutoImportRuleRunResult = this.emptyResult(false);
-    const attempts: ImportAttemptBudget = { count: 0 };
+    const projectBudgetKey: string = projectId.toString();
+    const attempts: ImportAttemptBudget = data.attemptBudgetsByProjectId
+      ? data.attemptBudgetsByProjectId.get(projectBudgetKey) || {
+          deviceCount: 0,
+          monitorCount: 0,
+        }
+      : { deviceCount: 0, monitorCount: 0 };
+
+    /*
+     * A project budget is shared across every scan in one worker sweep. Keep
+     * the starting values so a scan reached after an earlier scan consumed
+     * the budget can be distinguished from a scan whose own create attempts
+     * all failed. The former must remain unprocessed for the next sweep; the
+     * latter is deliberately retired to avoid an infinite retry loop.
+     */
+    const attemptsAtStart: ImportAttemptBudget = { ...attempts };
+
+    data.attemptBudgetsByProjectId?.set(projectBudgetKey, attempts);
 
     const createdIpAddresses: Array<string> = await this.importHostsFromScan({
       scan: scan,
       rules: rules,
-      existingHostnames: existingHostnames,
+      existingDevices: existingDevices,
+      existingMonitors: existingMonitors,
+      monitorTemplates: monitorTemplates,
       result: result,
       attempts: attempts,
       isDryRun: false,
@@ -244,12 +326,24 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
      * pass, so stamping keeps the two consistent. Run Now remains the
      * deliberate way back into a stamped scan.
      */
-    const shouldResume: boolean =
-      result.isTruncated && result.devicesCreated > 0;
+    const inheritedBudget: boolean =
+      result.isTruncated &&
+      (attemptsAtStart.deviceCount > 0 || attemptsAtStart.monitorCount > 0);
 
-    if (result.isTruncated && result.devicesCreated === 0) {
+    const shouldResume: boolean =
+      result.isTruncated &&
+      (result.devicesCreated > 0 ||
+        result.monitorsCreated > 0 ||
+        inheritedBudget);
+
+    if (
+      result.isTruncated &&
+      result.devicesCreated === 0 &&
+      result.monitorsCreated === 0 &&
+      !inheritedBudget
+    ) {
       logger.error(
-        `Auto-import: scan ${scan.id?.toString()} hit the per-pass cap with every create failing (${result.devicesFailed} failure(s)); stamping it processed so the sweep does not retry it forever. Inspect the failures and use the rule's Run Now to retry deliberately.`,
+        `Auto-import: scan ${scan.id?.toString()} hit a per-pass cap without making progress (${result.devicesFailed} device failure(s), ${result.monitorsFailed} monitor failure(s)); stamping it processed so the sweep does not retry it forever. Inspect the failures and use the rule's Run Now to retry deliberately.`,
         { projectId: projectId.toString() } as LogAttributes,
       );
     }
@@ -278,6 +372,7 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
     ruleId: ObjectID;
     projectId: ObjectID;
     isDryRun: boolean;
+    expectedMonitorTemplateId?: ObjectID | null;
   }): Promise<AutoImportRuleRunResult> {
     const rule: NetworkDeviceAutoImportRule | null =
       await NetworkDeviceAutoImportRuleService.findOneBy({
@@ -295,12 +390,26 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
           sysDescrPattern: true,
           sysObjectIdPattern: true,
           includePingOnlyHosts: true,
+          monitorTemplateId: true,
         },
         props: { isRoot: true },
       });
 
     if (!rule) {
       throw new BadDataException("Auto-import rule not found.");
+    }
+
+    if (data.expectedMonitorTemplateId !== undefined) {
+      const expectedTemplateId: string =
+        data.expectedMonitorTemplateId?.toString() || "";
+      const currentTemplateId: string =
+        rule.monitorTemplateId?.toString() || "";
+
+      if (expectedTemplateId !== currentTemplateId) {
+        throw new BadDataException(
+          "This auto-import rule changed while the run was being authorized. Review it and run it again.",
+        );
+      }
     }
 
     /*
@@ -384,12 +493,25 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
       ...exclusionRules,
     ];
 
-    const existingHostnames: Set<string> = await this.loadExistingHostnames(
-      data.projectId,
+    const existingDevices: Map<string, NetworkDevice> =
+      await this.loadExistingDevices(data.projectId);
+    const hasMonitorProvisioningRule: boolean = Boolean(
+      data.rule.monitorTemplateId,
     );
+    const existingMonitors: ExistingMonitorProvisioningState =
+      hasMonitorProvisioningRule
+        ? await this.loadExistingMonitors(data.projectId)
+        : this.emptyExistingMonitorProvisioningState();
+    const monitorTemplates: Map<string, MonitorTemplate> =
+      hasMonitorProvisioningRule
+        ? await this.loadMonitorTemplates({
+            projectId: data.projectId,
+            rules: rules,
+          })
+        : new Map();
 
     const result: AutoImportRuleRunResult = this.emptyResult(data.isDryRun);
-    const attempts: ImportAttemptBudget = { count: 0 };
+    const attempts: ImportAttemptBudget = { deviceCount: 0, monitorCount: 0 };
 
     /*
      * Newest results first: a manual run is "bring the estate up to date",
@@ -451,7 +573,9 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
       const createdIpAddresses: Array<string> = await this.importHostsFromScan({
         scan: scan,
         rules: rules,
-        existingHostnames: existingHostnames,
+        existingDevices: existingDevices,
+        existingMonitors: existingMonitors,
+        monitorTemplates: monitorTemplates,
         result: result,
         attempts: attempts,
         isDryRun: data.isDryRun,
@@ -506,10 +630,23 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
       hostsSkippedAlreadyRegistered: 0,
       devicesCreated: 0,
       devicesFailed: 0,
+      monitorsWouldCreate: 0,
+      monitorsCreated: 0,
+      monitorsSkippedAlreadyExisting: 0,
+      monitorsSkippedUnsupportedHost: 0,
+      monitorsFailed: 0,
       isTruncated: false,
       hasMoreScans: false,
       isDryRun: isDryRun,
       matchedIpAddressSample: [],
+    };
+  }
+
+  private emptyExistingMonitorProvisioningState(): ExistingMonitorProvisioningState {
+    return {
+      autoProvisionedKeys: new Set(),
+      manuallyMonitoredDeviceIds: new Set(),
+      attemptedProvisioningKeys: new Set(),
     };
   }
 
@@ -543,6 +680,7 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
             sysDescrPattern: true,
             sysObjectIdPattern: true,
             includePingOnlyHosts: true,
+            monitorTemplateId: true,
           },
           sort: {
             createdAt: SortOrder.Ascending,
@@ -573,19 +711,19 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
     );
   }
 
-  private async getExistingHostnames(data: {
+  private async getExistingDevices(data: {
     projectId: ObjectID;
     cache: ExistingHostnamesByProjectId;
-  }): Promise<Set<string>> {
+  }): Promise<Map<string, NetworkDevice>> {
     const key: string = data.projectId.toString();
 
-    const cached: Set<string> | undefined = data.cache.get(key);
+    const cached: Map<string, NetworkDevice> | undefined = data.cache.get(key);
 
     if (cached) {
       return cached;
     }
 
-    const loaded: Set<string> = await this.loadExistingHostnames(
+    const loaded: Map<string, NetworkDevice> = await this.loadExistingDevices(
       data.projectId,
     );
     data.cache.set(key, loaded);
@@ -599,10 +737,10 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
    * a truncated answer produces duplicate devices, which is worse than a
    * slow answer. Sorted for stable paging.
    */
-  private async loadExistingHostnames(
+  private async loadExistingDevices(
     projectId: ObjectID,
-  ): Promise<Set<string>> {
-    const existingHostnames: Set<string> = new Set<string>();
+  ): Promise<Map<string, NetworkDevice>> {
+    const existingDevices: Map<string, NetworkDevice> = new Map();
 
     for (let skip: number = 0; ; skip += LIMIT_MAX) {
       const existing: Array<NetworkDevice> = await NetworkDeviceService.findBy({
@@ -610,7 +748,11 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
           projectId: projectId,
         },
         select: {
+          _id: true,
+          projectId: true,
+          name: true,
           hostname: true,
+          monitoringMethod: true,
         },
         sort: {
           createdAt: SortOrder.Ascending,
@@ -624,7 +766,7 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
 
       for (const device of existing) {
         if (device.hostname) {
-          existingHostnames.add(device.hostname);
+          existingDevices.set(device.hostname, device);
         }
       }
 
@@ -633,21 +775,236 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
       }
     }
 
-    return existingHostnames;
+    return existingDevices;
+  }
+
+  private static monitorProvisioningKey(
+    networkDeviceId: ObjectID | string,
+    monitorTemplateId: ObjectID | string,
+  ): string {
+    return `${networkDeviceId.toString()}:${monitorTemplateId.toString()}`;
+  }
+
+  private async getExistingMonitors(data: {
+    projectId: ObjectID;
+    cache: ExistingMonitorsByProjectId;
+  }): Promise<ExistingMonitorProvisioningState> {
+    const key: string = data.projectId.toString();
+    const cached: ExistingMonitorProvisioningState | undefined =
+      data.cache.get(key);
+
+    if (cached) {
+      return cached;
+    }
+
+    const loaded: ExistingMonitorProvisioningState =
+      await this.loadExistingMonitors(data.projectId);
+    data.cache.set(key, loaded);
+    return loaded;
+  }
+
+  /*
+   * Queryable provenance is the concurrency/idempotency key for monitors
+   * created by this engine. Existing manually-created Network Device
+   * monitors are parsed once and suppress automatic duplicates: an operator
+   * who already chose how to monitor a device must not receive a second,
+   * potentially billable monitor merely because an import rule was edited.
+   */
+  private async loadExistingMonitors(
+    projectId: ObjectID,
+  ): Promise<ExistingMonitorProvisioningState> {
+    const state: ExistingMonitorProvisioningState =
+      this.emptyExistingMonitorProvisioningState();
+
+    for (let skip: number = 0; ; skip += LIMIT_MAX) {
+      const monitors: Array<Monitor> = await MonitorService.findBy({
+        query: {
+          projectId: projectId,
+          monitorType: MonitorType.NetworkDevice,
+        },
+        select: {
+          _id: true,
+          monitorType: true,
+          monitorSteps: true,
+          monitorTemplateId: true,
+          autoProvisionedNetworkDeviceId: true,
+        },
+        sort: {
+          createdAt: SortOrder.Ascending,
+        },
+        limit: LIMIT_MAX,
+        skip: skip,
+        props: { isRoot: true },
+      });
+
+      for (const monitor of monitors) {
+        this.recordExistingMonitor(state, monitor);
+      }
+
+      if (monitors.length < LIMIT_MAX) {
+        break;
+      }
+    }
+
+    return state;
+  }
+
+  /*
+   * Classify one stored monitor from both its queryable provenance and its
+   * actual step binding. Provenance is trusted only while the monitor still
+   * watches the device it was provisioned for. An orphaned template link or
+   * any legacy drift is treated as an operator-managed monitor on its actual
+   * device(s), which is the conservative no-duplicate behavior.
+   */
+  private recordExistingMonitor(
+    state: ExistingMonitorProvisioningState,
+    monitor: Monitor,
+  ): void {
+    const referencedDeviceIds: Set<string> = new Set(
+      NetworkDeviceHydrationUtil.getReferencedNetworkDeviceIds([monitor]),
+    );
+    const provenanceDeviceId: string =
+      monitor.autoProvisionedNetworkDeviceId?.toString() || "";
+
+    if (
+      provenanceDeviceId &&
+      monitor.monitorTemplateId &&
+      referencedDeviceIds.size === 1 &&
+      referencedDeviceIds.has(provenanceDeviceId)
+    ) {
+      state.autoProvisionedKeys.add(
+        NetworkDeviceAutoImportRuleEngineServiceClass.monitorProvisioningKey(
+          provenanceDeviceId,
+          monitor.monitorTemplateId,
+        ),
+      );
+      return;
+    }
+
+    for (const networkDeviceId of referencedDeviceIds) {
+      state.manuallyMonitoredDeviceIds.add(networkDeviceId);
+    }
+  }
+
+  /*
+   * Close the practical manual-create race left by the project-wide snapshot:
+   * immediately before provisioning a device, search the JSON step payload
+   * for its UUID and classify exact bindings. The automatic (device,template)
+   * partial unique index remains the final concurrent-auto backstop; this
+   * narrow read prevents a monitor a human just created from being ignored by
+   * a long-running sweep.
+   */
+  private async refreshExistingMonitorsForDevice(data: {
+    projectId: ObjectID;
+    networkDeviceId: ObjectID;
+    state: ExistingMonitorProvisioningState;
+  }): Promise<void> {
+    for (let skip: number = 0; ; skip += LIMIT_MAX) {
+      const monitors: Array<Monitor> = await MonitorService.findBy({
+        query: {
+          projectId: data.projectId,
+          monitorType: MonitorType.NetworkDevice,
+          monitorSteps: QueryHelper.search(data.networkDeviceId.toString()),
+        },
+        select: {
+          _id: true,
+          monitorType: true,
+          monitorSteps: true,
+          monitorTemplateId: true,
+          autoProvisionedNetworkDeviceId: true,
+        },
+        sort: { createdAt: SortOrder.Ascending },
+        limit: LIMIT_MAX,
+        skip: skip,
+        props: { isRoot: true },
+      });
+
+      for (const monitor of monitors) {
+        this.recordExistingMonitor(data.state, monitor);
+      }
+
+      if (monitors.length < LIMIT_MAX) {
+        break;
+      }
+    }
+  }
+
+  private async loadMonitorTemplates(data: {
+    projectId: ObjectID;
+    rules: Array<NetworkDeviceAutoImportRule>;
+  }): Promise<Map<string, MonitorTemplate>> {
+    const ids: Array<ObjectID | string> = Array.from(
+      new Map<string, ObjectID | string>(
+        data.rules
+          .filter((rule: NetworkDeviceAutoImportRule): boolean => {
+            return Boolean(rule.monitorTemplateId);
+          })
+          .map((rule: NetworkDeviceAutoImportRule) => {
+            const id: ObjectID | string = rule.monitorTemplateId!;
+            return [id.toString(), id];
+          }),
+      ).values(),
+    );
+
+    const templatesById: Map<string, MonitorTemplate> = new Map();
+    if (ids.length === 0) {
+      return templatesById;
+    }
+
+    for (let skip: number = 0; ; skip += LIMIT_MAX) {
+      const templates: Array<MonitorTemplate> =
+        await MonitorTemplateService.findBy({
+          query: {
+            _id: QueryHelper.any(ids),
+            projectId: data.projectId,
+            monitorType: MonitorType.NetworkDevice,
+          },
+          select: {
+            _id: true,
+            projectId: true,
+            monitorName: true,
+            monitorDescription: true,
+            monitorType: true,
+            monitorSteps: true,
+            monitoringInterval: true,
+            minimumProbeAgreement: true,
+            customFields: true,
+            labels: { _id: true },
+          },
+          sort: { createdAt: SortOrder.Ascending },
+          limit: LIMIT_MAX,
+          skip: skip,
+          props: { isRoot: true },
+        });
+
+      for (const template of templates) {
+        if (template.id) {
+          templatesById.set(template.id.toString(), template);
+        }
+      }
+
+      if (templates.length < LIMIT_MAX) {
+        break;
+      }
+    }
+
+    return templatesById;
   }
 
   /*
    * The core loop: evaluate every discovered host of one scan against the
-   * rule set, create what should import, and account for every host in the
-   * shared result. Returns the addresses actually created (for the jsonb
-   * write-back). Mutates `existingHostnames` as it creates, which is what
-   * makes duplicate rows, overlapping scans in one sweep, and repeat runs
-   * idempotent.
+   * rule set, create what should import, reconcile selected template monitors,
+   * and account for every host in the shared result. Returns the addresses
+   * actually created (for the jsonb write-back). Mutates `existingDevices` as
+   * it creates, which is what makes duplicate rows, overlapping scans in one
+   * sweep, and repeat runs idempotent.
    */
   private async importHostsFromScan(data: {
     scan: NetworkDeviceDiscoveryScan;
     rules: Array<NetworkDeviceAutoImportRule>;
-    existingHostnames: Set<string>;
+    existingDevices: Map<string, NetworkDevice>;
+    existingMonitors: ExistingMonitorProvisioningState;
+    monitorTemplates: Map<string, MonitorTemplate>;
     result: AutoImportRuleRunResult;
     attempts: ImportAttemptBudget;
     isDryRun: boolean;
@@ -699,59 +1056,332 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
 
       result.hostsMatched++;
 
+      const templateIds: Array<string> = Array.from(
+        new Set(
+          evaluation.matchedRules
+            .map((matchedRule: AutoImportRuleCandidate): string => {
+              return matchedRule.monitorTemplateId?.toString() || "";
+            })
+            .filter((id: string): boolean => {
+              return Boolean(id);
+            }),
+        ),
+      );
+
+      let networkDevice: NetworkDevice | undefined = data.existingDevices.get(
+        host.ipAddress,
+      );
+      let deviceWasCreated: boolean = false;
+
       /*
        * The frozen isAlreadyRegistered flag AND the live set: the flag is a
        * point-in-time answer from the last upload, the set covers devices
        * created since — including by this very run, which is what collapses
        * duplicate rows and overlapping scans into one device.
        */
-      if (
-        host.isAlreadyRegistered ||
-        data.existingHostnames.has(host.ipAddress)
-      ) {
+      if (host.isAlreadyRegistered || networkDevice) {
         result.hostsSkippedAlreadyRegistered++;
-        continue;
-      }
 
-      if (data.attempts.count >= MAX_DEVICES_PER_AUTO_IMPORT_RUN) {
-        result.isTruncated = true;
-        break;
+        /*
+         * A stale scan can claim a deleted device is still registered. With
+         * no live row there is neither a safe binding nor enough intent to
+         * recreate it from old data, so preserve the established skip.
+         */
+        if (!networkDevice) {
+          continue;
+        }
       }
 
       if (result.matchedIpAddressSample.length < MAX_MATCHED_IP_SAMPLE) {
-        result.matchedIpAddressSample.push(host.ipAddress);
+        if (!result.matchedIpAddressSample.includes(host.ipAddress)) {
+          result.matchedIpAddressSample.push(host.ipAddress);
+        }
       }
 
-      if (data.isDryRun) {
-        /*
-         * A dry run reports the device as "created" in no counter at all —
-         * hostsMatched minus hostsSkippedAlreadyRegistered is exactly what a
-         * real run would attempt, and the sample above says which hosts.
-         * The address still joins the set, simulating the create's dedupe:
-         * without this, a host on duplicate rows (or in two overlapping
-         * scans) would be counted as importable once per appearance, and
-         * the dry run would promise more than the real run does.
-         */
-        data.attempts.count++;
-        data.existingHostnames.add(host.ipAddress);
+      if (!networkDevice) {
+        if (data.attempts.deviceCount >= MAX_DEVICES_PER_AUTO_IMPORT_RUN) {
+          result.isTruncated = true;
+          break;
+        }
+
+        if (data.isDryRun) {
+          /*
+           * Add a fully-shaped in-memory device to simulate the create. Its
+           * generated id never leaves this process; it merely lets monitor
+           * reconciliation deduplicate the same host across duplicate rows
+           * and overlapping scans exactly as a real run would.
+           */
+          data.attempts.deviceCount++;
+          networkDevice = buildNetworkDeviceFromDiscoveredHost({
+            projectId: scan.projectId,
+            host: host,
+            scan: scan,
+            autoApplyVendorHealthTemplate: true,
+          });
+          networkDevice.id = ObjectID.generate();
+          data.existingDevices.set(host.ipAddress, networkDevice);
+        } else {
+          const createResult: {
+            device: NetworkDevice | null;
+            wasCreated: boolean;
+          } = await this.createDeviceForHost({
+            projectId: scan.projectId,
+            scan: scan,
+            host: host,
+            existingDevices: data.existingDevices,
+            result: result,
+            attempts: data.attempts,
+          });
+
+          networkDevice = createResult.device || undefined;
+          deviceWasCreated = createResult.wasCreated;
+
+          if (!networkDevice) {
+            continue;
+          }
+        }
+      }
+
+      if (deviceWasCreated) {
+        createdIpAddresses.push(host.ipAddress);
+      }
+
+      if (templateIds.length === 0) {
         continue;
       }
 
-      const wasCreated: boolean = await this.createDeviceForHost({
-        projectId: scan.projectId,
-        scan: scan,
-        host: host,
-        existingHostnames: data.existingHostnames,
-        result: result,
-        attempts: data.attempts,
-      });
+      const monitorsWereTruncated: boolean = await this.ensureMonitorsForDevice(
+        {
+          projectId: scan.projectId,
+          host: host,
+          networkDevice: networkDevice,
+          templateIds: templateIds,
+          monitorTemplates: data.monitorTemplates,
+          existingMonitors: data.existingMonitors,
+          result: result,
+          attempts: data.attempts,
+          isDryRun: data.isDryRun,
+        },
+      );
 
-      if (wasCreated) {
-        createdIpAddresses.push(host.ipAddress);
+      if (monitorsWereTruncated) {
+        result.isTruncated = true;
+        break;
       }
     }
 
     return createdIpAddresses;
+  }
+
+  private async ensureMonitorsForDevice(data: {
+    projectId: ObjectID;
+    host: DiscoveredNetworkDevice;
+    networkDevice: NetworkDevice;
+    templateIds: Array<string>;
+    monitorTemplates: Map<string, MonitorTemplate>;
+    existingMonitors: ExistingMonitorProvisioningState;
+    result: AutoImportRuleRunResult;
+    attempts: ImportAttemptBudget;
+    isDryRun: boolean;
+  }): Promise<boolean> {
+    /*
+     * A Network Device monitor is evaluated from SNMP walks. A ping-only
+     * import intentionally has polling disabled and can never supply those
+     * results. Rule validation prevents this combination, while this guard
+     * keeps legacy or directly-written rows from creating inert monitors.
+     */
+    if (
+      monitoringMethodForDiscoveredHost(data.host) ===
+        NetworkDeviceMonitoringMethod.Monitor ||
+      NetworkDeviceMonitoringMethodUtil.isMonitorBacked(
+        data.networkDevice.monitoringMethod,
+      )
+    ) {
+      data.result.monitorsSkippedUnsupportedHost += data.templateIds.length;
+      return false;
+    }
+
+    if (!data.networkDevice.id) {
+      data.result.monitorsFailed += data.templateIds.length;
+      logger.error(
+        `Auto-import: cannot provision monitor(s) for ${data.host.ipAddress} because the Network Device has no id.`,
+        { projectId: data.projectId.toString() } as LogAttributes,
+      );
+      return false;
+    }
+
+    const networkDeviceId: ObjectID = data.networkDevice.id;
+    const networkDeviceIdString: string = networkDeviceId.toString();
+    const pendingTemplateIds: Array<string> = [];
+
+    /*
+     * The project-wide snapshot is complete and indexed. Settle everything
+     * it already covers before issuing the narrow JSON race-check query; an
+     * established fleet whose monitors are already reconciled must not do one
+     * full monitor-table search per discovered device on every scan.
+     */
+    for (const templateId of data.templateIds) {
+      const key: string =
+        NetworkDeviceAutoImportRuleEngineServiceClass.monitorProvisioningKey(
+          networkDeviceId,
+          templateId,
+        );
+
+      if (data.existingMonitors.autoProvisionedKeys.has(key)) {
+        data.result.monitorsSkippedAlreadyExisting++;
+        continue;
+      }
+
+      if (data.existingMonitors.attemptedProvisioningKeys.has(key)) {
+        continue;
+      }
+
+      pendingTemplateIds.push(templateId);
+    }
+
+    if (pendingTemplateIds.length === 0) {
+      return false;
+    }
+
+    if (
+      data.existingMonitors.manuallyMonitoredDeviceIds.has(
+        networkDeviceIdString,
+      )
+    ) {
+      data.result.monitorsSkippedAlreadyExisting += pendingTemplateIds.length;
+      return false;
+    }
+
+    /*
+     * Do not run the unindexed JSON race-check after this run's monitor-work
+     * budget is already exhausted. The device remains unreconciled and the
+     * truncated marker protocol brings it back on the next bounded pass.
+     */
+    if (data.attempts.monitorCount >= MAX_MONITORS_PER_AUTO_IMPORT_RUN) {
+      return true;
+    }
+
+    if (!data.isDryRun) {
+      await this.refreshExistingMonitorsForDevice({
+        projectId: data.projectId,
+        networkDeviceId: networkDeviceId,
+        state: data.existingMonitors,
+      });
+    }
+
+    if (
+      data.existingMonitors.manuallyMonitoredDeviceIds.has(
+        networkDeviceIdString,
+      )
+    ) {
+      data.result.monitorsSkippedAlreadyExisting += pendingTemplateIds.length;
+      return false;
+    }
+
+    for (const templateId of pendingTemplateIds) {
+      const key: string =
+        NetworkDeviceAutoImportRuleEngineServiceClass.monitorProvisioningKey(
+          networkDeviceId,
+          templateId,
+        );
+
+      /* The race-check may have found this key after the initial snapshot. */
+      if (data.existingMonitors.autoProvisionedKeys.has(key)) {
+        data.result.monitorsSkippedAlreadyExisting++;
+        continue;
+      }
+
+      if (data.attempts.monitorCount >= MAX_MONITORS_PER_AUTO_IMPORT_RUN) {
+        return true;
+      }
+
+      data.attempts.monitorCount++;
+      data.existingMonitors.attemptedProvisioningKeys.add(key);
+
+      /*
+       * Invalid or concurrently deleted templates are failed attempts too.
+       * Count them inside the same cap before looking up the cached template;
+       * otherwise one stale rule could walk and log an unbounded estate in a
+       * single API request or worker tick.
+       */
+      const template: MonitorTemplate | undefined =
+        data.monitorTemplates.get(templateId);
+
+      if (!template) {
+        data.result.monitorsFailed++;
+        logger.error(
+          `Auto-import: Network Device monitor template ${templateId} is missing, deleted, or not valid for project ${data.projectId.toString()}.`,
+          { projectId: data.projectId.toString() } as LogAttributes,
+        );
+        continue;
+      }
+
+      if (data.isDryRun) {
+        data.result.monitorsWouldCreate++;
+        data.existingMonitors.autoProvisionedKeys.add(key);
+        continue;
+      }
+
+      try {
+        const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+          template: template,
+          networkDevice: data.networkDevice,
+        });
+
+        await MonitorService.create({
+          data: monitor,
+          props: {
+            isRoot: true,
+            tenantId: data.projectId,
+          },
+        });
+
+        data.existingMonitors.autoProvisionedKeys.add(key);
+        data.result.monitorsCreated++;
+      } catch (error) {
+        /*
+         * The partial unique index is the final race backstop. If another
+         * writer won between our cache read and create, classify that as an
+         * idempotent skip; otherwise expose a real provisioning failure and
+         * leave the key absent so a later scan or Run Now can retry it.
+         */
+        const createdMeanwhile: Monitor | null = await MonitorService.findOneBy(
+          {
+            query: {
+              projectId: data.projectId,
+              monitorType: MonitorType.NetworkDevice,
+              monitorTemplateId: new ObjectID(templateId),
+              autoProvisionedNetworkDeviceId: networkDeviceId,
+            },
+            select: {
+              _id: true,
+              monitorType: true,
+              monitorSteps: true,
+              monitorTemplateId: true,
+              autoProvisionedNetworkDeviceId: true,
+            },
+            props: { isRoot: true },
+          },
+        );
+
+        if (createdMeanwhile) {
+          this.recordExistingMonitor(data.existingMonitors, createdMeanwhile);
+
+          if (data.existingMonitors.autoProvisionedKeys.has(key)) {
+            data.result.monitorsSkippedAlreadyExisting++;
+            continue;
+          }
+        }
+
+        data.result.monitorsFailed++;
+        logger.error(
+          `Auto-import: could not create monitor from template ${templateId} for Network Device ${networkDeviceId.toString()} (${data.host.ipAddress}): ${error}`,
+          { projectId: data.projectId.toString() } as LogAttributes,
+        );
+      }
+    }
+
+    return false;
   }
 
   /*
@@ -769,15 +1399,15 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
     projectId: ObjectID;
     scan: NetworkDeviceDiscoveryScan;
     host: DiscoveredNetworkDevice;
-    existingHostnames: Set<string>;
+    existingDevices: Map<string, NetworkDevice>;
     result: AutoImportRuleRunResult;
     attempts: ImportAttemptBudget;
-  }): Promise<boolean> {
-    data.attempts.count++;
+  }): Promise<{ device: NetworkDevice | null; wasCreated: boolean }> {
+    data.attempts.deviceCount++;
 
-    const attemptCreate: (name?: string) => Promise<void> = async (
+    const attemptCreate: (name?: string) => Promise<NetworkDevice> = async (
       name?: string,
-    ): Promise<void> => {
+    ): Promise<NetworkDevice> => {
       const device: NetworkDevice = buildNetworkDeviceFromDiscoveredHost({
         projectId: data.projectId,
         host: data.host,
@@ -792,16 +1422,20 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
         autoApplyVendorHealthTemplate: true,
       });
 
-      await NetworkDeviceService.create({
+      const created: NetworkDevice = await NetworkDeviceService.create({
         data: device,
         props: {
           isRoot: true,
         },
       });
+
+      return created || device;
     };
 
+    let createdDevice: NetworkDevice;
+
     try {
-      await attemptCreate();
+      createdDevice = await attemptCreate();
     } catch (firstError) {
       const registeredMeanwhile: NetworkDevice | null =
         await NetworkDeviceService.findOneBy({
@@ -809,33 +1443,39 @@ class NetworkDeviceAutoImportRuleEngineServiceClass {
             projectId: data.projectId,
             hostname: data.host.ipAddress,
           },
-          select: { _id: true },
+          select: {
+            _id: true,
+            projectId: true,
+            name: true,
+            hostname: true,
+            monitoringMethod: true,
+          },
           props: { isRoot: true },
         });
 
       if (registeredMeanwhile) {
         // Skipped is a sub-bucket of matched, same as the other run results.
         data.result.hostsSkippedAlreadyRegistered++;
-        data.existingHostnames.add(data.host.ipAddress);
-        return false;
+        data.existingDevices.set(data.host.ipAddress, registeredMeanwhile);
+        return { device: registeredMeanwhile, wasCreated: false };
       }
 
       try {
-        await attemptCreate(buildFallbackDeviceName(data.host));
+        createdDevice = await attemptCreate(buildFallbackDeviceName(data.host));
       } catch (secondError) {
         data.result.devicesFailed++;
         logger.error(
           `Auto-import: could not create a device for ${data.host.ipAddress} (scan ${data.scan.id?.toString()}): ${firstError} / retry: ${secondError}`,
           { projectId: data.projectId.toString() } as LogAttributes,
         );
-        return false;
+        return { device: null, wasCreated: false };
       }
     }
 
     data.result.devicesCreated++;
-    data.existingHostnames.add(data.host.ipAddress);
+    data.existingDevices.set(data.host.ipAddress, createdDevice);
 
-    return true;
+    return { device: createdDevice, wasCreated: true };
   }
 
   /*

--- a/Common/Server/Services/NetworkDeviceAutoImportRuleService.ts
+++ b/Common/Server/Services/NetworkDeviceAutoImportRuleService.ts
@@ -1,13 +1,23 @@
 import DatabaseService from "./DatabaseService";
+import MonitorTemplateService from "./MonitorTemplateService";
 import Model from "../../Models/DatabaseModels/NetworkDeviceAutoImportRule";
+import Monitor from "../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../Models/DatabaseModels/MonitorTemplate";
 import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import CreateBy from "../Types/Database/CreateBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
+import MonitorType from "../../Types/Monitor/MonitorType";
+import ObjectID from "../../Types/ObjectID";
 import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import ScanTargetUtil from "../../Utils/NetworkDiscovery/ScanTargetUtil";
+import RelationIdUtil from "../Utils/Database/RelationIdUtil";
+import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import DatabaseRequestType from "../Types/BaseDatabase/DatabaseRequestType";
+import TablePermission from "../Types/Database/Permissions/TablePermission";
+import NetworkDeviceMonitorTemplateUtil from "../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
 
 /*
  * Write-time validation for auto-import rules, following the
@@ -23,6 +33,19 @@ import ScanTargetUtil from "../../Utils/NetworkDiscovery/ScanTargetUtil";
  * same reason as CidrMatchUtil.
  */
 const OID_PATTERN_SHAPE: RegExp = /^\.?[\d.*]+$/;
+const MONITOR_TEMPLATE_KEYS: Array<string> = [
+  "monitorTemplateId",
+  "monitorTemplate",
+];
+
+function readMonitorTemplateId(data: Record<string, unknown>): ObjectID | null {
+  return RelationIdUtil.readConsistent(
+    data,
+    MONITOR_TEMPLATE_KEYS,
+    "Monitor Template",
+  );
+}
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -39,6 +62,20 @@ export class Service extends DatabaseService<Model> {
       sysObjectIdPattern: createBy.data.sysObjectIdPattern,
     });
 
+    const monitorTemplateId: ObjectID | null = readMonitorTemplateId(
+      createBy.data as unknown as Record<string, unknown>,
+    );
+
+    if (monitorTemplateId) {
+      await this.validateMonitorTemplateSelection({
+        monitorTemplateId: monitorTemplateId,
+        projectId: createBy.props.tenantId || createBy.data.projectId,
+        isExclusion: createBy.data.isExclusion,
+        includePingOnlyHosts: createBy.data.includePingOnlyHosts,
+        props: createBy.props,
+      });
+    }
+
     return { createBy, carryForward: null };
   }
 
@@ -54,7 +91,13 @@ export class Service extends DatabaseService<Model> {
       dataKeys.includes("sysDescrPattern") ||
       dataKeys.includes("sysObjectIdPattern");
 
-    if (!isCriteriaChange) {
+    const isMonitorProvisioningChange: boolean =
+      RelationIdUtil.isWritten(dataKeys, MONITOR_TEMPLATE_KEYS) ||
+      dataKeys.includes("isExclusion") ||
+      dataKeys.includes("includePingOnlyHosts") ||
+      dataKeys.includes("isEnabled");
+
+    if (!isCriteriaChange && !isMonitorProvisioningChange) {
       return { updateBy, carryForward: null };
     }
 
@@ -63,13 +106,26 @@ export class Service extends DatabaseService<Model> {
      * stored row, so validate the RESULTING state of every matched row.
      */
     const existingRules: Array<Model> = await this.findBy({
-      query: updateBy.query,
+      /*
+       * Hooks run before DatabaseService applies tenant permissions. Scope
+       * this privileged snapshot now so a guessed cross-project rule ID
+       * cannot become a state oracle through template validation errors.
+       */
+      query:
+        !updateBy.props.isRoot && updateBy.props.tenantId
+          ? { ...updateBy.query, projectId: updateBy.props.tenantId }
+          : updateBy.query,
       select: {
         _id: true,
+        projectId: true,
         ipMatchTarget: true,
         sysNamePattern: true,
         sysDescrPattern: true,
         sysObjectIdPattern: true,
+        isExclusion: true,
+        includePingOnlyHosts: true,
+        isEnabled: true,
+        monitorTemplateId: true,
       },
       limit: LIMIT_MAX,
       skip: 0,
@@ -82,25 +138,152 @@ export class Service extends DatabaseService<Model> {
       string,
       unknown
     >;
+    const isMonitorTemplateWritten: boolean = RelationIdUtil.isWritten(
+      dataKeys,
+      MONITOR_TEMPLATE_KEYS,
+    );
+    const writtenMonitorTemplateId: ObjectID | null =
+      readMonitorTemplateId(data);
 
     for (const existingRule of existingRules) {
-      this.validateCriteria({
-        ipMatchTarget: dataKeys.includes("ipMatchTarget")
-          ? (data["ipMatchTarget"] as string | null)
-          : existingRule.ipMatchTarget,
-        sysNamePattern: dataKeys.includes("sysNamePattern")
-          ? (data["sysNamePattern"] as string | null)
-          : existingRule.sysNamePattern,
-        sysDescrPattern: dataKeys.includes("sysDescrPattern")
-          ? (data["sysDescrPattern"] as string | null)
-          : existingRule.sysDescrPattern,
-        sysObjectIdPattern: dataKeys.includes("sysObjectIdPattern")
-          ? (data["sysObjectIdPattern"] as string | null)
-          : existingRule.sysObjectIdPattern,
-      });
+      if (isCriteriaChange) {
+        this.validateCriteria({
+          ipMatchTarget: dataKeys.includes("ipMatchTarget")
+            ? (data["ipMatchTarget"] as string | null)
+            : existingRule.ipMatchTarget,
+          sysNamePattern: dataKeys.includes("sysNamePattern")
+            ? (data["sysNamePattern"] as string | null)
+            : existingRule.sysNamePattern,
+          sysDescrPattern: dataKeys.includes("sysDescrPattern")
+            ? (data["sysDescrPattern"] as string | null)
+            : existingRule.sysDescrPattern,
+          sysObjectIdPattern: dataKeys.includes("sysObjectIdPattern")
+            ? (data["sysObjectIdPattern"] as string | null)
+            : existingRule.sysObjectIdPattern,
+        });
+      }
+
+      const isCriteriaChangeOnEnabledTemplateRule: boolean = Boolean(
+        isCriteriaChange &&
+          existingRule.monitorTemplateId &&
+          (dataKeys.includes("isEnabled")
+            ? data["isEnabled"] === true
+            : existingRule.isEnabled),
+      );
+
+      if (
+        isMonitorProvisioningChange ||
+        isCriteriaChangeOnEnabledTemplateRule
+      ) {
+        const monitorTemplateId: ObjectID | null = isMonitorTemplateWritten
+          ? writtenMonitorTemplateId
+          : existingRule.monitorTemplateId || null;
+
+        const isOnlyDisablingRule: boolean =
+          dataKeys.includes("isEnabled") &&
+          data["isEnabled"] === false &&
+          !isMonitorTemplateWritten &&
+          !dataKeys.includes("isExclusion") &&
+          !dataKeys.includes("includePingOnlyHosts");
+
+        if (monitorTemplateId && !isOnlyDisablingRule) {
+          await this.validateMonitorTemplateSelection({
+            monitorTemplateId: monitorTemplateId,
+            projectId: updateBy.props.tenantId || existingRule.projectId,
+            isExclusion: dataKeys.includes("isExclusion")
+              ? data["isExclusion"] === true
+              : existingRule.isExclusion,
+            includePingOnlyHosts: dataKeys.includes("includePingOnlyHosts")
+              ? data["includePingOnlyHosts"] === true
+              : existingRule.includePingOnlyHosts,
+            props: updateBy.props,
+          });
+        }
+      }
     }
 
     return { updateBy, carryForward: null };
+  }
+
+  private async validateMonitorTemplateSelection(data: {
+    monitorTemplateId: ObjectID;
+    projectId: ObjectID | undefined;
+    isExclusion?: boolean | null | undefined;
+    includePingOnlyHosts?: boolean | null | undefined;
+    props: DatabaseCommonInteractionProps;
+  }): Promise<void> {
+    if (data.isExclusion) {
+      throw new BadDataException(
+        "Exclusion rules cannot select a monitor template.",
+      );
+    }
+
+    if (data.includePingOnlyHosts) {
+      throw new BadDataException(
+        "Rules that include ping-only hosts cannot select a Network Device monitor template.",
+      );
+    }
+
+    if (!data.projectId) {
+      throw new BadDataException(
+        "A project is required when selecting a monitor template.",
+      );
+    }
+
+    if (!data.props.isRoot && !data.props.isMasterAdmin) {
+      TablePermission.checkTableLevelPermissions(
+        Monitor,
+        data.props,
+        DatabaseRequestType.Create,
+      );
+      TablePermission.checkTableLevelBlockPermissions(
+        Monitor,
+        data.props,
+        DatabaseRequestType.Create,
+      );
+    }
+
+    const monitorTemplate: MonitorTemplate | null =
+      await MonitorTemplateService.findOneById({
+        id: data.monitorTemplateId,
+        select: {
+          _id: true,
+          projectId: true,
+          monitorType: true,
+          monitorSteps: true,
+        },
+        /*
+         * Selecting a template is also a read of that template. Preserve the
+         * caller's tenant, ownership and label scopes here; otherwise a user
+         * who may edit rules and create monitors could attach a template they
+         * cannot see, and the background worker would later clone it as root.
+         */
+        props: data.props,
+      });
+
+    if (!monitorTemplate) {
+      throw new BadDataException("Monitor template not found.");
+    }
+
+    if (
+      !monitorTemplate.projectId ||
+      monitorTemplate.projectId.toString() !== data.projectId.toString()
+    ) {
+      throw new BadDataException(
+        "Monitor template must belong to the same project.",
+      );
+    }
+
+    if (monitorTemplate.monitorType !== MonitorType.NetworkDevice) {
+      throw new BadDataException(
+        "Monitor template must be a Network Device monitor template.",
+      );
+    }
+
+    NetworkDeviceMonitorTemplateUtil.validateMonitorSteps(
+      monitorTemplate.monitorSteps,
+      "Monitor template",
+    );
   }
 
   private validateCriteria(data: {

--- a/Common/Server/Services/NetworkDeviceService.ts
+++ b/Common/Server/Services/NetworkDeviceService.ts
@@ -8,8 +8,9 @@ import Model from "../../Models/DatabaseModels/NetworkDevice";
 import Monitor from "../../Models/DatabaseModels/Monitor";
 import NetworkSite from "../../Models/DatabaseModels/NetworkSite";
 import NetworkSiteAssignmentRule from "../../Models/DatabaseModels/NetworkSiteAssignmentRule";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import CreateBy from "../Types/Database/CreateBy";
+import DeleteBy from "../Types/Database/DeleteBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import Query from "../Types/Database/Query";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -18,6 +19,7 @@ import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import BadDataException from "../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import CidrMatchUtil from "../../Utils/NetworkSite/CidrMatchUtil";
@@ -25,6 +27,8 @@ import { SiteAssignmentRuleRunResult } from "../../Types/NetworkAutomation/RuleR
 import { NetworkDeviceMonitoringMethodUtil } from "../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
 import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import { EntityManager } from "typeorm";
+import ModelPermission from "../Types/Database/Permissions/Index";
+import QueryHelper from "../Types/Database/QueryHelper";
 
 /*
  * Columns a NetworkSiteAssignmentRule's hostname pattern is matched against.
@@ -116,6 +120,155 @@ function toRuleMatchTarget(device: Model): {
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * The provenance FK uses RESTRICT as a final race backstop: PostgreSQL must
+   * never silently remove an active monitor with its device. An ordinary
+   * service deletion therefore authorizes and resolves the exact device rows
+   * first, then deletes their automatic monitors through MonitorService so
+   * Monitor delete permissions, workspace cleanup, workflows, audit,
+   * realtime, and billing hooks all run before the devices are removed.
+   */
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    const authorizedQuery: Query<Model> =
+      await ModelPermission.checkDeleteQueryPermission(
+        Model,
+        deleteBy.query,
+        deleteBy.props,
+      );
+
+    const devices: Array<Model> = await this.findBy({
+      query: authorizedQuery,
+      select: {
+        _id: true,
+        projectId: true,
+      },
+      limit: deleteBy.limit,
+      skip: deleteBy.skip,
+      props: { isRoot: true },
+    });
+
+    const countAutomaticMonitors: (
+      query: Query<Monitor>,
+    ) => Promise<number> = async (query: Query<Monitor>): Promise<number> => {
+      return (
+        await MonitorService.countBy({
+          query,
+          props: { isRoot: true },
+        })
+      ).toNumber();
+    };
+    const cleanupPlans: Array<{
+      automaticMonitorQuery: Query<Monitor>;
+      monitorDeleteProps: DatabaseCommonInteractionProps;
+      monitorCount: number;
+    }> = [];
+
+    /*
+     * Preflight every device in the bulk request before deleting the first
+     * monitor. Otherwise a later inaccessible device could abort the request
+     * after earlier devices had already lost their automatic monitors.
+     */
+    for (const device of devices) {
+      if (!device.id || !device.projectId) {
+        continue;
+      }
+
+      const automaticMonitorQuery: Query<Monitor> = {
+        projectId: device.projectId,
+        autoProvisionedNetworkDeviceId: device.id,
+      };
+      const monitorDeleteProps: DatabaseCommonInteractionProps = {
+        ...deleteBy.props,
+        tenantId: device.projectId,
+      };
+      const monitorCount: number = await countAutomaticMonitors(
+        automaticMonitorQuery,
+      );
+
+      if (monitorCount === 0) {
+        continue;
+      }
+
+      /*
+       * Prove access BEFORE deleting anything. Without this preflight an
+       * access-control query could delete only the monitors visible to the
+       * caller before the RESTRICT constraint rejects the device deletion,
+       * leaving a partially cleaned-up request. The authorized query is a
+       * subset of automaticMonitorQuery, so equal counts prove that it covers
+       * the full set at this instant.
+       */
+      const authorizedMonitorQuery: Query<Monitor> =
+        await ModelPermission.checkDeleteQueryPermission(
+          Monitor,
+          automaticMonitorQuery,
+          monitorDeleteProps,
+        );
+      const authorizedMonitorCount: number = await countAutomaticMonitors(
+        authorizedMonitorQuery,
+      );
+
+      if (authorizedMonitorCount !== monitorCount) {
+        throw new NotAuthorizedException(
+          "You do not have permission to delete every auto-provisioned monitor linked to this Network Device.",
+        );
+      }
+
+      cleanupPlans.push({
+        automaticMonitorQuery,
+        monitorDeleteProps,
+        monitorCount,
+      });
+    }
+
+    for (const cleanupPlan of cleanupPlans) {
+      /*
+       * LIMIT_MAX is a per-service-call cap, not a lifecycle cap. Always
+       * delete from offset zero because each successful batch shrinks the
+       * result set. Recount as root after every batch: a permission change or
+       * concurrent inaccessible insert must fail closed, with the FK's
+       * RESTRICT policy remaining the last guard before device deletion.
+       */
+      let remainingMonitorCount: number = cleanupPlan.monitorCount;
+      while (remainingMonitorCount > 0) {
+        await MonitorService.deleteBy({
+          query: cleanupPlan.automaticMonitorQuery,
+          limit: LIMIT_MAX,
+          skip: 0,
+          props: cleanupPlan.monitorDeleteProps,
+        });
+
+        const previousMonitorCount: number = remainingMonitorCount;
+        remainingMonitorCount = await countAutomaticMonitors(
+          cleanupPlan.automaticMonitorQuery,
+        );
+
+        if (remainingMonitorCount >= previousMonitorCount) {
+          throw new NotAuthorizedException(
+            "Could not delete every auto-provisioned monitor linked to this Network Device.",
+          );
+        }
+      }
+    }
+
+    return {
+      deleteBy: {
+        ...deleteBy,
+        query: {
+          _id: QueryHelper.any(
+            devices.flatMap((device: Model): Array<ObjectID> => {
+              return device.id ? [device.id] : [];
+            }),
+          ),
+        },
+        skip: 0,
+      },
+      carryForward: null,
+    };
   }
 
   /*

--- a/Common/Server/Utils/Database/RelationIdUtil.ts
+++ b/Common/Server/Utils/Database/RelationIdUtil.ts
@@ -1,4 +1,5 @@
 import ObjectID from "../../../Types/ObjectID";
+import BadDataException from "../../../Types/Exception/BadDataException";
 
 /*
  * A many-to-one reference reaches a service hook under TWO different keys.
@@ -64,5 +65,46 @@ export default class RelationIdUtil {
     }
 
     return null;
+  }
+
+  /**
+   * Read one logical relation while rejecting payloads that point its scalar
+   * FK and relation-object spellings at different rows. TypeORM's precedence
+   * for two writes to the same join column is not a security boundary: a hook
+   * must validate the exact ID that can be persisted.
+   */
+  public static readConsistent(
+    data: Record<string, unknown> | undefined | null,
+    keys: Array<string>,
+    relationTitle: string,
+  ): ObjectID | null {
+    const ids: Array<ObjectID> = [];
+    const distinctIds: Set<string> = new Set();
+    let hasExplicitNull: boolean = false;
+
+    for (const key of keys) {
+      const value: unknown = (data || {})[key];
+
+      // Undefined is an omitted model property; null is an explicit clear.
+      if (value === undefined) {
+        continue;
+      }
+
+      const id: ObjectID | null = this.read(data, [key]);
+      if (id) {
+        ids.push(id);
+        distinctIds.add(id.toString());
+      } else {
+        hasExplicitNull = true;
+      }
+    }
+
+    if (distinctIds.size > 1 || (hasExplicitNull && distinctIds.size > 0)) {
+      throw new BadDataException(
+        `Conflicting ${relationTitle} references were provided.`,
+      );
+    }
+
+    return ids[0] || null;
   }
 }

--- a/Common/Tests/Server/Services/MonitorTemplateServiceNetworkDeviceSync.test.ts
+++ b/Common/Tests/Server/Services/MonitorTemplateServiceNetworkDeviceSync.test.ts
@@ -1,0 +1,383 @@
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import DatabaseBaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Label from "../../../Models/DatabaseModels/Label";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorTemplateService, {
+  SyncLinkedMonitorsResult,
+} from "../../../Server/Services/MonitorTemplateService";
+import Query from "../../../Server/Types/Database/Query";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { SpyInstance } from "jest-mock";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const TEMPLATE_DEVICE_ID: string = "33333333-3333-4333-8333-333333333333";
+const DEVICE_ONE_ID: string = "44444444-4444-4444-8444-444444444444";
+const DEVICE_TWO_ID: string = "55555555-5555-4555-8555-555555555555";
+
+function buildSteps(deviceIds: Array<string>): MonitorSteps {
+  const steps: MonitorSteps = new MonitorSteps();
+  steps.data = {
+    monitorStepsInstanceArray: deviceIds.map(
+      (deviceId: string, index: number): MonitorStep => {
+        const step: MonitorStep = new MonitorStep();
+        step.data!.id = `step-${index}`;
+        step.data!.networkDeviceMonitor = {
+          networkDeviceId: deviceId,
+          monitorInterfaces: index % 2 === 0,
+          collectEndpoints: true,
+          oids: [
+            {
+              oid: `1.3.6.1.4.1.${index + 1}`,
+              name: `health-${index}`,
+              description: "Template criterion",
+            },
+          ],
+        };
+        return step;
+      },
+    ),
+    defaultMonitorStatusId: ObjectID.generate(),
+  };
+  return steps;
+}
+
+function buildTemplate(
+  monitorType: MonitorType = MonitorType.NetworkDevice,
+): MonitorTemplate {
+  const template: MonitorTemplate = new MonitorTemplate();
+  template.id = TEMPLATE_ID;
+  template.projectId = PROJECT_ID;
+  template.monitorType = monitorType;
+  template.monitorSteps = buildSteps([TEMPLATE_DEVICE_ID, TEMPLATE_DEVICE_ID]);
+  template.monitoringInterval = "*/10 * * * *";
+  template.minimumProbeAgreement = 2;
+  return template;
+}
+
+function buildLinkedMonitor(deviceIds: Array<string>): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.id = ObjectID.generate();
+  monitor.projectId = PROJECT_ID;
+  monitor.monitorType = MonitorType.NetworkDevice;
+  monitor.monitorTemplateId = TEMPLATE_ID;
+  monitor.monitorSteps = buildSteps(deviceIds);
+  return monitor;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("MonitorTemplateService Network Device synchronization", () => {
+  it("syncs two linked monitors without retargeting either device", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const firstMonitor: Monitor = buildLinkedMonitor([DEVICE_ONE_ID]);
+    const secondMonitor: Monitor = buildLinkedMonitor([
+      DEVICE_TWO_ID,
+      DEVICE_TWO_ID,
+    ]);
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest
+      .spyOn(MonitorTemplateService, "countLinkedMonitors")
+      .mockResolvedValue(2);
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([firstMonitor, secondMonitor]);
+    const updateOneSpy: SpyInstance<typeof MonitorService.updateOneById> = jest
+      .spyOn(MonitorService, "updateOneById")
+      .mockResolvedValue(1);
+    const bulkUpdateSpy: SpyInstance<typeof MonitorService.updateBy> =
+      jest.spyOn(MonitorService, "updateBy");
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["monitorSteps", "monitoringInterval"],
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 2, syncedMonitors: 2 });
+    expect(updateOneSpy).toHaveBeenCalledTimes(2);
+    expect(bulkUpdateSpy).not.toHaveBeenCalled();
+
+    const firstSteps: MonitorSteps = updateOneSpy.mock.calls[0]![0].data
+      .monitorSteps as MonitorSteps;
+    const secondSteps: MonitorSteps = updateOneSpy.mock.calls[1]![0].data
+      .monitorSteps as MonitorSteps;
+
+    expect(
+      firstSteps.data?.monitorStepsInstanceArray.map((step: MonitorStep) => {
+        return step.data?.networkDeviceMonitor?.networkDeviceId;
+      }),
+    ).toEqual([DEVICE_ONE_ID, DEVICE_ONE_ID]);
+    expect(
+      secondSteps.data?.monitorStepsInstanceArray.map((step: MonitorStep) => {
+        return step.data?.networkDeviceMonitor?.networkDeviceId;
+      }),
+    ).toEqual([DEVICE_TWO_ID, DEVICE_TWO_ID]);
+    expect(updateOneSpy.mock.calls[0]![0].data.monitoringInterval).toBe(
+      "*/10 * * * *",
+    );
+
+    // Sync clones; the template's design-time placeholder remains untouched.
+    expect(
+      template.monitorSteps?.data?.monitorStepsInstanceArray.map(
+        (step: MonitorStep) => {
+          return step.data?.networkDeviceMonitor?.networkDeviceId;
+        },
+      ),
+    ).toEqual([TEMPLATE_DEVICE_ID, TEMPLATE_DEVICE_ID]);
+  });
+
+  it("precomputes a mixed-label caller's authorized monitor set before writing", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const visibleMonitor: Monitor = buildLinkedMonitor([DEVICE_ONE_ID]);
+    const hiddenMonitor: Monitor = buildLinkedMonitor([DEVICE_TWO_ID]);
+    const visibleLabel: Label = new Label();
+    visibleLabel.id = ObjectID.generate();
+    const authorizedQuery: Query<Monitor> = {
+      monitorTemplateId: TEMPLATE_ID,
+      projectId: PROJECT_ID,
+      labels: [visibleLabel],
+    };
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest
+      .spyOn(MonitorTemplateService, "countLinkedMonitors")
+      .mockResolvedValue(2);
+    const permissionSpy: SpyInstance<
+      typeof ModelPermission.checkUpdateQueryPermissions
+    > = jest
+      .spyOn(ModelPermission, "checkUpdateQueryPermissions")
+      .mockResolvedValue(authorizedQuery);
+    const findSpy: SpyInstance<typeof MonitorService.findBy> = jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([visibleMonitor]);
+    const updateOneSpy: SpyInstance<typeof MonitorService.updateOneById> = jest
+      .spyOn(MonitorService, "updateOneById")
+      .mockResolvedValue(1);
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["monitorSteps"],
+        props,
+      });
+
+    expect(permissionSpy).toHaveBeenCalledWith(
+      Monitor,
+      {
+        monitorTemplateId: TEMPLATE_ID,
+        projectId: PROJECT_ID,
+      },
+      expect.objectContaining({ monitorSteps: template.monitorSteps }),
+      props,
+    );
+    expect(findSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: authorizedQuery,
+        props: { isRoot: true },
+      }),
+    );
+    expect(updateOneSpy).toHaveBeenCalledTimes(1);
+    expect(updateOneSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: visibleMonitor.id }),
+    );
+    expect(updateOneSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: hiddenMonitor.id }),
+    );
+    expect(result).toEqual({ totalLinkedMonitors: 2, syncedMonitors: 1 });
+  });
+
+  it("does not report a concurrently deleted monitor as synced", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildLinkedMonitor([DEVICE_ONE_ID]);
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest
+      .spyOn(MonitorTemplateService, "countLinkedMonitors")
+      .mockResolvedValue(1);
+    jest
+      .spyOn(ModelPermission, "checkUpdateQueryPermissions")
+      .mockImplementation(
+        async <TBaseModel extends DatabaseBaseModel>(
+          _model: { new (): TBaseModel },
+          query: Query<TBaseModel>,
+        ): Promise<Query<TBaseModel>> => {
+          return query;
+        },
+      );
+    jest.spyOn(MonitorService, "findBy").mockResolvedValue([monitor]);
+    jest.spyOn(MonitorService, "updateOneById").mockResolvedValue(0);
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["monitorSteps"],
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 1, syncedMonitors: 0 });
+  });
+
+  it("validates every device binding before updating the first linked monitor", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const validMonitor: Monitor = buildLinkedMonitor([DEVICE_ONE_ID]);
+    const ambiguousMonitor: Monitor = buildLinkedMonitor([
+      DEVICE_ONE_ID,
+      DEVICE_TWO_ID,
+    ]);
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest
+      .spyOn(MonitorTemplateService, "countLinkedMonitors")
+      .mockResolvedValue(2);
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([validMonitor, ambiguousMonitor]);
+    const updateSpy: SpyInstance<typeof MonitorService.updateOneById> =
+      jest.spyOn(MonitorService, "updateOneById");
+
+    await expect(
+      MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["monitorSteps"],
+        props: { isRoot: true },
+      }),
+    ).rejects.toThrow("exactly one distinct Network Device binding");
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses auto-provisioning provenance when a legacy monitor has no stored step binding", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildLinkedMonitor([]);
+    monitor.autoProvisionedNetworkDeviceId = new ObjectID(DEVICE_ONE_ID);
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest.spyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+    const updateSpy: SpyInstance<typeof MonitorService.updateOneById> = jest
+      .spyOn(MonitorService, "updateOneById")
+      .mockResolvedValue(1);
+
+    await MonitorTemplateService.syncToMonitor({
+      monitorTemplateId: TEMPLATE_ID,
+      monitorId: monitor.id!,
+      fields: ["monitorSteps"],
+      props: { isRoot: true },
+    });
+
+    const syncedSteps: MonitorSteps = updateSpy.mock.calls[0]![0].data
+      .monitorSteps as MonitorSteps;
+    expect(
+      syncedSteps.data?.monitorStepsInstanceArray.map((step: MonitorStep) => {
+        return step.data?.networkDeviceMonitor?.networkDeviceId;
+      }),
+    ).toEqual([DEVICE_ONE_ID, DEVICE_ONE_ID]);
+  });
+
+  it("repairs a drifted automatic binding from immutable provenance during sync", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildLinkedMonitor([DEVICE_TWO_ID]);
+    monitor.autoProvisionedNetworkDeviceId = new ObjectID(DEVICE_ONE_ID);
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest.spyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+    const updateSpy: SpyInstance<typeof MonitorService.updateOneById> = jest
+      .spyOn(MonitorService, "updateOneById")
+      .mockResolvedValue(1);
+
+    await MonitorTemplateService.syncToMonitor({
+      monitorTemplateId: TEMPLATE_ID,
+      monitorId: monitor.id!,
+      fields: ["monitorSteps"],
+      props: { isRoot: true },
+    });
+
+    const syncedSteps: MonitorSteps = updateSpy.mock.calls[0]![0].data
+      .monitorSteps as MonitorSteps;
+    expect(
+      syncedSteps.data?.monitorStepsInstanceArray.map((step: MonitorStep) => {
+        return step.data?.networkDeviceMonitor?.networkDeviceId;
+      }),
+    ).toEqual([DEVICE_ONE_ID, DEVICE_ONE_ID]);
+  });
+
+  it("rejects an ambiguous linked monitor instead of guessing which device wins", async () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = buildLinkedMonitor([DEVICE_ONE_ID, DEVICE_TWO_ID]);
+
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest.spyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+    const updateSpy: SpyInstance<typeof MonitorService.updateOneById> =
+      jest.spyOn(MonitorService, "updateOneById");
+
+    await expect(
+      MonitorTemplateService.syncToMonitor({
+        monitorTemplateId: TEMPLATE_ID,
+        monitorId: monitor.id!,
+        fields: ["monitorSteps"],
+        props: { isRoot: true },
+      }),
+    ).rejects.toThrow(BadDataException);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("retains the efficient bulk-update path when device bindings are irrelevant", async () => {
+    const template: MonitorTemplate = buildTemplate(MonitorType.API);
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+    jest
+      .spyOn(MonitorTemplateService, "countLinkedMonitors")
+      .mockResolvedValue(3);
+    const bulkUpdateSpy: SpyInstance<typeof MonitorService.updateBy> = jest
+      .spyOn(MonitorService, "updateBy")
+      .mockResolvedValue(3);
+    const findMonitorsSpy: SpyInstance<typeof MonitorService.findBy> =
+      jest.spyOn(MonitorService, "findBy");
+
+    const result: SyncLinkedMonitorsResult =
+      await MonitorTemplateService.syncLinkedMonitors({
+        monitorTemplateId: TEMPLATE_ID,
+        fields: ["monitoringInterval"],
+        props: { isRoot: true },
+      });
+
+    expect(result).toEqual({ totalLinkedMonitors: 3, syncedMonitors: 3 });
+    expect(bulkUpdateSpy).toHaveBeenCalledTimes(1);
+    expect(findMonitorsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleEngineService.test.ts
@@ -67,6 +67,26 @@ jest.mock("../../../Server/Services/NetworkDeviceAutoImportRuleService", () => {
   };
 });
 
+jest.mock("../../../Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(),
+      findBy: jest.fn(),
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/MonitorTemplateService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+    },
+  };
+});
+
 jest.mock("../../../Server/Infrastructure/Semaphore", () => {
   return {
     __esModule: true,
@@ -95,16 +115,22 @@ import NetworkDeviceAutoImportRuleEngineService, {
   AUTO_IMPORT_SWEEP_LOCK_NAMESPACE,
   AUTO_IMPORT_SWEEP_LOCK_TIMEOUT_MS,
   ExistingHostnamesByProjectId,
+  ImportAttemptBudgetsByProjectId,
   MAX_DEVICES_PER_AUTO_IMPORT_RUN,
+  MAX_MONITORS_PER_AUTO_IMPORT_RUN,
   MAX_RESULT_AGE_IN_HOURS,
   MAX_SCANS_PER_AUTO_IMPORT_RULE_RUN,
 } from "../../../Server/Services/NetworkDeviceAutoImportRuleEngineService";
 import NetworkDeviceAutoImportRuleService from "../../../Server/Services/NetworkDeviceAutoImportRuleService";
 import NetworkDeviceDiscoveryScanService from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
 import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorTemplateService from "../../../Server/Services/MonitorTemplateService";
 import Semaphore from "../../../Server/Infrastructure/Semaphore";
 import logger from "../../../Server/Utils/Logger";
 import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
 import NetworkDeviceAutoImportRule from "../../../Models/DatabaseModels/NetworkDeviceAutoImportRule";
 import NetworkDeviceDiscoveryScan, {
   DiscoveredNetworkDevice,
@@ -112,6 +138,9 @@ import NetworkDeviceDiscoveryScan, {
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
 import OneUptimeDate from "../../../Types/Date";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../Types/Monitor/MonitorType";
 import {
   AutoImportRuleRunResult,
   MAX_MATCHED_IP_SAMPLE,
@@ -138,6 +167,10 @@ const PROJECT_ID: ObjectID = new ObjectID(
 const PROBE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
 const SCAN_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
 const RULE_ID: ObjectID = new ObjectID("77777777-7777-4777-8777-777777777777");
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "88888888-8888-4888-8888-888888888888",
+);
+const TEMPLATE_DEVICE_ID: string = "99999999-9999-4999-8999-999999999999";
 
 // What the mocked Semaphore.lock hands back and release must get back.
 const FAKE_MUTEX: { id: string } = { id: "fake-sweep-mutex" };
@@ -148,6 +181,14 @@ const deviceFindByMock: jest.Mock =
   NetworkDeviceService.findBy as unknown as jest.Mock;
 const deviceFindOneByMock: jest.Mock =
   NetworkDeviceService.findOneBy as unknown as jest.Mock;
+const monitorCreateMock: jest.Mock =
+  MonitorService.create as unknown as jest.Mock;
+const monitorFindByMock: jest.Mock =
+  MonitorService.findBy as unknown as jest.Mock;
+const monitorFindOneByMock: jest.Mock =
+  MonitorService.findOneBy as unknown as jest.Mock;
+const monitorTemplateFindByMock: jest.Mock =
+  MonitorTemplateService.findBy as unknown as jest.Mock;
 const scanFindOneByMock: jest.Mock =
   NetworkDeviceDiscoveryScanService.findOneBy as unknown as jest.Mock;
 const scanFindByMock: jest.Mock =
@@ -212,6 +253,67 @@ function makeHost(
     sysDescr: "Cisco IOS Software, C2960X",
     ...overrides,
   };
+}
+
+function makeMonitorSteps(
+  networkDeviceId: string = TEMPLATE_DEVICE_ID,
+): MonitorSteps {
+  const step: MonitorStep = new MonitorStep();
+  step.data!.networkDeviceMonitor = {
+    networkDeviceId: networkDeviceId,
+    monitorInterfaces: true,
+    collectEndpoints: true,
+    oids: [
+      {
+        oid: "1.3.6.1.2.1.1.3.0",
+        name: "sysUpTime",
+        description: "System uptime",
+      },
+    ],
+  };
+
+  const monitorSteps: MonitorSteps = new MonitorSteps();
+  monitorSteps.data = {
+    monitorStepsInstanceArray: [step],
+    defaultMonitorStatusId: new ObjectID(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    ),
+  };
+  return monitorSteps;
+}
+
+function makeTemplate(
+  overrides: Record<string, unknown> = {},
+): MonitorTemplate {
+  const template: MonitorTemplate = new MonitorTemplate();
+  template.id = TEMPLATE_ID;
+  template.projectId = PROJECT_ID;
+  template.templateName = "Core switch health";
+  template.monitorName = "SNMP health";
+  template.monitorDescription = "Provisioned from discovery";
+  template.monitorType = MonitorType.NetworkDevice;
+  template.monitorSteps = makeMonitorSteps();
+  template.monitoringInterval = "*/5 * * * *";
+  template.minimumProbeAgreement = 2;
+  template.customFields = { source: "auto-import" };
+  Object.assign(template, overrides);
+  return template;
+}
+
+function makeExistingDevice(
+  overrides: Record<string, unknown> = {},
+): NetworkDevice {
+  const device: NetworkDevice = new NetworkDevice();
+  device.id = new ObjectID("44444444-4444-4444-8444-444444444444");
+  device.projectId = PROJECT_ID;
+  device.name = "core-switch-01";
+  device.hostname = "10.0.0.5";
+  Object.assign(device, overrides);
+  return device;
+}
+
+function provisionedMonitor(callIndex: number): Monitor {
+  return monitorCreateMock.mock.calls[callIndex]![0].data as Monitor;
 }
 
 // Enough unique in-target addresses to overrun the attempt budget.
@@ -285,7 +387,21 @@ beforeEach(() => {
    */
   deviceFindByMock.mockResolvedValue([]);
   deviceFindOneByMock.mockResolvedValue(null);
-  createMock.mockResolvedValue({});
+  createMock.mockImplementation(
+    ({ data }: { data: NetworkDevice }): Promise<NetworkDevice> => {
+      data.id = data.id || ObjectID.generate();
+      return Promise.resolve(data);
+    },
+  );
+  monitorFindByMock.mockResolvedValue([]);
+  monitorFindOneByMock.mockResolvedValue(null);
+  monitorTemplateFindByMock.mockResolvedValue([]);
+  monitorCreateMock.mockImplementation(
+    ({ data }: { data: Monitor }): Promise<Monitor> => {
+      data.id = data.id || ObjectID.generate();
+      return Promise.resolve(data);
+    },
+  );
   scanUpdateMock.mockResolvedValue(undefined);
   ruleFindByMock.mockResolvedValue([makeRule()]);
   semaphoreLockMock.mockResolvedValue(FAKE_MUTEX);
@@ -386,6 +502,8 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
     });
 
     expect(createMock).toHaveBeenCalledTimes(1);
+    expect(monitorFindByMock).not.toHaveBeenCalled();
+    expect(monitorTemplateFindByMock).not.toHaveBeenCalled();
     const device: NetworkDevice = createdDevice(0);
     // The address is the hostname AND the dedup key downstream.
     expect(device.hostname).toBe("10.0.0.5");
@@ -442,6 +560,500 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
     // Nothing created, so the stamp carries the marker alone.
     const updateCall: any = scanUpdateMock.mock.calls[0]![0];
     expect(Object.keys(updateCall.data)).toEqual(["autoImportProcessedAt"]);
+  });
+
+  describe("monitor-template provisioning", () => {
+    it("creates an active monitor from the selected template and rebinds it to the new device", async () => {
+      const template: MonitorTemplate = makeTemplate();
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([template]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        devicesCreated: 1,
+        monitorsCreated: 1,
+        monitorsWouldCreate: 0,
+        monitorsFailed: 0,
+      });
+      expect(monitorCreateMock).toHaveBeenCalledTimes(1);
+
+      const device: NetworkDevice = createdDevice(0);
+      const monitor: Monitor = provisionedMonitor(0);
+      expect(monitor.name).toBe("core-switch-01 - SNMP health");
+      expect(monitor.description).toBe("Provisioned from discovery");
+      expect(monitor.monitorType).toBe(MonitorType.NetworkDevice);
+      expect(monitor.monitorTemplateId?.toString()).toBe(
+        TEMPLATE_ID.toString(),
+      );
+      expect(monitor.autoProvisionedNetworkDeviceId?.toString()).toBe(
+        device.id?.toString(),
+      );
+      expect(
+        monitor.monitorSteps?.data?.monitorStepsInstanceArray[0]?.data
+          ?.networkDeviceMonitor?.networkDeviceId,
+      ).toBe(device.id?.toString());
+      expect(monitor.monitoringInterval).toBe("*/5 * * * *");
+      expect(monitor.minimumProbeAgreement).toBe(2);
+      expect(monitor.customFields).toEqual({ source: "auto-import" });
+      expect(monitorCreateMock.mock.calls[0]![0].props).toEqual({
+        isRoot: true,
+        tenantId: PROJECT_ID,
+      });
+
+      // A cached template is reused across an estate and must never mutate.
+      expect(
+        template.monitorSteps?.data?.monitorStepsInstanceArray[0]?.data
+          ?.networkDeviceMonitor?.networkDeviceId,
+      ).toBe(TEMPLATE_DEVICE_ID);
+    });
+
+    it("backfills a selected template monitor for an already-registered matching device", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({
+          discoveredDevices: [makeHost({ isAlreadyRegistered: true })],
+        }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        hostsSkippedAlreadyRegistered: 1,
+        devicesCreated: 0,
+        monitorsCreated: 1,
+      });
+      expect(createMock).not.toHaveBeenCalled();
+      expect(deviceFindByMock.mock.calls[0]![0].select.projectId).toBe(true);
+      expect(
+        provisionedMonitor(0).autoProvisionedNetworkDeviceId?.toString(),
+      ).toBe(existingDevice.id?.toString());
+    });
+
+    it("does not duplicate a manually configured monitor already watching the device", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      const manualMonitor: Monitor = new Monitor();
+      manualMonitor.id = ObjectID.generate();
+      manualMonitor.monitorType = MonitorType.NetworkDevice;
+      manualMonitor.monitorSteps = makeMonitorSteps(
+        existingDevice.id!.toString(),
+      );
+
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      monitorFindByMock.mockResolvedValue([manualMonitor]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedAlreadyExisting: 1,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+      expect(monitorFindByMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses provenance to skip an automatic monitor that already exists", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      const existingMonitor: Monitor = new Monitor();
+      existingMonitor.id = ObjectID.generate();
+      existingMonitor.monitorType = MonitorType.NetworkDevice;
+      existingMonitor.monitorTemplateId = TEMPLATE_ID;
+      existingMonitor.autoProvisionedNetworkDeviceId = existingDevice.id!;
+      existingMonitor.monitorSteps = makeMonitorSteps(
+        existingDevice.id!.toString(),
+      );
+
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      monitorFindByMock.mockResolvedValue([existingMonitor]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedAlreadyExisting: 1,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+      expect(monitorFindByMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("deduplicates two matching rules that select the same template", async () => {
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+        makeRule({
+          id: ObjectID.generate(),
+          ipMatchTarget: undefined,
+          sysNamePattern: "core-switch",
+          monitorTemplateId: TEMPLATE_ID,
+        }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result?.monitorsCreated).toBe(1);
+      expect(monitorCreateMock).toHaveBeenCalledTimes(1);
+      expect(monitorTemplateFindByMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates one monitor per distinct template selected by matching rules", async () => {
+      const secondTemplateId: ObjectID = new ObjectID(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      );
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+        makeRule({
+          id: ObjectID.generate(),
+          ipMatchTarget: undefined,
+          sysNamePattern: "core-switch",
+          monitorTemplateId: secondTemplateId,
+        }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([
+        makeTemplate(),
+        makeTemplate({
+          id: secondTemplateId,
+          monitorName: "Interface health",
+        }),
+      ]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result?.monitorsCreated).toBe(2);
+      expect(monitorCreateMock).toHaveBeenCalledTimes(2);
+      expect(
+        monitorCreateMock.mock.calls.map((call: Array<any>): string => {
+          return call[0].data.monitorTemplateId.toString();
+        }),
+      ).toEqual([TEMPLATE_ID.toString(), secondTemplateId.toString()]);
+    });
+
+    it("reports monitor failures separately and leaves them retryable", async () => {
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+      monitorCreateMock.mockRejectedValueOnce(new Error("plan limit reached"));
+
+      const firstResult: AutoImportRuleRunResult | null = await processScan();
+
+      expect(firstResult).toMatchObject({
+        devicesCreated: 1,
+        monitorsCreated: 0,
+        monitorsFailed: 1,
+      });
+
+      const created: NetworkDevice = createdDevice(0);
+      jest.clearAllMocks();
+      deviceFindByMock.mockResolvedValue([created]);
+      monitorFindByMock.mockResolvedValue([]);
+      monitorFindOneByMock.mockResolvedValue(null);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      scanUpdateMock.mockResolvedValue(undefined);
+      monitorCreateMock.mockImplementation(
+        ({ data }: { data: Monitor }): Promise<Monitor> => {
+          return Promise.resolve(data);
+        },
+      );
+
+      const retryResult: AutoImportRuleRunResult | null = await processScan();
+
+      expect(retryResult).toMatchObject({
+        devicesCreated: 0,
+        monitorsCreated: 1,
+        monitorsFailed: 0,
+      });
+    });
+
+    it("defensively skips inert Network Device monitors for ping-only hosts", async () => {
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({
+          discoveredDevices: [makeHost({ snmpReachable: false })],
+        }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({
+          includePingOnlyHosts: true,
+          monitorTemplateId: TEMPLATE_ID,
+        }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        devicesCreated: 1,
+        monitorsCreated: 0,
+        monitorsSkippedUnsupportedHost: 1,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("does not backfill an SNMP monitor onto an existing monitor-backed device", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice({
+        monitoringMethod: "Monitor",
+      });
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost({ snmpReachable: true })] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedUnsupportedHost: 1,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("sees a manual monitor created after the initial project snapshot", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      const manualMonitor: Monitor = new Monitor();
+      manualMonitor.monitorType = MonitorType.NetworkDevice;
+      manualMonitor.monitorSteps = makeMonitorSteps(
+        existingDevice.id!.toString(),
+      );
+
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      monitorFindByMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([manualMonitor]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedAlreadyExisting: 1,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+      expect(monitorFindByMock).toHaveBeenCalledTimes(2);
+      expect(monitorFindByMock.mock.calls[1]![0].select.monitorType).toBe(true);
+    });
+
+    it("reports a conflicting drifted provenance row instead of treating it as a successful race winner", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      const otherDeviceId: ObjectID = new ObjectID(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      );
+      const driftedMonitor: Monitor = new Monitor();
+      driftedMonitor.monitorType = MonitorType.NetworkDevice;
+      driftedMonitor.monitorTemplateId = TEMPLATE_ID;
+      driftedMonitor.autoProvisionedNetworkDeviceId = existingDevice.id!;
+      driftedMonitor.monitorSteps = makeMonitorSteps(otherDeviceId.toString());
+
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      monitorFindByMock.mockResolvedValue([driftedMonitor]);
+      monitorCreateMock.mockRejectedValue(new Error("duplicate key"));
+      monitorFindOneByMock.mockResolvedValue(driftedMonitor);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedAlreadyExisting: 0,
+        monitorsFailed: 1,
+      });
+      expect(monitorCreateMock).toHaveBeenCalledTimes(1);
+      expect(monitorFindOneByMock.mock.calls[0]![0].select).toMatchObject({
+        monitorType: true,
+        monitorSteps: true,
+        monitorTemplateId: true,
+        autoProvisionedNetworkDeviceId: true,
+      });
+    });
+
+    it("classifies a valid concurrent automatic create as an idempotent skip", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      const concurrentMonitor: Monitor = new Monitor();
+      concurrentMonitor.monitorType = MonitorType.NetworkDevice;
+      concurrentMonitor.monitorTemplateId = TEMPLATE_ID;
+      concurrentMonitor.autoProvisionedNetworkDeviceId = existingDevice.id!;
+      concurrentMonitor.monitorSteps = makeMonitorSteps(
+        existingDevice.id!.toString(),
+      );
+
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      monitorFindByMock.mockResolvedValue([]);
+      monitorCreateMock.mockRejectedValue(new Error("duplicate key"));
+      monitorFindOneByMock.mockResolvedValue(concurrentMonitor);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedAlreadyExisting: 1,
+        monitorsFailed: 0,
+      });
+    });
+
+    it("treats an automatic monitor orphaned from its template as an existing operator-managed monitor", async () => {
+      const existingDevice: NetworkDevice = makeExistingDevice();
+      const orphanedMonitor: Monitor = new Monitor();
+      orphanedMonitor.monitorType = MonitorType.NetworkDevice;
+      orphanedMonitor.autoProvisionedNetworkDeviceId = existingDevice.id!;
+      orphanedMonitor.monitorSteps = makeMonitorSteps(
+        existingDevice.id!.toString(),
+      );
+
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost()] }),
+      );
+      deviceFindByMock.mockResolvedValue([existingDevice]);
+      monitorFindByMock.mockResolvedValue([orphanedMonitor]);
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsSkippedAlreadyExisting: 1,
+      });
+    });
+
+    it("attempts one failed device-template key only once per run even when the host is duplicated", async () => {
+      scanFindOneByMock.mockResolvedValue(
+        makeScan({ discoveredDevices: [makeHost(), makeHost()] }),
+      );
+      ruleFindByMock.mockResolvedValue([
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      ]);
+      monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+      monitorCreateMock.mockRejectedValue(new Error("plan limit reached"));
+
+      const result: AutoImportRuleRunResult | null = await processScan();
+
+      expect(result).toMatchObject({
+        monitorsCreated: 0,
+        monitorsFailed: 1,
+      });
+      expect(monitorCreateMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a missing template consistently instead of promising it in a dry run", async () => {
+      ruleFindOneByMock.mockResolvedValue(
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      );
+      ruleFindByMock.mockResolvedValue([]);
+      monitorTemplateFindByMock.mockResolvedValue([]);
+      mockRunNowScans([makeScan({ discoveredDevices: [makeHost()] })]);
+
+      const result: AutoImportRuleRunResult = await runRule(true);
+
+      expect(result).toMatchObject({
+        monitorsWouldCreate: 0,
+        monitorsFailed: 1,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("caps missing-template failures across a large existing estate", async () => {
+      const hosts: Array<DiscoveredNetworkDevice> = Array.from(
+        { length: MAX_MONITORS_PER_AUTO_IMPORT_RUN + 1 },
+        (_value: unknown, index: number): DiscoveredNetworkDevice => {
+          return makeHost({
+            ipAddress: `10.2.${Math.floor(index / 256)}.${index % 256}`,
+            sysName: `missing-template-switch-${index}`,
+          });
+        },
+      );
+      const devices: Array<NetworkDevice> = hosts.map(
+        (host: DiscoveredNetworkDevice): NetworkDevice => {
+          return makeExistingDevice({
+            id: ObjectID.generate(),
+            hostname: host.ipAddress,
+            name: host.sysName,
+          });
+        },
+      );
+
+      ruleFindOneByMock.mockResolvedValue(
+        makeRule({
+          ipMatchTarget: "10.0.0.0/8",
+          monitorTemplateId: TEMPLATE_ID,
+        }),
+      );
+      ruleFindByMock.mockResolvedValue([]);
+      deviceFindByMock.mockResolvedValue(devices);
+      monitorTemplateFindByMock.mockResolvedValue([]);
+      mockRunNowScans([makeScan({ discoveredDevices: hosts })]);
+
+      const result: AutoImportRuleRunResult = await runRule(true);
+
+      expect(result).toMatchObject({
+        monitorsWouldCreate: 0,
+        monitorsFailed: MAX_MONITORS_PER_AUTO_IMPORT_RUN,
+        isTruncated: true,
+        isDryRun: true,
+      });
+      expect(monitorCreateMock).not.toHaveBeenCalled();
+    });
   });
 
   /*
@@ -527,6 +1139,7 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
       const result: AutoImportRuleRunResult | null = await processScan();
 
       expect(createMock).toHaveBeenCalledTimes(1);
+      expect(deviceFindOneByMock.mock.calls[0]![0].select.projectId).toBe(true);
       expect(result).toMatchObject({
         hostsMatched: 1,
         hostsSkippedAlreadyRegistered: 1,
@@ -566,6 +1179,126 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
     expect(Object.keys(updateCall.data)).not.toContain("autoImportProcessedAt");
   });
 
+  it("does not stamp a later scan when an earlier scan exactly exhausted the shared project budget", async () => {
+    scanFindOneByMock.mockResolvedValue(
+      makeScan({ discoveredDevices: [makeHost()] }),
+    );
+    ruleFindByMock.mockResolvedValue([
+      makeRule({ ipMatchTarget: "10.0.0.0/8" }),
+    ]);
+    const attemptBudgets: ImportAttemptBudgetsByProjectId = new Map([
+      [
+        PROJECT_ID.toString(),
+        {
+          deviceCount: MAX_DEVICES_PER_AUTO_IMPORT_RUN,
+          monitorCount: 0,
+        },
+      ],
+    ]);
+
+    const result: AutoImportRuleRunResult | null =
+      await NetworkDeviceAutoImportRuleEngineService.processCompletedScan({
+        scanId: SCAN_ID,
+        existingHostnamesByProjectId: new Map(),
+        attemptBudgetsByProjectId: attemptBudgets,
+      });
+
+    expect(result).toMatchObject({
+      devicesCreated: 0,
+      devicesFailed: 0,
+      isTruncated: true,
+    });
+    expect(createMock).not.toHaveBeenCalled();
+    // This scan contains unattempted work. The next sweep must see it again.
+    expect(scanUpdateMock).not.toHaveBeenCalled();
+    expect(
+      loggerErrorMock.mock.calls.some((call: Array<unknown>) => {
+        return String(call[0]).includes("without making progress");
+      }),
+    ).toBe(false);
+  });
+
+  it("does not run a per-device monitor JSON search after the inherited monitor budget is exhausted", async () => {
+    const existingDevice: NetworkDevice = makeExistingDevice();
+    scanFindOneByMock.mockResolvedValue(
+      makeScan({ discoveredDevices: [makeHost()] }),
+    );
+    deviceFindByMock.mockResolvedValue([existingDevice]);
+    ruleFindByMock.mockResolvedValue([
+      makeRule({ monitorTemplateId: TEMPLATE_ID }),
+    ]);
+    monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+    const attemptBudgets: ImportAttemptBudgetsByProjectId = new Map([
+      [
+        PROJECT_ID.toString(),
+        {
+          deviceCount: 0,
+          monitorCount: MAX_MONITORS_PER_AUTO_IMPORT_RUN,
+        },
+      ],
+    ]);
+
+    const result: AutoImportRuleRunResult | null =
+      await NetworkDeviceAutoImportRuleEngineService.processCompletedScan({
+        scanId: SCAN_ID,
+        existingHostnamesByProjectId: new Map(),
+        existingMonitorsByProjectId: new Map(),
+        attemptBudgetsByProjectId: attemptBudgets,
+      });
+
+    expect(result).toMatchObject({
+      monitorsCreated: 0,
+      monitorsFailed: 0,
+      isTruncated: true,
+    });
+    // One project snapshot only; no second JSON-search refresh for the host.
+    expect(monitorFindByMock).toHaveBeenCalledTimes(1);
+    expect(monitorCreateMock).not.toHaveBeenCalled();
+    expect(scanUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not retire unattempted hosts when a partial inherited budget is exhausted by failures", async () => {
+    scanFindOneByMock.mockResolvedValue(
+      makeScan({
+        discoveredDevices: [
+          makeHost(),
+          makeHost({ ipAddress: "10.0.0.6", sysName: "core-switch-02" }),
+        ],
+      }),
+    );
+    ruleFindByMock.mockResolvedValue([
+      makeRule({ ipMatchTarget: "10.0.0.0/8" }),
+    ]);
+    createMock.mockRejectedValue(new BadDataException("create is broken"));
+    deviceFindOneByMock.mockResolvedValue(null);
+    const attemptBudgets: ImportAttemptBudgetsByProjectId = new Map([
+      [
+        PROJECT_ID.toString(),
+        {
+          deviceCount: MAX_DEVICES_PER_AUTO_IMPORT_RUN - 1,
+          monitorCount: 0,
+        },
+      ],
+    ]);
+
+    const result: AutoImportRuleRunResult | null =
+      await NetworkDeviceAutoImportRuleEngineService.processCompletedScan({
+        scanId: SCAN_ID,
+        existingHostnamesByProjectId: new Map(),
+        attemptBudgetsByProjectId: attemptBudgets,
+      });
+
+    expect(result).toMatchObject({
+      hostsEvaluated: 2,
+      hostsMatched: 2,
+      devicesCreated: 0,
+      devicesFailed: 1,
+      isTruncated: true,
+    });
+    expect(createMock).toHaveBeenCalledTimes(2); // primary + fallback name
+    expect(scanUpdateMock).not.toHaveBeenCalled();
+  });
+
   /*
    * The resume protocol's other half: a truncated pass that created NOTHING
    * — every attempt failed — is stamped anyway. Leaving the marker NULL
@@ -600,7 +1333,7 @@ describe("NetworkDeviceAutoImportRuleEngineService.processCompletedScan", () => 
     // And the operator is told, loudly, why nothing imported.
     expect(
       loggerErrorMock.mock.calls.some((call: Array<unknown>) => {
-        return String(call[0]).includes("every create failing");
+        return String(call[0]).includes("without making progress");
       }),
     ).toBe(true);
   });
@@ -680,6 +1413,75 @@ describe("NetworkDeviceAutoImportRuleEngineService.applyRuleToCompletedScans", (
     expect(scanUpdateMock).not.toHaveBeenCalled();
     // And no lock: a run that writes nothing has nothing to serialize.
     expect(semaphoreLockMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-runs monitor reconciliation without creating a device or monitor", async () => {
+    ruleFindOneByMock.mockResolvedValue(
+      makeRule({ monitorTemplateId: TEMPLATE_ID }),
+    );
+    ruleFindByMock.mockResolvedValue([]);
+    monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+    mockRunNowScans([
+      makeScan({ discoveredDevices: [makeHost(), makeHost()] }),
+    ]);
+
+    const result: AutoImportRuleRunResult = await runRule(true);
+
+    expect(result).toMatchObject({
+      hostsMatched: 2,
+      hostsSkippedAlreadyRegistered: 1,
+      devicesCreated: 0,
+      monitorsWouldCreate: 1,
+      monitorsCreated: 0,
+      monitorsSkippedAlreadyExisting: 1,
+      monitorsFailed: 0,
+      isDryRun: true,
+    });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(monitorCreateMock).not.toHaveBeenCalled();
+    expect(scanUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("caps monitor backfill work even when every matching device already exists", async () => {
+    const hosts: Array<DiscoveredNetworkDevice> = Array.from(
+      { length: MAX_MONITORS_PER_AUTO_IMPORT_RUN + 1 },
+      (_value: unknown, index: number): DiscoveredNetworkDevice => {
+        return makeHost({
+          ipAddress: `10.1.${Math.floor(index / 256)}.${index % 256}`,
+          sysName: `existing-switch-${index}`,
+        });
+      },
+    );
+    const devices: Array<NetworkDevice> = hosts.map(
+      (host: DiscoveredNetworkDevice): NetworkDevice => {
+        return makeExistingDevice({
+          id: ObjectID.generate(),
+          hostname: host.ipAddress,
+          name: host.sysName,
+        });
+      },
+    );
+
+    ruleFindOneByMock.mockResolvedValue(
+      makeRule({
+        ipMatchTarget: "10.0.0.0/8",
+        monitorTemplateId: TEMPLATE_ID,
+      }),
+    );
+    ruleFindByMock.mockResolvedValue([]);
+    deviceFindByMock.mockResolvedValue(devices);
+    monitorTemplateFindByMock.mockResolvedValue([makeTemplate()]);
+    mockRunNowScans([makeScan({ discoveredDevices: hosts })]);
+
+    const result: AutoImportRuleRunResult = await runRule(true);
+
+    expect(result).toMatchObject({
+      devicesCreated: 0,
+      monitorsWouldCreate: MAX_MONITORS_PER_AUTO_IMPORT_RUN,
+      isTruncated: true,
+      isDryRun: true,
+    });
+    expect(monitorCreateMock).not.toHaveBeenCalled();
   });
 
   /*
@@ -928,6 +1730,24 @@ describe("NetworkDeviceAutoImportRuleEngineService.applyRuleToCompletedScans", (
       await expect(runRule(false)).rejects.toThrow(
         "Auto-import rule not found.",
       );
+    });
+
+    it("rejects a rule whose template changed after the caller authorized it", async () => {
+      ruleFindOneByMock.mockResolvedValue(
+        makeRule({ monitorTemplateId: TEMPLATE_ID }),
+      );
+
+      await expect(
+        NetworkDeviceAutoImportRuleEngineService.applyRuleToCompletedScans({
+          ruleId: RULE_ID,
+          projectId: PROJECT_ID,
+          isDryRun: true,
+          expectedMonitorTemplateId: null,
+        }),
+      ).rejects.toThrow("changed while the run was being authorized");
+
+      expect(scanFindByMock).not.toHaveBeenCalled();
+      expect(monitorCreateMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceAutoImportRuleService.test.ts
@@ -1,0 +1,817 @@
+import NetworkDeviceAutoImportRuleService from "../../../Server/Services/NetworkDeviceAutoImportRuleService";
+import MonitorTemplateService from "../../../Server/Services/MonitorTemplateService";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import NetworkDeviceAutoImportRule from "../../../Models/DatabaseModels/NetworkDeviceAutoImportRule";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+import { afterEach, describe, expect, it } from "@jest/globals";
+import { getMetadataArgsStorage } from "typeorm";
+import { IndexMetadataArgs } from "typeorm/metadata-args/IndexMetadataArgs";
+import TablePermission from "../../../Server/Types/Database/Permissions/TablePermission";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_TEMPLATE_COLUMNS: Array<string> = [
+  "monitorTemplate",
+  "monitorTemplateId",
+];
+const MONITOR_CREATE_PERMISSIONS: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.ProjectMember,
+  Permission.MonitorAdmin,
+  Permission.MonitorMember,
+  Permission.CreateProjectMonitor,
+];
+const MONITOR_TEMPLATE_READ_PERMISSIONS: Array<Permission> = [
+  Permission.ProjectOwner,
+  Permission.ProjectAdmin,
+  Permission.ProjectMember,
+  Permission.Viewer,
+  Permission.MonitorAdmin,
+  Permission.MonitorMember,
+  Permission.MonitorViewer,
+  Permission.ReadMonitorTemplate,
+];
+
+function makeCreateBy(
+  overrides: Partial<NetworkDeviceAutoImportRule> = {},
+): CreateBy<NetworkDeviceAutoImportRule> {
+  const rule: NetworkDeviceAutoImportRule = new NetworkDeviceAutoImportRule();
+  rule.projectId = PROJECT_ID;
+  rule.ipMatchTarget = "10.0.0.0/24";
+  Object.assign(rule, overrides);
+
+  return {
+    data: rule,
+    props: { isRoot: true },
+  };
+}
+
+function mockMonitorTemplate(
+  overrides: Partial<MonitorTemplate> = {},
+  hasProject: boolean = true,
+): jest.SpyInstance {
+  const monitorTemplate: MonitorTemplate = new MonitorTemplate();
+  monitorTemplate.projectId = PROJECT_ID;
+  monitorTemplate.monitorType = MonitorType.NetworkDevice;
+  const step: MonitorStep = new MonitorStep();
+  step.data!.networkDeviceMonitor = {
+    networkDeviceId: ObjectID.generate().toString(),
+    monitorInterfaces: true,
+    oids: [],
+  };
+  monitorTemplate.monitorSteps = new MonitorSteps();
+  monitorTemplate.monitorSteps.data = {
+    monitorStepsInstanceArray: [step],
+  };
+  Object.assign(monitorTemplate, overrides);
+  if (!hasProject) {
+    delete monitorTemplate.projectId;
+  }
+
+  return jest
+    .spyOn(MonitorTemplateService, "findOneById")
+    .mockResolvedValue(monitorTemplate);
+}
+
+describe("NetworkDeviceAutoImportRule monitor template column access", () => {
+  const rule: NetworkDeviceAutoImportRule = new NetworkDeviceAutoImportRule();
+
+  it.each(MONITOR_TEMPLATE_COLUMNS)(
+    "%s requires monitor-create permission to write",
+    (columnName: string) => {
+      const accessControl: ReturnType<
+        NetworkDeviceAutoImportRule["getColumnAccessControlFor"]
+      > = rule.getColumnAccessControlFor(columnName);
+
+      expect(accessControl?.create).toEqual(MONITOR_CREATE_PERMISSIONS);
+      expect(accessControl?.update).toEqual(MONITOR_CREATE_PERMISSIONS);
+      expect(accessControl?.create).not.toContain(
+        Permission.CreateNetworkDeviceAutoImportRule,
+      );
+      expect(accessControl?.update).not.toContain(
+        Permission.EditNetworkDeviceAutoImportRule,
+      );
+    },
+  );
+
+  it.each(MONITOR_TEMPLATE_COLUMNS)(
+    "%s requires monitor-template permission to read",
+    (columnName: string) => {
+      expect(rule.getColumnAccessControlFor(columnName)?.read).toEqual(
+        MONITOR_TEMPLATE_READ_PERMISSIONS,
+      );
+    },
+  );
+});
+
+describe("Monitor auto-provisioning provenance", () => {
+  it("allows only one live monitor for a device and template", () => {
+    const uniqueIndex: IndexMetadataArgs | undefined =
+      getMetadataArgsStorage().indices.find(
+        (index: IndexMetadataArgs): boolean => {
+          return (
+            index.target === Monitor &&
+            index.name === "IDX_monitor_auto_provisioned_device_template_unique"
+          );
+        },
+      );
+
+    expect(uniqueIndex?.columns).toEqual([
+      "autoProvisionedNetworkDeviceId",
+      "monitorTemplateId",
+    ]);
+    expect(uniqueIndex?.unique).toBe(true);
+    expect(uniqueIndex?.where).toBe(
+      '"deletedAt" IS NULL AND "autoProvisionedNetworkDeviceId" IS NOT NULL AND "monitorTemplateId" IS NOT NULL',
+    );
+  });
+});
+
+describe("NetworkDeviceAutoImportRuleService.onBeforeCreate monitor template validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not look up a template when no template is selected", async () => {
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy(),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts a Network Device template from the same project", async () => {
+    const findTemplateSpy: jest.SpyInstance = mockMonitorTemplate();
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: TEMPLATE_ID }),
+    );
+  });
+
+  it("uses the request tenant before DatabaseService injects projectId", async () => {
+    mockMonitorTemplate();
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    delete createBy.data.projectId;
+    createBy.props.tenantId = PROJECT_ID;
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy),
+    ).resolves.toBeDefined();
+  });
+
+  it("validates the dashboard's monitorTemplate relation payload", async () => {
+    const findTemplateSpy: jest.SpyInstance = mockMonitorTemplate();
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy();
+    (createBy.data as any).monitorTemplate = {
+      _id: TEMPLATE_ID.toString(),
+    };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(ObjectID) }),
+    );
+  });
+
+  it("rejects conflicting scalar and relation template IDs on create", async () => {
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    (createBy.data as any).monitorTemplate = { _id: OTHER_PROJECT_ID };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy),
+    ).rejects.toThrow("Conflicting Monitor Template references");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a monitor template that does not exist", async () => {
+    jest.spyOn(MonitorTemplateService, "findOneById").mockResolvedValue(null);
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).rejects.toThrow("Monitor template not found.");
+  });
+
+  it("rejects a monitor template from another project", async () => {
+    mockMonitorTemplate({ projectId: OTHER_PROJECT_ID });
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).rejects.toThrow("Monitor template must belong to the same project.");
+  });
+
+  it("rejects a monitor template without a project", async () => {
+    mockMonitorTemplate({}, false);
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a template for any other monitor type", async () => {
+    mockMonitorTemplate({ monitorType: MonitorType.Ping });
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).rejects.toThrow(
+      "Monitor template must be a Network Device monitor template.",
+    );
+  });
+
+  it("rejects a Network Device template without usable monitor steps", async () => {
+    mockMonitorTemplate({ monitorSteps: null as never });
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).rejects.toThrow("Monitor template monitor steps are required.");
+  });
+
+  it("checks both Monitor create allow and block permissions for a template-backed rule", async () => {
+    mockMonitorTemplate();
+    const allowSpy: jest.SpyInstance = jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    const blockSpy: jest.SpyInstance = jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    createBy.props = { tenantId: PROJECT_ID };
+
+    await (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy);
+
+    expect(allowSpy).toHaveBeenCalledWith(Monitor, createBy.props, "create");
+    expect(blockSpy).toHaveBeenCalledWith(Monitor, createBy.props, "create");
+  });
+
+  it("reads the selected template with the caller's tenant and label scope", async () => {
+    const findTemplateSpy: jest.SpyInstance = mockMonitorTemplate();
+    jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    createBy.props = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+
+    await (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy);
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: TEMPLATE_ID,
+        props: createBy.props,
+      }),
+    );
+  });
+
+  it("refuses a template the caller's read scope hides", async () => {
+    const readDenied: NotAuthorizedException = new NotAuthorizedException(
+      "Monitor template is outside your label scope",
+    );
+    const findTemplateSpy: jest.SpyInstance = jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockRejectedValue(readDenied);
+    jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    createBy.props = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy),
+    ).rejects.toBe(readDenied);
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ props: createBy.props }),
+    );
+  });
+
+  it("refuses a template-backed rule when Monitor creation is explicitly blocked", async () => {
+    const findTemplateSpy: jest.SpyInstance = mockMonitorTemplate();
+    jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        throw new NotAuthorizedException("Monitor create is blocked");
+      });
+    const createBy: CreateBy<NetworkDeviceAutoImportRule> = makeCreateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    createBy.props = { tenantId: PROJECT_ID };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(createBy),
+    ).rejects.toThrow("Monitor create is blocked");
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects selecting a template on an exclusion rule without a lookup", async () => {
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({
+          monitorTemplateId: TEMPLATE_ID,
+          isExclusion: true,
+        }),
+      ),
+    ).rejects.toThrow("Exclusion rules cannot select a monitor template.");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects selecting a template when ping-only hosts are included without a lookup", async () => {
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({
+          monitorTemplateId: TEMPLATE_ID,
+          includePingOnlyHosts: true,
+        }),
+      ),
+    ).rejects.toThrow(
+      "Rules that include ping-only hosts cannot select a Network Device monitor template.",
+    );
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows exclusion and ping-only rules when no template is selected", async () => {
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeCreate(
+        makeCreateBy({ isExclusion: true, includePingOnlyHosts: true }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("NetworkDeviceAutoImportRuleService.onBeforeUpdate monitor template validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function makeUpdateBy(
+    data: Record<string, unknown>,
+  ): UpdateBy<NetworkDeviceAutoImportRule> {
+    return {
+      query: { _id: "some-rule-id" },
+      data: data,
+      props: { isRoot: true },
+    } as unknown as UpdateBy<NetworkDeviceAutoImportRule>;
+  }
+
+  function mockExistingRule(
+    overrides: Partial<NetworkDeviceAutoImportRule> = {},
+  ): jest.SpyInstance {
+    const rule: NetworkDeviceAutoImportRule = new NetworkDeviceAutoImportRule();
+    rule.projectId = PROJECT_ID;
+    rule.ipMatchTarget = "10.0.0.0/24";
+    rule.isExclusion = false;
+    rule.includePingOnlyHosts = false;
+    Object.assign(rule, overrides);
+
+    return jest
+      .spyOn(NetworkDeviceAutoImportRuleService, "findBy")
+      .mockResolvedValue([rule]);
+  }
+
+  it("avoids both row and template lookups for an unrelated update", async () => {
+    const findRulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceAutoImportRuleService,
+      "findBy",
+    );
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ name: "Updated name" }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findRulesSpy).not.toHaveBeenCalled();
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("tenant-scopes the privileged update snapshot before validating a guessed rule ID", async () => {
+    const findRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceAutoImportRuleService, "findBy")
+      .mockResolvedValue([]);
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+    const updateBy: UpdateBy<NetworkDeviceAutoImportRule> = makeUpdateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    updateBy.props = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(updateBy),
+    ).resolves.toBeDefined();
+
+    expect(findRulesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          _id: "some-rule-id",
+          projectId: PROJECT_ID,
+        },
+        props: { isRoot: true },
+      }),
+    );
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps criteria-only updates independent of template lookup", async () => {
+    mockExistingRule();
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ ipMatchTarget: "192.168.0.0/16" }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rechecks Monitor create permission before broadening an enabled template-backed rule", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID, isEnabled: true });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+    jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        throw new NotAuthorizedException("Monitor create is blocked");
+      });
+    const updateBy: UpdateBy<NetworkDeviceAutoImportRule> = makeUpdateBy({
+      ipMatchTarget: "0.0.0.0/0",
+    });
+    updateBy.props = { tenantId: PROJECT_ID };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(updateBy),
+    ).rejects.toThrow("Monitor create is blocked");
+
+    // Authorization happens before the root template lookup.
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rechecks template read scope before broadening an enabled template-backed rule", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID, isEnabled: true });
+    jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    const readDenied: NotAuthorizedException = new NotAuthorizedException(
+      "Monitor template is outside your label scope",
+    );
+    const findTemplateSpy: jest.SpyInstance = jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockRejectedValue(readDenied);
+    const updateBy: UpdateBy<NetworkDeviceAutoImportRule> = makeUpdateBy({
+      ipMatchTarget: "0.0.0.0/0",
+    });
+    updateBy.props = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(updateBy),
+    ).rejects.toBe(readDenied);
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ props: updateBy.props }),
+    );
+  });
+
+  it("allows criteria edits on a disabled template-backed rule until it is enabled", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID, isEnabled: false });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+    const allowSpy: jest.SpyInstance = jest.spyOn(
+      TablePermission,
+      "checkTableLevelPermissions",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ ipMatchTarget: "0.0.0.0/0" }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(allowSpy).not.toHaveBeenCalled();
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts selecting a valid template by ID", async () => {
+    mockExistingRule();
+    mockMonitorTemplate();
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("uses the update request tenant as the authoritative project", async () => {
+    mockExistingRule({ projectId: OTHER_PROJECT_ID });
+    mockMonitorTemplate();
+    const updateBy: UpdateBy<NetworkDeviceAutoImportRule> = makeUpdateBy({
+      monitorTemplateId: TEMPLATE_ID,
+    });
+    updateBy.props.tenantId = PROJECT_ID;
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(updateBy),
+    ).resolves.toBeDefined();
+  });
+
+  it("accepts selecting a valid template by relation", async () => {
+    mockExistingRule();
+    const findTemplateSpy: jest.SpyInstance = mockMonitorTemplate();
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({
+          monitorTemplate: { _id: TEMPLATE_ID.toString() },
+        }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).toHaveBeenCalled();
+  });
+
+  it("rejects conflicting scalar and relation template IDs on update", async () => {
+    mockExistingRule();
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({
+          monitorTemplateId: TEMPLATE_ID,
+          monitorTemplate: { _id: OTHER_PROJECT_ID },
+        }),
+      ),
+    ).rejects.toThrow("Conflicting Monitor Template references");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit relation clear that conflicts with a scalar template ID", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({
+          monitorTemplateId: TEMPLATE_ID,
+          monitorTemplate: null,
+        }),
+      ),
+    ).rejects.toThrow("Conflicting Monitor Template references");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects turning a template-backed rule into an exclusion rule", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ isExclusion: true }),
+      ),
+    ).rejects.toThrow("Exclusion rules cannot select a monitor template.");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects enabling ping-only hosts on a template-backed rule", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ includePingOnlyHosts: true }),
+      ),
+    ).rejects.toThrow(BadDataException);
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects selecting a template on an existing exclusion rule", async () => {
+    mockExistingRule({ isExclusion: true });
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ monitorTemplateId: TEMPLATE_ID }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("allows clearing a template while enabling exclusion", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ monitorTemplateId: null, isExclusion: true }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("validates a stored template when a compatible flag is updated", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID });
+    const findTemplateSpy: jest.SpyInstance = mockMonitorTemplate();
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ isExclusion: false }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findTemplateSpy).toHaveBeenCalled();
+  });
+
+  it("rechecks Monitor create permission when a stored template-backed rule is enabled", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID, isEnabled: false });
+    mockMonitorTemplate();
+    const allowSpy: jest.SpyInstance = jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelBlockPermissions")
+      .mockImplementation(() => {
+        return undefined;
+      });
+    const updateBy: UpdateBy<NetworkDeviceAutoImportRule> = makeUpdateBy({
+      isEnabled: true,
+    });
+    updateBy.props = { tenantId: PROJECT_ID };
+
+    await (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(updateBy);
+
+    expect(allowSpy).toHaveBeenCalled();
+  });
+
+  it("allows a user to disable a template-backed rule without Monitor create permission", async () => {
+    mockExistingRule({ monitorTemplateId: TEMPLATE_ID, isEnabled: true });
+    const findTemplateSpy: jest.SpyInstance = jest.spyOn(
+      MonitorTemplateService,
+      "findOneById",
+    );
+    const allowSpy: jest.SpyInstance = jest.spyOn(
+      TablePermission,
+      "checkTableLevelPermissions",
+    );
+
+    await expect(
+      (NetworkDeviceAutoImportRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ isEnabled: false }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(allowSpy).not.toHaveBeenCalled();
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/NetworkDeviceAutoMonitorLifecycle.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceAutoMonitorLifecycle.test.ts
@@ -1,0 +1,528 @@
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorTemplateService from "../../../Server/Services/MonitorTemplateService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import Query from "../../../Server/Types/Database/Query";
+import MonitorStepsProjectValidator from "../../../Server/Utils/Monitor/MonitorStepsProjectValidator";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { SpyInstance } from "jest-mock";
+import { getMetadataArgsStorage } from "typeorm";
+import { RelationMetadataArgs } from "typeorm/metadata-args/RelationMetadataArgs";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const DEVICE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_DEVICE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OTHER_TEMPLATE_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+function stepsFor(deviceId: ObjectID): MonitorSteps {
+  const step: MonitorStep = new MonitorStep();
+  step.data!.networkDeviceMonitor = {
+    networkDeviceId: deviceId.toString(),
+    monitorInterfaces: false,
+    oids: [],
+  };
+  const steps: MonitorSteps = new MonitorSteps();
+  steps.data = { monitorStepsInstanceArray: [step] };
+  return steps;
+}
+
+function automaticMonitor(): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor.id = ObjectID.generate();
+  monitor.projectId = PROJECT_ID;
+  monitor.monitorType = MonitorType.NetworkDevice;
+  monitor.monitorTemplateId = TEMPLATE_ID;
+  monitor.autoProvisionedNetworkDeviceId = DEVICE_ID;
+  monitor.monitorSteps = stepsFor(DEVICE_ID);
+  return monitor;
+}
+
+async function allowDeleteQuery<TBaseModel extends BaseModel>(
+  _model: { new (): TBaseModel },
+  query: Query<TBaseModel>,
+  _props: DatabaseCommonInteractionProps,
+): Promise<Query<TBaseModel>> {
+  return query;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("auto-provisioned Monitor lifecycle", () => {
+  it("refuses a direct create that links a template hidden by the caller's read scope", async () => {
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+    const readDenied: NotAuthorizedException = new NotAuthorizedException(
+      "Monitor template is outside your label scope",
+    );
+    const findTemplateSpy: SpyInstance<
+      typeof MonitorTemplateService.findOneById
+    > = jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockRejectedValue(readDenied);
+    const monitor: Monitor = new Monitor();
+    monitor.monitorType = MonitorType.NetworkDevice;
+    monitor.monitorTemplateId = TEMPLATE_ID;
+
+    await expect(
+      (MonitorService as any).onBeforeCreate({
+        data: monitor,
+        props,
+      }),
+    ).rejects.toBe(readDenied);
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ props }),
+    );
+  });
+
+  it("rejects conflicting scalar and relation template IDs on direct create", async () => {
+    const findTemplateSpy: SpyInstance<
+      typeof MonitorTemplateService.findOneById
+    > = jest.spyOn(MonitorTemplateService, "findOneById");
+    const monitor: Monitor = new Monitor();
+    monitor.monitorType = MonitorType.NetworkDevice;
+    monitor.monitorTemplateId = TEMPLATE_ID;
+    monitor.monitorTemplate = new MonitorTemplate();
+    monitor.monitorTemplate.id = OTHER_TEMPLATE_ID;
+
+    await expect(
+      (MonitorService as any).onBeforeCreate({
+        data: monitor,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("Conflicting Monitor Template references");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects retargeting while provenance still points at the original device", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([automaticMonitor()]);
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: { monitorSteps: stepsFor(OTHER_DEVICE_ID) },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("cannot be retargeted");
+  });
+
+  it("allows criteria edits that retain the provisioned device binding", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([automaticMonitor()]);
+    jest
+      .spyOn(
+        MonitorStepsProjectValidator,
+        "validateMonitorStepsBelongToProject",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: { monitorSteps: stepsFor(DEVICE_ID) },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects clearing the steps of an automatic monitor", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([automaticMonitor()]);
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: { monitorSteps: null },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("monitor steps are required");
+  });
+
+  it("rejects relinking or unlinking an automatic monitor's template", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([automaticMonitor()]);
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: { monitorTemplateId: OTHER_TEMPLATE_ID },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("cannot be relinked or unlinked");
+  });
+
+  it("validates project and type when a regular monitor is linked directly through CRUD", async () => {
+    const monitor: Monitor = new Monitor();
+    monitor.projectId = PROJECT_ID;
+    monitor.monitorType = MonitorType.NetworkDevice;
+    jest.spyOn(MonitorService, "findBy").mockResolvedValue([monitor]);
+    const template: MonitorTemplate = new MonitorTemplate();
+    template.projectId = ObjectID.generate();
+    template.monitorType = MonitorType.NetworkDevice;
+    jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockResolvedValue(template);
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: { monitorTemplateId: TEMPLATE_ID },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("same project as the monitor");
+  });
+
+  it("refuses a direct update that links a template hidden by the caller's read scope", async () => {
+    const monitor: Monitor = new Monitor();
+    monitor.projectId = PROJECT_ID;
+    monitor.monitorType = MonitorType.NetworkDevice;
+    jest.spyOn(MonitorService, "findBy").mockResolvedValue([monitor]);
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+    const readDenied: NotAuthorizedException = new NotAuthorizedException(
+      "Monitor template is outside your label scope",
+    );
+    const findTemplateSpy: SpyInstance<
+      typeof MonitorTemplateService.findOneById
+    > = jest
+      .spyOn(MonitorTemplateService, "findOneById")
+      .mockRejectedValue(readDenied);
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: { monitorTemplateId: TEMPLATE_ID },
+        limit: 1,
+        skip: 0,
+        props,
+      }),
+    ).rejects.toBe(readDenied);
+
+    expect(findTemplateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ props }),
+    );
+  });
+
+  it("rejects conflicting scalar and relation template IDs on direct update", async () => {
+    const monitor: Monitor = new Monitor();
+    monitor.projectId = PROJECT_ID;
+    monitor.monitorType = MonitorType.NetworkDevice;
+    jest.spyOn(MonitorService, "findBy").mockResolvedValue([monitor]);
+    const findTemplateSpy: SpyInstance<
+      typeof MonitorTemplateService.findOneById
+    > = jest.spyOn(MonitorTemplateService, "findOneById");
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: {
+          monitorTemplateId: TEMPLATE_ID,
+          monitorTemplate: { _id: OTHER_TEMPLATE_ID },
+        },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("Conflicting Monitor Template references");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit relation clear paired with an automatic monitor's stored template ID", async () => {
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([automaticMonitor()]);
+    const findTemplateSpy: SpyInstance<
+      typeof MonitorTemplateService.findOneById
+    > = jest.spyOn(MonitorTemplateService, "findOneById");
+
+    await expect(
+      (MonitorService as any).onBeforeUpdate({
+        query: { _id: ObjectID.generate() },
+        data: {
+          monitorTemplateId: TEMPLATE_ID,
+          monitorTemplate: null,
+        },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true, tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("Conflicting Monitor Template references");
+
+    expect(findTemplateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Network Device deletion with automatic monitors", () => {
+  it("fails closed at the foreign key when a monitor appears after service preflight", () => {
+    const provenanceRelation: RelationMetadataArgs | undefined =
+      getMetadataArgsStorage().relations.find(
+        (relation: RelationMetadataArgs): boolean => {
+          return (
+            relation.target === Monitor &&
+            relation.propertyName === "autoProvisionedNetworkDevice"
+          );
+        },
+      );
+
+    expect(provenanceRelation?.options.onDelete).toBe("RESTRICT");
+  });
+
+  function device(): NetworkDevice {
+    const networkDevice: NetworkDevice = new NetworkDevice();
+    networkDevice.id = DEVICE_ID;
+    networkDevice.projectId = PROJECT_ID;
+    return networkDevice;
+  }
+
+  function otherDevice(): NetworkDevice {
+    const networkDevice: NetworkDevice = new NetworkDevice();
+    networkDevice.id = OTHER_DEVICE_ID;
+    networkDevice.projectId = PROJECT_ID;
+    return networkDevice;
+  }
+
+  it("deletes the automatic monitor through MonitorService with tenant and caller context", async () => {
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: PROJECT_ID,
+      userId: ObjectID.generate(),
+    };
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([device()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(0));
+    const deleteMonitorSpy: SpyInstance<typeof MonitorService.deleteBy> = jest
+      .spyOn(MonitorService, "deleteBy")
+      .mockResolvedValue(1);
+
+    await (NetworkDeviceService as any).onBeforeDelete({
+      query: { _id: DEVICE_ID },
+      limit: 1,
+      skip: 0,
+      props: props,
+    });
+
+    expect(deleteMonitorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          projectId: PROJECT_ID,
+          autoProvisionedNetworkDeviceId: DEVICE_ID,
+        },
+        props: expect.objectContaining({
+          tenantId: PROJECT_ID,
+          userId: props.userId,
+        }),
+      }),
+    );
+  });
+
+  it("does not require Monitor delete permission when the device has no automatic monitor", async () => {
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([device()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0));
+    const deleteMonitorSpy: SpyInstance<typeof MonitorService.deleteBy> =
+      jest.spyOn(MonitorService, "deleteBy");
+
+    await (NetworkDeviceService as any).onBeforeDelete({
+      query: { _id: DEVICE_ID },
+      limit: 1,
+      skip: 0,
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(deleteMonitorSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the device when Monitor deletion is not authorized", async () => {
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([device()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(1));
+    jest
+      .spyOn(MonitorService, "deleteBy")
+      .mockRejectedValue(
+        new NotAuthorizedException("Monitor delete is blocked"),
+      );
+
+    await expect(
+      (NetworkDeviceService as any).onBeforeDelete({
+        query: { _id: DEVICE_ID },
+        limit: 1,
+        skip: 0,
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("Monitor delete is blocked");
+  });
+
+  it("fails before deleting anything when permission scope excludes an automatic monitor", async () => {
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([device()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(2))
+      .mockResolvedValueOnce(new PositiveNumber(1));
+    const deleteMonitorSpy: SpyInstance<typeof MonitorService.deleteBy> =
+      jest.spyOn(MonitorService, "deleteBy");
+
+    await expect(
+      (NetworkDeviceService as any).onBeforeDelete({
+        query: { _id: DEVICE_ID },
+        limit: 1,
+        skip: 0,
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("permission to delete every auto-provisioned monitor");
+
+    expect(deleteMonitorSpy).not.toHaveBeenCalled();
+  });
+
+  it("preflights every device in a bulk delete before deleting any monitor", async () => {
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockResolvedValue([device(), otherDevice()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(0));
+    const deleteMonitorSpy: SpyInstance<typeof MonitorService.deleteBy> =
+      jest.spyOn(MonitorService, "deleteBy");
+
+    await expect(
+      (NetworkDeviceService as any).onBeforeDelete({
+        query: { projectId: PROJECT_ID },
+        limit: 2,
+        skip: 0,
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("permission to delete every auto-provisioned monitor");
+
+    expect(deleteMonitorSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes automatic monitors in repeated bounded batches", async () => {
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([device()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(LIMIT_MAX + 1))
+      .mockResolvedValueOnce(new PositiveNumber(LIMIT_MAX + 1))
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(0));
+    const deleteMonitorSpy: SpyInstance<typeof MonitorService.deleteBy> = jest
+      .spyOn(MonitorService, "deleteBy")
+      .mockResolvedValueOnce(LIMIT_MAX)
+      .mockResolvedValueOnce(1);
+
+    await (NetworkDeviceService as any).onBeforeDelete({
+      query: { _id: DEVICE_ID },
+      limit: 1,
+      skip: 0,
+      props: { tenantId: PROJECT_ID },
+    });
+
+    expect(deleteMonitorSpy).toHaveBeenCalledTimes(2);
+    expect(deleteMonitorSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ limit: LIMIT_MAX, skip: 0 }),
+    );
+    expect(deleteMonitorSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ limit: LIMIT_MAX, skip: 0 }),
+    );
+  });
+
+  it("fails closed when a permission-scoped batch makes no progress", async () => {
+    jest
+      .spyOn(ModelPermission, "checkDeleteQueryPermission")
+      .mockImplementation(allowDeleteQuery);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([device()]);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(1))
+      .mockResolvedValueOnce(new PositiveNumber(1));
+    jest.spyOn(MonitorService, "deleteBy").mockResolvedValue(0);
+
+    await expect(
+      (NetworkDeviceService as any).onBeforeDelete({
+        query: { _id: DEVICE_ID },
+        limit: 1,
+        skip: 0,
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow("Could not delete every auto-provisioned monitor");
+  });
+});

--- a/Common/Tests/Types/NetworkAutomation/RuleRunResult.test.ts
+++ b/Common/Tests/Types/NetworkAutomation/RuleRunResult.test.ts
@@ -1,4 +1,5 @@
 import {
+  AutoImportRuleRunResult,
   LabelRuleRunResult,
   RuleRunResultUtil,
   SiteAssignmentRuleRunResult,
@@ -180,5 +181,106 @@ describe("RuleRunResultUtil.parseLabelRuleRunResult", () => {
 
     expect(parsed.labelsAttached).toBe(0);
     expect(parsed.devicesLabeled).toBe(0);
+  });
+});
+
+describe("RuleRunResultUtil.parseAutoImportRuleRunResult", () => {
+  it("reads the device and active-monitor outcome independently", () => {
+    const parsed: AutoImportRuleRunResult =
+      RuleRunResultUtil.parseAutoImportRuleRunResult({
+        hostsEvaluated: 20,
+        hostsMatched: 10,
+        hostsExcluded: 2,
+        hostsSkippedAlreadyRegistered: 3,
+        devicesCreated: 4,
+        devicesFailed: 1,
+        monitorsWouldCreate: 0,
+        monitorsCreated: 3,
+        monitorsSkippedAlreadyExisting: 2,
+        monitorsSkippedUnsupportedHost: 1,
+        monitorsFailed: 1,
+        isTruncated: true,
+        hasMoreScans: true,
+        isDryRun: false,
+        matchedIpAddressSample: ["10.0.0.1", "10.0.0.2"],
+      } as JSONObject);
+
+    expect(parsed).toEqual({
+      hostsEvaluated: 20,
+      hostsMatched: 10,
+      hostsExcluded: 2,
+      hostsSkippedAlreadyRegistered: 3,
+      devicesCreated: 4,
+      devicesFailed: 1,
+      monitorsWouldCreate: 0,
+      monitorsCreated: 3,
+      monitorsSkippedAlreadyExisting: 2,
+      monitorsSkippedUnsupportedHost: 1,
+      monitorsFailed: 1,
+      isTruncated: true,
+      hasMoreScans: true,
+      isDryRun: false,
+      matchedIpAddressSample: ["10.0.0.1", "10.0.0.2"],
+    });
+  });
+
+  it("reads every missing monitor counter as zero for older servers", () => {
+    const parsed: AutoImportRuleRunResult =
+      RuleRunResultUtil.parseAutoImportRuleRunResult({
+        hostsEvaluated: 1,
+      });
+
+    expect(parsed.monitorsWouldCreate).toBe(0);
+    expect(parsed.monitorsCreated).toBe(0);
+    expect(parsed.monitorsSkippedAlreadyExisting).toBe(0);
+    expect(parsed.monitorsSkippedUnsupportedHost).toBe(0);
+    expect(parsed.monitorsFailed).toBe(0);
+  });
+
+  it("refuses malformed and non-finite monitor counters", () => {
+    const parsed: AutoImportRuleRunResult =
+      RuleRunResultUtil.parseAutoImportRuleRunResult({
+        monitorsWouldCreate: "4",
+        monitorsCreated: Number.NaN,
+        monitorsSkippedAlreadyExisting: null,
+        monitorsSkippedUnsupportedHost: {},
+        monitorsFailed: Number.POSITIVE_INFINITY,
+      } as unknown as JSONObject);
+
+    expect(parsed.monitorsWouldCreate).toBe(0);
+    expect(parsed.monitorsCreated).toBe(0);
+    expect(parsed.monitorsSkippedAlreadyExisting).toBe(0);
+    expect(parsed.monitorsSkippedUnsupportedHost).toBe(0);
+    expect(parsed.monitorsFailed).toBe(0);
+  });
+
+  it("keeps only a bounded sample of string IP addresses", () => {
+    const sample: Array<unknown> = Array.from(
+      { length: 60 },
+      (_value: unknown, index: number): unknown => {
+        return index === 1 ? 42 : `10.0.0.${index}`;
+      },
+    );
+
+    const parsed: AutoImportRuleRunResult =
+      RuleRunResultUtil.parseAutoImportRuleRunResult({
+        matchedIpAddressSample: sample,
+      } as unknown as JSONObject);
+
+    expect(parsed.matchedIpAddressSample).toHaveLength(50);
+    expect(parsed.matchedIpAddressSample).not.toContain(42);
+  });
+
+  it("treats only literal true as dry-run and truncation flags", () => {
+    const parsed: AutoImportRuleRunResult =
+      RuleRunResultUtil.parseAutoImportRuleRunResult({
+        isDryRun: "true",
+        isTruncated: 1,
+        hasMoreScans: true,
+      } as unknown as JSONObject);
+
+    expect(parsed.isDryRun).toBe(false);
+    expect(parsed.isTruncated).toBe(false);
+    expect(parsed.hasMoreScans).toBe(true);
   });
 });

--- a/Common/Tests/Utils/Monitor/NetworkDeviceMonitorTemplateUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkDeviceMonitorTemplateUtil.test.ts
@@ -1,0 +1,626 @@
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import NetworkDeviceMonitorTemplateUtil from "../../../Utils/Monitor/NetworkDeviceMonitorTemplateUtil";
+import { describe, expect, it } from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const TEMPLATE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const DEVICE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const TEMPLATE_DEVICE_ID_ONE: string = "55555555-5555-4555-8555-555555555555";
+const TEMPLATE_DEVICE_ID_TWO: string = "66666666-6666-4666-8666-666666666666";
+const CURRENT_DEVICE_ID: string = "77777777-7777-4777-8777-777777777777";
+const FALLBACK_DEVICE_ID: ObjectID = new ObjectID(
+  "88888888-8888-4888-8888-888888888888",
+);
+const DEFAULT_MONITOR_STATUS_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+
+function buildStep(
+  networkDeviceId: string | undefined,
+  suffix: string,
+): MonitorStep {
+  const step: MonitorStep = new MonitorStep();
+  step.data!.id = `step-${suffix}`;
+  step.data!.networkDeviceMonitor = {
+    networkDeviceId,
+    monitorInterfaces: false,
+    collectEndpoints: true,
+    oids: [
+      {
+        oid: `1.3.6.1.4.1.${suffix}`,
+        name: `health-${suffix}`,
+        description: `Health OID ${suffix}`,
+      },
+    ],
+  };
+  step.data!.requestBody = `preserve-${suffix}`;
+  return step;
+}
+
+function buildSteps(
+  bindings: Array<string | undefined> = [TEMPLATE_DEVICE_ID_ONE],
+): MonitorSteps {
+  const monitorSteps: MonitorSteps = new MonitorSteps();
+  monitorSteps.data = {
+    monitorStepsInstanceArray: bindings.map(
+      (binding: string | undefined, index: number): MonitorStep => {
+        return buildStep(binding, String(index + 1));
+      },
+    ),
+    defaultMonitorStatusId: DEFAULT_MONITOR_STATUS_ID,
+  };
+  return monitorSteps;
+}
+
+function buildLabel(id: string, name: string): Label {
+  const label: Label = new Label();
+  label.id = new ObjectID(id);
+  label.name = name;
+  return label;
+}
+
+function buildTemplate(data?: {
+  withId?: boolean | undefined;
+  projectId?: ObjectID | undefined;
+  monitorType?: MonitorType | undefined;
+  monitorSteps?: MonitorSteps | undefined;
+  monitorName?: string | undefined;
+}): MonitorTemplate {
+  const template: MonitorTemplate = new MonitorTemplate();
+
+  if (data?.withId !== false) {
+    template.id = TEMPLATE_ID;
+  }
+
+  if (!data || !("projectId" in data)) {
+    template.projectId = PROJECT_ID;
+  } else if (data.projectId) {
+    template.projectId = data.projectId;
+  }
+  template.monitorType = data?.monitorType || MonitorType.NetworkDevice;
+  if (!data || !("monitorName" in data)) {
+    template.monitorName = "Standard Network Alerting";
+  } else if (data.monitorName !== undefined) {
+    template.monitorName = data.monitorName;
+  }
+  template.monitorDescription =
+    "Alert on reachability, interfaces, and health OIDs.";
+  if (!data || !("monitorSteps" in data)) {
+    template.monitorSteps = buildSteps([
+      TEMPLATE_DEVICE_ID_ONE,
+      TEMPLATE_DEVICE_ID_TWO,
+    ]);
+  } else if (data.monitorSteps) {
+    template.monitorSteps = data.monitorSteps;
+  }
+  template.monitoringInterval = "*/5 * * * *";
+  template.minimumProbeAgreement = 2;
+  template.customFields = {
+    environment: "production",
+    nested: {
+      enabled: true,
+      thresholds: [70, 90],
+    },
+  };
+  template.labels = [
+    buildLabel("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "network"),
+    buildLabel("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", "production"),
+  ];
+
+  return template;
+}
+
+function buildDevice(data?: {
+  withId?: boolean | undefined;
+  projectId?: ObjectID | undefined;
+  name?: string | undefined;
+  hostname?: string | undefined;
+}): NetworkDevice {
+  const networkDevice: NetworkDevice = new NetworkDevice();
+
+  if (data?.withId !== false) {
+    networkDevice.id = DEVICE_ID;
+  }
+
+  if (!data || !("projectId" in data)) {
+    networkDevice.projectId = PROJECT_ID;
+  } else if (data.projectId) {
+    networkDevice.projectId = data.projectId;
+  }
+  if (!data || !("name" in data)) {
+    networkDevice.name = "London Core Switch";
+  } else if (data.name !== undefined) {
+    networkDevice.name = data.name;
+  }
+  if (!data || !("hostname" in data)) {
+    networkDevice.hostname = "10.10.0.1";
+  } else if (data.hostname !== undefined) {
+    networkDevice.hostname = data.hostname;
+  }
+  return networkDevice;
+}
+
+function getProvisionedDeviceId(monitor: Monitor): string | undefined {
+  return monitor.autoProvisionedNetworkDeviceId?.toString();
+}
+
+function expectBadData(run: () => unknown, message: string): void {
+  expect(run).toThrow(BadDataException);
+  expect(run).toThrow(message);
+}
+
+describe("NetworkDeviceMonitorTemplateUtil.buildMonitor", () => {
+  it("materializes and links every supported Monitor field", () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template,
+      networkDevice: buildDevice(),
+    });
+
+    expect(monitor.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(monitor.name).toBe("London Core Switch - Standard Network Alerting");
+    expect(monitor.description).toBe(template.monitorDescription);
+    expect(monitor.monitorType).toBe(MonitorType.NetworkDevice);
+    expect(monitor.monitoringInterval).toBe(template.monitoringInterval);
+    expect(monitor.minimumProbeAgreement).toBe(2);
+    expect(monitor.customFields).toEqual(template.customFields);
+    expect(
+      monitor.labels?.map((label: Label): string => {
+        return label.id!.toString();
+      }),
+    ).toEqual(
+      template.labels?.map((label: Label): string => {
+        return label.id!.toString();
+      }),
+    );
+    expect(monitor.monitorTemplateId?.toString()).toBe(TEMPLATE_ID.toString());
+    expect(getProvisionedDeviceId(monitor)).toBe(DEVICE_ID.toString());
+  });
+
+  it("rebinds every template step to the target device", () => {
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template: buildTemplate(),
+      networkDevice: buildDevice(),
+    });
+
+    expect(
+      monitor.monitorSteps?.data?.monitorStepsInstanceArray.map(
+        (step: MonitorStep): string | undefined => {
+          return step.data?.networkDeviceMonitor?.networkDeviceId;
+        },
+      ),
+    ).toEqual([DEVICE_ID.toString(), DEVICE_ID.toString()]);
+    expect(monitor.monitorSteps?.data?.defaultMonitorStatusId?.toString()).toBe(
+      DEFAULT_MONITOR_STATUS_ID.toString(),
+    );
+  });
+
+  it("deep-clones steps and never mutates the reusable template", () => {
+    const template: MonitorTemplate = buildTemplate();
+    const originalStepsJson: JSONObject = template.monitorSteps!.toJSON();
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template,
+      networkDevice: buildDevice(),
+    });
+
+    expect(monitor.monitorSteps).not.toBe(template.monitorSteps);
+    expect(monitor.monitorSteps?.data?.monitorStepsInstanceArray[0]).not.toBe(
+      template.monitorSteps?.data?.monitorStepsInstanceArray[0],
+    );
+    expect(template.monitorSteps!.toJSON()).toEqual(originalStepsJson);
+
+    monitor.monitorSteps!.data!.monitorStepsInstanceArray[0]!.data!.networkDeviceMonitor!.oids[0]!.name =
+      "changed on monitor";
+
+    expect(
+      template.monitorSteps?.data?.monitorStepsInstanceArray[0]?.data
+        ?.networkDeviceMonitor?.oids[0]?.name,
+    ).toBe("health-1");
+  });
+
+  it("copies custom fields deeply and labels into a distinct relation array", () => {
+    const template: MonitorTemplate = buildTemplate();
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template,
+      networkDevice: buildDevice(),
+    });
+
+    expect(monitor.customFields).not.toBe(template.customFields);
+    expect(monitor.customFields?.["nested"]).not.toBe(
+      template.customFields?.["nested"],
+    );
+    expect(monitor.labels).not.toBe(template.labels);
+
+    (monitor.customFields!["nested"] as JSONObject)["enabled"] = false;
+    monitor.labels!.pop();
+
+    expect((template.customFields!["nested"] as JSONObject)["enabled"]).toBe(
+      true,
+    );
+    expect(template.labels).toHaveLength(2);
+  });
+
+  it("preserves explicit empty labels and custom fields", () => {
+    const template: MonitorTemplate = buildTemplate();
+    template.labels = [];
+    template.customFields = {};
+
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template,
+      networkDevice: buildDevice(),
+    });
+
+    expect(monitor.labels).toEqual([]);
+    expect(monitor.customFields).toEqual({});
+    expect(monitor.labels).not.toBe(template.labels);
+    expect(monitor.customFields).not.toBe(template.customFields);
+  });
+
+  it("uses the hostname when the device name is blank", () => {
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template: buildTemplate(),
+      networkDevice: buildDevice({ name: "   ", hostname: "10.20.30.40" }),
+    });
+
+    expect(monitor.name).toBe("10.20.30.40 - Standard Network Alerting");
+  });
+
+  it("uses the device id when both friendly identity fields are blank", () => {
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template: buildTemplate({ monitorName: "   " }),
+      networkDevice: buildDevice({ name: " ", hostname: " " }),
+    });
+
+    expect(monitor.name).toBe(
+      `Network Device ${DEVICE_ID.toString()} - Monitor`,
+    );
+    expect(monitor.name?.trim()).not.toBe("");
+  });
+
+  it("caps names at ShortText without leaving half a surrogate pair", () => {
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template: buildTemplate({ monitorName: "🔥 alerting" }),
+      networkDevice: buildDevice({ name: "d".repeat(96) }),
+    });
+    const loneSurrogate: RegExp =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+    expect(monitor.name!.length).toBeLessThanOrEqual(ColumnLength.ShortText);
+    expect(monitor.name!.length).toBe(99);
+    expect(loneSurrogate.test(monitor.name!)).toBe(false);
+    expect(monitor.name!.startsWith("d".repeat(96))).toBe(true);
+  });
+
+  it("keeps a composed name exactly at the column limit", () => {
+    const deviceName: string = "d".repeat(80);
+    const templateName: string = "t".repeat(17);
+    const monitor: Monitor = NetworkDeviceMonitorTemplateUtil.buildMonitor({
+      template: buildTemplate({ monitorName: templateName }),
+      networkDevice: buildDevice({ name: deviceName }),
+    });
+
+    expect(monitor.name).toBe(`${deviceName} - ${templateName}`);
+    expect(monitor.name).toHaveLength(ColumnLength.ShortText);
+  });
+
+  it("rejects a template without an id", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate({ withId: false }),
+        networkDevice: buildDevice(),
+      });
+    }, "Monitor template ID is required");
+  });
+
+  it("rejects a Network Device without an id", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate(),
+        networkDevice: buildDevice({ withId: false }),
+      });
+    }, "Network Device ID is required");
+  });
+
+  it("rejects a template without a project id", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate({ projectId: undefined }),
+        networkDevice: buildDevice(),
+      });
+    }, "Monitor template project ID is required");
+  });
+
+  it("rejects a Network Device without a project id", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate(),
+        networkDevice: buildDevice({ projectId: undefined }),
+      });
+    }, "Network Device project ID is required");
+  });
+
+  it("rejects cross-project materialization", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate(),
+        networkDevice: buildDevice({ projectId: OTHER_PROJECT_ID }),
+      });
+    }, "must belong to the same project");
+  });
+
+  it("rejects templates for another Monitor type", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate({ monitorType: MonitorType.Ping }),
+        networkDevice: buildDevice(),
+      });
+    }, 'must have type "Network Device"');
+  });
+
+  it("rejects an absent MonitorSteps object", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate({ monitorSteps: undefined }),
+        networkDevice: buildDevice(),
+      });
+    }, "Monitor template monitor steps are required");
+  });
+
+  it("rejects MonitorSteps with no data", () => {
+    const steps: MonitorSteps = buildSteps();
+    steps.data = undefined;
+
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate({ monitorSteps: steps }),
+        networkDevice: buildDevice(),
+      });
+    }, "Monitor template monitor steps are required");
+  });
+
+  it("rejects an empty step list", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildMonitor({
+        template: buildTemplate({ monitorSteps: buildSteps([]) }),
+        networkDevice: buildDevice(),
+      });
+    }, "Monitor template monitor steps are required");
+  });
+
+  it.each([undefined, {}])(
+    "rejects a malformed step-list value without leaking a TypeError",
+    (stepList: unknown) => {
+      const steps: MonitorSteps = new MonitorSteps();
+      steps.data = {
+        monitorStepsInstanceArray: stepList,
+      } as never;
+
+      expectBadData(() => {
+        NetworkDeviceMonitorTemplateUtil.validateMonitorSteps(
+          steps,
+          "Monitor template",
+        );
+      }, "Monitor template monitor steps are required");
+    },
+  );
+});
+
+describe("NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps", () => {
+  it("returns an independent full clone with every step rebound", () => {
+    const source: MonitorSteps = buildSteps([
+      TEMPLATE_DEVICE_ID_ONE,
+      TEMPLATE_DEVICE_ID_TWO,
+    ]);
+    const rebound: MonitorSteps =
+      NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+        monitorSteps: source,
+        networkDeviceId: DEVICE_ID,
+      });
+
+    expect(rebound).not.toBe(source);
+    expect(rebound.data?.defaultMonitorStatusId?.toString()).toBe(
+      DEFAULT_MONITOR_STATUS_ID.toString(),
+    );
+    expect(
+      rebound.data?.monitorStepsInstanceArray.map(
+        (step: MonitorStep): string | undefined => {
+          return step.data?.networkDeviceMonitor?.networkDeviceId;
+        },
+      ),
+    ).toEqual([DEVICE_ID.toString(), DEVICE_ID.toString()]);
+    expect(rebound.data?.monitorStepsInstanceArray[1]?.data?.requestBody).toBe(
+      "preserve-2",
+    );
+    expect(
+      source.data?.monitorStepsInstanceArray.map(
+        (step: MonitorStep): string | undefined => {
+          return step.data?.networkDeviceMonitor?.networkDeviceId;
+        },
+      ),
+    ).toEqual([TEMPLATE_DEVICE_ID_ONE, TEMPLATE_DEVICE_ID_TWO]);
+  });
+
+  it("accepts a serialized target id", () => {
+    const rebound: MonitorSteps =
+      NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+        monitorSteps: buildSteps(),
+        networkDeviceId: DEVICE_ID.toString(),
+      });
+
+    expect(
+      rebound.data?.monitorStepsInstanceArray[0]?.data?.networkDeviceMonitor
+        ?.networkDeviceId,
+    ).toBe(DEVICE_ID.toString());
+  });
+
+  it("rejects a blank target id", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+        monitorSteps: buildSteps(),
+        networkDeviceId: "   ",
+      });
+    }, "Network Device ID is required");
+  });
+
+  it("rejects a missing source step object", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+        monitorSteps: undefined,
+        networkDeviceId: DEVICE_ID,
+      });
+    }, "Monitor template monitor steps are required");
+  });
+
+  it("rejects a malformed Network Device step", () => {
+    const steps: MonitorSteps = buildSteps();
+    steps.data!.monitorStepsInstanceArray[0]!.data!.networkDeviceMonitor =
+      undefined;
+
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.rebindMonitorSteps({
+        monitorSteps: steps,
+        networkDeviceId: DEVICE_ID,
+      });
+    }, "without Network Device configuration");
+  });
+});
+
+describe("NetworkDeviceMonitorTemplateUtil.assertMonitorStepsBoundToNetworkDevice", () => {
+  it("accepts multiple steps that all retain the provisioned device", () => {
+    expect(() => {
+      NetworkDeviceMonitorTemplateUtil.assertMonitorStepsBoundToNetworkDevice({
+        monitorSteps: buildSteps([DEVICE_ID.toString(), DEVICE_ID.toString()]),
+        networkDeviceId: DEVICE_ID,
+      });
+    }).not.toThrow();
+  });
+
+  it("rejects a retargeted or mixed-device step set", () => {
+    expectBadData(() => {
+      NetworkDeviceMonitorTemplateUtil.assertMonitorStepsBoundToNetworkDevice({
+        monitorSteps: buildSteps([
+          DEVICE_ID.toString(),
+          TEMPLATE_DEVICE_ID_ONE,
+        ]),
+        networkDeviceId: DEVICE_ID,
+      });
+    }, "cannot be retargeted");
+  });
+});
+
+describe("NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps", () => {
+  it("preserves one current binding across every newly-synced template step", () => {
+    const templateSteps: MonitorSteps = buildSteps([
+      TEMPLATE_DEVICE_ID_ONE,
+      TEMPLATE_DEVICE_ID_TWO,
+    ]);
+    const templateJsonBefore: JSONObject = templateSteps.toJSON();
+    const synced: MonitorSteps =
+      NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: templateSteps,
+        currentMonitorSteps: buildSteps([CURRENT_DEVICE_ID, CURRENT_DEVICE_ID]),
+      });
+
+    expect(
+      synced.data?.monitorStepsInstanceArray.map(
+        (step: MonitorStep): string | undefined => {
+          return step.data?.networkDeviceMonitor?.networkDeviceId;
+        },
+      ),
+    ).toEqual([CURRENT_DEVICE_ID, CURRENT_DEVICE_ID]);
+    expect(templateSteps.toJSON()).toEqual(templateJsonBefore);
+    expect(synced).not.toBe(templateSteps);
+  });
+
+  it("prefers the current binding over a different fallback marker", () => {
+    const synced: MonitorSteps =
+      NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: buildSteps(),
+        currentMonitorSteps: buildSteps([CURRENT_DEVICE_ID]),
+        fallbackNetworkDeviceId: FALLBACK_DEVICE_ID,
+      });
+
+    expect(
+      synced.data?.monitorStepsInstanceArray[0]?.data?.networkDeviceMonitor
+        ?.networkDeviceId,
+    ).toBe(CURRENT_DEVICE_ID);
+  });
+
+  it("uses the fallback marker when current steps are absent", () => {
+    const synced: MonitorSteps =
+      NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: buildSteps(),
+        currentMonitorSteps: undefined,
+        fallbackNetworkDeviceId: FALLBACK_DEVICE_ID,
+      });
+
+    expect(
+      synced.data?.monitorStepsInstanceArray[0]?.data?.networkDeviceMonitor
+        ?.networkDeviceId,
+    ).toBe(FALLBACK_DEVICE_ID.toString());
+  });
+
+  it("uses the fallback marker when current steps carry no binding", () => {
+    const synced: MonitorSteps =
+      NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: buildSteps(),
+        currentMonitorSteps: buildSteps([undefined]),
+        fallbackNetworkDeviceId: FALLBACK_DEVICE_ID.toString(),
+      });
+
+    expect(
+      synced.data?.monitorStepsInstanceArray[0]?.data?.networkDeviceMonitor
+        ?.networkDeviceId,
+    ).toBe(FALLBACK_DEVICE_ID.toString());
+  });
+
+  it("rejects multiple distinct current bindings instead of guessing", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: buildSteps(),
+        currentMonitorSteps: buildSteps([
+          CURRENT_DEVICE_ID,
+          DEVICE_ID.toString(),
+        ]),
+        fallbackNetworkDeviceId: FALLBACK_DEVICE_ID,
+      });
+    }, "exactly one distinct Network Device binding");
+  });
+
+  it("rejects a sync with neither a current binding nor a fallback", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: buildSteps(),
+        currentMonitorSteps: buildSteps([undefined]),
+      });
+    }, "no Network Device binding to preserve");
+  });
+
+  it("validates template steps after resolving the binding", () => {
+    expectBadData(() => {
+      return NetworkDeviceMonitorTemplateUtil.buildSyncedMonitorSteps({
+        templateMonitorSteps: undefined,
+        currentMonitorSteps: buildSteps([CURRENT_DEVICE_ID]),
+      });
+    }, "Monitor template monitor steps are required");
+  });
+});

--- a/Common/Types/NetworkAutomation/RuleRunResult.ts
+++ b/Common/Types/NetworkAutomation/RuleRunResult.ts
@@ -93,8 +93,30 @@ export interface AutoImportRuleRunResult {
   // Matched hosts whose create threw. Logged server-side, never fatal.
   devicesFailed: number;
   /*
-   * True when the run stopped at the DEVICE cap with matched hosts left
-   * over. Running again continues: already-imported hosts are skipped.
+   * Active Network Device monitors a dry run predicts it would create from
+   * the rule's selected Monitor Template. Always zero on a real run: real
+   * work is counted by monitorsCreated / monitorsFailed instead.
+   */
+  monitorsWouldCreate: number;
+  // Active Network Device monitors actually created and linked to a template.
+  monitorsCreated: number;
+  /*
+   * Matched devices left alone because a Network Device monitor already
+   * watches them. Existing manual monitors count too: automation must never
+   * add a duplicate simply because it did not create the first one.
+   */
+  monitorsSkippedAlreadyExisting: number;
+  /*
+   * Matched hosts that can become inventory records but cannot be backed by a
+   * Network Device monitor, such as a ping-only discovery result.
+   */
+  monitorsSkippedUnsupportedHost: number;
+  // Monitor creates that failed after the device was available.
+  monitorsFailed: number;
+  /*
+   * True when the run stopped at the device-create or monitor-create cap
+   * with work left over. Running again continues from idempotent inventory
+   * and provisioning keys.
    */
   isTruncated: boolean;
   /*
@@ -196,6 +218,17 @@ export class RuleRunResultUtil {
       ),
       devicesCreated: readCount(source, "devicesCreated"),
       devicesFailed: readCount(source, "devicesFailed"),
+      monitorsWouldCreate: readCount(source, "monitorsWouldCreate"),
+      monitorsCreated: readCount(source, "monitorsCreated"),
+      monitorsSkippedAlreadyExisting: readCount(
+        source,
+        "monitorsSkippedAlreadyExisting",
+      ),
+      monitorsSkippedUnsupportedHost: readCount(
+        source,
+        "monitorsSkippedUnsupportedHost",
+      ),
+      monitorsFailed: readCount(source, "monitorsFailed"),
       isTruncated: source["isTruncated"] === true,
       hasMoreScans: source["hasMoreScans"] === true,
       isDryRun: source["isDryRun"] === true,

--- a/Common/Utils/Monitor/NetworkDeviceMonitorTemplateUtil.ts
+++ b/Common/Utils/Monitor/NetworkDeviceMonitorTemplateUtil.ts
@@ -1,0 +1,333 @@
+import Monitor from "../../Models/DatabaseModels/Monitor";
+import MonitorTemplate from "../../Models/DatabaseModels/MonitorTemplate";
+import NetworkDevice from "../../Models/DatabaseModels/NetworkDevice";
+import ColumnLength from "../../Types/Database/ColumnLength";
+import BadDataException from "../../Types/Exception/BadDataException";
+import { JSONObject } from "../../Types/JSON";
+import JSONFunctions from "../../Types/JSONFunctions";
+import MonitorSteps from "../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../Types/Monitor/MonitorType";
+import ObjectID from "../../Types/ObjectID";
+
+/*
+ * Materialises a project MonitorTemplate for one discovered NetworkDevice.
+ *
+ * A Network Device template necessarily contains a concrete device id today:
+ * the ordinary template form uses the same required step editor as a Monitor.
+ * That id is only a design-time placeholder when the template is used by
+ * discovery automation. Every step is therefore cloned and rebound here; the
+ * template object must never be mutated, because the same instance can serve a
+ * whole discovered estate.
+ *
+ * This utility deliberately performs no database or permission work. Callers
+ * remain responsible for fetching a template with its labels, then persisting
+ * the returned Monitor through MonitorService so tenant, billing, reference,
+ * rule-engine, and audit hooks still run.
+ */
+
+type NetworkDeviceId = ObjectID | string | null | undefined;
+
+export interface RebindNetworkDeviceMonitorStepsData {
+  monitorSteps: MonitorSteps | undefined;
+  networkDeviceId: NetworkDeviceId;
+}
+
+export interface BuildSyncedNetworkDeviceMonitorStepsData {
+  templateMonitorSteps: MonitorSteps | undefined;
+  currentMonitorSteps: MonitorSteps | undefined;
+  fallbackNetworkDeviceId?: NetworkDeviceId;
+}
+
+export interface BuildMonitorFromTemplateData {
+  template: MonitorTemplate;
+  networkDevice: NetworkDevice;
+}
+
+export default class NetworkDeviceMonitorTemplateUtil {
+  /**
+   * Deep-clone a Network Device monitor's steps and point every step at the
+   * supplied device. The source MonitorSteps and every nested object remain
+   * untouched.
+   */
+  public static rebindMonitorSteps(
+    data: RebindNetworkDeviceMonitorStepsData,
+  ): MonitorSteps {
+    const networkDeviceId: string =
+      data.networkDeviceId?.toString().trim() || "";
+
+    if (!networkDeviceId) {
+      throw new BadDataException(
+        "Network Device ID is required to bind monitor template steps.",
+      );
+    }
+
+    this.validateMonitorSteps(data.monitorSteps, "Monitor template");
+
+    const clonedSteps: MonitorSteps = MonitorSteps.clone(data.monitorSteps!);
+
+    for (const step of clonedSteps.data!.monitorStepsInstanceArray) {
+      if (!step.data?.networkDeviceMonitor) {
+        throw new BadDataException(
+          "Monitor template contains a Network Device step without Network Device configuration.",
+        );
+      }
+
+      step.data.networkDeviceMonitor.networkDeviceId = networkDeviceId;
+    }
+
+    return clonedSteps;
+  }
+
+  /**
+   * Clone freshly-edited template steps for a linked Monitor while retaining
+   * that Monitor's instance-specific device. Multiple steps may reference the
+   * same device. More than one distinct binding is rejected because choosing
+   * one would silently retarget alerting; when no current binding survives, a
+   * persisted auto-provisioning marker can be supplied as the fallback.
+   */
+  public static buildSyncedMonitorSteps(
+    data: BuildSyncedNetworkDeviceMonitorStepsData,
+  ): MonitorSteps {
+    const currentDeviceIds: Set<string> = new Set<string>();
+
+    for (const step of data.currentMonitorSteps?.data
+      ?.monitorStepsInstanceArray || []) {
+      const currentDeviceId: string | undefined =
+        step.data?.networkDeviceMonitor?.networkDeviceId?.trim() || undefined;
+
+      if (currentDeviceId) {
+        currentDeviceIds.add(currentDeviceId);
+      }
+    }
+
+    if (currentDeviceIds.size > 1) {
+      throw new BadDataException(
+        "Linked Network Device monitor must have exactly one distinct Network Device binding.",
+      );
+    }
+
+    const preservedNetworkDeviceId: string =
+      Array.from(currentDeviceIds)[0] ||
+      data.fallbackNetworkDeviceId?.toString().trim() ||
+      "";
+
+    if (!preservedNetworkDeviceId) {
+      throw new BadDataException(
+        "Linked Network Device monitor has no Network Device binding to preserve.",
+      );
+    }
+
+    return this.rebindMonitorSteps({
+      monitorSteps: data.templateMonitorSteps,
+      networkDeviceId: preservedNetworkDeviceId,
+    });
+  }
+
+  /**
+   * Build (but do not persist) the Monitor managed for one discovered device.
+   */
+  public static buildMonitor(data: BuildMonitorFromTemplateData): Monitor {
+    const monitorTemplate: MonitorTemplate = data.template;
+    const networkDevice: NetworkDevice = data.networkDevice;
+
+    const monitorTemplateId: ObjectID | null = monitorTemplate.id;
+    if (!monitorTemplateId) {
+      throw new BadDataException(
+        "Monitor template ID is required to provision a Network Device monitor.",
+      );
+    }
+
+    const networkDeviceId: ObjectID | null = networkDevice.id;
+    if (!networkDeviceId) {
+      throw new BadDataException(
+        "Network Device ID is required to provision a monitor.",
+      );
+    }
+
+    if (!monitorTemplate.projectId) {
+      throw new BadDataException(
+        "Monitor template project ID is required to provision a Network Device monitor.",
+      );
+    }
+
+    if (!networkDevice.projectId) {
+      throw new BadDataException(
+        "Network Device project ID is required to provision a monitor.",
+      );
+    }
+
+    if (
+      monitorTemplate.projectId.toString() !==
+      networkDevice.projectId.toString()
+    ) {
+      throw new BadDataException(
+        "Monitor template and Network Device must belong to the same project.",
+      );
+    }
+
+    if (monitorTemplate.monitorType !== MonitorType.NetworkDevice) {
+      throw new BadDataException(
+        `Monitor template must have type "${MonitorType.NetworkDevice}" to provision a Network Device monitor.`,
+      );
+    }
+
+    this.validateMonitorSteps(monitorTemplate.monitorSteps, "Monitor template");
+
+    const monitor: Monitor = new Monitor();
+    monitor.projectId = new ObjectID(networkDevice.projectId.toString());
+    monitor.name = this.buildDeviceIdentifiableName({
+      monitorTemplate,
+      networkDevice,
+    });
+    if (monitorTemplate.monitorDescription !== undefined) {
+      monitor.description = monitorTemplate.monitorDescription;
+    }
+    monitor.monitorType = MonitorType.NetworkDevice;
+    monitor.monitorSteps = this.rebindMonitorSteps({
+      monitorSteps: monitorTemplate.monitorSteps,
+      networkDeviceId,
+    });
+    if (monitorTemplate.monitoringInterval !== undefined) {
+      monitor.monitoringInterval = monitorTemplate.monitoringInterval;
+    }
+    if (monitorTemplate.minimumProbeAgreement !== undefined) {
+      monitor.minimumProbeAgreement = monitorTemplate.minimumProbeAgreement;
+    }
+    if (monitorTemplate.customFields !== undefined) {
+      monitor.customFields = this.cloneCustomFields(
+        monitorTemplate.customFields,
+      );
+    }
+    if (monitorTemplate.labels !== undefined) {
+      monitor.labels = [...monitorTemplate.labels];
+    }
+    monitor.monitorTemplateId = new ObjectID(monitorTemplateId.toString());
+    monitor.autoProvisionedNetworkDeviceId = new ObjectID(
+      networkDeviceId.toString(),
+    );
+
+    return monitor;
+  }
+
+  public static validateMonitorSteps(
+    monitorSteps: MonitorSteps | JSONObject | undefined,
+    subject: string = "Network Device monitor",
+  ): void {
+    const normalizedSteps: MonitorSteps = this.normalizeMonitorSteps(
+      monitorSteps,
+      subject,
+    );
+
+    if (
+      !Array.isArray(normalizedSteps.data?.monitorStepsInstanceArray) ||
+      normalizedSteps.data.monitorStepsInstanceArray.length === 0
+    ) {
+      throw new BadDataException(`${subject} monitor steps are required.`);
+    }
+
+    for (const step of normalizedSteps.data.monitorStepsInstanceArray) {
+      if (!step.data?.networkDeviceMonitor) {
+        throw new BadDataException(
+          `${subject} contains a Network Device step without Network Device configuration.`,
+        );
+      }
+    }
+  }
+
+  public static getReferencedNetworkDeviceIds(
+    monitorSteps: MonitorSteps | JSONObject | undefined,
+  ): Set<string> {
+    this.validateMonitorSteps(monitorSteps);
+    const normalizedSteps: MonitorSteps = this.normalizeMonitorSteps(
+      monitorSteps,
+      "Network Device monitor",
+    );
+    const ids: Set<string> = new Set();
+
+    for (const step of normalizedSteps.data!.monitorStepsInstanceArray) {
+      const networkDeviceId: string =
+        step.data!.networkDeviceMonitor!.networkDeviceId?.trim() || "";
+      if (networkDeviceId) {
+        ids.add(networkDeviceId);
+      }
+    }
+
+    return ids;
+  }
+
+  public static assertMonitorStepsBoundToNetworkDevice(data: {
+    monitorSteps: MonitorSteps | JSONObject | undefined;
+    networkDeviceId: ObjectID | string;
+  }): void {
+    const expectedId: string = data.networkDeviceId.toString();
+    const referencedIds: Set<string> = this.getReferencedNetworkDeviceIds(
+      data.monitorSteps,
+    );
+
+    if (referencedIds.size !== 1 || !referencedIds.has(expectedId)) {
+      throw new BadDataException(
+        "An auto-provisioned Network Device monitor cannot be retargeted. Delete it and create a manual monitor for a different device instead.",
+      );
+    }
+  }
+
+  private static normalizeMonitorSteps(
+    monitorSteps: MonitorSteps | JSONObject | undefined,
+    subject: string,
+  ): MonitorSteps {
+    if (monitorSteps instanceof MonitorSteps) {
+      return monitorSteps;
+    }
+
+    if (!monitorSteps) {
+      throw new BadDataException(`${subject} monitor steps are required.`);
+    }
+
+    try {
+      return MonitorSteps.fromJSON(monitorSteps);
+    } catch {
+      throw new BadDataException(`${subject} monitor steps are invalid.`);
+    }
+  }
+
+  private static buildDeviceIdentifiableName(data: {
+    monitorTemplate: MonitorTemplate;
+    networkDevice: NetworkDevice;
+  }): string {
+    const networkDeviceId: string = data.networkDevice.id!.toString();
+    const deviceIdentity: string =
+      data.networkDevice.name?.trim() ||
+      data.networkDevice.hostname?.trim() ||
+      `Network Device ${networkDeviceId}`;
+    const templateMonitorName: string =
+      data.monitorTemplate.monitorName?.trim() || "Monitor";
+
+    return this.truncateWithoutSplittingSurrogatePair(
+      `${deviceIdentity} - ${templateMonitorName}`,
+      ColumnLength.ShortText,
+    );
+  }
+
+  private static truncateWithoutSplittingSurrogatePair(
+    value: string,
+    maximumLength: number,
+  ): string {
+    if (value.length <= maximumLength) {
+      return value;
+    }
+
+    const truncated: string = value.substring(0, maximumLength);
+    const finalCodeUnit: number = truncated.charCodeAt(truncated.length - 1);
+
+    // A cut between an astral character's UTF-16 surrogate pair is invalid.
+    if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+      return truncated.substring(0, truncated.length - 1);
+    }
+
+    return truncated;
+  }
+
+  private static cloneCustomFields(customFields: JSONObject): JSONObject {
+    return JSONFunctions.deserialize(JSONFunctions.serialize(customFields));
+  }
+}

--- a/Common/Utils/NetworkDiscovery/AutoImportRuleMatcher.ts
+++ b/Common/Utils/NetworkDiscovery/AutoImportRuleMatcher.ts
@@ -1,5 +1,6 @@
 import { DiscoveredNetworkDevice } from "../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import NetworkDeviceMonitoringMethod from "../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import ObjectID from "../../Types/ObjectID";
 import CidrMatchUtil from "../NetworkSite/CidrMatchUtil";
 import RulePatternMatchUtil from "../Rules/RulePatternMatchUtil";
 import { monitoringMethodForDiscoveredHost } from "./DiscoveryImportEligibility";
@@ -32,6 +33,7 @@ import ScanTargetUtil from "./ScanTargetUtil";
  * this structurally, and tests can build literals.
  */
 export interface AutoImportRuleCandidate {
+  monitorTemplateId?: ObjectID | string | null | undefined;
   ipMatchTarget?: string | null | undefined;
   sysNamePattern?: string | null | undefined;
   sysDescrPattern?: string | null | undefined;


### PR DESCRIPTION
Closes #3417

## Recommendation

Implement this as an opt-in alerting operation on the existing Network Device auto-import rule, not as new default behavior and not as a second independent rule engine.

- Existing rules remain inventory-only.
- Selecting a Network Device Monitor Template explicitly enables active-monitor provisioning and warns that it can affect plan usage/billing.
- The Monitor Template is the alerting layer: criteria, interval, minimum probe agreement, custom fields, and monitor labels are copied. Health OIDs, interface walking, endpoint collection, and vendor template seeding remain polling concerns on the Network Device.
- Template changes are non-destructive: automation does not delete or retarget monitors created from an older selection.

## What changed

- Added an optional, permission-gated Monitor Template relation to Network Device auto-import rules.
- Added immutable monitor provenance plus a partial unique `(network device, template)` index for race-safe idempotency.
- Reconciles selected template monitors for both newly imported devices and already-registered matching devices.
- Suppresses automation when a device already has a manually configured Network Device monitor.
- Deduplicates the same template across matching rules while allowing deliberately different templates to create different monitors.
- Copies the template through `MonitorService`, so normal plan, lifecycle, Monitor Label/Owner Rule, audit, realtime, and billing behavior still runs.
- Preserves each device binding when a Network Device Monitor Template is synchronized later.
- Deletes auto-provisioned monitors through `MonitorService` before deleting their Network Device; an FK `RESTRICT` policy is the final late-insert race guard.
- Re-authorizes template visibility and Monitor-create permission for edits and human-triggered Run Now operations.
- Extended Dry Run / Run Now results and UI messaging with monitor create/skip/failure counters.
- Added separate per-project caps of 500 device attempts and 500 monitor attempts per sweep/run, shared across scans without blocking other projects.

## Validation

- `npm run fix`
- Common `npm run compile`
- App `npm run compile -- --baseUrl ..`
- Dashboard `npm run compile -- --baseUrl ../../..`
- 170 focused Common service, lifecycle, migration-ordering, result, and template utility tests passed on the feature tree.
- Post-rebase Common smoke: 5 suites, 114/114 tests passed.
- Post-rebase App/API/UI/worker smoke: 4 suites, 56/56 tests passed.
- Generated PostgreSQL migration exercised up/down/up successfully.
- `npm run check-postgres-schema-drift`: `No schema drift. The database matches the entities.`

The explicit `baseUrl` compile arguments keep this isolated worktree from resolving Common through the primary checkout's `node_modules` symlink; both compiles complete without diagnostics.
