### PR TITLE
perf(ci): stop the two jobs that set PR wall-clock from doing avoidable work

### DIFF
--- a/.github/workflows/common-jobs.yaml
+++ b/.github/workflows/common-jobs.yaml
@@ -61,10 +61,18 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y curl gcc
-      - run: sudo apt-get install -y build-essential
-      - run: sudo apt-get install -y nodejs
+      # This job used to `apt-get update` and then install curl, gcc,
+      # build-essential and nodejs. ubuntu-latest ships all four, and the apt
+      # `nodejs` package is older than the Node this repo requires anyway (it
+      # installs as /usr/bin/nodejs and never shadowed the runner's node), so
+      # the four steps cost a minute of package-index traffic and changed
+      # nothing. setup-node pins the Node the rest of CI uses and caches the
+      # npm download for the install below.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: npm install
       - run: npm run lint
       - name: Validate locale files (key parity + placeholders)

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,6 +14,9 @@ on:
       - master
 
 
+# Every job below runs at least one `npm install`. `cache: npm` keyed on every
+# lockfile in the repo gives them all one shared ~/.npm cache entry, so only the
+# first job to run pays the registry download.
 jobs:
 
   compile-accounts:
@@ -25,6 +28,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile Accounts
         uses: nick-fields/retry@v3
@@ -42,6 +47,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - name: Compile Common
         uses: nick-fields/retry@v3
         with:
@@ -58,6 +65,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile App
         uses: nick-fields/retry@v3
@@ -75,6 +84,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile Home
         uses: nick-fields/retry@v3
@@ -93,6 +104,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       
       - name: Compile Nginx
@@ -127,6 +140,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       
       - name: Compile Admin Dashboard
@@ -145,6 +160,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       
       - name: Compile Dashboard
@@ -164,6 +181,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       # The session-replay recorder deliberately does NOT depend on Common:
       # it is bundled and served to third-party origins, so it must not carry
@@ -191,6 +210,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: sudo apt-get update
       - run: cd Common && npm install
       - name: Compile E2E
@@ -213,6 +234,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile Probe
         uses: nick-fields/retry@v3
@@ -230,6 +253,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
 
       - name: Compile Status Page
@@ -250,6 +275,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       # PublicDashboard imports Dashboard sources directly (e.g.
       # src/Components/DashboardCanvas.tsx -> ../../../Dashboard/src/...), and
@@ -273,6 +300,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile Test Server
         uses: nick-fields/retry@v3
@@ -290,6 +319,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install && npm run compile
       - name: Compile MobileApp
         uses: nick-fields/retry@v3
@@ -307,6 +338,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile Runner
         uses: nick-fields/retry@v3
@@ -324,6 +357,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - name: Compile CLI
         uses: nick-fields/retry@v3

--- a/.github/workflows/postgres-schema-drift.yaml
+++ b/.github/workflows/postgres-schema-drift.yaml
@@ -56,6 +56,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       # typeorm + ts-node live in the root package; the entities the check
       # reflects over resolve their imports through Common's.

--- a/.github/workflows/terraform-provider-e2e.yml
+++ b/.github/workflows/terraform-provider-e2e.yml
@@ -219,13 +219,32 @@ jobs:
       # slow service boot), so it is the only step that gets retried. The test
       # suite itself runs exactly once — retrying it would mask real provider
       # bugs as flakes.
+      #
+      # Only `app` and `ingress` are named. A bare `npm run dev` brings up every
+      # service in docker-compose.dev.yml, and since each carries a `build:`
+      # section that means building every image from source on a cold runner:
+      # `home` (which clones the ~4 GB blog repo),
+      # `e2e` (which downloads Playwright's browsers), both probes, the runner,
+      # test-server, fluentd and fluent-bit. That was ~27 of this job's ~43
+      # minutes spent on containers no assertion in this suite ever reaches:
+      # every request it makes is `http://localhost/api/...`, which is nginx in
+      # front of `app`.
+      #
+      # Nothing is lost by naming them. postgres, redis and clickhouse still
+      # come up — `app` and `ingress` both depend_on them with
+      # condition: service_healthy — and all eight endpoints status-check waits
+      # on (/, /dashboard, /admin/env.js, /public-dashboard, /accounts,
+      # /status-page, /status, /status/ready) are served by `app` through nginx,
+      # so the readiness gate below still means exactly what it did before.
+      # (`/` proxies to `home` only when BILLING_ENABLED=true; config.env
+      # defaults it to false, which is what this job runs with.)
       - name: Start OneUptime services
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           max_attempts: 3
           command: |
-            npm run dev
+            npm run dev --services="app ingress"
             npm run status-check
 
       - name: Set up test account

--- a/.github/workflows/test.app.yaml
+++ b/.github/workflows/test.app.yaml
@@ -39,6 +39,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && bash test-setup.sh
       # App tests import Common sources directly (jest maps Common/* to
       # ../Common), so Common's own dependencies must be installed too.

--- a/.github/workflows/test.browser-recorder.yaml
+++ b/.github/workflows/test.browser-recorder.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       # No Common install: the recorder is bundled for third-party origins and
       # must not pull server dependencies. The shared pure logic it does use

