### PR TITLE
fix(teams): stop steering self-hosted admins into installing the wrong app

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChatsCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChatsCard.tsx
@@ -15,7 +15,11 @@ import Exception from "Common/Types/Exception/Exception";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
-import { APP_API_URL, MicrosoftTeamsAppClientId } from "Common/UI/Config";
+import {
+  APP_API_URL,
+  BILLING_ENABLED,
+  MicrosoftTeamsAppClientId,
+} from "Common/UI/Config";
 import { JSONObject } from "Common/Types/JSON";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
@@ -150,7 +154,17 @@ const MicrosoftTeamsChatsCard: FunctionComponent = (): ReactElement => {
                 you.
               </p>
             </div>
-            {MicrosoftTeamsAppClientId && (
+            {/*
+             * Store-only. On a self-hosted deployment this screen is reached
+             * precisely when no chat has ever registered, and the most common
+             * reason is that no package built from this deployment has been
+             * uploaded yet — at which point teams.microsoft.com/l/app/<id> has
+             * nothing to resolve to. Offering it as the primary action there
+             * also nudges admins toward the store listing, which is the one
+             * package that can never work here. Self-hosted gets the check that
+             * actually settles it instead.
+             */}
+            {MicrosoftTeamsAppClientId && BILLING_ENABLED && (
               <button
                 type="button"
                 className="mt-6 inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500"
@@ -169,6 +183,18 @@ const MicrosoftTeamsChatsCard: FunctionComponent = (): ReactElement => {
                 />
                 Open OneUptime in Microsoft Teams
               </button>
+            )}
+
+            {!BILLING_ENABLED && MicrosoftTeamsAppClientId && (
+              <p className="mx-auto mt-6 max-w-md text-xs text-gray-500">
+                Chats only register for the app package built for this
+                deployment (bot id{" "}
+                <span className="font-mono">{MicrosoftTeamsAppClientId}</span>).
+                If you added the OneUptime app from the Microsoft Teams store,
+                it reports to OneUptime Cloud and will never appear here —
+                remove it and upload the manifest from Project Settings &gt;
+                Workspace &gt; Microsoft Teams instead.
+              </p>
             )}
           </div>
         )}

--- a/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegration.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegration.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
 } from "react";
 import Card, { CardButtonSchema } from "Common/UI/Components/Card/Card";
+import CollapsibleSection from "Common/UI/Components/CollapsibleSection/CollapsibleSection";
 import IconProp from "Common/Types/Icon/IconProp";
 import Navigation from "Common/UI/Utils/Navigation";
 import URL from "Common/Types/API/URL";
@@ -538,13 +539,28 @@ const MicrosoftTeamsIntegration: FunctionComponent<ComponentProps> = (
           </div>
         )}
 
