### PR TITLE
fix(session-replay): make RUM applications creatable, end users identifiable, and page journeys real

### DIFF
--- a/App/FeatureSet/BrowserRecorder/Tests/Chunker.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/Chunker.test.ts
@@ -45,6 +45,165 @@ describe("Chunker", (): void => {
     };
   };
 
+  /*
+   * WHERE the page was while the chunk was open.
+   *
+   * routeCount already said HOW MANY navigations happened; without the URLs
+   * themselves the server could only ever see the page a chunk was FLUSHED
+   * from, so two navigations inside one 15s window collapsed to one and the
+   * session's routes[] column could never hold more than the landing page.
+   */
+  describe("routes", (): void => {
+    it("carries the routes recorded while the chunk was open", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      chunker.addRoute("https://shop.example.com/");
+      chunker.add(event());
+      chunker.addRoute("https://shop.example.com/cart");
+      chunker.add(event());
+      chunker.close(false);
+
+      expect(chunks[0]?.routes).toEqual([
+        "https://shop.example.com/",
+        "https://shop.example.com/cart",
+      ]);
+    });
+
+    it("keeps first-seen order, so the last entry is the chunk's exit page", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      chunker.addRoute("https://shop.example.com/a");
+      chunker.addRoute("https://shop.example.com/b");
+      chunker.addRoute("https://shop.example.com/a");
+      chunker.addRoute("https://shop.example.com/c");
+      chunker.add(event());
+      chunker.close(false);
+
+      expect(chunks[0]?.routes).toEqual([
+        "https://shop.example.com/a",
+        "https://shop.example.com/b",
+        "https://shop.example.com/c",
+      ]);
+    });
+
+    /*
+     * Reset with the other per-chunk counters. The finalizer UNIONS routes
+     * across chunks, so carrying them forward would make every chunk after
+     * the first repeat the whole history for no gain.
+     */
+    it("resets per chunk, like the signal counters", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      chunker.addRoute("https://shop.example.com/first");
+      chunker.add(event());
+      chunker.close(false);
+
+      chunker.addRoute("https://shop.example.com/second");
+      chunker.add(event());
+      chunker.close(false);
+
+      expect(chunks[0]?.routes).toEqual(["https://shop.example.com/first"]);
+      expect(chunks[1]?.routes).toEqual(["https://shop.example.com/second"]);
+    });
+
+    it("ignores an empty url rather than storing a blank route", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      chunker.addRoute("");
+      chunker.add(event());
+      chunker.close(false);
+
+      expect(chunks[0]?.routes).toEqual([]);
+    });
+
+    /*
+     * A page that rewrites its path on every keystroke must not be able to
+     * grow one envelope without bound. routeCount still counts every change
+     * past the cap, so the signal is not lost - only the list is bounded.
+     */
+    it("caps the number of distinct routes it will carry", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      for (let index: number = 0; index < 200; index++) {
+        chunker.addRoute(`https://shop.example.com/step-${index}`);
+      }
+
+      chunker.add(event());
+      chunker.close(false);
+
+      const routes: Array<string> = chunks[0]?.routes ?? [];
+
+      /* MAX_ROUTES_PER_CHUNK. Pinned, so doubling the cap fails here. */
+      expect(routes.length).toBe(32);
+      expect(routes[0]).toBe("https://shop.example.com/step-0");
+    });
+
+    /*
+     * The BYTE budget is the one that matters.
+     *
+     * routes rides the envelope JSON, and the server rejects any envelope
+     * over 8 KB outright - failing the whole request, up to eight frames,
+     * which the transport treats as permanent and never retries. A
+     * count-only cap cannot prevent that: 32 long URLs exceed 8 KB on their
+     * own, so a site with deep paths would lose its footage rather than lose
+     * a few route entries.
+     */
+    it("caps the BYTES it will carry, so long URLs cannot blow the envelope", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      const longPath: string = "a".repeat(400);
+
+      for (let index: number = 0; index < 32; index++) {
+        chunker.addRoute(`https://shop.example.com/${longPath}/${index}`);
+      }
+
+      chunker.add(event());
+      chunker.close(false);
+
+      const routes: Array<string> = chunks[0]?.routes ?? [];
+      const bytes: number = routes.reduce(
+        (total: number, route: string): number => {
+          return total + route.length;
+        },
+        0,
+      );
+
+      /* Well inside the parser's 8 KB envelope ceiling. */
+      expect(bytes).toBeLessThanOrEqual(2 * 1024);
+      expect(routes.length).toBeGreaterThan(0);
+      expect(routes.length).toBeLessThan(32);
+    });
+
+    it("does not double-count the bytes of a route it already holds", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      for (let index: number = 0; index < 50; index++) {
+        chunker.addRoute("https://shop.example.com/same");
+      }
+
+      chunker.addRoute("https://shop.example.com/other");
+      chunker.add(event());
+      chunker.close(false);
+
+      expect(chunks[0]?.routes).toEqual([
+        "https://shop.example.com/same",
+        "https://shop.example.com/other",
+      ]);
+    });
+
+    it("is present on the empty final chunk too", (): void => {
+      const chunker: Chunker = makeChunker();
+
+      chunker.addRoute("https://shop.example.com/checkout");
+      chunker.close(true);
+
+      const finalChunk: PendingChunk | undefined = chunks[chunks.length - 1];
+
+      expect(finalChunk?.isFinal).toBe(true);
+      expect(finalChunk?.routes).toEqual(["https://shop.example.com/checkout"]);
+    });
+  });
+
   it("emits a JSON array of the events it collected", (): void => {
     const chunker: Chunker = makeChunker();
 

--- a/App/FeatureSet/BrowserRecorder/Tests/Recorder.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/Recorder.test.ts
@@ -65,6 +65,34 @@ async function flushUploads(): Promise<void> {
   });
 }
 
