### PR TITLE
test(network-site): make the service stubs prove they match the route

### DIFF
--- a/App/Tests/BaseAPI/NetworkSiteMapAPI.test.ts
+++ b/App/Tests/BaseAPI/NetworkSiteMapAPI.test.ts
@@ -3,6 +3,8 @@ import CommonAPI from "Common/Server/API/CommonAPI";
 import Response from "Common/Server/Utils/Response";
 import NetworkSiteService from "Common/Server/Services/NetworkSiteService";
 import NetworkSiteLinkService from "Common/Server/Services/NetworkSiteLinkService";
+import NetworkSiteStatusTimelineService from "Common/Server/Services/NetworkSiteStatusTimelineService";
+import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
 import MonitorService from "Common/Server/Services/MonitorService";
 import MonitorStatusService from "Common/Server/Services/MonitorStatusService";
 import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
@@ -10,15 +12,19 @@ import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
 import NetworkSiteLink from "Common/Models/DatabaseModels/NetworkSiteLink";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorStatus from "Common/Models/DatabaseModels/MonitorStatus";
+import { DeviceHealthGroup } from "Common/Server/Utils/NetworkDevice/DeviceHealthAggregation";
 import Color from "Common/Types/Color";
 import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
+import PositiveNumber from "Common/Types/PositiveNumber";
 import {
   ExpressRequest,
   ExpressResponse,
   NextFunction,
 } from "Common/Server/Utils/Express";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
 
 /*
  * The /network-site/map endpoint's LINK half.
@@ -33,6 +39,11 @@ import { beforeEach, describe, expect, jest, test } from "@jest/globals";
  * The marker maths is covered by NetworkSiteMapUtil.test.ts; what is pinned
  * here is the wiring — which links survive, which monitors get queried, and
  * what the client is handed for each.
+ *
+ * Below the map tests sit two things the mocks at the top of this file drag
+ * in with them: the /network-site/children wiring, because the stubs those
+ * calls land on are declared here and nowhere else, and a guard that reads
+ * the route and checks those stubs still describe it.
  */
 
 jest.mock("Common/Server/Utils/Express", () => {
@@ -88,8 +99,22 @@ jest.mock("Common/Server/Services/NetworkSiteStatusTimelineService", () => {
   return { __esModule: true, default: { findBy: jest.fn() } };
 });
 
+/*
+ * The rollup asks NetworkDeviceService for per-site health BUCKETS and for
+ * the two project-wide device counts. It does NOT read device rows — the
+ * `findBy` this stub used to carry was left behind by the change that
+ * replaced the paging loop with a grouped aggregate, and stood here
+ * claiming a call site that no longer exists.
+ */
 jest.mock("Common/Server/Services/NetworkDeviceService", () => {
-  return { __esModule: true, default: { findBy: jest.fn() } };
+  return {
+    __esModule: true,
+    default: {
+      getHealthGroupsForSites: jest.fn(),
+      getHealthGroups: jest.fn(),
+      countBy: jest.fn(),
+    },
+  };
 });
 
 jest.mock("Common/Server/Services/MonitorService", () => {
@@ -116,6 +141,15 @@ const siteService: { findBy: jest.Mock; findOneBy: jest.Mock } =
   NetworkSiteService as unknown as { findBy: jest.Mock; findOneBy: jest.Mock };
 const linkService: { findBy: jest.Mock } =
   NetworkSiteLinkService as unknown as { findBy: jest.Mock };
+const timelineService: { findBy: jest.Mock } =
+  NetworkSiteStatusTimelineService as unknown as { findBy: jest.Mock };
+type MockedDeviceService = {
+  getHealthGroupsForSites: jest.Mock;
+  getHealthGroups: jest.Mock;
+  countBy: jest.Mock;
+};
+const deviceService: MockedDeviceService =
+  NetworkDeviceService as unknown as MockedDeviceService;
 const monitorService: { findBy: jest.Mock } = MonitorService as unknown as {
   findBy: jest.Mock;
 };
@@ -135,6 +169,19 @@ const callMap: CallMapFunction = async (
   const req: ExpressRequest = { body: body } as unknown as ExpressRequest;
   await mockRouter
     .match("post", "/network-site/map")
+    .handlerFunction(req, mockResponse, next);
+  return next;
+};
+
+type CallChildrenFunction = (body: JSONObject) => Promise<NextFunction>;
+
+const callChildren: CallChildrenFunction = async (
+  body: JSONObject,
+): Promise<NextFunction> => {
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+  const req: ExpressRequest = { body: body } as unknown as ExpressRequest;
+  await mockRouter
+    .match("post", "/network-site/children")
     .handlerFunction(req, mockResponse, next);
   return next;
 };
@@ -219,6 +266,36 @@ function makeStatus(options: {
   return status;
 }
 
+/*
+ * One health BUCKET, as the grouped aggregate hands it back: a set of
+ * devices the classifier cannot tell apart, plus how many of them there are.
+ * The facts are set so the shared classifier reaches the stated verdict —
+ * reachable is healthy, unreachable is down, never-polled is unknown — which
+ * is what makes an assertion on the resulting counts mean anything.
+ */
+function makeDeviceGroup(options: {
+  siteId: ObjectID | null;
+  deviceCount: number;
+  isReachable?: boolean | null | undefined;
+  hasDownInterfaces?: boolean | undefined;
+}): DeviceHealthGroup {
+  const isReachable: boolean | null =
+    options.isReachable === undefined ? true : options.isReachable;
+  return {
+    siteId: options.siteId ? options.siteId.toString() : null,
+    monitorStatusId: null,
+    monitoringMethod: null,
+    isReachable: isReachable,
+    // Never polled and never seen is the only honest "unknown".
+    hasBeenPolled: isReachable !== null,
+    hasBeenSeen: isReachable === true,
+    isStale: false,
+    hasDownInterfaces: Boolean(options.hasDownInterfaces),
+    deviceCount: options.deviceCount,
+    interfacesDownTotal: options.hasDownInterfaces ? options.deviceCount : 0,
+  };
+}
+
 function lastResponseBody(): JSONObject {
   expect(responseUtil.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
   return responseUtil.sendJsonObjectResponse.mock.calls[0]![2] as JSONObject;
@@ -237,6 +314,15 @@ function idsInAnyOperator(operator: unknown): Array<string> {
     "objectLiteralParameters"
   ] as JSONObject;
   return Object.values(parameters)[0] as Array<string>;
+}
+
+/*
+ * QueryHelper.isNull()/notNull() compile to a TypeORM Raw operator carrying
+ * its SQL as a function of the column alias; rendering it is how a test says
+ * WHICH of the two a query used. They are otherwise indistinguishable.
+ */
+function rawSqlFor(operator: unknown, column: string): string {
+  return (operator as { getSql: (alias: string) => string }).getSql(column);
 }
 
 describe("POST /network-site/map — link lines", () => {
@@ -717,4 +803,340 @@ describe("POST /network-site/map — link lines", () => {
       }),
     ).toEqual(["Primary", "Backup", "Tertiary"]);
   });
+});
+
+/*
+ * The OTHER route on this module.
+ *
+ * /network-site/children is the drill-down the map sits next to, and it is
+ * the only caller of three NetworkDeviceService methods. It is covered here
+ * rather than in a file of its own because a jest.mock factory is
+ * file-scoped: the stubs those calls land on are the ones declared at the
+ * top of THIS file, so this is the only place that can prove they are the
+ * right shape. What is pinned is the wiring — which aggregate the level
+ * asks for, where a bucket's devices are counted, and what the two device
+ * counts are allowed to cost — not the rollup arithmetic, which
+ * NetworkSiteHierarchyUtil.test.ts covers over the pure aggregator.
+ */
+describe("POST /network-site/children — the device rollup's service calls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    commonAPI.getDatabaseCommonInteractionProps.mockResolvedValue({
+      tenantId: projectId,
+    } as never);
+    siteService.findBy.mockResolvedValue([] as never);
+    siteService.findOneBy.mockResolvedValue(null as never);
+    linkService.findBy.mockResolvedValue([] as never);
+    timelineService.findBy.mockResolvedValue([] as never);
+    monitorService.findBy.mockResolvedValue([] as never);
+    monitorStatusService.findBy.mockResolvedValue([] as never);
+    deviceService.getHealthGroups.mockResolvedValue([] as never);
+    deviceService.getHealthGroupsForSites.mockResolvedValue([] as never);
+    deviceService.countBy.mockResolvedValue(new PositiveNumber(0) as never);
+  });
+
+  /*
+   * Listing roots has no subtree to scope to — the answer really is the
+   * project — so it takes the whole-project aggregate rather than building
+   * an id list of every site there is.
+   */
+  test("the root level takes the whole-project aggregate", async () => {
+    const next: NextFunction = await callChildren({});
+    expect(next).not.toHaveBeenCalled();
+
+    expect(deviceService.getHealthGroupsForSites).not.toHaveBeenCalled();
+    expect(deviceService.getHealthGroups).toHaveBeenCalledTimes(1);
+    const call: JSONObject = deviceService.getHealthGroups.mock
+      .calls[0]![0] as JSONObject;
+    expect((call["projectId"] as ObjectID).toString()).toBe(
+      projectId.toString(),
+    );
+    expect(call["onlyAttachedToSite"]).toBe(true);
+    expect(call["groupBySite"]).toBe(true);
+  });
+
+  /*
+   * Drilling into one region must not read every other region's devices.
+   * The drilled site is in the id list alongside its subtree: its OWN
+   * devices belong to no child and would otherwise be scoped out of the
+   * very response that has to report them.
+   */
+  test("drilling into a site scopes the aggregate to it and its subtree", async () => {
+    const region: NetworkSite = makeSite({ name: "Region East" });
+    const market: NetworkSite = makeSite({
+      name: "Market North",
+      parentSiteId: region.id!,
+      materializedPath: `/${region.id!.toString()}/`,
+    });
+    const store: NetworkSite = makeSite({
+      name: "Store 1",
+      isUnitLevel: true,
+      parentSiteId: market.id!,
+      materializedPath: `/${region.id!.toString()}/${market.id!.toString()}/`,
+    });
+
+    siteService.findOneBy.mockResolvedValue(region as never);
+    mockSiteQueries([market], [market, store]);
+
+    const next: NextFunction = await callChildren({
+      siteId: region.id!.toString(),
+    });
+    expect(next).not.toHaveBeenCalled();
+
+    expect(deviceService.getHealthGroups).not.toHaveBeenCalled();
+    expect(deviceService.getHealthGroupsForSites).toHaveBeenCalledTimes(1);
+    const call: JSONObject = deviceService.getHealthGroupsForSites.mock
+      .calls[0]![0] as JSONObject;
+    expect(
+      (call["siteIds"] as Array<ObjectID>).map((siteId: ObjectID): string => {
+        return siteId.toString();
+      }),
+    ).toEqual([
+      region.id!.toString(),
+      market.id!.toString(),
+      store.id!.toString(),
+    ]);
+    expect(call["groupBySite"]).toBe(true);
+  });
+
+  /*
+   * A bucket is counted against the CHILD whose subtree holds the site it
+   * hangs off, not against that site — the drill-down has one card per
+   * child, and a store's devices are what make its market's card worth
+   * clicking.
+   */
+  test("a bucket's devices roll up onto the child whose subtree holds them", async () => {
+    const region: NetworkSite = makeSite({ name: "Region East" });
+    const market: NetworkSite = makeSite({
+      name: "Market North",
+      parentSiteId: region.id!,
+      materializedPath: `/${region.id!.toString()}/`,
+    });
+    const store: NetworkSite = makeSite({
+      name: "Store 1",
+      isUnitLevel: true,
+      parentSiteId: market.id!,
+      materializedPath: `/${region.id!.toString()}/${market.id!.toString()}/`,
+    });
+
+    siteService.findOneBy.mockResolvedValue(region as never);
+    mockSiteQueries([market], [market, store]);
+    deviceService.getHealthGroupsForSites.mockResolvedValue([
+      makeDeviceGroup({ siteId: store.id!, deviceCount: 3 }),
+      makeDeviceGroup({
+        siteId: store.id!,
+        deviceCount: 2,
+        isReachable: false,
+      }),
+      makeDeviceGroup({ siteId: store.id!, deviceCount: 1, isReachable: null }),
+    ] as never);
+
+    await callChildren({ siteId: region.id!.toString() });
+
+    const children: Array<JSONObject> = lastResponseBody()[
+      "children"
+    ] as Array<JSONObject>;
+    expect(children).toHaveLength(1);
+    expect(children[0]!["name"]).toBe("Market North");
+    expect(children[0]!["deviceCount"]).toBe(6);
+    expect(children[0]!["deviceStats"]).toEqual({
+      total: 6,
+      down: 2,
+      degraded: 0,
+      healthy: 3,
+      unknown: 1,
+    });
+  });
+
+  /*
+   * Devices on the level the reader is STANDING on belong to no child's
+   * subtree — a distribution centre's own core switches above a dozen
+   * stores. They are reported separately; folding them into a child would
+   * attribute them to a site that does not hold them, and dropping them
+   * puts them nowhere at all, which is where they used to be.
+   */
+  test("the level's own devices are reported apart from its children's", async () => {
+    const region: NetworkSite = makeSite({ name: "Region East" });
+    const market: NetworkSite = makeSite({
+      name: "Market North",
+      parentSiteId: region.id!,
+      materializedPath: `/${region.id!.toString()}/`,
+    });
+
+    siteService.findOneBy.mockResolvedValue(region as never);
+    mockSiteQueries([market], [market]);
+    deviceService.getHealthGroupsForSites.mockResolvedValue([
+      makeDeviceGroup({ siteId: region.id!, deviceCount: 4 }),
+      makeDeviceGroup({ siteId: market.id!, deviceCount: 2 }),
+    ] as never);
+
+    await callChildren({ siteId: region.id!.toString() });
+
+    const body: JSONObject = lastResponseBody();
+    expect(body["ownDeviceStats"]).toEqual({
+      total: 4,
+      down: 0,
+      degraded: 0,
+      healthy: 4,
+      unknown: 0,
+    });
+    const children: Array<JSONObject> = body["children"] as Array<JSONObject>;
+    expect(children[0]!["deviceCount"]).toBe(2);
+  });
+
+  /*
+   * The two numbers the topology explorer decides its whole opening view
+   * on: whether ANY device in the project is attached to a site, and how
+   * many the hierarchy is therefore not showing.
+   *
+   * Two counted queries, and deliberately no `limit` on either — countBy
+   * applies limit as a take() over the counted set, so a limit here would
+   * cap the ANSWER. A project with fifty thousand unattached devices would
+   * be told ten thousand of them are missing, and nothing on screen would
+   * look wrong.
+   */
+  test("the device scope is two uncapped counts, attached and unattached", async () => {
+    deviceService.countBy
+      .mockResolvedValueOnce(new PositiveNumber(7) as never)
+      .mockResolvedValueOnce(new PositiveNumber(4) as never);
+
+    await callChildren({});
+
+    expect(deviceService.countBy).toHaveBeenCalledTimes(2);
+    const attached: JSONObject = deviceService.countBy.mock
+      .calls[0]![0] as JSONObject;
+    const unattached: JSONObject = deviceService.countBy.mock
+      .calls[1]![0] as JSONObject;
+
+    for (const call of [attached, unattached]) {
+      const query: JSONObject = call["query"] as JSONObject;
+      expect((query["projectId"] as ObjectID).toString()).toBe(
+        projectId.toString(),
+      );
+      // Decommissioned devices keep their siteId and must not be counted.
+      expect(query["isArchived"]).toBe(false);
+      expect(call["limit"]).toBeUndefined();
+    }
+
+    expect(
+      rawSqlFor((attached["query"] as JSONObject)["siteId"], "siteId"),
+    ).toBe("(siteId IS NOT NULL)");
+    expect(
+      rawSqlFor((unattached["query"] as JSONObject)["siteId"], "siteId"),
+    ).toBe("(siteId IS NULL)");
+
+    expect(lastResponseBody()["deviceScope"]).toEqual({
+      attachedDeviceCount: 7,
+      unattachedDeviceCount: 4,
+    });
+  });
+});
+
+/*
+ * The stubs above stand in for real service modules, and a jest.mock factory
+ * is an object literal TypeScript never checks against the module it
+ * replaces. So the two ways a stub goes wrong are both silent:
+ *
+ * - It omits a method the route calls. Nothing fails until somebody writes
+ *   the first test that reaches that line, and then it fails as "x is not a
+ *   function" in a test that has nothing to do with the omission.
+ * - It keeps a method the route stopped calling. Nothing fails ever. The
+ *   stub reads as a claim about the route that is no longer true, and the
+ *   next reader trusts it — which is how `findBy` outlived the paging loop
+ *   it was written for.
+ *
+ * Reading the route settles both here, against the source rather than
+ * against whichever handlers this file happens to invoke.
+ */
+const ROUTE_SOURCE_PATH: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "BaseAPI",
+  "API",
+  "NetworkSiteHierarchy.ts",
+);
+
+/*
+ * Comments stripped first. That module explains itself at length and names
+ * its own service methods in prose; a mention in a comment must not read as
+ * a call site, or a deleted call would keep the stub that served it alive.
+ */
+const ROUTE_SOURCE: string = fs
+  .readFileSync(ROUTE_SOURCE_PATH, "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, " ")
+  .replace(/\/\/.*$/gm, " ");
+
+function membersUsedOn(serviceName: string): Set<string> {
+  const pattern: RegExp = new RegExp(
+    `\\b${serviceName}\\.([A-Za-z0-9_]+)`,
+    "g",
+  );
+  const members: Set<string> = new Set<string>();
+  let match: RegExpExecArray | null = pattern.exec(ROUTE_SOURCE);
+  while (match) {
+    members.add(match[1] as string);
+    match = pattern.exec(ROUTE_SOURCE);
+  }
+  return members;
+}
+
+const MOCKED_MODULES: Array<{
+  name: string;
+  stub: Record<string, unknown>;
+}> = [
+  { name: "NetworkSiteService", stub: siteService as Record<string, unknown> },
+  {
+    name: "NetworkSiteLinkService",
+    stub: linkService as Record<string, unknown>,
+  },
+  {
+    name: "NetworkSiteStatusTimelineService",
+    stub: timelineService as Record<string, unknown>,
+  },
+  {
+    name: "NetworkDeviceService",
+    stub: deviceService as Record<string, unknown>,
+  },
+  { name: "MonitorService", stub: monitorService as Record<string, unknown> },
+  {
+    name: "MonitorStatusService",
+    stub: monitorStatusService as Record<string, unknown>,
+  },
+  { name: "CommonAPI", stub: commonAPI as Record<string, unknown> },
+  { name: "Response", stub: responseUtil as Record<string, unknown> },
+];
+
+describe("the service stubs in this file track the route they stand in for", () => {
+  for (const mocked of MOCKED_MODULES) {
+    /*
+     * Every one of these is expected to be used, so an empty set means the
+     * route stopped importing it under this name and the two assertions
+     * below have quietly become vacuous — which is worse than either drift
+     * they exist to catch.
+     */
+    test(`${mocked.name} is still called by the route under that name`, () => {
+      expect(Array.from(membersUsedOn(mocked.name)).sort()).not.toEqual([]);
+    });
+
+    test(`${mocked.name}'s stub provides every method the route calls`, () => {
+      const missing: Array<string> = Array.from(
+        membersUsedOn(mocked.name),
+      ).filter((member: string): boolean => {
+        return !(member in mocked.stub);
+      });
+      expect(missing).toEqual([]);
+    });
+
+    test(`${mocked.name}'s stub provides nothing the route stopped calling`, () => {
+      const used: Set<string> = membersUsedOn(mocked.name);
+      const dead: Array<string> = Object.keys(mocked.stub).filter(
+        (member: string): boolean => {
+          return !used.has(member);
+        },
+      );
+      expect(dead).toEqual([]);
+    });
+  }
 });


### PR DESCRIPTION
### Title of this pull request?

test(network-site): make the service stubs prove they match the route

### Small Description?

The `jest.mock` factory for `NetworkDeviceService` in `App/Tests/BaseAPI/NetworkSiteMapAPI.test.ts` had drifted from `App/FeatureSet/BaseAPI/API/NetworkSiteHierarchy.ts` in **both directions at once**.

**It provided a method nothing calls.** `findBy` was left behind by the change that replaced the device rollup's paging loop with a grouped aggregate. A stub for a call site that no longer exists is a claim about the route that the next reader has no reason to doubt.

**It was missing all three methods the module actually calls** — `getHealthGroupsForSites`, `getHealthGroups` and `countBy`, every one of them on the `/network-site/children` handler. Nothing failed today only because the file registered a `match()` for `/network-site/map` alone. The first test anyone wrote for the drill-down would have died on `getHealthGroupsForSites is not a function`, in a test that had nothing to do with the omission.

#### What changed

- **Dropped the dead `findBy` stub**, added the three the route really calls.
- **Covered the `/network-site/children` handler**, so the new stubs are exercised rather than merely present — five tests, one per way the wiring can be quietly wrong:
  - which aggregate each level asks for: the whole project at the root, `getHealthGroupsForSites` scoped to the drilled site **and** its subtree below it (the drilled site's own id is in that list — scoping it out would drop the very devices `ownDeviceStats` reports);
  - a bucket's devices roll up onto the child whose subtree holds them, healthy/down/unknown split intact;
  - the level's own devices stay out of its children's counts;
  - `deviceScope` is two `countBy` calls, attached (`IS NOT NULL`) vs unattached (`IS NULL`), both `isArchived: false` and both **uncapped** — `countBy` applies `limit` as a `take()` over the counted set, so a limit there caps the *answer*, not the work.

  The stubs live in this file because a `jest.mock` factory is file-scoped, so this is the only place that can exercise them. The rollup arithmetic itself stays where it was, over the pure aggregator in `NetworkSiteHierarchyUtil.test.ts`.

- **Added a drift guard.** TypeScript never checks a mock factory against the module it replaces, so both failures above are silent. The new describe block reads the route's source (comments stripped, so prose naming a method isn't read as a call site) and asserts, per mocked module — services plus `Response` and `CommonAPI` — that the stub provides every method the route calls, provides nothing it stopped calling, and that the module is still referenced under that name at all. That last one matters: a rename would otherwise make the first two vacuously true.

#### For the reviewer

The guard was mutation-tested rather than trusted on a green run:

| Mutation | Result |
| --- | --- |
| delete `getHealthGroupsForSites` from the stub | 6 failures — the 5 children tests *and* the guard |
| re-add the dead `findBy` | fails exactly the dead-stub test, naming `findBy` in the diff |
| rename a service entry | fails the vacuity test |

**`App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts` has the same class of drift and is red on this branch** — its stub offers `findBy` where `DiscoveryScan.ts` calls `getRegisteredHostnames` (15 failures). That fix is deliberately **not** in this PR; it is in hand separately, and touching it here would collide with that work.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None — found while fixing the same class of bug in `ProbeIngestDiscoveryScan.test.ts`, which went stale after #3441.

### Screenshots (if appropriate):

n/a — test-only change.

```
cd App && node node_modules/.bin/jest ./Tests/BaseAPI/NetworkSiteMapAPI.test.ts --forceExit
Test Suites: 1 passed, 1 total
Tests:       43 passed, 43 total
```

prettier and eslint clean.