### PR TITLE
fix(workspace-notifications): wire the On-Call Duty Policy rule conditions

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleForm/NotificationRuleConditions.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleForm/NotificationRuleConditions.tsx
@@ -44,6 +44,9 @@ const NotificationRuleConditions: FunctionComponent<ComponentProps> = (
     }
   }, [notificationRuleConditions]);
 
+  const checkOnByEventType: Array<NotificationRuleConditionCheckOn> =
+    NotificationRuleConditionUtil.getCheckOnByEventType(props.eventType);
+
   return (
     <div>
       {notificationRuleConditions.length === 0 && (
@@ -84,23 +87,33 @@ const NotificationRuleConditions: FunctionComponent<ComponentProps> = (
           title="Add Condition"
           buttonSize={ButtonSize.Small}
           icon={IconProp.Add}
+          disabled={checkOnByEventType.length === 0}
           onClick={() => {
+            const firstCheckOn: NotificationRuleConditionCheckOn | undefined =
+              checkOnByEventType[0];
+
+            /*
+             * An event type with no check-ons has nothing to filter on. Adding
+             * a row anyway is what left the Filter Type dropdown empty on the
+             * On-Call Duty Policy rule editor (#3459): the row went in with an
+             * undefined checkOn over an empty option list, and the rule could
+             * not be saved or removed except by deleting the filter.
+             */
+            if (!firstCheckOn) {
+              return;
+            }
+
             const newNotificationRuleConditions: Array<NotificationRuleCondition> =
               [...notificationRuleConditions];
 
-            const checkOnByEventType: Array<NotificationRuleConditionCheckOn> =
-              NotificationRuleConditionUtil.getCheckOnByEventType(
-                props.eventType,
-              );
-
             const conditionTypes: Array<ConditionType> =
               NotificationRuleConditionUtil.getConditionTypeByCheckOn(
-                checkOnByEventType[0]!,
+                firstCheckOn,
               );
 
             newNotificationRuleConditions.push({
-              checkOn: checkOnByEventType[0]!,
-              conditionType: conditionTypes[0]!,
+              checkOn: firstCheckOn,
+              conditionType: conditionTypes[0],
               value: "",
             });
 

--- a/App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleViewElement/NotificationRuleViewCondition.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleViewElement/NotificationRuleViewCondition.tsx
@@ -37,6 +37,26 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const getValueElement: GetReactElementFunction = (): ReactElement => {
+    const checkOn: NotificationRuleConditionCheckOn | undefined =
+      props.notificationRuleCondition?.checkOn;
+
+    /*
+     * Every dropdown-backed check-on stores its value as an array of ids, but
+     * a row saved before the check-on became a dropdown - or one saved with
+     * no value at all - can still hold a bare string or nothing. Normalise
+     * once: a bad row then renders as "nothing selected" instead of throwing
+     * and taking the whole rule view down with it.
+     */
+    const selectedIds: Array<string> = Array.isArray(
+      props.notificationRuleCondition?.value,
+    )
+      ? props.notificationRuleCondition.value.map((value: string) => {
+          return value?.toString();
+        })
+      : props.notificationRuleCondition?.value
+        ? [props.notificationRuleCondition.value.toString()]
+        : [];
+
     let valueElement: ReactElement | undefined = Array.isArray(
       props.notificationRuleCondition?.value,
     ) ? (
@@ -46,17 +66,12 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
     );
 
     if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.AlertSeverity
+      checkOn === NotificationRuleConditionCheckOn.AlertSeverity ||
+      checkOn === NotificationRuleConditionCheckOn.AlertEpisodeSeverity
     ) {
       const selectedAlertSeverities: Array<AlertSeverity> =
         props.alertSeverities.filter((alertSeverity: AlertSeverity) => {
-          const selectedAlertSeveritiies: Array<string> = props
-            .notificationRuleCondition?.value as Array<string>;
-
-          return selectedAlertSeveritiies.includes(
-            alertSeverity.id!.toString(),
-          );
+          return selectedIds.includes(alertSeverity.id!.toString());
         });
 
       valueElement = (
@@ -76,15 +91,12 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
     }
 
     if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.AlertState
+      checkOn === NotificationRuleConditionCheckOn.AlertState ||
+      checkOn === NotificationRuleConditionCheckOn.AlertEpisodeState
     ) {
       const selectedAlertStates: Array<AlertState> = props.alertStates.filter(
         (alertState: AlertState) => {
-          const selectedAlertStates: Array<string> = props
-            .notificationRuleCondition?.value as Array<string>;
-
-          return selectedAlertStates.includes(alertState.id!.toString());
+          return selectedIds.includes(alertState.id!.toString());
         },
       );
 
@@ -98,18 +110,13 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
     }
 
     if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.IncidentSeverity
+      checkOn === NotificationRuleConditionCheckOn.IncidentSeverity ||
+      checkOn === NotificationRuleConditionCheckOn.IncidentEpisodeSeverity
     ) {
       const selectedIncidentSeverities: Array<IncidentSeverity> =
         props.incidentSeverities.filter(
           (incidentSeverity: IncidentSeverity) => {
-            const selectedIncidentSeverities: Array<string> = props
-              .notificationRuleCondition?.value as Array<string>;
-
-            return selectedIncidentSeverities.includes(
-              incidentSeverity.id!.toString(),
-            );
+            return selectedIds.includes(incidentSeverity.id!.toString());
           },
         );
 
@@ -130,15 +137,12 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
     }
 
     if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.IncidentState
+      checkOn === NotificationRuleConditionCheckOn.IncidentState ||
+      checkOn === NotificationRuleConditionCheckOn.IncidentEpisodeState
     ) {
       const selectedIncidentStates: Array<IncidentState> =
         props.incidentStates.filter((incidentState: IncidentState) => {
-          const selectedIncidentStates: Array<string> = props
-            .notificationRuleCondition?.value as Array<string>;
-
-          return selectedIncidentStates.includes(incidentState.id!.toString());
+          return selectedIds.includes(incidentState.id!.toString());
         });
 
       valueElement = (
@@ -158,16 +162,12 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
     }
 
     if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.ScheduledMaintenanceState
+      checkOn === NotificationRuleConditionCheckOn.ScheduledMaintenanceState
     ) {
       const selectedScheduledMaintenanceStates: Array<ScheduledMaintenanceState> =
         props.scheduledMaintenanceStates.filter(
           (scheduledMaintenanceState: ScheduledMaintenanceState) => {
-            const selectedScheduledMaintenanceStates: Array<string> = props
-              .notificationRuleCondition?.value as Array<string>;
-
-            return selectedScheduledMaintenanceStates.includes(
+            return selectedIds.includes(
               scheduledMaintenanceState.id!.toString(),
             );
           },
@@ -192,77 +192,69 @@ const NotificationRuleConditionElement: FunctionComponent<ComponentProps> = (
       );
     }
 
-    if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.MonitorStatus
-    ) {
+    if (checkOn === NotificationRuleConditionCheckOn.MonitorStatus) {
       const selectedMonitorStatuses: Array<MonitorStatus> =
         props.monitorStatus.filter((monitorStatus: MonitorStatus) => {
-          const selectedMonitorStatuses: Array<string> = props
-            .notificationRuleCondition?.value as Array<string>;
-
-          return selectedMonitorStatuses.includes(monitorStatus.id!.toString());
+          return selectedIds.includes(monitorStatus.id!.toString());
         });
 
       valueElement = (
         <div className="flex space-x-2 py-1">
-          {selectedMonitorStatuses.map((monitorStatus: MonitorStatus) => {
-            return (
-              <MonitorStatusElement
-                shouldAnimate={false}
-                monitorStatus={monitorStatus}
-              />
-            );
-          })}
+          {selectedMonitorStatuses.map(
+            (monitorStatus: MonitorStatus, index: number) => {
+              return (
+                <MonitorStatusElement
+                  shouldAnimate={false}
+                  monitorStatus={monitorStatus}
+                  key={index}
+                />
+              );
+            },
+          )}
         </div>
       );
     }
 
+    /*
+     * Every label-backed check-on renders the same way. They are listed one
+     * by one rather than matched on a "Labels" suffix so a new check-on has
+     * to be added here deliberately.
+     */
     if (
-      props.notificationRuleCondition?.checkOn ===
-        NotificationRuleConditionCheckOn.AlertLabels ||
-      props.notificationRuleCondition?.checkOn ===
-        NotificationRuleConditionCheckOn.IncidentLabels ||
-      props.notificationRuleCondition?.checkOn ===
-        NotificationRuleConditionCheckOn.MonitorLabels ||
-      props.notificationRuleCondition?.checkOn ===
-        NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels
+      checkOn === NotificationRuleConditionCheckOn.AlertLabels ||
+      checkOn === NotificationRuleConditionCheckOn.AlertEpisodeLabels ||
+      checkOn === NotificationRuleConditionCheckOn.IncidentLabels ||
+      checkOn === NotificationRuleConditionCheckOn.IncidentEpisodeLabels ||
+      checkOn === NotificationRuleConditionCheckOn.MonitorLabels ||
+      checkOn === NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels ||
+      checkOn === NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels
     ) {
       const selectedLabels: Array<Label> = props.labels.filter(
         (label: Label) => {
-          const selectedLabels: Array<string> = props.notificationRuleCondition
-            ?.value as Array<string>;
-
-          return selectedLabels.includes(label.id!.toString());
+          return selectedIds.includes(label.id!.toString());
         },
       );
 
       valueElement = (
         <div className="flex space-x-2 py-1">
-          {selectedLabels.map((label: Label) => {
-            return <LabelElement label={label} />;
+          {selectedLabels.map((label: Label, index: number) => {
+            return <LabelElement label={label} key={index} />;
           })}
         </div>
       );
     }
 
-    if (
-      props.notificationRuleCondition?.checkOn ===
-      NotificationRuleConditionCheckOn.Monitors
-    ) {
+    if (checkOn === NotificationRuleConditionCheckOn.Monitors) {
       const selectedMonitors: Array<Monitor> = props.monitors.filter(
         (monitor: Monitor) => {
-          const selectedMonitors: Array<string> = props
-            .notificationRuleCondition?.value as Array<string>;
-
-          return selectedMonitors.includes(monitor.id!.toString());
+          return selectedIds.includes(monitor.id!.toString());
         },
       );
 
       valueElement = (
         <div className="flex space-x-2 py-1">
-          {selectedMonitors.map((monitor: Monitor) => {
-            return <MonitorElement monitor={monitor} />;
+          {selectedMonitors.map((monitor: Monitor, index: number) => {
+            return <MonitorElement monitor={monitor} key={index} />;
           })}
         </div>
       );

--- a/App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleViewElement/NotificationRuleViewElement.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleViewElement/NotificationRuleViewElement.tsx
@@ -220,6 +220,11 @@ const NotificationRuleViewElement: FunctionComponent<ComponentProps> = (
     archiveDescription = `Archive the ${getWorkspaceTypeDisplayName(props.workspaceType)} channel automatically when the scheduled maintenance is completed.`;
   }
 
+  if (props.eventType === NotificationRuleEventType.OnCallDutyPolicy) {
+    archiveTitle = `Archive ${getWorkspaceTypeDisplayName(props.workspaceType)} Channel Automatically`;
+    archiveDescription = `Archive the ${getWorkspaceTypeDisplayName(props.workspaceType)} channel automatically when the on call duty policy is deleted.`;
+  }
+
   // incident.
   if (props.eventType === NotificationRuleEventType.Incident) {
     archiveTitle = `Archive ${getWorkspaceTypeDisplayName(props.workspaceType)} Channel Automatically`;

--- a/Common/Tests/App/Dashboard/WorkspaceNotificationRuleConditions.test.tsx
+++ b/Common/Tests/App/Dashboard/WorkspaceNotificationRuleConditions.test.tsx
@@ -1,0 +1,439 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, test } from "@jest/globals";
+import NotificationRuleConditionsElement from "../../../../App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleForm/NotificationRuleConditions";
+import NotificationRuleViewConditionElement from "../../../../App/FeatureSet/Dashboard/src/Components/Workspace/NotificationRuleViewElement/NotificationRuleViewCondition";
+import NotificationRuleEventType from "../../../Types/Workspace/NotificationRules/EventType";
+import NotificationRuleCondition, {
+  ConditionType,
+  NotificationRuleConditionCheckOn,
+  NotificationRuleConditionUtil,
+} from "../../../Types/Workspace/NotificationRules/NotificationRuleCondition";
+import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
+import AlertState from "../../../Models/DatabaseModels/AlertState";
+import IncidentSeverity from "../../../Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "../../../Models/DatabaseModels/IncidentState";
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import ScheduledMaintenanceState from "../../../Models/DatabaseModels/ScheduledMaintenanceState";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * #3459 as the user met it: on On-Call Duty → a policy → Notification Rules →
+ * Microsoft Teams, "Add Condition" dropped in a condition block whose "Filter
+ * Type" dropdown opened onto react-select's "No options". Nothing could be
+ * chosen, so the rule stayed "trigger for every On-Call Duty Policy".
+ *
+ * OnCallDutyPolicyConditions.test.ts pins the option lists themselves. This
+ * file drives the real components, because "No options" is something
+ * react-select renders when the list it was handed is empty - a rule about
+ * lists cannot say whether that reaches the screen, only the rendered form
+ * can.
+ *
+ * Assertions stay on plain DOM text: jest-dom's matchers do not typecheck
+ * repo-wide.
+ */
+
+// react-select's own empty-list message, i.e. the bug as it appeared.
+const NO_OPTIONS: string = "No options";
+
+const PAYMENTS_LABEL_ID: string = "a1a1a1a1a1a1a1a1a1a1a1a1";
+const SEARCH_LABEL_ID: string = "b2b2b2b2b2b2b2b2b2b2b2b2";
+
+function named<T extends { _id?: string; name?: string }>(
+  model: T,
+  id: string,
+  name: string,
+): T {
+  model._id = id;
+  model.name = name;
+  return model;
+}
+
+function projectLabels(): Array<Label> {
+  return [
+    named(new Label(), PAYMENTS_LABEL_ID, "Payments"),
+    named(new Label(), SEARCH_LABEL_ID, "Search"),
+  ];
+}
+
+// Everything both components need to turn stored ids into names.
+function lookupProps(): {
+  monitors: Array<Monitor>;
+  labels: Array<Label>;
+  alertStates: Array<AlertState>;
+  alertSeverities: Array<AlertSeverity>;
+  incidentSeverities: Array<IncidentSeverity>;
+  incidentStates: Array<IncidentState>;
+  scheduledMaintenanceStates: Array<ScheduledMaintenanceState>;
+  monitorStatus: Array<MonitorStatus>;
+} {
+  return {
+    monitors: [named(new Monitor(), "c7c7c7c7c7c7c7c7c7c7c7c7", "API")],
+    labels: projectLabels(),
+    alertStates: [
+      named(new AlertState(), "c2c2c2c2c2c2c2c2c2c2c2c2", "Created"),
+    ],
+    alertSeverities: [
+      named(new AlertSeverity(), "c1c1c1c1c1c1c1c1c1c1c1c1", "Sev 1"),
+    ],
+    incidentSeverities: [
+      named(new IncidentSeverity(), "c3c3c3c3c3c3c3c3c3c3c3c3", "Major"),
+    ],
+    incidentStates: [
+      named(new IncidentState(), "c5c5c5c5c5c5c5c5c5c5c5c5", "Acknowledged"),
+    ],
+    scheduledMaintenanceStates: [
+      named(
+        new ScheduledMaintenanceState(),
+        "c6c6c6c6c6c6c6c6c6c6c6c6",
+        "Ongoing",
+      ),
+    ],
+    monitorStatus: [
+      named(new MonitorStatus(), "c4c4c4c4c4c4c4c4c4c4c4c4", "Offline"),
+    ],
+  };
+}
+
+function renderConditions(eventType: NotificationRuleEventType): {
+  onChange: MockFunction;
+} {
+  const onChange: MockFunction = getJestMockFunction();
+
+  render(
+    <NotificationRuleConditionsElement
+      {...lookupProps()}
+      eventType={eventType}
+      value={[]}
+      onChange={
+        onChange as unknown as (value: Array<NotificationRuleCondition>) => void
+      }
+    />,
+  );
+
+  return { onChange: onChange };
+}
+
+// The condition list the newest onChange handed back.
+function lastConditionsFrom(
+  onChange: MockFunction,
+): Array<NotificationRuleCondition> {
+  expect(onChange.mock.calls.length).toBeGreaterThan(0);
+
+  return onChange.mock.calls[
+    onChange.mock.calls.length - 1
+  ]![0] as Array<NotificationRuleCondition>;
+}
+
+async function clickAddCondition(): Promise<void> {
+  const user: ReturnType<typeof userEvent.setup> = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /Add Condition/i }));
+}
+
+/*
+ * react-select renders one text input per dropdown, in form order:
+ * 0 = Filter Type, 1 = Filter Condition, 2 = Value (when it is a dropdown).
+ */
+async function openDropdown(index: number): Promise<void> {
+  const user: ReturnType<typeof userEvent.setup> = userEvent.setup();
+  const comboboxes: Array<HTMLElement> = screen.getAllByRole("combobox");
+
+  expect(comboboxes.length).toBeGreaterThan(index);
+
+  await user.click(comboboxes[index]!);
+}
+
+async function pickFromDropdown(input: {
+  index: number;
+  optionLabel: string;
+}): Promise<void> {
+  const user: ReturnType<typeof userEvent.setup> = userEvent.setup();
+
+  await openDropdown(input.index);
+  await user.click(await screen.findByText(input.optionLabel));
+}
+
+describe("The workspace notification rule Conditions editor", () => {
+  describe("the On-Call Duty Policy editor reported in #3459", () => {
+    test("the Filter Type dropdown lists the on-call fields instead of 'No options'", async () => {
+      renderConditions(NotificationRuleEventType.OnCallDutyPolicy);
+
+      await clickAddCondition();
+      await openDropdown(0);
+
+      expect(screen.queryByText(NO_OPTIONS)).toBeNull();
+      expect(
+        screen.getAllByText(
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+        ).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+        ).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+
+    test("Add Condition seeds a usable row rather than an undefined check-on", async () => {
+      const { onChange } = renderConditions(
+        NotificationRuleEventType.OnCallDutyPolicy,
+      );
+
+      await clickAddCondition();
+
+      const conditions: Array<NotificationRuleCondition> =
+        lastConditionsFrom(onChange);
+
+      expect(conditions.length).toBe(1);
+      expect(conditions[0]!.checkOn).toBe(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+      );
+      expect(conditions[0]!.conditionType).toBe(ConditionType.EqualTo);
+    });
+
+    test("the Filter Condition dropdown offers the text operators once a field is chosen", async () => {
+      renderConditions(NotificationRuleEventType.OnCallDutyPolicy);
+
+      await clickAddCondition();
+      await pickFromDropdown({
+        index: 0,
+        optionLabel:
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+      });
+      await openDropdown(1);
+
+      expect(screen.queryByText(NO_OPTIONS)).toBeNull();
+      expect(
+        screen.getAllByText(ConditionType.Contains).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(ConditionType.StartsWith).length,
+      ).toBeGreaterThan(0);
+    });
+
+    test("choosing the labels field offers the project's labels as the value", async () => {
+      renderConditions(NotificationRuleEventType.OnCallDutyPolicy);
+
+      await clickAddCondition();
+      await pickFromDropdown({
+        index: 0,
+        optionLabel: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      });
+      await pickFromDropdown({
+        index: 1,
+        optionLabel: ConditionType.ContainsAny,
+      });
+      await openDropdown(2);
+
+      expect(screen.queryByText(NO_OPTIONS)).toBeNull();
+      expect(screen.getAllByText("Payments").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Search").length).toBeGreaterThan(0);
+    });
+
+    test("a chosen label is recorded on the condition by id", async () => {
+      const { onChange } = renderConditions(
+        NotificationRuleEventType.OnCallDutyPolicy,
+      );
+
+      await clickAddCondition();
+      await pickFromDropdown({
+        index: 0,
+        optionLabel: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      });
+      await pickFromDropdown({
+        index: 1,
+        optionLabel: ConditionType.ContainsAny,
+      });
+      await pickFromDropdown({ index: 2, optionLabel: "Payments" });
+
+      const conditions: Array<NotificationRuleCondition> =
+        lastConditionsFrom(onChange);
+
+      expect(conditions[0]!.checkOn).toBe(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      );
+      expect(conditions[0]!.conditionType).toBe(ConditionType.ContainsAny);
+      expect(conditions[0]!.value).toEqual([PAYMENTS_LABEL_ID]);
+    });
+  });
+
+  describe("every event type a Workspace Connections page can open", () => {
+    /*
+     * The On-Call page was not special: any event type missing from
+     * getCheckOnByEventType renders the same dead condition block. Walk the
+     * whole enum so the next resource cannot ship the same way.
+     */
+    test.each(Object.values(NotificationRuleEventType))(
+      "%s seeds a fully-formed condition and shows filter types",
+      async (eventType: NotificationRuleEventType) => {
+        const { onChange } = renderConditions(eventType);
+
+        await clickAddCondition();
+
+        const conditions: Array<NotificationRuleCondition> =
+          lastConditionsFrom(onChange);
+
+        expect(conditions.length).toBe(1);
+        expect(conditions[0]!.checkOn).toBeDefined();
+        expect(conditions[0]!.conditionType).toBeDefined();
+
+        await openDropdown(0);
+        expect(screen.queryByText(NO_OPTIONS)).toBeNull();
+      },
+    );
+
+    test.each(Object.values(NotificationRuleEventType))(
+      "%s seeds the first check-on its own option list starts with",
+      async (eventType: NotificationRuleEventType) => {
+        const { onChange } = renderConditions(eventType);
+
+        await clickAddCondition();
+
+        expect(lastConditionsFrom(onChange)[0]!.checkOn).toBe(
+          NotificationRuleConditionUtil.getCheckOnByEventType(eventType)[0],
+        );
+      },
+    );
+  });
+});
+
+describe("The saved-rule condition view", () => {
+  function renderView(condition: NotificationRuleCondition): void {
+    render(
+      <NotificationRuleViewConditionElement
+        {...lookupProps()}
+        notificationRuleCondition={condition}
+      />,
+    );
+  }
+
+  test("renders on-call policy labels by name, not by stored id", () => {
+    /*
+     * The label check-ons were listed one by one in the view, and the on-call
+     * one was missing - so a saved on-call rule read back as a raw uuid.
+     */
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      conditionType: ConditionType.ContainsAny,
+      value: [PAYMENTS_LABEL_ID],
+    });
+
+    expect(screen.getAllByText("Payments").length).toBeGreaterThan(0);
+    expect(screen.queryByText(PAYMENTS_LABEL_ID)).toBeNull();
+  });
+
+  test("renders alert episode labels by name", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.AlertEpisodeLabels,
+      conditionType: ConditionType.ContainsAny,
+      value: [SEARCH_LABEL_ID],
+    });
+
+    expect(screen.getAllByText("Search").length).toBeGreaterThan(0);
+    expect(screen.queryByText(SEARCH_LABEL_ID)).toBeNull();
+  });
+
+  test("renders incident episode labels by name", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.IncidentEpisodeLabels,
+      conditionType: ConditionType.ContainsAny,
+      value: [PAYMENTS_LABEL_ID],
+    });
+
+    expect(screen.getAllByText("Payments").length).toBeGreaterThan(0);
+    expect(screen.queryByText(PAYMENTS_LABEL_ID)).toBeNull();
+  });
+
+  test("renders alert episode severity by name", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.AlertEpisodeSeverity,
+      conditionType: ConditionType.ContainsAny,
+      value: ["c1c1c1c1c1c1c1c1c1c1c1c1"],
+    });
+
+    expect(screen.getAllByText("Sev 1").length).toBeGreaterThan(0);
+  });
+
+  test("renders alert episode state by name", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.AlertEpisodeState,
+      conditionType: ConditionType.ContainsAny,
+      value: ["c2c2c2c2c2c2c2c2c2c2c2c2"],
+    });
+
+    expect(screen.getAllByText("Created").length).toBeGreaterThan(0);
+  });
+
+  test("renders incident episode severity by name", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.IncidentEpisodeSeverity,
+      conditionType: ConditionType.ContainsAny,
+      value: ["c3c3c3c3c3c3c3c3c3c3c3c3"],
+    });
+
+    expect(screen.getAllByText("Major").length).toBeGreaterThan(0);
+  });
+
+  test("renders incident episode state by name", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.IncidentEpisodeState,
+      conditionType: ConditionType.ContainsAny,
+      value: ["c5c5c5c5c5c5c5c5c5c5c5c5"],
+    });
+
+    expect(screen.getAllByText("Acknowledged").length).toBeGreaterThan(0);
+  });
+
+  test("renders the on-call policy name filter as plain text", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+      conditionType: ConditionType.Contains,
+      value: "Payments Escalation",
+    });
+
+    expect(screen.getAllByText("Payments Escalation").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  test.each([
+    NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+    NotificationRuleConditionCheckOn.IncidentLabels,
+    NotificationRuleConditionCheckOn.IncidentState,
+    NotificationRuleConditionCheckOn.Monitors,
+  ])(
+    "survives a %s condition saved without a value",
+    (checkOn: NotificationRuleConditionCheckOn) => {
+      /*
+       * A dropdown-backed condition whose value never got picked used to reach
+       * `undefined.includes(...)` and take the whole rule view down with it.
+       */
+      renderView({
+        checkOn: checkOn,
+        conditionType: ConditionType.ContainsAny,
+        value: undefined,
+      });
+
+      expect(screen.getAllByText(checkOn).length).toBeGreaterThan(0);
+      expect(screen.queryByText("Payments")).toBeNull();
+    },
+  );
+
+  test("survives a label condition saved as a single string", () => {
+    renderView({
+      checkOn: NotificationRuleConditionCheckOn.IncidentLabels,
+      conditionType: ConditionType.ContainsAny,
+      value: PAYMENTS_LABEL_ID,
+    });
+
+    expect(screen.getAllByText("Payments").length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Services/WorkspaceNotificationRuleOnCallDutyPolicy.test.ts
+++ b/Common/Tests/Server/Services/WorkspaceNotificationRuleOnCallDutyPolicy.test.ts
@@ -1,0 +1,306 @@
+import WorkspaceNotificationRuleService, {
+  NotificationFor,
+} from "../../../Server/Services/WorkspaceNotificationRuleService";
+import OnCallDutyPolicyService from "../../../Server/Services/OnCallDutyPolicyService";
+import Label from "../../../Models/DatabaseModels/Label";
+import OnCallDutyPolicy from "../../../Models/DatabaseModels/OnCallDutyPolicy";
+import WorkspaceNotificationRule from "../../../Models/DatabaseModels/WorkspaceNotificationRule";
+import FilterCondition from "../../../Types/Filter/FilterCondition";
+import ObjectID from "../../../Types/ObjectID";
+import NotificationRuleEventType from "../../../Types/Workspace/NotificationRules/EventType";
+import NotificationRuleCondition, {
+  ConditionType,
+  NotificationRuleConditionCheckOn,
+  NotificationRuleConditionUtil,
+} from "../../../Types/Workspace/NotificationRules/NotificationRuleCondition";
+import BaseNotificationRule from "../../../Types/Workspace/NotificationRules/BaseNotificationRule";
+import WorkspaceType from "../../../Types/Workspace/WorkspaceType";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The other half of #3459. Once the editor can build an On-Call Duty Policy
+ * condition, the rule has to actually scope the notification - otherwise the
+ * dropdown is fixed and the rule still fires for every policy.
+ *
+ * getMatchingNotificationRules is the seam every on-call workspace
+ * notification goes through: it loads the project's rules, resolves the
+ * policy behind notificationFor.onCallDutyPolicyId into the check-on values,
+ * and keeps the rules whose filters match. Both DB reads are stubbed here so
+ * the value resolution and the matching are what is under test.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const POLICY_ID: ObjectID = ObjectID.generate();
+const PAYMENTS_LABEL_ID: ObjectID = ObjectID.generate();
+const SEARCH_LABEL_ID: ObjectID = ObjectID.generate();
+
+function label(id: ObjectID, name: string): Label {
+  const model: Label = new Label();
+  model._id = id.toString();
+  model.name = name;
+  return model;
+}
+
+function policy(data: {
+  name: string;
+  description: string;
+  labels: Array<Label>;
+}): OnCallDutyPolicy {
+  const model: OnCallDutyPolicy = new OnCallDutyPolicy();
+  model._id = POLICY_ID.toString();
+  model.name = data.name;
+  model.description = data.description;
+  model.labels = data.labels;
+  return model;
+}
+
+function ruleWithFilters(data: {
+  name: string;
+  filters: Array<NotificationRuleCondition>;
+  filterCondition?: FilterCondition | undefined;
+}): WorkspaceNotificationRule {
+  const rule: WorkspaceNotificationRule = new WorkspaceNotificationRule();
+  rule.id = ObjectID.generate();
+  rule.projectId = PROJECT_ID;
+  rule.name = data.name;
+  rule.workspaceType = WorkspaceType.MicrosoftTeams;
+  rule.eventType = NotificationRuleEventType.OnCallDutyPolicy;
+  rule.notificationRule = {
+    _type: "NotificationRule",
+    filterCondition: data.filterCondition || FilterCondition.All,
+    filters: data.filters,
+    shouldCreateNewChannel: true,
+    newChannelTemplateName: "oneuptime-on-call-duty-policy-",
+    shouldPostToExistingChannel: false,
+    existingChannelNames: "",
+  } as unknown as BaseNotificationRule;
+
+  return rule;
+}
+
+async function matchingRuleNames(): Promise<Array<string>> {
+  const notificationFor: NotificationFor = {
+    onCallDutyPolicyId: POLICY_ID,
+  };
+
+  const matched: Array<WorkspaceNotificationRule> =
+    await WorkspaceNotificationRuleService.getMatchingNotificationRules({
+      projectId: PROJECT_ID,
+      workspaceType: WorkspaceType.MicrosoftTeams,
+      notificationRuleEventType: NotificationRuleEventType.OnCallDutyPolicy,
+      notificationFor: notificationFor,
+    });
+
+  return matched.map((rule: WorkspaceNotificationRule) => {
+    return rule.name || "";
+  });
+}
+
+describe("On-Call Duty Policy workspace notification rules (#3459)", () => {
+  let findBySpy: ReturnType<typeof jest.spyOn>;
+  let findPolicySpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    findPolicySpy = jest
+      .spyOn(OnCallDutyPolicyService, "findOneById")
+      .mockResolvedValue(
+        policy({
+          name: "Payments Escalation",
+          description: "Pages the payments team after 5 minutes.",
+          labels: [label(PAYMENTS_LABEL_ID, "Payments")],
+        }) as never,
+      ) as ReturnType<typeof jest.spyOn>;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function givenProjectRules(rules: Array<WorkspaceNotificationRule>): void {
+    findBySpy = jest
+      .spyOn(WorkspaceNotificationRuleService, "findBy")
+      .mockResolvedValue(rules as never) as ReturnType<typeof jest.spyOn>;
+  }
+
+  test("keeps only the rule whose policy-name filter matches", async () => {
+    givenProjectRules([
+      ruleWithFilters({
+        name: "Payments rule",
+        filters: [
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+            conditionType: ConditionType.Contains,
+            value: "Payments",
+          },
+        ],
+      }),
+      ruleWithFilters({
+        name: "Search rule",
+        filters: [
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+            conditionType: ConditionType.Contains,
+            value: "Search",
+          },
+        ],
+      }),
+    ]);
+
+    expect(await matchingRuleNames()).toEqual(["Payments rule"]);
+    expect(findPolicySpy).toHaveBeenCalled();
+    expect(findBySpy).toHaveBeenCalled();
+  });
+
+  test("keeps a rule filtered on the policy's labels", async () => {
+    givenProjectRules([
+      ruleWithFilters({
+        name: "Payments label rule",
+        filters: [
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+            conditionType: ConditionType.ContainsAny,
+            value: [PAYMENTS_LABEL_ID.toString()],
+          },
+        ],
+      }),
+      ruleWithFilters({
+        name: "Search label rule",
+        filters: [
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+            conditionType: ConditionType.ContainsAny,
+            value: [SEARCH_LABEL_ID.toString()],
+          },
+        ],
+      }),
+    ]);
+
+    expect(await matchingRuleNames()).toEqual(["Payments label rule"]);
+  });
+
+  test("keeps a rule filtered on the policy's description", async () => {
+    givenProjectRules([
+      ruleWithFilters({
+        name: "Description rule",
+        filters: [
+          {
+            checkOn:
+              NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+            conditionType: ConditionType.Contains,
+            value: "payments team",
+          },
+        ],
+      }),
+    ]);
+
+    expect(await matchingRuleNames()).toEqual(["Description rule"]);
+  });
+
+  test("requires every filter under the All condition", async () => {
+    givenProjectRules([
+      ruleWithFilters({
+        name: "Name and label",
+        filterCondition: FilterCondition.All,
+        filters: [
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+            conditionType: ConditionType.StartsWith,
+            value: "Payments",
+          },
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+            conditionType: ConditionType.ContainsAny,
+            value: [SEARCH_LABEL_ID.toString()],
+          },
+        ],
+      }),
+    ]);
+
+    expect(await matchingRuleNames()).toEqual([]);
+  });
+
+  test("needs only one filter under the Any condition", async () => {
+    givenProjectRules([
+      ruleWithFilters({
+        name: "Name or label",
+        filterCondition: FilterCondition.Any,
+        filters: [
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+            conditionType: ConditionType.EqualTo,
+            value: "Something Else",
+          },
+          {
+            checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+            conditionType: ConditionType.ContainsAny,
+            value: [PAYMENTS_LABEL_ID.toString()],
+          },
+        ],
+      }),
+    ]);
+
+    expect(await matchingRuleNames()).toEqual(["Name or label"]);
+  });
+
+  test("an unfiltered rule still fires for every policy", async () => {
+    givenProjectRules([ruleWithFilters({ name: "Catch all", filters: [] })]);
+
+    expect(await matchingRuleNames()).toEqual(["Catch all"]);
+  });
+
+  test("resolves a value for every check-on the on-call editor offers", async () => {
+    /*
+     * The editor's Filter Type list and the values the server resolves have to
+     * agree: a check-on the form offers but the server leaves undefined builds
+     * a rule that can never match. Each one is asserted through a filter that
+     * must match the stubbed policy.
+     */
+    const filtersPerCheckOn: {
+      [key: string]: NotificationRuleCondition;
+    } = {
+      [NotificationRuleConditionCheckOn.OnCallDutyPolicyName]: {
+        checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+        conditionType: ConditionType.EqualTo,
+        value: "Payments Escalation",
+      },
+      [NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription]: {
+        checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+        conditionType: ConditionType.EqualTo,
+        value: "Pages the payments team after 5 minutes.",
+      },
+      [NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels]: {
+        checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+        conditionType: ConditionType.ContainsAll,
+        value: [PAYMENTS_LABEL_ID.toString()],
+      },
+    };
+
+    const checkOns: Array<NotificationRuleConditionCheckOn> =
+      NotificationRuleConditionUtil.getCheckOnByEventType(
+        NotificationRuleEventType.OnCallDutyPolicy,
+      );
+
+    // Guard the loop: an empty list is the #3459 bug, not a passing test.
+    expect(checkOns.length).toBeGreaterThan(0);
+
+    for (const checkOn of checkOns) {
+      const filter: NotificationRuleCondition | undefined =
+        filtersPerCheckOn[checkOn];
+
+      expect(filter).toBeDefined();
+
+      givenProjectRules([
+        ruleWithFilters({ name: checkOn, filters: [filter!] }),
+      ]);
+
+      expect(await matchingRuleNames()).toEqual([checkOn]);
+    }
+  });
+});

