### PR TITLE
fix(migrations): renumber AddOnCallCalendarFeeds off the colliding timestamp

### DIFF
--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1790400000000-AddOnCallCalendarFeeds.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1790400000000-AddOnCallCalendarFeeds.ts
@@ -16,8 +16,8 @@ import { MigrationInterface, QueryRunner } from "typeorm";
  * hand-written.
  */
 
-export class AddOnCallCalendarFeeds1790300000000 implements MigrationInterface {
-  public name: string = "AddOnCallCalendarFeeds1790300000000";
+export class AddOnCallCalendarFeeds1790400000000 implements MigrationInterface {
+  public name: string = "AddOnCallCalendarFeeds1790400000000";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -562,8 +562,8 @@ import { AddSnmpConfigsToNetworkDeviceDiscoveryScan1790000000001 } from "./17900
 import { AddSnmpEnabledToNetworkDeviceDiscoveryScan1790003445000 } from "./1790003445000-AddSnmpEnabledToNetworkDeviceDiscoveryScan";
 import { AddResourceActivityFeeds1790100000000 } from "./1790100000000-AddResourceActivityFeeds";
 import { AllowNullMonitorNameOnMonitorTemplate1790200000000 } from "./1790200000000-AllowNullMonitorNameOnMonitorTemplate";
-import { AddOnCallCalendarFeeds1790300000000 } from "./1790300000000-AddOnCallCalendarFeeds";
 import { AddCertificateReissueRequestedAtToDomains1790300000000 } from "./1790300000000-AddCertificateReissueRequestedAtToDomains";
+import { AddOnCallCalendarFeeds1790400000000 } from "./1790400000000-AddOnCallCalendarFeeds";
 
 export default [
   InitialMigration,
@@ -1130,6 +1130,6 @@ export default [
   AddSnmpEnabledToNetworkDeviceDiscoveryScan1790003445000,
   AddResourceActivityFeeds1790100000000,
   AllowNullMonitorNameOnMonitorTemplate1790200000000,
-  AddOnCallCalendarFeeds1790300000000,
   AddCertificateReissueRequestedAtToDomains1790300000000,
+  AddOnCallCalendarFeeds1790400000000,
 ];

--- a/Common/Tests/Server/Infrastructure/Postgres/AddOnCallCalendarFeedsMigration.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/AddOnCallCalendarFeedsMigration.test.ts
@@ -1,4 +1,4 @@
-import { AddOnCallCalendarFeeds1790300000000 } from "../../../../Server/Infrastructure/Postgres/SchemaMigrations/1790300000000-AddOnCallCalendarFeeds";
+import { AddOnCallCalendarFeeds1790400000000 } from "../../../../Server/Infrastructure/Postgres/SchemaMigrations/1790400000000-AddOnCallCalendarFeeds";
 import SchemaMigrations from "../../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
 import { MigrationInterface, QueryRunner } from "typeorm";
 import fs from "fs";
@@ -16,7 +16,7 @@ import { beforeAll, describe, expect, test } from "@jest/globals";
  * it.
  */
 
-const MIGRATION_NAME: string = "AddOnCallCalendarFeeds1790300000000";
+const MIGRATION_NAME: string = "AddOnCallCalendarFeeds1790400000000";
 
 const NEW_TABLES: Array<string> = [
   "UserOnCallCalendarFeed",
@@ -43,8 +43,8 @@ async function run(direction: "up" | "down"): Promise<Array<string>> {
     },
   } as unknown as QueryRunner;
 
-  const migration: AddOnCallCalendarFeeds1790300000000 =
-    new AddOnCallCalendarFeeds1790300000000();
+  const migration: AddOnCallCalendarFeeds1790400000000 =
+    new AddOnCallCalendarFeeds1790400000000();
 
   if (direction === "up") {
     await migration.up(runner);
@@ -104,10 +104,10 @@ beforeAll(async () => {
 
 describe("AddOnCallCalendarFeeds migration", () => {
   test("names itself after its timestamp, in the class and the recorded name", () => {
-    const migration: AddOnCallCalendarFeeds1790300000000 =
-      new AddOnCallCalendarFeeds1790300000000();
+    const migration: AddOnCallCalendarFeeds1790400000000 =
+      new AddOnCallCalendarFeeds1790400000000();
 
-    expect(AddOnCallCalendarFeeds1790300000000.name).toBe(MIGRATION_NAME);
+    expect(AddOnCallCalendarFeeds1790400000000.name).toBe(MIGRATION_NAME);
     expect(migration.name).toBe(MIGRATION_NAME);
   });
 
@@ -116,11 +116,11 @@ describe("AddOnCallCalendarFeeds migration", () => {
       SchemaMigrations as Array<MigrationClass>;
 
     expect(registered[registered.length - 1]).toBe(
-      AddOnCallCalendarFeeds1790300000000,
+      AddOnCallCalendarFeeds1790400000000,
     );
     expect(
       registered.filter((migration: MigrationClass) => {
-        return migration === AddOnCallCalendarFeeds1790300000000;
+        return migration === AddOnCallCalendarFeeds1790400000000;
       }),
     ).toHaveLength(1);
   });
@@ -134,10 +134,10 @@ describe("AddOnCallCalendarFeeds migration", () => {
     const files: Array<string> = fs
       .readdirSync(directory)
       .filter((file: string) => {
-        return file.startsWith("1790300000000-");
+        return file.startsWith("1790400000000-");
       });
 
-    expect(files).toEqual(["1790300000000-AddOnCallCalendarFeeds.ts"]);
+    expect(files).toEqual(["1790400000000-AddOnCallCalendarFeeds.ts"]);
   });
 
   test("creates exactly the five new tables", () => {


### PR DESCRIPTION
## What broke

Merging #3500 turned master red: `Common Test` failed on shards 5 and 7 with 5 failures across two suites.

#3500 and #3496 were developed in parallel and both picked `1790300000000`, so the merge landed two migrations on a single timestamp:

- `AddCertificateReissueRequestedAtToDomains1790300000000`
- `AddOnCallCalendarFeeds1790300000000`

That tripped every guard built for exactly this:

- `SchemaMigrationsOrdering` — "gives the last-registered migration the highest timestamp", "never registers the same timestamp twice", "backs every registered migration with exactly one file on disk"
- `AddOnCallCalendarFeedsMigration` — "is registered LAST, above every timestamp already registered", "is backed by exactly one file carrying the same timestamp"

## Which one moves

`AddCertificateReissueRequestedAtToDomains` is already on the `release` branch and is shipping as 12.0.29 right now, so renaming it would rename a migration that is going out the door. It stays.

`AddOnCallCalendarFeeds` is on master only — not in tag 12.0.28, not on `release` — so it has never run against a production database. It moves to `1790400000000`, above the current maximum, following the repo's existing spacing.

This is what `SchemaMigrationsOrdering` prescribes in its own failure comment: rename the new migration rather than move it up the array. I deliberately did **not** add the pair to `SHIPPED_DUPLICATE_MIGRATIONS` — that list is for collisions already out in the world that can no longer be undone, and this one hadn't shipped. Grandfathering it would have permanently excused a collision that was still free to fix.

## Changes

- `git mv` the migration to `1790400000000-AddOnCallCalendarFeeds.ts`; class and `name` property follow.
- `Index.ts`: import and registry entry renamed, and the entry moved after the certificate migration — registry order is run order, so the highest timestamp belongs last.
- The migration's own test: class references, import path, and the bare `"1790300000000-"` prefix in its file glob, which had been matching the certificate migration too.

## Verification

Both suites run locally against the change: **23 passed, 0 failed.** No stale references to the old timestamp or class name remain anywhere outside `node_modules`.