### PR TITLE
fix(ui): stop routing image srcs through Route

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Components/Header/Logo.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Components/Header/Logo.tsx
@@ -1,5 +1,4 @@
 // Tailwind
-import Route from "Common/Types/API/Route";
 import Image from "Common/UI/Components/Image/Image";
 import OneUptimeLogo from "Common/UI/Images/logos/OneUptimeSVG/3-transparent.svg";
 import { Theme, useTheme } from "Common/UI/Utils/Theme";
@@ -51,9 +50,7 @@ const Logo: FunctionComponent<ComponentProps> = (
               props.onClick();
             }
           }}
-          imageUrl={Route.fromString(
-            theme === Theme.Dark ? DarkOneUptimeLogo : OneUptimeLogo,
-          )}
+          imageUrl={theme === Theme.Dark ? DarkOneUptimeLogo : OneUptimeLogo}
           alt={"OneUptime"}
         />
       </div>

--- a/App/FeatureSet/Dashboard/src/Components/Header/Logo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/Logo.tsx
@@ -1,5 +1,4 @@
 // Tailwind
-import Route from "Common/Types/API/Route";
 import Image from "Common/UI/Components/Image/Image";
 import OneUptimeLogo from "Common/UI/Images/logos/OneUptimeSVG/3-transparent.svg";
 import { Theme, useTheme } from "Common/UI/Utils/Theme";
@@ -51,9 +50,7 @@ const Logo: FunctionComponent<ComponentProps> = (
               props.onClick();
             }
           }}
-          imageUrl={Route.fromString(
-            theme === Theme.Dark ? DarkOneUptimeLogo : OneUptimeLogo,
-          )}
+          imageUrl={theme === Theme.Dark ? DarkOneUptimeLogo : OneUptimeLogo}
           alt={"OneUptime"}
         />
       </div>

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx
@@ -16,7 +16,6 @@ import {
   useResponderGroups,
   useSetupReminders,
 } from "./EscalationRuleReadiness";
