### PR TITLE
fix(e2e): bound the run and make the readiness gate mean something

### DIFF
--- a/E2E/playwright.config.ts
+++ b/E2E/playwright.config.ts
@@ -13,7 +13,20 @@ export default defineConfig({
   testDir: "./Tests",
   /* Maximum time one test can run for. */
   timeout: 240 * 1000,
-  //  globalTimeout: 600 * 1000,
+  /*
+   * Ceiling for the whole run. Without it a broken suite does not fail - it
+   * hangs until GitHub kills the job at its 6 hour limit, which reports
+   * "cancelled" and uploads nothing, so nobody learns what broke. That is not
+   * hypothetical: the 12.0.29 release run and the master run after it both
+   * died that way, six hours apart, having told us nothing.
+   *
+   * With workers=1 a single failing test costs timeout x (retries + 1), so a
+   * few dozen failures cannot fit in six hours no matter how long we wait.
+   * 90 minutes is roughly 2.5x a healthy run (~37 min), so a genuinely slow
+   * but working suite still finishes, while a broken one reports inside the
+   * hour with its artifacts intact.
+   */
+  globalTimeout: 90 * 60 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
@@ -25,8 +38,12 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: Boolean(process.env["CI"]),
-  /* Retry on CI only */
-  retries: 3,
+  /*
+   * Three retries meant four attempts per test, and at workers=1 that is up to
+   * 16 minutes spent on one failing test before the run moves on. Two retries
+   * keeps genuine flakes covered while cutting the worst case by a quarter.
+   */
+  retries: 2,
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -38,8 +55,13 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on",
+    /*
+     * Trace every retry, not every test. "on" traced all 372 tests and built a
+     * ~1GB artifact each run - upload time and disk churn that buys nothing
+     * for the tests that passed. Anything that fails is retried, so failures
+     * still arrive with a full trace attached.
+     */
+    trace: "on-first-retry",
   },
 
   /* Configure projects for major browsers */

--- a/Tests/Scripts/status-check.sh
+++ b/Tests/Scripts/status-check.sh
@@ -33,6 +33,60 @@ bash $scriptDir/endpoint-status.sh "Accounts" $HOST_TO_CHECK/accounts
 
 bash $scriptDir/endpoint-status.sh "Status Page" $HOST_TO_CHECK/status-page
 
+# Each check above stops at the first HTTP 200, which is a weaker claim than it
+# looks: nginx serves the static bundles and answers /status/ready as soon as
+# the backend accepts one connection, so a stack still settling can pass every
+# check above in well under a second. It has - the run that gated 12.0.29
+# cleared all eight in 94ms and then handed a half-warm backend to a suite
+# whose first test gives up after four minutes.
+#
+# So require the readiness endpoint to hold, not just answer once. A backend
+# still finishing its boot flaps; one that is genuinely ready returns 200 every
+# time. Consecutive successes are what separates the two, and the counter
+# resets on any non-200 so a flapping backend can never accumulate a pass.
+REQUIRED_CONSECUTIVE_OK=5
+STABILITY_INTERVAL=5
+MAX_STABILITY_ATTEMPTS=60
+
+echo ""
+echo "⏳ Confirming the backend stays ready (need ${REQUIRED_CONSECUTIVE_OK} consecutive checks)"
+
+consecutive_ok=0
+attempts=0
+
+while [ "$consecutive_ok" -lt "$REQUIRED_CONSECUTIVE_OK" ]; do
+    if [ "$attempts" -ge "$MAX_STABILITY_ATTEMPTS" ]; then
+        echo "❌ Error: backend never stayed ready for ${REQUIRED_CONSECUTIVE_OK} checks in a row."
+        echo "   It answered at least once, so this is a backend that is flapping rather than one that is down."
+        exit 1
+    fi
+
+    attempts=$((attempts + 1))
+
+    # `|| true` so a connection failure is a non-200 to handle, not a `set -e` abort.
+    status=$(curl -s -o /dev/null -w "%{http_code}" -L "$HOST_TO_CHECK/status/ready" || true)
+
+    if [ "$status" = "200" ]; then
+        consecutive_ok=$((consecutive_ok + 1))
+        echo "   ✅ ready ${consecutive_ok}/${REQUIRED_CONSECUTIVE_OK}"
+    else
+        # Reset, not decrement: five in a row must mean five in a row.
+        if [ "$consecutive_ok" -gt 0 ]; then
+            echo "   ↺ backend returned HTTP ${status} after ${consecutive_ok} good check(s) - starting the count again"
+        else
+            echo "   … backend returned HTTP ${status}, waiting"
+        fi
+        consecutive_ok=0
+    fi
+
+    if [ "$consecutive_ok" -lt "$REQUIRED_CONSECUTIVE_OK" ]; then
+        sleep "$STABILITY_INTERVAL"
+    fi
+done
+
+echo "✅ Backend held ready across ${REQUIRED_CONSECUTIVE_OK} consecutive checks"
+echo ""
+
 echo "🚀 OneUptime is up! 🚀"
 echo ""
 echo "🎉🎉🎉  Done! 🎉🎉🎉"


### PR DESCRIPTION
## Why

The E2E suite has not reported a result since 2026-08-31. The 12.0.29 release run and the master run after it each ran for **exactly six hours** and were killed by GitHub's job ceiling — which records `cancelled` and uploads no artifacts.

That matters beyond the noise: `push-release-tags` and `draft-github-release` both `needs:` these jobs, so the release gate has been shut the whole time. 12.0.29 is currently half-shipped as a result — `oneuptime/app:12.0.29` is live on Docker Hub and npm published, because those jobs run *before* the E2E gate, but there is no `12.0.29` tag and no GitHub release.

## What kept it silent

**`globalTimeout` was commented out.** Nothing capped the run. With `workers: 1`, a failing test costs `timeout × (retries + 1)`; at ~72 failures the suite cannot finish inside six hours *arithmetically*, so it always died at the ceiling rather than reporting. Now 90 minutes — about 2.5× a healthy run (~37 min), so slow-but-working still finishes while broken reports inside the hour with artifacts intact.

**`retries: 3`** meant four attempts, up to 16 minutes on a single failing test. Two retries still covers genuine flakes at three quarters of the cost.

**`trace: "on"`** traced all 372 tests into a ~1GB artifact every run. Failures are retried, so `on-first-retry` still captures a full trace for everything that fails, without the disk and upload churn for the ones that passed — churn that is a plausible contributor to the browser crashes (`Target page, context or browser has been closed`, `Object with guid … was not bound in the connection`) seen across these runs.

**The readiness gate did not gate.** Every check stopped at the first HTTP 200, and nginx serves the static bundles and answers `/status/ready` as soon as the backend accepts one connection. The run that gated 12.0.29 cleared all eight endpoints in **94ms**, then handed a still-settling stack to a suite whose first test gives up after four minutes. It now requires `/status/ready` to return 200 five times running, resetting the count on any non-200 — which is what distinguishes a backend that is ready from one that is merely answering.

## Scope — what this does not do

This does **not** claim to fix the underlying failure. The observed symptom is that registration succeeds (`navigated to http://localhost/dashboard/`) but never advances to `/dashboard/welcome`, so the suite's foundational test times out and ~72 tests cascade. I found no code change in `Accounts`, `Identity`, `Dashboard/src`, or the project-routing utils between the last passing E2E (`4e35a09bc2`) and now, and the dashboard commits I suspected all predate that passing run.

The point of this PR is that the next failure reports in under an hour **with its trace attached**, instead of six hours of silence. That is what makes the real cause diagnosable.

## Verification

The stability gate was exercised against a stub backend:

- Flapping (`200, 200, 503, 200×5`) — correctly reset at the 503 and only passed after five clean consecutive checks.
- Never ready — exited 1 at the attempt cap; connection failures surface as HTTP `000` and do not trip `set -e`.
- `bash -n` clean.

`status-check.sh` is also used by the Helm chart test; the added wait is ~25s in the healthy case and ~5 minutes worst case.