### PR TITLE
feat(telemetry): implement the LogPipeline GrokParser processor

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/LogPipeline/ProcessorForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/LogPipeline/ProcessorForm.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, ReactElement, useState } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useMemo,
+  useState,
+} from "react";
 import Button, {
   ButtonSize,
   ButtonStyleType,
@@ -20,6 +25,15 @@ import LogFilterConfig from "../FilterQueryBuilder/LogFilterConfig";
 import SeverityMappingRow, { SeverityMapping } from "./SeverityMappingRow";
 import { JSONObject, JSONValue } from "Common/Types/JSON";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import API from "Common/UI/Utils/API/API";
+import TextArea from "Common/UI/Components/TextArea/TextArea";
+import {
+  CompiledGrokPattern,
+  GrokValue,
+  compileGrokPattern,
+  matchGrokPattern,
+} from "Common/Utils/Grok/Grok";
+import { getGrokPatternNames } from "Common/Utils/Grok/GrokPatterns";
 
 export interface ComponentProps {
   pipelineId: ObjectID;
@@ -28,12 +42,19 @@ export interface ComponentProps {
 }
 
 type ProcessorType =
+  | "GrokParser"
   | "SeverityRemapper"
   | "AttributeRemapper"
   | "CategoryProcessor"
   | "";
 
 const processorTypeOptions: Array<DropdownOption> = [
+  {
+    value: "GrokParser",
+    label: "Grok Parser",
+    description:
+      "Pulls structured fields out of an unstructured log line (e.g. an nginx access line) and stores them as log attributes",
+  },
   {
     value: "SeverityRemapper",
     label: "Severity Remapper",
@@ -59,6 +80,38 @@ interface CategoryRule {
   filterQuery: string;
 }
 
+interface GrokTestResult {
+  /** The pattern compiles, but there is no sample line to run it on yet. */
+  compiledOnly?: boolean;
+  error?: string;
+  matched?: boolean;
+  fields?: Record<string, GrokValue>;
+}
+
+/*
+ * A prefix names a namespace, so the separator is implied unless the
+ * user typed one. Mirrors LogPipelineService.normalizeGrokTargetPrefix -
+ * this is only used to render the preview of the resulting keys.
+ */
+function previewAttributeKey(targetPrefix: string, fieldName: string): string {
+  const prefix: string = targetPrefix.trim();
+
+  if (!prefix) {
+    return fieldName;
+  }
+
+  if (
+    prefix.endsWith(".") ||
+    prefix.endsWith("_") ||
+    prefix.endsWith("-") ||
+    prefix.endsWith(":")
+  ) {
+    return `${prefix}${fieldName}`;
+  }
+
+  return `${prefix}.${fieldName}`;
+}
+
 const ProcessorForm: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
@@ -66,6 +119,14 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
   const [name, setName] = useState<string>("");
   const [processorType, setProcessorType] = useState<ProcessorType>("");
   const [isEnabled, setIsEnabled] = useState<boolean>(true);
+
+  // Grok Parser fields
+  const [grokSource, setGrokSource] = useState<string>("body");
+  const [grokPattern, setGrokPattern] = useState<string>("");
+  const [grokTargetPrefix, setGrokTargetPrefix] = useState<string>("");
+  const [grokSample, setGrokSample] = useState<string>("");
+  const [showGrokPatternList, setShowGrokPatternList] =
+    useState<boolean>(false);
 
   // Severity Remapper fields
   const [severitySourceKey, setSeveritySourceKey] = useState<string>("level");
@@ -89,8 +150,55 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
 
+  /*
+   * Live pattern tester. The same compiler the ingest pipeline uses runs
+   * here on whatever sample line the user pastes, so "does my pattern
+   * actually pull these fields out?" is answered before the processor is
+   * saved rather than after logs have flowed past it.
+   */
+  const grokTestResult: GrokTestResult | null = useMemo(() => {
+    if (processorType !== "GrokParser") {
+      return null;
+    }
+
+    if (!grokPattern.trim()) {
+      return null;
+    }
+
+    let compiled: CompiledGrokPattern;
+
+    try {
+      compiled = compileGrokPattern(grokPattern.trim());
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    if (!grokSample) {
+      return { compiledOnly: true };
+    }
+
+    const fields: Record<string, GrokValue> | null = matchGrokPattern(
+      compiled,
+      grokSample,
+    );
+
+    if (!fields) {
+      return { matched: false };
+    }
+
+    return { matched: true, fields: fields };
+  }, [processorType, grokPattern, grokSample]);
+
   const buildConfiguration: () => JSONObject = (): JSONObject => {
     switch (processorType) {
+      case "GrokParser":
+        return {
+          source: grokSource.trim() || "body",
+          pattern: grokPattern.trim(),
+          targetPrefix: grokTargetPrefix.trim(),
+        };
       case "SeverityRemapper":
         return {
           sourceKey: severitySourceKey,
@@ -126,6 +234,26 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
     }
 
     switch (processorType) {
+      case "GrokParser": {
+        if (!grokSource.trim()) {
+          return "Source field is required.";
+        }
+        if (!grokPattern.trim()) {
+          return "Grok pattern is required.";
+        }
+
+        /*
+         * Compile before saving. The API rejects an uncompilable pattern
+         * too, but the message reads better next to the field that
+         * produced it.
+         */
+        try {
+          compileGrokPattern(grokPattern.trim());
+        } catch (err) {
+          return err instanceof Error ? err.message : String(err);
+        }
+        break;
+      }
       case "SeverityRemapper": {
         if (!severitySourceKey.trim()) {
           return "Source key is required for Severity Remapper.";
@@ -192,8 +320,14 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
       });
 
       props.onProcessorCreated();
-    } catch {
-      setError("Failed to create processor. Please try again.");
+    } catch (err) {
+      /*
+       * The API validates the grok pattern too, and ModelAPI throws an
+       * HTTPErrorResponse rather than an Error - getFriendlyMessage
+       * reads both. "Unknown grok pattern %{IPV44}" is worth showing;
+       * "please try again" is not.
+       */
+      setError(API.getFriendlyMessage(err));
     } finally {
       setIsSaving(false);
     }
@@ -258,6 +392,242 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
             />
           </div>
         </div>
+
+        {/* === Grok Parser Configuration === */}
+        {processorType === "GrokParser" && (
+          <div className="border border-indigo-200 rounded-lg p-4 bg-indigo-50/30">
+            <h4 className="text-sm font-semibold text-gray-700 mb-1">
+              Grok Parser Configuration
+            </h4>
+            <p className="text-xs text-gray-500 mb-3">
+              Extracts structured fields out of an unstructured log line and
+              stores them in the log&apos;s{" "}
+              <code className="px-1 py-0.5 bg-indigo-100 rounded text-indigo-700 text-[11px]">
+                attributes
+              </code>{" "}
+              object, so you can search and filter on them. A grok pattern is
+              regex with names:{" "}
+              <code className="px-1 py-0.5 bg-indigo-100 rounded text-indigo-700 text-[11px]">
+                %&#123;IPV4:client_ip&#125;
+              </code>{" "}
+              means &quot;match an IPv4 address and store it as client_ip&quot;.
+            </p>
+
+            {/* How it works */}
+            <div className="mb-4 p-3 bg-white rounded-md border border-indigo-100">
+              <p className="text-xs font-semibold text-gray-600 mb-1.5">
+                How it works
+              </p>
+              <div className="text-xs text-gray-500 space-y-1">
+                <p>
+                  1. Reads the text from the Source Field (usually the log{" "}
+                  <code className="px-1 py-0.5 bg-gray-100 rounded text-gray-600 text-[11px]">
+                    body
+                  </code>
+                  ).
+                </p>
+                <p>
+                  2. Runs your pattern against it. The pattern does not have to
+                  match the whole line.
+                </p>
+                <p>
+                  3. Every named capture becomes a log attribute. Add{" "}
+                  <code className="px-1 py-0.5 bg-gray-100 rounded text-gray-600 text-[11px]">
+                    :int
+                  </code>{" "}
+                  or{" "}
+                  <code className="px-1 py-0.5 bg-gray-100 rounded text-gray-600 text-[11px]">
+                    :float
+                  </code>{" "}
+                  to a capture to store it as a number.
+                </p>
+                <p>
+                  4. If the line does not match, the log passes through
+                  unchanged.
+                </p>
+              </div>
+              <div className="mt-2 p-2 bg-gray-900 rounded text-[11px] font-mono text-gray-300 leading-relaxed overflow-x-auto">
+                <span className="text-gray-500">// Log body</span>
+                <br />
+                <span className="text-sky-400">10.0.1.5 - GET /health 200</span>
+                <br />
+                <span className="text-gray-500">// Pattern</span>
+                <br />
+                <span className="text-emerald-400">
+                  %&#123;IPV4:client_ip&#125; - %&#123;WORD:method&#125;
+                  %&#123;NOTSPACE:path&#125; %&#123;NUMBER:status:int&#125;
+                </span>
+                <br />
+                <span className="text-gray-500">// Attributes added</span>
+                <br />
+                <span className="text-amber-400">client_ip</span>:{" "}
+                <span className="text-sky-400">&quot;10.0.1.5&quot;</span>,{" "}
+                <span className="text-amber-400">method</span>:{" "}
+                <span className="text-sky-400">&quot;GET&quot;</span>,{" "}
+                <span className="text-amber-400">path</span>:{" "}
+                <span className="text-sky-400">&quot;/health&quot;</span>,{" "}
+                <span className="text-amber-400">status</span>:{" "}
+                <span className="text-sky-400">200</span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <div>
+                <FieldLabelElement
+                  title="Source Field"
+                  description="The field to parse. Use 'body' for the log message, or an attribute key like 'attributes.raw_line'."
+                />
+                <div className="mt-1">
+                  <Input
+                    type={InputType.TEXT}
+                    placeholder="body"
+                    value={grokSource}
+                    onChange={setGrokSource}
+                  />
+                </div>
+              </div>
+              <div>
+                <FieldLabelElement
+                  title="Target Prefix (optional)"
+                  description="Namespace for the extracted attributes. 'http' stores status as http.status."
+                />
+                <div className="mt-1">
+                  <Input
+                    type={InputType.TEXT}
+                    placeholder="e.g. http"
+                    value={grokTargetPrefix}
+                    onChange={setGrokTargetPrefix}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="mb-4">
+              <FieldLabelElement
+                title="Grok Pattern"
+                description="Named patterns like %{IPV4:client_ip}, mixed with any literal text or regex."
+              />
+              <div className="mt-1">
+                <TextArea
+                  placeholder={
+                    '%{IPV4:client_ip} %{USER:ident} %{USER:auth} [%{HTTPDATE:timestamp}] "%{WORD:verb} %{NOTSPACE:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status:int} %{NUMBER:bytes:int}'
+                  }
+                  value={grokPattern}
+                  onChange={setGrokPattern}
+                  disableSpellCheck={true}
+                  className="block w-full rounded-md border border-gray-300 bg-white py-2 px-3 text-xs font-mono placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-y min-h-24"
+                />
+              </div>
+              <div className="mt-2">
+                <Button
+                  title={
+                    showGrokPatternList
+                      ? "Hide available patterns"
+                      : "Show available patterns"
+                  }
+                  buttonStyle={ButtonStyleType.OUTLINE}
+                  buttonSize={ButtonSize.Small}
+                  onClick={() => {
+                    setShowGrokPatternList(!showGrokPatternList);
+                  }}
+                />
+              </div>
+              {showGrokPatternList && (
+                <div className="mt-2 max-h-40 overflow-y-auto p-2 bg-white rounded-md border border-indigo-100">
+                  <div className="flex flex-wrap gap-1">
+                    {getGrokPatternNames().map((patternName: string) => {
+                      return (
+                        <code
+                          key={patternName}
+                          className="px-1 py-0.5 bg-gray-100 rounded text-gray-600 text-[11px]"
+                        >
+                          {`%{${patternName}}`}
+                        </code>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Pattern tester */}
+            <div>
+              <FieldLabelElement
+                title="Test Your Pattern"
+                description="Paste a real log line here to see exactly which attributes this processor would add."
+              />
+              <div className="mt-1">
+                <TextArea
+                  placeholder='10.0.1.5 - - [10/Oct/2023:13:55:36 -0700] "GET /health HTTP/1.1" 200 1234'
+                  value={grokSample}
+                  onChange={setGrokSample}
+                  disableSpellCheck={true}
+                  className="block w-full rounded-md border border-gray-300 bg-white py-2 px-3 text-xs font-mono placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-y min-h-16"
+                />
+              </div>
+
+              {grokTestResult?.error && (
+                <div className="mt-2 p-2 rounded-md border border-red-200 bg-red-50 text-xs text-red-700">
+                  {grokTestResult.error}
+                </div>
+              )}
+
+              {grokTestResult?.compiledOnly && (
+                <div className="mt-2 p-2 rounded-md border border-gray-200 bg-gray-50 text-xs text-gray-500">
+                  Pattern is valid. Paste a sample log line above to see what it
+                  extracts.
+                </div>
+              )}
+
+              {grokTestResult?.matched === false && (
+                <div className="mt-2 p-2 rounded-md border border-amber-200 bg-amber-50 text-xs text-amber-700">
+                  This pattern does not match the sample line. Logs that do not
+                  match are left unchanged.
+                </div>
+              )}
+
+              {grokTestResult?.matched === true && (
+                <div className="mt-2 p-2 rounded-md border border-emerald-200 bg-emerald-50">
+                  {Object.keys(grokTestResult.fields || {}).length === 0 ? (
+                    <p className="text-xs text-emerald-700">
+                      Matches, but captures nothing. Name your captures like
+                      %&#123;WORD:my_field&#125; to store them.
+                    </p>
+                  ) : (
+                    <div className="space-y-1">
+                      <p className="text-xs font-semibold text-emerald-700">
+                        Attributes this processor would add
+                      </p>
+                      {Object.entries(grokTestResult.fields || {}).map(
+                        ([fieldName, fieldValue]: [string, GrokValue]) => {
+                          return (
+                            <div
+                              key={fieldName}
+                              className="text-[11px] font-mono text-gray-700"
+                            >
+                              <span className="text-indigo-700">
+                                {previewAttributeKey(
+                                  grokTargetPrefix,
+                                  fieldName,
+                                )}
+                              </span>
+                              {": "}
+                              <span className="text-gray-600">
+                                {typeof fieldValue === "string"
+                                  ? `"${fieldValue}"`
+                                  : String(fieldValue)}
+                              </span>
+                            </div>
+                          );
+                        },
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* === Severity Remapper Configuration === */}
         {processorType === "SeverityRemapper" && (

--- a/App/FeatureSet/Dashboard/src/Pages/Logs/Settings/PipelineView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Logs/Settings/PipelineView.tsx
@@ -43,6 +43,27 @@ flowchart LR
 
 ### Processor Types
 
+#### Grok Parser
+Pulls structured fields out of an unstructured log line and stores them as log attributes.
+
+**When to use:** Your logs arrive as plain text lines (nginx access logs, syslog, a legacy app that prints its own format) and you want to search and filter on the pieces inside them.
+
+**How it works:**
+1. Reads the **Source Field** — usually the log \`body\`, but any attribute key works
+2. Runs your **grok pattern** against it. A grok pattern is regex with names: \`%{IPV4:client_ip}\` means "match an IPv4 address and store it as \`client_ip\`"
+3. Every named capture becomes a log attribute, optionally namespaced under a **Target Prefix**
+4. A line that does not match is left untouched — grok never drops or blanks a log
+
+Add \`:int\` or \`:float\` to a capture to store it as a number, e.g. \`%{NUMBER:status:int}\`.
+
+| Log body | Pattern | Attributes added |
+|----------|---------|------------------|
+| \`10.0.1.5 - GET /health 200\` | \`%{IPV4:client_ip} - %{WORD:method} %{NOTSPACE:path} %{NUMBER:status:int}\` | client_ip, method, path, status |
+
+The processor form has a **pattern tester**: paste a real log line and it shows the exact attributes the processor would add, before you save it.
+
+---
+
 #### Severity Remapper
 Maps a log field to a standard OpenTelemetry severity level.
 
@@ -90,7 +111,7 @@ Tags logs with a category label based on filter conditions.
 ---
 
 ### Tips
-- **Order matters** — processors run sequentially, so a severity remapper should run before a category processor that filters by severity
+- **Order matters** — processors run sequentially, so a grok parser should run before a severity remapper that reads a field grok extracted
 - **Disable without deleting** — toggle a processor off to temporarily skip it
 - **Test incrementally** — add one processor at a time and verify in the Logs view
 `;
@@ -228,7 +249,7 @@ const LogPipelineView: FunctionComponent<PageComponentProps> = (
         helpContent={{
           title: "How Log Processors Work",
           description:
-            "Understanding Severity Remapper, Attribute Remapper, and Category Processor",
+            "Understanding Grok Parser, Severity Remapper, Attribute Remapper, and Category Processor",
           markdown: processorsDocMarkdown,
         }}
         noItemsMessage={

--- a/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
@@ -9,6 +9,7 @@ import LogPipelineProcessorType, {
   AttributeRemapperConfig,
   SeverityRemapperConfig,
   CategoryProcessorConfig,
+  GrokParserConfig,
 } from "Common/Types/Log/LogPipelineProcessorType";
 import LogSeverity, {
   LogSeverityNumber,
@@ -18,7 +19,14 @@ import {
   compileFilter,
   CompiledFilter,
   evaluateCompiledFilter,
+  getRowFieldValue,
 } from "../Utils/LogFilterEvaluator";
+import {
+  CompiledGrokPattern,
+  GrokValue,
+  compileGrokPatternCached,
+  matchGrokPattern,
+} from "Common/Utils/Grok/Grok";
 import logger from "Common/Server/Utils/Logger";
 import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
@@ -46,6 +54,17 @@ interface CompiledCategoryConfig extends CategoryProcessorConfig {
 
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
 const MAX_CACHED_PROJECTS: number = 10_000;
+
+/*
+ * A grok pattern that does not compile cannot be fixed by retrying it,
+ * and applyProcessor runs once per record - logging the failure per
+ * record would turn one bad processor into an unbounded error stream.
+ * Save-time validation rejects most of these; this covers processors
+ * saved before that validation existed and ones written through the API
+ * with hooks skipped.
+ */
+const MAX_LOGGED_INVALID_GROK_PATTERNS: number = 1000;
+const loggedInvalidGrokPatterns: Set<string> = new Set<string>();
 
 const pipelineCache: InMemoryTTLCache<Array<LoadedPipeline>> =
   new InMemoryTTLCache<Array<LoadedPipeline>>(MAX_CACHED_PROJECTS);
@@ -200,9 +219,142 @@ export class LogPipelineService {
           logRow,
           config as unknown as CompiledCategoryConfig,
         );
+      case LogPipelineProcessorType.GrokParser:
+        return LogPipelineService.applyGrokParser(
+          logRow,
+          config as unknown as GrokParserConfig,
+          processor.name || "",
+        );
       default:
         return logRow;
     }
+  }
+
+  /*
+   * Grok: pull structured fields out of an unstructured line.
+   *
+   * `source` names the field to parse and resolves the same way a filter
+   * query's field does ("body", "attributes.message", or a bare
+   * attribute key); it defaults to the log body, which is what a grok
+   * processor is for. Extracted fields land in the log's attributes,
+   * under `targetPrefix` when one is configured, so they are searchable
+   * and filterable like any other attribute.
+   *
+   * The pattern is compiled once per distinct pattern text and reused
+   * (see compileGrokPatternCached) - never per record.
+   */
+  private static applyGrokParser(
+    logRow: JSONObject,
+    config: GrokParserConfig,
+    processorName: string,
+  ): JSONObject {
+    const pattern: string = (config.pattern || "").trim();
+
+    if (!pattern) {
+      return logRow;
+    }
+
+    const sourceField: string = (config.source || "").trim() || "body";
+
+    let compiled: CompiledGrokPattern;
+
+    try {
+      compiled = compileGrokPatternCached(pattern);
+    } catch (err) {
+      LogPipelineService.logInvalidGrokPatternOnce(processorName, pattern, err);
+      return logRow;
+    }
+
+    const sourceValue: string = getRowFieldValue(logRow, sourceField);
+
+    if (!sourceValue) {
+      return logRow;
+    }
+
+    const extracted: Record<string, GrokValue> | null = matchGrokPattern(
+      compiled,
+      sourceValue,
+    );
+
+    /*
+     * No match is not an error - a pipeline filter is usually broader
+     * than the one line shape a pattern describes. The log passes
+     * through untouched.
+     */
+    if (!extracted) {
+      return logRow;
+    }
+
+    const fieldNames: Array<string> = Object.keys(extracted);
+
+    if (fieldNames.length === 0) {
+      return logRow;
+    }
+
+    const prefix: string = LogPipelineService.normalizeGrokTargetPrefix(
+      config.targetPrefix,
+    );
+
+    const attrs: Record<string, unknown> = {
+      ...((logRow["attributes"] as Record<string, unknown>) || {}),
+    };
+
+    for (const fieldName of fieldNames) {
+      attrs[`${prefix}${fieldName}`] = extracted[fieldName];
+    }
+
+    const attributeKeys: Array<string> = Object.keys(attrs);
+
+    return { ...logRow, attributes: attrs as JSONObject, attributeKeys };
+  }
+
+  /*
+   * A prefix of "http" is meant as a namespace, not as a string to jam
+   * onto the front of the field name, so a separator is added unless the
+   * user already ended it with one: "http" + "status" => "http.status",
+   * while "http_" + "status" stays "http_status".
+   */
+  private static normalizeGrokTargetPrefix(
+    targetPrefix: string | undefined,
+  ): string {
+    const prefix: string = (targetPrefix || "").trim();
+
+    if (!prefix) {
+      return "";
+    }
+
+    if (
+      prefix.endsWith(".") ||
+      prefix.endsWith("_") ||
+      prefix.endsWith("-") ||
+      prefix.endsWith(":")
+    ) {
+      return prefix;
+    }
+
+    return `${prefix}.`;
+  }
+
+  private static logInvalidGrokPatternOnce(
+    processorName: string,
+    pattern: string,
+    err: unknown,
+  ): void {
+    if (loggedInvalidGrokPatterns.has(pattern)) {
+      return;
+    }
+
+    if (loggedInvalidGrokPatterns.size >= MAX_LOGGED_INVALID_GROK_PATTERNS) {
+      loggedInvalidGrokPatterns.clear();
+    }
+
+    loggedInvalidGrokPatterns.add(pattern);
+
+    logger.error(
+      `Grok processor "${processorName}" has a pattern that does not compile and will not run: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 
   private static applyAttributeRemapper(

--- a/App/FeatureSet/Telemetry/Utils/LogFilterEvaluator.ts
+++ b/App/FeatureSet/Telemetry/Utils/LogFilterEvaluator.ts
@@ -64,7 +64,17 @@ function stringifyAttrValue(val: unknown): string {
   return String(val);
 }
 
-function getFieldValue(logRow: JSONObject, fieldPath: string): string {
+/*
+ * Resolve a user-written field path against a log/span row and return it
+ * as a string. Exported because the pipeline's grok processor reads its
+ * source field with exactly these semantics - a grok `source` of
+ * "body", "attributes.message" or a bare attribute key has to mean the
+ * same thing it means in a filter query.
+ */
+export function getRowFieldValue(
+  logRow: JSONObject,
+  fieldPath: string,
+): string {
   if (fieldPath.startsWith("attributes.")) {
     const attrKey: string = fieldPath.slice("attributes.".length);
     const attrs: Record<string, unknown> =
@@ -438,7 +448,7 @@ function evaluateExpr(logRow: JSONObject, expr: FilterExpression): boolean {
   switch (expr.type) {
     case "comparison": {
       const comp: ComparisonExpr = expr as ComparisonExpr;
-      const fieldVal: string = getFieldValue(logRow, comp.field);
+      const fieldVal: string = getRowFieldValue(logRow, comp.field);
 
       switch (comp.operator) {
         case "=":

--- a/App/Tests/Dashboard/LogPipelineGrokProcessorForm.test.ts
+++ b/App/Tests/Dashboard/LogPipelineGrokProcessorForm.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Source-pinning tests for the GrokParser half of the log pipeline
+ * processor form. The App suite runs in a plain Node environment, so the
+ * form cannot be rendered here; these pin the INTENT with tolerant
+ * patterns instead, in the style of AppShellWiring.
+ *
+ * What they exist to stop is the shape of OneUptime/oneuptime#2515:
+ * GrokParser was a first-class processor type in the enum, the model
+ * description and the API, but nothing in the product could create one
+ * and nothing in ingest ran one. Half a wiring is what made it invisible
+ * for so long, so the dropdown entry, the configuration panel and the
+ * saved configuration keys are pinned together.
+ *
+ * The pattern tester is pinned to the SHARED engine on purpose: a
+ * tester with its own regex implementation would be free to disagree
+ * with what ingest actually does, which is worse than no tester.
+ */
+
+const PROCESSOR_FORM_PATH: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "LogPipeline",
+  "ProcessorForm.tsx",
+);
+
+function stripComments(raw: string): string {
+  return raw.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+const FORM_SOURCE: string = stripComments(
+  fs.readFileSync(PROCESSOR_FORM_PATH, "utf8"),
+);
+
+describe("the processor form offers GrokParser", () => {
+  test("GrokParser is one of the processor types a user can pick", () => {
+    expect(FORM_SOURCE).toMatch(/value:\s*["']GrokParser["']/);
+  });
+
+  test("it sits alongside the three processor types that already worked", () => {
+    for (const processorType of [
+      "GrokParser",
+      "SeverityRemapper",
+      "AttributeRemapper",
+      "CategoryProcessor",
+    ]) {
+      expect(FORM_SOURCE).toMatch(
+        new RegExp(`value:\\s*["']${processorType}["']`),
+      );
+    }
+  });
+
+  test("picking it reveals a configuration panel", () => {
+    expect(FORM_SOURCE).toMatch(
+      /processorType === ["']GrokParser["'][\s\S]{0,200}Grok Parser Configuration/,
+    );
+  });
+});
+
+describe("the form saves the configuration the engine reads", () => {
+  /*
+   * GrokParserConfig is { source, pattern, targetPrefix } and
+   * LogPipelineService.applyGrokParser reads exactly those keys. A form
+   * that saved "grokPattern" instead would be another silent no-op.
+   */
+  test("the GrokParser branch writes source, pattern and targetPrefix", () => {
+    const branch: RegExpMatchArray | null = FORM_SOURCE.match(
+      /case ["']GrokParser["']:\s*return \{[\s\S]*?\};/,
+    );
+
+    expect(branch).not.toBeNull();
+
+    const branchSource: string = (branch as RegExpMatchArray)[0];
+
+    expect(branchSource).toMatch(/\bsource:/);
+    expect(branchSource).toMatch(/\bpattern:/);
+    expect(branchSource).toMatch(/\btargetPrefix:/);
+  });
+});
+
+describe("the form validates the pattern before it is saved", () => {
+  test("it compiles the pattern with the shared engine", () => {
+    expect(FORM_SOURCE).toMatch(
+      /import \{[\s\S]*?compileGrokPattern[\s\S]*?\} from ["']Common\/Utils\/Grok\/Grok["']/,
+    );
+    expect(FORM_SOURCE).toMatch(/compileGrokPattern\(/);
+  });
+
+  test("the pattern tester runs the same matcher ingest runs", () => {
+    expect(FORM_SOURCE).toMatch(
+      /import \{[\s\S]*?matchGrokPattern[\s\S]*?\} from ["']Common\/Utils\/Grok\/Grok["']/,
+    );
+    expect(FORM_SOURCE).toMatch(/matchGrokPattern\(/);
+  });
+
+  test("it lists the available patterns from the shared library", () => {
+    expect(FORM_SOURCE).toMatch(
+      /getGrokPatternNames[\s\S]*?from ["']Common\/Utils\/Grok\/GrokPatterns["']/,
+    );
+  });
+
+  test("a rejected save shows what the API said, not a generic retry message", () => {
+    /*
+     * ModelAPI throws an HTTPErrorResponse, which is not an Error - the
+     * shared helper is what reads a message out of both.
+     */
+    expect(FORM_SOURCE).toMatch(/setError\(API\.getFriendlyMessage\(err\)\)/);
+  });
+});

--- a/App/Tests/Telemetry/LogPipelineGrokParser.test.ts
+++ b/App/Tests/Telemetry/LogPipelineGrokParser.test.ts
@@ -1,0 +1,415 @@
+import LogPipelineService, {
+  LoadedPipeline,
+} from "../../FeatureSet/Telemetry/Services/LogPipelineService";
+import { compileFilter } from "../../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
+import LogPipelineProcessorType from "Common/Types/Log/LogPipelineProcessorType";
+import LogSeverity from "Common/Types/Log/LogSeverity";
+import { JSONObject } from "Common/Types/JSON";
+import { clearGrokCompileCache } from "Common/Utils/Grok/Grok";
+import logger from "Common/Server/Utils/Logger";
+
+/*
+ * GrokParser was a defined processor type with a documented config
+ * shape, a place in the API and a place in the enum - and no branch in
+ * applyProcessor. A processor created with it fell through to
+ * `default: return logRow`, so every log flowed past it untouched and
+ * nothing said so (OneUptime/oneuptime#2515).
+ *
+ * These tests pin the wiring itself (the regression), then the
+ * behaviour a user configuring one depends on: where the parsed fields
+ * land, what happens when a line does not match, and that a broken
+ * pattern degrades to "leave the log alone" instead of taking ingest
+ * down with it.
+ */
+
+type ProcessorSpec = {
+  processorType: string;
+  configuration: JSONObject | string;
+  name?: string;
+};
+
+function pipelineWith(
+  processors: Array<ProcessorSpec>,
+  filterQuery?: string,
+): Array<LoadedPipeline> {
+  return [
+    {
+      pipeline: { name: "test-pipeline" },
+      compiledFilter: compileFilter(filterQuery || ""),
+      processors: processors.map((processor: ProcessorSpec) => {
+        return {
+          name: processor.name || "grok",
+          processorType: processor.processorType,
+          configuration: processor.configuration,
+        };
+      }),
+    },
+  ] as unknown as Array<LoadedPipeline>;
+}
+
+function grokPipeline(
+  configuration: JSONObject | string,
+): Array<LoadedPipeline> {
+  return pipelineWith([
+    {
+      processorType: LogPipelineProcessorType.GrokParser,
+      configuration,
+    },
+  ]);
+}
+
+const NGINX_LINE: string =
+  '10.0.1.5 - - [10/Oct/2023:13:55:36 -0700] "GET /health HTTP/1.1" 200 1234';
+
+function logRowWithBody(body: string): JSONObject {
+  return {
+    body: body,
+    severityText: LogSeverity.Unspecified,
+    severityNumber: 0,
+    attributes: { "service.name": "api" },
+    attributeKeys: ["service.name"],
+  };
+}
+
+describe("GrokParser processor is wired into the pipeline", () => {
+  beforeEach(() => {
+    clearGrokCompileCache();
+  });
+
+  it("extracts fields from the log body into attributes", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody(NGINX_LINE),
+      grokPipeline({
+        source: "body",
+        pattern:
+          '%{IPV4:client_ip} %{USER:ident} %{USER:auth} \\[%{HTTPDATE:ts}\\] "%{WORD:verb} %{NOTSPACE:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status:int} %{NUMBER:bytes:int}',
+      }),
+    );
+
+    expect(out["attributes"]).toEqual({
+      "service.name": "api",
+      client_ip: "10.0.1.5",
+      ident: "-",
+      auth: "-",
+      ts: "10/Oct/2023:13:55:36 -0700",
+      verb: "GET",
+      request: "/health",
+      http_version: "1.1",
+      status: 200,
+      bytes: 1234,
+    });
+  });
+
+  it("keeps attributeKeys in step with the attributes it added", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("level=warn msg=disk-full"),
+      grokPipeline({
+        source: "body",
+        pattern: "level=%{WORD:level} msg=%{NOTSPACE:message}",
+      }),
+    );
+
+    expect(out["attributeKeys"]).toEqual(
+      expect.arrayContaining(["service.name", "level", "message"]),
+    );
+    expect((out["attributeKeys"] as Array<string>).sort()).toEqual(
+      Object.keys(out["attributes"] as JSONObject).sort(),
+    );
+  });
+
+  it("leaves the log untouched when the line does not match", () => {
+    const row: JSONObject = logRowWithBody("this line has no ip address");
+
+    const out: JSONObject = LogPipelineService.processLog(
+      row,
+      grokPipeline({ source: "body", pattern: "%{IPV4:client_ip}" }),
+    );
+
+    expect(out["attributes"]).toEqual({ "service.name": "api" });
+    expect(out["attributeKeys"]).toEqual(["service.name"]);
+  });
+
+  it("does not mutate the row it was given", () => {
+    const row: JSONObject = logRowWithBody("status=500");
+
+    LogPipelineService.processLog(
+      row,
+      grokPipeline({ source: "body", pattern: "status=%{NUMBER:status:int}" }),
+    );
+
+    expect(row["attributes"]).toEqual({ "service.name": "api" });
+  });
+
+  it("only runs when the pipeline filter matches the log", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("status=500"),
+      pipelineWith(
+        [
+          {
+            processorType: LogPipelineProcessorType.GrokParser,
+            configuration: {
+              source: "body",
+              pattern: "status=%{NUMBER:status:int}",
+            },
+          },
+        ],
+        "severityText = 'Error'",
+      ),
+    );
+
+    expect(out["attributes"]).toEqual({ "service.name": "api" });
+  });
+});
+
+describe("GrokParser - source field resolution", () => {
+  beforeEach(() => {
+    clearGrokCompileCache();
+  });
+
+  it("defaults to the log body when no source is configured", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("took 125ms"),
+      grokPipeline({ pattern: "took %{NUMBER:duration_ms:int}ms" }),
+    );
+
+    expect((out["attributes"] as JSONObject)["duration_ms"]).toBe(125);
+  });
+
+  it("reads an attribute with the attributes. prefix", () => {
+    const row: JSONObject = {
+      body: "",
+      attributes: { raw_line: "user=jane action=login" },
+      attributeKeys: ["raw_line"],
+    };
+
+    const out: JSONObject = LogPipelineService.processLog(
+      row,
+      grokPipeline({
+        source: "attributes.raw_line",
+        pattern: "user=%{USERNAME:user} action=%{WORD:action}",
+      }),
+    );
+
+    expect(out["attributes"]).toEqual({
+      raw_line: "user=jane action=login",
+      user: "jane",
+      action: "login",
+    });
+  });
+
+  it("reads a bare attribute key, like a filter query does", () => {
+    const row: JSONObject = {
+      body: "",
+      attributes: { raw_line: "user=jane action=login" },
+      attributeKeys: ["raw_line"],
+    };
+
+    const out: JSONObject = LogPipelineService.processLog(
+      row,
+      grokPipeline({
+        source: "raw_line",
+        pattern: "action=%{WORD:action}",
+      }),
+    );
+
+    expect((out["attributes"] as JSONObject)["action"]).toBe("login");
+  });
+
+  it("leaves the log alone when the source field is empty or missing", () => {
+    const row: JSONObject = logRowWithBody("");
+
+    const out: JSONObject = LogPipelineService.processLog(
+      row,
+      grokPipeline({ source: "nosuchfield", pattern: "%{GREEDYDATA:all}" }),
+    );
+
+    expect(out["attributes"]).toEqual({ "service.name": "api" });
+  });
+});
+
+describe("GrokParser - target prefix", () => {
+  beforeEach(() => {
+    clearGrokCompileCache();
+  });
+
+  it("namespaces extracted fields under the prefix", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("GET /health 200"),
+      grokPipeline({
+        source: "body",
+        pattern: "%{WORD:method} %{NOTSPACE:path} %{NUMBER:status:int}",
+        targetPrefix: "http",
+      }),
+    );
+
+    expect(out["attributes"]).toEqual({
+      "service.name": "api",
+      "http.method": "GET",
+      "http.path": "/health",
+      "http.status": 200,
+    });
+  });
+
+  it("does not add a second separator when the prefix already ends with one", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("GET /health"),
+      grokPipeline({
+        source: "body",
+        pattern: "%{WORD:method}",
+        targetPrefix: "http_",
+      }),
+    );
+
+    expect((out["attributes"] as JSONObject)["http_method"]).toBe("GET");
+  });
+
+  it("writes bare field names when no prefix is configured", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("GET /health"),
+      grokPipeline({
+        source: "body",
+        pattern: "%{WORD:method}",
+        targetPrefix: "  ",
+      }),
+    );
+
+    expect((out["attributes"] as JSONObject)["method"]).toBe("GET");
+  });
+});
+
+describe("GrokParser - broken configuration degrades safely", () => {
+  beforeEach(() => {
+    clearGrokCompileCache();
+  });
+
+  it("passes the log through when the pattern does not compile", () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const out: JSONObject = LogPipelineService.processLog(
+        logRowWithBody("anything"),
+        grokPipeline({ source: "body", pattern: "%{NOSUCHPATTERN:x}" }),
+      );
+
+      expect(out["attributes"]).toEqual({ "service.name": "api" });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("logs an uncompilable pattern once, not once per record", () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const pipelines: Array<LoadedPipeline> = grokPipeline({
+        source: "body",
+        pattern: "%{WORD:verb} (unclosed",
+      });
+
+      for (let i: number = 0; i < 25; i++) {
+        LogPipelineService.processLog(logRowWithBody("GET /x"), pipelines);
+      }
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("passes the log through when the pattern is missing", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("anything"),
+      grokPipeline({ source: "body" }),
+    );
+
+    expect(out["attributes"]).toEqual({ "service.name": "api" });
+  });
+
+  it("reads a configuration that was persisted as a JSON string", () => {
+    /*
+     * The dashboard's JSON form field has historically saved this column
+     * as a JSON string literal rather than an object - see
+     * LogPipelineService.normalizeProcessorConfig.
+     */
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("status=418"),
+      grokPipeline(
+        JSON.stringify({
+          source: "body",
+          pattern: "status=%{NUMBER:status:int}",
+        }),
+      ),
+    );
+
+    expect((out["attributes"] as JSONObject)["status"]).toBe(418);
+  });
+
+  it("refuses to parse an input over the length ceiling", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody(`status=418 ${"x".repeat(40000)}`),
+      grokPipeline({ source: "body", pattern: "status=%{NUMBER:status:int}" }),
+    );
+
+    expect(out["attributes"]).toEqual({ "service.name": "api" });
+  });
+});
+
+describe("GrokParser - composes with the rest of the pipeline", () => {
+  beforeEach(() => {
+    clearGrokCompileCache();
+  });
+
+  it("feeds a severity remapper that runs after it", () => {
+    const out: JSONObject = LogPipelineService.processLog(
+      logRowWithBody("2023-10-10 warn disk is nearly full"),
+      pipelineWith([
+        {
+          name: "parse",
+          processorType: LogPipelineProcessorType.GrokParser,
+          configuration: {
+            source: "body",
+            pattern: "%{NOTSPACE:date} %{WORD:level} %{GREEDYDATA:message}",
+          },
+        },
+        {
+          name: "remap severity",
+          processorType: LogPipelineProcessorType.SeverityRemapper,
+          configuration: {
+            sourceKey: "level",
+            mappings: [
+              {
+                matchValue: "warn",
+                severityText: "Warning",
+                severityNumber: 13,
+              },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect((out["attributes"] as JSONObject)["level"]).toBe("warn");
+    expect(out["severityText"]).toBe(LogSeverity.Warning);
+    expect(out["severityNumber"]).toBe(13);
+  });
+
+  it("overwrites an existing attribute of the same name", () => {
+    const row: JSONObject = {
+      body: "status=500",
+      attributes: { status: "unknown" },
+      attributeKeys: ["status"],
+    };
+
+    const out: JSONObject = LogPipelineService.processLog(
+      row,
+      grokPipeline({ source: "body", pattern: "status=%{NUMBER:status:int}" }),
+    );
+
+    expect((out["attributes"] as JSONObject)["status"]).toBe(500);
+  });
+});

--- a/Common/Server/Services/LogPipelineProcessorService.ts
+++ b/Common/Server/Services/LogPipelineProcessorService.ts
@@ -1,9 +1,97 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/LogPipelineProcessor";
+import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
+import { JSONObject } from "../../Types/JSON";
+import { validateLogPipelineProcessor } from "../Utils/LogPipelineProcessorValidation";
+
+/*
+ * `PartialEntity` values may be `() => string` raw SQL expressions rather
+ * than literals. One cannot be evaluated here, so an update that sets a
+ * validated field to an expression is skipped - validating a stringified
+ * function would be worse than not validating at all. Nothing in the
+ * product writes processor fields this way.
+ */
+function isSqlExpressionValue(value: unknown): boolean {
+  return typeof value === "function";
+}
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    validateLogPipelineProcessor({
+      processorType: createBy.data.processorType,
+      configuration: createBy.data.configuration as JSONObject | undefined,
+    });
+
+    return { createBy, carryForward: null };
+  }
+
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    /*
+     * An edit can break a row without naming both fields: switching
+     * `processorType` to GrokParser while the stored configuration is
+     * still a severity-remapper blob, or replacing the pattern on a row
+     * that is already a GrokParser. So validate the MERGED row.
+     *
+     * Only pay for the SELECT when the update touches one of them.
+     * Processor edits are rare, human-driven config changes - this is
+     * not a hot path.
+     */
+    const incomingProcessorType: unknown = updateBy.data.processorType;
+    const incomingConfiguration: unknown = updateBy.data.configuration;
+
+    if (
+      incomingProcessorType === undefined &&
+      incomingConfiguration === undefined
+    ) {
+      return { updateBy, carryForward: null };
+    }
+
+    if (
+      isSqlExpressionValue(incomingProcessorType) ||
+      isSqlExpressionValue(incomingConfiguration)
+    ) {
+      return { updateBy, carryForward: null };
+    }
+
+    const existingRows: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      skip: 0,
+      limit: LIMIT_MAX,
+      select: {
+        _id: true,
+        processorType: true,
+        configuration: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    for (const existing of existingRows) {
+      validateLogPipelineProcessor({
+        processorType:
+          incomingProcessorType !== undefined
+            ? (incomingProcessorType as string | null)
+            : existing.processorType,
+        configuration:
+          incomingConfiguration !== undefined
+            ? (incomingConfiguration as JSONObject | string | null)
+            : (existing.configuration as JSONObject | undefined),
+      });
+    }
+
+    return { updateBy, carryForward: null };
   }
 }
 

--- a/Common/Server/Utils/LogPipelineProcessorValidation.ts
+++ b/Common/Server/Utils/LogPipelineProcessorValidation.ts
@@ -1,0 +1,112 @@
+import BadDataException from "../../Types/Exception/BadDataException";
+import { JSONObject } from "../../Types/JSON";
+import LogPipelineProcessorType, {
+  GrokParserConfig,
+} from "../../Types/Log/LogPipelineProcessorType";
+import { compileGrokPattern } from "../../Utils/Grok/Grok";
+
+/*
+ * Save-time validation for log pipeline processors.
+ *
+ * A processor that cannot do anything is worse than a rejected one: it
+ * sits in the pipeline list looking configured while every log flows
+ * past it untouched, and nothing surfaces the fact. That is exactly how
+ * GrokParser behaved before it was implemented
+ * (OneUptime/oneuptime#2515).
+ *
+ * The grok pattern is the one field where a typo is both easy and
+ * invisible - `%{IPV4:client ip}` or a stray bracket compiles to
+ * nothing. Compiling it here is cheap, happens once per human edit, and
+ * puts the error in front of the only person who can fix it. The ingest
+ * path stays defensive anyway: rows saved before this validation
+ * existed still fail closed to "leave the log alone".
+ */
+
+/*
+ * Prefixes become the leading part of an attribute key, so hold them to
+ * what an attribute key can sensibly be.
+ */
+const TARGET_PREFIX_REGEX: RegExp = /^[A-Za-z_][A-Za-z0-9_.@:-]*$/;
+
+export interface LogPipelineProcessorCandidate {
+  processorType: string | undefined | null;
+  configuration: JSONObject | string | undefined | null;
+}
+
+/*
+ * `configuration` is a jsonb column, but the dashboard's JSON form field
+ * has historically persisted it as a JSON string literal - so both
+ * shapes reach here (see LogPipelineService.normalizeProcessorConfig).
+ */
+function readConfiguration(
+  configuration: JSONObject | string | undefined | null,
+): JSONObject | null {
+  if (configuration && typeof configuration === "object") {
+    return configuration as JSONObject;
+  }
+
+  if (typeof configuration === "string") {
+    try {
+      const parsed: unknown = JSON.parse(configuration);
+
+      if (parsed && typeof parsed === "object") {
+        return parsed as JSONObject;
+      }
+    } catch {
+      throw new BadDataException("Processor configuration is not valid JSON.");
+    }
+  }
+
+  return null;
+}
+
+export function validateLogPipelineProcessor(
+  candidate: LogPipelineProcessorCandidate,
+): void {
+  if (candidate.processorType !== LogPipelineProcessorType.GrokParser) {
+    return;
+  }
+
+  const configuration: JSONObject | null = readConfiguration(
+    candidate.configuration,
+  );
+
+  if (!configuration) {
+    throw new BadDataException(
+      "A Grok Parser processor needs a configuration with a grok pattern.",
+    );
+  }
+
+  const config: GrokParserConfig = configuration as unknown as GrokParserConfig;
+  const pattern: string =
+    typeof config.pattern === "string" ? config.pattern.trim() : "";
+
+  if (!pattern) {
+    throw new BadDataException(
+      "A Grok Parser processor needs a grok pattern, for example: %{IPV4:client_ip} %{WORD:verb}",
+    );
+  }
+
+  // Throws BadDataException with a message written for the person editing.
+  compileGrokPattern(pattern);
+
+  if (config.targetPrefix !== undefined && config.targetPrefix !== null) {
+    if (typeof config.targetPrefix !== "string") {
+      throw new BadDataException("Target prefix must be text.");
+    }
+
+    const targetPrefix: string = config.targetPrefix.trim();
+
+    if (targetPrefix && !TARGET_PREFIX_REGEX.test(targetPrefix)) {
+      throw new BadDataException(
+        `"${config.targetPrefix}" is not a valid target prefix. Use letters, digits, and . _ - : @ (starting with a letter or underscore).`,
+      );
+    }
+  }
+
+  if (config.source !== undefined && config.source !== null) {
+    if (typeof config.source !== "string") {
+      throw new BadDataException("Source field must be text.");
+    }
+  }
+}

--- a/Common/Tests/Server/Services/LogPipelineProcessorSaveValidation.test.ts
+++ b/Common/Tests/Server/Services/LogPipelineProcessorSaveValidation.test.ts
@@ -1,0 +1,249 @@
+import LogPipelineProcessorService from "../../../Server/Services/LogPipelineProcessorService";
+import LogPipelineProcessor from "../../../Models/DatabaseModels/LogPipelineProcessor";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import LogPipelineProcessorType from "../../../Types/Log/LogPipelineProcessorType";
+import ObjectID from "../../../Types/ObjectID";
+import { JSONObject } from "../../../Types/JSON";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Contract under test — the create/update hooks on
+ * LogPipelineProcessorService.
+ *
+ * `processorType` is a free-text column, so the API has always accepted
+ * a GrokParser processor with any configuration at all. Before the
+ * processor was implemented that meant a silent no-op
+ * (OneUptime/oneuptime#2515); now it means an unparsable pattern would
+ * be a silent no-op instead, which is the same failure wearing a
+ * different hat. The hooks compile the pattern while a human is still
+ * looking at the form.
+ *
+ * Update is the harder half: a request need not name both fields, so
+ * switching `processorType` to GrokParser over a stored severity-remap
+ * configuration, or replacing the pattern on a row that is already a
+ * GrokParser, both have to be caught by validating the MERGED row.
+ */
+
+const PROCESSOR_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const service: any = LogPipelineProcessorService as any;
+
+function createBy(data: {
+  processorType?: string | undefined;
+  configuration?: JSONObject | string | undefined;
+}): CreateBy<LogPipelineProcessor> {
+  const model: any = new LogPipelineProcessor();
+  model.name = "Parse nginx access logs";
+  model.processorType = data.processorType;
+  model.configuration = data.configuration;
+
+  return {
+    data: model,
+    props: { isRoot: true },
+  } as CreateBy<LogPipelineProcessor>;
+}
+
+function updateBy(
+  patch: Record<string, unknown>,
+): UpdateBy<LogPipelineProcessor> {
+  return {
+    query: { _id: PROCESSOR_ID.toString() },
+    data: patch,
+    props: { isRoot: true },
+  } as unknown as UpdateBy<LogPipelineProcessor>;
+}
+
+/*
+ * The update hook reads the rows the update matches so it can merge the
+ * patch over them. This stands in for that read.
+ */
+function mockStoredRow(row: {
+  processorType: string;
+  configuration: JSONObject | string;
+}): void {
+  const model: any = new LogPipelineProcessor();
+  model._id = PROCESSOR_ID.toString();
+  model.processorType = row.processorType;
+  model.configuration = row.configuration;
+
+  jest
+    .spyOn(service, "findBy")
+    .mockImplementation(async (): Promise<Array<LogPipelineProcessor>> => {
+      return [model];
+    });
+}
+
+describe("LogPipelineProcessorService — on create", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("accepts a grok processor with a pattern that compiles", async () => {
+    await expect(
+      service.onBeforeCreate(
+        createBy({
+          processorType: LogPipelineProcessorType.GrokParser,
+          configuration: {
+            source: "body",
+            pattern: "%{IPV4:client_ip} %{WORD:verb}",
+          },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects a grok processor whose pattern does not compile", async () => {
+    await expect(
+      service.onBeforeCreate(
+        createBy({
+          processorType: LogPipelineProcessorType.GrokParser,
+          configuration: { source: "body", pattern: "%{NOSUCHTHING:x}" },
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a grok processor created with no pattern at all", async () => {
+    await expect(
+      service.onBeforeCreate(
+        createBy({
+          processorType: LogPipelineProcessorType.GrokParser,
+          configuration: { source: "body" },
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("accepts the other processor types unchanged", async () => {
+    await expect(
+      service.onBeforeCreate(
+        createBy({
+          processorType: LogPipelineProcessorType.SeverityRemapper,
+          configuration: {
+            sourceKey: "level",
+            mappings: [
+              {
+                matchValue: "warn",
+                severityText: "Warning",
+                severityNumber: 13,
+              },
+            ],
+          },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("LogPipelineProcessorService — on update", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("accepts a new pattern that compiles", async () => {
+    mockStoredRow({
+      processorType: LogPipelineProcessorType.GrokParser,
+      configuration: { source: "body", pattern: "%{WORD:verb}" },
+    });
+
+    await expect(
+      service.onBeforeUpdate(
+        updateBy({
+          configuration: { source: "body", pattern: "%{IPV4:client_ip}" },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects a new pattern that does not compile", async () => {
+    mockStoredRow({
+      processorType: LogPipelineProcessorType.GrokParser,
+      configuration: { source: "body", pattern: "%{WORD:verb}" },
+    });
+
+    await expect(
+      service.onBeforeUpdate(
+        updateBy({
+          configuration: { source: "body", pattern: "%{NOSUCHTHING:x}" },
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("catches a type switch to GrokParser over an unrelated stored configuration", async () => {
+    mockStoredRow({
+      processorType: LogPipelineProcessorType.SeverityRemapper,
+      configuration: { sourceKey: "level", mappings: [] },
+    });
+
+    await expect(
+      service.onBeforeUpdate(
+        updateBy({ processorType: LogPipelineProcessorType.GrokParser }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("catches a broken pattern written onto a row that is already a GrokParser", async () => {
+    mockStoredRow({
+      processorType: LogPipelineProcessorType.GrokParser,
+      configuration: { source: "body", pattern: "%{WORD:verb}" },
+    });
+
+    await expect(
+      service.onBeforeUpdate(
+        updateBy({ configuration: { source: "body", pattern: "%{WORD:a b}" } }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("does not read the stored row when the update touches neither field", async () => {
+    const findBySpy: any = jest
+      .spyOn(service, "findBy")
+      .mockImplementation(async (): Promise<Array<LogPipelineProcessor>> => {
+        return [];
+      });
+
+    await expect(
+      service.onBeforeUpdate(updateBy({ name: "renamed" })),
+    ).resolves.toBeDefined();
+
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("skips validation for a raw SQL expression it cannot evaluate", async () => {
+    const findBySpy: any = jest
+      .spyOn(service, "findBy")
+      .mockImplementation(async (): Promise<Array<LogPipelineProcessor>> => {
+        return [];
+      });
+
+    await expect(
+      service.onBeforeUpdate(
+        updateBy({
+          configuration: () => {
+            return "some_sql_expression";
+          },
+        }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("leaves a non-grok processor's configuration alone", async () => {
+    mockStoredRow({
+      processorType: LogPipelineProcessorType.AttributeRemapper,
+      configuration: { sourceKey: "src_ip", targetKey: "source_ip" },
+    });
+
+    await expect(
+      service.onBeforeUpdate(
+        updateBy({ configuration: { sourceKey: "a", targetKey: "b" } }),
+      ),
+    ).resolves.toBeDefined();
+  });
+});

--- a/Common/Tests/Server/Utils/LogPipelineProcessorValidation.test.ts
+++ b/Common/Tests/Server/Utils/LogPipelineProcessorValidation.test.ts
@@ -1,0 +1,198 @@
+import { validateLogPipelineProcessor } from "../../../Server/Utils/LogPipelineProcessorValidation";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import LogPipelineProcessorType from "../../../Types/Log/LogPipelineProcessorType";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — the save-time gate on log pipeline processors.
+ *
+ * A processor that cannot run is invisible: it sits in the pipeline list
+ * looking configured while every log flows past it untouched. That is
+ * exactly the shape of OneUptime/oneuptime#2515, where GrokParser was a
+ * valid processor type with no implementation behind it.
+ *
+ * The grok pattern is where a typo is easy and silent, so it is compiled
+ * here — once per human edit, in front of the only person who can fix
+ * it. Everything else is left alone: this gate exists to catch what
+ * would otherwise fail quietly, not to re-validate the whole form.
+ */
+
+function grokProcessor(configuration: JSONObject | string): {
+  processorType: string;
+  configuration: JSONObject | string;
+} {
+  return {
+    processorType: LogPipelineProcessorType.GrokParser,
+    configuration: configuration,
+  };
+}
+
+describe("log pipeline processor validation — grok patterns", () => {
+  it("accepts a valid pattern", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({
+          source: "body",
+          pattern: "%{IPV4:client_ip} %{WORD:verb} %{NUMBER:status:int}",
+        }),
+      );
+    }).not.toThrow();
+  });
+
+  it("accepts a configuration persisted as a JSON string", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor(
+          JSON.stringify({ source: "body", pattern: "%{WORD:verb}" }),
+        ),
+      );
+    }).not.toThrow();
+  });
+
+  it("rejects a configuration string that is not JSON", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(grokProcessor("not json at all"));
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects a missing configuration", () => {
+    expect(() => {
+      return validateLogPipelineProcessor({
+        processorType: LogPipelineProcessorType.GrokParser,
+        configuration: null,
+      });
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects a missing or blank pattern", () => {
+    for (const pattern of [undefined, "", "   "]) {
+      expect(() => {
+        return validateLogPipelineProcessor(
+          grokProcessor({ source: "body", pattern: pattern as string }),
+        );
+      }).toThrow(BadDataException);
+    }
+  });
+
+  it("rejects an unknown pattern name, naming it in the error", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({ source: "body", pattern: "%{NOSUCHTHING:x}" }),
+      );
+    }).toThrow('Unknown grok pattern "%{NOSUCHTHING}"');
+  });
+
+  it("rejects a pattern whose regex does not parse", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({ source: "body", pattern: "%{WORD:verb} ([unclosed" }),
+      );
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects a field name that could not become an attribute key", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({ source: "body", pattern: "%{WORD:client ip}" }),
+      );
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects an unknown capture type", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({ source: "body", pattern: "%{NUMBER:status:decimal}" }),
+      );
+    }).toThrow(BadDataException);
+  });
+});
+
+describe("log pipeline processor validation — target prefix", () => {
+  it("accepts prefixes that read like attribute-key namespaces", () => {
+    for (const targetPrefix of ["http", "http.", "http_", "_private", "a-b"]) {
+      expect(() => {
+        return validateLogPipelineProcessor(
+          grokProcessor({
+            source: "body",
+            pattern: "%{WORD:verb}",
+            targetPrefix,
+          }),
+        );
+      }).not.toThrow();
+    }
+  });
+
+  it("accepts an absent or blank prefix", () => {
+    for (const targetPrefix of [undefined, "", "  "]) {
+      expect(() => {
+        return validateLogPipelineProcessor(
+          grokProcessor({
+            source: "body",
+            pattern: "%{WORD:verb}",
+            targetPrefix: targetPrefix as string,
+          }),
+        );
+      }).not.toThrow();
+    }
+  });
+
+  it("rejects a prefix with characters an attribute key should not carry", () => {
+    for (const targetPrefix of ["my prefix", "1http", "http!", "{x}"]) {
+      expect(() => {
+        return validateLogPipelineProcessor(
+          grokProcessor({
+            source: "body",
+            pattern: "%{WORD:verb}",
+            targetPrefix,
+          }),
+        );
+      }).toThrow(BadDataException);
+    }
+  });
+
+  it("rejects a non-string prefix or source", () => {
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({
+          source: "body",
+          pattern: "%{WORD:verb}",
+          targetPrefix: 12 as unknown as string,
+        } as unknown as JSONObject),
+      );
+    }).toThrow(BadDataException);
+
+    expect(() => {
+      return validateLogPipelineProcessor(
+        grokProcessor({
+          source: 12 as unknown as string,
+          pattern: "%{WORD:verb}",
+        } as unknown as JSONObject),
+      );
+    }).toThrow(BadDataException);
+  });
+});
+
+describe("log pipeline processor validation — other processor types", () => {
+  /*
+   * The other three processor types were shipped without a save-time
+   * gate and are not silently broken the way grok was. Adding one for
+   * them is a separate decision; this pins that it did not happen by
+   * accident here.
+   */
+  it("leaves non-grok processors alone", () => {
+    for (const processorType of [
+      LogPipelineProcessorType.AttributeRemapper,
+      LogPipelineProcessorType.SeverityRemapper,
+      LogPipelineProcessorType.CategoryProcessor,
+      "SomethingElse",
+    ]) {
+      expect(() => {
+        return validateLogPipelineProcessor({
+          processorType: processorType,
+          configuration: { anything: "goes" },
+        });
+      }).not.toThrow();
+    }
+  });
+});

--- a/Common/Tests/Utils/Grok/Grok.test.ts
+++ b/Common/Tests/Utils/Grok/Grok.test.ts
@@ -1,0 +1,492 @@
+import BadDataException from "../../../Types/Exception/BadDataException";
+import {
+  CompiledGrokPattern,
+  GrokValue,
+  MAX_GROK_INPUT_LENGTH,
+  clearGrokCompileCache,
+  compileGrokPattern,
+  compileGrokPatternCached,
+  matchGrokPattern,
+  parseWithGrokPattern,
+} from "../../../Utils/Grok/Grok";
+import GrokPatterns, {
+  getGrokPatternNames,
+} from "../../../Utils/Grok/GrokPatterns";
+
+/*
+ * The grok engine behind the LogPipeline GrokParser processor
+ * (OneUptime/oneuptime#2515). It runs once per ingested log record
+ * against text the customer's users control, so both halves matter: it
+ * has to extract what a user's pattern says it extracts, and it has to
+ * refuse anything that would let a pattern or an input run away with the
+ * ingest worker.
+ */
+
+describe("Grok - reference forms", () => {
+  it("captures a named field", () => {
+    expect(parseWithGrokPattern("%{WORD:verb}", "GET /index.html")).toEqual({
+      verb: "GET",
+    });
+  });
+
+  it("matches without capturing when no field name is given", () => {
+    expect(
+      parseWithGrokPattern("%{WORD} %{WORD:second}", "hello world"),
+    ).toEqual({ second: "world" });
+  });
+
+  it("mixes literal regex with grok references", () => {
+    expect(
+      parseWithGrokPattern(
+        "^\\[%{LOGLEVEL:level}\\] %{GREEDYDATA:message}$",
+        "[ERROR] disk is full",
+      ),
+    ).toEqual({ level: "ERROR", message: "disk is full" });
+  });
+
+  it("is unanchored, like Logstash", () => {
+    expect(
+      parseWithGrokPattern("%{IPV4:client_ip}", "request from 10.0.1.5 ok"),
+    ).toEqual({ client_ip: "10.0.1.5" });
+  });
+
+  it("returns null when the pattern does not match", () => {
+    expect(
+      parseWithGrokPattern("%{IPV4:client_ip}", "no address here"),
+    ).toBeNull();
+  });
+
+  it("returns an empty object for a pattern that matches but captures nothing", () => {
+    expect(parseWithGrokPattern("%{WORD}", "hello")).toEqual({});
+  });
+
+  it("expands nested references, keeping the sub-pattern's own field names", () => {
+    // SYSLOGBASE names timestamp / logsource / program / pid internally.
+    const parsed: Record<string, GrokValue> | null = parseWithGrokPattern(
+      "%{SYSLOGBASE} %{GREEDYDATA:message}",
+      "Oct 12 14:03:21 web-01 sshd[1234]: connection closed",
+    );
+
+    expect(parsed).toEqual({
+      timestamp: "Oct 12 14:03:21",
+      logsource: "web-01",
+      program: "sshd",
+      pid: "1234",
+      message: "connection closed",
+    });
+  });
+});
+
+describe("Grok - type coercion", () => {
+  it("coerces int / integer / long to a number", () => {
+    expect(parseWithGrokPattern("%{NUMBER:status:int}", "status 404")).toEqual({
+      status: 404,
+    });
+    expect(
+      parseWithGrokPattern("%{NUMBER:status:integer}", "status 404"),
+    ).toEqual({ status: 404 });
+    expect(parseWithGrokPattern("%{NUMBER:bytes:long}", "bytes 1024")).toEqual({
+      bytes: 1024,
+    });
+  });
+
+  it("coerces float / double / number to a number", () => {
+    expect(
+      parseWithGrokPattern("%{NUMBER:duration:float}", "took 12.5ms"),
+    ).toEqual({ duration: 12.5 });
+    expect(
+      parseWithGrokPattern("%{NUMBER:duration:double}", "took 12.5ms"),
+    ).toEqual({ duration: 12.5 });
+  });
+
+  it("keeps a negative number's sign", () => {
+    expect(
+      parseWithGrokPattern("%{NUMBER:delta:float}", "delta -3.25"),
+    ).toEqual({ delta: -3.25 });
+  });
+
+  it("coerces booleans from the usual spellings", () => {
+    expect(parseWithGrokPattern("%{WORD:cached:boolean}", "true")).toEqual({
+      cached: true,
+    });
+    expect(parseWithGrokPattern("%{WORD:cached:bool}", "no")).toEqual({
+      cached: false,
+    });
+    expect(parseWithGrokPattern("%{WORD:cached:boolean}", "1")).toEqual({
+      cached: true,
+    });
+  });
+
+  it("leaves a value that is not recognisably boolean as text", () => {
+    expect(parseWithGrokPattern("%{WORD:cached:boolean}", "maybe")).toEqual({
+      cached: "maybe",
+    });
+  });
+
+  it("defaults to string when no type is given", () => {
+    expect(parseWithGrokPattern("%{NUMBER:status}", "status 404")).toEqual({
+      status: "404",
+    });
+  });
+
+  it("rejects an unknown type at compile time", () => {
+    expect(() => {
+      return compileGrokPattern("%{WORD:foo:datetime}");
+    }).toThrow(BadDataException);
+  });
+});
+
+describe("Grok - capture semantics", () => {
+  it("drops captures that did not participate in the match", () => {
+    const parsed: Record<string, GrokValue> | null = parseWithGrokPattern(
+      "%{WORD:verb}(?: %{NUMBER:status:int})?",
+      "GET",
+    );
+
+    expect(parsed).toEqual({ verb: "GET" });
+    expect(parsed).not.toHaveProperty("status");
+  });
+
+  it("drops empty captures", () => {
+    expect(parseWithGrokPattern("a%{SPACE:gap}b", "ab")).toEqual({});
+  });
+
+  it("keeps the first branch that actually matched when a name repeats", () => {
+    expect(
+      parseWithGrokPattern(
+        "(?:%{IPV4:host}|%{HOSTNAME:host})",
+        "web-01 online",
+      ),
+    ).toEqual({ host: "web-01" });
+  });
+
+  it("does not leak internal group names", () => {
+    const parsed: Record<string, GrokValue> | null = parseWithGrokPattern(
+      "%{WORD:verb}",
+      "GET",
+    );
+
+    expect(Object.keys(parsed as Record<string, GrokValue>)).toEqual(["verb"]);
+  });
+});
+
+describe("Grok - pattern library", () => {
+  it("parses a combined Apache access log line", () => {
+    const line: string =
+      '10.0.0.7 - frank [10/Oct/2023:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://example.com/start.html" "Mozilla/5.0"';
+
+    expect(parseWithGrokPattern("%{COMBINEDAPACHELOG}", line)).toEqual({
+      clientip: "10.0.0.7",
+      ident: "-",
+      auth: "frank",
+      timestamp: "10/Oct/2023:13:55:36 -0700",
+      verb: "GET",
+      request: "/apache_pb.gif",
+      httpversion: "1.0",
+      response: "200",
+      bytes: "2326",
+      referrer: '"http://example.com/start.html"',
+      agent: '"Mozilla/5.0"',
+    });
+  });
+
+  it("parses an ISO8601 timestamped application line", () => {
+    expect(
+      parseWithGrokPattern(
+        "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{JAVACLASS:logger} - %{GREEDYDATA:message}",
+        "2023-10-10T13:55:36.123Z WARN com.example.svc.Worker - queue is backing up",
+      ),
+    ).toEqual({
+      timestamp: "2023-10-10T13:55:36.123Z",
+      level: "WARN",
+      logger: "com.example.svc.Worker",
+      message: "queue is backing up",
+    });
+  });
+
+  it("matches IPv6 addresses", () => {
+    expect(
+      parseWithGrokPattern(
+        "%{IP:client_ip}",
+        "from 2001:db8::8a2e:370:7334 ok",
+      ),
+    ).toEqual({ client_ip: "2001:db8::8a2e:370:7334" });
+  });
+
+  it("matches email addresses, UUIDs and MAC addresses", () => {
+    expect(
+      parseWithGrokPattern(
+        "%{EMAILADDRESS:email}",
+        "user: jane.doe@example.com",
+      ),
+    ).toEqual({ email: "jane.doe@example.com" });
+
+    expect(
+      parseWithGrokPattern(
+        "%{UUID:request_id}",
+        "rid=123e4567-e89b-12d3-a456-426614174000",
+      ),
+    ).toEqual({ request_id: "123e4567-e89b-12d3-a456-426614174000" });
+
+    expect(parseWithGrokPattern("%{MAC:mac}", "mac 00:1A:2B:3C:4D:5E")).toEqual(
+      {
+        mac: "00:1A:2B:3C:4D:5E",
+      },
+    );
+  });
+
+  it("matches quoted strings and URIs", () => {
+    expect(
+      parseWithGrokPattern("%{QS:quoted}", 'said "hello world" once'),
+    ).toEqual({ quoted: '"hello world"' });
+
+    expect(
+      parseWithGrokPattern(
+        "%{URI:url}",
+        "fetching https://example.com/a/b?c=1 now",
+      ),
+    ).toEqual({ url: "https://example.com/a/b?c=1" });
+  });
+
+  it("rejects an out-of-range IPv4 octet", () => {
+    expect(parseWithGrokPattern("%{IPV4:ip}", "999.1.1.1")).toBeNull();
+  });
+
+  it("every library definition compiles on its own", () => {
+    for (const name of getGrokPatternNames()) {
+      expect(() => {
+        return compileGrokPattern(`%{${name}}`);
+      }).not.toThrow();
+    }
+  });
+
+  it("no library definition uses a capturing group", () => {
+    for (const [name, definition] of Object.entries(GrokPatterns)) {
+      /*
+       * The engine reads captures back by group NAME and injects those
+       * names itself, so a bare "(" in a definition would burn a capture
+       * slot on every record for nothing. Escapes and character classes
+       * are stripped first - "\\(" and "[(]" are literal parentheses.
+       */
+      const withoutEscapes: string = definition.replace(/\\./g, "");
+      const withoutCharacterClasses: string = withoutEscapes.replace(
+        /\[[^\]]*\]/g,
+        "",
+      );
+      const capturing: RegExpMatchArray | null =
+        withoutCharacterClasses.match(/\((?!\?)/);
+
+      expect([name, capturing]).toEqual([name, null]);
+    }
+  });
+});
+
+describe("Grok - compile errors are actionable", () => {
+  it("rejects an empty pattern", () => {
+    expect(() => {
+      return compileGrokPattern("   ");
+    }).toThrow("Grok pattern cannot be empty.");
+  });
+
+  it("rejects an unknown pattern name", () => {
+    expect(() => {
+      return compileGrokPattern("%{NOSUCHPATTERN:foo}");
+    }).toThrow('Unknown grok pattern "%{NOSUCHPATTERN}"');
+  });
+
+  it("rejects an invalid field name", () => {
+    expect(() => {
+      return compileGrokPattern("%{WORD:my field}");
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects invalid raw regex", () => {
+    expect(() => {
+      return compileGrokPattern("%{WORD:verb} (unclosed");
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects an over-long pattern", () => {
+    expect(() => {
+      return compileGrokPattern(`%{WORD:verb}${"x".repeat(4000)}`);
+    }).toThrow("cannot be longer than");
+  });
+});
+
+describe("Grok - runaway guards", () => {
+  it("rejects a circular pattern reference instead of hanging", () => {
+    expect(() => {
+      return compileGrokPattern("%{A_PATTERN:x}", {
+        A_PATTERN: "%{B_PATTERN}",
+        B_PATTERN: "%{A_PATTERN}",
+      });
+    }).toThrow("refers to itself");
+  });
+
+  it("rejects a self-referencing pattern", () => {
+    expect(() => {
+      return compileGrokPattern("%{SELF:x}", { SELF: "a%{SELF}" });
+    }).toThrow("refers to itself");
+  });
+
+  it("rejects nesting deeper than the depth ceiling", () => {
+    const deep: Record<string, string> = {};
+
+    for (let i: number = 0; i < 30; i++) {
+      deep[`LEVEL${i}`] = `%{LEVEL${i + 1}}`;
+    }
+
+    deep["LEVEL30"] = "x";
+
+    expect(() => {
+      return compileGrokPattern("%{LEVEL0:x}", deep);
+    }).toThrow("levels deep");
+  });
+
+  it("rejects a pattern that expands past the source-length ceiling", () => {
+    /*
+     * Each level doubles, so this blows the size ceiling long before the
+     * depth one - the guard that has to hold for a pattern which is
+     * shallow but explosive.
+     */
+    const doubling: Record<string, string> = { WIDE10: "x" };
+
+    for (let i: number = 0; i < 10; i++) {
+      doubling[`WIDE${i}`] = `%{WIDE${i + 1}}%{WIDE${i + 1}}`;
+    }
+
+    expect(() => {
+      return compileGrokPattern("%{WIDE0:x}", doubling);
+    }).toThrow(BadDataException);
+  });
+
+  it("rejects a pattern capturing more fields than the ceiling allows", () => {
+    const many: string = new Array(120)
+      .fill(null)
+      .map((_unused: null, index: number) => {
+        return `%{WORD:field_${index}}`;
+      })
+      .join(" ");
+
+    expect(() => {
+      return compileGrokPattern(many);
+    }).toThrow("captures more than");
+  });
+
+  it("refuses to run against an input over the length ceiling", () => {
+    const compiled: CompiledGrokPattern = compileGrokPattern("%{WORD:first}");
+
+    expect(matchGrokPattern(compiled, "hello")).toEqual({ first: "hello" });
+    expect(
+      matchGrokPattern(compiled, "a".repeat(MAX_GROK_INPUT_LENGTH + 1)),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty input", () => {
+    const compiled: CompiledGrokPattern =
+      compileGrokPattern("%{GREEDYDATA:all}");
+
+    expect(matchGrokPattern(compiled, "")).toBeNull();
+  });
+});
+
+describe("Grok - compiled patterns are reusable", () => {
+  it("does not carry match state between calls", () => {
+    const compiled: CompiledGrokPattern = compileGrokPattern("%{WORD:word}");
+
+    expect(compiled.regex.global).toBe(false);
+    expect(compiled.regex.sticky).toBe(false);
+
+    for (let i: number = 0; i < 5; i++) {
+      expect(matchGrokPattern(compiled, "alpha beta")).toEqual({
+        word: "alpha",
+      });
+    }
+  });
+});
+
+describe("Grok - library patterns stay linear on hostile input", () => {
+  /*
+   * These run once per ingested record against text a customer's users
+   * control, and a backtracking regex cannot be interrupted once it
+   * starts. Every library definition is written so each repetition
+   * consumes at least one character; this is the check that nobody adds
+   * an `(a*)*`-shaped one later. Thresholds are deliberately loose - the
+   * failure mode being caught is seconds-to-forever, not milliseconds.
+   */
+  const HOSTILE_LINES: Array<[string, string]> = [
+    ["%{COMBINEDAPACHELOG}", `10.0.0.7 - - [${"a".repeat(4000)}`],
+    ["%{URI:url}", `https://example.com/${"a/".repeat(2000)}`],
+    ["%{PATH:path}", `/${"a/".repeat(2000)}`],
+    ["%{IPV6:ip}", `${"1:".repeat(2000)}z`],
+    ["%{QS:quoted}", `"${"\\".repeat(2000)}`],
+    ["%{EMAILADDRESS:email}", `${"a.".repeat(2000)}@`],
+    ["%{TIMESTAMP_ISO8601:ts}", `${"2023-10-10T13:55:".repeat(500)}x`],
+    ["%{HOSTNAME:host}", `${"a.".repeat(2000)}!`],
+  ];
+
+  it.each(HOSTILE_LINES)(
+    "%s finishes quickly on input built to make it backtrack",
+    (pattern: string, input: string) => {
+      const compiled: CompiledGrokPattern = compileGrokPattern(pattern);
+      const startedAt: number = Date.now();
+
+      matchGrokPattern(compiled, input);
+
+      expect(Date.now() - startedAt).toBeLessThan(2000);
+    },
+  );
+
+  it("stays quick across a whole batch of records", () => {
+    const compiled: CompiledGrokPattern = compileGrokPattern(
+      "%{COMBINEDAPACHELOG}",
+    );
+    const line: string =
+      '10.0.0.7 - frank [10/Oct/2023:13:55:36 -0700] "GET /a HTTP/1.0" 200 23 "-" "-"';
+
+    const startedAt: number = Date.now();
+
+    for (let i: number = 0; i < 2000; i++) {
+      matchGrokPattern(compiled, line);
+    }
+
+    expect(Date.now() - startedAt).toBeLessThan(2000);
+  });
+});
+
+describe("Grok - compile cache", () => {
+  beforeEach(() => {
+    clearGrokCompileCache();
+  });
+
+  it("returns the same compiled instance for the same pattern text", () => {
+    const first: CompiledGrokPattern = compileGrokPatternCached("%{WORD:verb}");
+    const second: CompiledGrokPattern =
+      compileGrokPatternCached("%{WORD:verb}");
+
+    expect(second).toBe(first);
+  });
+
+  it("re-throws for a pattern that failed to compile, without recompiling", () => {
+    expect(() => {
+      return compileGrokPatternCached("%{NOSUCHPATTERN}");
+    }).toThrow(BadDataException);
+
+    expect(() => {
+      return compileGrokPatternCached("%{NOSUCHPATTERN}");
+    }).toThrow(BadDataException);
+  });
+
+  it("stays bounded", () => {
+    for (let i: number = 0; i < 600; i++) {
+      compileGrokPatternCached(`%{WORD:field_${i}}`);
+    }
+
+    // The oldest entries were evicted, so this recompiles into a new object.
+    const recompiled: CompiledGrokPattern =
+      compileGrokPatternCached("%{WORD:field_0}");
+
+    expect(recompiled).not.toBe(compileGrokPatternCached("%{WORD:field_599}"));
+    expect(recompiled.captures).toHaveLength(1);
+  });
+});

--- a/Common/Utils/Grok/Grok.ts
+++ b/Common/Utils/Grok/Grok.ts
@@ -1,0 +1,461 @@
+import BadDataException from "../../Types/Exception/BadDataException";
+import GrokPatterns from "./GrokPatterns";
+
+/*
+ * Grok engine.
+ *
+ * A grok pattern is a regex with named references into a pattern
+ * library: `%{IPV4:client_ip} - %{WORD:verb}` means "the IPv4 regex,
+ * captured as client_ip, then a literal ' - ', then a word captured as
+ * verb". Anything that is not a `%{...}` reference is passed through to
+ * the regex verbatim, so raw regex and grok references can be mixed.
+ *
+ * Supported reference forms:
+ *
+ *   %{NAME}              match, capture nothing
+ *   %{NAME:field}        capture into `field` as a string
+ *   %{NAME:field:type}   capture into `field`, coerced (int/float/boolean)
+ *
+ * Compilation expands references recursively into one JavaScript RegExp
+ * and records, for each captured field, the internal group name that
+ * holds it. Only the groups this engine injects capture — every library
+ * definition uses `(?:...)` — so extraction is a `match.groups` lookup
+ * with no index arithmetic.
+ *
+ * Matching is deliberately UNANCHORED, like Logstash: a pattern
+ * describes a fragment of the line unless the author anchors it with
+ * `^`/`$` themselves.
+ *
+ * This runs once per ingested log record on the telemetry hot path
+ * against text the customer's users control, so the compiler enforces
+ * hard ceilings on expansion (depth, count, final source length) and
+ * the matcher refuses inputs above MAX_GROK_INPUT_LENGTH rather than
+ * handing an unbounded string to a backtracking engine.
+ */
+
+export enum GrokFieldType {
+  String = "string",
+  Integer = "integer",
+  Float = "float",
+  Boolean = "boolean",
+}
+
+export type GrokValue = string | number | boolean;
+
+export interface GrokCapture {
+  /** Internal RegExp group name, e.g. "oug0". Never surfaced to users. */
+  groupName: string;
+  /** Attribute name the user asked for, e.g. "client_ip". */
+  fieldName: string;
+  fieldType: GrokFieldType;
+}
+
+export interface CompiledGrokPattern {
+  regex: RegExp;
+  captures: Array<GrokCapture>;
+  /** Expanded regex source. Useful for debugging and for the UI tester. */
+  source: string;
+}
+
+/** Longest raw pattern a user may save. */
+export const MAX_GROK_PATTERN_LENGTH: number = 4000;
+
+/** Longest expanded regex source a pattern may compile to. */
+export const MAX_GROK_SOURCE_LENGTH: number = 20000;
+
+/** How deep `%{A}` -> `%{B}` -> `%{C}` nesting may go. */
+export const MAX_GROK_EXPANSION_DEPTH: number = 20;
+
+/** Total number of references expanded while compiling one pattern. */
+export const MAX_GROK_EXPANSIONS: number = 500;
+
+/** Fields one pattern may capture. */
+export const MAX_GROK_CAPTURES: number = 100;
+
+/*
+ * Inputs longer than this are not parsed. A backtracking regex cannot be
+ * interrupted once started, so the only bound available on the ingest
+ * hot path is the length of what we feed it.
+ */
+export const MAX_GROK_INPUT_LENGTH: number = 32768;
+
+/*
+ * `%{NAME}`, `%{NAME:field}` or `%{NAME:field:type}`. The field and type
+ * segments exclude `{`, `}` and `:` so a malformed reference fails to
+ * match here and is reported as unparsable rather than being silently
+ * split at the wrong colon.
+ */
+const GROK_REFERENCE_SOURCE: string =
+  "%\\{([A-Za-z0-9_]+)(?::([^:{}]*))?(?::([^:{}]*))?\\}";
+
+/*
+ * Field names become log attribute keys. Dots are allowed because OTel
+ * semantic-convention keys use them (`http.request.method`).
+ */
+const FIELD_NAME_REGEX: RegExp = /^[A-Za-z_][A-Za-z0-9_.@-]*$/;
+
+interface CompileContext {
+  patterns: Record<string, string>;
+  captures: Array<GrokCapture>;
+  /** Names currently being expanded — used to reject circular references. */
+  stack: Array<string>;
+  expansions: number;
+}
+
+function parseFieldType(rawType: string | undefined): GrokFieldType {
+  if (!rawType) {
+    return GrokFieldType.String;
+  }
+
+  switch (rawType.trim().toLowerCase()) {
+    case "int":
+    case "integer":
+    case "long":
+      return GrokFieldType.Integer;
+    case "float":
+    case "double":
+    case "number":
+      return GrokFieldType.Float;
+    case "bool":
+    case "boolean":
+      return GrokFieldType.Boolean;
+    case "string":
+    case "text":
+      return GrokFieldType.String;
+    default:
+      throw new BadDataException(
+        `Unknown grok field type "${rawType}". Supported types are: int, long, float, double, boolean, string.`,
+      );
+  }
+}
+
+function resolveReference(
+  match: RegExpExecArray,
+  context: CompileContext,
+): string {
+  const patternName: string = match[1] as string;
+  const rawFieldName: string | undefined = match[2];
+  const rawFieldType: string | undefined = match[3];
+
+  context.expansions++;
+
+  if (context.expansions > MAX_GROK_EXPANSIONS) {
+    throw new BadDataException(
+      `This grok pattern expands to more than ${MAX_GROK_EXPANSIONS} sub-patterns. Please simplify it.`,
+    );
+  }
+
+  const definition: string | undefined = context.patterns[patternName];
+
+  if (definition === undefined) {
+    throw new BadDataException(
+      `Unknown grok pattern "%{${patternName}}". Check the list of supported patterns.`,
+    );
+  }
+
+  if (context.stack.includes(patternName)) {
+    throw new BadDataException(
+      `Grok pattern "%{${patternName}}" refers to itself. Circular pattern references are not supported.`,
+    );
+  }
+
+  if (context.stack.length >= MAX_GROK_EXPANSION_DEPTH) {
+    throw new BadDataException(
+      `Grok pattern "%{${patternName}}" nests more than ${MAX_GROK_EXPANSION_DEPTH} levels deep. Please simplify it.`,
+    );
+  }
+
+  context.stack.push(patternName);
+  const expanded: string = expandPattern(definition, context);
+  context.stack.pop();
+
+  if (rawFieldName === undefined) {
+    return `(?:${expanded})`;
+  }
+
+  const fieldName: string = rawFieldName.trim();
+
+  if (!FIELD_NAME_REGEX.test(fieldName)) {
+    throw new BadDataException(
+      `"${rawFieldName}" is not a valid grok field name. Use letters, digits, and . _ - @ (starting with a letter or underscore).`,
+    );
+  }
+
+  if (context.captures.length >= MAX_GROK_CAPTURES) {
+    throw new BadDataException(
+      `This grok pattern captures more than ${MAX_GROK_CAPTURES} fields. Please capture fewer fields.`,
+    );
+  }
+
+  const groupName: string = `oug${context.captures.length}`;
+
+  context.captures.push({
+    groupName: groupName,
+    fieldName: fieldName,
+    fieldType: parseFieldType(rawFieldType),
+  });
+
+  return `(?<${groupName}>${expanded})`;
+}
+
+function expandPattern(source: string, context: CompileContext): string {
+  /*
+   * A fresh RegExp per call: `lastIndex` is per-object state and
+   * expansion recurses, so a shared instance would have nested calls
+   * stepping on each other's scan position.
+   */
+  const referenceRegex: RegExp = new RegExp(GROK_REFERENCE_SOURCE, "g");
+
+  let output: string = "";
+  let cursor: number = 0;
+  let match: RegExpExecArray | null = referenceRegex.exec(source);
+
+  while (match !== null) {
+    output += source.slice(cursor, match.index);
+    output += resolveReference(match, context);
+    cursor = match.index + match[0].length;
+
+    if (output.length > MAX_GROK_SOURCE_LENGTH) {
+      throw new BadDataException(
+        `This grok pattern expands to more than ${MAX_GROK_SOURCE_LENGTH} characters of regex. Please simplify it.`,
+      );
+    }
+
+    match = referenceRegex.exec(source);
+  }
+
+  output += source.slice(cursor);
+
+  return output;
+}
+
+/*
+ * Compile a grok pattern. Throws BadDataException with a message meant
+ * for the person who typed the pattern — this is what save-time
+ * validation and the pattern tester in the dashboard show.
+ */
+export function compileGrokPattern(
+  pattern: string,
+  extraPatterns?: Record<string, string> | undefined,
+): CompiledGrokPattern {
+  if (typeof pattern !== "string" || pattern.trim().length === 0) {
+    throw new BadDataException("Grok pattern cannot be empty.");
+  }
+
+  if (pattern.length > MAX_GROK_PATTERN_LENGTH) {
+    throw new BadDataException(
+      `Grok pattern cannot be longer than ${MAX_GROK_PATTERN_LENGTH} characters.`,
+    );
+  }
+
+  const context: CompileContext = {
+    patterns: extraPatterns
+      ? { ...GrokPatterns, ...extraPatterns }
+      : GrokPatterns,
+    captures: [],
+    stack: [],
+    expansions: 0,
+  };
+
+  const source: string = expandPattern(pattern, context);
+
+  if (source.length > MAX_GROK_SOURCE_LENGTH) {
+    throw new BadDataException(
+      `This grok pattern expands to more than ${MAX_GROK_SOURCE_LENGTH} characters of regex. Please simplify it.`,
+    );
+  }
+
+  let regex: RegExp;
+
+  try {
+    /*
+     * No `g`/`y` flag on purpose: those carry `lastIndex` between calls
+     * and a compiled pattern is reused for every record.
+     */
+    regex = new RegExp(source);
+  } catch (err) {
+    throw new BadDataException(
+      `This grok pattern is not valid: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return {
+    regex: regex,
+    captures: context.captures,
+    source: source,
+  };
+}
+
+function coerceValue(raw: string, fieldType: GrokFieldType): GrokValue {
+  if (fieldType === GrokFieldType.Integer) {
+    const parsed: number = parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : raw;
+  }
+
+  if (fieldType === GrokFieldType.Float) {
+    const parsed: number = parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : raw;
+  }
+
+  if (fieldType === GrokFieldType.Boolean) {
+    const normalized: string = raw.trim().toLowerCase();
+
+    if (
+      normalized === "true" ||
+      normalized === "yes" ||
+      normalized === "y" ||
+      normalized === "1"
+    ) {
+      return true;
+    }
+
+    if (
+      normalized === "false" ||
+      normalized === "no" ||
+      normalized === "n" ||
+      normalized === "0"
+    ) {
+      return false;
+    }
+
+    /*
+     * Not recognisably a boolean — keep the raw text rather than
+     * inventing a `false` the log never said.
+     */
+    return raw;
+  }
+
+  return raw;
+}
+
+/*
+ * Run a compiled pattern against one string. Returns null when the
+ * pattern does not match; returns the captured fields otherwise (which
+ * is an empty object for a pattern that matches but captures nothing).
+ *
+ * Empty captures are dropped, matching Logstash's default
+ * `keep_empty_captures => false`: an optional group that did not
+ * participate should not write a blank attribute onto the log.
+ */
+export function matchGrokPattern(
+  compiled: CompiledGrokPattern,
+  input: string,
+): Record<string, GrokValue> | null {
+  if (typeof input !== "string" || input.length === 0) {
+    return null;
+  }
+
+  if (input.length > MAX_GROK_INPUT_LENGTH) {
+    return null;
+  }
+
+  const match: RegExpExecArray | null = compiled.regex.exec(input);
+
+  if (!match) {
+    return null;
+  }
+
+  const groups: Record<string, string | undefined> = match.groups || {};
+  const extracted: Record<string, GrokValue> = {};
+
+  for (const capture of compiled.captures) {
+    const raw: string | undefined = groups[capture.groupName];
+
+    if (raw === undefined || raw === "") {
+      continue;
+    }
+
+    /*
+     * The same field name can legitimately appear twice (alternation
+     * branches, or a library pattern that already names it). Whichever
+     * group actually matched first wins, so a later branch that did not
+     * participate cannot blank out a real value.
+     */
+    if (extracted[capture.fieldName] !== undefined) {
+      continue;
+    }
+
+    extracted[capture.fieldName] = coerceValue(raw, capture.fieldType);
+  }
+
+  return extracted;
+}
+
+/*
+ * Process-wide compile cache for the ingest path.
+ *
+ * Compiling walks the pattern library and builds a RegExp; doing that
+ * per log record would dominate the cost of the processor. Compiled
+ * patterns are immutable and carry no `lastIndex` state (no `g` flag),
+ * so one instance is safely shared by every project using the same
+ * pattern text.
+ *
+ * Failures are cached too. An invalid pattern that reaches ingest would
+ * otherwise be recompiled — and rejected — once per record.
+ */
+const compileCache: Map<string, CompiledGrokPattern | BadDataException> =
+  new Map<string, CompiledGrokPattern | BadDataException>();
+
+export const MAX_CACHED_GROK_PATTERNS: number = 500;
+
+export function compileGrokPatternCached(pattern: string): CompiledGrokPattern {
+  const cached: CompiledGrokPattern | BadDataException | undefined =
+    compileCache.get(pattern);
+
+  if (cached !== undefined) {
+    if (cached instanceof BadDataException) {
+      throw cached;
+    }
+
+    return cached;
+  }
+
+  let result: CompiledGrokPattern | BadDataException;
+
+  try {
+    result = compileGrokPattern(pattern);
+  } catch (err) {
+    result =
+      err instanceof BadDataException ? err : new BadDataException(String(err));
+  }
+
+  if (compileCache.size >= MAX_CACHED_GROK_PATTERNS) {
+    // Insertion-ordered: drop the oldest entry to bound the cache.
+    const oldestKey: string | undefined = compileCache.keys().next().value;
+
+    if (oldestKey !== undefined) {
+      compileCache.delete(oldestKey);
+    }
+  }
+
+  compileCache.set(pattern, result);
+
+  if (result instanceof BadDataException) {
+    throw result;
+  }
+
+  return result;
+}
+
+/** Test seam: forget every cached compilation. */
+export function clearGrokCompileCache(): void {
+  compileCache.clear();
+}
+
+/*
+ * Compile + match in one call. Convenience for the dashboard's pattern
+ * tester and for tests; ingest compiles once and reuses the result.
+ */
+export function parseWithGrokPattern(
+  pattern: string,
+  input: string,
+): Record<string, GrokValue> | null {
+  return matchGrokPattern(compileGrokPattern(pattern), input);
+}
+
+export default {
+  compileGrokPattern,
+  compileGrokPatternCached,
+  matchGrokPattern,
+  parseWithGrokPattern,
+};

--- a/Common/Utils/Grok/GrokPatterns.ts
+++ b/Common/Utils/Grok/GrokPatterns.ts
@@ -1,0 +1,118 @@
+/*
+ * Built-in grok pattern library.
+ *
+ * Grok is regex with names: `%{IPV4:client_ip}` is just the IPv4 regex
+ * plus "put what it matched in client_ip". This file holds the named
+ * regex halves; Grok.ts does the naming.
+ *
+ * Two rules every entry here must follow:
+ *
+ *   1. NO capturing groups. Use `(?:...)`. Grok.ts injects its own
+ *      named groups around the pattern it is asked to capture and reads
+ *      results back through `match.groups`, so a stray `(...)` in a
+ *      definition would silently shift nothing but still cost a capture
+ *      slot on every record.
+ *
+ *   2. JavaScript-compatible syntax only. The upstream Logstash
+ *      definitions are Oniguruma and use possessive quantifiers (`++`)
+ *      and atomic groups (`(?>...)`), neither of which V8 accepts —
+ *      those have been rewritten here rather than copied.
+ *
+ * Every repetition of a group consumes at least one character, which is
+ * what keeps `(?:/[\w]*)+`-shaped patterns linear instead of
+ * exponential. Keep it that way when adding patterns: these run once
+ * per ingested log record against attacker-supplied text.
+ */
+
+const GrokPatterns: Record<string, string> = {
+  /* --- Primitives --- */
+  USERNAME: String.raw`[a-zA-Z0-9._-]+`,
+  USER: String.raw`%{USERNAME}`,
+  INT: String.raw`(?:[+-]?(?:[0-9]+))`,
+  BASE10NUM: String.raw`(?:[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+))`,
+  NUMBER: String.raw`(?:%{BASE10NUM})`,
+  BASE16NUM: String.raw`(?:0[xX])?(?:[0-9A-Fa-f]+)`,
+  POSINT: String.raw`\b(?:[1-9][0-9]*)\b`,
+  NONNEGINT: String.raw`\b(?:[0-9]+)\b`,
+  WORD: String.raw`\b\w+\b`,
+  NOTSPACE: String.raw`\S+`,
+  SPACE: String.raw`\s*`,
+  DATA: String.raw`.*?`,
+  GREEDYDATA: String.raw`.*`,
+  QUOTEDSTRING: String.raw`(?:"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*')`,
+  QS: String.raw`%{QUOTEDSTRING}`,
+  UUID: String.raw`[A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}`,
+
+  /* --- Network --- */
+  IPV4: String.raw`(?<![0-9])(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?![0-9])`,
+  /*
+   * Alternation is first-match, not longest-match, so order carries
+   * meaning here: the IPv4-embedded forms come first (a generic hex form
+   * would otherwise stop before the dotted quad), and the "::"-elision
+   * forms are ordered so a shape that can only match a prefix never sits
+   * ahead of one that matches the whole address.
+   */
+  IPV6: String.raw`(?:::(?:[Ff]{4}(?::0{1,4})?:)?%{IPV4}|(?:[0-9A-Fa-f]{1,4}:){1,4}:%{IPV4}|(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|[0-9A-Fa-f]{1,4}:(?::[0-9A-Fa-f]{1,4}){1,6}|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|:(?:(?::[0-9A-Fa-f]{1,4}){1,7}|:))`,
+  IP: String.raw`(?:%{IPV6}|%{IPV4})`,
+  HOSTNAME: String.raw`\b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*\.?`,
+  IPORHOST: String.raw`(?:%{IP}|%{HOSTNAME})`,
+  HOSTPORT: String.raw`%{IPORHOST}:%{POSINT}`,
+  COMMONMAC: String.raw`(?:(?:[A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2})`,
+  CISCOMAC: String.raw`(?:(?:[A-Fa-f0-9]{4}\.){2}[A-Fa-f0-9]{4})`,
+  WINDOWSMAC: String.raw`(?:(?:[A-Fa-f0-9]{2}-){5}[A-Fa-f0-9]{2})`,
+  MAC: String.raw`(?:%{CISCOMAC}|%{WINDOWSMAC}|%{COMMONMAC})`,
+  EMAILLOCALPART: String.raw`[a-zA-Z0-9!#$%&'*+\-/=?^_{|}~]{1,64}(?:\.[a-zA-Z0-9!#$%&'*+\-/=?^_{|}~]{1,62}){0,63}`,
+  EMAILADDRESS: String.raw`%{EMAILLOCALPART}@%{HOSTNAME}`,
+
+  /* --- Paths and URIs --- */
+  UNIXPATH: String.raw`(?:/[\w_%!$@:.,+~-]*)+`,
+  WINPATH: String.raw`(?:[A-Za-z]+:|\\)(?:\\[^\\?*]*)+`,
+  PATH: String.raw`(?:%{UNIXPATH}|%{WINPATH})`,
+  URIPROTO: String.raw`[A-Za-z][A-Za-z0-9+.-]+`,
+  URIHOST: String.raw`%{IPORHOST}(?::%{POSINT})?`,
+  URIPATH: String.raw`(?:/[A-Za-z0-9$.+!*'(){},~:;=@#%&_-]*)+`,
+  URIPARAM: String.raw`\?[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?<>\[\]-]*`,
+  URIPATHPARAM: String.raw`%{URIPATH}(?:%{URIPARAM})?`,
+  URI: String.raw`%{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?`,
+
+  /* --- Dates and times --- */
+  MONTH: String.raw`\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b`,
+  MONTHNUM: String.raw`(?:0?[1-9]|1[0-2])`,
+  MONTHNUM2: String.raw`(?:0[1-9]|1[0-2])`,
+  MONTHDAY: String.raw`(?:0[1-9]|[12][0-9]|3[01]|[1-9])`,
+  DAY: String.raw`(?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)`,
+  YEAR: String.raw`(?:\d\d){1,2}`,
+  HOUR: String.raw`(?:2[0123]|[01]?[0-9])`,
+  MINUTE: String.raw`(?:[0-5][0-9])`,
+  SECOND: String.raw`(?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?)`,
+  TIME: String.raw`(?:%{HOUR}:%{MINUTE}(?::%{SECOND})?)`,
+  DATE_US: String.raw`%{MONTHNUM}[/-]%{MONTHDAY}[/-]%{YEAR}`,
+  DATE_EU: String.raw`%{MONTHDAY}[./-]%{MONTHNUM}[./-]%{YEAR}`,
+  DATE: String.raw`(?:%{DATE_US}|%{DATE_EU})`,
+  ISO8601_TIMEZONE: String.raw`(?:Z|[+-]%{HOUR}(?::?%{MINUTE})?)`,
+  TIMESTAMP_ISO8601: String.raw`%{YEAR}-%{MONTHNUM2}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?(?:%{ISO8601_TIMEZONE})?`,
+  DATESTAMP: String.raw`%{DATE}[- ]%{TIME}`,
+  TZ: String.raw`(?:[APMCE][SD]T|UTC|GMT)`,
+  HTTPDATE: String.raw`%{MONTHDAY}/%{MONTH}/%{YEAR}:%{TIME} %{INT}`,
+  SYSLOGTIMESTAMP: String.raw`%{MONTH} +%{MONTHDAY} %{TIME}`,
+
+  /* --- Log shapes --- */
+  LOGLEVEL: String.raw`(?:[Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo(?:rmation)?|INFO(?:RMATION)?|[Ww]arn(?:ing)?|WARN(?:ING)?|[Ee]rr(?:or)?|ERR(?:OR)?|[Cc]rit(?:ical)?|CRIT(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|[Ee]merg(?:ency)?|EMERG(?:ENCY)?)`,
+  PROG: String.raw`[\x21-\x5a\x5c\x5e-\x7e]+`,
+  SYSLOGPROG: String.raw`%{PROG:program}(?:\[%{POSINT:pid}\])?`,
+  SYSLOGFACILITY: String.raw`<%{NONNEGINT:facility}\.%{NONNEGINT:priority}>`,
+  SYSLOGBASE: String.raw`%{SYSLOGTIMESTAMP:timestamp} (?:%{SYSLOGFACILITY} )?%{IPORHOST:logsource} %{SYSLOGPROG}:`,
+  JAVACLASS: String.raw`(?:[a-zA-Z$_][a-zA-Z$_0-9]*\.)*[a-zA-Z$_][a-zA-Z$_0-9]*`,
+  COMMONAPACHELOG: String.raw`%{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)`,
+  COMBINEDAPACHELOG: String.raw`%{COMMONAPACHELOG} %{QS:referrer} %{QS:agent}`,
+};
+
+/*
+ * Names only, sorted — the pattern picker in the processor form lists
+ * these so a user can see what is available without leaving the page.
+ */
+export function getGrokPatternNames(): Array<string> {
+  return Object.keys(GrokPatterns).sort();
+}
+
+export default GrokPatterns;


### PR DESCRIPTION
Fixes #2515.

## The bug is real

`GrokParser` is a member of `LogPipelineProcessorType`, has a documented `GrokParserConfig`, is named in the `LogPipelineProcessor` model's own column description, and is accepted by the API because `processorType` is a free-text column. But `LogPipelineService.applyProcessor` had no branch for it, so any processor created with it fell through to `default: return logRow` and silently did nothing.

One correction to the report: the dashboard's processor dropdown never offered GrokParser, so the only way to create one was the API. Everything else in the issue checks out, and a second user has been running a custom image to get the feature.

## What this does

Implements it (option 1 in the issue) rather than hiding it.

**`Common/Utils/Grok`** — a grok engine, no new dependencies. Compiles `%{NAME:field:type}` references against a built-in pattern library into one JavaScript `RegExp`, capturing through injected named groups so extraction is a `match.groups` lookup with no index arithmetic. Matching is unanchored like Logstash, and empty captures are dropped the way `keep_empty_captures => false` does.

The library is written for V8 rather than copied from Oniguruma — no possessive quantifiers, no atomic groups — and every definition uses non-capturing groups whose repetitions consume at least one character, so patterns stay linear on hostile input. The compiler enforces ceilings on expansion depth, expansion count, expanded source length and capture count, and rejects circular references. The matcher refuses inputs over 32KB: a backtracking regex cannot be interrupted once started, so input length is the only bound available on the ingest hot path.

**`LogPipelineService.applyGrokParser`** — reads the source field with the same semantics a filter query uses (`body`, `attributes.x`, or a bare attribute key), writes captures into the log's attributes under an optional target prefix, and keeps `attributeKeys` in step. Patterns compile once per distinct pattern text, never per record. A line that does not match, a missing source field, or a pattern that does not compile all leave the log untouched — and an uncompilable pattern is logged once per process, not once per record.

**`LogPipelineProcessorService`** — compiles the pattern on create, and on the merged row on update, so a typo is rejected while a human is still looking at the form instead of becoming another silent no-op.

**The processor form** — now offers Grok Parser, with a pattern tester that runs the same compiler and matcher ingest runs and shows the exact attributes the processor would add before it is saved. A rejected save now shows what the API said instead of "please try again".

## Tests

101 new tests across four suites.

- `Common/Tests/Utils/Grok/Grok.test.ts` (51) — reference forms, nested expansion, type coercion, capture semantics, the pattern library against real Apache/syslog/ISO8601 lines, every compile-error path, every runaway guard, cache behaviour, and a set of hostile inputs built to make each library pattern backtrack.
- `App/Tests/Telemetry/LogPipelineGrokParser.test.ts` (19) — the regression itself, plus source resolution, target prefixes, degradation on a broken pattern, a configuration persisted as a JSON string, and composition with a severity remapper downstream.
- `Common/Tests/Server/{Utils,Services}` (25) — the save-time gate and both hooks, including the merged-row cases on update.
- `App/Tests/Dashboard/LogPipelineGrokProcessorForm.test.ts` (8) — pins the form wiring, including that the tester uses the shared engine rather than a second implementation free to disagree with ingest.

`npx tsc --noEmit` is clean in both `App` and `Common`; eslint is clean on every changed file. No schema change, so no migration.