### PR TITLE
fix(ui): write a custom telemetry range on the clock the user's computer uses

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer.tsx
@@ -409,12 +409,27 @@ const InvestigationDrawer: FunctionComponent<ComponentProps> = (
     ExplorerLink.openInExplorer(pinnedViewData);
   };
 
+  /*
+   * The window this panel is pinned to is the one the user just picked in the
+   * time range picker a click away, so it has to be written the same way that
+   * button writes it: on the machine's own 12- or 24-hour clock, in the
+   * configured timezone. getInBetweenDatesAsFormattedString cannot do that -
+   * it forwards no options, so it is hardcoded to a 24-hour clock, and it
+   * formats the digits in the browser's zone while labelling them with the
+   * configured zone's abbreviation.
+   */
+  const formatPinnedWindow: () => string = (): string => {
+    const format: (date: Date) => string = (date: Date): string => {
+      return OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(date);
+    };
+
+    return `${format(pinnedWindow.startValue)} - ${format(pinnedWindow.endValue)}`;
+  };
+
   return (
     <SideOver
       title={props.title || "Investigate window"}
-      description={OneUptimeDate.getInBetweenDatesAsFormattedString(
-        pinnedWindow,
-      )}
+      description={formatPinnedWindow()}
       size={SideOverSize.Large}
       onClose={props.onClose}
     >

--- a/App/Tests/Dashboard/ExplorerTimeRangePickerWiring.test.ts
+++ b/App/Tests/Dashboard/ExplorerTimeRangePickerWiring.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The reported bug was one hand-rolled formatter behind the time range picker's
+ * custom-range label, which wrote a 24-hour clock in the browser's own timezone
+ * no matter what the user's computer was set to. The formatter is fixed and
+ * unit-tested in Common (DateLocalShortDateTimeString.test.ts), and the label
+ * it produces is covered by rendering the picker in
+ * Common/Tests/UI/Components/TimeRangePickerClockFormat.test.tsx.
+ *
+ * What neither of those can see is the claim the bug report actually makes:
+ * that Metrics, Traces AND Logs are all fixed. They are, because all three
+ * mount the one shared picker - but nothing stops a future explorer from
+ * growing its own range label instead, which is exactly how the defect got in.
+ * So this pins the wiring.
+ *
+ * The App suite runs in plain Node with no renderer, so the check is made by
+ * reading the sources, the same way TelemetryPreviewSnapshotWindow.test.ts and
+ * IncidentMetricSeriesScope.test.ts do. Sources are comment-stripped and
+ * whitespace-squashed first so a prettier re-wrap cannot turn a real regression
+ * check into a red herring.
+ */
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    stripComments(
+      fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+    ),
+  );
+}
+
+interface Explorer {
+  name: string;
+  source: string;
+}
+
+/*
+ * The three surfaces named in the bug report, plus the metric explorer that
+ * shares the metrics screen with the metrics dashboard.
+ */
+const EXPLORERS: Array<Explorer> = [
+  {
+    name: "metrics",
+    source: readSource("Components", "Metrics", "MetricsDashboard.tsx"),
+  },
+  {
+    name: "single metric",
+    source: readSource("Components", "Metrics", "MetricExplorer.tsx"),
+  },
+  {
+    name: "traces",
+    source: readSource("Components", "Traces", "TracesDashboard.tsx"),
+  },
+  {
+    name: "logs",
+    source: readSource("Components", "Logs", "LogsDashboard.tsx"),
+  },
+];
+
+describe.each(EXPLORERS)(
+  "the $name explorer's time range picker",
+  (explorer: Explorer) => {
+    test("is the shared picker, so it inherits the fixed label", () => {
+      expect(explorer.source).toContain(
+        'import TelemetryTimeRangePicker from "Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker"',
+      );
+      expect(explorer.source).toContain("<TelemetryTimeRangePicker");
+    });
+
+    test("writes no range label of its own", () => {
+      /*
+       * The defect in one line: a component that formats a picked window by
+       * reading fields off the Date, or by pinning a locale, cannot see either
+       * the user's configured timezone or their machine's clock preference.
+       */
+      for (const bannedIdiom of [
+        'toLocaleString("en-US"',
+        "toLocaleTimeString([]",
+        "hour12: false",
+        "hour12: true",
+      ]) {
+        expect(explorer.source).not.toContain(bannedIdiom);
+      }
+    });
+  },
+);
+
+describe("the shared picker itself", () => {
+  const PICKER: string = squash(
+    stripComments(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "..",
+          "Common",
+          "UI",
+          "Components",
+          "Date",
+          "TimeRangePickerDropdown.tsx",
+        ),
+        "utf8",
+      ),
+    ),
+  );
+
+  test("formats a custom window through the timezone- and clock-aware helper", () => {
+    expect(PICKER).toContain("OneUptimeDate.getDateAsLocalShortDateTimeString");
+  });
+
+  test("reads no wall-clock field off the Date and pins no locale", () => {
+    for (const bannedIdiom of [
+      ".getHours()",
+      ".getMinutes()",
+      ".getDate()",
+      '"en-US"',
+      "hour12",
+    ]) {
+      expect(PICKER).not.toContain(bannedIdiom);
+    }
+  });
+});

--- a/App/Tests/Dashboard/ExplorerTimeRangePickerWiring.test.ts
+++ b/App/Tests/Dashboard/ExplorerTimeRangePickerWiring.test.ts
@@ -47,6 +47,33 @@ function readSource(...relativeParts: Array<string>): string {
   );
 }
 