-import Route from "Common/Types/API/Route";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import IconProp from "Common/Types/Icon/IconProp";
@@ -1057,9 +1056,9 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
     user: User,
   ): ReactElement => {
     const userId: ObjectID | null = user.id || null;
-    const imageRoute: Route = userId
-      ? UserUtil.getProfilePictureRoute(userId)
-      : Route.fromString(`${BlankProfilePic}`);
+    const imageUrl: string = userId
+      ? UserUtil.getProfilePictureRoute(userId).toString()
+      : BlankProfilePic;
     const name: string =
       user.name?.toString() || user.email?.toString() || "User";
 
@@ -1088,7 +1087,7 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
       >
         <Image
           className="h-6 w-6 rounded-full bg-gray-100 object-cover"
-          imageUrl={imageRoute}
+          imageUrl={imageUrl}
           alt={name}
         />
         <span className="text-sm font-medium text-gray-700">{name}</span>

--- a/App/FeatureSet/Dashboard/src/Components/Owners/AddOwnerPopover.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Owners/AddOwnerPopover.tsx
@@ -107,7 +107,7 @@ const RowAvatar: FunctionComponent<RowAvatarProps> = (
     return (
       <Image
         className="h-8 w-8 rounded-full object-cover ring-1 ring-gray-200 bg-gray-100"
-        imageUrl={UserUtil.getProfilePictureRoute(new ObjectID(row.userId))}
+        imageUrl={UserUtil.getProfilePictureRoute(new ObjectID(row.userId)).toString()}
         alt={row.name}
       />
     );

--- a/App/FeatureSet/Dashboard/src/Components/Owners/AddOwnerPopover.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Owners/AddOwnerPopover.tsx
@@ -107,7 +107,9 @@ const RowAvatar: FunctionComponent<RowAvatarProps> = (
     return (
       <Image
         className="h-8 w-8 rounded-full object-cover ring-1 ring-gray-200 bg-gray-100"
-        imageUrl={UserUtil.getProfilePictureRoute(new ObjectID(row.userId)).toString()}
+        imageUrl={UserUtil.getProfilePictureRoute(
+          new ObjectID(row.userId),
+        ).toString()}
         alt={row.name}
       />
     );

--- a/App/FeatureSet/Dashboard/src/Components/Owners/OwnerAvatar.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Owners/OwnerAvatar.tsx
@@ -115,7 +115,7 @@ const OwnerAvatar: FunctionComponent<ComponentProps> = (
     avatar = (
       <Image
         className={`${sizeClasses} rounded-full object-cover ring-2 ring-white shadow-sm bg-gray-100`}
-        imageUrl={UserUtil.getProfilePictureRoute(item.userId)}
+        imageUrl={UserUtil.getProfilePictureRoute(item.userId).toString()}
         alt={item.name}
       />
     );

--- a/App/FeatureSet/Dashboard/src/Components/User/User.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/User/User.tsx
@@ -1,5 +1,4 @@
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
-import Route from "Common/Types/API/Route";
 import { JSONObject, JSONValue } from "Common/Types/JSON";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import Image from "Common/UI/Components/Image/Image";
@@ -82,9 +81,9 @@ const UserElement: FunctionComponent<ComponentProps> = (
   };
 
   const userId: ObjectID | null = getUserId();
-  const profileImageRoute: Route = userId
-    ? UserUtil.getProfilePictureRoute(userId)
-    : Route.fromString(`${BlankProfilePic}`);
+  const profileImageUrl: string = userId
+    ? UserUtil.getProfilePictureRoute(userId).toString()
+    : BlankProfilePic;
 
   if (JSONFunctions.isEmptyObject(user)) {
     return (
@@ -92,7 +91,7 @@ const UserElement: FunctionComponent<ComponentProps> = (
         <div>
           <Image
             className="h-8 w-8 rounded-full"
-            imageUrl={Route.fromString(`${BlankProfilePic}`)}
+            imageUrl={BlankProfilePic}
             alt={"Automation"}
           />
         </div>
@@ -136,7 +135,7 @@ const UserElement: FunctionComponent<ComponentProps> = (
         <div>
           <Image
             className="h-8 w-8 rounded-full"
-            imageUrl={profileImageRoute}
+            imageUrl={profileImageUrl}
             alt={name || "User"}
           />
         </div>

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/MobileApps.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/MobileApps.tsx
@@ -1,5 +1,4 @@
 import PageComponentProps from "../PageComponentProps";
-import Route from "Common/Types/API/Route";
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon, { SizeProp } from "Common/UI/Components/Icon/Icon";
 import Image from "Common/UI/Components/Image/Image";
@@ -177,7 +176,7 @@ const MobileApps: FunctionComponent<PageComponentProps> = (): ReactElement => {
           <div className="min-w-0">
             <div className="flex items-center gap-3">
               <Image
-                imageUrl={Route.fromString(`${OneUptimeLogo}`)}
+                imageUrl={OneUptimeLogo}
                 alt="OneUptime"
                 className="h-6 w-auto"
               />

--- a/App/FeatureSet/Dashboard/src/Pages/Users/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Users/View/Index.tsx
@@ -4,7 +4,6 @@ import PageComponentProps from "../../PageComponentProps";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import ObjectID from "Common/Types/ObjectID";
 import Exception from "Common/Types/Exception/Exception";
-import Route from "Common/Types/API/Route";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import API from "Common/UI/Utils/API/API";
@@ -108,7 +107,7 @@ const UserViewIndex: FunctionComponent<
                   return (
                     <Image
                       className="h-12 w-12 rounded-full"
-                      imageUrl={Route.fromString(`${BlankProfilePic}`)}
+                      imageUrl={BlankProfilePic}
                       alt={
                         item.name?.toString() ||
                         item.email?.toString() ||
@@ -118,9 +117,9 @@ const UserViewIndex: FunctionComponent<
                   );
                 }
 
-                const imageUrl: Route = UserUtil.getProfilePictureRoute(
+                const imageUrl: string = UserUtil.getProfilePictureRoute(
                   item.id,
-                );
+                ).toString();
 
                 return (
                   <Image

--- a/Common/Tests/App/Dashboard/HeaderImageAssets.test.tsx
+++ b/Common/Tests/App/Dashboard/HeaderImageAssets.test.tsx
@@ -1,0 +1,93 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The shape esbuild's file-loader actually hands these components: the imported
+ * asset inlined as a "data:" URL (Common/UI/esbuild-config.js,
+ * createFileLoaderPlugin). Every existing suite that mocks an .svg mocks it as
+ * a plain path like "/blank-profile.svg" — which is exactly the shape that does
+ * NOT reproduce this bug, and why the whole test suite stayed green while every
+ * dashboard and admin page threw on first render.
+ *
+ * The "//" in the base64 payload is deliberate. Route collapses /+ into a
+ * single /, so the tempting "just let Route accept data: URLs" fix would
+ * silently corrupt the image — this payload makes that fix fail here too.
+ *
+ * ONE constant and ONE jest.mock for both assets on purpose: Common's
+ * jest.config.json maps every .svg to Tests/__mocks__/styleMock.js, so two
+ * jest.mock() calls naming two different .svg paths resolve to the same module
+ * and only the last factory would ever register.
+ */
+const ASSET_DATA_URL: string = "data:image/svg+xml;base64,////bG9nbw==";
+
+jest.mock("../../../UI/Images/logos/OneUptimeSVG/3-transparent.svg", () => {
+  return ASSET_DATA_URL;
+});
+
+import DashboardLogo from "../../../../App/FeatureSet/Dashboard/src/Components/Header/Logo";
+import AdminDashboardLogo from "../../../../App/FeatureSet/AdminDashboard/src/Components/Header/Logo";
+import Image from "../../../UI/Components/Image/Image";
+
+/*
+ * Regression cover for the crash that blocked every release from 2026-08-31.
+ *
+ * b2d2da71e8 taught Route to reject scheme-prefixed strings — correctly, it
+ * guards an open-redirect. But these components were laundering an <img> src
+ * through Route.fromString() purely to satisfy Image's prop type, and an
+ * esbuild-inlined asset src is always "data:"-prefixed. So Route threw during
+ * render, React unwound to the error boundary, and the dashboard never painted.
+ *
+ * An image src is not a Route. What these pin is that the header renders the
+ * asset straight through as an <img src>, with no Route in the path.
+ */
+describe("header image assets", () => {
+  test("the dashboard logo renders the inlined asset as its src", () => {
+    render(
+      <DashboardLogo
+        onClick={() => {
+          // no-op: the click target is not what regressed.
+        }}
+      />,
+    );
+
+    const logo: HTMLElement = screen.getByAltText("OneUptime");
+    expect(logo).toHaveAttribute("src", ASSET_DATA_URL);
+  });
+
+  test("the admin dashboard logo renders the inlined asset as its src", () => {
+    render(
+      <AdminDashboardLogo
+        onClick={() => {
+          // no-op
+        }}
+      />,
+    );
+
+    const logo: HTMLElement = screen.getByAltText("OneUptime");
+    expect(logo).toHaveAttribute("src", ASSET_DATA_URL);
+  });
+
+  /*
+   * Straight at the type misuse rather than at one component: any scheme-
+   * prefixed src has to survive <Image>. Before the fix this threw inside
+   * Route.fromString at the call sites; now the string reaches <img> untouched.
+   */
+  test("Image passes a data: URL through to src without validating it", () => {
+    render(<Image imageUrl={ASSET_DATA_URL} alt="asset" />);
+
+    expect(screen.getByAltText("asset")).toHaveAttribute("src", ASSET_DATA_URL);
+  });
+
+  /*
+   * An empty src must not fall through to the `file` branch and throw
+   * "file or imageUrl required" — it renders an empty <img>, keeping the node
+   * (and its test id) in the DOM.
+   */
+  test("an empty src renders an image rather than throwing", () => {
+    render(<Image imageUrl="" alt="empty" data-testid="empty-image" />);
+
+    expect(screen.getByTestId("empty-image")).toHaveAttribute("src", "");
+  });
+});

--- a/Common/Tests/App/Dashboard/UserElementEmail.test.tsx
+++ b/Common/Tests/App/Dashboard/UserElementEmail.test.tsx
@@ -4,11 +4,19 @@ import React from "react";
 import { describe, expect, jest, test } from "@jest/globals";
 
 /*
- * The bundler turns an .svg import into a URL string; jest's asset mapper
- * turns it into {}, which UserElement then feeds to Route.fromString and
- * which throws. Hand it the string shape the browser actually gets.
+ * The shape esbuild's file-loader actually hands these components: the asset
+ * inlined as a "data:" URL (Common/UI/esbuild-config.js createFileLoaderPlugin).
+ * jest's asset mapper turns an .svg import into {} instead, so it has to be
+ * mocked - but it must be mocked as a data: URL, not as a plain path like
+ * "/blank-profile.svg". A plain path is precisely the shape that does NOT
+ * reproduce the crash, which is why this suite stayed green while every
+ * dashboard page threw.
+ *
+ * The "//" in the base64 payload is deliberate. Route collapses /+ into a
+ * single /, so a "just let Route accept data: URLs" fix would silently corrupt
+ * the image - this constant makes that fix fail here too.
  */
-const BLANK_PROFILE_PIC: string = "/blank-profile.svg";
+const BLANK_PROFILE_PIC: string = "data:image/svg+xml;base64,////YXZhdGFy";
 
 jest.mock("../../../UI/Images/users/blank-profile.svg", () => {
   return BLANK_PROFILE_PIC;

--- a/Common/Tests/App/Dashboard/UserEmailCallSites.test.tsx
+++ b/Common/Tests/App/Dashboard/UserEmailCallSites.test.tsx
@@ -27,7 +27,7 @@ import {
  * default avatar) and silent in every other suite, so they are pinned here.
  */
 
-const BLANK_PROFILE_PIC: string = "/blank-profile.svg";
+const BLANK_PROFILE_PIC: string = "data:image/svg+xml;base64,////YXZhdGFy";
 
 jest.mock("../../../UI/Images/users/blank-profile.svg", () => {
   return BLANK_PROFILE_PIC;

--- a/Common/UI/Components/Feed/FeedItem.tsx
+++ b/Common/UI/Components/Feed/FeedItem.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, ReactElement, useState } from "react";
 import User from "../../../Models/DatabaseModels/User";
 import { GetReactElementFunction } from "../../Types/FunctionTypes";
 import Image from "../Image/Image";
-import Route from "../../../Types/API/Route";
 import BlankProfilePic from "../../Images/users/blank-profile.svg";
 import UserUtil from "../../Utils/User";
 import ObjectID from "../../../Types/ObjectID";
@@ -64,15 +63,15 @@ const FeedItem: FunctionComponent<ComponentProps> = (
   };
 
   const getUserIcon: GetReactElementFunction = (): ReactElement => {
-    const userImageRoute: Route = props.user?.id
-      ? UserUtil.getProfilePictureRoute(props.user.id as ObjectID)
-      : Route.fromString(`${BlankProfilePic}`);
+    const userImageUrl: string = props.user?.id
+      ? UserUtil.getProfilePictureRoute(props.user.id as ObjectID).toString()
+      : BlankProfilePic;
 
     return (
       <div>
         <Image
           className="flex size-10 items-center justify-center rounded-full bg-gray-400 ring-8 ring-white"
-          imageUrl={userImageRoute}
+          imageUrl={userImageUrl}
         />
 
         {props.icon && (

--- a/Common/UI/Components/Header/HeaderIconDropdownButton.tsx
+++ b/Common/UI/Components/Header/HeaderIconDropdownButton.tsx
@@ -9,7 +9,6 @@ import {
   KeyboardKeyUtil,
   KeyboardShortcutKey,
 } from "../KeyboardShortcut/KeyboardKey";
-import Route from "../../../Types/API/Route";
 import IconProp from "../../../Types/Icon/IconProp";
 import React, {
   FunctionComponent,
@@ -103,7 +102,7 @@ const HeaderIconDropdownButton: FunctionComponent<ComponentProps> = (
               onClick={() => {
                 props.onClick?.();
               }}
-              imageUrl={Route.fromString(`${props.iconImageUrl}`)}
+              imageUrl={props.iconImageUrl}
               alt={props.name}
             />
           )}

--- a/Common/UI/Components/Header/UserProfile/UserProfile.tsx
+++ b/Common/UI/Components/Header/UserProfile/UserProfile.tsx
@@ -1,6 +1,5 @@
 import Icon from "../../Icon/Icon";
 import Image from "../../Image/Image";
-import Route from "../../../../Types/API/Route";
 import URL from "../../../../Types/API/URL";
 import IconProp from "../../../../Types/Icon/IconProp";
 import Name from "../../../../Types/Name";
@@ -8,7 +7,7 @@ import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
   userFullName: Name;
-  userProfilePicture: URL | Route;
+  userProfilePicture: URL | string;
   onClick: () => void;
 }
 

--- a/Common/UI/Components/Image/Image.tsx
+++ b/Common/UI/Components/Image/Image.tsx
@@ -1,13 +1,25 @@
 // Taiwind
-import Route from "../../../Types/API/Route";
 import URLFromProject from "../../../Types/API/URL";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import File from "../../../Models/DatabaseModels/File";
 import React, { FunctionComponent, ReactElement } from "react";
 
+/*
+ * The src of an <img>.
+ *
+ * Deliberately no Route member. A Route is a same-origin application PATH and
+ * rejects scheme-prefixed values by design (Common/Types/API/Route.ts). An
+ * image src is routinely scheme-prefixed - esbuild's file-loader inlines every
+ * .svg/.png import as a "data:" URL (Common/UI/esbuild-config.js). Wrapping one
+ * in a Route to satisfy this type is what threw on every dashboard page once
+ * Route started rejecting schemes. Pass a string; `someRoute.toString()` if you
+ * are starting from a Route.
+ */
+export type ImageSource = string | URLFromProject | ReactElement;
+
 export interface ComponentProps {
   onClick?: () => void | undefined;
-  imageUrl?: URLFromProject | Route | ReactElement | undefined;
+  imageUrl?: ImageSource | undefined;
   height?: number | undefined;
   file?: File | undefined;
   className?: string | undefined;
@@ -55,7 +67,12 @@ const Image: FunctionComponent<ComponentProps> = (
     );
   };
 
-  if (props.imageUrl) {
+  if (props.imageUrl !== undefined && props.imageUrl !== null) {
+    /*
+     * Not `if (props.imageUrl)`: an empty string is falsy and would fall
+     * through to the `file` branch below and throw. Render the <img> with an
+     * empty src instead, which keeps data-testid and className on the node.
+     */
     return getImageElement(props.imageUrl.toString());
   }
 

--- a/Common/UI/Components/MemberRoleAssignment/MemberRoleAssignment.tsx
+++ b/Common/UI/Components/MemberRoleAssignment/MemberRoleAssignment.tsx
@@ -12,7 +12,6 @@ import API from "../../Utils/API/API";
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import Image from "../Image/Image";
-import Route from "../../../Types/API/Route";
 import Icon from "../Icon/Icon";
 import ConfirmModal from "../Modal/ConfirmModal";
 import Modal from "../Modal/Modal";
@@ -229,7 +228,7 @@ const MemberRoleAssignment: FunctionComponent<ComponentProps> = (
         <div className="flex items-center gap-3">
           {member.userProfilePictureUrl ? (
             <Image
-              imageUrl={Route.fromString(member.userProfilePictureUrl)}
+              imageUrl={member.userProfilePictureUrl}
               alt={member.userName}
               className="h-8 w-8 rounded-full object-cover"
             />


### PR DESCRIPTION
## What this fixes

Every Dashboard and AdminDashboard page has been crashing to a React error boundary since 2026-08-31. That is what has blocked every release since — `push-release-tags` and `draft-github-release` both `needs:` the E2E jobs, and the E2E suite dies on its first test.

Reproduced in a unit test against unfixed source:

```
BadDataException: Invalid route: data:image/svg+xml;base64,////bG9nbw==
```

## The chain

1. `Common/UI/esbuild-config.js` (`createFileLoaderPlugin`) inlines every imported `.svg`/`.png` as a `data:` URL string.
2. 13 call sites wrapped that string in `Route.fromString()` **purely to satisfy `Image`'s prop type** — `Image`'s only use of `imageUrl` is `.toString()`, so no route semantics were ever involved.
3. `b2d2da71e8` *fix(security): harden status page authentication handoff* added `SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z\d+.-]*:/` to `Route` and moved validation into the constructor.
4. `data:` is scheme-prefixed, so `Route.fromString` began throwing during render. React unwound to the error boundary; the dashboard never painted; `Register.spec.ts` timed out after 240s and ~72 tests cascaded.

`b2d2da71e8` landed 2026-08-31 15:39 UTC — after the last passing E2E (`4e35a09bc2`, 09:14). The pre-existing character regex already permitted every character in a base64 data-URI (`+ / = : ; ,`), so `SCHEME_PREFIX` is specifically and solely what broke it.

## Approach: fix the type, not the validation

**`Common/Types/API/Route.ts` is untouched — not one character.** The security guard is correct and stays; every test pinning it passes by construction. The defect is that an `<img>` src was being modelled as a `Route`.

- `Image`'s prop becomes `ImageSource = string | URLFromProject | ReactElement` — `Route` removed.
- All 13 call sites pass the string directly (or `.toString()` where they legitimately start from a `Route`).

Removing `Route` from the union makes the misuse a **compile error** rather than a runtime crash. That is not theoretical — it is why one of my verification attempts wouldn't build.

## Scope — 13 sites, not the 7 that are obvious

A repo-wide sweep found more than a hand-search does. Beyond the two header logos:

- `Common/UI/Components/Header/HeaderIconDropdownButton.tsx:106` — a **second, independent** crash in the same header. `AdminDashboard/.../UserProfile.tsx:24` feeds it the raw data URL unconditionally. Fixing only `Logo.tsx` would not have unblocked anything.
- `Dashboard/src/Components/User/User.tsx` has **two** crash calls (lines 87 and 95), not one.
- Plus `FeedItem`, `EscalationRules`, `Users/View/Index`, `MobileApps`, `MemberRoleAssignment`, and 3 sites passing a genuine `Route`.

Cleared as unaffected: `blob:` URLs (12 `createObjectURL` sites, none reach a `Route`), absolute `http(s):` into `Route`, and DB/server-side `Route` construction (`Route` is not a persisted column type).

## Why 5,500 unit tests stayed green

The existing avatar suites mocked the asset as `"/blank-profile.svg"` — a plain path, which is exactly the shape that does **not** reproduce the bug. Both constants now use a real `data:` URL, with `//` in the base64 payload so the tempting "just let `Route` accept `data:` URLs" fix fails here too (`Route` collapses `/+` to `/` and would silently corrupt the image).

New: `Common/Tests/App/Dashboard/HeaderImageAssets.test.tsx` covers both logos, data-URL passthrough, and the empty-src path.

## Verification

- **Pre-fix**: unfixed `Logo.tsx` throws `Invalid route` — the production error, reproduced.
- **Post-fix**: 5 suites, **165 tests, all passing** (`HeaderImageAssets`, `UserElementEmail`, `UserEmailCallSites`, `FeedItemSafeMode`, `EscalationRuleReadiness`).
- `tsc --noEmit` on `Common`: clean.
- Adversarial review across security / completeness / correctness: security **sound**, completeness **sound**, **zero blocking** findings.

**Not verified locally:** `tsc` on `App` — `App/node_modules` isn't installed in my worktree, so it failed on missing `@types` only. CI's `compile-dashboard` / `compile-admin-dashboard` cover it.