### PR TITLE
feat(rum): let the session replay recorder explain why it is not recording

### DIFF
--- a/App/FeatureSet/BrowserRecorder/README.md
+++ b/App/FeatureSet/BrowserRecorder/README.md
@@ -77,6 +77,47 @@ made before it arrives.
 | `identify(userRef)` | attaches an opaque user reference (hashed server-side unless identity capture is enabled)  |
 | `stop()`            | stops recording                                                                            |
 | `getSessionId()`    | the current session id, or null                                                            |
+| `setDebug(bool)`    | turn the console diagnostics on or off for this page                                       |
+| `getDiagnostics()`  | the recorder's state plus its last 250 decisions, kept whether or not diagnostics were on  |
+
+### Diagnostics
+
+Every gate in this package fails **closed and silent**: no init options, a privacy signal, a config
+fetch that 404s behind a reverse proxy, an application somebody switched off, a deployment whose
+recorder artifact was never built, a session that lost the sample draw, a consent mode nobody
+granted, a 401 that trips the circuit breaker. Every one of those produces the same observable
+outcome on a customer's page — nothing, not even a network request — and server telemetry cannot see
+a recorder that never loaded.
+
+`src/Debug.ts` is the other half of the Dashboard's "test your installation" panel: the browser's
+side of the answer. It is **off by default** (a RUM script must not print into a customer's end
+users' consoles) and turns on without a redeploy, because the page that is failing is usually
+production:
+
+```js
+localStorage.setItem("oneuptime.sessionReplay.debug", "true"); // then reload
+```
+
+…or `?oneuptime_debug=1` on the URL, `data-oneuptime-debug="true"` on the tag, `debug: true` in the
+init global, `OneUptimeReplay.setDebug(true)` at runtime, or `SESSION_REPLAY_DEBUG=true` on the
+OneUptime deployment for every recorder it serves.
+
+Two properties are load-bearing and both have tests:
+
+- **Records are always kept; the switch gates OUTPUT.** The ring holds 250 entries, every call site
+  is a cold path (startup, a config fetch, a chunk boundary — never the rrweb emit hot path), and
+  the state lives on a global so the **loader stub** and the artifact share one timeline. So
+  `getDiagnostics()` returns the stub's records too, which are the ones that explain why the
+  artifact was never reached — and it works on a page nobody thought to instrument first.
+- **No page content, ever.** `DebugDetail` admits only primitives, values are truncated, and a
+  non-primitive handed in from untyped JavaScript is replaced with `<object omitted>` rather than
+  stringified. A diagnostics channel that could carry a DOM node would be a second, unmasked egress
+  path for exactly the data the rest of this package exists to protect.
+
+Each record carries a stable kebab-case `code`; `/docs/rum/session-replay-troubleshooting` is the
+index of what every one of them means. The messages in the bundle are deliberately terse for the
+same reason the loader has a byte budget at all — the remediation prose lives in the docs, not in
+every visitor's download.
 
 ## Two-stage load
 
@@ -263,6 +304,10 @@ defend in an incident review.
 | `src/ConsoleRecorder.ts`     | `console.error` / `console.warn` only                                     |
 | `src/RouteRecorder.ts`       | SPA navigation and forced snapshots                                       |
 | `src/FrustrationDetector.ts` | rage / dead / error clicks                                                |
+| `src/PerformanceRecorder.ts` | LCP, long tasks and slow requests — the performance trigger               |
+| `src/EarlyErrors.ts`         | the stub's pre-load error buffer, replayed through masking at start      |
+| `src/ExtendedConfig.ts`      | artifact-side normalisation of fields the stub passes through unvalidated |
+| `src/Debug.ts`               | the diagnostics switch, the record ring, and the redaction that keeps page content out of it |
 | `Manifest.ts`                | **server-side**, not bundled: reads `public/dist/manifest.json` and is the one place the published version, SRI hash and route policy come from |
 
 ## Commands
@@ -277,10 +322,18 @@ npm run analyze     # bundle composition
 
 ## Bundle weight
 
-Measured: **recorder.js 231 KB raw / 71.4 KB gzip**, **loader.js 4.9 KB raw /
-1.9 KB gzip**. Both raw AND gzip budgets are enforced by the build, which fails
+Measured: **recorder.js 245 KB raw / 75.7 KB gzip**, **loader.js 12.1 KB raw /
+4.6 KB gzip**. Both raw AND gzip budgets are enforced by the build, which fails
 rather than shipping a regression — gzip being the number a customer's browser
 actually pays.
+
+The stub was 6.5 KB raw / 2.5 KB gzip before the diagnostics module and the ~20
+decision points that report through it. That increase is real and was taken
+deliberately: the stub's entire job is to decide **not** to record, it did so
+five different ways that were indistinguishable from each other and from a
+broken installation, and the browser is the only place that answer exists.
+Roughly 1.9 KB gzip once, for output that is off unless somebody asks for it,
+against support round trips per incident.
 
 The design doc's ~52 KB gzip target is not reachable, and it is worth being
 precise about why rather than leaving it as an open action:

--- a/App/FeatureSet/BrowserRecorder/Tests/BundleHygiene.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/BundleHygiene.test.ts
@@ -99,9 +99,16 @@ describe("bundle hygiene", (): void => {
     const loaderGzip: number = manifest.files["loader.js"]?.gzipBytes || 0;
 
     expect(recorderGzip).toBeGreaterThan(0);
-    expect(recorderGzip).toBeLessThanOrEqual(76 * 1024);
+    expect(recorderGzip).toBeLessThanOrEqual(78 * 1024);
     expect(loaderGzip).toBeGreaterThan(0);
-    expect(loaderGzip).toBeLessThanOrEqual(3 * 1024);
+
+    /*
+     * Raised from 3 KB for src/Debug.ts and the decision points that report
+     * through it. esbuild.config.js carries the measurement and the reason;
+     * the two numbers are asserted in both places on purpose, because a
+     * budget only enforced by the thing being budgeted is not a budget.
+     */
+    expect(loaderGzip).toBeLessThanOrEqual(5 * 1024);
   });
 
   /*
@@ -161,7 +168,7 @@ describe("bundle hygiene", (): void => {
     /* A distinctive rrweb internal that would appear if it were bundled. */
     expect(loaderBundle).not.toContain("rrweb");
     expect(loaderBundle).not.toContain("takeFullSnapshot");
-    expect(loaderBundle.length).toBeLessThan(7 * 1024);
+    expect(loaderBundle.length).toBeLessThan(13 * 1024);
   });
 
   it("contains the recorder itself", (): void => {
@@ -179,6 +186,46 @@ describe("bundle hygiene", (): void => {
     expect(loaderBundle).toContain("/session-replay/v1/config");
     expect(loaderBundle).toContain("globalPrivacyControl");
     expect(loaderBundle).toContain("integrity");
+  });
+
+  /*
+   * The diagnostics have to survive into BOTH artifacts, and the loader's
+   * copy is the one that matters most: the stub decides five different ways
+   * not to record, all of them before the recorder artifact exists.
+   */
+  it("ships the diagnostics switch in both bundles", (): void => {
+    for (const bundle of [recorderBundle, loaderBundle]) {
+      expect(bundle).toContain("oneuptime.sessionReplay.debug");
+      expect(bundle).toContain("oneuptime_debug");
+      expect(bundle).toContain("__ONEUPTIME_SESSION_REPLAY_DEBUG__");
+    }
+  });
+
+  it("exposes getDiagnostics on the artifact's public API", (): void => {
+    expect(recorderBundle).toContain("getDiagnostics");
+    expect(recorderBundle).toContain("setDebug");
+  });
+
+  /*
+   * The output is off unless somebody asks for it. A recorder that printed
+   * on every visitor of every customer would be noise on somebody else's
+   * site, so the console calls must be reached through the enabled check
+   * rather than sprinkled across the bundle.
+   */
+  it("routes every console call in the loader through the diagnostics switch", (): void => {
+    const consoleCalls: number = (
+      loaderBundle.match(/console\.(info|warn|log|error|debug)/g) || []
+    ).length;
+
+    /*
+     * Exactly one: the unconditional misconfiguration warning, which is a
+     * setup error on the customer's own page and is meant to be seen. The
+     * diagnostics writer reaches the console through a dynamic property
+     * lookup on globalThis.console (a page may have replaced or frozen it),
+     * so it contributes no literal `console.` at all - which makes this a
+     * sharp check that no bare console call was added outside the switch.
+     */
+    expect(consoleCalls).toBe(1);
   });
 });
 

--- a/App/FeatureSet/BrowserRecorder/Tests/ConfigDiagnostics.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/ConfigDiagnostics.test.ts
@@ -1,0 +1,719 @@
+import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
+import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode";
+import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import Config, { LoaderConfig, RecorderInitOptions } from "../src/Config";
+import {
+  DebugRecord,
+  getDebugRecords,
+  getDebugSource,
+  isDebugEnabled,
+} from "../src/Debug";
+
+/*
+ * What Config.ts says out loud when an install is wrong.
+ *
+ * Every failure this file covers is invisible by construction: a missing
+ * data attribute, a 404 from the config endpoint, `enabled: false`, a
+ * masking mode this build has never heard of. All four produce exactly the
+ * same thing on the customer's page - no recording, no request, no error -
+ * so the record each one leaves behind is the ONLY thing that tells
+ * "replay is broken" apart from "replay is switched off". That makes these
+ * records behaviour rather than logging, and they are tested as behaviour.
+ *
+ * Config is driven directly rather than through the loader on purpose: the
+ * loader has its own reasons to stop early, and a diagnostic that only
+ * appears on the loader's happy path is one nobody gets when they need it.
+ */
+
+const STATE_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_DEBUG__";
+const INIT_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY__";
+
+type GlobalRecord = Record<string, unknown>;
+
+function globalRecord(): GlobalRecord {
+  return globalThis as unknown as GlobalRecord;
+}
+
+/*
+ * Diagnostics state lives on a global so the loader stub and the artifact
+ * share one timeline, which also means it survives between test cases.
+ * Every case here starts from nothing, or the previous case's `setEnabled`
+ * would make this one pass for the wrong reason.
+ */
+function resetDebugState(): void {
+  delete globalRecord()[STATE_GLOBAL];
+}
+
+function recordsFor(code: string): Array<DebugRecord> {
+  return getDebugRecords().filter((record: DebugRecord): boolean => {
+    return record.code === code;
+  });
+}
+
+function codes(): Array<string> {
+  return getDebugRecords().map((record: DebugRecord): string => {
+    return record.code;
+  });
+}
+
+function detailOf(code: string): Record<string, unknown> {
+  return (recordsFor(code)[0]?.detail || {}) as Record<string, unknown>;
+}
+
+function detailsOf(code: string): Array<Record<string, unknown>> {
+  return recordsFor(code).map(
+    (record: DebugRecord): Record<string, unknown> => {
+      return (record.detail || {}) as Record<string, unknown>;
+    },
+  );
+}
+
+describe("Config diagnostics", (): void => {
+  const validBody: Record<string, unknown> = {
+    enabled: true,
+    recorderVersion: "12.0.0",
+    maskingMode: SessionReplayMaskingMode.MaskAllText,
+    consentMode: SessionReplayConsentMode.RequireExplicit,
+    captureTrigger: SessionReplayCaptureTrigger.OnErrorOrFrustration,
+    samplePercentage: 0,
+  };
+
+  function bodyWith(extra: Record<string, unknown>): Record<string, unknown> {
+    return { enabled: true, recorderVersion: "12.0.0", ...extra };
+  }
+
+  const options: RecorderInitOptions = {
+    host: "https://oneuptime.com",
+    token: "t",
+    appIdentifier: "a",
+  };
+
+  beforeEach((): void => {
+    resetDebugState();
+
+    document.head.innerHTML = "";
+    delete globalRecord()[INIT_GLOBAL];
+
+    /*
+     * The ambient switches Debug resolves on its own. Left set by another
+     * case, any of them would turn logging on before Config ever ran and
+     * make the "stays off" assertions meaningless.
+     */
+    try {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    } catch {
+      /* jsdom always has both. */
+    }
+
+    /*
+     * Turning diagnostics on flushes the whole backlog to the console.
+     * Silenced so a passing run stays readable; every assertion below reads
+     * the records, which is what a support engineer actually gets handed.
+     */
+    jest.spyOn(console, "info").mockImplementation((): void => {
+      /* silenced */
+    });
+    jest.spyOn(console, "warn").mockImplementation((): void => {
+      /* silenced */
+    });
+  });
+
+  afterEach((): void => {
+    jest.restoreAllMocks();
+
+    document.head.innerHTML = "";
+    delete globalRecord()[INIT_GLOBAL];
+    delete globalRecord()["fetch"];
+
+    resetDebugState();
+  });
+
+  /*
+   * The switch a customer can flip without a console: it goes on the same
+   * script tag they already pasted. Debug.ts deliberately does NOT resolve
+   * this one itself (a document-wide querySelector on every page load, for
+   * a flag that is off on virtually all of them), so Config is the only
+   * thing that can apply it.
+   */
+  describe("the page's own debug switch", (): void => {
+    it("turns diagnostics on from the script tag attribute", (): void => {
+      document.head.innerHTML =
+        '<script data-oneuptime-host="https://oneuptime.com" data-oneuptime-token="t" data-oneuptime-app-identifier="a" data-oneuptime-debug="true"></script>';
+
+      expect(Config.readInitOptions()).not.toBeNull();
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("script-tag");
+    });
+
+    /*
+     * The spellings somebody actually types into an HTML attribute.
+     *
+     * The attribute used to be compared against the literal string "true"
+     * while the init global went through Debug's own resolver, which takes
+     * "1", "yes" and "on" in any case - so data-oneuptime-debug="1" silently
+     * did nothing while the equivalent global worked. On a switch whose whole
+     * purpose is being reachable by somebody who cannot get to a console, one
+     * that only works if you guess the right word is worse than none.
+     */
+    it("accepts the truthy spellings a person would type", (): void => {
+      for (const value of ["1", "yes", "TRUE", "on", "True"]) {
+        resetDebugState();
+
+        document.head.innerHTML = `<script data-oneuptime-host="https://oneuptime.com" data-oneuptime-token="t" data-oneuptime-app-identifier="a" data-oneuptime-debug="${value}"></script>`;
+
+        const read: RecorderInitOptions | null = Config.readInitOptions();
+
+        expect(read?.debug).toBe(true);
+        expect(isDebugEnabled()).toBe(true);
+      }
+    });
+
+    /*
+     * And stays off for everything else - a RUM script that starts printing
+     * into end users' consoles because an attribute was left as a templating
+     * placeholder is noise on somebody else's property.
+     */
+    it("leaves diagnostics off for a falsy or meaningless attribute value", (): void => {
+      for (const value of ["false", "0", "off", "", "{{DEBUG}}"]) {
+        resetDebugState();
+
+        document.head.innerHTML = `<script data-oneuptime-host="https://oneuptime.com" data-oneuptime-token="t" data-oneuptime-app-identifier="a" data-oneuptime-debug="${value}"></script>`;
+
+        const read: RecorderInitOptions | null = Config.readInitOptions();
+
+        expect(read).not.toBeNull();
+        expect("debug" in ((read || {}) as Record<string, unknown>)).toBe(
+          false,
+        );
+        expect(isDebugEnabled()).toBe(false);
+      }
+    });
+
+    /*
+     * The other install shape. Debug.ts resolves this same global by itself
+     * as "init-global" and Config applies it again through acceptOptions;
+     * both agree, so only the outcome is asserted - which of the two won
+     * the race is not a contract anyone depends on.
+     */
+    it("turns diagnostics on from the init global", (): void => {
+      globalRecord()[INIT_GLOBAL] = {
+        host: "https://oneuptime.com",
+        token: "t",
+        appIdentifier: "a",
+        debug: true,
+      };
+
+      expect(Config.readInitOptions()).not.toBeNull();
+      expect(isDebugEnabled()).toBe(true);
+    });
+
+    it("carries debug through into the options it returns", (): void => {
+      globalRecord()[INIT_GLOBAL] = {
+        host: "https://oneuptime.com",
+        token: "t",
+        appIdentifier: "a",
+        debug: true,
+      };
+
+      expect(Config.readInitOptions()?.debug).toBe(true);
+    });
+
+    /*
+     * Absent, not `debug: undefined`. exactOptionalPropertyTypes makes
+     * those different types, and a present-but-undefined key would spread
+     * into every `{ ...options }` downstream as an explicit "no" that
+     * overwrites whatever the server or the storage switch decided.
+     */
+    it("leaves the debug key absent when the page did not ask for it", (): void => {
+      globalRecord()[INIT_GLOBAL] = {
+        host: "https://oneuptime.com",
+        token: "t",
+        appIdentifier: "a",
+      };
+
+      const read: RecorderInitOptions | null = Config.readInitOptions();
+
+      expect(read).not.toBeNull();
+      expect("debug" in ((read || {}) as Record<string, unknown>)).toBe(false);
+    });
+
+    /*
+     * Which snippet the browser actually found, and what it made of it.
+     * "the tag is on the page but the host came out wrong" and "the global
+     * was set after the script ran" look identical from the outside.
+     */
+    it("reports which source the options came from", (): void => {
+      document.head.innerHTML =
+        '<script src="/proxy/recorder.js" data-oneuptime-token="t" data-oneuptime-app-identifier="app-42" data-oneuptime-respect-do-not-track="false"></script>';
+
+      Config.readInitOptions();
+
+      expect(detailOf("init-options-read")).toEqual({
+        source: "script-tag",
+        host: window.location.origin,
+        appIdentifier: "app-42",
+        respectDoNotTrack: false,
+      });
+    });
+
+    it("reports the init global as the source when both could apply", (): void => {
+      document.head.innerHTML =
+        '<script data-oneuptime-host="https://tag.example.com" data-oneuptime-token="t" data-oneuptime-app-identifier="from-tag"></script>';
+
+      globalRecord()[INIT_GLOBAL] = {
+        host: "https://global.example.com",
+        token: "t",
+        appIdentifier: "from-global",
+      };
+
+      Config.readInitOptions();
+
+      const detail: Record<string, unknown> = detailOf("init-options-read");
+
+      expect(detail["source"]).toBe("init-global");
+      expect(detail["appIdentifier"]).toBe("from-global");
+    });
+
+    /*
+     * WHICH field is missing, not merely that one is. "the snippet is
+     * incomplete" and "the host could not be derived from the script src"
+     * are different bugs with different fixes, and the recorder's silence
+     * is identical for both.
+     */
+    it("names the field a broken snippet is missing", (): void => {
+      document.head.innerHTML =
+        '<script data-oneuptime-token="t" data-oneuptime-app-identifier="a"></script>';
+
+      expect(Config.readInitOptions()).toBeNull();
+
+      expect(codes()).toEqual(["init-options-incomplete"]);
+      expect(detailOf("init-options-incomplete")).toEqual({
+        source: "script-tag",
+        hasHost: false,
+        hasToken: true,
+        hasAppIdentifier: true,
+      });
+    });
+  });
+
+  describe("validateConfig", (): void => {
+    /*
+     * The only switch reachable by an operator who cannot touch the
+     * customer's page, and the ordering is the whole point: it is applied
+     * BEFORE the enabled gate, so a response that says "off" can still
+     * explain itself. Applied afterwards, the one config body a customer
+     * most needs explained would be the one that returns in silence.
+     */
+    it("lets a disabled server response still turn diagnostics on", (): void => {
+      const config: LoaderConfig | null = Config.validateConfig({
+        enabled: false,
+        debug: true,
+        disabledReason: "recorder-not-built",
+      });
+
+      expect(config).toBeNull();
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("server-config");
+      expect(codes()).toContain("config-disabled");
+    });
+
+    it("reports why the server says replay is off", (): void => {
+      Config.validateConfig({
+        enabled: false,
+        disabledReason: "no-active-subscription",
+      });
+
+      expect(detailOf("config-disabled")).toEqual({
+        disabledReason: "no-active-subscription",
+      });
+    });
+
+    /*
+     * An older server sends no reason at all. The record still has to be
+     * distinguishable from one that reported an empty string, or a support
+     * engineer reads "off, reason: nothing" as a server bug.
+     */
+    it("says so when the server gave no reason", (): void => {
+      Config.validateConfig({ enabled: false });
+
+      expect(detailOf("config-disabled")["disabledReason"]).toBe(
+        "not-reported",
+      );
+    });
+
+    /*
+     * Usually a proxy, an SSO interstitial or an error page answering with
+     * HTML where JSON was expected. Indistinguishable at the call site from
+     * a server that is simply switched off.
+     */
+    it("reports a body that is not a JSON object", (): void => {
+      for (const body of [null, "enabled", 7, undefined]) {
+        resetDebugState();
+
+        expect(Config.validateConfig(body)).toBeNull();
+        expect(codes()).toEqual(["config-unparseable"]);
+      }
+    });
+
+    it("reports a recorder version no artifact could be published under", (): void => {
+      expect(
+        Config.validateConfig(bodyWith({ recorderVersion: "../../../admin" })),
+      ).toBeNull();
+
+      expect(codes()).toEqual(["config-recorder-version-invalid"]);
+      expect(detailOf("config-recorder-version-invalid")).toEqual({
+        recorderVersion: "../../../admin",
+      });
+    });
+
+    /*
+     * A deployment that never ran the recorder build sends no version at
+     * all, which is a different fix from a version that is merely
+     * malformed - so the record must not report an empty string.
+     */
+    it("says the version is missing rather than blank", (): void => {
+      expect(Config.validateConfig({ enabled: true })).toBeNull();
+
+      expect(
+        detailOf("config-recorder-version-invalid")["recorderVersion"],
+      ).toBe("missing");
+    });
+
+    /*
+     * The combination that explains nearly every "replay is on but there
+     * are no requests in the network tab": OnErrorOrFrustration with a
+     * sample percentage of 0 records into memory and uploads NOTHING until
+     * something goes wrong. Working as designed, and indistinguishable
+     * from broken without this line.
+     */
+    it("prints the policy it accepted", (): void => {
+      Config.validateConfig(validBody);
+
+      const detail: Record<string, unknown> = detailOf("config-accepted");
+
+      expect(detail["captureTrigger"]).toBe(
+        SessionReplayCaptureTrigger.OnErrorOrFrustration,
+      );
+      expect(detail["samplePercentage"]).toBe(0);
+      expect(detail["consentMode"]).toBe(
+        SessionReplayConsentMode.RequireExplicit,
+      );
+      expect(detail["maskingMode"]).toBe(SessionReplayMaskingMode.MaskAllText);
+      expect(detail["recorderVersion"]).toBe("12.0.0");
+    });
+  });
+
+  /*
+   * A value this build does not recognise collapses to the STRICTEST
+   * option rather than to the one the server meant. That is the right
+   * default and a genuinely confusing one: a newer server, or a proxy
+   * rewriting the body, leaves a customer looking at MaskAllText while the
+   * dashboard shows something else entirely - and silently.
+   */
+  describe("unrecognised config values", (): void => {
+    it("names the masking mode it refused and the one it used instead", (): void => {
+      Config.validateConfig(bodyWith({ maskingMode: "MaskNothing" }));
+
+      expect(recordsFor("config-value-unrecognised")).toHaveLength(1);
+      expect(detailOf("config-value-unrecognised")).toEqual({
+        field: "maskingMode",
+        sent: "MaskNothing",
+        using: SessionReplayMaskingMode.MaskAllText,
+      });
+    });
+
+    it("names an unrecognised consent mode", (): void => {
+      Config.validateConfig(bodyWith({ consentMode: "ImpliedByVisit" }));
+
+      expect(detailOf("config-value-unrecognised")).toEqual({
+        field: "consentMode",
+        sent: "ImpliedByVisit",
+        using: SessionReplayConsentMode.RequireExplicit,
+      });
+    });
+
+    it("names an unrecognised capture trigger", (): void => {
+      Config.validateConfig(bodyWith({ captureTrigger: "OnRageClickOnly" }));
+
+      expect(detailOf("config-value-unrecognised")).toEqual({
+        field: "captureTrigger",
+        sent: "OnRageClickOnly",
+        using: SessionReplayCaptureTrigger.OnErrorOrFrustration,
+      });
+    });
+
+    /*
+     * One record per field, not one for the body. Three quietly downgraded
+     * policies is a different conversation from one, and a single summary
+     * record would hide two of them.
+     */
+    it("warns once per field when several values are unknown", (): void => {
+      Config.validateConfig(
+        bodyWith({
+          maskingMode: "MaskNothing",
+          consentMode: "ImpliedByVisit",
+          captureTrigger: "OnRageClickOnly",
+        }),
+      );
+
+      expect(
+        detailsOf("config-value-unrecognised").map(
+          (detail: Record<string, unknown>): unknown => {
+            return detail["field"];
+          },
+        ),
+      ).toEqual(["maskingMode", "consentMode", "captureTrigger"]);
+    });
+
+    /*
+     * A tampered or garbled body can send a number where an enum belongs.
+     * The type is reported instead of the value so the record still says
+     * something useful without stringifying whatever arrived.
+     */
+    it("reports the type when the value is not even a string", (): void => {
+      Config.validateConfig(bodyWith({ maskingMode: 7 }));
+
+      expect(detailOf("config-value-unrecognised")["sent"]).toBe("number");
+    });
+
+    /*
+     * The noise floor. This warning has to mean something, and a recorder
+     * that warns about every policy it correctly understood trains people
+     * to scroll past the one time it matters.
+     */
+    it("stays quiet when every value is recognised", (): void => {
+      for (const maskingMode of [
+        SessionReplayMaskingMode.MaskAllText,
+        SessionReplayMaskingMode.MaskInputsOnly,
+        SessionReplayMaskingMode.MaskSensitiveInputsOnly,
+      ]) {
+        resetDebugState();
+
+        Config.validateConfig(
+          bodyWith({
+            maskingMode: maskingMode,
+            consentMode: SessionReplayConsentMode.NotRequired,
+            captureTrigger: SessionReplayCaptureTrigger.Always,
+          }),
+        );
+
+        expect(codes()).toEqual(["config-accepted"]);
+      }
+    });
+
+    /*
+     * An absent field is an older server, not a downgrade: the recorder
+     * chose the strict default because nothing was sent, which is not a
+     * discrepancy worth reporting.
+     */
+    it("stays quiet when the field was never sent", (): void => {
+      Config.validateConfig(bodyWith({}));
+
+      expect(codes()).toEqual(["config-accepted"]);
+    });
+  });
+
+  describe("fetchConfig", (): void => {
+    /*
+     * The exact URL, because the single most common cause of a silent
+     * recorder is a request that never reached the OneUptime router: a
+     * host with a typo, a missing /telemetry prefix, an nginx catch-all
+     * answering 404 while the CORS preflight succeeds. The URL in this
+     * record is what someone pastes into curl.
+     */
+    it("names the url it is about to request", async (): Promise<void> => {
+      globalRecord()["fetch"] = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async (): Promise<unknown> => {
+          return validBody;
+        },
+      });
+
+      await Config.fetchConfig(options);
+
+      expect(detailOf("config-fetch-start")["url"]).toBe(
+        "https://oneuptime.com/telemetry/session-replay/v1/config",
+      );
+      expect(codes()).toEqual(["config-fetch-start", "config-accepted"]);
+    });
+
+    /*
+     * The status is the whole diagnosis and each one points somewhere
+     * completely different: 401 is a key in Project Settings, 404 is a
+     * route, 403 is usually a header the tag never sent.
+     */
+    it("reports the status when the endpoint refuses", async (): Promise<void> => {
+      globalRecord()["fetch"] = jest
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401 });
+
+      expect(await Config.fetchConfig(options)).toBeNull();
+
+      expect(codes()).toEqual(["config-fetch-start", "config-fetch-rejected"]);
+      expect(detailOf("config-fetch-rejected")).toEqual({
+        url: "https://oneuptime.com/telemetry/session-replay/v1/config",
+        status: 401,
+      });
+    });
+
+    /*
+     * DNS, TLS, offline, an ad blocker, or a CSP connect-src that does not
+     * list the OneUptime origin. The browser prints its own message for
+     * some of these and nothing at all for others, and none of them reach
+     * the page as an error it could report.
+     */
+    it("reports a fetch that never completed", async (): Promise<void> => {
+      globalRecord()["fetch"] = jest
+        .fn()
+        .mockRejectedValue(new Error("Failed to fetch"));
+
+      expect(await Config.fetchConfig(options)).toBeNull();
+
+      expect(codes()).toEqual(["config-fetch-start", "config-fetch-failed"]);
+      expect(detailOf("config-fetch-failed")["url"]).toBe(
+        "https://oneuptime.com/telemetry/session-replay/v1/config",
+      );
+    });
+
+    /*
+     * A 200 whose body will not parse - an HTML login page, a captive
+     * portal, an SSO interstitial, or an error page from something in front
+     * of the router.
+     *
+     * Reported separately from a rejected fetch, and the distinction is the
+     * whole value of the record: "the request never left the browser" points
+     * at a CSP or an ad blocker, while "something answered 200 with HTML"
+     * points at the network path. These used to share one catch and one
+     * code, which sent the reader to the wrong one of the two.
+     */
+    it("distinguishes a body that will not parse from a request that failed", async (): Promise<void> => {
+      globalRecord()["fetch"] = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async (): Promise<unknown> => {
+          throw new Error("Unexpected token < in JSON");
+        },
+      });
+
+      expect(await Config.fetchConfig(options)).toBeNull();
+
+      expect(codes()).toEqual([
+        "config-fetch-start",
+        "config-body-unparseable",
+      ]);
+
+      /* The status is what says the request DID complete. */
+      expect(detailOf("config-body-unparseable")["status"]).toBe(200);
+    });
+
+    /*
+     * A rejected body still gets validated, so the fetch record and the
+     * reason it was refused arrive as one timeline rather than two.
+     */
+    it("keeps the fetch and the validation on one timeline", async (): Promise<void> => {
+      globalRecord()["fetch"] = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async (): Promise<unknown> => {
+          return { enabled: false, disabledReason: "not-sampled" };
+        },
+      });
+
+      expect(await Config.fetchConfig(options)).toBeNull();
+
+      expect(codes()).toEqual(["config-fetch-start", "config-disabled"]);
+    });
+  });
+
+  /*
+   * Diagnostics are printed into an end user's console and pasted into
+   * support tickets, so the channel has exactly one rule: it carries no
+   * secret and no page data. The two values that would do real damage are
+   * the ingestion token (it writes to the customer's telemetry) and the
+   * userRef (it identifies a human being).
+   */
+  describe("what a record may never contain", (): void => {
+    const token: string = "tok-DO-NOT-LOG-9f3c1d";
+    const userRef: string = "user-DO-NOT-LOG-4271";
+
+    function initWithSecrets(): RecorderInitOptions {
+      globalRecord()[INIT_GLOBAL] = {
+        host: "https://oneuptime.com",
+        token: token,
+        appIdentifier: "app-1",
+        userRef: userRef,
+
+        /* On, so the console path is exercised too, not just the ring. */
+        debug: true,
+      };
+
+      const read: RecorderInitOptions | null = Config.readInitOptions();
+
+      expect(read).not.toBeNull();
+
+      return read as RecorderInitOptions;
+    }
+
+    it("keeps the token and the userRef out of a successful run", async (): Promise<void> => {
+      const read: RecorderInitOptions = initWithSecrets();
+
+      globalRecord()["fetch"] = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async (): Promise<unknown> => {
+          return validBody;
+        },
+      });
+
+      expect(await Config.fetchConfig(read)).not.toBeNull();
+
+      const serialised: string = JSON.stringify(getDebugRecords());
+
+      /* Guard against the assertion passing because nothing was recorded. */
+      expect(getDebugRecords().length).toBeGreaterThan(2);
+      expect(serialised).not.toContain(token);
+      expect(serialised).not.toContain(userRef);
+    });
+
+    /*
+     * The failure path specifically: it is the one where a future "let us
+     * log the request we sent" would dump the headers, and the token and
+     * the userRef both travel as headers.
+     */
+    it("keeps them out of a failed run too", async (): Promise<void> => {
+      const read: RecorderInitOptions = initWithSecrets();
+
+      globalRecord()["fetch"] = jest
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401 });
+
+      expect(await Config.fetchConfig(read)).toBeNull();
+
+      const serialised: string = JSON.stringify(getDebugRecords());
+
+      expect(codes()).toContain("config-fetch-rejected");
+      expect(serialised).not.toContain(token);
+      expect(serialised).not.toContain(userRef);
+    });
+
+    /*
+     * The server's own body is not a safe source either. Nothing the
+     * server sends is echoed into a record except the policy fields, so a
+     * value parked in an unrelated key cannot ride the diagnostics channel
+     * back out into a console.
+     */
+    it("does not echo unrelated fields from the server body", (): void => {
+      Config.validateConfig(
+        bodyWith({
+          internalNote: "leak-DO-NOT-LOG-88",
+          apiKey: "leak-DO-NOT-LOG-99",
+        }),
+      );
+
+      expect(JSON.stringify(getDebugRecords())).not.toContain("DO-NOT-LOG");
+    });
+  });
+});

