### PR TITLE
fix(tests): keep the require on the line its eslint-disable covers

### DIFF
--- a/Common/Tests/Server/API/CustomDomainReissueSslAPI.test.ts
+++ b/Common/Tests/Server/API/CustomDomainReissueSslAPI.test.ts
@@ -104,6 +104,11 @@ import PositiveNumber from "../../../Types/PositiveNumber";
 
 type MockedFn = ReturnType<typeof jest.fn>;
 
+type ResponseModule = {
+  sendErrorResponse: MockedFn;
+  sendEmptySuccessResponse: MockedFn;
+};
+
 const sendEmptySuccessResponseMock: MockedFn =
   Response.sendEmptySuccessResponse as unknown as MockedFn;
 const sendErrorResponseMock: MockedFn =
@@ -411,11 +416,9 @@ describe("reissue-ssl with custom domains switched off", () => {
       const freshService: { reissueCert: unknown; countBy: unknown } = require(
         disabled.serviceModulePath,
       ).default;
+      const responseModulePath: string = "../../../Server/Utils/Response";
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const freshResponse: {
-        sendErrorResponse: MockedFn;
-        sendEmptySuccessResponse: MockedFn;
-      } = require("../../../Server/Utils/Response").default;
+      const freshResponse: ResponseModule = require(responseModulePath).default;
 
       mockRouter.routes.length = 0;
       new FreshAPI();


### PR DESCRIPTION
`js-lint` has been failing master since the Let's Encrypt reissue merge (254555dd).

```
Common/Tests/Server/API/CustomDomainReissueSslAPI.test.ts
  418:11  error  A `require()` style import is forbidden         @typescript-eslint/no-require-imports
  418:11  error  Require statement not part of import statement  @typescript-eslint/no-var-requires
```

The `eslint-disable-next-line` sat on 414 and only ever covered 415; the multi-line type annotation pushed the `require()` down to 418, outside it. The two requires above it pass only because their `require(` happens to land on the comment's next line.

Naming the annotation (`ResponseModule`) and the module path lets the declaration fit on the single line the comment guards. That shape matters: `prettier/prettier` is an `error` rule in this same job, and the obvious one-line rewrite is 93 chars, so prettier would wrap it back onto a third line and re-break the disable.

Verified locally: `eslint` exits 0 on the file, `prettier --check` is clean, and all 18 tests in the suite pass — including the two that exercise this exact block.