### PR TITLE
fix(ai): move the enableAi kill switch inside executeWithLogging

### DIFF
--- a/App/FeatureSet/Runbook/Services/AIStepExecutor.ts
+++ b/App/FeatureSet/Runbook/Services/AIStepExecutor.ts
@@ -6,6 +6,7 @@ import LlmProviderService from "Common/Server/Services/LlmProviderService";
 import AIService, {
   AILogRequest,
   AILogResponse,
+  AI_DISABLED_MESSAGE,
   RUNBOOK_AI_STEP_FEATURE,
 } from "Common/Server/Services/AIService";
 import ToolResultSerializer from "Common/Server/Utils/AI/Toolbox/Serializer";
@@ -424,6 +425,25 @@ export async function runAiStep(
         output: "",
         errorMessage:
           "AI step has no prompt configured. Edit the step and describe what the AI should do.",
+      };
+    }
+
+    /*
+     * The project's AI kill switch. A runbook containing an AI step can be
+     * run by hand by any member, which is the path the automated triggers'
+     * own gating (AutoRemediationRuleEngineService) never covers. The daily
+     * autonomous budget does bound this feature, but a budget is a ceiling on
+     * spend, not consent to spend at all.
+     *
+     * Failing here is the right shape for this lane: the catch below turns a
+     * throw into a failed step carrying the message, so the responder who
+     * pressed Run reads the reason on the step itself.
+     */
+    if (!(await AIService.isProjectAIEnabled(ctx.projectId))) {
+      return {
+        success: false,
+        output: "",
+        errorMessage: AI_DISABLED_MESSAGE,
       };
     }
 

--- a/App/Tests/Runbook/AIStepExecutor.test.ts
+++ b/App/Tests/Runbook/AIStepExecutor.test.ts
@@ -5,6 +5,7 @@ import { AIStepConfig, RunbookStep } from "Common/Types/Runbook/RunbookStep";
 import { RunbookStepExecutionState } from "Common/Types/Runbook/RunbookStepExecution";
 import AIService, {
   AILogRequest,
+  AI_DISABLED_MESSAGE,
   AUTONOMOUS_AI_FEATURES,
   RUNBOOK_AI_STEP_FEATURE,
 } from "Common/Server/Services/AIService";
