### PR TITLE
fix(terraform-provider): recover from the "column does not exist" select rejection

### DIFF
--- a/Common/Server/Types/AnalyticsDatabase/ModelPermission.ts
+++ b/Common/Server/Types/AnalyticsDatabase/ModelPermission.ts
@@ -609,12 +609,22 @@ export default class ModelPermission {
           },
         );
         if (!column) {
+          /*
+           * tableColumns holds AnalyticsTableColumn objects, so joining them
+           * rendered the remediation list as "[object Object], [object
+           * Object], ..." - the half of the sentence that tells the caller
+           * what to do instead said nothing at all.
+           */
+          const selectableColumns: string = tableColumns
+            .map((tableColumn: AnalyticsTableColumn) => {
+              return tableColumn.key;
+            })
+            .join(", ");
+
           throw new BadDataException(
             `Invalid select clause. Cannot select on "${key}". This column does not exist on ${
               model.singularName
-            }. Here are the columns you can select on instead: ${tableColumns.join(
-              ", ",
-            )}`,
+            }. Here are the columns you can select on instead: ${selectableColumns}`,
           );
         }
 

--- a/Common/Tests/Server/Types/Database/Permissions/SelectRejectionMessageContract.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/SelectRejectionMessageContract.test.ts
@@ -1,0 +1,424 @@
+import fs from "fs";
+import path from "path";
+import AnalyticsModelPermission from "../../../../../Server/Types/AnalyticsDatabase/ModelPermission";
+import SelectPermission from "../../../../../Server/Types/Database/Permissions/SelectPermission";
+import Log from "../../../../../Models/AnalyticsModels/Log";
+import StatusPage from "../../../../../Models/DatabaseModels/StatusPage";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Exception from "../../../../../Types/Exception/Exception";
+import ExceptionCode from "../../../../../Types/Exception/ExceptionCode";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission from "../../../../../Types/Permission";
+import { describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Every throw below is deliberate and asserted on, but @CaptureSpan hands each
+ * one to Telemetry, which logs the whole stack. Mocking Logger keeps the run
+ * readable; nothing under test is mocked.
+ */
+jest.mock("../../../../../Server/Utils/Logger");
+
+/*
+ * WHAT THIS FILE PINS
+ *
+ * When the API refuses a column in a select clause, the sentence it refuses
+ * with is a wire contract, not prose. The generated Terraform provider parses
+ * the column name back out of it and retries without that column, so that a
+ * permission-gated column, or one belonging to a schema newer than the
+ * deployment being talked to, costs one attribute instead of failing every
+ * `terraform plan` against that resource.
+ *
+ * Issue #3414 was the half of that contract nobody had written down: the
+ * provider understood the permission phrasing and not the unknown-column one,
+ * so a provider released ahead of a server hard-failed. Nothing connected the
+ * two sides, so nothing noticed.
+ *
+ * This connects them. It drives the real permission gates to produce the real
+ * messages, encodes them the way Express encodes an error, and runs the
+ * provider's own patterns - read out of the generator source, not copied -
+ * against the result. Reword a message here, or narrow a pattern there, and
+ * this fails instead of a customer's plan failing.
+ *
+ * The Go end of the contract (the retry loop that consumes these patterns) is
+ * covered by Scripts/TerraformProvider/StaticFiles/client_test.go.
+ */
+
+const PROVIDER_GENERATOR: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "Scripts",
+  "TerraformProvider",
+  "Core",
+  "ProviderGenerator.ts",
+);
+
+/*
+ * Hoisted: eslint's wrap-regex objects to a regex literal used as the object of
+ * a member expression. PATTERN_BLOCK is not global so `.exec` keeps no state;
+ * MUST_COMPILE is, and is therefore only ever used as a source to build a
+ * fresh scanner from, never `.exec`d directly.
+ */
+const PATTERN_BLOCK: RegExp =
+  /var droppableSelectColumnPatterns = \[\]\*regexp\.Regexp\{([\s\S]*?)\n\}/;
+const MUST_COMPILE: RegExp = /regexp\.MustCompile\(\\`([^`]*)\\`\)/g;
+
+/*
+ * The patterns live in a Go raw-string literal nested inside a TS template
+ * literal, so what is on disk is doubly escaped: a Go `\\?` is written `\\\\?`
+ * in the source. Reading the source text and compiling it as-is would test a
+ * regex the provider never runs - one that REQUIRES the backslash the shipped
+ * one makes optional - which is exactly the class of mistake this file exists
+ * to catch, so it is undone explicitly here.
+ */
+function unescapeTemplateLiteral(source: string): string {
+  return source.replace(/\\\\/g, "\\");
+}
+
+/*
+ * The select-rejection patterns the generator compiles into the provider's
+ * client.go, as JS RegExps. Go's RE2 and JS agree on the syntax these use,
+ * which is what makes running them here meaningful rather than decorative.
+ */
+function providerSelectPatterns(): Array<RegExp> {
+  const source: string = fs.readFileSync(PROVIDER_GENERATOR, "utf-8");
+  const block: RegExpExecArray | null = PATTERN_BLOCK.exec(source);
+
+  if (!block) {
+    throw new Error(
+      `Could not find droppableSelectColumnPatterns in ${PROVIDER_GENERATOR}. ` +
+        "If the provider's select-retry was restructured, this contract test " +
+        "has to be pointed at wherever the patterns live now.",
+    );
+  }
+
+  const patterns: Array<RegExp> = [];
+  const scanner: RegExp = new RegExp(MUST_COMPILE.source, "g");
+  let match: RegExpExecArray | null = scanner.exec(block[1] as string);
+  while (match !== null) {
+    patterns.push(new RegExp(unescapeTemplateLiteral(match[1] as string)));
+    match = scanner.exec(block[1] as string);
+  }
+  return patterns;
+}
+
+/*
+ * The first pattern to name a column in `text`, or null. This is the matching
+ * step on its own, with no decoding in front of it.
+ */
+function columnMatchedInText(text: string): string | null {
+  for (const pattern of providerSelectPatterns()) {
+    const match: RegExpMatchArray | null = text.match(pattern);
+    if (match) {
+      return match[1] as string;
+    }
+  }
+  return null;
+}
+
+/*
+ * Mirrors the provider's apiErrorMessage: decode the body and take the first of
+ * message / error / errorMessage, falling back to the bytes verbatim. Matching
+ * the raw body instead was the original defect, so the test has to run the same
+ * two steps in the same order rather than approximate them.
+ */
+function apiErrorMessage(body: string): string {
+  try {
+    const parsed: Record<string, unknown> = JSON.parse(body) as Record<
+      string,
+      unknown
+    >;
+    for (const key of ["message", "error", "errorMessage"]) {
+      const value: unknown = parsed[key];
+      if (typeof value === "string" && value !== "") {
+        return value;
+      }
+    }
+  } catch {
+    // Not JSON. The provider falls back to the raw body; so do we.
+  }
+  return body.trim();
+}
+
+// What the provider would drop, given a response body. Null when it sees none.
+function columnTheProviderWouldDrop(body: string): string | null {
+  return columnMatchedInText(apiErrorMessage(body));
+}
+
+/*
+ * Express serialises an Exception as a JSON object, so a quoted column name
+ * reaches the provider with its quotes backslash-escaped. Every assertion below
+ * goes through this rather than the bare message: the escaping is precisely
+ * what the fix in #3414 had to survive, and the bare message hides it.
+ *   Common/Server/Utils/StartServer.ts  -> { error: message }
+ *   Common/Server/Utils/Response.ts     -> { message }
+ */
+function wireBody(envelope: "error" | "message", message: string): string {
+  return JSON.stringify({ [envelope]: message });
+}
+
+function caught(runCheck: () => void): Exception {
+  try {
+    runCheck();
+  } catch (err) {
+    return err as Exception;
+  }
+  throw new Error("Expected the select gate to throw, but it returned.");
+}
+
+const projectId: ObjectID = ObjectID.generate();
+const userId: ObjectID = ObjectID.generate();
+
+function makeProps(
+  permissions: Array<Permission>,
+): DatabaseCommonInteractionProps {
+  return {
+    userId: userId,
+    tenantId: projectId,
+    userTenantAccessPermission: {
+      [projectId.toString()]: {
+        projectId: projectId,
+        permissions: permissions.map((permission: Permission) => {
+          return {
+            permission: permission,
+            labelIds: [],
+            isBlockPermission: false,
+            _type: "UserPermission" as const,
+          };
+        }),
+        _type: "UserTenantAccessPermission",
+      },
+    },
+  };
+}
+
+describe("select-rejection messages the Terraform provider parses", () => {
+  describe("the patterns are readable from the generator", () => {
+    it("finds the pattern list", () => {
+      expect(providerSelectPatterns().length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("every pattern captures exactly one group", () => {
+      for (const pattern of providerSelectPatterns()) {
+        expect(new RegExp(`|${pattern.source}`).exec("")).toHaveLength(2);
+      }
+    });
+
+    /*
+     * The patterns run against the DECODED message, so they must work on a
+     * bare quote. Compiling the source text without undoing the TS template
+     * escaping yields a regex that only matches an escaped quote - it passes
+     * every wire-body assertion below and fails this one, which is precisely
+     * the trap that shipped as issue #3414's suggested patch.
+     */
+    it("works on a bare quote, not only an escaped one", () => {
+      const message: string =
+        'Invalid select clause. Cannot select on "enableSearchEngineIndexing". This column does not exist on Status Page.';
+      expect(columnMatchedInText(message)).toBe("enableSearchEngineIndexing");
+    });
+
+    // And still on an escaped one, for a body no decoder could unwrap.
+    it("works on an escaped quote too", () => {
+      const body: string = wireBody(
+        "error",
+        'Invalid select clause. Cannot select on "enableSearchEngineIndexing".',
+      );
+      expect(body).toContain('\\"enableSearchEngineIndexing\\"');
+      expect(columnMatchedInText(body)).toBe("enableSearchEngineIndexing");
+    });
+  });
+
+  describe("Postgres-backed models", () => {
+    /*
+     * A column the deployment has never heard of. This is the shape of the
+     * skew in #3414: the provider is generated from a newer schema than the
+     * server it is pointed at, so it selects a column that does not exist yet.
+     */
+    it("names the unknown column in a way the provider can recover", () => {
+      const error: Exception = caught(() => {
+        return SelectPermission.checkSelectPermission(
+          StatusPage,
+          { aColumnThisDeploymentHasNeverHeardOf: true } as never,
+          makeProps([Permission.ProjectOwner]),
+        );
+      });
+
+      expect(error.message).toContain("Cannot select on");
+      for (const envelope of ["error", "message"] as const) {
+        expect(
+          columnTheProviderWouldDrop(wireBody(envelope, error.message)),
+        ).toBe("aColumnThisDeploymentHasNeverHeardOf");
+      }
+    });
+
+    it("returns that as a 400, which is a status the provider retries on", () => {
+      const error: Exception = caught(() => {
+        return SelectPermission.checkSelectPermission(
+          StatusPage,
+          { aColumnThisDeploymentHasNeverHeardOf: true } as never,
+          makeProps([Permission.ProjectOwner]),
+        );
+      });
+
+      expect(error.code).toBe(ExceptionCode.BadDataException);
+      expect(error.code).toBe(400);
+    });
+
+    /*
+     * A real column the caller's permissions do not reach. This phrasing has
+     * always worked; it is here so a change made for the other one cannot
+     * quietly break it.
+     */
+    it("names a permission-gated column in a way the provider can recover", () => {
+      const error: Exception = caught(() => {
+        return SelectPermission.checkSelectPermission(
+          StatusPage,
+          { enableSearchEngineIndexing: true } as never,
+          makeProps([]),
+        );
+      });
+
+      expect(error.message).toContain(
+        "You do not have permissions to select on",
+      );
+      for (const envelope of ["error", "message"] as const) {
+        expect(
+          columnTheProviderWouldDrop(wireBody(envelope, error.message)),
+        ).toBe("enableSearchEngineIndexing");
+      }
+    });
+
+    it("returns that as a 422, which is also a status the provider retries on", () => {
+      const error: Exception = caught(() => {
+        return SelectPermission.checkSelectPermission(
+          StatusPage,
+          { enableSearchEngineIndexing: true } as never,
+          makeProps([]),
+        );
+      });
+
+      expect(error.code).toBe(ExceptionCode.NotAuthorizedException);
+      expect(error.code).toBe(422);
+    });
+
+    it("keeps the column named in the message a real one", () => {
+      /*
+       * Guards the permission case above from silently becoming a second copy
+       * of the unknown-column case if the column is ever removed.
+       */
+      expect(new StatusPage().getTableColumns().columns).toContain(
+        "enableSearchEngineIndexing",
+      );
+    });
+  });
+
+  describe("ClickHouse-backed models", () => {
+    /*
+     * The analytics select gate is private, and its public entry point
+     * (checkReadPermission) resolves tenant and owner scopes against real
+     * services before it gets anywhere near the select. What is under test is
+     * the sentence, so the gate is called directly rather than mocking a
+     * database out from under it.
+     */
+    function checkAnalyticsSelect(
+      select: Record<string, boolean>,
+      permissions: Array<Permission> = [Permission.ProjectOwner],
+    ): Exception {
+      const gate: (
+        modelType: typeof Log,
+        select: Record<string, boolean>,
+        props: DatabaseCommonInteractionProps,
+      ) => void = (
+        AnalyticsModelPermission as unknown as Record<string, unknown>
+      )["checkSelectPermission"] as (
+        modelType: typeof Log,
+        select: Record<string, boolean>,
+        props: DatabaseCommonInteractionProps,
+      ) => void;
+
+      return caught(() => {
+        return gate.call(
+          AnalyticsModelPermission,
+          Log,
+          select,
+          makeProps(permissions),
+        );
+      });
+    }
+
+    it("names the unknown column in a way the provider can recover", () => {
+      const error: Exception = checkAnalyticsSelect({
+        aColumnThisDeploymentHasNeverHeardOf: true,
+      });
+
+      expect(error.message).toContain("Cannot select on");
+      expect(error.code).toBe(ExceptionCode.BadDataException);
+      for (const envelope of ["error", "message"] as const) {
+        expect(
+          columnTheProviderWouldDrop(wireBody(envelope, error.message)),
+        ).toBe("aColumnThisDeploymentHasNeverHeardOf");
+      }
+    });
+
+    it("lists the columns it would accept instead, by name", () => {
+      /*
+       * The remediation tail interpolated the column OBJECTS, so it rendered
+       * as "[object Object], [object Object], ..." - the half of the sentence
+       * that tells the caller what to do instead said nothing at all. It is
+       * also the part of the message a sloppy pattern could reach into, so it
+       * is worth keeping honest.
+       */
+      const error: Exception = checkAnalyticsSelect({
+        aColumnThisDeploymentHasNeverHeardOf: true,
+      });
+
+      expect(error.message).not.toContain("[object Object]");
+      expect(error.message).toContain(
+        "Here are the columns you can select on instead:",
+      );
+      expect(error.message).toContain("body");
+    });
+
+    it("names a permission-gated column the same way the Postgres gate does", () => {
+      const error: Exception = checkAnalyticsSelect({ body: true }, []);
+
+      expect(error.message).toContain(
+        "You do not have permissions to select on",
+      );
+      expect(error.code).toBe(ExceptionCode.NotAuthorizedException);
+      expect(columnTheProviderWouldDrop(wireBody("error", error.message))).toBe(
+        "body",
+      );
+    });
+  });
+
+  describe("clauses the provider must NOT treat as a droppable select column", () => {
+    it("ignores a query-clause permission rejection", () => {
+      /*
+       * One word away from the select phrasing. Dropping a query column would
+       * change which rows come back - a silently wrong read is worse than the
+       * loud failure it would be papering over.
+       */
+      expect(
+        columnTheProviderWouldDrop(
+          wireBody(
+            "message",
+            "You do not have permissions to query on - name. You need any one of these permissions: Project Owner",
+          ),
+        ),
+      ).toBeNull();
+    });
+
+    it("ignores an error that names no column at all", () => {
+      expect(
+        columnTheProviderWouldDrop(
+          wireBody("error", "Project ID not found in the request."),
+        ),
+      ).toBeNull();
+    });
+  });
+});

--- a/Scripts/TerraformProvider/Core/DataSourceGenerator.ts
+++ b/Scripts/TerraformProvider/Core/DataSourceGenerator.ts
@@ -254,6 +254,10 @@ ${this.generateReadMethod(dataSource, dataSourceVarName)}
    *   - name -> POST {crud}/get-list with query {name}, limit 2; exactly one
    *     match required — zero or multiple matches are errors, never silently
    *     empty state or an arbitrary first item
+   *
+   * Both paths post through the client's select-dropping helpers, so a column
+   * the server rejects (permission-gated, or unknown to an older deployment)
+   * costs that one attribute rather than the whole lookup.
    */
   private generateReadMethod(
     dataSource: TerraformDataSource,
@@ -300,7 +304,7 @@ ${this.generateReadMethod(dataSource, dataSourceVarName)}
             // limit 2 is enough to detect ambiguity without paging.
             "limit": 2,
         }
-        httpResp, err := d.client.Post(ctx, "${listOperation.path}", listBody)
+        httpResp, err := d.client.PostBodyWithSelect(ctx, "${listOperation.path}", listBody)
         if err != nil {
             resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list ${dataSource.name}, got error: %s", err))
             return

--- a/Scripts/TerraformProvider/Core/ProviderGenerator.ts
+++ b/Scripts/TerraformProvider/Core/ProviderGenerator.ts
@@ -182,6 +182,8 @@ import (
     "regexp"
     "strings"
     "time"
+
+    "github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Client represents the API client for ${this.config.providerName}
@@ -330,9 +332,37 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
     return c.DoRequest(ctx, "DELETE", path, nil)
 }
 
-// rejectedSelectColumn matches the server's column-permission error, e.g.
-// "You do not have permissions to select on - serviceLanguage."
-var rejectedSelectColumn = regexp.MustCompile(\`select on - ([A-Za-z0-9_]+)\`)
+/*
+ * Server phrasings that name one column the select has to give up on. They are
+ * matched against the DECODED error message (apiErrorMessage), never the raw
+ * response body: the unknown-column phrasing quotes the column name, and the
+ * API JSON-encodes its errors, so on the wire those quotes arrive backslash-
+ * escaped. A pattern anchored on a bare quote therefore never fires
+ * against raw bytes, which is exactly how the unknown-column phrasing went
+ * unhandled while the (quote-free) permission phrasing kept working. The
+ * optional backslash keeps every pattern honest on the fallback path too,
+ * where apiErrorMessage hands back an undecodable body verbatim.
+ */
+var droppableSelectColumnPatterns = []*regexp.Regexp{
+    // "You do not have permissions to select on - serviceLanguage."
+    regexp.MustCompile(\`select on - ([A-Za-z0-9_]+)\`),
+    // Invalid select clause. Cannot select on "enableSearchEngineIndexing".
+    regexp.MustCompile(\`Cannot select on \\\\?"([A-Za-z0-9_]+)\`),
+    // ClickHouse-backed models reject an unknown column more tersely.
+    regexp.MustCompile(\`Unknown column: ([A-Za-z0-9_]+)\`),
+}
+
+// droppableSelectColumn returns the column named by a select-rejection error
+// response, or "" when the body is not one.
+func droppableSelectColumn(body []byte) string {
+    message := apiErrorMessage(body)
+    for _, pattern := range droppableSelectColumnPatterns {
+        if match := pattern.FindStringSubmatch(message); match != nil {
+            return match[1]
+        }
+    }
+    return ""
+}
 
 // PostWithSelect performs a POST request with a select parameter. When the
 // server rejects a column in the select (permission-gated columns, or
@@ -340,14 +370,20 @@ var rejectedSelectColumn = regexp.MustCompile(\`select on - ([A-Za-z0-9_]+)\`)
 // dropped and the request retried — a version- or permission-skewed column
 // must not fail the entire read.
 func (c *Client) PostWithSelect(ctx context.Context, path string, selectParam interface{}) (*http.Response, error) {
-    selectMap, _ := selectParam.(map[string]interface{})
+    return c.PostBodyWithSelect(ctx, path, map[string]interface{}{
+        "select": selectParam,
+    })
+}
+
+// PostBodyWithSelect is PostWithSelect for callers whose request body carries
+// more than the select — the data sources' by-name lookup also sends "query"
+// and "limit". Everything other than the rejected column survives each retry.
+func (c *Client) PostBodyWithSelect(ctx context.Context, path string, requestBody map[string]interface{}) (*http.Response, error) {
+    selectMap, _ := requestBody["select"].(map[string]interface{})
 
     // One attempt per droppable column, bounded to keep worst cases sane.
     maxAttempts := 8
     for attempt := 0; attempt < maxAttempts; attempt++ {
-        requestBody := map[string]interface{}{
-            "select": selectParam,
-        }
         resp, err := c.DoRequest(ctx, "POST", path, requestBody)
         if err != nil {
             return nil, err
@@ -363,25 +399,31 @@ func (c *Client) PostWithSelect(ctx context.Context, path string, selectParam in
             return nil, fmt.Errorf("failed to read response body: %w", readErr)
         }
 
-        match := rejectedSelectColumn.FindSubmatch(body)
         rebuilt := func() *http.Response {
             resp.Body = io.NopCloser(bytes.NewReader(body))
             return resp
         }
-        if match == nil {
+        column := droppableSelectColumn(body)
+        if column == "" {
             // Not a select-column rejection: surface the original error.
             return rebuilt(), nil
         }
-        column := string(match[1])
         if _, present := selectMap[column]; !present {
             return rebuilt(), nil
         }
         delete(selectMap, column)
+
+        /*
+         * A dropped column leaves its attribute null in state, which shows up
+         * later as an "inconsistent result after apply" or a spurious diff.
+         * Say so at WARN rather than letting the read look clean.
+         */
+        tflog.Warn(ctx, "OneUptime rejected a column in the select; dropping it and retrying", map[string]any{
+            "path":   path,
+            "column": column,
+        })
     }
 
-    requestBody := map[string]interface{}{
-        "select": selectParam,
-    }
     return c.DoRequest(ctx, "POST", path, requestBody)
 }
 

--- a/Scripts/TerraformProvider/Core/ResourceGenerator.ts
+++ b/Scripts/TerraformProvider/Core/ResourceGenerator.ts
@@ -58,6 +58,15 @@ export class ResourceGenerator {
     );
 
     /*
+     * Exercises client.go's select-rejection retry against a real httptest
+     * server. client.go is generated (it lives in a template literal in
+     * ProviderGenerator.ts), so its test has to be a static file copied in
+     * beside it — copyStaticFile, not copyStaticFileIfExists, so a rename
+     * fails generation instead of silently testing nothing.
+     */
+    await this.copyStaticFile("client_test.go", "internal/provider");
+
+    /*
      * Package-level ObjectType registry shared by every resource and the
      * envelope validator (was duplicated as a per-resource map).
      */

--- a/Scripts/TerraformProvider/StaticFiles/client_test.go
+++ b/Scripts/TerraformProvider/StaticFiles/client_test.go
@@ -1,0 +1,729 @@
+package provider
+
+/*
+ * client.go's select-rejection retry, exercised end to end against a real HTTP
+ * server.
+ *
+ * WHAT THIS FILE PINS
+ *
+ * The retry exists so that one column the server will not hand over - gated by
+ * the API key's permissions, or simply absent from a deployment older than the
+ * provider - costs that one attribute instead of failing the whole read. The
+ * server has more than one way of saying no, and the retry originally
+ * recognised only the permission phrasing:
+ *
+ *   permission     You do not have permissions to select on - serviceLanguage.
+ *   unknown column Invalid select clause. Cannot select on "enableSearchEngineIndexing". ...
+ *   analytics      Unknown column: spanId
+ *
+ * The near-miss fix matters as much as the miss. The API JSON-encodes its error
+ * messages, so the quotes around the column name reach the client
+ * backslash-escaped; a pattern matched against the raw response body never
+ * fires, and nothing here would have noticed because the quote-free permission
+ * phrasing kept working. Every test below encodes its error body the way the
+ * server really encodes it, and TestDroppableSelectColumn_MatchesRawEscapedBody
+ * asserts the escaping is genuinely present rather than trusting it.
+ *
+ * The message templates below are copies, and copies drift. What stops them is
+ * Common/Tests/Server/Types/Database/Permissions/SelectRejectionMessageContract.test.ts,
+ * which drives the real permission gates and runs the real patterns over
+ * whatever they throw. Reword a message in
+ *   Common/Server/Types/Database/Permissions/SelectPermission.ts
+ *   Common/Server/Types/AnalyticsDatabase/ModelPermission.ts
+ *   Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+ * and that file fails; this one tests the retry given the message.
+ */
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+/*
+ * The two envelopes an error can arrive in. BaseAPI's CRUD routes fall through
+ * to the express error handler, which answers {"error": ...}
+ * (Common/Server/Utils/StartServer.ts); Response.sendErrorResponse answers
+ * {"message": ...}. Both must work - the provider does not get to choose.
+ */
+const (
+	envelopeError   = "error"
+	envelopeMessage = "message"
+)
+
+func permissionDeniedMessage(column string) string {
+	return fmt.Sprintf("You do not have permissions to select on - %s.\n"+
+		"                    You need any one of these permissions: Project Owner, Project Admin", column)
+}
+
+func unknownColumnMessage(column string) string {
+	return fmt.Sprintf("Invalid select clause. Cannot select on %q. "+
+		"This column does not exist on Monitor. "+
+		"Here are the columns you can select on instead: _id, createdAt, updatedAt, name", column)
+}
+
+func analyticsUnknownColumnMessage(column string) string {
+	return fmt.Sprintf("Unknown column: %s", column)
+}
+
+// rejection is one canned refusal, returned for as long as its column is still
+// present in the request's select.
+type rejection struct {
+	column     string
+	statusCode int
+	envelope   string
+	message    string
+	// rawBody, when set, is written instead of a JSON envelope. Used to cover
+	// the path where apiErrorMessage cannot decode the body and falls back to
+	// the bytes verbatim.
+	rawBody string
+}
+
+type fakeAPI struct {
+	t          *testing.T
+	rejections []rejection
+	// rejectAnything refuses whichever column it finds first, forever. Used to
+	// prove the retry is bounded rather than looping until the context dies.
+	rejectAnything bool
+	// bodies records every request body received, in order.
+	bodies []map[string]interface{}
+	paths  []string
+	server *httptest.Server
+}
+
+func newFakeAPI(t *testing.T, rejections ...rejection) (*fakeAPI, *Client) {
+	t.Helper()
+
+	api := &fakeAPI{t: t, rejections: rejections}
+	api.server = httptest.NewServer(http.HandlerFunc(api.handle))
+	t.Cleanup(api.server.Close)
+
+	client, err := NewClient(api.server.URL, "api-key", "test")
+	if err != nil {
+		t.Fatalf("NewClient: %s", err)
+	}
+	return api, client
+}
+
+func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.t.Errorf("reading request body: %s", err)
+		return
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		f.t.Errorf("request body was not JSON (%s): %s", err, raw)
+		return
+	}
+	f.bodies = append(f.bodies, decoded)
+	f.paths = append(f.paths, r.URL.Path)
+
+	selected, _ := decoded["select"].(map[string]interface{})
+
+	for _, reject := range f.rejections {
+		if _, present := selected[reject.column]; !present {
+			continue
+		}
+		f.writeError(w, reject)
+		return
+	}
+
+	if f.rejectAnything && len(selected) > 0 {
+		for column := range selected {
+			f.writeError(w, rejection{
+				column:     column,
+				statusCode: http.StatusBadRequest,
+				envelope:   envelopeError,
+				message:    unknownColumnMessage(column),
+			})
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, `{"data":{"_id":"abc123","name":"api-server"}}`)
+}
+
+func (f *fakeAPI) writeError(w http.ResponseWriter, reject rejection) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(reject.statusCode)
+
+	if reject.rawBody != "" {
+		_, _ = io.WriteString(w, reject.rawBody)
+		return
+	}
+	if err := json.NewEncoder(w).Encode(map[string]string{reject.envelope: reject.message}); err != nil {
+		f.t.Errorf("encoding error body: %s", err)
+	}
+}
+
+func (f *fakeAPI) requestCount() int {
+	return len(f.bodies)
+}
+
+// selectAt returns the select map from the nth (0-based) recorded request.
+func (f *fakeAPI) selectAt(n int) map[string]interface{} {
+	f.t.Helper()
+	if n >= len(f.bodies) {
+		f.t.Fatalf("wanted request %d, server only saw %d", n, len(f.bodies))
+	}
+	selected, ok := f.bodies[n]["select"].(map[string]interface{})
+	if !ok {
+		f.t.Fatalf("request %d carried no select object: %v", n, f.bodies[n])
+	}
+	return selected
+}
+
+func monitorSelect() map[string]interface{} {
+	return map[string]interface{}{
+		"_id":          true,
+		"name":         true,
+		"description":  true,
+		"internalNote": true,
+	}
+}
+
+func assertSelected(t *testing.T, selected map[string]interface{}, want ...string) {
+	t.Helper()
+	if len(selected) != len(want) {
+		t.Fatalf("select had %d columns %v, wanted %d %v", len(selected), keysOf(selected), len(want), want)
+	}
+	for _, column := range want {
+		if _, present := selected[column]; !present {
+			t.Errorf("select was missing %q; it had %v", column, keysOf(selected))
+		}
+	}
+}
+
+func keysOf(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func parseData(t *testing.T, client *Client, resp *http.Response) map[string]interface{} {
+	t.Helper()
+	var parsed map[string]interface{}
+	if err := client.ParseResponse(resp, &parsed); err != nil {
+		t.Fatalf("ParseResponse: %s", err)
+	}
+	data, ok := parsed["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response had no data object: %v", parsed)
+	}
+	return data
+}
+
+/*
+ * The permission phrasing. This one always worked; it is here so that a change
+ * made for the unknown-column phrasing cannot quietly break it.
+ */
+func TestPostWithSelect_DropsPermissionDeniedColumn(t *testing.T) {
+	api, client := newFakeAPI(t, rejection{
+		column:     "internalNote",
+		statusCode: http.StatusUnprocessableEntity,
+		envelope:   envelopeMessage,
+		message:    permissionDeniedMessage("internalNote"),
+	})
+
+	resp, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect())
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+
+	if api.requestCount() != 2 {
+		t.Fatalf("expected one retry (2 requests), got %d", api.requestCount())
+	}
+	assertSelected(t, api.selectAt(1), "_id", "name", "description")
+	if data := parseData(t, client, resp); data["_id"] != "abc123" {
+		t.Errorf("retry did not return the item: %v", data)
+	}
+}
+
+/*
+ * Issue #3414. A provider generated from a newer schema than the server it is
+ * pointed at selects a column that deployment has never heard of; before the
+ * fix the whole read failed instead of losing the one attribute.
+ */
+func TestPostWithSelect_DropsUnknownColumn(t *testing.T) {
+	selectParam := monitorSelect()
+	selectParam["enableSearchEngineIndexing"] = true
+
+	api, client := newFakeAPI(t, rejection{
+		column:     "enableSearchEngineIndexing",
+		statusCode: http.StatusBadRequest,
+		envelope:   envelopeError,
+		message:    unknownColumnMessage("enableSearchEngineIndexing"),
+	})
+
+	resp, err := client.PostWithSelect(context.Background(), "/status-page/abc/get-item", selectParam)
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+
+	if api.requestCount() != 2 {
+		t.Fatalf("expected one retry (2 requests), got %d", api.requestCount())
+	}
+	assertSelected(t, api.selectAt(1), "_id", "name", "description", "internalNote")
+	if data := parseData(t, client, resp); data["_id"] != "abc123" {
+		t.Errorf("retry did not return the item: %v", data)
+	}
+}
+
+// The same phrasing in the other envelope, and the permission phrasing in both.
+func TestPostWithSelect_HandlesBothErrorEnvelopes(t *testing.T) {
+	cases := []struct {
+		name     string
+		envelope string
+		status   int
+		message  func(string) string
+	}{
+		{"unknown column via error", envelopeError, http.StatusBadRequest, unknownColumnMessage},
+		{"unknown column via message", envelopeMessage, http.StatusBadRequest, unknownColumnMessage},
+		{"permission via error", envelopeError, http.StatusUnprocessableEntity, permissionDeniedMessage},
+		{"permission via message", envelopeMessage, http.StatusUnprocessableEntity, permissionDeniedMessage},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			api, client := newFakeAPI(t, rejection{
+				column:     "internalNote",
+				statusCode: testCase.status,
+				envelope:   testCase.envelope,
+				message:    testCase.message("internalNote"),
+			})
+
+			if _, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect()); err != nil {
+				t.Fatalf("PostWithSelect: %s", err)
+			}
+			if api.requestCount() != 2 {
+				t.Fatalf("expected one retry (2 requests), got %d", api.requestCount())
+			}
+			assertSelected(t, api.selectAt(1), "_id", "name", "description")
+		})
+	}
+}
+
+// ClickHouse-backed models refuse an unknown column with a terser sentence.
+func TestPostWithSelect_DropsAnalyticsUnknownColumn(t *testing.T) {
+	selectParam := map[string]interface{}{"_id": true, "body": true, "spanId": true}
+
+	api, client := newFakeAPI(t, rejection{
+		column:     "spanId",
+		statusCode: http.StatusBadRequest,
+		envelope:   envelopeError,
+		message:    analyticsUnknownColumnMessage("spanId"),
+	})
+
+	if _, err := client.PostWithSelect(context.Background(), "/log/get-list", selectParam); err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 2 {
+		t.Fatalf("expected one retry (2 requests), got %d", api.requestCount())
+	}
+	assertSelected(t, api.selectAt(1), "_id", "body")
+}
+
+/*
+ * A proxy or a crash can answer with something that is not the API's JSON
+ * envelope at all. apiErrorMessage hands those back verbatim, so the patterns
+ * have to cope with a bare, unescaped quote as well as an escaped one.
+ */
+func TestPostWithSelect_DropsUnknownColumnFromNonJSONBody(t *testing.T) {
+	api, client := newFakeAPI(t, rejection{
+		column:     "internalNote",
+		statusCode: http.StatusBadRequest,
+		rawBody:    unknownColumnMessage("internalNote"),
+	})
+
+	if _, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect()); err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 2 {
+		t.Fatalf("expected one retry (2 requests), got %d", api.requestCount())
+	}
+	assertSelected(t, api.selectAt(1), "_id", "name", "description")
+}
+
+// Several skewed columns in one select: each costs one round trip, none is lost.
+func TestPostWithSelect_DropsSeveralColumnsInSequence(t *testing.T) {
+	api, client := newFakeAPI(t,
+		rejection{column: "internalNote", statusCode: http.StatusUnprocessableEntity, envelope: envelopeMessage, message: permissionDeniedMessage("internalNote")},
+		rejection{column: "description", statusCode: http.StatusBadRequest, envelope: envelopeError, message: unknownColumnMessage("description")},
+		rejection{column: "name", statusCode: http.StatusBadRequest, envelope: envelopeError, message: analyticsUnknownColumnMessage("name")},
+	)
+
+	if _, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect()); err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 4 {
+		t.Fatalf("expected three retries (4 requests), got %d", api.requestCount())
+	}
+	assertSelected(t, api.selectAt(3), "_id")
+}
+
+/*
+ * A 400 that is not about a select column is the caller's to see. The body must
+ * still be readable: the retry consumed it to run the patterns and has to put
+ * it back before handing the response on.
+ */
+func TestPostWithSelect_SurfacesUnrelatedBadRequestWithBodyIntact(t *testing.T) {
+	api, client := newFakeAPI(t, rejection{
+		column:     "_id",
+		statusCode: http.StatusBadRequest,
+		envelope:   envelopeError,
+		message:    "Invalid query. Cannot query on \"nope\". This column does not exist on Monitor.",
+	})
+
+	resp, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect())
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 1 {
+		t.Fatalf("a non-select rejection must not be retried, got %d requests", api.requestCount())
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected the original 400, got %d", resp.StatusCode)
+	}
+
+	err = client.ParseResponse(resp, nil)
+	if err == nil {
+		t.Fatal("expected ParseResponse to surface the error")
+	}
+	if !strings.Contains(err.Error(), "Invalid query") {
+		t.Errorf("the error body was lost on the way out: %s", err)
+	}
+}
+
+/*
+ * If the server names a column the request never asked for, dropping it would
+ * change nothing and asking again would loop. Stop and let the caller see it.
+ */
+func TestPostWithSelect_StopsWhenTheNamedColumnIsNotInTheSelect(t *testing.T) {
+	api, client := newFakeAPI(t, rejection{
+		column:     "_id",
+		statusCode: http.StatusBadRequest,
+		envelope:   envelopeError,
+		message:    unknownColumnMessage("somethingElseEntirely"),
+	})
+
+	resp, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect())
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 1 {
+		t.Fatalf("expected no retry, got %d requests", api.requestCount())
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected the original 400, got %d", resp.StatusCode)
+	}
+}
+
+// A server that refuses everything must not keep the provider there forever.
+func TestPostWithSelect_IsBounded(t *testing.T) {
+	api, client := newFakeAPI(t)
+	api.rejectAnything = true
+
+	selectParam := map[string]interface{}{}
+	for index := 0; index < 12; index++ {
+		selectParam[fmt.Sprintf("column%d", index)] = true
+	}
+
+	resp, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", selectParam)
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+
+	// Eight attempts inside the loop, then one last unretried request.
+	if api.requestCount() != 9 {
+		t.Fatalf("expected the retry to stop after 9 requests, got %d", api.requestCount())
+	}
+
+	/*
+	 * The ninth request is the one code path outside the loop, and it is the
+	 * one a refactor is most likely to rebuild from scratch and get wrong. It
+	 * must still carry what is left of the caller's select, and the caller must
+	 * get the server's own refusal back with a readable body.
+	 */
+	if remaining := api.selectAt(8); len(remaining) != 4 {
+		t.Errorf("the last request should still carry the 4 undropped columns, had %v", keysOf(remaining))
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected the server's own 400 back, got %d", resp.StatusCode)
+	}
+	if err := client.ParseResponse(resp, nil); err == nil {
+		t.Error("expected the unresolved rejection to reach the caller as an error")
+	}
+}
+
+/*
+ * The retry can only work on a select it understands. Anything else has to pass
+ * straight through rather than be silently swallowed.
+ */
+func TestPostWithSelect_PassesThroughWhenSelectIsNotAMap(t *testing.T) {
+	api, client := newFakeAPI(t)
+	api.rejectAnything = true
+
+	resp, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", []string{"name"})
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 1 {
+		t.Fatalf("expected exactly one request, got %d", api.requestCount())
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected the server's own answer, got %d", resp.StatusCode)
+	}
+
+	/*
+	 * Passing through means the select still reaches the server. Tightening the
+	 * signature so only map-shaped selects are forwarded would drop this one on
+	 * the floor and return an unfiltered row set with a cheerful 200.
+	 */
+	sent, ok := api.bodies[0]["select"].([]interface{})
+	if !ok || len(sent) != 1 || sent[0] != "name" {
+		t.Errorf("the select never reached the server intact: %v", api.bodies[0])
+	}
+}
+
+// Nothing to retry: the body must reach the caller unread.
+func TestPostWithSelect_LeavesASuccessfulResponseAlone(t *testing.T) {
+	api, client := newFakeAPI(t)
+
+	resp, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", monitorSelect())
+	if err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if api.requestCount() != 1 {
+		t.Fatalf("expected exactly one request, got %d", api.requestCount())
+	}
+	if data := parseData(t, client, resp); data["name"] != "api-server" {
+		t.Errorf("the success body did not survive: %v", data)
+	}
+}
+
+/*
+ * The by-name data source lookup sends query and limit alongside the select.
+ * Retrying must not lose them - a retry that dropped the query would silently
+ * match the wrong row, which is worse than the failure it is fixing.
+ */
+func TestPostBodyWithSelect_PreservesTheRestOfTheBody(t *testing.T) {
+	api, client := newFakeAPI(t, rejection{
+		column:     "internalNote",
+		statusCode: http.StatusBadRequest,
+		envelope:   envelopeError,
+		message:    unknownColumnMessage("internalNote"),
+	})
+
+	listBody := map[string]interface{}{
+		"query":  map[string]interface{}{"name": "api-server"},
+		"select": monitorSelect(),
+		"limit":  2,
+	}
+
+	if _, err := client.PostBodyWithSelect(context.Background(), "/monitor/get-list", listBody); err != nil {
+		t.Fatalf("PostBodyWithSelect: %s", err)
+	}
+	if api.requestCount() != 2 {
+		t.Fatalf("expected one retry (2 requests), got %d", api.requestCount())
+	}
+	assertSelected(t, api.selectAt(1), "_id", "name", "description")
+
+	for index := 0; index < 2; index++ {
+		body := api.bodies[index]
+		query, ok := body["query"].(map[string]interface{})
+		if !ok || query["name"] != "api-server" {
+			t.Errorf("request %d lost its query: %v", index, body)
+		}
+		if limit, ok := body["limit"].(float64); !ok || limit != 2 {
+			t.Errorf("request %d lost its limit: %v", index, body)
+		}
+	}
+}
+
+// A body with no select at all has nothing to drop; do not retry it.
+func TestPostBodyWithSelect_PassesThroughABodyWithoutASelect(t *testing.T) {
+	api, client := newFakeAPI(t)
+	api.rejectAnything = true
+
+	resp, err := client.PostBodyWithSelect(context.Background(), "/monitor/get-list", map[string]interface{}{
+		"query": map[string]interface{}{"name": "api-server"},
+	})
+	if err != nil {
+		t.Fatalf("PostBodyWithSelect: %s", err)
+	}
+	if api.requestCount() != 1 {
+		t.Fatalf("expected exactly one request, got %d", api.requestCount())
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected the server's own answer, got %d", resp.StatusCode)
+	}
+}
+
+/*
+ * PostWithSelect deletes from the caller's map. Every generated caller builds a
+ * fresh select literal per request, so that is safe today - this pins it as a
+ * contract, so sharing or caching a select map becomes a deliberate decision
+ * rather than an accident that starts dropping columns for good.
+ */
+func TestPostWithSelect_MutatesTheCallersSelectMap(t *testing.T) {
+	_, client := newFakeAPI(t, rejection{
+		column:     "internalNote",
+		statusCode: http.StatusUnprocessableEntity,
+		envelope:   envelopeMessage,
+		message:    permissionDeniedMessage("internalNote"),
+	})
+
+	selectParam := monitorSelect()
+	if _, err := client.PostWithSelect(context.Background(), "/monitor/abc/get-item", selectParam); err != nil {
+		t.Fatalf("PostWithSelect: %s", err)
+	}
+	if _, present := selectParam["internalNote"]; present {
+		t.Error("expected the dropped column to be removed from the caller's map")
+	}
+}
+
+/*
+ * The escape tolerance, pinned where it actually applies. droppableSelectColumn
+ * decodes first, so on that path the tolerance never comes into play; it earns
+ * its keep only when apiErrorMessage cannot decode a body and hands back bytes
+ * whose quotes are still escaped - a proxy that re-wraps the error, or an
+ * envelope key we do not know about. Reaching that branch deliberately means
+ * running the patterns directly, which is what this does. Anchor a pattern on a
+ * bare quote and the first half fails; drop the quote entirely and the second
+ * half fails.
+ */
+func TestSelectPatterns_MatchEscapedAndBareQuotesAlike(t *testing.T) {
+	message := unknownColumnMessage("enableSearchEngineIndexing")
+	encoded, err := json.Marshal(map[string]string{envelopeError: message})
+	if err != nil {
+		t.Fatalf("marshalling the error body: %s", err)
+	}
+
+	if !strings.Contains(string(encoded), `\"enableSearchEngineIndexing\"`) {
+		t.Fatalf("this test is no longer testing the escaping it was written for: %s", encoded)
+	}
+
+	matched := func(text string) string {
+		for _, pattern := range droppableSelectColumnPatterns {
+			if match := pattern.FindStringSubmatch(text); match != nil {
+				return match[1]
+			}
+		}
+		return ""
+	}
+
+	if column := matched(string(encoded)); column != "enableSearchEngineIndexing" {
+		t.Errorf("escaped body: got %q, wanted enableSearchEngineIndexing", column)
+	}
+	if column := matched(message); column != "enableSearchEngineIndexing" {
+		t.Errorf("decoded message: got %q, wanted enableSearchEngineIndexing", column)
+	}
+}
+
+/*
+ * And the decode itself, pinned. Everywhere else the escape tolerance means a
+ * pattern would have found the column with or without apiErrorMessage, so
+ * putting the patterns back in front of raw bytes - the original defect - would
+ * go unnoticed. This body is valid JSON that spells the column with a \u escape,
+ * so the raw bytes do not contain the name at all and only the decode recovers
+ * it.
+ */
+func TestDroppableSelectColumn_DecodesBeforeMatching(t *testing.T) {
+	body := `{"error":"Invalid select clause. Cannot select on \"\u0065nableSearchEngineIndexing\". This column does not exist on Status Page."}`
+
+	if strings.Contains(body, "enableSearchEngineIndexing") {
+		t.Fatal("this test only means anything while the raw body hides the column name")
+	}
+	if column := droppableSelectColumn([]byte(body)); column != "enableSearchEngineIndexing" {
+		t.Errorf("got %q; the body has to be decoded before the patterns run", column)
+	}
+}
+
+func TestDroppableSelectColumn(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "permission, message envelope",
+			body: jsonBody(t, envelopeMessage, permissionDeniedMessage("serviceLanguage")),
+			want: "serviceLanguage",
+		},
+		{
+			name: "permission, error envelope",
+			body: jsonBody(t, envelopeError, permissionDeniedMessage("serviceLanguage")),
+			want: "serviceLanguage",
+		},
+		{
+			name: "unknown column, error envelope",
+			body: jsonBody(t, envelopeError, unknownColumnMessage("enableSearchEngineIndexing")),
+			want: "enableSearchEngineIndexing",
+		},
+		{
+			name: "unknown column, undecodable body",
+			body: unknownColumnMessage("enableSearchEngineIndexing"),
+			want: "enableSearchEngineIndexing",
+		},
+		{
+			name: "analytics unknown column",
+			body: jsonBody(t, envelopeError, analyticsUnknownColumnMessage("spanId")),
+			want: "spanId",
+		},
+		{
+			/*
+			 * The unknown-column message ends with "...you can select on
+			 * instead: _id, createdAt". A pattern that reached into that tail
+			 * would drop a column the server was recommending.
+			 */
+			name: "the remediation tail is not mistaken for the rejected column",
+			body: jsonBody(t, envelopeError, unknownColumnMessage("enableSearchEngineIndexing")),
+			want: "enableSearchEngineIndexing",
+		},
+		{
+			// Query rejections are a different clause; dropping a query column
+			// would change which rows come back.
+			name: "query permission rejection is not a select rejection",
+			body: jsonBody(t, envelopeMessage, "You do not have permissions to query on - name. You need any one of these permissions: Project Owner"),
+			want: "",
+		},
+		{
+			name: "an unrelated bad request names nothing",
+			body: jsonBody(t, envelopeError, "Project ID not found in the request."),
+			want: "",
+		},
+		{
+			name: "an empty body names nothing",
+			body: "",
+			want: "",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := droppableSelectColumn([]byte(testCase.body)); got != testCase.want {
+				t.Errorf("got %q, wanted %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func jsonBody(t *testing.T, envelope string, message string) string {
+	t.Helper()
+	encoded, err := json.Marshal(map[string]string{envelope: message})
+	if err != nil {
+		t.Fatalf("marshalling %s: %s", envelope, err)
+	}
+	return string(encoded)
+}

--- a/Scripts/TerraformProvider/Tests/ProviderGenerator.test.ts
+++ b/Scripts/TerraformProvider/Tests/ProviderGenerator.test.ts
@@ -1,0 +1,357 @@
+/*
+ * Contract tests for the generated internal/provider/client.go.
+ *
+ * client.go lives in a template literal, so nothing type-checks it and — until
+ * StaticFiles/client_test.go was added — nothing ran it either. These tests
+ * cover the half that a Go test cannot: that the generator still EMITS the
+ * client the Go tests are written against, and that the copy of client_test.go
+ * into the generated tree is still wired up. Drop that one line in
+ * ResourceGenerator and the Go suite silently stops existing while CI stays
+ * green, so it is asserted here rather than assumed.
+ *
+ * The select-rejection patterns get more than a spelling check. Each emitted Go
+ * pattern is compiled as a JS RegExp and run against the server's real message
+ * text, in both the decoded and the on-the-wire JSON-encoded form. That last
+ * part is the whole point: issue #3414 proposed `Cannot select on "([A-Za-z0-9_]+)"`,
+ * which reads fine and never fires, because the API JSON-encodes its errors and
+ * the quotes arrive backslash-escaped. Go's RE2 and JS agree on the syntax used
+ * by these patterns, so running them here is a real behavioral check.
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { DataSourceGenerator } from "../Core/DataSourceGenerator";
+import { ProviderGenerator } from "../Core/ProviderGenerator";
+import { ResourceGenerator } from "../Core/ResourceGenerator";
+import { buildFixtureSpec } from "./Fixtures";
+
+let outputDir: string;
+let clientGo: string;
+let monitorDataSourceGo: string;
+
+const GENERATED_DIR: string = "internal/provider";
+
+/*
+ * Verbatim from the server. A reword there without a matching change here is
+ * the failure this whole file exists to make loud:
+ *   Common/Server/Types/Database/Permissions/SelectPermission.ts
+ *   Common/Server/Types/AnalyticsDatabase/ModelPermission.ts
+ *   Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+ */
+const PERMISSION_MESSAGE: string =
+  "You do not have permissions to select on - serviceLanguage.\n" +
+  "                    You need any one of these permissions: Project Owner, Project Admin";
+
+const UNKNOWN_COLUMN_MESSAGE: string =
+  'Invalid select clause. Cannot select on "enableSearchEngineIndexing". ' +
+  "This column does not exist on Status Page. " +
+  "Here are the columns you can select on instead: _id, createdAt, updatedAt";
+
+const ANALYTICS_UNKNOWN_COLUMN_MESSAGE: string = "Unknown column: spanId";
+
+beforeAll(async () => {
+  outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "tfgen-provider-"));
+
+  const config: {
+    outputDir: string;
+    providerName: string;
+    providerVersion: string;
+    goModuleName: string;
+  } = {
+    outputDir,
+    providerName: "oneuptime",
+    providerVersion: "11.0.0",
+    goModuleName: "github.com/oneuptime/terraform-provider-oneuptime",
+  };
+  const spec: ReturnType<typeof buildFixtureSpec> = buildFixtureSpec();
+
+  await new ProviderGenerator(config, spec).generateProvider();
+  await new ResourceGenerator(config, spec).generateResources();
+  await new DataSourceGenerator(config, spec).generateDataSources();
+
+  clientGo = fs.readFileSync(
+    path.join(outputDir, GENERATED_DIR, "client.go"),
+    "utf-8",
+  );
+  monitorDataSourceGo = fs.readFileSync(
+    path.join(outputDir, GENERATED_DIR, "data_source_monitor.go"),
+    "utf-8",
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(outputDir, { recursive: true, force: true });
+});
+
+/*
+ * Hoisted: eslint's wrap-regex and prettier disagree about parenthesising a
+ * regex literal in a member expression. PATTERN_BLOCK is not global so `.exec`
+ * carries no lastIndex state; MUST_COMPILE is, and is therefore only ever used
+ * as a source to build a fresh scanner from, never `.exec`d directly.
+ */
+const PATTERN_BLOCK: RegExp =
+  /var droppableSelectColumnPatterns = \[\]\*regexp\.Regexp\{([\s\S]*?)\n\}/;
+const MUST_COMPILE: RegExp = /regexp\.MustCompile\(`([^`]*)`\)/g;
+
+/*
+ * The Go source of every pattern in droppableSelectColumnPatterns, in order.
+ * Fails loudly (empty list) rather than silently if the block is restructured.
+ */
+function emittedSelectPatterns(): Array<string> {
+  const block: RegExpExecArray | null = PATTERN_BLOCK.exec(clientGo);
+  if (!block) {
+    return [];
+  }
+
+  const patterns: Array<string> = [];
+  const scanner: RegExp = new RegExp(MUST_COMPILE.source, "g");
+  let match: RegExpExecArray | null = scanner.exec(block[1] as string);
+  while (match !== null) {
+    patterns.push(match[1] as string);
+    match = scanner.exec(block[1] as string);
+  }
+  return patterns;
+}
+
+// The column an emitted pattern pulls out of `text`, or null if none matches.
+function columnMatchedBySomePattern(text: string): string | null {
+  for (const pattern of emittedSelectPatterns()) {
+    const match: RegExpMatchArray | null = text.match(new RegExp(pattern));
+    if (match) {
+      return match[1] as string;
+    }
+  }
+  return null;
+}
+
+// The body the API actually puts on the wire for an error message.
+function wireBody(envelope: string, message: string): string {
+  return JSON.stringify({ [envelope]: message });
+}
+
+describe("select-rejection patterns", () => {
+  test("the generator emits a pattern list that can be read back", () => {
+    expect(emittedSelectPatterns().length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("every emitted pattern is a valid regex with one capture group", () => {
+    for (const pattern of emittedSelectPatterns()) {
+      /*
+       * Throws if the emitted Go pattern is not syntax JS can compile too,
+       * which is the premise the behavioural tests below rest on.
+       */
+      expect(() => {
+        return new RegExp(pattern);
+      }).not.toThrow();
+      expect(new RegExp(`|${pattern}`).exec("")).toHaveLength(2);
+    }
+  });
+
+  test.each([
+    ["permission denied", PERMISSION_MESSAGE, "serviceLanguage"],
+    ["unknown column", UNKNOWN_COLUMN_MESSAGE, "enableSearchEngineIndexing"],
+    ["analytics unknown column", ANALYTICS_UNKNOWN_COLUMN_MESSAGE, "spanId"],
+  ])(
+    "extracts the column from the decoded %s message",
+    (_name: string, message: string, column: string) => {
+      expect(columnMatchedBySomePattern(message)).toBe(column);
+    },
+  );
+
+  /*
+   * The defect the issue's own suggested patch would have shipped. The client
+   * decodes before matching, so this is belt and braces — but a pattern that
+   * cannot survive an escaped body is one refactor away from being matched
+   * against raw bytes again, which is exactly how this started.
+   */
+  test.each([
+    ["permission denied", PERMISSION_MESSAGE, "serviceLanguage"],
+    ["unknown column", UNKNOWN_COLUMN_MESSAGE, "enableSearchEngineIndexing"],
+    ["analytics unknown column", ANALYTICS_UNKNOWN_COLUMN_MESSAGE, "spanId"],
+  ])(
+    "extracts the column from the JSON-encoded %s body, quotes escaped and all",
+    (_name: string, message: string, column: string) => {
+      for (const envelope of ["error", "message"]) {
+        expect(columnMatchedBySomePattern(wireBody(envelope, message))).toBe(
+          column,
+        );
+      }
+    },
+  );
+
+  test("the JSON-encoded unknown-column body really does escape its quotes", () => {
+    /*
+     * Guards the test above from quietly becoming a duplicate of the decoded
+     * one if the server ever stops quoting the column name.
+     */
+    expect(wireBody("error", UNKNOWN_COLUMN_MESSAGE)).toContain(
+      '\\"enableSearchEngineIndexing\\"',
+    );
+  });
+
+  test("a query-clause rejection is not treated as a select rejection", () => {
+    /*
+     * "permissions to query on - name" is one word away from the select
+     * phrasing. Dropping a query column would change which rows come back,
+     * which is worse than the error it would be papering over.
+     */
+    expect(
+      columnMatchedBySomePattern(
+        "You do not have permissions to query on - name. You need any one of these permissions: Project Owner",
+      ),
+    ).toBeNull();
+  });
+
+  test("an unrelated bad request names no column", () => {
+    expect(
+      columnMatchedBySomePattern(
+        wireBody("error", "Project ID not found in the request."),
+      ),
+    ).toBeNull();
+  });
+
+  test("the remediation tail is never mistaken for the rejected column", () => {
+    /*
+     * The unknown-column message ends "...you can select on instead: _id,
+     * createdAt". A pattern reaching into that tail would drop a column the
+     * server was recommending, and the retry would make things worse.
+     */
+    expect(columnMatchedBySomePattern(UNKNOWN_COLUMN_MESSAGE)).not.toBe("_id");
+  });
+});
+
+describe("PostWithSelect", () => {
+  test("matches against the decoded message, never the raw body", () => {
+    /*
+     * The single most important line in the fix. Matching FindSubmatch(body)
+     * puts the patterns back in front of JSON-escaped bytes.
+     */
+    expect(clientGo).toContain("message := apiErrorMessage(body)");
+    expect(clientGo).not.toContain("FindSubmatch(body)");
+  });
+
+  test("both entry points exist and PostWithSelect delegates", () => {
+    expect(clientGo).toContain(
+      "func (c *Client) PostWithSelect(ctx context.Context, path string, selectParam interface{}) (*http.Response, error) {",
+    );
+    expect(clientGo).toContain(
+      "func (c *Client) PostBodyWithSelect(ctx context.Context, path string, requestBody map[string]interface{}) (*http.Response, error) {",
+    );
+
+    const postWithSelect: string = clientGo.slice(
+      clientGo.indexOf("func (c *Client) PostWithSelect("),
+      clientGo.indexOf("func (c *Client) PostBodyWithSelect("),
+    );
+    expect(postWithSelect).toContain("return c.PostBodyWithSelect(ctx, path,");
+  });
+
+  test("retries reuse the caller's body instead of rebuilding a select-only one", () => {
+    /*
+     * The by-name data source lookup sends query and limit next to the select.
+     * A retry that rebuilt the body from the select alone would drop the query
+     * and match an arbitrary row.
+     */
+    const postBodyWithSelect: string = clientGo.slice(
+      clientGo.indexOf("func (c *Client) PostBodyWithSelect("),
+    );
+    const loopBody: string = postBodyWithSelect.slice(
+      0,
+      postBodyWithSelect.indexOf("\n}"),
+    );
+    expect(loopBody).toContain(
+      'resp, err := c.DoRequest(ctx, "POST", path, requestBody)',
+    );
+    expect(loopBody).toContain(
+      'requestBody["select"].(map[string]interface{})',
+    );
+  });
+
+  test("a dropped column is reported rather than swallowed", () => {
+    /*
+     * A silently dropped column leaves its attribute null in state, which
+     * surfaces much later as an inconsistent-result-after-apply or a phantom
+     * diff. The warning is what makes that traceable.
+     */
+    expect(clientGo).toContain("tflog.Warn(ctx,");
+    expect(clientGo).toContain(
+      '"github.com/hashicorp/terraform-plugin-log/tflog"',
+    );
+  });
+
+  test("the retry stays bounded", () => {
+    expect(clientGo).toContain("maxAttempts := 8");
+    expect(clientGo).toContain(
+      "for attempt := 0; attempt < maxAttempts; attempt++ {",
+    );
+  });
+
+  test("a consumed error body is put back before the response is returned", () => {
+    expect(clientGo).toContain(
+      "resp.Body = io.NopCloser(bytes.NewReader(body))",
+    );
+  });
+});
+
+describe("data source lookups", () => {
+  test("the by-id lookup drops rejected select columns", () => {
+    expect(monitorDataSourceGo).toContain(
+      "d.client.PostWithSelect(ctx, readPath, selectParam)",
+    );
+  });
+
+  test("the by-name lookup drops them too", () => {
+    /*
+     * This path used to post through the plain client, so a permission-gated
+     * or version-skewed column failed the whole lookup with no retry at all —
+     * not even for the phrasing the retry already understood.
+     */
+    expect(monitorDataSourceGo).toContain("d.client.PostBodyWithSelect(ctx,");
+    expect(monitorDataSourceGo).not.toContain("d.client.Post(ctx,");
+  });
+
+  test("the by-name lookup still sends its query and limit", () => {
+    expect(monitorDataSourceGo).toContain('"query": map[string]interface{}{');
+    expect(monitorDataSourceGo).toContain('"limit": 2,');
+  });
+});
+
+describe("static Go test wiring", () => {
+  test("client_test.go is copied into the generated provider", () => {
+    /*
+     * Nothing else guards this. Without the copy, the Go suite that actually
+     * exercises the retry never reaches the tree CI runs `go test` on, and the
+     * loss looks exactly like success.
+     */
+    const copied: string = path.join(
+      outputDir,
+      GENERATED_DIR,
+      "client_test.go",
+    );
+    expect(fs.existsSync(copied)).toBe(true);
+
+    const contents: string = fs.readFileSync(copied, "utf-8");
+    expect(contents).toContain("package provider");
+    expect(contents).toContain("func TestPostWithSelect_DropsUnknownColumn(");
+    expect(contents).toContain(
+      "func TestPostBodyWithSelect_PreservesTheRestOfTheBody(",
+    );
+  });
+
+  test("the copied test targets symbols the generator actually emits", () => {
+    const contents: string = fs.readFileSync(
+      path.join(outputDir, GENERATED_DIR, "client_test.go"),
+      "utf-8",
+    );
+    for (const symbol of [
+      "droppableSelectColumn(",
+      "PostWithSelect(",
+      "PostBodyWithSelect(",
+      "ParseResponse(",
+      "NewClient(",
+    ]) {
+      expect(contents).toContain(symbol);
+      expect(clientGo).toContain(symbol);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3414.

## The reported bug is real

`Client.PostWithSelect` drops a column the server refuses from the `select` and retries, so a permission-gated or version-skewed column costs one attribute instead of failing the whole read. It matched only the permission phrasing (`...select on - <col>`), so the unknown-column phrasing a deployment older than the provider returns hard-failed every plan touching that resource.

Verified against the code: both phrasings exist (`SelectPermission.ts:52/61`, `AnalyticsDatabase/ModelPermission.ts:613/622`), both statuses (400 / 422) are inside the retry's gate, and a non-match returns immediately.

## The suggested patch does not work

The issue (and #3415) proposed:

```go
var unknownSelectColumn = regexp.MustCompile(`Cannot select on "([A-Za-z0-9_]+)"`)
```

The match ran against the **raw response body**, and the API JSON-encodes its errors:

```
{"error":"... Cannot select on \"enableSearchEngineIndexing\". ..."}
                                ^^                            ^^
```

A backslash sits where the pattern needs a bare quote, so it never fires. It went unnoticed because the permission phrasing contains no quotes to escape. Measured, not argued: run the new Go suite against the old code and 13 cases fail; against the proposed patch, **12 still fail**.

## What this does instead

- Matching runs over `apiErrorMessage(body)` — already present, and already handles both envelopes the API uses (`{"error"}` from the express handler, `{"message"}` from `Response.sendErrorResponse`). Patterns still tolerate an escaped quote for a body no decoder can unwrap.
- Adds the ClickHouse phrasing, `Unknown column: <col>`.
- The **by-name data source lookup** posted its select through the plain client, so it had no drop-and-retry at all — not even for the phrasing that already worked. `PostWithSelect` now delegates to `PostBodyWithSelect`, which retries the caller's own body, so the by-name lookup's `query` and `limit` survive untouched.
- A dropped column was entirely silent; it now logs which column and why.
- The analytics copy of the message joined column **objects**, so its "here are the columns you can select on instead" list read `[object Object], [object Object]`.

## Tests

Three layers, because the near-miss above is invisible to two of them:

| | cases | what it proves |
|---|---|---|
| `StaticFiles/client_test.go` | 26 | the real retry loop against `httptest`, with bodies encoded the way the server encodes them |
| `Tests/ProviderGenerator.test.ts` | 23 | the emitted Go patterns compiled as JS RegExps and run over the real messages, decoded **and** on-the-wire; also pins the copy of `client_test.go` into the generated tree |
| `SelectRejectionMessageContract.test.ts` | 14 | drives the real permission gates and runs the provider's own patterns over whatever they throw, so rewording a server message fails here rather than in someone's `terraform plan` |

Mutation-checked: reverting the decode, or swapping in the bare-quote pattern, each fails the suite.

Verified locally with a real Go toolchain: `go build`, `go vet`, and `go test -race -count=3` clean on a generated provider; `npm test` in `Scripts/TerraformProvider` 129 passed; `Common` permissions + analytics suites 920 passed; eslint clean.

## Not in this PR

- `App/FeatureSet/MCP/Services/OneUptimeApiService.ts` has the identical single-phrasing gap. Left out deliberately: its select can be caller-supplied, so silently dropping an unknown column would hide an agent's typo. The right fix scopes the drop to the auto-generated select, which is its own decision.
- A dropped column is written to state as null, which can surface later as an inconsistent-result-after-apply. That mechanism is pre-existing (the permission path has always behaved this way); this change widens its reach. Surfacing dropped columns as a Terraform warning diagnostic is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABB9sCMaBwLrFTFZDXCtP8