### PR TITLE
perf(ci): shard Common tests across eight jobs

### DIFF
--- a/.github/workflows/test.common.yaml
+++ b/.github/workflows/test.common.yaml
@@ -6,23 +6,37 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request: 
+  pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:
+    name: test (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # One slow or broken shard should not hide the results of the others.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
-      CI_PIPELINE_ID: ${{github.run_number}}
-      BILLING_PRIVATE_KEY: ${{secrets.TEST_BILLING_PRIVATE_KEY}}
+      CI_PIPELINE_ID: ${{ github.run_number }}
+      BILLING_PRIVATE_KEY: ${{ secrets.TEST_BILLING_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 26
-      - run: cd Common && bash test-setup.sh
-      - run: cd Common && npm install && rm -rf build && npm run test
-  
+          cache: npm
+          cache-dependency-path: Common/package-lock.json
+      - name: Set up test services
+        working-directory: Common
+        run: bash test-setup.sh
+      - name: Install dependencies
+        working-directory: Common
+        run: npm install
+      - name: Run test shard
+        working-directory: Common
+        run: rm -rf build && npm run test -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}


### PR DESCRIPTION
## Summary

- run the Common Jest suite as eight deterministic GitHub Actions shards
- keep each shard serial while distributing files across isolated runners
- add an npm download cache and a 30-minute shard timeout
- run push builds only on `master`, avoiding duplicate push and pull-request runs for the same commit

## Validation

- `npm run fix`
- Prettier check for `.github/workflows/test.common.yaml`
- workflow YAML parse
- verified all 1,546 Common test files are assigned exactly once across the eight shards: `194, 194, 194, 194, 194, 194, 194, 188`
- verified the existing npm test script forwards `--shard=8/8` correctly
