### PR TITLE
fix(teams): stop answering the bot messaging endpoint with "Page not found"

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx
@@ -78,6 +78,19 @@ Please note: Do not copy the secret ID, you need the secret VALUE which is typic
 5. Set the "Messaging endpoint" to \`${window.location.origin}/api/microsoft-bot/messages\`
 6. Save the configuration.
 
+**Verify the endpoint before moving on.** Azure Bot Service calls this URL from the public internet, so test it from outside your network — not from inside the cluster, and not over a VPN that can see this host when Azure cannot.
+
+\`\`\`bash
+curl -sS -i ${window.location.origin}/api/microsoft-bot/messages
+\`\`\`
+
+Use \`-i\` rather than just the status code: on a 404 the **body is the only thing that tells you who produced it**, and that distinction is the whole diagnosis.
+
+- **405** is the correct answer and means you are done here. The endpoint accepts POST only, so a GET is answered "Method Not Allowed", with \`Allow: POST\` and a description of itself. Reaching it at all is what is being tested.
+- **404 with a JSON body of \`{"message":"Page not found - /api/microsoft-bot/messages"}\`** came from OneUptime, so the request *did* arrive — either this deployment predates the 405 response above, or something in front of it is rewriting the path and stripping the \`/api\` prefix before the app sees it.
+- **404 with an HTML error page** from nginx, your ingress or a load balancer means the opposite: the request never reached OneUptime.
+- **A TLS error, timeout or refused connection** means Azure will not reach it either. See Troubleshooting below.
+
 ##### Step 6: Add Microsoft Teams Channel to the Bot
 
 1. In your Azure Bot resource, navigate to "Channels"
@@ -143,9 +156,31 @@ In order of likelihood:
 
 Grant **TeamsAppInstallation.ReadForTeam.All** (Step 3) and OneUptime will tell you which of these it is instead of listing them.
 
+**Card buttons say "Unable to reach app", and chats never appear**
+
+One failure, not two: **Azure Bot Service cannot reach your messaging endpoint.**
+
+Alert cards keep arriving, which makes the integration look healthy. It is not — the two directions are independent and only one works. OneUptime posts alerts by calling Microsoft, which needs no inbound access. Tapping a button on that card, typing \`help\` to the bot, and registering a chat all travel the other way: Azure Bot Service POSTs to \`${window.location.origin}/api/microsoft-bot/messages\`. A working alert proves your client secret and Graph permissions are fine and says nothing about the bot endpoint.
+
+1. **Look for the POST, not for 404s** — \`grep 'POST /api/microsoft-bot/messages' <access log>\`. No POST lines at all means Azure never got through, and nothing inside OneUptime is at fault. GET lines returning 404 are a different thing entirely (see below).
+2. **Call the endpoint from outside your network** (Step 5), with \`curl -i\` so you can see the body. A 405 proves the route is live and reachable from there. A TLS error, timeout or refused connection is your answer.
+3. **Check the certificate chain.** Azure requires HTTPS with a publicly trusted certificate served with its full chain. A self-signed certificate, an internal CA or a missing intermediate fails the handshake before OneUptime sees the request, so the access log stays empty and looks like Azure never tried.
+4. **Check the host resolves publicly.** Private DNS, a split-horizon record or an internal-only ingress all reach you and your VPN while staying invisible to Azure.
+
+**A 404 on \`GET /api/microsoft-bot/messages\` is not the bug, and it is not evidence Azure could not reach you.** The endpoint has always accepted POST only, so older versions answered a browser GET with OneUptime's generic \`{"message":"Page not found - /api/microsoft-bot/messages"}\`. That reads as a missing route and has sent admins hunting a regression that was not there — but note what it proves: OneUptime generated it, so the request *reached the app*. It is 58 bytes, which is why it appears in an access log as \`"GET /api/microsoft-bot/messages HTTP/1.1" 404 58\`. This version answers a GET with 405 plus a description of itself.
+
 **No chats appear under Microsoft Teams Chats**
 
-Chats register only when the bot receives a message. If the installed package points at a different deployment, its activities never reach this server and the list stays empty no matter how many times you click Refresh Chats. Verify the installed package first (Step 8).
+Chats register when the bot receives an activity from that chat — the app being installed, the bot being added to the conversation, or any message sent to the bot in it. An empty list means no such activity has ever arrived. Two causes, in order:
+
+1. **The messaging endpoint is unreachable** — see above. This is the more common one, and the giveaway is that alerts still post to channels.
+2. **The installed package points at a different deployment,** so its activities go somewhere else. Verify the installed package (Step 8).
+
+Refresh Chats re-reads what OneUptime already stored — Microsoft does not allow listing chats with application permissions, so it cannot go and fetch them.
+
+**Checking this deployment's bot configuration**
+
+\`curl -sS ${window.location.origin}/api/microsoft-bot/test\` reports the bot id this deployment expects your Teams app package to carry, plus which environment variables are set. It reads local configuration only — it does not call Azure, so it cannot confirm the Azure Bot resource, the Teams channel, the secret's validity, or that Azure can reach you. Its value is the bot id comparison against the app installed in Teams.
 
 **Other checks**
 

--- a/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
+++ b/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
@@ -80,6 +80,19 @@ If you uploaded the app manifest before this permission existed, download it aga
 5. Set the "Messaging endpoint" to `https://your-oneuptime-domain.com/api/microsoft-bot/messages`
 6. Save the configuration
 