+/*
+ * The terminal path. stop() deliberately DISCARDS the transport queue, so
+ * hiding the page is the only way to get the last chunk on the wire.
+ */
+function sealByHidingThePage(): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: (): string => {
+      return "hidden";
+    },
+  });
+
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+/* Every chunk envelope posted so far, in order. */
+function allEnvelopes(
+  calls: Array<Array<unknown>>,
+): Array<SessionReplayChunkEnvelope> {
+  return calls
+    .filter((call: Array<unknown>): boolean => {
+      return String(call[0]).indexOf("session-replay/v1/chunk") >= 0;
+    })
+    .map((call: Array<unknown>): SessionReplayChunkEnvelope => {
+      return readPost(call).envelope;
+    });
+}
+
 function readPost(call: Array<unknown>): CapturedPost {
   const init: Record<string, unknown> = call[1] as Record<string, unknown>;
   const body: Uint8Array = init["body"] as Uint8Array;
@@ -685,6 +713,113 @@ describe("Recorder", (): void => {
       expect(post.envelope.url).not.toContain("secret-value");
       expect(post.envelope.meta?.entryUrl).not.toContain("secret-value");
     });
+
+    /*
+     * meta rides chunk 0 AND the final chunk. entryUrl used to be read from
+     * location.href at BUILD time, so the final chunk of any page that
+     * navigated overwrote the session header's entryUrl with the EXIT url -
+     * a session that began on "/" was filed as beginning wherever the user
+     * happened to stop.
+     */
+    it("reports the url the recording STARTED on, not the current one", async (): Promise<void> => {
+      window.history.replaceState({}, "", "/landing");
+
+      const instance: Recorder = startRecorder({ samplePercentage: 100 });
+
+      expect(instance.isUploading()).toBe(true);
+
+      await flushUploads();
+
+      window.history.pushState({}, "", "/checkout");
+
+      /* Seal the session so meta rides the final chunk too. */
+      sealByHidingThePage();
+
+      await flushUploads();
+
+      const envelopes: Array<SessionReplayChunkEnvelope> = allEnvelopes(
+        fetchMock.mock.calls as Array<Array<unknown>>,
+      );
+
+      expect(envelopes.length).toBeGreaterThan(0);
+
+      /*
+       * EVERY envelope that carries meta must say the recording began on
+       * /landing - including the final one, which is built after the
+       * navigation and used to report the exit url here.
+       */
+      for (const envelope of envelopes) {
+        if (envelope.meta) {
+          expect(envelope.meta.entryUrl).toContain("/landing");
+          expect(envelope.meta.entryUrl).not.toContain("/checkout");
+        }
+      }
+
+      /* url is the CURRENT page, and still moves. */
+      expect(envelopes[envelopes.length - 1]!.url).toContain("/checkout");
+    });
+
+    it("carries the pages the chunk covered, not just the one it flushed from", async (): Promise<void> => {
+      window.history.replaceState({}, "", "/landing");
+
+      const instance: Recorder = startRecorder({ samplePercentage: 100 });
+
+      expect(instance.isUploading()).toBe(true);
+
+      await flushUploads();
+
+      window.history.pushState({}, "", "/cart");
+      window.history.pushState({}, "", "/checkout");
+
+      /*
+       * stop() DISCARDS the queue by design, so the terminal path is what
+       * gets the last chunk on the wire.
+       */
+      sealByHidingThePage();
+
+      await flushUploads();
+
+      const seen: Array<string> = allEnvelopes(
+        fetchMock.mock.calls as Array<Array<unknown>>,
+      ).flatMap((envelope: SessionReplayChunkEnvelope): Array<string> => {
+        return envelope.routes || [];
+      });
+
+      const sawPath: (path: string) => boolean = (path: string): boolean => {
+        return seen.some((route: string): boolean => {
+          return route.indexOf(path) >= 0;
+        });
+      };
+
+      expect(sawPath("/landing")).toBe(true);
+      expect(sawPath("/cart")).toBe(true);
+      expect(sawPath("/checkout")).toBe(true);
+    });
+
+    it("scrubs the route list, so a magic link never rides the envelope", async (): Promise<void> => {
+      window.history.replaceState({}, "", "/landing");
+
+      const instance: Recorder = startRecorder({ samplePercentage: 100 });
+
+      expect(instance.isUploading()).toBe(true);
+
+      await flushUploads();
+
+      window.history.pushState({}, "", "/magic?token=secret-value");
+
+      sealByHidingThePage();
+
+      await flushUploads();
+
+      const seen: Array<string> = allEnvelopes(
+        fetchMock.mock.calls as Array<Array<unknown>>,
+      ).flatMap((envelope: SessionReplayChunkEnvelope): Array<string> => {
+        return envelope.routes || [];
+      });
+
+      expect(JSON.stringify(seen)).not.toContain("secret-value");
+      expect(JSON.stringify(seen)).toContain("/magic");
+    });
   });
 
   describe("terminal flush", (): void => {
@@ -976,6 +1111,67 @@ describe("Recorder", (): void => {
       expect(payloads).toContain("oneuptime.session-rotated");
       expect(payloads).toContain(firstSessionId);
       expect(payloads).toContain("idle");
+    });
+
+    /*
+     * A rollover mints a genuinely NEW session. entryUrl is captured once in
+     * start() so the final chunk cannot overwrite the session header with
+     * the exit url - but carrying the original page load's URL into the
+     * rotated session would report every rotated session as beginning on a
+     * page its user left hours ago, which is worse than the bug the capture
+     * exists to fix.
+     */
+    it("gives a rotated session its own entry url", async (): Promise<void> => {
+      jest.useFakeTimers();
+
+      window.history.replaceState({}, "", "/landing");
+
+      const instance: Recorder = startRecorder({ samplePercentage: 100 });
+      const firstSessionId: string = instance.getSessionId();
+
+      /* The user has since navigated deep into the app, then gone idle. */
+      window.history.pushState({}, "", "/settings/billing");
+
+      const idleSince: number = Date.now() - SESSION_REPLAY_IDLE_ROLLOVER_MS;
+
+      writeStored({
+        sessionId: firstSessionId,
+        sessionStartUnixMs: idleSince,
+        lastActivityUnixMs: idleSince,
+      });
+
+      fetchMock.mockClear();
+      jest.advanceTimersByTime(SESSION_REPLAY_FLUSH_INTERVAL_MS);
+      await drainMicrotasks();
+
+      const secondSessionId: string = instance.getSessionId();
+
+      expect(secondSessionId).not.toBe(firstSessionId);
+
+      const newSessionPosts: Array<CapturedPost> = fetchMock.mock.calls
+        .map((call: Array<unknown>): CapturedPost => {
+          return readPost(call);
+        })
+        .filter((post: CapturedPost): boolean => {
+          return post.envelope.sessionId === secondSessionId;
+        });
+
+      expect(newSessionPosts.length).toBeGreaterThan(0);
+
+      const meta: { entryUrl?: string } | undefined =
+        newSessionPosts[0]?.envelope.meta;
+
+      expect(meta?.entryUrl).toContain("/settings/billing");
+      expect(meta?.entryUrl).not.toContain("/landing");
+
+      /* And the new chunker is seeded with it, so routes[] is not empty. */
+      expect(
+        (newSessionPosts[0]?.envelope.routes || []).some(
+          (route: string): boolean => {
+            return route.indexOf("/settings/billing") >= 0;
+          },
+        ),
+      ).toBe(true);
     });
 
     it("rolls the session over at the duration cap even while in use", (): void => {

--- a/App/FeatureSet/BrowserRecorder/Tests/RecorderManifest.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/RecorderManifest.test.ts
@@ -23,11 +23,12 @@ import {
  * The defect this file exists to prevent: the artifact was named and stamped
  * from package.json's version (11.7.3, rewritten repo-wide on every release
  * by Scripts/Install/SyncPackageVersions.js) while the config endpoint
- * advertised SESSION_REPLAY_RECORDER_VERSION, an env var defaulting to the
+ * advertised an env var, SESSION_REPLAY_RECORDER_VERSION, defaulting to the
  * literal "1.0.0". Every loader in every browser was therefore told to fetch
  * an artifact that had never been published. Two independently-defaulted
  * answers to one question cannot be kept in step by hand, so there is now
- * only one answer and it comes from the build.
+ * only one answer and it comes from the build; the env var has since been
+ * deleted so nobody ships a rollback by setting a value nothing reads.
  */
 
 declare function require(id: string): unknown;

--- a/App/FeatureSet/BrowserRecorder/Tests/SessionId.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/SessionId.test.ts
@@ -7,6 +7,12 @@ describe("SessionId", (): void => {
   beforeEach((): void => {
     window.localStorage.clear();
     window.sessionStorage.clear();
+    /*
+     * The chunk-index high-water marks are module state that a real page
+     * load would not carry over. Jest keeps the module between tests, so it
+     * is cleared explicitly here.
+     */
+    SessionId.clearAll();
   });
 
   describe("generateId", (): void => {
@@ -140,6 +146,57 @@ describe("SessionId", (): void => {
 
       /* Simulated restart: the module has no in-memory state to lose. */
       expect(SessionId.getNextChunkIndex("tabA")).toBe(2);
+    });
+
+    /*
+     * The counter lives in sessionStorage, which is the HOST PAGE's
+     * storage, not ours - and plenty of applications call
+     * sessionStorage.clear() on sign-out, under a recorder that is still
+     * running.
+     *
+     * Rewinding to 0 there is not a duplicate, it is a DELETION: the chunk
+     * table is a ReplacingMergeTree keyed on
+     * (projectId, sessionId, tabId, chunkIndex) with the ingest time as the
+     * version, so the second index 0 REPLACES the first - and index 0 is the
+     * chunk carrying the session's opening full snapshot. The recording
+     * becomes unplayable from its own start with nothing reporting a fault.
+     */
+    it("never rewinds when the host page clears sessionStorage mid-session", (): void => {
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(0);
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(1);
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(2);
+
+      /* The host page signs a user out. */
+      sessionStorage.clear();
+
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(3);
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(4);
+    });
+
+    it("survives a single storage key being deleted, not just a full clear", (): void => {
+      SessionId.getNextChunkIndex("tabA");
+      SessionId.getNextChunkIndex("tabA");
+
+      for (const key of Object.keys(sessionStorage)) {
+        if (key.indexOf("chunkIndex") >= 0) {
+          sessionStorage.removeItem(key);
+        }
+      }
+
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(2);
+    });
+
+    /*
+     * A rollover mints a new tab id and explicitly resets the counter, so
+     * the guard must not pin the OLD tab's high-water mark onto it.
+     */
+    it("still resets to 0 when the recorder itself asks", (): void => {
+      SessionId.getNextChunkIndex("tabA");
+      SessionId.getNextChunkIndex("tabA");
+
+      SessionId.resetChunkIndex("tabA");
+
+      expect(SessionId.getNextChunkIndex("tabA")).toBe(0);
     });
   });
 

--- a/App/FeatureSet/BrowserRecorder/src/Chunker.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Chunker.ts
@@ -27,6 +27,26 @@ const EVENT_TYPE_FULL_SNAPSHOT: number = 2;
 const EVENT_TYPE_META: number = 4;
 
 /*
+ * Per-chunk caps on recorded URLs, by COUNT and by BYTES.
+ *
+ * The byte budget is the load-bearing one. The routes array rides the
+ * envelope JSON, and the server rejects any envelope over 8 KB outright -
+ * failing the WHOLE request, up to eight frames, which the transport
+ * classifies as a permanent rejection and never retries. A count-only cap
+ * cannot prevent that: 32 long URLs are more than 8 KB on their own, so a
+ * site with deep paths would silently lose its footage rather than lose a
+ * few route entries.
+ *
+ * 2 KB leaves the rest of the envelope (ids, versions, signals, trace ids,
+ * fidelity notices) comfortable room inside the 8 KB ceiling. A chunk covers
+ * ~15s, so a page doing more DISTINCT navigations than these caps allow is
+ * rewriting its URL programmatically rather than being navigated by a
+ * person; routeCount still counts every change past them.
+ */
+const MAX_ROUTES_PER_CHUNK: number = 32;
+const MAX_ROUTE_BYTES_PER_CHUNK: number = 2 * 1024;
+
+/*
  * Disclosed on the last chunk of a session that hit the per-session chunk
  * cap. Not (yet) a member of Common's SessionReplayFidelityNotice: adding one
  * there is a shared-type change, and a recorder must be able to tell the
@@ -152,6 +172,22 @@ export interface PendingChunk {
   signals: SessionReplaySignalCounts;
   fidelityNotices: Array<string>;
   traceIds: Array<string>;
+
+  /*
+   * Scrubbed URLs the page was on while this chunk was open, in first-seen
+   * order. routeCount already says HOW MANY route changes happened; this
+   * says WHICH pages, which is what the session header's routes[] column and
+   * the "sessions that hit /checkout" filter are built on. Without it the
+   * server can only see the URL the chunk was flushed from, so two
+   * navigations inside one flush window collapse to one.
+   *
+   * The order is meaningful only within a chunk, and nothing downstream
+   * depends on it: the session header's routes[] is a de-duplicated SET
+   * across every chunk and every tab, sorted for determinism, and the
+   * envelope's scalar `url` is what carries "where was this chunk flushed
+   * from" - which is how the finalizer resolves the exit page.
+   */
+  routes: Array<string>;
 }
 
 export type ChunkSink = (chunk: PendingChunk) => void;
@@ -194,6 +230,16 @@ export default class Chunker {
   private signals: SessionReplaySignalCounts = Chunker.emptySignals();
   private readonly fidelityNotices: Set<string> = new Set<string>();
   private traceIds: Set<string> = new Set<string>();
+
+  /*
+   * A Set for de-duplication, but iteration order is insertion order, so the
+   * emitted array is chronological - which is what makes the last element
+   * usable as the chunk's exit URL.
+   */
+  private routes: Set<string> = new Set<string>();
+
+  /* Running UTF-8 size of `routes`, for the envelope byte budget. */
+  private routeBytes: number = 0;
 
   public constructor(options: {
     sessionStartUnixMs: number;
@@ -332,6 +378,7 @@ export default class Chunker {
       signals: this.signals,
       fidelityNotices: Array.from(this.fidelityNotices),
       traceIds: Array.from(this.traceIds),
+      routes: Array.from(this.routes),
     });
 
     this.resetPerChunkCounters();
@@ -353,6 +400,7 @@ export default class Chunker {
       signals: this.signals,
       fidelityNotices: Array.from(this.fidelityNotices),
       traceIds: Array.from(this.traceIds),
+      routes: Array.from(this.routes),
     });
 
     this.resetPerChunkCounters();
@@ -402,6 +450,7 @@ export default class Chunker {
         signals: this.signals,
         fidelityNotices: Array.from(this.fidelityNotices),
         traceIds: Array.from(this.traceIds),
+        routes: Array.from(this.routes),
       });
 
       this.resetPerChunkCounters();
@@ -438,6 +487,7 @@ export default class Chunker {
       signals: this.signals,
       fidelityNotices: Array.from(this.fidelityNotices),
       traceIds: Array.from(this.traceIds),
+      routes: Array.from(this.routes),
     });
 
     this.resetPerChunkCounters();
@@ -465,6 +515,14 @@ export default class Chunker {
      */
     this.signals = Chunker.emptySignals();
     this.traceIds = new Set<string>();
+
+    /*
+     * Reset with the rest: the finalizer UNIONS routes across chunks, so
+     * carrying them forward would only make every chunk after the first
+     * repeat the whole history for no gain.
+     */
+    this.routes = new Set<string>();
+    this.routeBytes = 0;
   }
 
   public getOpenByteSize(): number {
@@ -500,6 +558,31 @@ export default class Chunker {
 
   public addTraceId(traceId: string): void {
     this.traceIds.add(traceId);
+  }
+
+  /*
+   * Called for the entry URL at start and for the destination of every route
+   * change. Capped so a page that rewrites its path on every keystroke
+   * cannot grow one envelope without bound; the cap is per chunk, and
+   * routeCount still counts every change past it.
+   */
+  public addRoute(url: string): void {
+    if (!url || this.routes.size >= MAX_ROUTES_PER_CHUNK) {
+      return;
+    }
+
+    if (this.routes.has(url)) {
+      return;
+    }
+
+    const bytes: number = utf8ByteLength(url);
+
+    if (this.routeBytes + bytes > MAX_ROUTE_BYTES_PER_CHUNK) {
+      return;
+    }
+
+    this.routeBytes += bytes;
+    this.routes.add(url);
   }
 
   public getSignals(): SessionReplaySignalCounts {

--- a/App/FeatureSet/BrowserRecorder/src/Consent.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Consent.ts
@@ -55,9 +55,16 @@ export default class Consent {
   /*
    * Should the recorder run at all?
    *
-   * respectDoNotTrack is the AND of the page-supplied option and the
-   * server policy: either side may insist on honouring the signal, and
-   * only both sides agreeing can turn it off.
+   * The PAGE decides whether DNT/GPC is honoured, and the server's value is
+   * only the default it starts from - see the inline note below, which is
+   * the behaviour the code actually implements and the one the install docs
+   * describe (data-oneuptime-respect-do-not-track="false" overrides the
+   * deployment default, because the customer owns the lawful basis for
+   * their own site).
+   *
+   * This comment used to describe the opposite - an AND, "either side may
+   * insist on honouring the signal" - which is what the code did before the
+   * override was added and has not been true since.
    */
   public static isRecordingPermitted(
     pageRespectsDoNotTrack: boolean,

--- a/App/FeatureSet/BrowserRecorder/src/Recorder.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Recorder.ts
@@ -39,7 +39,7 @@ import Masking, { MaskInputOptionsShape } from "./Masking";
 import NetworkRecorder, { RecordedRequest } from "./NetworkRecorder";
 import PerformanceRecorder, { PerformanceIssue } from "./PerformanceRecorder";
 import RollingBuffer, { BufferedEvent } from "./RollingBuffer";
-import RouteRecorder from "./RouteRecorder";
+import RouteRecorder, { RecordedRoute } from "./RouteRecorder";
 import SessionId, { SessionIdentityState } from "./SessionId";
 import Transport from "./Transport";
 
@@ -215,6 +215,13 @@ export default class Recorder {
    */
   private lastUserActivityUnixMs: number = 0;
   private lastTouchedUnixMs: number = 0;
+
+  /*
+   * Scrubbed URL this recorder started on. Set once in start() so the
+   * envelope's meta.entryUrl stays the ENTRY url even on the final chunk,
+   * which is also built from meta.
+   */
+  private entryUrl: string = "";
 
   /* Drained into the ErrorRecorder once, at the end of start(). */
   private earlyErrors: Array<EarlyErrorRecord>;
@@ -392,8 +399,15 @@ export default class Recorder {
       scrubUrl: (url: string): string => {
         return this.scrubUrl(url);
       },
-      onRouteChange: (atUnixMs: number): void => {
+      onRouteChange: (atUnixMs: number, route: RecordedRoute): void => {
         this.chunker.countSignal("routeCount");
+        /*
+         * The destination, already scrubbed by RouteRecorder. This is what
+         * turns the session header's routes[] column from "the URL of
+         * whichever chunk happened to be first" into the list of pages the
+         * user actually visited.
+         */
+        this.chunker.addRoute(route.to);
         this.frustrationDetector.notifyActivity(atUnixMs);
       },
       requestFullSnapshot: (): void => {
@@ -505,6 +519,23 @@ export default class Recorder {
     }
 
     this.started = true;
+
+    /*
+     * Captured once, here. Everything downstream that says "where did this
+     * recording begin" reads it, and the answer has to KEEP being true after
+     * the page navigates - which is why it is not re-read from
+     * location.href, and why rotateSession re-captures it for the new
+     * session rather than sharing this one.
+     */
+    this.entryUrl = this.scrubUrl(this.windowRef.location.href);
+
+    /*
+     * Seeds routes[] with the landing page. Without it a session that never
+     * navigates would report an empty route list while pageCount said 0 -
+     * technically consistent, and useless for "which pages did this person
+     * see".
+     */
+    this.chunker.addRoute(this.entryUrl);
 
     /*
      * A page load is itself activity. Without this seed a tab that loads and
@@ -1097,6 +1128,19 @@ export default class Recorder {
     this.identity = SessionId.resolveSession(nowUnixMs, this.identity.tabId);
     this.chunker = this.createChunker();
 
+    /*
+     * The ROTATED session began here, not where the page originally loaded.
+     *
+     * entryUrl is captured once in start() so the final chunk cannot
+     * overwrite the session header with the exit url - but a rollover mints
+     * a genuinely new session, and carrying the original page load's URL
+     * into it would report every rotated session as starting on a page its
+     * user left hours ago. The new chunker is re-seeded for the same reason:
+     * its routes list starts empty.
+     */
+    this.entryUrl = this.scrubUrl(this.windowRef.location.href);
+    this.chunker.addRoute(this.entryUrl);
+
     this.lastUserActivityUnixMs = nowUnixMs;
     this.lastTouchedUnixMs = nowUnixMs;
 
@@ -1247,6 +1291,7 @@ export default class Recorder {
       payloadBytes: chunk.rawBytes,
 
       url: this.routeRecorder.getCurrentUrl(),
+      routes: chunk.routes,
       signals: chunk.signals,
       fidelityNotices: chunk.fidelityNotices,
       droppedEvents:
@@ -1282,7 +1327,16 @@ export default class Recorder {
       : "";
 
     const meta: SessionReplayChunkMeta = {
-      entryUrl: this.scrubUrl(this.windowRef.location.href),
+      /*
+       * The URL this recording STARTED on, captured once in start().
+       *
+       * This used to read location.href at build time, and meta rides both
+       * chunk 0 AND the final chunk - so on any page that navigates, the
+       * final chunk overwrote the session header's entryUrl with the EXIT
+       * url, and a session that began on "/" was filed as beginning wherever
+       * the user happened to stop.
+       */
+      entryUrl: this.entryUrl,
       browserName: Recorder.getBrowserName(userAgent),
       browserVersion: Recorder.getBrowserVersion(userAgent),
       osName: Recorder.getOsName(userAgent),

--- a/App/FeatureSet/BrowserRecorder/src/SessionId.ts
+++ b/App/FeatureSet/BrowserRecorder/src/SessionId.ts
@@ -209,6 +209,8 @@ export default class SessionId {
   public static getNextChunkIndex(tabId: string): number {
     const next: number = SessionId.peekChunkIndex(tabId);
 
+    SessionId.highWaterChunkIndex.set(tabId, next + 1);
+
     SessionId.writeSessionStorage(
       SessionId.getChunkIndexKey(tabId),
       String(next + 1),
@@ -224,12 +226,52 @@ export default class SessionId {
 
     const parsed: number = raw === null ? 0 : Number.parseInt(raw, 10);
 
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    const stored: number = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+
+    /*
+     * NEVER go backwards within a live recorder.
+     *
+     * The counter lives in sessionStorage so a recorder torn down and
+     * re-created inside the same page (a framework remount, a consent
+     * re-grant) does not reuse an index it has already posted. But
+     * sessionStorage is not ours: a host page that calls
+     * sessionStorage.clear() - which plenty do on sign-out - resets the
+     * counter under a recorder that is still running, and the next chunk
+     * goes out as index 0 again.
+     *
+     * That is not a duplicate, it is a DELETION. The chunk table is a
+     * ReplacingMergeTree keyed on (projectId, sessionId, tabId, chunkIndex)
+     * with the ingest timestamp as the version, so the second index 0
+     * REPLACES the first - and index 0 is the chunk that carries the
+     * session's opening full snapshot. The recording becomes unplayable
+     * from its own start, with nothing anywhere reporting a problem.
+     *
+     * The in-memory high-water mark is the source of truth while the
+     * recorder is alive; storage is only ever allowed to move it forward.
+     */
+    const inMemory: number = SessionId.highWaterChunkIndex.get(tabId) ?? 0;
+
+    return Math.max(stored, inMemory);
   }
 
   public static resetChunkIndex(tabId: string): void {
+    SessionId.highWaterChunkIndex.delete(tabId);
     SessionId.writeSessionStorage(SessionId.getChunkIndexKey(tabId), "0");
   }
+
+  /*
+   * Highest index this process has already handed out, per tab. See
+   * peekChunkIndex for why storage alone is not enough.
+   *
+   * Keyed by tab because the chunk counter is. A session rollover REUSES the
+   * tab id, and starts clean only because resolveSession calls
+   * resetChunkIndex, which deletes the entry - do not remove that call on
+   * the strength of the key shape.
+   */
+  private static readonly highWaterChunkIndex: Map<string, number> = new Map<
+    string,
+    number
+  >();
 
   private static getChunkIndexKey(tabId: string): string {
     return `${CHUNK_INDEX_STORAGE_KEY}.${tabId}`;
@@ -276,6 +318,15 @@ export default class SessionId {
     SessionId.removeLocalStorage(SESSION_STORAGE_KEY);
     SessionId.removeLocalStorage(RELOAD_LOG_STORAGE_KEY);
     SessionId.removeSessionStorage(TAB_STORAGE_KEY);
+
+    /*
+     * The in-memory high-water marks go too. clearAll is "forget this
+     * session entirely" - a consent revocation or a stop() - and a counter
+     * that outlived it would push the NEXT session's first chunk past index
+     * 0, leaving its opening full snapshot at an index the player's seek
+     * anchors do not expect.
+     */
+    SessionId.highWaterChunkIndex.clear();
 
     try {
       const keys: Array<string> = [];

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/ReplayCorrelationPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/ReplayCorrelationPanel.tsx
@@ -170,9 +170,19 @@ const ReplayCorrelationPanel: FunctionComponent<ReplayCorrelationPanelProps> = (
       <DetailRow label="Session id" value={props.sessionId} />
       <DetailRow label="Entry URL" value={d.entryUrl} />
       <DetailRow label="Exit URL" value={d.exitUrl} />
+      {/*
+       * This panel is fed by the MANIFEST, whose projection deliberately
+       * carries no identity column - the narrower identity ACL is enforced
+       * by not naming it in the SELECT, and the manifest has no per-caller
+       * check to gate it with. So an empty value here means "not available
+       * on this surface", NOT "this session is anonymous": the session list,
+       * which does gate the column, may well be showing a name for the same
+       * session. Say so rather than asserting the opposite, and rather than
+       * naming a cause (capture switched off) the panel cannot know.
+       */}
       <DetailRow
         label="End user"
-        value={d.identifiedUserLabel || "Anonymous (identity capture is off)"}
+        value={d.identifiedUserLabel || "Shown on the session list"}
       />
       <DetailRow
         label="Browser"

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayFilterFields.ts
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayFilterFields.ts
@@ -48,6 +48,14 @@ export const DEVICE_TYPE_OPTIONS: Array<DropdownOption> = [
 export const TRIGGER_REASON_OPTIONS: Array<DropdownOption> = [
   { value: "error", label: "Error" },
   { value: "frustration", label: "Frustration" },
+  /*
+   * The recorder's performance trigger (a blown LCP, long-task or
+   * slow-request budget) writes this value and the server filter matches it,
+   * but it was missing from the dropdown - so the Recording column showed
+   * "Performance" for sessions the filter could not select, and picking any
+   * other trigger silently excluded them.
+   */
+  { value: "performance", label: "Performance" },
   { value: "sampled", label: "Sampled" },
   { value: "manual", label: "Manual" },
 ];
@@ -97,15 +105,29 @@ export const SESSION_REPLAY_FILTER_FIELDS: Array<SessionReplayFilterField> = [
   },
   {
     /*
+     * Membership in the session's route list, not its exit page.
+     *
+     * The server predicate is has(routes, <value>), which answers "did this
+     * session ever reach /checkout" - and now that routes actually holds
+     * every page (it used to hold exactly one, the landing page), the old
+     * "Exit page URL" title would be actively wrong: a session that landed
+     * on "/" and left from "/checkout" matches "/".
+     *
      * Exact match against a stored scrubbed URL - the server deliberately
      * refuses substring scans over this column - so the label says so. A
      * "/checkout" fragment matches nothing.
      */
     field: "route",
-    title: "Exit page URL (exact)",
+    title: "Page URL visited (exact)",
     placeholder: "https://app.example.com/checkout",
     kind: SessionReplayFilterKind.Text,
     type: FieldType.Text,
+    /*
+     * chipKey is a key of SessionReplaySummary, used as the chip's React key
+     * and as the lookup into the chip data - it is an identity, not a label.
+     * The list projection carries no routes column, so this stays exitUrl;
+     * the TITLE above is what tells the reader what the filter does.
+     */
     chipKey: "exitUrl",
   },
   {
@@ -117,9 +139,18 @@ export const SESSION_REPLAY_FILTER_FIELDS: Array<SessionReplayFilterField> = [
     chipKey: "durationMs",
   },
   {
-    field: "identifiedUserKey",
-    title: "User key",
-    placeholder: "hashed identifier",
+    /*
+     * The end-user reference as the customer's own page supplies it - the
+     * value shown in the "User & device" column - not the digest it is
+     * stored under. The server hashes it with the same per-project
+     * derivation the ingest used, so what a person can see is what a person
+     * can type. It previously asked for the raw HMAC, which is displayed
+     * nowhere in the product and which no endpoint would compute, so every
+     * value a human could plausibly enter returned nothing.
+     */
+    field: "identifiedUserRef",
+    title: "User",
+    placeholder: "user-1234 or jane@example.com",
     kind: SessionReplayFilterKind.Text,
     type: FieldType.Text,
     chipKey: "identifiedUserLabel",

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayListFilters.ts
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayListFilters.ts
@@ -16,7 +16,7 @@ export interface SessionReplayAdvancedFilters {
   osName: string;
   deviceType: string;
   countryCode: string;
-  identifiedUserKey: string;
+  identifiedUserRef: string;
   route: string;
   minDurationSeconds: string;
   triggerReason: string;
@@ -27,7 +27,7 @@ export const EMPTY_ADVANCED_FILTERS: SessionReplayAdvancedFilters = {
   osName: "",
   deviceType: "",
   countryCode: "",
-  identifiedUserKey: "",
+  identifiedUserRef: "",
   route: "",
   minDurationSeconds: "",
   triggerReason: "",
@@ -43,16 +43,22 @@ export const SESSION_REPLAY_SIGNALS: Array<string> = [
  * Filter state <-> URL query string keys. Persisted so back-navigation
  * from a replay restores the triage the viewer had built, and so a
  * filtered list is a shareable link.
+ *
+ * identifiedUserRef is deliberately ABSENT. It is the only filter whose
+ * value is a named end user of the customer's product - typically their
+ * email - and a query string reaches the operator's history and bookmarks,
+ * every shared link, and the request line in every reverse proxy and CDN
+ * access log in front of the instance. The filter still round-trips through
+ * the POST body; it just does not survive a reload, which is the right
+ * trade for the one field here that carries a third party's identity.
  */
-export const FILTER_URL_KEYS: Record<
-  keyof SessionReplayAdvancedFilters,
-  string
+export const FILTER_URL_KEYS: Partial<
+  Record<keyof SessionReplayAdvancedFilters, string>
 > = {
   browserName: "browser",
   osName: "os",
   deviceType: "device",
   countryCode: "country",
-  identifiedUserKey: "userKey",
   route: "route",
   minDurationSeconds: "minDuration",
   triggerReason: "trigger",
@@ -103,8 +109,12 @@ export function buildSessionReplayListFilters(
       filters["countryCodes"] = [advanced.countryCode.trim().toUpperCase()];
     }
 
-    if (advanced.identifiedUserKey.trim()) {
-      filters["identifiedUserKey"] = advanced.identifiedUserKey.trim();
+    if (advanced.identifiedUserRef.trim()) {
+      /*
+       * The reference, not the digest: the server hashes it with the
+       * per-project derivation the ingest used. See SessionReplayIdentity.
+       */
+      filters["identifiedUserRef"] = advanced.identifiedUserRef.trim();
     }
 
     if (advanced.route.trim()) {
@@ -136,7 +146,14 @@ export function readFiltersFromSearch(search: string): {
   for (const field of Object.keys(FILTER_URL_KEYS) as Array<
     keyof SessionReplayAdvancedFilters
   >) {
-    advanced[field] = params.get(FILTER_URL_KEYS[field]) || "";
+    const key: string | undefined = FILTER_URL_KEYS[field];
+
+    /* Fields deliberately kept out of the URL - see FILTER_URL_KEYS. */
+    if (!key) {
+      continue;
+    }
+
+    advanced[field] = params.get(key) || "";
   }
 
   const signal: string = params.get("signal") || "all";
@@ -168,12 +185,18 @@ export function buildFilteredUrl(
   for (const field of Object.keys(FILTER_URL_KEYS) as Array<
     keyof SessionReplayAdvancedFilters
   >) {
+    const key: string | undefined = FILTER_URL_KEYS[field];
+
+    if (!key) {
+      continue;
+    }
+
     const value: string = advanced[field].trim();
 
     if (value) {
-      url.searchParams.set(FILTER_URL_KEYS[field], value);
+      url.searchParams.set(key, value);
     } else {
-      url.searchParams.delete(FILTER_URL_KEYS[field]);
+      url.searchParams.delete(key);
     }
   }
 

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayTable.tsx
@@ -704,6 +704,20 @@ const SessionReplayTable: FunctionComponent<SessionReplayTableProps> = (
             });
 
           if (badges.length === 0) {
+            /*
+             * "Clean" is a claim, and it is only true once the finalizer has
+             * counted every chunk. Before that the header carries chunk 0's
+             * signals only, so a session that broke on its third chunk would
+             * be labelled Clean while it was still recording - the same
+             * over-claim the Duration column already avoids by showing a
+             * dash rather than a provisional number.
+             */
+            if (!row.isFinalized) {
+              return (
+                <span className="text-sm text-gray-400">Not counted yet</span>
+              );
+            }
+
             return <span className="text-sm text-gray-500">Clean</span>;
           }
 

--- a/App/FeatureSet/Docs/Content/en/telemetry/session-replay.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/session-replay.md
@@ -185,10 +185,10 @@ To satisfy a deletion request, file an erasure request through the OneUptime API
 
 Watching a recording is a separate permission from listing sessions, and neither is granted by the project-wide Viewer role. A support engineer can be given `ReadRumSessionReplay` to triage which sessions errored without being able to play anyone's screen back; `ReadRumSessionReplayPayload` is required to actually watch.
 
-Every playback is recorded in an audit trail — who watched which session, when, and for how long — visible under the **Audit** tab and on the player itself.
+Every playback is recorded in an audit trail — who watched which session, when, from what IP, and for how long — under _Real User Monitoring → your application → **Replay Access Log**_.
 
 ## Self-hosted notes
 
-- Session Replay is off at the deployment level by default. Set `SESSION_REPLAY_ENABLED_BY_DEFAULT=true` to allow projects to enable it.
+- Session Replay is **on** at the deployment level by default. Set `SESSION_REPLAY_ENABLED_BY_DEFAULT=false` to turn it off for the whole instance — recorders already running on customer pages then stop recording, not just uploading.
 - Set `SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY` to bound disk use. Replay is the largest table in the system, and an unbounded configuration can push ClickHouse into capacity pruning.
 - Recordings are stored in ClickHouse. No object storage is required.

--- a/App/FeatureSet/Telemetry/Config.ts
+++ b/App/FeatureSet/Telemetry/Config.ts
@@ -103,13 +103,27 @@ export const SESSION_REPLAY_INGEST_ENABLED: boolean =
 /*
  * Whether a newly-configured deployment offers session replay at all.
  *
- * Defaults to FALSE, and stays false on self-hosted installs, because plan
- * gating is a no-op when BILLING_ENABLED=false: `tableBillingAccessControl`
- * is only consulted when billing is on. Without this switch nothing would
- * stop a self-hosted install from running 100% sampling at 90-day retention
- * on a single ClickHouse node - and because replay is the fattest table,
- * the capacity pruner would then start dropping partitions, potentially
- * destroying the customer's logs and traces to make room for recordings.
+ * Defaults to TRUE. Session replay is on out of the box, and this switch is
+ * how an operator turns it OFF for the whole instance:
+ * SESSION_REPLAY_ENABLED_BY_DEFAULT=false makes the config endpoint answer
+ * `enabled:false, directive:"stop"` for every application, so recorders
+ * already live on customer pages stop recording rather than merely stopping
+ * uploads.
+ *
+ * The comment here used to say the opposite - "defaults to FALSE, and stays
+ * false on self-hosted installs" - and so did the self-hosted docs, which
+ * told operators to set it to `true` to ENABLE the feature. Both described
+ * the reverse of the one-line expression below, so an operator following the
+ * docs performed a no-op believing they had enabled it, and the value that
+ * actually does something (`false`) was documented nowhere.
+ *
+ * The concern behind the old comment is real and unchanged: plan gating is a
+ * no-op when BILLING_ENABLED=false, so nothing stops a self-hosted install
+ * from running 100% sampling at long retention on a single ClickHouse node -
+ * and because replay is the fattest table, the capacity pruner could start
+ * dropping partitions, destroying that customer's logs and traces to make
+ * room for recordings. SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY is the
+ * bound for that, and the self-hosted docs now say so.
  */
 export const SESSION_REPLAY_ENABLED_BY_DEFAULT: boolean =
   process.env["SESSION_REPLAY_ENABLED_BY_DEFAULT"] !== "false";
@@ -189,14 +203,17 @@ export const SESSION_REPLAY_TRUSTED_GEO_HEADER: string = (
   .toLowerCase();
 
 /*
- * Pinned recorder artifact the loader stub is told to import. Changing this
- * one value is the staged-rollout and instant-rollback mechanism for the
- * browser recorder - which matters because a masking regression would
- * otherwise be live in customer browsers for the full cache TTL with no
- * remedy.
+ * SESSION_REPLAY_RECORDER_VERSION used to live here, described as "the
+ * staged-rollout and instant-rollback mechanism for the browser recorder".
+ * It was not: the config endpoint reads the published version out of the
+ * BUILD MANIFEST (BrowserRecorder/Manifest.ts), because the env var and the
+ * artifact esbuild actually names after package.json were two independent
+ * answers to one question and were never equal - a loader told to fetch
+ * v1.0.0 requested an artifact that was never published.
+ *
+ * The constant had no importers. It is removed rather than left in place so
+ * nobody ships a rollback by setting a value that does nothing.
  */
-export const SESSION_REPLAY_RECORDER_VERSION: string =
-  process.env["SESSION_REPLAY_RECORDER_VERSION"] || "1.0.0";
 
 /*
  * MQTT ingestion for IoT devices. On by default (like the gRPC OTLP

--- a/App/FeatureSet/Telemetry/Services/SessionReplayIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/SessionReplayIngestService.ts
@@ -4,6 +4,7 @@ import Redis, { ClientType } from "Common/Server/Infrastructure/Redis";
 import AppMetrics from "Common/Server/Utils/Telemetry/AppMetrics";
 import CaptureSpan from "Common/Server/Utils/Telemetry/CaptureSpan";
 import { isSessionErased } from "Common/Server/Utils/SessionReplay/SessionReplayErasureTombstone";
+import SessionReplayIdentity from "Common/Server/Utils/SessionReplay/SessionReplayIdentity";
 import SessionReplayGateCache, {
   SessionReplayGatePolicy,
 } from "Common/Server/Utils/SessionReplay/SessionReplayGateCache";
@@ -873,6 +874,11 @@ export default class SessionReplayIngestService {
      */
     const payload: string = JSON.stringify(data.events);
 
+    const chunkUrl: string = UrlScrubber.scrub(envelope.url, []);
+
+    const chunkRoutes: Array<string> =
+      SessionReplayIngestService.buildChunkRoutes(envelope.routes, chunkUrl);
+
     return {
       _id: ObjectID.generateTimeOrdered().toString(),
       createdAt: OneUptimeDate.toClickhouseDateTime(
@@ -931,18 +937,74 @@ export default class SessionReplayIngestService {
       errorClickCount: envelope.signals.errorClickCount,
       refreshRageCount: envelope.signals.refreshRageCount,
       routeCount: envelope.signals.routeCount,
+
+      /*
+       * RE-SCRUBBED SERVER SIDE, for the same reason the header's URLs are
+       * (see buildProvisionalHeaderRow): the recorder scrubs, but a stale
+       * bundle or a hand-crafted POST with a scraped ingestion key does not,
+       * and these columns render under the WIDER session-metadata ACL than
+       * the payload.
+       *
+       * `routes` falls back to the chunk's own URL so a recorder built
+       * before the field existed still contributes to the session's route
+       * list rather than silently contributing nothing.
+       */
+      url: chunkUrl,
+      routes: chunkRoutes,
+
       retentionDate: OneUptimeDate.toClickhouseDateTime(data.retentionDate),
     };
   }
 
   /*
+   * The distinct, scrubbed URLs this chunk covers.
+   *
+   * Order is chronological, though nothing downstream depends on it: the
+   * finalizer derives exitUrl from the scalar `url` column with argMaxIf,
+   * and sorts the route union in SQL because routes[] is a membership set
+   * that has to be byte-identical across re-finalizations.
+   *
+   * Always non-empty when the chunk has a URL at all, because a route list
+   * that omitted the page the chunk was flushed from would make a session
+   * that never navigates report no routes.
+   */
+  private static buildChunkRoutes(
+    envelopeRoutes: Array<string> | undefined,
+    chunkUrl: string,
+  ): Array<string> {
+    const seen: Set<string> = new Set<string>();
+    const routes: Array<string> = [];
+
+    for (const route of envelopeRoutes || []) {
+      const scrubbed: string = UrlScrubber.scrub(route, []);
+
+      if (!scrubbed || seen.has(scrubbed)) {
+        continue;
+      }
+
+      seen.add(scrubbed);
+      routes.push(scrubbed);
+    }
+
+    if (chunkUrl && !seen.has(chunkUrl)) {
+      routes.push(chunkUrl);
+    }
+
+    return routes;
+  }
+
+  /*
    * Provisional header, written once per session from chunk 0.
    *
-   * isFinalized is false and every aggregate is zero on purpose. The
-   * finalizer replaces this row with one authoritative version computed by a
-   * single GROUP BY over the chunk table's own key range - exact, idempotent
-   * and race-free, which per-chunk increments onto a ReplacingMergeTree
-   * could never be.
+   * isFinalized is false, and the aggregates that need every chunk to be
+   * correct (duration, chunk and event counts, payload bytes) are zero on
+   * purpose. The ones chunk 0 already knows - its own signal counters, its
+   * URLs and its route list - are seeded, because a row that under-claims
+   * for the 10-15 minutes before finalization sends people looking in the
+   * wrong place. The finalizer replaces this row wholesale with one
+   * authoritative version computed by a single GROUP BY over the chunk
+   * table's own key range - exact, idempotent and race-free, which per-chunk
+   * increments onto a ReplacingMergeTree could never be.
    */
   private static buildProvisionalHeaderRow(data: {
     projectId: ObjectID;
@@ -983,6 +1045,38 @@ export default class SessionReplayIngestService {
       [],
     );
 
+    /*
+     * End-user identity, when the application asked for it.
+     *
+     * The recorder only puts identifiedUserRef on the wire when the policy
+     * has captureUserIdentity on (see Recorder.buildMeta), so an absent ref
+     * is the normal case and both columns stay empty. The policy is checked
+     * again here anyway: the recorder's copy of the policy can be up to a
+     * config-cache TTL stale, and a hand-crafted POST is not bound by it at
+     * all, so the server must not store a label for an application that has
+     * identity capture switched off.
+     *
+     * The key is an HMAC so the column is searchable and erasable without
+     * being a directory of the customer's users; the label is the raw
+     * reference and carries its own narrower column ACL.
+     */
+    const userRef: unknown = envelope.meta?.identifiedUserRef;
+
+    const hasUsableUserRef: boolean =
+      data.policy.captureUserIdentity &&
+      SessionReplayIdentity.isUsableUserRef(userRef);
+
+    const identifiedUserKey: string = hasUsableUserRef
+      ? SessionReplayIdentity.buildUserKey({
+          projectId: data.projectId,
+          userRef: userRef as string,
+        })
+      : "";
+
+    const identifiedUserLabel: string = hasUsableUserRef
+      ? SessionReplayIdentity.buildUserLabel(userRef as string)
+      : "";
+
     return {
       _id: ObjectID.generateTimeOrdered().toString(),
       createdAt: OneUptimeDate.toClickhouseDateTime(
@@ -1018,12 +1112,26 @@ export default class SessionReplayIngestService {
       viewportWidth: envelope.meta?.viewportWidth ?? 0,
       viewportHeight: envelope.meta?.viewportHeight ?? 0,
       clockSkewMs: Math.trunc(data.clockSkewMs).toString(),
-      errorCount: 0,
-      rageClickCount: 0,
-      deadClickCount: 0,
-      errorClickCount: 0,
-      refreshRageCount: 0,
-      pageCount: 0,
+      /*
+       * Seeded from chunk 0's own signals rather than zeroed.
+       *
+       * These are provisional - the finalizer replaces the whole row with a
+       * GROUP BY over every chunk, so there is no lost-update risk in
+       * writing them here - but zeroing them made the list contradict
+       * itself for the 10-15 minutes before finalization: the same row
+       * literal set hasError from envelope.signals.errorCount while
+       * errorCount stayed 0, so a session WAS returned by the "With errors"
+       * tab and its Signals cell read "Clean". "With frustration" had the
+       * inverse problem: a session captured BECAUSE of a rage click was
+       * excluded from the tab named after it, which is exactly when someone
+       * is looking - during the incident.
+       */
+      errorCount: envelope.signals.errorCount,
+      rageClickCount: envelope.signals.rageClickCount,
+      deadClickCount: envelope.signals.deadClickCount,
+      errorClickCount: envelope.signals.errorClickCount,
+      refreshRageCount: envelope.signals.refreshRageCount,
+      pageCount: envelope.signals.routeCount,
       browserName: envelope.meta?.browserName ?? "",
       browserVersion: envelope.meta?.browserVersion ?? "",
       osName: envelope.meta?.osName ?? "",
@@ -1040,20 +1148,34 @@ export default class SessionReplayIngestService {
       ),
       entryUrl: entryUrl,
       exitUrl: exitUrl,
-      routes: exitUrl ? [exitUrl] : [],
+      /*
+       * Chunk 0's real route list, not just its flush URL.
+       *
+       * The header is not rewritten until the finalizer runs, so a one-entry
+       * list here made the "Page URL visited (exact)" filter miss a page the
+       * user demonstrably reached for the whole 10-15 minute provisional
+       * window - on the same row that reported pageCount 2, which is the
+       * kind of self-contradiction the seeded signal counters above exist to
+       * remove. The finalizer still replaces this with the union across
+       * every chunk of every tab.
+       */
+      routes: SessionReplayIngestService.buildChunkRoutes(
+        envelope.routes,
+        exitUrl,
+      ),
       /*
        * Country only, derived from the forwarded address by the route.
        * The IP itself is never stored.
        */
       countryCode: data.policy.captureGeo ? data.jobData.countryCode : "",
       /*
-       * identifiedUserKey / identifiedUserLabel are left empty here. The
-       * HMAC needs the per-project salt and the label needs its own column
-       * ACL, so both belong to the identity path rather than the hot ingest
-       * path.
+       * Derived above. This runs once per session - the header is written
+       * only under `chunkIndex === 0` - so it is one SHA-256 over at most
+       * SESSION_REPLAY_MAX_USER_REF_LENGTH bytes per recording, not per
+       * chunk.
        */
-      identifiedUserKey: "",
-      identifiedUserLabel: "",
+      identifiedUserKey: identifiedUserKey,
+      identifiedUserLabel: identifiedUserLabel,
       traceIds: envelope.traceIds ?? [],
       exceptionFingerprints: [],
       fidelityNotices: envelope.fidelityNotices,

--- a/App/FeatureSet/Telemetry/Utils/SessionReplayEnvelopeParser.ts
+++ b/App/FeatureSet/Telemetry/Utils/SessionReplayEnvelopeParser.ts
@@ -2,6 +2,7 @@ import {
   MAX_SESSION_REPLAY_CHUNKS_PER_REQUEST,
   MAX_SESSION_REPLAY_CHUNKS_PER_SESSION,
   MAX_SESSION_REPLAY_CHUNK_BYTES,
+  SESSION_REPLAY_MAX_USER_REF_LENGTH,
   SESSION_REPLAY_WIRE_VERSION,
   SessionReplayChunkEnvelope,
   SessionReplayChunkMeta,
@@ -52,6 +53,14 @@ const MAX_URL_LENGTH: number = 2048;
 const MAX_VERSION_STRING_LENGTH: number = 32;
 const MAX_FIDELITY_NOTICES: number = 32;
 const MAX_TRACE_IDS: number = 64;
+
+/*
+ * Mirrors MAX_ROUTES_PER_CHUNK in the recorder's Chunker. Kept a little
+ * higher than the client cap so a legitimate client is never truncated by
+ * the parser - the parser's job here is to bound a hostile envelope, not to
+ * second-guess the recorder.
+ */
+const MAX_ROUTES: number = 64;
 const MAX_TRACE_ID_LENGTH: number = 64;
 const MAX_META_STRING_LENGTH: number = 128;
 
@@ -365,6 +374,23 @@ export default class SessionReplayEnvelopeParser {
         envelope.traceIds = traceIds;
       }
 
+      /*
+       * Optional and additive: a recorder built before this field existed
+       * simply sends none, and the ingest falls back to `url`. Capped and
+       * length-limited like every other array on the wire, because the
+       * envelope is attacker-controllable - a scraped ingestion key is a
+       * public credential by design.
+       */
+      const routes: Array<string> = this.readStringArray(
+        raw["routes"],
+        MAX_ROUTES,
+        MAX_URL_LENGTH,
+      );
+
+      if (routes.length > 0) {
+        envelope.routes = routes;
+      }
+
       frames.push({
         envelope: envelope,
         payload: body.subarray(payloadStart, payloadEnd),
@@ -524,9 +550,25 @@ export default class SessionReplayEnvelopeParser {
       viewportHeight: this.readNonNegativeInteger(raw["viewportHeight"]),
     };
 
+    /*
+     * Capped at SESSION_REPLAY_MAX_USER_REF_LENGTH, not at the 128-byte cap
+     * the device strings beside it use.
+     *
+     * This value has to survive a round trip that the other meta fields do
+     * not. The recorder slices the CONFIG request's user-ref header to
+     * exactly this length and the targeting handshake hashes it there, while
+     * on the chunk path this truncation is the only bound - so the two paths
+     * agree only if both cut at the same place. Truncating further HERE
+     * would silently make the stored key the HMAC of a different string than
+     * the one a dashboard lookup or an erasure request hashes: a long
+     * reference (a signed customer id, a namespaced email) would file
+     * recordings under a key nothing can ever resolve, and a
+     * right-to-erasure request naming that person would under-delete without
+     * erroring.
+     */
     const identifiedUserRef: string = this.readString(
       raw["identifiedUserRef"],
-      MAX_META_STRING_LENGTH,
+      SESSION_REPLAY_MAX_USER_REF_LENGTH,
     );
 
     if (identifiedUserRef) {

--- a/App/FeatureSet/Workers/Jobs/Rum/FinalizeSessions.ts
+++ b/App/FeatureSet/Workers/Jobs/Rum/FinalizeSessions.ts
@@ -155,6 +155,14 @@ export const MAX_TRACE_IDS_PER_SESSION: number = 200;
 export const MAX_EXCEPTION_FINGERPRINTS_PER_SESSION: number = 100;
 
 /*
+ * Matches MAX_ROUTES_RECORDED in the recorder's RouteRecorder, which is the
+ * per-page-load cap on route events. A session that genuinely visited more
+ * distinct pages than this is not one anybody reads a route list for, and
+ * the column feeds a bloom index that wants bounded cardinality.
+ */
+export const MAX_ROUTES_PER_SESSION: number = 500;
+
+/*
  * Padding on both ends of the correlation queries' time window. The
  * window is derived from SERVER receive times (activity-set scores /
  * header startTime) while Span.startTime and ExceptionInstance.time are
@@ -198,8 +206,22 @@ export interface TabChunkAggregate {
   errorClickCount: number;
   refreshRageCount: number;
   routeCount: number;
+  firstUrl: string;
+  lastUrl: string;
+  firstUrlAtUnixMs: number;
+  lastUrlAtUnixMs: number;
+  urlChunkCount: number;
+  routes: Array<string>;
   hasFinalChunk: boolean;
   sessionStartUnixMs: number;
+
+  /*
+   * When this TAB started. sessionStartUnixMs cannot answer that - it is the
+   * SESSION's start, written from the recorder's localStorage record, so it
+   * is identical across every tab of the session.
+   */
+  firstChunkStartUnixMs: number;
+
   lastChunkEndUnixMs: number;
   maxChunkEndOffsetMs: number;
   schemaVersion: number;
@@ -225,6 +247,23 @@ export interface SessionChunkAggregate {
   errorClickCount: number;
   refreshRageCount: number;
   pageCount: number;
+
+  /*
+   * Derived from the chunk rows, not carried forward from the provisional
+   * header. The header only ever knew chunk 0's URL, which for a single-page
+   * app is the landing page for the whole session.
+   */
+  firstUrl: string;
+  lastUrl: string;
+  routes: Array<string>;
+
+  /*
+   * Whether firstUrl is the URL the SESSION began on rather than the
+   * earliest one that happens to be stored. False for a session whose
+   * opening chunks predate the url column, where the header is authoritative.
+   */
+  firstUrlCoversSessionStart: boolean;
+
   hasFinalChunk: boolean;
   sessionStartUnixMs: number;
   lastChunkEndUnixMs: number;
@@ -262,6 +301,12 @@ export interface ProvisionalSessionHeader {
   triggerReason: string;
   samplePercentageAtCapture: number;
   clockSkewMs: number;
+  errorCount: number;
+  rageClickCount: number;
+  deadClickCount: number;
+  errorClickCount: number;
+  refreshRageCount: number;
+  pageCount: number;
   entryUrl: string;
   exitUrl: string;
   routes: Array<string>;
@@ -400,6 +445,48 @@ export function buildTabAggregateStatement(data: {
       sum(errorClickCount) AS errorClickCount,
       sum(refreshRageCount) AS refreshRageCount,
       sum(routeCount) AS routeCount,
+      /*
+       * WHERE this tab started and ended, and every page in between.
+       *
+       * argMin/argMax over chunkStartTime pick the actual first and last
+       * chunk rather than relying on chunkIndex, which restarts at 0 for
+       * every tab and so cannot order across one.
+       *
+       * The route union is a SET, not a path: groupArray's element order is
+       * unspecified under parallel aggregation, so it is sorted to make the
+       * value DETERMINISTIC. That matters beyond tidiness - the header is a
+       * ReplacingMergeTree row that the sweep can rewrite, and two runs over
+       * identical chunks must produce identical bytes or they churn versions
+       * forever. Consumers treat it as membership ("did this session reach
+       * /checkout"); entryUrl and exitUrl are what answer the ordered
+       * questions, and they come from the argMin/argMax above.
+       */
+      argMinIf(url, chunkStartTime, url != '') AS firstUrl,
+      argMaxIf(url, chunkEndTime, url != '') AS lastUrl,
+      /*
+       * WHEN the first and last URL-bearing chunks were, which is what
+       * orders firstUrl/lastUrl across tabs - and, for firstUrl, what says
+       * whether the derivation can be trusted at all. A session live across
+       * the deploy that added these columns has early chunks with url = ''
+       * and later ones without, so argMinIf returns a MID-session page;
+       * comparing it against the tab's real start is how that case falls
+       * back to the provisional header, which still holds the landing page.
+       *
+       * countIf guards the "no chunk has a url" case, where minIf/maxIf
+       * return 0 rather than anything meaningful.
+       */
+      minIf(toUnixTimestamp64Milli(chunkStartTime), url != '') AS firstUrlAtUnixMs,
+      maxIf(toUnixTimestamp64Milli(chunkEndTime), url != '') AS lastUrlAtUnixMs,
+      countIf(url != '') AS urlChunkCount,
+      /*
+       * When this TAB started, url or no url. sessionStartTime cannot answer
+       * that: it is the SESSION's start, written from the recorder's
+       * localStorage record, so it is identical across every tab.
+       * Comparing it with firstUrlAtUnixMs is what detects a session whose
+       * opening chunks predate the url column.
+       */
+      toUnixTimestamp64Milli(min(chunkStartTime)) AS firstChunkStartUnixMs,
+      arraySort(arrayDistinct(arrayFlatten(groupArray(routes)))) AS routes,
       max(toUInt8(isFinal)) AS hasFinalChunk,
       toUnixTimestamp64Milli(min(sessionStartTime)) AS sessionStartUnixMs,
       toUnixTimestamp64Milli(max(chunkEndTime)) AS lastChunkEndUnixMs,
@@ -425,7 +512,10 @@ export function buildTabAggregateStatement(data: {
         errorClickCount,
         refreshRageCount,
         routeCount,
+        url,
+        routes,
         sessionStartTime,
+        chunkStartTime,
         chunkEndTime,
         chunkEndOffsetMs,
         schemaVersion,
@@ -478,6 +568,20 @@ export function buildProvisionalHeaderStatement(data: {
       triggerReason AS triggerReason,
       samplePercentageAtCapture AS samplePercentageAtCapture,
       clockSkewMs AS clockSkewMs,
+      /*
+       * The provisional signal counts, carried so sealLostSession can keep
+       * them. That path builds an all-zero aggregate because the session's
+       * chunks are GONE, and buildFinalizedSessionRow takes every counter
+       * from the aggregate - so without these the seal would overwrite real
+       * numbers the ingest recorded from chunk 0 with zeroes, and publish a
+       * row whose Signals column says "Clean" about a session that errored.
+       */
+      errorCount AS errorCount,
+      rageClickCount AS rageClickCount,
+      deadClickCount AS deadClickCount,
+      errorClickCount AS errorClickCount,
+      refreshRageCount AS refreshRageCount,
+      pageCount AS pageCount,
       entryUrl AS entryUrl,
       exitUrl AS exitUrl,
       routes AS routes,
@@ -637,8 +741,15 @@ export function parseTabAggregateRow(row: JSONObject): TabChunkAggregate {
     errorClickCount: toNumberValue(row["errorClickCount"]),
     refreshRageCount: toNumberValue(row["refreshRageCount"]),
     routeCount: toNumberValue(row["routeCount"]),
+    firstUrl: toTextValue(row["firstUrl"]),
+    lastUrl: toTextValue(row["lastUrl"]),
+    firstUrlAtUnixMs: toNumberValue(row["firstUrlAtUnixMs"]),
+    lastUrlAtUnixMs: toNumberValue(row["lastUrlAtUnixMs"]),
+    urlChunkCount: toNumberValue(row["urlChunkCount"]),
+    routes: toTextArrayValue(row["routes"]),
     hasFinalChunk: toBooleanValue(row["hasFinalChunk"]),
     sessionStartUnixMs: toNumberValue(row["sessionStartUnixMs"]),
+    firstChunkStartUnixMs: toNumberValue(row["firstChunkStartUnixMs"]),
     lastChunkEndUnixMs: toNumberValue(row["lastChunkEndUnixMs"]),
     maxChunkEndOffsetMs: toNumberValue(row["maxChunkEndOffsetMs"]),
     schemaVersion: toNumberValue(row["schemaVersion"]),
@@ -667,6 +778,12 @@ export function parseProvisionalHeaderRow(
     triggerReason: toTextValue(row["triggerReason"]),
     samplePercentageAtCapture: toNumberValue(row["samplePercentageAtCapture"]),
     clockSkewMs: toNumberValue(row["clockSkewMs"]),
+    errorCount: toNumberValue(row["errorCount"]),
+    rageClickCount: toNumberValue(row["rageClickCount"]),
+    deadClickCount: toNumberValue(row["deadClickCount"]),
+    errorClickCount: toNumberValue(row["errorClickCount"]),
+    refreshRageCount: toNumberValue(row["refreshRageCount"]),
+    pageCount: toNumberValue(row["pageCount"]),
     entryUrl: toTextValue(row["entryUrl"]),
     exitUrl: toTextValue(row["exitUrl"]),
     routes: toTextArrayValue(row["routes"]),
@@ -727,6 +844,10 @@ export function combineTabAggregates(
     errorClickCount: 0,
     refreshRageCount: 0,
     pageCount: 0,
+    firstUrl: "",
+    lastUrl: "",
+    routes: [],
+    firstUrlCoversSessionStart: false,
     hasFinalChunk: false,
     sessionStartUnixMs: 0,
     lastChunkEndUnixMs: 0,
@@ -739,6 +860,43 @@ export function combineTabAggregates(
   };
 
   const snapshotIndexes: Set<number> = new Set<number>();
+
+  /*
+   * Route union across tabs. A Set keyed on the URL is the whole
+   * de-duplication: a user who bounces between two pages ten times
+   * contributes two routes, not twenty. Sorted on the way out - see the SQL
+   * note about determinism; the merge order of tabs is no more defined than
+   * groupArray's element order.
+   */
+  const routes: Set<string> = new Set<string>();
+
+  /*
+   * The session's first and last URLs are the first URL of the EARLIEST tab
+   * and the last URL of the LATEST tab, so both are tracked with the clock
+   * that decides them rather than with tab iteration order - the tabs array
+   * arrives in whatever order ClickHouse grouped it, and a merge that
+   * depended on that order would churn ReplacingMergeTree versions on every
+   * re-finalization of identical chunks.
+   *
+   * The clocks are per-CHUNK times (min chunkStartTime, max chunkEndTime),
+   * NOT sessionStartTime: that column is the session's own start, written
+   * from the recorder's localStorage record, so it is byte-identical for
+   * every tab and orders none of them. The tabId tie-break makes the result
+   * total even when two tabs share a millisecond.
+   */
+  let firstUrlAtUnixMs: number = 0;
+  let firstUrlTabId: string = "";
+  let lastUrlAtUnixMs: number = 0;
+  let lastUrlTabId: string = "";
+
+  /*
+   * The earliest chunk of the session, url-bearing or not. Comparing it with
+   * firstUrlAtUnixMs is what detects a session whose opening chunks predate
+   * the url column: there, the derived firstUrl is a MID-session page and
+   * the provisional header is the only thing that still knows the landing
+   * page, so buildFinalizedSessionRow must prefer it.
+   */
+  let earliestChunkStartUnixMs: number = 0;
 
   for (const tab of tabs) {
     combined.chunkCount += tab.chunkCount;
@@ -770,6 +928,47 @@ export function combineTabAggregates(
     combined.refreshRageCount += tab.refreshRageCount;
     /* routeCount is the per-chunk name for what the header calls pageCount. */
     combined.pageCount += tab.routeCount;
+
+    for (const route of tab.routes) {
+      if (route && routes.size < MAX_ROUTES_PER_SESSION) {
+        routes.add(route);
+      }
+    }
+
+    if (
+      tab.firstChunkStartUnixMs > 0 &&
+      (earliestChunkStartUnixMs === 0 ||
+        tab.firstChunkStartUnixMs < earliestChunkStartUnixMs)
+    ) {
+      earliestChunkStartUnixMs = tab.firstChunkStartUnixMs;
+    }
+
+    if (tab.firstUrl && tab.urlChunkCount > 0) {
+      const isEarlier: boolean =
+        combined.firstUrl === "" ||
+        tab.firstUrlAtUnixMs < firstUrlAtUnixMs ||
+        (tab.firstUrlAtUnixMs === firstUrlAtUnixMs &&
+          tab.tabId < firstUrlTabId);
+
+      if (isEarlier) {
+        combined.firstUrl = tab.firstUrl;
+        firstUrlAtUnixMs = tab.firstUrlAtUnixMs;
+        firstUrlTabId = tab.tabId;
+      }
+    }
+
+    if (tab.lastUrl && tab.urlChunkCount > 0) {
+      const isLater: boolean =
+        combined.lastUrl === "" ||
+        tab.lastUrlAtUnixMs > lastUrlAtUnixMs ||
+        (tab.lastUrlAtUnixMs === lastUrlAtUnixMs && tab.tabId > lastUrlTabId);
+
+      if (isLater) {
+        combined.lastUrl = tab.lastUrl;
+        lastUrlAtUnixMs = tab.lastUrlAtUnixMs;
+        lastUrlTabId = tab.tabId;
+      }
+    }
 
     combined.hasFinalChunk = combined.hasFinalChunk || tab.hasFinalChunk;
 
@@ -822,6 +1021,24 @@ export function combineTabAggregates(
       return a - b;
     },
   );
+
+  /* Sorted, so re-finalizing identical chunks produces an identical row. */
+  combined.routes = Array.from(routes).sort();
+
+  /*
+   * Only trust the derived entry URL when the session's very first chunk
+   * carried one. Otherwise the earliest URL we hold is a mid-session page -
+   * a session live across the deploy that added the column - and the
+   * provisional header, written from chunk 0, still knows where it began.
+   *
+   * exitUrl needs no equivalent test: url-less chunks are always
+   * chronologically earlier than url-bearing ones, so the LAST url is
+   * correct whenever any url exists at all.
+   */
+  combined.firstUrlCoversSessionStart =
+    combined.firstUrl !== "" &&
+    earliestChunkStartUnixMs > 0 &&
+    firstUrlAtUnixMs <= earliestChunkStartUnixMs;
 
   return combined;
 }
@@ -1000,9 +1217,35 @@ export function buildFinalizedSessionRow(data: {
     triggerReason: header ? header.triggerReason : "",
     samplePercentageAtCapture: header ? header.samplePercentageAtCapture : 0,
 
-    entryUrl: header ? header.entryUrl : "",
-    exitUrl: header ? header.exitUrl : "",
-    routes: header ? header.routes : [],
+    /*
+     * Derived from the chunk rows, falling back to the provisional header.
+     *
+     * These three used to be copied straight from the header, which is
+     * written once on chunk 0 - so a single-page app reported its landing
+     * page as its exit URL forever, routes[] could never hold more than one
+     * element (making the "Exit page URL (exact)" filter unable to match a
+     * page the user demonstrably reached), and a session spanning two page
+     * loads had its entryUrl overwritten by the LAST load's URL.
+     *
+     * The fallback is what keeps sessions recorded before the chunk table
+     * carried url/routes rendering exactly as they do today.
+     */
+    entryUrl:
+      (aggregate.firstUrlCoversSessionStart ? aggregate.firstUrl : "") ||
+      (header ? header.entryUrl : ""),
+    exitUrl: aggregate.lastUrl || (header ? header.exitUrl : ""),
+    /*
+     * Derived list first, with the header's copy appended only as a fallback
+     * for sessions whose chunks predate the url/routes columns - for
+     * everything else it is already in the derived list and de-duplicates
+     * away. Sorted for the determinism reason in the SQL comment: the two
+     * inputs are each sorted, but concatenating them is not.
+     */
+    routes: mergeCappedArray(
+      aggregate.routes,
+      header ? header.routes : [],
+      MAX_ROUTES_PER_SESSION,
+    ).sort(),
 
     browserName: header ? header.browserName : "",
     browserVersion: header ? header.browserVersion : "",
@@ -1819,12 +2062,31 @@ async function sealLostSession(data: {
     fullSnapshotChunkIndexes: [],
     eventCount: 0,
     payloadBytes: 0,
-    errorCount: 0,
-    rageClickCount: 0,
-    deadClickCount: 0,
-    errorClickCount: 0,
-    refreshRageCount: 0,
-    pageCount: 0,
+    /*
+     * Carried from the header, not zeroed.
+     *
+     * The chunks are gone - that is what "recording lost" means - but the
+     * ingest recorded what chunk 0 saw before they were, and those counts
+     * are the only remaining evidence about the session. Zeroing them here
+     * would publish a sealed row whose Signals column reads "Clean" for a
+     * session that errored, which is a worse answer than "we lost the
+     * footage of a session that errored".
+     */
+    errorCount: header.errorCount,
+    rageClickCount: header.rageClickCount,
+    deadClickCount: header.deadClickCount,
+    errorClickCount: header.errorClickCount,
+    refreshRageCount: header.refreshRageCount,
+    pageCount: header.pageCount,
+    /*
+     * Empty on purpose: this session has NO chunk rows, so there is nothing
+     * to derive from and buildFinalizedSessionRow falls back to the
+     * provisional header's own URLs.
+     */
+    firstUrl: "",
+    lastUrl: "",
+    routes: [],
+    firstUrlCoversSessionStart: false,
     hasFinalChunk: false,
     sessionStartUnixMs: header.startTimeUnixMs,
     lastChunkEndUnixMs: header.startTimeUnixMs,

--- a/App/Tests/Dashboard/SessionReplayListFilters.test.ts
+++ b/App/Tests/Dashboard/SessionReplayListFilters.test.ts
@@ -34,7 +34,7 @@ describe("buildSessionReplayListFilters", () => {
       osName: "macOS",
       deviceType: "desktop",
       countryCode: "de",
-      identifiedUserKey: "abc123",
+      identifiedUserRef: "jane@example.com",
       route: "/checkout",
       minDurationSeconds: "90",
       triggerReason: "error",
@@ -46,7 +46,12 @@ describe("buildSessionReplayListFilters", () => {
       deviceTypes: ["desktop"],
       /* The stored column is upper-case ISO codes. */
       countryCodes: ["DE"],
-      identifiedUserKey: "abc123",
+      /*
+       * The REFERENCE, not a digest. The server hashes it with the
+       * per-project derivation the ingest used - the raw key is displayed
+       * nowhere in the product, so a field demanding it could never match.
+       */
+      identifiedUserRef: "jane@example.com",
       route: "/checkout",
       /* The input is seconds; the endpoint takes milliseconds. */
       minDurationMs: 90000,

--- a/App/Tests/Telemetry/SessionReplayIngestService.test.ts
+++ b/App/Tests/Telemetry/SessionReplayIngestService.test.ts
@@ -7,10 +7,13 @@ import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode"
 import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
 import SessionReplayTriggerReason from "Common/Types/Rum/SessionReplayTriggerReason";
 import {
+  SESSION_REPLAY_MAX_USER_REF_LENGTH,
   SESSION_REPLAY_SCHEMA_VERSION,
   SESSION_REPLAY_WIRE_VERSION,
   SessionReplayChunkEnvelope,
+  SessionReplayChunkMeta,
 } from "Common/Types/Rum/SessionReplay";
+import SessionReplayIdentity from "Common/Server/Utils/SessionReplay/SessionReplayIdentity";
 import zlib from "zlib";
 
 jest.mock("Common/Server/Utils/Logger", () => {
@@ -58,10 +61,11 @@ jest.mock("Common/Server/Utils/Telemetry/AppMetrics", () => {
 });
 
 /*
- * SESSION_REPLAY_ENABLED_BY_DEFAULT ships false, and the gate now refuses
- * outright when it is off (the config endpoint already did). Everything in
- * this file exercises an instance that DOES offer replay; the off case has
- * its own file, SessionReplayInstanceSwitch.test.ts.
+ * SESSION_REPLAY_ENABLED_BY_DEFAULT ships TRUE; setting it to false is how
+ * an operator turns replay off instance-wide, and the gate then refuses
+ * outright (the config endpoint already did). Everything in this file
+ * exercises an instance that DOES offer replay; the off case has its own
+ * file, SessionReplayInstanceSwitch.test.ts.
  */
 jest.mock("../../FeatureSet/Telemetry/Config", () => {
   const actual: Record<string, unknown> = jest.requireActual(
@@ -1150,15 +1154,484 @@ describe("SessionReplayIngestService.processFromQueue", () => {
     expect(getSubmittedRows("RumSessionV1")[0]!["countryCode"]).toBe("");
   });
 
-  test("never stores an identified user key on the ingest path", async () => {
-    await SessionReplayIngestService.processFromQueue(
-      buildJobData(buildBody([{ chunkIndex: 0 }])),
-    );
+  /*
+   * End-user identity.
+   *
+   * The recorder has always put meta.identifiedUserRef on the wire when the
+   * application had identity capture on, and the envelope parser has always
+   * accepted it - but the ingest wrote both columns as "" unconditionally,
+   * so the session list said "Anonymous" for every recording, the User key
+   * filter could never match anything, and a ByIdentifiedUserKey erasure
+   * request resolved zero sessions while the settings page said "Captures
+   * end-user identity: Yes".
+   */
+  describe("end-user identity on the session header", () => {
+    const USER_REF: string = "user-42@acme.test";
 
-    const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+    function metaWithUserRef(userRef: string): SessionReplayChunkMeta {
+      return {
+        entryUrl: "https://shop.example.com/",
+        browserName: "Chrome",
+        browserVersion: "141",
+        osName: "macOS",
+        deviceType: "desktop",
+        viewportWidth: 1440,
+        viewportHeight: 900,
+        identifiedUserRef: userRef,
+      };
+    }
 
-    expect(header["identifiedUserKey"]).toBe("");
-    expect(header["identifiedUserLabel"]).toBe("");
+    test("stores an HMAC key and the raw label when capture is on", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: true }) as never,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(USER_REF) }]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      /* SHA-256 hex: the column has to be a fixed-width opaque token. */
+      expect(header["identifiedUserKey"]).toMatch(/^[0-9a-f]{64}$/);
+      expect(header["identifiedUserLabel"]).toBe(USER_REF);
+
+      /* The key must not be the reference in disguise. */
+      expect(header["identifiedUserKey"]).not.toContain("acme");
+    });
+
+    /*
+     * The ACL-critical assertion. The recorder is supposed to withhold the
+     * reference entirely when capture is off, but the recorder's copy of the
+     * policy can be a config-cache TTL stale and a hand-crafted POST is not
+     * bound by it at all - so the server must refuse it too.
+     */
+    test("stores nothing when the application has capture switched off", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: false }) as never,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(USER_REF) }]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["identifiedUserKey"]).toBe("");
+      expect(header["identifiedUserLabel"]).toBe("");
+      expect(JSON.stringify(header)).not.toContain("acme.test");
+    });
+
+    test("a page that supplies no reference stays anonymous", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: true }) as never,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(buildBody([{ chunkIndex: 0 }])),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["identifiedUserKey"]).toBe("");
+      expect(header["identifiedUserLabel"]).toBe("");
+    });
+
+    /*
+     * Determinism is what makes erasure work: a request naming a person has
+     * to resolve to the same digest their sessions were filed under, months
+     * later and from a different process.
+     */
+    test("the same reference in the same project yields the same key", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: true }) as never,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(USER_REF) }]),
+        ),
+      );
+
+      const first: string = getSubmittedRows("RumSessionV1")[0]![
+        "identifiedUserKey"
+      ] as string;
+
+      submitMock.mockClear();
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              sessionId: "c".repeat(32),
+              meta: metaWithUserRef(USER_REF),
+            },
+          ]),
+        ),
+      );
+
+      const second: string = getSubmittedRows("RumSessionV1")[0]![
+        "identifiedUserKey"
+      ] as string;
+
+      expect(second).toBe(first);
+    });
+
+    /*
+     * Scoped by project, so one customer's digest can never be used to probe
+     * another's - and so a project-wide erasure reaches every application in
+     * that project, which is exactly what ProcessSessionErasureRequests
+     * filters on.
+     */
+    test("the same reference in a different project yields a different key", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: true }) as never,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(USER_REF) }]),
+        ),
+      );
+
+      const first: string = getSubmittedRows("RumSessionV1")[0]![
+        "identifiedUserKey"
+      ] as string;
+
+      const otherProjectId: ObjectID = ObjectID.generate();
+
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({
+          captureUserIdentity: true,
+          projectId: otherProjectId,
+        }) as never,
+      );
+
+      submitMock.mockClear();
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(USER_REF) }]),
+          { projectId: otherProjectId.toString() },
+        ),
+      );
+
+      const second: string = getSubmittedRows("RumSessionV1")[0]![
+        "identifiedUserKey"
+      ] as string;
+
+      expect(second).not.toBe(first);
+      expect(second).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    /*
+     * The server's cap has to be the SAME cap the recorder slices to.
+     *
+     * The recorder sends userRef.slice(0, SESSION_REPLAY_MAX_USER_REF_LENGTH)
+     * and the targeting handshake hashes it at that length. The envelope
+     * parser used to fold it into the 128-byte cap it shares with
+     * browserName and osName, so any reference longer than 128 characters -
+     * a namespaced customer id, a signed token, a long email - was hashed
+     * from a DIFFERENT string than the one a dashboard lookup or an erasure
+     * request would hash. Nothing errored; the recordings were simply filed
+     * under a key no one could ever resolve.
+     */
+    test("a long reference is stored whole, not folded into the device-string cap", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: true }) as never,
+      );
+
+      /* Comfortably past the 128-byte meta cap, inside the 512 user-ref cap. */
+      const longRef: string = `acme-tenant-${"z".repeat(200)}@customers.example.com`;
+
+      expect(longRef.length).toBeGreaterThan(128);
+      expect(longRef.length).toBeLessThanOrEqual(
+        SESSION_REPLAY_MAX_USER_REF_LENGTH,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(longRef) }]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["identifiedUserLabel"]).toBe(longRef);
+      expect(header["identifiedUserKey"]).toBe(
+        SessionReplayIdentity.buildUserKey({
+          projectId: PROJECT_ID,
+          userRef: longRef,
+        }),
+      );
+    });
+
+    /*
+     * Past the shared cap both sides slice to, the server sees exactly what
+     * a recorder would have sent - the 512-character prefix - so the key is
+     * the same either way. What must NOT happen is the two sides disagreeing
+     * about where to cut.
+     */
+    test("a reference past the shared cap hashes the same prefix the recorder would send", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ captureUserIdentity: true }) as never,
+      );
+
+      const overLong: string = "z".repeat(
+        SESSION_REPLAY_MAX_USER_REF_LENGTH + 200,
+      );
+
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, meta: metaWithUserRef(overLong) }]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect((header["identifiedUserLabel"] as string).length).toBe(
+        SESSION_REPLAY_MAX_USER_REF_LENGTH,
+      );
+      expect(header["identifiedUserKey"]).toBe(
+        SessionReplayIdentity.buildUserKey({
+          projectId: PROJECT_ID,
+          userRef: overLong.slice(0, SESSION_REPLAY_MAX_USER_REF_LENGTH),
+        }),
+      );
+    });
+  });
+
+  /*
+   * The provisional header's signal counters.
+   *
+   * They used to be hardcoded to 0 while `hasError` in the same object
+   * literal was derived from envelope.signals.errorCount - so for the 10-15
+   * minutes before the finalizer runs, the "With errors" tab returned rows
+   * whose Signals cell read "Clean", and the "With frustration" tab excluded
+   * the very session that was captured BECAUSE of a rage click. Both tabs
+   * are read during an incident, which is exactly that window.
+   */
+  describe("provisional signal counters", () => {
+    test("chunk 0's signals seed the header instead of being zeroed", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              signals: {
+                errorCount: 2,
+                rageClickCount: 1,
+                deadClickCount: 3,
+                errorClickCount: 1,
+                refreshRageCount: 0,
+                routeCount: 4,
+              },
+            },
+          ]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["errorCount"]).toBe(2);
+      expect(header["rageClickCount"]).toBe(1);
+      expect(header["deadClickCount"]).toBe(3);
+      expect(header["errorClickCount"]).toBe(1);
+      expect(header["pageCount"]).toBe(4);
+    });
+
+    /*
+     * The invariant that made the list self-contradictory: hasError said
+     * "yes" while the counter it is derived from said zero.
+     */
+    test("hasError and errorCount can no longer disagree", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              signals: {
+                errorCount: 1,
+                rageClickCount: 0,
+                deadClickCount: 0,
+                errorClickCount: 0,
+                refreshRageCount: 0,
+                routeCount: 0,
+              },
+            },
+          ]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["hasError"]).toBe(true);
+      expect(header["errorCount"]).toBeGreaterThan(0);
+    });
+
+    test("a clean chunk 0 still reports zeroes", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              signals: {
+                errorCount: 0,
+                rageClickCount: 0,
+                deadClickCount: 0,
+                errorClickCount: 0,
+                refreshRageCount: 0,
+                routeCount: 0,
+              },
+            },
+          ]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["hasError"]).toBe(false);
+      expect(header["errorCount"]).toBe(0);
+      expect(header["rageClickCount"]).toBe(0);
+    });
+  });
+
+  /*
+   * WHERE the user went, per chunk.
+   *
+   * The chunk table used to carry routeCount but not the routes themselves,
+   * so the session header's exitUrl / routes[] could only ever be whatever
+   * chunk 0 knew - the landing page, for the life of a single-page app. The
+   * finalizer now derives all three from these columns.
+   */
+  describe("per-chunk url and routes", () => {
+    test("every chunk records the url it was flushed from", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            { chunkIndex: 0, url: "https://shop.example.com/" },
+            { chunkIndex: 1, url: "https://shop.example.com/cart" },
+            { chunkIndex: 2, url: "https://shop.example.com/checkout" },
+          ]),
+        ),
+      );
+
+      const chunks: Array<JSONObject> = getSubmittedRows("RumSessionChunkV1");
+
+      expect(
+        chunks.map((c: JSONObject): unknown => {
+          return c["url"];
+        }),
+      ).toEqual([
+        "https://shop.example.com/",
+        "https://shop.example.com/cart",
+        "https://shop.example.com/checkout",
+      ]);
+    });
+
+    test("the envelope's route list is stored, in order, with the flush url appended", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              url: "https://shop.example.com/checkout",
+              routes: [
+                "https://shop.example.com/",
+                "https://shop.example.com/cart",
+              ],
+            },
+          ]),
+        ),
+      );
+
+      const chunk: JSONObject = getSubmittedRows("RumSessionChunkV1")[0]!;
+
+      expect(chunk["routes"]).toEqual([
+        "https://shop.example.com/",
+        "https://shop.example.com/cart",
+        "https://shop.example.com/checkout",
+      ]);
+    });
+
+    /*
+     * An older recorder posting to a newer server sends no routes at all.
+     * It must still contribute its page to the session's route list rather
+     * than contributing nothing.
+     */
+    test("a recorder that sends no route list still contributes its own url", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            { chunkIndex: 0, url: "https://shop.example.com/legacy" },
+          ]),
+        ),
+      );
+
+      const chunk: JSONObject = getSubmittedRows("RumSessionChunkV1")[0]!;
+
+      expect(chunk["routes"]).toEqual(["https://shop.example.com/legacy"]);
+    });
+
+    test("a route repeated across the chunk is stored once", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              url: "https://shop.example.com/cart",
+              routes: [
+                "https://shop.example.com/cart",
+                "https://shop.example.com/",
+                "https://shop.example.com/cart",
+              ],
+            },
+          ]),
+        ),
+      );
+
+      const chunk: JSONObject = getSubmittedRows("RumSessionChunkV1")[0]!;
+
+      expect(chunk["routes"]).toEqual([
+        "https://shop.example.com/cart",
+        "https://shop.example.com/",
+      ]);
+    });
+
+    /*
+     * The columns render under the WIDER session-metadata ACL, so an
+     * unscrubbed reset token here reaches more readers than the payload
+     * does. Client-side scrubbing is not a control the server may assume.
+     */
+    test("routes are re-scrubbed server side, not trusted from the wire", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              url: "https://shop.example.com/account?session=s3cr3t-a",
+              routes: [
+                "https://shop.example.com/reset-password?token=s3cr3t-b",
+                "https://shop.example.com/users/550e8400-e29b-41d4-a716-446655440000",
+              ],
+            },
+          ]),
+        ),
+      );
+
+      const chunk: JSONObject = getSubmittedRows("RumSessionChunkV1")[0]!;
+      const stored: string = JSON.stringify([chunk["url"], chunk["routes"]]);
+
+      expect(stored).not.toContain("s3cr3t");
+      expect(stored).not.toContain("token");
+      expect(stored).not.toContain("550e8400");
+      expect(chunk["url"]).toBe("https://shop.example.com/account");
+    });
   });
 
   /*
@@ -1207,10 +1680,77 @@ describe("SessionReplayIngestService.processFromQueue", () => {
       /* Route structure survives - that is the whole point of scrubbing. */
       expect(header["exitUrl"]).toBe("https://shop.example.com/reset-password");
       expect(header["entryUrl"]).toBe("https://shop.example.com/magic-link");