--- a/Common/Tests/Types/Workspace/NotificationRuleConditionUtil.test.ts
+++ b/Common/Tests/Types/Workspace/NotificationRuleConditionUtil.test.ts
@@ -292,12 +292,38 @@ describe("NotificationRuleConditionUtil.getCheckOnByEventType", () => {
     expect(checkOns).toContain(NotificationRuleConditionCheckOn.MonitorStatus);
   });
 
-  it("returns an empty list for an event type with no check-ons", () => {
-    expect(
+  it("returns on-call-scoped check-ons for the OnCallDutyPolicy event", () => {
+    /*
+     * #3459: this returned [] and the Filter Type dropdown on the on-call
+     * rule editor read "No options", so no on-call rule could be scoped.
+     */
+    const checkOns: Array<NotificationRuleConditionCheckOn> =
       NotificationRuleConditionUtil.getCheckOnByEventType(
         NotificationRuleEventType.OnCallDutyPolicy,
-      ),
-    ).toEqual([]);
+      );
+
+    expect(checkOns).toEqual([
+      NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+      NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+      NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+    ]);
+    // Incident-only check-ons must not leak into the on-call editor.
+    expect(checkOns).not.toContain(
+      NotificationRuleConditionCheckOn.IncidentTitle,
+    );
+  });
+
+  it("returns a non-empty list for every event type the editor can be opened with", () => {
+    /*
+     * The editor renders one dropdown per event type off this list, so an
+     * event type missing from the switch is a dead form - which is exactly
+     * how #3459 shipped. Enumerating the enum catches the next one.
+     */
+    for (const eventType of Object.values(NotificationRuleEventType)) {
+      expect(
+        NotificationRuleConditionUtil.getCheckOnByEventType(eventType),
+      ).not.toEqual([]);
+    }
   });
 });
 
