### PR TITLE
test(network): let the discovery-scan tests describe the lookup as it is now

### DIFF
--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -1,16 +1,16 @@
+import fs from "fs";
+import path from "path";
 import { mockRouter } from "Common/Tests/Server/API/Helpers";
 import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
 import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
 import Response from "Common/Server/Utils/Response";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
-import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import DatabaseBaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import Probe from "Common/Models/DatabaseModels/Probe";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import {
   ExpressRequest,
   ExpressResponse,
@@ -64,11 +64,18 @@ jest.mock("Common/Server/Services/NetworkDeviceDiscoveryScanService", () => {
   };
 });
 
+/*
+ * Only the one method this route uses. Deliberately narrow: the route used to
+ * page every device in the project itself with findBy, and leaving findBy on
+ * this mock would let that walk quietly come back — the tests here would keep
+ * passing while the request went back to eight full-table scans. With just
+ * this method mocked, any other call on the service throws.
+ */
 jest.mock("Common/Server/Services/NetworkDeviceService", () => {
   return {
     __esModule: true,
     default: {
-      findBy: jest.fn(),
+      getRegisteredHostnames: jest.fn(),
     },
   };
 });
@@ -99,8 +106,8 @@ type MockedService = {
 
 const scanService: MockedService =
   NetworkDeviceDiscoveryScanService as unknown as MockedService;
-const deviceService: { findBy: jest.Mock } =
-  NetworkDeviceService as unknown as { findBy: jest.Mock };
+const deviceService: { getRegisteredHostnames: jest.Mock } =
+  NetworkDeviceService as unknown as { getRegisteredHostnames: jest.Mock };
 const responseUtil: {
   sendErrorResponse: jest.Mock;
   sendEntityArrayResponse: jest.Mock;
@@ -395,7 +402,9 @@ describe("POST /probe/discovery-scan/result", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    deviceService.findBy.mockResolvedValue([] as never);
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>() as never,
+    );
     scanService.updateOneById.mockResolvedValue(undefined as never);
   });
 
