### PR TITLE
fix(network-discovery): let a discovery scan's settings be edited after creation

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -14,6 +14,7 @@ import Button, {
   ButtonSize,
   ButtonStyleType,
 } from "Common/UI/Components/Button/Button";
+import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
 import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import FilterButtons, {
@@ -27,6 +28,7 @@ import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
 import ModelField from "Common/UI/Components/Forms/Types/Field";
+import { FormStep } from "Common/UI/Components/Forms/Types/FormStep";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import API from "Common/UI/Utils/API/API";
@@ -111,6 +113,219 @@ const SCAN_NAME_FORM_FIELD: ModelField<NetworkDeviceDiscoveryScan> = {
   customValidation: validateScanName,
 };
 
+/*
+ * The three questions a discovery scan is defined by, in the order they are
+ * asked. Declared once and handed to BOTH the create wizard on the table and
+ * the Edit dialog below, because a step the edit form does not have is a
+ * setting that can be created and then never corrected — which is the whole
+ * of OneUptime issue #3444.
+ */
+const DISCOVERY_SCAN_FORM_STEPS: Array<FormStep<NetworkDeviceDiscoveryScan>> = [
+  { title: "Scan Target", id: "scan-target" },
+  { title: "SNMP Credentials", id: "snmp" },
+  { title: "Schedule", id: "schedule" },
+];
+
+export type GetDiscoveryScanFormFieldsFunction = (
+  probes: Array<Probe>,
+) => Array<ModelField<NetworkDeviceDiscoveryScan>>;
+
+/*
+ * Every field of a discovery scan, for both the create wizard and the Edit
+ * dialog. A factory rather than a constant only because the probe dropdown's
+ * options are fetched at runtime.
+ *
+ * ONE definition on purpose. Two copies would be two sets of descriptions, two
+ * validators and two `showIf` chains to keep in step, and the copy that
+ * drifted would be the edit one — the one nobody exercises until they are
+ * already trying to fix a scan that is not working.
+ */
+const getDiscoveryScanFormFields: GetDiscoveryScanFormFieldsFunction = (
+  probes: Array<Probe>,
+): Array<ModelField<NetworkDeviceDiscoveryScan>> => {
+  return [
+    SCAN_NAME_FORM_FIELD,
+    {
+      field: {
+        cidr: true,
+      },
+      title: "Scan Target",
+      stepId: "scan-target",
+      fieldType: FormFieldSchemaType.Text,
+      required: true,
+      placeholder: "192.168.1.0/24",
+      /*
+       * Both notations are described here rather than only CIDR because
+       * octet ranges are the only way to express the common real-world
+       * shape "the same handful of addresses in every one of these
+       * /24s" without creating hundreds of separate scans.
+       */
+      description:
+        "Either a subnet in CIDR notation (192.168.1.0/24), or an octet range where any octet may be an inclusive low-high range — 10.16-22.0-255.51-66 sweeps .51 to .66 in every /24 from 10.16 to 10.22. " +
+        `A single scan may cover at most ${ScanTargetUtil.MAX_SCAN_HOSTS.toLocaleString("en-US")} addresses.`,
+      /*
+       * Parses the target with exactly the function the server validates
+       * it with, on the step it was typed on. Without this the field's
+       * only check was `required`, so any non-empty string — a phone
+       * number, a hostname, a reversed octet range — walked through all
+       * three steps and surfaced as one combined banner above the
+       * Schedule step (issue #3377).
+       *
+       * It covers the length ceiling too, so no `validation.maxLength`
+       * is declared beside it: ModelForm infers 100 from the ShortText
+       * column, but customValidation runs after validateLength and would
+       * overwrite that message anyway — and the parser's own cap is the
+       * 64 the server enforces, not the column's 100.
+       */
+      customValidation: validateScanTarget,
+    },
+    {
+      field: {
+        probe: true,
+      },
+      title: "Probe",
+      stepId: "scan-target",
+      /*
+       * A probe can only sweep a subnet it can actually route to, so
+       * this list is the real constraint on what you can discover — not
+       * a preference. Say so here rather than letting the operator pick
+       * a probe in another network and wait for an empty result.
+       */
+      description:
+        "The probe that sweeps this subnet. It has to be able to reach the subnet directly — a probe in another network, or outside the firewall, will scan and find nothing. If you have no probe deployed on this network yet, create a custom probe and run it there; it appears in this list once it connects.",
+      sideLink: {
+        text: "Create a custom probe",
+        url: RouteUtil.populateRouteParams(
+          RouteMap[PageMap.MONITORS_SETTINGS_PROBES] as Route,
+        ),
+        openLinkInNewTab: true,
+      },
+      fieldType: FormFieldSchemaType.Dropdown,
+      /*
+       * A probe with no id cannot be scanned with, so it is dropped.
+       * A probe with no NAME still can be, so it is kept under a
+       * stand-in label.
+       *
+       * This used to throw for either. The .map runs in the component's
+       * render body, not lazily when the create modal opens, so a single
+       * unnamed probe row — a global probe, or one registered before it
+       * was named — did not degrade the dropdown: it threw during render
+       * and blanked the entire Discovery Scans page, including the list
+       * of existing scans.
+       */
+      dropdownOptions: probes
+        .filter((probe: Probe) => {
+          return Boolean(probe._id);
+        })
+        .map((probe: Probe) => {
+          return {
+            label: probe.name || `Probe ${probe._id}`,
+            value: probe._id!,
+          };
+        }),
+      required: true,
+      placeholder: "Probe",
+    },
+    /*
+     * Shared SNMP fields (version, community, full v3 credential set
+     * with showIf reveal logic) — the same helper the NetworkDevice
+     * forms use, so a v3 subnet scan collects the same credentials a v3
+     * device needs and the two can never drift apart.
+     */
+    ...getSnmpConfigFormFields({
+      communityStringDescription:
+        "Tried against every host in the subnet. Required for SNMP V1 and V2c. Not used for V3.",
+      stepId: "snmp",
+    }),
+    {
+      field: {
+        isRecurring: true,
+      },
+      title: "Repeat this scan",
+      stepId: "schedule",
+      fieldType: FormFieldSchemaType.Toggle,
+      required: false,
+      description:
+        "Re-run this scan automatically to keep discovery continuous. Newly found devices wait for your review before import, unless an auto-import rule matches them.",
+    },
+    /*
+     * Only meaningful together with the toggle above, so it reveals
+     * itself the same way the v3 credential fields do in
+     * SnmpConfigFormFields.ts: showIf on the controlling value.
+     */
+    {
+      field: {
+        rescanIntervalInMinutes: true,
+      },
+      title: "Rescan Interval (Minutes)",
+      stepId: "schedule",
+      fieldType: FormFieldSchemaType.Number,
+      required: true,
+      placeholder: "60",
+      description: `How often to re-run this scan, in minutes. Minimum ${MINIMUM_RESCAN_INTERVAL_IN_MINUTES} minutes.`,
+      /*
+       * One validator rather than a `validation: { minValue }` beside it:
+       * the built-in minimum runs the value through parseInt, so "20.5"
+       * reads as 20 and clears a floor of 15 before failing the INSERT
+       * against an integer column — and customValidation runs last, so a
+       * minValue declared alongside would only have its message
+       * overwritten. See DiscoveryScanFormValidation.
+       */
+      customValidation: validateRescanInterval,
+      showIf: (item: FormValues<NetworkDeviceDiscoveryScan>): boolean => {
+        return Boolean(item.isRecurring);
+      },
+    },
+  ];
+};
+
+/*
+ * The same fields, laid out for the Edit dialog: one page, grouped under the
+ * headings the create wizard uses as step titles.
+ *
+ * NOT a wizard. A stepped form has no Back button — the only way backwards is
+ * the step rail, which BasicForm hides below the `lg` breakpoint — and walking
+ * three steps to reach the toggle you came to flip is the wrong shape for a
+ * repair. The headings come from DISCOVERY_SCAN_FORM_STEPS rather than being
+ * written out again, so the two layouts can never describe the same field as
+ * belonging to two different things.
+ *
+ * BasicForm renders every field when a form declares no steps, and Validation
+ * skips its step guard for the same reason, so the fields keep the `stepId`
+ * the wizard needs and it simply goes unread here.
+ */
+const getDiscoveryScanEditFormFields: GetDiscoveryScanFormFieldsFunction = (
+  probes: Array<Probe>,
+): Array<ModelField<NetworkDeviceDiscoveryScan>> => {
+  const titledStepIds: Set<string> = new Set<string>();
+
+  return getDiscoveryScanFormFields(probes).map(
+    (field: ModelField<NetworkDeviceDiscoveryScan>) => {
+      const stepId: string | undefined = field.stepId;
+
+      if (!stepId || titledStepIds.has(stepId)) {
+        return field;
+      }
+
+      const step: FormStep<NetworkDeviceDiscoveryScan> | undefined =
+        DISCOVERY_SCAN_FORM_STEPS.find(
+          (candidate: FormStep<NetworkDeviceDiscoveryScan>) => {
+            return candidate.id === stepId;
+          },
+        );
+
+      if (!step) {
+        return field;
+      }
+
+      titledStepIds.add(stepId);
+
+      // The first field of each group carries the group's heading.
+      return { ...field, sectionTitle: step.title };
+    },
+  );
+};
+
 const NetworkDeviceDiscovery: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
@@ -123,12 +338,14 @@ const NetworkDeviceDiscovery: FunctionComponent<
   // Review Results modal state.
   const [showReviewModal, setShowReviewModal] = useState<boolean>(false);
   /*
-   * The scan the Rename dialog is open for, or null. A name that cannot be
-   * corrected is worse than no name at all — "Region 1100" on the wrong range
-   * misleads every operator who reads the list afterwards — and the only other
-   * way to fix one would be to delete the scan and lose its results with it.
+   * The scan the Edit dialog is open for, or null.
+   *
+   * Every setting a scan has used to be fixed at creation: a typo'd subnet, a
+   * probe on the wrong side of a firewall, a community string the devices
+   * reject — none of them could be corrected, and the only way out was to
+   * delete the scan and lose its results with it (OneUptime issue #3444).
    */
-  const [scanToRename, setScanToRename] =
+  const [scanToEdit, setScanToEdit] =
     useState<NetworkDeviceDiscoveryScan | null>(null);
   const [scanToReview, setScanToReview] =
     useState<NetworkDeviceDiscoveryScan | null>(null);
@@ -470,145 +687,8 @@ const NetworkDeviceDiscovery: FunctionComponent<
         noItemsMessage={
           "No discovery scans yet. Start one to sweep a subnet or octet range for SNMP devices."
         }
-        formSteps={[
-          { title: "Scan Target", id: "scan-target" },
-          { title: "SNMP Credentials", id: "snmp" },
-          { title: "Schedule", id: "schedule" },
-        ]}
-        formFields={[
-          SCAN_NAME_FORM_FIELD,
-          {
-            field: {
-              cidr: true,
-            },
-            title: "Scan Target",
-            stepId: "scan-target",
-            fieldType: FormFieldSchemaType.Text,
-            required: true,
-            placeholder: "192.168.1.0/24",
-            /*
-             * Both notations are described here rather than only CIDR because
-             * octet ranges are the only way to express the common real-world
-             * shape "the same handful of addresses in every one of these
-             * /24s" without creating hundreds of separate scans.
-             */
-            description:
-              "Either a subnet in CIDR notation (192.168.1.0/24), or an octet range where any octet may be an inclusive low-high range — 10.16-22.0-255.51-66 sweeps .51 to .66 in every /24 from 10.16 to 10.22. " +
-              `A single scan may cover at most ${ScanTargetUtil.MAX_SCAN_HOSTS.toLocaleString("en-US")} addresses.`,
-            /*
-             * Parses the target with exactly the function the server validates
-             * it with, on the step it was typed on. Without this the field's
-             * only check was `required`, so any non-empty string — a phone
-             * number, a hostname, a reversed octet range — walked through all
-             * three steps and surfaced as one combined banner above the
-             * Schedule step (issue #3377).
-             *
-             * It covers the length ceiling too, so no `validation.maxLength`
-             * is declared beside it: ModelForm infers 100 from the ShortText
-             * column, but customValidation runs after validateLength and would
-             * overwrite that message anyway — and the parser's own cap is the
-             * 64 the server enforces, not the column's 100.
-             */
-            customValidation: validateScanTarget,
-          },
-          {
-            field: {
-              probe: true,
-            },
-            title: "Probe",
-            stepId: "scan-target",
-            /*
-             * A probe can only sweep a subnet it can actually route to, so
-             * this list is the real constraint on what you can discover — not
-             * a preference. Say so here rather than letting the operator pick
-             * a probe in another network and wait for an empty result.
-             */
-            description:
-              "The probe that sweeps this subnet. It has to be able to reach the subnet directly — a probe in another network, or outside the firewall, will scan and find nothing. If you have no probe deployed on this network yet, create a custom probe and run it there; it appears in this list once it connects.",
-            sideLink: {
-              text: "Create a custom probe",
-              url: RouteUtil.populateRouteParams(
-                RouteMap[PageMap.MONITORS_SETTINGS_PROBES] as Route,
-              ),
-              openLinkInNewTab: true,
-            },
-            fieldType: FormFieldSchemaType.Dropdown,
-            /*
-             * A probe with no id cannot be scanned with, so it is dropped.
-             * A probe with no NAME still can be, so it is kept under a
-             * stand-in label.
-             *
-             * This used to throw for either. The .map runs in the component's
-             * render body, not lazily when the create modal opens, so a single
-             * unnamed probe row — a global probe, or one registered before it
-             * was named — did not degrade the dropdown: it threw during render
-             * and blanked the entire Discovery Scans page, including the list
-             * of existing scans.
-             */
-            dropdownOptions: probes
-              .filter((probe: Probe) => {
-                return Boolean(probe._id);
-              })
-              .map((probe: Probe) => {
-                return {
-                  label: probe.name || `Probe ${probe._id}`,
-                  value: probe._id!,
-                };
-              }),
-            required: true,
-            placeholder: "Probe",
-          },
-          /*
-           * Shared SNMP fields (version, community, full v3 credential set
-           * with showIf reveal logic) — the same helper the NetworkDevice
-           * forms use, so a v3 subnet scan collects the same credentials a v3
-           * device needs and the two can never drift apart.
-           */
-          ...getSnmpConfigFormFields({
-            communityStringDescription:
-              "Tried against every host in the subnet. Required for SNMP V1 and V2c. Not used for V3.",
-            stepId: "snmp",
-          }),
-          {
-            field: {
-              isRecurring: true,
-            },
-            title: "Repeat this scan",
-            stepId: "schedule",
-            fieldType: FormFieldSchemaType.Toggle,
-            required: false,
-            description:
-              "Re-run this scan automatically to keep discovery continuous. Newly found devices wait for your review before import, unless an auto-import rule matches them.",
-          },
-          /*
-           * Only meaningful together with the toggle above, so it reveals
-           * itself the same way the v3 credential fields do in
-           * SnmpConfigFormFields.ts: showIf on the controlling value.
-           */
-          {
-            field: {
-              rescanIntervalInMinutes: true,
-            },
-            title: "Rescan Interval (Minutes)",
-            stepId: "schedule",
-            fieldType: FormFieldSchemaType.Number,
-            required: true,
-            placeholder: "60",
-            description: `How often to re-run this scan, in minutes. Minimum ${MINIMUM_RESCAN_INTERVAL_IN_MINUTES} minutes.`,
-            /*
-             * One validator rather than a `validation: { minValue }` beside it:
-             * the built-in minimum runs the value through parseInt, so "20.5"
-             * reads as 20 and clears a floor of 15 before failing the INSERT
-             * against an integer column — and customValidation runs last, so a
-             * minValue declared alongside would only have its message
-             * overwritten. See DiscoveryScanFormValidation.
-             */
-            customValidation: validateRescanInterval,
-            showIf: (item: FormValues<NetworkDeviceDiscoveryScan>): boolean => {
-              return Boolean(item.isRecurring);
-            },
-          },
-        ]}
+        formSteps={DISCOVERY_SCAN_FORM_STEPS}
+        formFields={getDiscoveryScanFormFields(probes)}
         columns={[
           /*
            * The scan's identity, in one column: its name if it has one, with
@@ -827,15 +907,16 @@ const NetworkDeviceDiscovery: FunctionComponent<
         }}
         actionButtons={[
           {
-            title: "Rename",
+            title: "Edit",
             buttonStyleType: ButtonStyleType.NORMAL,
             icon: IconProp.Pencil,
             /*
-             * Hidden for anyone who could not save the rename anyway. The
-             * table sets isEditable={false}, so this button is the only edit
+             * Hidden for anyone who could not save the edit anyway. The table
+             * sets isEditable={false}, so this button is the only edit
              * affordance on the page and nothing else is gating it — a viewer
-             * would otherwise open a dialog whose one field ModelForm has
-             * already dropped for want of the update permission.
+             * would otherwise open a dialog whose fields ModelForm has already
+             * dropped for want of the update permission, and which says
+             * nothing about why it is empty.
              */
             isVisible: (): boolean => {
               return PermissionGate.check(
@@ -847,7 +928,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
               item: NetworkDeviceDiscoveryScan,
               onCompleteAction: VoidFunction,
             ) => {
-              setScanToRename(item);
+              setScanToEdit(item);
               onCompleteAction();
             },
           },
@@ -869,36 +950,59 @@ const NetworkDeviceDiscovery: FunctionComponent<
         ]}
       />
 
-      {scanToRename && (
+      {scanToEdit && (
         /*
-         * One field, no steps. ModelFormModal fetches the scan, prefills the
-         * box and PATCHes just this column. The schedule pair (isRecurring,
-         * rescanIntervalInMinutes) is updatable on the model too, but it is
-         * deliberately not offered here: this dialog answers "what is this
-         * scan called", and nothing about the sweep itself.
+         * Everything about the scan except what it found. ModelFormModal
+         * fetches the row, prefills every box from it and PATCHes the lot;
+         * the server works out what actually changed and, if the sweep itself
+         * did, re-queues the scan — see NetworkDeviceDiscoveryScanService.
+         *
+         * This replaced a Rename dialog that offered the name alone. Name is
+         * still the first thing in the form, and a save that changes only the
+         * name is inert exactly as the rename was: the server compares values,
+         * not which keys the form posted.
          */
         <ModelFormModal<NetworkDeviceDiscoveryScan>
           modelType={NetworkDeviceDiscoveryScan}
-          modelIdToEdit={scanToRename.id!}
-          name="Rename Discovery Scan"
-          title="Rename Discovery Scan"
-          description={`Give this scan a name you will recognise in the list. It sweeps ${
-            scanToRename.cidr || "the address range it was created with"
+          modelIdToEdit={scanToEdit.id!}
+          name="Edit Discovery Scan"
+          title="Edit Discovery Scan"
+          description={`Change what this scan sweeps, which probe runs it, the credentials it tries, or how often it repeats. It currently sweeps ${
+            scanToEdit.cidr || "the address range it was created with"
           }.`}
+          /*
+           * The one consequence that is not obvious from the form: a changed
+           * sweep makes the last run's hosts describe a scan that no longer
+           * exists, so they go. Said before the operator saves rather than
+           * discovered afterwards in an empty Review Results dialog.
+           */
+          footer={
+            <Alert
+              type={AlertType.INFO}
+              strongTitle="Changing the target, probe or credentials re-runs the scan"
+              title="The scan goes back to Pending and sweeps again with the new settings, and the hosts the last run found are cleared - they describe settings this scan no longer has. Devices you have already imported are not touched. Changing only the name or the schedule leaves the results alone."
+            />
+          }
+          modalWidth={ModalWidth.Medium}
           submitButtonText="Save Changes"
           onClose={() => {
-            setScanToRename(null);
+            setScanToEdit(null);
           }}
           onSuccess={() => {
-            setScanToRename(null);
-            // Same refresh the import path uses, so the list shows the new name.
+            setScanToEdit(null);
+            /*
+             * Same refresh the import path uses. The server's re-queue runs
+             * inside onUpdateSuccess, which the request waits on, so the
+             * refetched row already shows Pending rather than the results it
+             * is about to lose.
+             */
             setRefreshToggle(Date.now().toString());
           }}
           formProps={{
-            name: "Rename Discovery Scan",
+            name: "Edit Discovery Scan",
             modelType: NetworkDeviceDiscoveryScan,
-            id: "rename-network-device-discovery-scan-form",
-            fields: [SCAN_NAME_FORM_FIELD],
+            id: "edit-network-device-discovery-scan-form",
+            fields: getDiscoveryScanEditFormFields(probes),
             formType: FormType.Update,
           }}
         />

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -855,6 +855,20 @@ const NetworkDeviceDiscovery: FunctionComponent<
                 ? OneUptimeDate.fromString(item.nextScanAt)
                 : null;
 
+              /*
+               * A recurring scan with no next run used to render as the
+               * interval alone, and the second line was simply left off. That
+               * is the one state where the row most needs a second line: a
+               * scan whose recurrence is on and whose nextScanAt is NULL is
+               * never picked up by the requeue worker, because `NULL <= now`
+               * is UNKNOWN in SQL — so "Every 60 min" was, for those rows, a
+               * flat untruth with nothing to hint at it (OneUptime issue
+               * #3444). The server now derives the column instead, so a row
+               * like that should no longer exist; if one does, it says so.
+               */
+              const isRunUnderway: boolean =
+                item.status === "Pending" || item.status === "In Progress";
+
               return (
                 <div>
                   <div className="text-sm text-gray-900">
@@ -862,7 +876,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
                       ? `Every ${item.rescanIntervalInMinutes} min`
                       : "Recurring"}
                   </div>
-                  {nextScanAt && (
+                  {nextScanAt ? (
                     <div
                       className="text-xs text-gray-500"
                       title={OneUptimeDate.getDateAsLocalFormattedString(
@@ -871,6 +885,15 @@ const NetworkDeviceDiscovery: FunctionComponent<
                     >
                       {/* fromNow renders e.g. "in 12 minutes". */}
                       {`Next scan ${OneUptimeDate.fromNow(nextScanAt)}`}
+                    </div>
+                  ) : isRunUnderway ? (
+                    <div className="text-xs text-gray-500">
+                      Next scan is scheduled when this run finishes
+                    </div>
+                  ) : (
+                    <div className="text-xs text-yellow-600">
+                      No next scan is scheduled. Open Edit and save to schedule
+                      one.
                     </div>
                   )}
                 </div>

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -83,14 +83,13 @@ import React, {
 type DiscoveredDeviceEntry = DiscoveredNetworkDevice;
 
 /*
- * The scan's optional name, defined once and used twice: as the first field of
- * the create wizard, and as the only field of the Rename dialog. Two copies
- * would be two chances for the wizard's guidance and the rename dialog's to
- * drift apart, on a field whose entire job is to be read later.
+ * The scan's optional name — the first field of the create wizard, and the
+ * first field of the Edit dialog.
  *
- * It keeps its `stepId` in both places. The rename dialog declares no steps at
- * all, and BasicForm renders every field when there are none — see
- * Common/UI/Components/Forms/BasicForm.
+ * It carries a `stepId` because the wizard is stepped. The Edit dialog is not,
+ * and simply does not read it: BasicForm renders every field when a form
+ * declares no steps, and Validation skips its step guard for the same reason.
+ * See Common/UI/Components/Forms/BasicForm.
  */
 const SCAN_NAME_FORM_FIELD: ModelField<NetworkDeviceDiscoveryScan> = {
   field: {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/DiscoveryScanFormValidation.ts
@@ -2,6 +2,7 @@ import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDevi
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
 import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
+import { MINIMUM_RESCAN_INTERVAL_IN_MINUTES } from "Common/Utils/NetworkDiscovery/RescanIntervalUtil";
 
 /*
  * Client-side validators for the "Create New Network Device Discovery Scan"
@@ -31,10 +32,12 @@ import ScanNameUtil from "Common/Utils/NetworkDiscovery/ScanNameUtil";
  * module means App/Tests can exercise them directly, the same reason
  * SloFormFields.ts and DevicePollingFormFields.ts sit outside their pages.
  *
- * The field DEFINITIONS deliberately stay inline in Discovery.tsx: the wizard
+ * The field DEFINITIONS deliberately stay in Discovery.tsx: the wizard
  * invariants in App/Tests/Dashboard/NetworkFormStepsInvariants.test.ts match a
- * page's `formSteps={[...]}` ids against the `stepId: "..."` literals on that
- * same page, and moving the fields out would move the literals with them.
+ * page's declared step ids against the `stepId: "..."` literals on that same
+ * page, and moving the fields to another file would move the literals with
+ * them. (Module scope within Discovery.tsx is fine, and is where they live, so
+ * the create wizard and the edit dialog share one definition.)
  */
 
 /*
@@ -65,8 +68,13 @@ const readRawString: ReadRawStringFunction = (value: unknown): string => {
  * The floor RequeueRecurringScans is sized against: a sweep at the
  * ScanTargetUtil.MAX_SCAN_HOSTS ceiling can take the better part of an hour,
  * so re-queueing one more often than this stacks scans on the same probe.
+ *
+ * Re-exported rather than declared, so the form, the write hooks that derive
+ * the next run from it, and the probe-ingest endpoint that clamps to it are
+ * all quoting one number. It used to be written out separately in each of
+ * those three places.
  */
-export const MINIMUM_RESCAN_INTERVAL_IN_MINUTES: number = 15;
+export { MINIMUM_RESCAN_INTERVAL_IN_MINUTES } from "Common/Utils/NetworkDiscovery/RescanIntervalUtil";
 
 export type ScanTargetValidatorFunction = (
   values: FormValues<NetworkDeviceDiscoveryScan>,

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -6,6 +6,10 @@ import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
+import {
+  MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
+  clampRescanIntervalInMinutes,
+} from "Common/Utils/NetworkDiscovery/RescanIntervalUtil";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
 import QueryDeepPartialEntity from "Common/Types/Database/PartialEntity";
@@ -18,15 +22,6 @@ import Response from "Common/Server/Utils/Response";
 import logger from "Common/Server/Utils/Logger";
 
 const router: ExpressRouter = Express.getRouter();
-
-/*
- * Floor for recurring rescans. A discovery sweep is heavy (up to
- * ScanTargetUtil.MAX_SCAN_HOSTS addresses, one probe at a time), so anything
- * tighter than this would keep the probe permanently busy. Lower stored
- * intervals are clamped, not rejected — the scan still recurs, just no faster
- * than this.
- */
-const MINIMUM_RESCAN_INTERVAL_IN_MINUTES: number = 15;
 
 /*
  * NetworkDeviceDiscoveryScan.statusMessage is a varchar(500). The probe's
@@ -135,6 +130,39 @@ router.post(
              * the whole sweep, why it had not started.
              */
             statusMessage: null,
+          } as unknown as QueryDeepPartialEntity<NetworkDeviceDiscoveryScan>,
+          /*
+           * Claim ONLY IF everything just handed to the probe is still true.
+           *
+           * The SELECT above and this UPDATE are two statements, and the
+           * UPDATE addresses the row by id alone. A scan's settings became
+           * editable in OneUptime issue #3444, so a save landing in between
+           * would hand this probe one configuration and stamp the row with
+           * another — and, if the probe was reassigned, wedge the scan: the
+           * old probe's result is rejected on the probeId scope below, the new
+           * probe can never claim a row that is already In Progress, and it
+           * sits there until the two-hour reaper calls it a dead probe.
+           *
+           * Every expected column becomes `IS NOT DISTINCT FROM` in the
+           * UPDATE's WHERE, so a mismatch is simply zero rows affected: the
+           * scan stays Pending, this sweep's eventual result is discarded by
+           * the Pending guard in the result endpoint, and the next poll picks
+           * the scan up with its new settings. `name` is deliberately absent —
+           * a rename changes nothing about the sweep and must not cost one.
+           */
+          expectedData: {
+            status: "Pending",
+            probeId: probeId,
+            cidr: scan.cidr ?? null,
+            snmpVersion: scan.snmpVersion ?? null,
+            snmpCommunityString: scan.snmpCommunityString ?? null,
+            snmpPort: scan.snmpPort ?? null,
+            snmpV3SecurityLevel: scan.snmpV3SecurityLevel ?? null,
+            snmpV3Username: scan.snmpV3Username ?? null,
+            snmpV3AuthProtocol: scan.snmpV3AuthProtocol ?? null,
+            snmpV3AuthKey: scan.snmpV3AuthKey ?? null,
+            snmpV3PrivProtocol: scan.snmpV3PrivProtocol ?? null,
+            snmpV3PrivKey: scan.snmpV3PrivKey ?? null,
           } as unknown as QueryDeepPartialEntity<NetworkDeviceDiscoveryScan>,
         });
       }
@@ -341,15 +369,13 @@ router.post(
        * RequeueRecurringScans.ts) resets the scan to Pending once nextScanAt
        * is due.
        */
-      if (
-        scan.isRecurring &&
-        scan.rescanIntervalInMinutes &&
-        scan.rescanIntervalInMinutes > 0
-      ) {
-        let intervalInMinutes: number = scan.rescanIntervalInMinutes;
+      const clampedIntervalInMinutes: number | null =
+        clampRescanIntervalInMinutes(scan.rescanIntervalInMinutes);
 
-        if (intervalInMinutes < MINIMUM_RESCAN_INTERVAL_IN_MINUTES) {
-          intervalInMinutes = MINIMUM_RESCAN_INTERVAL_IN_MINUTES;
+      if (scan.isRecurring && clampedIntervalInMinutes !== null) {
+        const intervalInMinutes: number = clampedIntervalInMinutes;
+
+        if (intervalInMinutes !== scan.rescanIntervalInMinutes) {
           logger.warn(
             `Discovery scan ${scanId} rescan interval of ${scan.rescanIntervalInMinutes} minute(s) is below the ${MINIMUM_RESCAN_INTERVAL_IN_MINUTES}-minute minimum. Clamping.`,
           );
@@ -361,8 +387,18 @@ router.post(
             `Rescan interval is below the ${MINIMUM_RESCAN_INTERVAL_IN_MINUTES}-minute minimum; rescanning every ${MINIMUM_RESCAN_INTERVAL_IN_MINUTES} minutes instead.`;
         }
 
-        completed["nextScanAt"] =
-          OneUptimeDate.getSomeMinutesAfter(intervalInMinutes);
+        /*
+         * Measured from the completion this write is recording, not from
+         * "now", so the column holds exactly what
+         * RescanIntervalUtil.getNextScanAt would derive from the finished row.
+         * The service re-derives it whenever the schedule is edited, and two
+         * clocks a millisecond apart would make every such edit rewrite a
+         * value that had not actually changed.
+         */
+        completed["nextScanAt"] = OneUptimeDate.addRemoveMinutes(
+          completed["completedAt"] as Date,
+          intervalInMinutes,
+        );
       }
 
       // Last stop before the write — every append above has happened by now.

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -149,6 +149,12 @@ router.post(
            * the Pending guard in the result endpoint, and the next poll picks
            * the scan up with its new settings. `name` is deliberately absent —
            * a rename changes nothing about the sweep and must not cost one.
+           *
+           * The write reports no count, so the probe is still handed the scan
+           * and still sweeps it once for nothing when the guard bites. That is
+           * the cheap half of the trade: a wasted sweep in a race that needs a
+           * save to land inside a single round trip, against a scan wedged
+           * In Progress for two hours until the reaper gives up on it.
            */
           expectedData: {
             status: "Pending",

--- a/App/Tests/Dashboard/NetworkFormStepsInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkFormStepsInvariants.test.ts
@@ -104,16 +104,21 @@ function matchAll(pattern: RegExp, text: string): Array<string> {
 /*
  * The bodies of every step list on the page.
  *
- * Two spellings, because the two hosts of a stepped form name the prop
- * differently: ModelTable takes `formSteps={[ ... ]}` and ModelFormModal
- * takes `steps: [ ... ]` inside its formProps. Both hold only string
- * literals and predicate names, so the first terminator after the opening
- * always closes the list.
+ * Three spellings. The two hosts of a stepped form name the prop differently
+ * — ModelTable takes `formSteps={[ ... ]}` and ModelFormModal takes
+ * `steps: [ ... ]` inside its formProps — and a page that renders the same
+ * steps twice hoists them into a module-level
+ * `const X: Array<FormStep<Model>> = [ ... ];` and passes that instead, which
+ * is the shape Discovery.tsx uses to keep its create wizard and its edit
+ * dialog describing one set of groups. All three hold only string literals
+ * and predicate names, so the first terminator after the opening always
+ * closes the list.
  */
 function formStepBlocks(source: string): Array<string> {
   return [
     ...matchAll(/formSteps=\{\[(.*?)\]\}/, source),
     ...matchAll(/\bsteps:\s*\[(.*?)\],\s*fields:/, source),
+    ...matchAll(/\bArray<FormStep<[^>]*>> = \[(.*?)\];/, source),
   ];
 }
 
@@ -145,9 +150,7 @@ describe.each(STEPPED_FORM_PAGES)("%s form steps", (page: string) => {
   const source: string = readPage(page);
 
   test("renders its form as a wizard", () => {
-    expect(source.includes("formSteps={[") || source.includes("steps: [")).toBe(
-      true,
-    );
+    expect(formStepBlocks(source).length).toBeGreaterThan(0);
   });
 
   /*

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -222,9 +222,21 @@ describe("POST /probe/discovery-scan/list", () => {
       scanId,
     );
     scan.cidr = "192.168.1.0/24";
-    scan.snmpVersion = "V2c";
+    scan.snmpVersion = "V3";
     scan.snmpCommunityString = "public";
     scan.snmpPort = 161;
+    /*
+     * The v3 credentials are SET on this fixture on purpose. With them left
+     * unset the expectation could be satisfied by a guard that hardcoded null,
+     * and the assertion would say nothing about whether the claim actually
+     * carries the values the probe was handed.
+     */
+    scan.snmpV3SecurityLevel = "authPriv";
+    scan.snmpV3Username = "netops";
+    scan.snmpV3AuthProtocol = "sha";
+    scan.snmpV3AuthKey = "auth-secret";
+    scan.snmpV3PrivProtocol = "aes";
+    scan.snmpV3PrivKey = "priv-secret";
 
     scanService.findBy.mockResolvedValue([scan] as never);
     scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
@@ -250,17 +262,54 @@ describe("POST /probe/discovery-scan/list", () => {
 
     // ...then every setting that decides what the sweep actually does.
     expect(expected["cidr"]).toBe("192.168.1.0/24");
-    expect(expected["snmpVersion"]).toBe("V2c");
+    expect(expected["snmpVersion"]).toBe("V3");
     expect(expected["snmpCommunityString"]).toBe("public");
     expect(expected["snmpPort"]).toBe(161);
+    expect(expected["snmpV3SecurityLevel"]).toBe("authPriv");
+    expect(expected["snmpV3Username"]).toBe("netops");
+    expect(expected["snmpV3AuthProtocol"]).toBe("sha");
+    expect(expected["snmpV3AuthKey"]).toBe("auth-secret");
+    expect(expected["snmpV3PrivProtocol"]).toBe("aes");
+    expect(expected["snmpV3PrivKey"]).toBe("priv-secret");
 
     /*
-     * The v3 credentials are unset on this v2c scan and are expected as NULL
-     * rather than omitted: `expectedData` renders each key as
-     * `IS NOT DISTINCT FROM`, so an omitted key would let a credential
-     * appear between the SELECT and the UPDATE without voiding the claim.
+     * And NOT the name. A rename changes nothing about the sweep, and voiding
+     * a claim over one would cost the probe a whole cycle for nothing.
      */
+    expect(Object.keys(expected)).not.toContain("name");
+  });
+
+  /*
+   * An UNSET credential is expected as NULL rather than left out of the
+   * guard. expectedData renders each key as `IS NOT DISTINCT FROM`, so an
+   * omitted key is not "must still be empty" — it is "do not care", and a
+   * credential appearing between the SELECT and the UPDATE would not void the
+   * claim.
+   */
+  test("expects an unset credential to still be unset, rather than not caring", async () => {
+    const scanId: ObjectID = ObjectID.generate();
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(
+      scanId,
+    );
+    scan.cidr = "192.168.1.0/24";
+    scan.snmpVersion = "V2c";
+    scan.snmpCommunityString = "public";
+
+    scanService.findBy.mockResolvedValue([scan] as never);
+    scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+      undefined as never,
+    );
+
+    await callListEndpoint(makeRequest({ probeId }));
+
+    const updateArgs: JSONObject = scanService.updateColumnsByIdWithoutHooks
+      .mock.calls[0]![0] as JSONObject;
+    const expected: JSONObject = expectPlainUpdateData(
+      updateArgs["expectedData"],
+    );
+
     for (const column of [
+      "snmpPort",
       "snmpV3SecurityLevel",
       "snmpV3Username",
       "snmpV3AuthProtocol",
@@ -269,14 +318,11 @@ describe("POST /probe/discovery-scan/list", () => {
       "snmpV3PrivKey",
     ]) {
       expect(Object.keys(expected)).toContain(column);
-      expect(expected[column]).toBeNull();
+      expect({ column: column, value: expected[column] }).toEqual({
+        column: column,
+        value: null,
+      });
     }
-
-    /*
-     * And NOT the name. A rename changes nothing about the sweep, and voiding
-     * a claim over one would cost the probe a whole cycle for nothing.
-     */
-    expect(Object.keys(expected)).not.toContain("name");
   });
 
   test("hands out the probe's pending scans and marks each In Progress with plain column data", async () => {

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -202,6 +202,83 @@ describe("POST /probe/discovery-scan/list", () => {
     expect(select["cidr"]).toBe(true);
   });
 
+  /*
+   * The claim is a read-then-write: the SELECT above filters on
+   * `probeId + status = "Pending"`, but the UPDATE addresses the row by id
+   * alone. That gap was harmless while a scan's settings were fixed at
+   * creation. Once they became editable (OneUptime issue #3444) a save landing
+   * inside it would hand this probe one configuration and stamp the row with
+   * another — and, if the probe was reassigned, wedge the scan for two hours:
+   * the old probe's result is rejected on the probeId scope, and the new probe
+   * can never claim a row that already says In Progress.
+   *
+   * So the claim carries its own precondition. Every setting handed to the
+   * probe is asserted in the same statement, which makes a claim on stale
+   * settings a no-op rather than a lie.
+   */
+  test("claims a scan only while the settings it was handed are still current", async () => {
+    const scanId: ObjectID = ObjectID.generate();
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(
+      scanId,
+    );
+    scan.cidr = "192.168.1.0/24";
+    scan.snmpVersion = "V2c";
+    scan.snmpCommunityString = "public";
+    scan.snmpPort = 161;
+
+    scanService.findBy.mockResolvedValue([scan] as never);
+    scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+      undefined as never,
+    );
+
+    await callListEndpoint(makeRequest({ probeId }));
+
+    const updateArgs: JSONObject = scanService.updateColumnsByIdWithoutHooks
+      .mock.calls[0]![0] as JSONObject;
+    const expected: JSONObject = expectPlainUpdateData(
+      updateArgs["expectedData"],
+    );
+
+    /*
+     * Status and probe first: those are what a re-queue and a probe
+     * reassignment change, and either one invalidates a claim outright.
+     */
+    expect(expected["status"]).toBe("Pending");
+    expect((expected["probeId"] as ObjectID).toString()).toBe(
+      probeId.toString(),
+    );
+
+    // ...then every setting that decides what the sweep actually does.
+    expect(expected["cidr"]).toBe("192.168.1.0/24");
+    expect(expected["snmpVersion"]).toBe("V2c");
+    expect(expected["snmpCommunityString"]).toBe("public");
+    expect(expected["snmpPort"]).toBe(161);
+
+    /*
+     * The v3 credentials are unset on this v2c scan and are expected as NULL
+     * rather than omitted: `expectedData` renders each key as
+     * `IS NOT DISTINCT FROM`, so an omitted key would let a credential
+     * appear between the SELECT and the UPDATE without voiding the claim.
+     */
+    for (const column of [
+      "snmpV3SecurityLevel",
+      "snmpV3Username",
+      "snmpV3AuthProtocol",
+      "snmpV3AuthKey",
+      "snmpV3PrivProtocol",
+      "snmpV3PrivKey",
+    ]) {
+      expect(Object.keys(expected)).toContain(column);
+      expect(expected[column]).toBeNull();
+    }
+
+    /*
+     * And NOT the name. A rename changes nothing about the sweep, and voiding
+     * a claim over one would cost the probe a whole cycle for nothing.
+     */
+    expect(Object.keys(expected)).not.toContain("name");
+  });
+
   test("hands out the probe's pending scans and marks each In Progress with plain column data", async () => {
     const scanId: ObjectID = ObjectID.generate();
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(

--- a/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
@@ -191,7 +191,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     manyToOneRelationColumn: "probeId",
@@ -233,7 +240,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @Index()
   @TableColumn({
@@ -270,11 +284,21 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
     /*
-     * Updatable, unlike everything that describes the sweep itself: changing
-     * the target or the credentials of a scan mid-flight would mean the stored
-     * row no longer described the sweep that ran, so those grant no update at
-     * all. (The recurrence pair is updatable too — it describes the NEXT run
-     * rather than the one that happened.)
+     * Updatable, like everything else that DESCRIBES the scan — its target,
+     * its probe, its credentials and its schedule. Only what the scan
+     * REPORTED (status, results, host counts, timestamps) is read-only,
+     * because those belong to a run that happened and cannot be edited into
+     * having happened differently.
+     *
+     * Every one of those settings used to be create-only, on the reasoning
+     * that a row must not stop describing the sweep that ran. The reasoning
+     * was sound and the conclusion was not: the only way to fix a typo'd
+     * subnet or a rejected community string was to delete the scan — losing
+     * its results — and recreate it (OneUptime issue #3444). The invariant is
+     * kept where it belongs instead, in
+     * Common/Server/Services/NetworkDeviceDiscoveryScanService: changing any
+     * of them re-queues the scan and clears the previous run's results, so the
+     * row never advertises findings from settings it no longer has.
      *
      * A name describes nothing but itself, and the whole point of it is to be
      * fixable after the fact: a scan mislabelled "Region 1100" is worse than
@@ -336,7 +360,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   /*
    * The address space this scan sweeps. Two notations are accepted (see
@@ -382,7 +413,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -418,7 +456,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsMember,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -454,7 +499,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -473,9 +525,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
   /*
    * SNMP v3 credentials tried against every host in the subnet. These mirror
    * the flattened snmpV3* columns on NetworkDevice so a v3 scan can be imported
-   * into a v3 device without re-entering credentials. Like the other SNMP
-   * config columns above they are create+read only (update: []): a scan's
-   * config is fixed once it is dispatched to the probe.
+   * into a v3 device without re-entering credentials.
+   *
+   * Editable after creation, like the rest of the SNMP config above — a
+   * credential that the devices reject is exactly the thing an operator needs
+   * to correct without rebuilding the scan. Changing one re-queues the scan;
+   * see NetworkDeviceDiscoveryScanService. Their READ permissions stay
+   * narrower than the other columns' (no Viewer, no SettingsViewer): a
+   * passphrase is not a thing every reader of the scans list should be handed.
    */
   @ColumnAccessControl({
     create: [
@@ -496,7 +553,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -532,7 +596,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -567,7 +638,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -600,7 +678,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsMember,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -633,7 +718,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsViewer,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,
@@ -666,7 +758,14 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
       Permission.SettingsMember,
       Permission.ReadNetworkDeviceDiscoveryScan,
     ],
-    update: [],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceDiscoveryScan,
+    ],
   })
   @TableColumn({
     required: false,

--- a/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
@@ -530,9 +530,16 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
    * Editable after creation, like the rest of the SNMP config above — a
    * credential that the devices reject is exactly the thing an operator needs
    * to correct without rebuilding the scan. Changing one re-queues the scan;
-   * see NetworkDeviceDiscoveryScanService. Their READ permissions stay
-   * narrower than the other columns' (no Viewer, no SettingsViewer): a
-   * passphrase is not a thing every reader of the scans list should be handed.
+   * see NetworkDeviceDiscoveryScanService.
+   *
+   * READ permissions are untouched by that, and are not uniform across these
+   * columns: the two that carry a secret — snmpV3AuthKey and snmpV3PrivKey,
+   * like snmpCommunityString above them — are read by a narrower list than the
+   * rest of the model (no Viewer, no SettingsViewer), because a passphrase is
+   * not a thing every reader of the scans list should be handed. The security
+   * level, the username and the two protocol names describe HOW the scan
+   * authenticates rather than WITH WHAT, and are read as widely as the target
+   * is.
    */
   @ColumnAccessControl({
     create: [

--- a/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
+++ b/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
@@ -5,8 +5,93 @@ import CreateBy from "../Types/Database/CreateBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ObjectID from "../../Types/ObjectID";
+import OneUptimeDate from "../../Types/Date";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
+import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
+import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import ScanTargetUtil from "../../Utils/NetworkDiscovery/ScanTargetUtil";
 import ScanNameUtil from "../../Utils/NetworkDiscovery/ScanNameUtil";
+import { getNextScanAt } from "../../Utils/NetworkDiscovery/RescanIntervalUtil";
+
+/*
+ * The two spellings a many-to-one reference reaches a hook under: the
+ * dashboard posts the relation object, server callers write the FK column.
+ * See RelationIdUtil.
+ */
+const PROBE_RELATION_KEYS: Array<string> = ["probeId", "probe"];
+
+/*
+ * The columns that decide what the probe sweeps, and what it sweeps with.
+ * Changing any of them means the results already on the row describe a sweep
+ * that no longer exists — which is what onUpdateSuccess below acts on.
+ *
+ * `probe` is folded into `probeId` by RelationIdUtil rather than listed here,
+ * because the same reference arrives under either name.
+ */
+const SWEEP_COLUMNS: Array<string> = [
+  "cidr",
+  "probeId",
+  "snmpVersion",
+  "snmpCommunityString",
+  "snmpPort",
+  "snmpV3SecurityLevel",
+  "snmpV3Username",
+  "snmpV3AuthProtocol",
+  "snmpV3AuthKey",
+  "snmpV3PrivProtocol",
+  "snmpV3PrivKey",
+];
+
+/*
+ * The columns that decide WHEN the scan runs again, and nothing else. They
+ * never retire a result — they only re-derive nextScanAt.
+ */
+const SCHEDULE_COLUMNS: Array<string> = [
+  "isRecurring",
+  "rescanIntervalInMinutes",
+];
+
+/*
+ * Everything a finished run left on the row. Written together, as one
+ * statement, to put the scan back in the state a brand-new one is created in:
+ * queued, with nothing to show yet.
+ *
+ * This is the same reset the requeue worker performs on a recurring scan that
+ * is due (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts) with
+ * one deliberate difference: the results ARE cleared here. The worker keeps
+ * them because a recurring scan re-runs the SAME sweep, so last run's
+ * inventory is still the best answer available until the next one lands. A
+ * scan whose target or credentials just changed has no such excuse — its
+ * hosts came from somewhere the scan no longer points at.
+ */
+const RETIRE_RUN_PAYLOAD: Record<string, unknown> = {
+  status: "Pending",
+  statusMessage: null,
+  startedAt: null,
+  completedAt: null,
+  nextScanAt: null,
+  discoveredDevices: null,
+  scannedHostCount: null,
+  respondedHostCount: null,
+  autoImportProcessedAt: null,
+};
+
+/*
+ * What onUpdateSuccess has to know about each row being updated, worked out
+ * while the pre-update values are still readable.
+ */
+interface ScanUpdatePlan {
+  // A sweep-defining column really changed value (not merely was re-sent).
+  isSweepChanged: boolean;
+  // The schedule the row will hold once the update lands.
+  isRecurring: boolean | null | undefined;
+  rescanIntervalInMinutes: number | null | undefined;
+  // The run state the row holds now, which a retire would replace.
+  status: string | null | undefined;
+  completedAt: Date | null | undefined;
+  nextScanAt: Date | null | undefined;
+}
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -57,21 +142,26 @@ export class Service extends DatabaseService<Model> {
   }
 
   /*
-   * The target column is not user-updatable (its ColumnAccessControl grants no
-   * update permission), but root writers — the probe-ingest endpoints, workers,
-   * migrations — bypass that. Validating any update that carries the column
-   * keeps the invariant true for every writer instead of just the form.
+   * Everything that has to be true of an update before it is allowed to land,
+   * plus the reading of the row that onUpdateSuccess needs and can no longer
+   * take once the write has happened.
+   *
+   * Two classes of writer arrive here. The form, editing a scan's settings —
+   * which is what this hook mostly exists for now (OneUptime issue #3444) —
+   * and the server's own root writers: the probe-ingest endpoints, the
+   * recurring-scan worker, migrations. The root writers carry only run-state
+   * columns and take the cheap exit below without paying for a read.
    */
   @CaptureSpan()
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
-    const dataKeys: Array<string> = Object.keys(updateBy.data || {});
+    const data: Record<string, unknown> = (updateBy.data ||
+      {}) as unknown as Record<string, unknown>;
+    const dataKeys: Array<string> = Object.keys(data);
 
     if (dataKeys.includes("cidr")) {
-      this.validateScanTarget(
-        (updateBy.data as Record<string, unknown>)["cidr"],
-      );
+      this.validateScanTarget(data["cidr"]);
     }
 
     /*
@@ -86,16 +176,310 @@ export class Service extends DatabaseService<Model> {
      * would try to write.
      */
     if (dataKeys.includes("name")) {
-      const data: Record<string, unknown> = updateBy.data as Record<
-        string,
-        unknown
-      >;
-
       this.validateScanName(data["name"]);
       data["name"] = ScanNameUtil.normalize(data["name"]);
     }
 
-    return { updateBy, carryForward: null };
+    const isSweepWritten: boolean =
+      RelationIdUtil.isWritten(dataKeys, PROBE_RELATION_KEYS) ||
+      SWEEP_COLUMNS.some((column: string) => {
+        return dataKeys.includes(column);
+      });
+
+    const isScheduleWritten: boolean = SCHEDULE_COLUMNS.some(
+      (column: string) => {
+        return dataKeys.includes(column);
+      },
+    );
+
+    /*
+     * THE CHEAP EXIT, and it is load-bearing rather than an optimisation.
+     *
+     * Every server-side writer of this model touches run state only — the
+     * claim writes status/startedAt/statusMessage, the result ingest writes
+     * the results, the requeue worker and the stale-scan reaper write status
+     * and timestamps, the unclaimed-diagnosis pass writes statusMessage. None
+     * of them carries a sweep or schedule column, so none of them reads a row
+     * here, and none can trip the reconciliation below into retiring the very
+     * result it is in the middle of storing.
+     *
+     * `updateBy` is also handed back as the SAME object, which is what
+     * Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+     * pins: the claim's hook-free write is only safe while this hook is a
+     * pass-through for the claim's payload.
+     */
+    if (!isSweepWritten && !isScheduleWritten) {
+      return { updateBy, carryForward: null };
+    }
+
+    /*
+     * probeId is NOT NULL. A payload that names the probe but resolves to
+     * nothing is an operator clearing the box, and without this it reaches
+     * Postgres as a constraint violation — a 500 where the truthful answer is
+     * a 400 with a sentence in it.
+     */
+    if (RelationIdUtil.isWritten(dataKeys, PROBE_RELATION_KEYS)) {
+      const probeId: ObjectID | null = RelationIdUtil.readConsistent(
+        data,
+        PROBE_RELATION_KEYS,
+        "Probe",
+      );
+
+      if (!probeId) {
+        throw new BadDataException(
+          "A discovery scan needs a probe to run it. Pick the probe that can reach this address range.",
+        );
+      }
+    }
+
+    /*
+     * Scoped by hand, because this hook runs BEFORE
+     * ModelPermission.checkUpdateQueryPermissions and BaseAPI hands the
+     * service a bare `{_id}` query — so reading with the caller's own query as
+     * root, unscoped, would answer "does this id exist, and what are its
+     * credentials" for every project on the instance. Same shape as
+     * MonitorService.onBeforeUpdate.
+     */
+    const scans: Array<Model> = await this.findBy({
+      query:
+        !updateBy.props.isRoot && updateBy.props.tenantId
+          ? { ...updateBy.query, projectId: updateBy.props.tenantId }
+          : updateBy.query,
+      select: {
+        _id: true,
+        status: true,
+        isRecurring: true,
+        rescanIntervalInMinutes: true,
+        completedAt: true,
+        nextScanAt: true,
+        cidr: true,
+        probeId: true,
+        snmpVersion: true,
+        snmpCommunityString: true,
+        snmpPort: true,
+        snmpV3SecurityLevel: true,
+        snmpV3Username: true,
+        snmpV3AuthProtocol: true,
+        snmpV3AuthKey: true,
+        snmpV3PrivProtocol: true,
+        snmpV3PrivKey: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+
+    const plans: Record<string, ScanUpdatePlan> = {};
+
+    for (const scan of scans) {
+      const scanId: string | undefined = scan._id?.toString();
+
+      if (!scanId) {
+        continue;
+      }
+
+      plans[scanId] = {
+        isSweepChanged: isSweepWritten
+          ? this.hasSweepChanged(scan, data, dataKeys)
+          : false,
+        /*
+         * The schedule the row will hold AFTER the write: the update's value
+         * where it carries one, the stored value where it does not. Worked out
+         * here so onUpdateSuccess needs no second read.
+         */
+        isRecurring: dataKeys.includes("isRecurring")
+          ? (data["isRecurring"] as boolean | null | undefined)
+          : scan.isRecurring,
+        rescanIntervalInMinutes: dataKeys.includes("rescanIntervalInMinutes")
+          ? (data["rescanIntervalInMinutes"] as number | null | undefined)
+          : scan.rescanIntervalInMinutes,
+        status: scan.status,
+        completedAt: scan.completedAt,
+        nextScanAt: scan.nextScanAt,
+      };
+    }
+
+    return { updateBy, carryForward: plans };
+  }
+
+  /*
+   * Put the row back into a state that describes itself honestly.
+   *
+   * Two things can be wrong the moment a settings edit lands, and neither can
+   * be fixed in the update itself: the columns that would fix them
+   * (status, nextScanAt, the result columns) grant no update permission to
+   * anybody, and ModelPermission checks the payload AFTER onBeforeUpdate has
+   * run — so a payload carrying them would be refused for the very user doing
+   * the editing. They are written here instead, as root, through the same
+   * hook-free single-statement path the probe's claim uses.
+   *
+   *   1. A changed target, probe or credential leaves the row advertising
+   *      hosts from a sweep that is no longer the sweep this scan describes:
+   *      "12 of 254 hosts" beside a range it never visited, a Review Results
+   *      dialog offering them for import under the new credentials, and an
+   *      auto-import worker willing to create devices from them. The run is
+   *      retired and the scan re-queued, so the probe simply sweeps again.
+   *
+   *   2. nextScanAt is derived state that only the result-ingest endpoint used
+   *      to write. Turning recurrence ON for a scan that had already finished
+   *      therefore scheduled nothing at all — the column stayed NULL, and the
+   *      requeue worker's `nextScanAt <= now` is never true of NULL — so the
+   *      list said "Every 60 min" over a scan that would never run again.
+   *      Shortening the interval had the same shape of bug: the new cadence
+   *      only took effect one full old cadence later.
+   *
+   * A known and deliberate gap: this is a second statement, so between the two
+   * writes the row briefly holds the new settings with the old run state. A
+   * probe result landing inside that window is stamped onto the new settings.
+   * Closing it needs the probe to echo a run identity back, which is a probe
+   * protocol change; the window is one database round trip.
+   */
+  @CaptureSpan()
+  protected override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    const plans: Record<string, ScanUpdatePlan> | null =
+      (onUpdate.carryForward as Record<string, ScanUpdatePlan> | null) || null;
+
+    if (!plans) {
+      return onUpdate;
+    }
+
+    const now: Date = OneUptimeDate.getCurrentDate();
+
+    for (const itemId of updatedItemIds) {
+      const plan: ScanUpdatePlan | undefined = plans[itemId.toString()];
+
+      if (!plan) {
+        continue;
+      }
+
+      const reconcile: Record<string, unknown> = plan.isSweepChanged
+        ? { ...RETIRE_RUN_PAYLOAD }
+        : {};
+
+      /*
+       * Derived from the state the row is in once this update has landed —
+       * which, for a retired run, is the queued state written just above, not
+       * the finished one it held a moment ago.
+       */
+      const nextScanAt: Date | null = getNextScanAt(
+        {
+          isRecurring: plan.isRecurring,
+          rescanIntervalInMinutes: plan.rescanIntervalInMinutes,
+          status: plan.isSweepChanged ? "Pending" : plan.status,
+          completedAt: plan.isSweepChanged ? null : plan.completedAt,
+        },
+        now,
+      );
+
+      if (!this.isSameMoment(nextScanAt, plan.nextScanAt)) {
+        reconcile["nextScanAt"] = nextScanAt;
+      }
+
+      if (Object.keys(reconcile).length === 0) {
+        continue;
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: itemId,
+        // Cast: the model's JSON column makes DeepPartial recursion blow up.
+        data: reconcile as unknown as QueryDeepPartialEntity<Model>,
+      });
+    }
+
+    return onUpdate;
+  }
+
+  /*
+   * Whether this update actually changes what the probe would sweep.
+   *
+   * VALUE comparison, never key presence: ModelForm posts every field it
+   * declares on every save, dirty or not, so an operator who opened Edit and
+   * pressed Save without typing sends the whole sweep back verbatim. Keyed on
+   * presence, that would retire a good result set on every no-op save.
+   */
+  private hasSweepChanged(
+    scan: Model,
+    data: Record<string, unknown>,
+    dataKeys: Array<string>,
+  ): boolean {
+    if (RelationIdUtil.isWritten(dataKeys, PROBE_RELATION_KEYS)) {
+      const probeId: ObjectID | null = RelationIdUtil.read(
+        data,
+        PROBE_RELATION_KEYS,
+      );
+
+      if (probeId?.toString() !== scan.probeId?.toString()) {
+        return true;
+      }
+    }
+
+    for (const column of SWEEP_COLUMNS) {
+      if (column === "probeId" || !dataKeys.includes(column)) {
+        continue;
+      }
+
+      if (
+        this.normalizeSweepValue(data[column]) !==
+        this.normalizeSweepValue(
+          (scan as unknown as Record<string, unknown>)[column],
+        )
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /*
+   * A sweep column's value as a comparable string.
+   *
+   * An empty box and an unset column are the SAME setting and must compare
+   * equal, or a V3 scan — whose community string is NULL in the database and
+   * "" in the form — would read as changed on the first save and retire its
+   * own results. Numbers are compared as numbers so the port arriving as the
+   * string "161" from a form field does not read as a change either.
+   */
+  private normalizeSweepValue(value: unknown): string {
+    if (value === undefined || value === null || value === "") {
+      return "";
+    }
+
+    if (typeof value === "number") {
+      return String(value);
+    }
+
+    if (typeof value === "string") {
+      return value.trim();
+    }
+
+    return String(value);
+  }
+
+  /*
+   * Two nullable timestamps, compared by the instant they name. The stored
+   * value comes back from Postgres and the derived one is built here, so a
+   * strict equality between the two objects is never true even when the moment
+   * is identical, and every no-op save would write the column again.
+   */
+  private isSameMoment(
+    left: Date | null | undefined,
+    right: Date | null | undefined,
+  ): boolean {
+    if (!left || !right) {
+      return !left && !right;
+    }
+
+    return (
+      OneUptimeDate.fromString(left).getTime() ===
+      OneUptimeDate.fromString(right).getTime()
+    );
   }
 
   /*

--- a/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
+++ b/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
@@ -9,6 +9,8 @@ import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
+import ProbeService from "./ProbeService";
+import Probe from "../../Models/DatabaseModels/Probe";
 import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import ScanTargetUtil from "../../Utils/NetworkDiscovery/ScanTargetUtil";
 import ScanNameUtil from "../../Utils/NetworkDiscovery/ScanNameUtil";
@@ -44,6 +46,21 @@ const SWEEP_COLUMNS: Array<string> = [
 ];
 
 /*
+ * The numeric columns a form can hand back as an empty string.
+ *
+ * A Number field posts its value as text (Common/UI/Components/Forms/Fields/
+ * FormField.tsx sets it straight from the input), so an operator who clears
+ * the box sends "" — and "" into an integer column is a Postgres error, i.e. a
+ * 500 where the operator simply meant "leave this unset". Clearing a box was
+ * hard to do before these fields were editable, because a create form starts
+ * them empty; an edit form starts them filled.
+ */
+const NULLABLE_NUMBER_COLUMNS: Array<string> = [
+  "snmpPort",
+  "rescanIntervalInMinutes",
+];
+
+/*
  * The columns that decide WHEN the scan runs again, and nothing else. They
  * never retire a result — they only re-derive nextScanAt.
  */
@@ -67,7 +84,16 @@ const SCHEDULE_COLUMNS: Array<string> = [
  */
 const RETIRE_RUN_PAYLOAD: Record<string, unknown> = {
   status: "Pending",
-  statusMessage: null,
+  /*
+   * Not cleared but replaced, because the row has some explaining to do: the
+   * operator saved a settings change and the scan's results vanished. The
+   * scans list renders this sentence in the results cell of a scan that has
+   * not reported (Dashboard Components/NetworkDevice/DiscoveryScanOutcome),
+   * which is exactly where the missing results used to be. The claim endpoint
+   * clears it the moment a probe picks the scan up.
+   */
+  statusMessage:
+    "Settings changed, so this scan is queued to run again. The hosts the previous run found have been cleared - they described settings this scan no longer has.",
   startedAt: null,
   completedAt: null,
   nextScanAt: null,
@@ -78,19 +104,24 @@ const RETIRE_RUN_PAYLOAD: Record<string, unknown> = {
 };
 
 /*
- * What onUpdateSuccess has to know about each row being updated, worked out
- * while the pre-update values are still readable.
+ * The one thing onUpdateSuccess cannot work out for itself, because answering
+ * it needs the values the update has already overwritten: did this save
+ * actually change what the probe sweeps?
+ *
+ * Everything else it needs — the schedule, the run state — it re-reads from
+ * the row afterwards rather than predicting from the payload. Predicting would
+ * mean trusting the request's types (a number field posted as "60", a toggle
+ * posted as "false"), and a schedule mis-read as "no cadence" silently
+ * unschedules a recurring scan.
  */
 interface ScanUpdatePlan {
-  // A sweep-defining column really changed value (not merely was re-sent).
   isSweepChanged: boolean;
-  // The schedule the row will hold once the update lands.
-  isRecurring: boolean | null | undefined;
-  rescanIntervalInMinutes: number | null | undefined;
-  // The run state the row holds now, which a retire would replace.
-  status: string | null | undefined;
-  completedAt: Date | null | undefined;
-  nextScanAt: Date | null | undefined;
+  /*
+   * Whether the save asked about the schedule at all. Only a save that did
+   * gets its next run re-derived — so an edit that leaves the recurrence boxes
+   * alone cannot move a scan the stale-scan reaper had made due immediately.
+   */
+  isScheduleWritten: boolean;
 }
 
 export class Service extends DatabaseService<Model> {
@@ -138,6 +169,17 @@ export class Service extends DatabaseService<Model> {
     (createBy.data as unknown as Record<string, unknown>)["name"] =
       ScanNameUtil.normalize(createBy.data.name) ?? undefined;
 
+    this.nullEmptyNumbers(
+      createBy.data as unknown as Record<string, unknown>,
+      Object.keys(createBy.data || {}),
+    );
+
+    await this.validateProbeIsUsable({
+      data: createBy.data as unknown as Record<string, unknown>,
+      dataKeys: Object.keys(createBy.data || {}),
+      projectId: createBy.data.projectId || createBy.props.tenantId,
+    });
+
     return { createBy, carryForward: null };
   }
 
@@ -180,6 +222,8 @@ export class Service extends DatabaseService<Model> {
       data["name"] = ScanNameUtil.normalize(data["name"]);
     }
 
+    this.nullEmptyNumbers(data, dataKeys);
+
     const isSweepWritten: boolean =
       RelationIdUtil.isWritten(dataKeys, PROBE_RELATION_KEYS) ||
       SWEEP_COLUMNS.some((column: string) => {
@@ -213,26 +257,6 @@ export class Service extends DatabaseService<Model> {
     }
 
     /*
-     * probeId is NOT NULL. A payload that names the probe but resolves to
-     * nothing is an operator clearing the box, and without this it reaches
-     * Postgres as a constraint violation — a 500 where the truthful answer is
-     * a 400 with a sentence in it.
-     */
-    if (RelationIdUtil.isWritten(dataKeys, PROBE_RELATION_KEYS)) {
-      const probeId: ObjectID | null = RelationIdUtil.readConsistent(
-        data,
-        PROBE_RELATION_KEYS,
-        "Probe",
-      );
-
-      if (!probeId) {
-        throw new BadDataException(
-          "A discovery scan needs a probe to run it. Pick the probe that can reach this address range.",
-        );
-      }
-    }
-
-    /*
      * Scoped by hand, because this hook runs BEFORE
      * ModelPermission.checkUpdateQueryPermissions and BaseAPI hands the
      * service a bare `{_id}` query — so reading with the caller's own query as
@@ -247,11 +271,7 @@ export class Service extends DatabaseService<Model> {
           : updateBy.query,
       select: {
         _id: true,
-        status: true,
-        isRecurring: true,
-        rescanIntervalInMinutes: true,
-        completedAt: true,
-        nextScanAt: true,
+        projectId: true,
         cidr: true,
         probeId: true,
         snmpVersion: true,
@@ -281,24 +301,22 @@ export class Service extends DatabaseService<Model> {
         continue;
       }
 
+      /*
+       * Checked per matched scan, because the answer depends on which project
+       * the scan belongs to — and read from the row rather than from the
+       * caller's tenant, so a root writer is held to the same rule.
+       */
+      await this.validateProbeIsUsable({
+        data: data,
+        dataKeys: dataKeys,
+        projectId: scan.projectId,
+      });
+
       plans[scanId] = {
         isSweepChanged: isSweepWritten
           ? this.hasSweepChanged(scan, data, dataKeys)
           : false,
-        /*
-         * The schedule the row will hold AFTER the write: the update's value
-         * where it carries one, the stored value where it does not. Worked out
-         * here so onUpdateSuccess needs no second read.
-         */
-        isRecurring: dataKeys.includes("isRecurring")
-          ? (data["isRecurring"] as boolean | null | undefined)
-          : scan.isRecurring,
-        rescanIntervalInMinutes: dataKeys.includes("rescanIntervalInMinutes")
-          ? (data["rescanIntervalInMinutes"] as number | null | undefined)
-          : scan.rescanIntervalInMinutes,
-        status: scan.status,
-        completedAt: scan.completedAt,
-        nextScanAt: scan.nextScanAt,
+        isScheduleWritten: isScheduleWritten,
       };
     }
 
@@ -332,10 +350,20 @@ export class Service extends DatabaseService<Model> {
    *      only took effect one full old cadence later.
    *
    * A known and deliberate gap: this is a second statement, so between the two
-   * writes the row briefly holds the new settings with the old run state. A
-   * probe result landing inside that window is stamped onto the new settings.
-   * Closing it needs the probe to echo a run identity back, which is a probe
-   * protocol change; the window is one database round trip.
+   * writes the row briefly holds the new settings with the old run state. Two
+   * things can go wrong inside that window, both of them one database round
+   * trip wide. A probe result landing there is stamped onto the new settings;
+   * closing that needs the probe to echo a run identity back, which is a probe
+   * protocol change. And if this write itself fails while the settings write
+   * succeeded, the row keeps the new settings with the old results until the
+   * next edit that actually changes something — the operator sees the error,
+   * but re-saving the same values will not repair it, because by then nothing
+   * has changed.
+   *
+   * Doing it FIRST instead, in onBeforeUpdate, would be worse rather than
+   * better: that hook runs before the row-level gate as well, so a caller
+   * whose update is about to be refused would have retired the scan on the way
+   * through.
    */
   @CaptureSpan()
   protected override async onUpdateSuccess(
@@ -358,26 +386,60 @@ export class Service extends DatabaseService<Model> {
         continue;
       }
 
+      /*
+       * Nothing to do at all: the save named a setting but changed none of
+       * them, and never mentioned the schedule.
+       */
+      if (!plan.isSweepChanged && !plan.isScheduleWritten) {
+        continue;
+      }
+
+      /*
+       * The row as it stands now that the update has landed. Read rather than
+       * predicted from the payload: the schedule columns are what the next run
+       * is derived from, and reading them back means the derivation sees the
+       * values the DATABASE holds — properly typed — instead of whatever
+       * shape the request happened to send them in.
+       */
+      const scan: Model | null = await this.findOneById({
+        id: itemId,
+        select: {
+          status: true,
+          isRecurring: true,
+          rescanIntervalInMinutes: true,
+          completedAt: true,
+          nextScanAt: true,
+        },
+        props: {
+          isRoot: true,
+          ignoreHooks: true,
+        },
+      });
+
+      // Hard-deleted between the write and this read. Nothing to reconcile.
+      if (!scan) {
+        continue;
+      }
+
       const reconcile: Record<string, unknown> = plan.isSweepChanged
         ? { ...RETIRE_RUN_PAYLOAD }
         : {};
 
       /*
-       * Derived from the state the row is in once this update has landed —
-       * which, for a retired run, is the queued state written just above, not
-       * the finished one it held a moment ago.
+       * For a retired run the state to derive from is the queued one written
+       * just above, not the finished one the row still shows.
        */
       const nextScanAt: Date | null = getNextScanAt(
         {
-          isRecurring: plan.isRecurring,
-          rescanIntervalInMinutes: plan.rescanIntervalInMinutes,
-          status: plan.isSweepChanged ? "Pending" : plan.status,
-          completedAt: plan.isSweepChanged ? null : plan.completedAt,
+          isRecurring: scan.isRecurring,
+          rescanIntervalInMinutes: scan.rescanIntervalInMinutes,
+          status: plan.isSweepChanged ? "Pending" : scan.status,
+          completedAt: plan.isSweepChanged ? null : scan.completedAt,
         },
         now,
       );
 
-      if (!this.isSameMoment(nextScanAt, plan.nextScanAt)) {
+      if (!this.isSameMoment(nextScanAt, scan.nextScanAt)) {
         reconcile["nextScanAt"] = nextScanAt;
       }
 
@@ -435,6 +497,109 @@ export class Service extends DatabaseService<Model> {
     }
 
     return false;
+  }
+
+  /*
+   * The probe a scan is pointed at has to be one this project may actually use
+   * — its own, or a global one.
+   *
+   * The scan is dispatched by probe id alone: the claim endpoint hands a
+   * Pending scan to whichever probe authenticates as that id, with no project
+   * check of its own, and the results are written back onto this row. So a
+   * scan pointing at ANOTHER project's probe is a scan that makes that
+   * project's probe sweep its own network and report the hosts it finds into
+   * this one. The ids are not guessable and the probe list is tenant-scoped,
+   * so this is a lock rather than a repair — but it is the lock that has to
+   * exist now that the column can be re-pointed after creation, and it is
+   * applied on create for the same reason.
+   *
+   * A probe with no project is a global probe and is available to everyone.
+   */
+  private async validateProbeIsUsable(input: {
+    data: Record<string, unknown>;
+    dataKeys: Array<string>;
+    projectId: ObjectID | undefined;
+  }): Promise<void> {
+    if (!RelationIdUtil.isWritten(input.dataKeys, PROBE_RELATION_KEYS)) {
+      return;
+    }
+
+    /*
+     * readConsistent, not read: a payload that points the FK column and the
+     * relation object at two different probes must be refused rather than
+     * validated against whichever one TypeORM happens to persist.
+     */
+    const probeId: ObjectID | null = RelationIdUtil.readConsistent(
+      input.data,
+      PROBE_RELATION_KEYS,
+      "Probe",
+    );
+
+    /*
+     * probeId is NOT NULL, so a payload that names the probe and resolves to
+     * nothing is an operator clearing the box. Without this it reaches
+     * Postgres as a constraint violation — a 500 where the truthful answer is
+     * a 400 with a sentence in it.
+     */
+    if (!probeId) {
+      throw new BadDataException(
+        "A discovery scan needs a probe to run it. Pick the probe that can reach this address range.",
+      );
+    }
+
+    // Nothing to compare against; the write itself is still tenant-checked.
+    if (!input.projectId) {
+      return;
+    }
+
+    const probe: Probe | null = await ProbeService.findOneById({
+      id: probeId,
+      select: {
+        _id: true,
+        projectId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!probe) {
+      throw new BadDataException(
+        "That probe could not be found. Pick a probe that can reach this address range.",
+      );
+    }
+
+    if (
+      probe.projectId &&
+      probe.projectId.toString() !== input.projectId.toString()
+    ) {
+      throw new BadDataException(
+        "That probe belongs to another project. Pick one of this project's probes, or a global probe.",
+      );
+    }
+  }
+
+  /*
+   * An emptied number box means "unset", not "the empty string".
+   *
+   * Written in place, like the name normalization above, so the value the rest
+   * of the pipeline sees is the value that will be stored.
+   */
+  private nullEmptyNumbers(
+    data: Record<string, unknown>,
+    dataKeys: Array<string>,
+  ): void {
+    for (const column of NULLABLE_NUMBER_COLUMNS) {
+      if (!dataKeys.includes(column)) {
+        continue;
+      }
+
+      const value: unknown = data[column];
+
+      if (typeof value === "string" && value.trim() === "") {
+        data[column] = null;
+      }
+    }
   }
 
   /*

--- a/Common/Tests/App/Dashboard/DiscoveryScanEditForm.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanEditForm.test.tsx
@@ -148,20 +148,6 @@ function editFieldNamed(key: string): CapturedFormField {
   return field;
 }
 
-function wizardFieldNamed(key: string): CapturedFormField {
-  const field: CapturedFormField | undefined = (
-    capturedTableProps?.formFields || []
-  ).find((candidate: CapturedFormField): boolean => {
-    return fieldKeyOf(candidate) === key;
-  });
-
-  if (!field) {
-    throw new Error(`Create wizard field "${key}" not found`);
-  }
-
-  return field;
-}
-
 function editAction(): CapturedActionButton {
   const action: CapturedActionButton | undefined = (
     capturedTableProps?.actionButtons || []
@@ -325,19 +311,67 @@ describe("Editing a discovery scan after it was created", () => {
    * be this one — the one nobody exercises until they are already trying to
    * fix a scan that is not working.
    */
-  test("uses the same validators the create wizard does", async () => {
+  /*
+   * One definition, two layouts. A second copy of the field array would be a
+   * second set of descriptions, validators and reveal rules to keep in step,
+   * and the copy that drifted would be this one — the one nobody exercises
+   * until they are already trying to fix a scan that is not working.
+   *
+   * Compared field by field rather than by object identity: the factory builds
+   * fresh objects for each form, deliberately, because ModelForm mutates the
+   * field objects it is handed (it writes an inferred maxLength onto them) and
+   * two forms must not share one mutable object.
+   */
+  test("describes every field exactly as the create wizard does", async () => {
     await openEditDialog();
 
-    for (const key of ["name", "cidr", "rescanIntervalInMinutes"]) {
-      expect(editFieldNamed(key).customValidation).toBe(
-        wizardFieldNamed(key).customValidation,
-      );
-    }
+    const wizardFields: Array<CapturedFormField> =
+      capturedTableProps?.formFields || [];
 
-    // And they are really wired, not merely identical undefineds.
+    expect(editFields()).toHaveLength(wizardFields.length);
+
+    let headed: number = 0;
+
+    editFields().forEach((field: CapturedFormField, index: number) => {
+      const wizardField: CapturedFormField = wizardFields[
+        index
+      ] as CapturedFormField;
+
+      expect({
+        key: fieldKeyOf(field),
+        title: field.title,
+        stepId: field.stepId,
+        required: field.required,
+        // Module-level functions, so identity is the right comparison here.
+        customValidation: field.customValidation,
+        hasShowIf: Boolean(field.showIf),
+      }).toEqual({
+        key: fieldKeyOf(wizardField),
+        title: wizardField.title,
+        stepId: wizardField.stepId,
+        required: wizardField.required,
+        customValidation: wizardField.customValidation,
+        hasShowIf: Boolean(wizardField.showIf),
+      });
+
+      // The only thing the edit layout adds is the group heading.
+      if (field.sectionTitle) {
+        headed++;
+      }
+
+      expect(wizardField.sectionTitle).toBeUndefined();
+    });
+
+    expect(headed).toBe((capturedTableProps?.formSteps || []).length);
+
+    // And the validators are really wired, not merely identical undefineds.
     expect(
       editFieldNamed("cidr").customValidation?.({ cidr: "10.0.0.0/33" }),
     ).toBe(ScanTargetUtil.getValidationError("10.0.0.0/33"));
+    expect(
+      editFieldNamed("rescanIntervalInMinutes").customValidation,
+    ).toBeDefined();
+    expect(editFieldNamed("name").customValidation).toBeDefined();
   });
 
   test("offers the probes that were fetched for the create wizard", async () => {

--- a/Common/Tests/App/Dashboard/DiscoveryScanEditForm.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanEditForm.test.tsx
@@ -1,0 +1,415 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+/*
+ * The wiring half of OneUptime issue #3444.
+ *
+ * A discovery scan's settings used to be fixed at creation. A typo'd subnet, a
+ * probe on the wrong side of a firewall, a community string the devices
+ * reject, a one-time scan that should have repeated — each of them could only
+ * be fixed by deleting the scan, losing its results, and building it again.
+ * The row actions were Rename, Review Results and Delete, and none of them
+ * touched the sweep.
+ *
+ * The dialog that fixes this is configuration, not markup: an action button
+ * whose onClick opens a ModelFormModal whose formProps carry the field set.
+ * Every way of getting it wrong is silent — a field dropped from the array
+ * simply cannot be edited, a validator dropped from a field simply stops
+ * being enforced, `formType` left at Create posts a new scan instead of
+ * saving this one — so the modal is mocked to capture those props and they
+ * are asserted directly. Same approach as
+ * DiscoveryScanWizardValidation.test.tsx, which does this for the create
+ * wizard on the same page.
+ */
+
+type CapturedFormField = {
+  field: Record<string, boolean>;
+  title?: string | undefined;
+  stepId?: string | undefined;
+  sectionTitle?: string | undefined;
+  required?: boolean | undefined;
+  customValidation?:
+    | ((values: Record<string, unknown>) => string | null)
+    | undefined;
+  showIf?: ((values: Record<string, unknown>) => boolean) | undefined;
+  dropdownOptions?: Array<{ label: string; value: string }> | undefined;
+};
+
+type CapturedActionButton = {
+  title?: string | undefined;
+  icon?: unknown;
+  isVisible?: ((item: NetworkDeviceDiscoveryScan) => boolean) | undefined;
+  onClick?:
+    | ((
+        item: NetworkDeviceDiscoveryScan,
+        onCompleteAction: VoidFunction,
+      ) => Promise<void>)
+    | undefined;
+};
+
+type CapturedTableProps = {
+  formFields?: Array<CapturedFormField>;
+  formSteps?: Array<{ id: string; title: string }>;
+  actionButtons?: Array<CapturedActionButton>;
+  isEditable?: boolean | undefined;
+};
+
+type CapturedModalProps = {
+  title?: string | undefined;
+  description?: string | undefined;
+  footer?: React.ReactElement | undefined;
+  submitButtonText?: string | undefined;
+  modelIdToEdit?: { toString: () => string } | undefined;
+  formProps?:
+    | {
+        formType?: unknown;
+        fields?: Array<CapturedFormField>;
+        steps?: Array<{ id: string; title: string }> | undefined;
+        id?: string | undefined;
+      }
+    | undefined;
+};
+
+let capturedTableProps: CapturedTableProps | null = null;
+let capturedModalProps: CapturedModalProps | null = null;
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedTableProps) => {
+      capturedTableProps = props;
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/ModelFormModal/ModelFormModal", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedModalProps) => {
+      capturedModalProps = props;
+      return null;
+    },
+  };
+});
+
+import DiscoveryPage from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery";
+import ProbeUtil from "../../../../App/FeatureSet/Dashboard/src/Utils/Probe";
+import { FormType } from "../../../UI/Components/Forms/ModelForm";
+import Project from "../../../Models/DatabaseModels/Project";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import ProjectUtil from "../../../UI/Utils/Project";
+import PermissionUtil from "../../../UI/Utils/Permission";
+import Permission from "../../../Types/Permission";
+import ScanTargetUtil from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
+import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ObjectID from "../../../Types/ObjectID";
+import Route from "../../../Types/API/Route";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const PROBE_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const SCAN_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+
+function editFields(): Array<CapturedFormField> {
+  return capturedModalProps?.formProps?.fields || [];
+}
+
+function fieldKeyOf(field: CapturedFormField): string {
+  return Object.keys(field.field || {})[0] as string;
+}
+
+function editFieldKeys(): Array<string> {
+  return editFields().map(fieldKeyOf);
+}
+
+function editFieldNamed(key: string): CapturedFormField {
+  const field: CapturedFormField | undefined = editFields().find(
+    (candidate: CapturedFormField): boolean => {
+      return fieldKeyOf(candidate) === key;
+    },
+  );
+
+  if (!field) {
+    throw new Error(`Edit dialog field "${key}" not found`);
+  }
+
+  return field;
+}
+
+function wizardFieldNamed(key: string): CapturedFormField {
+  const field: CapturedFormField | undefined = (
+    capturedTableProps?.formFields || []
+  ).find((candidate: CapturedFormField): boolean => {
+    return fieldKeyOf(candidate) === key;
+  });
+
+  if (!field) {
+    throw new Error(`Create wizard field "${key}" not found`);
+  }
+
+  return field;
+}
+
+function editAction(): CapturedActionButton {
+  const action: CapturedActionButton | undefined = (
+    capturedTableProps?.actionButtons || []
+  ).find((button: CapturedActionButton): boolean => {
+    return button.title === "Edit";
+  });
+
+  if (!action) {
+    throw new Error("The scans table has no Edit action");
+  }
+
+  return action;
+}
+
+function storedScan(): NetworkDeviceDiscoveryScan {
+  const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+
+  scan.id = SCAN_ID;
+  scan.cidr = "192.168.1.0/24";
+  scan.status = "Completed";
+
+  return scan;
+}
+
+async function renderPage(): Promise<void> {
+  const project: Project = new Project();
+  project.id = PROJECT_ID;
+
+  render(
+    <MemoryRouter>
+      <DiscoveryPage
+        pageRoute={new Route("/dashboard/network-devices/discovery")}
+        currentProject={project}
+        hasPaymentMethod={true}
+      />
+    </MemoryRouter>,
+  );
+
+  // The page renders a loader until its probe fetch settles.
+  await waitFor(() => {
+    expect(capturedTableProps).not.toBeNull();
+  });
+}
+
+// Open the dialog the way the operator does: press the row's Edit button.
+async function openEditDialog(): Promise<void> {
+  await renderPage();
+
+  const onClick: CapturedActionButton["onClick"] = editAction().onClick;
+
+  if (!onClick) {
+    throw new Error("The Edit action does nothing when clicked");
+  }
+
+  await act(async () => {
+    await onClick(storedScan(), () => {});
+  });
+
+  await waitFor(() => {
+    expect(capturedModalProps).not.toBeNull();
+  });
+}
+
+describe("Editing a discovery scan after it was created", () => {
+  beforeEach(() => {
+    capturedTableProps = null;
+    capturedModalProps = null;
+
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+
+    const probe: Probe = new Probe();
+    probe._id = PROBE_ID.toString();
+    probe.name = "Region 1100 probe";
+
+    jest.spyOn(ProbeUtil, "getAllProbes").mockResolvedValue([probe] as never);
+
+    jest
+      .spyOn(PermissionUtil, "getAllPermissions")
+      .mockReturnValue([Permission.ProjectAdmin]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    capturedTableProps = null;
+    capturedModalProps = null;
+  });
+
+  test("nothing opens until the operator asks for it", async () => {
+    await renderPage();
+
+    expect(capturedModalProps).toBeNull();
+  });
+
+  test("the dialog edits the scan that was clicked, rather than creating one", async () => {
+    await openEditDialog();
+
+    expect(capturedModalProps?.formProps?.formType).toBe(FormType.Update);
+    expect(capturedModalProps?.modelIdToEdit?.toString()).toBe(
+      SCAN_ID.toString(),
+    );
+    expect(capturedModalProps?.submitButtonText).toBe("Save Changes");
+  });
+
+  /*
+   * The issue's actual complaint, field by field: the target, the probe, the
+   * credentials and the schedule. Asserted as a set rather than a count, so a
+   * new field on the create wizard that is not offered for editing is a
+   * failure here rather than a discovery months later.
+   */
+  test("offers every setting the create wizard collects", async () => {
+    await openEditDialog();
+
+    const wizardKeys: Array<string> = (
+      capturedTableProps?.formFields || []
+    ).map(fieldKeyOf);
+
+    expect(editFieldKeys()).toEqual(wizardKeys);
+
+    for (const key of [
+      "name",
+      "cidr",
+      "probe",
+      "snmpVersion",
+      "snmpCommunityString",
+      "snmpPort",
+      "snmpV3SecurityLevel",
+      "snmpV3Username",
+      "snmpV3AuthProtocol",
+      "snmpV3AuthKey",
+      "snmpV3PrivProtocol",
+      "snmpV3PrivKey",
+      "isRecurring",
+      "rescanIntervalInMinutes",
+    ]) {
+      expect(editFieldKeys()).toContain(key);
+    }
+  });
+
+  /*
+   * "Repeat this scan" is the setting named in the issue title, and the one
+   * whose absence sent people to delete-and-recreate.
+   */
+  test("offers recurrence, which is what the report was about", async () => {
+    await openEditDialog();
+
+    const isRecurring: CapturedFormField = editFieldNamed("isRecurring");
+    const interval: CapturedFormField = editFieldNamed(
+      "rescanIntervalInMinutes",
+    );
+
+    expect(isRecurring.title).toBe("Repeat this scan");
+    // The interval reveals itself off the toggle, exactly as in the wizard.
+    expect(interval.showIf?.({ isRecurring: true })).toBe(true);
+    expect(interval.showIf?.({ isRecurring: false })).toBe(false);
+  });
+
+  /*
+   * One definition, two layouts. A second copy of the field array would be a
+   * second set of validators to keep in step, and the copy that drifted would
+   * be this one — the one nobody exercises until they are already trying to
+   * fix a scan that is not working.
+   */
+  test("uses the same validators the create wizard does", async () => {
+    await openEditDialog();
+
+    for (const key of ["name", "cidr", "rescanIntervalInMinutes"]) {
+      expect(editFieldNamed(key).customValidation).toBe(
+        wizardFieldNamed(key).customValidation,
+      );
+    }
+
+    // And they are really wired, not merely identical undefineds.
+    expect(
+      editFieldNamed("cidr").customValidation?.({ cidr: "10.0.0.0/33" }),
+    ).toBe(ScanTargetUtil.getValidationError("10.0.0.0/33"));
+  });
+
+  test("offers the probes that were fetched for the create wizard", async () => {
+    await openEditDialog();
+
+    expect(editFieldNamed("probe").dropdownOptions).toEqual([
+      { label: "Region 1100 probe", value: PROBE_ID.toString() },
+    ]);
+  });
+
+  /*
+   * Not a wizard. A stepped form has no Back button — the only way backwards
+   * is the step rail, which BasicForm hides below the `lg` breakpoint — and
+   * three "Next" clicks to reach the toggle you came to flip is the wrong
+   * shape for a repair. The wizard's step titles survive as section headings
+   * so the grouping is not lost with the steps.
+   */
+  test("lays the settings out on one page, under the wizard's own headings", async () => {
+    await openEditDialog();
+
+    expect(capturedModalProps?.formProps?.steps).toBeUndefined();
+
+    const headings: Array<string> = editFields()
+      .map((field: CapturedFormField): string | undefined => {
+        return field.sectionTitle;
+      })
+      .filter((title: string | undefined): boolean => {
+        return Boolean(title);
+      }) as Array<string>;
+
+    expect(headings).toEqual(
+      (capturedTableProps?.formSteps || []).map(
+        (step: { title: string }): string => {
+          return step.title;
+        },
+      ),
+    );
+  });
+
+  /*
+   * Changing the sweep clears the last run's hosts, and that is not something
+   * to find out afterwards in an empty Review Results dialog.
+   */
+  test("says what changing the sweep will cost before it is saved", async () => {
+    await openEditDialog();
+
+    const footerElement: React.ReactElement | undefined =
+      capturedModalProps?.footer;
+
+    expect(footerElement).toBeDefined();
+
+    /*
+     * Rendered rather than inspected: what matters is the sentence the
+     * operator reads, not which component carries it.
+     */
+    const { container } = render(<MemoryRouter>{footerElement}</MemoryRouter>);
+    const warning: string = container.textContent || "";
+
+    expect(warning).toContain("re-runs the scan");
+    expect(warning).toContain("cleared");
+    // ...and that a rename or a schedule change costs nothing.
+    expect(warning).toContain("name or the schedule");
+  });
+
+  /*
+   * The table itself must stay non-editable, or the operator gets two Edit
+   * buttons: this one, and ModelTable's own — which has no room for the
+   * warning above and no per-row visibility hook.
+   */
+  test("does not also turn on the table's built-in edit button", async () => {
+    await renderPage();
+
+    expect(capturedTableProps?.isEditable).toBe(false);
+  });
+});

--- a/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
@@ -641,11 +641,14 @@ describe("Name identifies the scan in the list", () => {
   });
 
   /*
-   * A name that cannot be corrected is worse than no name: "Region 1100" on
-   * the wrong range misleads everyone who reads the list afterwards, and the
-   * only other way to fix it would be deleting the scan and its results.
+   * A scan that cannot be corrected is worse than no scan: a name on the wrong
+   * range misleads everyone who reads the list afterwards, a typo'd subnet
+   * sweeps nothing, and a rejected community string finds nothing — and the
+   * only way to fix any of them used to be deleting the scan and its results
+   * and starting again (OneUptime issue #3444). One dialog fixes all of them;
+   * it replaced a Rename dialog that could only fix the first.
    */
-  test("a scan can be renamed after it was created", async () => {
+  test("a scan can be edited after it was created", async () => {
     await renderPage();
 
     const actions: Array<string> = (
@@ -654,22 +657,24 @@ describe("Name identifies the scan in the list", () => {
       return button.title || "";
     });
 
-    expect(actions).toContain("Rename");
+    expect(actions).toContain("Edit");
+    // Superseded: everything it offered is the first field of Edit.
+    expect(actions).not.toContain("Rename");
   });
 
   /*
    * The table is not editable, so this button is the page's only edit
    * affordance and nothing else gates it. Offered to a reader, it would open a
-   * dialog whose one field ModelForm has already dropped for want of the
-   * update permission — a box that cannot be saved and does not say why.
+   * dialog whose fields ModelForm has already dropped for want of the update
+   * permission — boxes that cannot be saved and do not say why.
    */
-  test("renaming is offered only to someone who could save it", async () => {
+  test("editing is offered only to someone who could save it", async () => {
     await renderPage();
 
-    const rename: CapturedActionButton | undefined = (
+    const edit: CapturedActionButton | undefined = (
       capturedTableProps?.actionButtons || []
     ).find((button: CapturedActionButton): boolean => {
-      return button.title === "Rename";
+      return button.title === "Edit";
     });
 
     const scan: NetworkDeviceDiscoveryScan = {
@@ -680,12 +685,41 @@ describe("Name identifies the scan in the list", () => {
       .spyOn(PermissionUtil, "getAllPermissions")
       .mockReturnValue([Permission.Viewer]);
 
-    expect(rename?.isVisible?.(scan)).toBe(false);
+    expect(edit?.isVisible?.(scan)).toBe(false);
 
     jest
       .spyOn(PermissionUtil, "getAllPermissions")
       .mockReturnValue([Permission.ProjectAdmin]);
 
-    expect(rename?.isVisible?.(scan)).toBe(true);
+    expect(edit?.isVisible?.(scan)).toBe(true);
+  });
+
+  /*
+   * The complaint in the issue was that a finished scan could not be given a
+   * schedule. Nothing may hide Edit behind a status: a Completed scan is the
+   * one people most need to change, and an In Progress one abandons its sweep
+   * and starts again with the new settings rather than refusing.
+   */
+  test("editing is offered whatever state the scan is in", async () => {
+    await renderPage();
+
+    const edit: CapturedActionButton | undefined = (
+      capturedTableProps?.actionButtons || []
+    ).find((button: CapturedActionButton): boolean => {
+      return button.title === "Edit";
+    });
+
+    jest
+      .spyOn(PermissionUtil, "getAllPermissions")
+      .mockReturnValue([Permission.ProjectAdmin]);
+
+    for (const status of ["Pending", "In Progress", "Completed", "Failed"]) {
+      const scan: NetworkDeviceDiscoveryScan = {
+        cidr: "10.0.0.0/24",
+        status: status,
+      } as NetworkDeviceDiscoveryScan;
+
+      expect(edit?.isVisible?.(scan)).toBe(true);
+    }
   });
 });

--- a/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
@@ -174,6 +174,29 @@ function renderScanCell(scan: Partial<NetworkDeviceDiscoveryScan>): string {
   return container.textContent || "";
 }
 
+/*
+ * What the Recurrence column puts on screen. Rendered rather than inspected,
+ * for the same reason the Scan cell is: the thing under test is a sentence an
+ * operator reads, not a shape in the element tree.
+ */
+function renderRecurrenceCell(
+  scan: Partial<NetworkDeviceDiscoveryScan>,
+): string {
+  const column: CapturedColumn = columnNamed("isRecurring");
+
+  if (!column.getElement) {
+    throw new Error("The Recurrence column renders no element");
+  }
+
+  const { container } = render(
+    <MemoryRouter>
+      {column.getElement(scan as NetworkDeviceDiscoveryScan)}
+    </MemoryRouter>,
+  );
+
+  return container.textContent || "";
+}
+
 function validate(key: string, values: Record<string, unknown>): string | null {
   const field: CapturedFormField = fieldNamed(key);
 
@@ -692,6 +715,65 @@ describe("Name identifies the scan in the list", () => {
       .mockReturnValue([Permission.ProjectAdmin]);
 
     expect(edit?.isVisible?.(scan)).toBe(true);
+  });
+
+  test("a one-time scan reads as one-time", async () => {
+    await renderPage();
+
+    expect(renderRecurrenceCell({ isRecurring: false })).toContain("One-time");
+  });
+
+  test("a scheduled recurring scan says when it next runs", async () => {
+    await renderPage();
+
+    const cell: string = renderRecurrenceCell({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+      status: "Completed",
+      nextScanAt: new Date(Date.now() + 30 * 60000),
+    });
+
+    expect(cell).toContain("Every 60 min");
+    expect(cell).toContain("Next scan");
+  });
+
+  /*
+   * The half-truth this column used to tell. A recurring scan whose
+   * nextScanAt is NULL is never re-queued — the worker's predicate is
+   * `nextScanAt <= now`, and that is UNKNOWN for NULL — but the cell printed
+   * the cadence and simply omitted the second line, so a scan that would never
+   * run again was indistinguishable from one due in an hour.
+   */
+  test("a recurring scan with nothing scheduled says so rather than showing a bare cadence", async () => {
+    await renderPage();
+
+    const cell: string = renderRecurrenceCell({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+      status: "Completed",
+    });
+
+    expect(cell).toContain("Every 60 min");
+    expect(cell).toContain("No next scan is scheduled");
+  });
+
+  /*
+   * ...but that is only alarming once the scan has finished. A run that is
+   * queued or under way has its next one scheduled when it reports.
+   */
+  test("a recurring scan mid-run explains that the next one waits for it", async () => {
+    await renderPage();
+
+    for (const status of ["Pending", "In Progress"]) {
+      const cell: string = renderRecurrenceCell({
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        status: status,
+      });
+
+      expect(cell).toContain("when this run finishes");
+      expect(cell).not.toContain("No next scan is scheduled");
+    }
   });
 
   /*

--- a/Common/Tests/Models/DiscoveryScanNameColumn.test.ts
+++ b/Common/Tests/Models/DiscoveryScanNameColumn.test.ts
@@ -208,7 +208,7 @@ describe("NetworkDeviceDiscoveryScan.name access control", () => {
   });
 
   /*
-   * The Rename dialog on the Discovery page depends on this list being
+   * The Edit dialog on the Discovery page depends on this list being
    * non-empty — ModelForm drops a field whose column grants no update
    * permission, so an empty list here would turn the dialog into a permission
    * error rather than a text box.
@@ -221,21 +221,31 @@ describe("NetworkDeviceDiscoveryScan.name access control", () => {
   });
 
   /*
-   * And the sweep itself stays read-only. This is the claim worth pinning:
-   * adding an editable column must not have made anything that DESCRIBES a
-   * sweep editable with it. A target or a credential changed after a probe
-   * took the scan would leave the stored row describing a sweep that never
-   * ran, and a status or a result changed by hand would be a lie about one
-   * that did.
+   * THE LINE THIS MODEL IS DIVIDED ALONG, and the reason both halves are
+   * pinned here rather than left to whoever edits the model next.
    *
-   * (The recurrence pair is editable, and always was — it describes the NEXT
-   * run rather than the one that happened.)
+   * Everything that DESCRIBES the scan is editable. That is a reversal: every
+   * one of these columns was create-only until OneUptime issue #3444, on the
+   * reasoning that a row must never stop describing the sweep that ran. The
+   * reasoning was right and the conclusion was wrong — it made a typo'd subnet
+   * or a rejected community string unfixable except by deleting the scan and
+   * losing its results. The invariant now lives in
+   * NetworkDeviceDiscoveryScanService instead: changing any of them re-queues
+   * the scan and clears the previous run.
+   *
+   * Everything the scan REPORTED stays read-only, and that half is
+   * load-bearing. The service writes those columns as root through the
+   * hook-free path, which has no column access control at all, so this list is
+   * the only thing standing between the public CRUD API and a hand-edited
+   * result: a scan that claims to have found hosts it never saw.
    */
-  test("does not make any part of the sweep editable", () => {
+  test("makes every setting of the sweep editable", () => {
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
 
-    const sweepColumns: Array<string> = [
+    const settingColumns: Array<string> = [
       "cidr",
+      // Both spellings: the dashboard posts `probe`, API clients post `probeId`.
+      "probe",
       "probeId",
       "snmpVersion",
       "snmpCommunityString",
@@ -246,6 +256,23 @@ describe("NetworkDeviceDiscoveryScan.name access control", () => {
       "snmpV3AuthKey",
       "snmpV3PrivProtocol",
       "snmpV3PrivKey",
+      // The pair that describes the NEXT run rather than the one that happened.
+      "isRecurring",
+      "rescanIntervalInMinutes",
+    ];
+
+    for (const column of settingColumns) {
+      expect({
+        column: column,
+        update: scan.getColumnAccessControlFor(column)?.update,
+      }).toEqual({ column: column, update: EDITORS });
+    }
+  });
+
+  test("keeps everything the scan reported read-only", () => {
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+
+    const resultColumns: Array<string> = [
       "status",
       "statusMessage",
       "discoveredDevices",
@@ -253,10 +280,12 @@ describe("NetworkDeviceDiscoveryScan.name access control", () => {
       "respondedHostCount",
       "startedAt",
       "completedAt",
+      // Derived by the server from the schedule; never set by hand.
       "nextScanAt",
+      "autoImportProcessedAt",
     ];
 
-    for (const column of sweepColumns) {
+    for (const column of resultColumns) {
       expect({
         column: column,
         update: scan.getColumnAccessControlFor(column)?.update,
@@ -264,12 +293,36 @@ describe("NetworkDeviceDiscoveryScan.name access control", () => {
     }
   });
 
-  // ...while the two columns that describe a future run stay editable.
-  test("leaves the recurrence pair editable, as it already was", () => {
+  /*
+   * Widening `update` must not have widened `read`. The three credential
+   * columns are read by a narrower list than the rest of the model on purpose
+   * — a passphrase is not something every reader of the scans list should be
+   * handed — and every editor is already inside it, so the Edit dialog can
+   * still prefill them.
+   */
+  test("does not widen read access to the credentials", () => {
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
 
-    for (const column of ["isRecurring", "rescanIntervalInMinutes"]) {
-      expect(scan.getColumnAccessControlFor(column)?.update).toEqual(EDITORS);
+    const credentialColumns: Array<string> = [
+      "snmpCommunityString",
+      "snmpV3AuthKey",
+      "snmpV3PrivKey",
+    ];
+
+    for (const column of credentialColumns) {
+      const readers: Array<Permission> =
+        scan.getColumnAccessControlFor(column)?.read || [];
+
+      expect(readers).not.toContain(Permission.Viewer);
+      expect(readers).not.toContain(Permission.SettingsViewer);
+
+      for (const editor of EDITORS) {
+        if (editor === Permission.EditNetworkDeviceDiscoveryScan) {
+          continue;
+        }
+
+        expect(readers).toContain(editor);
+      }
     }
   });
 

--- a/Common/Tests/Server/Services/DatabaseServiceUpdateWriteRouting.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceUpdateWriteRouting.test.ts
@@ -81,6 +81,18 @@ describe("DatabaseService._updateBy — save() vs update() write routing", () =>
       .spyOn(NetworkDeviceDiscoveryScanService, "getRepository")
       .mockReturnValue({ save: saveMock, update: updateMock } as never);
 
+    /*
+     * The scan service reconciles after a settings update — a write of its own
+     * that re-queues a scan whose sweep changed (OneUptime issue #3444). It
+     * runs through the raw single-statement path, which reaches for
+     * repository.manager.connection.driver and finds neither on the two-method
+     * stub above. Stubbed out: these tests are about which primitive
+     * _updateBy chooses, not about what the service does afterwards.
+     */
+    jest
+      .spyOn(NetworkDeviceDiscoveryScanService, "updateColumnsByIdWithoutHooks")
+      .mockResolvedValue(undefined as never);
+
     // The permission layer needs a DB and is not what these tests exercise.
     jest
       .spyOn(ModelPermission, "checkUpdatePermissionByModel")

--- a/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+++ b/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
@@ -97,17 +97,27 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
     const updateHooks: Array<string> = ["onBeforeUpdate", "onUpdateSuccess"];
 
     /*
-     * onUpdateSuccess is still un-overridden: nothing runs AFTER the write
-     * that the fast path would drop. Only onBeforeUpdate is overridden, and
-     * the tests below pin that it is inert for the claim payload.
+     * BOTH hooks are overridden now, so neither can be dismissed as "there is
+     * nothing to skip" — which is what this suite used to assert about
+     * onUpdateSuccess. What licenses the claim's hook-free write today is
+     * narrower and is pinned below instead: the hooks look only at columns the
+     * claim payload does not carry, and onBeforeUpdate is demonstrably a
+     * pass-through when handed that payload.
+     *
+     * onUpdateSuccess re-queues a scan whose target, probe or credentials just
+     * changed, and re-derives nextScanAt from the recurrence pair (OneUptime
+     * issue #3444). None of those columns is in the claim.
      */
-    test("NetworkDeviceDiscoveryScanService does not override onUpdateSuccess", () => {
-      expect(
-        Object.prototype.hasOwnProperty.call(
-          NetworkDeviceDiscoveryScanServiceClass.prototype,
-          "onUpdateSuccess",
-        ),
-      ).toBe(false);
+    test("both update hooks are overridden, so the disjointness below is what matters", () => {
+      for (const hook of updateHooks) {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            NetworkDeviceDiscoveryScanServiceClass.prototype,
+            hook,
+          ),
+        ).toBe(true);
+      }
+
       // The default export is an instance of the class checked above.
       expect(NetworkDeviceDiscoveryScanService).toBeInstanceOf(
         NetworkDeviceDiscoveryScanServiceClass,
@@ -128,13 +138,13 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
     });
 
     /*
-     * The columns the claim write stamps and the column the onBeforeUpdate
-     * override validates must stay disjoint. This is the assertion that
-     * actually licenses the hookless claim write: if someone adds `cidr` to
-     * the claim payload, or teaches the hook to validate `status`, the
-     * overlap shows up here.
+     * The columns the claim write stamps and the columns the update hooks
+     * react to must stay disjoint. This is the assertion that actually
+     * licenses the hookless claim write: if someone adds `cidr` to the claim
+     * payload, or teaches a hook to react to `status`, the overlap shows up
+     * here.
      */
-    test("the claim write's columns are disjoint from what onBeforeUpdate validates", () => {
+    test("the claim write's columns are disjoint from what the hooks react to", () => {
       const claimWriteColumns: Array<string> = [
         "status",
         "startedAt",
@@ -142,14 +152,76 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
       ];
       /*
        * `name` joined `cidr` here when discovery scans became nameable
-       * (issue #3391): the hook validates and normalizes it on any update that
-       * carries it. The claim payload does not, which is what keeps the
-       * hookless write honest.
+       * (issue #3391), and the sweep and schedule columns joined them when a
+       * scan's settings became editable (issue #3444): an update carrying any
+       * of these makes the hooks read the row and, if a setting really
+       * changed, re-queue the scan afterwards. The claim payload carries none
+       * of them, which is what keeps the hookless write honest.
        */
-      const columnsValidatedByHook: Array<string> = ["cidr", "name"];
+      const columnsReactedToByHooks: Array<string> = [
+        "cidr",
+        "name",
+        "probe",
+        "probeId",
+        "snmpVersion",
+        "snmpCommunityString",
+        "snmpPort",
+        "snmpV3SecurityLevel",
+        "snmpV3Username",
+        "snmpV3AuthProtocol",
+        "snmpV3AuthKey",
+        "snmpV3PrivProtocol",
+        "snmpV3PrivKey",
+        "isRecurring",
+        "rescanIntervalInMinutes",
+      ];
 
       for (const column of claimWriteColumns) {
-        expect(columnsValidatedByHook).not.toContain(column);
+        expect(columnsReactedToByHooks).not.toContain(column);
+      }
+    });
+
+    /*
+     * The same disjointness asserted against the OTHER root writers of this
+     * model, because every one of them takes the same shortcut in spirit: the
+     * result ingest, the requeue worker, the stale-scan reaper, the
+     * unclaimed-scan diagnosis and the auto-import stamp all write run state
+     * and nothing else. If one of them ever carried a setting, it would start
+     * re-queueing the very scan it is reporting on.
+     */
+    test("no server-side writer of this model carries a column the hooks react to", () => {
+      const serverWrittenColumns: Array<string> = [
+        "status",
+        "statusMessage",
+        "startedAt",
+        "completedAt",
+        "nextScanAt",
+        "discoveredDevices",
+        "scannedHostCount",
+        "respondedHostCount",
+        "autoImportProcessedAt",
+      ];
+
+      const columnsReactedToByHooks: Array<string> = [
+        "cidr",
+        "name",
+        "probe",
+        "probeId",
+        "snmpVersion",
+        "snmpCommunityString",
+        "snmpPort",
+        "snmpV3SecurityLevel",
+        "snmpV3Username",
+        "snmpV3AuthProtocol",
+        "snmpV3AuthKey",
+        "snmpV3PrivProtocol",
+        "snmpV3PrivKey",
+        "isRecurring",
+        "rescanIntervalInMinutes",
+      ];
+
+      for (const column of serverWrittenColumns) {
+        expect(columnsReactedToByHooks).not.toContain(column);
       }
     });
 
@@ -171,11 +243,19 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
         skip: 0,
       };
 
-      const result: { updateBy: unknown } = await (
+      const result: { updateBy: unknown; carryForward: unknown } = await (
         NetworkDeviceDiscoveryScanService as any
       ).onBeforeUpdate(claimUpdateBy);
 
       expect(result.updateBy).toBe(claimUpdateBy);
+
+      /*
+       * And nothing was carried forward, so onUpdateSuccess would have had
+       * nothing to reconcile even if the claim had gone the long way round.
+       * This is also the proof the hook did not read the database for a
+       * payload the probe polls with every minute.
+       */
+      expect(result.carryForward).toBeNull();
     });
 
     /*

--- a/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+++ b/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
@@ -3,7 +3,14 @@ import NetworkDeviceDiscoveryScanService, {
 } from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
 import DatabaseService from "../../../Server/Services/DatabaseService";
 import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
-import { describe, expect, test } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
 
 /*
  * The /probe-ingest/probe/discovery-scan/list route hands the requesting
@@ -97,6 +104,31 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
     const updateHooks: Array<string> = ["onBeforeUpdate", "onUpdateSuccess"];
 
     /*
+     * The hook reads the rows an edit is about to change. Stubbed to nothing,
+     * so "did it read?" becomes an assertion rather than a database
+     * dependency.
+     */
+    const findBy: jest.Mock = jest.fn() as unknown as jest.Mock;
+
+    beforeEach(() => {
+      findBy.mockReset();
+      findBy.mockResolvedValue([] as never);
+
+      jest
+        .spyOn(
+          NetworkDeviceDiscoveryScanService as unknown as {
+            findBy: () => Promise<unknown>;
+          },
+          "findBy",
+        )
+        .mockImplementation(findBy as never);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    /*
      * BOTH hooks are overridden now, so neither can be dismissed as "there is
      * nothing to skip" — which is what this suite used to assert about
      * onUpdateSuccess. What licenses the claim's hook-free write today is
@@ -140,72 +172,57 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
     /*
      * The columns the claim write stamps and the columns the update hooks
      * react to must stay disjoint. This is the assertion that actually
-     * licenses the hookless claim write: if someone adds `cidr` to the claim
-     * payload, or teaches a hook to react to `status`, the overlap shows up
-     * here.
+     * licenses the hookless claim write.
+     *
+     * Asked of the HOOK, one column at a time, rather than of two lists of
+     * strings written down beside each other: a test that compares one
+     * literal against another literal passes whatever production does, and
+     * this is the one place in the suite where that would matter. An update
+     * carrying a single column takes the hook's early exit — nothing carried
+     * forward, and no row read — exactly when that column is none of the
+     * hook's business.
      */
-    test("the claim write's columns are disjoint from what the hooks react to", () => {
+    test("the claim write's columns are none of the update hooks' business", async () => {
       const claimWriteColumns: Array<string> = [
         "status",
         "startedAt",
         "statusMessage",
       ];
-      /*
-       * `name` joined `cidr` here when discovery scans became nameable
-       * (issue #3391), and the sweep and schedule columns joined them when a
-       * scan's settings became editable (issue #3444): an update carrying any
-       * of these makes the hooks read the row and, if a setting really
-       * changed, re-queue the scan afterwards. The claim payload carries none
-       * of them, which is what keeps the hookless write honest.
-       */
-      const columnsReactedToByHooks: Array<string> = [
-        "cidr",
-        "name",
-        "probe",
-        "probeId",
-        "snmpVersion",
-        "snmpCommunityString",
-        "snmpPort",
-        "snmpV3SecurityLevel",
-        "snmpV3Username",
-        "snmpV3AuthProtocol",
-        "snmpV3AuthKey",
-        "snmpV3PrivProtocol",
-        "snmpV3PrivKey",
-        "isRecurring",
-        "rescanIntervalInMinutes",
-      ];
 
       for (const column of claimWriteColumns) {
-        expect(columnsReactedToByHooks).not.toContain(column);
+        findBy.mockClear();
+
+        const result: { carryForward: unknown } = await (
+          NetworkDeviceDiscoveryScanService as any
+        ).onBeforeUpdate({
+          query: { _id: "some-scan-id" },
+          data: { [column]: null },
+          props: { isRoot: true },
+          limit: 1,
+          skip: 0,
+        });
+
+        expect({
+          column: column,
+          carryForward: result.carryForward,
+          rowsRead: findBy.mock.calls.length,
+        }).toEqual({ column: column, carryForward: null, rowsRead: 0 });
       }
     });
 
     /*
-     * The same disjointness asserted against the OTHER root writers of this
-     * model, because every one of them takes the same shortcut in spirit: the
-     * result ingest, the requeue worker, the stale-scan reaper, the
-     * unclaimed-scan diagnosis and the auto-import stamp all write run state
-     * and nothing else. If one of them ever carried a setting, it would start
-     * re-queueing the very scan it is reporting on.
+     * The same question the other way round, so the assertion above cannot
+     * pass by the hook having quietly become inert: every column an edit can
+     * carry DOES make the hook read the row it is about to change.
      */
-    test("no server-side writer of this model carries a column the hooks react to", () => {
-      const serverWrittenColumns: Array<string> = [
-        "status",
-        "statusMessage",
-        "startedAt",
-        "completedAt",
-        "nextScanAt",
-        "discoveredDevices",
-        "scannedHostCount",
-        "respondedHostCount",
-        "autoImportProcessedAt",
-      ];
+    const SETTING_VALUES: Record<string, string> = {
+      cidr: "10.0.0.0/24",
+      probeId: "44444444-4444-4444-8444-444444444444",
+    };
 
-      const columnsReactedToByHooks: Array<string> = [
+    test("a settings column, by contrast, does make the hooks read the row", async () => {
+      const settingColumns: Array<string> = [
         "cidr",
-        "name",
-        "probe",
         "probeId",
         "snmpVersion",
         "snmpCommunityString",
@@ -220,8 +237,31 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
         "rescanIntervalInMinutes",
       ];
 
-      for (const column of serverWrittenColumns) {
-        expect(columnsReactedToByHooks).not.toContain(column);
+      for (const column of settingColumns) {
+        findBy.mockClear();
+
+        const result: { carryForward: unknown } = await (
+          NetworkDeviceDiscoveryScanService as any
+        ).onBeforeUpdate({
+          query: { _id: "some-scan-id" },
+          /*
+           * Two columns the hook refuses to CLEAR are given a value instead —
+           * the scan target, which it validates, and the probe, which the
+           * column cannot be without. Every other column accepts an empty box.
+           */
+          data: {
+            [column]: SETTING_VALUES[column] ?? null,
+          },
+          props: { isRoot: true },
+          limit: 1,
+          skip: 0,
+        });
+
+        expect({ column: column, rowsRead: findBy.mock.calls.length }).toEqual({
+          column: column,
+          rowsRead: 1,
+        });
+        expect(result.carryForward).not.toBeNull();
       }
     });
 

--- a/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
@@ -6,7 +6,15 @@ import ScanTargetUtil from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
 import ScanNameUtil from "../../../Utils/NetworkDiscovery/ScanNameUtil";
 import CreateBy from "../../../Server/Types/Database/CreateBy";
 import UpdateBy from "../../../Server/Types/Database/UpdateBy";
-import { describe, expect, it } from "@jest/globals";
+import OneUptimeDate from "../../../Types/Date";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 
 /*
  * Contract under test: a discovery scan cannot be saved with a target the
@@ -452,5 +460,544 @@ describe("NetworkDeviceDiscoveryScanService name validation on update", () => {
     expect(Object.prototype.hasOwnProperty.call(updateBy.data, "name")).toBe(
       false,
     );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Editing a scan's settings after creation (OneUptime issue #3444).
+ * ---------------------------------------------------------------------------
+ *
+ * The hooks stopped being pure the moment a scan's target and credentials
+ * became editable: deciding whether a save actually CHANGED the sweep means
+ * reading the row it is about to overwrite. So from here down the service's
+ * two database calls are stubbed — `findBy` hands back the stored row, and
+ * `updateColumnsByIdWithoutHooks` records the reconciling write instead of
+ * making it — and the assertions are about what the hooks decide, not about
+ * Postgres.
+ */
+
+const SCAN_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const OTHER_PROBE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+interface ReconcileWrite {
+  id: string;
+  data: Record<string, unknown>;
+}
+
+interface StoredScanOverrides {
+  status?: string;
+  cidr?: string;
+  probeId?: ObjectID;
+  snmpVersion?: string | undefined;
+  snmpCommunityString?: string | null | undefined;
+  snmpPort?: number | undefined;
+  snmpV3Username?: string | null | undefined;
+  isRecurring?: boolean;
+  rescanIntervalInMinutes?: number | null | undefined;
+  completedAt?: Date | null | undefined;
+  nextScanAt?: Date | null | undefined;
+}
+
+/*
+ * A scan as it sits in the database: completed, one-time, sweeping a /24 with
+ * a v2c community string. Every test below starts from this and changes the
+ * one thing it is about.
+ */
+function storedScan(
+  overrides?: StoredScanOverrides,
+): NetworkDeviceDiscoveryScan {
+  const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+
+  scan._id = SCAN_ID.toString();
+  scan.projectId = PROJECT_ID;
+  scan.probeId = PROBE_ID;
+  scan.cidr = "192.168.1.0/24";
+  scan.status = "Completed";
+  scan.snmpVersion = "V2c";
+  scan.snmpCommunityString = "public";
+  scan.snmpPort = 161;
+  scan.isRecurring = false;
+
+  Object.assign(scan, overrides || {});
+
+  return scan;
+}
+
+let storedScans: Array<NetworkDeviceDiscoveryScan> = [];
+let reconcileWrites: Array<ReconcileWrite> = [];
+let lastFindByArgs: Record<string, unknown> | null = null;
+
+beforeEach(() => {
+  storedScans = [storedScan()];
+  reconcileWrites = [];
+  lastFindByArgs = null;
+
+  jest
+    .spyOn(
+      NetworkDeviceDiscoveryScanService as unknown as {
+        findBy: (args: Record<string, unknown>) => Promise<unknown>;
+      },
+      "findBy",
+    )
+    .mockImplementation(async (args: Record<string, unknown>) => {
+      lastFindByArgs = args;
+
+      return storedScans;
+    });
+
+  jest
+    .spyOn(
+      NetworkDeviceDiscoveryScanService as unknown as {
+        updateColumnsByIdWithoutHooks: (input: {
+          id: ObjectID;
+          data: Record<string, unknown>;
+        }) => Promise<void>;
+      },
+      "updateColumnsByIdWithoutHooks",
+    )
+    .mockImplementation(
+      async (input: { id: ObjectID; data: Record<string, unknown> }) => {
+        reconcileWrites.push({
+          id: input.id.toString(),
+          data: input.data,
+        });
+      },
+    );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/*
+ * Run one settings save end to end through both hooks, exactly as
+ * DatabaseService does: onBeforeUpdate, then the write, then onUpdateSuccess
+ * with the ids the write touched.
+ */
+async function saveSettings(
+  data: Record<string, unknown>,
+  options?: { isRoot?: boolean },
+): Promise<Array<ReconcileWrite>> {
+  const updateBy: UpdateBy<NetworkDeviceDiscoveryScan> = {
+    query: { _id: SCAN_ID },
+    data: data,
+    props: options?.isRoot
+      ? { isRoot: true }
+      : { isRoot: false, tenantId: PROJECT_ID },
+    limit: 1,
+    skip: 0,
+  } as unknown as UpdateBy<NetworkDeviceDiscoveryScan>;
+
+  const onUpdate: { updateBy: unknown; carryForward: unknown } =
+    (await onBeforeUpdate(updateBy)) as {
+      updateBy: unknown;
+      carryForward: unknown;
+    };
+
+  await (NetworkDeviceDiscoveryScanService as any).onUpdateSuccess(onUpdate, [
+    SCAN_ID,
+  ]);
+
+  return reconcileWrites;
+}
+
+/*
+ * Everything the create wizard posts, unchanged from the stored row. This is
+ * what the Edit dialog actually sends when the operator opens it and saves
+ * without typing: ModelForm posts every field it declares, dirty or not.
+ */
+function unchangedSave(): Record<string, unknown> {
+  return {
+    name: "Region 1100",
+    cidr: "192.168.1.0/24",
+    probe: { _id: PROBE_ID.toString() },
+    snmpVersion: "V2c",
+    snmpCommunityString: "public",
+    snmpPort: 161,
+    snmpV3SecurityLevel: "",
+    snmpV3Username: "",
+    snmpV3AuthProtocol: "",
+    snmpV3AuthKey: "",
+    snmpV3PrivProtocol: "",
+    snmpV3PrivKey: "",
+    isRecurring: false,
+    rescanIntervalInMinutes: null,
+  };
+}
+
+describe("NetworkDeviceDiscoveryScanService: editing a scan's settings", () => {
+  it("reads nothing for an update that touches neither settings nor schedule", async () => {
+    const updateBy: UpdateBy<NetworkDeviceDiscoveryScan> = makeUpdateBy({
+      status: "In Progress",
+      startedAt: new Date(0),
+      statusMessage: null,
+    });
+
+    const result: { updateBy: unknown; carryForward: unknown } =
+      (await onBeforeUpdate(updateBy)) as {
+        updateBy: unknown;
+        carryForward: unknown;
+      };
+
+    expect(lastFindByArgs).toBeNull();
+    expect(result.carryForward).toBeNull();
+    expect(result.updateBy).toBe(updateBy);
+  });
+
+  it("reads nothing for a rename, so renaming can never re-queue a scan", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      name: "Region 1200",
+    });
+
+    expect(lastFindByArgs).toBeNull();
+    expect(writes).toEqual([]);
+  });
+
+  /*
+   * The hook runs BEFORE the permission layer scopes the query, and the API
+   * hands the service a bare `{_id}`. Reading with that as root and no tenant
+   * of our own would answer "does this id exist, and what are its SNMP
+   * credentials" for every project on the instance.
+   */
+  it("scopes its read to the caller's project", async () => {
+    await saveSettings({ cidr: "10.0.0.0/24" });
+
+    expect(lastFindByArgs).not.toBeNull();
+    expect((lastFindByArgs as any).query).toEqual({
+      _id: SCAN_ID,
+      projectId: PROJECT_ID,
+    });
+    expect((lastFindByArgs as any).props.isRoot).toBe(true);
+  });
+
+  it("leaves a root caller's query alone, since it has no tenant to scope to", async () => {
+    await saveSettings({ cidr: "10.0.0.0/24" }, { isRoot: true });
+
+    expect((lastFindByArgs as any).query).toEqual({ _id: SCAN_ID });
+  });
+
+  it("re-queues the scan and clears its results when the target changes", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      cidr: "10.0.0.0/24",
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.id).toBe(SCAN_ID.toString());
+    expect(writes[0]!.data).toEqual({
+      status: "Pending",
+      statusMessage: null,
+      startedAt: null,
+      completedAt: null,
+      nextScanAt: null,
+      discoveredDevices: null,
+      scannedHostCount: null,
+      respondedHostCount: null,
+      autoImportProcessedAt: null,
+    });
+  });
+
+  it("does nothing at all when the whole form is re-posted unchanged", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings(unchangedSave());
+
+    expect(writes).toEqual([]);
+  });
+
+  /*
+   * The v3 columns of a v2c scan are NULL in the database and empty strings in
+   * the form. Reading those as different values would retire a good result set
+   * the first time anybody opened the dialog and pressed Save.
+   */
+  it("treats an empty box and an unset column as the same setting", async () => {
+    storedScans = [
+      storedScan({
+        snmpCommunityString: null,
+        snmpVersion: "V3",
+        snmpV3Username: "netops",
+      }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      ...unchangedSave(),
+      snmpVersion: "V3",
+      snmpCommunityString: "",
+      snmpV3Username: "netops",
+    });
+
+    expect(writes).toEqual([]);
+  });
+
+  it("re-queues when a credential changes", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      ...unchangedSave(),
+      snmpCommunityString: "private",
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.data["status"]).toBe("Pending");
+  });
+
+  it("re-queues when the port changes, even though the form sends it as text", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      ...unchangedSave(),
+      snmpPort: "1161",
+    });
+
+    expect(writes).toHaveLength(1);
+  });
+
+  it("does not re-queue when the port is re-sent as text unchanged", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      ...unchangedSave(),
+      snmpPort: "161",
+    });
+
+    expect(writes).toEqual([]);
+  });
+
+  /*
+   * The dashboard posts the relation object and server callers post the FK
+   * column. A hook that understood only one spelling would silently ignore
+   * every probe change made through the other.
+   */
+  it("re-queues when the probe changes, posted as a relation", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      ...unchangedSave(),
+      probe: { _id: OTHER_PROBE_ID.toString() },
+    });
+
+    expect(writes).toHaveLength(1);
+  });
+
+  it("re-queues when the probe changes, posted as probeId", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      probeId: OTHER_PROBE_ID,
+    });
+
+    expect(writes).toHaveLength(1);
+  });
+
+  it("refuses to clear the probe rather than letting the column reject it", async () => {
+    await expect(saveSettings({ probe: null })).rejects.toThrow(
+      BadDataException,
+    );
+  });
+
+  it("abandons a run that is still in progress when the target changes", async () => {
+    storedScans = [storedScan({ status: "In Progress" })];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      cidr: "10.0.0.0/24",
+    });
+
+    /*
+     * Back to Pending, and startedAt cleared. The probe is still sweeping the
+     * old target; when it reports, the result endpoint discards the result
+     * precisely because the scan is Pending again.
+     */
+    expect(writes[0]!.data["status"]).toBe("Pending");
+    expect(writes[0]!.data["startedAt"]).toBeNull();
+  });
+
+  it("reconciles only the rows the write actually touched", async () => {
+    const otherId: ObjectID = new ObjectID(
+      "55555555-5555-4555-8555-555555555555",
+    );
+
+    await saveSettings({ cidr: "10.0.0.0/24" });
+
+    expect(
+      reconcileWrites.map((write: ReconcileWrite) => {
+        return write.id;
+      }),
+    ).toEqual([SCAN_ID.toString()]);
+    expect(otherId.toString()).not.toBe(SCAN_ID.toString());
+  });
+});
+
+describe("NetworkDeviceDiscoveryScanService: when the next run is due", () => {
+  const COMPLETED_AT: Date = OneUptimeDate.fromString(
+    "2026-01-01T00:00:00.000Z",
+  );
+
+  /*
+   * The bug this whole derivation exists for. Turning recurrence on for a scan
+   * that had already finished used to write the flag and nothing else — and
+   * the requeue worker matches on `nextScanAt <= now`, which is never true of
+   * NULL. The list said "Every 60 min" over a scan that would never run again.
+   */
+  it("schedules a finished one-time scan the moment recurrence is turned on", async () => {
+    storedScans = [
+      storedScan({ status: "Completed", completedAt: COMPLETED_AT }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(
+      OneUptimeDate.fromString(writes[0]!.data["nextScanAt"] as Date).getTime(),
+    ).toBe(COMPLETED_AT.getTime() + 60 * 60 * 1000);
+  });
+
+  it("re-derives the next run when the interval is shortened", async () => {
+    storedScans = [
+      storedScan({
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+        isRecurring: true,
+        rescanIntervalInMinutes: 1440,
+        nextScanAt: OneUptimeDate.addRemoveMinutes(COMPLETED_AT, 1440),
+      }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+    });
+
+    /*
+     * Measured from the last run, not from the save — so a scan whose cadence
+     * was shortened past its own last completion reads as already due, which
+     * is exactly what it is. Before this, the new cadence did not take effect
+     * until one full OLD cadence had elapsed.
+     */
+    expect(writes).toHaveLength(1);
+    expect(
+      OneUptimeDate.fromString(writes[0]!.data["nextScanAt"] as Date).getTime(),
+    ).toBe(COMPLETED_AT.getTime() + 60 * 60 * 1000);
+  });
+
+  it("clears the next run when recurrence is turned off", async () => {
+    storedScans = [
+      storedScan({
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        nextScanAt: OneUptimeDate.addRemoveMinutes(COMPLETED_AT, 60),
+      }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: false,
+      rescanIntervalInMinutes: 60,
+    });
+
+    /*
+     * A stale timestamp left behind here is not inert: turning recurrence back
+     * on months later would find it already in the past and fire an immediate,
+     * unasked-for sweep.
+     */
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.data["nextScanAt"]).toBeNull();
+  });
+
+  it("writes nothing when the schedule is re-posted unchanged", async () => {
+    storedScans = [
+      storedScan({
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        nextScanAt: OneUptimeDate.addRemoveMinutes(COMPLETED_AT, 60),
+      }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+    });
+
+    expect(writes).toEqual([]);
+  });
+
+  it("clamps a sub-minimum interval instead of scheduling a sweep every minute", async () => {
+    storedScans = [
+      storedScan({ status: "Completed", completedAt: COMPLETED_AT }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: 1,
+    });
+
+    expect(
+      OneUptimeDate.fromString(writes[0]!.data["nextScanAt"] as Date).getTime(),
+    ).toBe(COMPLETED_AT.getTime() + 15 * 60 * 1000);
+  });
+
+  it("schedules nothing for a recurring scan with no interval", async () => {
+    storedScans = [
+      storedScan({ status: "Completed", completedAt: COMPLETED_AT }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: null,
+    });
+
+    expect(writes).toEqual([]);
+  });
+
+  /*
+   * A scan that is queued or mid-sweep has a run coming already; the result
+   * endpoint stamps the one after it. Scheduling from here would race it.
+   */
+  it("schedules nothing while a run is queued or in flight", async () => {
+    for (const status of ["Pending", "In Progress"]) {
+      reconcileWrites = [];
+      storedScans = [storedScan({ status: status, completedAt: null })];
+
+      const writes: Array<ReconcileWrite> = await saveSettings({
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+      });
+
+      expect(writes).toEqual([]);
+    }
+  });
+
+  it("schedules a failed run too, so a transient failure does not end the recurrence", async () => {
+    storedScans = [storedScan({ status: "Failed", completedAt: COMPLETED_AT })];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.data["nextScanAt"]).not.toBeNull();
+  });
+
+  /*
+   * Both at once: the target changed AND the scan is recurring. The re-queue
+   * wins — the run it would have been scheduled from no longer exists, and the
+   * next one is scheduled when the new sweep reports.
+   */
+  it("leaves no next run scheduled when the sweep is re-queued", async () => {
+    storedScans = [
+      storedScan({
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        nextScanAt: OneUptimeDate.addRemoveMinutes(COMPLETED_AT, 60),
+      }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      cidr: "10.0.0.0/24",
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.data["status"]).toBe("Pending");
+    expect(writes[0]!.data["nextScanAt"]).toBeNull();
   });
 });

--- a/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
@@ -1,5 +1,7 @@
 import NetworkDeviceDiscoveryScanService from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
 import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import ProbeService from "../../../Server/Services/ProbeService";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
 import ScanTargetUtil from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
@@ -527,6 +529,8 @@ function storedScan(
 }
 
 let storedScans: Array<NetworkDeviceDiscoveryScan> = [];
+// What the probe lookup finds. Null stands in for a probe that is not there.
+let probeOnLookup: Probe | null = null;
 let reconcileWrites: Array<ReconcileWrite> = [];
 let lastFindByArgs: Record<string, unknown> | null = null;
 
@@ -534,6 +538,26 @@ beforeEach(() => {
   storedScans = [storedScan()];
   reconcileWrites = [];
   lastFindByArgs = null;
+
+  /*
+   * The probe a scan points at is looked up so it can be checked against the
+   * scan's own project. By default it is one of this project's probes.
+   */
+  const probe: Probe = new Probe();
+  probe._id = PROBE_ID.toString();
+  probe.projectId = PROJECT_ID;
+  probeOnLookup = probe;
+
+  jest
+    .spyOn(
+      ProbeService as unknown as {
+        findOneById: (args: Record<string, unknown>) => Promise<unknown>;
+      },
+      "findOneById",
+    )
+    .mockImplementation(async () => {
+      return probeOnLookup;
+    });
 
   jest
     .spyOn(
@@ -546,6 +570,23 @@ beforeEach(() => {
       lastFindByArgs = args;
 
       return storedScans;
+    });
+
+  /*
+   * The row as it stands after the write. onUpdateSuccess re-reads it rather
+   * than predicting it from the payload, so the stub hands back the same
+   * fixture the pre-image came from — with the update applied, exactly as the
+   * database would have applied it.
+   */
+  jest
+    .spyOn(
+      NetworkDeviceDiscoveryScanService as unknown as {
+        findOneById: (args: Record<string, unknown>) => Promise<unknown>;
+      },
+      "findOneById",
+    )
+    .mockImplementation(async () => {
+      return storedScans[0] || null;
     });
 
   jest
@@ -596,6 +637,37 @@ async function saveSettings(
       updateBy: unknown;
       carryForward: unknown;
     };
+
+  /*
+   * Stand in for the write itself, so the row onUpdateSuccess re-reads is the
+   * row the update produced. Values are coerced the way the column types
+   * would coerce them, which is the whole reason the hook reads the row back
+   * instead of trusting the payload: a Number column posted as "60" is a
+   * number by the time anybody reads it again.
+   */
+  const stored: NetworkDeviceDiscoveryScan | undefined = storedScans[0];
+
+  if (stored) {
+    for (const key of Object.keys(data)) {
+      const value: unknown = data[key];
+
+      if (key === "isRecurring") {
+        stored.isRecurring = Boolean(value);
+      } else if (key === "rescanIntervalInMinutes") {
+        /*
+         * Written through a cast because `exactOptionalPropertyTypes` forbids
+         * assigning undefined to an optional property, and a cleared interval
+         * is exactly that assignment.
+         */
+        (stored as unknown as Record<string, unknown>)[key] =
+          value === null || value === undefined || value === ""
+            ? undefined
+            : Number(value);
+      } else if (key !== "probe") {
+        (stored as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
+  }
 
   await (NetworkDeviceDiscoveryScanService as any).onUpdateSuccess(onUpdate, [
     SCAN_ID,
@@ -688,7 +760,6 @@ describe("NetworkDeviceDiscoveryScanService: editing a scan's settings", () => {
     expect(writes[0]!.id).toBe(SCAN_ID.toString());
     expect(writes[0]!.data).toEqual({
       status: "Pending",
-      statusMessage: null,
       startedAt: null,
       completedAt: null,
       nextScanAt: null,
@@ -696,7 +767,50 @@ describe("NetworkDeviceDiscoveryScanService: editing a scan's settings", () => {
       scannedHostCount: null,
       respondedHostCount: null,
       autoImportProcessedAt: null,
+      /*
+       * The row explains itself rather than going quiet: the operator saved a
+       * change and the results they were looking at disappeared, and the scans
+       * list renders this in the cell where those results used to be.
+       */
+      statusMessage: expect.stringContaining("queued to run again"),
     });
+  });
+
+  /*
+   * Every column that decides what the probe sweeps, one at a time. Three of
+   * them used to be covered and eight were not, which is exactly the shape of
+   * gap that lets a column quietly fall out of the list: nothing fails, the
+   * scan simply keeps advertising results from credentials it no longer has.
+   */
+  it("re-queues the scan when any single setting of the sweep changes", async () => {
+    const changes: Record<string, unknown> = {
+      cidr: "10.0.0.0/24",
+      snmpVersion: "V3",
+      snmpCommunityString: "private",
+      snmpPort: 1161,
+      snmpV3SecurityLevel: "authPriv",
+      snmpV3Username: "netops",
+      snmpV3AuthProtocol: "sha",
+      snmpV3AuthKey: "auth-secret",
+      snmpV3PrivProtocol: "aes",
+      snmpV3PrivKey: "priv-secret",
+    };
+
+    for (const column of Object.keys(changes)) {
+      reconcileWrites = [];
+      storedScans = [storedScan()];
+
+      const writes: Array<ReconcileWrite> = await saveSettings({
+        ...unchangedSave(),
+        [column]: changes[column],
+      });
+
+      expect({ column: column, retired: writes.length }).toEqual({
+        column: column,
+        retired: 1,
+      });
+      expect(writes[0]!.data["status"]).toBe("Pending");
+    }
   });
 
   it("does nothing at all when the whole form is re-posted unchanged", async () => {
@@ -727,6 +841,43 @@ describe("NetworkDeviceDiscoveryScanService: editing a scan's settings", () => {
     });
 
     expect(writes).toEqual([]);
+  });
+
+  /*
+   * A Number field posts its contents as text, so clearing the box sends "" —
+   * and "" into an integer column is a Postgres error, i.e. a bare 500 in
+   * answer to "I do not want a custom port". Easy to reach only now that the
+   * box arrives pre-filled.
+   */
+  it("reads an emptied number box as unset rather than as an empty string", async () => {
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      ...unchangedSave(),
+      snmpPort: "",
+    });
+
+    // Stored as NULL...
+    expect(storedScans[0]!.snmpPort).toBeNull();
+    // ...and it is a real change, so the scan sweeps again.
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.data["status"]).toBe("Pending");
+  });
+
+  it("reads an emptied interval box as unset too", async () => {
+    const updateBy: UpdateBy<NetworkDeviceDiscoveryScan> = {
+      query: { _id: SCAN_ID },
+      data: { isRecurring: false, rescanIntervalInMinutes: "   " },
+      props: { isRoot: false, tenantId: PROJECT_ID },
+      limit: 1,
+      skip: 0,
+    } as unknown as UpdateBy<NetworkDeviceDiscoveryScan>;
+
+    await onBeforeUpdate(updateBy);
+
+    expect(
+      (updateBy.data as unknown as Record<string, unknown>)[
+        "rescanIntervalInMinutes"
+      ],
+    ).toBeNull();
   });
 
   it("re-queues when a credential changes", async () => {
@@ -785,6 +936,81 @@ describe("NetworkDeviceDiscoveryScanService: editing a scan's settings", () => {
     );
   });
 
+  /*
+   * A scan is dispatched by probe id alone: the claim endpoint hands a Pending
+   * scan to whichever probe authenticates as that id, with no project check of
+   * its own, and writes the hosts it reports back onto this row. Pointing a
+   * scan at another project's probe is therefore pointing it at another
+   * project's NETWORK — so the reference is checked wherever it can be
+   * written.
+   */
+  it("refuses a probe that belongs to another project", async () => {
+    const foreignProbe: Probe = new Probe();
+    foreignProbe._id = OTHER_PROBE_ID.toString();
+    foreignProbe.projectId = new ObjectID(
+      "99999999-9999-4999-8999-999999999999",
+    );
+    probeOnLookup = foreignProbe;
+
+    await expect(
+      saveSettings({ probe: { _id: OTHER_PROBE_ID.toString() } }),
+    ).rejects.toThrow(/another project/);
+  });
+
+  // A probe with no project of its own is a global probe: anyone may use it.
+  it("accepts a global probe", async () => {
+    const globalProbe: Probe = new Probe();
+    globalProbe._id = OTHER_PROBE_ID.toString();
+    probeOnLookup = globalProbe;
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      probe: { _id: OTHER_PROBE_ID.toString() },
+    });
+
+    expect(writes).toHaveLength(1);
+  });
+
+  it("refuses a probe that does not exist", async () => {
+    probeOnLookup = null;
+
+    await expect(
+      saveSettings({ probe: { _id: OTHER_PROBE_ID.toString() } }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  /*
+   * A payload pointing the FK column and the relation object at two different
+   * probes must be refused rather than validated against whichever one TypeORM
+   * happens to persist.
+   */
+  it("refuses a payload that names two different probes", async () => {
+    await expect(
+      saveSettings({
+        probeId: PROBE_ID,
+        probe: { _id: OTHER_PROBE_ID.toString() },
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("checks the probe against the SCAN's project, not the caller's tenant", async () => {
+    const otherProjectId: ObjectID = new ObjectID(
+      "99999999-9999-4999-8999-999999999999",
+    );
+
+    // The scan belongs to another project; so does the probe being set.
+    storedScans = [storedScan()];
+    (storedScans[0] as NetworkDeviceDiscoveryScan).projectId = otherProjectId;
+
+    const probeInThatProject: Probe = new Probe();
+    probeInThatProject._id = OTHER_PROBE_ID.toString();
+    probeInThatProject.projectId = otherProjectId;
+    probeOnLookup = probeInThatProject;
+
+    await expect(
+      saveSettings({ probe: { _id: OTHER_PROBE_ID.toString() } }),
+    ).resolves.toBeDefined();
+  });
+
   it("abandons a run that is still in progress when the target changes", async () => {
     storedScans = [storedScan({ status: "In Progress" })];
 
@@ -801,19 +1027,50 @@ describe("NetworkDeviceDiscoveryScanService: editing a scan's settings", () => {
     expect(writes[0]!.data["startedAt"]).toBeNull();
   });
 
+  /*
+   * The hook plans for every row the update MATCHED, but the write may affect
+   * fewer — a row hard-deleted in between, or a limit. Reconciling a row that
+   * was not written would retire a scan nobody edited.
+   */
   it("reconciles only the rows the write actually touched", async () => {
     const otherId: ObjectID = new ObjectID(
       "55555555-5555-4555-8555-555555555555",
     );
 
-    await saveSettings({ cidr: "10.0.0.0/24" });
+    const otherScan: NetworkDeviceDiscoveryScan = storedScan();
+    otherScan._id = otherId.toString();
+
+    storedScans = [storedScan(), otherScan];
+
+    const updateBy: UpdateBy<NetworkDeviceDiscoveryScan> = {
+      query: { projectId: PROJECT_ID },
+      data: { cidr: "10.0.0.0/24" },
+      props: { isRoot: false, tenantId: PROJECT_ID },
+      limit: 2,
+      skip: 0,
+    } as unknown as UpdateBy<NetworkDeviceDiscoveryScan>;
+
+    const onUpdate: { updateBy: unknown; carryForward: unknown } =
+      (await onBeforeUpdate(updateBy)) as {
+        updateBy: unknown;
+        carryForward: unknown;
+      };
+
+    // Both rows were planned for...
+    expect(
+      Object.keys(onUpdate.carryForward as Record<string, unknown>).sort(),
+    ).toEqual([SCAN_ID.toString(), otherId.toString()].sort());
+
+    // ...but only one was written.
+    await (NetworkDeviceDiscoveryScanService as any).onUpdateSuccess(onUpdate, [
+      SCAN_ID,
+    ]);
 
     expect(
       reconcileWrites.map((write: ReconcileWrite) => {
         return write.id;
       }),
     ).toEqual([SCAN_ID.toString()]);
-    expect(otherId.toString()).not.toBe(SCAN_ID.toString());
   });
 });
 
@@ -872,6 +1129,29 @@ describe("NetworkDeviceDiscoveryScanService: when the next run is due", () => {
     ).toBe(COMPLETED_AT.getTime() + 60 * 60 * 1000);
   });
 
+  /*
+   * The form posts a Number field, and what arrives on the wire is not
+   * guaranteed to be a number. Predicting the post-write schedule from the
+   * payload would read "60" as "no cadence" and quietly unschedule a scan the
+   * operator had just scheduled; the hook reads the stored row back instead,
+   * where the column type has already had its say.
+   */
+  it("schedules from the stored value, not from whatever shape the request sent", async () => {
+    storedScans = [
+      storedScan({ status: "Completed", completedAt: COMPLETED_AT }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      isRecurring: true,
+      rescanIntervalInMinutes: "60",
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(
+      OneUptimeDate.fromString(writes[0]!.data["nextScanAt"] as Date).getTime(),
+    ).toBe(COMPLETED_AT.getTime() + 60 * 60 * 1000);
+  });
+
   it("clears the next run when recurrence is turned off", async () => {
     storedScans = [
       storedScan({
@@ -892,9 +1172,13 @@ describe("NetworkDeviceDiscoveryScanService: when the next run is due", () => {
      * A stale timestamp left behind here is not inert: turning recurrence back
      * on months later would find it already in the past and fire an immediate,
      * unasked-for sweep.
+     *
+     * The whole payload is asserted, not just the one key: turning recurrence
+     * off must not touch the run — the scan keeps its results and its status,
+     * and only its schedule changes.
      */
     expect(writes).toHaveLength(1);
-    expect(writes[0]!.data["nextScanAt"]).toBeNull();
+    expect(writes[0]!.data).toEqual({ nextScanAt: null });
   });
 
   it("writes nothing when the schedule is re-posted unchanged", async () => {
@@ -972,6 +1256,32 @@ describe("NetworkDeviceDiscoveryScanService: when the next run is due", () => {
 
     expect(writes).toHaveLength(1);
     expect(writes[0]!.data["nextScanAt"]).not.toBeNull();
+  });
+
+  /*
+   * A save that never mentions the schedule must not move it. The stale-scan
+   * reaper deliberately marks a stranded run due IMMEDIATELY rather than one
+   * interval later, and re-deriving on an unrelated save would quietly push
+   * that recovery out by a whole cadence.
+   */
+  it("leaves the schedule alone when the save did not ask about it", async () => {
+    storedScans = [
+      storedScan({
+        status: "Failed",
+        completedAt: COMPLETED_AT,
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        // What the reaper writes: due now, not one interval after the failure.
+        nextScanAt: COMPLETED_AT,
+      }),
+    ];
+
+    const writes: Array<ReconcileWrite> = await saveSettings({
+      cidr: "192.168.1.0/24",
+      snmpCommunityString: "public",
+    });
+
+    expect(writes).toEqual([]);
   });
 
   /*

--- a/Common/Tests/UI/Components/IconOpticalSize.test.tsx
+++ b/Common/Tests/UI/Components/IconOpticalSize.test.tsx
@@ -352,7 +352,15 @@ describe("Icon optical size", () => {
     expect(getIconPaths(IconProp.Edit)).toEqual(getIconPaths(IconProp.Pencil));
   });
 
-  it("keeps the pencil inside the box the other icons sit in", () => {
+  /*
+   * A second, blunter statement of the same fix, so a redraw that happened to
+   * keep the ink length while pushing the glyph back into the corners fails
+   * here. This is the pencil's OWN keyline box — the icons around it are not
+   * all inside it (the trash can runs from 2.25 to 21.75 vertically), and they
+   * do not need to be: an upright shape is read by its height, a lone diagonal
+   * by its length, and only the diagonal has to be pulled in to match.
+   */
+  it("keeps the pencil inside its keyline box", () => {
     const vertices: Array<Point> = getIconPaths(IconProp.Pencil).flatMap(
       (pathData: string) => {
         return parsePathVertices(pathData);

--- a/Common/Tests/UI/Components/IconOpticalSize.test.tsx
+++ b/Common/Tests/UI/Components/IconOpticalSize.test.tsx
@@ -1,0 +1,369 @@
+import Icon from "../../../UI/Components/Icon/Icon";
+import IconProp from "../../../Types/Icon/IconProp";
+import { describe, expect, it } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * Every icon in Icon.tsx is hand-written path data in one long if/else chain,
+ * and they all share a 24x24 viewBox. The viewBox is not what the eye
+ * measures, though - the INK is. An icon whose drawing runs corner to corner
+ * reads as bigger than one that sits inside a keyline square, at the same
+ * nominal size, on the same row, in the same button.
+ *
+ * That is what happened to the pencil. Heroicons' pencil is a single unbroken
+ * diagonal spanning the full box, so its ink ran ~25 units tip to eraser
+ * while the Trash and List it sits beside in a table row's action buttons run
+ * ~20. Rendered by Button at 20px (Button.tsx pins the icon to `w-5 h-5`), the
+ * pencil drew a stroke longer than the box it was sized into, and looked a
+ * size larger than every button next to it (OneUptime issue #3444's
+ * screenshot).
+ *
+ * A path string pinned by equality would catch a revert and nothing else - it
+ * says nothing about WHY the string is what it is, and it goes stale the
+ * moment anyone redraws the glyph for an unrelated reason. So this measures
+ * the geometry instead: the pencil's ink must stay in the same size class as
+ * the icons it is rendered beside. Redraw the pencil however you like; it just
+ * may not go back to overshooting its neighbours.
+ */
+
+/*
+ * Hoisted rather than written inline: eslint's `wrap-regex` wants a literal in
+ * parentheses and prettier takes them straight back out, so an inline one can
+ * never satisfy both.
+ */
+const DIGIT: RegExp = /[0-9]/;
+const COMMAND_LETTER: RegExp = /[a-zA-Z]/;
+
+type GetIconPathsFunction = (icon: IconProp) => Array<string>;
+
+const getIconPaths: GetIconPathsFunction = (icon: IconProp): Array<string> => {
+  const { container } = render(<Icon icon={icon} />);
+
+  return Array.from(container.querySelectorAll("path")).map(
+    (path: SVGPathElement) => {
+      return path.getAttribute("d") || "";
+    },
+  );
+};
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/*
+ * The vertices of an SVG path: every on-path point the path data names, in
+ * user units.
+ *
+ * Deliberately vertices and not a true outline. Curves and arcs bulge past
+ * their endpoints - the pencil's eraser cap is a semicircle that reaches
+ * ~0.4 units beyond its own arc endpoint - so this under-measures every icon
+ * by a fraction of a unit. That is fine and it is why the comparison below is
+ * relative: every icon is measured the same way, so the bias cancels, and the
+ * question being asked ("is the pencil in the same size class as the trash
+ * can") is not sensitive to a rounding of a stroke width.
+ *
+ * Control points of curves are skipped rather than treated as vertices: they
+ * routinely sit outside the drawn shape and would report ink that is not
+ * there.
+ */
+type ParsePathVerticesFunction = (pathData: string) => Array<Point>;
+
+const parsePathVertices: ParsePathVerticesFunction = (
+  pathData: string,
+): Array<Point> => {
+  const vertices: Array<Point> = [];
+
+  let cursor: number = 0;
+  let current: Point = { x: 0, y: 0 };
+  let subpathStart: Point = { x: 0, y: 0 };
+  let command: string = "";
+
+  type SkipSeparatorsFunction = () => void;
+
+  const skipSeparators: SkipSeparatorsFunction = (): void => {
+    while (cursor < pathData.length && " ,\t\n\r".includes(pathData[cursor]!)) {
+      cursor++;
+    }
+  };
+
+  type ReadNumberFunction = () => number;
+
+  const readNumber: ReadNumberFunction = (): number => {
+    skipSeparators();
+
+    const start: number = cursor;
+
+    if (pathData[cursor] === "-" || pathData[cursor] === "+") {
+      cursor++;
+    }
+
+    /*
+     * At most one decimal point, because path data may run two numbers
+     * together with no separator at all: "-1.518.904" is -1.518 followed by
+     * 0.904, and ".64.64" is 0.64 twice. Consuming greedily reads them as one
+     * malformed token.
+     */
+    let hasDecimalPoint: boolean = false;
+
+    while (cursor < pathData.length) {
+      const character: string = pathData[cursor] as string;
+
+      if (character === ".") {
+        if (hasDecimalPoint) {
+          break;
+        }
+
+        hasDecimalPoint = true;
+      } else if (!DIGIT.test(character)) {
+        break;
+      }
+
+      cursor++;
+    }
+
+    // Scientific notation does not appear in this file, but reject it loudly.
+    if (pathData[cursor] === "e" || pathData[cursor] === "E") {
+      throw new Error(`Unsupported exponent in path data at ${cursor}`);
+    }
+
+    const value: number = Number(pathData.substring(start, cursor));
+
+    if (start === cursor || Number.isNaN(value)) {
+      throw new Error(
+        `Expected a number at ${start} in path data: ${pathData.substring(start, start + 24)}`,
+      );
+    }
+
+    return value;
+  };
+
+  /*
+   * Arc flags may be written without any separator - "a1.5 1.5 0 112.122
+   * 2.652" packs `large-arc=1`, `sweep=1` and `x=2.122` into "112.122" - so
+   * they are read one character at a time rather than as numbers.
+   */
+  type ReadFlagFunction = () => void;
+
+  const readFlag: ReadFlagFunction = (): void => {
+    skipSeparators();
+
+    if (pathData[cursor] !== "0" && pathData[cursor] !== "1") {
+      throw new Error(`Expected an arc flag at ${cursor} in path data`);
+    }
+
+    cursor++;
+  };
+
+  while (cursor < pathData.length) {
+    skipSeparators();
+
+    if (cursor >= pathData.length) {
+      break;
+    }
+
+    if (COMMAND_LETTER.test(pathData[cursor] as string)) {
+      command = pathData[cursor] as string;
+      cursor++;
+    } else if (!command) {
+      throw new Error(`Path data does not start with a command: ${pathData}`);
+    }
+
+    const isRelative: boolean = command === command.toLowerCase();
+    const absolute: string = command.toUpperCase();
+
+    if (absolute === "Z") {
+      current = { ...subpathStart };
+      vertices.push({ ...current });
+      continue;
+    }
+
+    const originX: number = isRelative ? current.x : 0;
+    const originY: number = isRelative ? current.y : 0;
+
+    if (absolute === "H") {
+      current = { x: originX + readNumber(), y: current.y };
+    } else if (absolute === "V") {
+      current = { x: current.x, y: originY + readNumber() };
+    } else if (absolute === "A") {
+      // rx ry rotation, then the two flags, then the endpoint.
+      readNumber();
+      readNumber();
+      readNumber();
+      readFlag();
+      readFlag();
+      current = { x: originX + readNumber(), y: originY + readNumber() };
+    } else if (absolute === "C" || absolute === "S" || absolute === "Q") {
+      // Control points are read and dropped; only the endpoint is on the path.
+      const controlPointCount: number = absolute === "C" ? 2 : 1;
+
+      for (let index: number = 0; index < controlPointCount; index++) {
+        readNumber();
+        readNumber();
+      }
+
+      current = { x: originX + readNumber(), y: originY + readNumber() };
+    } else if (absolute === "M" || absolute === "L" || absolute === "T") {
+      current = { x: originX + readNumber(), y: originY + readNumber() };
+
+      if (absolute === "M") {
+        subpathStart = { ...current };
+        // An implicit repeat after a moveto is a lineto, per the SVG grammar.
+        command = isRelative ? "l" : "L";
+      }
+    } else {
+      throw new Error(`Unsupported path command "${command}"`);
+    }
+
+    /*
+     * A command may be followed by several argument sets ("l1 2 3 4" is two
+     * linetos); the loop simply comes round again, finds no command letter,
+     * and reuses the one still in `command`.
+     */
+    vertices.push({ ...current });
+  }
+
+  return vertices;
+};
+
+/*
+ * The longest straight line that fits inside a set of vertices - the number
+ * the eye compares when two icons sit side by side. For the pencil this is
+ * its length; for the trash can it is its height; for a circle its diameter.
+ */
+type LongestSpanFunction = (vertices: Array<Point>) => number;
+
+const longestSpan: LongestSpanFunction = (vertices: Array<Point>): number => {
+  let longest: number = 0;
+
+  for (let i: number = 0; i < vertices.length; i++) {
+    for (let j: number = i + 1; j < vertices.length; j++) {
+      const a: Point = vertices[i] as Point;
+      const b: Point = vertices[j] as Point;
+
+      longest = Math.max(longest, Math.hypot(a.x - b.x, a.y - b.y));
+    }
+  }
+
+  return longest;
+};
+
+type MeasurePathFunction = (pathData: string) => number;
+
+const measurePath: MeasurePathFunction = (pathData: string): number => {
+  return longestSpan(parsePathVertices(pathData));
+};
+
+// The same measurement, for an icon rendered by the component under test.
+type InkExtentFunction = (icon: IconProp) => number;
+
+const inkExtent: InkExtentFunction = (icon: IconProp): number => {
+  const vertices: Array<Point> = getIconPaths(icon).flatMap(
+    (pathData: string) => {
+      return parsePathVertices(pathData);
+    },
+  );
+
+  expect(vertices.length).toBeGreaterThan(1);
+
+  return longestSpan(vertices);
+};
+
+/*
+ * Heroicons' stock pencil, the glyph this file exists to keep out. Kept here
+ * as the negative control: it proves the measurement below can actually tell
+ * the two apart, so a broken parser fails the suite instead of quietly
+ * agreeing with everything.
+ */
+const OVERSIZED_HEROICONS_PENCIL: string =
+  "M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125";
+
+describe("path measurement", () => {
+  /*
+   * Every assertion in the suite below is only as good as the parser, and a
+   * parser that silently returns nothing would make all of them pass. These
+   * measure two icons whose geometry can be read straight off their path data
+   * by hand.
+   */
+  it("measures a path whose geometry is obvious by inspection", () => {
+    // "M6 18L18 6M6 6l12 12" - an X across a 12x12 square, so 12 * sqrt(2).
+    expect(measurePath("M6 18L18 6M6 6l12 12")).toBeCloseTo(16.97, 2);
+
+    // "M12 4.5v15m7.5-7.5h-15" - a plus with 15-unit arms.
+    expect(measurePath("M12 4.5v15m7.5-7.5h-15")).toBeCloseTo(15, 2);
+  });
+
+  it("reads arc flags that are packed against their coordinates", () => {
+    /*
+     * "a1.875 1.875 0 112.652 2.652" is large-arc=1, sweep=1, dx=2.652 - not
+     * a coordinate of 112.652. Getting this wrong is the one parsing mistake
+     * that would silently mismeasure the pencil, which is an arc-carrying
+     * path, so it is asserted directly.
+     */
+    expect(measurePath("M0 0a1.875 1.875 0 112.652 2.652")).toBeCloseTo(
+      Math.hypot(2.652, 2.652),
+      3,
+    );
+  });
+});
+
+/*
+ * The icons a discovery scan's row actions put next to each other, and the
+ * ones every other ModelTable row shows: Rename (pencil), Review Results
+ * (list), Delete (trash).
+ */
+describe("Icon optical size", () => {
+  it("draws a pencil no larger than the icons it shares a row with", () => {
+    const pencil: number = inkExtent(IconProp.Pencil);
+    const trash: number = inkExtent(IconProp.Trash);
+    const list: number = inkExtent(IconProp.List);
+
+    /*
+     * The trash can is the biggest thing in a standard row of actions, so it
+     * is the ceiling. A little slack, because a diagonal glyph is allowed to
+     * be marginally longer than an upright one at the same apparent size -
+     * but nothing like the 25% the stock Heroicon was over.
+     */
+    expect(pencil).toBeLessThanOrEqual(trash * 1.05);
+
+    // And not shrunk into a different size class either.
+    expect(pencil).toBeGreaterThanOrEqual(list * 0.9);
+  });
+
+  it("would fail for the stock Heroicons pencil", () => {
+    const stock: number = measurePath(OVERSIZED_HEROICONS_PENCIL);
+    const trash: number = inkExtent(IconProp.Trash);
+
+    // The regression this test exists for: 25 units of ink against the bin's 20.
+    expect(stock).toBeGreaterThan(trash * 1.2);
+  });
+
+  it("draws the same pencil for Pencil and Edit", () => {
+    /*
+     * Both names route to one branch in Icon.tsx, and a good deal of the
+     * dashboard reaches for whichever it thought of first. If they ever
+     * diverge, half the product's edit buttons change shape and nothing says
+     * so.
+     */
+    expect(getIconPaths(IconProp.Edit)).toEqual(getIconPaths(IconProp.Pencil));
+  });
+
+  it("keeps the pencil inside the box the other icons sit in", () => {
+    const vertices: Array<Point> = getIconPaths(IconProp.Pencil).flatMap(
+      (pathData: string) => {
+        return parsePathVertices(pathData);
+      },
+    );
+
+    for (const vertex of vertices) {
+      expect(vertex.x).toBeGreaterThanOrEqual(4);
+      expect(vertex.x).toBeLessThanOrEqual(20);
+      expect(vertex.y).toBeGreaterThanOrEqual(4);
+      expect(vertex.y).toBeLessThanOrEqual(20);
+    }
+  });
+});

--- a/Common/Tests/Utils/NetworkDiscovery/RescanIntervalUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/RescanIntervalUtil.test.ts
@@ -1,0 +1,262 @@
+import {
+  MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
+  clampRescanIntervalInMinutes,
+  getNextScanAt,
+} from "../../../Utils/NetworkDiscovery/RescanIntervalUtil";
+import OneUptimeDate from "../../../Types/Date";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test: when a recurring discovery scan runs again.
+ *
+ * `nextScanAt` is the ONLY thing the requeue worker looks at — its query is
+ * `isRecurring = true AND nextScanAt <= now AND status IN (Completed,
+ * Failed)` — and `NULL <= now` is UNKNOWN in SQL, so a NULL there does not
+ * mean "soon", it means "never". That is the shape of the bug this module was
+ * written for: the column had exactly one writer, the endpoint that records a
+ * finished run, and it only wrote when the scan was ALREADY recurring at that
+ * moment. Turning recurrence on afterwards set the flag and scheduled
+ * nothing, and the scans list rendered "Every 60 min" over a scan that would
+ * never run again (OneUptime issue #3444).
+ *
+ * So the column stops being a fact somebody remembered to write and becomes
+ * derived state: a function of the recurrence settings and the last
+ * completion, recomputed by the service whenever those change. Two properties
+ * carry the whole design and are pinned below:
+ *
+ *   - it is TOTAL. Every combination has an answer, and `null` is one of the
+ *     answers rather than "no opinion" — a scan with recurrence off must have
+ *     the column CLEARED, or turning recurrence back on months later would
+ *     find a timestamp already in the past and fire an unasked-for sweep.
+ *   - it is IDEMPOTENT. The same row always produces the same moment, so
+ *     re-saving an unchanged schedule writes nothing. This is why it is not
+ *     clamped forward to "now": a due-in-the-past answer is correct, and
+ *     clamping would make every save move it.
+ */
+
+const COMPLETED_AT: Date = OneUptimeDate.fromString("2026-01-01T00:00:00.000Z");
+const NOW: Date = OneUptimeDate.fromString("2026-01-01T00:30:00.000Z");
+
+type MinutesAfterCompletionFunction = (result: Date | null) => number | null;
+
+const minutesAfterCompletion: MinutesAfterCompletionFunction = (
+  result: Date | null,
+): number | null => {
+  if (!result) {
+    return null;
+  }
+
+  return (result.getTime() - COMPLETED_AT.getTime()) / 60000;
+};
+
+describe("clampRescanIntervalInMinutes", () => {
+  it("leaves an interval at or above the floor alone", () => {
+    expect(clampRescanIntervalInMinutes(15)).toBe(15);
+    expect(clampRescanIntervalInMinutes(60)).toBe(60);
+    expect(clampRescanIntervalInMinutes(1440)).toBe(1440);
+  });
+
+  /*
+   * Clamped, not rejected — the stated policy of the ingest endpoint this
+   * replaced. A row stored before the form enforced a floor, or by an API
+   * client, still recurs; it just cannot outrun the probe.
+   */
+  it("raises a too-short interval to the floor rather than refusing it", () => {
+    expect(clampRescanIntervalInMinutes(1)).toBe(
+      MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
+    );
+    expect(clampRescanIntervalInMinutes(14)).toBe(
+      MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
+    );
+  });
+
+  /*
+   * Null for everything that is not a cadence at all. Zero especially: the
+   * column is nullable and a zero would otherwise divide the schedule into
+   * "run again immediately, forever".
+   */
+  it("reports anything that is not a cadence as no cadence", () => {
+    expect(clampRescanIntervalInMinutes(0)).toBeNull();
+    expect(clampRescanIntervalInMinutes(-5)).toBeNull();
+    expect(clampRescanIntervalInMinutes(null)).toBeNull();
+    expect(clampRescanIntervalInMinutes(undefined)).toBeNull();
+    expect(clampRescanIntervalInMinutes(NaN)).toBeNull();
+    expect(clampRescanIntervalInMinutes(Infinity)).toBeNull();
+  });
+
+  it("keeps the floor the whole product is sized against", () => {
+    expect(MINIMUM_RESCAN_INTERVAL_IN_MINUTES).toBe(15);
+  });
+});
+
+describe("getNextScanAt", () => {
+  it("schedules a finished recurring scan one interval after it finished", () => {
+    const result: Date | null = getNextScanAt(
+      {
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+      },
+      NOW,
+    );
+
+    expect(minutesAfterCompletion(result)).toBe(60);
+  });
+
+  /*
+   * A failed sweep is still a completed run. Ending the recurrence because one
+   * sweep failed would quietly turn a monitoring scan off at exactly the
+   * moment something is wrong.
+   */
+  it("schedules a failed run the same way", () => {
+    const result: Date | null = getNextScanAt(
+      {
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        status: "Failed",
+        completedAt: COMPLETED_AT,
+      },
+      NOW,
+    );
+
+    expect(minutesAfterCompletion(result)).toBe(60);
+  });
+
+  it("schedules nothing at all when recurrence is off", () => {
+    expect(
+      getNextScanAt(
+        {
+          isRecurring: false,
+          rescanIntervalInMinutes: 60,
+          status: "Completed",
+          completedAt: COMPLETED_AT,
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  /*
+   * The gate the ingest endpoint has always had. A recurring scan with no
+   * interval must not become due, or the worker re-queues it every minute
+   * forever.
+   */
+  it("schedules nothing for a recurring scan with no usable interval", () => {
+    for (const interval of [null, undefined, 0, -1]) {
+      expect(
+        getNextScanAt(
+          {
+            isRecurring: true,
+            rescanIntervalInMinutes: interval,
+            status: "Completed",
+            completedAt: COMPLETED_AT,
+          },
+          NOW,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  /*
+   * A run is already queued or under way; the endpoint that records its
+   * result schedules the one after it. Answering here would race that.
+   */
+  it("schedules nothing while a run is queued or in flight", () => {
+    for (const status of ["Pending", "In Progress"]) {
+      expect(
+        getNextScanAt(
+          {
+            isRecurring: true,
+            rescanIntervalInMinutes: 60,
+            status: status,
+            completedAt: null,
+          },
+          NOW,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("applies the floor, so a one-minute cadence cannot be scheduled", () => {
+    const result: Date | null = getNextScanAt(
+      {
+        isRecurring: true,
+        rescanIntervalInMinutes: 1,
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+      },
+      NOW,
+    );
+
+    expect(minutesAfterCompletion(result)).toBe(
+      MINIMUM_RESCAN_INTERVAL_IN_MINUTES,
+    );
+  });
+
+  /*
+   * Measured from the last run, never from the caller's clock — that is what
+   * makes it safe to recompute on every save. The answer here is already in
+   * the past, and deliberately so: the worker's predicate is `<= now`, so a
+   * past moment reads as "due", and clamping it forward would make an
+   * unchanged schedule rewrite the column every time it was saved.
+   */
+  it("answers with a moment already past for an overdue scan, rather than moving it", () => {
+    const longAfter: Date = OneUptimeDate.fromString(
+      "2026-06-01T00:00:00.000Z",
+    );
+
+    const result: Date | null = getNextScanAt(
+      {
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        status: "Completed",
+        completedAt: COMPLETED_AT,
+      },
+      longAfter,
+    );
+
+    expect(minutesAfterCompletion(result)).toBe(60);
+    expect(result!.getTime()).toBeLessThan(longAfter.getTime());
+  });
+
+  it("gives the same answer every time it is asked", () => {
+    const scan: {
+      isRecurring: boolean;
+      rescanIntervalInMinutes: number;
+      status: string;
+      completedAt: Date;
+    } = {
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+      status: "Completed",
+      completedAt: COMPLETED_AT,
+    };
+
+    expect(getNextScanAt(scan, NOW)!.getTime()).toBe(
+      getNextScanAt(
+        scan,
+        OneUptimeDate.fromString("2026-03-03T03:03:00.000Z"),
+      )!.getTime(),
+    );
+  });
+
+  /*
+   * A Completed row with no completedAt should not exist — every writer of one
+   * writes the other — but a row written by an older build must still get a
+   * next run rather than being stranded.
+   */
+  it("falls back to now for a finished scan that never recorded when", () => {
+    const result: Date | null = getNextScanAt(
+      {
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        status: "Completed",
+        completedAt: null,
+      },
+      NOW,
+    );
+
+    expect(result!.getTime()).toBe(NOW.getTime() + 60 * 60000);
+  });
+});

--- a/Common/UI/Components/Icon/Icon.tsx
+++ b/Common/UI/Components/Icon/Icon.tsx
@@ -397,12 +397,32 @@ const Icon: FunctionComponent<ComponentProps> = ({
      * alone is what everybody already reads as edit, and it survives being
      * small. IconProp.PencilSquare still draws the composite for the handful of
      * places that want it.
+     *
+     * DRAWN AT 80% OF THE UPSTREAM HEROICON, and that is the whole point of
+     * this path existing rather than the stock one.
+     *
+     * Every icon here shares a 24x24 box, but the eye does not measure the
+     * box - it measures the ink. Heroicons' pencil is one unbroken diagonal
+     * from corner to corner, so its ink ran 26.8 units end to end: the
+     * longest stroke of any icon in this file, against a median of 21 and
+     * against the 20.5 of the Trash and the 19.9 of the List it sits beside
+     * in a table row. At the 20px a Button renders it at, that is a 22px
+     * stroke inside a 20px box - it overshot the cap height of its own label
+     * and read as a size larger than every button next to it.
+     *
+     * Scaling by 0.8 about the centre of the box brings the ink to 21.4 -
+     * between Trash and Copy, at the median - while keeping the glyph
+     * itself untouched: a uniform scale preserves the arc flags, the 45
+     * degree barrel, and the tangency of the nib and eraser arcs. The
+     * numbers stay exact (radii 1.5 and 3.6, tip at 4.2 19.8), and the
+     * stroke width deliberately does NOT scale, so the pencil keeps the same
+     * weight as its neighbours instead of thinning out.
      */
     return getSvgWrapper(
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
-        d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125"
+        d="M15.89 5.99l1.35-1.35a1.5 1.5 0 112.122 2.122L7.866 18.256a3.6 3.6 0 01-1.518.904l-2.148.64.64-2.148a3.6 3.6 0 01.904-1.518L15.89 5.99zm0 0L18 8.1"
       />,
     );
   } else if (icon === IconProp.Equals) {

--- a/Common/UI/Components/Icon/Icon.tsx
+++ b/Common/UI/Components/Icon/Icon.tsx
@@ -410,6 +410,13 @@ const Icon: FunctionComponent<ComponentProps> = ({
      * stroke inside a 20px box - it overshot the cap height of its own label
      * and read as a size larger than every button next to it.
      *
+     * (Those figures are the longest distance across each glyph's drawn ink,
+     * with arcs and curves sampled. Common/Tests/UI/Components/
+     * IconOpticalSize.test.tsx measures the same quantity from the path
+     * VERTICES alone, which under-reads every icon by a fraction of a unit -
+     * so its numbers are smaller than these and its comparison is relative
+     * rather than absolute.)
+     *
      * Scaling by 0.8 about the centre of the box brings the ink to 21.4 -
      * between Trash and Copy, at the median - while keeping the glyph
      * itself untouched: a uniform scale preserves the arc flags, the 45

--- a/Common/Utils/NetworkDiscovery/RescanIntervalUtil.ts
+++ b/Common/Utils/NetworkDiscovery/RescanIntervalUtil.ts
@@ -1,0 +1,148 @@
+/*
+ * The recurrence cadence of a Network Device Discovery Scan: how often a
+ * recurring scan re-runs, and when the next run is due.
+ *
+ * WHY IT LIVES IN Common
+ *
+ * Four places have an opinion about this number and they must not disagree:
+ *
+ *   - the create/edit form (App Dashboard, DiscoveryScanFormValidation) — so
+ *     the operator is told the floor before they save, not after;
+ *   - the write hooks (Common server service) — which derive `nextScanAt` on
+ *     an edit, because the requeue worker only ever looks at that column and
+ *     a NULL there means "never runs again";
+ *   - the probe-ingest result endpoint (App Telemetry) — which stamps
+ *     `nextScanAt` when a run finishes;
+ *   - the requeue worker (App Workers) — which is sized against this floor.
+ *
+ * The floor and the clamp used to be written out three times, in three
+ * packages, with three chances to drift. Same reason ScanTargetUtil and
+ * ScanNameUtil sit next door.
+ */
+
+import OneUptimeDate from "../../Types/Date";
+
+/*
+ * The shortest cadence a recurring discovery scan may run at.
+ *
+ * A sweep is bounded but heavy: at the ScanTargetUtil.MAX_SCAN_HOSTS ceiling
+ * (32,768 addresses) it can take the better part of an hour, and a probe runs
+ * one sweep at a time. Re-queueing more often than this simply stacks scans on
+ * the probe, which never catches up.
+ */
+export const MINIMUM_RESCAN_INTERVAL_IN_MINUTES: number = 15;
+
+export type ClampRescanIntervalFunction = (
+  intervalInMinutes: number | null | undefined,
+) => number | null;
+
+/*
+ * The cadence a stored interval actually runs at.
+ *
+ * Clamped rather than rejected, and that is deliberate: rows written before
+ * the form enforced a floor — and rows written by an API client, which the
+ * server does not refuse — still recur, just no faster than the probe can
+ * keep up with. Returns null for a value that does not describe a cadence at
+ * all (absent, zero, negative, NaN), which is the caller's signal that there
+ * is no next run to schedule.
+ */
+export const clampRescanIntervalInMinutes: ClampRescanIntervalFunction = (
+  intervalInMinutes: number | null | undefined,
+): number | null => {
+  if (
+    typeof intervalInMinutes !== "number" ||
+    !isFinite(intervalInMinutes) ||
+    intervalInMinutes <= 0
+  ) {
+    return null;
+  }
+
+  return Math.max(intervalInMinutes, MINIMUM_RESCAN_INTERVAL_IN_MINUTES);
+};
+
+/*
+ * The scan state that decides when — or whether — a scan runs again. Kept
+ * structural rather than typed as the model, so a partially-selected row
+ * satisfies it and so this module does not drag a database model into the
+ * Probe's bundle. Same shape rule as ScanNameUtil.
+ */
+export interface RescanScheduleInput {
+  isRecurring?: boolean | null | undefined;
+  rescanIntervalInMinutes?: number | null | undefined;
+  /*
+   * "Pending" / "In Progress" / "Completed" / "Failed". A run that is still
+   * queued or in flight has no next run to schedule yet — the ingest endpoint
+   * stamps one when it reports.
+   */
+  status?: string | null | undefined;
+  // When the last run finished. The clock the next run is measured from.
+  completedAt?: Date | null | undefined;
+}
+
+export type GetNextScanAtFunction = (
+  scan: RescanScheduleInput,
+  now: Date,
+) => Date | null;
+
+/*
+ * When a scan is next due, derived from the scan itself.
+ *
+ * `nextScanAt` is not an independent fact, it is a function of the recurrence
+ * settings and the last completion — which is exactly why it can be recomputed
+ * when those settings change. Before it was derived, the only writer was the
+ * result-ingest endpoint at the moment a run finished, so turning recurrence
+ * ON for a scan that had already completed stamped nothing: the column stayed
+ * NULL, `("nextScanAt" <= now)` is UNKNOWN for NULL, and the requeue worker
+ * never matched the row again. The scan advertised "Every 60 min" in the list
+ * and never ran (OneUptime issue #3444).
+ *
+ * The value returned for an unchanged, already-recurring scan is the same one
+ * the ingest endpoint stamped (it wrote `completedAt + interval` too), so
+ * recomputing is a no-op rather than a rescheduling.
+ *
+ *   - not recurring, or no usable interval -> null, i.e. never
+ *   - still Pending or In Progress -> null; the run in flight will stamp it
+ *   - Completed / Failed -> the moment one interval after it finished. Already
+ *     in the past is fine and means "due now": the worker's predicate is
+ *     `nextScanAt <= now`.
+ */
+export const getNextScanAt: GetNextScanAtFunction = (
+  scan: RescanScheduleInput,
+  now: Date,
+): Date | null => {
+  if (!scan.isRecurring) {
+    return null;
+  }
+
+  const intervalInMinutes: number | null = clampRescanIntervalInMinutes(
+    scan.rescanIntervalInMinutes,
+  );
+
+  if (intervalInMinutes === null) {
+    return null;
+  }
+
+  if (scan.status !== "Completed" && scan.status !== "Failed") {
+    return null;
+  }
+
+  /*
+   * A Completed row without a completedAt should not exist — every writer of
+   * one writes the other — but a row hand-edited or written by an older build
+   * still deserves a next run rather than being stranded, so it is scheduled
+   * from now.
+   */
+  const lastRunAt: Date = scan.completedAt || now;
+
+  /*
+   * Deliberately NOT clamped forward to `now`. A moment already in the past is
+   * a correct answer — it means "due, and the worker has not got to it yet" —
+   * and clamping would cost the property that makes this safe to re-derive on
+   * every save: the same row always produces the same answer, so re-posting an
+   * unchanged schedule writes nothing.
+   */
+  return OneUptimeDate.addRemoveMinutes(
+    OneUptimeDate.fromString(lastRunAt),
+    intervalInMinutes,
+  );
+};


### PR DESCRIPTION
Fixes #3444.

## The problem

Every setting of a Network Device Discovery Scan was fixed at creation. The row actions were Rename / Review Results / Delete, so a typo'd subnet, a probe on the wrong side of a firewall, a community string the devices reject, or a one-time scan that should have repeated could only be fixed one way: delete the scan — losing its results — and build it again.

There was a second, quieter half to the bug. `isRecurring` *was* technically updatable, but `nextScanAt` had exactly one writer: the endpoint that records a finished run, and only for scans that were already recurring when they finished. Turning recurrence on afterwards set the flag and scheduled nothing at all — and the requeue worker matches `nextScanAt <= now`, which is never true of NULL. The list would say "Every 60 min" over a scan that would never run again.

## What changes

**One `Edit` action, replacing `Rename`.** It opens a single-page dialog with everything a scan is: name, target, probe, SNMP credentials, schedule — grouped under the same three headings the create wizard uses as steps, from the same field definitions, so the two cannot drift. It is deliberately not a wizard: `BasicForm` has no Back button (the only way backwards is the step rail, which is hidden below `lg`), and an edit is a targeted repair rather than a guided creation. Rename is gone because Edit strictly subsumes it — `name` is the first field, and a save that changes only the name is provably inert.

**A scan's settings are editable; what it reported is not.** The twelve columns that describe the sweep gain the update permission `name` already had. `status`, `statusMessage`, `discoveredDevices`, the host counts, the timestamps and `nextScanAt` stay read-only to every principal — the server writes them through the root path, so a result can never be hand-edited through the API.

**Changing the sweep retires the run.** The invariant is that a row must never advertise results from settings it no longer has. So a save that actually changes the target, the probe or a credential puts the scan back to Pending and clears the previous run's hosts, counts and timestamps, leaving a sentence on the row saying why. Decided by comparing values against the stored row, never by which keys the form posted — the form posts every field on every save, so an untouched Save is a genuine no-op.

**`nextScanAt` becomes derived state.** `RescanIntervalUtil.getNextScanAt` computes it from the recurrence settings and the last completion; the service recomputes it whenever a save touches the schedule. Turning recurrence on for a finished scan now schedules it, a shortened interval takes effect immediately instead of after one full old cycle, and turning recurrence off clears the timestamp instead of leaving one that would fire an unasked-for sweep if recurrence were ever turned back on. The 15-minute floor moves out of its three separate copies into that one module.

**The probe's claim becomes a compare-and-set.** The claim SELECTs on `probeId + status` and UPDATEs by id alone, so an edit landing between the two would hand one probe a configuration and stamp the row with another — and, if the probe was reassigned, wedge the scan for two hours behind the stale-scan reaper. Every setting handed to the probe is now asserted in the same statement.

**A discovery scan can no longer be pointed at another project's probe.** A scan is dispatched by probe id alone — the claim endpoint hands a Pending scan to whichever probe authenticates as that id, with no project check of its own, and writes the hosts it reports back onto the row. That was reachable through create before this change and would have been reachable through edit after it; it is now refused on both paths. Global probes stay available to everyone.

**Per status.** Pending: settings written, and any stale "no probe has claimed this" note naming the old probe cleared. In Progress: the run is abandoned — the probe finishes sweeping the old settings, and the existing Pending-discard guard drops its result. Completed / Failed: results cleared, Review Results disappears with them, and the auto-import worker stops matching the row, so old hosts can never be imported under new credentials.

## The pencil icon

Separate ask, same screenshot. Every icon in `Icon.tsx` shares a 24×24 box, but the eye measures the ink, not the box — and Heroicons' pencil is one unbroken corner-to-corner diagonal, 26.8 units of ink against a median of ~21 and against the 20.5 of the Trash and the 19.9 of the List beside it in a table row. At the 20px a Button renders it at, it drew a 22px stroke inside a 20px box: the only icon in the set that overshoots its own label's cap height.

It is redrawn at 80% about the centre of the box — a uniform scale, so the arc flags, the 45° barrel and the tangency of the nib and eraser arcs are all preserved, the numbers stay exact (radii 1.5 and 3.6, tip at 4.2 19.8), and the stroke width deliberately does not scale, so it keeps the same weight as its neighbours. That is 21.4 units of ink: between Trash and Copy. One path, so all 32 render sites change together.

## Tests

- `RescanIntervalUtil` — the whole scheduling rule, including that it is total (null is an answer) and idempotent (re-deriving writes nothing).
- `NetworkDeviceDiscoveryScanService` — every sweep column re-queues; a re-posted form does not; `""` and NULL are the same setting; an emptied number box means unset rather than a 500; the probe tenancy rule; the schedule derived per status; the read scoped to the caller's project.
- `DiscoveryScanClaimHookFreeSafety` — the claim's disjointness from the hooks, now asked of the hook one column at a time rather than of two lists written down side by side.
- `ProbeIngestDiscoveryScan` — the claim's compare-and-set, including that an unset credential is expected as NULL rather than left out of the guard.
- `DiscoveryScanEditForm` (new) — the dialog offers every setting the wizard collects, describes each field exactly as the wizard does, lays them out on one page under the wizard's headings, is gated on update permission, and is offered whatever state the scan is in.
- `IconOpticalSize` (new) — measures the pencil's ink against the icons it sits beside, with the stock Heroicon kept as a negative control so the measurement is proved to be able to fail.

## One repair that is not mine

`createPingMonitorForHost` in the same file assigns `ObjectID | null | undefined` to an `ObjectID | undefined`, which fails `strictNullChecks`. It arrived with the ping-only import work and it makes `Discovery.tsx` fail to compile — in the Dashboard's own `tsc` and, more visibly, in the two Common suites that render the page, which cannot even start. It is one `?? undefined`, and it is here because it blocks this branch's own tests.

## Known gaps, deliberately left

- The settings write and the retire write are two statements. A probe result landing between them is stamped onto the new settings; closing that needs the probe to echo a run identity back, which is a probe protocol change. The window is one database round trip.
- A claim refused by the new compare-and-set is invisible to the endpoint, so the probe still sweeps once for nothing in that race. That is the cheap half of the trade against a scan wedged for two hours.
- Rows that already have `isRecurring` set with a NULL `nextScanAt` stay unscheduled until someone opens Edit and saves. They are repaired by an edit rather than by a backfill, because a backfill would re-run a fleet of scans nobody asked to re-run. The Recurrence column now says when a scan is in that state instead of showing a bare cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMFN7HoQLUc4NcUPvGLNdy
