### PR TITLE
Network Map: calm the map's ink instead of hiding its lines (#3432)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
@@ -59,6 +59,37 @@ import {
   getCachedGeometryFeatures,
   loadGeometryFeatures,
 } from "./Geo/WorldGeometry";
+import {
+  DEFAULT_MAP_LAYERS,
+  EMPHASIS_TRANSITION_MS,
+  EMPTY_MAP_ADJACENCY,
+  MAP_LAYERS_STORAGE_KEY,
+  MAP_LAYER_OPTIONS,
+  MapAdjacency,
+  MapFocus,
+  MapInkPlan,
+  MapLayerOption,
+  MapLayerSettings,
+  MapLineInk,
+  MapRole,
+  MapTooltipText,
+  NO_MAP_FOCUS,
+  buildMapAdjacency,
+  countHiddenMapLayers,
+  labelThreadInk,
+  linkInk,
+  linkRole,
+  markerRole,
+  normalizeMapLayers,
+  opacityForRole,
+  planMapInk,
+  positionAnchorDot,
+  positionLineInk,
+  setMapLayer,
+  splitMapTooltip,
+} from "./SiteMapInk";
+import LocalStorage from "Common/UI/Utils/LocalStorage";
+import { JSONObject } from "Common/Types/JSON";
 
 /*
  * Inline-SVG world map of network sites: checked-in country outlines
@@ -119,6 +150,15 @@ const LEGEND: Array<{ key: ClusterColorKey; label: string }> = [
   { key: "none", label: "No status" },
 ];
 
+/*
+ * What a line is drawn in once it has been quietened. A hairline is too
+ * thin to read a colour off, and a red hairline beside a red marker reads
+ * as a second claim about the site rather than as the bookkeeping it is —
+ * so a quiet thread gives up its colour along with its weight, and takes it
+ * back the moment the reader points at the marker it belongs to.
+ */
+const QUIET_LINE_COLOR: string = "var(--ou-chart-tick, #6b7280)";
+
 // One click of the zoom controls, and one press of an arrow key.
 const ZOOM_STEP: number = 2;
 const KEYBOARD_PAN_FRACTION: number = 0.2;
@@ -137,6 +177,44 @@ const DRAG_THRESHOLD_PX: number = 4;
  * push the map off the screen.
  */
 const UNPLACED_NAMES_SHOWN: number = 6;
+
+/*
+ * The layer preference, read straight out of localStorage rather than
+ * fetched in an effect: a map that painted every layer and then dropped two
+ * of them a frame later would flash the exact clutter the preference exists
+ * to avoid.
+ *
+ * Storage can be unavailable outright — a locked-down browser, a private
+ * window with its quota at zero — and it is shared with every tab and
+ * survives every deploy, so whatever comes back is run through
+ * normalizeMapLayers before anything is drawn from it.
+ */
+const readStoredMapLayers: () => MapLayerSettings = (): MapLayerSettings => {
+  try {
+    return normalizeMapLayers(LocalStorage.getItem(MAP_LAYERS_STORAGE_KEY));
+  } catch {
+    // A map is not worth an exception.
+    return { ...DEFAULT_MAP_LAYERS };
+  }
+};
+
+const storeMapLayers: (layers: MapLayerSettings) => void = (
+  layers: MapLayerSettings,
+): void => {
+  try {
+    const stored: JSONObject = {
+      names: layers.names,
+      links: layers.links,
+      positionLines: layers.positionLines,
+    };
+    LocalStorage.setItem(MAP_LAYERS_STORAGE_KEY, stored);
+  } catch {
+    /*
+     * Same bargain as the read: the map still works, the choice just does
+     * not outlive the page.
+     */
+  }
+};
 
 const dotColorForSite: (site: MapSiteView) => string = (
   site: MapSiteView,
@@ -157,10 +235,22 @@ interface OpenCluster {
   ids: Array<string>;
 }
 
-interface HoveredCluster {
+/*
+ * What the hover card is describing, and — just as important — which piece
+ * of the map it belongs to.
+ *
+ * The keys are what drive the emphasis. Pointing at a marker has to light
+ * that marker's own links and fade everything else back, not merely print
+ * its name in a box: on a level with forty markers and sixty lines, "which
+ * of these is this one wired to" is a question a reader cannot answer by
+ * eye, and it is the question the pointer is asking.
+ */
+interface HoveredTarget {
   x: number;
   y: number;
-  label: string;
+  tooltip: string;
+  markerKey: string | null;
+  linkKey: string | null;
 }
 
 /*
@@ -387,8 +477,24 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const [openCluster, setOpenCluster] = useState<OpenCluster | null>(null);
-  const [hovered, setHovered] = useState<HoveredCluster | null>(null);
+  const [hovered, setHovered] = useState<HoveredTarget | null>(null);
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  /*
+   * Which layers this reader wants drawn — issue #3432's switch. It is the
+   * escape hatch, not the design: the ink hierarchy below is what makes the
+   * DEFAULT map readable, and this is for the customer who wants a bare map
+   * of dots and knows what they are giving up.
+   */
+  const [layers, setLayers] = useState<MapLayerSettings>(readStoredMapLayers);
+  const [isLayerPanelOpen, setIsLayerPanelOpen] = useState<boolean>(false);
+
+  const changeLayers: (next: MapLayerSettings) => void = useCallback(
+    (next: MapLayerSettings): void => {
+      setLayers(next);
+      storeMapLayers(next);
+    },
+    [],
+  );
   const [overviewFeatures, setOverviewFeatures] =
     useState<Array<GeometryFeature> | null>(
       getCachedGeometryFeatures("overview"),
@@ -528,22 +634,73 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
     });
   }, [props.links, placedMarkers, zoom]);
 
-  // Whether the legend has to explain the leader lines this frame.
-  const hasNudgedMarkers: boolean = placedMarkers.some(
+  /*
+   * Who is wired to whom. Rebuilt with the LINES rather than with the
+   * pointer: the answer cannot change as somebody moves the mouse, and
+   * rebuilding it there would walk every link on every frame of a hover.
+   */
+  const adjacency: MapAdjacency = useMemo(() => {
+    return layers.links ? buildMapAdjacency(linkLines) : EMPTY_MAP_ADJACENCY;
+  }, [linkLines, layers.links]);
+
+  /*
+   * What the reader is pointing at, and therefore what the map lifts out of
+   * the crowd. The pointer wins over keyboard focus: a mouse that has moved
+   * onto a marker is a more recent statement of intent than a focus ring a
+   * tab left behind.
+   */
+  const focus: MapFocus = useMemo(() => {
+    if (hovered) {
+      return { markerKey: hovered.markerKey, linkKey: hovered.linkKey };
+    }
+    if (focusedKey) {
+      return { markerKey: focusedKey, linkKey: null };
+    }
+    return NO_MAP_FOCUS;
+  }, [hovered, focusedKey]);
+
+  // How many markers had to be moved, and so carry a thread back.
+  const nudgedMarkerCount: number = placedMarkers.filter(
     (marker: PlacedMapMarker): boolean => {
       return marker.needsLeaderLine;
     },
-  );
+  ).length;
 
   /*
-   * And whether it has to explain the OTHER kind of line: the thread from a
+   * And how many of the OTHER kind of thread there are: the line from a
    * marker to a name that could not fit against it.
    */
-  const hasThreadedLabels: boolean = Array.from(labelPlacements.values()).some(
-    (placement: LabelPlacement): boolean => {
-      return placement.leaderLine !== null;
-    },
-  );
+  const threadedLabelCount: number = Array.from(
+    labelPlacements.values(),
+  ).filter((placement: LabelPlacement): boolean => {
+    return placement.leaderLine !== null;
+  }).length;
+
+  // Whether the legend has to explain either kind this frame.
+  const hasNudgedMarkers: boolean = nudgedMarkerCount > 0;
+  const hasThreadedLabels: boolean = threadedLabelCount > 0;
+
+  /*
+   * How loudly each layer is drawn at rest — the whole of issue #3432's
+   * answer. A map with a couple of threads on it draws them exactly as it
+   * always has; a map with forty drops them to a hairline so they stop
+   * competing with the markers, and hands the weight back the moment the
+   * reader points at the marker a thread belongs to.
+   *
+   * Fed the counts the map is ACTUALLY drawing, so a layer switched off
+   * cannot make the layers still on screen read as crowded.
+   */
+  const inkPlan: MapInkPlan = planMapInk({
+    positionLineCount: layers.positionLines ? nudgedMarkerCount : 0,
+    labelThreadCount:
+      layers.positionLines && layers.names ? threadedLabelCount : 0,
+    linkCount: layers.links ? linkLines.length : 0,
+  });
+
+  const hiddenLayerCount: number = countHiddenMapLayers(layers);
+
+  // The hover card's two halves — the name, and everything qualifying it.
+  const hoverText: MapTooltipText = splitMapTooltip(hovered?.tooltip || "");
 
   /*
    * Zoom changes which sites share a marker, so an open picker's list can go
@@ -555,6 +712,7 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
       setViewport(next);
       setOpenCluster(null);
       setHovered(null);
+      setIsLayerPanelOpen(false);
     },
     [],
   );
@@ -738,6 +896,7 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
       });
       setOpenCluster(null);
       setHovered(null);
+      setIsLayerPanelOpen(false);
     };
     element.addEventListener("wheel", onWheel, { passive: false });
     return () => {
@@ -748,6 +907,12 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   const onPointerDown: (event: React.PointerEvent<SVGSVGElement>) => void = (
     event: React.PointerEvent<SVGSVGElement>,
   ): void => {
+    /*
+     * Touching the map dismisses the layer panel. It floats over the map it
+     * is about, and a panel that stayed open while somebody dragged the
+     * thing underneath it is a panel they have to go back and close.
+     */
+    setIsLayerPanelOpen(false);
     // One drag at a time — a second touch must not corrupt the pan.
     if (event.button !== 0 || dragState.current) {
       return;
@@ -953,6 +1118,24 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   );
   const isFitted: boolean = viewportsMatch(viewport, fittedViewport);
   const isWholeWorld: boolean = viewportsMatch(viewport, WORLD_VIEWPORT);
+  /*
+   * Whether the map has calmed anything down this frame. It is the one
+   * thing about the ink hierarchy a reader has to be told: a thread drawn
+   * at a hairline is easy to miss, and somebody who cannot see where a
+   * marker really sits needs to know the answer is a hover away rather than
+   * gone.
+   */
+  const isInkCalmed: boolean =
+    inkPlan.positionLines === "quiet" ||
+    inkPlan.labelThreads === "quiet" ||
+    inkPlan.links === "quiet";
+  const hasDrawnLinks: boolean = layers.links && linkLines.length > 0;
+  const emphasisHint: string = hasDrawnLinks
+    ? " Hover one to trace what it connects to."
+    : isInkCalmed
+      ? " Hover one to see exactly where it sits."
+      : "";
+
   const coverageLabel: string = describeMapCoverage({
     mode: props.mode,
     markerCount: markers.length,
@@ -971,10 +1154,11 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
          * is written above the map, not buried in a legend below it.
          */}
         <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-500" data-testid="site-geo-map-hint">
             {props.mode === "grouped"
               ? `Each marker is one ${props.childTypeLabel.toLowerCase()} — click to open it.`
               : "Each marker is one site. Nearby sites share a marker; zoom in to separate them."}
+            {emphasisHint}
           </p>
           <MapModeSwitch
             mode={props.selectedMode}
@@ -1117,64 +1301,92 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
              * the leader lines and the name labels use, so it survives a
              * coastline or a dark landmass.
              */}
