### PR TITLE
fix(logs): let go of the tooltip while dragging a range out of the histogram

### DIFF
--- a/Common/Tests/UI/Components/LogsHistogramDragTooltip.test.tsx
+++ b/Common/Tests/UI/Components/LogsHistogramDragTooltip.test.tsx
@@ -1,0 +1,393 @@
+/** @timezone UTC */
+
+import { HistogramBucket } from "../../../UI/Components/LogsViewer/types";
+import LogSeverity from "../../../Types/Log/LogSeverity";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Recharts resolves a pointer to a bucket from real layout — a bounding rect,
+ * an animation frame — none of which jsdom provides, so a drag fired at the
+ * real chart never reaches the component under test. The chart is replaced by
+ * a stand-in that hands each bucket a hit target and calls the very same
+ * onMouseDown / onMouseMove / onMouseUp props with the chart state recharts
+ * would have passed. What is left under test is exactly what this file is
+ * about: how LogsHistogram reacts to a drag.
+ *
+ * The tooltip stand-in reports the `active` prop it was handed, because that
+ * is the switch the fix flips — recharts hides the tooltip outright when
+ * `active` is false and picks its own behaviour back up when the prop is not
+ * passed at all.
+ */
+jest.mock("recharts", () => {
+  const react: typeof React = jest.requireActual("react") as typeof React;
+
+  interface StubRow {
+    time: string;
+  }
+
+  interface StubChartProps {
+    data: Array<StubRow>;
+    children?: React.ReactNode;
+    onMouseDown?: (state: { activeLabel: string }) => void;
+    onMouseMove?: (state: { activeLabel: string }) => void;
+    onMouseUp?: (state: { activeLabel: string }) => void;
+  }
+
+  return {
+    __esModule: true,
+    ResponsiveContainer: (props: { children: React.ReactNode }) => {
+      return react.createElement("div", null, props.children);
+    },
+    BarChart: (props: StubChartProps) => {
+      return react.createElement(
+        "div",
+        { "data-testid": "bar-chart" },
+        props.data.map((row: StubRow) => {
+          return react.createElement("div", {
+            key: row.time,
+            "data-testid": `bucket-${row.time}`,
+            onMouseDown: () => {
+              props.onMouseDown?.({ activeLabel: row.time });
+            },
+            onMouseMove: () => {
+              props.onMouseMove?.({ activeLabel: row.time });
+            },
+            onMouseUp: () => {
+              props.onMouseUp?.({ activeLabel: row.time });
+            },
+          });
+        }),
+        props.children,
+      );
+    },
+    Bar: () => {
+      return null;
+    },
+    XAxis: () => {
+      return null;
+    },
+    YAxis: () => {
+      return null;
+    },
+    Tooltip: (props: { active?: boolean }) => {
+      return react.createElement("div", {
+        "data-testid": "tooltip",
+        "data-active": String(props.active),
+      });
+    },
+    ReferenceArea: (props: { x1?: string; x2?: string }) => {
+      return react.createElement("div", {
+        "data-testid": "selection-band",
+        "data-x1": props.x1,
+        "data-x2": props.x2,
+      });
+    },
+  };
+});
+
+// Imported after the mock so the chart picks the stand-in up.
+import LogsHistogram from "../../../UI/Components/LogsViewer/components/LogsHistogram";
+
+const FIRST_BUCKET: string = "2026-08-05T11:58:00Z";
+const MIDDLE_BUCKET: string = "2026-08-05T11:59:00Z";
+const LAST_BUCKET: string = "2026-08-05T12:00:00Z";
+
+const BUCKETS: Array<HistogramBucket> = [
+  { time: FIRST_BUCKET, severity: LogSeverity.Error, count: 3 },
+  { time: MIDDLE_BUCKET, severity: LogSeverity.Error, count: 5 },
+  { time: LAST_BUCKET, severity: LogSeverity.Error, count: 7 },
+];
+
+const ZOOM_OUT_HINT: string = "Double-click to zoom out";
+
+function bucketAt(time: string): HTMLElement {
+  return screen.getByTestId(`bucket-${time}`);
+}
+
+/** What recharts was told to do with the tooltip on the last render. */
+function tooltipActiveProp(): string | null {
+  return screen.getByTestId("tooltip").getAttribute("data-active");
+}
+
+function isTooltipSuppressed(): boolean {
+  return tooltipActiveProp() === "false";
+}
+
+function selectionBand(): HTMLElement | null {
+  return screen.queryByTestId("selection-band");
+}
+
+interface RenderedHistogram {
+  onTimeRangeSelect: MockFunction;
+  onZoomOut: MockFunction;
+}
+
+function renderHistogram(
+  options: { canSelect?: boolean; canZoomOut?: boolean } = {},
+): RenderedHistogram {
+  const onTimeRangeSelect: MockFunction = getJestMockFunction();
+  const onZoomOut: MockFunction = getJestMockFunction();
+
+  render(
+    <LogsHistogram
+      buckets={BUCKETS}
+      isLoading={false}
+      {...(options.canSelect === false
+        ? {}
+        : { onTimeRangeSelect: onTimeRangeSelect })}
+      {...(options.canZoomOut ? { onZoomOut: onZoomOut } : {})}
+    />,
+  );
+
+  return { onTimeRangeSelect: onTimeRangeSelect, onZoomOut: onZoomOut };
+}
+
+describe("LogsHistogram — dragging out a time range", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /*
+   * The reported bug: the tooltip parks itself over the bars while the reader
+   * is dragging, hiding the very volumes they are dragging across to pick the
+   * range with.
+   */
+  describe("the tooltip while a selection is in progress", () => {
+    test("stays under recharts' own control before anything is dragged", () => {
+      renderHistogram();
+
+      expect(tooltipActiveProp()).toBe("undefined");
+    });
+
+    test("is held shut for the length of the drag", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      expect(isTooltipSuppressed()).toBe(true);
+
+      fireEvent.mouseMove(bucketAt(MIDDLE_BUCKET));
+      expect(isTooltipSuppressed()).toBe(true);
+
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      expect(isTooltipSuppressed()).toBe(true);
+    });
+
+    test("comes back the moment the reader lets go", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      fireEvent.mouseUp(bucketAt(LAST_BUCKET));
+
+      expect(tooltipActiveProp()).toBe("undefined");
+    });
+
+    /*
+     * The stuck-tooltip case from the report: the pointer leaves a 120px-tall
+     * chart mid-drag and is released somewhere else on the page, so the
+     * chart's own mouseup never fires.
+     */
+    test("comes back when the pointer is released outside the chart", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      expect(isTooltipSuppressed()).toBe(true);
+
+      fireEvent.mouseUp(document.body);
+
+      expect(tooltipActiveProp()).toBe("undefined");
+      expect(selectionBand()).toBeNull();
+    });
+
+    test("comes back after a click that selected nothing", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(MIDDLE_BUCKET));
+      fireEvent.mouseUp(bucketAt(MIDDLE_BUCKET));
+
+      expect(tooltipActiveProp()).toBe("undefined");
+    });
+
+    /*
+     * A chart the parent cannot zoom never starts a drag, so nothing should
+     * ever take the tooltip away from the reader.
+     */
+    test("is never suppressed on a chart that cannot be zoomed", () => {
+      renderHistogram({ canSelect: false });
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+
+      expect(tooltipActiveProp()).toBe("undefined");
+      expect(selectionBand()).toBeNull();
+    });
+  });
+
+  describe("the selection band", () => {
+    test("is only painted once the pointer has moved off the first bucket", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      expect(selectionBand()).toBeNull();
+
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+
+      expect(selectionBand()?.getAttribute("data-x1")).toBe(FIRST_BUCKET);
+      expect(selectionBand()?.getAttribute("data-x2")).toBe(LAST_BUCKET);
+    });
+
+    test("follows the pointer back and forth across the chart", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(LAST_BUCKET));
+      fireEvent.mouseMove(bucketAt(FIRST_BUCKET));
+      expect(selectionBand()?.getAttribute("data-x2")).toBe(FIRST_BUCKET);
+
+      fireEvent.mouseMove(bucketAt(MIDDLE_BUCKET));
+      expect(selectionBand()?.getAttribute("data-x2")).toBe(MIDDLE_BUCKET);
+    });
+
+    test("is cleared once the range has been handed to the parent", () => {
+      renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      fireEvent.mouseUp(bucketAt(LAST_BUCKET));
+
+      expect(selectionBand()).toBeNull();
+    });
+  });
+
+  describe("handing the range to the parent", () => {
+    test("reports the dragged window", () => {
+      const { onTimeRangeSelect } = renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      fireEvent.mouseUp(bucketAt(LAST_BUCKET));
+
+      expect(onTimeRangeSelect).toHaveBeenCalledTimes(1);
+      const [start, end] = onTimeRangeSelect.mock.calls[0] as [Date, Date];
+      expect(start.toISOString()).toBe(new Date(FIRST_BUCKET).toISOString());
+      expect(end.toISOString()).toBe(new Date(LAST_BUCKET).toISOString());
+    });
+
+    test("orders a right-to-left drag from earlier to later", () => {
+      const { onTimeRangeSelect } = renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(LAST_BUCKET));
+      fireEvent.mouseMove(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseUp(bucketAt(FIRST_BUCKET));
+
+      const [start, end] = onTimeRangeSelect.mock.calls[0] as [Date, Date];
+      expect(start.toISOString()).toBe(new Date(FIRST_BUCKET).toISOString());
+      expect(end.toISOString()).toBe(new Date(LAST_BUCKET).toISOString());
+    });
+
+    /*
+     * A mouseup inside the chart is seen twice — once by the chart, then by
+     * the page-wide listener that catches releases outside it. Zooming twice
+     * off one drag would leave the reader on the wrong window.
+     */
+    test("zooms once even though the release is seen twice", () => {
+      const { onTimeRangeSelect } = renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      fireEvent.mouseUp(bucketAt(LAST_BUCKET));
+
+      expect(onTimeRangeSelect).toHaveBeenCalledTimes(1);
+    });
+
+    test("still reports a drag that ended off the chart", () => {
+      const { onTimeRangeSelect } = renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(MIDDLE_BUCKET));
+      fireEvent.mouseUp(document.body);
+
+      expect(onTimeRangeSelect).toHaveBeenCalledTimes(1);
+      const [start, end] = onTimeRangeSelect.mock.calls[0] as [Date, Date];
+      expect(start.toISOString()).toBe(new Date(FIRST_BUCKET).toISOString());
+      expect(end.toISOString()).toBe(new Date(MIDDLE_BUCKET).toISOString());
+    });
+
+    test("treats a click that never moved as no selection at all", () => {
+      const { onTimeRangeSelect } = renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(MIDDLE_BUCKET));
+      fireEvent.mouseUp(bucketAt(MIDDLE_BUCKET));
+
+      expect(onTimeRangeSelect).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Releases go on arriving from the page for as long as the listener is
+     * attached; only the one that ends a drag may zoom.
+     */
+    test("ignores releases once the drag is over", () => {
+      const { onTimeRangeSelect } = renderHistogram();
+
+      fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+      fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+      fireEvent.mouseUp(document.body);
+      fireEvent.mouseUp(document.body);
+      fireEvent.mouseUp(document.body);
+
+      expect(onTimeRangeSelect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("double-click to zoom back out", () => {
+    test("puts the reader back on the window they came from", () => {
+      const { onZoomOut } = renderHistogram({ canZoomOut: true });
+
+      fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+      expect(onZoomOut).toHaveBeenCalledTimes(1);
+    });
+
+    test("offers the affordance only once there is something to undo", () => {
+      renderHistogram();
+
+      expect(screen.queryByText(ZOOM_OUT_HINT)).toBeNull();
+
+      cleanup();
+      renderHistogram({ canZoomOut: true });
+
+      expect(screen.queryByText(ZOOM_OUT_HINT)).not.toBeNull();
+    });
+
+    test("is inert on a chart that is already on its original window", () => {
+      renderHistogram();
+
+      // The chart is not zoomed, so this must be a no-op rather than a crash.
+      fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+      expect(screen.queryByText(ZOOM_OUT_HINT)).toBeNull();
+    });
+
+    /*
+     * A double-click is two mousedown/mouseup pairs on one bucket. Neither
+     * pair moves, so neither may be mistaken for a drag.
+     */
+    test("does not zoom in on its own clicks", () => {
+      const { onTimeRangeSelect, onZoomOut } = renderHistogram({
+        canZoomOut: true,
+      });
+
+      fireEvent.mouseDown(bucketAt(MIDDLE_BUCKET));
+      fireEvent.mouseUp(bucketAt(MIDDLE_BUCKET));
+      fireEvent.mouseDown(bucketAt(MIDDLE_BUCKET));
+      fireEvent.mouseUp(bucketAt(MIDDLE_BUCKET));
+      fireEvent.doubleClick(bucketAt(MIDDLE_BUCKET));
+
+      expect(onTimeRangeSelect).not.toHaveBeenCalled();
+      expect(onZoomOut).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/LogsViewerHistogramZoom.test.tsx
+++ b/Common/Tests/UI/Components/LogsViewerHistogramZoom.test.tsx
@@ -1,0 +1,248 @@
+/** @timezone UTC */
+
+import { HistogramBucket } from "../../../UI/Components/LogsViewer/types";
+import LogSeverity from "../../../Types/Log/LogSeverity";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * LogsViewer is the piece that makes double-click-to-zoom-out possible at
+ * all: the chart only reports the window a reader dragged out, and only the
+ * viewer knows which window they were on before they dragged it. This file
+ * covers that link — the chart's own behaviour is in
+ * LogsHistogramDragTooltip.test.tsx and the bookkeeping in
+ * UseHistogramZoom.test.tsx, and both stay green while this wiring is cut.
+ *
+ * The container loads services and log attributes on mount, so both API
+ * surfaces are mocked out; nothing here depends on what they return.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+const postMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      getCommonHeaders: () => {
+        return {};
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<any>) => {
+        return postMock(...args);
+      },
+      getFriendlyErrorMessage: (error: Error) => {
+        return error.message;
+      },
+      getFriendlyMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+
+// See LogsHistogramDragTooltip.test.tsx for why recharts is stood in for.
+jest.mock("recharts", () => {
+  const react: typeof React = jest.requireActual("react") as typeof React;
+
+  interface StubRow {
+    time: string;
+  }
+
+  interface StubChartProps {
+    data: Array<StubRow>;
+    children?: React.ReactNode;
+    onMouseDown?: (state: { activeLabel: string }) => void;
+    onMouseMove?: (state: { activeLabel: string }) => void;
+    onMouseUp?: (state: { activeLabel: string }) => void;
+  }
+
+  return {
+    __esModule: true,
+    ResponsiveContainer: (props: { children: React.ReactNode }) => {
+      return react.createElement("div", null, props.children);
+    },
+    BarChart: (props: StubChartProps) => {
+      return react.createElement(
+        "div",
+        { "data-testid": "bar-chart" },
+        props.data.map((row: StubRow) => {
+          return react.createElement("div", {
+            key: row.time,
+            "data-testid": `bucket-${row.time}`,
+            onMouseDown: () => {
+              props.onMouseDown?.({ activeLabel: row.time });
+            },
+            onMouseMove: () => {
+              props.onMouseMove?.({ activeLabel: row.time });
+            },
+            onMouseUp: () => {
+              props.onMouseUp?.({ activeLabel: row.time });
+            },
+          });
+        }),
+        props.children,
+      );
+    },
+    Bar: () => {
+      return null;
+    },
+    XAxis: () => {
+      return null;
+    },
+    YAxis: () => {
+      return null;
+    },
+    Tooltip: (props: { active?: boolean }) => {
+      return react.createElement("div", {
+        "data-testid": "tooltip",
+        "data-active": String(props.active),
+      });
+    },
+    ReferenceArea: () => {
+      return null;
+    },
+  };
+});
+
+getListMock.mockImplementation(() => {
+  return Promise.resolve({ data: [], count: 0, skip: 0, limit: 0 });
+});
+
+postMock.mockImplementation(() => {
+  return Promise.resolve({ data: {} });
+});
+
+// Imported after the mocks so the container picks them up.
+import LogsViewer from "../../../UI/Components/LogsViewer/LogsViewer";
+
+const FIRST_BUCKET: string = "2026-08-05T11:58:00Z";
+const LAST_BUCKET: string = "2026-08-05T12:00:00Z";
+
+const BUCKETS: Array<HistogramBucket> = [
+  { time: FIRST_BUCKET, severity: LogSeverity.Error, count: 3 },
+  { time: "2026-08-05T11:59:00Z", severity: LogSeverity.Error, count: 5 },
+  { time: LAST_BUCKET, severity: LogSeverity.Error, count: 7 },
+];
+
+const PAST_DAY: RangeStartAndEndDateTime = { range: TimeRange.PAST_ONE_DAY };
+const ZOOM_OUT_HINT: string = "Double-click to zoom out";
+
+interface RenderedViewer {
+  onHistogramTimeRangeSelect: MockFunction;
+  onTimeRangeChange: MockFunction;
+}
+
+async function renderViewer(): Promise<RenderedViewer> {
+  const onHistogramTimeRangeSelect: MockFunction = getJestMockFunction();
+  const onTimeRangeChange: MockFunction = getJestMockFunction();
+
+  render(
+    <LogsViewer
+      logs={[]}
+      isLoading={false}
+      filterData={{}}
+      onFilterChanged={getJestMockFunction()}
+      histogramBuckets={BUCKETS}
+      histogramLoading={false}
+      onHistogramTimeRangeSelect={onHistogramTimeRangeSelect}
+      timeRange={PAST_DAY}
+      onTimeRangeChange={onTimeRangeChange}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("bar-chart")).not.toBeNull();
+  });
+
+  return {
+    onHistogramTimeRangeSelect: onHistogramTimeRangeSelect,
+    onTimeRangeChange: onTimeRangeChange,
+  };
+}
+
+function dragAcrossHistogram(): void {
+  fireEvent.mouseDown(screen.getByTestId(`bucket-${FIRST_BUCKET}`));
+  fireEvent.mouseMove(screen.getByTestId(`bucket-${LAST_BUCKET}`));
+  fireEvent.mouseUp(screen.getByTestId(`bucket-${LAST_BUCKET}`));
+}
+
+describe("LogsViewer wires the histogram's zoom to the window it came from", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("a drag still reaches the host that applies the window", async () => {
+    const { onHistogramTimeRangeSelect } = await renderViewer();
+
+    dragAcrossHistogram();
+
+    expect(onHistogramTimeRangeSelect).toHaveBeenCalledTimes(1);
+    const [start, end] = onHistogramTimeRangeSelect.mock.calls[0] as [
+      Date,
+      Date,
+    ];
+    expect(start.toISOString()).toBe(new Date(FIRST_BUCKET).toISOString());
+    expect(end.toISOString()).toBe(new Date(LAST_BUCKET).toISOString());
+  });
+
+  test("the way back out only appears once a drag has zoomed in", async () => {
+    await renderViewer();
+
+    expect(screen.queryByText(ZOOM_OUT_HINT)).toBeNull();
+
+    dragAcrossHistogram();
+
+    expect(screen.queryByText(ZOOM_OUT_HINT)).not.toBeNull();
+  });
+
+  test("double-clicking the chart restores the window the reader was on", async () => {
+    const { onTimeRangeChange } = await renderViewer();
+
+    dragAcrossHistogram();
+    fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+    expect(onTimeRangeChange).toHaveBeenCalledTimes(1);
+    expect(onTimeRangeChange).toHaveBeenCalledWith(PAST_DAY);
+  });
+
+  test("double-clicking before any zoom leaves the window alone", async () => {
+    const { onTimeRangeChange } = await renderViewer();
+
+    fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+    expect(onTimeRangeChange).not.toHaveBeenCalled();
+  });
+
+  test("the way back out is spent once it has been taken", async () => {
+    const { onTimeRangeChange } = await renderViewer();
+
+    dragAcrossHistogram();
+    fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+    fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+    expect(onTimeRangeChange).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(ZOOM_OUT_HINT)).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/TelemetryHistogramDragTooltip.test.tsx
+++ b/Common/Tests/UI/Components/TelemetryHistogramDragTooltip.test.tsx
@@ -1,0 +1,205 @@
+/** @timezone UTC */
+
+import {
+  HistogramBucket,
+  HistogramSeriesOption,
+} from "../../../UI/Components/TelemetryViewer/types";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The traces / exceptions volume chart is the same chart as the log volume
+ * one, drawn from a different signal — so it carries the same drag-to-zoom
+ * behaviour and needs the same cover. See LogsHistogramDragTooltip.test.tsx
+ * for why recharts is stood in for here.
+ */
+jest.mock("recharts", () => {
+  const react: typeof React = jest.requireActual("react") as typeof React;
+
+  interface StubRow {
+    time: string;
+  }
+
+  interface StubChartProps {
+    data: Array<StubRow>;
+    children?: React.ReactNode;
+    onMouseDown?: (state: { activeLabel: string }) => void;
+    onMouseMove?: (state: { activeLabel: string }) => void;
+    onMouseUp?: (state: { activeLabel: string }) => void;
+  }
+
+  return {
+    __esModule: true,
+    ResponsiveContainer: (props: { children: React.ReactNode }) => {
+      return react.createElement("div", null, props.children);
+    },
+    BarChart: (props: StubChartProps) => {
+      return react.createElement(
+        "div",
+        { "data-testid": "bar-chart" },
+        props.data.map((row: StubRow) => {
+          return react.createElement("div", {
+            key: row.time,
+            "data-testid": `bucket-${row.time}`,
+            onMouseDown: () => {
+              props.onMouseDown?.({ activeLabel: row.time });
+            },
+            onMouseMove: () => {
+              props.onMouseMove?.({ activeLabel: row.time });
+            },
+            onMouseUp: () => {
+              props.onMouseUp?.({ activeLabel: row.time });
+            },
+          });
+        }),
+        props.children,
+      );
+    },
+    Bar: () => {
+      return null;
+    },
+    XAxis: () => {
+      return null;
+    },
+    YAxis: () => {
+      return null;
+    },
+    Tooltip: (props: { active?: boolean }) => {
+      return react.createElement("div", {
+        "data-testid": "tooltip",
+        "data-active": String(props.active),
+      });
+    },
+    ReferenceArea: (props: { x1?: string; x2?: string }) => {
+      return react.createElement("div", {
+        "data-testid": "selection-band",
+        "data-x1": props.x1,
+        "data-x2": props.x2,
+      });
+    },
+  };
+});
+
+// Imported after the mock so the chart picks the stand-in up.
+import TelemetryHistogram from "../../../UI/Components/TelemetryViewer/components/TelemetryHistogram";
+
+const FIRST_BUCKET: string = "2026-08-05T11:58:00Z";
+const LAST_BUCKET: string = "2026-08-05T12:00:00Z";
+
+const SERIES: Array<HistogramSeriesOption> = [
+  { key: "ok", label: "OK", color: "#34d399" },
+  { key: "error", label: "Error", color: "#f87171" },
+];
+
+const BUCKETS: Array<HistogramBucket> = [
+  { time: FIRST_BUCKET, series: "ok", count: 12 },
+  { time: "2026-08-05T11:59:00Z", series: "error", count: 4 },
+  { time: LAST_BUCKET, series: "ok", count: 9 },
+];
+
+const ZOOM_OUT_HINT: string = "Double-click to zoom out";
+
+function bucketAt(time: string): HTMLElement {
+  return screen.getByTestId(`bucket-${time}`);
+}
+
+function tooltipActiveProp(): string | null {
+  return screen.getByTestId("tooltip").getAttribute("data-active");
+}
+
+interface RenderedHistogram {
+  onTimeRangeSelect: MockFunction;
+  onZoomOut: MockFunction;
+}
+
+function renderHistogram(
+  options: { canZoomOut?: boolean } = {},
+): RenderedHistogram {
+  const onTimeRangeSelect: MockFunction = getJestMockFunction();
+  const onZoomOut: MockFunction = getJestMockFunction();
+
+  render(
+    <TelemetryHistogram
+      buckets={BUCKETS}
+      series={SERIES}
+      isLoading={false}
+      onTimeRangeSelect={onTimeRangeSelect}
+      {...(options.canZoomOut ? { onZoomOut: onZoomOut } : {})}
+    />,
+  );
+
+  return { onTimeRangeSelect: onTimeRangeSelect, onZoomOut: onZoomOut };
+}
+
+describe("TelemetryHistogram — dragging out a time range", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("holds the tooltip shut for the length of the drag", () => {
+    renderHistogram();
+
+    expect(tooltipActiveProp()).toBe("undefined");
+
+    fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+    fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+
+    expect(tooltipActiveProp()).toBe("false");
+  });
+
+  test("gives the tooltip back when the reader lets go", () => {
+    renderHistogram();
+
+    fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+    fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+    fireEvent.mouseUp(bucketAt(LAST_BUCKET));
+
+    expect(tooltipActiveProp()).toBe("undefined");
+  });
+
+  test("gives the tooltip back when the pointer is released off the chart", () => {
+    renderHistogram();
+
+    fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+    fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+    fireEvent.mouseUp(document.body);
+
+    expect(tooltipActiveProp()).toBe("undefined");
+    expect(screen.queryByTestId("selection-band")).toBeNull();
+  });
+
+  test("reports the dragged window once", () => {
+    const { onTimeRangeSelect } = renderHistogram();
+
+    fireEvent.mouseDown(bucketAt(FIRST_BUCKET));
+    fireEvent.mouseMove(bucketAt(LAST_BUCKET));
+    fireEvent.mouseUp(bucketAt(LAST_BUCKET));
+
+    expect(onTimeRangeSelect).toHaveBeenCalledTimes(1);
+    const [start, end] = onTimeRangeSelect.mock.calls[0] as [Date, Date];
+    expect(start.toISOString()).toBe(new Date(FIRST_BUCKET).toISOString());
+    expect(end.toISOString()).toBe(new Date(LAST_BUCKET).toISOString());
+  });
+
+  test("zooms back out on a double-click", () => {
+    const { onZoomOut } = renderHistogram({ canZoomOut: true });
+
+    expect(screen.queryByText(ZOOM_OUT_HINT)).not.toBeNull();
+
+    fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  test("offers no way out while the chart is on its original window", () => {
+    renderHistogram();
+
+    expect(screen.queryByText(ZOOM_OUT_HINT)).toBeNull();
+
+    fireEvent.doubleClick(screen.getByTestId("bar-chart"));
+
+    expect(screen.queryByText(ZOOM_OUT_HINT)).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/UseHistogramZoom.test.tsx
+++ b/Common/Tests/UI/Components/UseHistogramZoom.test.tsx
@@ -1,0 +1,262 @@
+/** @timezone UTC */
+
+import useHistogramZoom, {
+  HistogramZoomOptions,
+  HistogramZoomState,
+} from "../../../UI/Components/Charts/Utils/useHistogramZoom";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+const PAST_HOUR: RangeStartAndEndDateTime = { range: TimeRange.PAST_ONE_HOUR };
+const PAST_DAY: RangeStartAndEndDateTime = { range: TimeRange.PAST_ONE_DAY };
+
+function customRange(start: string, end: string): RangeStartAndEndDateTime {
+  return {
+    range: TimeRange.CUSTOM,
+    startAndEndDate: new InBetween<Date>(new Date(start), new Date(end)),
+  };
+}
+
+const DRAGGED_START: Date = new Date("2026-08-05T11:58:00Z");
+const DRAGGED_END: Date = new Date("2026-08-05T12:00:00Z");
+
+interface ZoomHarness {
+  result: { current: HistogramZoomState };
+  rerender: (options: HistogramZoomOptions) => void;
+  onTimeRangeSelect: MockFunction;
+  onTimeRangeChange: MockFunction;
+  /** Drags a range out of the histogram, the way the chart would. */
+  dragZoom: () => void;
+  /** Double-clicks the chart, the way the chart would. */
+  zoomOut: () => void;
+  /** Picks a range from the toolbar, the way the picker would. */
+  pickTimeRange: (timeRange: RangeStartAndEndDateTime) => void;
+}
+
+function renderZoom(
+  timeRange: RangeStartAndEndDateTime | undefined = PAST_HOUR,
+): ZoomHarness {
+  const onTimeRangeSelect: MockFunction = getJestMockFunction();
+  const onTimeRangeChange: MockFunction = getJestMockFunction();
+
+  const { result, rerender } = renderHook(
+    (options: HistogramZoomOptions) => {
+      return useHistogramZoom(options);
+    },
+    {
+      initialProps: {
+        timeRange: timeRange,
+        onTimeRangeSelect: onTimeRangeSelect,
+        onTimeRangeChange: onTimeRangeChange,
+      } as HistogramZoomOptions,
+    },
+  );
+
+  return {
+    result: result,
+    rerender: rerender,
+    onTimeRangeSelect: onTimeRangeSelect,
+    onTimeRangeChange: onTimeRangeChange,
+    dragZoom: (): void => {
+      act(() => {
+        result.current.onTimeRangeSelect?.(DRAGGED_START, DRAGGED_END);
+      });
+    },
+    zoomOut: (): void => {
+      act(() => {
+        result.current.onZoomOut?.();
+      });
+    },
+    pickTimeRange: (next: RangeStartAndEndDateTime): void => {
+      act(() => {
+        result.current.onTimeRangeChange?.(next);
+      });
+    },
+  };
+}
+
+describe("useHistogramZoom", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("before anything has been zoomed", () => {
+    test("offers no way out, because there is nowhere to go back to", () => {
+      const { result } = renderZoom();
+
+      expect(result.current.onZoomOut).toBeUndefined();
+    });
+
+    test("still passes a dragged range straight through to the host", () => {
+      const { dragZoom, onTimeRangeSelect } = renderZoom();
+
+      dragZoom();
+
+      expect(onTimeRangeSelect).toHaveBeenCalledWith(
+        DRAGGED_START,
+        DRAGGED_END,
+      );
+    });
+  });
+
+  describe("after a drag-zoom", () => {
+    test("offers a way back out", () => {
+      const { dragZoom, result } = renderZoom();
+
+      dragZoom();
+
+      expect(result.current.onZoomOut).toBeDefined();
+    });
+
+    test("restores the window the reader started on", () => {
+      const { dragZoom, zoomOut, onTimeRangeChange } = renderZoom(PAST_DAY);
+
+      dragZoom();
+      zoomOut();
+
+      expect(onTimeRangeChange).toHaveBeenCalledTimes(1);
+      expect(onTimeRangeChange).toHaveBeenCalledWith(PAST_DAY);
+    });
+
+    test("restores a custom window just as faithfully", () => {
+      const original: RangeStartAndEndDateTime = customRange(
+        "2026-08-05T00:00:00Z",
+        "2026-08-05T23:59:00Z",
+      );
+      const { dragZoom, zoomOut, onTimeRangeChange } = renderZoom(original);
+
+      dragZoom();
+      zoomOut();
+
+      expect(onTimeRangeChange).toHaveBeenCalledWith(original);
+    });
+
+    test("takes the way out away again once it has been used", () => {
+      const { dragZoom, zoomOut, result } = renderZoom();
+
+      dragZoom();
+      zoomOut();
+
+      expect(result.current.onZoomOut).toBeUndefined();
+    });
+  });
+
+  /*
+   * Drilling down twice is normal: an hour to a minute, a minute to ten
+   * seconds. One double-click has to return the whole hour, not the minute
+   * on the way — "zoom out to the original", as the report puts it.
+   */
+  describe("after drilling down more than once", () => {
+    test("still returns the window the reader started from", () => {
+      const harness: ZoomHarness = renderZoom(PAST_DAY);
+
+      harness.dragZoom();
+      // The host applies the dragged window, so the hook sees it next render.
+      harness.rerender({
+        timeRange: customRange("2026-08-05T11:58:00Z", "2026-08-05T12:00:00Z"),
+        onTimeRangeSelect: harness.onTimeRangeSelect,
+        onTimeRangeChange: harness.onTimeRangeChange,
+      });
+      harness.dragZoom();
+
+      harness.zoomOut();
+
+      expect(harness.onTimeRangeChange).toHaveBeenCalledTimes(1);
+      expect(harness.onTimeRangeChange).toHaveBeenCalledWith(PAST_DAY);
+    });
+  });
+
+  /*
+   * Picking a range anywhere else is the reader choosing a new starting
+   * point. Holding on to the old one would send a later double-click to a
+   * window they had already moved on from.
+   */
+  describe("when the range is changed by other means", () => {
+    test("forgets the remembered window", () => {
+      const { dragZoom, pickTimeRange, result } = renderZoom(PAST_DAY);
+
+      dragZoom();
+      pickTimeRange(PAST_HOUR);
+
+      expect(result.current.onZoomOut).toBeUndefined();
+    });
+
+    test("passes the picked range on to the host untouched", () => {
+      const { pickTimeRange, onTimeRangeChange } = renderZoom();
+
+      pickTimeRange(PAST_DAY);
+
+      expect(onTimeRangeChange).toHaveBeenCalledWith(PAST_DAY);
+    });
+
+    test("remembers the new starting point on the next drag", () => {
+      const harness: ZoomHarness = renderZoom(PAST_DAY);
+
+      harness.dragZoom();
+      harness.pickTimeRange(PAST_HOUR);
+      harness.rerender({
+        timeRange: PAST_HOUR,
+        onTimeRangeSelect: harness.onTimeRangeSelect,
+        onTimeRangeChange: harness.onTimeRangeChange,
+      });
+      harness.dragZoom();
+      harness.zoomOut();
+
+      expect(harness.onTimeRangeChange).toHaveBeenLastCalledWith(PAST_HOUR);
+    });
+  });
+
+  describe("hosts that wire up only part of this", () => {
+    test("a host with no time range gets no zoom-out to offer", () => {
+      const onTimeRangeSelect: MockFunction = getJestMockFunction();
+      const onTimeRangeChange: MockFunction = getJestMockFunction();
+
+      const { result } = renderHook(() => {
+        return useHistogramZoom({
+          onTimeRangeSelect: onTimeRangeSelect,
+          onTimeRangeChange: onTimeRangeChange,
+        });
+      });
+
+      act(() => {
+        result.current.onTimeRangeSelect?.(DRAGGED_START, DRAGGED_END);
+      });
+
+      // The drag still applies; there is simply no window to hand back.
+      expect(onTimeRangeSelect).toHaveBeenCalled();
+      expect(result.current.onZoomOut).toBeUndefined();
+    });
+
+    test("a host with no select handler leaves the chart unzoomable", () => {
+      const { result } = renderHook(() => {
+        return useHistogramZoom({ timeRange: PAST_HOUR });
+      });
+
+      expect(result.current.onTimeRangeSelect).toBeUndefined();
+      expect(result.current.onZoomOut).toBeUndefined();
+      expect(result.current.onTimeRangeChange).toBeUndefined();
+    });
+
+    test("a host that cannot apply a range change offers no zoom-out", () => {
+      const onTimeRangeSelect: MockFunction = getJestMockFunction();
+
+      const { result } = renderHook(() => {
+        return useHistogramZoom({
+          timeRange: PAST_HOUR,
+          onTimeRangeSelect: onTimeRangeSelect,
+        });
+      });
+
+      act(() => {
+        result.current.onTimeRangeSelect?.(DRAGGED_START, DRAGGED_END);
+      });
+
+      expect(onTimeRangeSelect).toHaveBeenCalled();
+      expect(result.current.onZoomOut).toBeUndefined();
+    });
+  });
+});

--- a/Common/UI/Components/Charts/Utils/useHistogramZoom.ts
+++ b/Common/UI/Components/Charts/Utils/useHistogramZoom.ts
@@ -1,0 +1,101 @@
+import { useCallback, useState } from "react";
+import RangeStartAndEndDateTime from "../../../../Types/Time/RangeStartAndEndDateTime";
+
+export interface HistogramZoomOptions {
+  /** The window the explorer is showing right now. */
+  timeRange?: RangeStartAndEndDateTime | undefined;
+  /** Applies a range the reader dragged out on the histogram. */
+  onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  /** Applies a range picked anywhere else (the toolbar picker, a reset). */
+  onTimeRangeChange?:
+    | ((timeRange: RangeStartAndEndDateTime) => void)
+    | undefined;
+}
+
+export interface HistogramZoomState {
+  /** Hand to the histogram in place of the raw select handler. */
+  onTimeRangeSelect: ((startTime: Date, endTime: Date) => void) | undefined;
+  /**
+   * Hand to the histogram: set only while a drag-zoom is in effect, so the
+   * chart can both offer the affordance and act on a double-click.
+   */
+  onZoomOut: (() => void) | undefined;
+  /** Hand to the time range picker in place of the raw change handler. */
+  onTimeRangeChange:
+    | ((timeRange: RangeStartAndEndDateTime) => void)
+    | undefined;
+}
+
+export type UseHistogramZoomFunction = (
+  options: HistogramZoomOptions,
+) => HistogramZoomState;
+
+/**
+ * Remembers the window a reader was on before they dragged a zoom out of the
+ * histogram, so a double-click can put them back on it.
+ *
+ * Only the *first* zoom is remembered: after drilling from "past one hour"
+ * into a minute and then into ten seconds, one double-click returns the whole
+ * hour rather than making the reader climb back out a level at a time. Any
+ * time range picked by other means — the toolbar picker, a saved view — is
+ * the reader choosing a new starting point, so it forgets what it held and
+ * the zoom-out affordance goes away until the next drag.
+ */
+const useHistogramZoom: UseHistogramZoomFunction = (
+  options: HistogramZoomOptions,
+): HistogramZoomState => {
+  const [rangeBeforeZoom, setRangeBeforeZoom] =
+    useState<RangeStartAndEndDateTime | null>(null);
+
+  const timeRange: RangeStartAndEndDateTime | undefined = options.timeRange;
+  const onTimeRangeSelect:
+    | ((startTime: Date, endTime: Date) => void)
+    | undefined = options.onTimeRangeSelect;
+  const onTimeRangeChange:
+    | ((timeRange: RangeStartAndEndDateTime) => void)
+    | undefined = options.onTimeRangeChange;
+
+  const handleTimeRangeSelect: (startTime: Date, endTime: Date) => void =
+    useCallback(
+      (startTime: Date, endTime: Date): void => {
+        if (!onTimeRangeSelect) {
+          return;
+        }
+
+        if (timeRange) {
+          setRangeBeforeZoom((current: RangeStartAndEndDateTime | null) => {
+            return current || timeRange;
+          });
+        }
+
+        onTimeRangeSelect(startTime, endTime);
+      },
+      [onTimeRangeSelect, timeRange],
+    );
+
+  const handleZoomOut: () => void = useCallback((): void => {
+    if (!rangeBeforeZoom || !onTimeRangeChange) {
+      return;
+    }
+
+    setRangeBeforeZoom(null);
+    onTimeRangeChange(rangeBeforeZoom);
+  }, [rangeBeforeZoom, onTimeRangeChange]);
+
+  const handleTimeRangeChange: (timeRange: RangeStartAndEndDateTime) => void =
+    useCallback(
+      (nextTimeRange: RangeStartAndEndDateTime): void => {
+        setRangeBeforeZoom(null);
+        onTimeRangeChange?.(nextTimeRange);
+      },
+      [onTimeRangeChange],
+    );
+
+  return {
+    onTimeRangeSelect: onTimeRangeSelect ? handleTimeRangeSelect : undefined,
+    onZoomOut: rangeBeforeZoom && onTimeRangeChange ? handleZoomOut : undefined,
+    onTimeRangeChange: onTimeRangeChange ? handleTimeRangeChange : undefined,
+  };
+};
+
+export default useHistogramZoom;

--- a/Common/UI/Components/LogsViewer/LogsViewer.tsx
+++ b/Common/UI/Components/LogsViewer/LogsViewer.tsx
@@ -66,6 +66,9 @@ import ProjectUtil from "../../Utils/Project";
 import TelemetryServiceUtil from "../../Utils/TelemetryService";
 import ObjectID from "../../../Types/ObjectID";
 import OneUptimeDate from "../../../Types/Date";
+import useHistogramZoom, {
+  HistogramZoomState,
+} from "../Charts/Utils/useHistogramZoom";
 
 export interface ComponentProps {
   logs: Array<Log>;
@@ -281,6 +284,18 @@ const LogsViewer: FunctionComponent<ComponentProps> = (
 
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] =
     useState<boolean>(false);
+
+  /*
+   * Drag-zooming the histogram is a one-way trip on its own: it swaps the
+   * window for a custom one and nothing remembers what the reader was
+   * looking at. This keeps that window so a double-click on the chart can
+   * hand it back.
+   */
+  const histogramZoom: HistogramZoomState = useHistogramZoom({
+    timeRange: props.timeRange,
+    onTimeRangeSelect: props.onHistogramTimeRangeSelect,
+    onTimeRangeChange: props.onTimeRangeChange,
+  });
 
   useEffect(() => {
     setFilterData(props.filterData);
@@ -1074,10 +1089,10 @@ const LogsViewer: FunctionComponent<ComponentProps> = (
       exportLogs(displayedLogs, LogExportFormat.JSON, selectedColumns);
     },
     ...(props.liveOptions ? { liveOptions: props.liveOptions } : {}),
-    ...(props.timeRange && props.onTimeRangeChange
+    ...(props.timeRange && histogramZoom.onTimeRangeChange
       ? {
           timeRange: props.timeRange,
-          onTimeRangeChange: props.onTimeRangeChange,
+          onTimeRangeChange: histogramZoom.onTimeRangeChange,
         }
       : {}),
     showKeyboardShortcuts,
@@ -1130,7 +1145,8 @@ const LogsViewer: FunctionComponent<ComponentProps> = (
         <LogsHistogram
           buckets={props.histogramBuckets}
           isLoading={props.histogramLoading || false}
-          onTimeRangeSelect={props.onHistogramTimeRangeSelect}
+          onTimeRangeSelect={histogramZoom.onTimeRangeSelect}
+          onZoomOut={histogramZoom.onZoomOut}
         />
       )}
 

--- a/Common/UI/Components/LogsViewer/components/LogsHistogram.tsx
+++ b/Common/UI/Components/LogsViewer/components/LogsHistogram.tsx
@@ -1,6 +1,7 @@
 import React, {
   FunctionComponent,
   ReactElement,
+  useEffect,
   useMemo,
   useCallback,
   useRef,
@@ -29,6 +30,12 @@ export interface LogsHistogramProps {
   buckets: Array<HistogramBucket>;
   isLoading: boolean;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  /*
+   * Set only while the chart is showing a window the reader dragged out of
+   * it. Double-clicking the chart then puts them back on the window they
+   * started from.
+   */
+  onZoomOut?: (() => void) | undefined;
 }
 
 interface PivotedRow {
@@ -86,6 +93,12 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
   const [selectionStart, setSelectionStart] = useState<string | null>(null);
   const [selectionEnd, setSelectionEnd] = useState<string | null>(null);
   const isSelecting: React.MutableRefObject<boolean> = useRef(false);
+  /*
+   * Mirrors isSelecting for rendering. The ref stays the authority so a
+   * mouseup handled twice (chart *and* window, below) cannot commit the same
+   * drag twice; the state is only here so the drag can change what is drawn.
+   */
+  const [isDragging, setIsDragging] = useState<boolean>(false);
 
   const pivotedData: Array<PivotedRow> = useMemo(() => {
     return pivotBuckets(props.buckets);
@@ -110,6 +123,7 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
       }
 
       isSelecting.current = true;
+      setIsDragging(true);
       setSelectionStart(e.activeLabel as string);
       setSelectionEnd(null);
     },
@@ -132,12 +146,14 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
       !props.onTimeRangeSelect
     ) {
       isSelecting.current = false;
+      setIsDragging(false);
       setSelectionStart(null);
       setSelectionEnd(null);
       return;
     }
 
     isSelecting.current = false;
+    setIsDragging(false);
 
     const start: Date = OneUptimeDate.fromString(selectionStart);
     const end: Date = OneUptimeDate.fromString(selectionEnd);
@@ -156,6 +172,28 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
     setSelectionStart(null);
     setSelectionEnd(null);
   }, [selectionStart, selectionEnd, props.onTimeRangeSelect]);
+
+  /*
+   * Readers routinely drag past the edge of a 120px-tall chart and let go
+   * outside it, where the chart's own mouseup never fires. Without this the
+   * drag would never end: the selection band would stay painted and the
+   * tooltip would stay suppressed until the next click.
+   */
+  useEffect(() => {
+    if (!isDragging) {
+      return undefined;
+    }
+
+    const finishDragOutsideChart: () => void = (): void => {
+      handleMouseUp();
+    };
+
+    window.addEventListener("mouseup", finishDragOutsideChart);
+
+    return () => {
+      window.removeEventListener("mouseup", finishDragOutsideChart);
+    };
+  }, [isDragging, handleMouseUp]);
 
   if (props.isLoading && pivotedData.length === 0) {
     return (
@@ -178,6 +216,11 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
           {props.onTimeRangeSelect && (
             <span className="text-[10px] text-gray-300">Drag to zoom</span>
           )}
+          {props.onZoomOut && (
+            <span className="text-[10px] text-gray-300">
+              Double-click to zoom out
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-3">
           {activeSeverities.map((severity: string) => {
@@ -197,11 +240,12 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
 
       {/* Chart */}
       <div
-        className="px-2 pb-1 pt-2"
+        className="select-none px-2 pb-1 pt-2"
         style={{
           height: 120,
           cursor: props.onTimeRangeSelect ? "crosshair" : "default",
         }}
+        onDoubleClick={props.onZoomOut}
       >
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
@@ -237,9 +281,16 @@ const LogsHistogram: FunctionComponent<LogsHistogramProps> = (
               allowDecimals={false}
               tickFormatter={formatYAxisTick}
             />
+            {/*
+             * The tooltip is pinned shut for the length of a drag: it would
+             * otherwise sit over the very bars the reader is trying to read
+             * while they pick the range. Dropping the prop hands control back
+             * to recharts once the drag ends.
+             */}
             <Tooltip
               content={<HistogramTooltip />}
               cursor={{ fill: "rgba(99,102,241,0.06)" }}
+              {...(isDragging ? { active: false } : {})}
             />
             {activeSeverities.map((severity: string, index: number) => {
               const isLast: boolean = index === activeSeverities.length - 1;

--- a/Common/UI/Components/TelemetryViewer/TelemetryViewer.tsx
+++ b/Common/UI/Components/TelemetryViewer/TelemetryViewer.tsx
@@ -21,6 +21,9 @@ import ComponentLoader from "../ComponentLoader/ComponentLoader";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import Icon from "../Icon/Icon";
 import IconProp from "../../../Types/Icon/IconProp";
+import useHistogramZoom, {
+  HistogramZoomState,
+} from "../Charts/Utils/useHistogramZoom";
 
 export interface TelemetryViewerProps<T> {
   // -- Data --
@@ -132,6 +135,18 @@ function TelemetryViewerInner<T>(props: TelemetryViewerProps<T>): ReactElement {
 
   const showHistogram: boolean = props.showHistogram ?? true;
 
+  /*
+   * Drag-zooming the histogram is a one-way trip on its own: it swaps the
+   * window for a custom one and nothing remembers what the reader was
+   * looking at. This keeps that window so a double-click on the chart can
+   * hand it back.
+   */
+  const histogramZoom: HistogramZoomState = useHistogramZoom({
+    timeRange: props.timeRange,
+    onTimeRangeSelect: props.onHistogramTimeRangeSelect,
+    onTimeRangeChange: props.onTimeRangeChange,
+  });
+
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col gap-3">
       {/* Toolbar */}
@@ -160,7 +175,7 @@ function TelemetryViewerInner<T>(props: TelemetryViewerProps<T>): ReactElement {
 
         <TelemetryTimeRangePicker
           value={props.timeRange}
-          onChange={props.onTimeRangeChange}
+          onChange={histogramZoom.onTimeRangeChange || props.onTimeRangeChange}
         />
 
         {props.live && (
@@ -231,7 +246,8 @@ function TelemetryViewerInner<T>(props: TelemetryViewerProps<T>): ReactElement {
             isLoading={props.histogramLoading || false}
             series={props.histogramSeries}
             title={props.histogramTitle}
-            onTimeRangeSelect={props.onHistogramTimeRangeSelect}
+            onTimeRangeSelect={histogramZoom.onTimeRangeSelect}
+            onZoomOut={histogramZoom.onZoomOut}
             headerActions={props.histogramHeaderActions}
             valueFormatter={props.histogramValueFormatter}
           />

--- a/Common/UI/Components/TelemetryViewer/components/TelemetryHistogram.tsx
+++ b/Common/UI/Components/TelemetryViewer/components/TelemetryHistogram.tsx
@@ -2,6 +2,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   ReactNode,
+  useEffect,
   useMemo,
   useCallback,
   useRef,
@@ -31,6 +32,12 @@ export interface TelemetryHistogramProps {
   series: Array<HistogramSeriesOption>;
   title?: string | undefined;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  /*
+   * Set only while the chart is showing a window the reader dragged out of
+   * it. Double-clicking the chart then puts them back on the window they
+   * started from.
+   */
+  onZoomOut?: (() => void) | undefined;
   // Extra controls rendered in the chart header (e.g. a metric selector).
   headerActions?: ReactNode;
   // Formats Y-axis ticks and tooltip values (e.g. milliseconds → "1.2 s").
@@ -91,6 +98,12 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
   const [selectionStart, setSelectionStart] = useState<string | null>(null);
   const [selectionEnd, setSelectionEnd] = useState<string | null>(null);
   const isSelecting: React.MutableRefObject<boolean> = useRef(false);
+  /*
+   * Mirrors isSelecting for rendering. The ref stays the authority so a
+   * mouseup handled twice (chart *and* window, below) cannot commit the same
+   * drag twice; the state is only here so the drag can change what is drawn.
+   */
+  const [isDragging, setIsDragging] = useState<boolean>(false);
 
   const pivotedData: Array<PivotedRow> = useMemo(() => {
     return pivotBuckets(props.buckets);
@@ -123,6 +136,7 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
       }
 
       isSelecting.current = true;
+      setIsDragging(true);
       setSelectionStart(e.activeLabel as string);
       setSelectionEnd(null);
     },
@@ -145,12 +159,14 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
       !props.onTimeRangeSelect
     ) {
       isSelecting.current = false;
+      setIsDragging(false);
       setSelectionStart(null);
       setSelectionEnd(null);
       return;
     }
 
     isSelecting.current = false;
+    setIsDragging(false);
 
     const start: Date = OneUptimeDate.fromString(selectionStart);
     const end: Date = OneUptimeDate.fromString(selectionEnd);
@@ -169,6 +185,28 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
     setSelectionStart(null);
     setSelectionEnd(null);
   }, [selectionStart, selectionEnd, props.onTimeRangeSelect]);
+
+  /*
+   * Readers routinely drag past the edge of a 120px-tall chart and let go
+   * outside it, where the chart's own mouseup never fires. Without this the
+   * drag would never end: the selection band would stay painted and the
+   * tooltip would stay suppressed until the next click.
+   */
+  useEffect(() => {
+    if (!isDragging) {
+      return undefined;
+    }
+
+    const finishDragOutsideChart: () => void = (): void => {
+      handleMouseUp();
+    };
+
+    window.addEventListener("mouseup", finishDragOutsideChart);
+
+    return () => {
+      window.removeEventListener("mouseup", finishDragOutsideChart);
+    };
+  }, [isDragging, handleMouseUp]);
 
   if (props.isLoading && pivotedData.length === 0) {
     return (
@@ -197,6 +235,11 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
           {props.onTimeRangeSelect && (
             <span className="text-[10px] text-gray-300">Drag to zoom</span>
           )}
+          {props.onZoomOut && (
+            <span className="text-[10px] text-gray-300">
+              Double-click to zoom out
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-3">
           {activeSeries.map((option: HistogramSeriesOption) => {
@@ -223,11 +266,12 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
 
       {pivotedData.length > 0 && (
         <div
-          className="px-2 pb-1 pt-2"
+          className="select-none px-2 pb-1 pt-2"
           style={{
             height: 120,
             cursor: props.onTimeRangeSelect ? "crosshair" : "default",
           }}
+          onDoubleClick={props.onZoomOut}
         >
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
@@ -263,6 +307,12 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
                 allowDecimals={Boolean(props.valueFormatter)}
                 tickFormatter={props.valueFormatter || formatYAxisTick}
               />
+              {/*
+               * The tooltip is pinned shut for the length of a drag: it would
+               * otherwise sit over the very bars the reader is trying to read
+               * while they pick the range. Dropping the prop hands control back
+               * to recharts once the drag ends.
+               */}
               <Tooltip
                 content={
                   <TelemetryHistogramTooltip
@@ -271,6 +321,7 @@ const TelemetryHistogram: FunctionComponent<TelemetryHistogramProps> = (
                   />
                 }
                 cursor={{ fill: "rgba(99,102,241,0.06)" }}
+                {...(isDragging ? { active: false } : {})}
               />
               {activeSeries.map(
                 (option: HistogramSeriesOption, index: number) => {


### PR DESCRIPTION
Fixes #3466.

## The report

Scrubbing the log volume chart to pick a time range left the hover tooltip parked over the bars — hiding the very volumes the reader was dragging across to choose the range — with nothing to dismiss it. The reporter also asked for a way to get back out of a zoom, "like Grafana does with their charts".

## What changed

**The tooltip lets go for the length of a drag.** `LogsHistogram` and `TelemetryHistogram` now pass `active: false` to recharts' `Tooltip` while a selection is in progress and drop the prop the moment the drag ends, handing control back to recharts. The selection band stays, so the reader can still see what they are picking.

A page-wide `mouseup` listener is attached for the length of the drag. Readers routinely drag past the edge of a 120px-tall chart and let go somewhere else on the page, where the chart's own `mouseup` never fires — that is exactly the stuck tooltip in the report. The drag now ends wherever the pointer is released, and the range it covered is still applied. The chart's own `mouseup` still fires first for a release inside it; a ref guards the commit so one drag cannot zoom twice.

**Double-click zooms back out.** New `useHistogramZoom` hook, used by both `LogsViewer` and `TelemetryViewer`, remembers the window the reader was on before their first drag-zoom and hands it back on a double-click. The *first* window is what is kept, so drilling from "past one hour" into a minute and then into ten seconds returns the whole hour in one double-click rather than making the reader climb back out a level at a time. Picking a range anywhere else — the toolbar picker, a saved view — is the reader choosing a new starting point, so the hook forgets what it held and the "Double-click to zoom out" hint goes away until the next drag.

Both volume charts are covered: the log volume histogram, and the traces / exceptions volume chart that shares its behaviour. The metrics explorer passes `showHistogram={false}` and the investigation drawer's read-only histogram takes no zoom handlers, so neither is affected.

## Tests

43 new tests across four files, all passing:

- `LogsHistogramDragTooltip.test.tsx` — the tooltip through a whole drag (before, during, on release, on release *outside* the chart, after a click that selected nothing, and on a chart that cannot be zoomed); the selection band; the range handed to the parent, including right-to-left drags, drags that ended off the chart, and the one-drag-one-zoom guard against the release being seen twice; double-click behaviour, including that a double-click's own clicks never read as a drag.
- `TelemetryHistogramDragTooltip.test.tsx` — the same behaviour on the traces / exceptions chart.
- `UseHistogramZoom.test.tsx` — what is remembered and when: nothing before a zoom, the original window after one or several drills, forgotten when the range changes by other means, spent once used, and the partial wirings (no time range, no select handler, no change handler).
- `LogsViewerHistogramZoom.test.tsx` — the wiring itself, through the real `LogsViewer`: a drag still reaches the host, the affordance appears only after a zoom, and a double-click restores the exact window the reader came from.

Recharts resolves a pointer to a bucket from real layout — a bounding rect, an animation frame — none of which jsdom provides, so the interaction tests stand the chart in with a component that hands each bucket a hit target and calls the same handlers recharts would. The existing `LogsHistogram.test.tsx`, which renders the real chart, still passes untouched.

`npx tsc --noEmit` is clean in both `Common` and `App`; eslint is clean on every changed file.