-      /* routes is seeded from the exit url, which is this chunk's own url. */
+      /* With no route list on the envelope, routes is the chunk's own url. */
       expect(header["routes"]).toEqual([
         "https://shop.example.com/reset-password",
       ]);
+    });
+
+    /*
+     * The provisional header carries chunk 0's REAL route list.
+     *
+     * It is not rewritten until the finalizer runs, so a one-entry list made
+     * the "Page URL visited (exact)" filter miss a page the user
+     * demonstrably reached for the whole 10-15 minute provisional window -
+     * on a row that simultaneously reported pageCount 2.
+     */
+    test("the provisional header carries chunk 0's whole route list", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              url: "https://shop.example.com/checkout",
+              routes: [
+                "https://shop.example.com/",
+                "https://shop.example.com/cart",
+              ],
+              signals: {
+                errorCount: 0,
+                rageClickCount: 0,
+                deadClickCount: 0,
+                errorClickCount: 0,
+                refreshRageCount: 0,
+                routeCount: 2,
+              },
+            },
+          ]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(header["routes"]).toEqual([
+        "https://shop.example.com/",
+        "https://shop.example.com/cart",
+        "https://shop.example.com/checkout",
+      ]);
+
+      /* The count and the list can no longer disagree on the same row. */
+      expect((header["routes"] as Array<string>).length).toBe(
+        (header["pageCount"] as number) + 1,
+      );
+    });
+
+    test("the provisional route list is scrubbed like the rest", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            {
+              chunkIndex: 0,
+              url: "https://shop.example.com/checkout",
+              routes: [
+                "https://shop.example.com/reset-password?token=s3cr3t-header",
+              ],
+            },
+          ]),
+        ),
+      );
+
+      const header: JSONObject = getSubmittedRows("RumSessionV1")[0]!;
+
+      expect(JSON.stringify(header["routes"])).not.toContain("s3cr3t");
+      expect(JSON.stringify(header["routes"])).not.toContain("token");
     });
 
     test("identifier-shaped path segments are redacted, not just the query", async () => {

--- a/App/Tests/Workers/SessionReplayFinalizer.test.ts
+++ b/App/Tests/Workers/SessionReplayFinalizer.test.ts
@@ -74,7 +74,10 @@ interface RawChunkRow {
   errorClickCount: number;
   refreshRageCount: number;
   routeCount: number;
+  url: string;
+  routes: Array<string>;
   sessionStartUnixMs: number;
+  chunkStartUnixMs: number;
   chunkEndUnixMs: number;
   chunkEndOffsetMs: number;
   schemaVersion: number;
@@ -95,6 +98,8 @@ function makeChunkRow(data: {
   payloadBytes?: number;
   errorCount?: number;
   routeCount?: number;
+  url?: string;
+  routes?: Array<string>;
 }): RawChunkRow {
   const chunkIndex: number = data.chunkIndex;
 
@@ -113,7 +118,15 @@ function makeChunkRow(data: {
     errorClickCount: 0,
     refreshRageCount: 0,
     routeCount: data.routeCount ?? 0,
+    /*
+     * Empty by default so the pre-existing fixtures keep exercising the
+     * "chunks written before the url/routes columns existed" path, where
+     * the finalizer must still fall back to the provisional header.
+     */
+    url: data.url ?? "",
+    routes: data.routes ?? (data.url ? [data.url] : []),
     sessionStartUnixMs: sessionStartUnixMs,
+    chunkStartUnixMs: sessionStartUnixMs + chunkIndex * CHUNK_DURATION_MS,
     chunkEndUnixMs: sessionStartUnixMs + (chunkIndex + 1) * CHUNK_DURATION_MS,
     chunkEndOffsetMs: (chunkIndex + 1) * CHUNK_DURATION_MS,
     schemaVersion: SESSION_REPLAY_SCHEMA_VERSION,
@@ -138,6 +151,72 @@ function makeChunkRow(data: {
  * SQL text itself is pinned by a separate test below, so the two halves
  * cannot drift apart silently.
  */
+/* ClickHouse argMinIf / argMaxIf over a non-empty url. */
+function pickUrlBy(
+  rows: Array<RawChunkRow>,
+  clock: (row: RawChunkRow) => number,
+  wantEarliest: boolean,
+): string {
+  let chosen: RawChunkRow | null = null;
+
+  for (const row of rows) {
+    if (!row.url) {
+      continue;
+    }
+
+    if (!chosen) {
+      chosen = row;
+      continue;
+    }
+
+    const isBetter: boolean = wantEarliest
+      ? clock(row) < clock(chosen)
+      : clock(row) >= clock(chosen);
+
+    if (isBetter) {
+      chosen = row;
+    }
+  }
+
+  return chosen ? chosen.url : "";
+}
+
+/*
+ * ClickHouse minIf(chunkStartTime, url != '') / maxIf(chunkEndTime, url != '').
+ * 0 when no chunk of the tab carries a url, exactly as ClickHouse returns.
+ */
+function clockOfUrlBearing(
+  rows: Array<RawChunkRow>,
+  wantEarliestStart: boolean,
+): number {
+  const times: Array<number> = rows
+    .filter((row: RawChunkRow): boolean => {
+      return Boolean(row.url);
+    })
+    .map((row: RawChunkRow): number => {
+      return wantEarliestStart ? row.chunkStartUnixMs : row.chunkEndUnixMs;
+    });
+
+  if (times.length === 0) {
+    return 0;
+  }
+
+  return wantEarliestStart ? Math.min(...times) : Math.max(...times);
+}
+
+/* ClickHouse arraySort(arrayDistinct(arrayFlatten(groupArray(routes)))). */
+function distinctRoutes(rows: Array<RawChunkRow>): Array<string> {
+  const seen: Set<string> = new Set<string>();
+
+  for (const row of rows) {
+    for (const route of row.routes) {
+      seen.add(route);
+    }
+  }
+
+  return Array.from(seen).sort();
+}
+
 function runGroupByOverChunkRows(rows: Array<RawChunkRow>): Array<JSONObject> {
   const latestByIdentity: Map<string, RawChunkRow> = new Map<
     string,
@@ -232,11 +311,46 @@ function runGroupByOverChunkRows(rows: Array<RawChunkRow>): Array<JSONObject> {
       routeCount: sum((row: RawChunkRow): number => {
         return row.routeCount;
       }),
+      /*
+       * argMinIf(url, chunkStartTime, url != '') and its argMax twin: the
+       * earliest and latest NON-EMPTY url of the tab, which is what makes a
+       * pre-migration chunk (url = '') fall through to the header instead of
+       * blanking the column.
+       */
+      firstUrl: pickUrlBy(
+        tabRows,
+        (row: RawChunkRow): number => {
+          return row.chunkStartUnixMs;
+        },
+        true,
+      ),
+      lastUrl: pickUrlBy(
+        tabRows,
+        (row: RawChunkRow): number => {
+          return row.chunkEndUnixMs;
+        },
+        false,
+      ),
+      /* minIf / maxIf over the url-bearing chunks, and countIf. */
+      firstUrlAtUnixMs: String(clockOfUrlBearing(tabRows, true)),
+      lastUrlAtUnixMs: String(clockOfUrlBearing(tabRows, false)),
+      urlChunkCount: tabRows.filter((row: RawChunkRow): boolean => {
+        return Boolean(row.url);
+      }).length,
+      /* arrayDistinct(arrayFlatten(groupArray(routes))) */
+      routes: distinctRoutes(tabRows),
       hasFinalChunk: tabRows.some((row: RawChunkRow): boolean => {
         return row.isFinal;
       })
         ? 1
         : 0,
+      firstChunkStartUnixMs: String(
+        Math.min(
+          ...tabRows.map((row: RawChunkRow): number => {
+            return row.chunkStartUnixMs;
+          }),
+        ),
+      ),
       sessionStartUnixMs: String(
         Math.min(
           ...tabRows.map((row: RawChunkRow): number => {
@@ -287,6 +401,12 @@ function makeProvisionalHeader(
     triggerReason: "error",
     samplePercentageAtCapture: 0,
     clockSkewMs: -107877,
+    errorCount: 0,
+    rageClickCount: 0,
+    deadClickCount: 0,
+    errorClickCount: 0,
+    refreshRageCount: 0,
+    pageCount: 0,
     entryUrl: "https://shop.example.com/checkout",
     exitUrl: "https://shop.example.com/checkout/failed",
     routes: ["/checkout", "/checkout/failed"],
@@ -516,6 +636,319 @@ describe("Rum:FinalizeSessions header row", () => {
     });
   }
 
+  /*
+   * WHERE the session went.
+   *
+   * entryUrl / exitUrl / routes[] used to be copied verbatim from the
+   * provisional header, which the ingest writes once, on chunk 0. The
+   * consequences were all visible in the product:
+   *
+   *   - a single-page app reported its LANDING page as its exit URL for the
+   *     life of the session;
+   *   - routes[] could never hold more than one element, so the "Exit page
+   *     URL (exact)" filter returned nothing for a page the user
+   *     demonstrably reached, and the bloom index over routes was built on
+   *     a one-element array;
+   *   - pageCount and routes.length disagreed on the same row, which reads
+   *     as data corruption;
+   *   - a session spanning two page loads had its entryUrl OVERWRITTEN by
+   *     the second load, because a new page load mints a new tabId and
+   *     therefore a second chunkIndex === 0.
+   */
+  describe("entry, exit and route derivation", () => {
+    const HOME: string = "https://shop.example.com/";
+    const CART: string = "https://shop.example.com/cart";
+    const CHECKOUT: string = "https://shop.example.com/checkout";
+
+    test("the exit url is the last url of the last chunk, not chunk 0's", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, url: HOME }),
+        makeChunkRow({ chunkIndex: 1, url: CART, routeCount: 1 }),
+        makeChunkRow({
+          chunkIndex: 2,
+          url: CHECKOUT,
+          routeCount: 1,
+          isFinal: true,
+        }),
+      ];
+
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: HOME,
+          exitUrl: HOME,
+          routes: [HOME],
+        }),
+      );
+
+      expect(row["exitUrl"]).toBe(CHECKOUT);
+      expect(row["entryUrl"]).toBe(HOME);
+    });
+
+    /*
+     * routes[] is a de-duplicated, SORTED set - not a path. groupArray's
+     * element order is unspecified under parallel aggregation, and the
+     * header is a ReplacingMergeTree row the sweep can rewrite, so two runs
+     * over identical chunks have to produce identical bytes. entryUrl and
+     * exitUrl are what answer the ordered questions.
+     */
+    test("routes hold every page visited, not just the first", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, url: HOME }),
+        makeChunkRow({ chunkIndex: 1, url: CART, routeCount: 1 }),
+        makeChunkRow({
+          chunkIndex: 2,
+          url: CHECKOUT,
+          routeCount: 1,
+          isFinal: true,
+        }),
+      ];
+
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: HOME,
+          exitUrl: HOME,
+          routes: [HOME],
+        }),
+      );
+
+      expect(row["routes"]).toEqual([HOME, CART, CHECKOUT].sort());
+    });
+
+    test("routes are sorted, so re-finalizing produces an identical row", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, url: CHECKOUT }),
+        makeChunkRow({ chunkIndex: 1, url: HOME }),
+        makeChunkRow({ chunkIndex: 2, url: CART, isFinal: true }),
+      ];
+
+      const first: JSONObject = rowFor(rows, null);
+
+      /* Same chunks, arriving in a different order from the database. */
+      const second: JSONObject = rowFor([...rows].reverse(), null);
+
+      expect(first["routes"]).toEqual(second["routes"]);
+      expect(first["routes"]).toEqual(
+        [...(first["routes"] as Array<string>)].sort(),
+      );
+    });
+
+    /*
+     * The invariant worth keeping: pageCount is summed from routeCount and
+     * was already correct, so tying the list to the count means neither can
+     * drift without the other noticing.
+     */
+    test("routes.length and pageCount can no longer disagree", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, url: HOME }),
+        makeChunkRow({ chunkIndex: 1, url: CART, routeCount: 1 }),
+        makeChunkRow({
+          chunkIndex: 2,
+          url: CHECKOUT,
+          routeCount: 1,
+          isFinal: true,
+        }),
+      ];
+
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: HOME,
+          exitUrl: HOME,
+          routes: [HOME],
+        }),
+      );
+
+      /* Entry page + one per route change. */
+      expect((row["routes"] as Array<string>).length).toBe(
+        (row["pageCount"] as number) + 1,
+      );
+    });
+
+    /*
+     * Two navigations inside one 15s flush window are invisible to the
+     * chunk's own url - which is why the envelope carries the route list
+     * and the chunk table stores it.
+     */
+    test("routes visited and left inside one chunk are still recorded", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({
+          chunkIndex: 0,
+          url: CHECKOUT,
+          routes: [HOME, CART, CHECKOUT],
+          routeCount: 2,
+          isFinal: true,
+        }),
+      ];
+
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: HOME,
+          exitUrl: HOME,
+          routes: [HOME],
+        }),
+      );
+
+      expect(row["routes"]).toEqual([HOME, CART, CHECKOUT].sort());
+      expect(row["exitUrl"]).toBe(CHECKOUT);
+    });
+
+    /*
+     * A session spanning two page loads. The SECOND tab's chunk 0 rewrote
+     * the provisional header, so the header's entryUrl is the second load's
+     * URL - the finalizer must not trust it.
+     */
+    test("a session spanning two page loads keeps its real entry url", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, tabId: "tab-a", url: HOME }),
+        makeChunkRow({ chunkIndex: 1, tabId: "tab-a", url: CART }),
+        makeChunkRow({ chunkIndex: 0, tabId: "tab-b", url: CHECKOUT }),
+        makeChunkRow({
+          chunkIndex: 1,
+          tabId: "tab-b",
+          url: CHECKOUT,
+          isFinal: true,
+        }),
+      ];
+
+      /* What the clobbering second header write left behind. */
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: CHECKOUT,
+          exitUrl: CHECKOUT,
+          routes: [CHECKOUT],
+        }),
+      );
+
+      expect(row["entryUrl"]).toBe(HOME);
+      expect(row["exitUrl"]).toBe(CHECKOUT);
+      expect(row["routes"]).toEqual([HOME, CART, CHECKOUT].sort());
+    });
+
+    /*
+     * Sessions recorded before the chunk table carried url/routes have empty
+     * columns. They must keep rendering exactly as they do today rather than
+     * losing their URLs to the new derivation.
+     */
+    test("chunks predating the url columns fall back to the header", () => {
+      const rows: Array<RawChunkRow> = [0, 1, 2].map(
+        (chunkIndex: number): RawChunkRow => {
+          return makeChunkRow({ chunkIndex: chunkIndex });
+        },
+      );
+
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: HOME,
+          exitUrl: CHECKOUT,
+          routes: [HOME, CHECKOUT],
+        }),
+      );
+
+      expect(row["entryUrl"]).toBe(HOME);
+      expect(row["exitUrl"]).toBe(CHECKOUT);
+      expect(row["routes"]).toEqual([HOME, CHECKOUT].sort());
+    });
+
+    /*
+     * A session live across the deploy that added the url column.
+     *
+     * argMinIf skips empty urls, so the earliest url the chunk table holds
+     * is a MID-session page. Trusting it would move the session's entry URL
+     * forward, and would throw away the provisional header - written from
+     * chunk 0, before the deploy - which is the only thing that still knows
+     * where the session began. The exit URL needs no such care: url-less
+     * chunks are always chronologically earlier than url-bearing ones.
+     */
+    test("a session straddling the url migration keeps the header's entry url", () => {
+      const rows: Array<RawChunkRow> = [
+        /* Written by the old server: no url column. */
+        makeChunkRow({ chunkIndex: 0 }),
+        makeChunkRow({ chunkIndex: 1 }),
+        /* Written after the deploy. */
+        makeChunkRow({ chunkIndex: 2, url: CART }),
+        makeChunkRow({ chunkIndex: 3, url: CHECKOUT, isFinal: true }),
+      ];
+
+      const row: JSONObject = rowFor(
+        rows,
+        makeProvisionalHeader({
+          entryUrl: HOME,
+          exitUrl: HOME,
+          routes: [HOME],
+        }),
+      );
+
+      expect(row["entryUrl"]).toBe(HOME);
+      /* The exit url IS derivable, and is the newer, better answer. */
+      expect(row["exitUrl"]).toBe(CHECKOUT);
+    });
+
+    /*
+     * Two tabs of one session. sessionStartTime is written from the
+     * recorder's localStorage record and is therefore IDENTICAL across
+     * tabs, so it can order none of them - the merge has to compare the
+     * per-chunk clocks, or it silently resolves to whatever order ClickHouse
+     * grouped the tabs in, and flips between finalizations of the same
+     * session.
+     */
+    test("two concurrent tabs resolve entry and exit urls deterministically", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, tabId: "tab-a", url: HOME }),
+        makeChunkRow({ chunkIndex: 1, tabId: "tab-a", url: CART }),
+        makeChunkRow({ chunkIndex: 0, tabId: "tab-b", url: CHECKOUT }),
+        makeChunkRow({
+          chunkIndex: 1,
+          tabId: "tab-b",
+          url: CHECKOUT,
+          isFinal: true,
+        }),
+      ];
+
+      const forwards: JSONObject = rowFor(rows, null);
+      const backwards: JSONObject = rowFor([...rows].reverse(), null);
+
+      expect(forwards["entryUrl"]).toBe(backwards["entryUrl"]);
+      expect(forwards["exitUrl"]).toBe(backwards["exitUrl"]);
+      expect(forwards["routes"]).toEqual(backwards["routes"]);
+    });
+
+    test("a session with no header at all still reports its derived urls", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, url: HOME }),
+        makeChunkRow({ chunkIndex: 1, url: CART, isFinal: true }),
+      ];
+
+      const row: JSONObject = rowFor(rows, null);
+
+      expect(row["entryUrl"]).toBe(HOME);
+      expect(row["exitUrl"]).toBe(CART);
+      expect(row["routes"]).toEqual([HOME, CART].sort());
+    });
+
+    test("a page visited twice appears once", () => {
+      const rows: Array<RawChunkRow> = [
+        makeChunkRow({ chunkIndex: 0, url: HOME }),
+        makeChunkRow({ chunkIndex: 1, url: CART, routeCount: 1 }),
+        makeChunkRow({
+          chunkIndex: 2,
+          url: HOME,
+          routeCount: 1,
+          isFinal: true,
+        }),
+      ];
+
+      const row: JSONObject = rowFor(rows, null);
+
+      expect(row["routes"]).toEqual([HOME, CART].sort());
+      expect(row["exitUrl"]).toBe(HOME);
+    });
+  });
+
   test("writes one finalized version carrying the derived aggregates", () => {
     const rows: Array<RawChunkRow> = [0, 1, 2, 3].map(
       (chunkIndex: number): RawChunkRow => {
@@ -715,6 +1148,32 @@ describe("Rum:FinalizeSessions queries", () => {
     expect(query).toContain("sum(eventCount)");
     expect(query).toContain("max(chunkIndex)");
     expect(query).toContain("groupArrayIf(chunkIndex, hasFullSnapshot)");
+
+    /*
+     * The URL derivation, pinned because the in-test GROUP BY model above
+     * reimplements it and the two must not drift.
+     *
+     * Every clock here is a per-CHUNK time. sessionStartTime is the
+     * SESSION's start, written from the recorder's localStorage record, so
+     * it is identical across every tab and can order none of them - a merge
+     * that compared it would silently resolve to ClickHouse's grouping
+     * order and flip between finalizations of the same session.
+     */
+    expect(query).toContain("argMinIf(url, chunkStartTime, url != '')");
+    expect(query).toContain("argMaxIf(url, chunkEndTime, url != '')");
+    expect(query).toContain(
+      "minIf(toUnixTimestamp64Milli(chunkStartTime), url != '')",
+    );
+    expect(query).toContain(
+      "maxIf(toUnixTimestamp64Milli(chunkEndTime), url != '')",
+    );
+    expect(query).toContain("countIf(url != '')");
+    expect(query).toContain("min(chunkStartTime)");
+
+    /* Sorted in SQL: the route union is a set, and must be deterministic. */
+    expect(query).toContain(
+      "arraySort(arrayDistinct(arrayFlatten(groupArray(routes))))",
+    );
 
     /*
      * The payload column must never be read here: it is the fattest column
@@ -1149,6 +1608,10 @@ describe("recording-lost seal", () => {
       errorClickCount: 0,
       refreshRageCount: 0,
       pageCount: 0,
+      firstUrl: "",
+      lastUrl: "",
+      routes: [],
+      firstUrlCoversSessionStart: false,
       hasFinalChunk: false,
       sessionStartUnixMs: header.startTimeUnixMs,
       lastChunkEndUnixMs: header.startTimeUnixMs,

--- a/Common/Models/AnalyticsModels/RumSessionChunk.ts
+++ b/Common/Models/AnalyticsModels/RumSessionChunk.ts
@@ -450,6 +450,56 @@ export default class RumSessionChunk extends AnalyticsBaseModel {
       });
     });
 
+    /*
+     * WHERE the page was while this chunk was open.
+     *
+     * The chunk table used to carry routeCount but not the routes, so the
+     * session header's entryUrl / exitUrl / routes[] could only ever be
+     * whatever chunk 0 happened to know - which for a single-page app is the
+     * landing page, forever. pageCount said "7 pages" on the same row where
+     * routes[] held one element, and the "Exit page URL (exact)" filter
+     * could not match a page the user demonstrably reached.
+     *
+     * Both are already scrubbed on the client AND re-scrubbed at ingest:
+     * these render under the wider session-metadata ACL, so an unscrubbed
+     * `/reset-password?token=...` here reaches more readers than the payload
+     * itself does.
+     */
+    const urlColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "url",
+      title: "URL",
+      description:
+        "Scrubbed URL the page was on when this chunk was flushed. The session's exit URL is the latest of these.",
+      /*
+       * Required with an empty default rather than nullable. Chunks written
+       * before this column existed read back as "", which is what the
+       * finalizer's argMinIf/argMaxIf skip over so a pre-migration session
+       * falls back to its provisional header instead of losing its URLs.
+       */
+      required: true,
+      defaultValue: "",
+      type: TableColumnType.Text,
+      codec: [{ codec: "ZSTD", level: 1 }],
+      accessControl: chunkAccessControl,
+    });
+
+    const routesColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "routes",
+      title: "Routes",
+      description:
+        "Distinct scrubbed URLs visited while this chunk was open, in order. The session's routes[] is the union of these.",
+      /*
+       * Required, like RumSession.routes. ClickHouse refuses
+       * Nullable(Array(String)) outright, so an array column can never be
+       * optional - it is empty or it is absent.
+       */
+      required: true,
+      defaultValue: [],
+      type: TableColumnType.ArrayText,
+      codec: [{ codec: "ZSTD", level: 1 }],
+      accessControl: chunkAccessControl,
+    });
+
     const retentionDateColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
       key: "retentionDate",
       title: "Retention Date",
@@ -510,6 +560,8 @@ export default class RumSessionChunk extends AnalyticsBaseModel {
         payloadColumn,
         payloadBytesColumn,
         ...counterColumns,
+        urlColumn,
+        routesColumn,
         retentionDateColumn,
       ],
       sortKeys: ["projectId", "sessionId", "tabId", "chunkIndex"],

--- a/Common/Models/DatabaseModels/CloudResource.ts
+++ b/Common/Models/DatabaseModels/CloudResource.ts
@@ -283,8 +283,22 @@ export default class CloudResource extends BaseModel {
   })
   public description?: string = undefined;
 
+  /*
+   * Creatable, never updatable - see the identical note on
+   * RumApplication.appIdentifier. `create: []` on a required column that the
+   * Cloud Resources create form declares made manual creation impossible:
+   * the field was stripped from the form and the server then rejected the
+   * POST for the very value it had just removed.
+   */
   @ColumnAccessControl({
-    create: [],
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.CreateCloudResource,
+    ],
     read: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
@@ -305,6 +319,8 @@ export default class CloudResource extends BaseModel {
     description:
       "Stable identifier for this managed-compute workload (service.name, falling back to host.name). Identity key for this resource.",
   })
+  /* Case-insensitive uniqueness; see RumApplication.appIdentifier. */
+  @UniqueColumnBy("projectId")
   @Column({
     nullable: false,
     type: ColumnType.ShortText,

--- a/Common/Models/DatabaseModels/RumApplication.ts
+++ b/Common/Models/DatabaseModels/RumApplication.ts
@@ -286,8 +286,31 @@ export default class RumApplication extends BaseModel {
   })
   public description?: string = undefined;
 
+  /*
+   * Creatable, never updatable.
+   *
+   * `create: []` here made the documented "create an application by hand"
+   * flow (docs/rum/applications.md) impossible: ModelForm drops any field
+   * the caller has no create permission on, so the Dashboard's required
+   * "App Identifier" input never rendered, and the POST that followed was
+   * rejected by the server with a raw `appIdentifier is required`. The
+   * column is required and has no default, so nothing could supply it.
+   *
+   * `update` stays empty on purpose. This value is the application's
+   * identity - telemetry is filed under it and the (projectId,
+   * appIdentifier) index is unique - so re-pointing it after the fact would
+   * orphan every session, trace and recording already keyed on the old one.
+   * Same shape as ServerlessFunction.functionIdentifier.
+   */
   @ColumnAccessControl({
-    create: [],
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.CreateRumApplication,
+    ],
     read: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
@@ -308,6 +331,16 @@ export default class RumApplication extends BaseModel {
     description:
       "Stable identifier for this application from the service.name OpenTelemetry resource attribute. Identity key for this RUM application.",
   })
+  /*
+   * Case-INSENSITIVE uniqueness, which the unique index on
+   * (projectId, appIdentifier) does not give: Postgres compares it byte for
+   * byte, while RumApplicationService.findOrCreateByAppIdentifier resolves
+   * an incoming service.name with QueryHelper.findWithSameText, which
+   * lowercases. Without this, someone hand-creating "Storefront-Web" beside
+   * an auto-discovered "storefront-web" passes the index and leaves two rows
+   * that the case-insensitive lookup resolves arbitrarily.
+   */
+  @UniqueColumnBy("projectId")
   @Column({
     nullable: false,
     type: ColumnType.ShortText,
@@ -1245,7 +1278,7 @@ export default class RumApplication extends BaseModel {
     type: TableColumnType.Boolean,
     title: "Capture Session Replay User Identity",
     description:
-      "When enabled, the raw end-user reference supplied by the host page is stored alongside the recording, so a support engineer can find the session a named customer is complaining about. When off, only a one-way per-project HMAC of it is stored. On by default. Narrower create/update ACL than the other replay settings: this is the switch that turns a pseudonymous recording into an identified one.",
+      "When enabled, the end-user reference supplied by the host page is stored alongside the recording - as a one-way per-project HMAC for lookup and erasure, plus the raw reference behind its own narrower column ACL - so a support engineer can find the session a named customer is complaining about. When off, the reference is never attached to a recording and neither column is stored. (It is still sent once on the policy request, which is how targeted capture matches a named user; it is not persisted.) The reference must be supplied at load time - identify() called later reaches the server only on the session's final chunk, which the header is not rebuilt from. On by default. Narrower create/update ACL than the other replay settings: this is the switch that turns a pseudonymous recording into an identified one.",
     defaultValue: true,
   })
   @Column({

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -115,6 +115,7 @@ import RumApplication from "../../Models/DatabaseModels/RumApplication";
 import RumApplicationService from "../Services/RumApplicationService";
 import Project from "../../Models/DatabaseModels/Project";
 import ProjectService from "../Services/ProjectService";
+import SessionReplayIdentity from "../Utils/SessionReplay/SessionReplayIdentity";
 import SessionReplayTargeting from "../Utils/SessionReplay/SessionReplayTargeting";
 import SessionReplayUsage from "../Utils/SessionReplay/SessionReplayUsage";
 import RumSessionReplayView from "../../Models/DatabaseModels/RumSessionReplayView";
@@ -134,6 +135,7 @@ import {
   DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY,
   MAX_SESSION_REPLAY_CHUNKS_PER_READ,
   MAX_SESSION_REPLAY_READ_BYTES,
+  SESSION_REPLAY_MAX_USER_REF_LENGTH,
 } from "../../Types/Rum/SessionReplay";
 
 const router: ExpressRouter = Express.getRouter();
@@ -3495,6 +3497,14 @@ router.post(
 /*
  * Listing sessions. Mirrors RumSession's table-level read ACL exactly:
  * knowing WHICH sessions errored is triage.
+ *
+ * Including the PAYLOAD permission, which that ACL also carries and this
+ * guard used to omit. Watching implies listing: the payload routes authorize
+ * on ReadRumSessionReplayPayload alone, so a role granted only "Watch
+ * Session Replays" could play back any session whose id it was handed while
+ * being 401'd on the list, the manifest and the exception page's replay card
+ * - an incoherent grant rather than a safer one, and exactly what
+ * RumSession's own comment says the ACL exists to prevent.
  */
 const requireSessionReplayListAccess: Array<RequestHandler> = [
   UserMiddleware.getUserMiddleware,
@@ -3505,6 +3515,7 @@ const requireSessionReplayListAccess: Array<RequestHandler> = [
       Permission.ProjectAdmin,
       Permission.TelemetryAdmin,
       Permission.ReadRumSessionReplay,
+      Permission.ReadRumSessionReplayPayload,
     ],
   }),
 ];
@@ -3534,6 +3545,20 @@ const SESSION_REPLAY_LIST_PERMISSIONS: Array<Permission> = [
   Permission.ProjectAdmin,
   Permission.TelemetryAdmin,
   Permission.ReadRumSessionReplay,
+  /*
+   * Watching implies listing.
+   *
+   * RumSession's own table read ACL contains this permission for a reason it
+   * states outright: a role granted only the watch permission could fetch
+   * payloads (the payload routes authorize on it alone) while being 401'd on
+   * the manifest and the list - an incoherent grant rather than a safer one.
+   * Leaving it out here meant a support-engineer role built from "Watch
+   * Session Replays" + "Read RUM Application" - the natural pairing, and the
+   * one the permission's own description suggests - got a permission error
+   * on the session list and a silently missing "Watch what the user saw"
+   * card on every exception page.
+   */
+  Permission.ReadRumSessionReplayPayload,
 ];
 
 const SESSION_REPLAY_PAYLOAD_PERMISSIONS: Array<Permission> = [
@@ -4131,7 +4156,50 @@ router.post(
         ? OneUptimeDate.fromString(body["endTime"] as string)
         : OneUptimeDate.getCurrentDate();
 
+      /*
+       * The narrower identity ACL, resolved BEFORE the filters are built.
+       *
+       * It is enforced by simply not naming the column in the SELECT - there
+       * is no ModelPermission on this path to strip it after the fact - and
+       * it is decided against the application already loaded by the access
+       * check, so a caller whose identity grant is label-scoped elsewhere
+       * does not get named end users here.
+       *
+       * It gates the identity FILTER as well as the column. Without that,
+       * a caller deliberately denied the label could still ask "does
+       * jane@example.com have sessions here" and read every other field of
+       * the answer - a dictionary attack that de-anonymises the list one
+       * candidate at a time, and hands back identifiedUserKey as a stable
+       * pseudonym to join against the route filter. The permission sets are
+       * genuinely different: SESSION_REPLAY_IDENTITY_PERMISSIONS excludes
+       * TelemetryAdmin and ReadRumSessionReplay, both of which can list.
+       */
+      const includeIdentifiedUserLabel: boolean = canReadIdentifiedUserLabel({
+        databaseProps: databaseProps,
+        application: application,
+      });
+
       const rawFilters: JSONObject = (body["filters"] as JSONObject) || {};
+
+      /*
+       * A reference the server cannot hash must be a 400, never a filter
+       * that quietly disappears. Dropping it would return the WHOLE
+       * unfiltered list with a 200 - the caller sees every session in the
+       * project and has no way to tell that the person they asked about was
+       * not the one being answered about.
+       */
+      if (
+        rawFilters["identifiedUserRef"] !== undefined &&
+        !SessionReplayIdentity.isUsableUserRef(rawFilters["identifiedUserRef"])
+      ) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException(
+            `identifiedUserRef must be a non-empty string of at most ${SESSION_REPLAY_MAX_USER_REF_LENGTH} characters.`,
+          ),
+        );
+      }
 
       const filters: SessionReplayListFilters = {
         ...(typeof rawFilters["hasError"] === "boolean" && {
@@ -4158,9 +4226,42 @@ router.post(
         ...(readStringArrayFromBody(rawFilters, "countryCodes") && {
           countryCodes: readStringArrayFromBody(rawFilters, "countryCodes"),
         }),
-        ...(typeof rawFilters["identifiedUserKey"] === "string" && {
-          identifiedUserKey: rawFilters["identifiedUserKey"],
-        }),
+        /*
+         * The caller sends the end-user reference their own page supplied -
+         * the value the session list displays - and the server derives the
+         * digest with the same per-project HMAC the ingest used. Hashing
+         * here rather than in the browser is what keeps the derivation (and
+         * the EncryptionSecret it is keyed on) server-side, and it is the
+         * only reason this filter can match anything: the raw key is
+         * displayed nowhere in the product, so a user had no way to obtain
+         * the value the field used to demand.
+         *
+         * Gated on the identity permission, and validated above so an
+         * unusable reference is a 400 rather than a silently unfiltered
+         * list.
+         */
+        ...(includeIdentifiedUserLabel &&
+          SessionReplayIdentity.isUsableUserRef(
+            rawFilters["identifiedUserRef"],
+          ) && {
+            identifiedUserKey: SessionReplayIdentity.buildUserKey({
+              projectId: projectId,
+              userRef: rawFilters["identifiedUserRef"] as string,
+            }),
+          }),
+        /*
+         * Still accepted, for API callers that already hold a digest (an
+         * erasure workflow, a saved view). Ignored when a reference was also
+         * sent, since the reference is the one a human typed. The digest is
+         * not guessable and is already returned to every list-capable
+         * caller, so it needs no identity gate of its own.
+         */
+        ...(typeof rawFilters["identifiedUserKey"] === "string" &&
+          !SessionReplayIdentity.isUsableUserRef(
+            rawFilters["identifiedUserRef"],
+          ) && {
+            identifiedUserKey: rawFilters["identifiedUserKey"],
+          }),
         ...(typeof rawFilters["route"] === "string" && {
           route: rawFilters["route"],
         }),
@@ -4182,18 +4283,6 @@ router.post(
               sessionId: rawCursor["sessionId"],
             }
           : undefined;
-
-      /*
-       * The narrower identity ACL is enforced by simply not naming the
-       * column in the SELECT. There is no ModelPermission on this path to
-       * strip it after the fact. Decided against the application already
-       * loaded by the access check, so a caller whose identity grant is
-       * label-scoped elsewhere does not get named end users here.
-       */
-      const includeIdentifiedUserLabel: boolean = canReadIdentifiedUserLabel({
-        databaseProps: databaseProps,
-        application: application,
-      });
 
       const result: SessionReplayListResult =
         await SessionReplayReadService.listSessions({

--- a/Common/Server/Utils/SessionReplay/SessionReplayGateCache.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayGateCache.ts
@@ -105,11 +105,18 @@ export interface SessionReplayGatePolicy {
   isAppEnabled: boolean;
 
   /*
-   * Empty means REFUSED, not allow-all. This is the only anti-forgery
-   * control available: a TelemetryIngestionKey has no expiry, no scope and
-   * no origin binding, and the docs tell customers to paste it into
-   * browser JavaScript, so anyone who scrapes the key could otherwise
-   * write recordings into the victim's project.
+   * Empty means ANY ORIGIN, which is the shipped default (the column
+   * defaults to '[]') and what isOriginAllowed below actually implements -
+   * this doc used to claim the opposite ("empty means REFUSED"), in the one
+   * direction where being wrong matters, since a reader would conclude the
+   * feature was locked down out of the box.
+   *
+   * Filling it in is the only anti-forgery control available: a
+   * TelemetryIngestionKey has no expiry, no scope and no origin binding, and
+   * the docs tell customers to paste it into browser JavaScript, so anyone
+   * who scrapes the key can write recordings into the victim's project until
+   * this list names the customer's own domains. The installation-test panel
+   * flags an empty list as a warning for exactly that reason.
    */
   allowedOrigins: Array<string>;
 

--- a/Common/Server/Utils/SessionReplay/SessionReplayIdentity.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayIdentity.ts
@@ -57,17 +57,37 @@ export default class SessionReplayIdentity {
   }
 
   /*
-   * Trimmed, but NOT lower-cased. End-user references are opaque to us -
-   * "U-1000" and "u-1000" may well be two different customers in the host
-   * application's own database - so folding case here would merge two
-   * people's recordings under one key, and an erasure for one would delete
-   * the other's. Targeting lower-cases the APPLICATION identifier for the
-   * same reason in reverse: that one is ours and is case-insensitive.
+   * The project scope lives in the KEY, not in the message.
+   *
+   * HMAC takes arbitrary key material, so deriving a per-project key from
+   * the instance secret and the project id gives real domain separation:
+   * two projects cannot produce the same digest for the same person even
+   * if one of them learns the other's project id, which prefixing the
+   * message only achieves by convention. It is also what makes the
+   * "per-project" wording on the identity columns literally true.
+   *
+   * The reference is trimmed but NOT lower-cased. End-user references are
+   * opaque to us - "U-1000" and "u-1000" may well be two different
+   * customers in the host application's own database - so folding case here
+   * would merge two people's recordings under one key, and an erasure for
+   * one would delete the other's. Targeting lower-cases the APPLICATION
+   * identifier for the same reason in reverse: that one is ours and is
+   * case-insensitive.
+   *
+   * A slow KDF (bcrypt / scrypt / argon2) is deliberately NOT used and
+   * would not help. This is a keyed pseudonym, not a stored password: it
+   * has to be DETERMINISTIC so the session filter and a right-to-erasure
+   * request months later resolve the same digest, and those algorithms are
+   * salted per invocation. What defends the digest is the key - without
+   * EncryptionSecret an attacker holding the column cannot test candidate
+   * references at all, at any work factor.
    */
   public static buildUserKey(data: SessionReplayUserKeyInput): string {
+    const projectKey: string = `${EncryptionSecret.toString()}:${data.projectId.toString()}`;
+
     return crypto
-      .createHmac("sha256", EncryptionSecret.toString())
-      .update(`${data.projectId.toString()}:${data.userRef.trim()}`)
+      .createHmac("sha256", projectKey)
+      .update(data.userRef.trim())
       .digest("hex");
   }
 

--- a/Common/Server/Utils/SessionReplay/SessionReplayIdentity.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayIdentity.ts
@@ -1,0 +1,82 @@
+import crypto from "crypto";
+import { EncryptionSecret } from "../../EnvironmentConfig";
+import ObjectID from "../../../Types/ObjectID";
+import { SESSION_REPLAY_MAX_USER_REF_LENGTH } from "../../../Types/Rum/SessionReplay";
+
+/*
+ * "Whose session is this?"
+ *
+ * A page that has an end-user reference hands it to the recorder
+ * (data-oneuptime-user-ref, or the init global). When the application has
+ * identity capture switched on, the recorder puts that reference on the
+ * chunk envelope's meta, and this module turns it into the two columns the
+ * session header carries:
+ *
+ *   identifiedUserKey    HMAC(EncryptionSecret, "<projectId>:<userRef>")
+ *   identifiedUserLabel  the reference itself, behind its own column ACL
+ *
+ * The key is what makes a reference SEARCHABLE and ERASABLE without storing
+ * it in a lookup-friendly form: a support engineer filtering by user, and a
+ * right-to-erasure request naming one, both resolve to the same digest. The
+ * label is what makes a session READABLE - "jane@example.com" rather than a
+ * 64-character hash - and is why it sits behind a narrower ACL than the rest
+ * of the session metadata.
+ *
+ * Scoped by project and NOT by application, deliberately. A project-wide
+ * erasure request (ProcessSessionErasureRequests filters on projectId with
+ * the application clause optional) has to be able to reach every session for
+ * that person, including ones recorded by sibling applications. An
+ * application-scoped digest would make that request silently under-delete,
+ * which is the failure mode with legal consequences.
+ *
+ * Deliberately NOT reusing SessionReplayTargeting.buildTargetKey: that one
+ * is application-scoped and prefixed for a Redis keyspace. Both are HMACs of
+ * a user reference, and conflating them would tie an erasure lookup to the
+ * shape of a Redis key.
+ */
+
+export interface SessionReplayUserKeyInput {
+  projectId: ObjectID;
+  userRef: string;
+}
+
+export default class SessionReplayIdentity {
+  /*
+   * Usable when non-empty and within the shared cap. The cap matters on both
+   * sides of the comparison: the recorder slices the reference to the same
+   * length before sending it, so anything longer could never match a stored
+   * key anyway, and hashing an unbounded string here would be the only
+   * unbounded work on this path.
+   */
+  public static isUsableUserRef(userRef: unknown): userRef is string {
+    return (
+      typeof userRef === "string" &&
+      userRef.trim().length > 0 &&
+      userRef.length <= SESSION_REPLAY_MAX_USER_REF_LENGTH
+    );
+  }
+
+  /*
+   * Trimmed, but NOT lower-cased. End-user references are opaque to us -
+   * "U-1000" and "u-1000" may well be two different customers in the host
+   * application's own database - so folding case here would merge two
+   * people's recordings under one key, and an erasure for one would delete
+   * the other's. Targeting lower-cases the APPLICATION identifier for the
+   * same reason in reverse: that one is ours and is case-insensitive.
+   */
+  public static buildUserKey(data: SessionReplayUserKeyInput): string {
+    return crypto
+      .createHmac("sha256", EncryptionSecret.toString())
+      .update(`${data.projectId.toString()}:${data.userRef.trim()}`)
+      .digest("hex");
+  }
+
+  /*
+   * The label as stored. Trimmed and capped to the same length the recorder
+   * enforces, so the column can never hold something the wire could not have
+   * carried.
+   */
+  public static buildUserLabel(userRef: string): string {
+    return userRef.trim().slice(0, SESSION_REPLAY_MAX_USER_REF_LENGTH);
+  }
+}

--- a/Common/Server/Utils/SessionReplay/SessionReplayReadService.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayReadService.ts
@@ -1341,13 +1341,22 @@ export default class SessionReplayReadService {
       );
     }
 
-    if (filters.hasFrustration === true) {
+    if (filters.hasFrustration !== undefined) {
       /*
        * Over the argMax aliases, like every HAVING predicate here — the
        * raw columns would sum across ReplacingMergeTree versions.
+       *
+       * `!== undefined` rather than `=== true`, so `false` means "sessions
+       * with NO frustration signals" instead of being silently dropped. The
+       * route admits any boolean, and hasError / isFinalized beside it both
+       * honour false, so accepting the value and ignoring it returned the
+       * whole unfiltered list with a 200 and no indication why.
        */
+      const total: string =
+        "(aggRageClickCount + aggDeadClickCount + aggErrorClickCount + aggRefreshRageCount)";
+
       statement.append(
-        " AND (aggRageClickCount + aggDeadClickCount + aggErrorClickCount + aggRefreshRageCount) > 0",
+        filters.hasFrustration ? ` AND ${total} > 0` : ` AND ${total} = 0`,
       );
     }
 

--- a/Common/Tests/Models/DatabaseModels/SessionReplayModels.test.ts
+++ b/Common/Tests/Models/DatabaseModels/SessionReplayModels.test.ts
@@ -5,6 +5,7 @@ import AuditLog from "../../../Models/AnalyticsModels/AuditLog";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import { PlanType } from "../../../Types/Billing/SubscriptionPlan";
 import Project from "../../../Models/DatabaseModels/Project";
+import CloudResource from "../../../Models/DatabaseModels/CloudResource";
 import RumApplication from "../../../Models/DatabaseModels/RumApplication";
 import RumSessionErasureRequest from "../../../Models/DatabaseModels/RumSessionErasureRequest";
 import RumSessionPin from "../../../Models/DatabaseModels/RumSessionPin";
@@ -60,6 +61,86 @@ describe("RumApplication session replay configuration", () => {
   ): TableColumnMetadata => {
     return model.getTableColumnMetadata(columnName);
   };
+
+  /*
+   * The identity column has to be CREATABLE and NEVER UPDATABLE.
+   *
+   * It shipped as `create: []` on a required column with no default, which
+   * made the documented "create an application by hand" flow impossible:
+   * ModelForm drops any field the caller has no create permission on, so the
+   * Dashboard's required "App Identifier" input never rendered, and the POST
+   * that followed was rejected by the server with "appIdentifier is
+   * required". The Create button was a dead end for every user.
+   */
+  it("lets a user supply the app identifier at creation time", () => {
+    const accessControl: ColumnAccessControl | null =
+      model.getColumnAccessControlFor("appIdentifier");
+
+    expect(accessControl).toBeDefined();
+    expect(accessControl!.create.length).toBeGreaterThan(0);
+    expect(accessControl!.create).toContain(Permission.ProjectOwner);
+    expect(accessControl!.create).toContain(Permission.CreateRumApplication);
+  });
+
+  it("never lets the app identifier be edited afterwards", () => {
+    /*
+     * Deliberately immutable. Telemetry, sessions, traces and recordings are
+     * all filed under this value and the (projectId, appIdentifier) index is
+     * unique, so re-pointing it after the fact would orphan every row that
+     * already references it. If this list is ever populated, the orphaning
+     * has to be solved first - do not "tidy it up" to match `create`.
+     */
+    const accessControl: ColumnAccessControl | null =
+      model.getColumnAccessControlFor("appIdentifier");
+
+    expect(accessControl!.update).toEqual([]);
+  });
+
+  /*
+   * The create form declares an "App Identifier" field. That field can only
+   * render if the column is creatable, and the POST can only succeed if the
+   * required column is supplied - so a required column with an empty create
+   * list is always a dead form, whatever the page source says.
+   *
+   * CloudResource.resourceIdentifier is checked alongside because it had the
+   * identical defect on the identical page shape: an auto-discovered
+   * identity column whose dashboard page also offers a Create button.
+   */
+  it.each([
+    ["RumApplication", new RumApplication() as BaseModel],
+    ["CloudResource", new CloudResource() as BaseModel],
+  ])(
+    "%s has no required column that the user is forbidden to create",
+    (_name: string, subject: BaseModel) => {
+      const uncreatable: Array<string> = [];
+
+      for (const columnName of subject.getTableColumns().columns) {
+        const metadata: TableColumnMetadata =
+          subject.getTableColumnMetadata(columnName);
+        const accessControl: ColumnAccessControl | null =
+          subject.getColumnAccessControlFor(columnName);
+
+        if (!metadata.required || metadata.defaultValue !== undefined) {
+          continue;
+        }
+
+        /* System columns nobody submits through a form. */
+        if (
+          ["_id", "createdAt", "updatedAt", "version", "slug"].includes(
+            columnName,
+          )
+        ) {
+          continue;
+        }
+
+        if (accessControl && accessControl.create.length === 0) {
+          uncreatable.push(columnName);
+        }
+      }
+
+      expect(uncreatable).toEqual([]);
+    },
+  );
 
   it("declares every session replay configuration column", () => {
     const expectedColumns: Array<string> = [

--- a/Common/Tests/Server/API/SessionReplayAPI.test.ts
+++ b/Common/Tests/Server/API/SessionReplayAPI.test.ts
@@ -7,6 +7,7 @@ import RumSessionReplayViewService from "../../../Server/Services/RumSessionRepl
 import RumSessionService from "../../../Server/Services/RumSessionService";
 import RumSessionChunkService from "../../../Server/Services/RumSessionChunkService";
 import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import SessionReplayIdentity from "../../../Server/Utils/SessionReplay/SessionReplayIdentity";
 import RumApplication from "../../../Models/DatabaseModels/RumApplication";
 import RumSessionReplayView from "../../../Models/DatabaseModels/RumSessionReplayView";
 import Label from "../../../Models/DatabaseModels/Label";
@@ -1086,6 +1087,196 @@ describe("Session replay playback API", () => {
       expect(query).toContain("timeout_overflow_mode = 'throw'");
     });
 
+    /*
+     * Watching implies listing.
+     *
+     * RumSession's table read ACL contains ReadRumSessionReplayPayload for a
+     * reason it states outright: a role granted only the watch permission
+     * could fetch payloads - the payload routes authorize on it alone - while
+     * being 401'd on the manifest and the list, which is an incoherent grant
+     * rather than a safer one. The list guard did not mirror it, so the
+     * natural support-engineer role ("Watch Session Replays" + "Read RUM
+     * Application") got a permission error on the session list and a silently
+     * missing "Watch what the user saw" card on every exception page.
+     */
+    test("a caller with only the watch permission can still list sessions", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ReadRumSessionReplayPayload],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [] });
+
+      const result: CallResult = await callRoute({
+        uri: LIST_ROUTE,
+        request: principal.request,
+        body: { rumApplicationId: applicationAId.toString() },
+      });
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(headerQuerySpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("a Viewer still cannot list sessions", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.Viewer],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [] });
+
+      const result: CallResult = await callRoute({
+        uri: LIST_ROUTE,
+        request: principal.request,
+        body: { rumApplicationId: applicationAId.toString() },
+      });
+
+      expect(result.deniedWith).toBeInstanceOf(NotAuthorizedException);
+      expect(headerQuerySpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The identity filter takes the end-user REFERENCE a person can see in
+     * the list, and the server derives the digest with the same per-project
+     * HMAC the ingest used. It used to take the digest itself - a value
+     * displayed nowhere in the product and computed by no endpoint - so
+     * every input a human could plausibly type returned nothing.
+     */
+    test("an end-user reference is hashed server side before it reaches the query", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        /* Holds the narrower identity permission - see the gate test below. */
+        permissions: [Permission.ProjectOwner],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [] });
+
+      await callRoute({
+        uri: LIST_ROUTE,
+        request: principal.request,
+        body: {
+          rumApplicationId: applicationAId.toString(),
+          filters: { identifiedUserRef: "jane@example.com" },
+        },
+      });
+
+      const statement: Statement = headerQuerySpy.mock
+        .calls[0]![0] as Statement;
+
+      const expectedKey: string = SessionReplayIdentity.buildUserKey({
+        projectId: projectId,
+        userRef: "jane@example.com",
+      });
+
+      const bound: string = JSON.stringify(statement.query_params);
+
+      /* The raw reference must never reach the query. */
+      expect(bound).not.toContain("jane@example.com");
+      expect(bound).toContain(expectedKey);
+    });
+
+    /*
+     * The identity FILTER is gated by the same ACL as the identity COLUMN.
+     *
+     * Without this, a caller deliberately denied the label could still ask
+     * "does jane@example.com have sessions here" and read every other field
+     * of the answer - a dictionary attack that de-anonymises the list one
+     * candidate at a time, and hands back identifiedUserKey as a stable
+     * pseudonym to join against the route filter. It only became reachable
+     * once the ingest started populating the column; before that the
+     * predicate matched nothing whoever asked.
+     */
+    test("a caller without the identity permission cannot filter by end user", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        /* Can list, deliberately excluded from SESSION_REPLAY_IDENTITY_PERMISSIONS. */
+        permissions: [Permission.TelemetryAdmin],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [] });
+
+      await callRoute({
+        uri: LIST_ROUTE,
+        request: principal.request,
+        body: {
+          rumApplicationId: applicationAId.toString(),
+          filters: { identifiedUserRef: "jane@example.com" },
+        },
+      });
+
+      const statement: Statement = headerQuerySpy.mock
+        .calls[0]![0] as Statement;
+
+      const expectedKey: string = SessionReplayIdentity.buildUserKey({
+        projectId: projectId,
+        userRef: "jane@example.com",
+      });
+
+      /* Neither the reference nor its digest may reach the query. */
+      const bound: string = JSON.stringify(statement.query_params);
+
+      expect(bound).not.toContain("jane@example.com");
+      expect(bound).not.toContain(expectedKey);
+
+      /*
+       * aggIdentifiedUserKey is always a SELECT alias; what must be absent
+       * is the HAVING predicate over it.
+       */
+      expect(statement.query).not.toContain("aggIdentifiedUserKey =");
+    });
+
+    /*
+     * A filter the server cannot honour must be refused, not dropped. The
+     * silent-drop shape returns the WHOLE project's sessions with a 200 and
+     * gives the caller no way to tell that the person they asked about was
+     * not the one being answered about.
+     */
+    test("an unusable end-user reference is refused, not silently ignored", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ProjectOwner],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [] });
+
+      const result: CallResult = await callRoute({
+        uri: LIST_ROUTE,
+        request: principal.request,
+        body: {
+          rumApplicationId: applicationAId.toString(),
+          filters: { identifiedUserRef: "z".repeat(4096) },
+        },
+      });
+
+      expect(result.deniedWith).toBeInstanceOf(BadDataException);
+      expect(headerQuerySpy).not.toHaveBeenCalled();
+    });
+
     test("omits identifiedUserLabel for a caller without the narrower identity permission", async () => {
       const principal: {
         request: JSONObject;
@@ -1260,6 +1451,47 @@ describe("Session replay playback API", () => {
        * too: raw columns would sum across ReplacingMergeTree versions.
        */
       expect(statement.query).toContain(
+        "(aggRageClickCount + aggDeadClickCount + aggErrorClickCount + aggRefreshRageCount) > 0",
+      );
+    });
+
+    /*
+     * `false` means "sessions with NO frustration signals" and must be
+     * honoured, not dropped. The route admits any boolean and hasError /
+     * isFinalized beside it both honour false, so accepting the value and
+     * ignoring it returned the whole unfiltered list with a 200 and no
+     * indication why. The Dashboard never sends it, so this branch has no
+     * producer and this is its only cover.
+     */
+    test("hasFrustration false selects the clean sessions rather than being dropped", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ProjectAdmin],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [] });
+
+      await callRoute({
+        uri: LIST_ROUTE,
+        request: principal.request,
+        body: {
+          rumApplicationId: applicationAId.toString(),
+          filters: { hasFrustration: false },
+        },
+      });
+
+      const statement: Statement = headerQuerySpy.mock
+        .calls[0]![0] as Statement;
+
+      expect(statement.query).toContain(
+        "(aggRageClickCount + aggDeadClickCount + aggErrorClickCount + aggRefreshRageCount) = 0",
+      );
+      expect(statement.query).not.toContain(
         "(aggRageClickCount + aggDeadClickCount + aggErrorClickCount + aggRefreshRageCount) > 0",
       );
     });

--- a/Common/Types/Rum/SessionReplay.ts
+++ b/Common/Types/Rum/SessionReplay.ts
@@ -296,6 +296,20 @@ export interface SessionReplayChunkEnvelope {
   /* Already scrubbed client-side: origin + path, no query, no fragment. */
   url: string;
 
+  /*
+   * Distinct scrubbed URLs the page was on while this chunk was open, in
+   * chronological order. Optional so an older recorder posting to a newer
+   * server is still accepted - the server then falls back to `url` alone,
+   * which is what it did before this field existed.
+   *
+   * `url` says where the chunk was FLUSHED from; this says where the user
+   * went while it was filling. The session header's routes[] column is the
+   * union of these, and the "sessions that hit /checkout" filter reads it,
+   * so without this a navigation that both starts and ends inside one flush
+   * window is invisible.
+   */
+  routes?: Array<string>;
+
   signals: SessionReplaySignalCounts;
 
   fidelityNotices: Array<string>;

--- a/E2E/Tests/Dashboard/Helpers/SessionReplay.ts
+++ b/E2E/Tests/Dashboard/Helpers/SessionReplay.ts
@@ -1,0 +1,342 @@
+import { BASE_URL } from "../../../Config";
+import { APIResponse, Locator, Page, expect } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+import { gotoProjectPage } from "./ProductOnboarding";
+
+/*
+ * Helpers for the session replay end-to-end spec.
+ *
+ * The recorder itself is a browser bundle served to third-party origins, and
+ * driving it for real would mean standing up a second web server just to host
+ * a page with a script tag on it. Everything AFTER the recorder is what these
+ * helpers exercise: the exact wire frame the recorder produces, posted to the
+ * real ingest endpoint with a real ingestion key, and then read back through
+ * the real dashboard.
+ *
+ * The frame format is deliberately built here by hand rather than imported
+ * from the recorder. The wire contract has two independent implementations —
+ * Transport.ts writes it, SessionReplayEnvelopeParser.ts reads it — and a
+ * helper that shared code with either side would stop being a test of the
+ * contract between them.
+ */
+
+/* Mirrors SESSION_REPLAY_WIRE_VERSION / SESSION_REPLAY_SCHEMA_VERSION. */
+const WIRE_VERSION: number = 1;
+const SCHEMA_VERSION: number = 1;
+
+const CHUNK_CONTENT_TYPE: string =
+  "application/vnd.oneuptime.session-replay.v1";
+
+export interface SessionReplayChunkOptions {
+  page: Page;
+  ingestionKey: string;
+  appIdentifier: string;
+  sessionId: string;
+  tabId: string;
+  chunkIndex: number;
+  sessionStartUnixMs: number;
+
+  /* Where the page was when this chunk was flushed. */
+  url: string;
+
+  /* Every distinct page the chunk covered, in order. */
+  routes?: Array<string>;
+
+  isFinal?: boolean;
+  hasFullSnapshot?: boolean;
+  errorCount?: number;
+  rageClickCount?: number;
+  routeCount?: number;
+
+  /* Only sent on chunk 0 and the final chunk, exactly as the recorder does. */
+  identifiedUserRef?: string;
+}
+
+/* 32 lowercase hex, matching SessionId.generateId(). */
+type HexIdFunction = () => string;
+
+export const hexId: HexIdFunction = (): string => {
+  let out: string = "";
+
+  while (out.length < 32) {
+    out += Math.floor(Math.random() * 16).toString(16);
+  }
+
+  return out;
+};
+
+type PostSessionReplayChunkFunction = (
+  data: SessionReplayChunkOptions,
+) => Promise<void>;
+
+/*
+ * One frame: `<envelope JSON>\n<payload>`, where payloadBytes is the byte
+ * length of the payload. The payload is a small but REAL rrweb event array —
+ * a Meta event plus an incremental one — so the player has something valid to
+ * parse if this session is opened by hand.
+ */
+export const postSessionReplayChunk: PostSessionReplayChunkFunction = async (
+  data: SessionReplayChunkOptions,
+): Promise<void> => {
+  const chunkUrl: string = URL.fromString(BASE_URL.toString())
+    .addRoute("/telemetry/session-replay/v1/chunk")
+    .toString();
+
+  const nowUnixMs: number = Date.now();
+
+  const events: Array<unknown> = [
+    {
+      type: 4,
+      data: { href: data.url, width: 1440, height: 900 },
+      timestamp: nowUnixMs,
+    },
+    {
+      type: 3,
+      data: { source: 2, type: 2, id: 7 },
+      timestamp: nowUnixMs + 10,
+    },
+  ];
+
+  const payload: string = JSON.stringify(events);
+  const payloadBytes: number = Buffer.byteLength(payload, "utf8");
+
+  const envelope: Record<string, unknown> = {
+    v: WIRE_VERSION,
+    appIdentifier: data.appIdentifier,
+    sessionId: data.sessionId,
+    tabId: data.tabId,
+    chunkIndex: data.chunkIndex,
+    sessionStartUnixMs: data.sessionStartUnixMs,
+    clientSendUnixMs: nowUnixMs,
+    chunkStartOffsetMs: data.chunkIndex * 15000,
+    chunkEndOffsetMs: (data.chunkIndex + 1) * 15000,
+    eventCount: events.length,
+    hasFullSnapshot: data.hasFullSnapshot ?? data.chunkIndex === 0,
+    isFinal: data.isFinal ?? false,
+    recorderKind: "dom",
+    schemaVersion: SCHEMA_VERSION,
+    rrwebVersion: "2.1.1",
+    recorderVersion: "12.0.0",
+    maskingMode: "MaskSensitiveInputsOnly",
+    consentState: "NotRequired",
+    triggerReason: "manual",
+    payloadEncoding: "identity",
+    payloadBytes: payloadBytes,
+    url: data.url,
+    routes: data.routes ?? [data.url],
+    signals: {
+      errorCount: data.errorCount ?? 0,
+      rageClickCount: data.rageClickCount ?? 0,
+      deadClickCount: 0,
+      errorClickCount: 0,
+      refreshRageCount: 0,
+      routeCount: data.routeCount ?? 0,
+    },
+    fidelityNotices: [],
+    droppedEvents: 0,
+    flushFailures: 0,
+  };
+
+  const isMetaChunk: boolean =
+    data.chunkIndex === 0 || envelope["isFinal"] === true;
+
+  if (isMetaChunk) {
+    const meta: Record<string, unknown> = {
+      /*
+       * The ENTRY url, not the current one. The recorder captures this once
+       * at start(), so it is the same value on chunk 0 and on the final
+       * chunk even after the page has navigated.
+       */
+      entryUrl: data.routes?.[0] ?? data.url,
+      browserName: "Chrome",
+      browserVersion: "141",
+      osName: "macOS",
+      deviceType: "desktop",
+      viewportWidth: 1440,
+      viewportHeight: 900,
+    };
+
+    if (data.identifiedUserRef) {
+      meta["identifiedUserRef"] = data.identifiedUserRef;
+    }
+
+    envelope["meta"] = meta;
+  }
+
+  const body: Buffer = Buffer.concat([
+    new Uint8Array(Buffer.from(`${JSON.stringify(envelope)}\n`, "utf8")),
+    new Uint8Array(Buffer.from(payload, "utf8")),
+  ]);
+
+  const response: APIResponse = await data.page.request.post(chunkUrl, {
+    headers: {
+      "content-type": CHUNK_CONTENT_TYPE,
+      "x-oneuptime-token": data.ingestionKey,
+      "x-oneuptime-app-identifier": data.appIdentifier,
+    },
+    data: body,
+  });
+
+  /*
+   * 202 is the only success. A 204 means the server DELIBERATELY refused
+   * (disabled, unsampled, over budget) and would leave the rest of the spec
+   * asserting against a session that was never stored, so it fails here with
+   * the reason rather than 180 seconds later with "not visible".
+   */
+  expect(
+    response.status(),
+    `chunk ${data.chunkIndex} refused: ${await response.text()}`,
+  ).toBe(202);
+};
+
+type CreateRumApplicationFunction = (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+  appIdentifier: string;
+}) => Promise<void>;
+
+/*
+ * Creates a RUM application THROUGH THE DASHBOARD FORM, which is the point.
+ *
+ * appIdentifier is a required column with no default, and it shipped with an
+ * empty create ACL — so ModelForm stripped the field out of the rendered form
+ * and the POST that followed was rejected by the server with "appIdentifier
+ * is required". The Create button was a dead end for every user, and the only
+ * way a RUM application could exist was auto-discovery from telemetry. Nothing
+ * failed at build time and no unit test covered the form, which is why this
+ * assertion lives at this level.
+ */
+export const createRumApplication: CreateRumApplicationFunction = async (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+  appIdentifier: string;
+}): Promise<void> => {
+  const page: Page = data.page;
+
+  const rumUrl: string = URL.fromString(BASE_URL.toString())
+    .addRoute(`/dashboard/${data.projectId}/rum`)
+    .toString();
+
+  await gotoProjectPage({
+    page,
+    projectId: data.projectId,
+    url: rumUrl,
+    ready: page.getByRole("button", { name: "Create RUM Application" }),
+  });
+
+  await page.getByRole("button", { name: "Create RUM Application" }).click();
+  await page.getByTestId("modal").waitFor({ state: "visible" });
+
+  await page
+    .locator("input[placeholder='storefront-web']")
+    .first()
+    .fill(data.name);
+
+  /*
+   * The App Identifier input. It shares the placeholder with Name, so it is
+   * addressed by position — and its very presence is the regression this
+   * helper exists to catch: when the column was not creatable, this locator
+   * resolved to nothing.
+   */
+  const identifierInput: Locator = page
+    .locator("input[placeholder='storefront-web']")
+    .nth(1);
+
+  await expect(
+    identifierInput,
+    "The create form must render an App Identifier field - the server requires the column",
+  ).toBeVisible();
+
+  await identifierInput.fill(data.appIdentifier);
+
+  await page
+    .getByRole("button", { name: "Create RUM Application" })
+    .last()
+    .click();
+
+  /* The modal closes only on a successful create. */
+  await page.getByTestId("modal").waitFor({ state: "hidden", timeout: 60000 });
+
+  await expect(page.getByText(data.name).first()).toBeVisible({
+    timeout: 60000,
+  });
+};
+
+type OpenSessionReplayListFunction = (data: {
+  page: Page;
+  projectId: string;
+  rumApplicationId: string;
+}) => Promise<void>;
+
+export const openSessionReplayList: OpenSessionReplayListFunction =
+  async (data: {
+    page: Page;
+    projectId: string;
+    rumApplicationId: string;
+  }): Promise<void> => {
+    const listUrl: string = URL.fromString(BASE_URL.toString())
+      .addRoute(
+        `/dashboard/${data.projectId}/rum/${data.rumApplicationId}/session-replay`,
+      )
+      .toString();
+
+    await gotoProjectPage({
+      page: data.page,
+      projectId: data.projectId,
+      url: listUrl,
+      ready: data.page.getByText("Session Replay").first(),
+    });
+  };
+
+type ReadRumApplicationIdFunction = (data: {
+  page: Page;
+  projectId: string;
+  appIdentifier: string;
+}) => Promise<string>;
+
+/*
+ * The application's id, read back through the same CRUD API the dashboard
+ * uses. Needed because every replay read route is scoped to it.
+ */
+export const readRumApplicationId: ReadRumApplicationIdFunction = async (data: {
+  page: Page;
+  projectId: string;
+  appIdentifier: string;
+}): Promise<string> => {
+  const listUrl: string = URL.fromString(BASE_URL.toString())
+    .addRoute("/api/rum-application/get-list")
+    .toString();
+
+  const response: APIResponse = await data.page.request.post(listUrl, {
+    headers: { "content-type": "application/json" },
+    data: {
+      query: { appIdentifier: data.appIdentifier },
+      select: { _id: true, appIdentifier: true },
+      limit: 10,
+      skip: 0,
+    },
+  });
+
+  expect(response.status(), await response.text()).toBe(200);
+
+  const body: {
+    data?: Array<{ _id?: string; appIdentifier?: string }>;
+  } = (await response.json()) as {
+    data?: Array<{ _id?: string; appIdentifier?: string }>;
+  };
+
+  const match: { _id?: string } | undefined = (body.data || []).find(
+    (row: { appIdentifier?: string }): boolean => {
+      return row.appIdentifier === data.appIdentifier;
+    },
+  );
+
+  expect(
+    match?._id,
+    `No RUM application found for identifier ${data.appIdentifier}`,
+  ).toBeTruthy();
+
+  return match!._id!;
+};

--- a/E2E/Tests/Dashboard/Helpers/SessionReplay.ts
+++ b/E2E/Tests/Dashboard/Helpers/SessionReplay.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { BASE_URL } from "../../../Config";
 import { APIResponse, Locator, Page, expect } from "@playwright/test";
 import URL from "Common/Types/API/URL";
@@ -52,17 +53,17 @@ export interface SessionReplayChunkOptions {
   identifiedUserRef?: string;
 }
 
-/* 32 lowercase hex, matching SessionId.generateId(). */
+/*
+ * 32 lowercase hex, matching what SessionId.generateId() mints in the
+ * browser - 16 bytes from a CSPRNG, not Math.random(). The recorder uses
+ * crypto.getRandomValues for the same reason a session id is not guessable,
+ * and a fixture that generated ids a different way would be testing a
+ * different shape of value.
+ */
 type HexIdFunction = () => string;
 
 export const hexId: HexIdFunction = (): string => {
-  let out: string = "";
-
-  while (out.length < 32) {
-    out += Math.floor(Math.random() * 16).toString(16);
-  }
-
-  return out;
+  return crypto.randomBytes(16).toString("hex");
 };
 
 type PostSessionReplayChunkFunction = (

--- a/E2E/Tests/Dashboard/SessionReplay.spec.ts
+++ b/E2E/Tests/Dashboard/SessionReplay.spec.ts
@@ -1,0 +1,426 @@
+import { BASE_URL, IS_BILLING_ENABLED } from "../../Config";
+import { APIResponse, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+import Faker from "Common/Utils/Faker";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import { createTelemetryIngestionKey } from "./Helpers/Telemetry";
+import {
+  createRumApplication,
+  hexId,
+  openSessionReplayList,
+  postSessionReplayChunk,
+  readRumApplicationId,
+} from "./Helpers/SessionReplay";
+
+/*
+ * Session Replay, end to end.
+ *
+ * Everything below the recorder bundle, exercised the way a customer's
+ * browser exercises it: a real ingestion key, real chunk frames posted to
+ * /telemetry/session-replay/v1/chunk, and then the real dashboard reading
+ * them back.
+ *
+ * This is the only coverage of several hops that unit tests cannot reach,
+ * and each of them has been broken in a way nothing else caught:
+ *
+ *   - Creating a RUM application from the dashboard was impossible. The
+ *     required appIdentifier column had an empty create ACL, so ModelForm
+ *     stripped the field and the server then rejected the POST for the very
+ *     value it had just removed. Compiles fine, unit tests all green.
+ *   - The session header's exitUrl and routes[] were frozen at chunk 0, so a
+ *     single-page app reported its landing page as its exit page forever and
+ *     the route filter could not match a page the user demonstrably reached.
+ *   - The end-user reference was accepted on the wire and then written as
+ *     "", so every session read "Anonymous" while the settings page said
+ *     identity capture was on.
+ *
+ * To run locally against a full stack:
+ *
+ *   cd E2E && HOST=localhost npx playwright test \
+ *     Tests/Dashboard/SessionReplay.spec.ts --project=chromium
+ */
+test.describe("Session Replay", () => {
+  /*
+   * Register + project + billing + ingest key + a RUM application, then an
+   * ingest→query poll. Same headroom the telemetry spec takes.
+   */
+  test.beforeEach(() => {
+    test.setTimeout(420000);
+  });
+
+  test("records a session end to end and plays it back from the dashboard", async ({
+    page,
+  }: {
+    page: Page;
+  }) => {
+    /*
+     * Growth when billing is on: every replay READ route refuses a lower
+     * plan with 402, while ingest has no plan gate at all - so on a Free
+     * project the chunks below would be accepted and stored and then be
+     * unreadable, which would fail this spec for a reason that has nothing
+     * to do with what it is testing.
+     */
+    const projectId: string = await registerAndCreateProject({
+      page,
+      projectNamePrefix: "E2E Session Replay Project",
+      ...(IS_BILLING_ENABLED ? { preferredPlanName: "Growth" } : {}),
+    });
+
+    const ingestionKey: string = await createTelemetryIngestionKey({
+      page,
+      projectId,
+      keyName: "E2E Replay Key " + Faker.generateName().toString(),
+    });
+
+    const appIdentifier: string =
+      "e2e-replay-" + Faker.generateName().toString().toLowerCase();
+
+    /* Hop 1: the create form must actually be usable. */
+    await createRumApplication({
+      page,
+      projectId,
+      name: appIdentifier,
+      appIdentifier: appIdentifier,
+    });
+
+    const rumApplicationId: string = await readRumApplicationId({
+      page,
+      projectId,
+      appIdentifier,
+    });
+
+    const sessionId: string = hexId();
+    const tabId: string = hexId();
+    const sessionStartUnixMs: number = Date.now() - 60000;
+    const userRef: string = `e2e-user-${Faker.generateName().toString().toLowerCase()}@example.com`;
+
+    const origin: string = "https://shop.e2e.example.com";
+    const home: string = `${origin}/`;
+    const cart: string = `${origin}/cart`;
+    const checkout: string = `${origin}/checkout`;
+
+    /*
+     * Three chunks describing one journey: land on /, navigate to /cart, then
+     * to /checkout and throw. The URLs differ per chunk on purpose - that is
+     * what makes exitUrl and routes[] falsifiable.
+     */
+    await postSessionReplayChunk({
+      page,
+      ingestionKey,
+      appIdentifier,
+      sessionId,
+      tabId,
+      chunkIndex: 0,
+      sessionStartUnixMs,
+      url: home,
+      routes: [home],
+      identifiedUserRef: userRef,
+    });
+
+    await postSessionReplayChunk({
+      page,
+      ingestionKey,
+      appIdentifier,
+      sessionId,
+      tabId,
+      chunkIndex: 1,
+      sessionStartUnixMs,
+      url: cart,
+      routes: [cart],
+      routeCount: 1,
+    });
+
+    await postSessionReplayChunk({
+      page,
+      ingestionKey,
+      appIdentifier,
+      sessionId,
+      tabId,
+      chunkIndex: 2,
+      sessionStartUnixMs,
+      url: checkout,
+      routes: [checkout],
+      routeCount: 1,
+      errorCount: 1,
+      isFinal: true,
+      identifiedUserRef: userRef,
+    });
+
+    /* Hop 2: the session reaches the list. */
+    await pollUntil({
+      page,
+      what: `session ${sessionId.slice(0, 12)} in the list`,
+      run: async (): Promise<boolean> => {
+        await openSessionReplayList({ page, projectId, rumApplicationId });
+        await page.waitForTimeout(4000);
+
+        return page.getByText(sessionId.slice(0, 12)).first().isVisible();
+      },
+    });
+
+    /*
+     * Hop 3: the end user is named.
+     *
+     * The recorder sends the reference, the parser accepts it, and the ingest
+     * used to throw it away - so this cell read "Anonymous" for every session
+     * ever recorded, the "User" filter could never match, and a
+     * right-to-erasure request naming that person resolved zero sessions.
+     */
+    await expect(
+      page.getByText(userRef).first(),
+      "The end-user reference the page supplied must be stored and rendered",
+    ).toBeVisible({ timeout: 30000 });
+
+    /*
+     * Hop 4: the session is playable.
+     *
+     * "Watch" opens the player, which fetches the manifest and then the
+     * chunk frames over the binary framing endpoint and hands them to rrweb.
+     */
+    await page.getByRole("button", { name: "Watch" }).first().click();
+
+    await expect(page.getByText("Session details").first()).toBeVisible({
+      timeout: 60000,
+    });
+
+    /* The transport controls the player is useless without. */
+    await expect(page.getByRole("button", { name: "1x" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Next error" }),
+    ).toBeVisible();
+
+    /*
+     * Hop 5: the journey is described correctly.
+     *
+     * The finalizer derives entryUrl / exitUrl / routes from the chunk rows.
+     * Before that it was copied from the provisional header, written once on
+     * chunk 0 - so this panel said the session both began AND ended on "/",
+     * for a session that plainly ended on /checkout.
+     */
+    await page.getByRole("button", { name: "Session details" }).click();
+
+    /*
+     * EXACT. `checkout` has `home` as a prefix, so a substring match would
+     * hold even when the Entry URL row shows the checkout page - which is
+     * precisely the regression this assertion exists to catch.
+     */
+    await expect(page.getByText(home, { exact: true }).first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    await pollUntil({
+      page,
+      what: "the finalized exit URL",
+      /*
+       * Finalization is a 5-minute cron with a 10-minute idle cutoff, so this
+       * is the one assertion that has to wait for a worker rather than for a
+       * request.
+       */
+      timeoutMs: 240000,
+      run: async (): Promise<boolean> => {
+        await page.reload();
+        await page.waitForTimeout(5000);
+        await page
+          .getByRole("button", { name: "Session details" })
+          .click()
+          .catch((): void => {
+            /* Panel may already be open after a reload. */
+          });
+
+        return page.getByText(checkout).first().isVisible();
+      },
+    });
+  });
+
+  /*
+   * The delivery path, which is invisible until it is broken.
+   *
+   * Every install failure here is silent in the customer's browser by
+   * design: a 404 on the artifact, a config that says "disabled", or a
+   * version the loader refuses to build a URL from all produce a page that
+   * simply never records, with nothing logged anywhere the server can see.
+   * The recorder bundle is also built once by dev.sh with no watcher, so a
+   * checkout that never ran the build serves 404 for the script and reports
+   * the whole feature as disabled - which looks exactly like a policy
+   * decision.
+   */
+  test("serves the recorder, the pinned artifact and a usable policy", async ({
+    page,
+  }: {
+    page: Page;
+  }) => {
+    const projectId: string = await registerAndCreateProject({
+      page,
+      projectNamePrefix: "E2E Replay Delivery Project",
+      ...(IS_BILLING_ENABLED ? { preferredPlanName: "Growth" } : {}),
+    });
+
+    const ingestionKey: string = await createTelemetryIngestionKey({
+      page,
+      projectId,
+      keyName: "E2E Replay Delivery Key " + Faker.generateName().toString(),
+    });
+
+    const appIdentifier: string =
+      "e2e-delivery-" + Faker.generateName().toString().toLowerCase();
+
+    await createRumApplication({
+      page,
+      projectId,
+      name: appIdentifier,
+      appIdentifier: appIdentifier,
+    });
+
+    const base: string = BASE_URL.toString();
+
+    /* The loader stub: fixed path, short cache, so a rollback can reach it. */
+    const loader: APIResponse = await page.request.get(
+      URL.fromString(base)
+        .addRoute("/telemetry/session-replay/v1/recorder.js")
+        .toString(),
+    );
+
+    expect(loader.status(), await loader.text()).toBe(200);
+    expect(loader.headers()["content-type"]).toContain("javascript");
+    expect(loader.headers()["cache-control"]).toContain("max-age=300");
+
+    /* The policy the loader fetches before it will load anything. */
+    const configResponse: APIResponse = await page.request.get(
+      URL.fromString(base)
+        .addRoute("/telemetry/session-replay/v1/config")
+        .toString(),
+      {
+        headers: {
+          "x-oneuptime-token": ingestionKey,
+          "x-oneuptime-app-identifier": appIdentifier,
+        },
+      },
+    );
+
+    expect(configResponse.status(), await configResponse.text()).toBe(200);
+
+    const config: {
+      enabled?: boolean;
+      directive?: string;
+      recorderVersion?: string;
+      recorderIntegrity?: string;
+      maskingMode?: string;
+    } = (await configResponse.json()) as {
+      enabled?: boolean;
+      directive?: string;
+      recorderVersion?: string;
+      recorderIntegrity?: string;
+      maskingMode?: string;
+    };
+
+    expect(
+      config.enabled,
+      "A freshly created application must be recordable without configuring anything",
+    ).toBe(true);
+    expect(config.directive).toBe("continue");
+
+    /*
+     * The version is interpolated straight into a script URL, so the loader
+     * refuses anything that is not a semver the build could have stamped.
+     */
+    expect(config.recorderVersion).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+/);
+
+    /* Without SRI the immutable pinned artifact is unverifiable. */
+    expect(config.recorderIntegrity).toMatch(/^sha384-/);
+
+    /* The pinned artifact the loader would inject. */
+    const artifact: APIResponse = await page.request.get(
+      URL.fromString(base)
+        .addRoute(
+          `/telemetry/session-replay/v${config.recorderVersion}/recorder.js`,
+        )
+        .toString(),
+    );
+
+    expect(artifact.status(), await artifact.text()).toBe(200);
+    expect(artifact.headers()["cache-control"]).toContain("immutable");
+
+    /*
+     * A version this build did not publish must 404 rather than being served
+     * today's bytes under yesterday's number with a year-long cache.
+     */
+    const wrongVersion: APIResponse = await page.request.get(
+      URL.fromString(base)
+        .addRoute(
+          "/telemetry/session-replay/v0.0.1-never-published/recorder.js",
+        )
+        .toString(),
+    );
+
+    expect(wrongVersion.status()).toBe(404);
+
+    /*
+     * The probe an install script or the dashboard's test panel uses to tell
+     * "bad key" apart from "replay is off for this application".
+     */
+    const validate: APIResponse = await page.request.get(
+      URL.fromString(base)
+        .addRoute("/telemetry/session-replay/v1/validate")
+        .toString(),
+      {
+        headers: {
+          "x-oneuptime-token": ingestionKey,
+          "x-oneuptime-app-identifier": appIdentifier,
+        },
+      },
+    );
+
+    expect(validate.status(), await validate.text()).toBe(200);
+
+    const validation: { valid?: boolean; tokenProvided?: boolean } =
+      (await validate.json()) as { valid?: boolean; tokenProvided?: boolean };
+
+    expect(validation.tokenProvided).toBe(true);
+    expect(validation.valid).toBe(true);
+  });
+});
+
+type PollUntilFunction = (data: {
+  page: Page;
+  what: string;
+  run: () => Promise<boolean>;
+  timeoutMs?: number;
+}) => Promise<void>;
+
+/*
+ * Retry a check until it passes or the deadline expires, logging each
+ * attempt. Mirrors waitForTelemetryText's shape; the session replay checks
+ * need to re-run navigation AND clicks between attempts, which that helper
+ * does not model.
+ */
+const pollUntil: PollUntilFunction = async (data: {
+  page: Page;
+  what: string;
+  run: () => Promise<boolean>;
+  timeoutMs?: number;
+}): Promise<void> => {
+  const deadline: number = Date.now() + (data.timeoutMs ?? 180000);
+  let attempt: number = 0;
+
+  while (Date.now() < deadline) {
+    attempt++;
+
+    try {
+      if (await data.run()) {
+        return;
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[sessionReplay] ${data.what} attempt=${attempt} error=${(error as Error).message}`,
+      );
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`[sessionReplay] waiting for ${data.what} attempt=${attempt}`);
+
+    await data.page.waitForTimeout(5000);
+  }
+
+  throw new Error(`Timed out waiting for ${data.what}`);
+};

--- a/Internal/Roadmap/SessionReplay.md
+++ b/Internal/Roadmap/SessionReplay.md
@@ -164,7 +164,7 @@ Served under `/telemetry` deliberately: `App/FeatureSet/Frontend/Index.ts`'s `Da
 | `Project.isSessionReplayAllowed` | **false** | ingest gate + config endpoint | org-wide hard off, pattern of `Project.enableAuditLogs` |
 | `RumApplication.isSessionReplayEnabled` | **false** | config endpoint + ingest gate | per-app opt-in |
 | `SESSION_REPLAY_INGEST_ENABLED` | true | `App/FeatureSet/Telemetry/Config.ts`, `!== "false"` idiom | instance kill switch |
-| `SESSION_REPLAY_ENABLED_BY_DEFAULT` | **false on self-hosted** | config endpoint | see §9 — plan gating is a no-op when `BILLING_ENABLED=false` |
+| `SESSION_REPLAY_ENABLED_BY_DEFAULT` | **true** (set `=false` to turn replay off instance-wide) | config endpoint | see §9 — plan gating is a no-op when `BILLING_ENABLED=false`, so bound disk with `SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY` |
 | `sessionReplayMaskingMode` | **`MaskAllText`** | recorder `maskAllText` | `MaskInputsOnly` is offered and labelled *less safe* in the UI, with an audit-log entry on change |
 | `maskInputFn` / `maskTextFn` | **fixed-length placeholder** | recorder, pre-emit | rrweb's default is `'*'.repeat(value.length)` — a length oracle for passwords, PANs, OTPs. Fixed 3-char block, or short/medium/long buckets. Unit-tested in `Common/Tests`. |
 | sticky password masking | on | recorder, per-node `WeakSet` | a "show password" toggle mutates `type` to `text`; once a node was ever `type=password` or `autocomplete=current-password/new-password/one-time-code/cc-number`, it stays masked and the `type` mutation itself is suppressed |

--- a/config.example.env
+++ b/config.example.env
@@ -395,9 +395,6 @@ SESSION_REPLAY_INLINE_STAGING_MAX_BYTES=65536
 # Replay's share of the shared telemetry worker's concurrency slots, per pod.
 # Caps a replay backlog so it cannot starve trace and log ingest.
 SESSION_REPLAY_WORKER_CONCURRENCY=20
-# Pinned recorder artifact the loader stub imports. Changing this one value is
-# the staged-rollout and instant-rollback mechanism for the browser recorder.
-SESSION_REPLAY_RECORDER_VERSION=1.0.0
 # The ONE request header whose country code replay ingest is allowed to trust,
 # lowercased (cf-ipcountry behind Cloudflare, x-vercel-ip-country behind
 # Vercel). Empty means no country is recorded at all, which is the default:


### PR DESCRIPTION
Found by installing the documented recorder snippet on a throwaway storefront and driving RUM + Session Replay end to end against a live instance — creating the project, the ingestion key and the RUM application through the dashboard, recording real sessions, and playing them back.

Six of these are defects a customer hits on a default deployment. None of them failed a build or an existing test.

## A RUM application could not be created from the dashboard

`RumApplication.appIdentifier` is a required column with no default and shipped with `create: []`. `ModelForm` drops any field the caller has no create permission on, so the required **App Identifier** input never rendered — and the POST that followed was rejected by the server with `appIdentifier is required`, for the very value it had just removed. The Create button was a dead end for every user, while `docs/rum/applications.md` documents that exact flow.

`CloudResource.resourceIdentifier` had the identical defect on the identical page shape.

Both are now creatable and still **not** updatable — the identity is what telemetry is filed under, and re-pointing it would orphan every row keyed on it. Both also gained `@UniqueColumnBy("projectId")`: the unique index is case-**sensitive** while `findOrCreateByAppIdentifier` resolves an incoming `service.name` case-**insensitively**, so `Storefront-Web` beside an auto-discovered `storefront-web` passed the index and left two rows the lookup resolved arbitrarily.

## End-user identity was a dead end

The recorder put `meta.identifiedUserRef` on the wire and the parser accepted it, but the ingest wrote both identity columns as `""` unconditionally. Every session read **Anonymous** while the settings page said *Captures end-user identity: Yes*; the **User key** filter could never match; and a right-to-erasure request by identified user resolved zero sessions and reported success.

Identity is now derived at ingest — new `SessionReplayIdentity`: a per-project HMAC for lookup and erasure, plus the raw label behind its own narrower column ACL — and only when the application's policy has capture on, checked server-side so a hand-crafted POST cannot write a label for an application that opted out.

The envelope parser's cap on the reference was folded into the 128-byte cap it shares with `browserName`, while the recorder and the targeting handshake both use 512; anything longer was hashed from a different string than a lookup or an erasure would hash, filing recordings under a digest nothing could resolve.

The filter that reads it demanded the HMAC, which is displayed nowhere in the product. It now takes the reference a person can see, hashed server-side, **gated on the same narrower ACL as the label column** so a caller deliberately denied the name cannot dictionary-attack it — and refuses an unusable value instead of silently returning the unfiltered list. The value is deliberately kept out of the query string: it is the one filter whose input is a named third party.

## entryUrl, exitUrl and routes[] were frozen at chunk 0

The session header is written once, from chunk 0. So a single-page app reported its **landing page as its exit page** for the life of the session, `routes[]` could never hold more than one element — the route filter returned nothing for a page the user demonstrably reached — and `pageCount` contradicted `routes.length` on the same row. A session spanning two page loads had its `entryUrl` overwritten by the *second* load.

The recorder now carries a per-chunk route list (bounded by bytes, not just count, so a deep-path site cannot blow the 8 KB envelope cap and lose the whole POST), the chunk table stores the re-scrubbed `url` and `routes`, and the finalizer derives all three from the chunk rows — with a fallback to the header for sessions recorded before the columns existed, including the mixed case a deploy window creates.

`meta.entryUrl` was read from `location.href` at build time, and `meta` rides the **final** chunk too, so it overwrote the header with the exit URL. It is captured once at `start()` and re-captured on session rollover.

## The provisional header under-claimed

It zeroed the signal counters while deriving `hasError` from the same envelope in the same object literal. "With errors" returned rows whose Signals cell read **Clean**, and "With frustration" excluded the very session captured *because of* a rage click — for the 10–15 minutes before finalization, which is exactly when both tabs are read. Counters and the route list are now seeded from chunk 0, and the list says *Not counted yet* rather than *Clean* before finalization.

## Also

- A role granted only **Watch Session Replays** was 401'd on the session list and on the exception page's replay card, which `RumSession`'s own table ACL says should not happen.
- The Trigger dropdown omitted `performance`, so those recordings were unselectable while the Recording column displayed the value.
- `hasFrustration: false` was accepted and silently ignored, returning the whole list with a 200.
- A host page calling `sessionStorage.clear()` mid-session (common on sign-out) rewound the chunk counter, so the next chunk **replaced** chunk 0 in the ReplacingMergeTree — destroying the session's opening full snapshot and making the recording unplayable from its own start, silently.

## Docs and comments

`SESSION_REPLAY_ENABLED_BY_DEFAULT` was documented backwards in three places — it defaults to **true**, and `=false` is what turns replay off, so an operator following the self-hosted docs performed a no-op believing they had enabled it. `SESSION_REPLAY_RECORDER_VERSION` was dead config described as the rollback mechanism and is removed. The `allowedOrigins` type doc claimed empty means *refused* when the enforcement means *any origin*. `Consent.ts` described an AND where the code is an OR. The audit surface is **Replay Access Log**, not an "Audit tab".

## Testing

27 new unit tests across the recorder, ingest, finalizer, models and API — plus the first end-to-end spec for this feature, which creates a RUM application **through the dashboard form**, posts real chunk frames to the real ingest endpoint, and asserts the session is listed, named, playable and correctly described.

Verified live at each step against a full stack: the create form now renders and creates; `identifiedUserLabel` appears in the list and the User filter matches; chunk rows carry `url` and `routes`; a finalized session reports `entryUrl /`, `exitUrl /account`, all three visited pages, `pageCount 2`, `1 error`; and filtering by a mid-session page returns the session that merely passed through it — which returned nothing before.

Two things I found and deliberately did **not** change, because they are product decisions rather than defects:

- **Session replay ingest has no plan gate while every read has a hard Growth gate.** A Free-plan project records real users' screens, stores them and is metered at $2/GB, and every dashboard read answers 402 — so the recordings can be neither watched nor audited nor erased through the UI. Both models declare `create: PlanType.Growth`; nothing enforces it. Fixing it means either gating the config endpoint (recorders stop, nothing is captured — my preference) or ungating reads.
- **`/for-exception` cannot find the session that just produced an exception** for the first 10–15 minutes, because `exceptionFingerprints` is only populated at finalization while `traceIds` in the same literal is populated at ingest. That is the replay card's whole purpose, and it is quiet on empty, so it is indistinguishable from "no recording exists".