+/*
+ * The idioms that cannot see the user's timezone or clock preference. Every
+ * one of these was in the picker before the fix; the point of the list is that
+ * none of them comes back, here or on a surface that grows its own label.
+ *
+ * Whitespace is permissive throughout because these are matched against
+ * squash()ed source, where a prettier line break has become a single space.
+ */
+const BANNED_DATE_IDIOMS: Array<RegExp> = [
+  // Wall-clock fields read off the Date, i.e. in the browser process's zone.
+  /\.getHours\s*\(\s*\)/,
+  /\.getMinutes\s*\(\s*\)/,
+  /\.getDate\s*\(\s*\)/,
+  /\.getMonth\s*\(\s*\)/,
+  /\.getFullYear\s*\(\s*\)/,
+  /\.getSeconds\s*\(\s*\)/,
+  /*
+   * A date formatted through toLocale*String - with a pinned locale, an empty
+   * locale array, or an explicit undefined. Number#toLocaleString() on a count
+   * takes no argument and is deliberately not matched.
+   */
+  /toLocale(Date|Time)?String\s*\(\s*["'`[]/,
+  /toLocale(Date|Time)?String\s*\(\s*undefined/,
+  // An hour cycle nailed open in either direction.
+  /hour12\s*:/,
+];
+
 interface Explorer {
   name: string;
   source: string;
@@ -88,16 +115,17 @@ describe.each(EXPLORERS)(
     test("writes no range label of its own", () => {
       /*
        * The defect in one line: a component that formats a picked window by
-       * reading fields off the Date, or by pinning a locale, cannot see either
-       * the user's configured timezone or their machine's clock preference.
+       * reading fields off the Date, or by pinning a locale, or by nailing the
+       * hour cycle open, cannot see either the user's configured timezone or
+       * their machine's clock preference.
+       *
+       * These are regexes rather than substrings because squash() has already
+       * collapsed the source's newlines to single spaces - a prettier-wrapped
+       * `toLocaleString(\n  "en-US",` arrives here as `toLocaleString( "en-US",`
+       * and slips straight past an exact-substring check.
        */
-      for (const bannedIdiom of [
-        'toLocaleString("en-US"',
-        "toLocaleTimeString([]",
-        "hour12: false",
-        "hour12: true",
-      ]) {
-        expect(explorer.source).not.toContain(bannedIdiom);
+      for (const bannedIdiom of BANNED_DATE_IDIOMS) {
+        expect(explorer.source).not.toMatch(bannedIdiom);
       }
     });
   },
@@ -128,14 +156,8 @@ describe("the shared picker itself", () => {
   });
 
   test("reads no wall-clock field off the Date and pins no locale", () => {
-    for (const bannedIdiom of [
-      ".getHours()",
-      ".getMinutes()",
-      ".getDate()",
-      '"en-US"',
-      "hour12",
-    ]) {
-      expect(PICKER).not.toContain(bannedIdiom);
+    for (const bannedIdiom of BANNED_DATE_IDIOMS) {
+      expect(PICKER).not.toMatch(bannedIdiom);
     }
   });
 });

--- a/Common/Tests/Types/DateLocalShortDateTimeString.test.ts
+++ b/Common/Tests/Types/DateLocalShortDateTimeString.test.ts
@@ -16,6 +16,7 @@
  */
 import OneUptimeDate from "../../Types/Date";
 import Timezone from "../../Types/Timezone";
+import moment from "moment-timezone";
 import {
   afterEach,
   beforeEach,
@@ -348,13 +349,47 @@ describe("OneUptimeDate.getDateAsLocalShortDateTimeString", () => {
       OneUptimeDate.setUserTimezone(null);
 
       /*
-       * Without a configured zone the label must still be a well-formed one -
-       * this asserts the shape rather than the digits, which depend on the TZ
-       * the suite runs under.
+       * The digits depend on the zone the suite runs under, so derive the
+       * expectation the same way - anchored to moment.tz.guess() rather than
+       * to a literal. A shape-only regex would have accepted a hardcoded UTC,
+       * which is the mistake this guards.
        */
-      expect(
-        format("2024-03-01T14:30:00.000Z", { use12HourFormat: false }),
-      ).toMatch(/^[A-Z][a-z]{2} \d{1,2}, \d{2}:\d{2}$/);
+      const instant: string = "2024-03-01T14:30:00.000Z";
+      const expected: string = moment(new Date(instant))
+        .tz(moment.tz.guess())
+        .format("MMM D, HH:mm");
+
+      expect(format(instant, { use12HourFormat: false })).toBe(expected);
+    });
+
+    it("does not silently render in UTC when no zone is configured", () => {
+      /*
+       * Pin the fallback against the specific wrong answer: hardcoding UTC
+       * passes every other case in this file, because they all set a zone.
+       */
+      OneUptimeDate.setUserTimezone(null);
+
+      const instant: string = "2024-03-01T14:30:00.000Z";
+      const inUtc: string = moment(new Date(instant))
+        .tz("UTC")
+        .format("MMM D, HH:mm");
+      const inGuessedZone: string = moment(new Date(instant))
+        .tz(moment.tz.guess())
+        .format("MMM D, HH:mm");
+
+      if (inGuessedZone === inUtc) {
+        /*
+         * The suite is running on a zone that agrees with UTC at this instant,
+         * so it cannot tell the two apart. Assert against a zone that never
+         * does instead.
+         */
+        OneUptimeDate.setUserTimezone(KOLKATA);
+        expect(format(instant, { use12HourFormat: false })).not.toBe(inUtc);
+        return;
+      }
+
+      expect(format(instant, { use12HourFormat: false })).toBe(inGuessedZone);
+      expect(format(instant, { use12HourFormat: false })).not.toBe(inUtc);
     });
   });
 

--- a/Common/Tests/Types/DateLocalShortDateTimeString.test.ts
+++ b/Common/Tests/Types/DateLocalShortDateTimeString.test.ts
@@ -1,0 +1,483 @@
+/**
+ * The compact "Mar 1, 2:30 PM" label the metrics / traces / logs time range
+ * picker puts on its button once a custom window is applied.
+ *
+ * The bug these lock in: the picker read the digits straight off the Date
+ * (`date.getHours().padStart(2, "0")`), so the label was always on a 24-hour
+ * clock and always in whatever zone the browser process happened to be in. A
+ * user whose computer is set to AM/PM picked "1 Mar, 2:30 PM" and got back a
+ * button reading "Mar 1, 14:30" — and a user who had set a different timezone
+ * in User Settings got a label that disagreed with every other date on screen.
+ *
+ * Every case here pins the timezone explicitly and passes `use12HourFormat`
+ * rather than letting the host machine decide, so the assertions hold under
+ * whatever TZ and locale the suite runs in. Detection of the machine's own
+ * preference is covered separately in DateUserPrefers12HourFormat.test.ts.
+ */
+import OneUptimeDate from "../../Types/Date";
+import Timezone from "../../Types/Timezone";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const UTC: Timezone = Timezone.UTC;
+const NEW_YORK: Timezone = Timezone.AmericaNew_York;
+const KOLKATA: Timezone = Timezone.AsiaKolkata;
+
+type FormatFunction = (
+  isoString: string,
+  options?: {
+    use12HourFormat?: boolean | undefined;
+    includeSeconds?: boolean | undefined;
+  },
+) => string;
+
+const format: FormatFunction = (
+  isoString: string,
+  options?: {
+    use12HourFormat?: boolean | undefined;
+    includeSeconds?: boolean | undefined;
+  },
+): string => {
+  return OneUptimeDate.getDateAsLocalShortDateTimeString(
+    new Date(isoString),
+    options,
+  );
+};
+
+describe("OneUptimeDate.getDateAsLocalShortDateTimeString", () => {
+  afterEach(() => {
+    // Never leak a pinned zone or a mocked preference into the rest of the suite.
+    OneUptimeDate.setUserTimezone(null);
+    jest.restoreAllMocks();
+  });
+
+  describe("12-hour clock", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(UTC);
+    });
+
+    it("writes an afternoon time with a PM marker", () => {
+      expect(
+        format("2024-03-01T14:30:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 2:30 PM");
+    });
+
+    it("writes a morning time with an AM marker", () => {
+      expect(
+        format("2024-03-01T09:05:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 9:05 AM");
+    });
+
+    it("writes midnight as 12 AM rather than 0 AM", () => {
+      expect(
+        format("2024-03-01T00:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 12:00 AM");
+    });
+
+    it("keeps the minute after midnight in the AM half", () => {
+      expect(
+        format("2024-03-01T00:01:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 12:01 AM");
+    });
+
+    it("writes noon as 12 PM rather than 0 PM", () => {
+      expect(
+        format("2024-03-01T12:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 12:00 PM");
+    });
+
+    it("keeps the last minute before 1 PM in the 12 PM hour", () => {
+      expect(
+        format("2024-03-01T12:59:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 12:59 PM");
+    });
+
+    it("rolls 13:00 over to 1 PM", () => {
+      expect(
+        format("2024-03-01T13:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 1:00 PM");
+    });
+
+    it("writes the last minute of the day as 11:59 PM", () => {
+      expect(
+        format("2024-03-01T23:59:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 11:59 PM");
+    });
+
+    it("leaves a single-digit hour unpadded", () => {
+      /*
+       * "09:05 AM" is not how a 12-hour clock is written; the padding only
+       * belongs on the 24-hour form, where it keeps the column aligned.
+       */
+      const label: string = format("2024-03-01T09:05:00.000Z", {
+        use12HourFormat: true,
+      });
+
+      expect(label).toBe("Mar 1, 9:05 AM");
+      expect(label).not.toContain("09:05");
+    });
+
+    it("covers every hour of the day with an AM or PM marker", () => {
+      const markers: Array<string> = [];
+
+      for (let hour: number = 0; hour < 24; hour++) {
+        const isoHour: string = hour.toString().padStart(2, "0");
+        const label: string = format(`2024-03-01T${isoHour}:00:00.000Z`, {
+          use12HourFormat: true,
+        });
+
+        expect(label).toMatch(/^Mar 1, (1[0-2]|[1-9]):00 (AM|PM)$/);
+        markers.push(label.slice(-2));
+      }
+
+      // Twelve of each, and never a bare 24-hour reading.
+      expect(
+        markers.filter((marker: string) => {
+          return marker === "AM";
+        }),
+      ).toHaveLength(12);
+      expect(
+        markers.filter((marker: string) => {
+          return marker === "PM";
+        }),
+      ).toHaveLength(12);
+    });
+  });
+
+  describe("24-hour clock", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(UTC);
+    });
+
+    it("writes an afternoon time on the 24-hour clock with no marker", () => {
+      const label: string = format("2024-03-01T14:30:00.000Z", {
+        use12HourFormat: false,
+      });
+
+      expect(label).toBe("Mar 1, 14:30");
+      expect(label).not.toMatch(/AM|PM/);
+    });
+
+    it("pads a single-digit hour", () => {
+      expect(
+        format("2024-03-01T09:05:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 09:05");
+    });
+
+    it("writes midnight as 00:00", () => {
+      expect(
+        format("2024-03-01T00:00:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 00:00");
+    });
+
+    it("writes noon as 12:00", () => {
+      expect(
+        format("2024-03-01T12:00:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 12:00");
+    });
+
+    it("writes the last minute of the day as 23:59", () => {
+      expect(
+        format("2024-03-01T23:59:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 23:59");
+    });
+
+    it("never emits a day period on any hour of the day", () => {
+      for (let hour: number = 0; hour < 24; hour++) {
+        const isoHour: string = hour.toString().padStart(2, "0");
+        const label: string = format(`2024-03-01T${isoHour}:00:00.000Z`, {
+          use12HourFormat: false,
+        });
+
+        expect(label).toBe(`Mar 1, ${isoHour}:00`);
+      }
+    });
+  });
+
+  describe("seconds", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(UTC);
+    });
+
+    it("is omitted by default", () => {
+      expect(
+        format("2024-03-01T14:30:45.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 14:30");
+    });
+
+    it("sits before the day period on a 12-hour clock", () => {
+      expect(
+        format("2024-03-01T14:30:45.000Z", {
+          use12HourFormat: true,
+          includeSeconds: true,
+        }),
+      ).toBe("Mar 1, 2:30:45 PM");
+    });
+
+    it("is appended to a 24-hour clock", () => {
+      expect(
+        format("2024-03-01T14:30:45.000Z", {
+          use12HourFormat: false,
+          includeSeconds: true,
+        }),
+      ).toBe("Mar 1, 14:30:45");
+    });
+
+    it("pads a single-digit second", () => {
+      expect(
+        format("2024-03-01T14:30:05.000Z", {
+          use12HourFormat: false,
+          includeSeconds: true,
+        }),
+      ).toBe("Mar 1, 14:30:05");
+    });
+  });
+
+  describe("the date half", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(UTC);
+    });
+
+    it("leaves the day of the month unpadded", () => {
+      expect(
+        format("2024-03-01T14:30:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 14:30");
+    });
+
+    it("writes a two-digit day as-is", () => {
+      expect(
+        format("2024-03-21T14:30:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 21, 14:30");
+    });
+
+    it("abbreviates every month", () => {
+      const months: Array<string> = [];
+
+      for (let month: number = 1; month <= 12; month++) {
+        const isoMonth: string = month.toString().padStart(2, "0");
+        months.push(
+          format(`2024-${isoMonth}-15T12:00:00.000Z`, {
+            use12HourFormat: false,
+          }),
+        );
+      }
+
+      expect(months).toEqual([
+        "Jan 15, 12:00",
+        "Feb 15, 12:00",
+        "Mar 15, 12:00",
+        "Apr 15, 12:00",
+        "May 15, 12:00",
+        "Jun 15, 12:00",
+        "Jul 15, 12:00",
+        "Aug 15, 12:00",
+        "Sep 15, 12:00",
+        "Oct 15, 12:00",
+        "Nov 15, 12:00",
+        "Dec 15, 12:00",
+      ]);
+    });
+
+    it("carries no year, which is what keeps the label short", () => {
+      expect(
+        format("2024-03-01T14:30:00.000Z", { use12HourFormat: false }),
+      ).not.toMatch(/2024/);
+    });
+  });
+
+  describe("timezone", () => {
+    it("reads the wall clock in the timezone the user configured", () => {
+      OneUptimeDate.setUserTimezone(NEW_YORK);
+
+      // 02:30 UTC on 1 Mar is 21:30 the previous evening in New York (EST).
+      expect(
+        format("2024-03-01T02:30:00.000Z", { use12HourFormat: true }),
+      ).toBe("Feb 29, 9:30 PM");
+    });
+
+    it("moves the date as well as the time when the zone crosses midnight", () => {
+      OneUptimeDate.setUserTimezone(KOLKATA);
+
+      // 20:00 UTC is 01:30 the next morning at +05:30.
+      expect(
+        format("2024-03-01T20:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 2, 1:30 AM");
+    });
+
+    it("gives a different label for the same instant in a different zone", () => {
+      const instant: string = "2024-03-01T20:00:00.000Z";
+
+      OneUptimeDate.setUserTimezone(UTC);
+      const inUtc: string = format(instant, { use12HourFormat: false });
+
+      OneUptimeDate.setUserTimezone(KOLKATA);
+      const inKolkata: string = format(instant, { use12HourFormat: false });
+
+      expect(inUtc).toBe("Mar 1, 20:00");
+      expect(inKolkata).toBe("Mar 2, 01:30");
+    });
+
+    it("follows a zone change without the instant moving", () => {
+      const instant: Date = new Date("2024-07-04T16:00:00.000Z");
+
+      OneUptimeDate.setUserTimezone(UTC);
+      expect(
+        OneUptimeDate.getDateAsLocalShortDateTimeString(instant, {
+          use12HourFormat: true,
+        }),
+      ).toBe("Jul 4, 4:00 PM");
+
+      OneUptimeDate.setUserTimezone(NEW_YORK);
+      expect(
+        OneUptimeDate.getDateAsLocalShortDateTimeString(instant, {
+          use12HourFormat: true,
+        }),
+      ).toBe("Jul 4, 12:00 PM");
+
+      // The Date itself was never mutated.
+      expect(instant.toISOString()).toBe("2024-07-04T16:00:00.000Z");
+    });
+
+    it("falls back to the zone the browser reports when none is configured", () => {
+      OneUptimeDate.setUserTimezone(null);
+
+      /*
+       * Without a configured zone the label must still be a well-formed one -
+       * this asserts the shape rather than the digits, which depend on the TZ
+       * the suite runs under.
+       */
+      expect(
+        format("2024-03-01T14:30:00.000Z", { use12HourFormat: false }),
+      ).toMatch(/^[A-Z][a-z]{2} \d{1,2}, \d{2}:\d{2}$/);
+    });
+  });
+
+  describe("daylight saving", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(NEW_YORK);
+    });
+
+    it("reads the minute before a spring-forward jump on standard time", () => {
+      expect(
+        format("2024-03-10T06:59:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 10, 1:59 AM");
+    });
+
+    it("skips the hour that does not exist on the spring-forward day", () => {
+      // 07:00 UTC is 03:00 EDT - 02:00 never happens in New York that day.
+      expect(
+        format("2024-03-10T07:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 10, 3:00 AM");
+    });
+
+    it("writes both halves of the repeated fall-back hour on the same clock", () => {
+      /*
+       * 05:00 and 06:00 UTC are two different instants that both read 01:00 in
+       * New York on the day the clocks go back. Both are correct - the label is
+       * a wall clock, and this pins that it does not silently offset one.
+       */
+      expect(
+        format("2024-11-03T05:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Nov 3, 1:00 AM");
+      expect(
+        format("2024-11-03T06:00:00.000Z", { use12HourFormat: true }),
+      ).toBe("Nov 3, 1:00 AM");
+    });
+  });
+
+  describe("input handling", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(UTC);
+    });
+
+    it("accepts an ISO string as well as a Date", () => {
+      expect(
+        OneUptimeDate.getDateAsLocalShortDateTimeString(
+          "2024-03-01T14:30:00.000Z",
+          { use12HourFormat: true },
+        ),
+      ).toBe("Mar 1, 2:30 PM");
+    });
+
+    it("gives the same answer for a Date and its ISO string", () => {
+      const instant: Date = new Date("2024-03-01T14:30:00.000Z");
+
+      expect(
+        OneUptimeDate.getDateAsLocalShortDateTimeString(instant, {
+          use12HourFormat: true,
+        }),
+      ).toBe(
+        OneUptimeDate.getDateAsLocalShortDateTimeString(instant.toISOString(), {
+          use12HourFormat: true,
+        }),
+      );
+    });
+  });
+
+  describe("defaulting to the machine's preference", () => {
+    beforeEach(() => {
+      OneUptimeDate.setUserTimezone(UTC);
+    });
+
+    it("uses a 12-hour clock when the machine is on one", () => {
+      jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(true);
+
+      expect(format("2024-03-01T14:30:00.000Z")).toBe("Mar 1, 2:30 PM");
+    });
+
+    it("uses a 24-hour clock when the machine is on one", () => {
+      jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(false);
+
+      expect(format("2024-03-01T14:30:00.000Z")).toBe("Mar 1, 14:30");
+    });
+
+    it("lets an explicit 24-hour caller override a 12-hour machine", () => {
+      jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(true);
+
+      expect(
+        format("2024-03-01T14:30:00.000Z", { use12HourFormat: false }),
+      ).toBe("Mar 1, 14:30");
+    });
+
+    it("lets an explicit 12-hour caller override a 24-hour machine", () => {
+      jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(false);
+
+      expect(
+        format("2024-03-01T14:30:00.000Z", { use12HourFormat: true }),
+      ).toBe("Mar 1, 2:30 PM");
+    });
+
+    it("asks the machine once per call rather than caching an answer", () => {
+      /*
+       * The preference can change under a running tab - the user flips their
+       * OS clock setting and comes back. Nothing may hold a stale copy.
+       */
+      jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(false);
+
+      expect(format("2024-03-01T14:30:00.000Z")).toBe("Mar 1, 14:30");
+
+      // The same tab, after the user flips their OS clock setting.
+      jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(true);
+
+      expect(format("2024-03-01T14:30:00.000Z")).toBe("Mar 1, 2:30 PM");
+    });
+  });
+});

--- a/Common/Tests/Types/DateUserPrefers12HourFormat.test.ts
+++ b/Common/Tests/Types/DateUserPrefers12HourFormat.test.ts
@@ -14,6 +14,7 @@
  * as a fallback for an engine without a usable Intl.
  */
 import OneUptimeDate from "../../Types/Date";
+import Timezone from "../../Types/Timezone";
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
 
 type ResolvedOptionsStub = {
@@ -61,6 +62,16 @@ const stubIntl: StubIntlFunction = (
     );
 };
 
+type StubFormattedTimeFunction = (formatted: string) => void;
+
+const stubFormattedTime: StubFormattedTimeFunction = (
+  formatted: string,
+): void => {
+  jest.spyOn(Date.prototype, "toLocaleTimeString").mockImplementation(() => {
+    return formatted;
+  });
+};
+
 /*
  * Delegate to the real Intl but pin the locale, so a case can assert what a
  * machine actually configured to that locale reports rather than a hand-made
@@ -83,22 +94,21 @@ const stubIntlWithLocale: StubIntlWithLocaleFunction = (
         return new realDateTimeFormat(locale, options);
       },
     );
-};
 
-type StubFormattedTimeFunction = (formatted: string) => void;
-
-const stubFormattedTime: StubFormattedTimeFunction = (
-  formatted: string,
-): void => {
-  jest.spyOn(Date.prototype, "toLocaleTimeString").mockImplementation(() => {
-    return formatted;
-  });
+  /*
+   * Hold the legacy string probe to a bare 24-hour reading. Without this the
+   * fallback still sees the HOST's locale, so on a US runner the old am/pm
+   * substring check would answer "12-hour" by luck and the cases below would
+   * pass against the very implementation they exist to rule out.
+   */
+  stubFormattedTime("14:30:00");
 };
 
 describe("OneUptimeDate.getUserPrefers12HourFormat", () => {
   afterEach(() => {
     probeCalls.length = 0;
     jest.restoreAllMocks();
+    OneUptimeDate.setUserTimezone(null);
   });
 
   describe("reading the machine's clock setting from Intl", () => {
@@ -128,6 +138,12 @@ describe("OneUptimeDate.getUserPrefers12HourFormat", () => {
 
       OneUptimeDate.getUserPrefers12HourFormat();
 
+      /*
+       * Assert the probe ran before reading what it asked for - without this,
+       * an implementation that never called Intl would satisfy the line below
+       * on an empty array.
+       */
+      expect(probeCalls).toHaveLength(1);
       // `undefined` is what makes Intl resolve the browser's default locale.
       expect(probeCalls[0]?.locales).toBeUndefined();
     });
@@ -270,6 +286,13 @@ describe("OneUptimeDate.getUserPrefers12HourFormat", () => {
        * The user-visible consequence, end to end: the same instant is written
        * two different ways purely on the strength of this one answer.
        */
+      /*
+       * Pin the zone: without it this reads 2:30 PM on a UTC runner and 6:30 AM
+       * on a Los Angeles one, and the assertion is about the clock, not the
+       * zone.
+       */
+      OneUptimeDate.setUserTimezone(Timezone.UTC);
+
       stubIntlWithLocale("en-US");
       const on12HourMachine: string =
         OneUptimeDate.getDateAsLocalShortDateTimeString(
@@ -286,8 +309,8 @@ describe("OneUptimeDate.getUserPrefers12HourFormat", () => {
           { use12HourFormat: OneUptimeDate.getUserPrefers12HourFormat() },
         );
 
-      expect(on12HourMachine).toMatch(/2:30 PM$/);
-      expect(on24HourMachine).toMatch(/14:30$/);
+      expect(on12HourMachine).toBe("Mar 1, 2:30 PM");
+      expect(on24HourMachine).toBe("Mar 1, 14:30");
     });
   });
 });

--- a/Common/Tests/Types/DateUserPrefers12HourFormat.test.ts
+++ b/Common/Tests/Types/DateUserPrefers12HourFormat.test.ts
@@ -1,0 +1,293 @@
+/**
+ * How OneUptime decides whether to write times on a 12- or a 24-hour clock.
+ *
+ * The answer has to come from the machine the person is sitting at: a browser
+ * resolves its default locale against the operating system's own clock setting,
+ * so toggling macOS's "24-Hour Time" (or the Windows/Linux equivalent) is meant
+ * to flip every time in the product.
+ *
+ * The bug these lock in: the check used to format a time and look for the
+ * letters "am"/"pm" in it. That is only how Latin-script locales mark the day
+ * period - ko-KR writes 오후, ar-EG writes م - so 12-hour machines in those
+ * locales were misread as 24-hour and got 24-hour times back. Intl reports the
+ * hour cycle directly, so it is asked first and the string probe is kept only
+ * as a fallback for an engine without a usable Intl.
+ */
+import OneUptimeDate from "../../Types/Date";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+type ResolvedOptionsStub = {
+  hour12?: boolean | undefined;
+  hourCycle?: string | undefined;
+};
+
+/*
+ * Stand in for the browser's resolved locale. `locales` records what the probe
+ * asked for so a test can assert it requested an hour at all - Intl only
+ * reports `hour12` when the format includes one, so a probe that forgot to ask
+ * would silently fall through to the string check on every engine.
+ */
+type IntlProbeCall = {
+  locales: Intl.LocalesArgument;
+  options: Intl.DateTimeFormatOptions | undefined;
+};
+
+const probeCalls: Array<IntlProbeCall> = [];
+
+type StubIntlFunction = (resolved: ResolvedOptionsStub | (() => never)) => void;
+
+const stubIntl: StubIntlFunction = (
+  resolved: ResolvedOptionsStub | (() => never),
+): void => {
+  jest
+    .spyOn(Intl, "DateTimeFormat")
+    .mockImplementation(
+      (
+        locales?: Intl.LocalesArgument,
+        options?: Intl.DateTimeFormatOptions,
+      ) => {
+        probeCalls.push({ locales: locales, options: options });
+
+        if (typeof resolved === "function") {
+          resolved();
+        }
+
+        return {
+          resolvedOptions: () => {
+            return resolved as Intl.ResolvedDateTimeFormatOptions;
+          },
+        } as unknown as Intl.DateTimeFormat;
+      },
+    );
+};
+
+/*
+ * Delegate to the real Intl but pin the locale, so a case can assert what a
+ * machine actually configured to that locale reports rather than a hand-made
+ * stub of it.
+ */
+type StubIntlWithLocaleFunction = (locale: string) => void;
+
+const stubIntlWithLocale: StubIntlWithLocaleFunction = (
+  locale: string,
+): void => {
+  const realDateTimeFormat: typeof Intl.DateTimeFormat = Intl.DateTimeFormat;
+
+  jest
+    .spyOn(Intl, "DateTimeFormat")
+    .mockImplementation(
+      (
+        _locales?: Intl.LocalesArgument,
+        options?: Intl.DateTimeFormatOptions,
+      ) => {
+        return new realDateTimeFormat(locale, options);
+      },
+    );
+};
+
+type StubFormattedTimeFunction = (formatted: string) => void;
+
+const stubFormattedTime: StubFormattedTimeFunction = (
+  formatted: string,
+): void => {
+  jest.spyOn(Date.prototype, "toLocaleTimeString").mockImplementation(() => {
+    return formatted;
+  });
+};
+
+describe("OneUptimeDate.getUserPrefers12HourFormat", () => {
+  afterEach(() => {
+    probeCalls.length = 0;
+    jest.restoreAllMocks();
+  });
+
+  describe("reading the machine's clock setting from Intl", () => {
+    it("reports a 12-hour machine as 12-hour", () => {
+      stubIntl({ hour12: true, hourCycle: "h12" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("reports a 24-hour machine as 24-hour", () => {
+      stubIntl({ hour12: false, hourCycle: "h23" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("asks for an hour, without which Intl reports no clock at all", () => {
+      stubIntl({ hour12: true });
+
+      OneUptimeDate.getUserPrefers12HourFormat();
+
+      expect(probeCalls).toHaveLength(1);
+      expect(probeCalls[0]?.options?.hour).toBeDefined();
+    });
+
+    it("asks for the machine's own locale rather than pinning one", () => {
+      stubIntl({ hour12: true });
+
+      OneUptimeDate.getUserPrefers12HourFormat();
+
+      // `undefined` is what makes Intl resolve the browser's default locale.
+      expect(probeCalls[0]?.locales).toBeUndefined();
+    });
+  });
+
+  describe("engines that report the cycle but not the boolean", () => {
+    it("treats h12 as a 12-hour clock", () => {
+      stubIntl({ hourCycle: "h12" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("treats h11 as a 12-hour clock", () => {
+      stubIntl({ hourCycle: "h11" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("treats h23 as a 24-hour clock", () => {
+      stubIntl({ hourCycle: "h23" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("treats h24 as a 24-hour clock", () => {
+      stubIntl({ hourCycle: "h24" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("prefers the boolean when both are reported and they disagree", () => {
+      /*
+       * hour12 is the value the spec says to honour; hourCycle is only read
+       * because older engines omit hour12 entirely.
+       */
+      stubIntl({ hour12: false, hourCycle: "h12" });
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+  });
+
+  describe("real locales", () => {
+    it("reads en-US as a 12-hour machine", () => {
+      stubIntlWithLocale("en-US");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("reads en-GB as a 24-hour machine", () => {
+      stubIntlWithLocale("en-GB");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("reads de-DE as a 24-hour machine", () => {
+      stubIntlWithLocale("de-DE");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("honours an explicit 24-hour override on a 12-hour locale", () => {
+      // What a US machine with "24-Hour Time" switched on resolves to.
+      stubIntlWithLocale("en-US-u-hc-h23");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("honours an explicit 12-hour override on a 24-hour locale", () => {
+      stubIntlWithLocale("de-DE-u-hc-h12");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("reads ko-KR as a 12-hour machine even though it writes 오후, not PM", () => {
+      /*
+       * The regression this whole change exists for: the old string probe saw
+       * "오후 2:30:00", found no "am"/"pm", and told a Korean user on a
+       * 12-hour machine they were on a 24-hour one.
+       */
+      stubIntlWithLocale("ko-KR");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("reads ar-EG as a 12-hour machine even though it writes م, not PM", () => {
+      stubIntlWithLocale("ar-EG");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+  });
+
+  describe("falling back when Intl cannot answer", () => {
+    it("reads a Latin AM/PM out of a formatted time when Intl throws", () => {
+      stubIntl(() => {
+        throw new Error("Intl unavailable");
+      });
+      stubFormattedTime("2:30:00 PM");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("reads a bare 24-hour time out of a formatted time when Intl throws", () => {
+      stubIntl(() => {
+        throw new Error("Intl unavailable");
+      });
+      stubFormattedTime("14:30:00");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(false);
+    });
+
+    it("falls back when Intl answers with neither a boolean nor a cycle", () => {
+      stubIntl({});
+      stubFormattedTime("2:30:00 AM");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("matches a lowercase day period", () => {
+      stubIntl({});
+      stubFormattedTime("2:30:00 pm");
+
+      expect(OneUptimeDate.getUserPrefers12HourFormat()).toBe(true);
+    });
+
+    it("does not throw when Intl is broken and the time has no day period", () => {
+      stubIntl(() => {
+        throw new Error("Intl unavailable");
+      });
+      stubFormattedTime("14:30:00");
+
+      expect(() => {
+        return OneUptimeDate.getUserPrefers12HourFormat();
+      }).not.toThrow();
+    });
+  });
+
+  describe("as a decision the rest of the product reads", () => {
+    it("drives the clock of the time range picker's custom label", () => {
+      /*
+       * The user-visible consequence, end to end: the same instant is written
+       * two different ways purely on the strength of this one answer.
+       */
+      stubIntlWithLocale("en-US");
+      const on12HourMachine: string =
+        OneUptimeDate.getDateAsLocalShortDateTimeString(
+          new Date("2024-03-01T14:30:00.000Z"),
+          { use12HourFormat: OneUptimeDate.getUserPrefers12HourFormat() },
+        );
+
+      jest.restoreAllMocks();
+
+      stubIntlWithLocale("en-GB");
+      const on24HourMachine: string =
+        OneUptimeDate.getDateAsLocalShortDateTimeString(
+          new Date("2024-03-01T14:30:00.000Z"),
+          { use12HourFormat: OneUptimeDate.getUserPrefers12HourFormat() },
+        );
+
+      expect(on12HourMachine).toMatch(/2:30 PM$/);
+      expect(on24HourMachine).toMatch(/14:30$/);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/LogsViewerEmptyStateTimeRange.test.tsx
+++ b/Common/Tests/UI/Components/LogsViewerEmptyStateTimeRange.test.tsx
@@ -1,0 +1,212 @@
+/** @timezone UTC */
+/**
+ * The sentence the logs explorer shows when a search comes back empty repeats
+ * the window that was searched, so the reader can tell "nothing matched" apart
+ * from "you are looking at the wrong hour".
+ *
+ * It had the same defect as the picker button above it, in mirror image: the
+ * window was formatted with a hardcoded `toLocaleString("en-US", ...)`, so it
+ * always came out on a 12-hour clock even for a user whose machine is set to
+ * 24-hour, and always in the browser's own zone rather than the one configured
+ * in User Settings. The picker meanwhile always said 24-hour. One screen, one
+ * window, two disagreeing renderings, neither of them the user's.
+ */
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Declared before jest.mock but dereferenced inside the factories: ts-jest
+ * hoists the jest.mock calls above these initializers, so naming the mocks
+ * directly in a factory would capture undefined.
+ */
+const getListMock: MockFunction = getJestMockFunction();
+const postMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      getCommonHeaders: () => {
+        return {};
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<any>) => {
+        return postMock(...args);
+      },
+      getFriendlyErrorMessage: (error: Error) => {
+        return error.message;
+      },
+      getFriendlyMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+
+getListMock.mockImplementation(() => {
+  return Promise.resolve({ data: [], count: 0, skip: 0, limit: 0 });
+});
+
+postMock.mockImplementation(() => {
+  return Promise.resolve({ data: {} });
+});
+
+// Imported after the mocks so the module picks the mocked API surfaces up.
+import { getEmptyMessageWithTimeRange } from "../../../UI/Components/LogsViewer/LogsViewer";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
+import TimeRange from "../../../Types/Time/TimeRange";
+import Timezone from "../../../Types/Timezone";
+
+const AFTERNOON: InBetween<Date> = new InBetween<Date>(
+  new Date("2024-03-01T14:30:00.000Z"),
+  new Date("2024-03-01T18:45:00.000Z"),
+);
+
+function pin(use12HourFormat: boolean): void {
+  jest
+    .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+    .mockReturnValue(use12HourFormat);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  OneUptimeDate.setUserTimezone(null);
+});
+
+describe("getEmptyMessageWithTimeRange", () => {
+  describe("a custom window", () => {
+    test("is written with AM/PM on a 12-hour machine", () => {
+      pin(true);
+
+      expect(
+        getEmptyMessageWithTimeRange({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: AFTERNOON,
+        }),
+      ).toBe(
+        "Time range: Mar 1, 2:30 PM – Mar 1, 6:45 PM. Try adjusting filters or expanding the time range.",
+      );
+    });
+
+    test("is written on a 24-hour clock on a 24-hour machine", () => {
+      pin(false);
+
+      const message: string = getEmptyMessageWithTimeRange({
+        range: TimeRange.CUSTOM,
+        startAndEndDate: AFTERNOON,
+      });
+
+      expect(message).toBe(
+        "Time range: Mar 1, 14:30 – Mar 1, 18:45. Try adjusting filters or expanding the time range.",
+      );
+      expect(message).not.toMatch(/AM|PM/);
+    });
+
+    test("no longer forces AM/PM on a 24-hour machine", () => {
+      /*
+       * The exact regression: `toLocaleString("en-US", ...)` pinned the locale,
+       * so this sentence said "02:30 PM" to a reader whose whole machine - and
+       * whose picker button - was on a 24-hour clock.
+       */
+      pin(false);
+
+      expect(
+        getEmptyMessageWithTimeRange({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: AFTERNOON,
+        }),
+      ).not.toContain("02:30 PM");
+    });
+
+    test("is read in the timezone configured in User Settings", () => {
+      pin(true);
+      OneUptimeDate.setUserTimezone(Timezone.AsiaKolkata);
+
+      expect(
+        getEmptyMessageWithTimeRange({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: AFTERNOON,
+        }),
+      ).toContain("Mar 1, 8:00 PM – Mar 2, 12:15 AM");
+    });
+
+    test("matches the label the picker button puts on the same window", () => {
+      /*
+       * The two sit on the same screen describing the same window, so they must
+       * not disagree. Both now go through one formatter - this pins that they
+       * still do.
+       */
+      pin(true);
+      OneUptimeDate.setUserTimezone(Timezone.AmericaNew_York);
+
+      const start: string = OneUptimeDate.getDateAsLocalShortDateTimeString(
+        AFTERNOON.startValue,
+      );
+      const end: string = OneUptimeDate.getDateAsLocalShortDateTimeString(
+        AFTERNOON.endValue,
+      );
+
+      expect(
+        getEmptyMessageWithTimeRange({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: AFTERNOON,
+        }),
+      ).toContain(`${start} – ${end}`);
+    });
+  });
+
+  describe("a preset window", () => {
+    test("names the preset rather than any clock time", () => {
+      pin(true);
+
+      const message: string = getEmptyMessageWithTimeRange({
+        range: TimeRange.PAST_ONE_HOUR,
+      });
+
+      expect(message).toBe(
+        "Time range: past 1 hour. Try adjusting filters or expanding the time range.",
+      );
+      expect(message).not.toMatch(/\d{1,2}:\d{2}/);
+    });
+
+    test("reads the same on either clock", () => {
+      pin(true);
+      const on12Hour: string = getEmptyMessageWithTimeRange({
+        range: TimeRange.PAST_THIRTY_MINS,
+      });
+
+      pin(false);
+      const on24Hour: string = getEmptyMessageWithTimeRange({
+        range: TimeRange.PAST_THIRTY_MINS,
+      });
+
+      expect(on12Hour).toBe(on24Hour);
+    });
+  });
+
+  describe("no window at all", () => {
+    test("falls back to a message with no range in it", () => {
+      expect(getEmptyMessageWithTimeRange(undefined)).toBe(
+        "Adjust filters or check again later.",
+      );
+    });
+
+    test("falls back when a custom range carries no dates", () => {
+      expect(getEmptyMessageWithTimeRange({ range: TimeRange.CUSTOM })).toBe(
+        "Time range: custom. Try adjusting filters or expanding the time range.",
+      );
+    });
+  });
+});

--- a/Common/Tests/UI/Components/TimeRangePickerClockFormat.test.tsx
+++ b/Common/Tests/UI/Components/TimeRangePickerClockFormat.test.tsx
@@ -1,0 +1,409 @@
+/** @timezone UTC */
+/**
+ * The reported bug, exercised through the two pickers that actually sit above
+ * the Metrics, Traces and Logs explorers: pick a custom window, and the button
+ * summarising it must speak the clock and the timezone the person's computer is
+ * set to.
+ *
+ * It did not. The label was assembled by reading the digits off the Date
+ * (`date.getHours().toString().padStart(2, "0")`), which is a 24-hour clock in
+ * the browser process's zone and nothing else - so a user on an AM/PM machine
+ * picked 2:30 PM in the modal and got a button reading "Mar 1, 14:30", and a
+ * user who had set a timezone in User Settings got a button disagreeing with
+ * the modal they had just set the window in.
+ *
+ * These render the real components rather than calling the formatter, because
+ * the formatter being right is worth nothing if the button stops reading from
+ * it. The timezone is pinned to UTC by the docblock above and the 12/24-hour
+ * preference is pinned per test, so the assertions hold on any machine.
+ */
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import Timezone from "../../../Types/Timezone";
+import LogTimeRangePicker, {
+  LOG_TIME_RANGE_PICKER_TEST_ID_PREFIX,
+} from "../../../UI/Components/LogsViewer/components/LogTimeRangePicker";
+import TelemetryTimeRangePicker, {
+  TELEMETRY_TIME_RANGE_PICKER_TEST_ID_PREFIX,
+} from "../../../UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker";
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * An afternoon window, so a 12-hour clock has to do real work: 14:30 becoming
+ * "2:30 PM" is the exact translation the bug was skipping.
+ */
+const AFTERNOON_WINDOW: InBetween<Date> = new InBetween<Date>(
+  new Date("2024-03-01T14:30:00.000Z"),
+  new Date("2024-03-01T18:45:00.000Z"),
+);
+
+const CUSTOM_AFTERNOON: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: AFTERNOON_WINDOW,
+};
+
+interface Surface {
+  name: string;
+  prefix: string;
+  render: (value: RangeStartAndEndDateTime) => void;
+}
+
+const SURFACES: Array<Surface> = [
+  {
+    name: "metrics and traces",
+    prefix: TELEMETRY_TIME_RANGE_PICKER_TEST_ID_PREFIX,
+    render: (value: RangeStartAndEndDateTime): void => {
+      render(
+        <TelemetryTimeRangePicker
+          value={value}
+          onChange={() => {
+            // The label under test does not depend on the change handler.
+          }}
+        />,
+      );
+    },
+  },
+  {
+    name: "logs",
+    prefix: LOG_TIME_RANGE_PICKER_TEST_ID_PREFIX,
+    render: (value: RangeStartAndEndDateTime): void => {
+      render(
+        <LogTimeRangePicker
+          value={value}
+          onChange={() => {
+            // The label under test does not depend on the change handler.
+          }}
+        />,
+      );
+    },
+  },
+];
+
+function pin(use12HourFormat: boolean): void {
+  jest
+    .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+    .mockReturnValue(use12HourFormat);
+}
+
+function buttonText(prefix: string): string {
+  return (screen.getByTestId(`${prefix}-button`).textContent || "").trim();
+}
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+  OneUptimeDate.setUserTimezone(null);
+});
+
+describe.each(SURFACES)(
+  "the $name time range picker button",
+  (surface: Surface) => {
+    describe("on a machine set to a 12-hour clock", () => {
+      test("writes the custom window with AM/PM", () => {
+        pin(true);
+        surface.render(CUSTOM_AFTERNOON);
+
+        expect(buttonText(surface.prefix)).toBe(
+          "Mar 1, 2:30 PM – Mar 1, 6:45 PM",
+        );
+      });
+
+      test("never leaves a bare 24-hour reading on the button", () => {
+        pin(true);
+        surface.render(CUSTOM_AFTERNOON);
+
+        const label: string = buttonText(surface.prefix);
+
+        expect(label).toContain("PM");
+        expect(label).not.toContain("14:30");
+        expect(label).not.toContain("18:45");
+      });
+
+      test("marks a window that straddles noon AM then PM", () => {
+        pin(true);
+        surface.render({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T08:00:00.000Z"),
+            new Date("2024-03-01T20:00:00.000Z"),
+          ),
+        });
+
+        expect(buttonText(surface.prefix)).toBe(
+          "Mar 1, 8:00 AM – Mar 1, 8:00 PM",
+        );
+      });
+
+      test("writes a whole day from 12 AM to 11:59 PM", () => {
+        pin(true);
+        surface.render({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T00:00:00.000Z"),
+            new Date("2024-03-01T23:59:00.000Z"),
+          ),
+        });
+
+        expect(buttonText(surface.prefix)).toBe(
+          "Mar 1, 12:00 AM – Mar 1, 11:59 PM",
+        );
+      });
+    });
+
+    describe("on a machine set to a 24-hour clock", () => {
+      test("writes the custom window on a 24-hour clock", () => {
+        pin(false);
+        surface.render(CUSTOM_AFTERNOON);
+
+        expect(buttonText(surface.prefix)).toBe("Mar 1, 14:30 – Mar 1, 18:45");
+      });
+
+      test("puts no day period on the button", () => {
+        pin(false);
+        surface.render(CUSTOM_AFTERNOON);
+
+        expect(buttonText(surface.prefix)).not.toMatch(/AM|PM/);
+      });
+
+      test("pads a single-digit hour", () => {
+        pin(false);
+        surface.render({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T08:00:00.000Z"),
+            new Date("2024-03-01T09:05:00.000Z"),
+          ),
+        });
+
+        expect(buttonText(surface.prefix)).toBe("Mar 1, 08:00 – Mar 1, 09:05");
+      });
+    });
+
+    describe("timezone", () => {
+      test("reads the window in the timezone set in User Settings", () => {
+        pin(true);
+        OneUptimeDate.setUserTimezone(Timezone.AsiaKolkata);
+        surface.render(CUSTOM_AFTERNOON);
+
+        // 14:30 and 18:45 UTC are 20:00 and 00:15 (next day) at +05:30.
+        expect(buttonText(surface.prefix)).toBe(
+          "Mar 1, 8:00 PM – Mar 2, 12:15 AM",
+        );
+      });
+
+      test("rolls the date back when the configured zone is behind UTC", () => {
+        pin(false);
+        OneUptimeDate.setUserTimezone(Timezone.AmericaLos_Angeles);
+        surface.render({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T02:00:00.000Z"),
+            new Date("2024-03-01T10:00:00.000Z"),
+          ),
+        });
+
+        // 02:00 UTC is 18:00 the previous evening in Los Angeles (PST).
+        expect(buttonText(surface.prefix)).toBe("Feb 29, 18:00 – Mar 1, 02:00");
+      });
+
+      test("agrees with the summary inside the modal that set the window", () => {
+        /*
+         * The two used to disagree outright: the modal summary already went
+         * through the timezone- and clock-aware formatter while the button did
+         * not, so the same window read two different ways on one screen.
+         */
+        pin(true);
+        OneUptimeDate.setUserTimezone(Timezone.AsiaKolkata);
+        surface.render(CUSTOM_AFTERNOON);
+
+        fireEvent.click(screen.getByTestId(`${surface.prefix}-button`));
+        fireEvent.click(screen.getByTestId(`${surface.prefix}-custom-option`));
+
+        const summary: string =
+          screen.getByTestId("custom-time-range-summary").textContent || "";
+
+        /*
+         * The summary carries seconds and a year the compact button label
+         * drops, so compare the parts they both claim: the wall clock.
+         */
+        expect(summary).toContain("8:00:00 PM");
+        expect(summary).toContain("12:15:00 AM");
+        expect(buttonText(surface.prefix)).toContain("8:00 PM");
+        expect(buttonText(surface.prefix)).toContain("12:15 AM");
+      });
+    });
+
+    describe("presets are unaffected", () => {
+      test("shows the preset's own label on a 12-hour machine", () => {
+        pin(true);
+        surface.render({ range: TimeRange.PAST_ONE_HOUR });
+
+        expect(buttonText(surface.prefix)).toBe("Past 1 Hour");
+      });
+
+      test("shows the preset's own label on a 24-hour machine", () => {
+        pin(false);
+        surface.render({ range: TimeRange.PAST_ONE_HOUR });
+
+        expect(buttonText(surface.prefix)).toBe("Past 1 Hour");
+      });
+
+      test("shows no time at all for a preset", () => {
+        pin(true);
+        surface.render({ range: TimeRange.PAST_THIRTY_MINS });
+
+        expect(buttonText(surface.prefix)).not.toMatch(/\d{1,2}:\d{2}/);
+      });
+    });
+  },
+);
+
+describe("applying a window from the modal", () => {
+  test("re-labels the button on the machine's clock once applied", () => {
+    /*
+     * End to end: open the picker, pick the custom editor, type a window,
+     * apply, and read back what the button now says. This is the path the bug
+     * report walks.
+     */
+    pin(true);
+
+    const emitted: Array<RangeStartAndEndDateTime> = [];
+    const prefix: string = TELEMETRY_TIME_RANGE_PICKER_TEST_ID_PREFIX;
+
+    const view: { rerender: (ui: React.ReactElement) => void } = render(
+      <TelemetryTimeRangePicker
+        value={{ range: TimeRange.PAST_ONE_HOUR }}
+        onChange={(next: RangeStartAndEndDateTime) => {
+          emitted.push(next);
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId(`${prefix}-button`));
+    fireEvent.click(screen.getByTestId(`${prefix}-custom-option`));
+
+    fireEvent.change(screen.getByTestId("custom-time-range-start"), {
+      target: { value: "2024-03-01T14:30:00" },
+    });
+    fireEvent.change(screen.getByTestId("custom-time-range-end"), {
+      target: { value: "2024-03-01T18:45:00" },
+    });
+
+    fireEvent.click(screen.getByText("Apply"));
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.range).toBe(TimeRange.CUSTOM);
+
+    // The parent re-renders the picker with the window it was handed.
+    view.rerender(
+      <TelemetryTimeRangePicker
+        value={emitted[0] as RangeStartAndEndDateTime}
+        onChange={() => {
+          // Not exercised again.
+        }}
+      />,
+    );
+
+    expect(buttonText(prefix)).toBe("Mar 1, 2:30 PM – Mar 1, 6:45 PM");
+  });
+
+  test("re-labels the same applied window on a 24-hour machine", () => {
+    pin(false);
+
+    const emitted: Array<RangeStartAndEndDateTime> = [];
+    const prefix: string = LOG_TIME_RANGE_PICKER_TEST_ID_PREFIX;
+
+    const view: { rerender: (ui: React.ReactElement) => void } = render(
+      <LogTimeRangePicker
+        value={{ range: TimeRange.PAST_ONE_HOUR }}
+        onChange={(next: RangeStartAndEndDateTime) => {
+          emitted.push(next);
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId(`${prefix}-button`));
+    fireEvent.click(screen.getByTestId(`${prefix}-custom-option`));
+
+    fireEvent.change(screen.getByTestId("custom-time-range-start"), {
+      target: { value: "2024-03-01T14:30:00" },
+    });
+    fireEvent.change(screen.getByTestId("custom-time-range-end"), {
+      target: { value: "2024-03-01T18:45:00" },
+    });
+
+    fireEvent.click(screen.getByText("Apply"));
+
+    view.rerender(
+      <LogTimeRangePicker
+        value={emitted[0] as RangeStartAndEndDateTime}
+        onChange={() => {
+          // Not exercised again.
+        }}
+      />,
+    );
+
+    expect(buttonText(prefix)).toBe("Mar 1, 14:30 – Mar 1, 18:45");
+  });
+});
+
+/*
+ * The defect was not a wrong format string - it was a formatter hand-rolled out
+ * of Date's own getters, which cannot see either the configured timezone or the
+ * machine's clock preference. A rendering test cannot catch that coming back on
+ * some future surface, so this reads the source and refuses the idiom outright.
+ */
+describe("the picker never hand-rolls a date format again", () => {
+  const PICKER_SOURCE: string = fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "UI",
+      "Components",
+      "Date",
+      "TimeRangePickerDropdown.tsx",
+    ),
+    "utf-8",
+  );
+
+  test("reads no wall-clock field off the Date itself", () => {
+    /*
+     * getHours/getMinutes/getDate report the browser process's zone, never the
+     * one the user configured, so none of them belongs in a rendered label.
+     */
+    for (const banned of [
+      ".getHours()",
+      ".getMinutes()",
+      ".getDate()",
+      ".getMonth()",
+    ]) {
+      expect(PICKER_SOURCE).not.toContain(banned);
+    }
+  });
+
+  test("pins no locale of its own", () => {
+    expect(PICKER_SOURCE).not.toContain('"en-US"');
+    expect(PICKER_SOURCE).not.toContain("toLocaleString");
+    expect(PICKER_SOURCE).not.toContain("toLocaleTimeString");
+    expect(PICKER_SOURCE).not.toContain("toLocaleDateString");
+  });
+
+  test("hardcodes no hour cycle", () => {
+    expect(PICKER_SOURCE).not.toContain("hour12");
+  });
+
+  test("goes through the shared timezone- and clock-aware formatter", () => {
+    expect(PICKER_SOURCE).toContain(
+      "OneUptimeDate.getDateAsLocalShortDateTimeString",
+    );
+  });
+});

--- a/Common/Tests/UI/Components/TimeRangePickerClockFormat.test.tsx
+++ b/Common/Tests/UI/Components/TimeRangePickerClockFormat.test.tsx
@@ -361,19 +361,27 @@ describe("applying a window from the modal", () => {
  * some future surface, so this reads the source and refuses the idiom outright.
  */
 describe("the picker never hand-rolls a date format again", () => {
-  const PICKER_SOURCE: string = fs.readFileSync(
-    path.join(
-      __dirname,
-      "..",
-      "..",
-      "..",
-      "UI",
-      "Components",
-      "Date",
-      "TimeRangePickerDropdown.tsx",
-    ),
-    "utf-8",
-  );
+  /*
+   * Comments are stripped first: the banned tokens are exactly the words this
+   * file's own comments use to explain what went wrong, so a guard that reads
+   * them would fail on a prose edit that changes no behaviour.
+   */
+  const PICKER_SOURCE: string = fs
+    .readFileSync(
+      path.join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "UI",
+        "Components",
+        "Date",
+        "TimeRangePickerDropdown.tsx",
+      ),
+      "utf-8",
+    )
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ");
 
   test("reads no wall-clock field off the Date itself", () => {
     /*
@@ -391,10 +399,15 @@ describe("the picker never hand-rolls a date format again", () => {
   });
 
   test("pins no locale of its own", () => {
+    /*
+     * Match the date-shaped calls only. A bare "toLocaleString" ban would also
+     * catch Number.prototype.toLocaleString, which formats counts and has
+     * nothing to do with this bug.
+     */
     expect(PICKER_SOURCE).not.toContain('"en-US"');
-    expect(PICKER_SOURCE).not.toContain("toLocaleString");
-    expect(PICKER_SOURCE).not.toContain("toLocaleTimeString");
-    expect(PICKER_SOURCE).not.toContain("toLocaleDateString");
+    expect(PICKER_SOURCE).not.toMatch(
+      /toLocale(Date|Time)?String\s*\(\s*["'`[]/,
+    );
   });
 
   test("hardcodes no hour cycle", () => {

--- a/Common/Tests/UI/Components/TimeRangePickerDropdown.test.tsx
+++ b/Common/Tests/UI/Components/TimeRangePickerDropdown.test.tsx
@@ -8,10 +8,11 @@ import InBetween from "../../../Types/BaseDatabase/InBetween";
 import OneUptimeDate from "../../../Types/Date";
 import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
 import TimeRange from "../../../Types/Time/TimeRange";
+import Timezone from "../../../Types/Timezone";
 import "@testing-library/jest-dom";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, test } from "@jest/globals";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
 
 const PREFIX: string = "test-range-picker";
 const DROPDOWN_WIDTH_IN_PX: number = 288;
@@ -71,7 +72,30 @@ function minutesBetweenFields(): number {
 
 afterEach(() => {
   cleanup();
+  jest.restoreAllMocks();
+  OneUptimeDate.setUserTimezone(null);
 });
+
+/*
+ * The label writes times the way the machine running the browser writes them,
+ * so a test that does not pin the preference reads "Mar 1, 10:00" on a European
+ * laptop and "Mar 1, 10:00 AM" on a US one. Pinning it is what lets these
+ * assert the digits rather than a regex loose enough to accept the time going
+ * missing altogether.
+ */
+function pin(use12HourFormat: boolean): void {
+  jest
+    .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+    .mockReturnValue(use12HourFormat);
+}
+
+const CUSTOM_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(
+    new Date("2024-03-01T10:00:00.000Z"),
+    new Date("2024-03-02T13:30:00.000Z"),
+  ),
+};
 
 describe("getTimeRangeButtonLabel", () => {
   test("uses the preset label for a preset range", () => {
@@ -87,15 +111,129 @@ describe("getTimeRangeButtonLabel", () => {
   });
 
   test("summarises a custom range as a start–end pair", () => {
-    const label: string = getTimeRangeButtonLabel({
-      range: TimeRange.CUSTOM,
-      startAndEndDate: new InBetween<Date>(
-        new Date("2024-03-01T10:00:00.000Z"),
-        new Date("2024-03-02T13:30:00.000Z"),
-      ),
+    pin(false);
+
+    expect(getTimeRangeButtonLabel(CUSTOM_RANGE)).toBe(
+      "Mar 1, 10:00 – Mar 2, 13:30",
+    );
+  });
+
+  /*
+   * The bug these cover: the label was built by reading the digits off the
+   * Date - `date.getHours().toString().padStart(2, "0")` - so it was always a
+   * 24-hour clock in the browser process's own zone. A user whose computer is
+   * set to AM/PM picked an afternoon window and got "Mar 1, 14:30" back, and a
+   * user with a timezone set in User Settings got a label that disagreed with
+   * the modal they had just picked the window in.
+   */
+  describe("clock format", () => {
+    test("writes both ends with AM/PM on a 12-hour machine", () => {
+      pin(true);
+
+      expect(getTimeRangeButtonLabel(CUSTOM_RANGE)).toBe(
+        "Mar 1, 10:00 AM – Mar 2, 1:30 PM",
+      );
     });
 
-    expect(label).toBe("Mar 1, 10:00 – Mar 2, 13:30");
+    test("writes both ends on a 24-hour clock on a 24-hour machine", () => {
+      pin(false);
+
+      const label: string = getTimeRangeButtonLabel(CUSTOM_RANGE);
+
+      expect(label).toBe("Mar 1, 10:00 – Mar 2, 13:30");
+      expect(label).not.toMatch(/AM|PM/);
+    });
+
+    test("marks a morning start AM and an afternoon end PM", () => {
+      pin(true);
+
+      expect(
+        getTimeRangeButtonLabel({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T09:15:00.000Z"),
+            new Date("2024-03-01T17:45:00.000Z"),
+          ),
+        }),
+      ).toBe("Mar 1, 9:15 AM – Mar 1, 5:45 PM");
+    });
+
+    test("writes a midnight-to-noon window as 12 AM to 12 PM", () => {
+      pin(true);
+
+      expect(
+        getTimeRangeButtonLabel({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T00:00:00.000Z"),
+            new Date("2024-03-01T12:00:00.000Z"),
+          ),
+        }),
+      ).toBe("Mar 1, 12:00 AM – Mar 1, 12:00 PM");
+    });
+
+    test("keeps the en dash separator on both clocks", () => {
+      pin(true);
+      expect(getTimeRangeButtonLabel(CUSTOM_RANGE)).toContain(" – ");
+
+      pin(false);
+      expect(getTimeRangeButtonLabel(CUSTOM_RANGE)).toContain(" – ");
+    });
+
+    test("leaves preset labels untouched by the clock preference", () => {
+      pin(true);
+      const on12Hour: string = getTimeRangeButtonLabel({
+        range: TimeRange.PAST_ONE_HOUR,
+      });
+
+      pin(false);
+      const on24Hour: string = getTimeRangeButtonLabel({
+        range: TimeRange.PAST_ONE_HOUR,
+      });
+
+      expect(on12Hour).toBe("Past 1 Hour");
+      expect(on24Hour).toBe("Past 1 Hour");
+    });
+  });
+
+  describe("timezone", () => {
+    test("reads the window in the timezone configured in User Settings", () => {
+      pin(true);
+      OneUptimeDate.setUserTimezone(Timezone.AsiaKolkata);
+
+      // 10:00 and 13:30 UTC are 15:30 and 19:00 at +05:30.
+      expect(getTimeRangeButtonLabel(CUSTOM_RANGE)).toBe(
+        "Mar 1, 3:30 PM – Mar 2, 7:00 PM",
+      );
+    });
+
+    test("moves the date too when the configured zone crosses midnight", () => {
+      pin(false);
+      OneUptimeDate.setUserTimezone(Timezone.AmericaNew_York);
+
+      expect(
+        getTimeRangeButtonLabel({
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            new Date("2024-03-01T02:00:00.000Z"),
+            new Date("2024-03-01T06:00:00.000Z"),
+          ),
+        }),
+      ).toBe("Feb 29, 21:00 – Mar 1, 01:00");
+    });
+
+    test("relabels the same window when the configured zone changes", () => {
+      pin(false);
+
+      OneUptimeDate.setUserTimezone(Timezone.UTC);
+      const inUtc: string = getTimeRangeButtonLabel(CUSTOM_RANGE);
+
+      OneUptimeDate.setUserTimezone(Timezone.AsiaKolkata);
+      const inKolkata: string = getTimeRangeButtonLabel(CUSTOM_RANGE);
+
+      expect(inUtc).toBe("Mar 1, 10:00 – Mar 2, 13:30");
+      expect(inKolkata).toBe("Mar 1, 15:30 – Mar 2, 19:00");
+    });
   });
 });
 

--- a/Common/Types/Date.ts
+++ b/Common/Types/Date.ts
@@ -1502,11 +1502,21 @@ export default class OneUptimeDate {
 
   /**
    * Whether the machine this is running on writes the time of day on a 12-hour
-   * clock. Asked of Intl rather than inferred from a formatted string: the
-   * browser resolves its default locale against the operating system's own
-   * clock preference, so flipping macOS's "24-Hour Time" (or the equivalent on
-   * Windows/Linux) flips this, and an explicit -u-hc- override on the locale is
-   * honoured too.
+   * clock, read from the browser's resolved default locale - which browsers
+   * derive from the operating system's language and region, so changing those
+   * changes this. An explicit -u-hc- override on the locale is honoured too.
+   *
+   * Note what this cannot see: the standalone "24-Hour Time" switch macOS and
+   * Windows offer separately from the region. Safari and recent Firefox fold
+   * that into the locale they resolve; Chromium does not. A user who wants a
+   * clock that ignores their region would need an explicit preference stored
+   * alongside the timezone in User Settings - there is none today.
+   *
+   * Asked of Intl rather than inferred from a formatted string. The string
+   * probe below only recognises the Latin "AM"/"PM", so it misread every
+   * 12-hour locale that marks the day period some other way - ko-KR writes
+   * the equivalent of "PM" in Hangul, ar-EG in Arabic script - and served
+   * those users a 24-hour clock against their own convention.
    */
   public static getUserPrefers12HourFormat(): boolean {
     if (typeof window === "undefined") {

--- a/Common/Types/Date.ts
+++ b/Common/Types/Date.ts
@@ -237,6 +237,41 @@ export default class OneUptimeDate {
     return `${this.getDateAsLocalDayMonthString(date)}, ${this.getLocalTimeString(date, { includeMinutes: false })}:00`;
   }
 
+  /**
+   * A compact "Mar 1, 14:30" (or "Mar 1, 2:30 PM") label for one instant, used
+   * where a whole window has to fit on a button - the time range picker above
+   * the metrics, traces and logs explorers, chiefly.
+   *
+   * Both halves follow the user's machine: the wall clock is resolved in the
+   * configured timezone (falling back to the one the browser reports), and the
+   * 12- vs 24-hour choice follows the operating system's clock preference
+   * unless a caller overrides it.
+   */
+  public static getDateAsLocalShortDateTimeString(
+    date: Date | string,
+    options?: {
+      use12HourFormat?: boolean | undefined;
+      includeSeconds?: boolean | undefined;
+    },
+  ): string {
+    date = this.fromString(date);
+
+    const use12HourFormat: boolean =
+      options?.use12HourFormat ?? this.getUserPrefers12HourFormat();
+
+    let timeFormat: string = use12HourFormat ? "h:mm" : "HH:mm";
+
+    if (options?.includeSeconds) {
+      timeFormat += ":ss";
+    }
+
+    if (use12HourFormat) {
+      timeFormat += " A";
+    }
+
+    return this.inCurrentTimezone(date).format(`MMM D, ${timeFormat}`);
+  }
+
   public static getDateAsLocalMonthYearString(date: Date | string): string {
     date = this.fromString(date);
 
@@ -1465,15 +1500,65 @@ export default class OneUptimeDate {
     return this.getDateAsFormattedString(new Date(), options);
   }
 
+  /**
+   * Whether the machine this is running on writes the time of day on a 12-hour
+   * clock. Asked of Intl rather than inferred from a formatted string: the
+   * browser resolves its default locale against the operating system's own
+   * clock preference, so flipping macOS's "24-Hour Time" (or the equivalent on
+   * Windows/Linux) flips this, and an explicit -u-hc- override on the locale is
+   * honoured too.
+   */
   public static getUserPrefers12HourFormat(): boolean {
     if (typeof window === "undefined") {
       // Server-side: default to 12-hour format for user-friendly display
       return true;
     }
 
-    // Client-side: detect user's preferred time format from browser locale
-    const testDate: Date = new Date();
-    const timeString: string = testDate.toLocaleTimeString();
+    /*
+     * `hour12` is only reported when the format actually asks for an hour, so
+     * the probe has to request one.
+     */
+    try {
+      /*
+       * Typed structurally rather than as Intl.ResolvedDateTimeFormatOptions:
+       * `hourCycle` only appears on that interface from the ES2021 lib, and
+       * this file has to compile against the older one too.
+       */
+      const resolvedOptions: {
+        hour12?: boolean | undefined;
+        hourCycle?: string | undefined;
+      } = new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+      }).resolvedOptions();
+
+      if (typeof resolvedOptions.hour12 === "boolean") {
+        return resolvedOptions.hour12;
+      }
+
+      /*
+       * Older engines report the cycle but not the boolean. h11/h12 are the
+       * two 12-hour cycles; h23/h24 are the 24-hour ones.
+       */
+      if (resolvedOptions.hourCycle) {
+        return (
+          resolvedOptions.hourCycle === "h11" ||
+          resolvedOptions.hourCycle === "h12"
+        );
+      }
+    } catch {
+      /*
+       * A missing or broken Intl must not take every timestamp in the UI down
+       * with it - fall through to the string probe below.
+       */
+    }
+
+    /*
+     * Last resort: read a formatted time and look for a day-period marker.
+     * This only recognises the Latin "AM"/"PM" - which is exactly why it is the
+     * fallback and not the primary check, since locales like ko-KR and ar-EG
+     * are 12-hour but mark the day period with characters this cannot see.
+     */
+    const timeString: string = new Date().toLocaleTimeString();
     return (
       timeString.toLowerCase().includes("am") ||
       timeString.toLowerCase().includes("pm")

--- a/Common/UI/Components/Date/TimeRangePickerDropdown.tsx
+++ b/Common/UI/Components/Date/TimeRangePickerDropdown.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from "react";
 import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
 import IconProp from "../../../Types/Icon/IconProp";
 import RangeStartAndEndDateTime, {
   RangeStartAndEndDateTimeUtil,
@@ -54,12 +55,15 @@ export const TIME_RANGE_PRESET_OPTIONS: Array<TimeRangePickerPresetOption> = [
   { range: TimeRange.PAST_THREE_MONTHS, label: "Past 3 Months" },
 ];
 
+/*
+ * Both ends of a custom window are written the way the user's machine writes
+ * times: on its 12- or 24-hour clock, in the timezone they configured. Reading
+ * the digits off the Date itself - which is what this used to do - pinned the
+ * label to a 24-hour clock in whatever zone the browser process happened to be
+ * in, so a machine set to AM/PM still got "Mar 1, 14:30" back.
+ */
 function formatDateShort(date: Date): string {
-  const month: string = date.toLocaleString("en-US", { month: "short" });
-  const day: number = date.getDate();
-  const hours: string = date.getHours().toString().padStart(2, "0");
-  const minutes: string = date.getMinutes().toString().padStart(2, "0");
-  return `${month} ${day}, ${hours}:${minutes}`;
+  return OneUptimeDate.getDateAsLocalShortDateTimeString(date);
 }
 
 export function getTimeRangeButtonLabel(

--- a/Common/UI/Components/LogsViewer/LogsViewer.tsx
+++ b/Common/UI/Components/LogsViewer/LogsViewer.tsx
@@ -175,7 +175,11 @@ const severityWeight: Record<string, number> = {
   trace: 1,
 };
 
-function getEmptyMessageWithTimeRange(
+/*
+ * Exported so the window it reports can be unit-tested directly - rendering the
+ * whole viewer to read one sentence is not worth the setup.
+ */
+export function getEmptyMessageWithTimeRange(
   timeRange: RangeStartAndEndDateTime | undefined,
 ): string {
   if (!timeRange) {
@@ -185,13 +189,14 @@ function getEmptyMessageWithTimeRange(
   if (timeRange.range === TimeRange.CUSTOM && timeRange.startAndEndDate) {
     const startDate: Date = timeRange.startAndEndDate.startValue;
     const endDate: Date = timeRange.startAndEndDate.endValue;
+    /*
+     * Same shape, clock and timezone as the label on the picker button that
+     * set this window - pinning en-US here handed a US viewer AM/PM even on a
+     * 24-hour machine, and read the digits in the browser's zone rather than
+     * the one configured in User Settings.
+     */
     const fmt: (d: Date) => string = (d: Date): string => {
-      return d.toLocaleString("en-US", {
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
+      return OneUptimeDate.getDateAsLocalShortDateTimeString(d);
     };
 
     return `Time range: ${fmt(startDate)} – ${fmt(endDate)}. Try adjusting filters or expanding the time range.`;


### PR DESCRIPTION
## The bug

Picking a custom date range on the **metrics, traces or logs** explorers put a label like `Mar 1, 14:30 – Mar 1, 18:45` on the picker button no matter what the person's computer was set to. The label was assembled by hand from the `Date`'s own getters:

```ts
const month: string = date.toLocaleString("en-US", { month: "short" });
const day: number = date.getDate();
const hours: string = date.getHours().toString().padStart(2, "0");
const minutes: string = date.getMinutes().toString().padStart(2, "0");
```

That is a 24-hour clock, in whatever timezone the browser process happens to be in, in `en-US` — none of which is a setting the user controls. So a machine on AM/PM got 24-hour times back, and a user who had set a timezone in **User Settings** got a button that disagreed with the modal they had just picked the window in.

The logs explorer's empty-state sentence, which repeats the very same window, had the mirror-image defect: it pinned `"en-US"`, so it always said AM/PM *even on a 24-hour machine*, and it too read the browser's zone. One screen, one window, two disagreeing renderings, neither of them the user's.

## The fix

Both now go through one helper, `OneUptimeDate.getDateAsLocalShortDateTimeString`, which resolves the wall clock in the configured timezone and picks the clock from the machine's own preference.

That preference is also read properly now. It used to be inferred by formatting a time and searching it for the letters `"am"`/`"pm"` — which is only how Latin-script locales mark the day period, so `ko-KR` (`오후`) and `ar-EG` (`م`) machines were misread as 24-hour and served 24-hour times. `Intl` reports the hour cycle directly, and the browser resolves its default locale against the operating system's clock setting, so toggling macOS **24-Hour Time** now flips the label. The old string probe is kept as a fallback for an engine without a usable `Intl`.

| | before | after (12h machine) | after (24h machine) |
|---|---|---|---|
| picker button | `Mar 1, 14:30 – Mar 1, 18:45` | `Mar 1, 2:30 PM – Mar 1, 6:45 PM` | `Mar 1, 14:30 – Mar 1, 18:45` |
| logs empty state | `Mar 1, 02:30 PM – …` | `Mar 1, 2:30 PM – …` | `Mar 1, 14:30 – …` |

Timezone now comes from `getCurrentTimezone()` on both, so a window set by a user on `Asia/Kolkata` reads `Mar 1, 8:00 PM – Mar 2, 12:15 AM` rather than the browser's UTC digits.

## Tests

141 tests across five suites, plus a wiring guard:

- **`Common/Tests/Types/DateLocalShortDateTimeString.test.ts`** (39) — output on both clocks; the `12 AM` / `12 PM` boundaries and every hour of the day; seconds; unpadded 12-hour vs padded 24-hour; all twelve month abbreviations; configured-timezone reads that move the date across midnight and month end (`Feb 29`); spring-forward and the repeated fall-back hour; `Date` and ISO-string inputs; explicit override beating the detected preference in both directions.
- **`Common/Tests/Types/DateUserPrefers12HourFormat.test.ts`** (22) — `hour12`, `hourCycle` h11/h12/h23/h24, the boolean winning when they disagree, real locales (`en-US`, `en-GB`, `de-DE`, `ko-KR`, `ar-EG`) and `-u-hc-` overrides, and each fallback path when `Intl` throws or answers with nothing usable.
- **`Common/Tests/UI/Components/TimeRangePickerClockFormat.test.tsx`** (32) — both real pickers (metrics/traces and logs) rendered, including the full open → pick → apply → re-label path, and a check that the button now agrees with the modal summary that set the window.
- **`Common/Tests/UI/Components/LogsViewerEmptyStateTimeRange.test.tsx`** (9) — the empty-state sentence on both clocks and under a configured timezone.
- **`Common/Tests/UI/Components/TimeRangePickerDropdown.test.tsx`** — extended with clock-format and timezone coverage; the pre-existing label assertion now pins the preference instead of inheriting the developer's locale.
- **`App/Tests/Dashboard/ExplorerTimeRangePickerWiring.test.ts`** (10) — pins that metrics, traces and logs all mount the one shared picker, and refuses the hand-rolled-formatter idiom (`.getHours()`, a pinned locale, a hardcoded `hour12`) coming back on any of them.

## Verification

- `Common` `tsc --noEmit`: clean. `eslint`: clean on every touched file.
- `Common/Tests/Types`: **320 suites / 8483 tests** pass.
- 31 date-rendering UI suites (TimePicker, Charts, Dashboard utils, histograms, custom fields, all three pickers): **1040 tests** pass.
- All new suites pass.

## Deliberately not in this change

The histogram ticks, chart tooltips and trace-row timestamps on those same three screens still hardcode `hour12: false` and read the browser's zone — the same defect class, but a much wider visual change across ~12 components, so it is tracked separately. Also left alone: `OneUptimeDate.getLocalTimeString`'s 24-hour default (which drives the metrics chart x-axis product-wide) and `getDateAsFormattedString`, which labels browser-zone digits with the configured zone's abbreviation — a different bug with a far larger blast radius.