@@ -343,11 +369,55 @@ describe("NotificationRuleConditionUtil.getConditionTypeByCheckOn", () => {
     ]);
   });
 
-  it("returns an empty list for a check-on with no configured operators", () => {
+  it("offers text operators for the on-call policy name and description", () => {
+    const textOperators: Array<ConditionType> = [
+      ConditionType.EqualTo,
+      ConditionType.NotEqualTo,
+      ConditionType.Contains,
+      ConditionType.NotContains,
+      ConditionType.StartsWith,
+      ConditionType.EndsWith,
+    ];
+
     expect(
       NotificationRuleConditionUtil.getConditionTypeByCheckOn(
         NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
       ),
-    ).toEqual([]);
+    ).toEqual(textOperators);
+    expect(
+      NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+      ),
+    ).toEqual(textOperators);
+  });
+
+  it("offers set operators for on-call policy labels", () => {
+    expect(
+      NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      ),
+    ).toEqual([
+      ConditionType.ContainsAny,
+      ConditionType.NotContains,
+      ConditionType.ContainsAll,
+    ]);
+  });
+
+  it("returns operators for every check-on any event type offers", () => {
+    /*
+     * A check-on the Filter Type dropdown lists but that has no operators
+     * leaves the Filter Condition dropdown empty, and the rule then fails
+     * validation with "Filter Condition is required" and no way to satisfy
+     * it. Walk both lists together so the pair stays complete.
+     */
+    for (const eventType of Object.values(NotificationRuleEventType)) {
+      for (const checkOn of NotificationRuleConditionUtil.getCheckOnByEventType(
+        eventType,
+      )) {
+        expect(
+          NotificationRuleConditionUtil.getConditionTypeByCheckOn(checkOn),
+        ).not.toEqual([]);
+      }
+    }
   });
 });