@@ -541,9 +550,9 @@ describe("POST /probe/discovery-scan/result", () => {
   test("flags hosts that already exist as devices so the UI can't re-import them", async () => {
     scanService.findOneBy.mockResolvedValue(makeFoundScan() as never);
 
-    const existing: NetworkDevice = new NetworkDevice();
-    existing.hostname = "10.0.0.5";
-    deviceService.findBy.mockResolvedValue([existing] as never);
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
 
     await callResultEndpoint(
       makeRequest({
@@ -559,13 +568,11 @@ describe("POST /probe/discovery-scan/result", () => {
     );
 
     // Existing devices are looked up within the scan's project.
-    const deviceFindArgs: JSONObject = deviceService.findBy.mock
+    const lookupArgs: JSONObject = deviceService.getRegisteredHostnames.mock
       .calls[0]![0] as JSONObject;
-    expect(
-      (
-        (deviceFindArgs["query"] as JSONObject)["projectId"] as ObjectID
-      ).toString(),
-    ).toBe(projectId.toString());
+    expect((lookupArgs["projectId"] as ObjectID).toString()).toBe(
+      projectId.toString(),
+    );
 
     const devices: Array<JSONObject> = lastUpdateData()[
       "discoveredDevices"
@@ -854,7 +861,9 @@ describe("POST /probe/discovery-scan/result — a result for a superseded run", 
 
   beforeEach(() => {
     jest.clearAllMocks();
-    deviceService.findBy.mockResolvedValue([] as never);
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>() as never,
+    );
     scanService.updateOneById.mockResolvedValue(undefined as never);
   });
 
@@ -917,117 +926,583 @@ describe("POST /probe/discovery-scan/result — a result for a superseded run", 
 });
 
 /*
- * The already-registered flag used to come from ONE findBy at LIMIT_MAX with
- * no paging and no sort. A project with more devices than that got an
- * arbitrary 10,000 of them, so every device past the cap was reported to the
- * dashboard as NOT registered and the reviewer's "import" re-created devices
- * that already existed.
+ * Which discovered hosts already have a device — the flag the review modal
+ * uses to grey out "import", and therefore the thing standing between a
+ * re-scan and a duplicated inventory.
+ *
+ * The endpoint used to work this out itself, by copying every hostname in the
+ * project into a Set: first one findBy capped at 10,000 (so a larger fleet
+ * silently reported its devices as NOT registered), then a paged walk ordered
+ * by createdAt (so a bulk import's identically-stamped rows made the pages
+ * overlap and skip, with the same result). It now ASKS — one narrow question
+ * about the addresses this sweep actually found.
+ *
+ * That moved the interesting arithmetic — chunking, dedup, how many
+ * statements — into NetworkDeviceService, where
+ * Common/Tests/Server/Services/NetworkDeviceRegisteredHostnames.test.ts
+ * covers it. What is left for the endpoint, and what this block covers, is
+ * the contract between the two: ask about the right addresses in the right
+ * project, and put the answer on the right hosts.
  */
 describe("POST /probe/discovery-scan/result — flagging already-registered hosts", () => {
   const probeId: ObjectID = ObjectID.generate();
   const scanId: ObjectID = ObjectID.generate();
   const projectId: ObjectID = ObjectID.generate();
 
-  function makeFullPage(): Array<NetworkDevice> {
-    const page: Array<NetworkDevice> = [];
-    for (let index: number = 0; index < LIMIT_MAX; index++) {
-      const device: NetworkDevice = new NetworkDevice();
-      device.hostname = `10.99.${Math.floor(index / 256)}.${index % 256}`;
-      page.push(device);
-    }
-    return page;
-  }
-
-  function deviceWithHostname(hostname: string): NetworkDevice {
-    const device: NetworkDevice = new NetworkDevice();
-    device.hostname = hostname;
-    return device;
-  }
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    scanService.updateOneById.mockResolvedValue(undefined as never);
+  function makeScan(
+    status: string = "In Progress",
+  ): NetworkDeviceDiscoveryScan {
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(
       scanId,
     );
     scan.projectId = projectId;
-    scan.status = "In Progress";
-    scanService.findOneBy.mockResolvedValue(scan as never);
-  });
+    scan.status = status;
+    return scan;
+  }
 
-  function discoveredResultRequest(): ExpressRequest {
+  function resultRequest(discoveredDevices: Array<JSONObject>): ExpressRequest {
     return makeRequest({
       probeId,
       body: {
         scanId: scanId.toString(),
         success: true,
-        discoveredDevices: [
-          { ipAddress: "10.0.0.5" },
-          { ipAddress: "10.0.0.6" },
-        ],
+        discoveredDevices: discoveredDevices,
       },
     });
   }
 
-  test("a single short page is fetched once and not paged again", async () => {
-    deviceService.findBy.mockResolvedValue([
-      deviceWithHostname("10.0.0.5"),
-    ] as never);
+  // The argument the endpoint handed the service.
+  function lookupArgs(): JSONObject {
+    expect(deviceService.getRegisteredHostnames).toHaveBeenCalledTimes(1);
+    return deviceService.getRegisteredHostnames.mock.calls[0]![0] as JSONObject;
+  }
 
-    await callResultEndpoint(discoveredResultRequest());
+  function askedAbout(): Array<string> {
+    return lookupArgs()["hostnames"] as Array<string>;
+  }
 
-    expect(deviceService.findBy).toHaveBeenCalledTimes(1);
-
+  // The hosts as they were written to the scan row, flags and all.
+  function storedDevices(): Array<JSONObject> {
+    expect(scanService.updateOneById).toHaveBeenCalledTimes(1);
     const data: JSONObject = expectPlainUpdateData(
       (scanService.updateOneById.mock.calls[0]![0] as JSONObject)["data"],
     );
-    const devices: Array<JSONObject> = data[
-      "discoveredDevices"
-    ] as Array<JSONObject>;
-    expect(devices[0]!["isAlreadyRegistered"]).toBe(true);
-    expect(devices[1]!["isAlreadyRegistered"]).toBe(false);
-  });
+    return data["discoveredDevices"] as Array<JSONObject>;
+  }
 
-  test("a full page is followed by another, so device 10,001 is still seen", async () => {
-    deviceService.findBy
-      .mockResolvedValueOnce(makeFullPage() as never)
-      .mockResolvedValueOnce([deviceWithHostname("10.0.0.6")] as never);
-
-    await callResultEndpoint(discoveredResultRequest());
-
-    expect(deviceService.findBy).toHaveBeenCalledTimes(2);
-
-    // The second call must actually move the cursor, or this loops forever.
-    const firstCall: JSONObject = deviceService.findBy.mock
-      .calls[0]![0] as JSONObject;
-    const secondCall: JSONObject = deviceService.findBy.mock
-      .calls[1]![0] as JSONObject;
-    expect(firstCall["skip"]).toBe(0);
-    expect(secondCall["skip"]).toBe(LIMIT_MAX);
-
-    const data: JSONObject = expectPlainUpdateData(
-      (scanService.updateOneById.mock.calls[0]![0] as JSONObject)["data"],
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scanService.updateOneById.mockResolvedValue(undefined as never);
+    scanService.findOneBy.mockResolvedValue(makeScan() as never);
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>() as never,
     );
-    const devices: Array<JSONObject> = data[
-      "discoveredDevices"
-    ] as Array<JSONObject>;
-    // Only found on the SECOND page — the case the old cap silently dropped.
-    expect(devices[1]!["isAlreadyRegistered"]).toBe(true);
   });
 
   /*
-   * Postgres makes no ordering promise without an ORDER BY, so an unsorted
-   * paged read can return a row twice, or skip one entirely, between pages.
+   * The load-bearing one. The question is about the sweep's addresses, so its
+   * cost is bounded by the sweep — not by the fleet, which is what made the
+   * old walk both slow and wrong.
    */
-  test("paging is stably ordered", async () => {
-    deviceService.findBy.mockResolvedValue([] as never);
-
-    await callResultEndpoint(discoveredResultRequest());
-
-    const findArgs: JSONObject = deviceService.findBy.mock
-      .calls[0]![0] as JSONObject;
-    expect((findArgs["sort"] as JSONObject)["createdAt"]).toBe(
-      SortOrder.Ascending,
+  test("asks about the addresses this sweep found, not about the whole project", async () => {
+    await callResultEndpoint(
+      resultRequest([{ ipAddress: "10.0.0.5" }, { ipAddress: "10.0.0.6" }]),
     );
+
+    expect(askedAbout()).toEqual(["10.0.0.5", "10.0.0.6"]);
+  });
+
+  test("asks within the scan's own project", async () => {
+    await callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }]));
+
+    expect((lookupArgs()["projectId"] as ObjectID).toString()).toBe(
+      projectId.toString(),
+    );
+  });
+
+  /*
+   * The probe is authenticated as a probe, not as a project member, so the
+   * lookup has no user permissions to ride on.
+   */
+  test("asks as root", async () => {
+    await callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }]));
+
+    expect((lookupArgs()["props"] as JSONObject)["isRoot"]).toBe(true);
+  });
+
+  /*
+   * One question for the whole sweep. The endpoint no longer loops: a large
+   * sweep must not turn into a page-at-a-time walk inside the request the
+   * probe is synchronously waiting on.
+   */
+  test("asks once, however many hosts the sweep found", async () => {
+    const discovered: Array<JSONObject> = [];
+    for (let index: number = 0; index < 300; index++) {
+      discovered.push({
+        ipAddress: `10.7.${Math.floor(index / 256)}.${index % 256}`,
+      });
+    }
+
+    await callResultEndpoint(resultRequest(discovered));
+
+    expect(deviceService.getRegisteredHostnames).toHaveBeenCalledTimes(1);
+    expect(askedAbout()).toHaveLength(300);
+  });
+
+  test("flags exactly the hosts the answer named", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5", "10.0.0.7"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.5" },
+        { ipAddress: "10.0.0.6" },
+        { ipAddress: "10.0.0.7" },
+      ]),
+    );
+
+    expect(
+      storedDevices().map((device: JSONObject) => {
+        return device["isAlreadyRegistered"];
+      }),
+    ).toEqual([true, false, true]);
+  });
+
+  /*
+   * Every host carries the flag explicitly. A missing key reads as falsy in
+   * the review modal by accident rather than by decision, and "accidentally
+   * importable" is the failure mode that duplicates devices.
+   */
+  test("every host is flagged, never left undefined", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([{ ipAddress: "10.0.0.5" }, { ipAddress: "10.0.0.6" }]),
+    );
+
+    for (const device of storedDevices()) {
+      expect(Object.keys(device)).toContain("isAlreadyRegistered");
+      expect(typeof device["isAlreadyRegistered"]).toBe("boolean");
+    }
+  });
+
+  /*
+   * A host the probe found but could not name. It is asked about as the empty
+   * string — which the service drops — and must never come back flagged, or
+   * the modal would refuse to import a host that has no device at all.
+   */
+  test("a host with no ipAddress is asked about as an empty string and is not flagged", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([{ ipAddress: "10.0.0.5" }, { sysName: "unnamed" }]),
+    );
+
+    expect(askedAbout()).toEqual(["10.0.0.5", ""]);
+    expect(storedDevices()[1]!["isAlreadyRegistered"]).toBe(false);
+  });
+
+  test("a host reported with a null ipAddress is handled the same way", async () => {
+    await callResultEndpoint(resultRequest([{ ipAddress: null }]));
+
+    expect(askedAbout()).toEqual([""]);
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(false);
+  });
+
+  /*
+   * A sweep can report the same address twice — two interfaces answering, or
+   * a probe retry. Both entries describe the same device, so both must be
+   * flagged; flagging only the first would offer the second for import.
+   */
+  test("a repeated address is flagged on every entry that carries it", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.5", sysName: "first" },
+        { ipAddress: "10.0.0.5", sysName: "second" },
+      ]),
+    );
+
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(true);
+    expect(storedDevices()[1]!["isAlreadyRegistered"]).toBe(true);
+  });
+
+  /*
+   * Ping-only hosts are offered for import too (as ICMP-monitored devices),
+   * so they need the same guard against being imported twice.
+   */
+  test("ping-only hosts are asked about alongside the SNMP responders", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.20"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.5", snmpReachable: true },
+        { ipAddress: "10.0.0.20", snmpReachable: false },
+      ]),
+    );
+
+    expect(askedAbout()).toEqual(["10.0.0.5", "10.0.0.20"]);
+    expect(storedDevices()[1]!["isAlreadyRegistered"]).toBe(true);
+  });
+
+  test("addresses are asked about in the order the probe reported them", async () => {
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.9" },
+        { ipAddress: "10.0.0.5" },
+        { ipAddress: "10.0.0.7" },
+      ]),
+    );
+
+    expect(askedAbout()).toEqual(["10.0.0.9", "10.0.0.5", "10.0.0.7"]);
+  });
+
+  test("a sweep that found nothing asks about nothing and stores nothing", async () => {
+    await callResultEndpoint(resultRequest([]));
+
+    expect(askedAbout()).toEqual([]);
+    expect(storedDevices()).toEqual([]);
+  });
+
+  /*
+   * The flags have to survive onto the array that is actually persisted — the
+   * review modal reads them off the stored row, not off the request.
+   */
+  test("the flags land on the hosts written to the scan row", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.5", sysName: "known" },
+        { ipAddress: "10.0.0.9", sysName: "new" },
+      ]),
+    );
+
+    expect(storedDevices()).toEqual([
+      { ipAddress: "10.0.0.5", sysName: "known", isAlreadyRegistered: true },
+      { ipAddress: "10.0.0.9", sysName: "new", isAlreadyRegistered: false },
+    ]);
+  });
+
+  test("the hosts are flagged before the row is written", async () => {
+    await callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }]));
+
+    expect(
+      deviceService.getRegisteredHostnames.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(scanService.updateOneById.mock.invocationCallOrder[0]!);
+  });
+
+  /*
+   * A result for a run that was already superseded is discarded, and a
+   * discarded result must not spend a query proving it.
+   */
+  test("a result for a superseded run never asks", async () => {
+    scanService.findOneBy.mockResolvedValue(makeScan("Pending") as never);
+
+    await callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }]));
+
+    expect(deviceService.getRegisteredHostnames).not.toHaveBeenCalled();
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  /*
+   * If the lookup fails, the honest answer is an error. Treating the failure
+   * as "none of these are registered" would offer the whole sweep for import
+   * and duplicate every device in it.
+   */
+  test("a failed lookup errors instead of storing every host as new", async () => {
+    const boom: Error = new Error("db down");
+    deviceService.getRegisteredHostnames.mockRejectedValue(boom as never);
+
+    const { next } = await callResultEndpoint(
+      resultRequest([{ ipAddress: "10.0.0.5" }]),
+    );
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The scale the endpoint has to survive: a sweep of ScanTargetUtil-sized
+   * range. Still one question, and the answer still lands on the right hosts.
+   */
+  test("a 5,000-host sweep is one question, and the flags still land correctly", async () => {
+    const discovered: Array<JSONObject> = [];
+    for (let index: number = 0; index < 5000; index++) {
+      discovered.push({
+        ipAddress: `10.60.${Math.floor(index / 256)}.${index % 256}`,
+      });
+    }
+
+    const registeredAddress: string = discovered[4999]!["ipAddress"] as string;
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>([registeredAddress]) as never,
+    );
+
+    await callResultEndpoint(resultRequest(discovered));
+
+    expect(deviceService.getRegisteredHostnames).toHaveBeenCalledTimes(1);
+    expect(askedAbout()).toHaveLength(5000);
+
+    const stored: Array<JSONObject> = storedDevices();
+    expect(stored[4999]!["isAlreadyRegistered"]).toBe(true);
+    expect(
+      stored.filter((device: JSONObject) => {
+        return device["isAlreadyRegistered"] === true;
+      }),
+    ).toHaveLength(1);
+  });
+
+  /*
+   * Three things and no more. The paging arguments the endpoint used to build
+   * itself — skip, limit, sort — are the service's business now, and passing
+   * one from here would mean the walk had started growing back.
+   */
+  test("asks with exactly three things: the project, the addresses, and root", () => {
+    return callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }])).then(
+      (): void => {
+        expect(Object.keys(lookupArgs()).sort()).toEqual([
+          "hostnames",
+          "projectId",
+          "props",
+        ]);
+      },
+    );
+  });
+
+  /*
+   * The flag is the endpoint's answer, not the probe's claim. A probe that
+   * sent isAlreadyRegistered itself — buggy, old, or hostile — could
+   * otherwise hide a host from the review modal, or offer a host that already
+   * has a device.
+   */
+  test("a flag the probe sent itself is overwritten, not trusted", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.5", isAlreadyRegistered: false },
+        { ipAddress: "10.0.0.9", isAlreadyRegistered: true },
+      ]),
+    );
+
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(true);
+    expect(storedDevices()[1]!["isAlreadyRegistered"]).toBe(false);
+  });
+
+  test("a numeric ipAddress is asked about as its string form", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["42"]) as never,
+    );
+
+    await callResultEndpoint(resultRequest([{ ipAddress: 42 }]));
+
+    expect(askedAbout()).toEqual(["42"]);
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(true);
+  });
+
+  /*
+   * Exact string matching, and deliberately so — "10.0.0.5 " and "10.0.0.5"
+   * are different hostnames in the column this is asked of, and pretending
+   * otherwise here would flag a host against a device that does not exist.
+   */
+  test("matching is exact — a padded or differently-cased answer flags nothing", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>([" 10.0.0.5", "SWITCH-1"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([{ ipAddress: "10.0.0.5" }, { ipAddress: "switch-1" }]),
+    );
+
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(false);
+    expect(storedDevices()[1]!["isAlreadyRegistered"]).toBe(false);
+  });
+
+  test("an answer naming an address this sweep never reported changes nothing", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5", "192.168.1.1"]) as never,
+    );
+
+    await callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }]));
+
+    expect(storedDevices()).toHaveLength(1);
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(true);
+  });
+
+  /*
+   * The two things the endpoint does to the host list are independent: a host
+   * that already has a device still answered SNMP, and still counts.
+   */
+  test("flagging a host does not take it out of respondedHostCount", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5", "10.0.0.6"]) as never,
+    );
+
+    await callResultEndpoint(
+      resultRequest([
+        { ipAddress: "10.0.0.5", snmpReachable: true },
+        { ipAddress: "10.0.0.6", snmpReachable: true },
+      ]),
+    );
+
+    const data: JSONObject = expectPlainUpdateData(
+      (scanService.updateOneById.mock.calls[0]![0] as JSONObject)["data"],
+    );
+    expect(data["respondedHostCount"]).toBe(2);
+  });
+
+  // A failed sweep still reports the hosts it managed to find.
+  test("a sweep the probe reports as failed still gets its hosts flagged", async () => {
+    deviceService.getRegisteredHostnames.mockResolvedValue(
+      new Set<string>(["10.0.0.5"]) as never,
+    );
+
+    await callResultEndpoint(
+      makeRequest({
+        probeId,
+        body: {
+          scanId: scanId.toString(),
+          success: false,
+          statusMessage: "probe crashed mid-sweep",
+          discoveredDevices: [{ ipAddress: "10.0.0.5" }],
+        },
+      }),
+    );
+
+    expect(storedDevices()[0]!["isAlreadyRegistered"]).toBe(true);
+  });
+
+  test("the happy path never reaches the error handler", async () => {
+    const { next } = await callResultEndpoint(
+      resultRequest([{ ipAddress: "10.0.0.5" }]),
+    );
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Every way the request can be turned away before the scan is in hand. None
+   * of them should spend a query on a result that is going to be refused.
+   */
+  test("a request refused before the scan is loaded never asks", async () => {
+    await callResultEndpoint(makeRequest({ probeId, body: {} }));
+    expect(deviceService.getRegisteredHostnames).not.toHaveBeenCalled();
+
+    await callResultEndpoint(
+      makeRequest({ body: { scanId: scanId.toString() } }),
+    );
+    expect(deviceService.getRegisteredHostnames).not.toHaveBeenCalled();
+
+    scanService.findOneBy.mockResolvedValue(null as never);
+    await callResultEndpoint(resultRequest([{ ipAddress: "10.0.0.5" }]));
+    expect(deviceService.getRegisteredHostnames).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * The failure this file was recovered from, guarded from the other side.
+ *
+ * PR #3441 moved the already-registered lookup into
+ * NetworkDeviceService.getRegisteredHostnames. The mock factory at the top of
+ * this file still offered only findBy, so every test here died with
+ * "getRegisteredHostnames is not a function" and the App Test job went red on
+ * master.
+ *
+ * TypeScript could not see it coming: a jest.mock factory is an untyped
+ * object literal, and nothing checks it against the module it replaces. So
+ * the route's own source is read here and every service method it calls is
+ * required to exist on the stub. A method nobody stubbed now fails with a
+ * sentence naming it, instead of thirty identical TypeErrors.
+ */
+describe("the service stubs in this file track the route they stand in for", () => {
+  const ROUTE_SOURCE_PATH: string = path.join(
+    __dirname,
+    "..",
+    "..",
+    "FeatureSet",
+    "Telemetry",
+    "API",
+    "ProbeIngest",
+    "DiscoveryScan.ts",
+  );
+
+  /*
+   * Comments are stripped first: this file's own prose names these services
+   * and their methods, and the route's does too. Only real call sites count.
+   */
+  const routeCode: string = fs
+    .readFileSync(ROUTE_SOURCE_PATH, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
+
+  function methodsCalledOn(serviceName: string): Array<string> {
+    const called: Set<string> = new Set<string>();
+    const callSite: RegExp = new RegExp(
+      `\\b${serviceName}\\.([A-Za-z0-9_]+)\\s*\\(`,
+      "g",
+    );
+
+    let match: RegExpExecArray | null = callSite.exec(routeCode);
+
+    while (match) {
+      called.add(match[1]!);
+      match = callSite.exec(routeCode);
+    }
+
+    return Array.from(called).sort();
+  }
+
+  function methodsMissingFrom(
+    stub: unknown,
+    serviceName: string,
+  ): Array<string> {
+    return methodsCalledOn(serviceName).filter((method: string): boolean => {
+      return typeof (stub as JSONObject)[method] !== "function";
+    });
+  }
+
+  /*
+   * If the route ever moves, the scan below would find nothing and pass
+   * vacuously. Pin what it is expected to see.
+   */
+  test("the route's source is found and its calls are visible", () => {
+    expect(methodsCalledOn("NetworkDeviceService")).toEqual([
+      "getRegisteredHostnames",
+    ]);
+    expect(methodsCalledOn("NetworkDeviceDiscoveryScanService")).toEqual(
+      expect.arrayContaining([
+        "findBy",
+        "findOneBy",
+        "updateColumnsByIdWithoutHooks",
+        "updateOneById",
+      ]),
+    );
+  });
+
+  test("every NetworkDeviceService method the route calls is stubbed here", () => {
+    expect(methodsMissingFrom(deviceService, "NetworkDeviceService")).toEqual(
+      [],
+    );
+  });
+
+  test("every NetworkDeviceDiscoveryScanService method the route calls is stubbed here", () => {
+    expect(
+      methodsMissingFrom(scanService, "NetworkDeviceDiscoveryScanService"),
+    ).toEqual([]);
   });
 });

--- a/Common/Tests/Server/Services/NetworkDeviceRegisteredHostnames.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceRegisteredHostnames.test.ts
@@ -1,0 +1,1023 @@
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import ObjectID from "../../../Types/ObjectID";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import { JSONObject } from "../../../Types/JSON";
+import { FindOperator } from "typeorm";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * "Which of THESE addresses already have a device in this project."
+ *
+ * The probe's discovery-scan result endpoint asks this of every host a sweep
+ * found, and the answer decides whether the dashboard offers the host as
+ * importable. A WRONG "not registered" is not a cosmetic miss: the reviewer
+ * clicks import and a second device appears at an address that already had
+ * one.
+ *
+ * The walk this replaced got that wrong at scale, and this suite exists to
+ * pin the shape that cannot. It paged every device in the project with
+ * `ORDER BY createdAt LIMIT 10000 OFFSET n` — and a bulk discovery import
+ * stamps every device it creates with the SAME createdAt, so on a fleet of
+ * 80,000 devices all 80,000 shared one sort value. LIMIT/OFFSET over a
+ * single-valued sort key is not stable: Postgres may return a row twice
+ * across two pages and never return another at all, and the row it never
+ * returned reads as "not registered". The walk also cost eight sequential
+ * full-table scans inside a request the probe synchronously waits on.
+ *
+ * So the tests here are mostly about STATEMENTS, not results: how many reads
+ * are issued, which addresses each one asks about, and — the load-bearing
+ * one — that the read count is a function of the SWEEP's size alone and never
+ * of what any page returned. Those assertions used to live in the API's own
+ * test (App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts) because the API
+ * did the paging; they belong here now that it does not.
+ *
+ * No Postgres: findBy is spied on the service singleton and the tests read
+ * the query objects it was handed.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+/*
+ * Must track HOSTNAME_LOOKUP_CHUNK_SIZE in NetworkDeviceService. Written out
+ * rather than imported (it is module-private) so that changing the service
+ * constant fails HERE — the number is a promise about the longest literal
+ * `IN (...)` list this code will ever hand the planner, and a promise nobody
+ * asserts is not a promise.
+ */
+const CHUNK_SIZE: number = 500;
+
+const ROOT_PROPS: DatabaseCommonInteractionProps = {
+  isRoot: true,
+};
+
+let findBySpy: jest.SpyInstance;
+
+function deviceAt(hostname: string): NetworkDevice {
+  const device: NetworkDevice = new NetworkDevice();
+  device.hostname = hostname;
+  return device;
+}
+
+// A row the query returned that carries no hostname at all.
+function deviceWithNoHostname(): NetworkDevice {
+  return new NetworkDevice();
+}
+
+/*
+ * `count` distinct, well-formed addresses. Kept under 40 x 256 so every
+ * generated address is unique — a duplicate would silently weaken the
+ * chunk-arithmetic cases below, which count on the input being distinct.
+ */
+function addresses(count: number, secondOctet: number = 99): Array<string> {
+  const list: Array<string> = [];
+
+  for (let index: number = 0; index < count; index++) {
+    list.push(`10.${secondOctet}.${Math.floor(index / 256)}.${index % 256}`);
+  }
+
+  return list;
+}
+
+function findByArgs(callIndex: number): JSONObject {
+  return findBySpy.mock.calls[callIndex]![0] as JSONObject;
+}
+
+function queryOf(callIndex: number): JSONObject {
+  return findByArgs(callIndex)["query"] as JSONObject;
+}
+
+/*
+ * The addresses one read actually asked about. QueryHelper.any renders the
+ * chunk into a TypeORM Raw operator — `(alias IN (:...rid))` with a RANDOM
+ * parameter name — so the list is recovered from the operator's parameters
+ * rather than from a key a test could hard-code.
+ */
+function askedAboutInCall(callIndex: number): Array<string> {
+  const operator: FindOperator<string> = queryOf(callIndex)[
+    "hostname"
+  ] as unknown as FindOperator<string>;
+
+  const parameters: Record<string, unknown> =
+    (operator.objectLiteralParameters || {}) as Record<string, unknown>;
+
+  const values: Array<unknown> =
+    (Object.values(parameters)[0] as Array<unknown>) || [];
+
+  return values.map((value: unknown): string => {
+    return String(value);
+  });
+}
+
+// Every address asked about, across every read, in the order they were asked.
+function askedAbout(): Array<string> {
+  const asked: Array<string> = [];
+
+  for (let index: number = 0; index < findBySpy.mock.calls.length; index++) {
+    asked.push(...askedAboutInCall(index));
+  }
+
+  return asked;
+}
+
+function chunkSizes(): Array<number> {
+  const sizes: Array<number> = [];
+
+  for (let index: number = 0; index < findBySpy.mock.calls.length; index++) {
+    sizes.push(askedAboutInCall(index).length);
+  }
+
+  return sizes;
+}
+
+beforeEach(() => {
+  findBySpy = jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("NetworkDeviceService.getDevicesByHostnames — the read it issues", () => {
+  it("asks one indexed lookup for the addresses it was given", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5", "10.0.0.6", "10.0.0.7"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(askedAboutInCall(0)).toEqual(["10.0.0.5", "10.0.0.6", "10.0.0.7"]);
+  });
+
+  /*
+   * A hostname predicate is the whole point. Without it this is a table scan
+   * that happens to be filtered in Node — which is exactly the walk that was
+   * removed.
+   */
+  it("filters by hostname in the database, with an IN list", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    const operator: FindOperator<string> = queryOf(0)[
+      "hostname"
+    ] as unknown as FindOperator<string>;
+
+    expect(operator.type).toBe("raw");
+    expect(operator.getSql!(`"NetworkDevice"."hostname"`)).toMatch(
+      /IN \(:\.\.\./,
+    );
+  });
+
+  /*
+   * The addresses come off the wire — a probe reports whatever the sweep saw.
+   * They travel as a bound parameter list, never spliced into the statement
+   * text.
+   */
+  it("binds the address list as a parameter rather than writing it into the statement", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ['10.0.0.5\'; DROP TABLE "NetworkDevice"; --'],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    const operator: FindOperator<string> = queryOf(0)[
+      "hostname"
+    ] as unknown as FindOperator<string>;
+
+    const sql: string = operator.getSql!(`"NetworkDevice"."hostname"`);
+
+    expect(sql).not.toContain("DROP TABLE");
+    expect(sql).not.toContain("10.0.0.5");
+    // It is still asked about — as a value.
+    expect(askedAboutInCall(0)).toEqual([
+      '10.0.0.5\'; DROP TABLE "NetworkDevice"; --',
+    ]);
+  });
+
+  it("scopes every read to the project it was asked about", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE + 1),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(2);
+
+    for (let index: number = 0; index < 2; index++) {
+      expect((queryOf(index)["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+    }
+  });
+
+  it("a different project asks a different question", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: OTHER_PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect((queryOf(0)["projectId"] as ObjectID).toString()).toBe(
+      OTHER_PROJECT_ID.toString(),
+    );
+  });
+
+  /*
+   * Project and address, and nothing else. Notably NOT `isArchived: false`,
+   * which the fleet-counting queries on this service do use: an archived
+   * device still occupies its address, so it must still read as registered or
+   * an import would create a second device there.
+   */
+  it("narrows by project and address only", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(Object.keys(queryOf(0)).sort()).toEqual(["hostname", "projectId"]);
+  });
+
+  /*
+   * The old walk's ORDER BY createdAt is the specific thing that made it
+   * wrong — every row of a bulk import shares one createdAt, so ordering by
+   * it ordered nothing, and the OFFSET pages that rode on it overlapped and
+   * skipped. Nothing here may sort, and nothing here may offset.
+   */
+  it("never orders the read and never offsets into it", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE * 2 + 3),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(3);
+
+    for (let index: number = 0; index < 3; index++) {
+      expect(findByArgs(index)["sort"]).toEqual({});
+      expect((findByArgs(index)["sort"] as JSONObject)["createdAt"]).toBe(
+        undefined,
+      );
+      expect(findByArgs(index)["skip"]).toBe(0);
+      expect(findByArgs(index)["limit"]).toBe(LIMIT_MAX);
+    }
+  });
+
+  it("keeps the caller's select and always reads the hostname it keys by", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      select: { _id: true, monitoringMethod: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findByArgs(0)["select"]).toEqual({
+      _id: true,
+      monitoringMethod: true,
+      hostname: true,
+    });
+  });
+
+  it("a caller that selects nothing still gets the hostname", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      select: {},
+      props: ROOT_PROPS,
+    });
+
+    expect(findByArgs(0)["select"]).toEqual({ hostname: true });
+  });
+
+  /*
+   * The returned Map is keyed by hostname, so a caller that opted the column
+   * out would get a map of nothing. The column is forced on, not trusted.
+   */
+  it("a caller that opts the hostname out is overruled", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      select: { hostname: false },
+      props: ROOT_PROPS,
+    });
+
+    expect((findByArgs(0)["select"] as JSONObject)["hostname"]).toBe(true);
+  });
+
+  it("hands the caller's props through to every read", async () => {
+    const props: DatabaseCommonInteractionProps = { isRoot: true };
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE + 1),
+      select: { _id: true },
+      props: props,
+    });
+
+    expect(findByArgs(0)["props"]).toBe(props);
+    expect(findByArgs(1)["props"]).toBe(props);
+  });
+});
+
+describe("NetworkDeviceService.getDevicesByHostnames — chunking", () => {
+  /*
+   * The whole list is rendered into the statement text as a literal
+   * `IN (...)`, and a sweep may cover tens of thousands of addresses
+   * (ScanTargetUtil.MAX_SCAN_HOSTS). One IN list that long costs more to
+   * parse and plan than the lookups it saves.
+   */
+  it("asks the database nothing when there is nothing to ask about", async () => {
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: [],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(found.size).toBe(0);
+  });
+
+  it("a list of only blank addresses asks the database nothing", async () => {
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["", "", ""],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(found.size).toBe(0);
+  });
+
+  it("one address below the bound is one read", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE - 1),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE - 1]);
+  });
+
+  it("exactly the bound is still one read", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE]);
+  });
+
+  it("one over the bound splits into a full chunk and a remainder", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE + 1),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE, 1]);
+  });
+
+  it("two full chunks are two reads, not three", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE * 2),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE, CHUNK_SIZE]);
+  });
+
+  it("one over two full chunks adds a one-address read", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE * 2 + 1),
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE, CHUNK_SIZE, 1]);
+  });
+
+  /*
+   * The scale that motivated the change: a /18 sweep. Twenty indexed reads,
+   * not one statement with a 10,000-item IN list and not 10,000 statements.
+   */
+  it("a 10,000-address sweep costs twenty reads", async () => {
+    const wanted: Array<string> = addresses(10000);
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: wanted,
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(20);
+
+    for (const size of chunkSizes()) {
+      expect(size).toBeLessThanOrEqual(CHUNK_SIZE);
+    }
+  });
+
+  /*
+   * A partition, not a sample and not an overlap: every address asked about
+   * exactly once, in input order. This is the property the old OFFSET paging
+   * could not hold, and losing it is what created duplicate devices.
+   */
+  it("the chunks partition the input exactly — nothing asked twice, nothing dropped", async () => {
+    const wanted: Array<string> = addresses(CHUNK_SIZE * 2 + 137);
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: wanted,
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    const asked: Array<string> = askedAbout();
+
+    expect(asked).toEqual(wanted);
+    expect(new Set<string>(asked).size).toBe(wanted.length);
+  });
+
+  it("the same question chunks the same way every time", async () => {
+    const wanted: Array<string> = addresses(CHUNK_SIZE + 7);
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: wanted,
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    const first: Array<Array<string>> = [
+      askedAboutInCall(0),
+      askedAboutInCall(1),
+    ];
+
+    findBySpy.mockClear();
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: wanted,
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect([askedAboutInCall(0), askedAboutInCall(1)]).toEqual(first);
+  });
+});
+
+describe("NetworkDeviceService.getDevicesByHostnames — the addresses it asks about", () => {
+  it("asks about a repeated address once", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5", "10.0.0.6", "10.0.0.5", "10.0.0.6"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(askedAboutInCall(0)).toEqual(["10.0.0.5", "10.0.0.6"]);
+  });
+
+  /*
+   * Deduplication happens BEFORE chunking, so a noisy sweep that reports the
+   * same handful of addresses hundreds of times still costs one read — not
+   * one read per 500 repetitions.
+   */
+  it("600 repetitions of two addresses is one read, not two", async () => {
+    const noisy: Array<string> = [];
+
+    for (let index: number = 0; index < 300; index++) {
+      noisy.push("10.0.0.5", "10.0.0.6");
+    }
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: noisy,
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(askedAboutInCall(0)).toEqual(["10.0.0.5", "10.0.0.6"]);
+  });
+
+  it("501 entries with only 500 distinct addresses fit in one read", async () => {
+    const wanted: Array<string> = addresses(CHUNK_SIZE);
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: [...wanted, wanted[0]!],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE]);
+  });
+
+  it("keeps first-seen order when it drops duplicates", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.9", "10.0.0.5", "10.0.0.9", "10.0.0.7"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(askedAboutInCall(0)).toEqual(["10.0.0.9", "10.0.0.5", "10.0.0.7"]);
+  });
+
+  /*
+   * The API's caller maps a discovered host with no ipAddress to the empty
+   * string. Asking the database `hostname IN ('')` would be a wasted lookup,
+   * and a device row that somehow carried an empty hostname would come back
+   * and flag that host as already registered.
+   */
+  it("drops blank addresses before it asks", async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5", "", "10.0.0.6", ""],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(askedAboutInCall(0)).toEqual(["10.0.0.5", "10.0.0.6"]);
+  });
+
+  /*
+   * `Boolean("0")` is true. A hostname of "0" is a strange address but a real
+   * value, and dropping it would report a registered device as importable.
+   */
+  it('the string "0" is a real address, not a blank one', async () => {
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["0", "", "10.0.0.5"],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(askedAboutInCall(0)).toEqual(["0", "10.0.0.5"]);
+  });
+
+  /*
+   * Dedup runs before chunking, so what decides the number of reads is the
+   * DISTINCT count crossing the bound — not the entry count.
+   */
+  it("1,000 entries covering 501 distinct addresses is two reads", async () => {
+    const distinct: Array<string> = addresses(CHUNK_SIZE + 1);
+    const noisy: Array<string> = [...distinct];
+
+    while (noisy.length < 1000) {
+      noisy.push(distinct[noisy.length % distinct.length]!);
+    }
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: noisy,
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE, 1]);
+  });
+
+  it("a list that is 500 real addresses plus blanks is still one read", async () => {
+    const wanted: Array<string> = addresses(CHUNK_SIZE);
+
+    await NetworkDeviceService.getDevicesByHostnames({
+      projectId: PROJECT_ID,
+      hostnames: [...wanted, "", "", ""],
+      select: { _id: true },
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE]);
+  });
+});
+
+describe("NetworkDeviceService.getDevicesByHostnames — the map it returns", () => {
+  it("keys each device it found by its address", async () => {
+    const five: NetworkDevice = deviceAt("10.0.0.5");
+    const six: NetworkDevice = deviceAt("10.0.0.6");
+    findBySpy.mockResolvedValue([five, six]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5", "10.0.0.6"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(found.size).toBe(2);
+    expect(found.get("10.0.0.5")).toBe(five);
+    expect(found.get("10.0.0.6")).toBe(six);
+  });
+
+  it("an address with no device is simply absent", async () => {
+    findBySpy.mockResolvedValue([deviceAt("10.0.0.5")]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5", "10.0.0.6"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(found.has("10.0.0.5")).toBe(true);
+    expect(found.has("10.0.0.6")).toBe(false);
+  });
+
+  /*
+   * A row with no hostname cannot answer "is this address registered", and
+   * keying it under "" would make the empty string look registered to any
+   * caller that asked about a host with no address.
+   */
+  it("a row with no hostname is skipped, not keyed under the empty string", async () => {
+    findBySpy.mockResolvedValue([deviceAt("10.0.0.5"), deviceWithNoHostname()]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(found.size).toBe(1);
+    expect(found.has("")).toBe(false);
+  });
+
+  it("merges the rows from every chunk into one map", async () => {
+    findBySpy
+      .mockResolvedValueOnce([deviceAt("10.99.0.0")])
+      .mockResolvedValueOnce([deviceAt("10.99.1.244")]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: addresses(CHUNK_SIZE + 1),
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(findBySpy).toHaveBeenCalledTimes(2);
+    expect(found.size).toBe(2);
+    expect(found.has("10.99.0.0")).toBe(true);
+    // Only reachable via the SECOND chunk — the case a lost page used to drop.
+    expect(found.has("10.99.1.244")).toBe(true);
+  });
+
+  it("returns an empty map when the project has none of these addresses", async () => {
+    findBySpy.mockResolvedValue([]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5", "10.0.0.6"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(found.size).toBe(0);
+  });
+
+  /*
+   * A row keyed by the address it carries, not by the address that was asked
+   * for. The two are the same for every query this issues; stated here so
+   * that a change to the predicate has to face the question deliberately.
+   */
+  it("keys a row by the address the row itself carries", async () => {
+    findBySpy.mockResolvedValue([deviceAt("10.0.0.99")]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(Array.from(found.keys())).toEqual(["10.0.0.99"]);
+  });
+
+  /*
+   * Two devices at one address is a broken inventory, not something this
+   * lookup can resolve. It answers with one of them — the last seen — rather
+   * than dropping the address, because "registered" is still the truth.
+   */
+  it("two rows sharing an address collapse to the last one seen", async () => {
+    const first: NetworkDevice = deviceAt("10.0.0.5");
+    const second: NetworkDevice = deviceAt("10.0.0.5");
+    findBySpy.mockResolvedValue([first, second]);
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    expect(found.size).toBe(1);
+    expect(found.get("10.0.0.5")).toBe(second);
+  });
+
+  it("a read that fails rejects rather than answering 'none of them'", async () => {
+    const boom: Error = new Error("db down");
+    findBySpy.mockRejectedValue(boom);
+
+    await expect(
+      NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5"],
+        select: { _id: true },
+        props: ROOT_PROPS,
+      }),
+    ).rejects.toThrow("db down");
+  });
+
+  /*
+   * A chunk that fails stops the whole lookup. Carrying on would return a
+   * partial answer indistinguishable from a complete one — and every address
+   * in the chunks it skipped would read as unregistered.
+   */
+  it("a failure on a later chunk rejects and stops asking", async () => {
+    findBySpy
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("db down"));
+
+    await expect(
+      NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: addresses(CHUNK_SIZE * 3),
+        select: { _id: true },
+        props: ROOT_PROPS,
+      }),
+    ).rejects.toThrow("db down");
+
+    // The third chunk is never asked about.
+    expect(findBySpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("NetworkDeviceService.getRegisteredHostnames", () => {
+  it("answers with the addresses that already have a device", async () => {
+    findBySpy.mockResolvedValue([deviceAt("10.0.0.5")]);
+
+    const registered: Set<string> =
+      await NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5", "10.0.0.6"],
+        props: ROOT_PROPS,
+      });
+
+    expect(registered.has("10.0.0.5")).toBe(true);
+    expect(registered.has("10.0.0.6")).toBe(false);
+  });
+
+  /*
+   * A Set, so the caller's per-host `has` is a hash lookup. The endpoint runs
+   * this over every host a sweep found.
+   */
+  it("answers with a Set", async () => {
+    findBySpy.mockResolvedValue([deviceAt("10.0.0.5")]);
+
+    const registered: Set<string> =
+      await NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5"],
+        props: ROOT_PROPS,
+      });
+
+    expect(registered).toBeInstanceOf(Set);
+    expect(registered.size).toBe(1);
+  });
+
+  // Existence is the whole question, so hostname is the only column read.
+  it("reads only the column it answers with", async () => {
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: ROOT_PROPS,
+    });
+
+    expect(findByArgs(0)["select"]).toEqual({ hostname: true });
+  });
+
+  it("chunks the same way its row-returning sibling does", async () => {
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE + 1),
+      props: ROOT_PROPS,
+    });
+
+    expect(chunkSizes()).toEqual([CHUNK_SIZE, 1]);
+  });
+
+  it("scopes the question to the project it was given", async () => {
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: OTHER_PROJECT_ID,
+      hostnames: ["10.0.0.5"],
+      props: ROOT_PROPS,
+    });
+
+    expect((queryOf(0)["projectId"] as ObjectID).toString()).toBe(
+      OTHER_PROJECT_ID.toString(),
+    );
+  });
+
+  it("an empty sweep asks nothing and answers with an empty set", async () => {
+    const registered: Set<string> =
+      await NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: [],
+        props: ROOT_PROPS,
+      });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(registered.size).toBe(0);
+  });
+
+  // The two methods are one query with two shapes of answer.
+  it("answers with exactly the keys of the map its sibling returns", async () => {
+    findBySpy.mockResolvedValue([deviceAt("10.0.0.5"), deviceAt("10.0.0.7")]);
+
+    const asked: Array<string> = ["10.0.0.5", "10.0.0.6", "10.0.0.7"];
+
+    const found: Map<string, NetworkDevice> =
+      await NetworkDeviceService.getDevicesByHostnames({
+        projectId: PROJECT_ID,
+        hostnames: asked,
+        select: { _id: true },
+        props: ROOT_PROPS,
+      });
+
+    const registered: Set<string> =
+      await NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: asked,
+        props: ROOT_PROPS,
+      });
+
+    expect(Array.from(registered).sort()).toEqual(
+      Array.from(found.keys()).sort(),
+    );
+  });
+
+  it("collects the answer across every chunk", async () => {
+    findBySpy
+      .mockResolvedValueOnce([deviceAt("10.99.0.0")])
+      .mockResolvedValueOnce([deviceAt("10.99.1.244")]);
+
+    const registered: Set<string> =
+      await NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: addresses(CHUNK_SIZE + 1),
+        props: ROOT_PROPS,
+      });
+
+    expect(Array.from(registered).sort()).toEqual(["10.99.0.0", "10.99.1.244"]);
+  });
+
+  /*
+   * Swallowing the failure and answering "none of these are registered" would
+   * present every host in the sweep as importable, and the reviewer's import
+   * would then duplicate the whole estate. Failing loudly is the safe answer.
+   */
+  it("a read that fails rejects rather than reporting every host as new", async () => {
+    findBySpy.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: ["10.0.0.5"],
+        props: ROOT_PROPS,
+      }),
+    ).rejects.toThrow("db down");
+  });
+});
+
+/*
+ * The specific failure mode the old implementation had, asserted directly.
+ *
+ * The walk kept paging while a page came back full — `if (existing.length <
+ * LIMIT_MAX) break;` — so the number of statements it issued was a function
+ * of how many devices the PROJECT had. This lookup's cost must depend only on
+ * how many addresses the SWEEP found; a full page is just a full page.
+ */
+describe("NetworkDeviceService hostname lookups — the walk they replaced", () => {
+  function fullPage(): Array<NetworkDevice> {
+    const page: Array<NetworkDevice> = [];
+
+    for (let index: number = 0; index < LIMIT_MAX; index++) {
+      page.push(deviceAt(`10.42.${Math.floor(index / 256)}.${index % 256}`));
+    }
+
+    return page;
+  }
+
+  it("a full page of results never triggers a follow-up page", async () => {
+    findBySpy.mockResolvedValue(fullPage());
+
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: PROJECT_ID,
+      hostnames: ["10.0.0.5", "10.0.0.6"],
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("the number of reads is set by the sweep, not by the size of the fleet", async () => {
+    findBySpy.mockResolvedValue(fullPage());
+
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE + 1),
+      props: ROOT_PROPS,
+    });
+
+    // Two chunks of addresses — two reads, regardless of what came back.
+    expect(findBySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("no read is ever ordered by createdAt", async () => {
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE * 3),
+      props: ROOT_PROPS,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(3);
+
+    for (let index: number = 0; index < 3; index++) {
+      const sort: JSONObject = findByArgs(index)["sort"] as JSONObject;
+      expect(sort["createdAt"]).toBe(undefined);
+    }
+  });
+
+  it("no read ever offsets into a result set", async () => {
+    await NetworkDeviceService.getRegisteredHostnames({
+      projectId: PROJECT_ID,
+      hostnames: addresses(CHUNK_SIZE * 3),
+      props: ROOT_PROPS,
+    });
+
+    for (let index: number = 0; index < 3; index++) {
+      expect(findByArgs(index)["skip"]).toBe(0);
+    }
+  });
+
+  /*
+   * The end-to-end shape of the bug: a project whose devices all share one
+   * createdAt. Here that is simply irrelevant — the answer is decided by the
+   * address predicate, so an address that exists is found on the first and
+   * only read that asks about it.
+   */
+  it("finds an address that a same-createdAt fleet used to hide", async () => {
+    const wanted: Array<string> = addresses(CHUNK_SIZE + 1);
+    const lastAddress: string = wanted[wanted.length - 1]!;
+
+    findBySpy
+      .mockResolvedValueOnce(fullPage())
+      .mockResolvedValueOnce([deviceAt(lastAddress)]);
+
+    const registered: Set<string> =
+      await NetworkDeviceService.getRegisteredHostnames({
+        projectId: PROJECT_ID,
+        hostnames: wanted,
+        props: ROOT_PROPS,
+      });
+
+    expect(registered.has(lastAddress)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The failure

`App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts` was red on `master` — 18 of its 32 cases failing with:

```
TypeError: NetworkDeviceService_1.default.getRegisteredHostnames is not a function
```

[#3441](https://github.com/OneUptime/oneuptime/pull/3441) moved "which of these hosts already have a device" out of the probe ingest route and into `NetworkDeviceService.getRegisteredHostnames`, but left the route's test stubbing only `findBy`. This predates [#3442](https://github.com/OneUptime/oneuptime/pull/3442) — run 33151636018 (head `fd5ad00573`, 07:37Z) shows the same failure, and #3442 merged at 07:47Z touching none of these files.

## Not a one-line fix

Three of the failures were stale *intent*, not a stale stub. They asserted on paged `findBy` calls — `skip: 0`, then `skip: LIMIT_MAX`, sorted by `createdAt` — for a paging loop the route no longer runs. Adding `findBy` back to the stub would have made them green while describing code that does not exist, so they moved to where the paging now lives.

## What changed

**`Common/Tests/Server/Services/NetworkDeviceRegisteredHostnames.test.ts`** — new, 52 cases over `getRegisteredHostnames` and `getDevicesByHostnames`. Chunk arithmetic at the 500 boundary (0/1/499/500/501/1000/1001/10000), dedup before chunking, blank-address filtering, the query shape (project and address only, `sort: {}`, `skip: 0`, `limit: LIMIT_MAX`, select forced to carry `hostname`), the Map and Set it answers with, and error propagation — a failing chunk rejects rather than returning a partial answer that would read as "none of these are registered".

A closing block pins the specific failure the old walk had. It paged `ORDER BY createdAt`, and a bulk import stamps every device it creates with the same `createdAt`, so `LIMIT/OFFSET` over that single-valued sort key returned an arbitrary slice per call: pages overlapped and skipped, a skipped hostname read as unregistered, and the reviewer's import re-created a device that already existed. So — a full page never triggers a follow-up read, nothing sorts by `createdAt`, nothing offsets, and the read count tracks the sweep's size rather than the fleet's.

**`App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts`** — 32 → 58 cases. What is left for the route is the contract between the two: the right addresses in the right project as root, the answer landing on the right hosts, and the edges — missing and null `ipAddress`, duplicates, ping-only hosts, exact matching, a 5,000-host sweep, a flag the probe set itself being overwritten, a superseded run never asking, and a failed lookup erroring instead of offering the whole sweep for import.

**A guard for the bug class.** TypeScript cannot typecheck a `jest.mock` factory, which is why this drift reached `master` at all. The suite now reads the route's source, extracts every method it calls on a stubbed service, and requires the stub to provide it. Mutation-checked: removing `getRegisteredHostnames` from the stub fails with `+ ["getRegisteredHostnames"]` rather than thirty identical TypeErrors.

## Verification

| Check | Result |
|---|---|
| `App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts` | 58 passed |
| `Common/Tests/Server/Services/NetworkDeviceRegisteredHostnames.test.ts` | 52 passed |
| `App` `tsc --noEmit` | clean |
| eslint + prettier, both files | clean |

A sweep of every other test file that `jest.mock`s a network service confirmed this was the only stale one. One latent hazard was found and left alone as out of scope: `App/Tests/BaseAPI/NetworkSiteMapAPI.test.ts` stubs a now-dead `NetworkDeviceService.findBy` and is missing `getHealthGroupsForSites` / `getHealthGroups` / `countBy`, which the same module's `/network-site/children` handler calls. Nothing fails today because that handler has no test — but the first one added will fail exactly the way this did.

Baseline on `master` for comparison: `App/Tests/Telemetry` was 18 failed / 907, all in this one file; `App/Tests/BaseAPI`, `App/Tests/Workers` and `App/Tests/Dashboard` fully green.