+      {/*
+       * Gated on either connection, not just the per-user one. The manifest is a
+       * property of the deployment, not of whoever happens to be signed in, and
+       * gating it on isUserAccountConnected alone hid the one required install
+       * step from projects that were otherwise fully working — the Channels and
+       * Chats cards above need only isProjectAccountConnected, so a deployment
+       * could browse and create channels while never being shown the package it
+       * has to upload before any of it can post.
+       *
+       * As the state is wired today isAdminConsentCompleted already implies
+       * isProjectAccountConnected (both are set from the same project-auth
+       * fetch), so the isUserAccountConnected arm is currently unreachable. It
+       * stays as a guard: the point of this gate is that the card must never be
+       * narrower than the cards it sits beside.
+       */}
       {isAdminConsentCompleted &&
-        isUserAccountConnected &&
+        (isProjectAccountConnected || isUserAccountConnected) &&
         !BILLING_ENABLED && (
           <div className="mt-6">
             <Card
-              title="Action Required: Install App on Microsoft Teams"
-              description="If you prefer to install the OneUptime app manually in Microsoft Teams, download the app manifest zip file and follow the instructions below."
+              title="Action Required: Install This Deployment's App on Microsoft Teams"
+              description="Microsoft Teams will only accept notifications from the app package built for this deployment. Download the manifest zip below and upload it to Teams."
               buttons={[
                 {
                   title: "Download App Manifest Zip",
@@ -563,9 +579,8 @@ const MicrosoftTeamsIntegration: FunctionComponent<ComponentProps> = (
                 text={`
 ##### Installation Steps:
 
-Pre-requisite: 
-- If you or anyone else in your organization has already installed the OneUptime app in Microsoft Teams, you can skip the installation steps. In this case, you do not need to do anything here.
-
+> **Do not skip this because a "OneUptime" app is already in your tenant.**
+> Only the package downloaded from this page carries this deployment's bot id (\`${MicrosoftTeamsAppClientId}\`). The OneUptime app in the Microsoft Teams store points at OneUptime Cloud's bot, so Teams will accept it, show it in **Manage team → Apps**, and then refuse every message this deployment sends with *"The bot is not part of the conversation roster."* If a OneUptime app is already installed and you did not upload it from this page, remove it first.
 
 1. **Download the zip file** using the button above
 2. **Upload to Microsoft Teams:**
@@ -651,6 +666,26 @@ If you prefer to manually sideload the app:
               `}
             />
           </Card>
+        </div>
+      )}
+
+      {/*
+       * The full setup guide used to render only when MICROSOFT_TEAMS_APP_CLIENT_ID
+       * was unset — so the moment a deployment was configured, the Azure Bot steps
+       * and the "upload this deployment's manifest" step became unreachable from
+       * the product. That is exactly when an admin goes looking for them, because
+       * that is when things start failing. Keep it here, collapsed, for self-hosted.
+       */}
+      {!BILLING_ENABLED && (
+        <div className="mt-6">
+          <CollapsibleSection
+            title="Full Microsoft Teams setup guide"
+            description="Azure app registration, Azure Bot resource, permissions and app manifest upload — every step, including the ones that are easy to miss."
+            variant="card"
+            defaultCollapsed={true}
+          >
+            <MicrosoftTeamsIntegrationDocumentation />
+          </CollapsibleSection>
         </div>
       )}
 

--- a/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx
@@ -38,6 +38,7 @@ Azure Account - You can create one by going to https://azure.com.
    - **Team.ReadBasic.All** - Required to list all teams in the organization after admin consent is granted
    - **Channel.ReadBasic.All** - Required to verify channel existence and retrieve channel details
    - **Channel.Create** - Required to create new channels for organizing notifications (e.g., separate channels for incidents, alerts)
+   - **TeamsAppInstallation.ReadForTeam.All** - Required for diagnosis. Lets OneUptime read which app package is actually installed in a team and compare it to this deployment's client id. Without it, a failed notification can only list the possible causes; with it, OneUptime tells you which one it is. This is the difference between a one-minute fix and a multi-day investigation, so grant it.
 
 **Note:** The Bot Framework handles message delivery using Resource-Specific Consent (RSC) permissions defined in the Teams app manifest. These permissions are:
    - **ChannelMessage.Send.Group** - Allows the bot to send messages to team channels
@@ -108,7 +109,9 @@ Restart your OneUptime server after adding these environment variables so they t
 
 ##### Step 8: Upload Teams App Manifest
 
-1. Go to project Settings -> Integrations -> Microsoft Teams
+> **Do not install "OneUptime" from the Microsoft Teams store for a self-hosted deployment.** That package's bot belongs to OneUptime Cloud. Teams will install it happily and show it under **Manage team → Apps**, and every notification this deployment sends will then be refused with *"The bot is not part of the conversation roster."* Only the manifest you download below carries your \`MICROSOFT_TEAMS_APP_CLIENT_ID\` as its bot id.
+
+1. Go to project Settings -> Workspace -> Microsoft Teams
 2. Download the Teams app manifest from there
 3. Go to Microsoft Teams, click on "Apps" in the sidebar
 4. At the bottom, click "Manage your apps"
@@ -116,14 +119,39 @@ Restart your OneUptime server after adding these environment variables so they t
 6. Select "Upload for me or my teams"
 7. Upload the manifest zip file you downloaded earlier
 
+##### Step 9: Add the App to Every Team You Want Notifications In
+
+Uploading the manifest is not enough on its own — installation is per team.
+
+1. In Microsoft Teams, click the "..." next to the **team name** (not the channel)
+2. Choose **Manage team → Apps → More apps**, find OneUptime and click **Add**
+3. For a **private** channel, also open the channel → "..." → **Manage channel → Apps → Add an app**. A team-level install does not cover private channels
+4. Microsoft Teams does not allow bots in **shared** channels, so those cannot receive notifications
+
+Connecting the integration grants tenant-wide Graph **read** access, which is why the channel picker can list channels in teams the bot cannot post to. Seeing a channel in OneUptime does not mean OneUptime can post to it.
+
 ##### Troubleshooting
 
-If you encounter issues:
+**"The bot is not part of the conversation roster" / "the OneUptime bot is not a member of that conversation"**
 
-- Ensure your app has the correct permissions granted
+In order of likelihood:
+
+1. **The installed app is a different package.** A tile named "OneUptime" under Manage team → Apps is not enough — what matters is whether its bot id equals this deployment's \`MICROSOFT_TEAMS_APP_CLIENT_ID\`. Remove it and upload your own manifest (Step 8).
+2. **The Azure Bot has no Microsoft Teams channel.** Complete Step 6. Without it the bot is never provisioned into Teams conversations, so it is in no channel's roster — even though the app installs cleanly.
+3. **The app is installed for you, but not in the team.** Complete Step 9.
+4. **The channel is private.** See Step 9.
+
+Grant **TeamsAppInstallation.ReadForTeam.All** (Step 3) and OneUptime will tell you which of these it is instead of listing them.
+
+**No chats appear under Microsoft Teams Chats**
+
+Chats register only when the bot receives a message. If the installed package points at a different deployment, its activities never reach this server and the list stays empty no matter how many times you click Refresh Chats. Verify the installed package first (Step 8).
+
+**Other checks**
+
+- Ensure your app has the correct permissions granted, including admin consent
 - Check that the redirect URI matches exactly
-- Verify your environment variables are set correctly
-- Make sure the bot is added to the channels you want to post to
+- Verify your environment variables are set correctly, and restart the server after changing them
 
 We would like to improve this integration, so feedback is more than welcome. Please send us any at hello@oneuptime.com
 

--- a/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
+++ b/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
@@ -40,7 +40,7 @@ To integrate Microsoft Teams with your self-hosted OneUptime instance, you need 
 - **Team.ReadBasic.All** - Required to list all teams in the organization after admin consent is granted
 - **Channel.ReadBasic.All** - Required to verify channel existence and retrieve channel details
 - **ChannelMessage.Send** - Required to send messages to channels programmatically
-- **TeamsAppInstallation.ReadForTeam.All** - Optional but strongly recommended. Lets OneUptime check whether the OneUptime app is really installed in a team before a notification is sent, so a failed send can tell you _which_ of the possible causes it is. Without it OneUptime cannot tell "not installed" apart from "installed, but something else is wrong", and simply reports what Microsoft said.
+- **TeamsAppInstallation.ReadForTeam.All** - Required for diagnosis. Lets OneUptime read which app package is really installed in a team and compare it against this deployment's client id, so a failed send can tell you _which_ of the possible causes it is. Without it OneUptime cannot tell "not installed" apart from "installed, but it is somebody else's package", and simply reports what Microsoft said — which is the single biggest reason this integration takes days instead of minutes to debug. Grant it.
 
 **Note:** The Bot Framework handles message delivery using Resource-Specific Consent (RSC) permissions defined in the Teams app manifest. These permissions are:
 

--- a/Common/Server/API/MicrosoftTeamsAPI.ts
+++ b/Common/Server/API/MicrosoftTeamsAPI.ts
@@ -987,7 +987,22 @@ export default class MicrosoftTeamsAPI {
       },
     );
 
-    // Test endpoint to verify Bot Framework setup
+    /*
+     * Echoes this deployment's bot configuration.
+     *
+     * It reads local environment variables and nothing else — it does not call
+     * Azure, so it cannot tell you the Azure Bot resource exists, that its
+     * messaging endpoint points back here, that the Teams channel is enabled, or
+     * that the installed Teams app package belongs to this deployment. It used
+     * to answer "Bot Framework endpoint is configured", which admins reasonably
+     * read as "the bot works" — and then spent days debugging a setup this
+     * endpoint had already blessed. It now says what it checked and, more
+     * importantly, what it did not.
+     *
+     * The one genuinely useful thing here is botId: it is the value that must
+     * appear in the installed Teams app package, and comparing the two is what
+     * settles the most common self-hosted failure.
+     */
     router.get(
       "/microsoft-bot/test",
       async (req: ExpressRequest, res: ExpressResponse) => {
@@ -1004,9 +1019,23 @@ export default class MicrosoftTeamsAPI {
         }
 
         return Response.sendJsonObjectResponse(req, res, {
-          status: "Bot Framework endpoint is configured",
+          status:
+            "Local configuration is present. This does NOT confirm the integration works.",
           clientId: MicrosoftTeamsAppClientId,
+          botId: MicrosoftTeamsAppClientId,
           messagingEndpoint: `${AppApiClientUrl.toString()}/microsoft-bot/messages`,
+          verified: [
+            "MICROSOFT_TEAMS_APP_CLIENT_ID is set",
+            "MICROSOFT_TEAMS_APP_CLIENT_SECRET is set",
+          ],
+          notVerified: [
+            "That an Azure Bot resource exists for this client id",
+            "That the Azure Bot's messaging endpoint points at this deployment",
+            "That the Azure Bot has the Microsoft Teams channel enabled",
+            "That the client secret is valid and has not expired",
+            "That the Teams app package installed in your teams was built from this deployment",
+          ],
+          nextStep: `Open the installed OneUptime app in Microsoft Teams and confirm its bot id is ${MicrosoftTeamsAppClientId}. If it is not, that package cannot receive messages from this deployment — download the manifest from Project Settings > Workspace > Microsoft Teams and upload that instead.`,
         });
       },
     );

--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -134,12 +134,32 @@ export interface MicrosoftTeamsTenantResolution {
  * Graph permission that deployments connected before it was documented have not
  * consented to, and a tenant that answers "I won't tell you" must never be
  * reported to an admin as "the app is not installed".
+ *
+ * PermissionDenied is that same "I won't tell you", separated out because it is
+ * the one flavour of Unknown the admin can fix in a minute — Microsoft is not
+ * failing, it is refusing, and it names the grant that would stop it. Folding it
+ * in with transport errors is what left admins reading a list of four possible
+ * causes when OneUptime could have told them which one it was.
  */
 export enum MicrosoftTeamsAppInstallState {
   Installed = "Installed",
   NotInstalled = "NotInstalled",
+  PermissionDenied = "PermissionDenied",
   Unknown = "Unknown",
 }
+
+/*
+ * The Graph application permission that lets OneUptime read a team's installed
+ * apps, and so tell "the app is missing" apart from "the app is there but is a
+ * different package".
+ *
+ * Server-side error text builds off this constant. The setup documentation and
+ * the docs site still spell it out literally, because prose there explains the
+ * permission rather than just naming it — if you rename it here, grep for the
+ * literal too.
+ */
+export const MICROSOFT_TEAMS_INSTALL_READ_PERMISSION: string =
+  "TeamsAppInstallation.ReadForTeam.All";
 
 /*
  * Microsoft's wording when the Bot Framework refuses a proactive post because
@@ -1861,11 +1881,27 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
     channelName: string;
     membershipType?: string | undefined;
   }): string {
+    /*
+     * "Not installed" here means no installed app carries THIS deployment's
+     * app id — which is also what a OneUptime tile from the Teams store looks
+     * like. Saying only "add OneUptime" to an admin who is looking straight at
+     * a OneUptime tile reads as nonsense and sends them round the loop again,
+     * so name that case explicitly.
+     */
+    const wrongPackageNote: string = `If a tile named OneUptime is already listed there, it is a different package — the app from the Teams store points at OneUptime Cloud's bot and will never accept posts from this deployment. Remove it, then upload the manifest from Project Settings > Workspace > Microsoft Teams, which is the only package built with this deployment's MICROSOFT_TEAMS_APP_CLIENT_ID.`;
+
+    /*
+     * No wrong-package note for private channels. The install check reads
+     * /teams/{id}/installedApps — team scope — and a private channel needs its
+     * own channel-scope install, so a correct channel install still reads as
+     * "not installed" here. Telling that admin their package is the wrong one
+     * and to remove it would destroy a working install to fix nothing.
+     */
     if (data.membershipType === "private") {
       return `The OneUptime app is not installed in the private channel "${data.channelName}". In Microsoft Teams, open the channel, click the "..." menu, then Manage channel > Apps > Add an app, and add OneUptime. Installing OneUptime in the parent team does not cover private channels.`;
     }
 
-    return `The OneUptime app is not installed in the Microsoft Teams team that owns "${data.channelName}". In Microsoft Teams, click the "..." next to the team name, then Manage team > Apps > More apps, and add OneUptime. Installing OneUptime for yourself or in a chat is not the same as adding it to the team.`;
+    return `The OneUptime app is not installed in the Microsoft Teams team that owns "${data.channelName}". In Microsoft Teams, click the "..." next to the team name, then Manage team > Apps > More apps, and add OneUptime. Installing OneUptime for yourself or in a chat is not the same as adding it to the team. ${wrongPackageNote}`;
   }
 
   /*
@@ -1889,8 +1925,18 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
         `"${data.channelName}" is a private channel, which needs the app installed into the channel itself (channel "..." > Manage channel > Apps > Add an app) — a team-level install does not cover it`,
       );
     } else if (data.installState === MicrosoftTeamsAppInstallState.Installed) {
+      /*
+       * Graph confirmed a package carrying THIS deployment's app id is in the
+       * team, so the usual suspect — a OneUptime package from somewhere else —
+       * is largely ruled out and should not lead. "Largely", not "entirely":
+       * the check matches teamsApp.externalId, which is the manifest id, and
+       * only OneUptime's own generator guarantees that equals the bot id. A
+       * hand-edited manifest can satisfy this and still carry a foreign bot, so
+       * the wording stays probabilistic rather than promising the admin the
+       * package is fine.
+       */
       causes.push(
-        "the app is installed in this team, so the bot behind it may not be the one this OneUptime deployment uses — check that the Teams app package was built from this deployment (Project Settings > Workspace > Microsoft Teams) and that its bot id matches MICROSOFT_TEAMS_APP_CLIENT_ID",
+        "the app installed in this team already matches this deployment's MICROSOFT_TEAMS_APP_CLIENT_ID, so the package is probably not the problem — the most likely remaining cause is the Azure Bot resource, below",
       );
     } else {
       causes.push(
@@ -1902,6 +1948,23 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       "the Azure Bot resource for this deployment does not have the Microsoft Teams channel enabled",
     );
 
+    /*
+     * The list above is a guess, and it only has to be a guess because Graph
+     * would not tell us. Say so, and say what turns it into an answer — this is
+     * the single cheapest step an admin reading this can take.
+     *
+     * The promise is hedged for private channels: the grant unlocks a
+     * team-scope read, and for a private channel the deciding fact is the
+     * channel-scope install, which that read cannot see. Worth granting anyway,
+     * just not worth promising it settles this particular send.
+     */
+    const suffixHint: string =
+      data.installState === MicrosoftTeamsAppInstallState.PermissionDenied
+        ? data.membershipType === "private"
+          ? ` OneUptime could not narrow this down because Microsoft Graph denied the installed-apps check: granting the ${MICROSOFT_TEAMS_INSTALL_READ_PERMISSION} application permission to this deployment's app registration restores that check for team-level installs, though a private channel's own install still has to be confirmed in Microsoft Teams.`
+          : ` OneUptime could not narrow this down because Microsoft Graph denied the installed-apps check: grant the ${MICROSOFT_TEAMS_INSTALL_READ_PERMISSION} application permission to this deployment's app registration, re-grant admin consent, and try again to be told which cause it is.`
+        : "";
+
     const microsoftMessage: string =
       data.microsoftError instanceof Error
         ? data.microsoftError.message
@@ -1911,7 +1974,43 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       ? ` Microsoft's response was: "${microsoftMessage}"`
       : "";
 
-    return `Microsoft Teams refused the message to "${data.channelName}" because the OneUptime bot is not a member of that conversation. Likely causes: ${causes.join("; ")}.${suffix}`;
+    return `Microsoft Teams refused the message to "${data.channelName}" because the OneUptime bot is not a member of that conversation. Likely causes: ${causes.join("; ")}.${suffixHint}${suffix}`;
+  }
+
+  /*
+   * True when Graph refused a read rather than failing it.
+   *
+   * 403 only, deliberately. Graph answers a missing application permission with
+   * 403 and reserves 401 for a token it would not accept — an expired secret, a
+   * cached app token we did not re-check (see getValidAccessToken, which returns
+   * a stored token unvalidated when miscData carries no expiry). Treating 401 as
+   * a permission problem would send an admin off to grant a Graph permission
+   * when their credential had simply gone stale, which is the same species of
+   * wrong-but-confident answer this whole diagnostic exists to stop producing.
+   *
+   * The error codes are still matched at any status, so a permission refusal
+   * that arrives with an unexpected status is not missed.
+   */
+  public static isGraphPermissionDeniedResponse(
+    response: HTTPErrorResponse,
+  ): boolean {
+    if (response.statusCode === 403) {
+      return true;
+    }
+
+    const message: string = (response.message || "").toLowerCase();
+
+    if (!message) {
+      return false;
+    }
+
+    return [
+      "authorization_requestdenied",
+      "accessdenied",
+      "insufficient privileges",
+    ].some((fragment: string) => {
+      return message.includes(fragment);
+    });
   }
 
   /*
@@ -1924,9 +2023,11 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
    * not the weaker one an admin can answer by eye ("is something called
    * OneUptime in the app list?").
    *
-   * Every failure is Unknown. The call needs TeamsAppInstallation.ReadForTeam.All,
-   * which deployments connected before it was documented have not granted, and a
-   * missing permission must not be reported as a missing install.
+   * No failure is ever reported as NotInstalled. The call needs
+   * TeamsAppInstallation.ReadForTeam.All, which deployments connected before it
+   * was documented have not granted, and a missing permission must not be
+   * reported as a missing install. A refusal comes back as PermissionDenied so
+   * the admin is told which grant to add; everything else is Unknown.
    */
   @CaptureSpan()
   public static async isAppInstalledInTeam(data: {
@@ -1968,6 +2069,19 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
           });
 
         if (response instanceof HTTPErrorResponse) {
+          /*
+           * A refusal is not a failure. That distinction is the whole value of
+           * this call: it is the difference between "we cannot tell you which of
+           * four causes this is" and "grant this one permission and we will tell
+           * you".
+           */
+          if (this.isGraphPermissionDeniedResponse(response)) {
+            logger.warn(
+              `Cannot read installed apps for team ${data.teamId}: Microsoft Graph denied the request. Grant the ${MICROSOFT_TEAMS_INSTALL_READ_PERMISSION} application permission to this app registration and re-grant admin consent so OneUptime can verify Teams app installs.`,
+            );
+            return MicrosoftTeamsAppInstallState.PermissionDenied;
+          }
+
           logger.debug(
             `Could not read installed apps for team ${data.teamId}; treating installation as unknown.`,
           );

--- a/Common/Tests/Server/API/MicrosoftTeamsBotTestEndpoint.test.ts
+++ b/Common/Tests/Server/API/MicrosoftTeamsBotTestEndpoint.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  ExpressRouter,
+} from "../../../Server/Utils/Express";
+import { JSONObject } from "../../../Types/JSON";
+import MicrosoftTeamsAPI from "../../../Server/API/MicrosoftTeamsAPI";
+
+const MOCK_TEAMS_CLIENT_ID: string = "11111111-2222-3333-4444-555555555555";
+const MOCK_TEAMS_CLIENT_SECRET: string =
+  "mock-teams-client-secret-that-must-never-be-echoed";
+
+/*
+ * The route reads the client id / secret from EnvironmentConfig at request
+ * time (TypeScript compiles the named imports down to property reads on the
+ * module object), so backing them with lazy getters lets a single loaded copy
+ * of the API module serve both the happy path and the two "not configured"
+ * branches. The mutable holder lives inside the mock factory because the
+ * factory is hoisted above every module-scope declaration in this file.
+ */
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const state: { clientId: string | null; clientSecret: string | null } = {
+    clientId: "11111111-2222-3333-4444-555555555555",
+    clientSecret: "mock-teams-client-secret-that-must-never-be-echoed",
+  };
+
+  const mocked: Record<string, unknown> = {
+    ...(jest.requireActual("../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    setMockTeamsConfig: (
+      clientId: string | null,
+      clientSecret: string | null,
+    ): void => {
+      state.clientId = clientId;
+      state.clientSecret = clientSecret;
+    },
+  };
+
+  Object.defineProperty(mocked, "MicrosoftTeamsAppClientId", {
+    get: (): string | null => {
+      return state.clientId;
+    },
+  });
+
+  Object.defineProperty(mocked, "MicrosoftTeamsAppClientSecret", {
+    get: (): string | null => {
+      return state.clientSecret;
+    },
+  });
+
+  return mocked;
+});
+
+type SetTeamsConfigFunction = (
+  clientId: string | null,
+  clientSecret: string | null,
+) => void;
+
+type SetMockTeamsConfigFunction = (
+  clientId: string | null,
+  clientSecret: string | null,
+) => void;
+
+const setTeamsConfig: SetTeamsConfigFunction = (
+  clientId: string | null,
+  clientSecret: string | null,
+): void => {
+  (
+    jest.requireMock("../../../Server/EnvironmentConfig") as {
+      setMockTeamsConfig: SetMockTeamsConfigFunction;
+    }
+  ).setMockTeamsConfig(clientId, clientSecret);
+};
+
+type ExpressRouteHandler = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+) => Promise<void> | void;
+
+type ExpressRouterLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: ExpressRouteHandler }>;
+  };
+};
+
+type GetBotTestHandlerFunction = () => ExpressRouteHandler;
+
+/*
+ * Reaches into the router built by the API class itself, so this test covers
+ * the real route wiring (path + method) and not just a hand-copied handler.
+ */
+const getBotTestHandler: GetBotTestHandlerFunction =
+  (): ExpressRouteHandler => {
+    const router: ExpressRouter = new MicrosoftTeamsAPI().getRouter();
+    const layers: Array<ExpressRouterLayer> = (
+      router as unknown as { stack: Array<ExpressRouterLayer> }
+    ).stack;
+
+    const layer: ExpressRouterLayer | undefined = layers.find(
+      (candidate: ExpressRouterLayer) => {
+        return (
+          candidate.route?.path === "/microsoft-bot/test" &&
+          candidate.route?.methods["get"] === true
+        );
+      },
+    );
+
+    if (!layer || !layer.route) {
+      throw new Error(
+        "GET /microsoft-bot/test is not registered on the MicrosoftTeamsAPI router",
+      );
+    }
+
+    const handlers: Array<{ handle: ExpressRouteHandler }> = layer.route.stack;
+    expect(handlers).toHaveLength(1);
+
+    return handlers[0]!.handle;
+  };
+
+type InvokedResponse = {
+  statusCode: number;
+  body: JSONObject;
+};
+
+type CallBotTestFunction = () => Promise<InvokedResponse>;
+
+const callBotTest: CallBotTestFunction = async (): Promise<InvokedResponse> => {
+  const handler: ExpressRouteHandler = getBotTestHandler();
+
+  const invoked: InvokedResponse = {
+    statusCode: 0,
+    body: {},
+  };
+
+  const res: Partial<ExpressResponse> = {
+    status(statusCode: number): ExpressResponse {
+      invoked.statusCode = statusCode;
+      return res as ExpressResponse;
+    },
+    send(body: JSONObject): ExpressResponse {
+      invoked.body = body;
+      return res as ExpressResponse;
+    },
+  } as unknown as Partial<ExpressResponse>;
+
+  const req: Partial<ExpressRequest> = {
+    query: {},
+  };
+
+  await handler(req as ExpressRequest, res as ExpressResponse);
+
+  return invoked;
+};
+
+type JoinStringsFunction = (values: unknown) => string;
+
+const joinStrings: JoinStringsFunction = (values: unknown): string => {
+  return (values as Array<string>).join(" | ").toLowerCase();
+};
+
+describe("GET /microsoft-bot/test", () => {
+  beforeEach(() => {
+    setTeamsConfig(MOCK_TEAMS_CLIENT_ID, MOCK_TEAMS_CLIENT_SECRET);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("when the client id and secret are configured", () => {
+    test("responds 200", async () => {
+      const response: InvokedResponse = await callBotTest();
+      expect(response.statusCode).toBe(200);
+    });
+
+    test("reports clientId and botId, both equal to the configured client id", async () => {
+      const response: InvokedResponse = await callBotTest();
+      expect(response.body["clientId"]).toBe(MOCK_TEAMS_CLIENT_ID);
+      expect(response.body["botId"]).toBe(MOCK_TEAMS_CLIENT_ID);
+    });
+
+    test("does NOT claim the Bot Framework endpoint is configured", async () => {
+      const response: InvokedResponse = await callBotTest();
+      const status: string = response.body["status"] as string;
+      expect(status).not.toBe("Bot Framework endpoint is configured");
+      expect(status.toLowerCase()).not.toContain(
+        "bot framework endpoint is configured",
+      );
+    });
+
+    test("status says the check does not confirm the integration works", async () => {
+      const response: InvokedResponse = await callBotTest();
+      const status: string = (response.body["status"] as string).toLowerCase();
+      expect(status).toContain("does not confirm");
+      expect(status).toContain("integration works");
+    });
+
+    test("messagingEndpoint ends with /microsoft-bot/messages", async () => {
+      const response: InvokedResponse = await callBotTest();
+      const messagingEndpoint: string = response.body[
+        "messagingEndpoint"
+      ] as string;
+      expect(typeof messagingEndpoint).toBe("string");
+      expect(messagingEndpoint.endsWith("/microsoft-bot/messages")).toBe(true);
+    });
+
+    test("verified is a non-empty array naming both Teams environment variables", async () => {
+      const response: InvokedResponse = await callBotTest();
+      const verified: Array<string> = response.body[
+        "verified"
+      ] as unknown as Array<string>;
+      expect(Array.isArray(verified)).toBe(true);
+      expect(verified.length).toBeGreaterThan(0);
+
+      const joined: string = joinStrings(verified);
+      expect(joined).toContain("microsoft_teams_app_client_id");
+      expect(joined).toContain("microsoft_teams_app_client_secret");
+    });
+
+    test("notVerified is a non-empty array", async () => {
+      const response: InvokedResponse = await callBotTest();
+      const notVerified: Array<string> = response.body[
+        "notVerified"
+      ] as unknown as Array<string>;
+      expect(Array.isArray(notVerified)).toBe(true);
+      expect(notVerified.length).toBeGreaterThan(0);
+    });
+
+    test.each([
+      ["the Azure Bot resource existing", ["azure bot", "exists"]],
+      ["the Teams channel being enabled", ["teams channel", "enabled"]],
+      [
+        "the installed Teams app package belonging to this deployment",
+        ["installed", "this deployment"],
+      ],
+    ])(
+      "notVerified explicitly disclaims %s",
+      async (_label: string, requiredFragments: Array<string>) => {
+        const response: InvokedResponse = await callBotTest();
+        const notVerified: Array<string> = response.body[
+          "notVerified"
+        ] as unknown as Array<string>;
+
+        const match: string | undefined = notVerified.find((entry: string) => {
+          const lowered: string = entry.toLowerCase();
+          return requiredFragments.every((fragment: string) => {
+            return lowered.includes(fragment);
+          });
+        });
+
+        expect(match).toBeDefined();
+      },
+    );
+
+    test("nextStep names the client id and tells the admin to compare it against the installed app's bot id", async () => {
+      const response: InvokedResponse = await callBotTest();
+      const nextStep: string = response.body["nextStep"] as string;
+      expect(typeof nextStep).toBe("string");
+      expect(nextStep).toContain(MOCK_TEAMS_CLIENT_ID);
+
+      const lowered: string = nextStep.toLowerCase();
+      expect(lowered).toContain("bot id");
+      expect(lowered).toContain("microsoft teams");
+    });
+  });
+
+  describe("when the configuration is missing", () => {
+    test("client id unset responds with an error and leaks no status or botId", async () => {
+      setTeamsConfig(null, MOCK_TEAMS_CLIENT_SECRET);
+
+      const response: InvokedResponse = await callBotTest();
+
+      expect(typeof response.body["error"]).toBe("string");
+      expect(response.body["error"]).toBe(
+        "Microsoft Teams App Client ID not configured",
+      );
+      expect(response.body["status"]).toBeUndefined();
+      expect(response.body["botId"]).toBeUndefined();
+      expect(response.body["clientId"]).toBeUndefined();
+      expect(response.body["messagingEndpoint"]).toBeUndefined();
+      expect(response.body["nextStep"]).toBeUndefined();
+    });
+
+    test("client secret unset responds with an error", async () => {
+      setTeamsConfig(MOCK_TEAMS_CLIENT_ID, null);
+
+      const response: InvokedResponse = await callBotTest();
+
+      expect(typeof response.body["error"]).toBe("string");
+      expect(response.body["error"]).toBe(
+        "Microsoft Teams App Client Secret not configured",
+      );
+      expect(response.body["status"]).toBeUndefined();
+      expect(response.body["botId"]).toBeUndefined();
+    });
+
+    test("an empty-string client id is treated as unset", async () => {
+      setTeamsConfig("", MOCK_TEAMS_CLIENT_SECRET);
+
+      const response: InvokedResponse = await callBotTest();
+
+      expect(response.body["error"]).toBe(
+        "Microsoft Teams App Client ID not configured",
+      );
+    });
+  });
+
+  describe("secret handling", () => {
+    test.each([
+      ["fully configured", MOCK_TEAMS_CLIENT_ID, MOCK_TEAMS_CLIENT_SECRET],
+      ["client id missing", null, MOCK_TEAMS_CLIENT_SECRET],
+      ["client secret missing", MOCK_TEAMS_CLIENT_ID, null],
+    ])(
+      "never echoes the client secret (%s)",
+      async (
+        _label: string,
+        clientId: string | null,
+        clientSecret: string | null,
+      ) => {
+        setTeamsConfig(clientId, clientSecret);
+
+        const response: InvokedResponse = await callBotTest();
+        const serialized: string = JSON.stringify(response.body);
+
+        expect(serialized).not.toContain(MOCK_TEAMS_CLIENT_SECRET);
+        expect(serialized.toLowerCase()).not.toContain("clientsecret");
+      },
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelSend.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelSend.test.ts
@@ -1052,6 +1052,42 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translatio
     );
   });
 
+  test("a Graph permission refusal reaches the admin as a named grant, end to end", async () => {
+    /*
+     * The payoff of the whole PermissionDenied split, exercised through the real
+     * send path rather than against the message builder in isolation: Graph
+     * refuses the installed-apps read, the send is still attempted (a refusal is
+     * not a missing install), Microsoft rejects it on the roster, and the
+     * exception an admin actually reads names the one permission that would turn
+     * the guess into an answer.
+     *
+     * Unit-testing the pieces separately leaves this green even if PermissionDenied
+     * were wired to short-circuit at the preflight, which would break both halves.
+     */
+    mockProjectAuth({});
+    mockInstallState(MicrosoftTeamsAppInstallState.PermissionDenied);
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel({ teamId: TEAM_ID });
+    } catch (err) {
+      thrown = err;
+    }
+
+    const message: string = (thrown as Error).message;
+
+    // The send was attempted: a refusal to answer is not a missing install.
+    expect(message).not.toContain(
+      "The OneUptime app is not installed in the Microsoft Teams team",
+    );
+    // And the admin is told what to grant.
+    expect(message).toContain("TeamsAppInstallation.ReadForTeam.All");
+    expect(message).toContain("admin consent");
+    // Microsoft's raw wording survives the rewrite.
+    expect(message).toContain(ROSTER_ERROR_TEXT);
+  });
+
   test("a STALE local install record is re-checked, and a confirmed removal gets the install instructions", async () => {
     /*
      * The local record let this send skip the preflight, but the app has since
@@ -1449,14 +1485,25 @@ describe("MicrosoftTeamsUtil.getRosterRejectionMessage", () => {
     }
   });
 
-  test("a known install points at a bot id mismatch, not a missing install", () => {
+  test("a known install stops blaming the package and points at the Azure Bot", () => {
+    /*
+     * Graph confirmed a package carrying this deployment's app id is installed,
+     * so the package is no longer the lead suspect. It used to be named anyway,
+     * which read to admins as though the error had not registered what they had
+     * already done. The identifier stays in the text — it is what they compare
+     * against — but the instruction now points somewhere new.
+     */
     const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
       channelName: "General",
       installState: MicrosoftTeamsAppInstallState.Installed,
     });
 
     expect(message).toContain("MICROSOFT_TEAMS_APP_CLIENT_ID");
-    expect(message).toContain("the app is installed in this team");
+    expect(message).toContain("probably not the problem");
+    expect(message).toContain("Azure Bot resource");
+    expect(message).not.toContain(
+      "check that the Teams app package was built from this deployment",
+    );
   });
 
   test("an unknown install state still suggests adding the app", () => {
@@ -1658,16 +1705,66 @@ describe("MicrosoftTeamsUtil.isAppInstalledInTeam", () => {
     expect(get).toHaveBeenCalledTimes(2);
   });
 
-  test("a Graph error is Unknown, never NotInstalled", async () => {
+  test("a 403 is PermissionDenied, never NotInstalled", async () => {
     /*
      * The realistic case: a workspace connected before
      * TeamsAppInstallation.ReadForTeam.All was documented gets a 403 here. It
-     * must not be told its app is missing.
+     * must not be told its app is missing — and it is worth separating from a
+     * plain Unknown, because a refusal names the grant that would fix it.
      */
     mockGraph([new HTTPErrorResponse(403, { error: "Forbidden" }, {})]);
 
     await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.PermissionDenied,
+    );
+  });
+
+  test("a non-permission Graph error is still Unknown, never NotInstalled", async () => {
+    /*
+     * A 500 is Microsoft failing, not refusing. Reporting it as PermissionDenied
+     * would tell the admin to grant a permission they already have.
+     */
+    mockGraph([
+      new HTTPErrorResponse(500, { error: "Internal Server Error" }, {}),
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
       MicrosoftTeamsAppInstallState.Unknown,
+    );
+  });
+
+  test("a 401 is Unknown, not PermissionDenied — a stale token is not a missing grant", async () => {
+    /*
+     * Graph answers a missing application permission with 403 and reserves 401
+     * for a token it will not accept. getValidAccessToken can hand over a cached
+     * app token without revalidating it when no expiry was stored, so a 401 here
+     * is a live possibility — and telling that admin to grant a Graph permission
+     * would be a confidently wrong answer.
+     */
+    mockGraph([
+      new HTTPErrorResponse(
+        401,
+        { error: { code: "InvalidAuthenticationToken" } },
+        {},
+      ),
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.Unknown,
+    );
+  });
+
+  test("an authorization error code is PermissionDenied whatever status carries it", async () => {
+    mockGraph([
+      new HTTPErrorResponse(
+        400,
+        { error: { code: "Authorization_RequestDenied" } },
+        {},
+      ),
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.PermissionDenied,
     );
   });
 

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsInstallStateDiagnostics.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsInstallStateDiagnostics.test.ts
@@ -1,0 +1,922 @@
+import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * Tests for the two pieces of MicrosoftTeamsUtil that turn "Microsoft said no"
+ * into something a OneUptime admin can act on:
+ *
+ * - isGraphPermissionDeniedResponse: tells a REFUSAL (401/403, or one of the
+ *   Graph authorization error codes returned with some other status) apart from
+ *   a FAILURE (transport error, throttling, Graph outage). Only a refusal names
+ *   a permission the admin can grant.
+ *
+ * - isAppInstalledInTeam: asks Graph whether a package carrying THIS
+ *   deployment's MICROSOFT_TEAMS_APP_CLIENT_ID is installed in a team, matching
+ *   on teamsApp.externalId. The customer scenario this whole diagnostic exists
+ *   for is an admin staring at a tile literally named "OneUptime" that was
+ *   installed from the Teams store and therefore carries OneUptime Cloud's app
+ *   id, not this deployment's — that MUST come back NotInstalled, because the
+ *   bot behind it will never accept posts from this deployment.
+ *
+ * The load-bearing invariant across the whole file: no failure mode is ever
+ * reported as NotInstalled. A tenant that answers "I won't tell you" is
+ * PermissionDenied (fixable in a minute by granting one permission) and
+ * everything else is Unknown — never a false "the app is missing", which is
+ * what sends admins round the install loop a second time.
+ */
+
+/*
+ * The client id has to be a literal here: jest.mock factories run while the
+ * module graph is being required, which is before any of this file's own consts
+ * exist. CLIENT_ID below repeats the same value, and a test asserts the two
+ * still agree so a copy-paste drift cannot quietly make every "Installed" case
+ * vacuous.
+ */
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...(jest.requireActual("../../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+    MicrosoftTeamsAppClientSecret: "test-secret",
+    MicrosoftTeamsAppTenantId: "test-tenant",
+  };
+});
+
+/*
+ * Same botbuilder module factory as the other MicrosoftTeams suites — the
+ * repo-wide manual mock does not expose everything MicrosoftTeams.ts touches at
+ * import time.
+ */
+jest.mock("botbuilder", () => {
+  return {
+    CloudAdapter: class CloudAdapter {},
+    ConfigurationBotFrameworkAuthentication: class ConfigurationBotFrameworkAuthentication {},
+    TeamsActivityHandler: class TeamsActivityHandler {},
+    TurnContext: class TurnContext {},
+    ActivityHandler: class ActivityHandler {},
+    MessageFactory: {
+      text: jest.fn(),
+      attachment: jest.fn(),
+    },
+    CardFactory: { heroCard: jest.fn() },
+    TeamsInfo: {
+      getMembers: jest.fn(),
+      getPagedMembers: jest.fn(),
+    },
+  };
+});
+
+import MicrosoftTeamsUtil, {
+  MicrosoftTeamsAppInstallState,
+  MICROSOFT_TEAMS_INSTALL_READ_PERMISSION,
+} from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import API from "../../../../Utils/API";
+import HTTPResponse from "../../../../Types/API/HTTPResponse";
+import HTTPErrorResponse from "../../../../Types/API/HTTPErrorResponse";
+import URL from "../../../../Types/API/URL";
+import Headers from "../../../../Types/API/Headers";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import { MessageFactory, CardFactory, TeamsInfo } from "botbuilder";
+
+const CLIENT_ID: string = "11111111-2222-3333-4444-555555555555";
+const GRAPH_TOKEN: string = "graph-token";
+const AUTH_TOKEN: string = "stored-auth-token";
+const TEAM_ID: string = "team-42";
+
+// Mirrors MICROSOFT_TEAMS_MAX_PAGES in MicrosoftTeams.ts, which is not exported.
+const MAX_PAGES: number = 500;
+
+const FIRST_PAGE_URL: string = `https://graph.microsoft.com/v1.0/teams/${TEAM_ID}/installedApps?$expand=teamsApp`;
+const SECOND_PAGE_URL: string = `https://graph.microsoft.com/v1.0/teams/${TEAM_ID}/installedApps?$expand=teamsApp&$skiptoken=page-2`;
+
+interface CapturedGetCall {
+  url: URL;
+  headers: Headers;
+}
+
+/*
+ * MicrosoftTeams.ts reads MicrosoftTeamsAppClientId off the module object on
+ * every call, so overwriting the property on the mocked module is enough to
+ * make the deployment look unconfigured for one test. afterEach puts it back.
+ */
+/*
+ * require(), not a top-level `import * as`, and deliberately so: an ES
+ * namespace import gives getter-only properties, and assigning to one throws
+ * "Cannot set property ... which has only a getter". The raw CommonJS module
+ * object is writable, which is the whole point — this flips the deployment to
+ * "unconfigured" for a single test and puts it back afterwards.
+ */
+function mutableEnvironmentConfig(): Record<string, unknown> {
+  /* eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+  return require("../../../../Server/EnvironmentConfig") as Record<
+    string,
+    unknown
+  >;
+}
+
+function setConfiguredClientId(clientId: string | null): void {
+  mutableEnvironmentConfig()["MicrosoftTeamsAppClientId"] = clientId;
+}
+
+function getConfiguredClientId(): unknown {
+  return mutableEnvironmentConfig()["MicrosoftTeamsAppClientId"];
+}
+
+function errorResponse(
+  statusCode: number,
+  body: JSONObject,
+): HTTPErrorResponse {
+  return new HTTPErrorResponse(statusCode, body, {});
+}
+
+function mockAccessToken(): jest.SpyInstance {
+  return jest
+    .spyOn(MicrosoftTeamsUtil, "getValidAccessToken")
+    .mockResolvedValue(GRAPH_TOKEN);
+}
+
+/*
+ * Queues one Graph result per page, in order. Each entry is either a raw JSON
+ * body (wrapped in a 200) or an already-built HTTPErrorResponse.
+ */
+function mockGraphPages(
+  pages: Array<JSONObject | HTTPErrorResponse>,
+): jest.SpyInstance {
+  const getSpy: jest.SpyInstance = jest.spyOn(API, "get");
+
+  for (const page of pages) {
+    if (page instanceof HTTPErrorResponse) {
+      getSpy.mockResolvedValueOnce(page);
+    } else {
+      getSpy.mockResolvedValueOnce(new HTTPResponse<JSONObject>(200, page, {}));
+    }
+  }
+
+  return getSpy;
+}
+
+function installedAppJson(teamsApp: JSONObject | null): JSONObject {
+  const installedApp: JSONObject = {
+    id: `install-${JSON.stringify(teamsApp)}`,
+  };
+  if (teamsApp !== null) {
+    installedApp["teamsApp"] = teamsApp;
+  }
+  return installedApp;
+}
+
+async function callIsAppInstalledInTeam(data?: {
+  teamId?: string | undefined;
+}): Promise<MicrosoftTeamsAppInstallState> {
+  return MicrosoftTeamsUtil.isAppInstalledInTeam({
+    authToken: AUTH_TOKEN,
+    projectId: ObjectID.generate(),
+    teamId: data?.teamId || TEAM_ID,
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  setConfiguredClientId(CLIENT_ID);
+});
+
+/*
+ * The botbuilder module mock's jest.fn()s are shared across test files in this
+ * suite run — jest.spyOn on an existing mock returns the same function, so call
+ * history and mockResolvedValueOnce queues leak between tests unless reset.
+ */
+beforeEach(() => {
+  (MessageFactory.text as jest.Mock).mockReset();
+  (MessageFactory.attachment as jest.Mock).mockReset();
+  (CardFactory.heroCard as jest.Mock).mockReset();
+  (TeamsInfo.getMembers as jest.Mock).mockReset();
+  (TeamsInfo.getPagedMembers as jest.Mock).mockReset();
+});
+
+describe("MicrosoftTeamsUtil.isGraphPermissionDeniedResponse", () => {
+  describe("status codes", () => {
+    test("returns FALSE for a 401 expired token — that is a credential problem, not a missing grant", () => {
+      /*
+       * Graph answers a missing application permission with 403 and reserves 401
+       * for a token it will not accept. getValidAccessToken can hand back a
+       * cached app token without revalidating it when miscData carries no
+       * expiry, so this 401 is reachable in practice — and answering it with
+       * "grant TeamsAppInstallation.ReadForTeam.All" would be exactly the
+       * confidently-wrong diagnosis this whole change exists to stop producing.
+       */
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(401, { message: "Access token has expired." }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns true for 403, regardless of body", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(403, { message: "Forbidden." }),
+        ),
+      ).toBe(true);
+    });
+
+    test("returns false for a bare 401 with no message", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(401, {}),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns true for a 401 that DOES carry an authorization error code", () => {
+      /*
+       * Status alone is not the whole signal. If Graph names an authorization
+       * refusal, honour it whatever status it arrived on.
+       */
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(401, {
+            error: { code: "Authorization_RequestDenied" },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    test("returns true for 403 even when the body carries no message at all", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(403, {}),
+        ),
+      ).toBe(true);
+    });
+
+    test("returns false for 500 with an unrelated message", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, {
+            message: "An internal server error occurred. Please try again.",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns false for 404 with an unrelated message", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(404, {
+            message: "No team found with the specified id.",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns false for 429 with an unrelated message (throttling is a failure, not a refusal)", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(429, {
+            message: "Too many requests. Retry after 30 seconds.",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns false when the body yields an empty message", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, {}),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns false when the body has only unrelated keys, so message resolves empty", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(503, { requestId: "abc-123", date: "2026-01-01" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("message fragments on a non-401/403 status", () => {
+    /*
+     * Graph is not consistent about the status it returns with these codes, so
+     * each has to be recognised on its own. 400 is used here precisely because
+     * the status alone would not trip the check.
+     */
+    const fragmentCases: Array<{ name: string; message: string }> = [
+      {
+        name: "Authorization_RequestDenied (as written by Graph)",
+        message:
+          "Authorization_RequestDenied: Insufficient privileges to complete the operation.",
+      },
+      {
+        name: "accessDenied (as written by Graph)",
+        message: "accessDenied: Failed to execute Skype backend request.",
+      },
+      {
+        name: "Insufficient privileges (as written by Graph)",
+        message: "Insufficient privileges to complete the operation.",
+      },
+    ];
+
+    for (const fragmentCase of fragmentCases) {
+      test(`returns true for a 400 whose message contains ${fragmentCase.name}`, () => {
+        expect(
+          MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+            errorResponse(400, { message: fragmentCase.message }),
+          ),
+        ).toBe(true);
+      });
+
+      test(`matches ${fragmentCase.name} case-insensitively (all upper case)`, () => {
+        expect(
+          MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+            errorResponse(400, {
+              message: fragmentCase.message.toUpperCase(),
+            }),
+          ),
+        ).toBe(true);
+      });
+
+      test(`matches ${fragmentCase.name} case-insensitively (all lower case)`, () => {
+        expect(
+          MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+            errorResponse(400, {
+              message: fragmentCase.message.toLowerCase(),
+            }),
+          ),
+        ).toBe(true);
+      });
+    }
+
+    test("matches a fragment embedded mid-sentence, not just at the start", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(400, {
+            message:
+              'Graph replied with code "Authorization_RequestDenied" while reading installedApps.',
+          }),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("nested body shapes (HTTPErrorResponse.message coercion)", () => {
+    test("finds the fragment in { error: { code, message } }, Graph's real error envelope", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(400, {
+            error: {
+              code: "Authorization_RequestDenied",
+              message: "Insufficient privileges to complete the operation.",
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    test("finds the fragment in { error: { error: '...' } }, the nested-error shape", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(400, {
+            error: { error: "accessDenied while expanding teamsApp" },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    test("finds the fragment in { data: { message } }, since data is checked first", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(400, {
+            data: { message: "Authorization_RequestDenied" },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    test("finds the fragment via the JSON.stringify fallback when the object has neither message nor error", () => {
+      /*
+       * coerceToMessage falls back to JSON.stringify for an object it cannot
+       * read a message out of, so the code survives inside the serialised blob.
+       */
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(400, {
+            error: {
+              code: "Authorization_RequestDenied",
+              innerError: { requestId: "abc" },
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    test("returns false for a nested body whose message is unrelated", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, {
+            error: {
+              code: "InternalServerError",
+              message: "An unexpected error occurred.",
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("near-misses (documenting the REAL matching behaviour)", () => {
+    /*
+     * The check is a plain substring test against three exact fragments, so
+     * English prose that MEANS the same thing does not match. These tests pin
+     * the real behaviour rather than the intended one: if someone later swaps
+     * the substring list for a looser regex, these will fail and force the
+     * change to be a deliberate one.
+     */
+    test("returns FALSE for 'access is denied for this user' on a 500 — the fragment is 'accessdenied' with no words between", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, {
+            message: "Access is denied for this user.",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns FALSE for 'Access denied' (with a space) on a 500 — only the run-together Graph code matches", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, { message: "Access denied." }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns FALSE for 'insufficient permissions' on a 500 — the fragment is 'insufficient privileges'", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, {
+            message: "Insufficient permissions to complete the operation.",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns FALSE for 'unauthorized' on a 500 — a word the check deliberately does not carry", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, { message: "Unauthorized." }),
+        ),
+      ).toBe(false);
+    });
+
+    test("returns TRUE for the bare code 'accessDenied' on a 500 — the run-together form is what matches", () => {
+      expect(
+        MicrosoftTeamsUtil.isGraphPermissionDeniedResponse(
+          errorResponse(500, { message: "accessDenied" }),
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("MicrosoftTeamsUtil.isAppInstalledInTeam", () => {
+  test("test fixture guard: the mocked deployment really is configured with CLIENT_ID", () => {
+    /*
+     * Every Installed assertion below is only meaningful if the client id the
+     * fixtures hand to Graph is the client id the code compares against. If
+     * these ever drift apart, the Installed cases would silently become
+     * NotInstalled cases and stop testing anything.
+     */
+    expect(getConfiguredClientId()).toBe(CLIENT_ID);
+  });
+
+  describe("Installed", () => {
+    test("Installed when a teamsApp externalId equals this deployment's client id", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        {
+          value: [
+            installedAppJson({
+              id: "graph-generated-id",
+              displayName: "OneUptime",
+              externalId: CLIENT_ID,
+            }),
+          ],
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Installed,
+      );
+    });
+
+    test("Installed when the match is on the SECOND page (@odata.nextLink pagination)", async () => {
+      mockAccessToken();
+      const getSpy: jest.SpyInstance = mockGraphPages([
+        {
+          value: [
+            installedAppJson({
+              displayName: "Planner",
+              externalId: "some-other-app-id",
+            }),
+          ],
+          "@odata.nextLink": SECOND_PAGE_URL,
+        },
+        {
+          value: [
+            installedAppJson({
+              displayName: "OneUptime",
+              externalId: CLIENT_ID,
+            }),
+          ],
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Installed,
+      );
+
+      expect(getSpy).toHaveBeenCalledTimes(2);
+
+      const firstCall: CapturedGetCall = getSpy.mock
+        .calls[0]?.[0] as CapturedGetCall;
+      const secondCall: CapturedGetCall = getSpy.mock
+        .calls[1]?.[0] as CapturedGetCall;
+
+      expect(firstCall.url.toString()).toBe(FIRST_PAGE_URL);
+      expect(secondCall.url.toString()).toBe(SECOND_PAGE_URL);
+      expect(firstCall.headers["Authorization"]).toBe(`Bearer ${GRAPH_TOKEN}`);
+      expect(secondCall.headers["Authorization"]).toBe(`Bearer ${GRAPH_TOKEN}`);
+    });
+
+    test("stops paginating as soon as it finds the match", async () => {
+      mockAccessToken();
+      const getSpy: jest.SpyInstance = mockGraphPages([
+        {
+          value: [
+            installedAppJson({
+              displayName: "OneUptime",
+              externalId: CLIENT_ID,
+            }),
+          ],
+          "@odata.nextLink": SECOND_PAGE_URL,
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Installed,
+      );
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("matches on externalId, not on displayName — a renamed package still counts as installed", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        {
+          value: [
+            installedAppJson({
+              displayName: "Acme Status (self-hosted)",
+              externalId: CLIENT_ID,
+            }),
+          ],
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Installed,
+      );
+    });
+  });
+
+  describe("NotInstalled", () => {
+    test("NotInstalled when a single page has no matching externalId", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        {
+          value: [
+            installedAppJson({
+              displayName: "Planner",
+              externalId: "planner-app-id",
+            }),
+            installedAppJson({
+              displayName: "Approvals",
+              externalId: "approvals-app-id",
+            }),
+          ],
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+    });
+
+    test("NotInstalled when the team has no installed apps at all", async () => {
+      mockAccessToken();
+      mockGraphPages([{ value: [] }]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+    });
+
+    test("NotInstalled when the response omits value entirely", async () => {
+      mockAccessToken();
+      mockGraphPages([{}]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+    });
+
+    test("NotInstalled when every page is exhausted with no matching externalId", async () => {
+      mockAccessToken();
+      const getSpy: jest.SpyInstance = mockGraphPages([
+        {
+          value: [
+            installedAppJson({ displayName: "Planner", externalId: "a" }),
+          ],
+          "@odata.nextLink": SECOND_PAGE_URL,
+        },
+        {
+          value: [installedAppJson({ displayName: "Forms", externalId: "b" })],
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    /*
+     * THE customer scenario. An admin installs "OneUptime" from the Teams
+     * store, sees the tile in Manage team > Apps, and reasonably concludes the
+     * integration is set up. That package carries OneUptime Cloud's app id, so
+     * its bot is a different bot and will never accept a proactive post from
+     * this deployment. Answering "Installed" here — matching on the name, or on
+     * anything other than this deployment's client id — would turn the whole
+     * diagnostic into a lie and send the admin looking at the Azure Bot
+     * resource for a problem that is really the wrong package.
+     */
+    test("NotInstalled for a DIFFERENT app that is also called OneUptime (the Teams-store package)", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        {
+          value: [
+            installedAppJson({
+              id: "store-catalog-id",
+              displayName: "OneUptime",
+              distributionMethod: "store",
+              externalId: "99999999-8888-7777-6666-555555555555",
+            }),
+          ],
+        },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+    });
+
+    test("NotInstalled when an installed app carries no teamsApp expansion", async () => {
+      mockAccessToken();
+      mockGraphPages([{ value: [installedAppJson(null)] }]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+    });
+
+    test("NotInstalled when a teamsApp has no externalId at all", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        { value: [installedAppJson({ displayName: "OneUptime" })] },
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.NotInstalled,
+      );
+    });
+  });
+
+  describe("PermissionDenied", () => {
+    test("PermissionDenied when Graph answers 403", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        errorResponse(403, {
+          error: {
+            code: "Authorization_RequestDenied",
+            message: "Insufficient privileges to complete the operation.",
+          },
+        }),
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.PermissionDenied,
+      );
+    });
+
+    test("Unknown — not PermissionDenied — when Graph answers 401 with a bad token", async () => {
+      /*
+       * An expired or empty token is a credential problem. Reporting it as
+       * PermissionDenied would put "grant this Graph permission" in front of an
+       * admin whose permission was never the issue.
+       */
+      mockAccessToken();
+      mockGraphPages([
+        errorResponse(401, {
+          error: {
+            code: "InvalidAuthenticationToken",
+            message: "Access token is empty.",
+          },
+        }),
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+    });
+
+    test("PermissionDenied on a non-401/403 status carrying an authorization code", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        errorResponse(400, {
+          error: {
+            code: "Authorization_RequestDenied",
+            message: "Insufficient privileges to complete the operation.",
+          },
+        }),
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.PermissionDenied,
+      );
+    });
+
+    test("PermissionDenied when the refusal arrives on the SECOND page, not the first", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        {
+          value: [
+            installedAppJson({ displayName: "Planner", externalId: "a" }),
+          ],
+          "@odata.nextLink": SECOND_PAGE_URL,
+        },
+        errorResponse(403, { message: "Forbidden." }),
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.PermissionDenied,
+      );
+    });
+
+    test("a refusal is never reported as NotInstalled", async () => {
+      mockAccessToken();
+      mockGraphPages([errorResponse(403, { message: "Forbidden." })]);
+
+      const state: MicrosoftTeamsAppInstallState =
+        await callIsAppInstalledInTeam();
+
+      expect(state).not.toBe(MicrosoftTeamsAppInstallState.NotInstalled);
+      expect(state).not.toBe(MicrosoftTeamsAppInstallState.Installed);
+    });
+
+    test("names the grant that fixes it in the roster rejection message", () => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "Ops",
+        installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+      });
+
+      expect(message).toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+      expect(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION).toBe(
+        "TeamsAppInstallation.ReadForTeam.All",
+      );
+    });
+  });
+
+  describe("Unknown", () => {
+    test("Unknown when Graph answers 500 with an unrelated message", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        errorResponse(500, {
+          error: {
+            code: "InternalServerError",
+            message: "An unexpected error occurred.",
+          },
+        }),
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+    });
+
+    test("Unknown when Graph answers 429 (throttling is a failure, not a refusal)", async () => {
+      mockAccessToken();
+      mockGraphPages([errorResponse(429, { message: "Too many requests." })]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+    });
+
+    test("Unknown when Graph answers 404 for the team", async () => {
+      mockAccessToken();
+      mockGraphPages([
+        errorResponse(404, { message: "No team found with the specified id." }),
+      ]);
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+    });
+
+    test("Unknown when getValidAccessToken throws", async () => {
+      jest
+        .spyOn(MicrosoftTeamsUtil, "getValidAccessToken")
+        .mockRejectedValue(new Error("Refresh token expired"));
+      const getSpy: jest.SpyInstance = jest.spyOn(API, "get");
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    test("Unknown when API.get itself rejects (transport failure)", async () => {
+      mockAccessToken();
+      jest
+        .spyOn(API, "get")
+        .mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+    });
+
+    test("Unknown when the client id is not configured, without calling Graph", async () => {
+      setConfiguredClientId(null);
+      const tokenSpy: jest.SpyInstance = mockAccessToken();
+      /*
+       * A rejecting implementation rather than a bare spy, so that a
+       * regression which does reach Graph fails loudly here instead of
+       * attempting a real network call.
+       */
+      const getSpy: jest.SpyInstance = jest
+        .spyOn(API, "get")
+        .mockRejectedValue(new Error("Graph must not be called"));
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+      expect(tokenSpy).not.toHaveBeenCalled();
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    test("Unknown when the client id is configured as an empty string", async () => {
+      setConfiguredClientId("");
+      const getSpy: jest.SpyInstance = jest
+        .spyOn(API, "get")
+        .mockRejectedValue(new Error("Graph must not be called"));
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+
+    test(`Unknown when pagination exceeds the ${MAX_PAGES}-page cap, and it stops after exactly ${MAX_PAGES} requests`, async () => {
+      mockAccessToken();
+
+      /*
+       * A Graph response that always points at another page. Without the cap
+       * this is an infinite loop, so the assertion on the call count is the
+       * one that matters: the guard must fire, and it must fire before the
+       * request that would have been page 501.
+       */
+      const getSpy: jest.SpyInstance = jest.spyOn(API, "get").mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          {
+            value: [
+              installedAppJson({
+                displayName: "Planner",
+                externalId: "not-this-deployment",
+              }),
+            ],
+            "@odata.nextLink": SECOND_PAGE_URL,
+          },
+          {},
+        ),
+      );
+
+      await expect(callIsAppInstalledInTeam()).resolves.toBe(
+        MicrosoftTeamsAppInstallState.Unknown,
+      );
+      expect(getSpy).toHaveBeenCalledTimes(MAX_PAGES);
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsRosterDiagnosticMessages.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsRosterDiagnosticMessages.test.ts
@@ -1,0 +1,642 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Tests for the two diagnostic message builders an admin actually reads when a
+ * Microsoft Teams notification fails: getBotNotInTeamMessage and
+ * getRosterRejectionMessage.
+ *
+ * The failure these messages exist to end is a self-hosted deployment whose
+ * admin installed the "OneUptime" app from the Microsoft Teams store. That
+ * package's bot belongs to OneUptime Cloud, so Teams installs it happily, shows
+ * a OneUptime tile under Manage team > Apps, and then refuses every proactive
+ * post from this deployment with "The bot is not part of the conversation
+ * roster." An admin looking straight at that tile reads "the OneUptime app is
+ * not installed" as nonsense and goes round the loop again, which is how this
+ * turns into a multi-day investigation.
+ *
+ * So both builders now carry the wrong-package note, and getRosterRejectionMessage
+ * distinguishes the four install states:
+ *
+ * - Installed: Graph confirmed a package with THIS deployment's app id is in
+ *   the team, so the package stops leading and the message must NOT send the
+ *   admin back to re-verify it. The wording stays hedged ("probably"), because
+ *   the check matches the manifest id rather than the bot id directly. This is
+ *   a behaviour change from the previous wording and is pinned below.
+ * - NotInstalled / Unknown: the package is still a live suspect, so the
+ *   "different package whose bot id is not this deployment's
+ *   MICROSOFT_TEAMS_APP_CLIENT_ID" wording stays.
+ * - PermissionDenied: Graph refused the installed-apps read, so OneUptime is
+ *   guessing only because it was not allowed to know. This — and only this —
+ *   state names TeamsAppInstallation.ReadForTeam.All and tells the admin that
+ *   granting it turns the guess into an answer.
+ *
+ * Message-shape coverage that already lives in MicrosoftTeamsChannelSend.test.ts
+ * (branch selection by membershipType, the basic "names the channel" case,
+ * quoting Microsoft's error) is not repeated here; this file covers the new
+ * behaviour and the branches that file misses.
+ */
+
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...(jest.requireActual("../../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+    MicrosoftTeamsAppClientSecret: "test-secret",
+    MicrosoftTeamsAppTenantId: "test-tenant",
+  };
+});
+
+import MicrosoftTeamsUtil, {
+  MICROSOFT_TEAMS_INSTALL_READ_PERMISSION,
+  MicrosoftTeamsAppInstallState,
+} from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+
+/*
+ * The note that must appear in BOTH branches of getBotNotInTeamMessage. Asserted
+ * as three separate claims rather than one long literal, so a rewording that
+ * keeps the substance does not fail, but dropping any of the three does.
+ */
+const WRONG_PACKAGE_IS_DIFFERENT: string = "it is a different package";
+const WRONG_PACKAGE_POINTS_AT_CLOUD: string =
+  "the app from the Teams store points at OneUptime Cloud's bot";
+const WRONG_PACKAGE_FIX: string =
+  "upload the manifest from Project Settings > Workspace > Microsoft Teams";
+
+/*
+ * The instruction the Installed branch used to carry and must not carry any
+ * more: Graph has already confirmed the package, so sending the admin back to
+ * check it is the thing that made this message feel unread.
+ */
+const OLD_RE_VERIFY_PACKAGE_INSTRUCTION: string =
+  "check that the Teams app package was built from this deployment";
+
+const AZURE_BOT_CAUSE: string =
+  "the Azure Bot resource for this deployment does not have the Microsoft Teams channel enabled";
+
+const MICROSOFT_QUOTE_PREFIX: string = "Microsoft's response was";
+
+const ALL_INSTALL_STATES: Array<MicrosoftTeamsAppInstallState> = [
+  MicrosoftTeamsAppInstallState.Installed,
+  MicrosoftTeamsAppInstallState.NotInstalled,
+  MicrosoftTeamsAppInstallState.PermissionDenied,
+  MicrosoftTeamsAppInstallState.Unknown,
+];
+
+function expectWrongPackageNote(message: string): void {
+  expect(message).toContain(WRONG_PACKAGE_IS_DIFFERENT);
+  expect(message).toContain(WRONG_PACKAGE_POINTS_AT_CLOUD);
+  expect(message).toContain(WRONG_PACKAGE_FIX);
+}
+
+describe("MicrosoftTeamsAppInstallState", () => {
+  test("PermissionDenied is a distinct state, not an alias of Unknown", () => {
+    /*
+     * The whole point of splitting it out: a tenant that answers "I won't tell
+     * you" is fixable in a minute, and a transport failure is not. Collapsing
+     * the two back together silently removes the one actionable hint.
+     */
+    expect(MicrosoftTeamsAppInstallState.PermissionDenied).toBe(
+      "PermissionDenied",
+    );
+    expect(MicrosoftTeamsAppInstallState.PermissionDenied).not.toBe(
+      MicrosoftTeamsAppInstallState.Unknown,
+    );
+  });
+
+  test("the permission the error names is the one the setup docs tell you to grant", () => {
+    /*
+     * A real cross-file check rather than asserting the constant equals its own
+     * literal. The error string builds off the constant while the setup guide
+     * and the docs site spell it out in prose, so a rename here silently leaves
+     * an admin hunting for a permission the documentation never mentions.
+     */
+    const docSources: Array<string> = [
+      "../../../../../App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md",
+      "../../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx",
+    ].map((relativePath: string) => {
+      return fs.readFileSync(path.join(__dirname, relativePath), "utf8");
+    });
+
+    for (const source of docSources) {
+      expect(source).toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+    }
+  });
+});
+
+describe("MicrosoftTeamsUtil.getBotNotInTeamMessage - wrong-package note", () => {
+  test("the standard-channel branch keeps its install path AND names the wrong-package case", () => {
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+      membershipType: "standard",
+    });
+
+    expect(message).toContain('team that owns "General"');
+    expect(message).toContain('"..."');
+    expect(message).toContain("Manage team > Apps > More apps");
+    expectWrongPackageNote(message);
+  });
+
+  test("the private-channel branch keeps its install path and deliberately omits the wrong-package note", () => {
+    /*
+     * The note must NOT appear here. The install check reads
+     * /teams/{id}/installedApps — team scope — while a private channel needs its
+     * own channel-scope install, so a perfectly correct channel install still
+     * comes back NotInstalled. Telling that admin their package is the wrong one
+     * and to "remove it" would talk them into destroying a working install to
+     * fix a problem they do not have.
+     */
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "Ops War Room",
+      membershipType: "private",
+    });
+
+    expect(message).toContain('private channel "Ops War Room"');
+    expect(message).toContain("Manage channel > Apps > Add an app");
+    expect(message).toContain(
+      "Installing OneUptime in the parent team does not cover private channels.",
+    );
+    expect(message).not.toContain(WRONG_PACKAGE_IS_DIFFERENT);
+    expect(message).not.toContain("Remove it");
+  });
+
+  test("an undefined membershipType takes the standard branch and still carries the note", () => {
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+    });
+
+    expect(message).toContain("Manage team > Apps > More apps");
+    expect(message).not.toContain("Manage channel");
+    expectWrongPackageNote(message);
+  });
+
+  test("the note explains why a OneUptime tile is not proof of anything", () => {
+    /*
+     * "Remove it, then upload ours" is the actionable half. Without it the note
+     * only tells the admin that what they are looking at is wrong, which is
+     * where they already were.
+     */
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+    });
+
+    expect(message).toContain("If a tile named OneUptime is already listed");
+    expect(message).toContain("Remove it");
+    expect(message).toContain("MICROSOFT_TEAMS_APP_CLIENT_ID");
+  });
+
+  test("the note is appended to, not substituted for, the install instructions", () => {
+    const standard: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+      membershipType: "standard",
+    });
+
+    expect(standard.indexOf("Manage team > Apps > More apps")).toBeLessThan(
+      standard.indexOf(WRONG_PACKAGE_IS_DIFFERENT),
+    );
+  });
+
+  test("a channel name containing quotes is interpolated verbatim in both branches", () => {
+    /*
+     * Teams allows quotes in channel names, and the message wraps the name in
+     * quotes of its own. Nothing escapes or strips it, and nothing should
+     * silently truncate at the inner quote.
+     */
+    const channelName: string = 'The "Real" Ops Channel';
+
+    const standard: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: channelName,
+      membershipType: "standard",
+    });
+    const privateChannel: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: channelName,
+      membershipType: "private",
+    });
+
+    expect(standard).toContain(`team that owns "${channelName}"`);
+    expect(privateChannel).toContain(`private channel "${channelName}"`);
+  });
+
+  test("a unicode channel name is interpolated verbatim in both branches", () => {
+    const channelName: string = "運用 – アラート 🚨";
+
+    const standard: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: channelName,
+      membershipType: "standard",
+    });
+    const privateChannel: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: channelName,
+      membershipType: "private",
+    });
+
+    expect(standard).toContain(`team that owns "${channelName}"`);
+    expect(privateChannel).toContain(`private channel "${channelName}"`);
+  });
+
+  test("an empty channel name still produces the instructions rather than an empty message", () => {
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "",
+    });
+
+    expect(message).toContain("Manage team > Apps > More apps");
+    expectWrongPackageNote(message);
+  });
+});
+
+describe("MicrosoftTeamsUtil.getRosterRejectionMessage - invariants across every install state", () => {
+  test.each(ALL_INSTALL_STATES)(
+    "%s names the refused channel and blames the roster",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "test public channel",
+        installState: installState,
+      });
+
+      expect(message).toContain(
+        'Microsoft Teams refused the message to "test public channel"',
+      );
+      expect(message).toContain(
+        "the OneUptime bot is not a member of that conversation",
+      );
+    },
+  );
+
+  test.each(ALL_INSTALL_STATES)(
+    "%s always lists the Azure Bot Microsoft Teams channel as a cause",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message).toContain(AZURE_BOT_CAUSE);
+    },
+  );
+
+  /*
+   * Removed: a test asserting getRosterRejectionMessage never contains "The
+   * OneUptime app is not installed in the Microsoft Teams team". That sentence
+   * only ever lived in getBotNotInTeamMessage, so the assertion could not fail
+   * before or after this change. The property it was reaching for — that a
+   * refusal to answer never reaches the admin as a statement that the app is
+   * missing — is real, but it belongs on the send path where the two builders
+   * are actually selected between. It is covered in
+   * MicrosoftTeamsChannelSend.test.ts ("a Graph permission refusal reaches the
+   * admin as a named grant, end to end").
+   */
+  test.each(ALL_INSTALL_STATES)(
+    "%s names the channel it is talking about",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message).toContain('"General"');
+    },
+  );
+
+  test.each(ALL_INSTALL_STATES)(
+    "%s produces a single sentence-terminated message with no dangling separators",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message.endsWith(".")).toBe(true);
+      expect(message).not.toContain(";.");
+      expect(message).not.toContain("  ");
+    },
+  );
+});
+
+describe("MicrosoftTeamsUtil.getRosterRejectionMessage - the PermissionDenied hint", () => {
+  test("PermissionDenied names the permission, the grant, and the retry", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+    });
+
+    expect(message).toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+    expect(message).toContain(
+      "Microsoft Graph denied the installed-apps check",
+    );
+    expect(message).toContain("application permission");
+    expect(message).toContain("re-grant admin consent");
+    expect(message).toContain("try again");
+  });
+
+  test.each([
+    MicrosoftTeamsAppInstallState.Installed,
+    MicrosoftTeamsAppInstallState.NotInstalled,
+    MicrosoftTeamsAppInstallState.Unknown,
+  ])(
+    "%s does NOT carry the grant-this-permission hint",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      /*
+       * The hint is only true when Graph refused. Attaching it to a transport
+       * failure or to a successful read sends an admin to change a permission
+       * that was never the problem.
+       */
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message).not.toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+      expect(message).not.toContain(
+        "Microsoft Graph denied the installed-apps check",
+      );
+    },
+  );
+
+  test("the hint survives a private channel, which takes a different causes branch", () => {
+    /*
+     * membershipType decides the FIRST cause; installState decides the hint.
+     * They are independent, and a private channel in a tenant that refused the
+     * Graph read needs both.
+     */
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "Ops War Room",
+      membershipType: "private",
+      installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+    });
+
+    expect(message).toContain("Manage channel > Apps");
+    expect(message).toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+  });
+});
+
+describe("MicrosoftTeamsUtil.getRosterRejectionMessage - the Installed branch no longer re-litigates the package", () => {
+  test("Installed states that the package is ruled out", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Installed,
+    });
+
+    /*
+     * "Probably", not "definitely". The check matches teamsApp.externalId, which
+     * is the manifest id; only OneUptime's own generator guarantees that equals
+     * the bot id, so a hand-edited manifest can satisfy it and still carry a
+     * foreign bot. The wording must not promise more than the evidence supports.
+     */
+    expect(message).toContain(
+      "already matches this deployment's MICROSOFT_TEAMS_APP_CLIENT_ID",
+    );
+    expect(message).toContain("probably not the problem");
+    expect(message).not.toContain("the package is not the problem");
+  });
+
+  test("Installed points at the Azure Bot resource as the remaining cause", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Installed,
+    });
+
+    expect(message).toContain(
+      "the most likely remaining cause is the Azure Bot resource",
+    );
+    expect(message).toContain(AZURE_BOT_CAUSE);
+  });
+
+  test("Installed no longer tells the admin to go and re-verify the package", () => {
+    /*
+     * Behaviour change, pinned deliberately. Graph already compared the
+     * installed package's externalId against this deployment's client id — that
+     * is the entire reason the state is Installed. Asking the admin to redo the
+     * check by eye is worse than saying nothing, because it reads as a message
+     * that did not take its own evidence into account.
+     */
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Installed,
+    });
+
+    expect(message).not.toContain(OLD_RE_VERIFY_PACKAGE_INSTRUCTION);
+    expect(message).not.toContain("Manage team > Apps");
+    /*
+     * The identifier itself stays. It is the value an admin compares against the
+     * installed app's bot id, so naming it is useful; what had to go was the
+     * instruction to go and redo a check OneUptime had already done for them.
+     */
+    expect(message).toContain("MICROSOFT_TEAMS_APP_CLIENT_ID");
+  });
+
+  test.each([
+    MicrosoftTeamsAppInstallState.NotInstalled,
+    MicrosoftTeamsAppInstallState.Unknown,
+  ])(
+    "%s still warns that the added app may be somebody else's package",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message).toContain("Manage team > Apps > More apps");
+      expect(message).toContain(
+        "the app that was added is a different package whose bot id is not this deployment's MICROSOFT_TEAMS_APP_CLIENT_ID",
+      );
+    },
+  );
+
+  test("PermissionDenied shares the not-installed causes, because we could not rule them out", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+    });
+
+    expect(message).toContain("Manage team > Apps > More apps");
+    expect(message).toContain(
+      "the app that was added is a different package whose bot id is not this deployment's MICROSOFT_TEAMS_APP_CLIENT_ID",
+    );
+  });
+
+  test.each(ALL_INSTALL_STATES)(
+    "a private channel takes the private branch regardless of installState (%s)",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "Ops War Room",
+        membershipType: "private",
+        installState: installState,
+      });
+
+      expect(message).toContain(
+        '"Ops War Room" is a private channel, which needs the app installed into the channel itself',
+      );
+      expect(message).toContain("Manage channel > Apps > Add an app");
+      expect(message).toContain("a team-level install does not cover it");
+      expect(message).not.toContain("Manage team > Apps");
+    },
+  );
+
+  test("only the exact string 'private' selects the private-channel cause", () => {
+    /*
+     * Graph returns membershipType lowercase, so the comparison is exact. Pin
+     * it here too: a loosened comparison would silently change which cause an
+     * admin is shown first.
+     */
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      membershipType: "Private",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+    });
+
+    expect(message).toContain("Manage team > Apps > More apps");
+    expect(message).not.toContain("Manage channel");
+  });
+});
+
+describe("MicrosoftTeamsUtil.getRosterRejectionMessage - Microsoft's raw response", () => {
+  test("an Error has its message appended in quotes", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: new Error(
+        "The bot is not part of the conversation roster.",
+      ),
+    });
+
+    expect(message).toContain(
+      `${MICROSOFT_QUOTE_PREFIX}: "The bot is not part of the conversation roster."`,
+    );
+  });
+
+  test("a subclassed Error is treated the same as a plain Error", () => {
+    class GraphError extends Error {}
+
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: new GraphError("BotNotInConversationRoster"),
+    });
+
+    expect(message).toContain(
+      `${MICROSOFT_QUOTE_PREFIX}: "BotNotInConversationRoster"`,
+    );
+  });
+
+  test("a plain string is appended as-is", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: "Forbidden: bot is not in roster",
+    });
+
+    expect(message).toContain(
+      `${MICROSOFT_QUOTE_PREFIX}: "Forbidden: bot is not in roster"`,
+    );
+  });
+
+  test.each(ALL_INSTALL_STATES)(
+    "an undefined microsoftError appends nothing (%s)",
+    (installState: MicrosoftTeamsAppInstallState) => {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+        microsoftError: undefined,
+      });
+
+      expect(message).not.toContain(MICROSOFT_QUOTE_PREFIX);
+    },
+  );
+
+  test("a null microsoftError appends nothing rather than the word null", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: null,
+    });
+
+    expect(message).not.toContain(MICROSOFT_QUOTE_PREFIX);
+    expect(message).not.toContain("null");
+  });
+
+  test("an empty-string microsoftError appends nothing rather than an empty quote", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: "",
+    });
+
+    expect(message).not.toContain(MICROSOFT_QUOTE_PREFIX);
+    expect(message).not.toContain('""');
+  });
+
+  test("an Error with an empty message appends nothing", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: new Error(""),
+    });
+
+    expect(message).not.toContain(MICROSOFT_QUOTE_PREFIX);
+  });
+});
+
+describe("MicrosoftTeamsUtil.getRosterRejectionMessage - ordering when both suffixes apply", () => {
+  test("PermissionDenied plus a Microsoft error yields both, hint first", () => {
+    /*
+     * The hint is the thing the admin can act on; Microsoft's raw wording is
+     * evidence. Evidence last, so the message does not trail off into the same
+     * opaque sentence that sent them here.
+     */
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+      microsoftError: new Error(
+        "The bot is not part of the conversation roster.",
+      ),
+    });
+
+    const hintIndex: number = message.indexOf(
+      MICROSOFT_TEAMS_INSTALL_READ_PERMISSION,
+    );
+    const quoteIndex: number = message.indexOf(MICROSOFT_QUOTE_PREFIX);
+
+    expect(hintIndex).toBeGreaterThan(-1);
+    expect(quoteIndex).toBeGreaterThan(-1);
+    expect(hintIndex).toBeLessThan(quoteIndex);
+  });
+
+  test("both suffixes come after the list of likely causes", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+      microsoftError: "Forbidden",
+    });
+
+    const causesIndex: number = message.indexOf(AZURE_BOT_CAUSE);
+
+    expect(causesIndex).toBeGreaterThan(-1);
+    expect(causesIndex).toBeLessThan(
+      message.indexOf(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION),
+    );
+    expect(causesIndex).toBeLessThan(message.indexOf(MICROSOFT_QUOTE_PREFIX));
+  });
+
+  test("a non-PermissionDenied state with a Microsoft error yields only the quote", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: "Forbidden",
+    });
+
+    expect(message).toContain(MICROSOFT_QUOTE_PREFIX);
+    expect(message).not.toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+  });
+
+  test("PermissionDenied without a Microsoft error yields only the hint", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.PermissionDenied,
+    });
+
+    expect(message).toContain(MICROSOFT_TEAMS_INSTALL_READ_PERMISSION);
+    expect(message).not.toContain(MICROSOFT_QUOTE_PREFIX);
+  });
+});