--- a/.github/workflows/test.cli.yaml
+++ b/.github/workflows/test.cli.yaml
@@ -21,5 +21,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - run: cd CLI && npm install && npm run test

--- a/.github/workflows/test.common.yaml
+++ b/.github/workflows/test.common.yaml
@@ -12,6 +12,29 @@ on:
       - master
 
 jobs:
+  # Common's `npm run test` used to pass --detectOpenHandles. Jest's scheduler
+  # turns that into an unconditional runInBand -- "detectOpenHandles makes no
+  # sense without runInBand, because it cannot detect leaks in workers", in
+  # @jest/core/build/testSchedulerHelper.js -- so the whole suite ran in one
+  # process, one file at a time. 1645 test files, each dragging Common's import
+  # graph through ts-jest's per-file type check, with nine tenths of the runner
+  # idle. That is what put every shard at 15 minutes and this workflow at ~2
+  # hours of runner time per commit. The suite now runs on Jest's worker pool.
+  #
+  # --forceExit stays, and it is the flag that actually mattered: it is what
+  # stops a leaked handle from hanging the job. --detectOpenHandles only prints
+  # the stack traces that say which handle leaked -- a debugging aid, not a
+  # gate; it never changed a pass into a fail. `npm run debug:test` still has
+  # it for when a leak needs chasing.
+  #
+  # Type checking is deliberately left on. App's suite could go transpile-only
+  # (App/jest.config.json, isolatedModules) because the compile-app job takes
+  # every App test file as a tsc program root, so nothing went unchecked.
+  # Common has no such job -- Common/tsconfig.json excludes Tests from the
+  # build -- so ts-jest is the only thing type-checking these 1645 files, and
+  # turning it off here would silently drop that. Doing it properly means
+  # giving Common's tests their own tsc project first, which is a change worth
+  # making on its own rather than smuggling into a CI-timing commit.
   test:
     name: test (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest

--- a/.github/workflows/test.mobile-app.yaml
+++ b/.github/workflows/test.mobile-app.yaml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd MobileApp && npm install
       - name: Run Expo Doctor
         run: cd MobileApp && npx expo-doctor@latest
@@ -34,6 +38,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd MobileApp && npm install
       - name: Run Jest Tests
         run: cd MobileApp && npm test
@@ -47,6 +55,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd MobileApp && npm install
       - name: Export Web Bundle
         uses: nick-fields/retry@v3

--- a/.github/workflows/test.nginx.yaml
+++ b/.github/workflows/test.nginx.yaml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       # These are structural assertions over default.conf.template and
       # nginx.conf. They use node:test and node:assert only, so no npm install
       # is needed and the job stays a few seconds long.

--- a/.github/workflows/test.ops.yaml
+++ b/.github/workflows/test.ops.yaml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       # Static/structural tests over the ClickHouse config.d drop-ins, the
       # docker-compose mounts and the backup/restore scripts. No services are
       # started, so this needs nothing beyond the package's own deps.

--- a/.github/workflows/test.probe.yaml
+++ b/.github/workflows/test.probe.yaml
@@ -21,6 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - run: cd Probe && npm install
       - run: cd Probe && npx playwright install --with-deps chromium firefox

--- a/.github/workflows/test.runner.yaml
+++ b/.github/workflows/test.runner.yaml
@@ -23,5 +23,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       - run: cd Common && npm install
       - run: cd Runner && npm install && npm run test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 26
+          # Restores ~/.npm so the npm install below resolves from cache
+          # instead of re-downloading the tree from the registry every run.
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
       # Home tests import Common sources directly (jest maps Common/* to
       # ../Common), so Common's own dependencies must be installed too —
       # otherwise transitive imports like moment-timezone fail to resolve.

--- a/Common/package.json
+++ b/Common/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "cd .. && export $(grep -v '^#' config.env | xargs) && cd Common && node --max-old-space-size=6144 node_modules/.bin/jest --runInBand ./Tests --detectOpenHandles --forceExit",
+    "test": "cd .. && export $(grep -v '^#' config.env | xargs) && cd Common && node --max-old-space-size=6144 node_modules/.bin/jest ./Tests --forceExit",
     "test-file": "cd .. && export $(grep -v '^#' config.env | xargs) && cd Common && node node_modules/.bin/jest --runInBand $1 --detectOpenHandles",
     "coverage": "jest --detectOpenHandles --coverage",
     "compile": "tsc",


### PR DESCRIPTION
Cuts the wall-clock of a PR's CI run by fixing the two jobs that actually set it, and removes the uncached `npm install` every other job was paying for.

"Before" numbers are the job durations from the workflow runs on `master` at `c0028753cb` (runs `33482077699`, `33482077631`, `33482077743`, `33482077871`).

| Job | Before | Why it was slow |
| --- | --- | --- |
| `terraform-e2e-tests` | **43m** | 27m of it building nine images the suite never touches |
| `Common Test` (per shard, ×8) | **15m** | whole suite ran one file at a time, single process |
| `js-lint` | **10m** | ~1m of apt steps installing packages the runner already has |
| `Compile` (×16 jobs) | 1–2m each | every job `npm install`s against the registry with no cache |

## 1. Terraform E2E: stop building nine images nobody tests

`Start OneUptime services` was **27 minutes of a 43-minute job**. A bare `npm run dev` brings up every service in `docker-compose.dev.yml`, and each carries a `build:` section, so on a cold runner that means building `home` (which clones the ~4 GB blog repo), `e2e` (which downloads Playwright's browsers), both probes, the runner, `test-server`, fluentd and fluent-bit — from source.

Every assertion in this suite is a `curl` to `http://localhost/api/...`, which is nginx in front of `app`. So the step now names `app` and `ingress`.

Nothing is given up:

- postgres, redis and clickhouse still come up — `app` and `ingress` both `depends_on` them with `condition: service_healthy`, and none of the three has a `build:` section, so they are pulled as before.
- All eight endpoints `status-check` waits on are served by `app` through nginx. `/` proxies to `home` only when `BILLING_ENABLED=true`; `config.example.env` defaults it to `false`, which is what this job runs with. The readiness gate means exactly what it did.

## 2. Common Test: the suite was running one file at a time

`Common/package.json`'s test script passed `--detectOpenHandles`. Jest's scheduler treats that as an unconditional `runInBand` — `@jest/core/build/testSchedulerHelper.js`:

```js
// detectOpenHandles makes no sense without runInBand, because it cannot detect leaks in workers
if (detectOpenHandles) {
  return true;
}
```

So all 1,645 test files ran in a single process with the rest of the runner idle. That is what put each of the 8 shards at 15 minutes — about **two hours of runner time per commit**.

`--forceExit` stays, and it was the flag doing the real work: it is what stops a leaked handle from hanging the job. `--detectOpenHandles` only prints the stack traces naming the leak — a debugging aid, never a gate, and it never turned a pass into a fail. `npm run debug:test` still carries it for when a leak needs chasing.

### What I deliberately did *not* do

The bigger win is `isolatedModules` — having ts-jest transpile instead of type-check. On the same 54-file sample that takes 226s → **14s**, and the full suite passes with it.

I left it out. App could go transpile-only (`App/jest.config.json`) because `compile-app` takes every App test file as a `tsc` program root, so nothing went unchecked. Common has no equivalent — `Common/tsconfig.json` excludes `Tests` from the build — so **ts-jest is the only thing type-checking these 1,645 files**, and flipping the flag would silently drop that.

I tried adding the missing `tsc` project. It does not drop in: 157 of these tests import `App/FeatureSet/*` sources, and a whole-program check over those surfaces errors ts-jest never sees — `*.svg` imports jest resolves to a mock, `recharts` and `i18next-browser-languagedetector` which aren't installed in a Common-only job, and a real `RefObject`/`LegacyRef` mismatch in `DashboardResourceHoneycomb.tsx`. That's worth doing on its own, not smuggled into a CI-timing commit — and it buys no wall-clock here, since at ~6m a shard Common Test is already off the critical path.

## 3. `js-lint`: four apt steps that installed nothing

The job ran `apt-get update` then installed `curl`, `gcc`, `build-essential` and `nodejs`. `ubuntu-latest` ships all four, and the apt `nodejs` package is older than this repo's `engines` requirement anyway — it lands at `/usr/bin/nodejs` and never shadowed the runner's node. Replaced with `actions/setup-node` pinned to the Node the rest of CI uses.

## 4. `npm install` was uncached everywhere

`Compile` alone runs 16 jobs, each doing at least one `npm install` against the registry with no `~/.npm` to fall back on. Added `cache: npm` keyed on `**/package-lock.json` so `Compile`, the ten PR test workflows and `postgres-schema-drift` share one cache entry and only the first job to run pays the download. It also takes a chunk of registry flakiness out of CI.

## Left alone, on purpose

`docker-build-home` is 14m and becomes the new critical path. It is dominated by the ~4 GB blog clone plus two `npm ci` runs under `--no-cache`. `--single-branch` looked promising until I checked: the blog's 106 branches are all `ahead=0` against `master`, so their objects are already in `master`'s history and it would save nothing. Going faster means either weakening the clean-build guarantee `--no-cache` exists for, or a shallow clone that breaks `BlogPostUtil.warmContributors()`'s full-history `git log`. Neither belongs here.

## Testing

- **54-file sample** (`Common/Tests/Types`, 699 tests), type checking unchanged in both: **226s → 88s**.
- **Full unsharded suite on the worker pool**: 1,645 suites / 42,716 tests, all passing. That run also had `isolatedModules` on — it is the same worker pool either way, so what it exercises is the parallelism, which is the part that ships.
- I could not get a clean full-suite number with type checking on: nine ts-jest workers put my machine into swap. The honest number for that configuration is the one this PR's own `Common Test` run produces.
- All 21 workflow files re-parsed as YAML.
- `npm run dev --services=...` passthrough verified against npm 11, including through the nested `npm run config-to-dev` / `npm run prerun` calls.