-            <g data-testid="site-geo-map-links">
-              {linkLines.map((link: DrawableMapLink): ReactElement => {
-                const path: string = mapLinkPath(link);
-                return (
-                  <g key={`link-${link.key}`}>
-                    <path
-                      d={path}
-                      fill="none"
-                      stroke="var(--ou-surface-primary, #ffffff)"
-                      strokeWidth={4 / zoom}
-                      strokeOpacity={0.85}
-                      strokeLinecap="round"
-                      style={{ pointerEvents: "none" }}
-                    />
-                    <path
-                      d={path}
-                      fill="none"
-                      stroke={link.color}
-                      strokeWidth={1.75 / zoom}
-                      strokeOpacity={0.95}
-                      strokeLinecap="round"
-                      strokeDasharray={
-                        link.hasMonitor ? undefined : `${5 / zoom} ${4 / zoom}`
-                      }
-                      style={{ pointerEvents: "none" }}
-                    />
-                    {/*
-                     * The hit area. A 2px line is unhoverable in practice,
-                     * and the name of a link is the whole reason to hover
-                     * one — so the pointer target is a fat invisible stroke
-                     * over the same path.
-                     */}
-                    <path
-                      d={path}
-                      fill="none"
-                      stroke="transparent"
-                      strokeWidth={12 / zoom}
-                      strokeLinecap="round"
-                      onMouseEnter={() => {
-                        if (dragState.current) {
-                          return;
-                        }
-                        setHovered({
-                          x: link.midX,
-                          y: link.midY,
-                          label: link.tooltip,
-                        });
-                      }}
-                      onMouseLeave={() => {
-                        setHovered(null);
+            {layers.links ? (
+              <g data-testid="site-geo-map-links">
+                {linkLines.map((link: DrawableMapLink): ReactElement => {
+                  const path: string = mapLinkPath(link);
+                  /*
+                   * What this line is relative to whatever the reader is
+                   * pointing at, and therefore how loudly it is drawn. With
+                   * nothing under the pointer every line is "idle" and the
+                   * weight is the resting one the ink plan chose.
+                   */
+                  const emphasis: MapRole = linkRole({
+                    focus: focus,
+                    link: link,
+                  });
+                  const ink: MapLineInk = linkInk(inkPlan.links, emphasis);
+                  return (
+                    <g
+                      key={`link-${link.key}`}
+                      opacity={opacityForRole(emphasis)}
+                      style={{
+                        transition: `opacity ${EMPHASIS_TRANSITION_MS}ms ease`,
                       }}
                     >
-                      <title>{link.tooltip}</title>
-                    </path>
-                  </g>
-                );
-              })}
-            </g>
+                      <path
+                        d={path}
+                        fill="none"
+                        stroke="var(--ou-surface-primary, #ffffff)"
+                        strokeWidth={ink.haloWidth / zoom}
+                        strokeOpacity={ink.haloOpacity}
+                        strokeLinecap="round"
+                        style={{ pointerEvents: "none" }}
+                      />
+                      <path
+                        d={path}
+                        fill="none"
+                        stroke={link.color}
+                        strokeWidth={ink.width / zoom}
+                        strokeOpacity={ink.opacity}
+                        strokeLinecap="round"
+                        strokeDasharray={
+                          link.hasMonitor
+                            ? undefined
+                            : `${5 / zoom} ${4 / zoom}`
+                        }
+                        style={{ pointerEvents: "none" }}
+                      />
+                      {/*
+                       * The hit area. A 2px line is unhoverable in practice,
+                       * and the name of a link is the whole reason to hover
+                       * one — so the pointer target is a fat invisible stroke
+                       * over the same path. It keeps its full width whatever
+                       * the drawn line has quietened to: a line the map has
+                       * calmed is exactly the one a reader needs to be able
+                       * to pick up again.
+                       */}
+                      <path
+                        d={path}
+                        fill="none"
+                        stroke="transparent"
+                        strokeWidth={12 / zoom}
+                        strokeLinecap="round"
+                        onMouseEnter={() => {
+                          if (dragState.current) {
+                            return;
+                          }
+                          setHovered({
+                            x: link.midX,
+                            y: link.midY,
+                            tooltip: link.tooltip,
+                            markerKey: null,
+                            linkKey: link.key,
+                          });
+                        }}
+                        onMouseLeave={() => {
+                          setHovered(null);
+                        }}
+                      >
+                        <title>{link.tooltip}</title>
+                      </path>
+                    </g>
+                  );
+                })}
+              </g>
+            ) : (
+              <></>
+            )}
 
             {/*
              * Leader lines, under the markers they belong to.
@@ -1191,53 +1403,87 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
              * survives a coastline or a dark landmass — the same trick the
              * name labels use.
              */}
-            <g style={{ pointerEvents: "none" }}>
-              {placedMarkers
-                .filter((marker: PlacedMapMarker): boolean => {
-                  return marker.needsLeaderLine;
-                })
-                .map((marker: PlacedMapMarker): ReactElement => {
-                  const color: string = CLUSTER_COLORS[marker.colorKey];
-                  return (
-                    <g key={`leader-${marker.key}`} aria-hidden="true">
-                      <line
-                        x1={marker.anchorX}
-                        y1={marker.anchorY}
-                        x2={marker.x}
-                        y2={marker.y}
-                        stroke="var(--ou-surface-primary, #ffffff)"
-                        strokeWidth={3.5 / zoom}
-                        strokeOpacity={0.9}
-                        strokeLinecap="round"
-                      />
-                      <line
-                        x1={marker.anchorX}
-                        y1={marker.anchorY}
-                        x2={marker.x}
-                        y2={marker.y}
-                        stroke={color}
-                        strokeWidth={1.25 / zoom}
-                        strokeOpacity={0.9}
-                        strokeLinecap="round"
-                      />
-                      {/* The exact spot: a white pip so the dot reads on
-                       * land, and the marker's colour inside it. */}
-                      <circle
-                        cx={marker.anchorX}
-                        cy={marker.anchorY}
-                        r={2.25 / zoom}
-                        fill="var(--ou-surface-primary, #ffffff)"
-                      />
-                      <circle
-                        cx={marker.anchorX}
-                        cy={marker.anchorY}
-                        r={1.25 / zoom}
-                        fill={color}
-                      />
-                    </g>
-                  );
-                })}
-            </g>
+            {layers.positionLines ? (
+              <g
+                data-testid="site-geo-map-position-lines"
+                style={{ pointerEvents: "none" }}
+              >
+                {placedMarkers
+                  .filter((marker: PlacedMapMarker): boolean => {
+                    return marker.needsLeaderLine;
+                  })
+                  .map((marker: PlacedMapMarker): ReactElement => {
+                    const emphasis: MapRole = markerRole({
+                      focus: focus,
+                      adjacency: adjacency,
+                      markerKey: marker.key,
+                    });
+                    const ink: MapLineInk = positionLineInk(
+                      inkPlan.positionLines,
+                      emphasis,
+                    );
+                    /*
+                     * A quiet thread gives up its colour with its weight —
+                     * see QUIET_LINE_COLOR — and takes it straight back when
+                     * the reader points at the marker it explains.
+                     */
+                    const color: string = ink.isColored
+                      ? CLUSTER_COLORS[marker.colorKey]
+                      : QUIET_LINE_COLOR;
+                    const dot: { radius: number; haloRadius: number } =
+                      positionAnchorDot(ink);
+                    return (
+                      <g
+                        key={`leader-${marker.key}`}
+                        aria-hidden="true"
+                        opacity={opacityForRole(emphasis)}
+                        style={{
+                          transition: `opacity ${EMPHASIS_TRANSITION_MS}ms ease`,
+                        }}
+                      >
+                        <line
+                          x1={marker.anchorX}
+                          y1={marker.anchorY}
+                          x2={marker.x}
+                          y2={marker.y}
+                          stroke="var(--ou-surface-primary, #ffffff)"
+                          strokeWidth={ink.haloWidth / zoom}
+                          strokeOpacity={ink.haloOpacity}
+                          strokeLinecap="round"
+                        />
+                        <line
+                          x1={marker.anchorX}
+                          y1={marker.anchorY}
+                          x2={marker.x}
+                          y2={marker.y}
+                          stroke={color}
+                          strokeWidth={ink.width / zoom}
+                          strokeOpacity={ink.opacity}
+                          strokeLinecap="round"
+                        />
+                        {/* The exact spot: a white pip so the dot reads on
+                         * land, and the thread's own colour inside it. */}
+                        <circle
+                          cx={marker.anchorX}
+                          cy={marker.anchorY}
+                          r={dot.haloRadius / zoom}
+                          fill="var(--ou-surface-primary, #ffffff)"
+                          fillOpacity={ink.haloOpacity}
+                        />
+                        <circle
+                          cx={marker.anchorX}
+                          cy={marker.anchorY}
+                          r={dot.radius / zoom}
+                          fill={color}
+                          fillOpacity={ink.opacity}
+                        />
+                      </g>
+                    );
+                  })}
+              </g>
+            ) : (
+              <></>
+            )}
 
             {/*
              * The markers. A CONTAINER — a region, a market, "Corp" — is
@@ -1293,13 +1539,42 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                 const side: number = radius * CONTAINER_SIDE_FACTOR;
                 const haloSide: number = side + ((hasCount ? 4 : 3) * 2) / zoom;
 
+                /*
+                 * What this marker is relative to whatever the reader is
+                 * pointing at: the subject itself, something one hop from
+                 * it, or part of the crowd that fades back so the other two
+                 * can be read. "idle" — nothing under the pointer — draws
+                 * every marker at full strength, which is the map at rest.
+                 */
+                const emphasis: MapRole = markerRole({
+                  focus: focus,
+                  adjacency: adjacency,
+                  markerKey: key,
+                });
+                const threadInk: MapLineInk = labelThreadInk(
+                  inkPlan.labelThreads,
+                  emphasis,
+                );
+
                 return (
                   <g
                     key={key}
                     role="button"
                     tabIndex={0}
                     aria-label={marker.tooltip}
-                    style={{ cursor: "pointer", outline: "none" }}
+                    /*
+                     * Opacity only. A muted marker keeps its hit area, its
+                     * tab stop and its accessible name: fading is how the
+                     * map answers a question, never a way of taking half of
+                     * it away from anybody reading with a keyboard or a
+                     * screen reader.
+                     */
+                    opacity={opacityForRole(emphasis)}
+                    style={{
+                      cursor: "pointer",
+                      outline: "none",
+                      transition: `opacity ${EMPHASIS_TRANSITION_MS}ms ease`,
+                    }}
                     onClick={() => {
                       // A pan that happened to end on a marker is not a click.
                       if (suppressClick.current) {
@@ -1321,7 +1596,9 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                       setHovered({
                         x: marker.x,
                         y: marker.y,
-                        label: marker.tooltip,
+                        tooltip: marker.tooltip,
+                        markerKey: key,
+                        linkKey: null,
                       });
                     }}
                     onMouseLeave={() => {
@@ -1332,7 +1609,9 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                       setHovered({
                         x: marker.x,
                         y: marker.y,
-                        label: marker.tooltip,
+                        tooltip: marker.tooltip,
+                        markerKey: key,
+                        linkKey: null,
                       });
                     }}
                     onBlur={() => {
@@ -1437,7 +1716,7 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                      * BEHIND the glyphs and the label stays readable over a
                      * coastline, a landmass or another marker.
                      */}
-                    {marker.label && labelPlacement ? (
+                    {layers.names && marker.label && labelPlacement ? (
                       <>
                         {/*
                          * A name that could not fit against its marker keeps
@@ -1448,8 +1727,14 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                          * name is typography, not status, and a second
                          * coloured thread beside the anchor line would read
                          * as a second claim about the site.
+                         *
+                         * It is a position line like the anchor thread is,
+                         * so it answers to the same switch and to the same
+                         * ink plan: on a level drawing dozens of them they
+                         * calm down together, and the one belonging to the
+                         * marker under the pointer comes back on its own.
                          */}
-                        {labelPlacement.leaderLine ? (
+                        {layers.positionLines && labelPlacement.leaderLine ? (
                           <g aria-hidden="true">
                             <line
                               x1={
@@ -1465,8 +1750,8 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                                 marker.y + labelPlacement.leaderLine.y2 / zoom
                               }
                               stroke="var(--ou-surface-primary, #ffffff)"
-                              strokeWidth={3 / zoom}
-                              strokeOpacity={0.9}
+                              strokeWidth={threadInk.haloWidth / zoom}
+                              strokeOpacity={threadInk.haloOpacity}
                               strokeLinecap="round"
                             />
                             <line
@@ -1482,9 +1767,9 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                               y2={
                                 marker.y + labelPlacement.leaderLine.y2 / zoom
                               }
-                              stroke="var(--ou-chart-tick, #6b7280)"
-                              strokeWidth={0.9 / zoom}
-                              strokeOpacity={0.75}
+                              stroke={QUIET_LINE_COLOR}
+                              strokeWidth={threadInk.width / zoom}
+                              strokeOpacity={threadInk.opacity}
                               strokeLinecap="round"
                             />
                           </g>
@@ -1552,49 +1837,169 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
             </g>
           </svg>
 
-          {/* Zoom and framing controls. */}
-          <div className="absolute right-2 top-2 z-10 flex flex-col rounded-lg border border-gray-200 bg-white/95 p-0.5 shadow-sm backdrop-blur">
-            <MapControlButton
-              label="Zoom in"
-              icon={IconProp.MagnifyingGlassPlus}
-              disabled={zoom >= MAX_ZOOM}
-              onClick={() => {
-                changeViewport(zoomViewport(viewport, ZOOM_STEP));
-              }}
-            />
-            <MapControlButton
-              label="Zoom out"
-              icon={IconProp.MagnifyingGlassMinus}
-              disabled={isWholeWorld}
-              onClick={() => {
-                changeViewport(zoomViewport(viewport, 1 / ZOOM_STEP));
-              }}
-            />
-            <MapControlButton
-              label="Fit to sites"
-              icon={IconProp.MapPin}
-              disabled={isFitted}
-              onClick={() => {
-                changeViewport(fittedViewport);
-              }}
-            />
-            <MapControlButton
-              label="Whole world"
-              icon={IconProp.Globe}
-              disabled={isWholeWorld}
-              onClick={() => {
-                changeViewport(clampViewport(WORLD_VIEWPORT));
-              }}
-            />
+          {/*
+           * Zoom, framing and the layer switch. One cluster, with the panel
+           * opening to the LEFT of the buttons rather than under them: the
+           * buttons are pinned to the map's top-right corner, and a panel
+           * dropped below them would cover the markers nearest the corner —
+           * which on a map framed to North America is most of the estate.
+           */}
+          <div className="absolute right-2 top-2 z-20 flex items-start gap-2">
+            {isLayerPanelOpen ? (
+              <div
+                data-testid="site-geo-map-layers-panel"
+                role="group"
+                aria-label="Map layers"
+                className="w-60 rounded-lg border border-gray-200 bg-white/95 p-1.5 shadow-lg backdrop-blur"
+              >
+                <p className="px-1.5 pb-1 text-xs font-medium text-gray-700">
+                  Show on the map
+                </p>
+                <ul role="list">
+                  {MAP_LAYER_OPTIONS.map(
+                    (option: MapLayerOption): ReactElement => {
+                      const isVisible: boolean = layers[option.key];
+                      return (
+                        <li key={option.key}>
+                          <button
+                            type="button"
+                            role="switch"
+                            aria-checked={isVisible}
+                            data-testid={`site-geo-map-layer-${option.key}`}
+                            className="flex w-full items-start gap-2 rounded-md px-1.5 py-1 text-left transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                            onClick={() => {
+                              changeLayers(
+                                setMapLayer(layers, option.key, !isVisible),
+                              );
+                            }}
+                          >
+                            <span
+                              aria-hidden="true"
+                              className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
+                                isVisible
+                                  ? "border-indigo-600 bg-indigo-600 text-white"
+                                  : "border-gray-300 bg-white text-transparent"
+                              }`}
+                            >
+                              <Icon className="h-3 w-3" icon={IconProp.Check} />
+                            </span>
+                            <span className="min-w-0">
+                              <span className="block text-xs font-medium text-gray-800">
+                                {option.label}
+                              </span>
+                              <span className="block text-xs leading-tight text-gray-500">
+                                {option.hint}
+                              </span>
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    },
+                  )}
+                </ul>
+              </div>
+            ) : (
+              <></>
+            )}
+            <div className="flex flex-col rounded-lg border border-gray-200 bg-white/95 p-0.5 shadow-sm backdrop-blur">
+              <MapControlButton
+                label="Zoom in"
+                icon={IconProp.MagnifyingGlassPlus}
+                disabled={zoom >= MAX_ZOOM}
+                onClick={() => {
+                  changeViewport(zoomViewport(viewport, ZOOM_STEP));
+                }}
+              />
+              <MapControlButton
+                label="Zoom out"
+                icon={IconProp.MagnifyingGlassMinus}
+                disabled={isWholeWorld}
+                onClick={() => {
+                  changeViewport(zoomViewport(viewport, 1 / ZOOM_STEP));
+                }}
+              />
+              <MapControlButton
+                label="Fit to sites"
+                icon={IconProp.MapPin}
+                disabled={isFitted}
+                onClick={() => {
+                  changeViewport(fittedViewport);
+                }}
+              />
+              <MapControlButton
+                label="Whole world"
+                icon={IconProp.Globe}
+                disabled={isWholeWorld}
+                onClick={() => {
+                  changeViewport(clampViewport(WORLD_VIEWPORT));
+                }}
+              />
+              <span
+                aria-hidden="true"
+                className="mx-1 my-0.5 block h-px bg-gray-200"
+              />
+              {/*
+               * The switch issue #3432 asked for. It carries a dot while
+               * anything is hidden, so a map missing its names says so
+               * without the panel being opened — a customer who turned a
+               * layer off last month and forgot must not spend an afternoon
+               * deciding their data is broken.
+               */}
+              <button
+                type="button"
+                title="Map layers"
+                aria-label="Map layers"
+                aria-expanded={isLayerPanelOpen}
+                data-testid="site-geo-map-layers-toggle"
+                className={`relative flex h-7 w-7 items-center justify-center rounded-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                  isLayerPanelOpen
+                    ? "bg-gray-100 text-gray-900"
+                    : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                }`}
+                onClick={() => {
+                  setIsLayerPanelOpen(!isLayerPanelOpen);
+                }}
+              >
+                <Icon className="h-4 w-4" icon={IconProp.Layers} />
+                {hiddenLayerCount > 0 ? (
+                  <span
+                    aria-hidden="true"
+                    data-testid="site-geo-map-layers-hidden-dot"
+                    className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-indigo-500"
+                  />
+                ) : (
+                  <></>
+                )}
+              </button>
+            </div>
           </div>
 
-          {/* Hover/focus label — readable in both themes, unlike a native title. */}
+          {/*
+           * Hover/focus card — readable in both themes, unlike a native
+           * title.
+           *
+           * The tooltip arrives as one " · "-joined line, which is exactly
+           * right for the marker's accessible name and exactly wrong here: a
+           * twelve-word grey sentence hides the one thing the reader was
+           * pointing at the marker to find out. So the name leads, and
+           * everything qualifying it follows underneath.
+           */}
           {hovered && !openCluster ? (
             <div
-              className="pointer-events-none absolute z-10 max-w-xs rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 shadow-md"
+              data-testid="site-geo-map-hover-card"
+              className="pointer-events-none absolute z-10 max-w-xs rounded-md border border-gray-200 bg-white px-2.5 py-1.5 shadow-md"
               style={overlayPosition(hovered.x, hovered.y, viewport, 12)}
             >
-              {hovered.label}
+              <p className="text-xs font-semibold text-gray-900">
+                {hoverText.title}
+              </p>
+              {hoverText.detail.length > 0 ? (
+                <p className="mt-0.5 text-xs leading-tight text-gray-500">
+                  {hoverText.detail.join(" · ")}
+                </p>
+              ) : (
+                <></>
+              )}
             </div>
           ) : (
             <></>
@@ -1737,7 +2142,7 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
          * it says both halves of the rule: the color comes from the monitor
          * on the link, and a link without one is dashed rather than absent.
          */}
-        {linkLines.length > 0 ? (
+        {hasDrawnLinks ? (
           <span
             data-testid="site-geo-map-link-key"
             className="flex items-center gap-1.5 text-xs text-gray-600"
@@ -1778,7 +2183,7 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
          * a key for something that is not on screen is clutter, and on most
          * levels nothing has to move at all.
          */}
-        {hasNudgedMarkers ? (
+        {layers.positionLines && hasNudgedMarkers ? (
           <span
             data-testid="site-geo-map-nudged-key"
             className="flex items-center gap-1.5 text-xs text-gray-600"
@@ -1807,12 +2212,35 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
         )}
 
         {/*
+         * A marker drawn off its coordinates with nothing saying so is the
+         * one thing this map may not do, and switching the lines off does
+         * not make the displacement go away. So the map says it in words
+         * instead, and says how to get the lines back.
+         */}
+        {!layers.positionLines && hasNudgedMarkers ? (
+          <span
+            data-testid="site-geo-map-nudged-hidden-key"
+            className="flex items-center gap-1.5 text-xs text-gray-500"
+          >
+            <Icon
+              className="h-3.5 w-3.5 flex-shrink-0 text-gray-400"
+              icon={IconProp.Layers}
+            />
+            {nudgedMarkerCount === 1
+              ? "1 marker is nudged apart to stay visible — turn position lines back on to see where it belongs"
+              : `${nudgedMarkerCount} markers are nudged apart to stay visible — turn position lines back on to see where they belong`}
+          </span>
+        ) : (
+          <></>
+        )}
+
+        {/*
          * A line on this map used to mean exactly one thing, and the key
          * above said so. A name that could not fit against its marker is
          * now joined to it by a second, thinner kind of line — so once any
          * are drawn, the key has to stop claiming every line is a nudge.
          */}
-        {hasThreadedLabels ? (
+        {layers.names && layers.positionLines && hasThreadedLabels ? (
           <span
             data-testid="site-geo-map-label-thread-key"
             className="flex items-center gap-1.5 text-xs text-gray-600"

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapInk.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapInk.ts
@@ -1,0 +1,673 @@
+/*
+ * Pure, react-free ink policy for the Network Map: how loudly each kind of
+ * line is drawn, and what the map lifts out of the crowd while the reader
+ * is pointing at something.
+ *
+ * Kept out of the component so the decisions can be imported (and
+ * unit-tested) in a plain Node/TypeScript environment — see
+ * Geo/GeoProjection.ts for why.
+ *
+ * WHY THIS EXISTS
+ *
+ * The map draws four kinds of ink at once: the markers themselves, the
+ * thread from a marker that had to be moved back to the spot it belongs to,
+ * the thread from a name that could not fit against its marker, and the
+ * links between connected sites. Every one of them earns its place, and
+ * every one of them used to be drawn at full strength all of the time.
+ *
+ * On a real franchise estate — forty regions piled over one country, wired
+ * together — that is not four layers. It is a web. Issue #3432 reported the
+ * symptom and asked for the obvious fix: a switch that hides the threads.
+ *
+ * A switch alone is the wrong fix, and it is worth being precise about why.
+ * The threads are not decoration: a marker is pushed off its coordinates
+ * only because it would otherwise be invisible under another one, and the
+ * thread is the entire licence for that move. Hide it and the map still
+ * draws a store twenty pixels from where the customer pinned it, with
+ * nothing on screen admitting so. The clutter would be gone and the map
+ * would be quietly wrong, which is worse.
+ *
+ * What was actually missing is a HIERARCHY. Everything on the map shouted,
+ * so nothing was legible. So:
+ *
+ *   - At rest, on a crowded map, the threads drop to a hairline and the
+ *     links thin out. They are still there — nothing is hidden, and a
+ *     reader who looks can still see exactly where a marker belongs — but
+ *     they stop competing with the markers for attention. On a map with
+ *     only a few of them there is no crowd to fix, and they are drawn at
+ *     full strength exactly as before.
+ *
+ *   - On hover or keyboard focus, one marker becomes the subject: its
+ *     thread, its name and its links go to full strength, the markers it is
+ *     connected to stay lit, and everything else fades back. That turns the
+ *     web into an answer to "what is this, where is it really, and what is
+ *     it wired to" — which is what a reader was trying to trace through the
+ *     spaghetti by eye.
+ *
+ *   - And the switch is still there (see MapLayerSettings), because a
+ *     customer who wants a bare map of dots should have one. It is the
+ *     escape hatch, not the design.
+ *
+ * Everything here is deterministic: same input, same output, no randomness
+ * and no clock access.
+ */
+
+/*
+ * ── How loud a kind of line is drawn ───────────────────────────────────
+ *
+ * "quiet" is not "off". It is the same line at a hairline weight and a low
+ * opacity, which is what lets a crowded map keep every one of its threads
+ * without any of them shouting.
+ */
+export type MapInkWeight = "full" | "quiet";
+
+/*
+ * What the map is about to draw. Counts, not markers — this decides a
+ * weight for a whole layer, and a layer is crowded or it is not.
+ */
+export interface MapInkInput {
+  // Markers that had to be moved, and therefore carry a thread.
+  positionLineCount: number;
+  // Names that could not fit against their marker, and carry one too.
+  labelThreadCount: number;
+  linkCount: number;
+}
+
+export interface MapInkPlan {
+  positionLines: MapInkWeight;
+  labelThreads: MapInkWeight;
+  links: MapInkWeight;
+}
+
+/*
+ * The counts at which a layer stops being a few pointers and starts being a
+ * texture.
+ *
+ * Deliberately low. The failure this fixes is not "a hundred lines"; it is
+ * the handful of lines that a reader has to visually subtract from the map
+ * before they can count the markers. Half a dozen threads over a country is
+ * already that. Below these numbers the lines genuinely help — three nudged
+ * markers on an otherwise empty map want saying so — so nothing changes for
+ * the maps that were never crowded.
+ */
+export const CALM_POSITION_LINE_LIMIT: number = 4;
+export const CALM_LABEL_THREAD_LIMIT: number = 4;
+/*
+ * Links get more room before they quieten: a link is a fact about the
+ * network that geography cannot show, and it is the only reason some
+ * customers open this map at all. It has to survive longer than a thread
+ * whose whole job is to explain a nudge.
+ */
+export const CALM_LINK_LIMIT: number = 8;
+
+const weightForCount: (count: number, limit: number) => MapInkWeight = (
+  count: number,
+  limit: number,
+): MapInkWeight => {
+  // A count the caller could not produce is not a crowd.
+  const safeCount: number = Number.isFinite(count) ? count : 0;
+  return safeCount > limit ? "quiet" : "full";
+};
+
+/**
+ * Decide how loudly each layer is drawn at rest, from how much of it there
+ * is. Each layer is judged on its own: a map with two nudged markers and
+ * thirty links quietens the links and leaves the two threads alone.
+ */
+export const planMapInk: (input: MapInkInput) => MapInkPlan = (
+  input: MapInkInput,
+): MapInkPlan => {
+  return {
+    positionLines: weightForCount(
+      input.positionLineCount,
+      CALM_POSITION_LINE_LIMIT,
+    ),
+    labelThreads: weightForCount(
+      input.labelThreadCount,
+      CALM_LABEL_THREAD_LIMIT,
+    ),
+    links: weightForCount(input.linkCount, CALM_LINK_LIMIT),
+  };
+};
+
+/*
+ * ── What the reader is pointing at ─────────────────────────────────────
+ *
+ * "idle" is the whole map at rest: nothing is emphasised, so nothing is
+ * dimmed either. The other three only ever appear together — the moment one
+ * element is "active", every other element on the map is "related" or
+ * "muted", and that is what makes the emphasis read.
+ */
+export type MapRole = "idle" | "active" | "related" | "muted";
+
+export interface MapFocus {
+  // The marker under the pointer, or holding keyboard focus.
+  markerKey: string | null;
+  // The link under the pointer. Never set at the same time as markerKey.
+  linkKey: string | null;
+}
+
+export const NO_MAP_FOCUS: MapFocus = { markerKey: null, linkKey: null };
+
+export const isMapFocused: (focus: MapFocus) => boolean = (
+  focus: MapFocus,
+): boolean => {
+  return focus.markerKey !== null || focus.linkKey !== null;
+};
+
+// What the adjacency index needs off a drawn link: its ends, by marker.
+export interface MapLinkEnds {
+  key: string;
+  fromMarkerKey: string;
+  toMarkerKey: string;
+}
+
+/**
+ * Who is wired to whom, in the two directions the emphasis has to answer:
+ * "which markers does this marker reach" and "which markers does this link
+ * join".
+ *
+ * Built once per frame rather than searched per marker — a level with forty
+ * markers and sixty links would otherwise walk the whole link list forty
+ * times on every pointer move.
+ */
+export interface MapAdjacency {
+  neighbours: Map<string, Set<string>>;
+  endpoints: Map<string, Array<string>>;
+}
+
+export const buildMapAdjacency: (links: Array<MapLinkEnds>) => MapAdjacency = (
+  links: Array<MapLinkEnds>,
+): MapAdjacency => {
+  const neighbours: Map<string, Set<string>> = new Map<string, Set<string>>();
+  const endpoints: Map<string, Array<string>> = new Map<
+    string,
+    Array<string>
+  >();
+
+  const join: (from: string, to: string) => void = (
+    from: string,
+    to: string,
+  ): void => {
+    const existing: Set<string> | undefined = neighbours.get(from);
+    if (existing) {
+      existing.add(to);
+      return;
+    }
+    neighbours.set(from, new Set<string>([to]));
+  };
+
+  for (const link of links) {
+    /*
+     * A link with an end the map is not drawing cannot emphasise anything,
+     * and a self-link joins a marker to itself — which would light the whole
+     * of its own neighbourhood for no reason.
+     */
+    if (!link.fromMarkerKey || !link.toMarkerKey) {
+      continue;
+    }
+    endpoints.set(link.key, [link.fromMarkerKey, link.toMarkerKey]);
+    if (link.fromMarkerKey === link.toMarkerKey) {
+      continue;
+    }
+    join(link.fromMarkerKey, link.toMarkerKey);
+    join(link.toMarkerKey, link.fromMarkerKey);
+  }
+
+  return { neighbours: neighbours, endpoints: endpoints };
+};
+
+/*
+ * What a map with no links to speak of hands to the emphasis. Shared rather
+ * than rebuilt per frame, and READ-ONLY by contract — nothing may write into
+ * it, or every map in the tab inherits the entry.
+ */
+export const EMPTY_MAP_ADJACENCY: MapAdjacency = buildMapAdjacency([]);
+
+/**
+ * What one marker is, relative to whatever the reader is pointing at.
+ *
+ * A marker is "related" when it is one hop from the marker in focus, or an
+ * end of the link in focus. One hop, never two: the point is to answer
+ * "what does this reach", and a transitive sweep would light most of a
+ * connected estate and emphasise nothing.
+ */
+export const markerRole: (input: {
+  focus: MapFocus;
+  adjacency: MapAdjacency;
+  markerKey: string;
+}) => MapRole = (input: {
+  focus: MapFocus;
+  adjacency: MapAdjacency;
+  markerKey: string;
+}): MapRole => {
+  if (!isMapFocused(input.focus)) {
+    return "idle";
+  }
+  if (input.focus.markerKey === input.markerKey) {
+    return "active";
+  }
+  if (
+    input.focus.markerKey !== null &&
+    input.adjacency.neighbours.get(input.focus.markerKey)?.has(input.markerKey)
+  ) {
+    return "related";
+  }
+  if (
+    input.focus.linkKey !== null &&
+    input.adjacency.endpoints
+      .get(input.focus.linkKey)
+      ?.includes(input.markerKey)
+  ) {
+    return "related";
+  }
+  return "muted";
+};
+
+/**
+ * What one link is, relative to the same focus: the link itself when it is
+ * the thing being pointed at, and every link touching the marker in focus.
+ */
+export const linkRole: (input: {
+  focus: MapFocus;
+  link: MapLinkEnds;
+}) => MapRole = (input: { focus: MapFocus; link: MapLinkEnds }): MapRole => {
+  if (!isMapFocused(input.focus)) {
+    return "idle";
+  }
+  if (input.focus.linkKey === input.link.key) {
+    return "active";
+  }
+  if (
+    input.focus.markerKey !== null &&
+    (input.focus.markerKey === input.link.fromMarkerKey ||
+      input.focus.markerKey === input.link.toMarkerKey)
+  ) {
+    return "related";
+  }
+  return "muted";
+};
+
+/*
+ * How far back a muted element goes. Far enough that the emphasised ones
+ * read as the subject, near enough that the map is still a map — a reader
+ * who hovers a marker to trace one link must not lose the coastline they
+ * are tracing it across, or the shape of the estate around it.
+ */
+export const MUTED_OPACITY: number = 0.22;
+
+export const opacityForRole: (role: MapRole) => number = (
+  role: MapRole,
+): number => {
+  return role === "muted" ? MUTED_OPACITY : 1;
+};
+
+/*
+ * How long the fade takes. Long enough not to flash as the pointer crosses
+ * a marker on its way somewhere else, short enough that the emphasis feels
+ * like a response rather than an animation.
+ */
+export const EMPHASIS_TRANSITION_MS: number = 120;
+
+/*
+ * ── The lines themselves ───────────────────────────────────────────────
+ *
+ * Widths are SCREEN units, the same units marker radii are in: the renderer
+ * divides by the zoom, so a line stays the same weight on screen however
+ * far the map is zoomed.
+ *
+ * Every line on this map is drawn twice — a pale under-stroke first, then
+ * the line itself — so it survives crossing a coastline or a dark landmass.
+ * The halo is part of the line's weight, so it belongs here rather than
+ * being a constant in the renderer that quietly stops matching.
+ */
+export interface MapLineInk {
+  width: number;
+  opacity: number;
+  haloWidth: number;
+  haloOpacity: number;
+  /*
+   * Whether the line carries its subject's own colour. A quiet position
+   * thread goes neutral: at a hairline weight the colour is not readable as
+   * a status anyway, and a red hairline beside a red marker is a second
+   * claim about the site that nobody can act on.
+   */
+  isColored: boolean;
+}
+
+/*
+ * The thread from a nudged marker back to the spot it belongs to. "full" is
+ * exactly what the map has always drawn.
+ */
+const POSITION_LINE_INK: Record<MapInkWeight, MapLineInk> = {
+  full: {
+    width: 1.25,
+    opacity: 0.9,
+    haloWidth: 3.5,
+    haloOpacity: 0.9,
+    isColored: true,
+  },
+  quiet: {
+    width: 0.7,
+    opacity: 0.4,
+    haloWidth: 2.2,
+    haloOpacity: 0.6,
+    isColored: false,
+  },
+};
+
+// The same thread, emphasised: the marker under the pointer.
+const POSITION_LINE_EMPHASIS: MapLineInk = {
+  width: 1.6,
+  opacity: 1,
+  haloWidth: 4,
+  haloOpacity: 1,
+  isColored: true,
+};
+
+// The thread from a marker to a name that could not sit against it.
+const LABEL_THREAD_INK: Record<MapInkWeight, MapLineInk> = {
+  full: {
+    width: 0.9,
+    opacity: 0.75,
+    haloWidth: 3,
+    haloOpacity: 0.9,
+    isColored: false,
+  },
+  quiet: {
+    width: 0.65,
+    opacity: 0.38,
+    haloWidth: 2.2,
+    haloOpacity: 0.6,
+    isColored: false,
+  },
+};
+
+const LABEL_THREAD_EMPHASIS: MapLineInk = {
+  width: 1.1,
+  opacity: 1,
+  haloWidth: 3.5,
+  haloOpacity: 1,
+  isColored: false,
+};
+
+/*
+ * A link line. It keeps its colour even when quiet: the colour is the
+ * monitor's verdict, and a link that is down has to stay findable on a map
+ * that has calmed everything else down.
+ */
+const LINK_INK: Record<MapInkWeight, MapLineInk> = {
+  full: {
+    width: 1.75,
+    opacity: 0.95,
+    haloWidth: 4,
+    haloOpacity: 0.85,
+    isColored: true,
+  },
+  quiet: {
+    width: 1.05,
+    opacity: 0.5,
+    haloWidth: 2.8,
+    haloOpacity: 0.6,
+    isColored: true,
+  },
+};
+
+const LINK_EMPHASIS: MapLineInk = {
+  width: 2.4,
+  opacity: 1,
+  haloWidth: 5,
+  haloOpacity: 1,
+  isColored: true,
+};
+
+/*
+ * The rule every layer shares: the thing being pointed at is drawn at its
+ * loudest, whatever the map decided at rest; everything one hop from it is
+ * drawn as though the map were calm; and everything else keeps the weight
+ * the plan chose, on top of which the muted opacity is applied by the
+ * renderer.
+ */
+const inkForRole: (
+  table: Record<MapInkWeight, MapLineInk>,
+  emphasis: MapLineInk,
+  weight: MapInkWeight,
+  role: MapRole,
+) => MapLineInk = (
+  table: Record<MapInkWeight, MapLineInk>,
+  emphasis: MapLineInk,
+  weight: MapInkWeight,
+  role: MapRole,
+): MapLineInk => {
+  if (role === "active") {
+    return emphasis;
+  }
+  if (role === "related") {
+    return table["full"];
+  }
+  return table[weight];
+};
+
+export const positionLineInk: (
+  weight: MapInkWeight,
+  role: MapRole,
+) => MapLineInk = (weight: MapInkWeight, role: MapRole): MapLineInk => {
+  return inkForRole(POSITION_LINE_INK, POSITION_LINE_EMPHASIS, weight, role);
+};
+
+export const labelThreadInk: (
+  weight: MapInkWeight,
+  role: MapRole,
+) => MapLineInk = (weight: MapInkWeight, role: MapRole): MapLineInk => {
+  return inkForRole(LABEL_THREAD_INK, LABEL_THREAD_EMPHASIS, weight, role);
+};
+
+export const linkInk: (weight: MapInkWeight, role: MapRole) => MapLineInk = (
+  weight: MapInkWeight,
+  role: MapRole,
+): MapLineInk => {
+  return inkForRole(LINK_INK, LINK_EMPHASIS, weight, role);
+};
+
+/**
+ * The pip on the far end of a position thread — the exact spot the marker
+ * belongs to.
+ *
+ * Sized from the thread's own weight rather than from a constant of its
+ * own, so the dot fades WITH the line. A full-strength full stop on the end
+ * of a hairline reads as a marker in its own right, which is the one thing
+ * this dot must never be mistaken for.
+ *
+ * At full weight the radii come out at exactly the 1.25 / 2.25 pair the map
+ * has drawn since the leader lines shipped, so a calm map is the same
+ * picture it always was. (The pip now carries its thread's opacity rather
+ * than a flat 1, which on a 2px dot is a difference nobody can see and one
+ * fewer constant that can drift.)
+ */
+export const positionAnchorDot: (ink: MapLineInk) => {
+  radius: number;
+  haloRadius: number;
+} = (ink: MapLineInk): { radius: number; haloRadius: number } => {
+  return { radius: ink.width, haloRadius: ink.width + 1 };
+};
+
+/*
+ * ── The escape hatch ───────────────────────────────────────────────────
+ *
+ * Issue #3432 asked for a switch, and it gets one — three, in fact, one per
+ * layer. The hierarchy above is what makes the DEFAULT map readable; these
+ * are for the customer who wants a bare map of dots and knows what they are
+ * giving up.
+ *
+ * Every layer defaults to ON, and an unreadable stored value reads as ON:
+ * a map that came back from a stale localStorage entry with its names
+ * missing is a bug report, not a preference.
+ */
+export type MapLayerKey = "names" | "links" | "positionLines";
+
+export interface MapLayerSettings {
+  names: boolean;
+  links: boolean;
+  positionLines: boolean;
+}
+
+export const DEFAULT_MAP_LAYERS: MapLayerSettings = {
+  names: true,
+  links: true,
+  positionLines: true,
+};
+
+/*
+ * One key for every map on the page — the choice is about how a reader
+ * wants maps to look, not about which level they happen to be on, and a
+ * preference that reset every time somebody drilled into a region would
+ * read as a control that does not work.
+ */
+export const MAP_LAYERS_STORAGE_KEY: string = "oneuptime-network-map-layers";
+
+export interface MapLayerOption {
+  key: MapLayerKey;
+  label: string;
+  hint: string;
+}
+
+/*
+ * In the order they matter to a reader who is turning things off: the names
+ * are the map's content, the links are the network, and the position lines
+ * are the bookkeeping that explains the other two.
+ */
+export const MAP_LAYER_OPTIONS: Array<MapLayerOption> = [
+  {
+    key: "names",
+    label: "Site names",
+    hint: "The name beside each marker.",
+  },
+  {
+    key: "links",
+    label: "Site links",
+    hint: "The lines between connected sites.",
+  },
+  {
+    key: "positionLines",
+    label: "Position lines",
+    hint: "The thread from a marker or a name back to the exact spot it belongs to.",
+  },
+];
+
+const readLayerFlag: (
+  source: Record<string, unknown>,
+  key: string,
+) => boolean = (source: Record<string, unknown>, key: string): boolean => {
+  const value: unknown = source[key];
+  return typeof value === "boolean" ? value : true;
+};
+
+/**
+ * A stored preference, made safe to draw with.
+ *
+ * localStorage is shared with every other tab and survives every deploy, so
+ * this is handed a value nobody in this build wrote: a string from an older
+ * shape, a null, an array, an object with two of the three keys. All of it
+ * reads as "show that layer", which is the only default that cannot hide
+ * something a customer is looking for.
+ */
+export const normalizeMapLayers: (value: unknown) => MapLayerSettings = (
+  value: unknown,
+): MapLayerSettings => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ...DEFAULT_MAP_LAYERS };
+  }
+  const source: Record<string, unknown> = value as Record<string, unknown>;
+  return {
+    names: readLayerFlag(source, "names"),
+    links: readLayerFlag(source, "links"),
+    positionLines: readLayerFlag(source, "positionLines"),
+  };
+};
+
+export const setMapLayer: (
+  layers: MapLayerSettings,
+  key: MapLayerKey,
+  isVisible: boolean,
+) => MapLayerSettings = (
+  layers: MapLayerSettings,
+  key: MapLayerKey,
+  isVisible: boolean,
+): MapLayerSettings => {
+  return { ...layers, [key]: isVisible };
+};
+
+/*
+ * How many layers are off — the badge on the control, so a map that is
+ * missing its names says so without being opened.
+ */
+export const countHiddenMapLayers: (layers: MapLayerSettings) => number = (
+  layers: MapLayerSettings,
+): number => {
+  return MAP_LAYER_OPTIONS.filter((option: MapLayerOption): boolean => {
+    return !layers[option.key];
+  }).length;
+};
+
+/*
+ * ── The hover card ─────────────────────────────────────────────────────
+ *
+ * Marker and link tooltips are built as one line of " · "-joined parts, and
+ * that line is also the marker's accessible name — which is exactly right
+ * for a screen reader and exactly wrong for a card, where a twelve-word
+ * grey sentence hides the one thing the reader wanted: the name.
+ *
+ * So the card splits it back apart. The name leads, in the page's text
+ * colour; everything else follows as quieter detail.
+ */
+export interface MapTooltipText {
+  title: string;
+  detail: Array<string>;
+}
+
+const TOOLTIP_PART_SEPARATOR: string = " · ";
+/*
+ * Both tooltip builders put the subject first and qualify it after an em
+ * dash — "Region 12 — Region", "Chicago fibre — No monitor attached" — so
+ * the first dash in the first part is where the name ends.
+ *
+ * The trailing space is optional because the qualifier can be blank: a site
+ * type is free text on a per-project row, and an empty one leaves the
+ * tooltip ending on a dangling dash that has no business on a card.
+ *
+ * A site whose own name contains a dash loses its tail to the detail line.
+ * It is still on the card, and threading a structured tooltip through every
+ * caller to avoid that would buy nothing else.
+ */
+const TOOLTIP_TITLE_SEPARATOR: RegExp = new RegExp("\\s—\\s*");
+
+export const splitMapTooltip: (tooltip: string) => MapTooltipText = (
+  tooltip: string,
+): MapTooltipText => {
+  const text: string = (tooltip || "").trim();
+  if (!text) {
+    return { title: "", detail: [] };
+  }
+
+  const parts: Array<string> = text
+    .split(TOOLTIP_PART_SEPARATOR)
+    .map((part: string): string => {
+      return part.trim();
+    })
+    .filter((part: string): boolean => {
+      return part.length > 0;
+    });
+
+  const head: string = parts.shift() || text;
+  const dash: RegExpExecArray | null = TOOLTIP_TITLE_SEPARATOR.exec(head);
+  // A head that IS the qualifier has no name to lead with.
+  if (!dash || dash.index <= 0) {
+    return { title: head, detail: parts };
+  }
+
+  const tail: string = head.slice(dash.index + dash[0].length).trim();
+  return {
+    title: head.slice(0, dash.index).trim(),
+    detail: tail ? [tail, ...parts] : parts,
+  };
+};

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
@@ -1768,6 +1768,18 @@ export interface DrawableMapLink {
   key: string;
   id: string;
   name: string;
+  /*
+   * The markers this line joins, by key rather than by site: a clustered
+   * marker in "all" mode speaks for every site in it, so the site ids on the
+   * link row do not identify the things actually on screen.
+   *
+   * Carried on the line so the map can answer "what is this marker wired
+   * to" without walking the link list once per marker — see
+   * SiteMapInk.buildMapAdjacency, which is what lights a marker's own links
+   * when a reader points at it.
+   */
+  fromMarkerKey: string;
+  toMarkerKey: string;
   x1: number;
   y1: number;
   x2: number;
@@ -1880,6 +1892,8 @@ export const buildMapLinks: (
       key: link.id,
       id: link.id,
       name: link.name,
+      fromMarkerKey: from.key,
+      toMarkerKey: to.key,
       x1: from.x,
       y1: from.y,
       x2: to.x,

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -978,7 +978,15 @@ describe("SiteGeoMap", () => {
    * because a thread nobody can see is ink for nothing.
    */
   test("a pushed name keeps a thread back to its marker", () => {
-    expect(source).toContain(squash("{labelPlacement.leaderLine ? ("));
+    /*
+     * The thread is a position line like the marker's own anchor thread is,
+     * so it answers to the same switch (issue #3432) — but only to that
+     * switch. Nothing else here may gate it, or a pushed name goes back to
+     * floating unattached.
+     */
+    expect(source).toContain(
+      squash("{layers.positionLines && labelPlacement.leaderLine ? ("),
+    );
     expect(source).toContain(
       squash("x1={ marker.x + labelPlacement.leaderLine.x1 / zoom }"),
     );
@@ -994,10 +1002,20 @@ describe("SiteGeoMap", () => {
    */
   test("the label threads get their own key, and only when there are some", () => {
     expect(source).toContain(
-      squash("const hasThreadedLabels: boolean = Array.from("),
+      squash("const threadedLabelCount: number = Array.from("),
     );
     expect(source).toContain(squash("return placement.leaderLine !== null;"));
-    expect(source).toContain(squash("{hasThreadedLabels ? ("));
+    expect(source).toContain(
+      squash("const hasThreadedLabels: boolean = threadedLabelCount > 0;"),
+    );
+    /*
+     * ...and not when the reader has switched off either of the two layers
+     * it takes to draw one. A key for ink that is not on screen is the
+     * clutter the key exists to prevent.
+     */
+    expect(source).toContain(
+      squash("{layers.names && layers.positionLines && hasThreadedLabels ? ("),
+    );
     expect(source).toContain('data-testid="site-geo-map-label-thread-key"');
   });
 
@@ -1008,7 +1026,7 @@ describe("SiteGeoMap", () => {
    */
   test("a displaced marker keeps a leader line to where it really is", () => {
     const leaders: string = source
-      .split('<g style={{ pointerEvents: "none" }}>')[1]!
+      .split('data-testid="site-geo-map-position-lines"')[1]!
       .split("</g>")[0]!;
     expect(leaders).toContain("return marker.needsLeaderLine;");
     expect(leaders).toContain("x1={marker.anchorX}");
@@ -1019,9 +1037,14 @@ describe("SiteGeoMap", () => {
 
   test("the leader lines are explained, and only when there are some", () => {
     expect(source).toContain(
-      squash("const hasNudgedMarkers: boolean = placedMarkers.some("),
+      squash("const nudgedMarkerCount: number = placedMarkers.filter("),
     );
-    expect(source).toContain(squash("{hasNudgedMarkers ? ("));
+    expect(source).toContain(
+      squash("const hasNudgedMarkers: boolean = nudgedMarkerCount > 0;"),
+    );
+    expect(source).toContain(
+      squash("{layers.positionLines && hasNudgedMarkers ? ("),
+    );
     expect(source).toContain('data-testid="site-geo-map-nudged-key"');
   });
 
@@ -1130,11 +1153,22 @@ describe("SiteGeoMap draws the site links", () => {
   test("each line carries a hit area and a name", () => {
     expect(source).toContain('stroke="transparent"');
     expect(source).toContain("<title>{link.tooltip}</title>");
-    expect(source).toContain("label: link.tooltip,");
+    expect(source).toContain("tooltip: link.tooltip,");
+    /*
+     * And it names the line it belongs to. Without the key the hover card
+     * would appear and nothing on the map would light up — the emphasis is
+     * keyed on what is under the pointer, not on where it is.
+     */
+    expect(source).toContain("linkKey: link.key,");
   });
 
   test("the lines are explained, and only when there are some", () => {
-    expect(source).toContain(squash("{linkLines.length > 0 ? ("));
+    expect(source).toContain(
+      squash(
+        "const hasDrawnLinks: boolean = layers.links && linkLines.length > 0;",
+      ),
+    );
+    expect(source).toContain(squash("{hasDrawnLinks ? ("));
     expect(source).toContain('data-testid="site-geo-map-link-key"');
     expect(source).toContain(
       "Site link — colored by its monitor; dashed when it has none",
@@ -1146,22 +1180,28 @@ describe("SiteGeoMap draws the site links", () => {
    * zoomed in". What that reported was the marker LEADER THREADS, which
    * correctly melt away as zoom pulls the markers apart — there were no
    * link lines on the map at all. Now that there are, they must never
-   * acquire a zoom condition of their own: the lines are a sibling of the
-   * other layers, drawn unconditionally, and only their stroke widths
-   * divide by the zoom to stay a constant size on screen.
+   * acquire a zoom condition of their own.
+   *
+   * The ONE gate they are allowed is the reader's own layer switch (issue
+   * #3432), which is a choice rather than a rule the map made up. Weight is
+   * not a gate: a line the map has calmed down is still drawn, and still
+   * hoverable — that is the whole difference between an ink hierarchy and
+   * hiding things.
    */
-  test("the lines are drawn at every zoom, not gated on one", () => {
+  test("the lines are drawn at every zoom, gated only on the reader's switch", () => {
     expect(code).toContain(
-      '</g> { } <g data-testid="site-geo-map-links"> {linkLines.map(',
+      '</g> { } {layers.links ? ( <g data-testid="site-geo-map-links"> {linkLines.map(',
     );
-    // Up to the leader-line group, which is the next layer on the map.
+    // Up to the position-line group, which is the next layer on the map.
     const group: string = code
       .split('data-testid="site-geo-map-links"')[1]!
-      .split('{ } <g style={{ pointerEvents: "none" }}>')[0]!;
+      .split("{ } {layers.positionLines ? (")[0]!;
     expect(group).not.toMatch(/zoom\s*[<>]/);
     expect(group).not.toContain("MAX_ZOOM");
     expect(group).not.toContain("needsDetail");
     expect(group).not.toContain("needsLeaderLine");
+    // The hit area is never quietened — a calm line is still a target.
+    expect(group).toContain('stroke="transparent" strokeWidth={12 / zoom}');
   });
 
   /*
@@ -1423,5 +1463,339 @@ describe("NetworkDeviceMonitorStepForm carries no data-collection controls", () 
     ["snmpOids"],
   ])("does not configure %s", (collectionField: string) => {
     expect(source).not.toContain(collectionField);
+  });
+});
+
+/*
+ * Issue #3432: "the lines on the Network Map are clutter — give me a switch
+ * to hide them."
+ *
+ * The switch shipped, and it is pinned at the bottom of this block. What is
+ * pinned above it is the reason a switch alone would have been the wrong
+ * answer.
+ *
+ * A marker is pushed off its coordinates only because it would otherwise be
+ * invisible under another marker, and the thread back to its real spot is
+ * the entire licence for that move. A map that hid the threads by default
+ * would draw a store twenty pixels from where the customer pinned it with
+ * nothing on screen admitting so — decluttered and quietly wrong.
+ *
+ * So the map got an ink HIERARCHY instead (SiteMapInk.ts, pinned by
+ * SiteMapInk.test.ts): a crowded frame draws its threads as hairlines
+ * rather than at the same weight as the markers, a frame with two of them
+ * is left exactly as it was, and pointing at anything hands its weight
+ * straight back while everything unrelated fades. Every assertion here is
+ * one wire in that, and each one fails if its line is reverted.
+ */
+describe("SiteGeoMap calms its ink rather than hiding it", () => {
+  const source: string = readSource(
+    "Components",
+    "NetworkSite",
+    "SiteGeoMap.tsx",
+  );
+  const code: string = readCode("Components", "NetworkSite", "SiteGeoMap.tsx");
+
+  /*
+   * The decisions live in the react-free module so they can be unit-tested
+   * in a plain Node environment — the same split as the projection, the
+   * viewport and the collision layout. A threshold re-derived here would be
+   * a threshold nothing tests.
+   */
+  test("the ink decisions come from the pure module, not from the renderer", () => {
+    expect(source).toContain('} from "./SiteMapInk";');
+    for (const helper of [
+      "planMapInk",
+      "markerRole",
+      "linkRole",
+      "opacityForRole",
+      "positionLineInk",
+      "labelThreadInk",
+      "linkInk",
+      "positionAnchorDot",
+      "buildMapAdjacency",
+    ]) {
+      expect([helper, source.includes(helper)]).toEqual([helper, true]);
+    }
+  });
+
+  /*
+   * The plan is fed the counts the map is ACTUALLY drawing. Counting a
+   * layer the reader has switched off would let hidden ink calm down the
+   * layers still on screen — a map with its links off would draw its two
+   * remaining threads as hairlines for no reason anybody could see.
+   */
+  test("the plan counts what is drawn, not what exists", () => {
+    expect(source).toContain(
+      squash(
+        "const inkPlan: MapInkPlan = planMapInk({ positionLineCount: layers.positionLines ? nudgedMarkerCount : 0, labelThreadCount: layers.positionLines && layers.names ? threadedLabelCount : 0, linkCount: layers.links ? linkLines.length : 0, });",
+      ),
+    );
+  });
+
+  /*
+   * Every stroke on the three line layers reads its weight off the ink, and
+   * every one of them still divides by the zoom. A literal left behind here
+   * is a line that ignores the hierarchy — and the failure is invisible on
+   * the calm maps everybody develops against, because there the plan hands
+   * back exactly the old numbers.
+   */
+  test("no line layer carries a hard-coded stroke weight any more", () => {
+    const positionLines: string = code
+      .split('data-testid="site-geo-map-position-lines"')[1]!
+      .split("</g>")[0]!;
+    expect(positionLines).toContain("strokeWidth={ink.haloWidth / zoom}");
+    expect(positionLines).toContain("strokeWidth={ink.width / zoom}");
+    expect(positionLines).not.toMatch(/strokeWidth=\{[\d.]+ \/ zoom\}/);
+
+    const links: string = code
+      .split('data-testid="site-geo-map-links"')[1]!
+      .split("{ } {layers.positionLines ? (")[0]!;
+    expect(links).toContain("strokeWidth={ink.haloWidth / zoom}");
+    expect(links).toContain("strokeWidth={ink.width / zoom}");
+
+    // The label thread reads the same way, off its own ink.
+    expect(source).toContain("strokeWidth={threadInk.haloWidth / zoom}");
+    expect(source).toContain("strokeWidth={threadInk.width / zoom}");
+  });
+
+  /*
+   * The pip on the end of a position thread is sized from that thread, so
+   * it fades with it. A constant here draws a full-strength full stop on
+   * the end of a hairline, which reads as a marker of its own.
+   */
+  test("the anchor dot is sized from its own thread", () => {
+    expect(source).toContain(
+      squash(
+        "const dot: { radius: number; haloRadius: number } = positionAnchorDot(ink);",
+      ),
+    );
+    expect(source).toContain("r={dot.haloRadius / zoom}");
+    expect(source).toContain("r={dot.radius / zoom}");
+  });
+
+  /*
+   * A quiet thread gives up its colour with its weight and takes it back
+   * when it is pointed at — decided by the ink, never re-derived here.
+   */
+  test("a thread's colour follows its ink", () => {
+    expect(source).toContain(
+      squash(
+        "const color: string = ink.isColored ? CLUSTER_COLORS[marker.colorKey] : QUIET_LINE_COLOR;",
+      ),
+    );
+  });
+
+  /*
+   * The emphasis is keyed on WHAT is under the pointer, not on where it is.
+   * Without the keys on the hover state the card would appear and nothing
+   * on the map would light up.
+   */
+  test("the hover state names the thing it is describing", () => {
+    expect(source).toContain("interface HoveredTarget {");
+    expect(source).toContain("markerKey: string | null;");
+    expect(source).toContain("linkKey: string | null;");
+    expect(source).toContain(squash("markerKey: key, linkKey: null,"));
+  });
+
+  /*
+   * The pointer wins over keyboard focus: a mouse that has moved onto a
+   * marker is a more recent statement of intent than a focus ring a tab
+   * left behind. Reading focusedKey first would leave the whole map
+   * emphasising something nobody is looking at.
+   */
+  test("the pointer outranks a focus ring left behind by a tab", () => {
+    const memo: string = source
+      .split("const focus: MapFocus = useMemo(() => {")[1]!
+      .split("]);")[0]!;
+    expect(memo).toContain(
+      squash(
+        "if (hovered) { return { markerKey: hovered.markerKey, linkKey: hovered.linkKey }; }",
+      ),
+    );
+    expect(memo.indexOf("hovered")).toBeLessThan(memo.indexOf("focusedKey"));
+    // Re-derived when either changes — the split above eats the closing.
+    expect(memo).toContain("}, [hovered, focusedKey");
+  });
+
+  /*
+   * Adjacency is rebuilt with the LINES. Rebuilt with the pointer instead,
+   * it would walk every link on the level on every frame of a hover — on
+   * the dense estates this feature is for, that is the hover being laggy
+   * exactly where it matters most.
+   */
+  test("who-is-wired-to-whom is computed once per frame, not per pointer move", () => {
+    expect(source).toContain(
+      squash(
+        "const adjacency: MapAdjacency = useMemo(() => { return layers.links ? buildMapAdjacency(linkLines) : EMPTY_MAP_ADJACENCY; }, [linkLines, layers.links]);",
+      ),
+    );
+  });
+
+  /*
+   * Fading is how the map answers a question, never a way of taking half of
+   * it away. A muted marker keeps its hit area, its tab stop and its
+   * accessible name — anything else would make the emphasis a trap for a
+   * reader using a keyboard or a screen reader.
+   */
+  test("the emphasis is opacity and nothing else", () => {
+    const markerGroup: string = code
+      .split(
+        "{placedMarkers.map((marker: PlacedMapMarker): ReactElement => {",
+      )[1]!
+      .split("onClick=")[0]!;
+    expect(markerGroup).toContain('role="button"');
+    expect(markerGroup).toContain("tabIndex={0}");
+    expect(markerGroup).toContain("aria-label={marker.tooltip}");
+    expect(markerGroup).toContain("opacity={opacityForRole(emphasis)}");
+    // No display/visibility gate, and no pointer-events opt-out.
+    expect(markerGroup).not.toContain("display:");
+    expect(markerGroup).not.toContain("visibility");
+    expect(markerGroup).not.toContain('pointerEvents: "none"');
+  });
+
+  test("every layer that fades also transitions, so a crossed pointer does not flash", () => {
+    expect(
+      source.split("transition: `opacity ${EMPHASIS_TRANSITION_MS}ms ease`")
+        .length - 1,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  /*
+   * A thread drawn at a hairline is easy to miss, so somebody who cannot
+   * see where a marker really sits has to be told the answer is a hover
+   * away rather than gone.
+   */
+  test("the map says when it has calmed something down", () => {
+    expect(source).toContain(
+      squash(
+        'const isInkCalmed: boolean = inkPlan.positionLines === "quiet" || inkPlan.labelThreads === "quiet" || inkPlan.links === "quiet";',
+      ),
+    );
+    expect(source).toContain('" Hover one to trace what it connects to."');
+    expect(source).toContain('" Hover one to see exactly where it sits."');
+    expect(source).toContain('data-testid="site-geo-map-hint"');
+  });
+
+  /*
+   * The tooltip is one " · "-joined line because that is exactly right for
+   * the marker's accessible name and exactly wrong for a card, where a
+   * twelve-word grey sentence hides the one thing the reader was pointing
+   * at the marker to find out.
+   */
+  test("the hover card leads with the name", () => {
+    expect(source).toContain(
+      squash(
+        'const hoverText: MapTooltipText = splitMapTooltip(hovered?.tooltip || "");',
+      ),
+    );
+    expect(source).toContain('data-testid="site-geo-map-hover-card"');
+    expect(source).toContain(squash("{hoverText.title}"));
+    expect(source).toContain(squash('{hoverText.detail.join(" · ")}'));
+  });
+});
+
+/*
+ * The switch issue #3432 actually asked for. It is the escape hatch rather
+ * than the design — the hierarchy above is what makes the default map
+ * readable — but a customer who wants a bare map of dots should have one,
+ * and it has to survive a reload and a drill-down or it reads as a control
+ * that does not work.
+ */
+describe("SiteGeoMap lets the reader switch layers off", () => {
+  const source: string = readSource(
+    "Components",
+    "NetworkSite",
+    "SiteGeoMap.tsx",
+  );
+
+  test("there is a control, and it lists every layer from the shared table", () => {
+    expect(source).toContain('data-testid="site-geo-map-layers-toggle"');
+    expect(source).toContain('data-testid="site-geo-map-layers-panel"');
+    expect(source).toContain(squash("{MAP_LAYER_OPTIONS.map("));
+    expect(source).toContain(
+      squash("data-testid={`site-geo-map-layer-${option.key}`}"),
+    );
+    // A switch, so a screen reader is told it is one and which way it is.
+    expect(source).toContain(squash('role="switch" aria-checked={isVisible}'));
+  });
+
+  /*
+   * The choice is about how a reader wants maps to look, not about which
+   * level they happen to be on. Held in component state alone it would
+   * reset on every drill-down and every reload.
+   */
+  test("the choice is read from storage on the first render and written back", () => {
+    expect(source).toContain(
+      squash(
+        "const [layers, setLayers] = useState<MapLayerSettings>(readStoredMapLayers);",
+      ),
+    );
+    expect(source).toContain(
+      squash(
+        "return normalizeMapLayers(LocalStorage.getItem(MAP_LAYERS_STORAGE_KEY));",
+      ),
+    );
+    expect(source).toContain(squash("setLayers(next); storeMapLayers(next);"));
+  });
+
+  /*
+   * Storage can be unavailable outright — a locked-down browser, a private
+   * window with its quota at zero. A map is not worth an exception.
+   */
+  test("neither the read nor the write can take the map down", () => {
+    const read: string = source
+      .split("const readStoredMapLayers:")[1]!
+      .split("const storeMapLayers:")[0]!;
+    expect(read).toContain("try {");
+    expect(read).toContain("} catch {");
+    const write: string = source
+      .split("const storeMapLayers:")[1]!
+      .split("const dotColorForSite:")[0]!;
+    expect(write).toContain("try {");
+    expect(write).toContain("} catch {");
+  });
+
+  /*
+   * THE thing switching the position lines off must not do. The
+   * displacement does not go away with the lines that explain it, so the
+   * map says it in words instead — and says how to get the lines back.
+   */
+  test("hiding the position lines still admits the markers were moved", () => {
+    expect(source).toContain(
+      squash("{!layers.positionLines && hasNudgedMarkers ? ("),
+    );
+    expect(source).toContain('data-testid="site-geo-map-nudged-hidden-key"');
+    expect(source).toContain("nudged apart to stay visible");
+  });
+
+  /*
+   * A layer switched off last month and forgotten is a support ticket about
+   * missing data. The control carries a dot while anything is hidden, so
+   * the map says so without being opened.
+   */
+  test("the control says when something is hidden", () => {
+    expect(source).toContain(
+      squash("const hiddenLayerCount: number = countHiddenMapLayers(layers);"),
+    );
+    expect(source).toContain(squash("{hiddenLayerCount > 0 ? ("));
+    expect(source).toContain('data-testid="site-geo-map-layers-hidden-dot"');
+  });
+
+  /*
+   * The panel floats over the map it is about, so touching the map has to
+   * dismiss it — otherwise it sits over the markers somebody just dragged
+   * into view and they have to go back and close it.
+   */
+  test("touching the map dismisses the panel", () => {
+    const down: string = source
+      .split("const onPointerDown:")[1]!
+      .split("const onPointerMove:")[0]!;
+    expect(down).toContain("setIsLayerPanelOpen(false);");
+    const change: string = source
+      .split(
+        "const changeViewport: (next: MapViewport) => void = useCallback(",
+      )[1]!
+      .split("[],")[0]!;
+    expect(change).toContain("setIsLayerPanelOpen(false);");
   });
 });

--- a/App/Tests/Dashboard/SiteMapInk.test.ts
+++ b/App/Tests/Dashboard/SiteMapInk.test.ts
@@ -1,0 +1,727 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  CALM_LABEL_THREAD_LIMIT,
+  CALM_LINK_LIMIT,
+  CALM_POSITION_LINE_LIMIT,
+  DEFAULT_MAP_LAYERS,
+  EMPHASIS_TRANSITION_MS,
+  EMPTY_MAP_ADJACENCY,
+  MAP_LAYERS_STORAGE_KEY,
+  MAP_LAYER_OPTIONS,
+  MUTED_OPACITY,
+  MapAdjacency,
+  MapFocus,
+  MapInkPlan,
+  MapInkWeight,
+  MapLayerKey,
+  MapLayerOption,
+  MapLayerSettings,
+  MapLineInk,
+  MapLinkEnds,
+  MapRole,
+  MapTooltipText,
+  NO_MAP_FOCUS,
+  buildMapAdjacency,
+  countHiddenMapLayers,
+  isMapFocused,
+  labelThreadInk,
+  linkInk,
+  linkRole,
+  markerRole,
+  normalizeMapLayers,
+  opacityForRole,
+  planMapInk,
+  positionAnchorDot,
+  positionLineInk,
+  setMapLayer,
+  splitMapTooltip,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapInk";
+
+/*
+ * Issue #3432: "the lines on the Network Map are clutter — give me a switch
+ * to hide them."
+ *
+ * The switch exists (MapLayerSettings, pinned at the bottom of this file),
+ * but a switch alone would have been the wrong answer, and the tests here
+ * are mostly about the right one. A marker is pushed off its coordinates
+ * only because it would otherwise be invisible under another marker, and
+ * the thread back to its real spot is the entire licence for that move.
+ * Hiding the threads leaves the map drawing a store twenty pixels from
+ * where the customer pinned it with nothing admitting so — decluttered and
+ * quietly wrong, which is worse than cluttered.
+ *
+ * So the module this pins does three things instead:
+ *
+ *   - it gives the map an ink HIERARCHY, so a crowded frame draws its
+ *     threads as hairlines rather than at the same weight as the markers,
+ *     while a frame with two of them is left exactly as it was;
+ *   - it decides what the map lifts out of the crowd when a reader points
+ *     at something, so "what is this wired to" stops being a question you
+ *     answer by tracing spaghetti with a finger;
+ *   - and it keeps the switch honest: unreadable stored preferences read as
+ *     "show everything", because a map that came back from a stale
+ *     localStorage entry with its names missing is a bug report, not a
+ *     preference.
+ */
+
+/*
+ * ── The ink plan ───────────────────────────────────────────────────────
+ */
+
+function inkInput(overrides: {
+  positionLineCount?: number;
+  labelThreadCount?: number;
+  linkCount?: number;
+}): {
+  positionLineCount: number;
+  labelThreadCount: number;
+  linkCount: number;
+} {
+  return {
+    positionLineCount: 0,
+    labelThreadCount: 0,
+    linkCount: 0,
+    ...overrides,
+  };
+}
+
+describe("planMapInk", () => {
+  test("an empty map draws every layer at full strength", () => {
+    expect(planMapInk(inkInput({}))).toEqual({
+      positionLines: "full",
+      labelThreads: "full",
+      links: "full",
+    });
+  });
+
+  /*
+   * The map this feature exists for. Nothing about a handful of threads is
+   * clutter, and quietening them would take away a pointer somebody needs.
+   */
+  test("a map at the limit is still drawn exactly as it always was", () => {
+    expect(
+      planMapInk(
+        inkInput({
+          positionLineCount: CALM_POSITION_LINE_LIMIT,
+          labelThreadCount: CALM_LABEL_THREAD_LIMIT,
+          linkCount: CALM_LINK_LIMIT,
+        }),
+      ),
+    ).toEqual({
+      positionLines: "full",
+      labelThreads: "full",
+      links: "full",
+    });
+  });
+
+  test("one past the limit quietens that layer", () => {
+    expect(
+      planMapInk(
+        inkInput({
+          positionLineCount: CALM_POSITION_LINE_LIMIT + 1,
+          labelThreadCount: CALM_LABEL_THREAD_LIMIT + 1,
+          linkCount: CALM_LINK_LIMIT + 1,
+        }),
+      ),
+    ).toEqual({
+      positionLines: "quiet",
+      labelThreads: "quiet",
+      links: "quiet",
+    });
+  });
+
+  /*
+   * Each layer is judged on its own. A map with two nudged markers and
+   * thirty links has one crowd on it, not three.
+   */
+  test("a crowded layer does not drag the calm ones down with it", () => {
+    const plan: MapInkPlan = planMapInk(
+      inkInput({ positionLineCount: 2, linkCount: 40 }),
+    );
+    expect(plan.positionLines).toBe("full");
+    expect(plan.labelThreads).toBe("full");
+    expect(plan.links).toBe("quiet");
+  });
+
+  /*
+   * Links survive longer than threads before they calm down: a link is a
+   * fact about the network that geography cannot show, and it is the only
+   * reason some customers open this map at all.
+   */
+  test("links are given more room than the threads that explain a nudge", () => {
+    expect(CALM_LINK_LIMIT).toBeGreaterThan(CALM_POSITION_LINE_LIMIT);
+    expect(CALM_LINK_LIMIT).toBeGreaterThan(CALM_LABEL_THREAD_LIMIT);
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["infinite", Infinity],
+    ["negative", -5],
+  ])("a %s count is not a crowd", (_name: string, count: number) => {
+    const plan: MapInkPlan = planMapInk(
+      inkInput({
+        positionLineCount: count,
+        labelThreadCount: count,
+        linkCount: count,
+      }),
+    );
+    /*
+     * Infinity is a real (if impossible) count and reads as crowded; the
+     * unreadable ones fall back to leaving the map alone. Either way the
+     * function returns a weight rather than propagating the junk.
+     */
+    for (const weight of [plan.positionLines, plan.labelThreads, plan.links]) {
+      expect(["full", "quiet"]).toContain(weight);
+    }
+  });
+
+  test("a NaN count specifically leaves the layer alone", () => {
+    expect(
+      planMapInk(inkInput({ positionLineCount: Number.NaN })).positionLines,
+    ).toBe("full");
+  });
+});
+
+/*
+ * ── Who is wired to whom ───────────────────────────────────────────────
+ */
+
+function linkEnds(
+  key: string,
+  fromMarkerKey: string,
+  toMarkerKey: string,
+): MapLinkEnds {
+  return { key, fromMarkerKey, toMarkerKey };
+}
+
+describe("buildMapAdjacency", () => {
+  test("a link is walkable from both of its ends", () => {
+    const adjacency: MapAdjacency = buildMapAdjacency([
+      linkEnds("l1", "a", "b"),
+    ]);
+    expect(Array.from(adjacency.neighbours.get("a") || [])).toEqual(["b"]);
+    expect(Array.from(adjacency.neighbours.get("b") || [])).toEqual(["a"]);
+    expect(adjacency.endpoints.get("l1")).toEqual(["a", "b"]);
+  });
+
+  test("a marker collects every neighbour it has", () => {
+    const adjacency: MapAdjacency = buildMapAdjacency([
+      linkEnds("l1", "hub", "a"),
+      linkEnds("l2", "b", "hub"),
+      linkEnds("l3", "hub", "c"),
+    ]);
+    expect(Array.from(adjacency.neighbours.get("hub") || []).sort()).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  /*
+   * Two links between one pair — a fibre pair, which is exactly what this
+   * map draws bowed apart — must not make either end its own neighbour
+   * twice or change what lights up.
+   */
+  test("parallel links between one pair collapse to one neighbour", () => {
+    const adjacency: MapAdjacency = buildMapAdjacency([
+      linkEnds("l1", "a", "b"),
+      linkEnds("l2", "a", "b"),
+    ]);
+    expect(Array.from(adjacency.neighbours.get("a") || [])).toEqual(["b"]);
+    expect(adjacency.endpoints.get("l1")).toEqual(["a", "b"]);
+    expect(adjacency.endpoints.get("l2")).toEqual(["a", "b"]);
+  });
+
+  /*
+   * A marker linked to itself would otherwise be its own neighbour, and
+   * "related" is supposed to mean something OTHER than the subject.
+   */
+  test("a self-link joins nothing", () => {
+    const adjacency: MapAdjacency = buildMapAdjacency([
+      linkEnds("l1", "a", "a"),
+    ]);
+    expect(adjacency.neighbours.get("a")).toBeUndefined();
+    // It is still a link the reader can point at.
+    expect(adjacency.endpoints.get("l1")).toEqual(["a", "a"]);
+  });
+
+  test("a link with an end the map is not drawing is skipped", () => {
+    const adjacency: MapAdjacency = buildMapAdjacency([
+      linkEnds("l1", "a", ""),
+      linkEnds("l2", "", "b"),
+    ]);
+    expect(adjacency.neighbours.size).toBe(0);
+    expect(adjacency.endpoints.size).toBe(0);
+  });
+
+  test("the shared empty index really is empty", () => {
+    expect(EMPTY_MAP_ADJACENCY.neighbours.size).toBe(0);
+    expect(EMPTY_MAP_ADJACENCY.endpoints.size).toBe(0);
+  });
+});
+
+/*
+ * ── What the reader is pointing at ─────────────────────────────────────
+ */
+
+const TRIANGLE: Array<MapLinkEnds> = [
+  linkEnds("a-b", "a", "b"),
+  linkEnds("b-c", "b", "c"),
+];
+
+function focusOn(overrides: Partial<MapFocus>): MapFocus {
+  return { ...NO_MAP_FOCUS, ...overrides };
+}
+
+describe("isMapFocused", () => {
+  test("a map with nothing under the pointer is not focused", () => {
+    expect(isMapFocused(NO_MAP_FOCUS)).toBe(false);
+  });
+
+  test("either kind of subject counts", () => {
+    expect(isMapFocused(focusOn({ markerKey: "a" }))).toBe(true);
+    expect(isMapFocused(focusOn({ linkKey: "a-b" }))).toBe(true);
+  });
+});
+
+describe("markerRole", () => {
+  const adjacency: MapAdjacency = buildMapAdjacency(TRIANGLE);
+
+  function roleOf(focus: MapFocus, markerKey: string): MapRole {
+    return markerRole({ focus, adjacency, markerKey });
+  }
+
+  /*
+   * The map at rest. Nothing is emphasised, so — and this is the half that
+   * matters — nothing is dimmed either: a map that permanently faded most
+   * of itself would be a worse map, not a calmer one.
+   */
+  test("with nothing under the pointer every marker is idle", () => {
+    for (const key of ["a", "b", "c"]) {
+      expect(roleOf(NO_MAP_FOCUS, key)).toBe("idle");
+    }
+  });
+
+  test("the marker under the pointer is the subject", () => {
+    expect(roleOf(focusOn({ markerKey: "b" }), "b")).toBe("active");
+  });
+
+  test("what it is wired to stays lit; everything else falls back", () => {
+    const focus: MapFocus = focusOn({ markerKey: "b" });
+    expect(roleOf(focus, "a")).toBe("related");
+    expect(roleOf(focus, "c")).toBe("related");
+    expect(roleOf(focus, "somewhere-else")).toBe("muted");
+  });
+
+  /*
+   * One hop, never two. A transitive sweep would light most of a connected
+   * estate, which emphasises nothing at all.
+   */
+  test("a neighbour's neighbour is not related", () => {
+    expect(roleOf(focusOn({ markerKey: "a" }), "c")).toBe("muted");
+  });
+
+  test("pointing at a link lights both of its ends", () => {
+    const focus: MapFocus = focusOn({ linkKey: "a-b" });
+    expect(roleOf(focus, "a")).toBe("related");
+    expect(roleOf(focus, "b")).toBe("related");
+    expect(roleOf(focus, "c")).toBe("muted");
+  });
+
+  test("a map with no links mutes everything but the subject", () => {
+    const bare: MapAdjacency = buildMapAdjacency([]);
+    expect(
+      markerRole({
+        focus: focusOn({ markerKey: "a" }),
+        adjacency: bare,
+        markerKey: "a",
+      }),
+    ).toBe("active");
+    expect(
+      markerRole({
+        focus: focusOn({ markerKey: "a" }),
+        adjacency: bare,
+        markerKey: "b",
+      }),
+    ).toBe("muted");
+  });
+});
+
+describe("linkRole", () => {
+  function roleOf(focus: MapFocus, link: MapLinkEnds): MapRole {
+    return linkRole({ focus, link });
+  }
+
+  test("with nothing under the pointer every line is idle", () => {
+    expect(roleOf(NO_MAP_FOCUS, TRIANGLE[0]!)).toBe("idle");
+  });
+
+  test("the line under the pointer is the subject", () => {
+    expect(roleOf(focusOn({ linkKey: "a-b" }), TRIANGLE[0]!)).toBe("active");
+    expect(roleOf(focusOn({ linkKey: "a-b" }), TRIANGLE[1]!)).toBe("muted");
+  });
+
+  /*
+   * The payoff for the reader: pointing at a marker picks its own lines out
+   * of the bundle crossing it.
+   */
+  test("pointing at a marker lights the lines that touch it", () => {
+    const focus: MapFocus = focusOn({ markerKey: "b" });
+    expect(roleOf(focus, TRIANGLE[0]!)).toBe("related");
+    expect(roleOf(focus, TRIANGLE[1]!)).toBe("related");
+    expect(roleOf(focus, linkEnds("x-y", "x", "y"))).toBe("muted");
+  });
+});
+
+describe("opacityForRole", () => {
+  test("only a muted element fades", () => {
+    expect(opacityForRole("idle")).toBe(1);
+    expect(opacityForRole("active")).toBe(1);
+    expect(opacityForRole("related")).toBe(1);
+    expect(opacityForRole("muted")).toBe(MUTED_OPACITY);
+  });
+
+  /*
+   * Far enough back that the emphasised elements read as the subject, near
+   * enough that the map is still a map — a reader tracing one link across a
+   * coastline must not lose the coastline.
+   */
+  test("muted is a fade, not a disappearance", () => {
+    expect(MUTED_OPACITY).toBeGreaterThan(0.1);
+    expect(MUTED_OPACITY).toBeLessThan(0.5);
+  });
+
+  test("the fade is quick enough to read as a response", () => {
+    expect(EMPHASIS_TRANSITION_MS).toBeGreaterThan(0);
+    expect(EMPHASIS_TRANSITION_MS).toBeLessThanOrEqual(200);
+  });
+});
+
+/*
+ * ── The lines themselves ───────────────────────────────────────────────
+ */
+
+const INK_KINDS: Array<{
+  name: string;
+  ink: (weight: MapInkWeight, role: MapRole) => MapLineInk;
+}> = [
+  { name: "position lines", ink: positionLineInk },
+  { name: "label threads", ink: labelThreadInk },
+  { name: "links", ink: linkInk },
+];
+
+describe.each(INK_KINDS)(
+  "$name",
+  (kind: {
+    name: string;
+    ink: (weight: MapInkWeight, role: MapRole) => MapLineInk;
+  }) => {
+    test("quiet is lighter than full in every dimension that reads", () => {
+      const full: MapLineInk = kind.ink("full", "idle");
+      const quiet: MapLineInk = kind.ink("quiet", "idle");
+      expect(quiet.width).toBeLessThan(full.width);
+      expect(quiet.opacity).toBeLessThan(full.opacity);
+      expect(quiet.haloWidth).toBeLessThan(full.haloWidth);
+    });
+
+    /*
+     * "quiet" is not "off". The whole bargain of the hierarchy is that
+     * nothing is hidden — a reader who looks can still see every thread on
+     * the map, they just do not have to look at all of them at once.
+     */
+    test("quiet is still drawn", () => {
+      const quiet: MapLineInk = kind.ink("quiet", "idle");
+      expect(quiet.width).toBeGreaterThan(0);
+      expect(quiet.opacity).toBeGreaterThan(0);
+    });
+
+    test("the subject is drawn at least as loudly as a calm map draws it", () => {
+      const full: MapLineInk = kind.ink("full", "idle");
+      const active: MapLineInk = kind.ink("quiet", "active");
+      expect(active.width).toBeGreaterThanOrEqual(full.width);
+      expect(active.opacity).toBeGreaterThanOrEqual(full.opacity);
+    });
+
+    /*
+     * The rule that makes the hover worth anything: on the crowded map,
+     * pointing at something hands back the weight the map took away.
+     */
+    test("pointing at it overrides a quiet plan", () => {
+      expect(kind.ink("quiet", "active")).not.toEqual(
+        kind.ink("quiet", "idle"),
+      );
+      expect(kind.ink("quiet", "related")).toEqual(kind.ink("full", "idle"));
+    });
+
+    test("a muted element keeps the plan's weight — the fade does the work", () => {
+      expect(kind.ink("quiet", "muted")).toEqual(kind.ink("quiet", "idle"));
+      expect(kind.ink("full", "muted")).toEqual(kind.ink("full", "idle"));
+    });
+
+    test("every line is drawn over an under-stroke wider than itself", () => {
+      for (const weight of ["full", "quiet"] as Array<MapInkWeight>) {
+        for (const role of ["idle", "active", "related"] as Array<MapRole>) {
+          const ink: MapLineInk = kind.ink(weight, role);
+          expect([kind.name, ink.haloWidth > ink.width]).toEqual([
+            kind.name,
+            true,
+          ]);
+        }
+      }
+    });
+  },
+);
+
+describe("what a line is coloured with", () => {
+  /*
+   * A hairline is too thin to read a colour off, and a red hairline beside
+   * a red marker reads as a second claim about the site rather than as the
+   * bookkeeping it is.
+   */
+  test("a quiet position thread gives up its colour with its weight", () => {
+    expect(positionLineInk("full", "idle").isColored).toBe(true);
+    expect(positionLineInk("quiet", "idle").isColored).toBe(false);
+  });
+
+  test("and takes it straight back when it is pointed at", () => {
+    expect(positionLineInk("quiet", "active").isColored).toBe(true);
+    expect(positionLineInk("quiet", "related").isColored).toBe(true);
+  });
+
+  /*
+   * A link's colour is its monitor's verdict. A link that is down has to
+   * stay findable on a map that has calmed everything else down.
+   */
+  test("a link keeps its colour however quiet it gets", () => {
+    for (const weight of ["full", "quiet"] as Array<MapInkWeight>) {
+      expect(linkInk(weight, "idle").isColored).toBe(true);
+      expect(linkInk(weight, "muted").isColored).toBe(true);
+    }
+  });
+
+  // A name is typography, not status — its thread never carries a colour.
+  test("a label thread is never coloured", () => {
+    for (const weight of ["full", "quiet"] as Array<MapInkWeight>) {
+      for (const role of [
+        "idle",
+        "active",
+        "related",
+        "muted",
+      ] as Array<MapRole>) {
+        expect(labelThreadInk(weight, role).isColored).toBe(false);
+      }
+    }
+  });
+});
+
+describe("positionAnchorDot", () => {
+  /*
+   * The pip on the end of a position thread is the exact spot the marker
+   * belongs to, so it has to fade WITH the thread — a full-strength full
+   * stop on a hairline reads as a marker of its own.
+   */
+  test("the dot is sized from its own thread", () => {
+    const full: MapLineInk = positionLineInk("full", "idle");
+    const quiet: MapLineInk = positionLineInk("quiet", "idle");
+    expect(positionAnchorDot(quiet).radius).toBeLessThan(
+      positionAnchorDot(full).radius,
+    );
+    expect(positionAnchorDot(quiet).haloRadius).toBeLessThan(
+      positionAnchorDot(full).haloRadius,
+    );
+  });
+
+  test("the white pip is always bigger than the coloured centre", () => {
+    for (const weight of ["full", "quiet"] as Array<MapInkWeight>) {
+      const dot: { radius: number; haloRadius: number } = positionAnchorDot(
+        positionLineInk(weight, "idle"),
+      );
+      expect(dot.haloRadius).toBeGreaterThan(dot.radius);
+    }
+  });
+
+  /*
+   * At full weight this is the 1.25 / 2.25 pair the map has drawn since the
+   * leader lines shipped — the hierarchy changes the crowded map, never the
+   * calm one.
+   */
+  test("a full-strength dot is exactly what the map always drew", () => {
+    expect(positionAnchorDot(positionLineInk("full", "idle"))).toEqual({
+      radius: 1.25,
+      haloRadius: 2.25,
+    });
+  });
+});
+
+/*
+ * ── The switch ─────────────────────────────────────────────────────────
+ */
+
+describe("map layer settings", () => {
+  test("every layer starts on", () => {
+    expect(DEFAULT_MAP_LAYERS).toEqual({
+      names: true,
+      links: true,
+      positionLines: true,
+    });
+  });
+
+  test("there is an option for every layer, and nothing else", () => {
+    expect(
+      MAP_LAYER_OPTIONS.map((option: MapLayerOption): MapLayerKey => {
+        return option.key;
+      }).sort(),
+    ).toEqual(["links", "names", "positionLines"]);
+    for (const option of MAP_LAYER_OPTIONS) {
+      expect([option.key, option.label.length > 0]).toEqual([option.key, true]);
+      expect([option.key, option.hint.length > 0]).toEqual([option.key, true]);
+    }
+  });
+
+  /*
+   * One key for every map on the page: the choice is about how a reader
+   * wants maps to look, not about which level they happen to be on, and a
+   * preference that reset on every drill-down would read as a control that
+   * does not work.
+   */
+  test("the preference is stored under one stable key", () => {
+    expect(MAP_LAYERS_STORAGE_KEY).toBe("oneuptime-network-map-layers");
+  });
+
+  test("setMapLayer changes one layer and leaves the rest alone", () => {
+    const next: MapLayerSettings = setMapLayer(
+      DEFAULT_MAP_LAYERS,
+      "positionLines",
+      false,
+    );
+    expect(next).toEqual({ names: true, links: true, positionLines: false });
+    // ...and does not mutate what it was handed.
+    expect(DEFAULT_MAP_LAYERS.positionLines).toBe(true);
+  });
+
+  test("the badge counts what is hidden", () => {
+    expect(countHiddenMapLayers(DEFAULT_MAP_LAYERS)).toBe(0);
+    expect(
+      countHiddenMapLayers({
+        names: false,
+        links: true,
+        positionLines: false,
+      }),
+    ).toBe(2);
+  });
+});
+
+describe("normalizeMapLayers", () => {
+  test("a stored preference comes back intact", () => {
+    expect(
+      normalizeMapLayers({ names: true, links: false, positionLines: false }),
+    ).toEqual({ names: true, links: false, positionLines: false });
+  });
+
+  /*
+   * localStorage is shared with every other tab and survives every deploy,
+   * so this is handed values nobody in this build wrote. All of them have
+   * to read as "show that layer": a map that came back with its names
+   * missing because of a stale entry is a bug report, not a preference.
+   */
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string from an older shape", "names,links"],
+    ["a number", 3],
+    ["an array", ["names"]],
+    ["an empty object", {}],
+  ])("%s reads as show everything", (_name: string, value: unknown) => {
+    expect(normalizeMapLayers(value)).toEqual(DEFAULT_MAP_LAYERS);
+  });
+
+  test("a half-written entry only keeps the halves it can read", () => {
+    expect(normalizeMapLayers({ links: false })).toEqual({
+      names: true,
+      links: false,
+      positionLines: true,
+    });
+  });
+
+  test("a non-boolean flag reads as on rather than as off", () => {
+    expect(
+      normalizeMapLayers({ names: "false", links: 0, positionLines: null }),
+    ).toEqual(DEFAULT_MAP_LAYERS);
+  });
+
+  test("keys nobody recognises are ignored", () => {
+    expect(
+      normalizeMapLayers({ names: false, borders: false, zoom: 4 }),
+    ).toEqual({ names: false, links: true, positionLines: true });
+  });
+
+  test("the result is a fresh object, never the shared default", () => {
+    const normalized: MapLayerSettings = normalizeMapLayers(null);
+    expect(normalized).not.toBe(DEFAULT_MAP_LAYERS);
+  });
+});
+
+/*
+ * ── The hover card ─────────────────────────────────────────────────────
+ */
+
+describe("splitMapTooltip", () => {
+  /*
+   * The tooltip is one " · "-joined line because that is exactly right for
+   * the marker's accessible name. On a card it is exactly wrong: a
+   * twelve-word grey sentence hides the one thing the reader was pointing
+   * at the marker to find out.
+   */
+  test("a marker's name leads, and everything qualifying it follows", () => {
+    const split: MapTooltipText = splitMapTooltip(
+      "Region 1300 — Region · 4 of 97 units down · 12 sites",
+    );
+    expect(split.title).toBe("Region 1300");
+    expect(split.detail).toEqual(["Region", "4 of 97 units down", "12 sites"]);
+  });
+
+  test("a link's name leads too", () => {
+    expect(splitMapTooltip("Chicago fibre — No monitor attached")).toEqual({
+      title: "Chicago fibre",
+      detail: ["No monitor attached"],
+    });
+  });
+
+  test("a bare name is all title and no detail", () => {
+    expect(splitMapTooltip("Store 41")).toEqual({
+      title: "Store 41",
+      detail: [],
+    });
+  });
+
+  test("a cluster's roll-up survives with its commas intact", () => {
+    expect(splitMapTooltip("4 sites: Alpha, Beta, Gamma, +1 more")).toEqual({
+      title: "4 sites: Alpha, Beta, Gamma, +1 more",
+      detail: [],
+    });
+  });
+
+  test.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+  ])(
+    "a %s tooltip splits into nothing at all",
+    (_name: string, value: string) => {
+      expect(splitMapTooltip(value)).toEqual({ title: "", detail: [] });
+    },
+  );
+
+  test("empty parts are dropped rather than drawn as blank lines", () => {
+    expect(splitMapTooltip("Store 41 — Unit ·  · Operational")).toEqual({
+      title: "Store 41",
+      detail: ["Unit", "Operational"],
+    });
+  });
+
+  test("a dash with nothing after it does not invent an empty detail line", () => {
+    expect(splitMapTooltip("Store 41 — ")).toEqual({
+      title: "Store 41",
+      detail: [],
+    });
+  });
+});

--- a/App/Tests/Dashboard/SiteMapViewModel.test.ts
+++ b/App/Tests/Dashboard/SiteMapViewModel.test.ts
@@ -3567,6 +3567,52 @@ describe("buildMapLinks", () => {
     expect([lines[0]!.x1, lines[0]!.x2]).toEqual([10, 90]);
   });
 
+  /*
+   * A line carries the MARKERS it joins, not the site ids off the link row.
+   * In "all" mode a clustered marker speaks for a dozen sites, so the site
+   * ids do not identify the things actually on screen — and the map's
+   * emphasis ("what is this marker wired to", issue #3432) is a question
+   * about what is drawn.
+   */
+  test("a line names the markers it joins, not the sites it came from", () => {
+    const lines: Array<DrawableMapLink> = buildMapLinks({
+      links: [linkRow({ id: "l1", fromSiteId: "s2", toSiteId: "s4" })],
+      markers: [
+        linkMarker("west", 10, 10, ["s1", "s2"]),
+        linkMarker("east", 90, 10, ["s3", "s4"]),
+      ],
+      zoom: 1,
+    });
+    expect(lines).toHaveLength(1);
+    expect([lines[0]!.fromMarkerKey, lines[0]!.toMarkerKey]).toEqual([
+      "west",
+      "east",
+    ]);
+  });
+
+  /*
+   * And the ends are recorded in the direction the LINK runs, so a bundle
+   * of parallel links between one pair all agree about which end is which.
+   */
+  test("the ends follow the link's own direction", () => {
+    const lines: Array<DrawableMapLink> = buildMapLinks({
+      links: [
+        linkRow({ id: "l1", fromSiteId: "a", toSiteId: "b" }),
+        linkRow({ id: "l2", fromSiteId: "b", toSiteId: "a" }),
+      ],
+      markers: [linkMarker("a", 0, 0), linkMarker("b", 200, 0)],
+      zoom: 1,
+    });
+    expect([lines[0]!.fromMarkerKey, lines[0]!.toMarkerKey]).toEqual([
+      "a",
+      "b",
+    ]);
+    expect([lines[1]!.fromMarkerKey, lines[1]!.toMarkerKey]).toEqual([
+      "b",
+      "a",
+    ]);
+  });
+
   test("a link whose ends share one marker is a dot, so it is dropped", () => {
     const lines: Array<DrawableMapLink> = buildMapLinks({
       links: [


### PR DESCRIPTION
### Title of this pull request?

Network Map: calm the map's ink instead of hiding its lines

### Small Description?

Issue #3432 asks for an option to hide the thin leader lines the Network Map draws from a nudged marker back to its exact coordinates. That option is in this PR — but shipping only the option would have been the wrong fix, so most of this change is the right one.

**Why a switch alone is wrong.** A marker is pushed off its coordinates only because it would otherwise be completely invisible under another marker; the thread back to its real spot is the entire licence for that move. Hide the threads and the map still draws a store twenty pixels from where the customer pinned it, with nothing on screen admitting so. Decluttered and quietly wrong is worse than cluttered.

**What was actually wrong.** The map draws four kinds of ink — markers, position threads, label threads, site links — and every one of them was drawn at full strength all of the time. On a real franchise estate (forty regions piled over one country, wired together, which is exactly the screenshot in the issue) that is not four layers, it is a web. The threads were only the strand the reporter happened to name.

So the map got an ink **hierarchy**, in a new react-free `SiteMapInk.ts`:

- **Calm at rest.** A crowded layer drops to a hairline; a calm one is drawn exactly as it always was, to the same constants. Nothing is hidden — a reader who looks can still see every thread, they just no longer have to look at all of them at once. Each layer is judged on its own, so two nudged markers next to thirty links quietens the links and leaves the two threads alone.
- **Spotlight on hover / keyboard focus.** One marker becomes the subject: its thread, its name and its links go to full strength, the markers it is wired to stay lit, and everything else fades to 22%. "What is this, where does it really sit, and what is it connected to" stops being a question you answer by tracing spaghetti with a finger. Fading is opacity only — a muted marker keeps its hit area, its tab stop and its accessible name.
- **A hover card instead of a sentence.** The tooltip is one `·`-joined line, which is right for a marker's accessible name and wrong for a card. The card now leads with the name and puts the qualifiers underneath.
- **The switch from the issue.** A Layers control in the map chrome — Site names / Site links / Position lines — persisted in `localStorage` so it survives a reload and a drill-down, with a dot on the control while anything is hidden. An unreadable stored value reads as "show everything": a map that came back from a stale entry with its names missing is a bug report, not a preference.
- **And it stays honest.** With the position lines switched off, the footer says in words how many markers are nudged apart and how to get the lines back.

Nothing about a map that was never crowded changes: with a handful of threads and links on it, every stroke resolves to the exact weight, opacity and radius the map has drawn since these layers shipped.

Not touched here: the Network Map dashboard *widget* draws label threads with the same shape and could inherit the same policy — it is a small tile with few markers, so it is left for a follow-up rather than bundled in.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Tests** — 710 passing across the ten affected suites:

- `App/Tests/Dashboard/SiteMapInk.test.ts` — 78 new cases: the ink plan's thresholds and its junk-count handling, the adjacency index (both directions, parallel links, self-links, ends the map is not drawing), the full marker/link role matrix, every ink table (quiet is lighter than full in every dimension that reads, quiet is still *drawn*, pointing at something overrides a quiet plan, a link keeps its colour and a label thread never gains one), the anchor-dot sizing, the stored preference including six shapes of unreadable value, and the tooltip split.
- `App/Tests/Dashboard/NetworkSitePageInvariants.test.ts` — two new blocks pinning the wiring end to end: the plan counts what is drawn rather than what exists, no line layer carries a hard-coded stroke weight any more, the emphasis is opacity and nothing else, the pointer outranks a stale focus ring, adjacency is built once per frame, the preference survives storage being unavailable, and hiding the position lines still admits the markers were moved. Existing assertions in the file were updated in place, not relaxed.
- `App/Tests/Dashboard/SiteMapViewModel.test.ts` — the marker keys now carried on each drawn link, including the "all"-mode case where a clustered marker speaks for several sites.

### Related Issue?

closes #3432

### Screenshots (if appropriate):

No app screenshots — I could not stand the stack up in this environment. The change was checked visually instead by driving the map's own view-model, collision layout and ink policy (`buildMapMarkers` → `layoutMapMarkers` → `resolveMarkerLabels` → `buildMapLinks` → `planMapInk`) over a synthetic 38-region US estate with 26 links — the same shape as the screenshot in the issue — and rendering the three frames in a browser. What that showed, and what a reviewer should look for on a dense level:

- **Before:** the bold green/red/amber link lines and the coloured position threads read at the same weight as the markers; the middle of the map is a web, and the region names compete with it.
- **After, at rest:** the links fall back to a thin, still-coloured trace and the position threads to a neutral hairline. What reads is the markers, their counts and their names. A down link is still obviously red.
- **After, pointing at one marker:** that marker's own links come forward at full weight, the regions on the other end of them stay lit with their names, and the rest of the estate drops to 22%. On the frame I checked, hovering one region resolved instantly to "these two links, one down, one unmonitored, reaching these two regions" — which is not readable at all in the first frame.

A calm level is pixel-identical to before: with few threads and links on it every stroke resolves to the same weight, opacity and radius the map has drawn since these layers shipped, which `SiteMapInk.test.ts` pins directly.