--- a/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsChatsCardInstallGuidance.test.tsx
+++ b/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsChatsCardInstallGuidance.test.tsx
@@ -1,0 +1,332 @@
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import * as React from "react";
+import { JSONObject } from "../../../Types/JSON";
+
+/*
+ * The regression under test lives in the empty state of the chats card.
+ *
+ * teams.microsoft.com/l/app/<id> only resolves for an app that is published to
+ * the Microsoft Teams store. A self-hosted deployment sideloads a manifest
+ * built from its own Entra registration, so that id has no store listing and
+ * the button sent admins to a 404 - from the exact screen where they were
+ * already stuck. Worse, it nudged them toward the store's OneUptime app, which
+ * carries a bot that reports to OneUptime Cloud and can never register a chat
+ * against a self-hosted install.
+ *
+ * So: the store button is now gated on BILLING_ENABLED (SaaS only), and
+ * self-hosted gets a paragraph naming the deployment's own bot id instead.
+ *
+ * BILLING_ENABLED and MicrosoftTeamsAppClientId are module-level consts in
+ * Common/UI/Config. Rather than jest.resetModules() + a dynamic require (which
+ * would hand the component a second copy of React and break its hooks), the
+ * Config module is mocked with getters over mutable test state. TypeScript
+ * compiles every read in the component to a property access on the module
+ * object, so flipping the state between renders is enough.
+ */
+
+let billingEnabled: boolean = false;
+let microsoftTeamsAppClientId: string | null = null;
+
+jest.mock("../../../UI/Config", () => {
+  const actualConfig: Record<string, unknown> = jest.requireActual(
+    "../../../UI/Config",
+  ) as Record<string, unknown>;
+
+  const mockedConfig: Record<string, unknown> = { ...actualConfig };
+
+  /*
+   * Object.defineProperty, not a getter in an object literal: this file is
+   * down-levelled, so `{ ...actual, get X() {} }` becomes Object.assign, which
+   * would read the getter once and freeze the value at module-load time.
+   */
+  Object.defineProperty(mockedConfig, "BILLING_ENABLED", {
+    get: (): boolean => {
+      return billingEnabled;
+    },
+  });
+
+  Object.defineProperty(mockedConfig, "MicrosoftTeamsAppClientId", {
+    get: (): string | null => {
+      return microsoftTeamsAppClientId;
+    },
+  });
+
+  return mockedConfig;
+});
+
+type ApiGetFunction = () => Promise<{ data: JSONObject }>;
+
+let apiGet: ApiGetFunction = async (): Promise<{ data: JSONObject }> => {
+  return { data: { chats: [] } };
+};
+
+jest.mock("../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: (): Promise<{ data: JSONObject }> => {
+        return apiGet();
+      },
+      getFriendlyErrorMessage: (): string => {
+        return "Something went wrong.";
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCommonHeaders: (): Record<string, string> => {
+        return {};
+      },
+    },
+  };
+});
+
+import MicrosoftTeamsChatsCard from "../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChatsCard";
+
+const SELF_HOSTED_BOT_ID: string = "9f6a2c31-self-hosted-registration";
+const SAAS_BOT_ID: string = "cbe1a1f7-oneuptime-cloud";
+
+const STORE_BUTTON_NAME: RegExp = /Open OneUptime in Microsoft Teams/i;
+const SELF_HOSTED_GUIDANCE: RegExp =
+  /it reports to OneUptime Cloud and will never appear here/i;
+
+interface RenderOptions {
+  billingEnabled: boolean;
+  clientId: string | null;
+  chats?: Array<JSONObject>;
+}
+
+async function renderCard(options: RenderOptions): Promise<void> {
+  billingEnabled = options.billingEnabled;
+  microsoftTeamsAppClientId = options.clientId;
+
+  const chats: Array<JSONObject> = options.chats || [];
+
+  apiGet = async (): Promise<{ data: JSONObject }> => {
+    return { data: { chats: chats } };
+  };
+
+  // The card fetches /microsoft-teams/chats on mount; settle that inside act.
+  await act(async (): Promise<void> => {
+    render(<MicrosoftTeamsChatsCard />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText("Microsoft Teams Chats")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Refresh Chats/i }),
+    ).toBeInTheDocument();
+  });
+}
+
+function queryStoreButton(): HTMLElement | null {
+  return screen.queryByRole("button", { name: STORE_BUTTON_NAME });
+}
+
+beforeEach(() => {
+  billingEnabled = false;
+  microsoftTeamsAppClientId = null;
+  apiGet = async (): Promise<{ data: JSONObject }> => {
+    return { data: { chats: [] } };
+  };
+});
+
+describe("MicrosoftTeamsChatsCard empty-state install guidance", () => {
+  describe("self-hosted (BILLING_ENABLED false)", () => {
+    test("does not offer the Teams store button, which 404s for a sideloaded app id", async () => {
+      await renderCard({
+        billingEnabled: false,
+        clientId: SELF_HOSTED_BOT_ID,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("No chats connected yet")).toBeInTheDocument();
+      });
+
+      expect(queryStoreButton()).not.toBeInTheDocument();
+    });
+
+    test("explains that the store app reports to OneUptime Cloud and names the deployment's own bot id", async () => {
+      await renderCard({
+        billingEnabled: false,
+        clientId: SELF_HOSTED_BOT_ID,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("No chats connected yet")).toBeInTheDocument();
+      });
+
+      const guidance: HTMLElement = screen.getByText(SELF_HOSTED_GUIDANCE);
+
+      expect(guidance).toBeInTheDocument();
+      expect(guidance).toHaveTextContent(SELF_HOSTED_BOT_ID);
+      expect(guidance).toHaveTextContent(
+        /Chats only register for the app package built for this deployment/i,
+      );
+      // It must point at the manifest upload, not at the store.
+      expect(guidance).toHaveTextContent(
+        /upload the manifest from Project Settings > Workspace > Microsoft Teams/i,
+      );
+    });
+
+    test("withholds the guidance when no client id is configured yet", async () => {
+      /*
+       * The guidance exists to give the admin a bot id to compare against the
+       * installed package. With nothing configured there is nothing to compare,
+       * and rendering it anyway produced the literal text "(bot id )." — an
+       * empty parenthetical that reads as a bug and helps no one. The setup
+       * guide is the right destination at that point, not this note.
+       */
+      await renderCard({ billingEnabled: false, clientId: null });
+
+      await waitFor(() => {
+        expect(screen.getByText("No chats connected yet")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(SELF_HOSTED_GUIDANCE)).not.toBeInTheDocument();
+      expect(queryStoreButton()).not.toBeInTheDocument();
+    });
+  });
+
+  describe("SaaS (BILLING_ENABLED true)", () => {
+    test("offers the Teams store button and withholds the self-hosted guidance", async () => {
+      await renderCard({ billingEnabled: true, clientId: SAAS_BOT_ID });
+
+      await waitFor(() => {
+        expect(screen.getByText("No chats connected yet")).toBeInTheDocument();
+      });
+
+      expect(queryStoreButton()).toBeInTheDocument();
+      expect(screen.queryByText(SELF_HOSTED_GUIDANCE)).not.toBeInTheDocument();
+    });
+
+    test.each([
+      ["null", null],
+      ["empty string", ""],
+    ])(
+      "withholds the store button when the client id is %s",
+      async (_label: string, clientId: string | null) => {
+        await renderCard({ billingEnabled: true, clientId: clientId });
+
+        await waitFor(() => {
+          expect(
+            screen.getByText("No chats connected yet"),
+          ).toBeInTheDocument();
+        });
+
+        expect(queryStoreButton()).not.toBeInTheDocument();
+        // Not self-hosted, so the self-hosted paragraph stays away too.
+        expect(
+          screen.queryByText(SELF_HOSTED_GUIDANCE),
+        ).not.toBeInTheDocument();
+      },
+    );
+  });
+
+  describe("copy shared by both deployment modes", () => {
+    test.each([
+      ["self-hosted", false, SELF_HOSTED_BOT_ID],
+      ["SaaS", true, SAAS_BOT_ID],
+    ])(
+      "renders the empty state and its three numbered steps on %s",
+      async (
+        _label: string,
+        isBillingEnabled: boolean,
+        clientId: string | null,
+      ) => {
+        await renderCard({
+          billingEnabled: isBillingEnabled,
+          clientId: clientId,
+        });
+
+        await waitFor(() => {
+          expect(
+            screen.getByText("No chats connected yet"),
+          ).toBeInTheDocument();
+        });
+
+        expect(
+          screen.getByText(
+            /Add the OneUptime app to a chat in Microsoft Teams and it will appear here/i,
+          ),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.getByText(
+            /Open Microsoft Teams and go to the group chat or one-on-one chat you want to notify/i,
+          ),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            /Click the \+ \(Add an app\) button at the top of the chat/i,
+          ),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/Come back here and click Refresh Chats/i),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.getByText(/Already have the OneUptime app in a chat\?/i),
+        ).toBeInTheDocument();
+      },
+    );
+  });
+
+  describe("with connected chats", () => {
+    const CHATS: Array<JSONObject> = [
+      {
+        id: "19:groupchat-1",
+        name: "Incident War Room",
+        chatType: "groupChat",
+        addedAt: null,
+      },
+      {
+        id: "19:personal-1",
+        name: "Jane Doe",
+        chatType: "personal",
+        addedAt: null,
+      },
+    ];
+
+    test.each([
+      ["self-hosted", false, SELF_HOSTED_BOT_ID],
+      ["SaaS", true, SAAS_BOT_ID],
+    ])(
+      "lists the chats and drops every piece of empty-state guidance on %s",
+      async (
+        _label: string,
+        isBillingEnabled: boolean,
+        clientId: string | null,
+      ) => {
+        await renderCard({
+          billingEnabled: isBillingEnabled,
+          clientId: clientId,
+          chats: CHATS,
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Incident War Room")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+        expect(screen.getByText("Connected chats (2)")).toBeInTheDocument();
+        expect(screen.getByText("Group chat")).toBeInTheDocument();
+        expect(screen.getByText("1:1 chat")).toBeInTheDocument();
+
+        expect(
+          screen.queryByText("No chats connected yet"),
+        ).not.toBeInTheDocument();
+        expect(queryStoreButton()).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(SELF_HOSTED_GUIDANCE),
+        ).not.toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsInstallGuidanceContent.test.tsx
+++ b/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsInstallGuidanceContent.test.tsx
@@ -1,0 +1,643 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import * as React from "react";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The self-hosted Microsoft Teams failure this suite guards is a content bug,
+ * not a logic bug: the product told admins, in prose, that they could skip the
+ * one step that makes notifications work ("if someone already installed the
+ * OneUptime app ... you can skip the installation steps"), and it hid the
+ * install card from projects whose connection was project-level rather than
+ * per-user. Both the gating and the words are asserted here.
+ */
+
+const MOCK_TEAMS_CLIENT_ID: string = "11111111-2222-3333-4444-555555555555";
+
+const REPO_ROOT: string = path.resolve(__dirname, "../../../..");
+
+const INTEGRATION_COMPONENT_PATH: string = path.join(
+  REPO_ROOT,
+  "App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegration.tsx",
+);
+
+const DOCS_MARKDOWN_PATH: string = path.join(
+  REPO_ROOT,
+  "App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md",
+);
+
+interface MockConfigState {
+  billingEnabled: boolean;
+}
+
+/*
+ * BILLING_ENABLED separates SaaS from self-hosted and has to differ per test,
+ * so it is exposed as a getter over mutable state rather than a frozen value.
+ */
+const mockConfigState: MockConfigState = {
+  billingEnabled: false,
+};
+
+interface MockAuthState {
+  isProjectConnected: boolean;
+  isUserConnected: boolean;
+  isAdminConsentGranted: boolean;
+}
+
+const mockAuthState: MockAuthState = {
+  isProjectConnected: false,
+  isUserConnected: false,
+  isAdminConsentGranted: false,
+};
+
+jest.mock("../../../UI/Config", () => {
+  const actualConfig: Record<string, unknown> = jest.requireActual(
+    "../../../UI/Config",
+  ) as Record<string, unknown>;
+
+  const mockedConfig: Record<string, unknown> = {
+    ...actualConfig,
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+  };
+
+  /*
+   * defineProperty rather than a `get` in the object literal: TypeScript
+   * downlevels a spread-plus-getter literal into Object.assign, which reads the
+   * getter once and freezes its value — the accessor has to be attached after
+   * the spread to stay live.
+   */
+  Object.defineProperty(mockedConfig, "BILLING_ENABLED", {
+    configurable: true,
+    enumerable: true,
+    get: (): boolean => {
+      return mockConfigState.billingEnabled;
+    },
+  });
+
+  return mockedConfig;
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return {
+          toString: () => {
+            return "project-id";
+          },
+        };
+      },
+      getCurrentProject: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUserId: () => {
+        return {
+          toString: () => {
+            return "user-id";
+          },
+        };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Navigation", () => {
+  return {
+    __esModule: true,
+    default: {
+      getQueryStringByName: () => {
+        return null;
+      },
+      navigate: () => {},
+      getLocation: () => {
+        return { pathname: "/" };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCommonHeaders: () => {
+        return {};
+      },
+      deleteItem: async () => {
+        return undefined;
+      },
+      getList: async (data: { modelType: { name?: string } }) => {
+        const modelName: string = data.modelType?.name || "";
+        const state: MockAuthState = mockAuthState as MockAuthState;
+
+        if (modelName.includes("Project")) {
+          if (!state.isProjectConnected) {
+            return { data: [], count: 0, skip: 0, limit: 1 };
+          }
+
+          return {
+            data: [
+              {
+                id: {
+                  toString: () => {
+                    return "project-auth-token-id";
+                  },
+                },
+                miscData: {
+                  adminConsentGranted: state.isAdminConsentGranted,
+                },
+              },
+            ],
+            count: 1,
+            skip: 0,
+            limit: 1,
+          };
+        }
+
+        if (!state.isUserConnected) {
+          return { data: [], count: 0, skip: 0, limit: 1 };
+        }
+
+        return {
+          data: [
+            {
+              id: {
+                toString: () => {
+                  return "user-auth-token-id";
+                },
+              },
+              miscData: {},
+            },
+          ],
+          count: 1,
+          skip: 0,
+          limit: 1,
+        };
+      },
+    },
+  };
+});
+
+/*
+ * The sibling cards each fetch on mount and are irrelevant to the install
+ * guidance; stubbing them keeps the render deterministic without weakening any
+ * assertion below.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChannelsCard",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return <div data-testid="channels-card" />;
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChatsCard",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return <div data-testid="chats-card" />;
+      },
+    };
+  },
+);
+
+import MicrosoftTeamsIntegration from "../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegration";
+import MicrosoftTeamsIntegrationDocumentation from "../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation";
+
+type ReadFileFunction = (filePath: string) => string;
+
+const readSource: ReadFileFunction = (filePath: string): string => {
+  return fs.readFileSync(filePath, "utf8");
+};
+
+type RenderDocumentationFunction = () => Promise<string>;
+
+/*
+ * MarkdownViewer is lazy-loaded and react-markdown is mocked to a div holding
+ * its children, so the resolved markdown source is what lands in the DOM.
+ * Returning the text makes substring assertions readable.
+ */
+const renderDocumentationText: RenderDocumentationFunction =
+  async (): Promise<string> => {
+    render(<MicrosoftTeamsIntegrationDocumentation />);
+
+    const markdown: HTMLElement = await screen.findByTestId("react-markdown");
+
+    return markdown.textContent || "";
+  };
+
+interface RenderIntegrationOptions {
+  billingEnabled: boolean;
+  isProjectConnected: boolean;
+  isUserConnected: boolean;
+  isAdminConsentGranted: boolean;
+}
+
+type RenderIntegrationFunction = (
+  options: RenderIntegrationOptions,
+) => Promise<void>;
+
+const renderIntegration: RenderIntegrationFunction = async (
+  options: RenderIntegrationOptions,
+): Promise<void> => {
+  mockConfigState.billingEnabled = options.billingEnabled;
+  mockAuthState.isProjectConnected = options.isProjectConnected;
+  mockAuthState.isUserConnected = options.isUserConnected;
+  mockAuthState.isAdminConsentGranted = options.isAdminConsentGranted;
+
+  render(
+    <MicrosoftTeamsIntegration
+      onConnected={() => {}}
+      onDisconnected={() => {}}
+    />,
+  );
+
+  /*
+   * The component mounts behind a PageLoader while it fetches auth state; the
+   * always-present admin-consent Card is the first thing painted once that
+   * settles.
+   */
+  await waitFor(() => {
+    expect(screen.queryAllByTestId("card").length).toBeGreaterThan(0);
+  });
+};
+
+beforeEach(() => {
+  mockConfigState.billingEnabled = false;
+  mockAuthState.isProjectConnected = false;
+  mockAuthState.isUserConnected = false;
+  mockAuthState.isAdminConsentGranted = false;
+});
+
+const INSTALL_CARD_TITLE: string =
+  "Action Required: Install This Deployment's App on Microsoft Teams";
+
+const SETUP_GUIDE_TITLE: string = "Full Microsoft Teams setup guide";
+
+describe("MicrosoftTeamsIntegration install card gating", () => {
+  test("shows the install card for a project-level connection with no per-user connection", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: true,
+      isUserConnected: false,
+      isAdminConsentGranted: true,
+    });
+
+    expect(await screen.findByText(INSTALL_CARD_TITLE)).toBeInTheDocument();
+  });
+
+  test("still shows the install card once the user is connected as well", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: true,
+      isUserConnected: true,
+      isAdminConsentGranted: true,
+    });
+
+    expect(await screen.findByText(INSTALL_CARD_TITLE)).toBeInTheDocument();
+  });
+
+  /*
+   * Admin consent is stored on the project auth token, so a user-only
+   * connection can never reach the consent-completed state — the card stays
+   * hidden for a reason that has nothing to do with the gate above.
+   */
+  test("hides the install card when only the user is connected", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: false,
+      isUserConnected: true,
+      isAdminConsentGranted: true,
+    });
+
+    expect(screen.queryByText(INSTALL_CARD_TITLE)).not.toBeInTheDocument();
+  });
+
+  test("hides the install card when admin consent has not been granted", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: true,
+      isUserConnected: true,
+      isAdminConsentGranted: false,
+    });
+
+    expect(screen.queryByText(INSTALL_CARD_TITLE)).not.toBeInTheDocument();
+  });
+
+  test("hides the install card on the billing-enabled (SaaS) deployment", async () => {
+    await renderIntegration({
+      billingEnabled: true,
+      isProjectConnected: true,
+      isUserConnected: true,
+      isAdminConsentGranted: true,
+    });
+
+    expect(screen.queryByText(INSTALL_CARD_TITLE)).not.toBeInTheDocument();
+  });
+});
+
+describe("MicrosoftTeamsIntegration setup guide availability", () => {
+  test("renders the collapsible full setup guide for self-hosted", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: true,
+      isUserConnected: true,
+      isAdminConsentGranted: true,
+    });
+
+    expect(await screen.findByText(SETUP_GUIDE_TITLE)).toBeInTheDocument();
+  });
+
+  test("the setup guide starts collapsed, not dumped onto a working page", async () => {
+    /*
+     * The guide is ~150 lines of Azure setup. Making it reachable was the fix;
+     * making it unavoidable would be a new problem for every deployment whose
+     * integration already works.
+     *
+     * CollapsibleSection keeps its children mounted and hides them with CSS, so
+     * the honest assertion is the accessible expanded state rather than the
+     * absence of the content from the DOM.
+     */
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: true,
+      isUserConnected: true,
+      isAdminConsentGranted: true,
+    });
+
+    const title: HTMLElement = await screen.findByText(SETUP_GUIDE_TITLE);
+    const toggle: HTMLElement | null = title.closest("[aria-expanded]");
+
+    expect(toggle).not.toBeNull();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("renders the setup guide even before anything is connected", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: false,
+      isUserConnected: false,
+      isAdminConsentGranted: false,
+    });
+
+    expect(await screen.findByText(SETUP_GUIDE_TITLE)).toBeInTheDocument();
+  });
+
+  test("does not render the setup guide on the billing-enabled (SaaS) deployment", async () => {
+    await renderIntegration({
+      billingEnabled: true,
+      isProjectConnected: true,
+      isUserConnected: true,
+      isAdminConsentGranted: true,
+    });
+
+    expect(screen.queryByText(SETUP_GUIDE_TITLE)).not.toBeInTheDocument();
+  });
+});
+
+describe("Install card markdown", () => {
+  /*
+   * Read from source rather than the DOM: this markdown template literal is
+   * built from a template string the component only evaluates behind several
+   * pieces of state, and the regression is a literal sentence of prose. A
+   * source-text assertion pins the sentence itself.
+   */
+  const integrationSource: string = readSource(INTEGRATION_COMPONENT_PATH);
+
+  test("no longer tells admins they can skip the installation steps", () => {
+    expect(integrationSource).not.toContain("you can skip the installation");
+    expect(integrationSource).not.toContain(
+      "you do not need to do anything here",
+    );
+  });
+
+  test("warns against assuming an existing OneUptime app is the right one", () => {
+    expect(integrationSource).toContain(
+      'Do not skip this because a "OneUptime" app is already in your tenant.',
+    );
+    expect(integrationSource).toContain("Microsoft Teams store");
+    expect(integrationSource).toContain(
+      "The bot is not part of the conversation roster.",
+    );
+  });
+
+  /*
+   * Removed: a source-text grep for the literal "${MicrosoftTeamsAppClientId}".
+   * It wrote the implementation out a second time and proved nothing the next
+   * test does not prove properly — that the id reaches the rendered DOM.
+   */
+
+  test("renders the interpolated client id in the install card for self-hosted", async () => {
+    await renderIntegration({
+      billingEnabled: false,
+      isProjectConnected: true,
+      isUserConnected: false,
+      isAdminConsentGranted: true,
+    });
+
+    await screen.findByText(INSTALL_CARD_TITLE);
+
+    await waitFor(() => {
+      const markdownBlocks: Array<HTMLElement> =
+        screen.getAllByTestId("react-markdown");
+
+      const combinedText: string = markdownBlocks
+        .map((element: HTMLElement) => {
+          return element.textContent || "";
+        })
+        .join("\n");
+
+      expect(combinedText).toContain(MOCK_TEAMS_CLIENT_ID);
+      expect(combinedText).not.toContain("you can skip the installation");
+      expect(combinedText).toContain(
+        'Do not skip this because a "OneUptime" app is already in your tenant.',
+      );
+    });
+  });
+});
+
+describe("MicrosoftTeamsIntegrationDocumentation", () => {
+  test("lists TeamsAppInstallation.ReadForTeam.All as a required application permission", async () => {
+    const text: string = await renderDocumentationText();
+
+    expect(text).toContain("**Add Application Permissions**");
+    expect(text).toContain("**TeamsAppInstallation.ReadForTeam.All**");
+
+    const permissionLine: string =
+      text
+        .split("\n")
+        .find((line: string) => {
+          return line.includes("TeamsAppInstallation.ReadForTeam.All");
+        })
+        ?.trim() || "";
+
+    expect(permissionLine).toContain("Required");
+    expect(permissionLine.toLowerCase()).not.toContain("optional");
+  });
+
+  test("Step 8 warns against installing from the Microsoft Teams store", async () => {
+    const text: string = await renderDocumentationText();
+
+    const stepEightSection: string = text
+      .split("##### Step 8")[1]!
+      .split("##### Step 9")[0]!;
+
+    expect(stepEightSection).toContain(
+      'Do not install "OneUptime" from the Microsoft Teams store for a self-hosted deployment.',
+    );
+    expect(stepEightSection).toContain("OneUptime Cloud");
+    expect(stepEightSection).toContain("MICROSOFT_TEAMS_APP_CLIENT_ID");
+  });
+
+  test("Step 9 tells the admin to add the app to every team", async () => {
+    const text: string = await renderDocumentationText();
+
+    expect(text).toContain(
+      "##### Step 9: Add the App to Every Team You Want Notifications In",
+    );
+
+    const stepNineSection: string = text
+      .split("##### Step 9")[1]!
+      .split("##### Troubleshooting")[0]!;
+
+    expect(stepNineSection).toContain("installation is per team");
+    expect(stepNineSection).toContain("Manage team");
+  });
+
+  test("Step 9 covers private channels needing their own install and shared channels being unsupported", async () => {
+    const text: string = await renderDocumentationText();
+
+    const stepNineSection: string = text
+      .split("##### Step 9")[1]!
+      .split("##### Troubleshooting")[0]!;
+
+    expect(stepNineSection).toContain("**private** channel");
+    expect(stepNineSection).toContain("Manage channel");
+    expect(stepNineSection).toContain(
+      "A team-level install does not cover private channels",
+    );
+    expect(stepNineSection).toContain(
+      "Microsoft Teams does not allow bots in **shared** channels",
+    );
+  });
+
+  test("Troubleshooting covers the roster error and names the diagnostic permission", async () => {
+    const text: string = await renderDocumentationText();
+
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain(
+      "The bot is not part of the conversation roster",
+    );
+    expect(troubleshooting).toContain(
+      "The installed app is a different package",
+    );
+    expect(troubleshooting).toContain(
+      "The Azure Bot has no Microsoft Teams channel",
+    );
+    expect(troubleshooting).toContain("TeamsAppInstallation.ReadForTeam.All");
+  });
+
+  test("Troubleshooting covers the empty-chats symptom", async () => {
+    const text: string = await renderDocumentationText();
+
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain(
+      "No chats appear under Microsoft Teams Chats",
+    );
+    expect(troubleshooting).toContain("Refresh Chats");
+  });
+});
+
+describe("Self-hosted docs markdown", () => {
+  const docsMarkdown: string = readSource(DOCS_MARKDOWN_PATH);
+
+  test("does not describe TeamsAppInstallation.ReadForTeam.All as optional", () => {
+    const permissionLine: string =
+      docsMarkdown
+        .split("\n")
+        .find((line: string) => {
+          return line.includes("TeamsAppInstallation.ReadForTeam.All");
+        })
+        ?.trim() || "";
+
+    expect(permissionLine).not.toBe("");
+    expect(permissionLine.toLowerCase()).not.toContain("optional");
+    expect(permissionLine).toContain("Required");
+  });
+});
+
+describe("Settings navigation path is stated consistently", () => {
+  /*
+   * Every one of these files tells an admin where to find the app manifest, and
+   * they must all name the same place. One of them used to say
+   * "Settings -> Integrations -> Microsoft Teams", which does not exist — the
+   * settings side menu section is "Workspace" — and it sat three lines below a
+   * blockquote insisting the manifest from that page is the only one that
+   * works. Prose assertions on individual sentences did not catch it, because
+   * each file was checked against itself rather than against the menu.
+   */
+  const NAVIGATION_SOURCES: Array<string> = [
+    INTEGRATION_COMPONENT_PATH,
+    DOCS_MARKDOWN_PATH,
+    path.join(
+      REPO_ROOT,
+      "App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx",
+    ),
+    path.join(
+      REPO_ROOT,
+      "App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChatsCard.tsx",
+    ),
+    path.join(
+      REPO_ROOT,
+      "Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts",
+    ),
+    path.join(REPO_ROOT, "Common/Server/API/MicrosoftTeamsAPI.ts"),
+  ];
+
+  test("the settings side menu really does call the section 'Workspace'", () => {
+    const sideMenu: string = readSource(
+      path.join(
+        REPO_ROOT,
+        "App/FeatureSet/Dashboard/src/Pages/Settings/SideMenu.tsx",
+      ),
+    );
+
+    expect(sideMenu).toContain('title: "Workspace"');
+  });
+
+  test.each(NAVIGATION_SOURCES)(
+    "%s never routes admins through a non-existent Integrations section",
+    (sourcePath: string) => {
+      const source: string = readSource(sourcePath);
+
+      for (const wrongPath of [
+        "Settings -> Integrations",
+        "Settings > Integrations",
+        "Settings &gt; Integrations",
+        "Integrations -> Microsoft Teams",
+        "Integrations > Microsoft Teams",
+      ]) {
+        expect(source).not.toContain(wrongPath);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## The failure

A self-hosted deployment can only be posted to by the Teams app package built from that deployment. The manifest generator stamps `MICROSOFT_TEAMS_APP_CLIENT_ID` into both the manifest id and `bots[].botId`, so no other package carries a bot this instance authenticates as.

Install the OneUptime app from the Teams store instead, and Teams accepts it, shows a OneUptime tile under **Manage team → Apps**, and then refuses every notification with `BotNotInConversationRoster` — while Graph-based channel listing and channel *creation* keep working, because those run on tenant-wide application permissions that have nothing to do with any install. The result is an integration that looks connected, lists your channels, creates channels on request, and silently cannot deliver a single message.

Traced from a self-hosted report: every channel failing, including channels OneUptime had just created itself, and a Chats page permanently reading "No chats connected yet".

## What steered admins there

- **The install card told them to skip the install.** *"If you or anyone else in your organization has already installed the OneUptime app … you can skip the installation steps."* For self-hosted that is false, and it is exactly the reasoning an admin applies to the store tile. Replaced with the opposite, naming this deployment's bot id.
- **The card was gated on the wrong flag.** `isUserAccountConnected`, while the Channels and Chats cards beside it need only `isProjectAccountConnected` — so a deployment could browse and create channels while never being shown the package it has to upload first. Now gated on either, which is strictly additive.
- **The setup guide vanished once configured.** It rendered only when `MICROSOFT_TEAMS_APP_CLIENT_ID` was unset, i.e. it disappeared exactly when an admin starts needing the Azure Bot steps. Now always reachable, collapsed.
- **The Chats empty state pushed the store.** "Open OneUptime in Microsoft Teams" is a store deep link, offered on the exact screen where a self-hosted admin is stuck. SaaS only now; self-hosted gets the check that actually settles it.
- **Step 8 sent them to a menu that does not exist.** `Settings > Integrations > Microsoft Teams`; it is `Settings > Workspace > Microsoft Teams`.

## What made it hard to diagnose

- **`isAppInstalledInTeam` collapsed every failure into `Unknown`,** so a Graph *refusal* looked like a Graph *outage* and the admin got a list of four possible causes instead of an answer. A 403 (or an authorization error code at any status) is now `PermissionDenied`, and the error names `TeamsAppInstallation.ReadForTeam.All`. **401 stays `Unknown` deliberately** — Graph reserves it for a token it will not accept, and `getValidAccessToken` can hand back a cached token unvalidated, so a stale credential must not be reported as a missing grant.
- **`getBotNotInTeamMessage` told an admin looking straight at a OneUptime tile to go and add OneUptime.** It now names the wrong-package case — except on private channels, where the team-scope read cannot speak to the channel-scope install and "remove it" would talk someone into deleting a working install.
- **`getRosterRejectionMessage`'s `Installed` branch still told admins to re-verify a package Graph had already matched.** It now points at the Azure Bot resource, hedged with "probably" because the match is on manifest id, not bot id.
- **`/api/microsoft-bot/test` answered "Bot Framework endpoint is configured" after checking two environment variables.** It never contacted Azure. It now reports what it verified and what it did not — the Azure Bot resource, the Teams channel, the secret, the installed package — and returns `botId`, so the comparison that settles this is one glance away.
- **`TeamsAppInstallation.ReadForTeam.All` promoted from "Optional but strongly recommended" to required**, in the docs site and the in-product permission list.

## Tests

529 across 13 suites. Beyond the per-unit coverage:

- An **end-to-end** case proving a Graph refusal reaches the admin as a named grant rather than a false "not installed" — the pieces were all unit-tested in isolation, so a refactor short-circuiting `PermissionDenied` at the preflight would have left everything else green.
- A **cross-file navigation check** that reads `SideMenu.tsx` and asserts no Teams file routes admins through a non-existent settings section. This is what let the Step 8 bug through: eight prose assertions sat three lines away, each checking a file against itself rather than against the menu.
- The customer's exact scenario pinned directly: a tile with `displayName: "OneUptime"` and a foreign `externalId` must resolve to `NotInstalled`.

`tsc --noEmit` clean, eslint clean.

## Verification note

The UI changes were verified by render tests, not in a browser: the local Docker stack mounts the main checkout rather than this worktree, so a preview would have shown the old code.