--- a/App/FeatureSet/BrowserRecorder/Tests/Debug.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/Debug.test.ts
@@ -1,0 +1,675 @@
+import {
+  DEBUG_STORAGE_KEY,
+  DebugRecord,
+  MAX_DEBUG_RECORDS,
+  MAX_DEBUG_VALUE_LENGTH,
+  clearDebugRecords,
+  debugLog,
+  debugWarn,
+  getDebugRecords,
+  getDebugSource,
+  isDebugEnabled,
+  setEnabled,
+} from "../src/Debug";
+
+/*
+ * The diagnostics module.
+ *
+ * Two properties matter more than any individual log line, and both are
+ * asserted here rather than left to review:
+ *
+ * 1. It is OFF unless somebody asked. This code runs on a customer's site in
+ *    THEIR end users' browsers; printing there unasked is noise on somebody
+ *    else's property, and a recorder that chatters is one a customer removes.
+ *
+ * 2. It cannot carry page content. `DebugDetail` admits only primitives at
+ *    the type level, but the API is reachable from untyped JavaScript on a
+ *    global, so the runtime has to refuse a DOM node too. A diagnostics
+ *    channel that could print a password field would be a second, unmasked
+ *    egress path for exactly the data this package exists to protect.
+ */
+
+const STATE_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_DEBUG__";
+
+type GlobalRecord = Record<string, unknown>;
+
+function globalRecord(): GlobalRecord {
+  return globalThis as unknown as GlobalRecord;
+}
+
+/*
+ * The state lives on a global so the two bundles share one timeline, which
+ * means it also survives between test cases. Every case starts from nothing.
+ */
+function resetDebugState(): void {
+  delete globalRecord()[STATE_GLOBAL];
+}
+
+/*
+ * jsdom treats an assignment to window.location as a navigation, and its
+ * Location properties are not configurable - so the query string is changed
+ * the way a real page would change it.
+ */
+function setUrl(relative: string): void {
+  window.history.replaceState({}, "", relative);
+}
+
+interface ConsoleSpies {
+  info: jest.Mock;
+  warn: jest.Mock;
+}
+
+function spyOnConsole(): ConsoleSpies {
+  const spies: ConsoleSpies = {
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  jest
+    .spyOn(console, "info")
+    .mockImplementation((...args: Array<unknown>): void => {
+      spies.info(...args);
+    });
+
+  jest
+    .spyOn(console, "warn")
+    .mockImplementation((...args: Array<unknown>): void => {
+      spies.warn(...args);
+    });
+
+  return spies;
+}
+
+function allConsoleText(spies: ConsoleSpies): string {
+  return [...spies.info.mock.calls, ...spies.warn.mock.calls]
+    .map((call: Array<unknown>): string => {
+      return call
+        .map((argument: unknown): string => {
+          return typeof argument === "string"
+            ? argument
+            : JSON.stringify(argument);
+        })
+        .join(" ");
+    })
+    .join("\n");
+}
+
+describe("Debug", (): void => {
+  let spies: ConsoleSpies;
+
+  beforeEach((): void => {
+    resetDebugState();
+
+    try {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    } catch {
+      /* jsdom always has both; a hostile environment is tested separately. */
+    }
+
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY__"];
+
+    spies = spyOnConsole();
+  });
+
+  afterEach((): void => {
+    jest.restoreAllMocks();
+    resetDebugState();
+    setUrl("/checkout");
+  });
+
+  describe("the switch", (): void => {
+    it("is off by default, and prints nothing", (): void => {
+      expect(isDebugEnabled()).toBe(false);
+
+      debugLog("something", "A thing happened.");
+      debugWarn("something-else", "A worse thing happened.");
+
+      expect(spies.info).not.toHaveBeenCalled();
+      expect(spies.warn).not.toHaveBeenCalled();
+    });
+
+    it("turns on from localStorage", (): void => {
+      window.localStorage.setItem(DEBUG_STORAGE_KEY, "true");
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("local-storage");
+    });
+
+    it("turns on from sessionStorage", (): void => {
+      window.sessionStorage.setItem(DEBUG_STORAGE_KEY, "1");
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("session-storage");
+    });
+
+    it("accepts the truthy spellings a human would actually type", (): void => {
+      for (const value of ["true", "TRUE", "1", "yes", "on"]) {
+        resetDebugState();
+        window.localStorage.setItem(DEBUG_STORAGE_KEY, value);
+
+        expect(isDebugEnabled()).toBe(true);
+      }
+    });
+
+    it("stays off for a falsy stored value", (): void => {
+      for (const value of ["false", "0", "off", "", "maybe"]) {
+        resetDebugState();
+        window.localStorage.setItem(DEBUG_STORAGE_KEY, value);
+
+        expect(isDebugEnabled()).toBe(false);
+      }
+    });
+
+    /*
+     * The switch a support engineer can send in a link. It has to work
+     * without asking the customer to open a console at all, which is what
+     * makes it the one to reach for with a non-technical reporter.
+     *
+     * Driven through history.replaceState rather than by assigning
+     * globalThis.location, which jsdom treats as a navigation.
+     */
+    it("turns on from a query parameter", (): void => {
+      setUrl("?a=1&oneuptime_debug=1");
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("query-param");
+    });
+
+    it("turns on from a bare query parameter and from the fragment", (): void => {
+      for (const url of ["?oneuptime_debug", "#oneuptime_debug=true"]) {
+        resetDebugState();
+        setUrl(url);
+
+        expect(isDebugEnabled()).toBe(true);
+      }
+    });
+
+    /*
+     * `?oneuptime_debug=0` must not enable it, so a link that turns it OFF
+     * reads the way anyone would expect.
+     */
+    it("does not turn on for an explicitly falsy query parameter", (): void => {
+      setUrl("?oneuptime_debug=0");
+
+      expect(isDebugEnabled()).toBe(false);
+    });
+
+    it("does not turn on for a parameter that merely contains the name", (): void => {
+      setUrl("?not_oneuptime_debugging=1");
+
+      expect(isDebugEnabled()).toBe(false);
+    });
+
+    it("turns on from the init global before any script tag is read", (): void => {
+      globalRecord()["__ONEUPTIME_SESSION_REPLAY__"] = {
+        host: "https://oneuptime.com",
+        token: "t",
+        appIdentifier: "a",
+        debug: true,
+      };
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("init-global");
+    });
+
+    it("can be turned on and off explicitly", (): void => {
+      setEnabled(true, "api");
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("api");
+
+      setEnabled(false, "api");
+      expect(isDebugEnabled()).toBe(false);
+    });
+
+    /*
+     * An explicit call must beat the ambient switches in BOTH directions;
+     * otherwise setDebug(false) would be undone by the first lazy resolve.
+     */
+    it("keeps an explicit off even when a storage switch is set", (): void => {
+      window.localStorage.setItem(DEBUG_STORAGE_KEY, "true");
+
+      setEnabled(false, "api");
+
+      expect(isDebugEnabled()).toBe(false);
+    });
+
+    /*
+     * THE accessor case, and the one that matters most.
+     *
+     * `window.localStorage` throws SecurityError on the PROPERTY READ - not
+     * on getItem - in an <iframe sandbox> without allow-same-origin and
+     * wherever the user has blocked site data for the origin. Guarding only
+     * getItem is therefore not enough, and getting this wrong is not a
+     * missing log line: `debugLog("loader-start", ...)` is the first
+     * statement of Loader.load(), so a throw here rejects load() before the
+     * init options are even read, the top-level catch swallows it, and
+     * session replay dies on that page with no recording, no request and no
+     * output. That is precisely the failure this whole module exists to end,
+     * reintroduced at the top of the loader.
+     */
+    it("survives a storage property accessor that throws", (): void => {
+      const original: PropertyDescriptor | undefined =
+        Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        get: (): never => {
+          throw new Error("SecurityError");
+        },
+      });
+
+      try {
+        expect((): boolean => {
+          return isDebugEnabled();
+        }).not.toThrow();
+
+        expect(isDebugEnabled()).toBe(false);
+
+        /* And the records still work, which is what the loader relies on. */
+        expect((): void => {
+          debugLog("loader-start", "Loader running.");
+        }).not.toThrow();
+
+        expect(getDebugRecords()).toHaveLength(1);
+      } finally {
+        if (original) {
+          Object.defineProperty(globalThis, "localStorage", original);
+        } else {
+          delete (globalThis as unknown as Record<string, unknown>)[
+            "localStorage"
+          ];
+        }
+      }
+    });
+
+    /*
+     * A page that froze globalThis makes the state assignment throw in
+     * strict mode. Losing the shared timeline is acceptable; throwing out of
+     * the loader's first statement is not.
+     */
+    it("survives a global object it cannot write to", (): void => {
+      const record: Record<string, unknown> = globalRecord();
+      const original: PropertyDescriptor | undefined =
+        Object.getOwnPropertyDescriptor(record, STATE_GLOBAL);
+
+      Object.defineProperty(record, STATE_GLOBAL, {
+        configurable: true,
+        get: (): undefined => {
+          return undefined;
+        },
+        set: (): never => {
+          throw new TypeError("Cannot add property, object is not extensible");
+        },
+      });
+
+      try {
+        expect((): void => {
+          debugLog("loader-start", "Loader running.");
+        }).not.toThrow();
+      } finally {
+        delete record[STATE_GLOBAL];
+
+        if (original) {
+          Object.defineProperty(record, STATE_GLOBAL, original);
+        }
+      }
+    });
+
+    /*
+     * getItem throws separately from the accessor - Safari private mode, and
+     * anywhere site data is blocked after the accessor itself succeeds.
+     */
+    it("survives a storage getItem that throws", (): void => {
+      jest
+        .spyOn(Object.getPrototypeOf(window.localStorage) as Storage, "getItem")
+        .mockImplementation((): never => {
+          throw new Error("SecurityError");
+        });
+
+      expect((): boolean => {
+        return isDebugEnabled();
+      }).not.toThrow();
+
+      expect(isDebugEnabled()).toBe(false);
+    });
+
+    it("survives a state global some other script parked a string on", (): void => {
+      globalRecord()[STATE_GLOBAL] = "hijacked";
+
+      expect((): void => {
+        debugLog("code", "message");
+      }).not.toThrow();
+
+      expect(getDebugRecords()).toHaveLength(1);
+    });
+  });
+
+  describe("records", (): void => {
+    /*
+     * The point of keeping records while switched off: a support engineer
+     * can ask for getDiagnostics() on a page nobody had instrumented, and
+     * get the whole timeline back without a reload.
+     */
+    it("are kept even when logging is off", (): void => {
+      debugLog("first", "one");
+      debugWarn("second", "two");
+
+      const records: Array<DebugRecord> = getDebugRecords();
+
+      expect(
+        records.map((r: DebugRecord): string => {
+          return r.code;
+        }),
+      ).toEqual(["first", "second"]);
+      expect(records[0]?.level).toBe("info");
+      expect(records[1]?.level).toBe("warn");
+      expect(spies.info).not.toHaveBeenCalled();
+    });
+
+    it("carry a timestamp and the detail supplied", (): void => {
+      debugLog("code", "message", {
+        status: 404,
+        url: "https://x.example.com",
+      });
+
+      const record: DebugRecord | undefined = getDebugRecords()[0];
+
+      expect(typeof record?.atUnixMs).toBe("number");
+      expect(record?.detail).toEqual({
+        status: 404,
+        url: "https://x.example.com",
+      });
+    });
+
+    it("are bounded, dropping the oldest first", (): void => {
+      for (let index: number = 0; index < MAX_DEBUG_RECORDS + 25; index++) {
+        debugLog(`code-${index}`, "message");
+      }
+
+      const records: Array<DebugRecord> = getDebugRecords();
+
+      expect(records).toHaveLength(MAX_DEBUG_RECORDS);
+      expect(records[0]?.code).toBe("code-25");
+      expect(records[records.length - 1]?.code).toBe(
+        `code-${MAX_DEBUG_RECORDS + 24}`,
+      );
+    });
+
+    it("are returned as a copy the caller cannot mutate", (): void => {
+      debugLog("code", "message");
+
+      getDebugRecords().push({
+        atUnixMs: 0,
+        level: "info",
+        code: "injected",
+        message: "",
+      });
+
+      expect(getDebugRecords()).toHaveLength(1);
+    });
+
+    it("can be cleared", (): void => {
+      debugLog("code", "message");
+      clearDebugRecords();
+
+      expect(getDebugRecords()).toEqual([]);
+    });
+  });
+
+  describe("output", (): void => {
+    it("prints the code and message once enabled", (): void => {
+      setEnabled(true, "api");
+
+      debugLog("config-accepted", "Policy accepted.");
+
+      expect(allConsoleText(spies)).toContain(
+        "[OneUptime Session Replay] config-accepted: Policy accepted.",
+      );
+    });
+
+    it("uses console.warn for a warning and console.info for a log", (): void => {
+      setEnabled(true, "api");
+
+      debugLog("fine", "fine");
+      debugWarn("bad", "bad");
+
+      expect(spies.info.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The backlog flush. The server-driven switch and the script tag
+     * attribute both arrive AFTER the loader has already decided several
+     * things, and those earlier decisions are usually the answer - so
+     * enabling has to reach back, not just forward.
+     */
+    it("flushes everything recorded before it was enabled", (): void => {
+      debugLog("loader-start", "Session replay loader running.");
+      debugWarn("config-disabled", "Replay is off for this application.");
+
+      expect(spies.warn).not.toHaveBeenCalled();
+
+      setEnabled(true, "server-config");
+
+      const text: string = allConsoleText(spies);
+
+      expect(text).toContain("loader-start");
+      expect(text).toContain("config-disabled");
+    });
+
+    it("says how it was switched on, and how to switch it off", (): void => {
+      setEnabled(true, "local-storage");
+
+      expect(allConsoleText(spies)).toContain(DEBUG_STORAGE_KEY);
+    });
+
+    it("does not re-flush the backlog when enabled twice", (): void => {
+      debugLog("one", "one");
+
+      setEnabled(true, "api");
+      const afterFirst: number = spies.info.mock.calls.length;
+
+      setEnabled(true, "api");
+
+      expect(spies.info.mock.calls.length).toBe(afterFirst);
+    });
+
+    it("survives a page that removed console.info", (): void => {
+      setEnabled(true, "api");
+
+      const original: unknown = (console as unknown as Record<string, unknown>)[
+        "info"
+      ];
+
+      (console as unknown as Record<string, unknown>)["info"] = undefined;
+
+      expect((): void => {
+        debugLog("code", "message");
+      }).not.toThrow();
+
+      (console as unknown as Record<string, unknown>)["info"] = original;
+    });
+
+    it("survives a console method that throws", (): void => {
+      setEnabled(true, "api");
+
+      jest.spyOn(console, "info").mockImplementation((): void => {
+        throw new Error("frozen console");
+      });
+
+      expect((): void => {
+        debugLog("code", "message");
+      }).not.toThrow();
+
+      /* The record is still kept even though printing it failed. */
+      expect(
+        getDebugRecords().some((r: DebugRecord): boolean => {
+          return r.code === "code";
+        }),
+      ).toBe(true);
+    });
+  });
+
+  /*
+   * The privacy boundary. Every case here is a value that must NOT survive
+   * into a record, because a record is printed to a console and handed to
+   * support.
+   */
+  describe("redaction", (): void => {
+    it("keeps primitives verbatim", (): void => {
+      debugLog("code", "message", {
+        text: "ok",
+        count: 7,
+        flag: false,
+        missing: null,
+      });
+
+      expect(getDebugRecords()[0]?.detail).toEqual({
+        text: "ok",
+        count: 7,
+        flag: false,
+        missing: null,
+      });
+    });
+
+    it("refuses a DOM node rather than stringifying it", (): void => {
+      const input: HTMLInputElement = document.createElement("input");
+
+      input.value = "hunter2";
+
+      debugLog("code", "message", {
+        element: input,
+      } as unknown as Record<string, string>);
+
+      const detail: Record<string, unknown> = (getDebugRecords()[0]?.detail ||
+        {}) as Record<string, unknown>;
+
+      expect(detail["element"]).toBe("<object omitted>");
+      expect(JSON.stringify(detail)).not.toContain("hunter2");
+    });
+
+    it("refuses objects, arrays and functions", (): void => {
+      debugLog("code", "message", {
+        object: { secret: "s3cret" },
+        array: ["s3cret"],
+        fn: (): string => {
+          return "s3cret";
+        },
+      } as unknown as Record<string, string>);
+
+      const detail: Record<string, unknown> = (getDebugRecords()[0]?.detail ||
+        {}) as Record<string, unknown>;
+
+      expect(detail["object"]).toBe("<object omitted>");
+      expect(detail["array"]).toBe("<object omitted>");
+      expect(detail["fn"]).toBe("<function omitted>");
+      expect(JSON.stringify(detail)).not.toContain("s3cret");
+    });
+
+    it("omits an undefined value entirely", (): void => {
+      debugLog("code", "message", {
+        present: "yes",
+        absent: undefined,
+      } as unknown as Record<string, string>);
+
+      const detail: Record<string, unknown> = (getDebugRecords()[0]?.detail ||
+        {}) as Record<string, unknown>;
+
+      expect("absent" in detail).toBe(false);
+      expect(detail["present"]).toBe("yes");
+    });
+
+    /*
+     * The bound that stops a long value - a stack, a serialised body someone
+     * passed by mistake - from riding into the console in full.
+     */
+    it("truncates a long string", (): void => {
+      const long: string = "x".repeat(MAX_DEBUG_VALUE_LENGTH + 500);
+
+      debugLog("code", "message", { value: long });
+
+      const value: unknown = (
+        (getDebugRecords()[0]?.detail || {}) as Record<string, unknown>
+      )["value"];
+
+      expect(String(value)).toHaveLength(MAX_DEBUG_VALUE_LENGTH + 1);
+      expect(String(value).endsWith("…")).toBe(true);
+    });
+
+    it("does not truncate a string at the limit", (): void => {
+      const exact: string = "x".repeat(MAX_DEBUG_VALUE_LENGTH);
+
+      debugLog("code", "message", { value: exact });
+
+      expect(
+        ((getDebugRecords()[0]?.detail || {}) as Record<string, unknown>)[
+          "value"
+        ],
+      ).toBe(exact);
+    });
+
+    it("keeps a non-finite number legible instead of dropping it", (): void => {
+      debugLog("code", "message", { a: NaN, b: Infinity });
+
+      const detail: Record<string, unknown> = (getDebugRecords()[0]?.detail ||
+        {}) as Record<string, unknown>;
+
+      expect(detail["a"]).toBe("NaN");
+      expect(detail["b"]).toBe("Infinity");
+    });
+
+    it("redacts before printing, not only before storing", (): void => {
+      setEnabled(true, "api");
+
+      const input: HTMLInputElement = document.createElement("input");
+
+      input.value = "hunter2";
+
+      debugLog("code", "message", {
+        element: input,
+      } as unknown as Record<string, string>);
+
+      expect(allConsoleText(spies)).not.toContain("hunter2");
+    });
+  });
+
+  /*
+   * The loader stub and the artifact are two separate bundles with two
+   * separate module instances. Without the shared global, getDiagnostics()
+   * on the artifact would be missing precisely the records that explain why
+   * the artifact was never reached.
+   */
+  describe("shared state", (): void => {
+    it("keeps one timeline across module instances", (): void => {
+      debugLog("from-loader", "the stub recorded this");
+
+      jest.resetModules();
+
+      /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+      const reloaded: typeof import("../src/Debug") = jest.requireActual(
+        "../src/Debug",
+      ) as typeof import("../src/Debug");
+
+      reloaded.debugLog("from-artifact", "the artifact recorded this");
+
+      expect(
+        reloaded.getDebugRecords().map((r: DebugRecord): string => {
+          return r.code;
+        }),
+      ).toEqual(["from-loader", "from-artifact"]);
+    });
+
+    it("carries an enable decision across module instances", (): void => {
+      setEnabled(true, "api");
+
+      jest.resetModules();
+
+      const reloaded: typeof import("../src/Debug") = jest.requireActual(
+        "../src/Debug",
+      ) as typeof import("../src/Debug");
+
+      expect(reloaded.isDebugEnabled()).toBe(true);
+    });
+  });
+});

--- a/App/FeatureSet/BrowserRecorder/Tests/DiagnosticsApi.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/DiagnosticsApi.test.ts
@@ -1,0 +1,567 @@
+import { SessionReplayConfigResponse } from "Common/Types/Rum/SessionReplay";
+import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
+import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode";
+import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import { RecorderInitOptions } from "../src/Config";
+import {
+  DebugRecord,
+  debugLog,
+  getDebugRecords,
+  getDebugSource,
+  isDebugEnabled,
+} from "../src/Debug";
+import { SessionReplayDiagnostics } from "../src/Index";
+
+/*
+ * The public diagnostics surface: OneUptimeReplay.setDebug() and
+ * OneUptimeReplay.getDiagnostics().
+ *
+ * This is the pair a support engineer asks a customer to paste into the
+ * console of the page that is misbehaving, so the properties that matter are
+ * the unglamorous ones: it answers on a page where the recorder never
+ * started, it answers whether or not anybody remembered to turn logging on
+ * first, and it carries the LOADER's decisions - the ones made before this
+ * bundle existed - because those are usually the answer.
+ *
+ * The gates are covered here from the outside for the same reason: every one
+ * of them ends in "nothing recorded, no request, no output", and the only
+ * thing that tells them apart on a customer's machine is the code each one
+ * leaves behind.
+ */
+
+const INIT_OPTIONS: RecorderInitOptions = {
+  host: "https://oneuptime.com",
+  token: "tok",
+  appIdentifier: "app-1",
+  respectDoNotTrack: true,
+};
+
+function baseConfig(): SessionReplayConfigResponse {
+  return {
+    enabled: true,
+    recorderVersion: "11.7.3",
+    maskingMode: SessionReplayMaskingMode.MaskAllText,
+    captureTrigger: SessionReplayCaptureTrigger.OnErrorOrFrustration,
+    consentMode: SessionReplayConsentMode.NotRequired,
+    samplePercentage: 0,
+    maskSelectors: [],
+    blockSelectors: [],
+    urlAllowlist: [],
+    ignoreErrorPatterns: [],
+    recordCanvas: false,
+    captureUserIdentity: false,
+    respectDoNotTrack: true,
+    configEpoch: 1,
+    directive: "continue",
+  };
+}
+
+type GlobalRecord = Record<string, unknown>;
+
+function globalRecord(): GlobalRecord {
+  return globalThis as unknown as GlobalRecord;
+}
+
+function codesIn(records: Array<DebugRecord>): Array<string> {
+  return records.map((record: DebugRecord): string => {
+    return record.code;
+  });
+}
+
+/* The shared timeline, which both bundles and every test case write into. */
+function codes(): Array<string> {
+  return codesIn(getDebugRecords());
+}
+
+function detailOf(code: string): Record<string, unknown> {
+  const record: DebugRecord | undefined = getDebugRecords().find(
+    (candidate: DebugRecord): boolean => {
+      return candidate.code === code;
+    },
+  );
+
+  return (record?.detail || {}) as Record<string, unknown>;
+}
+
+interface ConsoleSpies {
+  info: jest.Mock;
+  warn: jest.Mock;
+}
+
+function spyOnConsole(): ConsoleSpies {
+  const spies: ConsoleSpies = {
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  jest
+    .spyOn(console, "info")
+    .mockImplementation((...args: Array<unknown>): void => {
+      spies.info(...args);
+    });
+
+  jest
+    .spyOn(console, "warn")
+    .mockImplementation((...args: Array<unknown>): void => {
+      spies.warn(...args);
+    });
+
+  return spies;
+}
+
+function allConsoleText(spies: ConsoleSpies): string {
+  return [...spies.info.mock.calls, ...spies.warn.mock.calls]
+    .map((call: Array<unknown>): string => {
+      return call
+        .map((argument: unknown): string => {
+          return typeof argument === "string"
+            ? argument
+            : JSON.stringify(argument);
+        })
+        .join(" ");
+    })
+    .join("\n");
+}
+
+describe("Diagnostics API", (): void => {
+  let fetchMock: jest.Mock;
+
+  /*
+   * jsdom's navigator has no globalPrivacyControl at all, so the signal is
+   * defined onto it rather than assigned - and redefined back to false for
+   * every case, because a leaked `true` would silently turn every later
+   * bootstrap into a privacy-signal no-op.
+   */
+  const setPrivacySignal: (value: boolean) => void = (value: boolean): void => {
+    Object.defineProperty(window.navigator, "globalPrivacyControl", {
+      configurable: true,
+      value: value,
+    });
+  };
+
+  beforeEach((): void => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    document.head.innerHTML = "";
+    document.body.innerHTML = "<div id='app'><p>content</p></div>";
+
+    delete globalRecord()["CompressionStream"];
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY_STARTED__"];
+    delete globalRecord()["OneUptimeReplayQueue"];
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY__"];
+
+    /*
+     * The diagnostics state lives on a global so the stub and the artifact
+     * share one timeline - which also means it survives between test cases.
+     * Every case starts from an empty ring and a switch that is off.
+     */
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY_DEBUG__"];
+
+    setPrivacySignal(false);
+
+    fetchMock = jest.fn().mockResolvedValue({
+      status: 202,
+      headers: {
+        get: (): string | null => {
+          return null;
+        },
+      },
+      text: async (): Promise<string> => {
+        return "";
+      },
+    });
+
+    globalRecord()["fetch"] = fetchMock;
+    (window as unknown as Record<string, unknown>)["fetch"] = fetchMock;
+  });
+
+  afterEach((): void => {
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY_STARTED__"];
+    delete globalRecord()["OneUptimeReplayQueue"];
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY_DEBUG__"];
+    setPrivacySignal(false);
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The entry point holds module-level state - the active recorder and a
+   * page-level "already started" flag - so each case gets its own copy of
+   * the module, the way a fresh page load would.
+   */
+  const importIndex: () => Promise<
+    typeof import("../src/Index")
+  > = async (): Promise<typeof import("../src/Index")> => {
+    jest.resetModules();
+    return await import("../src/Index");
+  };
+
+  const tick: () => Promise<void> = async (): Promise<void> => {
+    await new Promise<void>((resolve: () => void): void => {
+      setTimeout(resolve, 0);
+    });
+  };
+
+  describe("getDiagnostics", (): void => {
+    it("answers on a page where nothing ever started", async (): Promise<void> => {
+      /*
+       * The likeliest moment anyone calls this: the recorder is missing, so
+       * every field is being read off a recorder that does not exist. If it
+       * threw here it would be useless in exactly the case it was built for.
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+
+      const diagnostics: SessionReplayDiagnostics = index.getDiagnostics();
+
+      expect(diagnostics.isRecording).toBe(false);
+      expect(diagnostics.sessionId).toBeNull();
+      expect(diagnostics.isUploading).toBe(false);
+      expect(diagnostics.triggerReason).toBeNull();
+
+      /* The version pins which artifact the page actually got. */
+      expect(typeof diagnostics.version).toBe("string");
+      expect(diagnostics.version.length).toBeGreaterThan(0);
+      expect(diagnostics.version).toBe(index.version);
+    });
+
+    it("includes records written before the artifact existed", async (): Promise<void> => {
+      /*
+       * The loader stub and the artifact are separate bundles with separate
+       * module instances, and the stub's records are the ones that explain
+       * why the artifact was never reached at all - a 404 on the policy, a
+       * disabled project, an unsampled session. If getDiagnostics() only
+       * reported what happened after this bundle loaded, every ticket where
+       * the answer is "the stub stopped" would come back empty.
+       */
+      debugLog("loader-stopped-before-artifact", "The stub got this far.");
+
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      const records: Array<DebugRecord> = index.getDiagnostics().records;
+
+      expect(codesIn(records)).toContain("loader-stopped-before-artifact");
+      expect(codesIn(records)).toContain("bootstrap");
+
+      index.stop();
+    });
+
+    it("hands back a copy of the timeline rather than the live ring", async (): Promise<void> => {
+      /*
+       * The return value goes straight into a support ticket, where it gets
+       * serialised, sorted and sliced. None of that may reach back into the
+       * recorder's own timeline.
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+
+      debugLog("a-real-step", "Something happened.");
+
+      const first: Array<DebugRecord> = index.getDiagnostics().records;
+      const originalLength: number = first.length;
+
+      first.push({
+        atUnixMs: 0,
+        level: "info",
+        code: "injected-by-the-caller",
+        message: "Not a real record.",
+      });
+
+      first.length = 0;
+
+      const second: Array<DebugRecord> = index.getDiagnostics().records;
+
+      expect(second.length).toBe(originalLength);
+      expect(codesIn(second)).toContain("a-real-step");
+      expect(codesIn(second)).not.toContain("injected-by-the-caller");
+    });
+  });
+
+  describe("setDebug", (): void => {
+    it("starts printing to the console once it is switched on", async (): Promise<void> => {
+      /*
+       * The mid-incident switch: the page is already loaded and cannot be
+       * redeployed, so turning logging on has to take effect on the next
+       * decision the recorder makes, with no reload.
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+      const spies: ConsoleSpies = spyOnConsole();
+
+      index.setDebug(true);
+
+      debugLog("a-step-after-the-switch", "A later step ran.");
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("api");
+      expect(allConsoleText(spies)).toContain("a-step-after-the-switch");
+    });
+
+    it("goes quiet again when switched off, but keeps recording the timeline", async (): Promise<void> => {
+      /*
+       * Switching off is what a customer does before handing the page back
+       * to real users, and it must not cost them the diagnostics: the ring
+       * is filled unconditionally so getDiagnostics() still has the answer
+       * afterwards. Output is the only thing the switch gates.
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+      const spies: ConsoleSpies = spyOnConsole();
+
+      index.setDebug(true);
+      index.setDebug(false);
+
+      debugLog("a-step-after-the-switch-off", "A later step ran.");
+
+      expect(isDebugEnabled()).toBe(false);
+      expect(allConsoleText(spies)).not.toContain(
+        "a-step-after-the-switch-off",
+      );
+      expect(codesIn(index.getDiagnostics().records)).toContain(
+        "a-step-after-the-switch-off",
+      );
+    });
+
+    it("is turned on by an init option carried through bootstrap", async (): Promise<void> => {
+      /*
+       * The install-time switch, for a customer who cannot open the console
+       * of the browser that is failing - it is applied as bootstrap's very
+       * first act, before any gate, so the run that a gate stops is still
+       * the run that explains itself.
+       */
+      const options: RecorderInitOptions = {
+        ...INIT_OPTIONS,
+        debug: true,
+      };
+
+      const index: typeof import("../src/Index") = await importIndex();
+      const spies: ConsoleSpies = spyOnConsole();
+
+      index.bootstrap(options, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      expect(isDebugEnabled()).toBe(true);
+      expect(getDebugSource()).toBe("init-options");
+      expect(allConsoleText(spies)).toContain("bootstrap");
+
+      index.stop();
+    });
+  });
+
+  describe("the bootstrap gates", (): void => {
+    it("records a normal start alongside the recorder's own state", async (): Promise<void> => {
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      const diagnostics: SessionReplayDiagnostics = index.getDiagnostics();
+
+      expect(codesIn(diagnostics.records)).toContain("bootstrap");
+
+      /*
+       * The positive control for every "nothing recorded" case below: a
+       * healthy page reports a session id, which is the value a support
+       * engineer needs in order to look the recording up server-side.
+       */
+      expect(diagnostics.isRecording).toBe(true);
+      expect(diagnostics.sessionId).not.toBeNull();
+
+      index.stop();
+    });
+
+    it("says bootstrap-already-started when a second bundle starts on the same page", async (): Promise<void> => {
+      /*
+       * The loader stub plus a self-hosted copy of the artifact, or two
+       * copies of the install snippet: two module instances, one page-level
+       * flag. The second one records nothing at all, and without this code
+       * the page just looks like a recorder that half works.
+       */
+      const first: typeof import("../src/Index") = await importIndex();
+
+      first.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      const second: typeof import("../src/Index") = await importIndex();
+
+      second.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      expect(codes()).toContain("bootstrap-already-started");
+      expect(second.getDiagnostics().isRecording).toBe(false);
+
+      first.stop();
+    });
+
+    it("says privacy-signal when the browser asked not to be tracked", async (): Promise<void> => {
+      /*
+       * Indistinguishable from a broken install without the code: nothing
+       * records, nothing uploads, nothing prints. The artifact re-checks the
+       * signal that the stub already checked because it can be loaded
+       * directly, and a signal honoured on only one of two entry paths is
+       * not honoured.
+       */
+      setPrivacySignal(true);
+
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      expect(codes()).toContain("privacy-signal");
+      expect(index.getDiagnostics().isRecording).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("says directive-stop when the policy carries a stop directive", async (): Promise<void> => {
+      /*
+       * A server-side kill switch - budget exhausted, or an incident - looks
+       * exactly like a broken recorder from the page. This is the one code
+       * that tells a customer to stop debugging their install.
+       */
+      const config: SessionReplayConfigResponse = {
+        ...baseConfig(),
+        directive: "stop",
+      };
+
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, config, []);
+
+      await tick();
+      await tick();
+
+      expect(codes()).toContain("directive-stop");
+      expect(index.getDiagnostics().isRecording).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("start", (): void => {
+    it("says init-options-missing when the page carries no install snippet", async (): Promise<void> => {
+      /*
+       * The SELF-HOSTED artifact path. The loader stub prints an
+       * unconditional console.warn for this identical condition, so a
+       * customer who bundles the artifact themselves used to get total
+       * silence from the one failure that WAS instrumented everywhere else.
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+
+      await index.start();
+
+      expect(codes()).toContain("init-options-missing");
+
+      /* Fail closed: no options means no endpoint to post screen content to. */
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(index.getDiagnostics().isRecording).toBe(false);
+    });
+  });
+
+  describe("the command queue", (): void => {
+    it("warns when the queue global is not an array", async (): Promise<void> => {
+      /*
+       * A page that assigned to window.OneUptimeReplayQueue instead of
+       * pushing onto it - the mistake the snippet's own shape invites. Every
+       * consent decision the page queued is dropped, so a RequireExplicit
+       * project records and never uploads, forever.
+       */
+      globalRecord()["OneUptimeReplayQueue"] = "grantConsent";
+
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      expect(codes()).toContain("command-queue-not-an-array");
+      expect(detailOf("command-queue-not-an-array")["type"]).toBe("string");
+
+      index.stop();
+    });
+
+    it("names a queued command it does not recognise", async (): Promise<void> => {
+      /*
+       * Unknown names are ignored on purpose - a page may be written against
+       * a newer recorder than the config pinned - but ignoring them silently
+       * is how a misspelt "grantconsent" becomes a session that records
+       * forever and uploads nothing. The name has to be in the record, or
+       * the record cannot point at the typo.
+       */
+      globalRecord()["OneUptimeReplayQueue"] = [["grantconsent"]];
+
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      expect(codes()).toContain("command-queue-unknown-command");
+      expect(detailOf("command-queue-unknown-command")["command"]).toBe(
+        "grantconsent",
+      );
+
+      index.stop();
+    });
+
+    it("stays quiet for a correctly queued grantConsent", async (): Promise<void> => {
+      /*
+       * The negative control. A diagnostic that cries wolf on the documented
+       * usage is one a customer learns to scroll past, and the two warnings
+       * above are only useful if the correct call is silent.
+       */
+      globalRecord()["OneUptimeReplayQueue"] = [["grantConsent"]];
+
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.bootstrap(INIT_OPTIONS, baseConfig(), []);
+
+      await tick();
+      await tick();
+
+      expect(codes()).toContain("api-grant-consent");
+      expect(codes()).not.toContain("command-queue-unknown-command");
+      expect(codes()).not.toContain("command-queue-not-an-array");
+
+      index.stop();
+    });
+  });
+
+  describe("the API with no recorder", (): void => {
+    it("says api-no-recorder when captureSession() finds nothing running", async (): Promise<void> => {
+      /*
+       * A consent banner or a "report a problem" button calling into the
+       * global after a gate already stopped the recorder. The call is a
+       * no-op by design, and this record is the only thing that separates
+       * "your button never fired" from "the recorder was not there to fire
+       * at".
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.captureSession();
+
+      expect(codes()).toContain("api-no-recorder");
+    });
+
+    it("says api-no-recorder when grantConsent() finds nothing running", async (): Promise<void> => {
+      /*
+       * The costlier half of the same mistake: a grant that lands before the
+       * artifact loaded is lost unless the page queued it, and nothing about
+       * the page changes to say so.
+       */
+      const index: typeof import("../src/Index") = await importIndex();
+
+      index.grantConsent();
+
+      expect(codes()).toContain("api-no-recorder");
+    });
+  });
+});

--- a/App/FeatureSet/BrowserRecorder/Tests/LoaderDiagnostics.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/LoaderDiagnostics.test.ts
@@ -1,0 +1,686 @@
+import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
+import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode";
+import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import { DEBUG_STORAGE_KEY, DebugRecord, getDebugRecords } from "../src/Debug";
+
+/*
+ * What the loader stub says about itself.
+ *
+ * Every gate in the stub fails closed and silently: no init options, a
+ * privacy signal, a 401, `enabled: false`, a directive to stand down, a
+ * blocked script tag. All six produce the identical observable outcome on a
+ * customer's page - no recording, and usually no request either - so the
+ * diagnostics timeline is the only thing that can tell them apart. These
+ * tests pin the `code` on each one, because a support ticket quotes the code
+ * and the troubleshooting docs are indexed by it; renaming one silently is
+ * the same as deleting the diagnostic.
+ *
+ * Assertions read the RECORD RING rather than the console on purpose.
+ * Records are kept whether or not logging is switched on, which is what lets
+ * a support engineer ask for the timeline from a page nobody had
+ * instrumented - and asserting on console output instead would quietly stop
+ * covering the off-by-default case, which is every real page.
+ */
+
+const STATE_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_DEBUG__";
+
+const CONFIG_URL: string =
+  "https://oneuptime.com/telemetry/session-replay/v1/config";
+
+const ARTIFACT_URL: string =
+  "https://oneuptime.com/telemetry/session-replay/v11.7.3/recorder.js";
+
+/*
+ * Distinctive enough that a substring search for it is meaningful. The
+ * ingestion key travels in a request header and must never reach a channel
+ * that gets pasted into a support ticket.
+ */
+const SECRET_TOKEN: string = "tok-must-never-be-logged-91af";
+const SECRET_USER_REF: string = "user-ref-must-never-be-logged-91af";
+
+const CONFIG_BODY: Record<string, unknown> = {
+  enabled: true,
+  recorderVersion: "11.7.3",
+  maskingMode: SessionReplayMaskingMode.MaskAllText,
+  consentMode: "NotRequired",
+  captureTrigger: "OnErrorOrFrustration",
+  samplePercentage: 0,
+  maskSelectors: [],
+  blockSelectors: [],
+  urlAllowlist: [],
+  ignoreErrorPatterns: [],
+  recordCanvas: false,
+  captureUserIdentity: false,
+  respectDoNotTrack: true,
+  configEpoch: 1,
+  directive: "continue",
+  recorderIntegrity: "sha384-testhash",
+};
+
+type GlobalRecord = Record<string, unknown>;
+
+function globalRecord(): GlobalRecord {
+  return globalThis as unknown as GlobalRecord;
+}
+
+/*
+ * The timeline lives on a global so the stub and the artifact share one
+ * ring, which also means it survives between test cases. Every case starts
+ * from an empty one or it would be reading the previous case's decisions.
+ */
+function resetDebugState(): void {
+  delete globalRecord()[STATE_GLOBAL];
+}
+
+function codes(): Array<string> {
+  return getDebugRecords().map((record: DebugRecord): string => {
+    return record.code;
+  });
+}
+
+function detailOf(code: string): Record<string, unknown> {
+  const record: DebugRecord | undefined = getDebugRecords().find(
+    (candidate: DebugRecord): boolean => {
+      return candidate.code === code;
+    },
+  );
+
+  return (record?.detail || {}) as Record<string, unknown>;
+}
+
+function consoleText(spy: jest.SpyInstance): string {
+  return spy.mock.calls
+    .map((call: Array<unknown>): string => {
+      return call
+        .map((argument: unknown): string => {
+          return typeof argument === "string"
+            ? argument
+            : JSON.stringify(argument);
+        })
+        .join(" ");
+    })
+    .join("\n");
+}
+
+describe("Loader diagnostics", (): void => {
+  let fetchMock: jest.Mock;
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  const setNavigatorSignal: (value: boolean) => void = (
+    value: boolean,
+  ): void => {
+    Object.defineProperty(window.navigator, "globalPrivacyControl", {
+      configurable: true,
+      value: value,
+    });
+  };
+
+  const setConfigResponse: (body: Record<string, unknown> | null) => void = (
+    body: Record<string, unknown> | null,
+  ): void => {
+    fetchMock.mockResolvedValue({
+      ok: body !== null,
+      status: body === null ? 404 : 200,
+      json: async (): Promise<unknown> => {
+        return body;
+      },
+    });
+  };
+
+  /* A refusal with a status the stub is expected to name back. */
+  const setConfigRefusal: (status: number) => void = (status: number): void => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: status,
+      json: async (): Promise<unknown> => {
+        return null;
+      },
+    });
+  };
+
+  const tick: () => Promise<void> = async (): Promise<void> => {
+    await new Promise<void>((resolve: () => void): void => {
+      setTimeout(resolve, 0);
+    });
+  };
+
+  /*
+   * The stub is a side effect, not a library: importing it runs it. Modules
+   * are reset between cases so each one gets a fresh execution.
+   */
+  const runLoader: () => Promise<void> = async (): Promise<void> => {
+    jest.resetModules();
+
+    await import("../src/Loader");
+
+    await tick();
+    await tick();
+  };
+
+  const injectedScript: () => HTMLScriptElement | null =
+    (): HTMLScriptElement | null => {
+      return document.querySelector<HTMLScriptElement>(
+        'script[src*="/telemetry/session-replay/"]',
+      );
+    };
+
+  const setInitOptions: (options: Record<string, unknown>) => void = (
+    options: Record<string, unknown>,
+  ): void => {
+    globalRecord()["__ONEUPTIME_SESSION_REPLAY__"] = options;
+  };
+
+  beforeEach((): void => {
+    resetDebugState();
+
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+
+    /*
+     * Both storages are ambient debug switches. A leftover key from another
+     * suite would switch logging on and make the "silent by default" case
+     * pass for the wrong reason.
+     */
+    try {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    } catch {
+      /* jsdom always has both; a hostile environment is Debug's problem. */
+    }
+
+    setNavigatorSignal(false);
+
+    setInitOptions({
+      host: "https://oneuptime.com",
+      token: SECRET_TOKEN,
+      appIdentifier: "app-1",
+    });
+
+    globalRecord()["OneUptimeReplay"] = {
+      bootstrap: (): void => {
+        /* The artifact is already present unless a case removes it. */
+      },
+    };
+
+    fetchMock = jest.fn();
+    globalRecord()["fetch"] = fetchMock;
+
+    setConfigResponse(CONFIG_BODY);
+
+    infoSpy = jest.spyOn(console, "info").mockImplementation((): void => {
+      /* Swallowed so a failing case does not print into the test output. */
+    });
+
+    warnSpy = jest.spyOn(console, "warn").mockImplementation((): void => {
+      /* Swallowed; asserted through the spy instead. */
+    });
+  });
+
+  afterEach((): void => {
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY__"];
+    delete globalRecord()["OneUptimeReplay"];
+
+    jest.restoreAllMocks();
+    resetDebugState();
+  });
+
+  /*
+   * "The stub never ran" - a CSP that blocked it, a tag that is not on the
+   * page, a bundler that dropped it - and "the stub ran and decided not to
+   * record" look identical from the network tab and have nothing in common.
+   * This record is the only thing that separates them, so it has to be
+   * emitted before anything the stub might stand down over.
+   */
+  it("records that it ran before it reads anything from the page", async (): Promise<void> => {
+    await runLoader();
+
+    expect(codes()[0]).toBe("loader-start");
+    expect(detailOf("loader-start")["diagnostics"]).toBe("off");
+  });
+
+  /*
+   * Nothing on the page to read at all: no init global and no
+   * script[data-oneuptime-token]. Distinct from a snippet that is present but
+   * incomplete, which Config reports field by field - here the marker
+   * attribute is misspelled, the snippet went into a different document, or a
+   * tag manager dropped it.
+   *
+   * Both records matter. loader-start is the only evidence the stub ever
+   * executed, and init-options-missing is what keeps getDiagnostics() a
+   * complete account rather than a timeline that stops without saying why.
+   */
+  it("records that it ran and that it found nothing to read", async (): Promise<void> => {
+    delete globalRecord()["__ONEUPTIME_SESSION_REPLAY__"];
+
+    await runLoader();
+
+    expect(codes()).toEqual(["loader-start", "init-options-missing"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe("init options", (): void => {
+    /*
+     * host and appIdentifier are the two values a wrong install gets wrong,
+     * and neither is a secret. The token is, and so is the customer's own
+     * user reference - this timeline is printed to an end user's console and
+     * pasted into support tickets, so it is an egress path like any other.
+     */
+    it("names the host and app identifier it read, and never the token", async (): Promise<void> => {
+      setInitOptions({
+        host: "https://oneuptime.com",
+        token: SECRET_TOKEN,
+        appIdentifier: "app-1",
+        userRef: SECRET_USER_REF,
+      });
+
+      await runLoader();
+
+      expect(detailOf("init-options-read")).toEqual({
+        source: "init-global",
+        host: "https://oneuptime.com",
+        appIdentifier: "app-1",
+        respectDoNotTrack: true,
+      });
+
+      const timeline: string = JSON.stringify(getDebugRecords());
+
+      expect(timeline).not.toContain(SECRET_TOKEN);
+      expect(timeline).not.toContain(SECRET_USER_REF);
+    });
+
+    /*
+     * WHICH field is missing, not just that one is. The unconditional
+     * console.warn below can only say "something is wrong with the snippet",
+     * and "you forgot the token" and "the host could not be derived from the
+     * script src" are different bugs with fixes in different places.
+     */
+    it("names a missing token", async (): Promise<void> => {
+      setInitOptions({
+        host: "https://oneuptime.com",
+        appIdentifier: "app-1",
+      });
+
+      await runLoader();
+
+      expect(codes()).toContain("init-options-incomplete");
+      expect(detailOf("init-options-incomplete")).toEqual({
+        source: "init-global",
+        hasHost: true,
+        hasToken: false,
+        hasAppIdentifier: true,
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /*
+     * `source` matters as much as the flags. The init global is only the
+     * FIRST of two sources the recorder tries, so a page that sets
+     * `window.__ONEUPTIME_SESSION_REPLAY__ = { debug: true }` purely to turn
+     * diagnostics on reaches this warning and then records perfectly well
+     * from its script tag. Naming the source is what keeps that from reading
+     * as a fault - see the case below.
+     */
+    it("names a missing app identifier", async (): Promise<void> => {
+      setInitOptions({
+        host: "https://oneuptime.com",
+        token: SECRET_TOKEN,
+      });
+
+      await runLoader();
+
+      expect(detailOf("init-options-incomplete")).toEqual({
+        source: "init-global",
+        hasHost: true,
+        hasToken: true,
+        hasAppIdentifier: false,
+      });
+    });
+
+    /*
+     * The host normally defaults to wherever the script itself was served
+     * from, so an inline tag - a customer who pasted the attributes onto a
+     * <script> with no src, or a bundler that inlined it - has no host to
+     * derive and nothing to say so. hasHost false is what points at the
+     * missing src rather than at the attributes, which are all present here.
+     */
+    it("reports the host as missing when it cannot be derived from the script src", async (): Promise<void> => {
+      delete globalRecord()["__ONEUPTIME_SESSION_REPLAY__"];
+
+      document.head.innerHTML =
+        '<script data-oneuptime-token="t" data-oneuptime-app-identifier="a"></script>';
+
+      await runLoader();
+
+      expect(detailOf("init-options-incomplete")).toEqual({
+        source: "script-tag",
+        hasHost: false,
+        hasToken: true,
+        hasAppIdentifier: true,
+      });
+    });
+
+    /*
+     * The documented way to turn diagnostics on for a tag-configured install
+     * is a global carrying nothing but `debug: true`. That global does not
+     * normalise, so it is skipped and the script tag answers instead - and
+     * the recorder must not report the skip as a failure. Telling the person
+     * who just enabled diagnostics that nothing will be recorded, moments
+     * before recording, is worse than saying nothing at all.
+     */
+    it("does not call a skipped init source a failure", async (): Promise<void> => {
+      (globalRecord() as Record<string, unknown>)[
+        "__ONEUPTIME_SESSION_REPLAY__"
+      ] = { debug: true };
+
+      document.head.innerHTML =
+        '<script src="https://oneuptime.com/telemetry/session-replay/v1/recorder.js" data-oneuptime-token="t" data-oneuptime-app-identifier="app-1"></script>';
+
+      await runLoader();
+
+      /* The skip is reported, and named as a skip on a named source. */
+      expect(detailOf("init-options-incomplete")["source"]).toBe("init-global");
+
+      const record: DebugRecord | undefined = getDebugRecords().find(
+        (r: DebugRecord): boolean => {
+          return r.code === "init-options-incomplete";
+        },
+      );
+
+      expect(record?.message).not.toContain("Nothing will be recorded");
+
+      /* And the script tag went on to answer, so the recorder started. */
+      expect(detailOf("init-options-read")["source"]).toBe("script-tag");
+      expect(codes()).toContain("config-accepted");
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    /*
+     * The one thing the recorder prints unasked. A misconfigured snippet used
+     * to produce total silence, which is indistinguishable from "replay is
+     * off for this app" and sent people looking in entirely the wrong place.
+     * It now also has to name the localStorage switch, because everything
+     * else this file asserts is invisible until somebody turns it on.
+     */
+    it("warns on the console about a missing snippet and says how to get the rest", async (): Promise<void> => {
+      delete globalRecord()["__ONEUPTIME_SESSION_REPLAY__"];
+
+      await runLoader();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      const text: string = consoleText(warnSpy);
+
+      expect(text).toContain("data-oneuptime-token");
+      expect(text).toContain("data-oneuptime-app-identifier");
+      expect(text).toContain(DEBUG_STORAGE_KEY);
+    });
+  });
+
+  /*
+   * The signal is checked BEFORE the config request. A user who has asked
+   * not to be tracked must not have a request made about them just to find
+   * out whether we would have recorded them - so the record for this gate
+   * and the absence of the fetch are one assertion, not two.
+   */
+  it("records the privacy signal without making a request about the user", async (): Promise<void> => {
+    setNavigatorSignal(true);
+
+    await runLoader();
+
+    expect(codes()).toEqual([
+      "loader-start",
+      "init-options-read",
+      "privacy-signal",
+    ]);
+
+    /*
+     * Which of the two DNT checks fired. The stub reads the signal once
+     * before the config request and again after it with the server's own
+     * setting, and telling them apart is the difference between "this
+     * browser sends the signal" and "this browser sends it and the
+     * deployment honours it".
+     */
+    expect(detailOf("privacy-signal")["stage"]).toBe("before-config-fetch");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe("the config round trip", (): void => {
+    /*
+     * A 401 is a key in Project Settings, a 404 is usually an nginx route
+     * that never reaches the telemetry app. Both come back as "nothing
+     * recorded, no error", and the status is the entire diagnosis - so it
+     * is carried verbatim rather than collapsed into "the request failed".
+     */
+    it("names the status when the config endpoint refuses the request", async (): Promise<void> => {
+      for (const status of [401, 404]) {
+        resetDebugState();
+        setConfigRefusal(status);
+
+        await runLoader();
+
+        expect(codes()).toContain("config-fetch-start");
+        expect(codes()).toContain("config-fetch-rejected");
+
+        /*
+         * The attempt has to be visible before its outcome, or a request
+         * that was never made and one that was refused read the same.
+         */
+        expect(codes().indexOf("config-fetch-start")).toBeLessThan(
+          codes().indexOf("config-fetch-rejected"),
+        );
+
+        expect(detailOf("config-fetch-rejected")).toEqual({
+          url: CONFIG_URL,
+          status: status,
+        });
+      }
+    });
+
+    /*
+     * A rejected fetch is a network-layer failure the page cannot see either
+     * - DNS, TLS, offline, an ad blocker, or a connect-src that does not list
+     * the ingest origin. There is no status to report, which is exactly why
+     * it needs its own code rather than sharing the refusal one.
+     */
+    it("distinguishes a request that never completed from one that was refused", async (): Promise<void> => {
+      fetchMock.mockRejectedValue(new Error("blocked by connect-src"));
+
+      await runLoader();
+
+      expect(codes()).toContain("config-fetch-failed");
+      expect(codes()).not.toContain("config-fetch-rejected");
+      expect(detailOf("config-fetch-failed")["url"]).toBe(CONFIG_URL);
+    });
+
+    /*
+     * "Replay is on in the dashboard but nothing happens" is the single most
+     * common report, and several unrelated causes all answer `enabled:
+     * false`. recorder-not-built in particular is a deployment that never ran
+     * the recorder build - no amount of dashboard configuration fixes it, so
+     * a customer left guessing will spend the afternoon on the wrong thing.
+     */
+    it("passes the server's reason for being off straight through", async (): Promise<void> => {
+      setConfigResponse({
+        ...CONFIG_BODY,
+        enabled: false,
+        disabledReason: "recorder-not-built",
+      });
+
+      await runLoader();
+
+      expect(detailOf("config-disabled")["disabledReason"]).toBe(
+        "recorder-not-built",
+      );
+    });
+
+    /*
+     * An older server does not send disabledReason at all. The record still
+     * has to say so explicitly: a missing key reads as "the recorder did not
+     * look", and would send someone hunting for a bug in the stub instead of
+     * upgrading the deployment that owns the answer.
+     */
+    it("says the reason was not reported when the server omits one", async (): Promise<void> => {
+      setConfigResponse({ ...CONFIG_BODY, enabled: false });
+
+      await runLoader();
+
+      expect(detailOf("config-disabled")["disabledReason"]).toBe(
+        "not-reported",
+      );
+    });
+
+    /*
+     * The version is interpolated into an artifact URL path, so a traversing
+     * or unpublished value is refused outright. Refusing silently is the same
+     * dead end as every other gate here, and the offending value is the whole
+     * diagnosis - it points at the server or at whatever rewrote its reply.
+     */
+    it("names the version it refused to build a URL from", async (): Promise<void> => {
+      for (const version of ["../../../admin", "latest"]) {
+        resetDebugState();
+        setConfigResponse({ ...CONFIG_BODY, recorderVersion: version });
+
+        await runLoader();
+
+        expect(detailOf("config-recorder-version-invalid")).toEqual({
+          recorderVersion: version,
+        });
+
+        expect(codes()).not.toContain("config-accepted");
+      }
+    });
+
+    /*
+     * The policy line, and the one that explains "there are no requests in
+     * the network tab": OnErrorOrFrustration with samplePercentage 0 records
+     * into memory and uploads nothing until something goes wrong. That is
+     * working as designed and it is indistinguishable from broken, so all
+     * four decisions are carried together - any one of them alone is enough
+     * to misread the other three.
+     */
+    it("carries the policy the recorder will now run under", async (): Promise<void> => {
+      await runLoader();
+
+      const detail: Record<string, unknown> = detailOf("config-accepted");
+
+      expect(detail["captureTrigger"]).toBe(
+        SessionReplayCaptureTrigger.OnErrorOrFrustration,
+      );
+      expect(detail["samplePercentage"]).toBe(0);
+      expect(detail["consentMode"]).toBe(SessionReplayConsentMode.NotRequired);
+      expect(detail["maskingMode"]).toBe(SessionReplayMaskingMode.MaskAllText);
+    });
+  });
+
+  describe("the artifact", (): void => {
+    beforeEach((): void => {
+      /*
+       * No artifact on the page, so the stub has to inject one. With the
+       * bootstrap global present it short-circuits and none of the injection
+       * diagnostics below are reachable at all.
+       */
+      delete globalRecord()["OneUptimeReplay"];
+    });
+
+    /*
+     * The kill switch has to stop RECORDING, not merely ingest. If the
+     * artifact were still fetched, live browsers would go on recording into
+     * a buffer for the rest of the page's life after the switch was thrown -
+     * so the absence of the script tag is as much the assertion as the code.
+     */
+    it("records the stand-down and injects nothing when told to stop", async (): Promise<void> => {
+      setConfigResponse({ ...CONFIG_BODY, directive: "stop" });
+
+      await runLoader();
+
+      expect(codes()).toContain("directive-stop");
+      expect(codes()).not.toContain("artifact-requested");
+      expect(injectedScript()).toBeNull();
+    });
+
+    /*
+     * The last record before the stub hands over. Everything after this point
+     * belongs to a bundle that may never load, so a timeline that ends here
+     * says "the stub did its whole job" rather than "the stub gave up".
+     */
+    it("records the artifact it asked for and whether it pinned a hash", async (): Promise<void> => {
+      await runLoader();
+
+      expect(detailOf("artifact-requested")).toEqual({
+        url: ARTIFACT_URL,
+        hasIntegrity: true,
+      });
+    });
+
+    it("says when no hash was published to pin", async (): Promise<void> => {
+      const body: Record<string, unknown> = { ...CONFIG_BODY };
+      delete body["recorderIntegrity"];
+
+      setConfigResponse(body);
+
+      await runLoader();
+
+      expect(detailOf("artifact-requested")["hasIntegrity"]).toBe(false);
+    });
+
+    /*
+     * Usually a customer CSP that does not list our origin in script-src,
+     * which fails silently from the page's point of view. Server telemetry
+     * cannot see a script that never loaded, so this record is one of only
+     * two diagnostics that exist for it - and hasIntegrity rides along
+     * because an SRI mismatch fails through exactly the same handler.
+     */
+    it("records a script that never loaded, which the server can never see", async (): Promise<void> => {
+      await runLoader();
+
+      const script: HTMLScriptElement | null = injectedScript();
+
+      expect(script).not.toBeNull();
+
+      if (script && script.onerror) {
+        script.onerror(new Event("error"));
+      }
+
+      expect(detailOf("artifact-load-failed")).toEqual({
+        url: ARTIFACT_URL,
+        hasIntegrity: true,
+      });
+    });
+
+    /*
+     * The script loaded and published nothing. That is a broken or
+     * substituted artifact rather than a blocked one - a proxy serving an
+     * HTML error page with a 200, or a build that shipped the wrong file -
+     * and it needs its own code, because "loaded fine, recorded nothing" is
+     * the least intuitive outcome the stub can produce.
+     */
+    it("records an artifact that loaded but published no API", async (): Promise<void> => {
+      await runLoader();
+
+      const script: HTMLScriptElement | null = injectedScript();
+
+      if (script && script.onload) {
+        script.onload(new Event("load"));
+      }
+
+      expect(detailOf("artifact-api-missing")["url"]).toBe(ARTIFACT_URL);
+    });
+  });
+
+  /*
+   * The rule the whole diagnostics design hangs on. This script runs in a
+   * customer's END USERS' browsers, not the customer's own, so a recorder
+   * that chatters is one a customer removes - and the timeline above is
+   * still fully populated while the console stays clean.
+   */
+  it("prints nothing at all on a normal page with diagnostics off", async (): Promise<void> => {
+    await runLoader();
+
+    expect(codes()).toContain("config-accepted");
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/App/FeatureSet/BrowserRecorder/Tests/RecorderDiagnostics.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/RecorderDiagnostics.test.ts
@@ -1,0 +1,589 @@
+import { SessionReplayConfigResponse } from "Common/Types/Rum/SessionReplay";
+import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
+import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode";
+import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import SessionReplayTriggerReason from "Common/Types/Rum/SessionReplayTriggerReason";
+import { RecorderInitOptions } from "../src/Config";
+import { DebugRecord, getDebugRecords, setEnabled } from "../src/Debug";
+import Recorder from "../src/Recorder";
+
+/*
+ * What the recorder SAYS about itself, asserted against the real recorder
+ * running real rrweb in jsdom rather than against a double.
+ *
+ * Every gate in this package fails closed and silently: an unsampled
+ * session, a consent mode nobody granted, a 401 that trips the circuit
+ * breaker, a server that switched the project off. From the customer's
+ * browser all four look identical - no recording, no request, no console
+ * output - which is why "session replay is broken" and "session replay is
+ * switched off" were indistinguishable, and why these diagnostics exist.
+ *
+ * The tests below are the contract for that: each silent stop has to leave a
+ * record behind naming ITSELF, carrying the specific values a support
+ * engineer needs, and the last test in the file asserts the whole channel
+ * cannot become a second, unmasked egress path for page content.
+ */
+
+const STATE_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_DEBUG__";
+
+const INIT_OPTIONS: RecorderInitOptions = {
+  host: "https://oneuptime.com",
+  token: "test-token",
+  appIdentifier: "app-1",
+};
+
+const baseConfig: () => SessionReplayConfigResponse =
+  (): SessionReplayConfigResponse => {
+    return {
+      enabled: true,
+      recorderVersion: "11.7.3",
+      maskingMode: SessionReplayMaskingMode.MaskAllText,
+      captureTrigger: SessionReplayCaptureTrigger.OnErrorOrFrustration,
+      consentMode: SessionReplayConsentMode.NotRequired,
+      samplePercentage: 0,
+      maskSelectors: [],
+      blockSelectors: [],
+      urlAllowlist: [],
+      ignoreErrorPatterns: [],
+      recordCanvas: false,
+      captureUserIdentity: false,
+      respectDoNotTrack: true,
+      configEpoch: 1,
+      directive: "continue",
+    };
+  };
+
+/*
+ * The diagnostics state lives on a global so the loader stub and the artifact
+ * share one timeline, which also means it survives between test cases. Every
+ * case here starts from an empty ring and logging switched off.
+ */
+function resetDebugState(): void {
+  delete (globalThis as unknown as Record<string, unknown>)[STATE_GLOBAL];
+}
+
+/* Records are kept even while logging is off, so these read the ring. */
+function codes(): Array<string> {
+  return getDebugRecords().map((record: DebugRecord): string => {
+    return record.code;
+  });
+}
+
+function recordFor(code: string): DebugRecord | undefined {
+  return getDebugRecords().find((record: DebugRecord): boolean => {
+    return record.code === code;
+  });
+}
+
+function detailOf(code: string): Record<string, unknown> {
+  return (recordFor(code)?.detail || {}) as Record<string, unknown>;
+}
+
+function countOf(code: string): number {
+  return codes().filter((candidate: string): boolean => {
+    return candidate === code;
+  }).length;
+}
+
+/*
+ * The non-terminal upload path awaits compression before it calls fetch, so
+ * anything that asserts on what the transport reported back has to let the
+ * microtask queue drain first.
+ */
+async function flushUploads(): Promise<void> {
+  await new Promise<void>((resolve: () => void): void => {
+    setTimeout(resolve, 0);
+  });
+}
+
+function setVisibility(state: string): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: (): string => {
+      return state;
+    },
+  });
+}
+
+/*
+ * The terminal flush path. stop() deliberately discards the transport queue,
+ * so hiding the page is the only way to make the recorder seal a chunk.
+ */
+function sealByHidingThePage(): void {
+  setVisibility("hidden");
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+interface ConsoleSpies {
+  info: jest.Mock;
+  warn: jest.Mock;
+}
+
+/*
+ * Mocked rather than merely observed: with diagnostics switched on the
+ * recorder writes a line per decision, and a test suite is not a customer's
+ * console either.
+ */
+function spyOnConsole(): ConsoleSpies {
+  const spies: ConsoleSpies = {
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  jest
+    .spyOn(console, "info")
+    .mockImplementation((...args: Array<unknown>): void => {
+      spies.info(...args);
+    });
+
+  jest
+    .spyOn(console, "warn")
+    .mockImplementation((...args: Array<unknown>): void => {
+      spies.warn(...args);
+    });
+
+  return spies;
+}
+
+function allConsoleText(spies: ConsoleSpies): string {
+  return [...spies.info.mock.calls, ...spies.warn.mock.calls]
+    .map((call: Array<unknown>): string => {
+      return call
+        .map((argument: unknown): string => {
+          return typeof argument === "string"
+            ? argument
+            : JSON.stringify(argument);
+        })
+        .join(" ");
+    })
+    .join("\n");
+}
+
+describe("Recorder diagnostics", (): void => {
+  let fetchMock: jest.Mock;
+  let spies: ConsoleSpies;
+  let recorder: Recorder | null = null;
+
+  beforeEach((): void => {
+    resetDebugState();
+
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    document.body.innerHTML = "<div id='app'><p>content</p></div>";
+    setVisibility("visible");
+
+    /*
+     * CompressionStream is removed so the upload path is short enough to
+     * assert on within one macrotask. The gzip branch has its own coverage in
+     * Transport.test.ts.
+     */
+    delete (globalThis as unknown as Record<string, unknown>)[
+      "CompressionStream"
+    ];
+
+    fetchMock = jest.fn().mockResolvedValue({
+      status: 202,
+      headers: {
+        get: (): string | null => {
+          return null;
+        },
+      },
+      text: async (): Promise<string> => {
+        return "";
+      },
+    });
+
+    (globalThis as unknown as Record<string, unknown>)["fetch"] = fetchMock;
+    (window as unknown as Record<string, unknown>)["fetch"] = fetchMock;
+
+    spies = spyOnConsole();
+  });
+
+  afterEach((): void => {
+    if (recorder) {
+      recorder.stop();
+      recorder = null;
+    }
+
+    jest.restoreAllMocks();
+    resetDebugState();
+  });
+
+  const startRecorder: (
+    overrides?: Partial<SessionReplayConfigResponse>,
+  ) => Recorder = (
+    overrides?: Partial<SessionReplayConfigResponse>,
+  ): Recorder => {
+    const instance: Recorder = new Recorder({
+      initOptions: INIT_OPTIONS,
+      config: { ...baseConfig(), ...overrides },
+    });
+
+    instance.start();
+    recorder = instance;
+
+    return instance;
+  };
+
+  describe("startup", (): void => {
+    /*
+     * The hardest no-op in the package to diagnose from outside.
+     *
+     * In Always mode the sample percentage is the only reachable trigger, so
+     * an unsampled session never starts rrweb at all: no listener is
+     * installed, no event is buffered, no chunk is built and no request is
+     * made. From the page that is byte-for-byte identical to a script tag
+     * with the wrong token, a 404ing config endpoint, or a bundle that never
+     * parsed - and because sampling is a pure function of the session id, it
+     * is not bad luck the customer can reload their way out of either. This
+     * record is the only thing that tells them which of those it was.
+     */
+    it("says so when the sample percentage excluded the session entirely", (): void => {
+      const documentSpy: jest.SpyInstance = jest.spyOn(
+        document,
+        "addEventListener",
+      );
+      const windowSpy: jest.SpyInstance = jest.spyOn(
+        window,
+        "addEventListener",
+      );
+
+      const instance: Recorder = startRecorder({
+        captureTrigger: SessionReplayCaptureTrigger.Always,
+        samplePercentage: 0,
+      });
+
+      expect(codes()).toContain("not-sampled");
+      expect(detailOf("not-sampled")["samplePercentage"]).toBe(0);
+      expect(detailOf("not-sampled")["sessionId"]).toBe(
+        instance.getSessionId(),
+      );
+
+      /*
+       * rrweb attaches its mouse, scroll and input observers to the document
+       * the moment record() is called, and the recorder's own
+       * visibilitychange/pagehide/focusin listeners go on immediately after
+       * the sampling gate. Zero registrations is therefore proof that start()
+       * bailed before either happened rather than merely proof that nothing
+       * uploaded.
+       */
+      expect(documentSpy.mock.calls.length).toBe(0);
+      expect(windowSpy.mock.calls.length).toBe(0);
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      /*
+       * The same probe against a session the sampler DID select, so the
+       * assertion above is a signal rather than a listener spy that never
+       * fires in jsdom for some unrelated reason.
+       */
+      startRecorder({
+        captureTrigger: SessionReplayCaptureTrigger.Always,
+        samplePercentage: 100,
+      });
+
+      expect(documentSpy.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    /*
+     * THE line that answers "I see no requests in my Network tab".
+     *
+     * Under the default policy - OnErrorOrFrustration with a 0% sample - a
+     * perfectly healthy recorder makes exactly one request per page load (the
+     * config fetch) and posts nothing unless something goes wrong. That is
+     * the entire design, and it is the single most common report filed
+     * against a recorder that is behaving exactly as intended, so the message
+     * has to name the escape hatch rather than merely say "recording".
+     */
+    it("explains that the default policy uploads nothing until a trigger fires", (): void => {
+      const instance: Recorder = startRecorder();
+
+      const record: DebugRecord | undefined = recordFor("recording");
+
+      expect(record).toBeDefined();
+      expect(record?.message).toContain("captureSession()");
+      expect(record?.message).toContain("Nothing uploads until a trigger");
+
+      const detail: Record<string, unknown> = detailOf("recording");
+
+      expect(detail["captureTrigger"]).toBe(
+        SessionReplayCaptureTrigger.OnErrorOrFrustration,
+      );
+      expect(detail["samplePercentage"]).toBe(0);
+      expect(detail["isSampled"]).toBe(false);
+      expect(detail["consentMode"]).toBe(SessionReplayConsentMode.NotRequired);
+      expect(detail["consentState"]).toBe("NotRequired");
+      expect(detail["uploading"]).toBe(false);
+      expect(instance.isUploading()).toBe(false);
+    });
+
+    /* The same record, on the other side of the branch. */
+    it("reports uploading when the session was sampled in", (): void => {
+      startRecorder({ samplePercentage: 100 });
+
+      expect(detailOf("recording")["isSampled"]).toBe(true);
+      expect(detailOf("recording")["uploading"]).toBe(true);
+      expect(recordFor("recording")?.message).toContain("uploading");
+    });
+  });
+
+  describe("triggers and uploading", (): void => {
+    /*
+     * The first reason wins, and the record has to agree with it. A session
+     * that rage-clicked and then threw is more usefully labelled by what
+     * happened first, so a second "trigger" line - or one carrying the later
+     * reason - would make the timeline disagree with the envelopes the server
+     * actually received.
+     */
+    it("records the first trigger reason once, however many triggers fire", (): void => {
+      const instance: Recorder = startRecorder();
+
+      instance.trigger(SessionReplayTriggerReason.Frustration);
+      instance.trigger(SessionReplayTriggerReason.Error);
+      instance.trigger(SessionReplayTriggerReason.Manual);
+
+      expect(countOf("trigger")).toBe(1);
+      expect(detailOf("trigger")["reason"]).toBe(
+        SessionReplayTriggerReason.Frustration,
+      );
+      expect(detailOf("trigger")["sessionId"]).toBe(instance.getSessionId());
+    });
+
+    it("records that uploading started when consent is not required", (): void => {
+      const instance: Recorder = startRecorder({
+        consentMode: SessionReplayConsentMode.NotRequired,
+      });
+
+      instance.trigger(SessionReplayTriggerReason.Error);
+
+      expect(codes()).toContain("upload-started");
+      expect(detailOf("upload-started")["triggerReason"]).toBe(
+        SessionReplayTriggerReason.Error,
+      );
+      expect(detailOf("upload-started")["sessionId"]).toBe(
+        instance.getSessionId(),
+      );
+      expect(instance.isUploading()).toBe(true);
+    });
+
+    /*
+     * A page that mounts the recorder under RequireExplicit and never wires
+     * grantConsent() into its cookie banner records forever and uploads
+     * nothing. That is correct behaviour and was completely invisible: the
+     * trigger fires, the buffer keeps filling, and the network stays silent.
+     */
+    it("names consent when a trigger fired but nobody ever granted it", async (): Promise<void> => {
+      const instance: Recorder = startRecorder({
+        consentMode: SessionReplayConsentMode.RequireExplicit,
+      });
+
+      instance.trigger(SessionReplayTriggerReason.Manual);
+
+      await flushUploads();
+
+      expect(codes()).toContain("upload-blocked-consent");
+      expect(codes()).not.toContain("upload-started");
+
+      const detail: Record<string, unknown> = detailOf(
+        "upload-blocked-consent",
+      );
+
+      expect(detail["consentMode"]).toBe(
+        SessionReplayConsentMode.RequireExplicit,
+      );
+      expect(detail["consentState"]).toBe("Unknown");
+      expect(detail["isRevoked"]).toBe(false);
+
+      /* The point of the record: nothing left the device. */
+      expect(instance.isUploading()).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    /*
+     * A chunk that was fully built and then thrown away.
+     *
+     * It is not re-queued, not counted against droppedEvents, and the chunker
+     * has already reset its per-chunk signals - so from the server's side
+     * this is simply a gap in the recording with nothing to explain it. The
+     * guard exists for the window between "consent said yes" and "the chunk
+     * closed", which is why the revoke here is applied to the live Consent
+     * object: the public revokeConsent() stops the recorder outright, so it
+     * can never produce the very race the branch defends against.
+     */
+    it("records a chunk discarded because consent no longer allows uploading", async (): Promise<void> => {
+      const instance: Recorder = startRecorder({
+        consentMode: SessionReplayConsentMode.RequireExplicit,
+      });
+
+      instance.trigger(SessionReplayTriggerReason.Manual);
+      instance.grantConsent();
+
+      await flushUploads();
+
+      expect(codes()).toContain("upload-started");
+
+      (
+        instance as unknown as { consent: { revoke: () => void } }
+      ).consent.revoke();
+
+      document.body.appendChild(document.createElement("span"));
+
+      await flushUploads();
+
+      const postsBeforeTheDiscard: number = fetchMock.mock.calls.length;
+
+      sealByHidingThePage();
+
+      expect(codes()).toContain("chunk-discarded-consent");
+      expect(detailOf("chunk-discarded-consent")["consentState"]).toBe(
+        "Unknown",
+      );
+
+      /*
+       * A real chunk with real events in it, not the empty final chunk the
+       * chunker emits when it has nothing to say - and it went nowhere.
+       */
+      expect(detailOf("chunk-discarded-consent")["eventCount"]).toBeGreaterThan(
+        0,
+      );
+      expect(fetchMock.mock.calls.length).toBe(postsBeforeTheDiscard);
+    });
+  });
+
+  describe("stopping", (): void => {
+    /*
+     * The closing line of the timeline, and the only place the three loss
+     * counters are ever reported. A support ticket that opens with "the
+     * replay is missing the last minute" is answered by droppedEvents,
+     * droppedChunks and flushFailures, none of which are on the envelope.
+     */
+    it("reports the loss counters when the recorder stops", (): void => {
+      const instance: Recorder = startRecorder();
+
+      instance.stop();
+
+      const detail: Record<string, unknown> = detailOf("recorder-stopped");
+
+      expect(codes()).toContain("recorder-stopped");
+      expect(detail["sessionId"]).toBe(instance.getSessionId());
+      expect(detail["uploaded"]).toBe(false);
+      expect(detail["droppedEvents"]).toBe(0);
+      expect(detail["droppedChunks"]).toBe(0);
+      expect(detail["flushFailures"]).toBe(0);
+    });
+
+    /*
+     * A wrong ingestion token used to shut the whole recorder down with
+     * nothing printed anywhere at all: the transport tripped its breaker, the
+     * recorder stopped, and the page went quiet mid-session. The reason is
+     * what distinguishes "fix your token" (401) from "fix your host" (404).
+     */
+    it("names the transport failure that stopped the recorder for good", async (): Promise<void> => {
+      fetchMock.mockResolvedValue({
+        status: 401,
+        headers: {
+          get: (): string | null => {
+            return null;
+          },
+        },
+        text: async (): Promise<string> => {
+          return "";
+        },
+      });
+
+      const instance: Recorder = startRecorder({ samplePercentage: 100 });
+
+      await flushUploads();
+
+      expect(codes()).toContain("recorder-stopped-transport");
+      expect(detailOf("recorder-stopped-transport")["reason"]).toBe("http-401");
+
+      /* The stop is real, not just announced. */
+      expect(codes()).toContain("recorder-stopped");
+      expect(instance.isUploading()).toBe(true);
+    });
+
+    /*
+     * The kill switch. Stopping inside one chunk window rather than waiting
+     * out the config cache is the whole point of the directive, and the
+     * server's reason is the only thing that tells the customer it was THEIR
+     * dashboard toggle rather than a bug on their site.
+     */
+    it("attributes a server-ordered stop to the server, with its reason", async (): Promise<void> => {
+      fetchMock.mockResolvedValue({
+        status: 204,
+        headers: {
+          get: (): string | null => {
+            return null;
+          },
+        },
+        text: async (): Promise<string> => {
+          return '{"directive":"stop","reason":"project-disabled"}';
+        },
+      });
+
+      startRecorder({ samplePercentage: 100 });
+
+      await flushUploads();
+
+      expect(codes()).toContain("recorder-stopped-by-server");
+      expect(detailOf("recorder-stopped-by-server")["reason"]).toBe(
+        "project-disabled",
+      );
+      expect(codes()).toContain("recorder-stopped");
+    });
+  });
+
+  /*
+   * The property that matters more than any individual line in this file.
+   *
+   * Diagnostics have no masking of their own, they are reachable from
+   * untyped JavaScript on a global, and when they are switched on they print
+   * into the end user's console on somebody else's website. If a single
+   * record could carry a form value or a text node, this channel would be a
+   * second, unmasked egress path for exactly the data the rest of the
+   * package exists to protect - and it would leak precisely on the pages
+   * where somebody turned debugging on to look at a problem.
+   */
+  describe("page content", (): void => {
+    it("never carries page content into a record or the console", async (): Promise<void> => {
+      const secret: string = "zzq-shibboleth-4417-do-not-log";
+
+      document.body.innerHTML = `<div id="app"><p>${secret}</p><input id="card" name="card" value="${secret}" /></div>`;
+
+      const field: HTMLInputElement | null = document.querySelector("#card");
+
+      if (field) {
+        field.value = secret;
+      }
+
+      /* On, before anything is recorded, so the console sees every line. */
+      setEnabled(true, "test");
+
+      const instance: Recorder = startRecorder({ samplePercentage: 100 });
+
+      instance.trigger(SessionReplayTriggerReason.Error);
+
+      document.body.appendChild(document.createTextNode(secret));
+
+      if (field) {
+        field.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+
+      await flushUploads();
+
+      sealByHidingThePage();
+
+      instance.stop();
+
+      /*
+       * Guards against the whole assertion passing because nothing was
+       * recorded or printed in the first place.
+       */
+      expect(getDebugRecords().length).toBeGreaterThan(3);
+      expect(allConsoleText(spies)).toContain("[OneUptime Session Replay]");
+
+      expect(JSON.stringify(getDebugRecords())).not.toContain(secret);
+      expect(allConsoleText(spies)).not.toContain(secret);
+    });
+  });
+});

--- a/App/FeatureSet/BrowserRecorder/Tests/SourceHygiene.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/SourceHygiene.test.ts
@@ -73,6 +73,7 @@ describe("source hygiene", (): void => {
       "Config.ts",
       "Consent.ts",
       "ConsoleRecorder.ts",
+      "Debug.ts",
       "EarlyErrors.ts",
       "ErrorRecorder.ts",
       "ExtendedConfig.ts",
@@ -274,6 +275,100 @@ describe("source hygiene", (): void => {
           }
         }
       }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  /*
+   * The diagnostics are a second channel out of the page, and unlike the
+   * recording itself they have no masking of their own - the guarantee comes
+   * entirely from DebugDetail admitting only primitives, plus the runtime
+   * redaction that refuses anything else. A call site that reached into the
+   * DOM for a value would satisfy neither, and it would put page content
+   * into a console line and into whatever a customer pastes into a support
+   * ticket.
+   *
+   * Scanned at the source level because a violation might live on a path no
+   * fixture ever exercises, which is the whole reason this file exists.
+   */
+  it("never reads page content into a diagnostic", (): void => {
+    /*
+     * Every debugLog/debugWarn call, including its multi-line detail object.
+     * Non-greedy up to the closing ");" at the start of a line, which is
+     * what prettier produces for every call in this package.
+     */
+    const callPattern: RegExp = /\bdebug(?:Log|Warn)\s*\(([\s\S]*?)\n\s*\);/g;
+
+    /*
+     * Reading a node's own content, an element's text, or a form value.
+     * `.value` is deliberately absent: it is far too common a property name
+     * on our own objects (config.value, entry.value) to scan for usefully,
+     * and DebugDetail already refuses the objects those live on.
+     */
+    const forbidden: Array<RegExp> = [
+      /\binnerHTML\b/,
+      /\bouterHTML\b/,
+      /\btextContent\b/,
+      /\binnerText\b/,
+      /\bnodeValue\b/,
+      /\bgetAttribute\s*\(/,
+      /\blocation\.href\b/,
+      /\bdocument\b/,
+    ];
+
+    const offenders: Array<string> = [];
+
+    for (const source of sources) {
+      let match: RegExpExecArray | null = callPattern.exec(source.contents);
+
+      while (match !== null) {
+        const call: string = match[1] || "";
+
+        for (const pattern of forbidden) {
+          if (pattern.test(call)) {
+            offenders.push(`${source.name}: ${pattern.source}`);
+          }
+        }
+
+        match = callPattern.exec(source.contents);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  /*
+   * The diagnostics must stay OFF by default. This bundle runs on a
+   * customer's site in THEIR end users' browsers, and a RUM script that
+   * chatters into those consoles is one a customer removes.
+   *
+   * Enforced by routing every console call through Debug.ts, which checks
+   * the switch first. The ONE exception is the unconditional misconfiguration
+   * warning in the loader, which is a setup error on the customer's own page
+   * and is meant to be seen.
+   */
+  it("keeps console output inside the diagnostics module", (): void => {
+    const offenders: Array<string> = [];
+
+    for (const source of sources) {
+      if (source.name === "Debug.ts") {
+        continue;
+      }
+
+      const calls: number = (
+        source.contents.match(/\bconsole\s*\.\s*[a-z]+/g) || []
+      ).length;
+
+      if (calls === 0) {
+        continue;
+      }
+
+      if (source.name === "Loader.ts" && calls === 1) {
+        continue;
+      }
+
+      offenders.push(`${source.name}: ${calls}`);
     }
 
     expect(offenders).toEqual([]);

--- a/App/FeatureSet/BrowserRecorder/Tests/TransportDirective.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/TransportDirective.test.ts
@@ -1,0 +1,734 @@
+import {
+  SESSION_REPLAY_KEEPALIVE_MAX_BYTES,
+  SESSION_REPLAY_MAX_FLUSH_FAILURES,
+  SessionReplayChunkEnvelope,
+  SessionReplayDirective,
+} from "Common/Types/Rum/SessionReplay";
+import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import SessionReplayTriggerReason from "Common/Types/Rum/SessionReplayTriggerReason";
+import Chunker from "../src/Chunker";
+import { DebugRecord, clearDebugRecords, getDebugRecords } from "../src/Debug";
+import Transport from "../src/Transport";
+
+/*
+ * What the server tells a live recorder to do, and what the recorder says
+ * about it afterwards.
+ *
+ * Two failures are the reason this file exists, and both of them looked like
+ * "session replay just stopped working" from the outside:
+ *
+ * 1. THE BODYLESS 204. The status the server sends when it stands a recorder
+ *    down - over budget, unsampled, rate limited - is 204, which has no body.
+ *    The instruction rides on x-oneuptime-replay-directive and the reason on
+ *    x-oneuptime-replay-reason, and CorsOptions exposes both cross-origin for
+ *    exactly this reader. applyDirective() only ever parsed the body and
+ *    returned early when it was empty, so every one of those responses was
+ *    read as a plain success: the kill switch's fast path did nothing at all
+ *    and the recorder kept posting chunks the server had already refused.
+ *
+ * 2. THE DROPPED REASON. SessionReplayChunkResponse has carried `reason`
+ *    from the start, documented as existing so that a recorder told to stop
+ *    without a reason does not leave the customer diagnosing silence - and
+ *    nothing read it. It is now handed to onDirective and logged.
+ *
+ * Because the reason arrives over the wire it is treated as untrusted input
+ * on the way to a log line, and that boundary is asserted here too.
+ *
+ * Assertions read getDebugRecords() rather than the console: records are kept
+ * whether or not logging is switched on, and the switch is off in these tests
+ * exactly as it is on a customer's page.
+ */
+
+const STATE_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_DEBUG__";
+
+/*
+ * Distinctive on purpose. Every record produced anywhere in this file is
+ * searched for it, because the transport is the one module that holds the
+ * ingest credential and also writes diagnostics a customer is asked to paste
+ * into a support ticket.
+ */
+const INGEST_TOKEN: string = "ingest-token-2f7c9a";
+
+interface ReceivedDirective {
+  directive: SessionReplayDirective;
+  reason: string | null;
+}
+
+function globalRecord(): Record<string, unknown> {
+  return globalThis as unknown as Record<string, unknown>;
+}
+
+/*
+ * The debug timeline lives on a global so the loader stub and the artifact
+ * share one timeline, which also means it outlives a test case. Every case
+ * starts from nothing.
+ */
+function resetDebugState(): void {
+  delete globalRecord()[STATE_GLOBAL];
+}
+
+function codes(): Array<string> {
+  return getDebugRecords().map((record: DebugRecord): string => {
+    return record.code;
+  });
+}
+
+function recordFor(code: string): DebugRecord | undefined {
+  return getDebugRecords().find((record: DebugRecord): boolean => {
+    return record.code === code;
+  });
+}
+
+function detailOf(code: string): Record<string, unknown> {
+  return (recordFor(code)?.detail || {}) as Record<string, unknown>;
+}
+
+/* Everything a support ticket would carry, as one searchable string. */
+function serializedRecords(): string {
+  return JSON.stringify(getDebugRecords());
+}
+
+describe("Transport directives and diagnostics", (): void => {
+  const envelope: SessionReplayChunkEnvelope = {
+    v: 1,
+    appIdentifier: "app-1",
+    sessionId: "a".repeat(32),
+    tabId: "b".repeat(32),
+    chunkIndex: 0,
+    sessionStartUnixMs: 1_700_000_000_000,
+    clientSendUnixMs: 1_700_000_015_000,
+    chunkStartOffsetMs: 0,
+    chunkEndOffsetMs: 15_000,
+    eventCount: 12,
+    hasFullSnapshot: true,
+    isFinal: false,
+    recorderKind: "dom",
+    schemaVersion: 1,
+    rrwebVersion: "2.1.1",
+    recorderVersion: "11.7.3",
+    maskingMode: SessionReplayMaskingMode.MaskAllText,
+    consentState: "Granted",
+    triggerReason: SessionReplayTriggerReason.Error,
+    payloadEncoding: "identity",
+    payloadBytes: 0,
+    url: "https://shop.example.com/checkout",
+    signals: Chunker.emptySignals(),
+    fidelityNotices: [],
+    droppedEvents: 0,
+    flushFailures: 0,
+  };
+
+  let directives: Array<ReceivedDirective> = [];
+  let permanentFailures: Array<string> = [];
+
+  const makeTransport: () => Transport = (): Transport => {
+    directives = [];
+    permanentFailures = [];
+
+    return new Transport({
+      url: "https://oneuptime.com/session-replay/v1/chunk",
+      headers: {
+        "x-oneuptime-token": INGEST_TOKEN,
+        "x-oneuptime-app-identifier": "app-1",
+      },
+      onDirective: (
+        directive: SessionReplayDirective,
+        reason: string | null,
+      ): void => {
+        directives.push({ directive: directive, reason: reason });
+      },
+      onPermanentFailure: (reason: string): void => {
+        permanentFailures.push(reason);
+      },
+    });
+  };
+
+  const respond: (
+    status: number,
+    body?: string,
+    headers?: Record<string, string>,
+  ) => Response = (
+    status: number,
+    body?: string,
+    headers?: Record<string, string>,
+  ): Response => {
+    return {
+      status: status,
+      headers: {
+        get: (name: string): string | null => {
+          return headers ? headers[name.toLowerCase()] || null : null;
+        },
+      },
+      text: async (): Promise<string> => {
+        return body || "";
+      },
+    } as unknown as Response;
+  };
+
+  const setFetch: (response: Response) => jest.Mock = (
+    response: Response,
+  ): jest.Mock => {
+    const fetchMock: jest.Mock = jest.fn().mockResolvedValue(response);
+
+    globalRecord()["fetch"] = fetchMock;
+
+    return fetchMock;
+  };
+
+  beforeEach((): void => {
+    resetDebugState();
+  });
+
+  afterEach((): void => {
+    jest.restoreAllMocks();
+    resetDebugState();
+  });
+
+  describe("the bodyless 204", (): void => {
+    /*
+     * The regression itself. A 204 has no body, so the old body-only parser
+     * returned early and the recorder read "stop, you are over budget" as a
+     * successful upload - then posted the next chunk, and the one after that.
+     */
+    it("reads the directive and the reason off the headers when there is no body", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(204, "", {
+          "x-oneuptime-replay-directive": "stop",
+          "x-oneuptime-replay-reason": "budget-exhausted",
+        }),
+      );
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives).toEqual([
+        { directive: "stop", reason: "budget-exhausted" },
+      ]);
+
+      /* `via` is what distinguishes the header fallback from the body path. */
+      expect(detailOf("server-directive")["via"]).toBe("header");
+      expect(detailOf("server-directive")["reason"]).toBe("budget-exhausted");
+    });
+
+    /*
+     * A server that predates the headers sends a bare 204. Inventing a
+     * directive there would stop recorders against every deployment that has
+     * not caught up yet, so the transport still treats it as a success at the
+     * protocol level.
+     *
+     * The DIAGNOSTIC is not "accepted", though. 204 is exactly the status the
+     * server sends when it deliberately did not record - over budget, not
+     * sampled, application disabled - and its own metrics middleware refuses
+     * the same conflation in as many words. The docs teach a customer to look
+     * for chunk-accepted as proof their install works, so calling a
+     * stand-down an acceptance would confirm an installation that is storing
+     * nothing.
+     */
+    it("reports a bare 204 as not recorded rather than accepted", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(204));
+
+      expect(await transport.send(envelope, "[{}]")).toBe(true);
+
+      expect(directives).toEqual([]);
+      expect(codes()).not.toContain("server-directive");
+      expect(codes()).not.toContain("chunk-accepted");
+      expect(codes()).toContain("chunk-not-recorded");
+      expect(detailOf("chunk-not-recorded")["status"]).toBe(204);
+    });
+
+    /* And a 202 - a chunk that was actually stored - still reads as accepted. */
+    it("reports a 202 as accepted", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(202));
+
+      expect(await transport.send(envelope, "[{}]")).toBe(true);
+
+      expect(codes()).toContain("chunk-accepted");
+      expect(codes()).not.toContain("chunk-not-recorded");
+    });
+
+    /*
+     * Not every fetch implementation on a customer's page is the platform's.
+     * A response object with no `headers` at all must be as uneventful as one
+     * whose headers are simply empty, and must not throw into their page.
+     */
+    it("survives a response object that has no headers at all", async (): Promise<void> => {
+      const headerless: Response = {
+        status: 204,
+        text: async (): Promise<string> => {
+          return "";
+        },
+      } as unknown as Response;
+
+      const transport: Transport = makeTransport();
+
+      setFetch(headerless);
+
+      expect(await transport.send(envelope, "[{}]")).toBe(true);
+      expect(directives).toEqual([]);
+    });
+  });
+
+  describe("the reason on a directive", (): void => {
+    /*
+     * The second fix. Without the reason, "your recorder was told to stop" is
+     * an answer nobody can act on; with it, the support reply is one line.
+     */
+    it("passes the reason through from a JSON body", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(200, '{"directive":"throttle","reason":"rate-limited"}'),
+      );
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives).toEqual([
+        { directive: "throttle", reason: "rate-limited" },
+      ]);
+      expect(detailOf("server-directive")["reason"]).toBe("rate-limited");
+    });
+
+    /*
+     * A directive with no reason is still a directive. It arrives as null so
+     * the recorder can say "not-reported" rather than print `undefined`.
+     */
+    it("reports null when the body names a directive without a reason", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(200, '{"directive":"stop"}'));
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives).toEqual([{ directive: "stop", reason: null }]);
+      expect(detailOf("server-directive")["reason"]).toBe("not-reported");
+    });
+
+    /*
+     * Headers are the fallback for the bodyless case only. A response that
+     * has both is a server that answered in full, and the body is the
+     * authoritative half - reading both would fire onDirective twice and
+     * could stop a recorder the body only asked to slow down.
+     */
+    it("prefers the body over the headers when a response carries both", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(200, '{"directive":"throttle","reason":"rate-limited"}', {
+          "x-oneuptime-replay-directive": "stop",
+          "x-oneuptime-replay-reason": "budget-exhausted",
+        }),
+      );
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives).toEqual([
+        { directive: "throttle", reason: "rate-limited" },
+      ]);
+      expect(detailOf("server-directive")["via"]).toBeUndefined();
+    });
+
+    /*
+     * The directive vocabulary is closed. Anything else is a proxy, a
+     * captive portal or a future server, and acting on it would let an
+     * intermediary switch off a customer's recording.
+     */
+    it("ignores a directive value it does not recognise, in the body or a header", async (): Promise<void> => {
+      const fromBody: Transport = makeTransport();
+
+      setFetch(respond(200, '{"directive":"self-destruct","reason":"nope"}'));
+
+      await fromBody.send(envelope, "[{}]");
+
+      expect(directives).toEqual([]);
+      expect(codes()).not.toContain("server-directive");
+
+      clearDebugRecords();
+
+      const fromHeader: Transport = makeTransport();
+
+      setFetch(
+        respond(204, "", {
+          "x-oneuptime-replay-directive": "self-destruct",
+          "x-oneuptime-replay-reason": "nope",
+        }),
+      );
+
+      await fromHeader.send(envelope, "[{}]");
+
+      expect(directives).toEqual([]);
+      expect(codes()).not.toContain("server-directive");
+      expect(fromHeader.isDisabled()).toBe(false);
+    });
+
+    /*
+     * The reason is a closed server-side vocabulary, but it still arrives
+     * over the network, so it is bounded before it is ever written to a
+     * record a customer will paste somewhere. A server, or anything sitting
+     * in front of it, must not be able to push 300 characters of its choosing
+     * into the diagnostics timeline.
+     *
+     * REJECTED rather than truncated, and the difference matters twice over.
+     * Slicing first and testing the slice let a long string made entirely of
+     * vocabulary characters through as its first 64 - which is not a member
+     * of the vocabulary, so nothing downstream can branch on it, and it is
+     * still 64 characters somebody else chose landing in a console line. The
+     * directive itself is unaffected: an unusable reason degrades to
+     * "not-reported", it never suppresses the instruction.
+     */
+    it("drops an over-long reason without dropping the directive", async (): Promise<void> => {
+      const longReason: string = "over-budget-".repeat(25);
+
+      expect(longReason.length).toBe(300);
+
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(200, JSON.stringify({ directive: "stop", reason: longReason })),
+      );
+
+      await transport.send(envelope, "[{}]");
+
+      const received: ReceivedDirective | undefined = directives[0];
+
+      expect(received?.directive).toBe("stop");
+      expect(received?.reason).toBeNull();
+
+      /* Neither the whole string nor any prefix of it reaches a log line. */
+      expect(serializedRecords()).not.toContain("over-budget-over-budget-");
+      expect(detailOf("server-directive")["reason"]).toBe("not-reported");
+    });
+
+    /* A reason exactly at the bound is still usable. */
+    it("keeps a reason at the length limit", async (): Promise<void> => {
+      const atLimit: string = "b".repeat(64);
+
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(200, JSON.stringify({ directive: "stop", reason: atLimit })),
+      );
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives[0]?.reason).toBe(atLimit);
+    });
+
+    /*
+     * Anything outside [A-Za-z0-9_.:-] is refused outright rather than
+     * escaped, because the destination is a console line and a support
+     * ticket. A newline in a reason forges a second log line, and markup in
+     * one lands wherever those records are later rendered - both from a
+     * string the recorder never asked a human to trust.
+     */
+    it("drops a reason that is not in the closed vocabulary", async (): Promise<void> => {
+      const hostile: Array<{ reason: string; marker: string }> = [
+        { reason: "budget-exhausted\nforged-second-line", marker: "forged" },
+        { reason: "budget-exhausted\n", marker: "exhausted" },
+        { reason: "<script>alert(1)</script>", marker: "alert(1)" },
+        { reason: "over budget", marker: "over budget" },
+      ];
+
+      for (const candidate of hostile) {
+        clearDebugRecords();
+
+        const transport: Transport = makeTransport();
+
+        setFetch(
+          respond(
+            200,
+            JSON.stringify({ directive: "stop", reason: candidate.reason }),
+          ),
+        );
+
+        await transport.send(envelope, "[{}]");
+
+        /* The directive still stands; only its unusable reason is dropped. */
+        expect(directives).toEqual([{ directive: "stop", reason: null }]);
+        expect(detailOf("server-directive")["reason"]).toBe("not-reported");
+        expect(serializedRecords()).not.toContain(candidate.marker);
+      }
+    });
+
+    /* The header path is the same reader, and it is the untrusted one. */
+    it("drops an unusable reason that arrives on the 204 headers", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(204, "", {
+          "x-oneuptime-replay-directive": "stop",
+          "x-oneuptime-replay-reason": "<script>alert(1)</script>",
+        }),
+      );
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives).toEqual([{ directive: "stop", reason: null }]);
+      expect(serializedRecords()).not.toContain("alert(1)");
+    });
+
+    /*
+     * Reading the directive out of a 2xx body must not cost the rest of that
+     * body: retryAfterSeconds is how a healthy server slows a recorder down
+     * without spending a 429 on it.
+     */
+    it("still honours retryAfterSeconds in a 2xx body", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(200, '{"directive":"continue","retryAfterSeconds":60}'));
+
+      await transport.send(envelope, "[{}]");
+
+      expect(directives).toEqual([{ directive: "continue", reason: null }]);
+      expect(transport.isThrottled()).toBe(true);
+    });
+  });
+
+  describe("diagnostics records", (): void => {
+    /*
+     * The one record that says uploading works. Its fields are what a
+     * support engineer reads first: which chunk, how big, and whether the
+     * final one made it - a bare "accepted" answers none of those.
+     *
+     * payloadBytes is the count from the envelope that ACTUALLY WENT on the
+     * wire, not the caller's. post() overwrites the envelope with the
+     * post-compression length before sending, so reporting the caller's
+     * would show a different number here from the one the server received
+     * for the same chunk - which is the kind of discrepancy that turns a
+     * five-minute support answer into an afternoon.
+     */
+    it("records chunk-accepted with the bytes that were actually sent", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(202));
+
+      /*
+       * A caller-supplied payloadBytes that could not possibly be right, so
+       * a regression to reading chunk.envelope fails loudly rather than
+       * coincidentally matching.
+       */
+      await transport.send(
+        { ...envelope, chunkIndex: 7, payloadBytes: 999999, isFinal: true },
+        "[{}]",
+      );
+
+      const detail: Record<string, unknown> = detailOf("chunk-accepted");
+
+      expect(detail["status"]).toBe(202);
+      expect(detail["chunkIndex"]).toBe(7);
+      expect(detail["isFinal"]).toBe(true);
+      expect(detail["payloadBytes"]).not.toBe(999999);
+      expect(typeof detail["payloadBytes"]).toBe("number");
+      expect(detail["payloadBytes"] as number).toBeGreaterThan(0);
+
+      /* And the encoding, so a gzip that silently fell back is visible. */
+      expect(["gzip", "identity"]).toContain(detail["payloadEncoding"]);
+    });
+
+    /*
+     * The three statuses that stop the recorder for good, each with a fix in
+     * a different place: a bad token, an origin the project does not allow,
+     * an ingest URL that does not exist. Before these records a recorder
+     * simply went quiet mid-session with nothing printed anywhere.
+     */
+    it("records the status and the disable reason on 401, 403 and 404", async (): Promise<void> => {
+      for (const status of [401, 403, 404]) {
+        clearDebugRecords();
+
+        const transport: Transport = makeTransport();
+
+        setFetch(respond(status));
+
+        await transport.send(envelope, "[{}]");
+
+        expect(detailOf("chunk-rejected-terminal")["status"]).toBe(status);
+        expect(detailOf("transport-disabled")["reason"]).toBe(`http-${status}`);
+        expect(transport.isDisabled()).toBe(true);
+        expect(permanentFailures).toEqual([`http-${status}`]);
+      }
+    });
+
+    /*
+     * A refused chunk is the chunk's problem, not the transport's. The
+     * record has to make that visible, because "one oversized chunk" and
+     * "uploading has stopped" are the same missing seconds in the player and
+     * completely different things to go and fix.
+     */
+    it("records chunk-refused on 413, 422 and 400 without disabling anything", async (): Promise<void> => {
+      for (const status of [413, 422, 400]) {
+        clearDebugRecords();
+
+        const transport: Transport = makeTransport();
+
+        setFetch(respond(status));
+
+        await transport.send({ ...envelope, chunkIndex: 3 }, "[{}]");
+
+        expect(detailOf("chunk-refused")).toMatchObject({
+          status: status,
+          chunkIndex: 3,
+        });
+        expect(codes()).not.toContain("transport-disabled");
+        expect(transport.isDisabled()).toBe(false);
+        expect(permanentFailures).toEqual([]);
+      }
+    });
+
+    /*
+     * A throttled recorder looks exactly like a broken one from the network
+     * tab. The wait it is serving is the whole answer.
+     */
+    it("records chunk-throttled with the seconds it will wait", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(429, "", { "retry-after": "45" }));
+
+      await transport.send(envelope, "[{}]");
+
+      expect(detailOf("chunk-throttled")["retryAfterSeconds"]).toBe(45);
+      expect(transport.isThrottled()).toBe(true);
+    });
+
+    /*
+     * The request never left, so there is nothing in the network tab to look
+     * at - which is why the URL that was attempted is in the record. It is
+     * the ingest endpoint, and an ad blocker or a CSP eating it is the most
+     * common cause of a recorder that uploads nothing.
+     */
+    it("records chunk-post-failed with the URL when fetch rejects", async (): Promise<void> => {
+      globalRecord()["fetch"] = jest
+        .fn()
+        .mockRejectedValue(new Error("offline"));
+
+      const transport: Transport = makeTransport();
+
+      await transport.send({ ...envelope, chunkIndex: 2 }, "[{}]");
+
+      expect(detailOf("chunk-post-failed")).toMatchObject({
+        url: "https://oneuptime.com/session-replay/v1/chunk",
+        chunkIndex: 2,
+        consecutiveFailures: 1,
+      });
+    });
+
+    /*
+     * A 5xx is retried, so the record carries how close the circuit breaker
+     * is to giving up - the difference between a blip and a recorder that is
+     * about to disable itself for the rest of the page's life.
+     */
+    it("records chunk-post-server-error with the failure count on a 500", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(respond(500));
+
+      await transport.send(envelope, "[{}]");
+
+      expect(detailOf("chunk-post-server-error")).toMatchObject({
+        status: 500,
+        consecutiveFailures: 1,
+        maxFlushFailures: SESSION_REPLAY_MAX_FLUSH_FAILURES,
+      });
+      expect(transport.isDisabled()).toBe(false);
+    });
+
+    /*
+     * The last seconds before the tab closed are the ones an investigation
+     * usually needs, and they are the ones the keepalive quota can silently
+     * eat. An acknowledged loss with the two byte counts in it beats a replay
+     * that just ends early for no stated reason.
+     */
+    it("records final-chunk-too-large when the tail exceeds the keepalive quota", (): void => {
+      setFetch(respond(202));
+
+      const transport: Transport = makeTransport();
+      const huge: string = `[${"x".repeat(SESSION_REPLAY_KEEPALIVE_MAX_BYTES)}]`;
+
+      expect(transport.sendTerminal(envelope, huge)).toBe(false);
+
+      const detail: Record<string, unknown> = detailOf("final-chunk-too-large");
+
+      expect(detail["maxBytes"]).toBe(SESSION_REPLAY_KEEPALIVE_MAX_BYTES);
+      expect(detail["bytes"] as number).toBeGreaterThan(
+        SESSION_REPLAY_KEEPALIVE_MAX_BYTES,
+      );
+    });
+
+    /*
+     * "continue" arrives on every accepted chunk of a healthy session. Warning
+     * about it would bury the two directives that actually change what the
+     * recorder does under a line every few seconds.
+     */
+    it("warns on stop and throttle but stays quiet on continue", async (): Promise<void> => {
+      const carryOn: Transport = makeTransport();
+
+      setFetch(respond(200, '{"directive":"continue"}'));
+
+      await carryOn.send(envelope, "[{}]");
+
+      expect(directives).toEqual([{ directive: "continue", reason: null }]);
+      expect(codes()).not.toContain("server-directive");
+
+      for (const directive of ["stop", "throttle"]) {
+        clearDebugRecords();
+
+        const transport: Transport = makeTransport();
+
+        setFetch(respond(200, JSON.stringify({ directive: directive })));
+
+        await transport.send(envelope, "[{}]");
+
+        expect(recordFor("server-directive")?.level).toBe("warn");
+        expect(detailOf("server-directive")["directive"]).toBe(directive);
+      }
+    });
+
+    /*
+     * The transport is the one module holding the ingest credential, and it
+     * is also the one writing records a customer is asked to paste into a
+     * support ticket. The token must not appear in any of them - not in the
+     * URL that failed, not in a rejection, not in the terminal path.
+     */
+    it("never writes the ingestion token into a record", async (): Promise<void> => {
+      const transport: Transport = makeTransport();
+
+      setFetch(
+        respond(202, '{"directive":"stop","reason":"budget-exhausted"}'),
+      );
+      await transport.send(envelope, "[{}]");
+
+      setFetch(respond(413));
+      await transport.send(envelope, "[{}]");
+
+      globalRecord()["fetch"] = jest
+        .fn()
+        .mockRejectedValue(new Error("offline"));
+      await transport.send(envelope, "[{}]");
+
+      setFetch(respond(401));
+      await transport.send(envelope, "[{}]");
+
+      transport.sendTerminal(
+        envelope,
+        `[${"x".repeat(SESSION_REPLAY_KEEPALIVE_MAX_BYTES)}]`,
+      );
+
+      /* The gamut really did produce records before they were searched. */
+      expect(codes()).toEqual(
+        expect.arrayContaining([
+          "chunk-accepted",
+          "server-directive",
+          "chunk-refused",
+          "chunk-post-failed",
+          "chunk-rejected-terminal",
+          "transport-disabled",
+        ]),
+      );
+
+      expect(serializedRecords()).not.toContain(INGEST_TOKEN);
+    });
+  });
+});

--- a/App/FeatureSet/BrowserRecorder/esbuild.config.js
+++ b/App/FeatureSet/BrowserRecorder/esbuild.config.js
@@ -86,10 +86,26 @@ const FORBIDDEN_IN_BUNDLE = [
  * Raised from 6 KB after three deliberate feature sets landed in the stub:
  * the pre-load early-error buffer, the host-defaulting + misconfiguration
  * warning from the end-to-end fixes, and the /telemetry-prefixed paths.
- * Measured 6345 bytes at the time of the raise; the gzip budget below is
- * unchanged and is the number a customer's browser actually pays.
+ * Measured 6345 bytes at the time of that raise.
+ *
+ * Raised again from 7 KB for the diagnostics module (src/Debug.ts) and the
+ * ~20 decision points that report through it. Measured 12386 bytes raw /
+ * 4662 gzip at the time of this raise, against 6608 / 2596 before it.
+ *
+ * That is a real cost - the stub is on the critical path of every page view
+ * on a customer's site - and it was taken deliberately. The stub's entire
+ * job is to decide NOT to record: no init options, a privacy signal, a
+ * config fetch that 404s behind a reverse proxy, an application that is
+ * switched off, a deployment whose recorder artifact was never built. All
+ * five produced exactly the same observable outcome (nothing at all, not
+ * even a network request) and there was no way to tell them apart from the
+ * failing browser, which is where the answer has to be found: server
+ * telemetry cannot see a recorder that never loaded. Roughly 1.9 KB gzip,
+ * once, to make those five distinguishable is the better trade than the
+ * support round trips the silence costs - and the output is off unless
+ * somebody asks for it.
  */
-const LOADER_MAX_BYTES = 7 * 1024;
+const LOADER_MAX_BYTES = 13 * 1024;
 const RECORDER_MAX_BYTES = 320 * 1024;
 
 /*
@@ -98,8 +114,10 @@ const RECORDER_MAX_BYTES = 320 * 1024;
  * minified JavaScript compresses 3-4x, and by very different ratios
  * depending on what changed.
  *
- * Measured at the time of writing: recorder.js 227 KB raw / 70.7 KB gzip,
- * loader.js 4.7 KB raw / 1.9 KB gzip. Of the recorder's 70.7 KB, rrweb's
+ * Measured after the diagnostics module landed: recorder.js 245 KB raw /
+ * 75.7 KB gzip, loader.js 12.1 KB raw / 4.6 KB gzip. Before it, and for the
+ * measurements the rest of this note is based on: recorder.js 227 KB raw /
+ * 70.7 KB gzip, loader.js 4.7 KB raw / 1.9 KB gzip. Of the recorder's 70.7 KB, rrweb's
  * record entry point alone is 57.8 KB gzip (182 KB raw) with the Replayer,
  * xstate, the fflate packer and the canvas-webgl path all already tree-shaken
  * out; this package's own 15 modules are the remaining ~12.8 KB. The design
@@ -109,8 +127,8 @@ const RECORDER_MAX_BYTES = 320 * 1024;
  * The budgets are set just above the measured values so a regression fails
  * the build rather than being discovered in a customer's Core Web Vitals.
  */
-const LOADER_MAX_GZIP_BYTES = 3 * 1024;
-const RECORDER_MAX_GZIP_BYTES = 76 * 1024;
+const LOADER_MAX_GZIP_BYTES = 5 * 1024;
+const RECORDER_MAX_GZIP_BYTES = 78 * 1024;
 
 function isInside(directory, candidate) {
   const withSeparator = directory.endsWith(path.sep)

--- a/App/FeatureSet/BrowserRecorder/src/Config.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Config.ts
@@ -6,6 +6,7 @@ import {
 import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
 import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode";
 import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import { debugLog, debugWarn, setEnabled } from "./Debug";
 
 /*
  * Init options and the policy fetch.
@@ -88,6 +89,14 @@ export const RECORDER_VERSION_PATTERN: RegExp =
 export const CONFIG_FETCH_TIMEOUT_MS: number = 5000;
 
 /*
+ * The spellings a person actually types into an HTML attribute. Kept
+ * identical to TRUTHY in Debug.ts, which resolves the same switch from the
+ * init global - a switch that works from one place and not the other is
+ * worse than no switch at all on a diagnostic nobody can reach a console for.
+ */
+const TRUTHY_OPTION_PATTERN: RegExp = /^(1|true|yes|on)$/i;
+
+/*
  * The policy snapshot as the recorder consumes it.
  *
  * recorderIntegrity is additive on top of the shared wire type: the loader
@@ -134,6 +143,14 @@ export interface RecorderInitOptions {
    * and the server's own respectDoNotTrack still applies on top.
    */
   respectDoNotTrack?: boolean;
+
+  /*
+   * Print the recorder's decisions to the console. Off unless asked for -
+   * this script runs on end users' machines, not the customer's - and
+   * equivalent to the localStorage and query-string switches in Debug.ts.
+   * See there for why the diagnostic exists at all.
+   */
+  debug?: boolean;
 }
 
 export default class Config {
@@ -155,10 +172,40 @@ export default class Config {
     );
 
     if (fromGlobal) {
-      return fromGlobal;
+      return Config.acceptOptions(fromGlobal, "init-global");
     }
 
-    return Config.readScriptTagOptions(documentRef);
+    const fromTag: RecorderInitOptions | null =
+      Config.readScriptTagOptions(documentRef);
+
+    return fromTag ? Config.acceptOptions(fromTag, "script-tag") : null;
+  }
+
+  /*
+   * One exit for both option sources.
+   *
+   * It applies the page's own debug switch - read here rather than in
+   * Debug.resolve, because resolving it there would mean a document-wide
+   * querySelector on every page load for a switch that is off on virtually
+   * all of them - and reports what was read. `host` and `appIdentifier` are
+   * the two values a wrong install gets wrong, and neither is user data.
+   */
+  private static acceptOptions(
+    options: RecorderInitOptions,
+    source: string,
+  ): RecorderInitOptions {
+    if (options.debug === true) {
+      setEnabled(true, source);
+    }
+
+    debugLog("init-options-read", "Init options read.", {
+      source: source,
+      host: options.host,
+      appIdentifier: options.appIdentifier,
+      respectDoNotTrack: options.respectDoNotTrack !== false,
+    });
+
+    return options;
   }
 
   private static readGlobalOptions(
@@ -170,7 +217,10 @@ export default class Config {
       return null;
     }
 
-    return Config.normaliseOptions(raw as Record<string, unknown>);
+    return Config.normaliseOptions(
+      raw as Record<string, unknown>,
+      "init-global",
+    );
   }
 
   private static readScriptTagOptions(
@@ -212,9 +262,10 @@ export default class Config {
       userRef: tag.getAttribute("data-oneuptime-user-ref"),
       respectDoNotTrack:
         tag.getAttribute("data-oneuptime-respect-do-not-track") !== "false",
+      debug: tag.getAttribute("data-oneuptime-debug"),
     };
 
-    return Config.normaliseOptions(dataset);
+    return Config.normaliseOptions(dataset, "script-tag");
   }
 
   /*
@@ -242,6 +293,7 @@ export default class Config {
 
   private static normaliseOptions(
     raw: Record<string, unknown>,
+    source: string,
   ): RecorderInitOptions | null {
     const host: unknown = raw["host"];
     const token: unknown = raw["token"];
@@ -257,6 +309,33 @@ export default class Config {
       !token ||
       !appIdentifier
     ) {
+      /*
+       * WHICH field is missing, and on WHICH source. "the snippet is wrong"
+       * and "the host could not be derived from the script src" are
+       * different bugs with different fixes, and the console.warn the loader
+       * prints for this case cannot tell them apart.
+       *
+       * Deliberately not phrased as an outcome. The global is only the FIRST
+       * of two sources, so a page that sets `window.__ONEUPTIME_SESSION_REPLAY__
+       * = { debug: true }` purely to switch diagnostics on - which is a
+       * documented way to do it - reaches this line and then records
+       * perfectly well from its script tag. Saying "nothing will be
+       * recorded" there would hand the person who just enabled diagnostics a
+       * fault that does not exist. Whether anything actually records is the
+       * loader's to report, and it does.
+       */
+      debugWarn(
+        "init-options-incomplete",
+        "An init source is missing a required field and was skipped.",
+        {
+          source: source,
+          hasHost: typeof host === "string" && Boolean(host),
+          hasToken: typeof token === "string" && Boolean(token),
+          hasAppIdentifier:
+            typeof appIdentifier === "string" && Boolean(appIdentifier),
+        },
+      );
+
       return null;
     }
 
@@ -267,6 +346,10 @@ export default class Config {
       respectDoNotTrack: respectDoNotTrack !== false,
     };
 
+    if (Config.readBooleanOption(raw["debug"])) {
+      options.debug = true;
+    }
+
     /*
      * Assigned conditionally rather than as `userRef: undefined`, because
      * exactOptionalPropertyTypes makes those two different types.
@@ -276,6 +359,24 @@ export default class Config {
     }
 
     return options;
+  }
+
+  /*
+   * The spellings a person actually types into an HTML attribute.
+   *
+   * The tag attribute used to be compared against the literal string "true"
+   * while the init global went through Debug's own resolver, which accepts
+   * "1", "yes" and "on" in any case - so data-oneuptime-debug="1" silently
+   * did nothing while the equivalent global worked. On a feature whose whole
+   * point is being reachable by somebody who cannot get to a console, a
+   * switch that only works if you guess the right word is worse than no
+   * switch.
+   */
+  private static readBooleanOption(value: unknown): boolean {
+    return (
+      value === true ||
+      (typeof value === "string" && TRUTHY_OPTION_PATTERN.test(value))
+    );
   }
 
   public static getConfigUrl(options: RecorderInitOptions): string {
@@ -357,8 +458,15 @@ export default class Config {
       }
     }
 
+    const url: string = Config.getConfigUrl(options);
+
+    debugLog("config-fetch-start", "Requesting the policy.", {
+      url: url,
+      timeoutMs: CONFIG_FETCH_TIMEOUT_MS,
+    });
+
     try {
-      const response: Response = await fetch(Config.getConfigUrl(options), {
+      const response: Response = await fetch(url, {
         method: "GET",
         headers: headers,
         signal: controller.signal,
@@ -373,13 +481,57 @@ export default class Config {
       });
 
       if (!response.ok) {
+        /*
+         * The three statuses that account for nearly every report, named
+         * because the fix for each is somewhere completely different: a
+         * key in Project Settings, an nginx route, a header on the tag.
+         */
+        debugWarn(
+          "config-fetch-rejected",
+          "The config endpoint refused the request. Nothing will be recorded.",
+          { url: url, status: response.status },
+        );
+
         return null;
       }
 
-      const body: unknown = await response.json();
+      let body: unknown = null;
+
+      try {
+        body = await response.json();
+      } catch {
+        /*
+         * A 2xx that is not JSON. Reported separately from the catch below,
+         * because "the request never left the browser" and "something on the
+         * path answered 200 with an HTML page" are different faults with
+         * different fixes - a CSP or an ad blocker for the first, a proxy,
+         * captive portal or SSO interstitial for the second - and collapsing
+         * them sends the reader to the wrong one.
+         */
+        debugWarn(
+          "config-body-unparseable",
+          "The config endpoint answered, but not with JSON. Something on the path is answering instead of OneUptime.",
+          { url: url, status: response.status },
+        );
+
+        return null;
+      }
 
       return Config.validateConfig(body);
     } catch {
+      /*
+       * A rejected fetch is a network-layer failure the page cannot see
+       * either: DNS, TLS, offline, an ad blocker, a CSP connect-src that
+       * does not list the OneUptime origin, or this request outliving
+       * CONFIG_FETCH_TIMEOUT_MS. The browser prints its own message for
+       * some of these and nothing at all for others.
+       */
+      debugWarn(
+        "config-fetch-failed",
+        "The config request never completed. Nothing will be recorded.",
+        { url: url, timeoutMs: CONFIG_FETCH_TIMEOUT_MS },
+      );
+
       return null;
     } finally {
       clearTimeout(timeout);
@@ -396,12 +548,46 @@ export default class Config {
    */
   public static validateConfig(body: unknown): LoaderConfig | null {
     if (!body || typeof body !== "object") {
+      debugWarn(
+        "config-unparseable",
+        "The config response was not a JSON object. Nothing will be recorded.",
+      );
+
       return null;
     }
 
     const raw: Record<string, unknown> = body as Record<string, unknown>;
 
+    /*
+     * The server can be told to turn diagnostics on for EVERY visitor, which
+     * is the only switch reachable by an operator who cannot touch the
+     * customer's page. Applied before the gates below so a disabled response
+     * still explains itself. See SESSION_REPLAY_DEBUG.
+     */
+    if (raw["debug"] === true) {
+      setEnabled(true, "server-config");
+    }
+
     if (raw["enabled"] !== true) {
+      /*
+       * The single most common answer to "replay is on in the dashboard but
+       * nothing happens", and until the server started sending
+       * disabledReason there was no way to tell the five causes apart from a
+       * browser. `recorder-not-built` in particular is a deployment that
+       * never ran the recorder build, which no amount of dashboard
+       * configuration will fix.
+       */
+      const reason: unknown = raw["disabledReason"];
+
+      debugWarn(
+        "config-disabled",
+        "The server says replay is off here. Nothing will be recorded.",
+        {
+          disabledReason:
+            typeof reason === "string" && reason ? reason : "not-reported",
+        },
+      );
+
       return null;
     }
 
@@ -413,6 +599,15 @@ export default class Config {
      * published artifact.
      */
     if (!Config.isValidRecorderVersion(recorderVersion)) {
+      debugWarn(
+        "config-recorder-version-invalid",
+        "The server named no published recorder version, so no artifact can load.",
+        {
+          recorderVersion:
+            typeof recorderVersion === "string" ? recorderVersion : "missing",
+        },
+      );
+
       return null;
     }
 
@@ -478,6 +673,57 @@ export default class Config {
 
     if (typeof integrity === "string" && integrity) {
       config.recorderIntegrity = integrity;
+    }
+
+    /*
+     * The policy line. Everything below is a decision the recorder will now
+     * make silently for the rest of the page's life, and the combination is
+     * what usually explains "no requests in the network tab":
+     * OnErrorOrFrustration with samplePercentage 0 is a session that records
+     * into memory and uploads NOTHING until something goes wrong. That is
+     * working as designed, and it is indistinguishable from broken.
+     */
+    debugLog("config-accepted", "Policy accepted.", {
+      captureTrigger: config.captureTrigger,
+      samplePercentage: config.samplePercentage,
+      consentMode: config.consentMode,
+      maskingMode: config.maskingMode,
+      recorderVersion: config.recorderVersion,
+      configEpoch: config.configEpoch,
+      directive: config.directive,
+      respectDoNotTrack: config.respectDoNotTrack,
+      hasIntegrity: Boolean(config.recorderIntegrity),
+    });
+
+    /*
+     * A value this build does not recognise collapses to the STRICTEST
+     * option, not to the one the server meant. That is the right default and
+     * a genuinely confusing one: a newer server, or a proxy rewriting the
+     * body, can leave a customer looking at MaskAllText while the dashboard
+     * shows something else entirely - and silently.
+     *
+     * One loop rather than three blocks: this file is bundled into the
+     * loader stub, which every visitor to a customer's site downloads.
+     */
+    for (const field of ["maskingMode", "consentMode", "captureTrigger"]) {
+      const sent: unknown = raw[field];
+
+      if (
+        sent !== undefined &&
+        sent !== (config as unknown as Record<string, unknown>)[field]
+      ) {
+        debugWarn(
+          "config-value-unrecognised",
+          "This build does not know a value the server sent; using the safest one instead.",
+          {
+            field: field,
+            sent: typeof sent === "string" ? sent : typeof sent,
+            using: String(
+              (config as unknown as Record<string, unknown>)[field],
+            ),
+          },
+        );
+      }
     }
 
     return config;

--- a/App/FeatureSet/BrowserRecorder/src/Debug.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Debug.ts
@@ -1,0 +1,510 @@
+/*
+ * Diagnostics for a recorder that is silent by design.
+ *
+ * Every gate in this package fails CLOSED and says nothing: no init options,
+ * a privacy signal, a config fetch that 404s, `enabled: false`, an unsampled
+ * session, a consent mode nobody granted, a 401 that trips the circuit
+ * breaker. Each of those produces exactly the same thing on the customer's
+ * page - no recording, no request, no console output - which is why "session
+ * replay is not working" and "session replay is switched off" are
+ * indistinguishable from a browser, and why the only diagnostic that existed
+ * was a server-side panel that cannot see a recorder which never loaded.
+ *
+ * This module is that missing half. It is OFF by default (a RUM script must
+ * not print into a customer's end users' consoles), and it is turned on
+ * per-browser without a redeploy - which matters, because the page that is
+ * failing is usually production and the person debugging it cannot ship a
+ * new script tag to look at it.
+ *
+ * Two rules keep it honest:
+ *
+ * 1. RECORDS ARE ALWAYS KEPT, output is what the switch gates. The ring is
+ *    bounded and every call site is a cold path (startup, a config fetch, a
+ *    chunk boundary - never the rrweb event hot path), so a support engineer
+ *    can ask for `OneUptimeReplay.getDiagnostics()` on a page where nobody
+ *    thought to turn logging on first, and get the whole timeline back.
+ *
+ * 2. NO PAGE CONTENT, EVER. `DebugDetail` admits only primitives, values are
+ *    truncated, and non-primitives handed in by untyped JavaScript are
+ *    dropped rather than stringified. A diagnostic channel that could carry
+ *    a DOM node or an unscrubbed URL would be a second, unmasked egress path
+ *    for exactly the data the rest of this package exists to protect.
+ *
+ * The state lives on a global rather than in module scope because the loader
+ * stub and the artifact are two separate bundles with two separate module
+ * instances. Without sharing, the artifact's `getDiagnostics()` would be
+ * missing precisely the records that matter most - everything the stub
+ * decided before the artifact existed.
+ */
+
+/* Shared by both bundles. See the note above. */
+const STATE_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_DEBUG__";
+
+/* Read before anything else, so a reload keeps logging without a code change. */
+export const DEBUG_STORAGE_KEY: string = "oneuptime.sessionReplay.debug";
+
+/* `?oneuptime_debug=1`, also honoured in the fragment. */
+export const DEBUG_QUERY_PARAM: string = "oneuptime_debug";
+
+/* The init global, read here as well as in Config so it works pre-tag. */
+const INIT_OPTIONS_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY__";
+
+const LOG_PREFIX: string = "[OneUptime Session Replay]";
+
+/* What every `code` below means, and what to do about it. */
+export const DEBUG_DOCS_URL: string =
+  "https://oneuptime.com/docs/rum/session-replay-troubleshooting";
+
+/*
+ * Bounded because this survives for the life of the page. 250 entries is
+ * several minutes of a badly behaved session and a few hundred bytes.
+ */
+export const MAX_DEBUG_RECORDS: number = 250;
+
+/* Long enough for a URL or a reason code, short enough not to hold a body. */
+export const MAX_DEBUG_VALUE_LENGTH: number = 256;
+
+/*
+ * Matches `oneuptime_debug`, `oneuptime_debug=1` and `oneuptime_debug=true`
+ * in a query string or a fragment. An explicit `=0` / `=false` does NOT
+ * match, so a link can turn it on and a later one can leave it off.
+ */
+const DEBUG_QUERY_PATTERN: RegExp =
+  /(^|[?&#])oneuptime_debug(=(1|true|yes|on))?($|[&#])/i;
+
+const TRUTHY: RegExp = /^(1|true|yes|on)$/i;
+
+/* Only primitives. See rule 2 above - this type IS the privacy boundary. */
+export type DebugDetailValue = string | number | boolean | null;
+export type DebugDetail = Record<string, DebugDetailValue>;
+
+export type DebugLevel = "info" | "warn";
+
+export interface DebugRecord {
+  atUnixMs: number;
+  level: DebugLevel;
+
+  /*
+   * Stable kebab-case identifier. This is what a support ticket quotes and
+   * what the docs index, so it is part of the contract in a way the prose
+   * message is not.
+   */
+  code: string;
+
+  message: string;
+  detail?: DebugDetail;
+}
+
+interface DebugState {
+  enabled: boolean;
+
+  /* Whether the ambient switches have been consulted yet. */
+  resolved: boolean;
+
+  /* How it got switched on, for the "why am I seeing this" line. */
+  source: string;
+
+  records: Array<DebugRecord>;
+}
+
+function getState(): DebugState {
+  const globalRecord: Record<string, unknown> = globalThis as unknown as Record<
+    string,
+    unknown
+  >;
+
+  const existing: unknown = globalRecord[STATE_GLOBAL];
+
+  /*
+   * Shape-checked rather than trusted: this is a well-known global name on a
+   * page we do not control, and a host script that parked a string there must
+   * not be able to break the recorder's startup.
+   */
+  if (
+    existing &&
+    typeof existing === "object" &&
+    Array.isArray((existing as Record<string, unknown>)["records"])
+  ) {
+    return existing as unknown as DebugState;
+  }
+
+  const state: DebugState = {
+    enabled: false,
+    resolved: false,
+    source: "",
+    records: [],
+  };
+
+  /*
+   * A page that froze globalThis makes this assignment throw in strict mode.
+   * The state is then per-module rather than shared, which costs the
+   * one-timeline property and nothing else - and is emphatically better than
+   * throwing out of the loader's first statement.
+   */
+  try {
+    globalRecord[STATE_GLOBAL] = state;
+  } catch {
+    /* Not shareable. Still perfectly usable. */
+  }
+
+  return state;
+}
+
+/*
+ * Read a property off the global object without ever throwing.
+ *
+ * `window.localStorage` throws SecurityError ON THE ACCESSOR - not on
+ * getItem - in a sandboxed iframe without allow-same-origin and wherever the
+ * user has blocked site data for the origin. Guarding only the getItem call
+ * is therefore not enough, and the distinction is not theoretical: the first
+ * statement of the loader asks whether diagnostics are on, so a throw here
+ * would take the whole recorder down on those pages - silently, which is the
+ * exact failure this module exists to end.
+ */
+function readGlobalProperty(
+  record: Record<string, unknown>,
+  key: string,
+): unknown {
+  try {
+    return record[key];
+  } catch {
+    return undefined;
+  }
+}
+
+/*
+ * And getItem throws separately, in Safari's private mode and wherever site
+ * data is blocked. A diagnostics switch must never be the thing that breaks
+ * the page it was turned on to debug.
+ */
+function readStorageFlag(storage: unknown): boolean {
+  try {
+    if (!storage || typeof storage !== "object") {
+      return false;
+    }
+
+    const getItem: unknown = (storage as Record<string, unknown>)["getItem"];
+
+    if (typeof getItem !== "function") {
+      return false;
+    }
+
+    const value: unknown = (
+      storage as unknown as { getItem: (key: string) => string | null }
+    ).getItem(DEBUG_STORAGE_KEY);
+
+    return typeof value === "string" && TRUTHY.test(value);
+  } catch {
+    return false;
+  }
+}
+
+function readQueryFlag(locationRef: unknown): boolean {
+  try {
+    if (!locationRef || typeof locationRef !== "object") {
+      return false;
+    }
+
+    const location: Record<string, unknown> = locationRef as Record<
+      string,
+      unknown
+    >;
+
+    const search: unknown = location["search"];
+    const hash: unknown = location["hash"];
+
+    return (
+      (typeof search === "string" && DEBUG_QUERY_PATTERN.test(search)) ||
+      (typeof hash === "string" && DEBUG_QUERY_PATTERN.test(hash))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readInitGlobalFlag(windowRecord: Record<string, unknown>): boolean {
+  const raw: unknown = windowRecord[INIT_OPTIONS_GLOBAL];
+
+  if (!raw || typeof raw !== "object") {
+    return false;
+  }
+
+  const value: unknown = (raw as Record<string, unknown>)["debug"];
+
+  /* Same spellings Config.readBooleanOption accepts on the script tag. */
+  return value === true || (typeof value === "string" && TRUTHY.test(value));
+}
+
+/*
+ * Consult the ambient switches once.
+ *
+ * Deliberately NOT including the script tag's data-oneuptime-debug attribute:
+ * that one is read by Config alongside the rest of the init options and
+ * applied through setEnabled(), because reading it here would mean a second
+ * document-wide querySelector on every page load for a feature that is off
+ * on virtually all of them.
+ */
+function resolve(state: DebugState): void {
+  if (state.resolved) {
+    return;
+  }
+
+  state.resolved = true;
+
+  const globalRecord: Record<string, unknown> = globalThis as unknown as Record<
+    string,
+    unknown
+  >;
+
+  if (readInitGlobalFlag(globalRecord)) {
+    setEnabled(true, "init-global");
+    return;
+  }
+
+  if (readQueryFlag(readGlobalProperty(globalRecord, "location"))) {
+    setEnabled(true, "query-param");
+    return;
+  }
+
+  if (readStorageFlag(readGlobalProperty(globalRecord, "localStorage"))) {
+    setEnabled(true, "local-storage");
+    return;
+  }
+
+  if (readStorageFlag(readGlobalProperty(globalRecord, "sessionStorage"))) {
+    setEnabled(true, "session-storage");
+  }
+}
+
+export function isDebugEnabled(): boolean {
+  const state: DebugState = getState();
+
+  resolve(state);
+
+  return state.enabled;
+}
+
+/*
+ * Turn logging on (or off) explicitly.
+ *
+ * Enabling FLUSHES the backlog to the console, which is the whole reason the
+ * ring is kept while disabled: the server-driven switch and the script tag
+ * attribute both arrive after the loader has already made several decisions,
+ * and those earlier decisions are usually the answer.
+ */
+export function setEnabled(enabled: boolean, source: string): void {
+  const state: DebugState = getState();
+
+  /* An explicit call is itself a resolution; do not let resolve() undo it. */
+  state.resolved = true;
+
+  if (!enabled) {
+    state.enabled = false;
+    state.source = "";
+    return;
+  }
+
+  if (state.enabled) {
+    return;
+  }
+
+  state.enabled = true;
+  state.source = source;
+
+  writeToConsole({
+    atUnixMs: Date.now(),
+    level: "info",
+
+    /*
+     * Printed once, not per line. Every message below is deliberately short
+     * - this bundle is downloaded by every visitor to a customer's site, and
+     * a paragraph of remediation prose per call site is measured in
+     * kilobytes of gzip on somebody else's Core Web Vitals. The `code` on
+     * each record is the stable identifier, and the page below explains
+     * every one of them in full.
+     */
+    code: "debug-enabled",
+    message: `Diagnostics on (${source}). Codes: ${DEBUG_DOCS_URL} — off: localStorage.removeItem("${DEBUG_STORAGE_KEY}")`,
+  });
+
+  for (const record of state.records) {
+    writeToConsole(record);
+  }
+}
+
+export function getDebugSource(): string {
+  return getState().source;
+}
+
+/*
+ * Everything recorded so far, oldest first. Handed straight to a support
+ * ticket, so it is a copy: a caller must not be able to mutate the timeline.
+ */
+export function getDebugRecords(): Array<DebugRecord> {
+  return getState().records.slice();
+}
+
+export function clearDebugRecords(): void {
+  getState().records.length = 0;
+}
+
+/*
+ * Drop everything that is not a primitive, and truncate what is left.
+ *
+ * Untyped JavaScript can call into this (the public API is on a global), and
+ * `String(value)` on a DOM node or a fetch Response would put page content
+ * into a channel that has no masking of its own. Dropping is the only safe
+ * default.
+ */
+function redact(detail: DebugDetail): DebugDetail {
+  const safe: DebugDetail = {};
+
+  for (const key of Object.keys(detail)) {
+    const value: unknown = detail[key];
+
+    if (value === null) {
+      safe[key] = null;
+      continue;
+    }
+
+    if (typeof value === "boolean") {
+      safe[key] = value;
+      continue;
+    }
+
+    if (typeof value === "number") {
+      safe[key] = Number.isFinite(value) ? value : String(value);
+      continue;
+    }
+
+    if (typeof value === "string") {
+      safe[key] =
+        value.length > MAX_DEBUG_VALUE_LENGTH
+          ? `${value.slice(0, MAX_DEBUG_VALUE_LENGTH)}…`
+          : value;
+      continue;
+    }
+
+    /*
+     * undefined, objects, arrays, functions, symbols. Named rather than
+     * omitted so a missing key reads as "not supplied" and this reads as
+     * "supplied, and refused".
+     */
+    if (value !== undefined) {
+      safe[key] = `<${typeof value} omitted>`;
+    }
+  }
+
+  return safe;
+}
+
+function writeToConsole(record: DebugRecord): void {
+  /*
+   * console is not ours: a page may have replaced it, frozen it, or removed
+   * a method. Diagnostics must never throw into the customer's page.
+   */
+  try {
+    const consoleRef: unknown = (
+      globalThis as unknown as Record<string, unknown>
+    )["console"];
+
+    if (!consoleRef || typeof consoleRef !== "object") {
+      return;
+    }
+
+    const method: unknown = (consoleRef as Record<string, unknown>)[
+      record.level === "warn" ? "warn" : "info"
+    ];
+
+    if (typeof method !== "function") {
+      return;
+    }
+
+    const line: string = `${LOG_PREFIX} ${record.code}: ${record.message}`;
+
+    if (record.detail) {
+      // eslint-disable-next-line no-console
+      (method as (...args: Array<unknown>) => void).call(
+        consoleRef,
+        line,
+        record.detail,
+      );
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    (method as (...args: Array<unknown>) => void).call(consoleRef, line);
+  } catch {
+    /* A console that throws is not a reason to stop recording. */
+  }
+}
+
+function push(
+  level: DebugLevel,
+  code: string,
+  message: string,
+  detail?: DebugDetail,
+): void {
+  const state: DebugState = getState();
+
+  resolve(state);
+
+  const record: DebugRecord = {
+    atUnixMs: Date.now(),
+    level: level,
+    code: code,
+    message: message,
+  };
+
+  if (detail) {
+    /*
+     * redact reads every value on the object it is handed. Everything this
+     * module is called with is a literal built a line above the call, so
+     * there is nothing here that can throw today - but the whole package's
+     * rule is that instrumentation never throws into the customer's page,
+     * and a diagnostic that took a host page down while somebody was
+     * debugging it would be the worst possible way to learn otherwise.
+     */
+    try {
+      record.detail = redact(detail);
+    } catch {
+      record.detail = { detail: "<unreadable>" };
+    }
+  }
+
+  state.records.push(record);
+
+  /*
+   * Drop the OLDEST. A long-lived tab's most recent decisions are the ones
+   * that explain what it is doing now.
+   */
+  while (state.records.length > MAX_DEBUG_RECORDS) {
+    state.records.shift();
+  }
+
+  if (state.enabled) {
+    writeToConsole(record);
+  }
+}
+
+/* A step that went as intended. */
+export function debugLog(
+  code: string,
+  message: string,
+  detail?: DebugDetail,
+): void {
+  push("info", code, message, detail);
+}
+
+/*
+ * A step that stopped, degraded, or silently changed the policy the server
+ * sent. Everything a customer chasing "replay is not working" is looking for
+ * is a warn.
+ */
+export function debugWarn(
+  code: string,
+  message: string,
+  detail?: DebugDetail,
+): void {
+  push("warn", code, message, detail);
+}

--- a/App/FeatureSet/BrowserRecorder/src/Index.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Index.ts
@@ -2,6 +2,13 @@ import { SessionReplayConfigResponse } from "Common/Types/Rum/SessionReplay";
 import SessionReplayTriggerReason from "Common/Types/Rum/SessionReplayTriggerReason";
 import Config, { RECORDER_VERSION, RecorderInitOptions } from "./Config";
 import Consent from "./Consent";
+import {
+  DebugRecord,
+  debugLog,
+  debugWarn,
+  getDebugRecords,
+  setEnabled,
+} from "./Debug";
 import { EarlyErrorRecord } from "./EarlyErrors";
 import Recorder from "./Recorder";
 
@@ -55,6 +62,33 @@ export interface SessionReplayApi {
   identify: (userRef: string) => void;
   stop: () => void;
   getSessionId: () => string | null;
+
+  /*
+   * Turn the console diagnostics on or off for this page only. The
+   * localStorage switch in Debug.ts is the one to reach for when the
+   * problem is that the recorder never starts, because this call needs an
+   * artifact that already loaded.
+   */
+  setDebug: (enabled: boolean) => void;
+
+  /*
+   * Everything the recorder decided, whether or not diagnostics were on.
+   *
+   * This is the call a support ticket asks for: the ring is filled
+   * unconditionally, and it includes the LOADER's records - the ones from
+   * before this bundle existed - because both bundles share one timeline.
+   */
+  getDiagnostics: () => SessionReplayDiagnostics;
+}
+
+/* Shape of getDiagnostics(). Additive-only, like everything else here. */
+export interface SessionReplayDiagnostics {
+  version: string;
+  sessionId: string | null;
+  isRecording: boolean;
+  isUploading: boolean;
+  triggerReason: string | null;
+  records: Array<DebugRecord>;
 }
 
 let activeRecorder: Recorder | null = null;
@@ -79,13 +113,36 @@ export function bootstrap(
   config: SessionReplayConfigResponse,
   earlyErrors?: Array<EarlyErrorRecord>,
 ): void {
+  if (initOptions.debug === true) {
+    setEnabled(true, "init-options");
+  }
+
   if (activeRecorder) {
+    debugWarn(
+      "bootstrap-already-running",
+      "bootstrap() called again while a recorder is running; ignored.",
+    );
+
     return;
   }
 
   if (!markStarted()) {
+    /*
+     * Two copies of the snippet, or a stub and a self-hosted artifact on the
+     * same page. Both would record the same session twice.
+     */
+    debugWarn(
+      "bootstrap-already-started",
+      "Already started on this page; ignoring a second start.",
+    );
+
     return;
   }
+
+  debugLog("bootstrap", "Artifact bootstrapping.", {
+    recorderVersion: RECORDER_VERSION,
+    earlyErrors: earlyErrors ? earlyErrors.length : 0,
+  });
 
   /*
    * Re-checked here even though the loader already checked. The artifact may
@@ -98,10 +155,20 @@ export function bootstrap(
       config.respectDoNotTrack,
     )
   ) {
+    debugWarn(
+      "privacy-signal",
+      "Do Not Track or Global Privacy Control is set. Nothing is recorded.",
+    );
+
     return;
   }
 
   if (config.directive === "stop") {
+    debugWarn(
+      "directive-stop",
+      "The policy carries a stop directive. Nothing is recorded.",
+    );
+
     return;
   }
 
@@ -125,6 +192,11 @@ export function bootstrap(
 
   if (!activeRecorder) {
     /* Revoked or stopped before it ever started. Nothing may upload. */
+    debugWarn(
+      "bootstrap-cancelled",
+      "A queued revokeConsent() or stop() ran before start().",
+    );
+
     return;
   }
 
@@ -138,6 +210,17 @@ export async function start(initOptions?: RecorderInitOptions): Promise<void> {
     initOptions === undefined ? Config.readInitOptions() : initOptions;
 
   if (!options) {
+    /*
+     * The self-hosted entry point. The loader stub prints an unconditional
+     * console.warn for this same condition and this path had nothing at all,
+     * so a customer who bundles the artifact themselves got total silence
+     * from the one failure that WAS instrumented.
+     */
+    debugWarn(
+      "init-options-missing",
+      "start() found no init options. Nothing will be recorded.",
+    );
+
     return;
   }
 
@@ -146,6 +229,11 @@ export async function start(initOptions?: RecorderInitOptions): Promise<void> {
 
   /* No config, no recording. The fail-closed rule, restated at the edge. */
   if (!config) {
+    debugWarn(
+      "start-stopped",
+      "No usable policy. start() will not record anything.",
+    );
+
     return;
   }
 
@@ -153,19 +241,39 @@ export async function start(initOptions?: RecorderInitOptions): Promise<void> {
 }
 
 export function captureSession(): void {
-  if (activeRecorder) {
-    activeRecorder.trigger(SessionReplayTriggerReason.Manual);
+  if (!activeRecorder) {
+    debugWarn(
+      "api-no-recorder",
+      "captureSession() called with no recorder running.",
+    );
+
+    return;
   }
+
+  debugLog("api-capture-session", "captureSession() called.");
+
+  activeRecorder.trigger(SessionReplayTriggerReason.Manual);
 }
 
 export function grantConsent(): void {
-  if (activeRecorder) {
-    activeRecorder.grantConsent();
+  if (!activeRecorder) {
+    debugWarn(
+      "api-no-recorder",
+      "grantConsent() called with no recorder running.",
+    );
+
+    return;
   }
+
+  debugLog("api-grant-consent", "grantConsent() called.");
+
+  activeRecorder.grantConsent();
 }
 
 export function revokeConsent(): void {
   if (activeRecorder) {
+    debugLog("api-revoke-consent", "revokeConsent() called.");
+
     activeRecorder.revokeConsent();
     activeRecorder = null;
   }
@@ -177,8 +285,25 @@ export function identify(userRef: string): void {
   }
 }
 
+export function setDebug(enabled: boolean): void {
+  setEnabled(enabled === true, "api");
+}
+
+export function getDiagnostics(): SessionReplayDiagnostics {
+  return {
+    version: RECORDER_VERSION,
+    sessionId: activeRecorder ? activeRecorder.getSessionId() : null,
+    isRecording: Boolean(activeRecorder),
+    isUploading: activeRecorder ? activeRecorder.isUploading() : false,
+    triggerReason: activeRecorder ? activeRecorder.getTriggerReason() : null,
+    records: getDebugRecords(),
+  };
+}
+
 export function stop(): void {
   if (activeRecorder) {
+    debugLog("api-stop", "stop() called.");
+
     activeRecorder.stop();
     activeRecorder = null;
   }
@@ -218,6 +343,20 @@ function drainCommandQueue(only?: ReadonlyArray<string>): void {
   const queue: unknown = globalRecord[COMMAND_QUEUE_GLOBAL];
 
   if (!Array.isArray(queue)) {
+    /*
+     * Reported on the FULL drain only. bootstrap() drains twice - the
+     * consent-shaped commands before start(), then everything after - and
+     * warning on both put the same line in the console twice for one page
+     * load, which reads like two different faults.
+     */
+    if (queue !== undefined && !only) {
+      debugWarn(
+        "command-queue-not-an-array",
+        `window.${COMMAND_QUEUE_GLOBAL} is not an array; queued commands ignored.`,
+        { type: typeof queue },
+      );
+    }
+
     return;
   }
 
@@ -246,6 +385,18 @@ function drainCommandQueue(only?: ReadonlyArray<string>): void {
       identify(argument);
     } else if (command === "stop") {
       stop();
+    } else {
+      /*
+       * Unknown names are ignored rather than thrown on - the page may have
+       * been written against a newer recorder than the config pinned - but
+       * ignoring them SILENTLY is how a misspelt "grantconsent" becomes a
+       * session that records forever and uploads nothing.
+       */
+      debugWarn(
+        "command-queue-unknown-command",
+        "A queued command was not recognised and was dropped.",
+        { command: typeof command === "string" ? command : typeof command },
+      );
     }
   }
 

--- a/App/FeatureSet/BrowserRecorder/src/Loader.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Loader.ts
@@ -1,6 +1,12 @@
 import Config, { LoaderConfig, RecorderInitOptions } from "./Config";
 import Consent from "./Consent";
 import {
+  DEBUG_STORAGE_KEY,
+  debugLog,
+  debugWarn,
+  isDebugEnabled,
+} from "./Debug";
+import {
   EarlyErrorBuffer,
   EarlyErrorRecord,
   installEarlyErrorBuffer,
@@ -35,6 +41,14 @@ const LOADER_FLAG_GLOBAL: string = "__ONEUPTIME_SESSION_REPLAY_LOADER__";
 
 const ARTIFACT_GLOBAL: string = "OneUptimeReplay";
 
+/*
+ * One string for both DNT checks. The signal is read before the config
+ * request and again after it, and both stand-downs look identical to a
+ * customer - so they read identically here too.
+ */
+const PRIVACY_SIGNAL_MESSAGE: string =
+  "Do Not Track or Global Privacy Control is set. Nothing is recorded.";
+
 interface ArtifactApi {
   bootstrap: (
     initOptions: RecorderInitOptions,
@@ -44,6 +58,16 @@ interface ArtifactApi {
 }
 
 export async function load(): Promise<void> {
+  /*
+   * The very first line, so a customer who turned diagnostics on can tell
+   * "the stub never ran" (CSP, a blocked request, a tag that is not on the
+   * page) from "the stub ran and decided not to record". Those two look
+   * identical from the network tab and have nothing in common.
+   */
+  debugLog("loader-start", "Loader running.", {
+    diagnostics: isDebugEnabled() ? "on" : "off",
+  });
+
   const options: RecorderInitOptions | null = Config.readInitOptions();
 
   if (!options) {
@@ -59,7 +83,20 @@ export async function load(): Promise<void> {
      */
     // eslint-disable-next-line no-console
     console.warn(
-      "OneUptime Session Replay: not starting. The script tag needs data-oneuptime-token and data-oneuptime-app-identifier, and a host it can derive from its own src (or an explicit data-oneuptime-host).",
+      `OneUptime Session Replay: not starting. The script tag needs data-oneuptime-token and data-oneuptime-app-identifier, and a host it can derive from its own src (or an explicit data-oneuptime-host). For a step-by-step diagnosis run localStorage.setItem("${DEBUG_STORAGE_KEY}", "true") and reload.`,
+    );
+
+    /*
+     * Also recorded, so getDiagnostics() is a complete account on its own.
+     * Config reports WHICH field was missing when it found a source to read;
+     * this is the case where it found none at all - a misspelt marker
+     * attribute, a snippet injected into a different document, or a tag
+     * manager that dropped it - and without this line the timeline would
+     * simply stop after loader-start.
+     */
+    debugWarn(
+      "init-options-missing",
+      "No usable init options on this page. Nothing will be recorded.",
     );
 
     return;
@@ -74,6 +111,10 @@ export async function load(): Promise<void> {
     options.respectDoNotTrack !== false &&
     Consent.hasPrivacySignal(navigator)
   ) {
+    debugWarn("privacy-signal", PRIVACY_SIGNAL_MESSAGE, {
+      stage: "before-config-fetch",
+    });
+
     return;
   }
 
@@ -91,6 +132,7 @@ export async function load(): Promise<void> {
   const config: LoaderConfig | null = await Config.fetchConfig(options);
 
   if (!config) {
+    /* fetchConfig has already logged which of the five reasons it was. */
     earlyErrors.discard();
     return;
   }
@@ -107,11 +149,21 @@ export async function load(): Promise<void> {
       navigator,
     )
   ) {
+    debugWarn("privacy-signal", PRIVACY_SIGNAL_MESSAGE, {
+      stage: "after-config-fetch",
+      policyRespectsDoNotTrack: config.respectDoNotTrack,
+    });
+
     earlyErrors.discard();
     return;
   }
 
   if (config.directive === "stop") {
+    debugWarn(
+      "directive-stop",
+      "The server told this recorder to stand down. Nothing is recorded.",
+    );
+
     earlyErrors.discard();
     return;
   }
@@ -152,6 +204,12 @@ function loadArtifact(
    * customer's page.
    */
   if (!url) {
+    debugWarn(
+      "artifact-url-invalid",
+      "The policy names a version this loader will not build a URL from.",
+      { recorderVersion: config.recorderVersion },
+    );
+
     earlyErrors.discard();
     return;
   }
@@ -189,6 +247,18 @@ function loadArtifact(
        */
       api.bootstrap(options, config, earlyErrors.drain());
     } else {
+      /*
+       * The script loaded and then the global was not there: something else
+       * on the page overwrote it, or a proxy served a different bundle. The
+       * artifact is on the page and doing nothing, which looks exactly like
+       * it never arrived.
+       */
+      debugWarn(
+        "artifact-api-missing",
+        `The artifact loaded but did not publish window.${ARTIFACT_GLOBAL}.`,
+        { url: url },
+      );
+
       earlyErrors.discard();
     }
   };
@@ -196,11 +266,17 @@ function loadArtifact(
   script.onerror = (): void => {
     /*
      * Most often a customer CSP that does not allow our origin in script-src,
-     * which fails silently from the page's point of view. There is nothing
-     * useful to do from here - the Dashboard's "test your installation" panel
-     * is the diagnostic, because server telemetry cannot see a script that
-     * never loaded. The buffer is released: no artifact will ever replay it.
+     * which fails silently from the page's point of view. Server telemetry
+     * cannot see a script that never loaded, so the Dashboard's "test your
+     * installation" panel and this line are the only two diagnostics there
+     * are. The buffer is released: no artifact will ever replay it.
      */
+    debugWarn(
+      "artifact-load-failed",
+      "The artifact failed to load. Check CSP script-src and SRI.",
+      { url: url, hasIntegrity: Boolean(config.recorderIntegrity) },
+    );
+
     earlyErrors.discard();
   };
 
@@ -213,6 +289,11 @@ function loadArtifact(
    * cross-origin fetch on a customer's page buys nothing, and bootstrap
    * happens from onload either way.
    */
+  debugLog("artifact-requested", "Injecting the artifact.", {
+    url: url,
+    hasIntegrity: Boolean(config.recorderIntegrity),
+  });
+
   parent.appendChild(script);
 }
 
@@ -244,6 +325,17 @@ function readArtifactApi(): ArtifactApi | null {
  * handler exists so a failure inside our own loading path can never surface
  * as an unhandled rejection on the customer's page.
  */
-void load().catch((): void => {
-  /* Intentionally silent. */
+void load().catch((error: unknown): void => {
+  /*
+   * Still silent for everyone else - an exception in our own loading path
+   * must not surface as an unhandled rejection on the customer's page - but
+   * no longer silent for someone who asked. This catch used to swallow every
+   * failure in the whole loader, so a genuine bug in here was
+   * indistinguishable from a deliberate stand-down.
+   */
+  debugWarn(
+    "loader-threw",
+    "The loader threw. This is a recorder bug; please report it.",
+    { error: String(error) },
+  );
 });

--- a/App/FeatureSet/BrowserRecorder/src/Recorder.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Recorder.ts
@@ -28,6 +28,7 @@ import Config, {
 } from "./Config";
 import Consent from "./Consent";
 import ConsoleRecorder, { RecordedConsoleEntry } from "./ConsoleRecorder";
+import { debugLog, debugWarn } from "./Debug";
 import { EarlyErrorRecord } from "./EarlyErrors";
 import ErrorRecorder, {
   CompiledIgnorePatterns,
@@ -262,8 +263,11 @@ export default class Recorder {
     this.transport = new Transport({
       url: getChunkUrl(this.initOptions),
       headers: Config.getIngestHeaders(this.initOptions),
-      onDirective: (directive: SessionReplayDirective): void => {
-        this.onDirective(directive);
+      onDirective: (
+        directive: SessionReplayDirective,
+        reason: string | null,
+      ): void => {
+        this.onDirective(directive, reason);
       },
       onPermanentFailure: (reason: string): void => {
         this.onPermanentFailure(reason);
@@ -514,6 +518,22 @@ export default class Recorder {
       this.config.captureTrigger === SessionReplayCaptureTrigger.Always &&
       !isSampled
     ) {
+      /*
+       * The hardest no-op in the package to diagnose from outside: no
+       * listener is installed, no chunk is built, no request is made, and it
+       * looks exactly like a broken script tag. Sampling is deterministic in
+       * the session id, so this is not bad luck the customer can reload
+       * their way out of - the same session will never be sampled.
+       */
+      debugWarn(
+        "not-sampled",
+        "Not selected by the sample percentage. Nothing is recorded.",
+        {
+          samplePercentage: this.config.samplePercentage,
+          sessionId: this.identity.sessionId,
+        },
+      );
+
       this.stopped = true;
       return;
     }
@@ -606,6 +626,35 @@ export default class Recorder {
     if (SessionId.isRefreshRage(refreshRageCount)) {
       this.frustrationDetector.reportRefreshRage(refreshRageCount, Date.now());
     }
+
+    /*
+     * The single most useful line in this whole file.
+     *
+     * Under the default policy - OnErrorOrFrustration with a 0% sample - a
+     * perfectly healthy recorder makes exactly ONE request per page load
+     * (the config fetch) and never posts a chunk unless something goes
+     * wrong. That is the entire design, and from a Network tab it is
+     * indistinguishable from an installation that does not work, which is
+     * why "I see no data going to OneUptime" is the most common report
+     * against a recorder that is behaving perfectly.
+     */
+    debugLog(
+      "recording",
+      this.uploading
+        ? "Recording and uploading."
+        : "Recording into memory. Nothing uploads until a trigger fires - call OneUptimeReplay.captureSession() to force one.",
+      {
+        sessionId: this.identity.sessionId,
+        tabId: this.identity.tabId,
+        captureTrigger: this.config.captureTrigger,
+        samplePercentage: this.config.samplePercentage,
+        isSampled: isSampled,
+        consentMode: this.config.consentMode,
+        consentState: this.consent.getState(),
+        uploading: this.uploading,
+        isTargeted: this.extendedConfig.isTargeted,
+      },
+    );
 
     /*
      * A dashboard user asked for this end user's next session by name.
@@ -742,6 +791,18 @@ export default class Recorder {
         return true;
       },
     });
+
+    if (stop === undefined) {
+      /*
+       * rrweb declines to start rather than throwing (no document, an
+       * environment it cannot serialise). Nothing downstream works after
+       * this: no snapshot, no events, no chunks, no custom events.
+       */
+      debugWarn(
+        "rrweb-did-not-start",
+        "rrweb declined to start; no DOM will be captured.",
+      );
+    }
 
     this.stopRrweb = stop === undefined ? null : stop;
   }
@@ -997,6 +1058,12 @@ export default class Recorder {
 
     if (this.triggerReason === null) {
       this.triggerReason = reason;
+
+      debugLog(
+        "trigger",
+        "A capture trigger fired; this session may upload now.",
+        { reason: reason, sessionId: this.identity.sessionId },
+      );
     }
 
     this.startUploadingIfAllowed();
@@ -1008,14 +1075,45 @@ export default class Recorder {
     }
 
     if (!this.consent.isUploadAllowed()) {
+      /*
+       * A trigger fired and the recording is being held rather than sent.
+       * Under RequireExplicit this is a page that never called
+       * grantConsent(), which records forever and uploads nothing - correct,
+       * and until now completely invisible.
+       */
+      debugWarn(
+        "upload-blocked-consent",
+        "Triggered, but consent was never granted. Call OneUptimeReplay.grantConsent().",
+        {
+          consentMode: this.config.consentMode,
+          consentState: this.consent.getState(),
+          isRevoked: this.consent.isRevoked(),
+        },
+      );
+
       return;
     }
 
     if (this.transport.isDisabled()) {
+      debugWarn(
+        "upload-blocked-transport",
+        "Triggered, but uploading is already disabled for this page.",
+        { reason: this.transport.getDisabledReason() },
+      );
+
       return;
     }
 
     this.uploading = true;
+
+    debugLog(
+      "upload-started",
+      "Uploading; the buffered pre-roll is being flushed.",
+      {
+        sessionId: this.identity.sessionId,
+        triggerReason: this.triggerReason,
+      },
+    );
 
     /*
      * The pre-roll becomes the front of the upload. Flushed immediately
@@ -1154,6 +1252,16 @@ export default class Recorder {
      */
     this.performanceRecorder.resetForNewSession();
 
+    debugLog(
+      "session-rotated",
+      "The session rolled over; a new recording starts here.",
+      {
+        previousSessionId: previousSessionId,
+        sessionId: this.identity.sessionId,
+        rotationReason: String(reason || SessionRotationReason.New),
+      },
+    );
+
     this.emitCustomEvent(SESSION_ROTATED_CUSTOM_EVENT_TAG, {
       previousSessionId: previousSessionId,
       rotationReason: reason || SessionRotationReason.New,
@@ -1244,6 +1352,28 @@ export default class Recorder {
 
   private onChunkClosed(chunk: PendingChunk): void {
     if (!this.consent.isUploadAllowed()) {
+      /*
+       * A fully built chunk, discarded. Not re-queued, not counted in
+       * droppedEvents, and the chunker has already reset its per-chunk
+       * signals - so from the outside this is simply a gap.
+       *
+       * Defensive rather than routine: every path that closes a chunk is
+       * already gated on this.uploading, which can only be set after
+       * isUploadAllowed() returned true, and the one public way to withdraw
+       * consent (revokeConsent) stops the recorder outright. So this fires
+       * only if a future change lets consent flip underneath a live
+       * recorder - and a chunk of end-user content vanishing silently is
+       * exactly the failure that would be worth knowing about if it did.
+       */
+      debugWarn(
+        "chunk-discarded-consent",
+        "A chunk was built but consent does not allow uploading; discarded.",
+        {
+          eventCount: chunk.eventCount,
+          consentState: this.consent.getState(),
+        },
+      );
+
       return;
     }
 
@@ -1504,22 +1634,55 @@ export default class Recorder {
     return false;
   }
 
-  private onDirective(directive: SessionReplayDirective): void {
+  private onDirective(
+    directive: SessionReplayDirective,
+    reason: string | null,
+  ): void {
     if (directive === "stop") {
       /*
        * The server has switched this project or application off. Stopping
        * here is what makes "I turned this off" take effect inside one chunk
        * window instead of waiting out the config cache.
        */
+      debugWarn(
+        "recorder-stopped-by-server",
+        "The server told this recorder to stop. Recording has ended.",
+        { reason: reason || "not-reported" },
+      );
+
       this.stop();
+      return;
+    }
+
+    if (directive === "throttle") {
+      /*
+       * Recognised, deliberately not acted on beyond the transport's own
+       * Retry-After handling - but no longer invisible. A throttled recorder
+       * looks exactly like a broken one from the network tab.
+       */
+      debugWarn(
+        "recorder-throttled-by-server",
+        "The server asked this recorder to slow down.",
+        { reason: reason || "not-reported" },
+      );
     }
   }
 
-  private onPermanentFailure(_reason: string): void {
+  private onPermanentFailure(reason: string): void {
     /*
      * The circuit breaker tripped. Release the buffer as well as stopping:
      * holding end-user content we will never upload is pure liability.
+     *
+     * The reason used to be an unused parameter, which meant a wrong
+     * ingestion token could shut the whole recorder down with nothing
+     * printed anywhere at all.
      */
+    debugWarn(
+      "recorder-stopped-transport",
+      "Uploading failed for good. Recording has stopped.",
+      { reason: reason },
+    );
+
     this.buffer.clear();
     this.stop();
   }
@@ -1577,6 +1740,14 @@ export default class Recorder {
     }
 
     this.stopped = true;
+
+    debugLog("recorder-stopped", "Recording has stopped.", {
+      sessionId: this.identity.sessionId,
+      uploaded: this.uploading,
+      droppedEvents: this.droppedEvents,
+      droppedChunks: this.transport.getDroppedChunkCount(),
+      flushFailures: this.transport.getFlushFailureCount(),
+    });
 
     if (this.flushTimer !== null) {
       clearInterval(this.flushTimer);

--- a/App/FeatureSet/BrowserRecorder/src/Transport.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Transport.ts
@@ -7,6 +7,7 @@ import {
   SessionReplayDirective,
   SessionReplayPayloadEncoding,
 } from "Common/Types/Rum/SessionReplay";
+import { debugLog, debugWarn } from "./Debug";
 
 /*
  * Chunk upload.
@@ -36,8 +37,21 @@ export interface TransportOptions {
   url: string;
   headers: Record<string, string>;
 
-  /* Server's instruction to a live recorder, carried on every response. */
-  onDirective: (directive: SessionReplayDirective) => void;
+  /*
+   * Server's instruction to a live recorder, carried on every response,
+   * together with the reason it gave.
+   *
+   * SessionReplayChunkResponse has carried `reason` from the start, for the
+   * stated purpose of letting "a recorder told to stop without a reason
+   * leave the customer diagnosing silence" - and it was read by nobody. It
+   * is a closed vocabulary ("budget-exhausted", "not-sampled",
+   * "rate-limited", ...) with no user data in it, so it is safe to log and
+   * it is exactly what a support ticket needs to quote.
+   */
+  onDirective: (
+    directive: SessionReplayDirective,
+    reason: string | null,
+  ) => void;
 
   /*
    * The circuit breaker tripped. The recorder must stop recording and
@@ -68,6 +82,14 @@ interface QueuedChunk {
  * behind it silently gone".
  */
 type PostOutcome = "accepted" | "chunk-rejected" | "halt";
+
+/*
+ * The shape of a directive reason. The server sends a closed vocabulary
+ * ("budget-exhausted", "not-sampled", "rate-limited"), but it arrives over
+ * the network and ends up in a console line a customer pastes into a support
+ * ticket, so anything outside this charset is dropped rather than printed.
+ */
+const DIRECTIVE_REASON_PATTERN: RegExp = /^[A-Za-z0-9_.:-]+$/;
 
 /*
  * Uint8Array<ArrayBuffer>, not the default Uint8Array<ArrayBufferLike>. The
@@ -307,6 +329,12 @@ export default class Transport {
     );
 
     if (body.length > SESSION_REPLAY_KEEPALIVE_MAX_BYTES) {
+      debugWarn(
+        "final-chunk-too-large",
+        "The final chunk was over the keepalive quota and was dropped.",
+        { bytes: body.length, maxBytes: SESSION_REPLAY_KEEPALIVE_MAX_BYTES },
+      );
+
       this.droppedChunks++;
       return false;
     }
@@ -365,22 +393,74 @@ export default class Transport {
       });
     } catch {
       /* Network-level failure: retryable, and it counts against the breaker. */
+      debugWarn(
+        "chunk-post-failed",
+        "A chunk upload never reached the server.",
+        {
+          url: this.options.url,
+          chunkIndex: chunk.envelope.chunkIndex,
+          consecutiveFailures: this.consecutiveFailures + 1,
+        },
+      );
+
       this.recordRetryableFailure(chunk, isRetry);
       return "halt";
     }
 
-    return await this.handleResponse(response, chunk, isRetry);
+    return await this.handleResponse(response, chunk, envelope, isRetry);
   }
 
+  /*
+   * `sent` is the envelope that actually went on the wire - the caller's
+   * envelope with the post-compression encoding and byte count written into
+   * it. The diagnostics report from `sent`, so the number a support engineer
+   * reads is the number the server received.
+   */
   private async handleResponse(
     response: Response,
     chunk: QueuedChunk,
+    sent: SessionReplayChunkEnvelope,
     isRetry: boolean,
   ): Promise<PostOutcome> {
     const status: number = response.status;
 
     if (status >= 200 && status < 300) {
       this.consecutiveFailures = 0;
+
+      /*
+       * 204 is NOT an accepted chunk. It is the status the server sends when
+       * it deliberately did not record - over budget, unsampled, application
+       * disabled, session chunk cap - and it carries the directive and the
+       * reason in headers rather than a body. The server's own metrics
+       * middleware refuses the same conflation in as many words ("204 is
+       * counted as 'refused' rather than 'accepted'"), and the docs teach a
+       * customer to look for "chunk-accepted" as proof their installation
+       * works, so calling a stand-down an acceptance would confirm an
+       * installation that is storing nothing.
+       *
+       * payloadBytes comes from `sent`, not from chunk.envelope: the
+       * caller's envelope carries the RAW count and post() replaces it with
+       * the post-gzip length before the request goes out. Reporting the raw
+       * one would show a support engineer a different number from the one
+       * the server received for the same chunk.
+       */
+      if (status === 204) {
+        debugWarn(
+          "chunk-not-recorded",
+          "The server accepted the request but deliberately did not record the chunk.",
+          { status: status, chunkIndex: sent.chunkIndex },
+        );
+      } else {
+        debugLog("chunk-accepted", "Chunk accepted.", {
+          status: status,
+          chunkIndex: sent.chunkIndex,
+          sessionId: sent.sessionId,
+          payloadBytes: sent.payloadBytes,
+          payloadEncoding: sent.payloadEncoding,
+          isFinal: sent.isFinal,
+        });
+      }
+
       await this.applyDirective(response);
       return "accepted";
     }
@@ -391,6 +471,17 @@ export default class Transport {
      * going quiet.
      */
     if (status === 401 || status === 403 || status === 404) {
+      /*
+       * The three statuses that stop the recorder for good, each with a fix
+       * in a different place. Until now this produced a recorder that simply
+       * went quiet mid-session with nothing printed anywhere.
+       */
+      debugWarn(
+        "chunk-rejected-terminal",
+        "Uploading stopped for good: the server refused this recorder.",
+        { status: status, url: this.options.url },
+      );
+
       this.disable(`http-${status}`);
       return "halt";
     }
@@ -401,12 +492,28 @@ export default class Transport {
      * against the circuit breaker - the transport is healthy.
      */
     if (status === 413 || status === 422 || status === 400) {
+      debugWarn(
+        "chunk-refused",
+        "The server refused one chunk; recording continues without it.",
+        {
+          status: status,
+          chunkIndex: sent.chunkIndex,
+          payloadBytes: sent.payloadBytes,
+        },
+      );
+
       this.droppedChunks++;
       return "chunk-rejected";
     }
 
     if (status === 429) {
       const retryAfterSeconds: number = Transport.parseRetryAfter(response);
+
+      debugWarn(
+        "chunk-throttled",
+        "Rate limited. Uploads pause and resume on their own.",
+        { retryAfterSeconds: retryAfterSeconds },
+      );
 
       this.throttledUntilUnixMs = Date.now() + retryAfterSeconds * 1000;
       this.enqueueForRetry(chunk);
@@ -418,6 +525,17 @@ export default class Transport {
       return "halt";
     }
 
+    debugWarn(
+      "chunk-post-server-error",
+      "The server could not accept a chunk. It will be retried.",
+      {
+        status: status,
+        chunkIndex: sent.chunkIndex,
+        consecutiveFailures: this.consecutiveFailures + 1,
+        maxFlushFailures: SESSION_REPLAY_MAX_FLUSH_FAILURES,
+      },
+    );
+
     this.recordRetryableFailure(chunk, isRetry);
 
     return "halt";
@@ -427,7 +545,21 @@ export default class Transport {
     try {
       const text: string = await response.text();
 
+      /*
+       * A 204 has NO BODY, and 204 is precisely the status the server sends
+       * when it is standing a recorder down - deliberately not recording,
+       * over budget, unsampled, rate limited. It puts the directive in
+       * x-oneuptime-replay-directive and the reason in
+       * x-oneuptime-replay-reason for that case, and CorsOptions exposes
+       * both cross-origin specifically so the recorder can read them.
+       *
+       * This method only ever parsed the body and returned early when it was
+       * empty, so every one of those responses was read as a plain success:
+       * the kill switch's fast path did not work, and the recorder kept
+       * posting chunks the server had already told it to stop sending.
+       */
       if (!text) {
+        this.applyHeaderDirective(response);
         return;
       }
 
@@ -439,13 +571,22 @@ export default class Transport {
 
       const raw: Record<string, unknown> = body as Record<string, unknown>;
       const directive: unknown = raw["directive"];
+      const reason: string | null = Transport.readReason(raw["reason"]);
 
       if (
         directive === "stop" ||
         directive === "throttle" ||
         directive === "continue"
       ) {
-        this.options.onDirective(directive);
+        if (directive !== "continue") {
+          debugWarn(
+            "server-directive",
+            "The server changed what this recorder should do.",
+            { directive: directive, reason: reason || "not-reported" },
+          );
+        }
+
+        this.options.onDirective(directive, reason);
       }
 
       const retryAfterSeconds: unknown = raw["retryAfterSeconds"];
@@ -463,6 +604,65 @@ export default class Transport {
        * directive is an optimisation, not a requirement.
        */
     }
+  }
+
+  /*
+   * The bodyless case. Reads the three headers CorsOptions exposes, all of
+   * which are absent on a same-origin-shaped or older server - in which case
+   * nothing happens, which is the pre-existing behaviour.
+   */
+  private applyHeaderDirective(response: Response): void {
+    if (!response.headers) {
+      return;
+    }
+
+    const directive: string | null = response.headers.get(
+      "x-oneuptime-replay-directive",
+    );
+
+    const reason: string | null = Transport.readReason(
+      response.headers.get("x-oneuptime-replay-reason"),
+    );
+
+    if (
+      directive !== "stop" &&
+      directive !== "throttle" &&
+      directive !== "continue"
+    ) {
+      return;
+    }
+
+    if (directive !== "continue") {
+      debugWarn(
+        "server-directive",
+        "The server told this recorder to change what it is doing.",
+        {
+          directive: directive,
+          reason: reason || "not-reported",
+          via: "header",
+        },
+      );
+    }
+
+    this.options.onDirective(directive, reason);
+  }
+
+  /*
+   * A closed server-side vocabulary, but it arrives over the wire, so it is
+   * bounded and character-restricted here before it is ever logged.
+   *
+   * REJECTED rather than truncated when it is too long. Slicing first and
+   * testing the slice let a 300-character string made only of vocabulary
+   * characters through as its first 64 - which is not a member of the
+   * vocabulary, matches nothing a reader could branch on, and is 64
+   * characters of someone else's choosing landing in a console line.
+   */
+  private static readReason(value: unknown): string | null {
+    if (typeof value !== "string" || !value || value.length > 64) {
+      return null;
+    }
+
+    return DIRECTIVE_REASON_PATTERN.test(value) ? value : null;
   }
 
   private recordRetryableFailure(chunk: QueuedChunk, isRetry: boolean): void {
@@ -513,6 +713,17 @@ export default class Transport {
 
     this.disabled = true;
     this.disabledReason = reason;
+
+    debugWarn(
+      "transport-disabled",
+      "Uploading has stopped for good. Fix the cause and reload.",
+      {
+        reason: reason,
+        queuedChunksDropped: this.retryQueue.length,
+        droppedChunks: this.droppedChunks,
+      },
+    );
+
     this.retryQueue = [];
 
     this.options.onPermanentFailure(reason);

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/InstallationTestPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/InstallationTestPanel.tsx
@@ -485,6 +485,45 @@ const InstallationTestPanel: FunctionComponent = (): ReactElement => {
                 {`script-src  ${oneuptimeUrl};
 connect-src ${oneuptimeUrl};`}
               </pre>
+
+              {/*
+               * Every check above answers from the SERVER's side, which is
+               * the half that cannot see a recorder that never loaded - a
+               * blocked script, a browser privacy signal, an unsampled
+               * session, a consent mode nobody granted. This is the other
+               * half, and it is the same panel's job to hand it over.
+               */}
+              <div className="mt-3 text-xs font-semibold text-gray-700">
+                Ask the browser instead
+              </div>
+              <p className="mt-1 text-xs text-gray-500">
+                These checks answer from the server&apos;s side. Anything that
+                stops the recorder before it uploads — a blocked script, a Do
+                Not Track signal, an unsampled session, consent that was never
+                granted — is only visible in the browser. Run this in the
+                console on the page that is failing, then reload:
+              </p>
+              <pre className="mt-2 overflow-x-auto whitespace-pre rounded bg-gray-900 p-3 text-[11px] leading-relaxed text-gray-100">
+                {`localStorage.setItem("oneuptime.sessionReplay.debug", "true");
+
+// after reloading, for a support ticket:
+OneUptimeReplay.getDiagnostics();`}
+              </pre>
+              <p className="mt-1 text-xs text-gray-500">
+                Every line is explained in{" "}
+                <a
+                  className="underline"
+                  href="/docs/rum/session-replay-troubleshooting"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Session Replay Troubleshooting
+                </a>
+                . Note that a recorder making no upload requests is usually
+                working correctly: under the <code>OnErrorOrFrustration</code>{" "}
+                trigger it uploads only when something goes wrong. Call{" "}
+                <code>OneUptimeReplay.captureSession()</code> to force one.
+              </p>
             </div>
           </div>
         )}

--- a/App/FeatureSet/Docs/Content/en/rum/session-replay-troubleshooting.md
+++ b/App/FeatureSet/Docs/Content/en/rum/session-replay-troubleshooting.md
@@ -1,0 +1,254 @@
+# Session Replay Troubleshooting
+
+Session replay records into memory and uploads **only when something goes wrong**. That design is the reason "I see no requests to OneUptime in the Network tab" is usually a recorder working exactly as intended — and it is also the reason a recorder that is genuinely broken looks identical.
+
+The recorder can now tell you which of the two you are looking at. Turn on diagnostics, reload once, and read the console.
+
+## Turn on diagnostics
+
+Pick whichever switch you can reach. They are equivalent.
+
+**In the browser that is failing** — no redeploy, works in production, survives reloads:
+
+```js
+localStorage.setItem("oneuptime.sessionReplay.debug", "true");
+// then reload the page
+```
+
+Turn it off again with:
+
+```js
+localStorage.removeItem("oneuptime.sessionReplay.debug");
+```
+
+**With a link** — for a non-technical reporter, or a page you cannot open a console on. Add `oneuptime_debug=1` to the URL. It also works in the fragment, which survives a server that strips unknown query parameters:
+
+```
+https://your-app.example.com/checkout?oneuptime_debug=1
+https://your-app.example.com/checkout#oneuptime_debug=1
+```
+
+**On the script tag** — for a staging environment where you want it on for everyone:
+
+```html
+<script
+  src="https://oneuptime.com/telemetry/session-replay/v1/recorder.js"
+  data-oneuptime-token="YOUR_TELEMETRY_INGESTION_KEY"
+  data-oneuptime-app-identifier="YOUR_RUM_APP_IDENTIFIER"
+  data-oneuptime-debug="true"
+  async
+></script>
+```
+
+**From the init global**, if you configure the recorder that way:
+
+```js
+window.__ONEUPTIME_SESSION_REPLAY__ = {
+  host: "https://oneuptime.com",
+  token: "YOUR_TELEMETRY_INGESTION_KEY",
+  appIdentifier: "YOUR_RUM_APP_IDENTIFIER",
+  debug: true,
+};
+```
+
+**From the OneUptime deployment**, which is the only switch that does not need somebody at the failing browser. Set `SESSION_REPLAY_DEBUG=true` and restart. Every recorder this instance serves then logs, on every page it runs on — so turn it on, collect one reload, and turn it off. It changes no policy: not sampling, not masking, not consent. See [Session Replay](/docs/telemetry/session-replay) for the other deployment settings.
+
+**At runtime**, once the recorder has loaded:
+
+```js
+OneUptimeReplay.setDebug(true);
+```
+
+Output looks like this:
+
+```
+[OneUptime Session Replay] loader-start: Loader running.
+[OneUptime Session Replay] init-options-read: Init options read. {host: "https://oneuptime.com", appIdentifier: "checkout-web", …}
+[OneUptime Session Replay] config-fetch-start: Requesting the policy. {url: "https://oneuptime.com/telemetry/session-replay/v1/config", …}
+[OneUptime Session Replay] config-accepted: Policy accepted. {captureTrigger: "OnErrorOrFrustration", samplePercentage: 0, …}
+[OneUptime Session Replay] recording: Recording into memory. Nothing uploads until a trigger fires …
+```
+
+## Get the timeline without turning anything on first
+
+The recorder keeps its last 250 decisions **whether or not diagnostics are switched on**. If the problem already happened, you do not need to reproduce it with logging enabled — ask for this instead:
+
+```js
+copy(JSON.stringify(OneUptimeReplay.getDiagnostics(), null, 2));
+```
+
+That returns the recorder version, the session id, whether it is recording, whether it is uploading, the trigger reason, and the full record list — including the records from the **loader stub**, which runs before the recorder artifact exists and is where most stand-downs are decided. It contains no page content by construction; see [What the diagnostics never contain](#what-the-diagnostics-never-contain).
+
+**If `OneUptimeReplay is not defined`**, the recorder artifact never loaded — which is itself the answer to a good half the codes below, and exactly when you most want the timeline. The records are still there, on a global the loader stub writes to before the artifact exists:
+
+```js
+copy(JSON.stringify(window.__ONEUPTIME_SESSION_REPLAY_DEBUG__.records, null, 2));
+```
+
+Paste either one into your support ticket. It is usually enough on its own.
+
+## The most common answer: nothing is wrong
+
+If the console says this:
+
+```
+[OneUptime Session Replay] recording: Recording into memory. Nothing uploads until a trigger fires - call OneUptimeReplay.captureSession() to force one.
+```
+
+…then the recorder is working. Under the default policy — capture trigger `OnErrorOrFrustration`, sample percentage `0` — a healthy page makes exactly **one** request to OneUptime per page load (the config fetch) and posts nothing else until an error, a 5xx, a frustration signal or a performance budget breach happens.
+
+To prove the whole path end to end, force an upload:
+
+```js
+OneUptimeReplay.captureSession();
+```
+
+You should immediately see a `POST /telemetry/session-replay/v1/chunk` in the Network tab and a `chunk-accepted` line in the console. If you do, the installation is correct and the replay will appear in the dashboard within a minute or so.
+
+A `202` with `chunk-accepted` is the one to look for. A **`204`** logs `chunk-not-recorded` instead: the request was fine and the server chose not to store it — over budget, not sampled, or the application is switched off. That is a policy answer, not an installation fault, and the `server-directive` line beside it says which.
+
+If you would rather record every session, set the capture trigger to **Always** and a sample percentage above 0 in _RUM → Session Replay Settings_.
+
+## Codes
+
+Every line carries a stable `code`. Look yours up here.
+
+### Startup
+
+| code                            | what it means                                                                                                                                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `loader-start`                  | The recorder script ran. If you do **not** see this and diagnostics are on, the script itself never executed — check the `<script>` request in the Network tab and your CSP `script-src`.                                                          |
+| `init-options-read`             | Options were found. Check the `host` and `appIdentifier` in the detail: `appIdentifier` must match the RUM application exactly, and `host` must be your OneUptime origin, not your own app's.                                                     |
+| `init-options-incomplete`       | A required option is missing. The detail says which of `hasHost` / `hasToken` / `hasAppIdentifier` is false. If `hasHost` is false, the script tag has no `src` the host can be derived from — add `data-oneuptime-host`.                          |
+| `privacy-signal`                | The browser sends Do Not Track or Global Privacy Control and both this page and the server honour it. Nothing is recorded and no config request is made. This is not a fault. Only set `data-oneuptime-respect-do-not-track="false"` if your lawful basis genuinely does not depend on the signal. |
+| `init-options-missing`          | Nothing on the page to read: no `script[data-oneuptime-token]` tag and no `window.__ONEUPTIME_SESSION_REPLAY__`. The marker attribute is misspelled, the snippet went into a different document, or a tag manager dropped it.                       |
+| `loader-threw`                  | A bug in the recorder itself, not in your configuration. Please report it with the diagnostics output.                                                                                                                                             |
+
+### Policy
+
+| code                               | what it means                                                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `config-fetch-start`               | About to request the policy. The `url` in the detail is the exact URL — check it resolves from a browser.                                             |
+| `config-fetch-rejected`            | The endpoint answered non-2xx. See [config fetch statuses](#config-fetch-statuses) below.                                                             |
+| `config-fetch-failed`              | The request never completed at all: CSP `connect-src`, an ad blocker, DNS, TLS, offline, or a 5-second timeout. The browser usually logs its own line next to this one. |
+| `config-body-unparseable`          | The endpoint answered 2xx with a body that is not JSON at all. Distinct from `config-fetch-failed`: the request *did* complete, so something on the path — a proxy, a captive portal, an SSO interstitial — answered instead of OneUptime. |
+| `config-unparseable`               | The body *was* valid JSON but not an object — `null`, a string, an array. A rewriting proxy, or a server answering a different route.                 |
+| `config-disabled`                  | The server says replay is off here. **The `disabledReason` in the detail is the answer** — see [disabledReason](#disabledreason) below.               |
+| `config-recorder-version-invalid`  | The policy carried a `recorderVersion` that is not a plain semver, so no artifact URL could be built. A rewriting proxy or a tampered response — a deployment with no build reports `config-disabled` with `recorder-not-built` instead. |
+| `config-accepted`                  | The policy was accepted. The detail is the whole policy — `captureTrigger`, `samplePercentage`, `consentMode`, `maskingMode`.                         |
+| `config-value-unrecognised`        | The server sent a value this recorder build does not know, so it fell back to the **safest** one — which may not be the one your dashboard shows. Usually a recorder pinned to an older version than the server. |
+| `directive-stop`                   | The server told this recorder to stand down. Check the application's ingest status for a budget, a rate limit or a kill switch.                       |
+
+#### config fetch statuses
+
+| status | fix                                                                                                                                                          |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `401`  | The ingestion token is wrong, revoked or from a different project. Create one in _Project Settings → Telemetry & APM → Ingestion Keys_ and confirm it with `GET /otlp/v1/validate`. |
+| `400`  | `data-oneuptime-app-identifier` is missing.                                                                                                                  |
+| `404`  | The path did not resolve on the OneUptime origin. This is nearly always a wrong `data-oneuptime-host` — or a reverse proxy in front of OneUptime that does not forward `/telemetry/*`. |
+| `5xx`  | A server-side fault; check the OneUptime app logs.                                                                                                           |
+
+#### disabledReason
+
+| value                       | what to do                                                                                                                                                                                                                                    |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `not-enabled-for-application` | Session replay is off for this RUM application, the identifier does not match one, or the project is not allowed replay. Check _RUM → your application → Session Replay Settings_.                                                            |
+| `recorder-not-built`        | **The deployment has no recorder artifact.** Nothing on the customer's page can fix this. The build that produces `App/FeatureSet/BrowserRecorder/public/dist/manifest.json` did not run, or its output did not reach the running image. Rebuild and redeploy the OneUptime app. This is the usual answer on a self-hosted install where replay has never worked at all. |
+| `disabled-by-default`       | `SESSION_REPLAY_ENABLED_BY_DEFAULT=false` on this deployment. Set it to `true` — and set `SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY` first if you are self-hosting, because replay is the fattest table you have.                            |
+| `ingest-disabled`           | `SESSION_REPLAY_INGEST_ENABLED=false` on this deployment.                                                                                                                                                                                     |
+| `policy-unavailable`        | The server could not resolve the policy — usually Redis or Postgres. It fails closed on purpose. Check the OneUptime app logs.                                                                                                                 |
+| `not-reported`              | The server is older than this field. Use the Dashboard's **Test your installation** panel in _RUM → Session Replay Settings_ instead.                                                                                                          |
+
+### The artifact
+
+| code                     | what it means                                                                                                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `artifact-requested`     | The pinned recorder bundle is being injected. The `url` is the exact one.                                                                                                                                |
+| `artifact-load-failed`   | It did not load. In order of likelihood: a CSP `script-src` that does not allow your OneUptime origin, an SRI mismatch (a proxy rewriting the bundle), or a 404 because the pinned version is not published. |
+| `artifact-url-invalid`   | The policy named a version that is not a plain semver, so no URL was built. A tampered or proxied config response.                                                                                        |
+| `artifact-api-missing`   | The bundle loaded but did not publish `window.OneUptimeReplay` — another script on the page overwrote it.                                                                                                 |
+| `bootstrap`              | The recorder artifact is starting.                                                                                                                                                                       |
+| `bootstrap-already-started` | Two copies of the snippet on one page. Remove one.                                                                                                                                                    |
+| `bootstrap-already-running` | `bootstrap()` was called again while a recorder was already running. Harmless; usually a duplicated integration.                                                                                       |
+| `bootstrap-cancelled`    | A `revokeConsent()` or `stop()` queued on `window.OneUptimeReplayQueue` ran before the recorder started, so this session is not recorded. Correct if your banner had already been declined.                |
+| `start-stopped`          | `start()` got no usable policy on the self-hosted-bundle path. The specific reason is on the `config-*` line just above it.                                                                               |
+| `rrweb-did-not-start`    | The DOM recorder declined to start. Please report it.                                                                                                                                                    |
+
+### Recording and upload
+
+| code                        | what it means                                                                                                                                                                                                        |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `not-sampled`               | This session lost the sample draw, so **nothing at all** is recorded. Sampling is deterministic in the session id, so reloading will not help this session. Raise the sample percentage.                              |
+| `recording`                 | Recording. Read the detail: `uploading: false` with `captureTrigger: "OnErrorOrFrustration"` is the normal, healthy, no-requests state.                                                                               |
+| `trigger`                   | Something worth keeping happened. The `reason` is one of `error`, `frustration`, `performance`, `sampled` or `manual`.                                                                                                |
+| `upload-started`            | The buffered pre-roll is being flushed. Chunk POSTs start here.                                                                                                                                                      |
+| `upload-blocked-consent`    | A trigger fired and nothing was uploaded because consent was never granted. Under consent mode `RequireExplicit` your page must call `OneUptimeReplay.grantConsent()` once your banner is accepted.                    |
+| `chunk-discarded-consent`   | The same cause, one layer down: a complete chunk was thrown away.                                                                                                                                                     |
+| `chunk-accepted`            | A chunk landed and was stored. The installation works.                                                                                                                                                               |
+| `chunk-not-recorded`        | The server took the request and deliberately did not record it — over budget, not sampled, application disabled, or the per-session chunk cap. The `server-directive` line next to it carries the reason. The installation is correct; the policy or the budget is not what you expect. |
+| `chunk-post-failed`         | The POST never reached the server. CSP `connect-src`, an ad blocker, or CORS on the ingest origin.                                                                                                                    |
+| `chunk-post-server-error`   | The server answered 5xx. The recorder retries; `consecutiveFailures` against `maxFlushFailures` in the detail says how close it is to giving up.                                                                      |
+| `final-chunk-too-large`     | The last chunk of the session was over the 56 KB the recorder allows itself for a page-hide flush — deliberately under the browser's 64 KB combined keepalive quota — and was dropped, so the recording ends a few seconds early. Nothing else is lost. |
+| `upload-blocked-transport`  | A trigger fired after uploading had already been disabled for this page. The `transport-disabled` line above it says why.                                                                                             |
+| `chunk-rejected-terminal`   | Uploading has stopped for good. `status: 401` is a bad token; `status: 403` is an origin not on the application's allowlist; `status: 404` is a wrong host. Fix and reload — the recorder does not retry on its own.   |
+| `chunk-refused`             | One chunk was refused (too large, or unparseable) and the recording continued without it.                                                                                                                            |
+| `chunk-throttled`           | Rate limited. Uploads pause and resume on their own.                                                                                                                                                                 |
+| `transport-disabled`        | The circuit breaker tripped after repeated failures. The `reason` says which.                                                                                                                                        |
+| `server-directive`          | The server changed what the recorder should do mid-session. The `reason` is a closed vocabulary — `budget-exhausted`, `not-sampled`, `rate-limited`, `session-chunk-cap`.                                             |
+| `recorder-stopped-by-server`| The server told the recorder to stop. Usually the daily byte budget.                                                                                                                                                 |
+| `recorder-throttled-by-server` | The server asked the recorder to slow down. Uploads resume on their own; nothing to do.                                                                                                                           |
+| `recorder-stopped-transport`| Uploading failed permanently, so recording stopped and the buffer was released. The `reason` is the same one `transport-disabled` reported.                                                                           |
+| `recorder-stopped`          | Recording ended, with the session's totals: `droppedEvents`, `droppedChunks`, `flushFailures`. All three should be 0 on a healthy session.                                                                            |
+| `session-rotated`           | The session rolled over (30 minutes idle, or 4 hours long). The recording continues under a new id.                                                                                                                  |
+| `command-queue-not-an-array`| `window.OneUptimeReplayQueue` is not an array, so every command queued on it was ignored. It must be an array of `[command, argument]` pairs.                                                                         |
+| `command-queue-unknown-command` | A queued command name was not recognised — check the spelling against the [public API](/docs/telemetry/session-replay).                                                                                           |
+
+### Calls your page made
+
+These record what your own code asked the recorder to do. They are useful for confirming that a consent banner or a manual capture actually reached the recorder, and when.
+
+| code                   | what it means                                                                                                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api-capture-session`  | `captureSession()` was called.                                                                                                                                       |
+| `api-grant-consent`    | `grantConsent()` was called.                                                                                                                                         |
+| `api-revoke-consent`   | `revokeConsent()` was called. Everything buffered was dropped and recording stopped — this is final for the page.                                                     |
+| `api-stop`             | `stop()` was called.                                                                                                                                                 |
+| `api-no-recorder`      | One of the calls above ran while no recorder was active — usually because it ran before the recorder artifact loaded. Push `[command, argument]` pairs onto `window.OneUptimeReplayQueue` instead, and they are applied as soon as it arrives. |
+
+## No request at all in the Network tab
+
+Work down this list; it is ordered by how often each one is the answer.
+
+1. **Filter for `session-replay`, not for the app identifier.** The config request is a `GET`, and it is the only request a healthy non-triggered session makes.
+2. **Is there a `GET .../session-replay/v1/config`?**
+   - **No, and no `loader-start` in the console** → the script never executed. Check that the `<script>` element is in the DOM, that its request succeeded, and your CSP `script-src`.
+   - **No, but `privacy-signal` is in the console** → Do Not Track or GPC. Working as designed.
+   - **Yes, non-2xx** → see [config fetch statuses](#config-fetch-statuses).
+3. **Is there no chunk `POST`?** Read the `recording` line. `uploading: false` under `OnErrorOrFrustration` is normal — call `OneUptimeReplay.captureSession()` to force one and confirm the path works.
+4. **Still nothing after `captureSession()`?** Look for `upload-blocked-consent` (call `grantConsent()`), `not-sampled`, or `transport-disabled`.
+
+## RUM telemetry is separate
+
+Session replay and RUM traces are two independent pipelines with two independent failure modes. A working recorder does not imply RUM telemetry is arriving, and a working RUM application is not a prerequisite for the recorder to load.
+
+If your **OTLP** requests are missing from the Network tab, that is the OpenTelemetry browser SDK on your page, not this recorder — see [RUM Troubleshooting](/docs/rum/troubleshooting), which covers the SDK-side causes in order.
+
+## What the diagnostics never contain
+
+The diagnostics carry no page content, and this is enforced rather than promised:
+
+- The detail on every record is restricted **at the type level** to strings, numbers, booleans and null. A DOM node, a Response or any other object handed in from untyped JavaScript is replaced with `<object omitted>` before the record is created, not merely before it is printed.
+- String values are truncated.
+- URLs that appear in records are either OneUptime's own endpoints or already scrubbed of query strings and fragments by the same scrubber the recording itself uses.
+
+So the output of `getDiagnostics()` is safe to paste into a support ticket. It is not safe to leave diagnostics switched **on** for every visitor of a production site — not for privacy reasons, but because it is noise in your end users' consoles.
+
+## Still stuck
+
+Collect these before asking for help:
+
+- The output of `OneUptimeReplay.getDiagnostics()`.
+- The status of the `session-replay/v1/config` request.
+- What the Dashboard's **Test your installation** panel says (_RUM → Session Replay Settings_). It answers from the server's side, which is the half a browser cannot see.
+
+Then contact support@oneuptime.com, or open an issue on [GitHub](https://github.com/OneUptime/oneuptime).

--- a/App/FeatureSet/Docs/Content/en/rum/troubleshooting.md
+++ b/App/FeatureSet/Docs/Content/en/rum/troubleshooting.md
@@ -95,9 +95,20 @@ An internal or low-traffic app with no overnight visitors is legitimately discon
 
 ## 8. Session Replay problems
 
-Session replay is a separate pipeline with its own failure modes — the recorder script, the origin allowlist, consent, CSP and masking. They are documented in [Session Replay](/docs/telemetry/session-replay); the **Test your installation** panel in _RUM → Session Replay Settings_ checks the token, origin allowlist and CSP together.
+Session replay is a separate pipeline with its own failure modes — the recorder script, the origin allowlist, consent, CSP and masking. They have their own page: [Session Replay Troubleshooting](/docs/rum/session-replay-troubleshooting).
 
-One overlap worth naming here: a working RUM application is **not** a prerequisite for the recorder to load, and a working recorder does not imply RUM telemetry is arriving. They are configured independently and can each fail alone.
+Start there rather than here, and start by turning on the recorder's diagnostics, because most of its failure modes are deliberately silent:
+
+```js
+localStorage.setItem("oneuptime.sessionReplay.debug", "true");
+// then reload the page
+```
+
+The **Test your installation** panel in _RUM → Session Replay Settings_ checks the token, origin allowlist and CSP from the server's side; the console tells you the half the server cannot see.
+
+Worth naming here: a session replay recorder that makes **no chunk requests at all** is usually working correctly. Under the default capture trigger it uploads only when something goes wrong. Call `OneUptimeReplay.captureSession()` to force an upload and prove the path.
+
+The two pipelines are independent: a working RUM application is **not** a prerequisite for the recorder to load, and a working recorder does not imply RUM telemetry is arriving. They are configured independently and can each fail alone.
 
 ## Still stuck
 

--- a/App/FeatureSet/Docs/Content/en/telemetry/session-replay.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/session-replay.md
@@ -187,8 +187,30 @@ Watching a recording is a separate permission from listing sessions, and neither
 
 Every playback is recorded in an audit trail — who watched which session, when, from what IP, and for how long — under _Real User Monitoring → your application → **Replay Access Log**_.
 
+## Troubleshooting
+
+Session replay records into memory and uploads only when something goes wrong, so **a healthy page makes exactly one request to OneUptime per page load** — the config fetch — and posts nothing else until an error, a 5xx, a frustration signal or a performance budget breach happens. From a Network tab that is indistinguishable from an installation that does not work.
+
+The recorder can tell you which one you are looking at. Turn on diagnostics in the failing browser:
+
+```js
+localStorage.setItem("oneuptime.sessionReplay.debug", "true");
+// then reload the page
+```
+
+Every decision the recorder makes is then printed with a stable code, and
+
+```js
+OneUptimeReplay.getDiagnostics();
+```
+
+returns the last 250 of them — **whether or not diagnostics were switched on when they happened**, so you do not have to reproduce the problem first. It carries no page content by construction, so it is safe to paste into a support ticket.
+
+[Session Replay Troubleshooting](/docs/rum/session-replay-troubleshooting) explains every code and what to do about it, and the **Test your installation** panel in _RUM → Session Replay Settings_ answers the same question from the server's side.
+
 ## Self-hosted notes
 
 - Session Replay is **on** at the deployment level by default. Set `SESSION_REPLAY_ENABLED_BY_DEFAULT=false` to turn it off for the whole instance — recorders already running on customer pages then stop recording, not just uploading.
 - Set `SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY` to bound disk use. Replay is the largest table in the system, and an unbounded configuration can push ClickHouse into capacity pruning.
 - Recordings are stored in ClickHouse. No object storage is required.
+- `SESSION_REPLAY_DEBUG=true` makes every recorder this deployment serves print its decisions to the browser console. It is the one diagnostics switch that does not need somebody at the failing browser, so it is useful when a customer reports "nothing happens" on a page you cannot open a console on. It changes no policy — not sampling, not masking, not consent — but it logs on **every** page every recorder runs on, so turn it on, collect one reload, and turn it off.

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -758,6 +758,10 @@ const DocsNav: NavGroup[] = [
       { title: "Core Web Vitals", url: "/docs/rum/web-vitals" },
       { title: "Managing Applications", url: "/docs/rum/applications" },
       { title: "Session Replay", url: "/docs/telemetry/session-replay" },
+      {
+        title: "Session Replay Troubleshooting",
+        url: "/docs/rum/session-replay-troubleshooting",
+      },
       { title: "RUM Troubleshooting", url: "/docs/rum/troubleshooting" },
     ],
   },

--- a/App/FeatureSet/Telemetry/API/SessionReplayIngest.ts
+++ b/App/FeatureSet/Telemetry/API/SessionReplayIngest.ts
@@ -24,6 +24,7 @@ import {
   SESSION_REPLAY_USER_REF_HEADER,
   SessionReplayChunkResponse,
   SessionReplayConfigResponse,
+  SessionReplayDisabledReason,
 } from "Common/Types/Rum/SessionReplay";
 import SessionReplayTargeting from "Common/Server/Utils/SessionReplay/SessionReplayTargeting";
 import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
@@ -31,6 +32,7 @@ import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode"
 import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
 import { JSONObject } from "Common/Types/JSON";
 import {
+  SESSION_REPLAY_DEBUG,
   SESSION_REPLAY_ENABLED_BY_DEFAULT,
   SESSION_REPLAY_INGEST_ENABLED,
   SESSION_REPLAY_TRUSTED_GEO_HEADER,
@@ -266,6 +268,25 @@ function readCountryCode(req: ExpressRequest): string {
   }
 
   return "";
+}
+
+/*
+ * Stamp a disabled config with WHY, and with the debug flag.
+ *
+ * A helper rather than five inline spreads so no future disabled branch can
+ * quietly ship without a reason: the customer-visible symptom of a missing
+ * one is total silence in the browser, which is precisely the failure mode
+ * the field exists to end.
+ */
+function sendDisabledConfig(
+  disabledResponse: SessionReplayConfigResponse,
+  reason: SessionReplayDisabledReason,
+): JSONObject {
+  return {
+    ...disabledResponse,
+    disabledReason: reason,
+    debug: SESSION_REPLAY_DEBUG,
+  } as unknown as JSONObject;
 }
 
 function sendChunkDirective(
@@ -641,10 +662,25 @@ router.get(
         !SESSION_REPLAY_ENABLED_BY_DEFAULT ||
         !publishedRecorderVersion
       ) {
+        /*
+         * Three deployment-level causes that a customer cannot fix from the
+         * Dashboard, and which used to be indistinguishable from "somebody
+         * switched this application off". `recorder-not-built` in particular
+         * is a self-hosted install whose recorder bundle was never produced:
+         * there is no artifact to serve, replay has never worked there and
+         * never will until the build runs, and nothing anywhere said so.
+         */
         Response.sendJsonObjectResponse(
           req,
           res,
-          disabledResponse as unknown as JSONObject,
+          sendDisabledConfig(
+            disabledResponse,
+            !SESSION_REPLAY_INGEST_ENABLED
+              ? SessionReplayDisabledReason.IngestDisabled
+              : !SESSION_REPLAY_ENABLED_BY_DEFAULT
+                ? SessionReplayDisabledReason.DisabledByDefault
+                : SessionReplayDisabledReason.RecorderNotBuilt,
+          ),
         );
         return;
       }
@@ -668,7 +704,10 @@ router.get(
         Response.sendJsonObjectResponse(
           req,
           res,
-          disabledResponse as unknown as JSONObject,
+          sendDisabledConfig(
+            disabledResponse,
+            SessionReplayDisabledReason.PolicyUnavailable,
+          ),
         );
         return;
       }
@@ -677,7 +716,10 @@ router.get(
         Response.sendJsonObjectResponse(
           req,
           res,
-          disabledResponse as unknown as JSONObject,
+          sendDisabledConfig(
+            disabledResponse,
+            SessionReplayDisabledReason.NotEnabledForApplication,
+          ),
         );
         return;
       }
@@ -736,6 +778,14 @@ router.get(
        * server that cannot produce one yields a script tag without integrity
        * rather than no recording at all.
        */
+      /*
+       * Deployment-wide recorder diagnostics. Adds console output on the
+       * customer's page and changes no policy; see SESSION_REPLAY_DEBUG.
+       */
+      if (SESSION_REPLAY_DEBUG) {
+        config.debug = true;
+      }
+
       const recorderIntegrity: string | null = getRecorderIntegrity();
 
       if (recorderIntegrity) {

--- a/App/FeatureSet/Telemetry/Config.ts
+++ b/App/FeatureSet/Telemetry/Config.ts
@@ -129,6 +129,26 @@ export const SESSION_REPLAY_ENABLED_BY_DEFAULT: boolean =
   process.env["SESSION_REPLAY_ENABLED_BY_DEFAULT"] !== "false";
 
 /*
+ * Ask every browser recorder this deployment serves to print its decisions
+ * to the console. OFF by default, and it must stay that way: the recorder
+ * runs on a customer's site in their end users' browsers, and logging there
+ * unasked is noise on somebody else's property.
+ *
+ * The recorder already has two per-browser switches (a localStorage key and
+ * a ?oneuptime_debug query parameter), and they are the right ones whenever
+ * somebody can reach the failing browser. This one exists for the case they
+ * cannot cover: an operator of a self-hosted install who needs to know why
+ * replay produces nothing on a page they do not own and cannot edit. Turn it
+ * on, ask the customer to reload once and send the console, turn it off.
+ *
+ * It changes no policy - not sampling, not masking, not consent - and it
+ * only ever adds output, so a deployment that leaves it on records exactly
+ * the same data it would have otherwise.
+ */
+export const SESSION_REPLAY_DEBUG: boolean =
+  process.env["SESSION_REPLAY_DEBUG"] === "true";
+
+/*
  * Per-project chunk rate ceiling, enforced with a Redis counter so it holds
  * across every app pod rather than per process. 20k chunks/min is roughly
  * 1,400 concurrently-recording tabs at the 15s flush cadence - far above

--- a/App/Tests/FeatureSet/Docs/SessionReplayTroubleshootingPage.test.ts
+++ b/App/Tests/FeatureSet/Docs/SessionReplayTroubleshootingPage.test.ts
@@ -1,0 +1,167 @@
+import DocsNav, { NavGroup, NavLink } from "../../../FeatureSet/Docs/Utils/Nav";
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The Session Replay troubleshooting page, and the nav entry that makes it
+ * reachable.
+ *
+ * Nav membership is load-bearing rather than cosmetic: the docs route looks
+ * the requested path up in the canonical English nav and renders NotFound if
+ * it is absent, so a markdown file with no nav entry is a 404 even though the
+ * file is right there on disk. That failure is invisible in review and only
+ * shows up when somebody follows the link.
+ *
+ * And this particular page IS a link target. The recorder prints its URL into
+ * the browser console the moment diagnostics are switched on, so a broken one
+ * lands in front of the exact person who is already having trouble.
+ */
+const CONTENT_DIR: string = path.resolve(
+  __dirname,
+  "../../../FeatureSet/Docs/Content",
+);
+
+const PAGE_URL: string = "/docs/rum/session-replay-troubleshooting";
+const PAGE_PATH: string = path.join(
+  CONTENT_DIR,
+  "en",
+  "rum",
+  "session-replay-troubleshooting.md",
+);
+
+const NAV_GROUP_TITLE: string = "Real User Monitoring";
+
+function readPage(): string {
+  return fs.readFileSync(PAGE_PATH, "utf8");
+}
+
+function ownGroup(): NavGroup | undefined {
+  return DocsNav.find((group: NavGroup): boolean => {
+    return group.title === NAV_GROUP_TITLE;
+  });
+}
+
+describe("Session Replay troubleshooting docs page", (): void => {
+  it("exists on disk", (): void => {
+    expect(fs.existsSync(PAGE_PATH)).toBe(true);
+  });
+
+  it("is listed in the nav, so the route can find it", (): void => {
+    const links: Array<NavLink> = ownGroup()?.links || [];
+
+    expect(
+      links.some((link: NavLink): boolean => {
+        return link.url === PAGE_URL;
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * The renderer strips the first line, because the title already appears in
+   * the page chrome. A page that does not open with an H1 therefore loses its
+   * first real paragraph.
+   */
+  it("opens with an H1 the renderer can strip", (): void => {
+    expect(readPage().split("\n")[0]).toBe("# Session Replay Troubleshooting");
+  });
+
+  /*
+   * Every nav entry in this group must resolve to a file. Scoped to the RUM
+   * group rather than the whole nav so this test fails for a reason its own
+   * name explains.
+   */
+  it("leaves no dangling nav entry in the RUM group", (): void => {
+    const missing: Array<string> = [];
+
+    for (const link of ownGroup()?.links || []) {
+      const relative: string = link.url.replace(/^\/docs\//, "");
+      const file: string = path.join(CONTENT_DIR, "en", `${relative}.md`);
+
+      if (!fs.existsSync(file)) {
+        missing.push(link.url);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  /*
+   * The switches the page documents are string literals in the recorder
+   * bundle. If one is renamed in src/Debug.ts and not here, the page tells a
+   * customer to type something that does nothing - and there is no build step
+   * that would notice, because markdown is not compiled.
+   */
+  it("documents the switches the recorder actually reads", (): void => {
+    const page: string = readPage();
+
+    const debugSource: string = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        "../../../FeatureSet/BrowserRecorder/src/Debug.ts",
+      ),
+      "utf8",
+    );
+
+    for (const literal of [
+      "oneuptime.sessionReplay.debug",
+      "oneuptime_debug",
+    ]) {
+      expect(debugSource).toContain(literal);
+      expect(page).toContain(literal);
+    }
+
+    /* The docs URL the recorder prints has to be this page's own URL. */
+    expect(debugSource).toContain(PAGE_URL);
+  });
+
+  /*
+   * The page is an index of codes, and the recorder's `code` strings are the
+   * stable part of the contract - a customer quotes one into a support
+   * ticket. A code that no longer exists in the source, or a source code the
+   * page never explains, is a broken lookup at the worst moment.
+   */
+  it("explains the codes the recorder can emit", (): void => {
+    const page: string = readPage();
+
+    const sourceDir: string = path.resolve(
+      __dirname,
+      "../../../FeatureSet/BrowserRecorder/src",
+    );
+
+    const emitted: Set<string> = new Set<string>();
+
+    for (const file of fs.readdirSync(sourceDir)) {
+      if (!file.endsWith(".ts") || file === "Debug.ts") {
+        continue;
+      }
+
+      const contents: string = fs.readFileSync(
+        path.join(sourceDir, file),
+        "utf8",
+      );
+
+      const matches: Array<string> =
+        contents.match(/\bdebug(?:Log|Warn)\(\s*"([a-z0-9-]+)"/g) || [];
+
+      for (const match of matches) {
+        const code: string | undefined = match.split('"')[1];
+
+        if (code) {
+          emitted.add(code);
+        }
+      }
+    }
+
+    /* Sanity: the scan found something, so the assertion below is not vacuous. */
+    expect(emitted.size).toBeGreaterThan(20);
+
+    const undocumented: Array<string> = Array.from(emitted)
+      .filter((code: string): boolean => {
+        return !page.includes(`\`${code}\``);
+      })
+      .sort();
+
+    expect(undocumented).toEqual([]);
+  });
+});

--- a/App/Tests/Telemetry/SessionReplayConfigDeploymentAnswers.test.ts
+++ b/App/Tests/Telemetry/SessionReplayConfigDeploymentAnswers.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import { SESSION_REPLAY_APP_IDENTIFIER_HEADER } from "Common/Types/Rum/SessionReplay";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+
+/*
+ * GET /session-replay/v1/config - the two deployment-level answers.
+ *
+ * Both of these are module-load constants, so they need their own file:
+ * SESSION_REPLAY_DEBUG (which asks every recorder this instance serves to
+ * print its decisions) and a build manifest that is absent, which is the
+ * `recorder-not-built` case.
+ *
+ * That last one is the reason this file exists at all. On a self-hosted
+ * install where session replay has never worked, the overwhelmingly likely
+ * cause is that the recorder bundle was never produced - so there is no
+ * artifact to serve and no version to pin - and the endpoint answered
+ * `enabled:false` for it exactly as it does for an application somebody
+ * switched off. The customer then spends their time in a settings page that
+ * was already correct, because nothing anywhere said which of the two it was.
+ */
+
+const registeredGetHandlers: Record<string, Array<unknown>> = {};
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: () => {
+        return {
+          post: (): void => {
+            // Chunk-path registration is irrelevant to this suite.
+          },
+          get: (uri: string, ...handlers: Array<unknown>) => {
+            registeredGetHandlers[uri] = handlers;
+          },
+        };
+      },
+    },
+    headerValueToString: (value: unknown): string | undefined => {
+      if (typeof value === "string") {
+        return value;
+      }
+      if (Array.isArray(value)) {
+        return value[0] as string | undefined;
+      }
+      return undefined;
+    },
+  };
+});
+
+jest.mock("Common/Server/Middleware/TelemetryIngest", () => {
+  return {
+    __esModule: true,
+    default: {
+      isAuthorizedServiceMiddleware: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Middleware/TelemetryIngestionDisabled", () => {
+  return {
+    __esModule: true,
+    default: {
+      middleware: jest.fn(),
+      isDisabled: jest.fn().mockReturnValue(false),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendEmptySuccessResponse: jest.fn(),
+      sendErrorResponse: jest.fn(),
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    getLogAttributesFromRequest: jest.fn(),
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry/CaptureSpan", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return (): void => {
+        // No-op decorator: the real one needs a live tracer provider.
+      };
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry/AppMetrics", () => {
+  const counter: { add: unknown } = { add: jest.fn() };
+  const histogram: { record: unknown } = { record: jest.fn() };
+
+  return {
+    __esModule: true,
+    default: {
+      getIngestCounter: () => {
+        return counter;
+      },
+      getIngestDuration: () => {
+        return histogram;
+      },
+      getIngestPayloadBytes: () => {
+        return histogram;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/SessionReplay/SessionReplayGateCache", () => {
+  return {
+    __esModule: true,
+    default: {
+      getPolicy: jest.fn(),
+      isOriginAllowed: jest.fn().mockReturnValue(true),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/SessionReplay/SessionReplayTargeting", () => {
+  return {
+    __esModule: true,
+    default: {
+      consumeTarget: jest.fn(),
+      isUsableUserRef: (userRef: unknown): boolean => {
+        return (
+          typeof userRef === "string" &&
+          userRef.trim().length > 0 &&
+          userRef.length <= 512
+        );
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/TelemetryIngestionKeyService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getProjectIdFromSecretKey: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/RumApplicationService", () => {
+  return {
+    __esModule: true,
+    default: {
+      markSessionReplayChunkReceived: jest.fn(),
+      markSessionReplayBudgetExceeded: jest.fn(),
+    },
+  };
+});
+
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/SessionReplayIngestService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        gateChunkRequest: jest.fn(),
+        getInlineStagingMaxBytes: () => {
+          return 65536;
+        },
+        isUnprocessableParseError: (): boolean => {
+          return false;
+        },
+      },
+      SessionReplayGateOutcome: {
+        Accepted: "accepted",
+        Stop: "stop",
+        OriginRefused: "origin-refused",
+        RateLimited: "rate-limited",
+        StorageUnavailable: "storage-unavailable",
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        addSessionReplayIngestJob: jest.fn(),
+      },
+    };
+  },
+);
+
+/* Diagnostics ON for the whole file - the switch this suite exists to cover. */
+jest.mock("../../FeatureSet/Telemetry/Config", () => {
+  return {
+    __esModule: true,
+    SESSION_REPLAY_ENABLED_BY_DEFAULT: true,
+    SESSION_REPLAY_INGEST_ENABLED: true,
+    SESSION_REPLAY_TRUSTED_GEO_HEADER: "",
+    SESSION_REPLAY_DEBUG: true,
+  };
+});
+
+/*
+ * NO published artifact. getRecorderVersion() returns null when
+ * public/dist/manifest.json is missing, unparseable, or fails validation -
+ * which is exactly the state of a deployment whose recorder build never ran.
+ */
+jest.mock("../../FeatureSet/BrowserRecorder/Manifest", () => {
+  return {
+    __esModule: true,
+    ARTIFACT_CONTENT_TYPE: "application/javascript",
+    LOADER_CACHE_CONTROL: "public, max-age=300",
+    RECORDER_CACHE_CONTROL: "public, max-age=31536000, immutable",
+    RECORDER_VERSION_PATTERN: /^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$/,
+    getArtifactFilePath: jest.fn(),
+    getPinnedRecorderPath: jest.fn(),
+    getRecorderVersion: (): string | null => {
+      return null;
+    },
+    getRecorderIntegrity: (): string | null => {
+      return null;
+    },
+  };
+});
+
+import Response from "Common/Server/Utils/Response";
+import SessionReplayGateCache from "Common/Server/Utils/SessionReplay/SessionReplayGateCache";
+// Importing the router module registers the routes on the mocked router.
+import "../../FeatureSet/Telemetry/API/SessionReplayIngest";
+
+type MockedFn = ReturnType<typeof jest.fn>;
+
+const getPolicyMock: MockedFn =
+  SessionReplayGateCache.getPolicy as unknown as MockedFn;
+const sendJsonMock: MockedFn =
+  Response.sendJsonObjectResponse as unknown as MockedFn;
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const APP_IDENTIFIER: string = "checkout-web";
+const CONFIG_ROUTE: string = "/session-replay/v1/config";
+
+interface FakeResponse {
+  headers: Record<string, string>;
+  setHeader: (name: string, value: string) => void;
+}
+
+function buildResponse(): FakeResponse {
+  const res: FakeResponse = {
+    headers: {},
+    setHeader: (name: string, value: string): void => {
+      res.headers[name] = value;
+    },
+  };
+
+  return res;
+}
+
+function buildRequest(): unknown {
+  return {
+    projectId: PROJECT_ID,
+    headers: {
+      [SESSION_REPLAY_APP_IDENTIFIER_HEADER]: APP_IDENTIFIER,
+    },
+  };
+}
+
+async function callConfigRoute(): Promise<JSONObject> {
+  const handlers: Array<unknown> = registeredGetHandlers[CONFIG_ROUTE] || [];
+  const terminal: unknown = handlers[handlers.length - 1];
+
+  expect(typeof terminal).toBe("function");
+
+  await (
+    terminal as (
+      req: ExpressRequest,
+      res: ExpressResponse,
+      next: NextFunction,
+    ) => Promise<void>
+  )(
+    buildRequest() as ExpressRequest,
+    buildResponse() as unknown as ExpressResponse,
+    jest.fn() as unknown as NextFunction,
+  );
+
+  expect(sendJsonMock).toHaveBeenCalledTimes(1);
+
+  return sendJsonMock.mock.calls[0]?.[2] as JSONObject;
+}
+
+describe("GET /session-replay/v1/config (deployment-level answers)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /*
+   * The self-hosted answer. Nothing on the customer's page can fix this and
+   * no dashboard setting reaches it, so naming it is the whole point: the
+   * recorder logs the reason verbatim, and the docs map it to "rebuild and
+   * redeploy the OneUptime app".
+   */
+  test("reports recorder-not-built when no artifact has been published", async () => {
+    getPolicyMock.mockResolvedValue(null as never);
+
+    const body: JSONObject = await callConfigRoute();
+
+    expect(body["enabled"]).toBe(false);
+    expect(body["disabledReason"]).toBe("recorder-not-built");
+
+    /*
+     * Checked BEFORE the policy, deliberately. An instance with no artifact
+     * cannot record for ANY application, so consulting the per-application
+     * policy first would report a per-application cause for an
+     * instance-wide fault.
+     */
+    expect(getPolicyMock).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The switch has to survive onto the DISABLED response too. That response
+   * is the one a customer chasing silence most needs explained, and a
+   * recorder that is not logging cannot tell them what it says.
+   */
+  test("asks recorders to log even when it is telling them not to record", async () => {
+    getPolicyMock.mockResolvedValue(null as never);
+
+    const body: JSONObject = await callConfigRoute();
+
+    expect(body["debug"]).toBe(true);
+  });
+});

--- a/App/Tests/Telemetry/SessionReplayConfigEndpoint.test.ts
+++ b/App/Tests/Telemetry/SessionReplayConfigEndpoint.test.ts
@@ -213,6 +213,7 @@ jest.mock("../../FeatureSet/Telemetry/Config", () => {
     SESSION_REPLAY_ENABLED_BY_DEFAULT: true,
     SESSION_REPLAY_INGEST_ENABLED: true,
     SESSION_REPLAY_TRUSTED_GEO_HEADER: "",
+    SESSION_REPLAY_DEBUG: false,
   };
 });
 
@@ -449,6 +450,89 @@ describe("GET /session-replay/v1/config (wave 4 fields)", () => {
      */
     expect(res.headers["Cache-Control"]).toBe("no-store");
     expect(consumeTargetMock).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * WHY a config says enabled:false.
+   *
+   * The disabled response is deliberately a well-formed config rather than an
+   * error, so a recorder that cannot parse one refuses to record. The cost of
+   * that was a single answer for five very different causes: from a browser,
+   * an instance kill switch, a deployment whose recorder bundle was never
+   * built, an application somebody switched off and a Redis outage were all
+   * "enabled: false" and nothing else - and no amount of dashboard
+   * configuration fixes three of them.
+   */
+  test("a disabled application says WHY it is disabled", async () => {
+    getPolicyMock.mockResolvedValue(null as never);
+
+    const body: JSONObject = await callConfigRoute(
+      buildRequest(),
+      buildResponse(),
+    );
+
+    expect(body["enabled"]).toBe(false);
+    expect(body["disabledReason"]).toBe("not-enabled-for-application");
+  });
+
+  /*
+   * Fail closed AND say that it failed. A policy lookup that throws produced
+   * a response identical to "this application is switched off", which sent
+   * the customer to a settings page that was already correct.
+   */
+  test("a policy lookup that throws is reported as unavailable, not as disabled", async () => {
+    getPolicyMock.mockRejectedValue(new Error("redis down") as never);
+
+    const body: JSONObject = await callConfigRoute(
+      buildRequest(),
+      buildResponse(),
+    );
+
+    expect(body["enabled"]).toBe(false);
+    expect(body["disabledReason"]).toBe("policy-unavailable");
+  });
+
+  /*
+   * A live config has nothing to explain, and a stray disabledReason on one
+   * would make the recorder log a warning about a policy that is working.
+   */
+  test("a live config carries no disabledReason", async () => {
+    getPolicyMock.mockResolvedValue(buildPolicy() as never);
+
+    const body: JSONObject = await callConfigRoute(
+      buildRequest(),
+      buildResponse(),
+    );
+
+    expect(body["enabled"]).toBe(true);
+    expect(body["disabledReason"]).toBeUndefined();
+  });
+
+  /*
+   * Recorder diagnostics are off unless the deployment asks for them. This
+   * script runs on customers' sites in their end users' browsers, so the
+   * default has to be silence.
+   */
+  test("does not ask recorders to log when SESSION_REPLAY_DEBUG is unset", async () => {
+    getPolicyMock.mockResolvedValue(buildPolicy() as never);
+
+    const live: JSONObject = await callConfigRoute(
+      buildRequest(),
+      buildResponse(),
+    );
+
+    expect(live["debug"]).toBeUndefined();
+
+    jest.clearAllMocks();
+    consumeTargetMock.mockResolvedValue(false as never);
+    getPolicyMock.mockResolvedValue(null as never);
+
+    const disabled: JSONObject = await callConfigRoute(
+      buildRequest(),
+      buildResponse(),
+    );
+
+    expect(disabled["debug"]).toBe(false);
   });
 
   test("malformed percent-encoding matches the literal header value instead of erroring", async () => {

--- a/Common/Types/Rum/SessionReplay.ts
+++ b/Common/Types/Rum/SessionReplay.ts
@@ -328,9 +328,51 @@ export interface SessionReplayChunkEnvelope {
 }
 
 /*
+ * WHY a config response says enabled:false.
+ *
+ * The disabled response is deliberately a complete, well-formed config
+ * rather than an error, so a recorder that cannot parse a config still
+ * refuses to record. The cost of that was one answer for five very
+ * different causes: from a browser, an instance-wide kill switch, a
+ * deployment whose recorder bundle was never built, an application
+ * somebody switched off and a Redis outage were all "enabled: false" and
+ * nothing else, and no amount of dashboard configuration fixes three of
+ * them.
+ *
+ * This is a closed vocabulary carrying no project data - it is answered
+ * only to a request already bearing a valid ingestion key for that
+ * project, and it says strictly less than the Dashboard's own ingest
+ * status endpoint already shows the same customer.
+ */
+export enum SessionReplayDisabledReason {
+  /* SESSION_REPLAY_INGEST_ENABLED=false on this deployment. */
+  IngestDisabled = "ingest-disabled",
+
+  /* SESSION_REPLAY_ENABLED_BY_DEFAULT=false on this deployment. */
+  DisabledByDefault = "disabled-by-default",
+
+  /*
+   * No published recorder artifact. The build never ran, or its output is
+   * not where the server looks for it - overwhelmingly the answer on a
+   * self-hosted install where replay has never worked at all.
+   */
+  RecorderNotBuilt = "recorder-not-built",
+
+  /* The policy lookup threw. Fail closed, and say that it failed. */
+  PolicyUnavailable = "policy-unavailable",
+
+  /*
+   * No policy for this project/application pair: the application is
+   * switched off, the project is not allowed replay, the identifier does
+   * not match one, or a kill key is set.
+   */
+  NotEnabledForApplication = "not-enabled-for-application",
+}
+
+/*
  * Policy snapshot handed to the recorder at startup. This endpoint is
  * what makes every server-side privacy control reachable by a live
- * recorder — without it, flipping a masking setting would never take
+ * recorder - without it, flipping a masking setting would never take
  * effect in a browser that already loaded.
  */
 export interface SessionReplayConfigResponse {
@@ -415,6 +457,25 @@ export interface SessionReplayConfigResponse {
   configEpoch: number;
 
   directive: SessionReplayDirective;
+
+  /*
+   * Set only alongside enabled:false. Optional on the wire like every
+   * other field added after v1: an older recorder ignores it, a newer one
+   * logs it, and neither breaks.
+   */
+  disabledReason?: SessionReplayDisabledReason;
+
+  /*
+   * Ask every recorder that reads this policy to print its decisions to
+   * the browser console (SESSION_REPLAY_DEBUG on the deployment).
+   *
+   * The switch of last resort, and the only one an operator can reach
+   * without editing a page they do not own: the per-browser localStorage
+   * and query-string switches need somebody at that browser. It is off by
+   * default and must stay that way - a RUM script logging on every visitor
+   * of every customer is noise on somebody else's site.
+   */
+  debug?: boolean;
 }
 
 /* Response to a chunk POST. Deliberately tiny. */

--- a/config.example.env
+++ b/config.example.env
@@ -380,6 +380,19 @@ SESSION_REPLAY_INGEST_ENABLED=true
 # dropping partitions, potentially destroying the install's logs and traces to
 # make room.
 SESSION_REPLAY_ENABLED_BY_DEFAULT=true
+# Ask every browser recorder this deployment serves to print its decisions to
+# the console. OFF by default and it should stay that way in normal operation:
+# the recorder runs on your customers' sites, in their end users' browsers.
+#
+# This is the switch of last resort, for an operator who needs to know why
+# replay produces nothing on a page they do not own and cannot edit. The
+# per-browser switches are usually the right ones instead —
+# localStorage.setItem("oneuptime.sessionReplay.debug", "true"), or an
+# ?oneuptime_debug=1 on the URL. Turn this on, collect one reload, turn it off.
+#
+# It changes no policy: not sampling, not masking, not consent. It only adds
+# output. See /docs/rum/session-replay-troubleshooting.
+SESSION_REPLAY_DEBUG=false
 # Per-project chunk ceiling per minute, counted in Redis so it holds across
 # every app pod. Exceeding it answers 429 with Retry-After.
 SESSION_REPLAY_MAX_CHUNKS_PER_PROJECT_PER_MINUTE=20000


### PR DESCRIPTION
## The problem

A customer reports that session replays are not appearing, and that they see **no requests leaving the browser** in the Network tab. Self-hosted OneUptime, self-hosted web app.

Both halves of that report are hard to answer today, because the browser recorder is **silent by design**. Every gate fails closed and says nothing:

| what happened | what the customer sees |
| --- | --- |
| no init options on the page | nothing |
| Do Not Track / GPC | nothing |
| config fetch 404s behind a reverse proxy | nothing |
| the application is switched off | nothing |
| the deployment never built the recorder artifact | nothing |
| the session lost the sample draw | nothing |
| consent mode is `RequireExplicit` and nobody granted it | nothing |
| a 401 tripped the circuit breaker mid-session | nothing |
| **everything is fine and nothing has gone wrong yet** | **nothing** |

That last row is the killer. Under the default policy — `OnErrorOrFrustration`, 0% sample — a perfectly healthy page makes exactly **one** request per page load and posts nothing else until something breaks. From a Network tab that is indistinguishable from an installation that does not work.

The Dashboard's "test your installation" panel answers from the server's side, but the server cannot see a recorder that never loaded. The browser is the only place the answer exists, and until now nothing asked it.

## What this adds

**`src/Debug.ts`** — an opt-in diagnostics channel, **off by default**, switched on in the failing browser without a redeploy:

```js
localStorage.setItem("oneuptime.sessionReplay.debug", "true"); // then reload
```

…or `?oneuptime_debug=1` on the URL (a link you can send a non-technical reporter), `data-oneuptime-debug="true"` on the tag, `debug: true` in the init global, `OneUptimeReplay.setDebug(true)` at runtime, or **`SESSION_REPLAY_DEBUG=true`** on the deployment — the one switch that does not need somebody at the failing browser, for an operator diagnosing a page they do not own.

About 30 decision points across the loader, config, bootstrap, sampling, trigger, consent and transport paths report through it, each with a stable kebab-case `code`:

```
[OneUptime Session Replay] loader-start: Loader running.
[OneUptime Session Replay] init-options-read: Init options read. {host: "…", appIdentifier: "checkout-web", …}
[OneUptime Session Replay] config-fetch-start: Requesting the policy. {url: "…/session-replay/v1/config"}
[OneUptime Session Replay] config-disabled: The server says replay is off here. {disabledReason: "recorder-not-built"}
```

**Two properties are load-bearing, and both have tests.**

*Records are always kept; the switch gates only output.* The ring holds 250 entries on a global shared by the loader stub and the artifact, so `OneUptimeReplay.getDiagnostics()` answers on a page nobody thought to instrument first — and it includes the **stub's** records, which are the ones that explain why the artifact was never reached. (When the artifact never loaded, `window.__ONEUPTIME_SESSION_REPLAY_DEBUG__.records` is the documented fallback.)

*No page content, ever.* `DebugDetail` admits only primitives, values are truncated, and a non-primitive handed in from untyped JavaScript is replaced with `<object omitted>` rather than stringified. A diagnostics channel that could carry a DOM node would be a second, unmasked egress path for exactly the data the rest of the package exists to protect. There is an end-to-end test that runs a full record-and-upload cycle with secrets in the DOM and asserts nothing leaks, plus a source-level invariant that no diagnostic call site reads page content.

**Server side**, a config response that says `enabled: false` now says **why**. One answer previously covered five very different causes, three of which no dashboard setting can fix:

`not-enabled-for-application` · `recorder-not-built` · `disabled-by-default` · `ingest-disabled` · `policy-unavailable`

`recorder-not-built` is the likely answer for the reporting customer: on a self-hosted install where replay has *never* worked, the overwhelmingly common cause is that the recorder bundle was never produced, so there is no artifact and no version to pin — and no amount of dashboard configuration reaches it.

## Bugs found and fixed along the way

- **The kill switch's fast path never worked.** The server stands a recorder down with a bodyless `204`, putting the instruction in `x-oneuptime-replay-directive` and the reason in `x-oneuptime-replay-reason`; `CorsOptions` exposes both cross-origin *specifically so the recorder can read them*. `Transport.applyDirective` only ever parsed the body and returned early when it was empty, so every one of those responses read as a plain success and the recorder kept posting chunks the server had already told it to stop sending.
- **`SessionReplayChunkResponse.reason` was read by nobody.** It exists, in its own words, so that "a recorder told to stop without a reason" does not leave the customer diagnosing silence. It now reaches `onDirective` and the log line.
- **`readReason` truncated instead of rejecting**, so 64 characters of a caller's choosing could reach a console line as a token matching nothing in the closed vocabulary.
- **`chunk-accepted` lied twice**: it reported the caller's raw byte count while the envelope on the wire carried the post-gzip length, and it called a `204` stand-down an accepted chunk — the same conflation the server's own metrics middleware refuses in as many words. A 204 now logs `chunk-not-recorded`.

## Bundle cost

The loader stub is on the critical path of every page view on a customer's site. It grew **6.5 KB → 12.1 KB raw, 2.5 KB → 4.6 KB gzip**, and the budgets were raised to match, with the measurement and the reasoning recorded in `esbuild.config.js` (the same way the previous raise was documented).

That is a real cost, taken deliberately: ~2 KB gzip once, for output that is off unless somebody asks for it, against five silent stand-downs that are otherwise indistinguishable from each other and from a broken install. Messages in the bundle are deliberately terse for the same reason — the remediation prose lives in the docs, keyed by `code`, not in every visitor's download.

## Docs

New page: **[Session Replay Troubleshooting](/docs/rum/session-replay-troubleshooting)** — how to turn diagnostics on, how to read `getDiagnostics()`, an index of every code, the config-fetch statuses, the `disabledReason` values, and a "no request at all in the Network tab" walk-through. It leads with the answer that is most often correct: *nothing is wrong*, and `OneUptimeReplay.captureSession()` will prove the path end to end.

The Dashboard's installation panel now hands the reader the browser-side half too, and `rum/troubleshooting.md` defers to the new page.

## Tests

**117 new cases across 7 files**, all green (552 total in the recorder package, 1095 in the server telemetry suites):

- `Debug.test.ts` — every switch source, redaction (DOM nodes, objects, functions, over-long strings, non-finite numbers), the shared timeline across module instances, and hostile environments: a storage accessor that throws, a frozen global, a page that removed `console.info`.
- `LoaderDiagnostics` / `ConfigDiagnostics` / `TransportDirective` / `RecorderDiagnostics` / `DiagnosticsApi` — a case per gate, asserting the code and its detail, plus regression tests for all four bug fixes.
- `SessionReplayTroubleshootingPage.test.ts` — **fails if the recorder can emit a code the docs do not explain.** It caught 16 on its first run.
- Server: `disabledReason` per cause, and that the deployment debug switch survives onto the *disabled* response — the one a customer chasing silence most needs explained.

The change was reviewed adversarially before opening; that pass caught a regression where a blocked-storage accessor threw out of the loader's first statement and killed the recorder silently — the exact failure this PR exists to end. Fixed, with a regression test.