--- a/Common/Tests/Types/Workspace/NotificationRules/NotificationRuleCondition.test.ts
+++ b/Common/Tests/Types/Workspace/NotificationRules/NotificationRuleCondition.test.ts
@@ -463,12 +463,24 @@ describe("NotificationRuleConditionUtil", () => {
       );
     });
 
-    test("returns an empty list for an unhandled event type", () => {
-      expect(
+    test("returns on-call checkOns for the OnCallDutyPolicy event", () => {
+      // #3459: this used to be [], leaving the Filter Type dropdown empty.
+      const checkOns: Array<NotificationRuleConditionCheckOn> =
         NotificationRuleConditionUtil.getCheckOnByEventType(
           NotificationRuleEventType.OnCallDutyPolicy,
-        ),
-      ).toEqual([]);
+        );
+      expect(checkOns).toContain(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+      );
+      expect(checkOns).toContain(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+      );
+      expect(checkOns).toContain(
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      );
+      expect(checkOns).not.toContain(
+        NotificationRuleConditionCheckOn.MonitorName,
+      );
     });
   });
 

--- a/Common/Tests/Types/Workspace/NotificationRules/OnCallDutyPolicyConditions.test.ts
+++ b/Common/Tests/Types/Workspace/NotificationRules/OnCallDutyPolicyConditions.test.ts
@@ -1,0 +1,669 @@
+import FilterCondition from "../../../../Types/Filter/FilterCondition";
+import NotificationRuleEventType from "../../../../Types/Workspace/NotificationRules/EventType";
+import {
+  ConditionType,
+  NotificationRuleConditionCheckOn,
+  NotificationRuleConditionUtil,
+} from "../../../../Types/Workspace/NotificationRules/NotificationRuleCondition";
+import { WorkspaceNotificationRuleUtil } from "../../../../Types/Workspace/NotificationRules/NotificationRuleUtil";
+import IncidentNotificationRule from "../../../../Types/Workspace/NotificationRules/NotificationRuleTypes/IncidentNotificationRule";
+import WorkspaceType from "../../../../Types/Workspace/WorkspaceType";
+import AlertSeverity from "../../../../Models/DatabaseModels/AlertSeverity";
+import AlertState from "../../../../Models/DatabaseModels/AlertState";
+import IncidentSeverity from "../../../../Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "../../../../Models/DatabaseModels/IncidentState";
+import Label from "../../../../Models/DatabaseModels/Label";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
+import ScheduledMaintenanceState from "../../../../Models/DatabaseModels/ScheduledMaintenanceState";
+import { DropdownOption } from "../../../../UI/Components/Dropdown/Dropdown";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * #3459: "Create On-Call Duty Policy Notification Rule (Microsoft Teams):
+ * Filter Type dropdown shows No options".
+ *
+ * The On-Call Duty Policy check-ons existed in the enum and the server already
+ * populated them when it evaluated a rule, but none of the four editor-facing
+ * helpers knew about them:
+ *
+ *   getCheckOnByEventType      -> [] , so the Filter Type dropdown was empty
+ *   getConditionTypeByCheckOn  -> [] , so Filter Condition would be empty too
+ *   isDropdownValueField       -> false for labels, so a label id had to be typed
+ *   getDropdownOptionsByCheckOn-> [] for labels, so there was nothing to pick
+ *
+ * The chain from "the dropdown lists it" through "the rule saves" to "the
+ * server matches it" is pinned end to end below, and the same chain is walked
+ * for every other event type so the next resource added cannot ship half-wired.
+ */
+
+type CheckOnValues = {
+  [key in NotificationRuleConditionCheckOn]: string | Array<string> | undefined;
+};
+
+const POLICY_LABEL_ID: string = "a1a1a1a1a1a1a1a1a1a1a1a1";
+const OTHER_LABEL_ID: string = "b2b2b2b2b2b2b2b2b2b2b2b2";
+
+/*
+ * getDropdownOptionsByCheckOn only ever reads `id` and `name`, and every model
+ * below derives `id` from `_id`, so a bare instance with those two set is all
+ * a fixture needs.
+ */
+function named<T extends { _id?: string; name?: string }>(
+  model: T,
+  id: string,
+  name: string,
+): T {
+  model._id = id;
+  model.name = name;
+  return model;
+}
+
+// Everything getDropdownOptionsByCheckOn needs, populated for every check-on.
+function dropdownData(): {
+  alertSeverities: Array<AlertSeverity>;
+  alertStates: Array<AlertState>;
+  incidentSeverities: Array<IncidentSeverity>;
+  monitorStatus: Array<MonitorStatus>;
+  incidentStates: Array<IncidentState>;
+  scheduledMaintenanceStates: Array<ScheduledMaintenanceState>;
+  labels: Array<Label>;
+  monitors: Array<Monitor>;
+} {
+  return {
+    alertSeverities: [
+      named(new AlertSeverity(), "c1c1c1c1c1c1c1c1c1c1c1c1", "Sev 1"),
+    ],
+    alertStates: [
+      named(new AlertState(), "c2c2c2c2c2c2c2c2c2c2c2c2", "Created"),
+    ],
+    incidentSeverities: [
+      named(new IncidentSeverity(), "c3c3c3c3c3c3c3c3c3c3c3c3", "Major"),
+    ],
+    monitorStatus: [
+      named(new MonitorStatus(), "c4c4c4c4c4c4c4c4c4c4c4c4", "Offline"),
+    ],
+    incidentStates: [
+      named(new IncidentState(), "c5c5c5c5c5c5c5c5c5c5c5c5", "Acknowledged"),
+    ],
+    scheduledMaintenanceStates: [
+      named(
+        new ScheduledMaintenanceState(),
+        "c6c6c6c6c6c6c6c6c6c6c6c6",
+        "Ongoing",
+      ),
+    ],
+    labels: [
+      named(new Label(), POLICY_LABEL_ID, "Payments"),
+      named(new Label(), OTHER_LABEL_ID, "Search"),
+    ],
+    monitors: [named(new Monitor(), "c7c7c7c7c7c7c7c7c7c7c7c7", "API")],
+  };
+}
+
+function onCallRule(
+  overrides: Partial<IncidentNotificationRule> = {},
+): IncidentNotificationRule {
+  return {
+    _type: "IncidentNotificationRule",
+    filterCondition: FilterCondition.All,
+    filters: [],
+    shouldCreateNewChannel: false,
+    shouldPostToExistingChannel: false,
+    existingChannelNames: "",
+    inviteTeamsToNewChannel: [],
+    inviteUsersToNewChannel: [],
+    shouldInviteOwnersToNewChannel: false,
+    newChannelTemplateName: "",
+    archiveChannelAutomatically: false,
+    shouldAutomaticallyInviteOnCallUsersToNewChannel: false,
+    ...overrides,
+  } as IncidentNotificationRule;
+}
+
+/*
+ * The server hands isRuleMatching a value for every check-on; only the on-call
+ * ones are populated when the notification is for an on-call duty policy.
+ */
+function valuesFor(partial: Partial<CheckOnValues>): CheckOnValues {
+  const base: Partial<CheckOnValues> = {};
+  for (const key of Object.values(NotificationRuleConditionCheckOn)) {
+    base[key] = undefined;
+  }
+  return { ...base, ...partial } as CheckOnValues;
+}
+
+function onCallValues(overrides: Partial<CheckOnValues> = {}): CheckOnValues {
+  return valuesFor({
+    [NotificationRuleConditionCheckOn.OnCallDutyPolicyName]:
+      "Payments Escalation",
+    [NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription]:
+      "Pages the payments team after 5 minutes.",
+    [NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels]: [
+      POLICY_LABEL_ID,
+    ],
+    ...overrides,
+  });
+}
+
+describe("On-Call Duty Policy notification rule conditions (#3459)", () => {
+  describe("the Filter Type dropdown", () => {
+    it("lists the three on-call check-ons instead of nothing", () => {
+      expect(
+        NotificationRuleConditionUtil.getCheckOnByEventType(
+          NotificationRuleEventType.OnCallDutyPolicy,
+        ),
+      ).toEqual([
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+        NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+      ]);
+    });
+
+    it("does not offer check-ons the server cannot resolve for an on-call policy", () => {
+      /*
+       * WorkspaceNotificationRuleService only fills the three on-call keys for
+       * an on-call notification; anything else is undefined, and a filter over
+       * an undefined value never matches. Offering one would build a rule that
+       * silently never fires.
+       */
+      const checkOns: Array<NotificationRuleConditionCheckOn> =
+        NotificationRuleConditionUtil.getCheckOnByEventType(
+          NotificationRuleEventType.OnCallDutyPolicy,
+        );
+
+      expect(checkOns).not.toContain(
+        NotificationRuleConditionCheckOn.IncidentTitle,
+      );
+      expect(checkOns).not.toContain(
+        NotificationRuleConditionCheckOn.MonitorName,
+      );
+      expect(checkOns).not.toContain(NotificationRuleConditionCheckOn.Monitors);
+      expect(checkOns).not.toContain(
+        NotificationRuleConditionCheckOn.MonitorLabels,
+      );
+    });
+
+    it("lists check-ons for every event type an editor can be opened with", () => {
+      for (const eventType of Object.values(NotificationRuleEventType)) {
+        expect(
+          NotificationRuleConditionUtil.getCheckOnByEventType(eventType).length,
+        ).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("the Filter Condition dropdown", () => {
+    it("offers the text operators for the policy name", () => {
+      expect(
+        NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+        ),
+      ).toEqual([
+        ConditionType.EqualTo,
+        ConditionType.NotEqualTo,
+        ConditionType.Contains,
+        ConditionType.NotContains,
+        ConditionType.StartsWith,
+        ConditionType.EndsWith,
+      ]);
+    });
+
+    it("offers the text operators for the policy description", () => {
+      expect(
+        NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+        ),
+      ).toEqual([
+        ConditionType.EqualTo,
+        ConditionType.NotEqualTo,
+        ConditionType.Contains,
+        ConditionType.NotContains,
+        ConditionType.StartsWith,
+        ConditionType.EndsWith,
+      ]);
+    });
+
+    it("offers the set operators for policy labels, matching the other label check-ons", () => {
+      expect(
+        NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+        ),
+      ).toEqual(
+        NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+          NotificationRuleConditionCheckOn.IncidentLabels,
+        ),
+      );
+    });
+
+    it("offers operators for every check-on any event type lists", () => {
+      for (const eventType of Object.values(NotificationRuleEventType)) {
+        for (const checkOn of NotificationRuleConditionUtil.getCheckOnByEventType(
+          eventType,
+        )) {
+          expect(
+            NotificationRuleConditionUtil.getConditionTypeByCheckOn(checkOn)
+              .length,
+          ).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("the Value field", () => {
+    it("renders labels as a dropdown, not a free-text box", () => {
+      expect(
+        NotificationRuleConditionUtil.isDropdownValueField({
+          checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+          conditionType: ConditionType.ContainsAny,
+        }),
+      ).toBe(true);
+    });
+
+    it("keeps the name and description as free text", () => {
+      expect(
+        NotificationRuleConditionUtil.isDropdownValueField({
+          checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+          conditionType: ConditionType.Contains,
+        }),
+      ).toBe(false);
+      expect(
+        NotificationRuleConditionUtil.isDropdownValueField({
+          checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+          conditionType: ConditionType.Contains,
+        }),
+      ).toBe(false);
+    });
+
+    it("shows a value field for the on-call check-ons under a value-taking operator", () => {
+      for (const checkOn of NotificationRuleConditionUtil.getCheckOnByEventType(
+        NotificationRuleEventType.OnCallDutyPolicy,
+      )) {
+        expect(
+          NotificationRuleConditionUtil.hasValueField({
+            checkOn: checkOn,
+            conditionType: ConditionType.Contains,
+          }),
+        ).toBe(true);
+      }
+    });
+
+    it("fills the label dropdown from the project's labels", () => {
+      const options: Array<DropdownOption> =
+        NotificationRuleConditionUtil.getDropdownOptionsByCheckOn({
+          ...dropdownData(),
+          checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+        });
+
+      expect(options).toEqual([
+        { value: POLICY_LABEL_ID, label: "Payments" },
+        { value: OTHER_LABEL_ID, label: "Search" },
+      ]);
+    });
+
+    it("gives the same options to on-call labels as to the other label check-ons", () => {
+      const forCheckOn: (
+        checkOn: NotificationRuleConditionCheckOn,
+      ) => Array<DropdownOption> = (
+        checkOn: NotificationRuleConditionCheckOn,
+      ): Array<DropdownOption> => {
+        return NotificationRuleConditionUtil.getDropdownOptionsByCheckOn({
+          ...dropdownData(),
+          checkOn: checkOn,
+        });
+      };
+
+      expect(
+        forCheckOn(NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels),
+      ).toEqual(forCheckOn(NotificationRuleConditionCheckOn.IncidentLabels));
+    });
+
+    it("has options for every dropdown-backed check-on any event type lists", () => {
+      /*
+       * A check-on the form renders as a dropdown but for which
+       * getDropdownOptionsByCheckOn returns nothing is the same dead end as
+       * #3459, one field further down the form.
+       */
+      for (const eventType of Object.values(NotificationRuleEventType)) {
+        for (const checkOn of NotificationRuleConditionUtil.getCheckOnByEventType(
+          eventType,
+        )) {
+          const conditionType: ConditionType =
+            NotificationRuleConditionUtil.getConditionTypeByCheckOn(
+              checkOn,
+            )[0]!;
+
+          if (
+            !NotificationRuleConditionUtil.isDropdownValueField({
+              checkOn: checkOn,
+              conditionType: conditionType,
+            })
+          ) {
+            continue;
+          }
+
+          expect(
+            NotificationRuleConditionUtil.getDropdownOptionsByCheckOn({
+              ...dropdownData(),
+              checkOn: checkOn,
+            }).length,
+          ).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("saving an on-call rule", () => {
+    it("accepts a name filter with a destination", () => {
+      expect(
+        NotificationRuleConditionUtil.getValidationError({
+          notificationRule: onCallRule({
+            shouldCreateNewChannel: true,
+            newChannelTemplateName: "oneuptime-on-call-duty-policy-",
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.Contains,
+                value: "Payments",
+              },
+            ],
+          }),
+          eventType: NotificationRuleEventType.OnCallDutyPolicy,
+          workspaceType: WorkspaceType.MicrosoftTeams,
+        }),
+      ).toBeNull();
+    });
+
+    it("accepts a label filter holding label ids", () => {
+      expect(
+        NotificationRuleConditionUtil.getValidationError({
+          notificationRule: onCallRule({
+            shouldCreateNewChannel: true,
+            newChannelTemplateName: "oneuptime-on-call-duty-policy-",
+            filters: [
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+                conditionType: ConditionType.ContainsAny,
+                value: [POLICY_LABEL_ID],
+              },
+            ],
+          }),
+          eventType: NotificationRuleEventType.OnCallDutyPolicy,
+          workspaceType: WorkspaceType.Slack,
+        }),
+      ).toBeNull();
+    });
+
+    it("still rejects a filter left without a condition", () => {
+      expect(
+        NotificationRuleConditionUtil.getValidationError({
+          notificationRule: onCallRule({
+            shouldCreateNewChannel: true,
+            newChannelTemplateName: "oneuptime-on-call-duty-policy-",
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: undefined,
+                value: "Payments",
+              },
+            ],
+          }),
+          eventType: NotificationRuleEventType.OnCallDutyPolicy,
+          workspaceType: WorkspaceType.MicrosoftTeams,
+        }),
+      ).toBe(
+        `Filter Condition is required for ${NotificationRuleConditionCheckOn.OnCallDutyPolicyName}`,
+      );
+    });
+
+    it("does not force a destination on an on-call rule", () => {
+      /*
+       * On-call rules are not in the either/or destination block: the rule can
+       * exist purely to name the channel the policy's messages land in.
+       */
+      expect(
+        NotificationRuleConditionUtil.getValidationError({
+          notificationRule: onCallRule(),
+          eventType: NotificationRuleEventType.OnCallDutyPolicy,
+          workspaceType: WorkspaceType.MicrosoftTeams,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("matching an on-call policy against a saved rule", () => {
+    it("matches a name filter against the policy the server resolved", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.Contains,
+                value: "Payments",
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(true);
+    });
+
+    it("does not match a name filter for a different policy", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.Contains,
+                value: "Search",
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(false);
+    });
+
+    it("matches a label filter against the policy's label ids", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+                conditionType: ConditionType.ContainsAny,
+                value: [POLICY_LABEL_ID, OTHER_LABEL_ID],
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(true);
+    });
+
+    it("does not match a label filter for a label the policy does not carry", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+                conditionType: ConditionType.ContainsAny,
+                value: [OTHER_LABEL_ID],
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(false);
+    });
+
+    it("combines a name and a description filter under All", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filterCondition: FilterCondition.All,
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.StartsWith,
+                value: "Payments",
+              },
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+                conditionType: ConditionType.Contains,
+                value: "payments team",
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(true);
+    });
+
+    it("fails All when only one of the two filters matches", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filterCondition: FilterCondition.All,
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.StartsWith,
+                value: "Payments",
+              },
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+                conditionType: ConditionType.Contains,
+                value: "search team",
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(false);
+    });
+
+    it("passes Any when one of the two filters matches", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filterCondition: FilterCondition.Any,
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.EqualTo,
+                value: "Nothing Like This",
+              },
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+                conditionType: ConditionType.ContainsAll,
+                value: [POLICY_LABEL_ID],
+              },
+            ],
+          }),
+          values: onCallValues(),
+        }),
+      ).toBe(true);
+    });
+
+    it("still fires an unfiltered on-call rule for every policy", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({ filters: [] }),
+          values: onCallValues(),
+        }),
+      ).toBe(true);
+    });
+
+    it("does not match an on-call filter when the event is not an on-call policy", () => {
+      /*
+       * The same rule row evaluated against, say, an incident's values: every
+       * on-call key is undefined there, and an undefined value never matches.
+       */
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.Contains,
+                value: "Payments",
+              },
+            ],
+          }),
+          values: valuesFor({
+            [NotificationRuleConditionCheckOn.IncidentTitle]: "Payments down",
+          }),
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("the on-call policy the server resolves", () => {
+    it("matches a policy with no labels only through the label-free filters", () => {
+      const values: CheckOnValues = onCallValues({
+        [NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels]: [],
+      });
+
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+                conditionType: ConditionType.ContainsAny,
+                value: [POLICY_LABEL_ID],
+              },
+            ],
+          }),
+          values: values,
+        }),
+      ).toBe(false);
+
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn: NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+                conditionType: ConditionType.Contains,
+                value: "Payments",
+              },
+            ],
+          }),
+          values: values,
+        }),
+      ).toBe(true);
+    });
+
+    it("matches an IsEmpty filter on a policy saved without a description", () => {
+      expect(
+        WorkspaceNotificationRuleUtil.isRuleMatching({
+          notificationRule: onCallRule({
+            filters: [
+              {
+                checkOn:
+                  NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+                conditionType: ConditionType.IsEmpty,
+                value: "",
+              },
+            ],
+          }),
+          values: onCallValues({
+            [NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription]: "",
+          }),
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/Common/Types/Workspace/NotificationRules/NotificationRuleCondition.ts
+++ b/Common/Types/Workspace/NotificationRules/NotificationRuleCondition.ts
@@ -195,6 +195,7 @@ export class NotificationRuleConditionUtil {
       case NotificationRuleConditionCheckOn.AlertEpisodeLabels:
       case NotificationRuleConditionCheckOn.IncidentEpisodeLabels:
       case NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels:
+      case NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels:
       case NotificationRuleConditionCheckOn.Monitors:
         return true;
       default:
@@ -287,7 +288,8 @@ export class NotificationRuleConditionUtil {
       data.checkOn === NotificationRuleConditionCheckOn.AlertEpisodeLabels ||
       data.checkOn === NotificationRuleConditionCheckOn.IncidentEpisodeLabels ||
       data.checkOn ===
-        NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels
+        NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels ||
+      data.checkOn === NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels
     ) {
       return data.labels.map((label: Label) => {
         return {
@@ -386,6 +388,12 @@ export class NotificationRuleConditionUtil {
           NotificationRuleConditionCheckOn.MonitorLabels,
           NotificationRuleConditionCheckOn.Monitors,
         ];
+      case NotificationRuleEventType.OnCallDutyPolicy:
+        return [
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyName,
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription,
+          NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels,
+        ];
       default:
         return [];
     }
@@ -406,6 +414,8 @@ export class NotificationRuleConditionUtil {
       case NotificationRuleConditionCheckOn.IncidentEpisodeDescription:
       case NotificationRuleConditionCheckOn.ScheduledMaintenanceTitle:
       case NotificationRuleConditionCheckOn.ScheduledMaintenanceDescription:
+      case NotificationRuleConditionCheckOn.OnCallDutyPolicyName:
+      case NotificationRuleConditionCheckOn.OnCallDutyPolicyDescription:
         return [
           ConditionType.EqualTo,
           ConditionType.NotEqualTo,
@@ -434,6 +444,7 @@ export class NotificationRuleConditionUtil {
       case NotificationRuleConditionCheckOn.IncidentLabels:
       case NotificationRuleConditionCheckOn.MonitorLabels:
       case NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels:
+      case NotificationRuleConditionCheckOn.OnCallDutyPolicyLabels:
         return [
           ConditionType.ContainsAny,
           ConditionType.NotContains,


### PR DESCRIPTION
### Title of this pull request?

fix(workspace-notifications): wire the On-Call Duty Policy rule conditions

### Small Description?

The "Filter Type" dropdown on an On-Call Duty Policy notification rule opened onto react-select's **"No options"**, so no on-call rule could ever be scoped — every one of them stayed "trigger for every On-Call Duty Policy", exactly as the helper text warned.

`getCheckOnByEventType` had no `OnCallDutyPolicy` case and fell through to `default: return []`. The three on-call check-ons already existed in the enum, and `WorkspaceNotificationRuleService` already resolved values for them when it evaluated a rule — the gap was entirely in the four editor-facing helpers on `NotificationRuleConditionUtil`:

| helper | was | now |
|---|---|---|
| `getCheckOnByEventType` | `[]` | Policy Name / Description / Labels |
| `getConditionTypeByCheckOn` | `[]` | text operators for name + description, set operators for labels |
| `isDropdownValueField` | `false` for labels | `true` |
| `getDropdownOptionsByCheckOn` | `[]` for labels | the project's labels |

The issue was filed against Microsoft Teams, but **Slack was affected identically** — both `Pages/OnCallDuty/WorkspaceConnectionSlack.tsx` and `…MicrosoftTeams.tsx` render the same editor off the same event type. The bug was never Teams-specific.

#### The other resources, as asked on the issue

Checking the rest of Workspace Connections for the same shape turned up two more:

- **The saved-rule view listed the label check-ons one by one and had never been extended past Scheduled Maintenance.** `AlertEpisodeLabels`, `IncidentEpisodeLabels` and `OnCallDutyPolicyLabels` all fell through to the raw-value branch, so a saved rule read back as a bare uuid instead of a label pill — and so did `AlertEpisodeSeverity` / `AlertEpisodeState` / `IncidentEpisodeSeverity` / `IncidentEpisodeState`. All of them now render by name. While in there, the view normalises the stored value once up front: a dropdown-backed condition saved *without* a value reached `undefined.includes(...)` and took the whole rule view down with it.

- **"Add Condition" pushed `checkOnByEventType[0]!` without checking there was one.** That non-null assertion over an empty list is what produced the row in the screenshot: an undefined `checkOn` sitting above an empty option list, unsavable (`Check On is required`) and only removable by deleting the filter. It now no-ops, and the button disables, when an event type has no check-ons — so a resource added in future degrades instead of shipping a dead form.

Server-side value resolution, `isRuleMatching`, the summary service and the test-rule route were all already event-type-complete; no server change was needed.

#### Tests

Three new files plus updates to two existing ones — both of which contained tests *pinning the buggy* `[]` return, which is a fair part of why this survived.

The new tests walk the whole `NotificationRuleEventType` enum rather than the one type that broke, so the next resource cannot ship half-wired:

- every event type must offer check-ons,
- every offered check-on must offer operators,
- every dropdown-backed check-on must offer options.

`Common/Tests/App/Dashboard/WorkspaceNotificationRuleConditions.test.tsx` drives the real components, because "No options" is something react-select decides to render when the list it was handed is empty — a rule about lists cannot say whether that reaches the screen, only the rendered form can. It also covers picking a label through the form and the saved-rule view rendering ids back as names.

`Common/Tests/Server/Services/WorkspaceNotificationRuleOnCallDutyPolicy.test.ts` stubs the two DB reads and asserts the whole loop through `getMatchingNotificationRules` — policy resolved, filters matched, All vs Any — for each of the three on-call check-ons. The check-on loop there is guarded with a non-empty assertion, since an empty list would otherwise make that test pass vacuously on the broken code.

Verified not vacuous: reverting only the source fix and keeping the tests fails **26** of them.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Locally: `eslint` and `prettier --check` clean on every changed file; `tsc --noEmit` clean in both `Common` and `App`; 286 tests pass across `Tests/Types/Workspace`, `Tests/Server/Services/Workspace*` and `Tests/App/Dashboard/WorkspaceNotificationRuleConditions`.

### Related Issue?

closes #3459