@@ -675,6 +676,12 @@ describe("runAiStep", () => {
     jest.spyOn(logger, "error").mockImplementation((): void => {
       return undefined;
     });
+    /*
+     * The step reads the project's enableAi kill switch before it builds any
+     * context. Every case here is about the step itself, so the switch is on;
+     * the off case is asserted separately below.
+     */
+    jest.spyOn(AIService, "isProjectAIEnabled").mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -688,6 +695,32 @@ describe("runAiStep", () => {
     );
     expect(result.success).toBe(false);
     expect(result.errorMessage).toContain("no prompt configured");
+  });
+
+  /*
+   * A member can run a runbook containing an AI step by hand, which the
+   * automated triggers' own gating never covers — the daily autonomous budget
+   * bounds this feature, but a ceiling on spend is not consent to spend. The
+   * step fails with the reason on it, rather than the step's caller learning
+   * nothing.
+   */
+  test("refuses when AI is switched off for the project, before any context is built", async () => {
+    jest.spyOn(AIService, "isProjectAIEnabled").mockResolvedValue(false);
+    const buildContext: jest.SpyInstance = jest.spyOn(
+      IncidentAIContextBuilder,
+      "buildIncidentContext",
+    );
+    const execute: jest.SpyInstance = jest.spyOn(
+      AIService,
+      "executeWithLogging",
+    );
+
+    const result: StepRunResult = await runAiStep(makeAiStep(), makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toBe(AI_DISABLED_MESSAGE);
+    expect(buildContext).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
   });
 
   test("a malformed config fails the step with the friendly message, not a TypeError", async () => {
@@ -880,6 +913,7 @@ describe("runAiStep — LLM provider pinning", () => {
     jest.spyOn(logger, "error").mockImplementation((): void => {
       return undefined;
     });
+    jest.spyOn(AIService, "isProjectAIEnabled").mockResolvedValue(true);
   });
 
   afterEach(() => {

--- a/Common/Server/API/SlackAPI.ts
+++ b/Common/Server/API/SlackAPI.ts
@@ -42,6 +42,7 @@ import WorkspaceProjectAuthToken, {
 } from "../../Models/DatabaseModels/WorkspaceProjectAuthToken";
 import UserMiddleware from "../Middleware/UserAuthorization";
 import CommonAPI from "./CommonAPI";
+import AIService, { AI_DISABLED_MESSAGE } from "../Services/AIService";
 import SlackUtil from "../Utils/Workspace/Slack/Slack";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import Dictionary from "../../Types/Dictionary";
@@ -1287,6 +1288,21 @@ export default class SlackAPI {
                 return;
               }
 
+              /*
+               * The project's AI kill switch, read before we acknowledge —
+               * so a project with AI off gets one clear refusal instead of
+               * an "on it" that is never followed by anything.
+               */
+              if (!(await AIService.isProjectAIEnabled(context.projectId))) {
+                await SlackUtil.sendMessageToThread({
+                  authToken: context.projectAuthToken,
+                  channelId: slackChannelId,
+                  threadTs: threadTs,
+                  text: SlackAPI.getAiDisabledMessage(),
+                });
+                return;
+              }
+
               // Immediate acknowledgement so the user sees we are working.
               try {
                 await SlackUtil.sendMessageToThread({
@@ -1419,6 +1435,25 @@ export default class SlackAPI {
               data: {
                 response_type: "ephemeral",
                 text: SlackAPI.getSlackAccountNotConnectedMessage(),
+              },
+              headers: {
+                ["Content-Type"]: "application/json",
+              },
+            });
+            return;
+          }
+
+          /*
+           * The project's AI kill switch. Ephemeral, like every other refusal
+           * on this slash-command path — the person who typed the command is
+           * the only one who needs to know the switch is off.
+           */
+          if (!(await AIService.isProjectAIEnabled(context.projectId))) {
+            await API.post({
+              url: URL.fromString(responseUrl),
+              data: {
+                response_type: "ephemeral",
+                text: SlackAPI.getAiDisabledMessage(),
               },
               headers: {
                 ["Content-Type"]: "application/json",
@@ -1690,5 +1725,18 @@ export default class SlackAPI {
    */
   private static getSlackAccountNotConnectedMessage(): string {
     return "Unfortunately your Slack account is not connected to OneUptime. Please log into your OneUptime account, click on User Settings and then connect your Slack account.";
+  }
+
+  /*
+   * Both AI Ops entry points above run their real work in a DETACHED
+   * fire-and-forget IIFE whose .catch only logs. An exception thrown out of
+   * the assistant — including the kill-switch refusal executeWithLogging
+   * raises — therefore reaches nobody: the user is left staring at "Looking
+   * into it…" forever. So the switch is read HERE, before the assistant is
+   * started, and the refusal is posted back over the same channel the answer
+   * would have used.
+   */
+  private static getAiDisabledMessage(): string {
+    return AI_DISABLED_MESSAGE;
   }
 }

--- a/Common/Server/Services/AIService.ts
+++ b/Common/Server/Services/AIService.ts
@@ -305,6 +305,16 @@ export interface AutonomousBudgetStatus {
  */
 export const INTERACTIVE_AI_GENERATION_TIMEOUT_IN_MS: number = 4 * 60 * 1000;
 
+/*
+ * The single wording for a refusal by the Project.enableAi kill switch. Every
+ * surface that has to tell somebody AI is switched off imports this, so the
+ * message a user reads in Slack, in Teams, on a runbook step and on a
+ * "Generate with AI" button is the same sentence, and it always names the
+ * screen where the switch can be turned back on.
+ */
+export const AI_DISABLED_MESSAGE: string =
+  "AI features are disabled for this project. Enable them in Project Settings > AI Credits.";
+
 export interface AILogRequest {
   projectId: ObjectID;
   userId?: ObjectID | undefined;
@@ -367,12 +377,12 @@ export class Service extends BaseService {
   /**
    * Assert the project-level `enableAi` kill switch, and nothing else.
    *
-   * This is the whole gate for the synchronous, user-triggered "Generate with
-   * AI" endpoints (incident/episode postmortems, incident/alert/maintenance
-   * notes). Those reach executeWithLogging directly, and executeWithLogging
-   * meters, bills and logs a call but never consults the project toggle — so
-   * without this a project that has switched AI off would still spend
-   * provider tokens through them.
+   * This is admission control, not the guarantee. The guarantee lives inside
+   * executeWithLogging (see assertProjectAIEnabledOnRow), which no caller can
+   * route around. What this buys on top is an EARLY refusal: the synchronous
+   * "Generate with AI" endpoints call it before their context builders run,
+   * so a project with AI off never pays for the expensive reads that only
+   * exist to build a prompt nobody is allowed to send.
    *
    * Fails closed: a project row we cannot read is not a project we can
    * confirm has AI enabled, so a missing project is refused rather than
@@ -386,6 +396,17 @@ export class Service extends BaseService {
       props: { isRoot: true },
     });
 
+    this.assertProjectAIEnabledOnRow(project);
+  }
+
+  /**
+   * The toggle verdict itself, over an already-loaded row. Split out so the
+   * one place that owns the rule is shared by every caller — the throwing
+   * assert above, the non-throwing predicate below, and the backstop inside
+   * executeWithLogging, which reads the row for its own reasons and must not
+   * pay for a second read to ask the same question.
+   */
+  private assertProjectAIEnabledOnRow(project: Project | null): void {
     if (!project) {
       throw new BadDataException("Project not found.");
     }
@@ -396,9 +417,32 @@ export class Service extends BaseService {
      * keep working — same semantics as every other enableAi read.
      */
     if (project.enableAi === false) {
-      throw new BadDataException(
-        "AI features are disabled for this project. Enable them in Project Settings > AI Credits.",
+      throw new BadDataException(AI_DISABLED_MESSAGE);
+    }
+  }
+
+  /**
+   * The same verdict as assertProjectAIEnabled, as a boolean.
+   *
+   * For the autonomous, fire-and-forget lanes — on-resolve grading and
+   * friends — where "this project has AI switched off" is not an error and
+   * must not be logged as one. Those callers sit inside a catch that reports
+   * failures, so letting the backstop throw would turn a deliberate,
+   * correctly-configured setting into recurring error noise. They ask this
+   * first and simply skip.
+   *
+   * Fails closed the same way: an unreadable project row answers false.
+   */
+  @CaptureSpan()
+  public async isProjectAIEnabled(projectId: ObjectID): Promise<boolean> {
+    try {
+      await this.assertProjectAIEnabled(projectId);
+      return true;
+    } catch (err) {
+      logger.debug(
+        `Project AI toggle: ${projectId.toString()} may not use AI — ${err}`,
       );
+      return false;
     }
   }
 
@@ -517,6 +561,40 @@ export class Service extends BaseService {
   ): Promise<AILogResponse> {
     this.assertSingleSubject(request);
 
+    /*
+     * ===================== The enableAi kill switch =======================
+     *
+     * Every AI call in this codebase — user-triggered, autonomous, chat-ops,
+     * runbook step, agent loop — comes through here. That makes this the only
+     * place the project toggle can be enforced ONCE and be true for callers
+     * that do not exist yet. Enforcing it at entry points instead is what
+     * this method used to rely on, and it leaked exactly the way per-site
+     * admission control always leaks: five endpoints were gated and nine
+     * other call sites were not, so a project with AI switched off could
+     * still be made to spend provider tokens through any of them.
+     *
+     * There is deliberately NO per-request opt-out. A `skipAICheck` flag
+     * would re-open the hole with a one-word diff, and the caller most likely
+     * to reach for it is the one that has not thought about the switch. A
+     * lane that must not throw — fire-and-forget autonomous work — asks
+     * isProjectAIEnabled() first and skips silently; a lane that owes the
+     * user a readable refusal (Slack, Teams) checks first and posts one. Both
+     * are about DELIVERY, and both still land here if they forget.
+     *
+     * The row is read once and carried to the balance check below, so on the
+     * billing path this costs no extra query. Off the billing path it adds a
+     * single primary-key read per LLM call — set against a provider round
+     * trip measured in seconds, and against the alternative of billing a
+     * project that told us not to.
+     */
+    const project: Project | null = await ProjectService.findOneById({
+      id: request.projectId,
+      select: { enableAi: true, aiCurrentBalanceInUSDCents: true },
+      props: { isRoot: true },
+    });
+
+    this.assertProjectAIEnabledOnRow(project);
+
     const startTime: Date = new Date();
 
     // Get LLM provider for the project (honoring an explicit per-chat choice).
@@ -598,29 +676,25 @@ export class Service extends BaseService {
       (llmProvider.isGlobalLlm || false) &&
       (llmProvider.costPerMillionTokensInUSDCents || 0) > 0;
 
-    // Check balance if billing enabled and using global provider
-    if (shouldBill) {
-      const project: Project | null = await ProjectService.findOneById({
-        id: request.projectId,
-        select: { aiCurrentBalanceInUSDCents: true },
+    /*
+     * Check balance if billing enabled and using global provider. The row was
+     * already read for the kill switch above and is non-null past that gate,
+     * so this reuses it rather than issuing a second read of the same row.
+     */
+    if (shouldBill && (project!.aiCurrentBalanceInUSDCents || 0) <= 0) {
+      logEntry.status = LlmLogStatus.InsufficientBalance;
+      logEntry.statusMessage = "Insufficient AI balance";
+      logEntry.requestCompletedAt = new Date();
+      logEntry.durationMs = new Date().getTime() - startTime.getTime();
+
+      await LlmLogService.create({
+        data: logEntry,
         props: { isRoot: true },
       });
 
-      if (!project || (project.aiCurrentBalanceInUSDCents || 0) <= 0) {
-        logEntry.status = LlmLogStatus.InsufficientBalance;
-        logEntry.statusMessage = "Insufficient AI balance";
-        logEntry.requestCompletedAt = new Date();
-        logEntry.durationMs = new Date().getTime() - startTime.getTime();
-
-        await LlmLogService.create({
-          data: logEntry,
-          props: { isRoot: true },
-        });
-
-        throw new BadDataException(
-          "Insufficient AI balance. Please recharge your AI balance in Project Settings > AI Credits.",
-        );
-      }
+      throw new BadDataException(
+        "Insufficient AI balance. Please recharge your AI balance in Project Settings > AI Credits.",
+      );
     }
 
     /*

--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -3872,6 +3872,17 @@ ${incidentSeverity.name}
       throw new BadDataException("Incident not found");
     }
 
+    /*
+     * The project's AI kill switch, at the service layer rather than only on
+     * the HTTP handler above it. This method is public and has a second
+     * caller (IncidentPostmortemRunner), so gating the route alone would
+     * leave the switch true for one entry point and false for the other.
+     * Checking here also refuses BEFORE the context builder below, which
+     * reads the whole incident dossier — private notes, workspace messages —
+     * to assemble a prompt this project has said it does not want sent.
+     */
+    await AIService.assertProjectAIEnabled(incident.projectId);
+
     // Build incident context - always include workspace messages
     const contextData: IncidentContextData =
       await IncidentAIContextBuilder.buildIncidentContext({

--- a/Common/Server/Utils/AI/CodeFix/CodeFixAgentCompletion.ts
+++ b/Common/Server/Utils/AI/CodeFix/CodeFixAgentCompletion.ts
@@ -177,6 +177,15 @@ export default class CodeFixAgentCompletion {
     }
 
     /*
+     * The project's AI kill switch, before the provider is resolved. This
+     * route is reached by an authenticated agent worker rather than a
+     * browser, so a throw is the correct delivery: /ai-agent-data/
+     * llm-completion turns it into an error response the worker reads and
+     * stops its loop on.
+     */
+    await AIService.assertProjectAIEnabled(run.projectId);
+
+    /*
      * Metered-path provider resolution: project-owned first, else the global
      * provider — on cloud too, because this call is executed through
      * AIService.executeWithLogging and therefore billed/logged/budgeted.

--- a/Common/Server/Utils/AI/SRE/InvestigationGrader.ts
+++ b/Common/Server/Utils/AI/SRE/InvestigationGrader.ts
@@ -136,6 +136,24 @@ export default class InvestigationGrader {
     const { incidentId, projectId } = data;
 
     try {
+      /*
+       * The project's AI kill switch, checked the non-throwing way.
+       *
+       * This runs fire-and-forget off an incident resolve, inside a catch
+       * that logs at error level. "This project switched AI off" is a
+       * setting, not a failure, so letting the backstop in
+       * executeWithLogging throw would file a permanent error for every
+       * incident such a project ever resolves. It is a silent skip instead —
+       * the same posture the sibling on-resolve job takes via
+       * AIInvestigationEngine.isEnabledForProject.
+       */
+      if (!(await AIService.isProjectAIEnabled(projectId))) {
+        logger.debug(
+          `AI grading: AI is disabled for project ${projectId.toString()} — skipping.`,
+        );
+        return;
+      }
+
       // The latest completed investigation for this incident (if any).
       const run: AIRun | null = await AIRunService.findOneBy({
         query: {

--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -108,6 +108,7 @@ import MicrosoftTeamsOnCallDutyActions from "./Actions/OnCallDutyPolicy";
  */
 import type { ObservabilityAssistantResult } from "../../AI/Chat/ObservabilityAssistant";
 import AccessTokenService from "../../../Services/AccessTokenService";
+import AIService, { AI_DISABLED_MESSAGE } from "../../../Services/AIService";
 import DatabaseCommonInteractionProps from "../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
 
@@ -3343,6 +3344,21 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       await turnContext.sendActivity(
         "I couldn't find your OneUptime account. Please connect your Microsoft Teams account in OneUptime User Settings before asking me questions.",
       );
+      return;
+    }
+
+    /*
+     * The project's AI kill switch, read before we acknowledge. The catch
+     * around the assistant below answers every failure with the same generic
+     * "I ran into a problem" — true for a provider outage, actively wrong for
+     * a setting somebody chose on purpose. Reading the switch here lets us
+     * say what actually happened, and where to undo it.
+     */
+    if (!(await AIService.isProjectAIEnabled(projectId))) {
+      logger.debug("AI Ops declined: AI is disabled for this project", {
+        projectId: projectId.toString(),
+      });
+      await turnContext.sendActivity(AI_DISABLED_MESSAGE);
       return;
     }
 

--- a/Common/Tests/Server/API/AIGenerationRequestBudget.test.ts
+++ b/Common/Tests/Server/API/AIGenerationRequestBudget.test.ts
@@ -4,6 +4,8 @@ import IncidentEpisodeAPI from "../../../Server/API/IncidentEpisodeAPI";
 import AlertAPI from "../../../Server/API/AlertAPI";
 import ScheduledMaintenanceAPI from "../../../Server/API/ScheduledMaintenanceAPI";
 import CommonAPI from "../../../Server/API/CommonAPI";
+import ProjectService from "../../../Server/Services/ProjectService";
+import Project from "../../../Models/DatabaseModels/Project";
 import AIService, {
   AILogRequest,
   INTERACTIVE_AI_GENERATION_TIMEOUT_IN_MS,
@@ -276,6 +278,18 @@ describe("synchronous Generate-with-AI endpoints bound their provider call", () 
     jest
       .spyOn(AIService, "executeWithLogging")
       .mockResolvedValue({ content: "generated" } as never);
+
+    /*
+     * The project's enableAi kill switch, which these handlers read before
+     * they build any context. Every assertion here is about the request
+     * budget the handler hands the provider, so the switch is on — the
+     * switch's own behaviour is covered in AIGenerationProjectAIToggle and
+     * AIKillSwitchBackstop.
+     */
+    jest.spyOn(ProjectService, "findOneById").mockResolvedValue({
+      id: PROJECT_ID,
+      enableAi: true,
+    } as unknown as Project);
   });
 
   it.each(

--- a/Common/Tests/Server/API/AIKillSwitchBackstop.test.ts
+++ b/Common/Tests/Server/API/AIKillSwitchBackstop.test.ts
@@ -1,0 +1,602 @@
+import AIService, {
+  AILogResponse,
+  AI_ALERT_INVESTIGATION_FEATURE,
+  AI_CODE_FIX_FEATURE,
+  AI_CONFIDENCE_CLASSIFICATION_FEATURE,
+  AI_DISABLED_MESSAGE,
+  AI_INCIDENT_INVESTIGATION_FEATURE,
+  AI_INVESTIGATION_GRADING_FEATURE,
+  RUNBOOK_AI_STEP_FEATURE,
+  WORKFLOW_AI_FEATURE,
+} from "../../../Server/Services/AIService";
+import AIBillingService from "../../../Server/Services/AIBillingService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import LlmLogService from "../../../Server/Services/LlmLogService";
+import LlmProviderService from "../../../Server/Services/LlmProviderService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import IncidentAIContextBuilder from "../../../Server/Utils/AI/IncidentAIContextBuilder";
+import InvestigationGrader from "../../../Server/Utils/AI/SRE/InvestigationGrader";
+import LLMService from "../../../Server/Utils/LLM/LLMService";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import LlmLog from "../../../Models/DatabaseModels/LlmLog";
+import LlmProvider from "../../../Models/DatabaseModels/LlmProvider";
+import Project from "../../../Models/DatabaseModels/Project";
+import Dictionary from "../../../Types/Dictionary";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import LlmType from "../../../Types/LLM/LlmType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Project.enableAi is the per-project kill switch for AI — the switch a
+ * project flips when it does not want its data going to a model, or does not
+ * want to spend money on one.
+ *
+ * It used to be enforced as ADMISSION CONTROL: each entry point that wanted to
+ * honour it read the toggle itself. That is the arrangement this suite exists
+ * to prevent coming back, because it leaked exactly the way per-site checks
+ * always leak — five "Generate with AI" endpoints were gated while nine other
+ * paths into the same provider call were not. A project with AI switched off
+ * could still be billed for tokens through a runbook step, a Slack question, a
+ * Teams question, on-resolve grading, the code-fix agent loop, or the
+ * postmortem service method under the gated route.
+ *
+ * The gate now lives INSIDE AIService.executeWithLogging, which every AI call
+ * in the codebase passes through. That is the guarantee, and it is what the
+ * first two describes below pin: the refusal, its cost (nothing), and the
+ * single project read that pays for it.
+ *
+ * Entry-point checks still exist, but their job is DELIVERY, not enforcement:
+ *   - throw          — the caller already turns exceptions into a message a
+ *                      human reads (runbook step, HTTP handler, agent worker)
+ *   - post-to-thread — Slack/Teams run their work in a detached IIFE whose
+ *                      .catch only logs, so an exception reaches nobody
+ *   - silent skip    — fire-and-forget autonomous work, where "AI is off" is
+ *                      a setting and logging it as an error is noise
+ *
+ * The last describe is the anti-drift guard. A new executeWithLogging caller
+ * is covered by the backstop automatically, but it still has to declare which
+ * of those three lanes it is in — and no caller may be handed a way to switch
+ * the gate off.
+ */
+
+type MockBillingGlobal = typeof globalThis & {
+  __oneuptimeKillSwitchTestBillingEnabled: boolean;
+};
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../../Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+  const mocked: Record<string, unknown> = { ...actual };
+  const mockGlobal: MockBillingGlobal = globalThis as MockBillingGlobal;
+  mockGlobal.__oneuptimeKillSwitchTestBillingEnabled = false;
+
+  Object.defineProperty(mocked, "IsBillingEnabled", {
+    configurable: true,
+    enumerable: true,
+    get: (): boolean => {
+      return mockGlobal.__oneuptimeKillSwitchTestBillingEnabled;
+    },
+  });
+
+  return mocked;
+});
+
+function setMockIsBillingEnabled(value: boolean): void {
+  (globalThis as MockBillingGlobal).__oneuptimeKillSwitchTestBillingEnabled =
+    value;
+}
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+/*
+ * A feature OUTSIDE AUTONOMOUS_AI_FEATURES, used wherever a test counts
+ * project reads. The autonomous features carry a second, unrelated read of
+ * their own — getAutonomousDailyBudgetStatus loads the project's daily token
+ * limits — which would make "how many times was the project read?" measure
+ * the daily budget rather than the kill switch.
+ */
+const INTERACTIVE_FEATURE: string = "Slack ChatOps";
+
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+const REPO_ROOT: string = path.join(__dirname, "..", "..", "..", "..");
+
+/*
+ * The shape of a field that would let a caller ask executeWithLogging to skip
+ * the kill switch. No such field may exist on AILogRequest.
+ */
+const OPT_OUT_FIELD_PATTERN: RegExp =
+  /skip|bypass|ignore|force|disableCheck|unsafe/i;
+
+// Spies asserted against on every row of the table below.
+let projectLookup: jest.SpyInstance;
+let getProvider: jest.SpyInstance;
+let getCompletion: jest.SpyInstance;
+let createLlmLog: jest.SpyInstance;
+
+function mockProject(
+  enableAi: boolean | undefined,
+  balanceInUSDCents: number = 1000,
+): void {
+  projectLookup.mockResolvedValue({
+    id: PROJECT_ID,
+    enableAi,
+    aiCurrentBalanceInUSDCents: balanceInUSDCents,
+  } as unknown as Project);
+}
+
+function mockProvider(
+  overrides: Partial<LlmProvider> = {},
+): jest.SpyInstance<Promise<LlmProvider | null>> {
+  return getProvider.mockResolvedValue({
+    id: ObjectID.generate(),
+    llmType: LlmType.OpenAI,
+    name: "test-provider",
+    modelName: "test-model",
+    isGlobalLlm: false,
+    costPerMillionTokensInUSDCents: 0,
+    ...overrides,
+  } as unknown as LlmProvider) as jest.SpyInstance<Promise<LlmProvider | null>>;
+}
+
+async function execute(feature: string): Promise<unknown> {
+  return AIService.executeWithLogging({
+    projectId: PROJECT_ID,
+    feature,
+    messages: [{ role: "user", content: "do the thing" }],
+  });
+}
+
+beforeEach(() => {
+  setMockIsBillingEnabled(false);
+  projectLookup = jest.spyOn(ProjectService, "findOneById");
+  getProvider = jest.spyOn(LlmProviderService, "getProviderForChat");
+  getCompletion = jest.spyOn(LLMService, "getCompletion");
+  createLlmLog = jest
+    .spyOn(LlmLogService, "create")
+    .mockResolvedValue(new LlmLog());
+
+  /*
+   * The metered tail of a successful call — only reached by the billing-path
+   * tests below, and only ever a write. Stubbed so those tests can assert on
+   * the READS the gate makes without a real balance deduction on the end.
+   */
+  jest
+    .spyOn(ProjectService, "deductAiBalanceInUSDCents")
+    .mockResolvedValue(undefined);
+  jest
+    .spyOn(AIBillingService, "rechargeIfBalanceIsLow")
+    .mockResolvedValue(undefined as never);
+
+  mockProvider();
+  getCompletion.mockResolvedValue({
+    content: "the model answered",
+    usage: { totalTokens: 10 },
+  } as Awaited<ReturnType<typeof LLMService.getCompletion>>);
+  mockProject(true);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  setMockIsBillingEnabled(false);
+});
+
+/*
+ * Every lane that reaches a provider does so through executeWithLogging, so
+ * every lane is represented here by the feature label it actually writes to
+ * LlmLog. The point of the table is that the verdict does NOT vary by lane:
+ * interactive, autonomous, chat-ops and agent-loop features are refused
+ * identically, because the switch is about the project, not about who asked.
+ */
+const LANES: Array<{ name: string; feature: string }> = [
+  { name: "a runbook AI step", feature: RUNBOOK_AI_STEP_FEATURE },
+  { name: "the code-fix agent loop", feature: AI_CODE_FIX_FEATURE },
+  { name: "a workflow AI component", feature: WORKFLOW_AI_FEATURE },
+  { name: "Slack / Teams chat-ops", feature: "Slack ChatOps" },
+  {
+    name: "an autonomous incident investigation",
+    feature: AI_INCIDENT_INVESTIGATION_FEATURE,
+  },
+  {
+    name: "an autonomous alert investigation",
+    feature: AI_ALERT_INVESTIGATION_FEATURE,
+  },
+  {
+    name: "on-resolve investigation grading",
+    feature: AI_INVESTIGATION_GRADING_FEATURE,
+  },
+  {
+    name: "the post-run confidence signal",
+    feature: AI_CONFIDENCE_CLASSIFICATION_FEATURE,
+  },
+];
+
+describe.each(LANES)(
+  "AIService.executeWithLogging refuses $name when the project switch is off",
+  ({ feature }: { name: string; feature: string }) => {
+    test("throws, naming the screen where the switch can be turned back on", async () => {
+      mockProject(false);
+
+      await expect(execute(feature)).rejects.toBeInstanceOf(BadDataException);
+      await expect(execute(feature)).rejects.toThrow(AI_DISABLED_MESSAGE);
+    });
+
+    /*
+     * The whole point of the bug. A refusal that still reached the provider
+     * would still cost the project money — which is what the switch was
+     * flipped to prevent.
+     */
+    test("spends no provider tokens", async () => {
+      mockProject(false);
+
+      await expect(execute(feature)).rejects.toThrow();
+
+      expect(getCompletion).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Ordering. Resolving a provider is a query, and on the metered path it
+     * is the step that decides who gets billed. A gate that fires after it
+     * has already done work for a request it is about to refuse.
+     */
+    test("refuses before a provider is even resolved", async () => {
+      mockProject(false);
+
+      await expect(execute(feature)).rejects.toThrow();
+
+      expect(getProvider).not.toHaveBeenCalled();
+    });
+
+    /*
+     * No LlmLog row. Nothing was spent, so nothing belongs in the ledger —
+     * and for the autonomous features in this table that ledger IS the daily
+     * budget (LlmLogService.getTotalTokensUsedSince matches on feature), so a
+     * refusal row would be a refusal that eats the budget it never used.
+     */
+    test("writes no LlmLog row, so the autonomous budget ledger is untouched", async () => {
+      mockProject(false);
+
+      await expect(execute(feature)).rejects.toThrow();
+
+      expect(createLlmLog).not.toHaveBeenCalled();
+    });
+
+    test("runs normally once the switch is on", async () => {
+      mockProject(true);
+
+      const response: AILogResponse = (await execute(feature)) as AILogResponse;
+
+      expect(response.content).toBe("the model answered");
+      expect(getCompletion).toHaveBeenCalledTimes(1);
+    });
+  },
+);
+
+describe("the shape of the backstop's project read", () => {
+  /*
+   * enableAi is NOT NULL DEFAULT true, so an unselected column means "not
+   * disabled". A backstop that read undefined as off would switch AI off for
+   * every project that never touched the setting — the loudest possible
+   * regression, and one no "it refuses when false" test would catch.
+   */
+  test("an unselected enableAi is not a disabled one", async () => {
+    mockProject(undefined);
+
+    await expect(execute(INTERACTIVE_FEATURE)).resolves.toBeDefined();
+    expect(getCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * Fail closed. With no readable row there is no basis for saying AI is
+   * enabled, and "enabled" is the expensive guess.
+   */
+  test("fails closed when the project row cannot be read", async () => {
+    projectLookup.mockResolvedValue(null);
+
+    await expect(execute(INTERACTIVE_FEATURE)).rejects.toThrow(
+      "Project not found.",
+    );
+    expect(getProvider).not.toHaveBeenCalled();
+    expect(getCompletion).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Both halves of this read are load-bearing, and each fails silently rather
+   * than loudly if it drifts:
+   *
+   *   - drop enableAi from `select` and every row comes back with it
+   *     undefined, which this gate deliberately reads as "not disabled". The
+   *     kill switch would pass every request and stay green above.
+   *   - drop isRoot and a permission-filtered read returns null for callers
+   *     who cannot see the project row, flipping fail-closed into refusing
+   *     legitimate traffic.
+   */
+  test("asks for enableAi as root", async () => {
+    await execute(INTERACTIVE_FEATURE);
+
+    const read: {
+      select: Dictionary<boolean>;
+      props: { isRoot?: boolean };
+    } = projectLookup.mock.calls[0]![0] as {
+      select: Dictionary<boolean>;
+      props: { isRoot?: boolean };
+    };
+
+    expect(read.select["enableAi"]).toBe(true);
+    expect(read.props.isRoot).toBe(true);
+  });
+
+  /*
+   * The gate is on the hot path of every AI call, so it does not get to add a
+   * query. It reads the balance column in the same round trip and hands the
+   * row to the billing check below — one read where there used to be one,
+   * not two.
+   */
+  test("reads the balance in the same round trip, not a second one", async () => {
+    setMockIsBillingEnabled(true);
+    mockProvider({
+      isGlobalLlm: true,
+      costPerMillionTokensInUSDCents: 100,
+    });
+
+    await execute(INTERACTIVE_FEATURE);
+
+    expect(projectLookup).toHaveBeenCalledTimes(1);
+
+    const read: { select: Dictionary<boolean> } = projectLookup.mock
+      .calls[0]![0] as {
+      select: Dictionary<boolean>;
+    };
+
+    expect(read.select["enableAi"]).toBe(true);
+    expect(read.select["aiCurrentBalanceInUSDCents"]).toBe(true);
+  });
+
+  /*
+   * Sharing the row must not have cost the billing gate its teeth: an
+   * enabled project with no balance is still refused, and still logged as
+   * InsufficientBalance.
+   */
+  test("the billing gate still fires on the shared row", async () => {
+    setMockIsBillingEnabled(true);
+    mockProject(true, 0);
+    mockProvider({
+      isGlobalLlm: true,
+      costPerMillionTokensInUSDCents: 100,
+    });
+
+    await expect(execute(INTERACTIVE_FEATURE)).rejects.toThrow(
+      /Insufficient AI balance/,
+    );
+    expect(getCompletion).not.toHaveBeenCalled();
+    expect(createLlmLog).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * Order between the two gates the shared row now serves. A project that
+   * switched AI off and also has no balance is refused for the reason it
+   * chose, not for a billing state it never asked about.
+   */
+  test("the kill switch is reported ahead of the balance", async () => {
+    setMockIsBillingEnabled(true);
+    mockProject(false, 0);
+    mockProvider({
+      isGlobalLlm: true,
+      costPerMillionTokensInUSDCents: 100,
+    });
+
+    await expect(execute(INTERACTIVE_FEATURE)).rejects.toThrow(
+      AI_DISABLED_MESSAGE,
+    );
+  });
+});
+
+/*
+ * The delivery lanes. Each of these already reaches the backstop; what is
+ * asserted here is that it reaches the USER the way that lane can actually
+ * deliver a message.
+ */
+describe("delivery: fire-and-forget autonomous work skips silently", () => {
+  /*
+   * gradeInvestigationOnResolve runs detached off an incident resolve, inside
+   * a catch that logs at error level. Letting the backstop throw would file a
+   * permanent error for every incident a switched-off project ever resolves —
+   * so this lane asks first and returns.
+   */
+  test("on-resolve grading returns without touching AI, and without erroring", async () => {
+    mockProject(false);
+    const execution: jest.SpyInstance = jest.spyOn(
+      AIService,
+      "executeWithLogging",
+    );
+
+    await expect(
+      InvestigationGrader.gradeInvestigationOnResolve({
+        incidentId: INCIDENT_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(execution).not.toHaveBeenCalled();
+  });
+});
+
+describe("delivery: the postmortem service method refuses at its own layer", () => {
+  /*
+   * generatePostmortemFromAI is public and has two callers — the (gated) HTTP
+   * handler and IncidentPostmortemRunner. Gating only the route would leave
+   * the switch true for one entry point and false for the other, so the
+   * service method reads it too.
+   */
+  test("refuses before the context builder reads the incident dossier", async () => {
+    mockProject(false);
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue({
+      id: INCIDENT_ID,
+      projectId: PROJECT_ID,
+    } as unknown as Incident);
+    const buildContext: jest.SpyInstance = jest.spyOn(
+      IncidentAIContextBuilder,
+      "buildIncidentContext",
+    );
+
+    await expect(
+      IncidentService.generatePostmortemFromAI({ incidentId: INCIDENT_ID }),
+    ).rejects.toThrow(AI_DISABLED_MESSAGE);
+
+    expect(buildContext).not.toHaveBeenCalled();
+    expect(getCompletion).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * ============================== anti-drift ==============================
+ *
+ * The backstop covers a new caller the moment it is written, which is the
+ * point of putting it inside executeWithLogging. But two things can still go
+ * wrong silently, and both are architectural rather than behavioural — no
+ * assertion above would notice either.
+ */
+type CallSite = {
+  file: string;
+  /*
+   * How a refusal reaches whoever triggered this call:
+   *   "throw"  — an exception here already becomes a message a human reads
+   *   "post"   — detached work; an exception reaches nobody, so the site
+   *              checks first and posts the refusal itself
+   *   "skip"   — autonomous; "AI is off" is a setting, not an error
+   */
+  delivery: "throw" | "post" | "skip";
+};
+
+/*
+ * Every place in the codebase that calls executeWithLogging, and the lane it
+ * belongs to. Adding a caller without adding it here fails the test below —
+ * which is the prompt to decide, once, whether an exception can actually
+ * reach that caller's user.
+ */
+const KNOWN_CALL_SITES: Array<CallSite> = [
+  {
+    file: "App/FeatureSet/Runbook/Services/AIStepExecutor.ts",
+    delivery: "throw",
+  },
+  {
+    file: "Common/Server/Types/Workflow/Components/AI/GenerateText.ts",
+    delivery: "throw",
+  },
+  {
+    file: "Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts",
+    delivery: "post",
+  },
+  { file: "Common/Server/Utils/AI/Chat/ChatAgentRunner.ts", delivery: "throw" },
+  {
+    file: "Common/Server/Utils/AI/CodeFix/CodeFixAgentCompletion.ts",
+    delivery: "throw",
+  },
+  {
+    file: "Common/Server/Utils/AI/SRE/InvestigationGrader.ts",
+    delivery: "skip",
+  },
+  { file: "Common/Server/Utils/AI/SRE/ConfidenceSignal.ts", delivery: "skip" },
+  { file: "Common/Server/Utils/AI/SRE/InvestigationTldr.ts", delivery: "skip" },
+  { file: "Common/Server/API/IncidentAPI.ts", delivery: "throw" },
+  { file: "Common/Server/API/IncidentEpisodeAPI.ts", delivery: "throw" },
+  { file: "Common/Server/API/AlertAPI.ts", delivery: "throw" },
+  { file: "Common/Server/API/ScheduledMaintenanceAPI.ts", delivery: "throw" },
+  { file: "Common/Server/Services/IncidentService.ts", delivery: "throw" },
+];
+
+function sourceFilesUnder(dir: string): Array<string> {
+  const absolute: string = path.join(REPO_ROOT, dir);
+
+  if (!fs.existsSync(absolute)) {
+    return [];
+  }
+
+  const found: Array<string> = [];
+
+  const walk: (current: string) => void = (current: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full: string = path.join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === "Tests") {
+          continue;
+        }
+        walk(full);
+        continue;
+      }
+
+      if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        found.push(path.relative(REPO_ROOT, full));
+      }
+    }
+  };
+
+  walk(absolute);
+
+  return found;
+}
+
+describe("no executeWithLogging caller escapes the kill switch", () => {
+  /*
+   * The registry is only a guarantee if it is exhaustive. A caller that is
+   * not listed is a caller whose error-delivery lane nobody chose — and the
+   * lanes are not interchangeable: a throw into detached Slack work is a
+   * question that never gets answered, and a throw into on-resolve grading is
+   * a permanent error on a correctly-configured project.
+   */
+  test("every call site is in the registry", () => {
+    const calling: Array<string> = [
+      ...sourceFilesUnder("Common/Server"),
+      ...sourceFilesUnder("App/FeatureSet"),
+    ]
+      .filter((file: string) => {
+        return fs
+          .readFileSync(path.join(REPO_ROOT, file), "utf8")
+          .includes("AIService.executeWithLogging(");
+      })
+      .sort();
+
+    const registered: Array<string> = KNOWN_CALL_SITES.map((site: CallSite) => {
+      return site.file;
+    }).sort();
+
+    expect(calling).toEqual(registered);
+  });
+
+  /*
+   * The other way this decision could be undone. An opt-out on the request —
+   * `skipProjectAICheck`, `force`, anything of that shape — would hand every
+   * future caller a one-word way back to the bug this suite is about, and the
+   * caller most likely to reach for it is the one that has not thought about
+   * the switch. The gate takes no parameters, and that is deliberate.
+   */
+  test("executeWithLogging offers no way to switch the gate off", () => {
+    const source: string = fs.readFileSync(
+      path.join(REPO_ROOT, "Common/Server/Services/AIService.ts"),
+      "utf8",
+    );
+
+    const requestInterface: string = (source.match(
+      /export interface AILogRequest \{[\s\S]*?\n\}/,
+    ) || [""])[0];
+
+    expect(requestInterface).toContain("projectId");
+
+    const optOutFields: Array<string> = (
+      requestInterface.match(/^\s*(\w+)\??:/gm) || []
+    ).filter((field: string) => {
+      return OPT_OUT_FIELD_PATTERN.test(field);
+    });
+
+    expect(optOutFields).toEqual([]);
+  });
+});

--- a/Common/Tests/Server/Services/AIServiceDailyBudget.test.ts
+++ b/Common/Tests/Server/Services/AIServiceDailyBudget.test.ts
@@ -534,6 +534,15 @@ describe("AIService.executeWithLogging autonomous lane forwarding", () => {
     const projectId: ObjectID = ObjectID.generate();
     const incidentId: ObjectID = ObjectID.generate();
     const aiRunId: ObjectID = ObjectID.generate();
+    /*
+     * executeWithLogging reads the project first — the enableAi kill switch
+     * is enforced there for every caller. This case is about the budget lane
+     * the call is attributed to, so the switch is on.
+     */
+    jest.spyOn(ProjectService, "findOneById").mockResolvedValue({
+      id: projectId,
+      enableAi: true,
+    } as unknown as Project);
     jest.spyOn(LlmProviderService, "getProviderForChat").mockResolvedValue({
       id: ObjectID.generate(),
       llmType: LlmType.OpenAI,

--- a/Common/Tests/Server/Services/AIServiceProjectAccess.test.ts
+++ b/Common/Tests/Server/Services/AIServiceProjectAccess.test.ts
@@ -182,6 +182,12 @@ describe("AIService.assertProjectCanUseAI", () => {
 function mockFailedProviderRequest(
   error: Error,
 ): jest.SpiedFunction<typeof LlmLogService.create> {
+  /*
+   * executeWithLogging reads the project before anything else — the enableAi
+   * kill switch is enforced there, not only at the entry points above. These
+   * cases are about what a PROVIDER failure discloses, so the switch is on.
+   */
+  jest.spyOn(ProjectService, "findOneById").mockResolvedValue(fakeProject());
   jest.spyOn(LlmProviderService, "getProviderForChat").mockResolvedValue({
     id: ObjectID.generate(),
     name: "Test Provider",

--- a/Common/Tests/Server/Utils/AI/CodeFixAgentCompletion.test.ts
+++ b/Common/Tests/Server/Utils/AI/CodeFixAgentCompletion.test.ts
@@ -77,6 +77,8 @@ function mockHappyDependencies(data?: {
   jest
     .spyOn(LlmProviderService, "getLlmProviderForMeteredAgentPath")
     .mockResolvedValue(fakeProvider());
+  // The project's enableAi kill switch, read before the provider is resolved.
+  jest.spyOn(AIService, "assertProjectAIEnabled").mockResolvedValue(undefined);
 
   const executeSpy: ExecuteSpy = jest
     .spyOn(AIService, "executeWithLogging")
@@ -130,6 +132,9 @@ describe("CodeFixAgentCompletion.execute guards", () => {
     jest.spyOn(AIService, "executeWithLogging").mockImplementation(() => {
       throw new Error("executeWithLogging must not be reached");
     });
+    jest
+      .spyOn(AIService, "assertProjectAIEnabled")
+      .mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/Common/Tests/Server/Utils/AI/InvestigationGrader.test.ts
+++ b/Common/Tests/Server/Utils/AI/InvestigationGrader.test.ts
@@ -2,14 +2,16 @@ import InvestigationGrader from "../../../../Server/Utils/AI/SRE/InvestigationGr
 import PostedRootCause from "../../../../Server/Utils/AI/SRE/PostedRootCause";
 import AIRunService from "../../../../Server/Services/AIRunService";
 import IncidentService from "../../../../Server/Services/IncidentService";
+import ProjectService from "../../../../Server/Services/ProjectService";
 import AIService, {
   AILogResponse,
 } from "../../../../Server/Services/AIService";
 import AIRun from "../../../../Models/DatabaseModels/AIRun";
 import Incident from "../../../../Models/DatabaseModels/Incident";
+import Project from "../../../../Models/DatabaseModels/Project";
 import AIRunAutoGrade from "../../../../Types/AI/AIRunAutoGrade";
 import ObjectID from "../../../../Types/ObjectID";
-import { describe, expect, test, afterEach } from "@jest/globals";
+import { beforeEach, describe, expect, test, afterEach } from "@jest/globals";
 
 /*
  * On-resolve investigation grading (Phase 2 measurement layer): when an
@@ -153,8 +155,44 @@ describe("InvestigationGrader.parseAutoGradeToken", () => {
 });
 
 describe("InvestigationGrader.gradeInvestigationOnResolve", () => {
+  /*
+   * Grading reads the project's enableAi kill switch first and returns
+   * quietly when it is off (the backstop inside executeWithLogging would
+   * throw, and this lane runs detached inside a catch that logs at error
+   * level — a switched-off project would file an error on every resolve).
+   * Every case below is about the grading logic, so the switch is on.
+   */
+  beforeEach(() => {
+    jest.spyOn(ProjectService, "findOneById").mockResolvedValue({
+      id: projectId,
+      enableAi: true,
+    } as unknown as Project);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  test("AI switched off for the project → skips silently, no LLM call", async () => {
+    jest.spyOn(ProjectService, "findOneById").mockResolvedValue({
+      id: projectId,
+      enableAi: false,
+    } as unknown as Project);
+    const findRun: jest.SpyInstance = jest.spyOn(AIRunService, "findOneBy");
+    const executeWithLogging: jest.SpyInstance = jest.spyOn(
+      AIService,
+      "executeWithLogging",
+    );
+
+    await expect(
+      InvestigationGrader.gradeInvestigationOnResolve({
+        incidentId,
+        projectId,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(findRun).not.toHaveBeenCalled();
+    expect(executeWithLogging).not.toHaveBeenCalled();
   });
 
   test("no completed investigation → skips before loading the incident, no LLM call", async () => {


### PR DESCRIPTION
### Title of this pull request?

fix(ai): move the enableAi kill switch inside executeWithLogging

### Small Description?

`Project.enableAi` is the per-project switch for AI — what a project flips when it does not want its data going to a model, or does not want to spend money on one. It was enforced as **admission control**: each entry point that wanted to honour it read the toggle itself.

That leaked the way per-site checks always leak. Five "Generate with AI" endpoints were gated; nine other paths into the same provider call were not. A project with AI switched off could still be billed for tokens through a runbook step run by hand, a Slack question, a Teams question, on-resolve investigation grading, the code-fix agent loop, or `IncidentService.generatePostmortemFromAI` called anywhere but the gated route.

The gate now lives inside `AIService.executeWithLogging`, which every AI call in the codebase passes through. One place, and true for callers that do not exist yet.

#### The decision, and the objections against it

There is deliberately **no per-request opt-out**. A `skipAICheck` flag would reopen the hole with a one-word diff, and the caller most likely to reach for it is the one that has not thought about the switch.

Entry-point checks remain, but their job is DELIVERY, not enforcement — because an exception cannot always reach the person who asked:

| lane | callers | why |
|---|---|---|
| **throw** | runbook AI step, the five HTTP handlers, the agent worker, `IncidentService.generatePostmortemFromAI` | the caller already turns exceptions into a message a human reads |
| **post** | Slack (mention + slash command), Teams | both run their real work in a detached IIFE whose `.catch` only logs — a thrown refusal reaches nobody, and the user is left on "Looking into it…" forever |
| **skip** | `InvestigationGrader` | fire-and-forget off an incident resolve, inside a catch that logs at error level. "AI is off" is a setting, not a failure; a throw would file an error for every incident a switched-off project ever resolves. Uses the new non-throwing `isProjectAIEnabled()`, matching the posture its sibling `IncidentPostmortemRunner` already takes |

The **extra DB read** objection dissolved. `executeWithLogging` reads the project once, before resolving a provider, and carries the row to the balance check. On the billing path that is the read the balance check already made; off it, one primary-key read against a provider round trip measured in seconds. A refusal writes **no** `LlmLog` row — nothing was spent, and for autonomous features that ledger *is* the daily budget.

`AI_DISABLED_MESSAGE` is now one exported constant, so the sentence a user reads in Slack, in Teams, on a runbook step and on a Generate button is the same one, and always names the screen where the switch goes back on.

#### Paths closed by this PR

- `App/FeatureSet/Runbook/Services/AIStepExecutor.ts` — a member running a runbook containing an AI step by hand (the automated triggers were already gated). The daily autonomous budget bounded this, but a ceiling on spend is not consent to spend.
- `Common/Server/API/SlackAPI.ts` ×2 and `Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts` — chat-ops questions via `ObservabilityAssistant.answerQuestion`. All three of its call sites are now gated (the third, `AIInvestigationEngine`, already was).
- `Common/Server/Utils/AI/SRE/InvestigationGrader.ts` — on-resolve grading.
- `Common/Server/Services/IncidentService.ts` — `generatePostmortemFromAI` at the service layer; it is public and has a second caller in `IncidentPostmortemRunner`, so gating the route alone left the switch true for one entry point and false for the other.
- `Common/Server/Utils/AI/CodeFix/CodeFixAgentCompletion.ts` — the `/ai-agent-data/llm-completion` agent loop.
- `ConfidenceSignal` and `InvestigationTldr` are downstream of an already-gated investigation run and never throw; the backstop covers them.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

Follows on from #3450, which closed the same hole for the five synchronous "Generate with AI" endpoints.

**Note for the reviewer:** #3450 was not on `master` when this branch was cut — its commits lived only on `claude/trusting-franklin-f0fc83`, alongside ~8k lines of unrelated network-site work. The two AI-toggle commits were cherry-picked here so this work builds on that base rather than duplicating it, so **this PR also lands #3450 under new SHAs**. If that branch merges separately, git will be reconciling identical content.

### Tests

New: `Common/Tests/Server/API/AIKillSwitchBackstop.test.ts` (50 tests). Table-driven over every lane by its real `LlmLog` feature label, asserting the refusal costs nothing — no provider resolution, no completion, no ledger row — plus the read's shape (`select` asks for `enableAi`, `props` is root), that an unselected `enableAi` still means enabled, fail-closed on an unreadable row, that the balance is read in the same round trip, and that the kill switch is reported ahead of the balance.

Two anti-drift tests:

1. every `AIService.executeWithLogging` call site in `Common/Server` and `App/FeatureSet` must appear in a registry naming its delivery lane — a new caller either joins it or fails the suite;
2. `AILogRequest` must contain no field that could switch the gate off.

Existing suites that drove the real `executeWithLogging` without a project row now mock one. `AIGenerationRequestBudget.test.ts` needed the same and **was already failing** against #3450's gated handlers — fixed here.

```
Common: 356 passed (15 suites)   App: 67 passed (1 suite)
tsc --noEmit clean on Common; eslint clean on all changed files
```

Pre-existing and untouched: `App` fails `tsc` on `Tests/Dashboard/LogsSavedViewOverrideMerge.test.ts:269` (`Includes` is not generic). Identical on `master` and unrelated to this change.