+**Verify the endpoint before you move on.** Azure Bot Service calls this URL from the public internet, so check it from somewhere outside your network — not from inside the cluster, and not from a VPN that can see the host when Azure cannot:
+
+```bash
+curl -sS -i https://your-oneuptime-domain.com/api/microsoft-bot/messages
+```
+
+Use `-i` rather than just the status code: on a 404 the **body is the only thing that tells you who produced it**, and that distinction is the whole diagnosis.
+
+- **405** is correct and means you are done. The endpoint only accepts POST, so a GET is answered `405 Method Not Allowed`, with `Allow: POST` and a description of the endpoint. Reaching it at all is the thing being tested.
+- **404 with a JSON body of `{"message":"Page not found - /api/microsoft-bot/messages"}`** came from OneUptime, so the request *did* arrive. Either this deployment predates the 405 response above — older versions served this path for POST only, so a GET fell through to the generic not-found handler — or something in front of OneUptime is rewriting the path and stripping the `/api` prefix before the app sees it (a Kubernetes ingress with `rewrite-target: /` is the usual culprit).
+- **404 with an HTML error page** from nginx, your ingress or a load balancer means the opposite: the request never reached OneUptime, and whatever is in front of it is not routing `/api` to the app.
+- **A TLS error, a timeout or a connection refusal** means Azure will not reach it either. See [the messaging endpoint troubleshooting section](#card-buttons-say-unable-to-reach-app-and-chats-never-appear) below.
+
 ### Step 5: Add Microsoft Teams Channel to the Bot
 
 1. In your Azure Bot resource, navigate to "Channels"
@@ -147,6 +160,61 @@ If you encounter issues:
 - Make sure the bot messaging endpoint is accessible from the internet
 - Verify that the bot is properly configured with the Teams channel
 - Check that the Teams app manifest has been uploaded successfully
+
+### Card buttons say "Unable to reach app", and chats never appear
+
+These are one failure, not two: **Azure Bot Service cannot reach your messaging endpoint.**
+
+The confusing part is that alert cards keep arriving in Teams, which makes the integration look mostly healthy. It is not — the two directions are independent, and only one of them is working:
+
+| Direction | How it travels | Needs Azure to reach you? |
+| --- | --- | --- |
+| OneUptime posts an alert card to a channel | OneUptime calls Microsoft, authenticating with your client secret | **No** |
+| You tap a button on that card | Azure Bot Service POSTs to `/api/microsoft-bot/messages` | **Yes** |
+| You type `help` to the bot | Azure Bot Service POSTs to `/api/microsoft-bot/messages` | **Yes** |
+| A chat registers under **Chats** | Azure Bot Service POSTs a bot activity to `/api/microsoft-bot/messages` | **Yes** |
+
+So a working alert tells you your client secret and Graph permissions are fine, and tells you nothing at all about the bot endpoint. Everything interactive depends on inbound traffic that never arrives.
+
+The empty **Chats** list is the clearest confirmation. Microsoft does not let an app list chats with application permissions, so OneUptime can only record a chat when the bot hears from it — the app being installed, the bot being added to the conversation, or simply any message sent to the bot in that chat. All three arrive over the same inbound endpoint, so "No chats connected yet" after adding the app to a chat *and* messaging the bot in it means no bot activity has ever been received at all. Clicking **Refresh Chats** re-reads what OneUptime already stored; it cannot go and fetch them.
+
+**Diagnose it in this order:**
+
+1. **Look for the POST, not for 404s.** This is where most investigations go wrong:
+
+   ```bash
+   grep 'POST /api/microsoft-bot/messages' <your access log>
+   ```
+
+   If there are no POST lines at all, Azure never got through, and nothing inside OneUptime is at fault. `GET` lines returning 404 are a different thing entirely — see the note below.
+
+2. **Call the endpoint from outside your network,** as in Step 4, with `curl -i` so you can see the body. A `405` proves the route is live and reachable from wherever you ran the command. A TLS error, timeout or refused connection is your answer.
+
+3. **Check the certificate chain.** Azure requires HTTPS with a publicly trusted certificate served with its full chain. A self-signed certificate, an internal CA, or a missing intermediate fails the TLS handshake before OneUptime sees the request — so your access log stays empty and looks like Azure never tried:
+
+   ```bash
+   openssl s_client -connect your-oneuptime-domain.com:443 -servername your-oneuptime-domain.com -verify_return_error </dev/null
+   ```
+
+4. **Check that the host is publicly resolvable.** A private DNS name, a split-horizon record, or an internal-only ingress all reach you and your VPN while remaining invisible to Azure. Resolve it from a network with no access to yours.
+
+5. **Confirm the endpoint on the Azure Bot resource** matches this deployment exactly, including scheme and path: `https://your-oneuptime-domain.com/api/microsoft-bot/messages`.
+
+**A 404 on `GET /api/microsoft-bot/messages` is not the bug, and it is not evidence Azure could not reach you.** The endpoint has always accepted POST only, so on versions before this one a browser GET fell through to OneUptime's generic not-found handler and came back `{"message":"Page not found - /api/microsoft-bot/messages"}`. That reads as a missing route and has sent more than one admin looking for a regression that was not there — but note what it actually proves: OneUptime generated that response, so the request reached the app. It is 58 bytes, which is why it shows up in an access log as `"GET /api/microsoft-bot/messages HTTP/1.1" 404 58`.
+
+This version answers a GET with `405 Method Not Allowed` and a description of itself, so the distinction no longer needs explaining. If you are still on an older build, judge a 404 by its body: OneUptime's JSON means the request arrived, an HTML error page from your proxy means it did not.
+
+### Checking this deployment's bot configuration
+
+```bash
+curl -sS https://your-oneuptime-domain.com/api/microsoft-bot/test | jq
+```
+
+This reports what OneUptime can see locally: whether `MICROSOFT_TEAMS_APP_CLIENT_ID` and `MICROSOFT_TEAMS_APP_CLIENT_SECRET` are set, the messaging endpoint this deployment expects, and — most usefully — the **bot id** your Teams app package must carry.
+
+It reads environment variables and nothing else. It does not call Azure, so it cannot tell you the Azure Bot resource exists, that its messaging endpoint points back here, that the Teams channel is enabled, that the secret is still valid, or that Azure can reach you. The response says as much, listing what it checked and what it did not, so it is never mistaken for a green light.
+
+The one decisive check it enables: compare the `botId` it returns against the bot id of the OneUptime app installed in Teams. If they differ, that package cannot receive messages from this deployment — see Step 7.
 
 ### "The OneUptime app is not installed in the Microsoft Teams team ..."
 

--- a/Common/Server/API/MicrosoftTeamsAPI.ts
+++ b/Common/Server/API/MicrosoftTeamsAPI.ts
@@ -920,6 +920,81 @@ export default class MicrosoftTeamsAPI {
     );
 
     /*
+     * The same path, answering the browser.
+     *
+     * Azure Bot Service only ever POSTs here, so for a long time GET fell
+     * through to the catch-all 404 in StartServer and answered
+     * "Page not found - /api/microsoft-bot/messages". That is the single
+     * cheapest thing an admin can do to check their messaging endpoint, and
+     * OneUptime replied with the words for "this route does not exist" — so
+     * admins concluded the route had been dropped from the build and went
+     * looking for a regression, while the actual fault (Azure cannot reach
+     * this deployment) sat untouched. The 404 was true of the method and false
+     * of the endpoint, and nothing in the response said which.
+     *
+     * 405 is the honest answer, and it is honest in a way a human reads at a
+     * glance: the route is here, the deployment is reachable from wherever the
+     * request came from, and POST is what it wants. Everything else in the
+     * body exists to redirect the next hour of debugging away from OneUptime's
+     * routing table and towards the network path Azure has to traverse.
+     */
+    router.get(
+      "/microsoft-bot/messages",
+      (_req: ExpressRequest, res: ExpressResponse) => {
+        res.setHeader("Allow", "POST");
+
+        /*
+         * Written straight onto the response rather than through
+         * Response.sendJsonObjectResponse, whose ?output-type=csv branch
+         * answers 200 regardless of the status code it was handed. The status
+         * code is the entire point of this route — it is what distinguishes
+         * "wrong method" from "no such route" — so no query parameter gets to
+         * rewrite it.
+         */
+        res.status(405).json({
+          status:
+            "This is the OneUptime Microsoft Teams bot messaging endpoint. It exists, and it accepts POST only.",
+          allow: ["POST"],
+          messagingEndpoint: `${AppApiClientUrl.toString()}/microsoft-bot/messages`,
+          /*
+           * Stated as a fact about this response rather than as advice,
+           * because it is the one thing the admin has actually proven by
+           * getting here and it is easy to under-read.
+           */
+          whatThisProves:
+            "You reached OneUptime. This endpoint is registered and this deployment served your request, so the messaging endpoint is not missing.",
+          whatThisDoesNotProve:
+            "That Azure Bot Service can reach this URL. Azure calls it from the public internet, and your browser or terminal may not be on the same path.",
+          /*
+           * A 404 on this path does NOT mean the request failed to arrive, and
+           * saying so would repeat the mistake this endpoint exists to end.
+           * OneUptime's own catch-all (StartServer's app.get("*")) answers an
+           * unmatched GET with a 404 whose body is
+           * {"message":"Page not found - <path>"} — 58 bytes for this path,
+           * which is exactly the `404 58` an admin sees in their access log.
+           * That 404 is proof the request arrived, not proof it did not. Only
+           * the body separates it from a proxy's own 404, so point at the body.
+           */
+          ifYouGetA404InsteadOfThis:
+            'Read the body, not just the status code. A body of {"message":"Page not found - /api/microsoft-bot/messages"} comes from OneUptime itself, which means the request DID arrive: either this deployment predates this 405 response (the path was POST-only, so a GET fell through to the generic not-found handler), or something in front of OneUptime rewrote the path and stripped the /api prefix before the app saw it. An HTML error page from nginx, your ingress or a load balancer means the opposite — the request never reached OneUptime.',
+          /*
+           * Ordered by what actually goes wrong on self-hosted deployments.
+           * Outbound-works-inbound-fails leads because it is the state that
+           * makes people doubt the route: alerts arrive in Teams, so the
+           * integration looks live, and only the interactive half is dead.
+           */
+          ifTeamsSaysUnableToReachApp: [
+            "Working outbound alerts prove nothing here. OneUptime posts cards by calling Microsoft, which needs no inbound access. Card buttons, bot commands and chat registration all travel the other way — Azure Bot Service POSTs to this URL — and that is the direction that is failing.",
+            "Confirm this exact URL is set as the messaging endpoint on the Azure Bot resource, then check that it resolves publicly. A private DNS name or an internal-only ingress is the most common cause.",
+            "Azure requires HTTPS with a publicly trusted certificate served with its full chain. A self-signed certificate, an internal CA, or a missing intermediate fails the TLS handshake before OneUptime ever sees the request, so nothing appears in your access log.",
+            "Then look for the POST, not the 404, in your access log: `grep 'POST /api/microsoft-bot/messages' <access log>`. No POST lines at all means Azure never got through, and the fault is the network path rather than OneUptime.",
+          ],
+          nextStep: `GET ${AppApiClientUrl.toString()}/microsoft-bot/test to see this deployment's bot id, and compare it with the bot id of the OneUptime app package installed in Microsoft Teams.`,
+        });
+      },
+    );
+
+    /*
      * Echoes this deployment's bot configuration.
      *
      * It reads local environment variables and nothing else — it does not call
@@ -963,6 +1038,15 @@ export default class MicrosoftTeamsAPI {
           notVerified: [
             "That an Azure Bot resource exists for this client id",
             "That the Azure Bot's messaging endpoint points at this deployment",
+            /*
+             * Reachability is listed separately from the endpoint being
+             * configured, because they fail separately and look identical from
+             * in here. A correctly configured endpoint on a deployment Azure
+             * cannot dial produces working outbound alerts and a completely
+             * dead bot, which reads as a half-broken integration rather than a
+             * network problem.
+             */
+            "That Azure Bot Service can actually reach this deployment over the public internet — outbound notifications work without it, so a working alert does not test this",
             "That the Azure Bot has the Microsoft Teams channel enabled",
             "That the client secret is valid and has not expired",
             "That the Teams app package installed in your teams was built from this deployment",

--- a/Common/Tests/Server/API/MicrosoftTeamsBotMessagesEndpoint.test.ts
+++ b/Common/Tests/Server/API/MicrosoftTeamsBotMessagesEndpoint.test.ts
@@ -1,0 +1,729 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  ExpressRouter,
+} from "../../../Server/Utils/Express";
+import { JSONObject } from "../../../Types/JSON";
+import MicrosoftTeamsAPI from "../../../Server/API/MicrosoftTeamsAPI";
+import MicrosoftTeamsUtil from "../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+
+/*
+ * The bug this suite exists for was not in the routing, it was in the answer.
+ *
+ * /api/microsoft-bot/messages accepts POST only, because Azure Bot Service is
+ * the only thing that ever calls it. Checking a messaging endpoint with a
+ * browser or curl is the first thing a self-hosted admin does, and that check
+ * is a GET — which fell through to the catch-all in StartServer and came back
+ * "Page not found - /api/microsoft-bot/messages". True of the method, false of
+ * the endpoint, and indistinguishable from a route that had been dropped from
+ * the build. Admins filed regressions against the route while the real fault
+ * (Azure could not reach the deployment at all) went untouched.
+ *
+ * So the assertions here are about the response being *diagnostic*: a 405 that
+ * separates "wrong method" from "no such route", and a body that redirects the
+ * next hour of debugging at the network path instead of OneUptime's routing
+ * table. Content assertions look brittle; they are the feature.
+ */
+
+const MOCK_TEAMS_CLIENT_ID: string = "11111111-2222-3333-4444-555555555555";
+const MOCK_TEAMS_CLIENT_SECRET: string =
+  "mock-teams-client-secret-that-must-never-be-echoed";
+
+/*
+ * Same lazy-getter shape as MicrosoftTeamsBotTestEndpoint.test.ts: the route
+ * reads these at request time (named imports compile to property reads on the
+ * module object), so getters let one loaded copy of the API module serve both
+ * the configured and unconfigured cases.
+ */
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const state: { clientId: string | null; clientSecret: string | null } = {
+    clientId: "11111111-2222-3333-4444-555555555555",
+    clientSecret: "mock-teams-client-secret-that-must-never-be-echoed",
+  };
+
+  const mocked: Record<string, unknown> = {
+    ...(jest.requireActual("../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    setMockTeamsConfig: (
+      clientId: string | null,
+      clientSecret: string | null,
+    ): void => {
+      state.clientId = clientId;
+      state.clientSecret = clientSecret;
+    },
+  };
+
+  Object.defineProperty(mocked, "MicrosoftTeamsAppClientId", {
+    get: (): string | null => {
+      return state.clientId;
+    },
+  });
+
+  Object.defineProperty(mocked, "MicrosoftTeamsAppClientSecret", {
+    get: (): string | null => {
+      return state.clientSecret;
+    },
+  });
+
+  return mocked;
+});
+
+type SetMockTeamsConfigFunction = (
+  clientId: string | null,
+  clientSecret: string | null,
+) => void;
+
+const setTeamsConfig: SetMockTeamsConfigFunction = (
+  clientId: string | null,
+  clientSecret: string | null,
+): void => {
+  (
+    jest.requireMock("../../../Server/EnvironmentConfig") as {
+      setMockTeamsConfig: SetMockTeamsConfigFunction;
+    }
+  ).setMockTeamsConfig(clientId, clientSecret);
+};
+
+type ExpressRouteHandler = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+) => Promise<void> | void;
+
+type ExpressRouterLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: ExpressRouteHandler }>;
+  };
+};
+
+const MESSAGES_PATH: string = "/microsoft-bot/messages";
+
+type FindRouteFunction = (
+  path: string,
+  method: string,
+) => ExpressRouterLayer["route"] | undefined;
+
+/*
+ * Reads the router the API class actually builds, so the route wiring (path +
+ * method) is under test rather than a hand-copied handler.
+ */
+const findRoute: FindRouteFunction = (
+  path: string,
+  method: string,
+): ExpressRouterLayer["route"] | undefined => {
+  const router: ExpressRouter = new MicrosoftTeamsAPI().getRouter();
+  const layers: Array<ExpressRouterLayer> = (
+    router as unknown as { stack: Array<ExpressRouterLayer> }
+  ).stack;
+
+  return layers.find((candidate: ExpressRouterLayer) => {
+    return (
+      candidate.route?.path === path &&
+      candidate.route?.methods[method] === true
+    );
+  })?.route;
+};
+
+type GetMessagesGetHandlerFunction = () => ExpressRouteHandler;
+
+const getMessagesGetHandler: GetMessagesGetHandlerFunction =
+  (): ExpressRouteHandler => {
+    const route: ExpressRouterLayer["route"] | undefined = findRoute(
+      MESSAGES_PATH,
+      "get",
+    );
+
+    if (!route) {
+      throw new Error(
+        `GET ${MESSAGES_PATH} is not registered on the MicrosoftTeamsAPI router`,
+      );
+    }
+
+    expect(route.stack).toHaveLength(1);
+
+    return route.stack[0]!.handle;
+  };
+
+type InvokedResponse = {
+  statusCode: number;
+  body: JSONObject;
+  headers: Record<string, string>;
+  sentAsCsv: boolean;
+};
+
+type CallMessagesGetFunction = (
+  query?: Record<string, string>,
+) => Promise<InvokedResponse>;
+
+const callMessagesGet: CallMessagesGetFunction = async (
+  query: Record<string, string> = {},
+): Promise<InvokedResponse> => {
+  const handler: ExpressRouteHandler = getMessagesGetHandler();
+
+  const invoked: InvokedResponse = {
+    statusCode: 0,
+    body: {},
+    headers: {},
+    sentAsCsv: false,
+  };
+
+  const res: Partial<ExpressResponse> = {
+    setHeader(name: string, value: string): ExpressResponse {
+      invoked.headers[name.toLowerCase()] = value;
+      return res as ExpressResponse;
+    },
+    status(statusCode: number): ExpressResponse {
+      invoked.statusCode = statusCode;
+      return res as ExpressResponse;
+    },
+    json(body: JSONObject): ExpressResponse {
+      invoked.body = body;
+      return res as ExpressResponse;
+    },
+    /*
+     * Present but never expected to fire. Response.sendJsonObjectResponse
+     * lands here for its ?output-type=csv branch, so a call to send() would
+     * mean the handler went back through the helper that can rewrite a 405
+     * into a 200.
+     */
+    send(body: unknown): ExpressResponse {
+      invoked.sentAsCsv = true;
+      invoked.body = body as JSONObject;
+      return res as ExpressResponse;
+    },
+  } as unknown as Partial<ExpressResponse>;
+
+  const req: Partial<ExpressRequest> = {
+    query: query,
+  };
+
+  await handler(req as ExpressRequest, res as ExpressResponse);
+
+  return invoked;
+};
+
+type JoinGuidanceFunction = (values: unknown) => string;
+
+const joinGuidance: JoinGuidanceFunction = (values: unknown): string => {
+  return (values as Array<string>).join(" | ").toLowerCase();
+};
+
+beforeEach(() => {
+  setTeamsConfig(MOCK_TEAMS_CLIENT_ID, MOCK_TEAMS_CLIENT_SECRET);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("bot messaging endpoint route registration", () => {
+  test("POST /microsoft-bot/messages is registered", () => {
+    /*
+     * The claim in the bug report was that this route had gone missing from
+     * the build. It had not, and this is the assertion that keeps it that way.
+     */
+    expect(findRoute(MESSAGES_PATH, "post")).toBeDefined();
+  });
+
+  test("GET /microsoft-bot/messages is registered", () => {
+    expect(findRoute(MESSAGES_PATH, "get")).toBeDefined();
+  });
+
+  test("the GET and POST handlers are different functions", () => {
+    const getRoute: ExpressRouterLayer["route"] | undefined = findRoute(
+      MESSAGES_PATH,
+      "get",
+    );
+    const postRoute: ExpressRouterLayer["route"] | undefined = findRoute(
+      MESSAGES_PATH,
+      "post",
+    );
+
+    expect(getRoute?.stack[0]?.handle).not.toBe(postRoute?.stack[0]?.handle);
+  });
+
+  test("the diagnostic GET is not registered for POST", () => {
+    const getRoute: ExpressRouterLayer["route"] | undefined = findRoute(
+      MESSAGES_PATH,
+      "get",
+    );
+
+    expect(getRoute?.methods["post"]).toBeFalsy();
+  });
+
+  test("GET /microsoft-bot/test is still registered alongside it", () => {
+    expect(findRoute("/microsoft-bot/test", "get")).toBeDefined();
+  });
+});
+
+/*
+ * The hazard this change introduces is exactly one: a GET handler sitting on
+ * the bot's own path. If it ever caught POSTs — someone "tidying" the pair into
+ * a router.all, or registering the GET above the POST with a next() — every
+ * Teams button tap and every chat installation event would be answered with a
+ * 405 explaining that the endpoint wants POST, which is the funniest possible
+ * way to break the integration and would look identical from inside Teams to
+ * the outage this whole change is about.
+ *
+ * Inspecting route.methods cannot see that: findRoute already selects the layer
+ * by method, and router.all() registers as `_all` rather than as each verb, so
+ * the tidied-up version would not even be found. Only dispatching through the
+ * real router settles it, so these drive router(req, res, next) directly and
+ * watch which handler runs.
+ */
+describe("dispatching through the real router", () => {
+  type DispatchResult = {
+    processBotActivityCalls: number;
+    statusCode: number;
+    fellThrough: boolean;
+  };
+
+  type DispatchFunction = (method: string) => Promise<DispatchResult>;
+
+  const dispatch: DispatchFunction = async (
+    method: string,
+  ): Promise<DispatchResult> => {
+    const result: DispatchResult = {
+      processBotActivityCalls: 0,
+      statusCode: 0,
+      fellThrough: false,
+    };
+
+    /*
+     * Counted by hand rather than read off the spy: jest.spyOn's return type
+     * varies across jest versions, and naming it would make this suite's
+     * compilation depend on which one is installed. afterEach's
+     * restoreAllMocks puts the real implementation back.
+     */
+    jest
+      .spyOn(MicrosoftTeamsUtil, "processBotActivity")
+      .mockImplementation(async (): Promise<void> => {
+        result.processBotActivityCalls++;
+        return undefined;
+      });
+
+    const router: ExpressRouter = new MicrosoftTeamsAPI().getRouter();
+
+    const res: Partial<ExpressResponse> = {
+      setHeader(): ExpressResponse {
+        return res as ExpressResponse;
+      },
+      status(statusCode: number): ExpressResponse {
+        result.statusCode = statusCode;
+        return res as ExpressResponse;
+      },
+      json(): ExpressResponse {
+        return res as ExpressResponse;
+      },
+      send(): ExpressResponse {
+        return res as ExpressResponse;
+      },
+      end(): ExpressResponse {
+        return res as ExpressResponse;
+      },
+    } as unknown as Partial<ExpressResponse>;
+
+    const req: Record<string, unknown> = {
+      method: method,
+      url: MESSAGES_PATH,
+      originalUrl: MESSAGES_PATH,
+      baseUrl: "",
+      query: {},
+      headers: {},
+      body: {
+        type: "message",
+        channelData: { tenant: { id: "tenant-id" } },
+      },
+    };
+
+    await new Promise<void>((resolve: () => void) => {
+      (router as unknown as (...args: Array<unknown>) => void)(
+        req,
+        res,
+        (): void => {
+          // next() means no route in this router matched the request.
+          result.fellThrough = true;
+          resolve();
+        },
+      );
+
+      /*
+       * Both handlers answer synchronously up to their first await, so a
+       * macrotask hop is enough to let either finish before we assert.
+       */
+      setTimeout(resolve, 0);
+    });
+
+    jest.restoreAllMocks();
+
+    return result;
+  };
+
+  test("a POST bot activity still reaches processBotActivity", async () => {
+    const result: DispatchResult = await dispatch("POST");
+
+    expect(result.processBotActivityCalls).toBe(1);
+    expect(result.fellThrough).toBe(false);
+  });
+
+  test("a POST bot activity is never answered 405 by the diagnostic handler", async () => {
+    const result: DispatchResult = await dispatch("POST");
+
+    expect(result.statusCode).not.toBe(405);
+  });
+
+  test("a GET is answered 405 and never invokes processBotActivity", async () => {
+    const result: DispatchResult = await dispatch("GET");
+
+    expect(result.statusCode).toBe(405);
+    expect(result.processBotActivityCalls).toBe(0);
+    expect(result.fellThrough).toBe(false);
+  });
+});
+
+describe("GET /microsoft-bot/messages", () => {
+  test("responds 405, not 404", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+
+    expect(response.statusCode).toBe(405);
+    expect(response.statusCode).not.toBe(404);
+  });
+
+  test("sets Allow: POST", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+
+    expect(response.headers["allow"]).toBe("POST");
+  });
+
+  test("advertises POST in the body as well as the header", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const allow: Array<string> = response.body[
+      "allow"
+    ] as unknown as Array<string>;
+
+    expect(Array.isArray(allow)).toBe(true);
+    expect(allow).toEqual(["POST"]);
+  });
+
+  test("never presents itself as a not-found", async () => {
+    /*
+     * "Page not found" is what the old catch-all said, and saying it here
+     * would put the admin straight back into believing the route is gone.
+     *
+     * It is banned from the fields that describe THIS response, not from the
+     * whole body: ifYouGetA404InsteadOfThis quotes the catch-all's exact body
+     * on purpose, because that quoted string is how an admin tells OneUptime's
+     * own 404 (request arrived) from a proxy's 404 (request did not). Banning
+     * the substring outright would forbid the one place it belongs.
+     */
+    const response: InvokedResponse = await callMessagesGet();
+
+    const selfDescribingFields: Array<string> = [
+      "status",
+      "whatThisProves",
+      "whatThisDoesNotProve",
+      "nextStep",
+    ];
+
+    selfDescribingFields.forEach((field: string) => {
+      const value: string = (response.body[field] as string).toLowerCase();
+      expect(value).not.toContain("page not found");
+      expect(value).not.toContain("not found -");
+    });
+  });
+
+  test("quotes the catch-all's body only inside the 404 guidance", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const on404: string = response.body["ifYouGetA404InsteadOfThis"] as string;
+
+    expect(on404).toContain(
+      '{"message":"Page not found - /api/microsoft-bot/messages"}',
+    );
+  });
+
+  test("states the endpoint exists and takes POST only", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const status: string = (response.body["status"] as string).toLowerCase();
+
+    expect(status).toContain("exists");
+    expect(status).toContain("post");
+  });
+
+  test("reports the messaging endpoint this deployment expects", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const messagingEndpoint: string = response.body[
+      "messagingEndpoint"
+    ] as string;
+
+    expect(typeof messagingEndpoint).toBe("string");
+    expect(messagingEndpoint.endsWith("/microsoft-bot/messages")).toBe(true);
+  });
+
+  test("points at /microsoft-bot/test as the next step", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const nextStep: string = response.body["nextStep"] as string;
+
+    expect(nextStep).toContain("/microsoft-bot/test");
+    expect(nextStep.toLowerCase()).toContain("bot id");
+  });
+});
+
+describe("the response separates what a 405 proves from what it does not", () => {
+  test("whatThisProves says the endpoint is registered and the request arrived", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const proves: string = (
+      response.body["whatThisProves"] as string
+    ).toLowerCase();
+
+    expect(proves).toContain("registered");
+    expect(proves).toContain("not missing");
+  });
+
+  test("whatThisProves does not claim a 404 would have meant the request never arrived", async () => {
+    /*
+     * It said exactly that in an earlier draft, and it was false in the one
+     * case that matters. OneUptime's own catch-all answers an unmatched GET
+     * with 404 and the body {"message":"Page not found - <path>"} — 58 bytes
+     * for this path, which is precisely the `404 58` the reporter of issue
+     * #3488 pasted from their access log. Their request DID arrive. Shipping
+     * "a 404 means it never arrived" inside the endpoint built to end that
+     * misreading would have taught admins to distrust the one log line
+     * proving their host was reachable.
+     */
+    const response: InvokedResponse = await callMessagesGet();
+    const proves: string = (
+      response.body["whatThisProves"] as string
+    ).toLowerCase();
+
+    expect(proves).not.toContain("never arrived");
+    expect(proves).not.toContain("would have meant");
+  });
+
+  test("a 404 is explained by its body, not by its status code alone", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const on404: string = (
+      response.body["ifYouGetA404InsteadOfThis"] as string
+    ).toLowerCase();
+
+    expect(on404).toContain("body");
+    expect(on404).toContain("page not found");
+  });
+
+  test("the 404 guidance says OneUptime's own JSON body means the request DID arrive", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const on404: string = (
+      response.body["ifYouGetA404InsteadOfThis"] as string
+    ).toLowerCase();
+
+    expect(on404).toContain("did arrive");
+    expect(on404).toMatch(/post-only|post only/);
+    expect(on404).toContain("/api");
+  });
+
+  test("the 404 guidance names the HTML error page as the opposite reading", async () => {
+    /*
+     * Both readings have to be present or the field just relocates the
+     * original error: a proxy's own 404 really does mean the request never
+     * reached OneUptime, and that is the case the admin must be able to tell
+     * apart from theirs.
+     */
+    const response: InvokedResponse = await callMessagesGet();
+    const on404: string = (
+      response.body["ifYouGetA404InsteadOfThis"] as string
+    ).toLowerCase();
+
+    expect(on404).toContain("html");
+    expect(on404).toMatch(/proxy|nginx|ingress|load balancer/);
+    expect(on404).toContain("never reached oneuptime");
+  });
+
+  test("whatThisDoesNotProve names Azure Bot Service reachability", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const doesNotProve: string = (
+      response.body["whatThisDoesNotProve"] as string
+    ).toLowerCase();
+
+    expect(doesNotProve).toContain("azure bot service");
+    expect(doesNotProve).toContain("reach");
+  });
+
+  test("the two claims are distinct fields, not one merged sentence", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+
+    expect(typeof response.body["whatThisProves"]).toBe("string");
+    expect(typeof response.body["whatThisDoesNotProve"]).toBe("string");
+    expect(response.body["whatThisProves"]).not.toBe(
+      response.body["whatThisDoesNotProve"],
+    );
+  });
+});
+
+describe("unable-to-reach-app guidance", () => {
+  test("is a non-empty ordered list", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const guidance: Array<string> = response.body[
+      "ifTeamsSaysUnableToReachApp"
+    ] as unknown as Array<string>;
+
+    expect(Array.isArray(guidance)).toBe(true);
+    expect(guidance.length).toBeGreaterThan(0);
+  });
+
+  test("leads with outbound alerts proving nothing about the bot endpoint", async () => {
+    /*
+     * This is the misreading that makes the integration look half-broken
+     * rather than network-broken: alert cards post fine because OneUptime
+     * calls Microsoft, and every inbound path is dead. It has to be first.
+     */
+    const response: InvokedResponse = await callMessagesGet();
+    const guidance: Array<string> = response.body[
+      "ifTeamsSaysUnableToReachApp"
+    ] as unknown as Array<string>;
+
+    const first: string = guidance[0]!.toLowerCase();
+
+    expect(first).toContain("outbound");
+    expect(first).toMatch(/prove(s)? nothing|no inbound access/);
+  });
+
+  test.each([
+    ["the TLS chain requirement", ["publicly trusted certificate"]],
+    ["public reachability of the host", ["private dns"]],
+    [
+      "grepping for the POST rather than the 404",
+      ["post /api/microsoft-bot/messages"],
+    ],
+    ["the Azure Bot messaging endpoint setting", ["azure bot resource"]],
+  ])("covers %s", async (_label: string, requiredFragments: Array<string>) => {
+    const response: InvokedResponse = await callMessagesGet();
+    const joined: string = joinGuidance(
+      response.body["ifTeamsSaysUnableToReachApp"],
+    );
+
+    requiredFragments.forEach((fragment: string) => {
+      expect(joined).toContain(fragment);
+    });
+  });
+
+  test("explains why a failed TLS handshake leaves no trace in the access log", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const joined: string = joinGuidance(
+      response.body["ifTeamsSaysUnableToReachApp"],
+    );
+
+    expect(joined).toContain("access log");
+    expect(joined).toMatch(/before oneuptime ever sees|never got through/);
+  });
+
+  test("names the three interactive paths that depend on inbound traffic", async () => {
+    const response: InvokedResponse = await callMessagesGet();
+    const joined: string = joinGuidance(
+      response.body["ifTeamsSaysUnableToReachApp"],
+    );
+
+    expect(joined).toContain("card buttons");
+    expect(joined).toContain("bot commands");
+    expect(joined).toContain("chat registration");
+  });
+});
+
+describe("the status code cannot be talked out of being 405", () => {
+  test("?output-type=csv still returns 405 JSON", async () => {
+    /*
+     * Response.sendJsonObjectResponse answers this query parameter with a 200
+     * and a CSV body regardless of the status code it was given. On an
+     * endpoint whose entire value is its status code that would undo the fix,
+     * so the handler writes the response itself.
+     */
+    const response: InvokedResponse = await callMessagesGet({
+      "output-type": "csv",
+    });
+
+    expect(response.statusCode).toBe(405);
+    expect(response.sentAsCsv).toBe(false);
+    expect(response.body["status"]).toBeDefined();
+  });
+
+  test("an unrelated query parameter does not change the response", async () => {
+    const withQuery: InvokedResponse = await callMessagesGet({
+      foo: "bar",
+    });
+
+    expect(withQuery.statusCode).toBe(405);
+    expect(withQuery.body["status"]).toBeDefined();
+  });
+});
+
+describe("the diagnostic answer does not depend on Teams being configured", () => {
+  test.each([
+    ["client id missing", null, MOCK_TEAMS_CLIENT_SECRET],
+    ["client secret missing", MOCK_TEAMS_CLIENT_ID, null],
+    ["both missing", null, null],
+    ["both empty strings", "", ""],
+  ])(
+    "still answers 405 with guidance when %s",
+    async (
+      _label: string,
+      clientId: string | null,
+      clientSecret: string | null,
+    ) => {
+      /*
+       * An admin whose credentials are wrong still needs to be told the route
+       * exists. Gating this response on configuration would put them back in
+       * front of a 404-shaped answer at exactly the wrong moment.
+       */
+      setTeamsConfig(clientId, clientSecret);
+
+      const response: InvokedResponse = await callMessagesGet();
+
+      expect(response.statusCode).toBe(405);
+      expect(response.headers["allow"]).toBe("POST");
+      expect(response.body["status"]).toBeDefined();
+      expect(
+        (
+          response.body[
+            "ifTeamsSaysUnableToReachApp"
+          ] as unknown as Array<string>
+        ).length,
+      ).toBeGreaterThan(0);
+    },
+  );
+});
+
+describe("secret handling", () => {
+  test.each([
+    ["fully configured", MOCK_TEAMS_CLIENT_ID, MOCK_TEAMS_CLIENT_SECRET],
+    ["client id missing", null, MOCK_TEAMS_CLIENT_SECRET],
+  ])(
+    "never echoes the client secret (%s)",
+    async (
+      _label: string,
+      clientId: string | null,
+      clientSecret: string | null,
+    ) => {
+      setTeamsConfig(clientId, clientSecret);
+
+      const response: InvokedResponse = await callMessagesGet();
+      const serialized: string = JSON.stringify(response.body);
+
+      expect(serialized).not.toContain(MOCK_TEAMS_CLIENT_SECRET);
+      expect(serialized.toLowerCase()).not.toContain("clientsecret");
+    },
+  );
+
+  test("does not echo the client id either — this route identifies the endpoint, not the bot", async () => {
+    /*
+     * /microsoft-bot/test is the place that returns botId, behind the same
+     * deployment but as a deliberate answer to "which package should be
+     * installed". This route is reachable by anyone who can reach the host,
+     * so it stays about the endpoint.
+     */
+    const response: InvokedResponse = await callMessagesGet();
+
+    expect(JSON.stringify(response.body)).not.toContain(MOCK_TEAMS_CLIENT_ID);
+  });
+});

