### PR TITLE
fix(enterprise-license): create a licence instead of answering Server Error

### DIFF
--- a/App/Tests/AdminDashboard/EnterpriseLicenseCreateWiring.test.ts
+++ b/App/Tests/AdminDashboard/EnterpriseLicenseCreateWiring.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import nodePath from "path";
+import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import EnterpriseLicense from "Common/Models/DatabaseModels/EnterpriseLicense";
+import { JSONObject } from "Common/Types/JSON";
+
+/*
+ * "I'm not able to create enterprise licenses in master admin dashboard. It
+ * says server error."
+ *
+ * Every create the admin form made answered HTTP 500 and wrote a licence row
+ * anyway. Expires At is a `FormFieldSchemaType.Date` field, a DOM input whose
+ * value is the string "YYYY-MM-DD"; that string travelled all the way onto the
+ * saved model, because TypeORM's save() returns the entity it was handed. The
+ * post-create hook then called `.toISOString()` on it, threw a TypeError after
+ * the INSERT had committed, and a TypeError is not something
+ * PostgresErrorTranslator turns into a readable 400 — so it reached the admin
+ * as a bare "Server Error" while duplicate licences piled up behind it.
+ *
+ * The admin dashboard has no React render harness (App's jest environment is
+ * "node" and the package carries no react/testing-library), so the page's
+ * wiring is asserted against the source text the way the other AdminDashboard
+ * suites do. The runtime half — that the values those declared fields produce
+ * survive the trip onto a model — is exercised against the real model below,
+ * so a field added to this form later cannot quietly reintroduce the same
+ * mismatch.
+ */
+
+const ADMIN_DASHBOARD_SRC: string = nodePath.join(
+  __dirname,
+  "../../FeatureSet/AdminDashboard/src",
+);
+
+type StripCommentsFunction = (source: string) => string;
+
+const stripComments: StripCommentsFunction = (source: string): string => {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+};
+
+const pageSource: string = stripComments(
+  fs.readFileSync(
+    nodePath.join(ADMIN_DASHBOARD_SRC, "Pages/EnterpriseLicenses/Index.tsx"),
+    "utf8",
+  ),
+);
+
+describe("Admin Dashboard > Enterprise Licenses > create", () => {
+  describe("the create form's wiring", () => {
+    test("offers creation from the licences table", () => {
+      expect(pageSource).toContain("isCreateable={true}");
+    });
+
+    /*
+     * The field type that produces the string at the centre of this bug. It is
+     * the correct choice for an expiry — it is pinned so the runtime
+     * assertions below stay tied to what the form actually renders, not to a
+     * type it used to have.
+     */
+    test("collects the expiry through a date field", () => {
+      // Scoped to the create form: expiresAt is also selected and filtered on.
+      const formFields: string = (
+        pageSource.split("formFields={[")[1] || ""
+      ).split("selectMoreFields=")[0] as string;
+
+      const expiresAtField: string =
+        formFields.split("expiresAt: true")[1] || "";
+
+      expect(expiresAtField).toContain("FormFieldSchemaType.Date");
+    });
+
+    test("auto-generates a licence key when the admin leaves it blank", () => {
+      expect(pageSource).toContain("onBeforeCreate");
+      expect(pageSource).toContain("item.licenseKey = UUID.generate()");
+    });
+  });
+
+  /*
+   * The form's values, as the browser produces them: every scalar that came
+   * from a DOM input is a string. This is the payload BaseAPI rebuilds a model
+   * from, so what the model holds afterwards is what every server-side hook
+   * sees.
+   */
+  describe("what the posted form becomes on the server", () => {
+    const postedForm: JSONObject = {
+      companyName: "Acme, Inc.",
+      email: "buyer@acme.com",
+      licenseKey: "b6f4c1a2-1111-2222-3333-444455556666",
+      expiresAt: "2027-01-01",
+      isEvaluationLicense: false,
+      userLimit: "50",
+      annualContractValue: "12000",
+    };
+
+    type BuildLicenseFunction = () => EnterpriseLicense;
+
+    const buildLicense: BuildLicenseFunction = (): EnterpriseLicense => {
+      return BaseModel.fromJSON(
+        postedForm,
+        EnterpriseLicense,
+      ) as EnterpriseLicense;
+    };
+
+    test("holds the expiry as a Date, not the string the input gave", () => {
+      const license: EnterpriseLicense = buildLicense();
+
+      expect(license.expiresAt).toBeInstanceOf(Date);
+      expect(license.expiresAt!.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+    });
+
+    /*
+     * The exact call that threw. A hook running after the row is committed
+     * must be able to make this call on the licence it is handed.
+     */
+    test("is safe for a post-create hook to read the expiry off", () => {
+      const license: EnterpriseLicense = buildLicense();
+
+      expect(() => {
+        return license.expiresAt!.toISOString();
+      }).not.toThrow();
+    });
+
+    test("holds the numeric fields as numbers", () => {
+      const license: EnterpriseLicense = buildLicense();
+
+      expect(license.userLimit).toBe(50);
+      expect(license.annualContractValue).toBe(12000);
+    });
+
+    test("keeps the text fields as typed", () => {
+      const license: EnterpriseLicense = buildLicense();
+
+      expect(license.companyName).toBe("Acme, Inc.");
+      expect(license.licenseKey).toBe("b6f4c1a2-1111-2222-3333-444455556666");
+      expect(license.isEvaluationLicense).toBe(false);
+    });
+
+    /*
+     * The minimum the form can submit: company name and expiry, with the key
+     * left blank for onBeforeCreate to fill in. This is the shape the reported
+     * failure was reproduced with.
+     */
+    test("works with only the required fields filled in", () => {
+      const license: EnterpriseLicense = BaseModel.fromJSON(
+        { companyName: "Acme, Inc.", expiresAt: "2027-01-01" },
+        EnterpriseLicense,
+      ) as EnterpriseLicense;
+
+      expect(license.expiresAt).toBeInstanceOf(Date);
+      expect(license.companyName).toBe("Acme, Inc.");
+    });
+  });
+});

--- a/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
+++ b/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
@@ -21,6 +21,10 @@ import {
   coerceNumericColumnValue,
   isNumericTableColumnType,
 } from "../../../Types/Database/NumericColumnValue";
+import {
+  coerceDateColumnValue,
+  isDateTableColumnType,
+} from "../../../Types/Database/DateColumnValue";
 import { getFirstColorFieldColumn } from "../../../Types/Database/ColorField";
 import Dictionary from "../../../Types/Dictionary";
 import Email from "../../../Types/Email";
@@ -768,6 +772,15 @@ export default class DatabaseBaseModel extends BaseEntity {
            * it. See Types/Database/NumericColumnValue.
            */
           (baseModel as any)[key] = coerceNumericColumnValue(json[key]);
+        } else if (isDateTableColumnType(tableColumnMetadata.type)) {
+          /*
+           * An `<input type="date">` hands back a string too, and until this
+           * ran a date column held that string all the way through the save —
+           * TypeORM returns the entity it was given, so a hook reading the
+           * saved row got "2027-01-01" where it expected a Date. See
+           * Types/Database/DateColumnValue.
+           */
+          (baseModel as any)[key] = coerceDateColumnValue(json[key]);
         } else {
           (baseModel as any)[key] = json[key];
         }

--- a/Common/Server/API/BaseAPI.ts
+++ b/Common/Server/API/BaseAPI.ts
@@ -23,6 +23,7 @@ import {
 } from "../../Types/Database/LimitMax";
 import PartialEntity from "../../Types/Database/PartialEntity";
 import { coerceNumericColumnsInJSON } from "../../Types/Database/NumericColumnValue";
+import { coerceDateColumnsInJSON } from "../../Types/Database/DateColumnValue";
 import BadDataException from "../../Types/Exception/BadDataException";
 import BadRequestException from "../../Types/Exception/BadRequestException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
@@ -468,10 +469,20 @@ export default class BaseAPI<
      * coerce them — a sample percentage of "10" was rejected as "not a
      * number" on a form that had one filled in.
      * github.com/OneUptime/oneuptime/issues/3027
+     *
+     * Date columns have the same problem for the same reason: an
+     * `<input type="date">` posts "2027-01-01", and a hook that reads the
+     * column back gets a string where it expects a Date. See
+     * Types/Database/DateColumnValue.
      */
-    const item: PartialEntity<TBaseModel> = coerceNumericColumnsInJSON(
-      JSONFunctions.deserialize(dataInBody as JSONObject),
-      new this.entityType(),
+    const entityModel: TBaseModel = new this.entityType();
+
+    const item: PartialEntity<TBaseModel> = coerceDateColumnsInJSON(
+      coerceNumericColumnsInJSON(
+        JSONFunctions.deserialize(dataInBody as JSONObject),
+        entityModel,
+      ),
+      entityModel,
     ) as PartialEntity<TBaseModel>;
 
     delete (item as any)["_id"];

--- a/Common/Server/Services/EnterpriseLicenseService.ts
+++ b/Common/Server/Services/EnterpriseLicenseService.ts
@@ -3,6 +3,7 @@ import EnterpriseLicense from "../../Models/DatabaseModels/EnterpriseLicense";
 import MarketingEventUtil from "../Utils/Marketing/MarketingEventUtil";
 import { MarketingEventType } from "../../Types/Marketing/MarketingEvent";
 import { OnCreate } from "../Types/Database/Hooks";
+import OneUptimeDate from "../../Types/Date";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 
 export class Service extends DatabaseService<EnterpriseLicense> {
@@ -29,8 +30,8 @@ export class Service extends DatabaseService<EnterpriseLicense> {
      * reported honestly rather than defaulted to zero, which would quietly
      * drag reported contract value down.
      */
-    MarketingEventUtil.emitInBackground(
-      MarketingEventUtil.buildEvent({
+    MarketingEventUtil.emitInBackground(() => {
+      return MarketingEventUtil.buildEvent({
         eventType: MarketingEventType.EnterpriseLicenseIssued,
         eventId: `${MarketingEventType.EnterpriseLicenseIssued}:${createdItem.id?.toString()}`,
         occurredAt: createdItem.createdAt || new Date(),
@@ -56,12 +57,19 @@ export class Service extends DatabaseService<EnterpriseLicense> {
             createdItem.userLimit === null
               ? null
               : createdItem.userLimit,
-          expiresAt: createdItem.expiresAt
-            ? createdItem.expiresAt.toISOString()
-            : null,
+          /*
+           * Read through OneUptimeDate rather than calling toISOString on the
+           * column directly. TypeORM's save() returns the entity it was handed,
+           * so this is whatever the caller supplied — a Date from the coercion
+           * in BaseModel.fromJSON, but a raw string from any caller that skips
+           * it. This hook runs AFTER the INSERT has committed, so a TypeError
+           * here does not undo the licence: it only turns a licence that exists
+           * into a "Server Error" the admin retries, creating another one.
+           */
+          expiresAt: OneUptimeDate.toIsoStringOrNull(createdItem.expiresAt),
         },
-      }),
-    );
+      });
+    });
 
     return createdItem;
   }

--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -979,14 +979,20 @@ These are no longer recorded against the project and have to be cancelled by han
       properties["currency"] = "USD";
     }
 
+    /*
+     * Captured before the deferred builder below closes over it: the narrowing
+     * from the createdOwnerEmail guard above does not survive into a callback.
+     */
+    const ownerEmail: string = data.project.createdOwnerEmail.toString();
+
     ProductAnalytics.capture({
       event: "server/subscription_started",
-      distinctId: data.project.createdOwnerEmail.toString(),
+      distinctId: ownerEmail,
       properties: properties,
     });
 
-    MarketingEventUtil.emitInBackground(
-      MarketingEventUtil.buildEvent({
+    MarketingEventUtil.emitInBackground(() => {
+      return MarketingEventUtil.buildEvent({
         eventType: MarketingEventType.SubscriptionStarted,
         /*
          * Naturally unique: a project has exactly one first subscription, so a
@@ -996,11 +1002,11 @@ These are no longer recorded against the project and have to be cancelled by han
          */
         eventId: `${MarketingEventType.SubscriptionStarted}:${data.project.id?.toString()}`,
         occurredAt: data.project.createdAt || new Date(),
-        email: data.project.createdOwnerEmail.toString(),
+        email: ownerEmail,
         attributionSource: data.project,
         data: properties,
-      }),
-    );
+      });
+    });
   }
 
   /*
@@ -1138,8 +1144,8 @@ These are no longer recorded against the project and have to be cancelled by han
 
     const occurredAt: Date = new Date();
 
-    MarketingEventUtil.emitInBackground(
-      MarketingEventUtil.buildEvent({
+    MarketingEventUtil.emitInBackground(() => {
+      return MarketingEventUtil.buildEvent({
         eventType: eventType,
         /*
          * A project can legitimately upgrade, downgrade and upgrade again, so
@@ -1151,8 +1157,8 @@ These are no longer recorded against the project and have to be cancelled by han
         email: data.project.createdOwnerEmail?.toString(),
         attributionSource: data.project,
         data: data.properties,
-      }),
-    );
+      });
+    });
   }
 
   private async sendSubscriptionChangeWebhookSlackNotification(

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -239,9 +239,16 @@ export class Service extends DatabaseService<Model> {
      * direct signups (true) from invited users (false).
      */
     if (createdItem.email) {
+      /*
+       * Captured before the deferred builder below closes over it: the
+       * narrowing this `if` gives us does not survive into a callback, and
+       * `email` is what makes the signup conversion joinable at all.
+       */
+      const signUpEmail: string = createdItem.email.toString();
+
       ProductAnalytics.capture({
         event: "server/user_created",
-        distinctId: createdItem.email.toString(),
+        distinctId: signUpEmail,
         properties: {
           has_password: Boolean(createdItem.password),
           ...utmAnalyticsProperties(createdItem as unknown as JSONObject),
@@ -263,19 +270,19 @@ export class Service extends DatabaseService<Model> {
        * users, only one is an acquisition, and the receiver decides which it
        * cares about rather than us deciding for it here.
        */
-      MarketingEventUtil.emitInBackground(
-        MarketingEventUtil.buildEvent({
+      MarketingEventUtil.emitInBackground(() => {
+        return MarketingEventUtil.buildEvent({
           eventType: MarketingEventType.SignUp,
           eventId: `${MarketingEventType.SignUp}:${createdItem.id?.toString()}`,
           occurredAt: createdItem.createdAt || new Date(),
-          email: createdItem.email.toString(),
+          email: signUpEmail,
           attributionSource: createdItem,
           data: {
             userId: createdItem.id?.toString() || "",
             hasPassword: Boolean(createdItem.password),
           },
-        }),
-      );
+        });
+      });
     }
 
     // A place holder method used for overriding.

--- a/Common/Server/Utils/Marketing/MarketingEventUtil.ts
+++ b/Common/Server/Utils/Marketing/MarketingEventUtil.ts
@@ -163,21 +163,50 @@ export default class MarketingEventUtil {
    *
    * Guarantees it neither throws nor rejects. Every caller is inside a
    * commercial transaction that has already succeeded by the time it gets
-   * here — a user is created, a plan is changed, a booking is verified — so
-   * the one thing this must never do is turn a completed action into a failed
-   * one. The rejection path is covered by .catch and the synchronous path by
-   * the try, because an argument expression that throws (buildEvent on a
-   * malformed row) would otherwise propagate straight into the caller.
+   * here — a user is created, a plan is changed, a licence is issued — so the
+   * one thing this must never do is turn a completed action into a failed one.
+   *
+   * PASS A BUILDER, NOT AN EVENT. `emitInBackground(buildEvent({...}))`
+   * evaluates the argument at the CALL SITE, outside this try, so anything
+   * that throws while assembling the event propagates straight into the caller
+   * and this wrapper never runs at all. That is not hypothetical: reading
+   * `createdItem.expiresAt.toISOString()` off a licence whose date column held
+   * a string threw a TypeError after the INSERT had committed, and the admin
+   * dashboard reported "Server Error" for a licence it had just created. The
+   * `() => MarketingEvent` form moves that work inside the try, which is what
+   * makes the guarantee above true rather than merely intended.
+   *
+   * A plain event is still accepted for callers that already hold one.
    */
-  public static emitInBackground(event: MarketingEvent): void {
+  public static emitInBackground(
+    event: MarketingEvent | (() => MarketingEvent),
+  ): void {
+    let builtEvent: MarketingEvent | null = null;
+
     try {
-      this.emit(event).catch((err: Error) => {
+      builtEvent = typeof event === "function" ? event() : event;
+
+      const eventToEmit: MarketingEvent = builtEvent;
+
+      this.emit(eventToEmit).catch((err: Error) => {
+        /*
+         * Optional, because the point of this method is that nothing it
+         * touches may throw: a builder that returned something malformed must
+         * still end as a log line, not as an unhandled rejection raised from
+         * inside the handler that exists to prevent one.
+         */
         logger.error(
-          `MarketingEvent: failed to emit ${event.eventType}: ${err}`,
+          `MarketingEvent: failed to emit ${
+            eventToEmit?.eventType || "event"
+          }: ${err}`,
         );
       });
     } catch (err) {
-      logger.error(`MarketingEvent: failed to emit ${event.eventType}: ${err}`);
+      logger.error(
+        `MarketingEvent: failed to emit ${
+          builtEvent?.eventType || "event"
+        }: ${err}`,
+      );
     }
   }
 }

--- a/Common/Tests/Models/DatabaseModels/DateColumnDeserialization.test.ts
+++ b/Common/Tests/Models/DatabaseModels/DateColumnDeserialization.test.ts
@@ -1,0 +1,182 @@
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import EnterpriseLicense from "../../../Models/DatabaseModels/EnterpriseLicense";
+import ScheduledMaintenance from "../../../Models/DatabaseModels/ScheduledMaintenance";
+import { JSONObject } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import OneUptimeDate from "../../../Types/Date";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — what a date column holds after a JSON round trip.
+ *
+ * `BaseModel.fromJSON` is the single door every model comes through, and it
+ * runs on BOTH sides of the wire: ModelForm builds the model it is about to
+ * POST with it, and BaseAPI rebuilds that model from the request body with
+ * it. That makes it the one place that can fix the following, once.
+ *
+ * HTML has no Date input event — `<input type="date">` gives you
+ * `e.target.value`, the string "YYYY-MM-DD" — so the dashboard posted a plain
+ * string for every date field in the product. Postgres parses that string on
+ * the way in, so it was invisible everywhere except where something reads the
+ * column back off the saved model: TypeORM's `save()` returns the entity it
+ * was handed, never a re-read row.
+ *
+ * EnterpriseLicenseService.onCreateSuccess does exactly that, and creating an
+ * enterprise licence in the admin dashboard answered:
+ *
+ *   HTTP 500 — Server Error
+ *
+ * for every attempt, having written a licence row for every attempt, because
+ * `createdItem.expiresAt.toISOString()` was called on a string after the
+ * INSERT had committed.
+ */
+
+describe("BaseModel.fromJSON on date columns", () => {
+  /*
+   * The reported payload, exactly as the admin dashboard's Enterprise
+   * Licenses form sends it: expiresAt comes from an <input type="date">, so
+   * it is the string "YYYY-MM-DD".
+   */
+  it("turns the admin licence form's payload into a real Date", () => {
+    const posted: JSONObject = {
+      companyName: "Acme, Inc.",
+      licenseKey: "b6f4c1a2-1111-2222-3333-444455556666",
+      expiresAt: "2027-01-01",
+      isEvaluationLicense: false,
+    };
+
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      posted,
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.expiresAt).toBeInstanceOf(Date);
+    expect(model.expiresAt!.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  /*
+   * The regression in one line: this is the call that threw, and it has to be
+   * safe on a model built the way the API builds one.
+   */
+  it("leaves the created model safe to call toISOString on", () => {
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      { companyName: "Acme, Inc.", expiresAt: "2027-01-01" },
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(() => {
+      return model.expiresAt!.toISOString();
+    }).not.toThrow();
+  });
+
+  it("does the same for a datetime-local field on another model", () => {
+    const model: ScheduledMaintenance = BaseModel.fromJSON(
+      {
+        title: "Database upgrade",
+        startsAt: "2027-01-01T10:30",
+        endsAt: "2027-01-01T12:00",
+      },
+      ScheduledMaintenance,
+    ) as ScheduledMaintenance;
+
+    expect(model.startsAt).toBeInstanceOf(Date);
+    expect(model.startsAt!.toISOString()).toBe("2027-01-01T10:30:00.000Z");
+    expect(model.endsAt).toBeInstanceOf(Date);
+    expect(model.endsAt!.toISOString()).toBe("2027-01-01T12:00:00.000Z");
+  });
+
+  /*
+   * The path that always worked — a Date serialized by JSONFunctions into
+   * { _type: "DateTime", value } — must keep working. Coercion sits after
+   * deserialization, so by the time it runs this is already a Date and it has
+   * nothing to do.
+   */
+  it("still handles the serialized DateTime wrapper", () => {
+    const expiresAt: Date = new Date("2027-03-04T05:06:07.000Z");
+
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      JSONFunctions.serialize({
+        companyName: "Acme, Inc.",
+        expiresAt: expiresAt,
+      }),
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.expiresAt).toBeInstanceOf(Date);
+    expect(model.expiresAt!.getTime()).toBe(expiresAt.getTime());
+  });
+
+  it("passes a Date straight through", () => {
+    const expiresAt: Date = new Date("2027-03-04T05:06:07.000Z");
+
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      { companyName: "Acme, Inc.", expiresAt: expiresAt } as JSONObject,
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.expiresAt).toBeInstanceOf(Date);
+    expect(model.expiresAt!.getTime()).toBe(expiresAt.getTime());
+  });
+
+  /*
+   * The instant that reaches Postgres must not move. An offset-less literal
+   * in a timestamptz column is parsed in the session timezone — UTC in every
+   * OneUptime deployment — so the coerced Date has to be the same instant the
+   * raw string used to become.
+   */
+  it("produces the instant Postgres produced from the same string", () => {
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      { expiresAt: "2027-01-01" },
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.expiresAt!.toISOString()).toBe(
+      OneUptimeDate.fromString("2027-01-01T00:00:00Z").toISOString(),
+    );
+  });
+
+  it("does not touch the other columns on the way past", () => {
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      {
+        companyName: "Acme, Inc.",
+        email: "buyer@acme.com",
+        licenseKey: "key-1",
+        expiresAt: "2027-01-01",
+        userLimit: "50",
+        annualContractValue: "12000",
+        isEvaluationLicense: true,
+      },
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.companyName).toBe("Acme, Inc.");
+    expect(model.licenseKey).toBe("key-1");
+    expect(model.userLimit).toBe(50);
+    expect(model.annualContractValue).toBe(12000);
+    expect(model.isEvaluationLicense).toBe(true);
+    expect(model.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("leaves a cleared date field alone rather than inventing an epoch", () => {
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      { companyName: "Acme, Inc.", expiresAt: "" },
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.expiresAt).toBe("");
+  });
+
+  /*
+   * An unparseable date is left as the string it was, so the required-field
+   * and database layers report the field. Inventing a date here would store a
+   * silently wrong expiry on a licence.
+   */
+  it("leaves an unparseable date alone so validation reports it", () => {
+    const model: EnterpriseLicense = BaseModel.fromJSON(
+      { companyName: "Acme, Inc.", expiresAt: "not-a-date" },
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect(model.expiresAt).toBe("not-a-date");
+  });
+});

--- a/Common/Tests/Server/API/BaseAPIUpdateDateColumns.test.ts
+++ b/Common/Tests/Server/API/BaseAPIUpdateDateColumns.test.ts
@@ -1,0 +1,154 @@
+import BaseAPI from "../../../Server/API/BaseAPI";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import {
+  ExpressResponse,
+  OneUptimeRequest,
+} from "../../../Server/Utils/Express";
+import { mockRouter } from "./Helpers";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { JSONObject } from "../../../Types/JSON";
+import EnterpriseLicense from "../../../Models/DatabaseModels/EnterpriseLicense";
+import { getJestSpyOn } from "../../Spy";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+/*
+ * PUT /<model>/:id never builds a model — it goes from the request body
+ * straight to a partial entity — so it does not get BaseModel.fromJSON's
+ * coercion for free the way POST does. Without the same normalization here, a
+ * PUT and a POST disagree about whether "2027-01-01" is a Date, and the
+ * save-time hooks see a different type depending on which verb the caller
+ * used. That is the same split that made a number column arrive as the string
+ * "10" on one path and the number 10 on the other.
+ */
+
+const TEST_ID: string = "550e8400-e29b-41d4-a716-446655440009";
+
+describe("BaseAPI.updateItem date column coercion", () => {
+  let service: DatabaseService<EnterpriseLicense>;
+  let api: BaseAPI<EnterpriseLicense, DatabaseService<EnterpriseLicense>>;
+  let response: ExpressResponse;
+
+  type RequestWithDataFunction = (data: JSONObject) => OneUptimeRequest;
+
+  const requestWithData: RequestWithDataFunction = (
+    data: JSONObject,
+  ): OneUptimeRequest => {
+    return {
+      params: { id: TEST_ID },
+      body: { data: data },
+      headers: {},
+    } as unknown as OneUptimeRequest;
+  };
+
+  type UpdatedDataFunction = () => JSONObject;
+
+  const updatedData: UpdatedDataFunction = (): JSONObject => {
+    const call: Array<unknown> = (service.updateOneById as unknown as jest.Mock)
+      .mock.calls[0] as Array<unknown>;
+
+    return (call[0] as { data: JSONObject }).data;
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    service = new DatabaseService<EnterpriseLicense>(EnterpriseLicense);
+    api = new BaseAPI<EnterpriseLicense, DatabaseService<EnterpriseLicense>>(
+      EnterpriseLicense,
+      service,
+    );
+
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+
+    getJestSpyOn(service, "updateOneById").mockResolvedValue(1);
+  });
+
+  it("turns the date string an edit form posts into a Date", async () => {
+    await api.updateItem(
+      requestWithData({ expiresAt: "2028-06-30" }),
+      response,
+    );
+
+    const data: JSONObject = updatedData();
+
+    expect(data["expiresAt"]).toBeInstanceOf(Date);
+    expect((data["expiresAt"] as Date).toISOString()).toBe(
+      "2028-06-30T00:00:00.000Z",
+    );
+  });
+
+  it("agrees with what a POST of the same value would have produced", async () => {
+    await api.updateItem(
+      requestWithData({ expiresAt: "2028-06-30" }),
+      response,
+    );
+
+    const created: EnterpriseLicense = EnterpriseLicense.fromJSON(
+      { expiresAt: "2028-06-30" },
+      EnterpriseLicense,
+    ) as EnterpriseLicense;
+
+    expect((updatedData()["expiresAt"] as Date).getTime()).toBe(
+      created.expiresAt!.getTime(),
+    );
+  });
+
+  it("still coerces number columns in the same patch", async () => {
+    await api.updateItem(
+      requestWithData({ expiresAt: "2028-06-30", userLimit: "75" }),
+      response,
+    );
+
+    const data: JSONObject = updatedData();
+
+    expect(data["expiresAt"]).toBeInstanceOf(Date);
+    expect(data["userLimit"]).toBe(75);
+  });
+
+  it("leaves the columns it does not own alone", async () => {
+    await api.updateItem(
+      requestWithData({
+        companyName: "Acme, Inc.",
+        licenseKey: "2028-06-30",
+        isEvaluationLicense: true,
+      }),
+      response,
+    );
+
+    const data: JSONObject = updatedData();
+
+    expect(data["companyName"]).toBe("Acme, Inc.");
+    expect(data["licenseKey"]).toBe("2028-06-30");
+    expect(data["isEvaluationLicense"]).toBe(true);
+  });
+
+  it("keeps an explicit null so a nullable date can be cleared", async () => {
+    await api.updateItem(
+      requestWithData({ userCountUpdatedAt: null }),
+      response,
+    );
+
+    expect(updatedData()["userCountUpdatedAt"]).toBeNull();
+  });
+});

--- a/Common/Tests/Server/Services/EnterpriseLicenseServiceCreate.test.ts
+++ b/Common/Tests/Server/Services/EnterpriseLicenseServiceCreate.test.ts
@@ -1,0 +1,292 @@
+import EnterpriseLicenseService from "../../../Server/Services/EnterpriseLicenseService";
+import MarketingEventUtil from "../../../Server/Utils/Marketing/MarketingEventUtil";
+import EnterpriseLicense from "../../../Models/DatabaseModels/EnterpriseLicense";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Email from "../../../Types/Email";
+import ObjectID from "../../../Types/ObjectID";
+import { JSONObject } from "../../../Types/JSON";
+import { MarketingEvent } from "../../../Types/Marketing/MarketingEvent";
+import { resolveEmittedMarketingEvent } from "../Utils/Marketing/EmittedMarketingEvent";
+import { afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Regression suite for "I'm not able to create enterprise licenses in master
+ * admin dashboard. It says server error."
+ *
+ * The admin form's expiresAt comes from an `<input type="date">`, so it
+ * reached the API as the string "2027-01-01" and stayed a string on the model.
+ * TypeORM's save() hands back the entity it was given rather than a re-read
+ * row, so onCreateSuccess — which runs AFTER the INSERT has committed — called
+ * `.toISOString()` on a string:
+ *
+ *   TypeError: createdItem.expiresAt.toISOString is not a function
+ *
+ * A TypeError is not one of the driver errors PostgresErrorTranslator knows
+ * how to turn into a 400, so it fell through to the generic handler as a bare
+ * 500 "Server Error". Every attempt wrote a licence row and then reported
+ * failure, so an admin retrying piled up duplicates.
+ *
+ * Two things are pinned here, because either one alone closes the hole and
+ * both together mean it cannot reopen from a new direction:
+ *   - the model built from the posted body holds a real Date, and
+ *   - the hook survives a licence whose date column is a string anyway.
+ */
+
+const LICENSE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const CREATED_AT: Date = new Date("2026-08-28T09:00:00.000Z");
+
+type CreatedLicenseFunction = (
+  overrides?: Record<string, unknown>,
+) => EnterpriseLicense;
+
+/*
+ * The row as it comes back out of `repository.save()`: the model the API
+ * built, with an id and createdAt stamped on it.
+ */
+const createdLicense: CreatedLicenseFunction = (
+  overrides?: Record<string, unknown>,
+): EnterpriseLicense => {
+  const license: EnterpriseLicense = new EnterpriseLicense();
+  license._id = LICENSE_ID.toString();
+  license.companyName = "Acme, Inc.";
+  license.licenseKey = "b6f4c1a2-1111-2222-3333-444455556666";
+  license.createdAt = CREATED_AT;
+  license.expiresAt = new Date("2027-01-01T00:00:00.000Z");
+  license.isEvaluationLicense = false;
+
+  Object.assign(license, overrides || {});
+
+  return license;
+};
+
+type RunCreateHookFunction = (
+  createdItem: EnterpriseLicense,
+) => Promise<EnterpriseLicense>;
+
+/*
+ * onCreateSuccess is the hook the create path runs once the row exists; it is
+ * protected, so it is reached the way the framework reaches it.
+ */
+const runCreateHook: RunCreateHookFunction = async (
+  createdItem: EnterpriseLicense,
+): Promise<EnterpriseLicense> => {
+  return await (
+    EnterpriseLicenseService as unknown as {
+      onCreateSuccess: (
+        onCreate: unknown,
+        createdItem: EnterpriseLicense,
+      ) => Promise<EnterpriseLicense>;
+    }
+  ).onCreateSuccess({}, createdItem);
+};
+
+describe("EnterpriseLicenseService create", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("the payload the admin dashboard posts", () => {
+    /*
+     * Straight from App/FeatureSet/AdminDashboard Pages/EnterpriseLicenses:
+     * Company Name is Text, Expires At is Date, User Limit and Annual
+     * Contract Value are PositiveNumber. Every one of those is a DOM input,
+     * so every one of those posts a string.
+     */
+    const postedBody: JSONObject = {
+      companyName: "Acme, Inc.",
+      email: "buyer@acme.com",
+      licenseKey: "b6f4c1a2-1111-2222-3333-444455556666",
+      expiresAt: "2027-01-01",
+      isEvaluationLicense: false,
+      userLimit: "50",
+      annualContractValue: "12000",
+    };
+
+    it("builds a licence whose expiry is a real Date", () => {
+      const license: EnterpriseLicense = BaseModel.fromJSON(
+        postedBody,
+        EnterpriseLicense,
+      ) as EnterpriseLicense;
+
+      expect(license.expiresAt).toBeInstanceOf(Date);
+      expect(license.expiresAt!.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+    });
+
+    it("creates without a server error", async () => {
+      jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      const license: EnterpriseLicense = BaseModel.fromJSON(
+        postedBody,
+        EnterpriseLicense,
+      ) as EnterpriseLicense;
+
+      license._id = LICENSE_ID.toString();
+      license.createdAt = CREATED_AT;
+
+      await expect(runCreateHook(license)).resolves.toBe(license);
+    });
+  });
+
+  describe("the enterprise_license_issued conversion", () => {
+    it("reports the expiry as an ISO instant", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      await runCreateHook(createdLicense());
+
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
+
+      expect(event.eventType).toBe("enterprise_license_issued");
+      expect(event.eventId).toBe(
+        `enterprise_license_issued:${LICENSE_ID.toString()}`,
+      );
+      expect(event.data["expiresAt"]).toBe("2027-01-01T00:00:00.000Z");
+      expect(event.data["companyName"]).toBe("Acme, Inc.");
+    });
+
+    /*
+     * The exact shape that used to throw. A licence created by anything that
+     * does not go through BaseModel.fromJSON — a script, a fixture, a service
+     * assigning the column by hand — still has a string here, and the hook
+     * runs after the row is committed, so it must report the expiry rather
+     * than take the create down with it.
+     */
+    it("survives an expiry that is still a string", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      const license: EnterpriseLicense = createdLicense({
+        expiresAt: "2027-01-01",
+      });
+
+      await expect(runCreateHook(license)).resolves.toBe(license);
+
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
+
+      expect(event.data["expiresAt"]).toBe("2027-01-01T00:00:00.000Z");
+    });
+
+    it("reports a missing expiry as null rather than failing", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      const license: EnterpriseLicense = createdLicense({
+        expiresAt: undefined,
+      });
+
+      await expect(runCreateHook(license)).resolves.toBe(license);
+
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
+
+      expect(event.data["expiresAt"]).toBeNull();
+    });
+
+    it("reports an unusable expiry as null rather than failing", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      const license: EnterpriseLicense = createdLicense({
+        expiresAt: "not-a-date",
+      });
+
+      await expect(runCreateHook(license)).resolves.toBe(license);
+
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
+
+      expect(event.data["expiresAt"]).toBeNull();
+    });
+
+    /*
+     * The two nulls are reported honestly rather than defaulted to zero,
+     * which would quietly drag reported contract value down.
+     */
+    it("reports an absent contract value and seat limit as null", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      await runCreateHook(createdLicense());
+
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
+
+      expect(event.data["annualContractValueInUSD"]).toBeNull();
+      expect(event.data["userLimit"]).toBeNull();
+      expect(event.data["currency"]).toBe("USD");
+    });
+
+    it("carries the licence's contact email so the conversion can be joined", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      await runCreateHook(
+        createdLicense({
+          email: new Email("buyer@acme.com"),
+          annualContractValue: 12000,
+          userLimit: 50,
+          isEvaluationLicense: true,
+        }),
+      );
+
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
+
+      expect(event.email).toBe("buyer@acme.com");
+      expect(event.data["annualContractValueInUSD"]).toBe(12000);
+      expect(event.data["userLimit"]).toBe(50);
+      expect(event.data["isEvaluationLicense"]).toBe(true);
+    });
+
+    /*
+     * Deferred, not built at the call site. This is what makes
+     * emitInBackground's "never turns a completed action into a failed one"
+     * guarantee real: an argument expression is evaluated by the caller,
+     * outside the wrapper's try, so building the event there is exactly how
+     * the original TypeError escaped.
+     */
+    it("hands emitInBackground a builder rather than a built event", async () => {
+      const emitInBackground: jest.SpyInstance = jest
+        .spyOn(MarketingEventUtil, "emitInBackground")
+        .mockReturnValue(undefined);
+
+      await runCreateHook(createdLicense());
+
+      expect(typeof emitInBackground.mock.calls[0]![0]).toBe("function");
+    });
+
+    /*
+     * The consequence of the line above, end to end: with the real
+     * emitInBackground in place, an event that cannot be assembled at all is
+     * logged and dropped. The licence row exists, so the admin must be told
+     * the licence was created.
+     */
+    it("does not fail the create when the event cannot be built", async () => {
+      jest.spyOn(MarketingEventUtil, "buildEvent").mockImplementation(() => {
+        throw new Error("marketing is having a bad day");
+      });
+
+      const license: EnterpriseLicense = createdLicense();
+
+      await expect(runCreateHook(license)).resolves.toBe(license);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/ProjectServiceChangePlan.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceChangePlan.test.ts
@@ -10,6 +10,7 @@ import logger from "../../../Server/Utils/Logger";
 import MarketingEventUtil from "../../../Server/Utils/Marketing/MarketingEventUtil";
 import ProductAnalytics from "../../../Server/Utils/ProductAnalytics";
 import { MarketingEvent } from "../../../Types/Marketing/MarketingEvent";
+import { resolveEmittedMarketingEvent } from "../Utils/Marketing/EmittedMarketingEvent";
 import { describe, expect, it, afterEach } from "@jest/globals";
 
 /*
@@ -715,7 +716,7 @@ describe("ProjectService.changePlan", () => {
 
       const emittedTypes: Array<string> = emitInBackground.mock.calls.map(
         (call: Array<unknown>) => {
-          return (call[0] as MarketingEvent).eventType as string;
+          return resolveEmittedMarketingEvent(call[0]).eventType as string;
         },
       );
 
@@ -774,8 +775,9 @@ describe("ProjectService.changePlan", () => {
         paymentProviderPlanId: NEW_PLAN_ID,
       });
 
-      const event: MarketingEvent = emitInBackground.mock
-        .calls[0]![0] as MarketingEvent;
+      const event: MarketingEvent = resolveEmittedMarketingEvent(
+        emitInBackground.mock.calls[0]![0],
+      );
 
       expect(event.eventId).toBe(
         `subscription_upgraded:${PROJECT_ID.toString()}:${event.occurredAt}`,

--- a/Common/Tests/Server/Services/ProjectServiceCreateSubscriptionStarted.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceCreateSubscriptionStarted.test.ts
@@ -5,6 +5,7 @@ import ProductAnalytics from "../../../Server/Utils/ProductAnalytics";
 import Project from "../../../Models/DatabaseModels/Project";
 import SubscriptionPlan from "../../../Types/Billing/SubscriptionPlan";
 import { MarketingEvent } from "../../../Types/Marketing/MarketingEvent";
+import { resolveEmittedMarketingEvent } from "../Utils/Marketing/EmittedMarketingEvent";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import { describe, expect, it, afterEach } from "@jest/globals";
@@ -202,7 +203,9 @@ describe("ProjectService project creation - subscription_started", () => {
   }
 
   function getEmittedEvent(spies: CreateSpies): MarketingEvent {
-    return spies.emitInBackground.mock.calls[0]![0] as MarketingEvent;
+    return resolveEmittedMarketingEvent(
+      spies.emitInBackground.mock.calls[0]![0],
+    );
   }
 
   function getEmittedData(spies: CreateSpies): JSONObject {
@@ -298,7 +301,7 @@ describe("ProjectService project creation - subscription_started", () => {
 
       const emittedTypes: Array<string> = spies.emitInBackground.mock.calls.map(
         (call: Array<unknown>) => {
-          return (call[0] as MarketingEvent).eventType as string;
+          return resolveEmittedMarketingEvent(call[0]).eventType as string;
         },
       );
 

--- a/Common/Tests/Server/Utils/Marketing/EmittedMarketingEvent.ts
+++ b/Common/Tests/Server/Utils/Marketing/EmittedMarketingEvent.ts
@@ -1,0 +1,23 @@
+import { MarketingEvent } from "../../../../Types/Marketing/MarketingEvent";
+
+/*
+ * Read the event out of one `emitInBackground` call recorded by a spy.
+ *
+ * Callers pass a `() => MarketingEvent` builder rather than a built event, so
+ * that assembling the event happens inside emitInBackground's try and cannot
+ * turn the already-committed transaction that triggered it into a failure.
+ * A spy therefore records the builder, not the event. Both forms are accepted
+ * here because emitInBackground accepts both.
+ */
+export type ResolveEmittedMarketingEventFunction = (
+  emitted: unknown,
+) => MarketingEvent;
+
+export const resolveEmittedMarketingEvent: ResolveEmittedMarketingEventFunction =
+  (emitted: unknown): MarketingEvent => {
+    if (typeof emitted === "function") {
+      return (emitted as () => MarketingEvent)();
+    }
+
+    return emitted as MarketingEvent;
+  };

--- a/Common/Tests/Server/Utils/Marketing/MarketingEventUtil.test.ts
+++ b/Common/Tests/Server/Utils/Marketing/MarketingEventUtil.test.ts
@@ -298,5 +298,56 @@ describe("MarketingEventUtil", () => {
         );
       }).not.toThrow();
     });
+
+    test("queues the event a builder returns", async () => {
+      MarketingEventUtil.emitInBackground(() => {
+        return MarketingEventUtil.buildEvent({
+          eventType: MarketingEventType.EnterpriseLicenseIssued,
+          eventId: "enterprise_license_issued:l1",
+          occurredAt: new Date("2026-08-28T09:00:00.000Z"),
+        });
+      });
+
+      await Promise.resolve();
+
+      expect(mockAddJob).toHaveBeenCalledTimes(1);
+      expect(mockAddJob.mock.calls[0]![1]).toBe("enterprise_license_issued:l1");
+    });
+
+    /*
+     * The reason the builder form exists at all.
+     * `emitInBackground(buildEvent({...}))` evaluates its argument at the CALL
+     * SITE, so a throw while assembling the event never reaches this try — it
+     * propagates into the caller, which is always a transaction that has
+     * already committed. Reading a date column that held a string is exactly
+     * how that happened: an enterprise licence was written and the admin
+     * dashboard reported "Server Error" for it.
+     */
+    test("never throws when the builder itself throws", () => {
+      expect(() => {
+        MarketingEventUtil.emitInBackground(() => {
+          throw new TypeError(
+            "createdItem.expiresAt.toISOString is not a function",
+          );
+        });
+      }).not.toThrow();
+
+      expect(mockAddJob).not.toHaveBeenCalled();
+    });
+
+    test("still accepts a plain event for callers that already hold one", async () => {
+      MarketingEventUtil.emitInBackground(
+        MarketingEventUtil.buildEvent({
+          eventType: MarketingEventType.SignUp,
+          eventId: "sign_up:u9",
+          occurredAt: new Date("2026-08-28T09:00:00.000Z"),
+        }),
+      );
+
+      await Promise.resolve();
+
+      expect(mockAddJob).toHaveBeenCalledTimes(1);
+      expect(mockAddJob.mock.calls[0]![1]).toBe("sign_up:u9");
+    });
   });
 });

--- a/Common/Tests/Types/Database/DateColumnValue.test.ts
+++ b/Common/Tests/Types/Database/DateColumnValue.test.ts
@@ -1,0 +1,265 @@
+import {
+  coerceDateColumnValue,
+  coerceDateColumnsInJSON,
+  isDateTableColumnType,
+} from "../../../Types/Database/DateColumnValue";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import { JSONObject } from "../../../Types/JSON";
+import EnterpriseLicense from "../../../Models/DatabaseModels/EnterpriseLicense";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — normalizing a JSON value bound for a date column.
+ *
+ * HTML has no Date input event: `<input type="date">` hands back
+ * `e.target.value`, the string "YYYY-MM-DD". So the dashboard posted a plain
+ * string for every date field, `BaseModel.fromJSON` assigned it verbatim, and
+ * Postgres quietly parsed it on the way in — which is why nobody noticed until
+ * something read the column back off the SAVED model. TypeORM's `save()`
+ * returns the entity it was handed, not a re-read row, so:
+ *
+ *   TypeError: createdItem.expiresAt.toISOString is not a function
+ *
+ * thrown from EnterpriseLicenseService.onCreateSuccess, AFTER the INSERT had
+ * committed. Creating an enterprise licence in the admin dashboard answered
+ * "Server Error" every time while writing a licence row every time.
+ */
+
+describe("isDateTableColumnType", () => {
+  it("covers every column type stored as a JS Date", () => {
+    expect(isDateTableColumnType(TableColumnType.Date)).toBe(true);
+  });
+
+  /*
+   * The types that would be destroyed by coercion. Everything numeric, every
+   * string type, and the wrapped objects.
+   */
+  it("excludes types that are not dates", () => {
+    for (const type of [
+      TableColumnType.Number,
+      TableColumnType.SmallNumber,
+      TableColumnType.BigNumber,
+      TableColumnType.PositiveNumber,
+      TableColumnType.Port,
+      TableColumnType.Version,
+      TableColumnType.ShortText,
+      TableColumnType.LongText,
+      TableColumnType.VeryLongText,
+      TableColumnType.Boolean,
+      TableColumnType.ObjectID,
+      TableColumnType.Entity,
+      TableColumnType.EntityArray,
+      TableColumnType.JSON,
+      TableColumnType.Email,
+    ]) {
+      expect(isDateTableColumnType(type)).toBe(false);
+    }
+  });
+
+  it("treats a missing type as not a date", () => {
+    expect(isDateTableColumnType(undefined)).toBe(false);
+    expect(isDateTableColumnType(null)).toBe(false);
+  });
+});
+
+describe("coerceDateColumnValue", () => {
+  it("converts the string an <input type=date> produces", () => {
+    const coerced: unknown = coerceDateColumnValue("2027-01-01");
+
+    expect(coerced).toBeInstanceOf(Date);
+    expect((coerced as Date).toISOString()).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  it("converts the string an <input type=datetime-local> produces", () => {
+    const coerced: unknown = coerceDateColumnValue("2027-01-01T10:30");
+
+    expect(coerced).toBeInstanceOf(Date);
+    expect((coerced as Date).toISOString()).toBe("2027-01-01T10:30:00.000Z");
+  });
+
+  it("converts a full ISO instant", () => {
+    const coerced: unknown = coerceDateColumnValue("2027-01-01T10:30:00.000Z");
+
+    expect(coerced).toBeInstanceOf(Date);
+    expect((coerced as Date).toISOString()).toBe("2027-01-01T10:30:00.000Z");
+  });
+
+  it("honours an explicit offset instead of assuming UTC", () => {
+    const coerced: unknown = coerceDateColumnValue("2027-01-01T10:30:00+02:00");
+
+    expect(coerced).toBeInstanceOf(Date);
+    expect((coerced as Date).toISOString()).toBe("2027-01-01T08:30:00.000Z");
+  });
+
+  it("converts the space-separated form Postgres renders", () => {
+    const coerced: unknown = coerceDateColumnValue("2027-01-01 10:30:00");
+
+    expect(coerced).toBeInstanceOf(Date);
+    expect((coerced as Date).toISOString()).toBe("2027-01-01T10:30:00.000Z");
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    const coerced: unknown = coerceDateColumnValue("  2027-01-01  ");
+
+    expect(coerced).toBeInstanceOf(Date);
+    expect((coerced as Date).toISOString()).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  /*
+   * The whole point of coercing at all: what lands in Postgres must not
+   * change. An offset-less literal in a timestamptz column is parsed in the
+   * session timezone, which is UTC in every OneUptime deployment, so reading
+   * it as UTC here reproduces the previous stored instant exactly — and does
+   * it independently of the timezone the Node process happens to run in,
+   * which moment's default local parse would not.
+   */
+  it("reads an offset-less string as UTC regardless of the host timezone", () => {
+    const originalTimezone: string | undefined = process.env["TZ"];
+
+    try {
+      process.env["TZ"] = "America/Los_Angeles";
+
+      const coerced: unknown = coerceDateColumnValue("2027-01-01");
+
+      expect((coerced as Date).toISOString()).toBe("2027-01-01T00:00:00.000Z");
+    } finally {
+      if (originalTimezone === undefined) {
+        delete process.env["TZ"];
+      } else {
+        process.env["TZ"] = originalTimezone;
+      }
+    }
+  });
+
+  it("leaves a Date exactly as it is", () => {
+    const date: Date = new Date("2027-01-01T00:00:00.000Z");
+
+    expect(coerceDateColumnValue(date)).toBe(date);
+  });
+
+  it("leaves null and undefined alone so a nullable column can be cleared", () => {
+    expect(coerceDateColumnValue(null)).toBeNull();
+    expect(coerceDateColumnValue(undefined)).toBeUndefined();
+  });
+
+  it("does not invent a date for a cleared field", () => {
+    expect(coerceDateColumnValue("")).toBe("");
+    expect(coerceDateColumnValue("   ")).toBe("   ");
+  });
+
+  /*
+   * moment's fallback parser accepts almost anything and invents a date for
+   * it: "12" becomes 2001-12-01 and "0" becomes 2000-01-01. Handing it every
+   * string that lands on a date column would silently manufacture values, so
+   * the gate is a recognised ISO shape and nothing else.
+   */
+  it("refuses the loose strings moment would happily invent a date for", () => {
+    for (const garbage of ["12", "0", "1", "2027", "true", "abc", "now"]) {
+      expect(coerceDateColumnValue(garbage)).toBe(garbage);
+    }
+  });
+
+  it("leaves an ISO-shaped but impossible date alone so validation reports it", () => {
+    expect(coerceDateColumnValue("2027-13-45")).toBe("2027-13-45");
+    expect(coerceDateColumnValue("2027-02-30T99:99")).toBe("2027-02-30T99:99");
+  });
+
+  it("leaves non-string, non-date values untouched", () => {
+    const object: JSONObject = { a: 1 };
+    const array: Array<number> = [1, 2];
+
+    expect(coerceDateColumnValue(object)).toBe(object);
+    expect(coerceDateColumnValue(array)).toBe(array);
+    expect(coerceDateColumnValue(true)).toBe(true);
+    expect(coerceDateColumnValue(42)).toBe(42);
+  });
+});
+
+/*
+ * The update half. `BaseAPI.updateItem` never builds a model — it goes from
+ * the request body straight to a partial entity — so it needs the same
+ * normalization applied to a loose patch, or a PUT and a POST disagree about
+ * what "2027-01-01" is and the save-time hooks see different types depending
+ * on which verb the caller used.
+ */
+describe("coerceDateColumnsInJSON on an update patch", () => {
+  it("coerces a date column the patch names", () => {
+    const patch: JSONObject = coerceDateColumnsInJSON(
+      { expiresAt: "2027-01-01" },
+      new EnterpriseLicense(),
+    );
+
+    expect(patch["expiresAt"]).toBeInstanceOf(Date);
+    expect((patch["expiresAt"] as Date).toISOString()).toBe(
+      "2027-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("leaves the columns it does not own alone", () => {
+    const patch: JSONObject = coerceDateColumnsInJSON(
+      {
+        companyName: "2027-01-01",
+        licenseKey: "2027-01-01",
+        userLimit: 50,
+        isEvaluationLicense: false,
+        expiresAt: "2027-01-01",
+      },
+      new EnterpriseLicense(),
+    );
+
+    expect(patch["companyName"]).toBe("2027-01-01");
+    expect(patch["licenseKey"]).toBe("2027-01-01");
+    expect(patch["userLimit"]).toBe(50);
+    expect(patch["isEvaluationLicense"]).toBe(false);
+    expect(patch["expiresAt"]).toBeInstanceOf(Date);
+  });
+
+  it("ignores keys that are not columns at all", () => {
+    const patch: JSONObject = coerceDateColumnsInJSON(
+      { notAColumn: "2027-01-01" },
+      new EnterpriseLicense(),
+    );
+
+    expect(patch["notAColumn"]).toBe("2027-01-01");
+  });
+
+  /*
+   * A PartialEntity may carry a `() => string` raw SQL expression instead of
+   * a literal. Coercion must not stringify or otherwise disturb one.
+   */
+  it("passes a raw SQL expression through untouched", () => {
+    const expression: () => string = (): string => {
+      return "NOW()";
+    };
+
+    const patch: JSONObject = coerceDateColumnsInJSON(
+      { expiresAt: expression as unknown as JSONObject },
+      new EnterpriseLicense(),
+    );
+
+    expect(patch["expiresAt"]).toBe(expression);
+  });
+
+  it("keeps an explicit null so a nullable column can be cleared", () => {
+    const patch: JSONObject = coerceDateColumnsInJSON(
+      { userCountUpdatedAt: null },
+      new EnterpriseLicense(),
+    );
+
+    expect(patch["userCountUpdatedAt"]).toBeNull();
+  });
+
+  /*
+   * The API layer hands this a freshly-constructed model of the entity being
+   * updated, so it has to work off an instance rather than the class.
+   */
+  it("works off any model instance, not just licences", () => {
+    const patch: JSONObject = coerceDateColumnsInJSON(
+      { disableActiveMonitoringBecauseOfManualIncident: false },
+      new Monitor(),
+    );
+
+    expect(patch["disableActiveMonitoringBecauseOfManualIncident"]).toBe(false);
+  });
+});

--- a/Common/Tests/Types/DateToIsoStringOrNull.test.ts
+++ b/Common/Tests/Types/DateToIsoStringOrNull.test.ts
@@ -1,0 +1,67 @@
+import OneUptimeDate from "../../Types/Date";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — the ISO instant for a value that is *declared* a Date
+ * but may not be one at runtime.
+ *
+ * TypeORM's save() hands back the entity it was given, so a date column read
+ * off a freshly created model holds whatever the caller supplied. Calling
+ * `.toISOString()` on that directly is what took enterprise licence creation
+ * down: a TypeError thrown from a post-create hook, after the INSERT had
+ * committed, surfacing as a bare HTTP 500 "Server Error" on a licence that
+ * had in fact been created.
+ */
+
+describe("OneUptimeDate.toIsoStringOrNull", () => {
+  it("returns the ISO instant for a Date", () => {
+    expect(
+      OneUptimeDate.toIsoStringOrNull(new Date("2027-01-01T10:30:00.000Z")),
+    ).toBe("2027-01-01T10:30:00.000Z");
+  });
+
+  it("parses the string a date column may still be holding", () => {
+    expect(OneUptimeDate.toIsoStringOrNull("2027-01-01T10:30:00.000Z")).toBe(
+      "2027-01-01T10:30:00.000Z",
+    );
+  });
+
+  it("returns null for an absent value rather than throwing", () => {
+    expect(OneUptimeDate.toIsoStringOrNull(undefined)).toBeNull();
+    expect(OneUptimeDate.toIsoStringOrNull(null)).toBeNull();
+    expect(OneUptimeDate.toIsoStringOrNull("")).toBeNull();
+  });
+
+  it("returns null for a value no parser can make a date of", () => {
+    expect(OneUptimeDate.toIsoStringOrNull("not-a-date")).toBeNull();
+    expect(OneUptimeDate.toIsoStringOrNull("2027-13-45")).toBeNull();
+  });
+
+  it("returns null for an Invalid Date instead of throwing on it", () => {
+    expect(OneUptimeDate.toIsoStringOrNull(new Date("nonsense"))).toBeNull();
+  });
+
+  /*
+   * The whole point: whatever it is handed, it answers. A reporting caller
+   * gets "unknown" instead of an exception it has no way to recover from.
+   */
+  it("never throws, whatever it is handed", () => {
+    for (const value of [
+      undefined,
+      null,
+      "",
+      "   ",
+      "not-a-date",
+      "0",
+      new Date("nonsense"),
+      new Date(),
+      "2027-01-01",
+    ]) {
+      expect(() => {
+        return OneUptimeDate.toIsoStringOrNull(
+          value as Date | string | undefined | null,
+        );
+      }).not.toThrow();
+    }
+  });
+});

--- a/Common/Types/Database/DateColumnValue.ts
+++ b/Common/Types/Database/DateColumnValue.ts
@@ -1,0 +1,184 @@
+import OneUptimeDate from "../Date";
+import { JSONObject, JSONValue } from "../JSON";
+import { TableColumnMetadata } from "./TableColumn";
+import TableColumnType from "./TableColumnType";
+
+/*
+ * Column types whose in-memory representation is a JavaScript `Date`.
+ *
+ * One entry today, but named rather than compared inline so the set is
+ * discoverable from the coercion below and from the tests that pin it.
+ */
+const DATE_TABLE_COLUMN_TYPES: Set<TableColumnType> = new Set<TableColumnType>([
+  TableColumnType.Date,
+]);
+
+export function isDateTableColumnType(
+  type: TableColumnType | undefined | null,
+): boolean {
+  if (!type) {
+    return false;
+  }
+
+  return DATE_TABLE_COLUMN_TYPES.has(type);
+}
+
+/*
+ * The shapes a date column may arrive in as a bare string, and only those.
+ *
+ * The gate is deliberately narrow. moment's fallback parser accepts almost
+ * anything and invents a date for it — "12" becomes 2001-12-01 and "0"
+ * becomes 2000-01-01 — so handing it every string that lands on a date column
+ * would silently manufacture values. Everything the product actually produces
+ * is ISO-shaped: `<input type="date">` yields "YYYY-MM-DD",
+ * `<input type="datetime-local">` yields "YYYY-MM-DDTHH:mm", JSON.stringify of
+ * a Date yields a Z-suffixed instant, and Postgres renders "YYYY-MM-DD
+ * HH:mm:ss". Anything else is left exactly as it was.
+ */
+const ISO_DATE_ONLY: RegExp = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATE_TIME_WITHOUT_ZONE: RegExp =
+  /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?(?:\.\d{1,9})?)$/;
+const ISO_DATE_TIME_WITH_ZONE: RegExp =
+  /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d{1,9})?(?:Z|[+-]\d{2}:?\d{2})$/;
+
+/*
+ * Rewrite a recognised date string into an unambiguous instant, or return null
+ * when it is not one of the recognised shapes.
+ *
+ * A string with no timezone designator is read as UTC, which is not an
+ * arbitrary choice: it is exactly what happened before this coercion existed.
+ * The raw string used to travel to Postgres untouched, where a `timestamptz`
+ * column parses an offset-less literal in the session timezone — UTC in every
+ * OneUptime deployment. Reading it as UTC here keeps the stored instant
+ * identical, and makes it independent of whatever timezone the Node process
+ * happens to run in, which the local-time parse in moment's default mode is
+ * not.
+ */
+type NormalizeIsoDateStringFunction = (value: string) => string | null;
+
+const normalizeIsoDateString: NormalizeIsoDateStringFunction = (
+  value: string,
+): string | null => {
+  if (ISO_DATE_ONLY.test(value)) {
+    return `${value}T00:00:00.000Z`;
+  }
+
+  const withoutZone: RegExpMatchArray | null = value.match(
+    ISO_DATE_TIME_WITHOUT_ZONE,
+  );
+
+  if (withoutZone) {
+    return `${withoutZone[1]}T${withoutZone[2]}Z`;
+  }
+
+  if (ISO_DATE_TIME_WITH_ZONE.test(value)) {
+    return value.replace(" ", "T");
+  }
+
+  return null;
+};
+
+/*
+ * Normalize a JSON value destined for a date column.
+ *
+ * The dashboard's date form field is an `<input type="date">`, and a DOM
+ * input's value is a *string* — there is no Date input event in HTML. So a
+ * date picked in a form reached the API as the JSON string "2027-01-01", and
+ * `BaseModel.fromJSON` assigned it to the model verbatim. Postgres accepts
+ * that string happily, which is why it went unnoticed on every date field in
+ * the product: the string only becomes visible when something reads the column
+ * back off the saved model, because TypeORM's `save()` returns the entity it
+ * was handed rather than a re-read row.
+ *
+ * That is what broke enterprise licence creation. The row was inserted, and
+ * then `EnterpriseLicenseService.onCreateSuccess` called
+ * `createdItem.expiresAt.toISOString()` on a string — a TypeError, thrown
+ * after the INSERT had already committed. The admin saw "Server Error" while
+ * a licence row was created for every attempt.
+ *
+ * Normalizing here — where the column's declared type is known, on both the
+ * browser side (ModelForm -> BaseModel.fromJSON) and the server side
+ * (BaseAPI -> BaseModel.fromJSON) — means a date column holds a Date by the
+ * time any hook, validator or query sees it. Mirrors
+ * Types/Database/NumericColumnValue, which fixed the same class of bug for
+ * `<input type="number">`.
+ *
+ * Only strings in a recognised ISO shape that parse to a valid date are
+ * converted. A blank string, a garbage string and an impossible date like
+ * "2027-13-45" are all left alone, so validation rejects them with a message
+ * about the field instead of this function inventing a value.
+ */
+export function coerceDateColumnValue(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed: string = value.trim();
+
+  if (trimmed.length === 0) {
+    return value;
+  }
+
+  const normalized: string | null = normalizeIsoDateString(trimmed);
+
+  if (!normalized) {
+    return value;
+  }
+
+  let parsed: Date;
+
+  try {
+    parsed = OneUptimeDate.fromString(normalized);
+  } catch {
+    return value;
+  }
+
+  if (!(parsed instanceof Date) || Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed;
+}
+
+/*
+ * The minimum a model has to offer for its date columns to be found.
+ * Every DatabaseBaseModel satisfies it; asking for only this keeps the
+ * coercion usable from the API layer without dragging the model class in.
+ */
+export interface ColumnMetadataSource {
+  getTableColumnMetadata: (columnName: string) => TableColumnMetadata;
+}
+
+/*
+ * Coerce the date columns of a loose JSON patch, in place.
+ *
+ * `BaseModel.fromJSON` does this on its way to building a model, but an update
+ * never builds one — `BaseAPI.updateItem` goes from the request body straight
+ * to a partial entity — so without this a PUT and a POST disagree about
+ * whether "2027-01-01" is a Date. That matters because the save-time hooks
+ * read these values before the database gets a chance to parse them.
+ *
+ * Values that are not strings are left exactly as they are, including the
+ * `() => string` raw SQL expressions a PartialEntity may carry.
+ */
+export function coerceDateColumnsInJSON(
+  json: JSONObject,
+  model: ColumnMetadataSource,
+): JSONObject {
+  for (const key of Object.keys(json)) {
+    const tableColumnMetadata: TableColumnMetadata =
+      model.getTableColumnMetadata(key);
+
+    if (!tableColumnMetadata) {
+      continue;
+    }
+
+    if (!isDateTableColumnType(tableColumnMetadata.type)) {
+      continue;
+    }
+
+    json[key] = coerceDateColumnValue(json[key]) as JSONValue;
+  }
+
+  return json;
+}

--- a/Common/Types/Date.ts
+++ b/Common/Types/Date.ts
@@ -636,6 +636,43 @@ export default class OneUptimeDate {
     return date.toISOString();
   }
 
+  /*
+   * The ISO instant for a value that is *declared* a Date but may not be one
+   * at runtime.
+   *
+   * TypeORM's save() hands back the entity it was given, so a date column read
+   * off a freshly created model holds whatever the caller supplied — a real
+   * Date once BaseModel.fromJSON has coerced it, a raw string from any caller
+   * that bypasses that path. `.toISOString()` on the latter is a TypeError,
+   * and post-create hooks are exactly where such a throw does the most damage:
+   * the row is already committed, so it converts a completed write into a
+   * server error the caller retries.
+   *
+   * Returns null for anything that is not a usable date, so a caller reporting
+   * an optional timestamp reports "unknown" instead of failing.
+   */
+  public static toIsoStringOrNull(
+    date: Date | string | undefined | null,
+  ): string | null {
+    if (!date) {
+      return null;
+    }
+
+    let parsedDate: Date;
+
+    try {
+      parsedDate = this.fromString(date);
+    } catch {
+      return null;
+    }
+
+    if (!(parsedDate instanceof Date) || Number.isNaN(parsedDate.getTime())) {
+      return null;
+    }
+
+    return parsedDate.toISOString();
+  }
+
   public static getCurrentMomentDate(): moment.Moment {
     return moment();
   }


### PR DESCRIPTION
## The bug

Every create from the master admin dashboard's **Enterprise Licenses** page answered HTTP 500 `Server Error` — and wrote a licence row anyway, so an admin retrying piled up duplicates.

Reproduced against a migrated database:

```
--- date input string, no email, no numbers (exactly what the admin form sends) ---
  CREATE FAILED: TypeError createdItem.expiresAt.toISOString is not a function
```

…with the row already committed:

```
 companyName |       expiresAt        | licenseKey
-------------+------------------------+------------
 Acme, Inc.  | 2027-01-01 00:00:00+00 | ...
```

## Why

`Expires At` is a `FormFieldSchemaType.Date` field — a DOM input whose value is the string `"2027-01-01"`. `BaseModel.fromJSON` assigned that string to the model verbatim, and TypeORM's `save()` returns the entity it was handed rather than a re-read row, so `EnterpriseLicenseService.onCreateSuccess` — which runs **after** the INSERT has committed — called `createdItem.expiresAt.toISOString()` on a string.

A `TypeError` is not one of the driver errors `PostgresErrorTranslator` turns into a readable 400, so it fell through to the generic handler as a bare 500.

Postgres parses that string happily on the way in, which is why this went unnoticed on every other date field in the product: the string is only visible to something that reads the column back off the saved model.

## The fix

Root cause, mirroring the numeric coercion that fixed the same class of bug for `<input type="number">` (`Types/Database/NumericColumnValue`):

- **`Types/Database/DateColumnValue`** coerces a date column's value to a real `Date` — in `BaseModel.fromJSON` (POST, and it runs on both sides of the wire) and in `BaseAPI.updateItem`'s loose patch (PUT), so a date column holds a `Date` before any hook, validator or query reads it.
  - Only recognised ISO shapes are converted. moment's fallback parser invents dates for loose strings (`"12"` → 2001-12-01, `"0"` → 2000-01-01), so the gate is narrow and anything else is left alone for validation to report.
  - Offset-less strings are read as **UTC** — exactly what a `timestamptz` column did with the raw literal in every OneUptime deployment — so the stored instant does not move, and no longer depends on the timezone the Node process runs in. Verified byte-for-byte against the same database before and after.

Hardening, so the same shape cannot turn a committed write into a failure again:

- **`OneUptimeDate.toIsoStringOrNull`** answers `null` for a value that is not a usable date instead of throwing; `EnterpriseLicenseService` reports the expiry through it.
- **`MarketingEventUtil.emitInBackground`** accepts a `() => MarketingEvent` builder and resolves it inside its own `try`. Its docstring already claimed the synchronous path was covered — it was not, because an argument expression is evaluated at the call site, which is exactly how this `TypeError` escaped. All four callers now pass a builder.

## Tests

56 new tests plus updates to three existing suites:

| Suite | Covers |
|---|---|
| `Types/Database/DateColumnValue.test.ts` | the coercion: input shapes, host-timezone independence, the loose strings moment would invent a date for, raw SQL expressions, cleared fields |
| `Models/DatabaseModels/DateColumnDeserialization.test.ts` | `fromJSON` on the admin form's payload, the serialized `DateTime` wrapper, unparseable values |
| `Server/API/BaseAPIUpdateDateColumns.test.ts` | PUT and POST agree on what `"2027-01-01"` is |
| `Server/Services/EnterpriseLicenseServiceCreate.test.ts` | the create hook, including an expiry that is still a string and an event that cannot be built at all |
| `Types/DateToIsoStringOrNull.test.ts` | never throws, whatever it is handed |
| `Server/Utils/Marketing/MarketingEventUtil.test.ts` | the builder form, and a throwing builder |
| `App/Tests/AdminDashboard/EnterpriseLicenseCreateWiring.test.ts` | the page's create wiring, and what its posted values become on the server |

Verified end to end against a migrated Postgres: the exact admin-form payload now creates cleanly and stores `2029-09-09 00:00:00+00`.

Green locally: 13,946 tests across `Tests/Types`, `Tests/Server/Types`, `Tests/Utils`; the full `Tests/Server/Services` and `Tests/Server/API` sweeps; `Tests/Models`, `Tests/Types/Database`, `Tests/Server/Utils/Marketing`; and App's `Tests/AdminDashboard` + `Tests/BaseAPI` (564).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xjc2Tw9SG3XFx5Zs1GQrN