### PR TITLE
fix(telemetry): don't create phantom Service rows from agent infra metrics (issue #3468)

### DIFF
--- a/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
@@ -481,6 +481,49 @@ export default abstract class OtelIngestBaseService {
   }
 
   /*
+   * Phantom-service gate (issue #3468): whether a batch is allowed to back a
+   * Service row.
+   *
+   * OneUptime infrastructure agents (Kubernetes / Docker / Podman / Proxmox /
+   * Ceph / host collectors) stamp an explicit service.name on every metric
+   * batch they emit - `kubernetes-agent-<cluster>` by default, or a workload
+   * name via the collector's transform processor - so the infra signal
+   * survives the discriminator above. Honouring that stamped name synthesizes
+   * a Service row that stays "Connected" via lastSeenAt but never receives
+   * requests / latency / logs / errors.
+   *
+   * Returns false (route to the discovered Host / KubernetesCluster entity
+   * instead) only when ALL three hold:
+   *
+   *   1. the METRICS path flagged the batch as infrastructure metric families
+   *      (data.isInfraMetricBatch - k8s.* / system.* / process.*). Logs,
+   *      traces, OBI RED metrics and Docker container metrics are never
+   *      flagged, so their legitimate service attribution is untouched;
+   *   2. it carries the agent marker `oneuptime.agent.version` - application
+   *      SDKs never set this;
+   *   3. it has a host / k8s resource signal (os.type, container.runtime or
+   *      k8s.cluster.name).
+   */
+  protected static shouldCreateServiceRow(data: {
+    isInfraMetricBatch?: boolean | undefined;
+    attributes: JSONArray;
+  }): boolean {
+    if (!data.isInfraMetricBatch) {
+      return true;
+    }
+
+    const hasAgentMarker: boolean =
+      this.getStringAttribute(data.attributes, "oneuptime.agent.version") !==
+      null;
+
+    if (!hasAgentMarker) {
+      return true;
+    }
+
+    return !this.hasHostResourceSignal(data.attributes);
+  }
+
+  /*
    * One-stop resolver used by every OTel / syslog / fluent ingest
    * path. Takes the already-discovered Host / DockerHost /
    * KubernetesCluster ids for this batch and dispatches:
@@ -544,6 +587,13 @@ export default abstract class OtelIngestBaseService {
      * falls back to its heuristic resolvers otherwise.
      */
     entityRefs?: Array<ResourceEntityRef> | undefined;