--- a/Common/Tests/Server/API/MicrosoftTeamsBotTestEndpoint.test.ts
+++ b/Common/Tests/Server/API/MicrosoftTeamsBotTestEndpoint.test.ts
@@ -238,6 +238,18 @@ describe("GET /microsoft-bot/test", () => {
         "the installed Teams app package belonging to this deployment",
         ["installed", "this deployment"],
       ],
+      /*
+       * Reachability is listed apart from the endpoint being *configured*
+       * because the two fail separately and are indistinguishable from in
+       * here. A correctly configured endpoint on a deployment Azure cannot
+       * dial produces working outbound alerts and a completely dead bot —
+       * which reads as a half-broken integration rather than a network
+       * problem, and is how this endpoint's blessing gets misread.
+       */
+      [
+        "Azure Bot Service being able to reach this deployment",
+        ["reach this deployment", "public internet"],
+      ],
     ])(
       "notVerified explicitly disclaims %s",
       async (_label: string, requiredFragments: Array<string>) => {
@@ -256,6 +268,20 @@ describe("GET /microsoft-bot/test", () => {
         expect(match).toBeDefined();
       },
     );
+
+    test("notVerified warns that a working alert does not test reachability", async () => {
+      /*
+       * The trap this endpoint exists to avoid: an admin whose alerts arrive
+       * in Teams reads that as proof the bot is wired up, when outbound
+       * notifications go out over a connection OneUptime opens itself and
+       * never touch the inbound path the bot depends on.
+       */
+      const response: InvokedResponse = await callBotTest();
+      const joined: string = joinStrings(response.body["notVerified"]);
+
+      expect(joined).toContain("outbound notifications work without it");
+      expect(joined).toContain("working alert does not test this");
+    });
 
     test("nextStep names the client id and tells the admin to compare it against the installed app's bot id", async () => {
       const response: InvokedResponse = await callBotTest();

--- a/Common/Tests/Server/API/MicrosoftTeamsLegacyWebhookRemoval.test.ts
+++ b/Common/Tests/Server/API/MicrosoftTeamsLegacyWebhookRemoval.test.ts
@@ -147,13 +147,44 @@ describe("Microsoft Teams inbound route authentication", () => {
   });
 
   test("keeps exactly one POST route for the authenticated Bot Framework adapter", () => {
+    /*
+     * Counted by method rather than by layer. What must stay unique is the
+     * inbound POST — a second one is how the unauthenticated legacy webhook
+     * got in, and this test exists to keep it out. The path itself carries a
+     * second layer on purpose since the 405 diagnostic landed: a GET handler
+     * that answers a browser probe instead of letting it fall through to the
+     * catch-all 404, which is what convinced the reporter of #3488 that the
+     * route had been dropped from the build.
+     *
+     * So: exactly one layer accepts POST, and no other layer on this path
+     * accepts POST either. The second assertion is the one doing the security
+     * work — a layer registered with router.all() would accept POST while
+     * reporting no `post` key of its own.
+     */
     const botFrameworkLayers: Array<ExpressRouterLayer> =
       getRouterLayers().filter((layer: ExpressRouterLayer): boolean => {
         return layer.route?.path === BOT_FRAMEWORK_PATH;
       });
 
-    expect(botFrameworkLayers).toHaveLength(1);
-    expect(botFrameworkLayers[0]!.route!.methods).toEqual({ post: true });
+    const postLayers: Array<ExpressRouterLayer> = botFrameworkLayers.filter(
+      (layer: ExpressRouterLayer): boolean => {
+        return layer.route?.methods["post"] === true;
+      },
+    );
+
+    expect(postLayers).toHaveLength(1);
+    expect(postLayers[0]!.route!.methods).toEqual({ post: true });
+
+    const otherLayerMethods: Array<string> = botFrameworkLayers
+      .filter((layer: ExpressRouterLayer): boolean => {
+        return layer !== postLayers[0];
+      })
+      .flatMap((layer: ExpressRouterLayer): Array<string> => {
+        return Object.keys(layer.route!.methods);
+      });
+
+    expect(otherLayerMethods).not.toContain("post");
+    expect(otherLayerMethods).not.toContain("_all");
   });
 
   test.each([

--- a/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
+++ b/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
@@ -1,0 +1,515 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "@jest/globals";
+import * as React from "react";
+import fs from "fs";
+import path from "path";
+
+import MicrosoftTeamsIntegrationDocumentation from "../../../../App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation";
+
+/*
+ * A self-hosted deployment that Azure Bot Service cannot reach does not look
+ * broken. Alert cards keep arriving, because OneUptime posts those by calling
+ * Microsoft — no inbound access needed. Everything that travels the other way
+ * is dead: card buttons answer "Unable to reach app", bot commands go
+ * unanswered, and chats never register because chat registration *is* an
+ * inbound bot activity.
+ *
+ * Read from inside Teams that reads as a half-finished integration, and the
+ * cheapest check an admin runs next — opening the messaging endpoint in a
+ * browser — used to return "Page not found". So the docs are what has to
+ * carry the diagnosis: the two directions are independent, a working alert
+ * tests only one of them, and an empty Chats list is the confirmation rather
+ * than a second unrelated bug.
+ *
+ * These assertions are on prose because the failure was prose.
+ */
+
+const REPO_ROOT: string = path.resolve(__dirname, "../../../..");
+
+const DOCS_MARKDOWN_PATH: string = path.join(
+  REPO_ROOT,
+  "App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md",
+);
+
+const IN_PRODUCT_GUIDE_PATH: string = path.join(
+  REPO_ROOT,
+  "App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegrationDocumentation.tsx",
+);
+
+const TEAMS_API_PATH: string = path.join(
+  REPO_ROOT,
+  "Common/Server/API/MicrosoftTeamsAPI.ts",
+);
+
+const MESSAGING_ENDPOINT_PATH: string = "/api/microsoft-bot/messages";
+
+type ReadFileFunction = (filePath: string) => string;
+
+const readSource: ReadFileFunction = (filePath: string): string => {
+  return fs.readFileSync(filePath, "utf8");
+};
+
+type RenderDocumentationFunction = () => Promise<string>;
+
+/*
+ * react-markdown is mocked globally to a div holding its children, so the
+ * resolved markdown (window.location.origin already interpolated) is what
+ * lands in the DOM.
+ *
+ * The explicit timeout is not padding. MarkdownViewer is a React.lazy import,
+ * so the very first render has to pull the viewer's whole module graph through
+ * ts-jest before anything reaches the DOM — comfortably past findBy's 1s
+ * default on a cold cache, while every later render resolves the already
+ * loaded chunk in single-digit milliseconds. Left at the default, the first
+ * test to render would fail and every other one would pass, which reads as a
+ * content bug rather than the warm-up cost it is.
+ */
+const renderDocumentationText: RenderDocumentationFunction =
+  async (): Promise<string> => {
+    render(<MicrosoftTeamsIntegrationDocumentation />);
+
+    const markdown: HTMLElement = await screen.findByTestId(
+      "react-markdown",
+      {},
+      { timeout: 30000 },
+    );
+
+    return markdown.textContent || "";
+  };
+
+/*
+ * Raised for the same reason: the lazy chunk has to load once, inside whichever
+ * test renders first, and 5s is not enough headroom for that on a cold cache
+ * under CI contention.
+ */
+jest.setTimeout(60000);
+
+const docsMarkdown: string = readSource(DOCS_MARKDOWN_PATH);
+
+describe("Self-hosted docs: verifying the messaging endpoint during setup", () => {
+  const stepFour: string = docsMarkdown
+    .split("### Step 4: Create a Bot Service")[1]!
+    .split("### Step 5:")[0]!;
+
+  test("tells the admin to verify the endpoint before moving on", () => {
+    expect(stepFour).toContain("Verify the endpoint before you move on");
+  });
+
+  test("says to test from outside the network, not from inside the cluster", () => {
+    const lowered: string = stepFour.toLowerCase();
+
+    expect(lowered).toContain("outside your network");
+    expect(lowered).toContain("inside the cluster");
+    expect(lowered).toContain("vpn");
+  });
+
+  test("gives a curl that shows the response body, not only the status code", () => {
+    /*
+     * An earlier draft used `-o /dev/null -w '%{http_code}'`, which throws
+     * away the one thing that makes a 404 diagnosable. Keep -i.
+     */
+    expect(stepFour).toContain("curl -sS -i");
+    expect(stepFour).not.toContain("-o /dev/null");
+    expect(stepFour).toContain(MESSAGING_ENDPOINT_PATH);
+  });
+
+  test("names 405 as the passing result", () => {
+    /*
+     * The status code is the whole signal, so it has to be stated as success
+     * outright — an admin who reads 405 as an error stops here.
+     */
+    expect(stepFour).toContain("**405**");
+    expect(stepFour.toLowerCase()).toMatch(/405.*(correct|done)/s);
+  });
+
+  test("splits 404 by response body rather than calling every 404 unreachable", () => {
+    /*
+     * The regression this guards is the one the reviewers caught: OneUptime's
+     * own not-found handler serves a 404 for this path, so "404 means the
+     * request did not reach OneUptime" is false exactly when an admin is most
+     * likely to hit it (any build older than the 405, or an ingress that
+     * strips the /api prefix). Both readings must be present and separated by
+     * the body.
+     */
+    const lowered: string = stepFour.toLowerCase();
+
+    expect(stepFour).toContain(
+      '**404 with a JSON body of `{"message":"Page not found - /api/microsoft-bot/messages"}`**',
+    );
+    expect(lowered).toContain(
+      "came from oneuptime, so the request *did* arrive",
+    );
+
+    expect(stepFour).toContain("**404 with an HTML error page**");
+    expect(lowered).toContain("never reached oneuptime");
+
+    expect(lowered).toMatch(/proxy|ingress|load balancer/);
+    expect(lowered).toContain("tls error");
+  });
+
+  test("explains why the body matters before listing the outcomes", () => {
+    expect(stepFour.toLowerCase()).toContain(
+      "the only thing that tells you who produced it",
+    );
+  });
+});
+
+describe("Self-hosted docs: the unreachable-endpoint troubleshooting section", () => {
+  const section: string = docsMarkdown
+    .split(
+      '### Card buttons say "Unable to reach app", and chats never appear',
+    )[1]!
+    .split("### Checking this deployment's bot configuration")[0]!;
+
+  test("the section exists and is reachable from the Step 4 anchor", () => {
+    expect(section.length).toBeGreaterThan(0);
+    expect(docsMarkdown).toContain(
+      "#card-buttons-say-unable-to-reach-app-and-chats-never-appear",
+    );
+  });
+
+  test("states the single root cause up front", () => {
+    expect(section).toContain(
+      "**Azure Bot Service cannot reach your messaging endpoint.**",
+    );
+    expect(section).toContain("These are one failure, not two");
+  });
+
+  test("explains that a working alert card tests the opposite direction", () => {
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain("oneuptime calls microsoft");
+    expect(lowered).toMatch(
+      /tells you nothing at all about the bot endpoint|working alert/,
+    );
+  });
+
+  test("tabulates which paths need inbound access and which do not", () => {
+    expect(section).toContain("| Direction |");
+    expect(section).toContain("Needs Azure to reach you?");
+
+    const rows: Array<string> = section.split("\n").filter((line: string) => {
+      return line.trim().startsWith("|") && line.includes("**");
+    });
+
+    /*
+     * One "No" row (the outbound alert) and three "Yes" rows (button tap, bot
+     * command, chat registration) — the asymmetry is the point of the table,
+     * so a table that lost the outbound row would still read as consistent
+     * and would no longer explain anything.
+     */
+    expect(
+      rows.filter((row: string) => {
+        return row.includes("**No**");
+      }),
+    ).toHaveLength(1);
+    expect(
+      rows.filter((row: string) => {
+        return row.includes("**Yes**");
+      }).length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  test("explains why the empty Chats list confirms the diagnosis", () => {
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain("refresh chats");
+    expect(lowered).toContain("application permissions");
+  });
+
+  test("names all three activities that register a chat, not just the install event", () => {
+    /*
+     * captureChatFromBotActivity is called from three inbound paths in
+     * MicrosoftTeams.ts: installationUpdate add/add-upgrade, conversationUpdate
+     * with the bot in membersAdded, and any message in a personal/groupChat
+     * conversation. That third one is deliberate — it is the documented
+     * recovery path for chats installed before chat capture shipped, and the
+     * Chats card's own empty state tells admins to use it. Saying a chat can
+     * only register from an installation event tells an admin their setup is
+     * broken when messaging the bot would have fixed it.
+     */
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain("installed");
+    expect(lowered).toContain("added to the conversation");
+    expect(lowered).toContain("any message sent to the bot");
+  });
+
+  test("the inbound table describes chat registration as an activity, not an install event", () => {
+    const chatRow: string =
+      section.split("\n").find((line: string) => {
+        return line.includes("A chat registers under");
+      }) || "";
+
+    expect(chatRow).not.toBe("");
+    expect(chatRow).toContain("bot activity");
+    expect(chatRow).not.toContain("installation event");
+  });
+
+  test("tells the admin to grep for the POST rather than the 404", () => {
+    expect(section).toContain("Look for the POST, not for 404s");
+    expect(section).toContain("grep 'POST /api/microsoft-bot/messages'");
+  });
+
+  test("covers the certificate chain, with a command that checks it", () => {
+    expect(section).toContain("publicly trusted certificate");
+    expect(section).toContain("full chain");
+    expect(section).toContain("openssl s_client");
+    expect(section).toContain("-verify_return_error");
+  });
+
+  test("explains why a TLS failure leaves the access log empty", () => {
+    expect(section.toLowerCase()).toContain(
+      "before oneuptime sees the request",
+    );
+  });
+
+  test("covers private DNS and split-horizon records", () => {
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain("private dns name");
+    expect(lowered).toContain("split-horizon");
+  });
+
+  test("says outright that a 404 on GET is not the bug", () => {
+    /*
+     * This is the sentence the issue was filed for. Without it the docs
+     * describe the right fix and still leave the misleading evidence
+     * unexplained.
+     */
+    expect(section).toContain(
+      "**A 404 on `GET /api/microsoft-bot/messages` is not the bug, and it is not evidence Azure could not reach you.**",
+    );
+    expect(section).toContain("has always accepted POST only");
+    expect(section).toContain("405 Method Not Allowed");
+  });
+
+  test("states that OneUptime generated that 404, so the request reached the app", () => {
+    /*
+     * The point that closes issue #3488: the reporter's `404 58` is 58 bytes
+     * of OneUptime's own JSON, so their request arrived. Reading that 404 as
+     * "Azure could not reach us" is the wrong turn the whole section exists
+     * to prevent, and the byte count is what makes it checkable against a
+     * real access log.
+     */
+    expect(section).toContain(
+      '{"message":"Page not found - /api/microsoft-bot/messages"}',
+    );
+    expect(section.toLowerCase()).toContain("the request reached the app");
+    expect(section).toContain("58 bytes");
+    expect(section).toContain(
+      '"GET /api/microsoft-bot/messages HTTP/1.1" 404 58',
+    );
+  });
+
+  test("tells admins on older builds to judge a 404 by its body", () => {
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain("judge a 404 by its body");
+    expect(lowered).toContain("html error page");
+  });
+});
+
+describe("Self-hosted docs: the bot configuration check", () => {
+  const section: string = docsMarkdown
+    .split("### Checking this deployment's bot configuration")[1]!
+    .split('### "The OneUptime app is not installed')[0]!;
+
+  test("documents the /api/microsoft-bot/test endpoint", () => {
+    expect(section).toContain("/api/microsoft-bot/test");
+    expect(section).toContain("curl");
+  });
+
+  test("says what it cannot tell you, so it is not mistaken for a green light", () => {
+    const lowered: string = section.toLowerCase();
+
+    expect(lowered).toContain("does not call azure");
+    expect(lowered).toContain("cannot tell you");
+    expect(lowered).toContain("reach you");
+  });
+
+  test("names the bot id comparison as the decisive check", () => {
+    expect(section).toContain("botId");
+    expect(section.toLowerCase()).toContain("bot id of the oneuptime app");
+  });
+});
+
+describe("In-product setup guide", () => {
+  test("Step 5 tells the admin to verify the endpoint and names 405 as correct", async () => {
+    const text: string = await renderDocumentationText();
+
+    const stepFive: string = text
+      .split("##### Step 5: Create a Bot Service")[1]!
+      .split("##### Step 6")[0]!;
+
+    expect(stepFive).toContain("Verify the endpoint before moving on");
+    expect(stepFive).toContain("**405**");
+    expect(stepFive).toContain("curl -sS -i");
+    expect(stepFive).not.toContain("-o /dev/null");
+    expect(stepFive.toLowerCase()).toContain("outside your network");
+  });
+
+  test("Step 5 splits 404 by response body, matching the self-hosted docs", async () => {
+    const text: string = await renderDocumentationText();
+
+    const stepFive: string = text
+      .split("##### Step 5: Create a Bot Service")[1]!
+      .split("##### Step 6")[0]!;
+
+    expect(stepFive).toContain("**404 with a JSON body of");
+    expect(stepFive).toContain("**404 with an HTML error page**");
+    expect(stepFive.toLowerCase()).toContain("the request *did* arrive");
+    expect(stepFive.toLowerCase()).toContain("never reached oneuptime");
+  });
+
+  test("Step 5 interpolates this deployment's own origin into the check", async () => {
+    const text: string = await renderDocumentationText();
+
+    const stepFive: string = text
+      .split("##### Step 5: Create a Bot Service")[1]!
+      .split("##### Step 6")[0]!;
+
+    expect(stepFive).toContain(
+      `${window.location.origin}${MESSAGING_ENDPOINT_PATH}`,
+    );
+  });
+
+  test("Troubleshooting covers the unreachable endpoint as one failure, not two", async () => {
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain(
+      'Card buttons say "Unable to reach app", and chats never appear',
+    );
+    expect(troubleshooting).toContain("One failure, not two");
+    expect(troubleshooting).toContain(
+      "**Azure Bot Service cannot reach your messaging endpoint.**",
+    );
+  });
+
+  test("Troubleshooting tells the admin to grep for the POST", async () => {
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain("Look for the POST, not for 404s");
+    expect(troubleshooting).toContain("POST /api/microsoft-bot/messages");
+  });
+
+  test("Troubleshooting covers the TLS chain and public DNS resolution", async () => {
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain("publicly trusted certificate");
+    expect(troubleshooting.toLowerCase()).toContain("split-horizon");
+  });
+
+  test("Troubleshooting says a 404 on GET is not the bug, and that OneUptime served it", async () => {
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain(
+      "A 404 on `GET /api/microsoft-bot/messages` is not the bug, and it is not evidence Azure could not reach you.",
+    );
+    expect(troubleshooting).toContain(
+      '{"message":"Page not found - /api/microsoft-bot/messages"}',
+    );
+    expect(troubleshooting.toLowerCase()).toContain("reached the app");
+    expect(troubleshooting).toContain("58 bytes");
+  });
+
+  test("the empty-chats entry names every activity that registers a chat", async () => {
+    /*
+     * An earlier draft said chats register "only when the bot receives an
+     * activity" here while the markdown said "only ... the installation
+     * event" — two documents in one change disagreeing, with the markdown
+     * being the wrong one. Both now name all three paths.
+     */
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    const chatsSection: string = troubleshooting.split(
+      "**No chats appear under Microsoft Teams Chats**",
+    )[1]!;
+
+    const lowered: string = chatsSection.toLowerCase();
+
+    expect(lowered).toContain("the app being installed");
+    expect(lowered).toContain("added to the conversation");
+    expect(lowered).toContain("any message sent to the bot");
+  });
+
+  test("the empty-chats entry now lists the unreachable endpoint first", async () => {
+    /*
+     * It used to name exactly one cause — a wrong app package — which is the
+     * rarer of the two and sends the admin to re-upload a manifest that was
+     * already correct. The giveaway for the common cause (alerts still post)
+     * has to be on this screen.
+     */
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    const chatsSection: string = troubleshooting.split(
+      "**No chats appear under Microsoft Teams Chats**",
+    )[1]!;
+
+    const unreachableIndex: number = chatsSection.indexOf(
+      "The messaging endpoint is unreachable",
+    );
+    const wrongPackageIndex: number = chatsSection.indexOf(
+      "The installed package points at a different deployment",
+    );
+
+    expect(unreachableIndex).toBeGreaterThan(-1);
+    expect(wrongPackageIndex).toBeGreaterThan(-1);
+    expect(unreachableIndex).toBeLessThan(wrongPackageIndex);
+    expect(chatsSection).toContain("alerts still post to channels");
+  });
+
+  test("documents /api/microsoft-bot/test and its limits", async () => {
+    const text: string = await renderDocumentationText();
+    const troubleshooting: string = text.split("##### Troubleshooting")[1]!;
+
+    expect(troubleshooting).toContain("/api/microsoft-bot/test");
+    expect(troubleshooting).toContain("does not call Azure");
+  });
+});
+
+describe("The messaging endpoint path is stated identically everywhere", () => {
+  /*
+   * Three files tell an admin what to paste into the Azure Bot's Configuration
+   * blade, and the API is the only one of them that decides what the server
+   * actually serves. A drift between them is unfalsifiable from inside Teams:
+   * the bot simply never responds, which is the same symptom as every other
+   * cause in this section.
+   */
+  const SOURCES: Array<string> = [
+    DOCS_MARKDOWN_PATH,
+    IN_PRODUCT_GUIDE_PATH,
+    TEAMS_API_PATH,
+  ];
+
+  test.each(SOURCES)("%s names /microsoft-bot/messages", (filePath: string) => {
+    expect(readSource(filePath)).toContain("/microsoft-bot/messages");
+  });
+
+  test("no source has drifted to a different bot path", () => {
+    const BOT_PATH_PATTERN: RegExp = /\/microsoft-bot\/[a-z-]+/g;
+    const KNOWN_PATHS: Array<string> = [
+      "/microsoft-bot/messages",
+      "/microsoft-bot/test",
+    ];
+
+    SOURCES.forEach((filePath: string) => {
+      const found: Array<string> = readSource(filePath).match(
+        BOT_PATH_PATTERN,
+      ) as Array<string>;
+
+      expect(found).not.toBeNull();
+
+      found.forEach((botPath: string) => {
+        expect(KNOWN_PATHS).toContain(botPath);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3488.

## The bug behind the bug

`/api/microsoft-bot/messages` accepts POST only — Azure Bot Service is the only thing that ever calls it. But checking a messaging endpoint with a browser or curl is the first thing a self-hosted admin does, and that check is a **GET**, which fell through to StartServer's catch-all and came back:

```json
{"message":"Page not found - /api/microsoft-bot/messages"}
```

True of the method, false of the endpoint, and indistinguishable from a route that had been dropped from the build.

In #3488 that cost an admin days. Their Azure Bot could not reach their private instance, so they saw alert cards arriving, every card button answering *"Unable to reach app"*, an empty **Chats** list, and that 404 in nginx — and filed a regression against a route that has been registered since Sept 2025 (`c0005618fe`). The 404 was the most misleading piece of evidence in the picture, because it was the one OneUptime produced itself.

## What changed

**`GET /api/microsoft-bot/messages` now answers `405` with `Allow: POST`** and a body that separates what reaching it *proves* (the route exists; this deployment served you) from what it *does not* (that Azure can reach the same URL), then points at the inbound network path rather than the routing table.

**The docs and the in-product setup guide** now explain the asymmetry that makes this so hard to see from inside Teams:

| Direction | How it travels | Needs Azure to reach you? |
| --- | --- | --- |
| OneUptime posts an alert card | OneUptime calls Microsoft | **No** |
| You tap a button on that card | Azure POSTs to `/api/microsoft-bot/messages` | **Yes** |
| You type `help` to the bot | Azure POSTs to `/api/microsoft-bot/messages` | **Yes** |
| A chat registers under **Chats** | Azure POSTs a bot activity | **Yes** |

A working alert tests the half that is working. Both files gained a verification step (Step 4 / Step 5) and a troubleshooting section for the whole failure. `/api/microsoft-bot/test` is documented for the first time, and now disclaims reachability alongside everything else it cannot check.

## Two defects adversarial review caught in the fix itself

Both had already made it into the change:

1. **"A 404 here would have meant the request never arrived" is false** — and false in the exact case that matters. OneUptime's own catch-all serves that 404, and its body is **58 bytes**, precisely the `"GET /api/microsoft-bot/messages HTTP/1.1" 404 58` in the reporter's log. Their request *did* arrive. Shipping that sentence inside the endpoint built to end this misreading would have taught admins to distrust the one log line proving their host was reachable. The guidance now splits a 404 by its **body**, and the docs' curl uses `-i` so the body is visible at all.

2. **Chats do not register only from installation events.** `captureChatFromBotActivity` runs for `installationUpdate`, for `conversationUpdate` when the bot is added, and for any message in a personal or group chat — the last being the documented recovery path the Chats card itself recommends. The markdown said "only ... the installation event" while the in-product guide said "activity". Both now name all three.

## Tests

**144 passing across 5 suites**, including two new files.

The new server suite **dispatches through the real router** to prove a POST bot activity still reaches `processBotActivity` and is not intercepted by the new GET. Inspecting `route.methods` cannot see that — a `router.all()` would not even be found by a method-keyed lookup — so only real dispatch settles the one hazard this change introduces.

Also verified: `tsc --noEmit` clean over `Common`, prettier clean, docs anchor checker passes.

`ZZVerifyChatsAuth.test.ts` times out locally on this machine, but does so **identically with and without this change** (209s on the unmodified file vs 168s with it) — a 30s per-test budget consumed by `await import(...)` under load average 165, not a regression.
