### PR TITLE
fix(ci): unbreak master's compile, build and lint

### DIFF
--- a/App/Tests/Dashboard/LogsSavedViewOverrideMerge.test.ts
+++ b/App/Tests/Dashboard/LogsSavedViewOverrideMerge.test.ts
@@ -266,7 +266,7 @@ describe("what the strip must not touch", () => {
     });
 
     expect(stripped["primaryEntityId"]).toBeDefined();
-    expect((stripped["primaryEntityId"] as Includes<string>).values).toEqual([
+    expect((stripped["primaryEntityId"] as Includes).values).toEqual([
       SERVICE_B,
     ]);
   });

--- a/App/Tests/Dashboard/MonitorBackedDeviceColumnHonesty.test.ts
+++ b/App/Tests/Dashboard/MonitorBackedDeviceColumnHonesty.test.ts
@@ -61,7 +61,11 @@ function devicesList(): string {
   return readCode("Pages", "NetworkDevice", "Devices.tsx");
 }
 
-function sliceBetween(data: { code: string; from: string; to: string }): string {
+function sliceBetween(data: {
+  code: string;
+  from: string;
+  to: string;
+}): string {
   const start: number = data.code.indexOf(data.from);
   const end: number = data.code.indexOf(data.to, start + 1);
 
@@ -235,12 +239,7 @@ describe("the device's own pages stop contradicting its status", () => {
 
   test("both pages that render the card pass the method through", () => {
     for (const page of ["Index.tsx", "Monitors.tsx"]) {
-      const source: string = readCode(
-        "Pages",
-        "NetworkDevice",
-        "View",
-        page,
-      );
+      const source: string = readCode("Pages", "NetworkDevice", "View", page);
 
       expect(source).toContain("getDeviceMonitorContext");
       expect(source).toContain("isMonitorBacked={isMonitorBacked}");


### PR DESCRIPTION
Master is red on **Compile**, **Build**, **Push Test Images** and **Common Jobs**. Two breaks, neither of which a single PR could have caught on its own.

### 1. `TS2315: Type 'Includes' is not generic` — fails Compile, Build *and* Push Test Images
`App/Tests/Dashboard/LogsSavedViewOverrideMerge.test.ts:269` casts to `Includes<string>`, but `Includes` takes no type parameter — it fixes its own element type as `QueryOperator<IncludesType>`. This single error failed `compile-app`, and because the same `npm run compile` runs inside the Dockerfile it also failed `docker-build-app` and the arm64 image build behind `Push Test Images`. It is the only `Includes<...>` usage in the repo.

### 2. Two prettier violations — fails Common Jobs (js-lint)
`MonitorBackedDeviceColumnHonesty.test.ts` lines 64 and 238. Applied `eslint --fix`.

Both changes are annotation- or formatting-only; no runtime behaviour changes.

### Dropped on rebase
This branch originally also fixed a `TS2322` in `Discovery.tsx`. #3462 fixed that independently with `?? undefined`, so the hunk was dropped rather than duplicated.

### Verification (local, against master tip `7e9551fc00`)
- `App` `tsc` — clean; previously emitted the TS2315
- `eslint` on both changed files — clean
- `jest` on both touched suites — 25/25 pass
- `Common/Tests/Server/API/AIGenerationRequestBudget.test.ts` — 6/6 pass (this suite was failing on the older base before #3461 landed its `ProjectService` mock; unrelated to this PR)