+    /*
+     * Set by the METRICS ingest when this resource's metric families are
+     * infrastructure (k8s.* / system.* / process.*). Feeds the
+     * phantom-service gate in selectPrimaryEntity (issue #3468); the logs,
+     * traces and profiles paths leave it unset and are unaffected.
+     */
+    isInfraMetricBatch?: boolean | undefined;
   }): Promise<TelemetryServiceMetadata> {
     /*
      * (a) pick the single primary entity via the precedence ladder — the
@@ -660,13 +710,25 @@ export default abstract class OtelIngestBaseService {
     cloudResourceId?: ObjectID | null;
     rumApplicationId?: ObjectID | null;
     iotFleetId?: ObjectID | null;
+    isInfraMetricBatch?: boolean | undefined;
   }): Promise<TelemetryServiceMetadata> {
     const serviceName: string | null = await this.getServiceNameFromAttributes(
       data.req,
       data.attributes,
     );
 
-    if (serviceName !== null) {
+    /*
+     * Phantom-service gate (issue #3468): infra agent metric batches carry an
+     * agent-stamped service.name that would otherwise synthesize a Service row
+     * which stays "Connected" via lastSeenAt but never receives requests /
+     * latency / logs / errors. See shouldCreateServiceRow for the conditions.
+     */
+    const shouldCreateServiceRow: boolean = this.shouldCreateServiceRow({
+      isInfraMetricBatch: data.isInfraMetricBatch,
+      attributes: data.attributes,
+    });
+
+    if (serviceName !== null && shouldCreateServiceRow) {
       return await OTelIngestService.telemetryServiceFromName({
         serviceName,
         projectId: data.projectId,
@@ -3199,6 +3261,47 @@ export default abstract class OtelIngestBaseService {
         }`,
       );
     }
+  }
+
+  /*
+   * Whether a resource's metric families are infrastructure telemetry
+   * (kubeletstats k8s.*, hostmetrics system.* / process.*). The METRICS ingest
+   * uses this to flag agent infra batches so the phantom-service gate in
+   * selectPrimaryEntity routes them to their Host / KubernetesCluster entity
+   * instead of synthesising a Service row (issue #3468). Deliberately narrow:
+   * container.* / http.* / rpc.* families are NOT flagged, so Docker agent
+   * container services and OBI RED metrics keep their Service rows.
+   */
+  protected static isInfraMetricBatch(
+    scopeMetrics: JSONArray | undefined,
+  ): boolean {
+    if (!scopeMetrics || !Array.isArray(scopeMetrics)) {
+      return false;
+    }
+
+    for (const scopeMetric of scopeMetrics) {
+      const metrics: JSONArray | undefined = (scopeMetric as JSONObject)?.[
+        "metrics"
+      ] as JSONArray | undefined;
+      if (!metrics || !Array.isArray(metrics)) {
+        continue;
+      }
+
+      for (const metric of metrics) {
+        const name: string = (
+          ((metric as JSONObject)["name"] as string) || ""
+        ).toLowerCase();
+        if (
+          name.startsWith("k8s.") ||
+          name.startsWith("system.") ||
+          name.startsWith("process.")
+        ) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
@@ -924,6 +924,13 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
               cloudResourceId,
               rumApplicationId,
               entityRefs: resourceEntityRefs,
+              /*
+               * Flag OneUptime agent infra metric batches (kubeletstats k8s.*,
+               * hostmetrics system.* / process.*) so selectPrimaryEntity routes
+               * them to their Host / KubernetesCluster entity instead of
+               * synthesising a phantom Service row (issue #3468).
+               */
+              isInfraMetricBatch: this.isInfraMetricBatch(scopeMetricsForScan),
             });
           const serviceName: string = serviceMetadata.serviceName;
 

--- a/App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts
+++ b/App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts
@@ -1,0 +1,265 @@
+/*
+ * Regression tests for issue #3468 - "Dozens of auto-created services
+ * (pd-*, kubernetes-agent-*, etc.) have no owners and never receive any
+ * telemetry data".
+ *
+ * The OneUptime Kubernetes agent's OTel collectors stamp an explicit
+ * service.name on every infrastructure metric batch it emits
+ * (`kubernetes-agent-<cluster>` by default, or a workload name via the
+ * collector's transform processor). Before this fix the metrics ingest
+ * honoured that stamped name, so `findOrCreateTelemetryService` synthesised a
+ * Service row for every infra batch - a row that stays "Connected" via
+ * lastSeenAt but never receives requests / latency / logs / errors.
+ *
+ * This suite pins the two new predicates that route those batches to their
+ * Host / KubernetesCluster entity instead:
+ *
+ *   - OtelIngestBaseService.isInfraMetricBatch      - infra metric families
+ *   - OtelIngestBaseService.shouldCreateServiceRow  - the phantom-service gate
+ *
+ * Same import strategy as Common/Tests/Server/Services/
+ * OpenTelemetryResourceRetentionMemo.test.ts: PasswordHash carries a TS5.9
+ * diagnostic that fails any suite whose require graph reaches DatabaseService
+ * (the base class of every concrete service this module imports), so it is
+ * replaced with a factory mock.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+import OtelIngestBaseService from "../../FeatureSet/Telemetry/Services/OtelIngestBaseService";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+class OtelIngestBaseServiceHarness extends OtelIngestBaseService {
+  public static isInfraMetricBatchPublic(
+    scopeMetrics: JSONArray | undefined,
+  ): boolean {
+    return this.isInfraMetricBatch(scopeMetrics);
+  }
+
+  public static shouldCreateServiceRowPublic(data: {
+    isInfraMetricBatch?: boolean | undefined;
+    attributes: JSONArray;
+  }): boolean {
+    return this.shouldCreateServiceRow(data);
+  }
+}
+
+function stringAttr(key: string, value: string): JSONObject {
+  return { key, value: { stringValue: value } };
+}
+
+function scopeMetrics(names: Array<string>): JSONArray {
+  const metrics: Array<JSONObject> = names.map((name: string) => {
+    return { name };
+  });
+  return [
+    {
+      scope: {},
+      metrics: metrics,
+    } as unknown as JSONObject,
+  ] as JSONArray;
+}
+
+describe("OtelIngestBaseService.isInfraMetricBatch", () => {
+  test("flags kubeletstats k8s.* metric families", () => {
+    const infra: boolean =
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic(
+        scopeMetrics([
+          "k8s.pod.cpu.usage",
+          "k8s.node.memory.usage",
+          "k8s.container.cpu.usage",
+        ]),
+      );
+    expect(infra).toBe(true);
+  });
+
+  test("flags hostmetrics system.* and process.* families", () => {
+    expect(
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic(
+        scopeMetrics(["system.cpu.utilization", "system.memory.usage"]),
+      ),
+    ).toBe(true);
+    expect(
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic(
+        scopeMetrics(["process.cpu.time", "process.memory.usage"]),
+      ),
+    ).toBe(true);
+  });
+
+  test("does NOT flag app / Docker / OBI families", () => {
+    expect(
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic(
+        scopeMetrics([
+          "http.server.request.duration",
+          "rpc.client.duration",
+          "db.client.operation.duration",
+        ]),
+      ),
+    ).toBe(false);
+    expect(
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic(
+        scopeMetrics(["container.cpu.usage.seconds", "container.memory.usage"]),
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for empty or missing scope metrics", () => {
+    expect(
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic(undefined),
+    ).toBe(false);
+    expect(OtelIngestBaseServiceHarness.isInfraMetricBatchPublic([])).toBe(
+      false,
+    );
+    expect(
+      OtelIngestBaseServiceHarness.isInfraMetricBatchPublic([
+        { scope: {} } as unknown as JSONObject,
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("OtelIngestBaseService.shouldCreateServiceRow (phantom-service gate)", () => {
+  test("returns true when the batch was not flagged as infra metrics", () => {
+    const appAttrs: JSONArray = [
+      stringAttr("service.name", "my-api"),
+      stringAttr("telemetry.sdk.language", "nodejs"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: false,
+        attributes: appAttrs,
+      }),
+    ).toBe(true);
+    // Unset flag (logs / traces / profiles paths) never triggers the gate.
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        attributes: appAttrs,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true when an infra batch lacks the OneUptime agent marker", () => {
+    // An app in a pod shipping k8s.* infra-looking families but no agent marker.
+    const attrs: JSONArray = [
+      stringAttr("service.name", "my-api"),
+      stringAttr("k8s.cluster.name", "wbmonclusk8"),
+      stringAttr("k8s.node.name", "node-1"),
+      stringAttr("telemetry.sdk.language", "nodejs"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: true,
+        attributes: attrs,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true when an infra agent batch has no host/k8s resource signal", () => {
+    const attrs: JSONArray = [
+      stringAttr("service.name", "kubernetes-agent-edge"),
+      stringAttr("oneuptime.agent.version", "1.0.0"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: true,
+        attributes: attrs,
+      }),
+    ).toBe(true);
+  });
+
+  test("THE BUG - returns false for a OneUptime agent kubeletstats batch (issue #3468)", () => {
+    // configmap-daemonset.yaml stamps service.name = "kubernetes-agent-<cluster>"
+    // (upsert) on every kubeletstats / hostmetrics batch, plus k8s.cluster.name
+    // and oneuptime.agent.version; k8sattributes adds k8s.node.name.
+    const attrs: JSONArray = [
+      stringAttr("service.name", "kubernetes-agent-wbmonclusk8"),
+      stringAttr("k8s.cluster.name", "wbmonclusk8"),
+      stringAttr("k8s.node.name", "aks-wbmon-12345678-vmss000001"),
+      stringAttr("k8s.pod.name", "kubernetes-agent-wbmonclusk8-abc12"),
+      stringAttr("k8s.namespace.name", "oneuptime"),
+      stringAttr("oneuptime.agent.version", "1.0.0"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: true,
+        attributes: attrs,
+      }),
+    ).toBe(false);
+  });
+
+  test("THE BUG - returns false for a workload-named kubeletstats batch (issue #3468)", () => {
+    // configmap-daemonset.yaml's transform processor overwrites service.name
+    // with the deployment name while the metric families stay k8s.* infra.
+    const attrs: JSONArray = [
+      stringAttr("service.name", "pd-jas"),
+      stringAttr("k8s.cluster.name", "wbmonclusk8"),
+      stringAttr("k8s.namespace.name", "prod"),
+      stringAttr("k8s.deployment.name", "pd-jas"),
+      stringAttr("k8s.pod.name", "pd-jas-8098-abcde"),
+      stringAttr("k8s.node.name", "aks-wbmon-12345678-vmss000001"),
+      stringAttr("oneuptime.agent.version", "1.0.0"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: true,
+        attributes: attrs,
+      }),
+    ).toBe(false);
+  });
+
+  test("OBI RED metrics keep their Service row (non-infra families)", () => {
+    const attrs: JSONArray = [
+      stringAttr("service.name", "pd-jas-8098"),
+      stringAttr("k8s.cluster.name", "wbmonclusk8"),
+      stringAttr("k8s.namespace.name", "prod"),
+      stringAttr("k8s.pod.name", "pd-jas-8098-abcde"),
+      stringAttr("oneuptime.agent.version", "1.0.0"),
+    ];
+    // http.* families are NOT infra, so the metrics path does not flag them.
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: false,
+        attributes: attrs,
+      }),
+    ).toBe(true);
+  });
+
+  test("control cases from the reproduction remain intact", () => {
+    // OneUptime agent hostmetrics batch (system.* families) - flagged infra,
+    // agent marker present, host signal present => no Service row.
+    const hostAttrs: JSONArray = [
+      stringAttr("os.type", "linux"),
+      stringAttr("host.name", "web-1.internal"),
+      stringAttr("oneuptime.agent.version", "1.0.0"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: true,
+        attributes: hostAttrs,
+      }),
+    ).toBe(false);
+
+    // Genuine app SDK batch - must still back a Service row.
+    const appAttrs: JSONArray = [
+      stringAttr("service.name", "my-api"),
+      stringAttr("telemetry.sdk.language", "nodejs"),
+    ];
+    expect(
+      OtelIngestBaseServiceHarness.shouldCreateServiceRowPublic({
+        isInfraMetricBatch: false,
+        attributes: appAttrs,
+      }),
+    ).toBe(true);
+  });
+});

--- a/App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts
+++ b/App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts
@@ -179,9 +179,11 @@ describe("OtelIngestBaseService.shouldCreateServiceRow (phantom-service gate)", 
   });
 
   test("THE BUG - returns false for a OneUptime agent kubeletstats batch (issue #3468)", () => {
-    // configmap-daemonset.yaml stamps service.name = "kubernetes-agent-<cluster>"
-    // (upsert) on every kubeletstats / hostmetrics batch, plus k8s.cluster.name
-    // and oneuptime.agent.version; k8sattributes adds k8s.node.name.
+    /*
+     * configmap-daemonset.yaml stamps service.name = "kubernetes-agent-<cluster>"
+     * (upsert) on every kubeletstats / hostmetrics batch, plus k8s.cluster.name
+     * and oneuptime.agent.version; k8sattributes adds k8s.node.name.
+     */
     const attrs: JSONArray = [
       stringAttr("service.name", "kubernetes-agent-wbmonclusk8"),
       stringAttr("k8s.cluster.name", "wbmonclusk8"),
@@ -199,8 +201,10 @@ describe("OtelIngestBaseService.shouldCreateServiceRow (phantom-service gate)", 
   });
 
   test("THE BUG - returns false for a workload-named kubeletstats batch (issue #3468)", () => {
-    // configmap-daemonset.yaml's transform processor overwrites service.name
-    // with the deployment name while the metric families stay k8s.* infra.
+    /*
+     * configmap-daemonset.yaml's transform processor overwrites service.name
+     * with the deployment name while the metric families stay k8s.* infra.
+     */
     const attrs: JSONArray = [
       stringAttr("service.name", "pd-jas"),
       stringAttr("k8s.cluster.name", "wbmonclusk8"),
@@ -236,8 +240,10 @@ describe("OtelIngestBaseService.shouldCreateServiceRow (phantom-service gate)", 
   });
 
   test("control cases from the reproduction remain intact", () => {
-    // OneUptime agent hostmetrics batch (system.* families) - flagged infra,
-    // agent marker present, host signal present => no Service row.
+    /*
+     * OneUptime agent hostmetrics batch (system.* families) - flagged infra,
+     * agent marker present, host signal present => no Service row.
+     */
     const hostAttrs: JSONArray = [
       stringAttr("os.type", "linux"),
       stringAttr("host.name", "web-1.internal"),


### PR DESCRIPTION
### Title of this pull request?

`fix(telemetry): don't create phantom Service rows from agent infra metrics`

### Small Description?

Issue #3468: with the Kubernetes agent installed, OneUptime accumulates dozens of auto-created `Service` rows (`kubernetes-agent-*`, workload names like `pd-jas`, per-pod names like `pd-jas-8098`, `coredns`, `keda-*`, ...) that are "Connected" and "recently seen" but never carry any telemetry — Requests = 0, Latency = `-`, and every Logs / Exceptions / Metrics panel empty.

Root cause: the agent's OTel collectors stamp an explicit `service.name` on **every infrastructure metric batch** they emit (kubeletstats / hostmetrics / cadvisor / cluster scrapes):

- `HelmChart/Public/kubernetes-agent/templates/configmap-daemonset.yaml` — the `resource` processor stamps `service.name = "kubernetes-agent-<cluster>"` (upsert) on every node/pod/container metric, and the `transform` processor overwrites it with the workload name where one is present.
- The ingest `getServiceNameFromAttributes` (`App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts`) honors any explicit `service.name` **before** its host/k8s gate, so `selectPrimaryEntity` routes the batch to `telemetryServiceFromName` → `findOrCreateTelemetryService`, which creates a `Service` row. `updateLastSeen` keeps it "Connected" forever, but the underlying signal is host/cluster infrastructure — it never populates the service's Requests / Latency / Logs / Exceptions.

### What changed?

- **`App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts`**
  - `isInfraMetricBatch(scopeMetrics)` — returns true when a resource's metric families are infrastructure (`k8s.*`, `system.*`, `process.*`). Deliberately narrow: `container.*` / `http.*` / `rpc.*` families are **not** flagged, so Docker agent container services and OBI RED metrics keep their Service rows.
  - `shouldCreateServiceRow({ isInfraMetricBatch, attributes })` — the phantom-service gate. Returns `false` only when **all three** hold: (1) the metrics path flagged infra families, (2) the batch carries the `oneuptime.agent.version` agent marker (application SDKs never set it), and (3) it has a host/k8s resource signal (`os.type`, `container.runtime` or `k8s.cluster.name`).
  - Plumbed an optional `isInfraMetricBatch` through `resolveTelemetryResource` → `selectPrimaryEntity`, applied before the Service-creation branch so such batches fall through to their discovered `Host` / `KubernetesCluster` entity.
- **`App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts`** — passes `isInfraMetricBatch: this.isInfraMetricBatch(scopeMetricsForScan)` at the per-resource `resolveTelemetryResource` call.
- **`App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts`** — regression suite pinning both new predicates: the two `THE BUG` cases (agent-stamped and workload-named kubeletstats batches → `shouldCreateServiceRow === false`), plus controls for app-SDK batches, OBI RED metrics, host-only batches, empty scope, and the marker/signal guard conditions.

### Why a signal-type-aware gate (not a check in `getServiceNameFromAttributes`)?

A blanket "ignore `service.name` when `oneuptime.agent.version` is present" in the shared resolver would also strip **pod-log** services — the daemonset's logs pipeline goes through the same `resource` processor and stamps the same marker — which is legitimate service attribution. Infra metric *families* are only observable on the metrics path, so the flag is set there and stays `undefined` (off) for logs / traces / profiles / fluent. No regression to those paths.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Did you write tests where appropriate? (`App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts`)
- [x] Prettier-clean on all touched files (`prettier@3.3.2 --check`); `esbuild` transpile-check passes on all three. Full `npm run fix` / jest were not runnable locally in this environment (App/Common dependencies not installed) — see Testing; CI will run them.

### Related Issue?

Closes #3468.

### Testing

- **Reproduction (before/after)** — a dependency-free, production-faithful model of the decision path (`getServiceNameFromAttributes` + `shouldCreateServiceRow` + `isInfraMetricBatch`) fed with the exact attributes the agent's collector configs emit:
  - BEFORE: 2/2 infra cases reproduce phantom Service rows.
  - AFTER: 2/2 infra cases route away from Service rows; 6/6 total cases (bug + controls) match expected behavior.
- **Static checks** — `esbuild` transpile passes on all three files; `prettier@3.3.2 --check` passes.
- **Jest suite** — `App/Tests/Telemetry/OtelPhantomServiceGuard.test.ts` is written and CI-ready but was not executed locally (App/Common `node_modules` not installed in this environment). Run with:
  `cd App && npm install && npx jest ./Tests/Telemetry/OtelPhantomServiceGuard.test.ts`

### Reviewer notes / follow-ups (not in scope here)

1. Server-side **provenance** on auto-created Services (which integration created it) + a **bulk-cleanup** affordance would answer the issue's expectation (b) — suggested as a follow-up.
2. The agent's collectors stamping `service.name` on infra metrics by design (`upsert`) is the upstream cause; a dedicated `k8s.workload.type` / infra attribute would be cleaner agent-side hygiene.
3. Known residual gap: cluster-scoped `k8s_cluster`/prometheus-scrape metrics whose batches carry no `host.name`/`k8s.node.name` are not caught (the gate requires a host/k8s signal); happy to extend if the maintainers prefer.

### Screenshots (if appropriate):

Not applicable — server-side ingest change, no UI.