### PR TITLE
perf(ci): avoid duplicate feature branch workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   
-      - 'release'
+    branches:
+      - master
 
 
 jobs:

--- a/.github/workflows/common-jobs.yaml
+++ b/.github/workflows/common-jobs.yaml
@@ -6,11 +6,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request: 
+  pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   # Every Helm chart test, in one check. The runner walks HelmChart/Tests/suites

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -8,11 +8,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request: 
+  pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   
-      - 'release'
+    branches:
+      - master
 
 
 jobs:

--- a/.github/workflows/openapi-spec-generation.yml
+++ b/.github/workflows/openapi-spec-generation.yml
@@ -6,11 +6,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request: 
+  pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   
-      - 'release'
+    branches:
+      - master
 
 jobs:
   generate-openapi-spec:

--- a/.github/workflows/postgres-schema-drift.yaml
+++ b/.github/workflows/postgres-schema-drift.yaml
@@ -11,9 +11,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   # Migrates an empty database with every migration registered in

--- a/.github/workflows/test.app.yaml
+++ b/.github/workflows/test.app.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.browser-recorder.yaml
+++ b/.github/workflows/test.browser-recorder.yaml
@@ -1,11 +1,15 @@
 name: Browser Recorder Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/test.cli.yaml
+++ b/.github/workflows/test.cli.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.infrastructure-agent.yaml
+++ b/.github/workflows/test.infrastructure-agent.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.mobile-app.yaml
+++ b/.github/workflows/test.mobile-app.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   expo-doctor:

--- a/.github/workflows/test.nginx.yaml
+++ b/.github/workflows/test.nginx.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.ops.yaml
+++ b/.github/workflows/test.ops.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.probe.yaml
+++ b/.github/workflows/test.probe.yaml
@@ -6,11 +6,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request: 
+  pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.runner.yaml
+++ b/.github/workflows/test.runner.yaml
@@ -8,9 +8,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'
-      - 'release'
+    branches:
+      - master
 
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,11 +6,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request: 
+  pull_request:
   push:
-    branches-ignore:
-      - 'hotfix-*'   # excludes hotfix branches
-      - 'release'
+    branches:
+      - master
 
 jobs:
   # App tests run in the dedicated "App Test" workflow (test.app.yaml),


### PR DESCRIPTION
## Summary

- keep pull request validation for all 15 routine CI workflows
- restrict push-triggered validation to `master` so feature branch commits do not launch a second identical workflow set
- add stale-run cancellation to Browser Recorder for consistency

## Expected impact

An audit of the latest 1,000 Actions runs found 271 avoidable push/pull-request duplicates. This preserves PR and post-merge `master` coverage while removing the redundant feature-branch copies.

## Validation

- `npm run fix`
- Prettier check for all workflow files
- YAML parse of all 21 workflows
- semantic assertion that all 15 targets retain `pull_request` and `push.branches: [master]`
- actionlint v1.7.12 on every changed workflow
- independent trigger-scope and release-safety reviews