### PR TITLE
fix(tests): drop the dotAll flag Common's es2017 target rejects

### DIFF
--- a/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
+++ b/Common/Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
@@ -120,7 +120,12 @@ describe("Self-hosted docs: verifying the messaging endpoint during setup", () =
      * outright — an admin who reads 405 as an error stops here.
      */
     expect(stepFour).toContain("**405**");
-    expect(stepFour.toLowerCase()).toMatch(/405.*(correct|done)/s);
+    /*
+     * [\s\S] rather than the dotAll flag: this package targets es2017, where
+     * /s is a compile error (TS1501) that takes the whole suite down with it.
+     * stepFour spans several lines, so `.` alone would not reach the verdict.
+     */
+    expect(stepFour.toLowerCase()).toMatch(/405[\s\S]*(correct|done)/);
   });
 
   test("splits 404 by response body rather than calling every 404 unreachable", () => {


### PR DESCRIPTION
`Common Test` shard 5/8 has been failing master. The suite never ran:

```
FAIL Tests/UI/MicrosoftTeams/MicrosoftTeamsMessagingEndpointGuidance.test.tsx
  ● Test suite failed to run
    ...:123:65 - error TS1501: This regular expression flag is only available
    when targeting 'es2018' or later.

    123     expect(stepFour.toLowerCase()).toMatch(/405.*(correct|done)/s);
```

`Common/tsconfig.json` targets `es2017`, where `/s` is a compile error. A suite that will not compile takes its whole shard with it — 5124 tests passed in that same shard and the job still exited 1.

`[\s\S]*` matches exactly what dotAll `.*` did, with no flag. `stepFour` is multi-line markdown, so the intent is preserved.

Why it reached master: `Common Test` is one of the long jobs that kept getting superseded and cancelled on every master push since #3494 landed, so it never reported. Its last completed run before today was green.

Checked repo-wide for the same pattern — this was the only dotAll regex literal. The `(?<!…)` lookbehinds elsewhere are all under `App/` (higher target, `App Test` passes) or inside a `String.raw` template that TS does not check.

Verified locally: 37/37 tests in the suite pass, `eslint` exits 0, `prettier --check` clean.