### PR TITLE
fix(rule-engines): evaluate every enabled rule in a project, not the newest 100

### DIFF
--- a/Common/Server/Services/AlertEpisodeLabelRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodeLabelRuleEngineService.ts
@@ -13,6 +13,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertEpisodeLabelRuleEngineServiceClass {
   /**
@@ -44,7 +45,7 @@ class AlertEpisodeLabelRuleEngineServiceClass {
             episodeDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/AlertEpisodeLabelRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodeLabelRuleEngineService.ts
@@ -14,6 +14,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertEpisodeLabelRuleEngineServiceClass {
   /**
@@ -48,6 +49,12 @@ class AlertEpisodeLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertEpisodeLabelRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/AlertEpisodeOnCallRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodeOnCallRuleEngineService.ts
@@ -15,6 +15,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertEpisodeOnCallRuleEngineServiceClass {
   /**
@@ -48,6 +49,12 @@ class AlertEpisodeOnCallRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertEpisodeOnCallRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/AlertEpisodeOnCallRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodeOnCallRuleEngineService.ts
@@ -14,6 +14,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertEpisodeOnCallRuleEngineServiceClass {
   /**
@@ -44,7 +45,7 @@ class AlertEpisodeOnCallRuleEngineServiceClass {
             episodeDescriptionPattern: true,
             onCallDutyPolicies: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/AlertEpisodeOwnerRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodeOwnerRuleEngineService.ts
@@ -16,6 +16,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertEpisodeOwnerRuleEngineServiceClass {
   /**
@@ -48,7 +49,7 @@ class AlertEpisodeOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/AlertEpisodeOwnerRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodeOwnerRuleEngineService.ts
@@ -17,6 +17,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertEpisodeOwnerRuleEngineServiceClass {
   /**
@@ -52,6 +53,12 @@ class AlertEpisodeOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertEpisodeOwnerRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/AlertEpisodePrivacyRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodePrivacyRuleEngineService.ts
@@ -10,6 +10,7 @@ import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertEpisodePrivacyRuleEngineServiceClass {
   /**
@@ -45,6 +46,12 @@ class AlertEpisodePrivacyRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertEpisodePrivacyRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return false;

--- a/Common/Server/Services/AlertEpisodePrivacyRuleEngineService.ts
+++ b/Common/Server/Services/AlertEpisodePrivacyRuleEngineService.ts
@@ -9,6 +9,7 @@ import { AlertEpisodeFeedEventType } from "../../Models/DatabaseModels/AlertEpis
 import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertEpisodePrivacyRuleEngineServiceClass {
   /**
@@ -41,7 +42,7 @@ class AlertEpisodePrivacyRuleEngineServiceClass {
             episodeTitlePattern: true,
             episodeDescriptionPattern: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/AlertGroupingEngineService.ts
+++ b/Common/Server/Services/AlertGroupingEngineService.ts
@@ -26,6 +26,8 @@ import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import AlertEpisodeFeedService from "./AlertEpisodeFeedService";
 import { AlertEpisodeFeedEventType } from "../../Models/DatabaseModels/AlertEpisodeFeed";
 import { Green500 } from "../../Types/BrandColors";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 export interface GroupingResult {
   grouped: boolean;
@@ -121,9 +123,15 @@ class AlertGroupingEngineServiceClass {
               _id: true,
             },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertGroupingRule",
+        projectId: alert.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         logger.debug(

--- a/Common/Server/Services/AlertLabelRuleEngineService.ts
+++ b/Common/Server/Services/AlertLabelRuleEngineService.ts
@@ -25,6 +25,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertLabelRuleEngineServiceClass {
   /**
@@ -72,7 +73,7 @@ class AlertLabelRuleEngineServiceClass {
           inheritLabelsFromPodmanHosts: true,
           inheritLabelsFromServices: true,
         },
-        limit: 100,
+        limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
 

--- a/Common/Server/Services/AlertLabelRuleEngineService.ts
+++ b/Common/Server/Services/AlertLabelRuleEngineService.ts
@@ -26,6 +26,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertLabelRuleEngineServiceClass {
   /**
@@ -75,6 +76,12 @@ class AlertLabelRuleEngineServiceClass {
         },
         limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
+      });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertLabelRule",
+        projectId: alert.projectId,
+        rulesRead: rules.length,
       });
 
       if (rules.length === 0) {

--- a/Common/Server/Services/AlertOnCallRuleEngineService.ts
+++ b/Common/Server/Services/AlertOnCallRuleEngineService.ts
@@ -17,6 +17,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertOnCallRuleEngineServiceClass {
   /**
@@ -56,6 +57,12 @@ class AlertOnCallRuleEngineServiceClass {
           skip: 0,
         },
       );
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertOnCallRule",
+        projectId: alert.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/AlertOnCallRuleEngineService.ts
+++ b/Common/Server/Services/AlertOnCallRuleEngineService.ts
@@ -16,6 +16,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertOnCallRuleEngineServiceClass {
   /**
@@ -51,7 +52,7 @@ class AlertOnCallRuleEngineServiceClass {
             monitorDescriptionPattern: true,
             onCallDutyPolicies: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         },
       );

--- a/Common/Server/Services/AlertOwnerRuleEngineService.ts
+++ b/Common/Server/Services/AlertOwnerRuleEngineService.ts
@@ -47,6 +47,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertOwnerRuleEngineServiceClass {
   /**
@@ -87,7 +88,7 @@ class AlertOwnerRuleEngineServiceClass {
           inheritOwnersFromPodmanHosts: true,
           inheritOwnersFromServices: true,
         },
-        limit: 100,
+        limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
 

--- a/Common/Server/Services/AlertOwnerRuleEngineService.ts
+++ b/Common/Server/Services/AlertOwnerRuleEngineService.ts
@@ -48,6 +48,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertOwnerRuleEngineServiceClass {
   /**
@@ -90,6 +91,12 @@ class AlertOwnerRuleEngineServiceClass {
         },
         limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
+      });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertOwnerRule",
+        projectId: alert.projectId,
+        rulesRead: rules.length,
       });
 
       if (rules.length === 0) {

--- a/Common/Server/Services/AlertPrivacyRuleEngineService.ts
+++ b/Common/Server/Services/AlertPrivacyRuleEngineService.ts
@@ -12,6 +12,7 @@ import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class AlertPrivacyRuleEngineServiceClass {
   /**
@@ -55,6 +56,12 @@ class AlertPrivacyRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "AlertPrivacyRule",
+        projectId: alert.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return false;

--- a/Common/Server/Services/AlertPrivacyRuleEngineService.ts
+++ b/Common/Server/Services/AlertPrivacyRuleEngineService.ts
@@ -11,6 +11,7 @@ import { AlertFeedEventType } from "../../Models/DatabaseModels/AlertFeed";
 import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class AlertPrivacyRuleEngineServiceClass {
   /**
@@ -51,7 +52,7 @@ class AlertPrivacyRuleEngineServiceClass {
             monitorNamePattern: true,
             monitorDescriptionPattern: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/AlertReminderRuleService.ts
+++ b/Common/Server/Services/AlertReminderRuleService.ts
@@ -15,6 +15,8 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -193,11 +195,17 @@ export class Service extends DatabaseService<Model> {
           _id: true,
         },
       },
-      limit: 100,
+      limit: MAX_RULES_EVALUATED_PER_PROJECT,
       skip: 0,
       props: {
         isRoot: true,
       },
+    });
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "AlertReminderRule",
+      projectId: data.projectId,
+      rulesRead: rules.length,
     });
 
     for (const rule of rules) {

--- a/Common/Server/Services/AutoRemediationRuleEngineService.ts
+++ b/Common/Server/Services/AutoRemediationRuleEngineService.ts
@@ -36,6 +36,7 @@ import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 /*
  * Guardrails (minimal G1 for auto-remediation Phase 1):
@@ -220,6 +221,12 @@ class AutoRemediationRuleEngineServiceClass {
         limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "AutoRemediationRule",
+      projectId: data.projectId,
+      rulesRead: rules.length,
+    });
 
     if (rules.length === 0) {
       return;

--- a/Common/Server/Services/AutoRemediationRuleEngineService.ts
+++ b/Common/Server/Services/AutoRemediationRuleEngineService.ts
@@ -35,6 +35,7 @@ import AIInvestigationQueue from "../Utils/AI/SRE/InvestigationQueue";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 /*
  * Guardrails (minimal G1 for auto-remediation Phase 1):
@@ -216,7 +217,7 @@ class AutoRemediationRuleEngineServiceClass {
           monitorLabels: { _id: true },
           runbooks: { _id: true, name: true },
         },
-        limit: 100,
+        limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
 

--- a/Common/Server/Services/CephClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/CephClusterLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class CephClusterLabelRuleEngineServiceClass {
   /**
@@ -44,6 +45,12 @@ class CephClusterLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "CephClusterLabelRule",
+        projectId: cephCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/CephClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/CephClusterLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class CephClusterLabelRuleEngineServiceClass {
   /**
@@ -40,7 +41,7 @@ class CephClusterLabelRuleEngineServiceClass {
             cephClusterDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/CephClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/CephClusterOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class CephClusterOwnerRuleEngineServiceClass {
   /**
@@ -51,6 +52,12 @@ class CephClusterOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "CephClusterOwnerRule",
+        projectId: cephCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/CephClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/CephClusterOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class CephClusterOwnerRuleEngineServiceClass {
   /**
@@ -47,7 +48,7 @@ class CephClusterOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/CloudResourceLabelRuleEngineService.ts
+++ b/Common/Server/Services/CloudResourceLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class CloudResourceLabelRuleEngineServiceClass {
   /**
@@ -44,6 +45,12 @@ class CloudResourceLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "CloudResourceLabelRule",
+        projectId: cloudResource.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/CloudResourceLabelRuleEngineService.ts
+++ b/Common/Server/Services/CloudResourceLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class CloudResourceLabelRuleEngineServiceClass {
   /**
@@ -40,7 +41,7 @@ class CloudResourceLabelRuleEngineServiceClass {
             descriptionRegexPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/CloudResourceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/CloudResourceOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class CloudResourceOwnerRuleEngineServiceClass {
   /**
@@ -50,6 +51,12 @@ class CloudResourceOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "CloudResourceOwnerRule",
+        projectId: cloudResource.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/CloudResourceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/CloudResourceOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class CloudResourceOwnerRuleEngineServiceClass {
   /**
@@ -46,7 +47,7 @@ class CloudResourceOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DashboardLabelRuleEngineService.ts
+++ b/Common/Server/Services/DashboardLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import DashboardService from "./DashboardService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class DashboardLabelRuleEngineServiceClass {
   /**
@@ -35,7 +36,7 @@ class DashboardLabelRuleEngineServiceClass {
             dashboardDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DashboardLabelRuleEngineService.ts
+++ b/Common/Server/Services/DashboardLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class DashboardLabelRuleEngineServiceClass {
   /**
@@ -39,6 +40,12 @@ class DashboardLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "DashboardLabelRule",
+        projectId: dashboard.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/DashboardOwnerRuleEngineService.ts
+++ b/Common/Server/Services/DashboardOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class DashboardOwnerRuleEngineServiceClass {
   /**
@@ -46,6 +47,12 @@ class DashboardOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "DashboardOwnerRule",
+        projectId: dashboard.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/DashboardOwnerRuleEngineService.ts
+++ b/Common/Server/Services/DashboardOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import DashboardService from "./DashboardService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class DashboardOwnerRuleEngineServiceClass {
   /**
@@ -42,7 +43,7 @@ class DashboardOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DockerHostLabelRuleEngineService.ts
+++ b/Common/Server/Services/DockerHostLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class DockerHostLabelRuleEngineServiceClass {
   /**
@@ -42,6 +43,12 @@ class DockerHostLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "DockerHostLabelRule",
+        projectId: dockerHost.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/DockerHostLabelRuleEngineService.ts
+++ b/Common/Server/Services/DockerHostLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class DockerHostLabelRuleEngineServiceClass {
   /**
@@ -38,7 +39,7 @@ class DockerHostLabelRuleEngineServiceClass {
             dockerHostDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DockerHostOwnerRuleEngineService.ts
+++ b/Common/Server/Services/DockerHostOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class DockerHostOwnerRuleEngineServiceClass {
   /**
@@ -45,7 +46,7 @@ class DockerHostOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DockerHostOwnerRuleEngineService.ts
+++ b/Common/Server/Services/DockerHostOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class DockerHostOwnerRuleEngineServiceClass {
   /**
@@ -49,6 +50,12 @@ class DockerHostOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "DockerHostOwnerRule",
+        projectId: dockerHost.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/DockerSwarmClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/DockerSwarmClusterLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class DockerSwarmClusterLabelRuleEngineServiceClass {
   /**
@@ -40,7 +41,7 @@ class DockerSwarmClusterLabelRuleEngineServiceClass {
             dockerSwarmClusterDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DockerSwarmClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/DockerSwarmClusterLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class DockerSwarmClusterLabelRuleEngineServiceClass {
   /**
@@ -44,6 +45,12 @@ class DockerSwarmClusterLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "DockerSwarmClusterLabelRule",
+        projectId: dockerSwarmCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/DockerSwarmClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/DockerSwarmClusterOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class DockerSwarmClusterOwnerRuleEngineServiceClass {
   /**
@@ -47,7 +48,7 @@ class DockerSwarmClusterOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/DockerSwarmClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/DockerSwarmClusterOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class DockerSwarmClusterOwnerRuleEngineServiceClass {
   /**
@@ -51,6 +52,12 @@ class DockerSwarmClusterOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "DockerSwarmClusterOwnerRule",
+        projectId: dockerSwarmCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/HostLabelRuleEngineService.ts
+++ b/Common/Server/Services/HostLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class HostLabelRuleEngineServiceClass {
   /**
@@ -37,7 +38,7 @@ class HostLabelRuleEngineServiceClass {
           hostDescriptionPattern: true,
           labelsToAdd: { _id: true },
         },
-        limit: 100,
+        limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
 

--- a/Common/Server/Services/HostLabelRuleEngineService.ts
+++ b/Common/Server/Services/HostLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class HostLabelRuleEngineServiceClass {
   /**
@@ -40,6 +41,12 @@ class HostLabelRuleEngineServiceClass {
         },
         limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
+      });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "HostLabelRule",
+        projectId: host.projectId,
+        rulesRead: rules.length,
       });
 
       if (rules.length === 0) {

--- a/Common/Server/Services/HostOwnerRuleEngineService.ts
+++ b/Common/Server/Services/HostOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class HostOwnerRuleEngineServiceClass {
   /**
@@ -44,7 +45,7 @@ class HostOwnerRuleEngineServiceClass {
           ownerUsers: { _id: true },
           ownerTeams: { _id: true },
         },
-        limit: 100,
+        limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
 

--- a/Common/Server/Services/HostOwnerRuleEngineService.ts
+++ b/Common/Server/Services/HostOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class HostOwnerRuleEngineServiceClass {
   /**
@@ -47,6 +48,12 @@ class HostOwnerRuleEngineServiceClass {
         },
         limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
+      });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "HostOwnerRule",
+        projectId: host.projectId,
+        rulesRead: rules.length,
       });
 
       if (rules.length === 0) {

--- a/Common/Server/Services/IncidentEpisodeLabelRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodeLabelRuleEngineService.ts
@@ -14,6 +14,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentEpisodeLabelRuleEngineServiceClass {
   /**
@@ -48,6 +49,12 @@ class IncidentEpisodeLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentEpisodeLabelRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncidentEpisodeLabelRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodeLabelRuleEngineService.ts
@@ -13,6 +13,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentEpisodeLabelRuleEngineServiceClass {
   /**
@@ -44,7 +45,7 @@ class IncidentEpisodeLabelRuleEngineServiceClass {
             episodeDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentEpisodeOnCallRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodeOnCallRuleEngineService.ts
@@ -14,6 +14,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentEpisodeOnCallRuleEngineServiceClass {
   /**
@@ -45,7 +46,7 @@ class IncidentEpisodeOnCallRuleEngineServiceClass {
             episodeDescriptionPattern: true,
             onCallDutyPolicies: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentEpisodeOnCallRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodeOnCallRuleEngineService.ts
@@ -15,6 +15,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentEpisodeOnCallRuleEngineServiceClass {
   /**
@@ -49,6 +50,12 @@ class IncidentEpisodeOnCallRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentEpisodeOnCallRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncidentEpisodeOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodeOwnerRuleEngineService.ts
@@ -16,6 +16,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentEpisodeOwnerRuleEngineServiceClass {
   /**
@@ -48,7 +49,7 @@ class IncidentEpisodeOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentEpisodeOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodeOwnerRuleEngineService.ts
@@ -17,6 +17,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentEpisodeOwnerRuleEngineServiceClass {
   /**
@@ -52,6 +53,12 @@ class IncidentEpisodeOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentEpisodeOwnerRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncidentEpisodePrivacyRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodePrivacyRuleEngineService.ts
@@ -9,6 +9,7 @@ import { IncidentEpisodeFeedEventType } from "../../Models/DatabaseModels/Incide
 import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentEpisodePrivacyRuleEngineServiceClass {
   /**
@@ -43,7 +44,7 @@ class IncidentEpisodePrivacyRuleEngineServiceClass {
             episodeTitlePattern: true,
             episodeDescriptionPattern: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentEpisodePrivacyRuleEngineService.ts
+++ b/Common/Server/Services/IncidentEpisodePrivacyRuleEngineService.ts
@@ -10,6 +10,7 @@ import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentEpisodePrivacyRuleEngineServiceClass {
   /**
@@ -47,6 +48,12 @@ class IncidentEpisodePrivacyRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentEpisodePrivacyRule",
+        projectId: episode.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return false;

--- a/Common/Server/Services/IncidentGroupingEngineService.ts
+++ b/Common/Server/Services/IncidentGroupingEngineService.ts
@@ -28,6 +28,8 @@ import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import IncidentEpisodeFeedService from "./IncidentEpisodeFeedService";
 import { IncidentEpisodeFeedEventType } from "../../Models/DatabaseModels/IncidentEpisodeFeed";
 import { Green500 } from "../../Types/BrandColors";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 export interface GroupingResult {
   grouped: boolean;
@@ -127,9 +129,15 @@ class IncidentGroupingEngineServiceClass {
             },
             episodeMemberRoleAssignments: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentGroupingRule",
+        projectId: incident.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         logger.debug(

--- a/Common/Server/Services/IncidentLabelRuleEngineService.ts
+++ b/Common/Server/Services/IncidentLabelRuleEngineService.ts
@@ -26,6 +26,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentLabelRuleEngineServiceClass {
   /**
@@ -77,6 +78,12 @@ class IncidentLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentLabelRule",
+        projectId: incident.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncidentLabelRuleEngineService.ts
+++ b/Common/Server/Services/IncidentLabelRuleEngineService.ts
@@ -25,6 +25,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentLabelRuleEngineServiceClass {
   /**
@@ -73,7 +74,7 @@ class IncidentLabelRuleEngineServiceClass {
             inheritLabelsFromPodmanHosts: true,
             inheritLabelsFromServices: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentOnCallRuleEngineService.ts
+++ b/Common/Server/Services/IncidentOnCallRuleEngineService.ts
@@ -17,6 +17,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentOnCallRuleEngineServiceClass {
   /**
@@ -55,6 +56,12 @@ class IncidentOnCallRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentOnCallRule",
+        projectId: incident.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncidentOnCallRuleEngineService.ts
+++ b/Common/Server/Services/IncidentOnCallRuleEngineService.ts
@@ -16,6 +16,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentOnCallRuleEngineServiceClass {
   /**
@@ -51,7 +52,7 @@ class IncidentOnCallRuleEngineServiceClass {
             monitorDescriptionPattern: true,
             onCallDutyPolicies: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IncidentOwnerRuleEngineService.ts
@@ -48,6 +48,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentOwnerRuleEngineServiceClass {
   /**
@@ -93,6 +94,12 @@ class IncidentOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentOwnerRule",
+        projectId: incident.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncidentOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IncidentOwnerRuleEngineService.ts
@@ -47,6 +47,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentOwnerRuleEngineServiceClass {
   /**
@@ -89,7 +90,7 @@ class IncidentOwnerRuleEngineServiceClass {
             inheritOwnersFromPodmanHosts: true,
             inheritOwnersFromServices: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentPrivacyRuleEngineService.ts
+++ b/Common/Server/Services/IncidentPrivacyRuleEngineService.ts
@@ -12,6 +12,7 @@ import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncidentPrivacyRuleEngineServiceClass {
   /**
@@ -56,6 +57,12 @@ class IncidentPrivacyRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncidentPrivacyRule",
+        projectId: incident.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return false;

--- a/Common/Server/Services/IncidentPrivacyRuleEngineService.ts
+++ b/Common/Server/Services/IncidentPrivacyRuleEngineService.ts
@@ -11,6 +11,7 @@ import { IncidentFeedEventType } from "../../Models/DatabaseModels/IncidentFeed"
 import { Red500 } from "../../Types/BrandColors";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncidentPrivacyRuleEngineServiceClass {
   /**
@@ -52,7 +53,7 @@ class IncidentPrivacyRuleEngineServiceClass {
             monitorNamePattern: true,
             monitorDescriptionPattern: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncidentReminderRuleService.ts
+++ b/Common/Server/Services/IncidentReminderRuleService.ts
@@ -15,6 +15,8 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -193,11 +195,17 @@ export class Service extends DatabaseService<Model> {
           _id: true,
         },
       },
-      limit: 100,
+      limit: MAX_RULES_EVALUATED_PER_PROJECT,
       skip: 0,
       props: {
         isRoot: true,
       },
+    });
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "IncidentReminderRule",
+      projectId: data.projectId,
+      rulesRead: rules.length,
     });
 
     for (const rule of rules) {

--- a/Common/Server/Services/IncidentSlaRuleService.ts
+++ b/Common/Server/Services/IncidentSlaRuleService.ts
@@ -13,6 +13,8 @@ import logger, { LogAttributes } from "../Utils/Logger";
 import { IsBillingEnabled } from "../EnvironmentConfig";
 import MonitorService from "./MonitorService";
 import IncidentService from "./IncidentService";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -132,11 +134,17 @@ export class Service extends DatabaseService<Model> {
         incidentTitlePattern: true,
         incidentDescriptionPattern: true,
       },
-      limit: 100,
+      limit: MAX_RULES_EVALUATED_PER_PROJECT,
       skip: 0,
       props: {
         isRoot: true,
       },
+    });
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "IncidentSlaRule",
+      projectId: data.projectId,
+      rulesRead: rules.length,
     });
 
     if (rules.length === 0) {

--- a/Common/Server/Services/IncomingCallPolicyLabelRuleEngineService.ts
+++ b/Common/Server/Services/IncomingCallPolicyLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import IncomingCallPolicyService from "./IncomingCallPolicyService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncomingCallPolicyLabelRuleEngineServiceClass {
   @CaptureSpan()
@@ -32,7 +33,7 @@ class IncomingCallPolicyLabelRuleEngineServiceClass {
             incomingCallPolicyDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncomingCallPolicyLabelRuleEngineService.ts
+++ b/Common/Server/Services/IncomingCallPolicyLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncomingCallPolicyLabelRuleEngineServiceClass {
   @CaptureSpan()
@@ -36,6 +37,12 @@ class IncomingCallPolicyLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncomingCallPolicyLabelRule",
+        projectId: policy.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IncomingCallPolicyOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IncomingCallPolicyOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import IncomingCallPolicyService from "./IncomingCallPolicyService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IncomingCallPolicyOwnerRuleEngineServiceClass {
   @CaptureSpan()
@@ -38,7 +39,7 @@ class IncomingCallPolicyOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IncomingCallPolicyOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IncomingCallPolicyOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IncomingCallPolicyOwnerRuleEngineServiceClass {
   @CaptureSpan()
@@ -42,6 +43,12 @@ class IncomingCallPolicyOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IncomingCallPolicyOwnerRule",
+        projectId: policy.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IoTFleetLabelRuleEngineService.ts
+++ b/Common/Server/Services/IoTFleetLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import IoTFleetService from "./IoTFleetService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IoTFleetLabelRuleEngineServiceClass {
   /**
@@ -35,7 +36,7 @@ class IoTFleetLabelRuleEngineServiceClass {
             iotFleetDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IoTFleetLabelRuleEngineService.ts
+++ b/Common/Server/Services/IoTFleetLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IoTFleetLabelRuleEngineServiceClass {
   /**
@@ -39,6 +40,12 @@ class IoTFleetLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IoTFleetLabelRule",
+        projectId: iotFleet.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/IoTFleetOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IoTFleetOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import IoTFleetService from "./IoTFleetService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class IoTFleetOwnerRuleEngineServiceClass {
   /**
@@ -42,7 +43,7 @@ class IoTFleetOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/IoTFleetOwnerRuleEngineService.ts
+++ b/Common/Server/Services/IoTFleetOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class IoTFleetOwnerRuleEngineServiceClass {
   /**
@@ -46,6 +47,12 @@ class IoTFleetOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "IoTFleetOwnerRule",
+        projectId: iotFleet.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/KubernetesClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/KubernetesClusterLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class KubernetesClusterLabelRuleEngineServiceClass {
   /**
@@ -40,7 +41,7 @@ class KubernetesClusterLabelRuleEngineServiceClass {
             kubernetesClusterDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/KubernetesClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/KubernetesClusterLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class KubernetesClusterLabelRuleEngineServiceClass {
   /**
@@ -44,6 +45,12 @@ class KubernetesClusterLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "KubernetesClusterLabelRule",
+        projectId: kubernetesCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/KubernetesClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/KubernetesClusterOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class KubernetesClusterOwnerRuleEngineServiceClass {
   /**
@@ -47,7 +48,7 @@ class KubernetesClusterOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/KubernetesClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/KubernetesClusterOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class KubernetesClusterOwnerRuleEngineServiceClass {
   /**
@@ -51,6 +52,12 @@ class KubernetesClusterOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "KubernetesClusterOwnerRule",
+        projectId: kubernetesCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/MonitorLabelRuleEngineService.ts
+++ b/Common/Server/Services/MonitorLabelRuleEngineService.ts
@@ -13,6 +13,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class MonitorLabelRuleEngineServiceClass {
   /**
@@ -45,6 +46,12 @@ class MonitorLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "MonitorLabelRule",
+        projectId: monitor.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/MonitorLabelRuleEngineService.ts
+++ b/Common/Server/Services/MonitorLabelRuleEngineService.ts
@@ -12,6 +12,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class MonitorLabelRuleEngineServiceClass {
   /**
@@ -41,7 +42,7 @@ class MonitorLabelRuleEngineServiceClass {
             monitorDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/MonitorOwnerRuleEngineService.ts
+++ b/Common/Server/Services/MonitorOwnerRuleEngineService.ts
@@ -15,6 +15,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class MonitorOwnerRuleEngineServiceClass {
   /**
@@ -46,7 +47,7 @@ class MonitorOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/MonitorOwnerRuleEngineService.ts
+++ b/Common/Server/Services/MonitorOwnerRuleEngineService.ts
@@ -16,6 +16,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class MonitorOwnerRuleEngineServiceClass {
   /**
@@ -50,6 +51,12 @@ class MonitorOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "MonitorOwnerRule",
+        projectId: monitor.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import { LabelRuleRunResult } from "../../Types/NetworkAutomation/RuleRunResult"
 import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 /*
  * Bounds on one manual "Run now" of a label rule. The automatic path only
@@ -65,7 +66,7 @@ class NetworkDeviceLabelRuleEngineServiceClass {
             networkDeviceDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
@@ -11,6 +11,7 @@ import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 /*
  * Bounds on one manual "Run now" of a label rule. The automatic path only
@@ -69,6 +70,12 @@ class NetworkDeviceLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "NetworkDeviceLabelRule",
+        projectId: networkDevice.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/NetworkDeviceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class NetworkDeviceOwnerRuleEngineServiceClass {
   /**
@@ -45,7 +46,7 @@ class NetworkDeviceOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/NetworkDeviceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceOwnerRuleEngineService.ts
@@ -12,6 +12,7 @@ import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class NetworkDeviceOwnerRuleEngineServiceClass {
   /**
@@ -49,6 +50,12 @@ class NetworkDeviceOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "NetworkDeviceOwnerRule",
+        projectId: networkDevice.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/OnCallDutyPolicyLabelRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class OnCallDutyPolicyLabelRuleEngineServiceClass {
   @CaptureSpan()
@@ -36,6 +37,12 @@ class OnCallDutyPolicyLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "OnCallDutyPolicyLabelRule",
+        projectId: onCallDutyPolicy.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/OnCallDutyPolicyLabelRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import OnCallDutyPolicyService from "./OnCallDutyPolicyService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class OnCallDutyPolicyLabelRuleEngineServiceClass {
   @CaptureSpan()
@@ -32,7 +33,7 @@ class OnCallDutyPolicyLabelRuleEngineServiceClass {
             onCallDutyPolicyDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/OnCallDutyPolicyOwnerRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import OnCallDutyPolicyService from "./OnCallDutyPolicyService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class OnCallDutyPolicyOwnerRuleEngineServiceClass {
   @CaptureSpan()
@@ -38,7 +39,7 @@ class OnCallDutyPolicyOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/OnCallDutyPolicyOwnerRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class OnCallDutyPolicyOwnerRuleEngineServiceClass {
   @CaptureSpan()
@@ -42,6 +43,12 @@ class OnCallDutyPolicyOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "OnCallDutyPolicyOwnerRule",
+        projectId: onCallDutyPolicy.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/OnCallDutyPolicyScheduleLabelRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyScheduleLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import OnCallDutyPolicyScheduleService from "./OnCallDutyPolicyScheduleService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class OnCallDutyPolicyScheduleLabelRuleEngineServiceClass {
   @CaptureSpan()
@@ -32,7 +33,7 @@ class OnCallDutyPolicyScheduleLabelRuleEngineServiceClass {
             onCallDutyPolicyScheduleDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/OnCallDutyPolicyScheduleLabelRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyScheduleLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class OnCallDutyPolicyScheduleLabelRuleEngineServiceClass {
   @CaptureSpan()
@@ -36,6 +37,12 @@ class OnCallDutyPolicyScheduleLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "OnCallDutyPolicyScheduleLabelRule",
+        projectId: schedule.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/OnCallDutyPolicyScheduleOwnerRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyScheduleOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class OnCallDutyPolicyScheduleOwnerRuleEngineServiceClass {
   @CaptureSpan()
@@ -42,6 +43,12 @@ class OnCallDutyPolicyScheduleOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "OnCallDutyPolicyScheduleOwnerRule",
+        projectId: schedule.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/OnCallDutyPolicyScheduleOwnerRuleEngineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyScheduleOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import OnCallDutyPolicyScheduleService from "./OnCallDutyPolicyScheduleService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class OnCallDutyPolicyScheduleOwnerRuleEngineServiceClass {
   @CaptureSpan()
@@ -38,7 +39,7 @@ class OnCallDutyPolicyScheduleOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/PodmanHostLabelRuleEngineService.ts
+++ b/Common/Server/Services/PodmanHostLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class PodmanHostLabelRuleEngineServiceClass {
   /**
@@ -38,7 +39,7 @@ class PodmanHostLabelRuleEngineServiceClass {
             podmanHostDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/PodmanHostLabelRuleEngineService.ts
+++ b/Common/Server/Services/PodmanHostLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class PodmanHostLabelRuleEngineServiceClass {
   /**
@@ -42,6 +43,12 @@ class PodmanHostLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "PodmanHostLabelRule",
+        projectId: podmanHost.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/PodmanHostOwnerRuleEngineService.ts
+++ b/Common/Server/Services/PodmanHostOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class PodmanHostOwnerRuleEngineServiceClass {
   /**
@@ -45,7 +46,7 @@ class PodmanHostOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/PodmanHostOwnerRuleEngineService.ts
+++ b/Common/Server/Services/PodmanHostOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class PodmanHostOwnerRuleEngineServiceClass {
   /**
@@ -49,6 +50,12 @@ class PodmanHostOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "PodmanHostOwnerRule",
+        projectId: podmanHost.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ProxmoxClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/ProxmoxClusterLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ProxmoxClusterLabelRuleEngineServiceClass {
   /**
@@ -40,7 +41,7 @@ class ProxmoxClusterLabelRuleEngineServiceClass {
             proxmoxClusterDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/ProxmoxClusterLabelRuleEngineService.ts
+++ b/Common/Server/Services/ProxmoxClusterLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ProxmoxClusterLabelRuleEngineServiceClass {
   /**
@@ -44,6 +45,12 @@ class ProxmoxClusterLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ProxmoxClusterLabelRule",
+        projectId: proxmoxCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ProxmoxClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ProxmoxClusterOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ProxmoxClusterOwnerRuleEngineServiceClass {
   /**
@@ -51,6 +52,12 @@ class ProxmoxClusterOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ProxmoxClusterOwnerRule",
+        projectId: proxmoxCluster.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ProxmoxClusterOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ProxmoxClusterOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ProxmoxClusterOwnerRuleEngineServiceClass {
   /**
@@ -47,7 +48,7 @@ class ProxmoxClusterOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/RumApplicationLabelRuleEngineService.ts
+++ b/Common/Server/Services/RumApplicationLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import RumApplicationService from "./RumApplicationService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class RumApplicationLabelRuleEngineServiceClass {
   /**
@@ -37,7 +38,7 @@ class RumApplicationLabelRuleEngineServiceClass {
             descriptionRegexPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/RumApplicationLabelRuleEngineService.ts
+++ b/Common/Server/Services/RumApplicationLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class RumApplicationLabelRuleEngineServiceClass {
   /**
@@ -41,6 +42,12 @@ class RumApplicationLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "RumApplicationLabelRule",
+        projectId: rumApplication.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/RumApplicationOwnerRuleEngineService.ts
+++ b/Common/Server/Services/RumApplicationOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import RumApplicationService from "./RumApplicationService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class RumApplicationOwnerRuleEngineServiceClass {
   /**
@@ -43,7 +44,7 @@ class RumApplicationOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/RumApplicationOwnerRuleEngineService.ts
+++ b/Common/Server/Services/RumApplicationOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class RumApplicationOwnerRuleEngineServiceClass {
   /**
@@ -47,6 +48,12 @@ class RumApplicationOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "RumApplicationOwnerRule",
+        projectId: rumApplication.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/RunbookLabelRuleEngineService.ts
+++ b/Common/Server/Services/RunbookLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class RunbookLabelRuleEngineServiceClass {
   /**
@@ -39,6 +40,12 @@ class RunbookLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "RunbookLabelRule",
+        projectId: runbook.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/RunbookLabelRuleEngineService.ts
+++ b/Common/Server/Services/RunbookLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import RunbookService from "./RunbookService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class RunbookLabelRuleEngineServiceClass {
   /**
@@ -35,7 +36,7 @@ class RunbookLabelRuleEngineServiceClass {
             runbookDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/RunbookOwnerRuleEngineService.ts
+++ b/Common/Server/Services/RunbookOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import RunbookService from "./RunbookService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class RunbookOwnerRuleEngineServiceClass {
   /**
@@ -42,7 +43,7 @@ class RunbookOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/RunbookOwnerRuleEngineService.ts
+++ b/Common/Server/Services/RunbookOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class RunbookOwnerRuleEngineServiceClass {
   /**
@@ -46,6 +47,12 @@ class RunbookOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "RunbookOwnerRule",
+        projectId: runbook.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/RunbookRuleEngineService.ts
+++ b/Common/Server/Services/RunbookRuleEngineService.ts
@@ -16,6 +16,7 @@ import RunbookRuleService from "./RunbookRuleService";
 import RunbookService from "./RunbookService";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 type EnqueueExecutionFn = (data: {
   runbookExecutionId: ObjectID;
@@ -100,7 +101,7 @@ class RunbookRuleEngineServiceClass {
           descriptionPattern: true,
           runbooks: { _id: true },
         },
-        limit: 100,
+        limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
       });
 

--- a/Common/Server/Services/RunbookRuleEngineService.ts
+++ b/Common/Server/Services/RunbookRuleEngineService.ts
@@ -17,6 +17,7 @@ import RunbookService from "./RunbookService";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 type EnqueueExecutionFn = (data: {
   runbookExecutionId: ObjectID;
@@ -103,6 +104,12 @@ class RunbookRuleEngineServiceClass {
         },
         limit: MAX_RULES_EVALUATED_PER_PROJECT,
         skip: 0,
+      });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "RunbookRule",
+        projectId: data.projectId,
+        rulesRead: rules.length,
       });
 
       if (rules.length === 0) {

--- a/Common/Server/Services/ScheduledMaintenanceLabelRuleEngineService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceLabelRuleEngineService.ts
@@ -24,6 +24,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ScheduledMaintenanceLabelRuleEngineServiceClass {
   /**
@@ -73,7 +74,7 @@ class ScheduledMaintenanceLabelRuleEngineServiceClass {
             inheritLabelsFromPodmanHosts: true,
             inheritLabelsFromServices: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/ScheduledMaintenanceLabelRuleEngineService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceLabelRuleEngineService.ts
@@ -25,6 +25,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ScheduledMaintenanceLabelRuleEngineServiceClass {
   /**
@@ -77,6 +78,12 @@ class ScheduledMaintenanceLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ScheduledMaintenanceLabelRule",
+        projectId: scheduledMaintenance.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ScheduledMaintenanceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceOwnerRuleEngineService.ts
@@ -47,6 +47,7 @@ import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ScheduledMaintenanceOwnerRuleEngineServiceClass {
   /**
@@ -94,6 +95,12 @@ class ScheduledMaintenanceOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ScheduledMaintenanceOwnerRule",
+        projectId: scheduledMaintenance.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ScheduledMaintenanceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceOwnerRuleEngineService.ts
@@ -46,6 +46,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ScheduledMaintenanceOwnerRuleEngineServiceClass {
   /**
@@ -90,7 +91,7 @@ class ScheduledMaintenanceOwnerRuleEngineServiceClass {
             inheritOwnersFromPodmanHosts: true,
             inheritOwnersFromServices: true,
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/ScheduledMaintenanceReminderRuleService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceReminderRuleService.ts
@@ -14,6 +14,8 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -192,11 +194,17 @@ export class Service extends DatabaseService<Model> {
           _id: true,
         },
       },
-      limit: 100,
+      limit: MAX_RULES_EVALUATED_PER_PROJECT,
       skip: 0,
       props: {
         isRoot: true,
       },
+    });
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "ScheduledMaintenanceReminderRule",
+      projectId: data.projectId,
+      rulesRead: rules.length,
     });
 
     for (const rule of rules) {

--- a/Common/Server/Services/ServerlessFunctionLabelRuleEngineService.ts
+++ b/Common/Server/Services/ServerlessFunctionLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import ServerlessFunctionService from "./ServerlessFunctionService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ServerlessFunctionLabelRuleEngineServiceClass {
   /**
@@ -37,7 +38,7 @@ class ServerlessFunctionLabelRuleEngineServiceClass {
             descriptionRegexPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/ServerlessFunctionLabelRuleEngineService.ts
+++ b/Common/Server/Services/ServerlessFunctionLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ServerlessFunctionLabelRuleEngineServiceClass {
   /**
@@ -41,6 +42,12 @@ class ServerlessFunctionLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ServerlessFunctionLabelRule",
+        projectId: serverlessFunction.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ServerlessFunctionOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ServerlessFunctionOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ServerlessFunctionOwnerRuleEngineServiceClass {
   /**
@@ -47,6 +48,12 @@ class ServerlessFunctionOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ServerlessFunctionOwnerRule",
+        projectId: serverlessFunction.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ServerlessFunctionOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ServerlessFunctionOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import ServerlessFunctionService from "./ServerlessFunctionService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ServerlessFunctionOwnerRuleEngineServiceClass {
   /**
@@ -43,7 +44,7 @@ class ServerlessFunctionOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/ServiceLabelRuleEngineService.ts
+++ b/Common/Server/Services/ServiceLabelRuleEngineService.ts
@@ -9,6 +9,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ServiceLabelRuleEngineServiceClass {
   /**
@@ -38,7 +39,7 @@ class ServiceLabelRuleEngineServiceClass {
             serviceDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/ServiceLabelRuleEngineService.ts
+++ b/Common/Server/Services/ServiceLabelRuleEngineService.ts
@@ -10,6 +10,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ServiceLabelRuleEngineServiceClass {
   /**
@@ -42,6 +43,12 @@ class ServiceLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ServiceLabelRule",
+        projectId: service.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ServiceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ServiceOwnerRuleEngineService.ts
@@ -14,6 +14,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class ServiceOwnerRuleEngineServiceClass {
   /**
@@ -49,6 +50,12 @@ class ServiceOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "ServiceOwnerRule",
+        projectId: service.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/ServiceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/ServiceOwnerRuleEngineService.ts
@@ -13,6 +13,7 @@ import { Purple500 } from "../../Types/BrandColors";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class ServiceOwnerRuleEngineServiceClass {
   /**
@@ -45,7 +46,7 @@ class ServiceOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/StatusPageLabelRuleEngineService.ts
+++ b/Common/Server/Services/StatusPageLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class StatusPageLabelRuleEngineServiceClass {
   /**
@@ -40,6 +41,12 @@ class StatusPageLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "StatusPageLabelRule",
+        projectId: statusPage.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/StatusPageLabelRuleEngineService.ts
+++ b/Common/Server/Services/StatusPageLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import StatusPageService from "./StatusPageService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class StatusPageLabelRuleEngineServiceClass {
   /**
@@ -36,7 +37,7 @@ class StatusPageLabelRuleEngineServiceClass {
             statusPageDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/StatusPageMonitorRuleEngineService.ts
+++ b/Common/Server/Services/StatusPageMonitorRuleEngineService.ts
@@ -11,6 +11,7 @@ import logger, { LogAttributes } from "../Utils/Logger";
 import MonitorService from "./MonitorService";
 import StatusPageMonitorRuleService from "./StatusPageMonitorRuleService";
 import StatusPageResourceService from "./StatusPageResourceService";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 /**
  * What a sync did, so callers (and tests) can assert on the outcome without
@@ -221,6 +222,12 @@ export class StatusPageMonitorRuleEngineServiceClass {
           isRoot: true,
         },
       });
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "StatusPageMonitorRule",
+      projectId: projectId,
+      rulesRead: rules.length,
+    });
 
     const results: Array<StatusPageMonitorRuleSyncResult> = [];
 

--- a/Common/Server/Services/StatusPageOwnerRuleEngineService.ts
+++ b/Common/Server/Services/StatusPageOwnerRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class StatusPageOwnerRuleEngineServiceClass {
   /**
@@ -42,6 +43,12 @@ class StatusPageOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "StatusPageOwnerRule",
+        projectId: statusPage.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/StatusPageOwnerRuleEngineService.ts
+++ b/Common/Server/Services/StatusPageOwnerRuleEngineService.ts
@@ -6,6 +6,7 @@ import StatusPageService from "./StatusPageService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class StatusPageOwnerRuleEngineServiceClass {
   /**
@@ -38,7 +39,7 @@ class StatusPageOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/WorkflowLabelRuleEngineService.ts
+++ b/Common/Server/Services/WorkflowLabelRuleEngineService.ts
@@ -6,6 +6,7 @@ import WorkflowService from "./WorkflowService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class WorkflowLabelRuleEngineServiceClass {
   /**
@@ -35,7 +36,7 @@ class WorkflowLabelRuleEngineServiceClass {
             workflowDescriptionPattern: true,
             labelsToAdd: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/WorkflowLabelRuleEngineService.ts
+++ b/Common/Server/Services/WorkflowLabelRuleEngineService.ts
@@ -7,6 +7,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class WorkflowLabelRuleEngineServiceClass {
   /**
@@ -39,6 +40,12 @@ class WorkflowLabelRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "WorkflowLabelRule",
+        projectId: workflow.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Services/WorkflowOwnerRuleEngineService.ts
+++ b/Common/Server/Services/WorkflowOwnerRuleEngineService.ts
@@ -10,6 +10,7 @@ import WorkflowService from "./WorkflowService";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
 
 class WorkflowOwnerRuleEngineServiceClass {
   /**
@@ -42,7 +43,7 @@ class WorkflowOwnerRuleEngineServiceClass {
             ownerUsers: { _id: true },
             ownerTeams: { _id: true },
           },
-          limit: 100,
+          limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
 

--- a/Common/Server/Services/WorkflowOwnerRuleEngineService.ts
+++ b/Common/Server/Services/WorkflowOwnerRuleEngineService.ts
@@ -11,6 +11,7 @@ import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../Utils/Rules/RuleEngineLimits";
+import logIfRuleReadWasTruncated from "../Utils/Rules/RuleEngineRuleRead";
 
 class WorkflowOwnerRuleEngineServiceClass {
   /**
@@ -46,6 +47,12 @@ class WorkflowOwnerRuleEngineServiceClass {
           limit: MAX_RULES_EVALUATED_PER_PROJECT,
           skip: 0,
         });
+
+      logIfRuleReadWasTruncated({
+        ruleKind: "WorkflowOwnerRule",
+        projectId: workflow.projectId,
+        rulesRead: rules.length,
+      });
 
       if (rules.length === 0) {
         return;

--- a/Common/Server/Utils/Rules/RuleEngineRuleRead.ts
+++ b/Common/Server/Utils/Rules/RuleEngineRuleRead.ts
@@ -1,0 +1,48 @@
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../../Utils/Rules/RuleEngineLimits";
+import ObjectID from "../../../Types/ObjectID";
+import logger, { LogAttributes } from "../Logger";
+
+/*
+ * The one thing that makes MAX_RULES_EVALUATED_PER_PROJECT a ceiling rather
+ * than a cliff.
+ *
+ * A rule engine reads a project's enabled rules as `limit: <cap>, skip: 0`
+ * and evaluates what comes back. There is no second page, so a project with
+ * more rules than the cap has the remainder evaluated by nobody — and the
+ * read cannot tell the difference between "that is all of them" and "that is
+ * as many as I was allowed to ask for".
+ *
+ * That gap is the whole of OneUptime/oneuptime#3506. The cap was 100, a
+ * project had 1,243 rules, and the 1,143 that never ran produced no log, no
+ * error, no counter and no span attribute. It surfaced as a customer noticing
+ * that most of a 1,000-monitor import had come out bare, a day later.
+ *
+ * Raising the cap to 10,000 moves that threshold somewhere projects are very
+ * unlikely to reach, but it does not change the shape of the failure: at
+ * 10,001 rules the oldest rule goes quiet exactly as before. So the read now
+ * says so. Crossing the ceiling is an operator-visible error, not silence.
+ *
+ * Deliberately not an exception. A project that walks past the ceiling still
+ * wants the 10,000 rules that did match to be applied; refusing to label
+ * anything would turn a partial evaluation into no evaluation.
+ */
+export default function logIfRuleReadWasTruncated(data: {
+  /** The rule model being read, e.g. "MonitorLabelRule". Names the config to go and look at. */
+  ruleKind: string;
+  projectId: ObjectID | undefined;
+  /** How many rows the read returned. */
+  rulesRead: number;
+}): boolean {
+  if (data.rulesRead < MAX_RULES_EVALUATED_PER_PROJECT) {
+    return false;
+  }
+
+  logger.error(
+    `${data.ruleKind}: this project has at least ${MAX_RULES_EVALUATED_PER_PROJECT} enabled rules, which is the most one evaluation reads. Rules beyond that are NOT being evaluated, and resources they would match will silently go without. Reduce or consolidate the project's ${data.ruleKind} rows.`,
+    {
+      projectId: data.projectId?.toString(),
+    } as LogAttributes,
+  );
+
+  return true;
+}

--- a/Common/Tests/Server/Services/MonitorLabelRuleEngineScale.test.ts
+++ b/Common/Tests/Server/Services/MonitorLabelRuleEngineScale.test.ts
@@ -1,0 +1,458 @@
+import MonitorLabelRuleEngineService from "../../../Server/Services/MonitorLabelRuleEngineService";
+import MonitorLabelRuleService from "../../../Server/Services/MonitorLabelRuleService";
+import MonitorFeedService from "../../../Server/Services/MonitorFeedService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import LabelService from "../../../Server/Services/LabelService";
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorLabelRule from "../../../Models/DatabaseModels/MonitorLabelRule";
+import ObjectID from "../../../Types/ObjectID";
+import FindBy from "../../../Server/Types/Database/FindBy";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../../Utils/Rules/RuleEngineLimits";
+import { describe, expect, it, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - how many of a project's monitor label rules one
+ * evaluation actually looks at.
+ *
+ * The engine read its rules with `limit: 100, skip: 0`. Nothing paged past
+ * that, so in a project with 1,243 enabled rules the 1,143 oldest were
+ * fetched by nobody and matched nothing. A bulk import of 1,000+ monitors
+ * came out with roughly the handful of monitors the newest 100 rules
+ * happened to cover, and the rest sat unlabelled - indistinguishable, from
+ * the outside, from a queue that never drains (OneUptime/oneuptime#3506).
+ *
+ * The numbers below are the reporter's: 1,243 rules, with the rule that
+ * matches sitting well past the old cutoff.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const UNIT_LABEL_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const SITE_LABEL_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+// The reporter's rule count.
+const RULES_IN_PROJECT: number = 1243;
+// What the engine used to read, and the whole of the bug.
+const OLD_RULE_FETCH_LIMIT: number = 100;
+
+function fakeLabel(id: ObjectID): Label {
+  return { id: id, _id: id.toString() } as unknown as Label;
+}
+
+// The monitor as onCreateSuccess hands it to the engine: ids only.
+function ruleTarget(): Monitor {
+  return {
+    id: MONITOR_ID,
+    _id: MONITOR_ID.toString(),
+    projectId: PROJECT_ID,
+  } as unknown as Monitor;
+}
+
+// The row the engine re-reads to match on.
+function fakeMonitorDetails(overrides: Record<string, unknown> = {}): Monitor {
+  return {
+    id: MONITOR_ID,
+    _id: MONITOR_ID.toString(),
+    projectId: PROJECT_ID,
+    name: "WB1396 - Core Switch",
+    labels: [],
+    ...overrides,
+  } as unknown as Monitor;
+}
+
+function fakeRule(
+  index: number,
+  data: Record<string, unknown> = {},
+): MonitorLabelRule {
+  return {
+    id: new ObjectID(
+      `77777777-7777-4777-8777-${index.toString().padStart(12, "0")}`,
+    ),
+    name: `Unit Label - Rule ${index}`,
+    labelsToAdd: [fakeLabel(UNIT_LABEL_ID)],
+    ...data,
+  } as unknown as MonitorLabelRule;
+}
+
+/*
+ * A project whose rules are one-per-unit, as the reporter's is: every rule
+ * keys on a different unit code and only `matchingIndex` names this
+ * monitor's. Ordered the way the engine reads them (createdAt descending),
+ * so `matchingIndex` is a position in the list the engine walks - the point
+ * being that it is past 100.
+ */
+function projectWithRules(data: {
+  ruleCount: number;
+  matchingIndex: number;
+}): Array<MonitorLabelRule> {
+  const rules: Array<MonitorLabelRule> = [];
+
+  for (let index: number = 0; index < data.ruleCount; index++) {
+    rules.push(
+      fakeRule(index, {
+        monitorNamePattern:
+          index === data.matchingIndex ? "WB1396" : `WB${9000 + index}`,
+        name:
+          index === data.matchingIndex
+            ? "Unit Label - WB1396"
+            : `Unit Label - WB${9000 + index}`,
+      }),
+    );
+  }
+
+  return rules;
+}
+
+/*
+ * The engine attaches through the relation query builder rather than a model
+ * write, so the assertion surface is the `.add(ids)` call at the end of that
+ * chain.
+ */
+function mockLabelAttach(): jest.Mock {
+  const addSpy: jest.Mock = jest.fn().mockResolvedValue(undefined);
+
+  jest.spyOn(MonitorService, "getRepository").mockReturnValue({
+    createQueryBuilder: (): any => {
+      return {
+        relation: (): any => {
+          return {
+            of: (): any => {
+              return { add: addSpy };
+            },
+          };
+        },
+      };
+    },
+  } as any);
+
+  return addSpy;
+}
+
+/*
+ * Stands in for the database: answers the engine's rule read with the page
+ * it actually asked for, so a query that asks for 100 rules gets 100 rules
+ * and no more. Without this the mock would hand back every rule regardless
+ * of the limit and the bug would be invisible to the test.
+ */
+function mockRuleFetch(rules: Array<MonitorLabelRule>): jest.Mock {
+  const findBySpy: jest.Mock = jest.fn(
+    async (findBy: FindBy<MonitorLabelRule>) => {
+      const skip: number = Number(findBy.skip ?? 0);
+      const limit: number = Number(findBy.limit ?? 0);
+      return rules.slice(skip, skip + limit);
+    },
+  );
+
+  jest
+    .spyOn(MonitorLabelRuleService, "findBy")
+    .mockImplementation(findBySpy as any);
+
+  return findBySpy;
+}
+
+function mockFeedItem(): jest.Mock {
+  jest.spyOn(LabelService, "findBy").mockResolvedValue([
+    {
+      id: UNIT_LABEL_ID,
+      name: "WB1396",
+    } as unknown as Label,
+  ]);
+
+  const feedSpy: jest.Mock = jest.fn().mockResolvedValue(undefined);
+
+  jest
+    .spyOn(MonitorFeedService, "createMonitorFeedItem")
+    .mockImplementation(feedSpy as any);
+
+  return feedSpy;
+}
+
+describe("MonitorLabelRuleEngineService - rule fetch is not capped at 100", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The reported bug, end to end: the reporter's "Unit Label - WB1396" rule
+   * against the monitor their dashboard showed as "No labels attached".
+   */
+  it("labels a monitor from a rule that sits past the old 100-rule cutoff", async () => {
+    const rules: Array<MonitorLabelRule> = projectWithRules({
+      ruleCount: RULES_IN_PROJECT,
+      matchingIndex: 1200,
+    });
+
+    // The premise of the test: the only matching rule was out of reach.
+    expect(1200).toBeGreaterThan(OLD_RULE_FETCH_LIMIT);
+
+    mockRuleFetch(rules);
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    const addSpy: jest.Mock = mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    expect(addSpy.mock.calls[0]![0]).toEqual([UNIT_LABEL_ID.toString()]);
+  });
+
+  it("asks the database for the project's whole rule set in one read", async () => {
+    const findBySpy: jest.Mock = mockRuleFetch(
+      projectWithRules({
+        ruleCount: RULES_IN_PROJECT,
+        matchingIndex: 1200,
+      }),
+    );
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+
+    const findBy: FindBy<MonitorLabelRule> = findBySpy.mock
+      .calls[0]![0] as FindBy<MonitorLabelRule>;
+
+    expect(Number(findBy.limit)).toBe(MAX_RULES_EVALUATED_PER_PROJECT);
+    expect(Number(findBy.skip)).toBe(0);
+    expect(Number(findBy.limit)).toBeGreaterThan(RULES_IN_PROJECT);
+    expect(findBy.query).toMatchObject({
+      projectId: PROJECT_ID,
+      isEnabled: true,
+    });
+  });
+
+  /*
+   * The counterfactual, stated as a test so the regression cannot come back
+   * quietly: with the old limit in place this same project and monitor
+   * produce no labels at all.
+   */
+  it("would have attached nothing under the old 100-rule limit", async () => {
+    const rules: Array<MonitorLabelRule> = projectWithRules({
+      ruleCount: RULES_IN_PROJECT,
+      matchingIndex: 1200,
+    });
+
+    const reachableUnderOldLimit: Array<MonitorLabelRule> = rules.slice(
+      0,
+      OLD_RULE_FETCH_LIMIT,
+    );
+
+    mockRuleFetch(reachableUnderOldLimit);
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    const addSpy: jest.Mock = mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A rule at the very end of a full-size project still runs. This is the
+   * boundary the constant itself promises.
+   */
+  it("evaluates the last rule of a project sitting at the ceiling", async () => {
+    const ruleCount: number = MAX_RULES_EVALUATED_PER_PROJECT;
+
+    mockRuleFetch(
+      projectWithRules({
+        ruleCount: ruleCount,
+        matchingIndex: ruleCount - 1,
+      }),
+    );
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    const addSpy: jest.Mock = mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MonitorLabelRuleEngineService - matching across a large rule set", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("unions the labels of every matching rule and attaches each once", async () => {
+    const rules: Array<MonitorLabelRule> = projectWithRules({
+      ruleCount: RULES_IN_PROJECT,
+      matchingIndex: 1200,
+    });
+
+    // A second rule, further down still, adding a different label.
+    rules[1240] = fakeRule(1240, {
+      name: "Site Label - WB1396",
+      monitorNamePattern: "WB1396",
+      labelsToAdd: [fakeLabel(SITE_LABEL_ID)],
+    });
+
+    // And a third repeating the first rule's label - it must not double up.
+    rules[1241] = fakeRule(1241, {
+      name: "Duplicate Unit Label - WB1396",
+      monitorNamePattern: "wb1396",
+      labelsToAdd: [fakeLabel(UNIT_LABEL_ID)],
+    });
+
+    mockRuleFetch(rules);
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    const addSpy: jest.Mock = mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+
+    const attached: Array<string> = addSpy.mock.calls[0]![0] as Array<string>;
+
+    expect(attached).toHaveLength(2);
+    expect(attached).toEqual(
+      expect.arrayContaining([
+        UNIT_LABEL_ID.toString(),
+        SITE_LABEL_ID.toString(),
+      ]),
+    );
+  });
+
+  /*
+   * Re-labelling is additive, so a monitor that already carries everything
+   * its rules attach must not produce an insert - the join table's primary
+   * key would reject it.
+   */
+  it("attaches nothing when the monitor already carries the matched labels", async () => {
+    mockRuleFetch(
+      projectWithRules({
+        ruleCount: RULES_IN_PROJECT,
+        matchingIndex: 1200,
+      }),
+    );
+    jest.spyOn(MonitorService, "findOneById").mockResolvedValue(
+      fakeMonitorDetails({
+        labels: [fakeLabel(UNIT_LABEL_ID)],
+      }),
+    );
+    const addSpy: jest.Mock = mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * One unparseable pattern among a thousand rules is a typo in one row, not
+   * a reason for the other 1,242 to stop being evaluated.
+   */
+  it("keeps evaluating later rules after an invalid regex", async () => {
+    const rules: Array<MonitorLabelRule> = projectWithRules({
+      ruleCount: RULES_IN_PROJECT,
+      matchingIndex: 1200,
+    });
+
+    rules[500] = fakeRule(500, {
+      name: "Broken Rule",
+      monitorNamePattern: "switch-(01",
+    });
+
+    mockRuleFetch(rules);
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    const addSpy: jest.Mock = mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    expect(addSpy.mock.calls[0]![0]).toEqual([UNIT_LABEL_ID.toString()]);
+  });
+
+  /*
+   * The engine writes the labels back onto the in-memory monitor so the
+   * owner-rule engine, which runs next in the same onCreateSuccess chain,
+   * can key on them. A rule found past position 100 has to land there too.
+   */
+  it("syncs the in-memory monitor with the labels a late rule added", async () => {
+    mockRuleFetch(
+      projectWithRules({
+        ruleCount: RULES_IN_PROJECT,
+        matchingIndex: 1200,
+      }),
+    );
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    mockLabelAttach();
+    mockFeedItem();
+
+    const monitor: Monitor = ruleTarget();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(monitor);
+
+    expect(
+      (monitor.labels || []).map((label: Label) => {
+        return label.id?.toString();
+      }),
+    ).toEqual([UNIT_LABEL_ID.toString()]);
+  });
+
+  it("names the rule that fired in the monitor's feed", async () => {
+    mockRuleFetch(
+      projectWithRules({
+        ruleCount: RULES_IN_PROJECT,
+        matchingIndex: 1200,
+      }),
+    );
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    mockLabelAttach();
+    const feedSpy: jest.Mock = mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(feedSpy).toHaveBeenCalledTimes(1);
+
+    const feedItem: { feedInfoInMarkdown: string } = feedSpy.mock
+      .calls[0]![0] as { feedInfoInMarkdown: string };
+
+    expect(feedItem.feedInfoInMarkdown).toContain("Unit Label - WB1396");
+    expect(feedItem.feedInfoInMarkdown).toContain("WB1396");
+  });
+
+  // A project with no rules must not pay for a monitor read it cannot use.
+  it("does not read the monitor when the project has no enabled rules", async () => {
+    mockRuleFetch([]);
+    const findOneByIdSpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(findOneByIdSpy).not.toHaveBeenCalled();
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/MonitorLabelRuleEngineScale.test.ts
+++ b/Common/Tests/Server/Services/MonitorLabelRuleEngineScale.test.ts
@@ -7,6 +7,7 @@ import Label from "../../../Models/DatabaseModels/Label";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import MonitorLabelRule from "../../../Models/DatabaseModels/MonitorLabelRule";
 import ObjectID from "../../../Types/ObjectID";
+import logger from "../../../Server/Utils/Logger";
 import FindBy from "../../../Server/Types/Database/FindBy";
 import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../../Utils/Rules/RuleEngineLimits";
 import { describe, expect, it, afterEach } from "@jest/globals";
@@ -262,6 +263,67 @@ describe("MonitorLabelRuleEngineService - rule fetch is not capped at 100", () =
     await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
 
     expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The ceiling is only a ceiling if crossing it is audible. A read that
+   * comes back exactly full is indistinguishable from a truncated one, so it
+   * has to be reported - otherwise 10,000 is the old 100-rule cliff moved
+   * 100x further out, and the next #3506 arrives the same way this one did:
+   * as a customer noticing bare monitors, with nothing in the logs.
+   */
+  it("logs an error when the read comes back at the ceiling", async () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    mockRuleFetch(
+      projectWithRules({
+        ruleCount: MAX_RULES_EVALUATED_PER_PROJECT,
+        matchingIndex: 0,
+      }),
+    );
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    const truncationLogs: Array<unknown> = errorSpy.mock.calls.filter(
+      (call: Array<unknown>) => {
+        return (
+          typeof call[0] === "string" && call[0].includes("MonitorLabelRule")
+        );
+      },
+    );
+
+    expect(truncationLogs).toHaveLength(1);
+    expect(String(truncationLogs[0])).toContain("NOT being evaluated");
+  });
+
+  // ...and stays quiet for the project size that actually broke.
+  it("stays silent at the reporter's 1,243 rules", async () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    mockRuleFetch(
+      projectWithRules({
+        ruleCount: RULES_IN_PROJECT,
+        matchingIndex: 1200,
+      }),
+    );
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorDetails());
+    mockLabelAttach();
+    mockFeedItem();
+
+    await MonitorLabelRuleEngineService.applyRulesToMonitor(ruleTarget());
+
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   /*

--- a/Common/Tests/Server/Services/RuleEngineRuleFetchLimit.test.ts
+++ b/Common/Tests/Server/Services/RuleEngineRuleFetchLimit.test.ts
@@ -1,0 +1,145 @@
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../../Utils/Rules/RuleEngineLimits";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Every rule engine asks the same question when a resource is created -
+ * "which of this project's enabled rules match it?" - and every one of them
+ * used to ask it with `limit: 100, skip: 0`. That is not a page of a paged
+ * walk; it is the entire evaluation. A project with more rules than the cap
+ * silently never consulted the rest, which is how 1,243 monitor label rules
+ * produced roughly 50-100 labelled monitors out of 1,000+
+ * (OneUptime/oneuptime#3506).
+ *
+ * The fix is one shared constant, and this is the guard on it: the bug was a
+ * copy-paste that spread across 62 files, so the next engine copied from a
+ * sibling has to inherit the fix rather than the cap. Scanning the directory
+ * catches a new engine; asserting on the constant catches the cap being
+ * reintroduced under a different number.
+ */
+
+const SERVICES_DIRECTORY: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "Server",
+  "Services",
+);
+
+interface RuleEngineSource {
+  /** Repo-relative-ish, so a failure message names something greppable. */
+  name: string;
+  contents: string;
+}
+
+/*
+ * The engines that evaluate a project's configured rules. Named by
+ * convention, and the convention is what a new engine will be named too.
+ */
+function readRuleEngineSources(): Array<RuleEngineSource> {
+  return fs
+    .readdirSync(SERVICES_DIRECTORY)
+    .filter((fileName: string) => {
+      return fileName.endsWith("RuleEngineService.ts");
+    })
+    .map((fileName: string) => {
+      return {
+        name: fileName,
+        contents: fs.readFileSync(
+          path.join(SERVICES_DIRECTORY, fileName),
+          "utf8",
+        ),
+      };
+    });
+}
+
+/*
+ * A file that reads a project's rules at all, and the shape of a limit that
+ * reads all of them. Hoisted rather than written inline: `/x/.test(y)` is a
+ * lint fight between `wrap-regex`, which wants parentheses, and prettier,
+ * which takes them straight back off.
+ */
+const RULE_FETCH_CALL: RegExp = /RuleService\.findBy\(|this\.findBy\(/;
+const WHOLE_PROJECT_LIMIT: RegExp =
+  /limit:\s*(MAX_RULES_EVALUATED_PER_PROJECT|LIMIT_PER_PROJECT|LIMIT_MAX)/;
+
+/*
+ * Every `limit: <literal number>` in the file. Limits written as a named
+ * constant - MAX_RULES_EVALUATED_PER_PROJECT, LIMIT_PER_PROJECT, LIMIT_MAX,
+ * or a page size the file defines and documents - are deliberate; a bare
+ * number in a rule read is the shape of the bug.
+ */
+function numericLimits(source: string): Array<number> {
+  const matches: Array<string> = source.match(/limit:\s*\d+/g) || [];
+
+  return matches.map((match: string) => {
+    return Number(match.replace(/limit:\s*/, ""));
+  });
+}
+
+describe("MAX_RULES_EVALUATED_PER_PROJECT", () => {
+  it("is the codebase's existing whole-project bound", () => {
+    expect(MAX_RULES_EVALUATED_PER_PROJECT).toBe(LIMIT_PER_PROJECT);
+  });
+
+  /*
+   * 1,243 is the reporter's rule count. A ceiling that a real project has
+   * already walked up to is not a ceiling.
+   */
+  it("leaves room well past the rule counts that broke", () => {
+    expect(MAX_RULES_EVALUATED_PER_PROJECT).toBeGreaterThanOrEqual(10000);
+  });
+});
+
+describe("rule engines read every enabled rule in the project", () => {
+  const sources: Array<RuleEngineSource> = readRuleEngineSources();
+
+  it("finds the rule engines to check", () => {
+    expect(sources.length).toBeGreaterThan(50);
+  });
+
+  it.each(
+    sources.map((source: RuleEngineSource) => {
+      return [source.name, source] as [string, RuleEngineSource];
+    }),
+  )(
+    "%s does not cap its rule read at a bare number",
+    (_name: string, source: RuleEngineSource) => {
+      /*
+       * `limit: 1` is a single-row existence probe, not a rule evaluation, and
+       * a couple of engines legitimately use one. Anything else written as a
+       * literal is a cap on how much configuration gets evaluated.
+       */
+      const suspiciousLimits: Array<number> = numericLimits(
+        source.contents,
+      ).filter((limit: number) => {
+        return limit > 1 && limit < LIMIT_PER_PROJECT;
+      });
+
+      expect(suspiciousLimits).toEqual([]);
+    },
+  );
+
+  /*
+   * The read is `limit: <cap>, skip: 0` - there is no second page - so the
+   * cap has to be the whole-project one. An engine that fetches rules must
+   * say so with the shared constant.
+   */
+  it.each(
+    sources
+      .filter((source: RuleEngineSource) => {
+        return RULE_FETCH_CALL.test(source.contents);
+      })
+      .map((source: RuleEngineSource) => {
+        return [source.name, source] as [string, RuleEngineSource];
+      }),
+  )(
+    "%s fetches its rules with a whole-project limit",
+    (_name: string, source: RuleEngineSource) => {
+      expect(WHOLE_PROJECT_LIMIT.test(source.contents)).toBe(true);
+    },
+  );
+});

--- a/Common/Tests/Server/Services/RuleEngineRuleFetchLimit.test.ts
+++ b/Common/Tests/Server/Services/RuleEngineRuleFetchLimit.test.ts
@@ -18,6 +18,12 @@ import path from "path";
  * sibling has to inherit the fix rather than the cap. Scanning the directory
  * catches a new engine; asserting on the constant catches the cap being
  * reintroduced under a different number.
+ *
+ * Raising the cap is only half of it. A read of `limit: <cap>, skip: 0` with
+ * no second page still cannot tell "that is all of them" from "that is all I
+ * was allowed to ask for", so an engine that reads rules must also REPORT
+ * hitting the ceiling. Without that, 10,000 is not a ceiling - it is the same
+ * cliff, further away. Both halves are asserted below.
  */
 
 const SERVICES_DIRECTORY: string = path.resolve(
@@ -36,6 +42,34 @@ interface RuleEngineSource {
 }
 
 /*
+ * Reads of a project's hand-authored rule config that do NOT carry the
+ * *RuleEngineService.ts suffix, and so were missed the first time the cap was
+ * lifted by filename. Five hang off IncidentService/AlertService
+ * onCreateSuccess and one off ScheduledMaintenanceService's - the same
+ * create-time chain, the same `limit: 100, skip: 0` shape, the same defect.
+ *
+ * Listed explicitly rather than matched by pattern: there is no naming
+ * convention that separates these from the hundreds of legitimate paged reads
+ * in the same directory, and a wrong pattern here would be a test that
+ * silently checks nothing.
+ */
+const OTHER_PROJECT_RULE_READS: Array<string> = [
+  "IncidentGroupingEngineService.ts",
+  "AlertGroupingEngineService.ts",
+  "IncidentSlaRuleService.ts",
+  "IncidentReminderRuleService.ts",
+  "AlertReminderRuleService.ts",
+  "ScheduledMaintenanceReminderRuleService.ts",
+];
+
+function readSource(fileName: string): RuleEngineSource {
+  return {
+    name: fileName,
+    contents: fs.readFileSync(path.join(SERVICES_DIRECTORY, fileName), "utf8"),
+  };
+}
+
+/*
  * The engines that evaluate a project's configured rules. Named by
  * convention, and the convention is what a new engine will be named too.
  */
@@ -45,15 +79,7 @@ function readRuleEngineSources(): Array<RuleEngineSource> {
     .filter((fileName: string) => {
       return fileName.endsWith("RuleEngineService.ts");
     })
-    .map((fileName: string) => {
-      return {
-        name: fileName,
-        contents: fs.readFileSync(
-          path.join(SERVICES_DIRECTORY, fileName),
-          "utf8",
-        ),
-      };
-    });
+    .map(readSource);
 }
 
 /*
@@ -65,6 +91,11 @@ function readRuleEngineSources(): Array<RuleEngineSource> {
 const RULE_FETCH_CALL: RegExp = /RuleService\.findBy\(|this\.findBy\(/;
 const WHOLE_PROJECT_LIMIT: RegExp =
   /limit:\s*(MAX_RULES_EVALUATED_PER_PROJECT|LIMIT_PER_PROJECT|LIMIT_MAX)/;
+/*
+ * A read that advances an offset rather than always starting at zero, i.e.
+ * one that pages. Such a read cannot truncate, so it needs no ceiling report.
+ */
+const PAGED_READ: RegExp = /skip:\s*skip,/;
 
 /*
  * Every `limit: <literal number>` in the file. Limits written as a named
@@ -140,6 +171,69 @@ describe("rule engines read every enabled rule in the project", () => {
     "%s fetches its rules with a whole-project limit",
     (_name: string, source: RuleEngineSource) => {
       expect(WHOLE_PROJECT_LIMIT.test(source.contents)).toBe(true);
+    },
+  );
+
+  /*
+   * The half that turns a cliff into a ceiling. `limit: <cap>, skip: 0`
+   * returns a full page whether or not more rows exist, so an engine that
+   * does not report the full page has merely relocated #3506 to a higher
+   * number.
+   *
+   * Two ways to satisfy that, and both are fine. Page to exhaustion, as
+   * NetworkDeviceAutoImportRuleEngineService.loadEnabledRules does - a read
+   * that keeps going until a short page proves the end has nothing left to
+   * truncate. Or read once and report a full result, which is what every
+   * other engine does. What is not fine is a single capped read that says
+   * nothing.
+   */
+  it.each(
+    sources
+      .filter((source: RuleEngineSource) => {
+        return RULE_FETCH_CALL.test(source.contents);
+      })
+      .map((source: RuleEngineSource) => {
+        return [source.name, source] as [string, RuleEngineSource];
+      }),
+  )(
+    "%s either pages its rule read to exhaustion or reports hitting the ceiling",
+    (_name: string, source: RuleEngineSource) => {
+      const pagesToExhaustion: boolean = PAGED_READ.test(source.contents);
+      const reportsCeiling: boolean =
+        source.contents.includes("logIfRuleReadWasTruncated({") &&
+        source.contents.includes("rulesRead:");
+
+      expect(pagesToExhaustion || reportsCeiling).toBe(true);
+    },
+  );
+});
+
+/*
+ * The same two properties for the rule reads that do not carry the
+ * *RuleEngineService.ts suffix. These were missed when the cap was first
+ * lifted, precisely because the fix was scoped by filename - which is the
+ * argument for listing them here by name rather than trusting a pattern.
+ */
+describe("project rule reads outside the *RuleEngineService.ts naming", () => {
+  const sources: Array<RuleEngineSource> =
+    OTHER_PROJECT_RULE_READS.map(readSource);
+
+  it.each(
+    sources.map((source: RuleEngineSource) => {
+      return [source.name, source] as [string, RuleEngineSource];
+    }),
+  )(
+    "%s reads its rules with a whole-project limit and reports the ceiling",
+    (_name: string, source: RuleEngineSource) => {
+      const suspiciousLimits: Array<number> = numericLimits(
+        source.contents,
+      ).filter((limit: number) => {
+        return limit > 1 && limit < LIMIT_PER_PROJECT;
+      });
+
+      expect(suspiciousLimits).toEqual([]);
+      expect(WHOLE_PROJECT_LIMIT.test(source.contents)).toBe(true);
+      expect(source.contents).toContain("logIfRuleReadWasTruncated({");
     },
   );
 });

--- a/Common/Tests/Server/Utils/Rules/RuleEngineRuleRead.test.ts
+++ b/Common/Tests/Server/Utils/Rules/RuleEngineRuleRead.test.ts
@@ -1,0 +1,115 @@
+import logIfRuleReadWasTruncated from "../../../../Server/Utils/Rules/RuleEngineRuleRead";
+import { MAX_RULES_EVALUATED_PER_PROJECT } from "../../../../Utils/Rules/RuleEngineLimits";
+import logger from "../../../../Server/Utils/Logger";
+import ObjectID from "../../../../Types/ObjectID";
+import { describe, expect, it, afterEach } from "@jest/globals";
+
+/*
+ * A rule engine reads its project's rules as `limit: <cap>, skip: 0` and
+ * evaluates whatever comes back. There is no second page, so a project past
+ * the cap has the remainder evaluated by nobody - and the read cannot tell
+ * "that is all of them" from "that is all I was allowed to ask for".
+ *
+ * That gap IS OneUptime/oneuptime#3506: the cap was 100, a project had 1,243
+ * rules, and the 1,143 that never ran produced no log and no counter. Raising
+ * the cap to 10,000 moves the threshold; it does not change the shape of the
+ * failure. This guard is what changes the shape - crossing the ceiling is now
+ * an operator-visible error rather than silence.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+describe("logIfRuleReadWasTruncated", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("says nothing for a project comfortably under the ceiling", () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    // The reporter's own rule count. It must not produce noise.
+    const wasTruncated: boolean = logIfRuleReadWasTruncated({
+      ruleKind: "MonitorLabelRule",
+      projectId: PROJECT_ID,
+      rulesRead: 1243,
+    });
+
+    expect(wasTruncated).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("says nothing at exactly one rule below the ceiling", () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    const wasTruncated: boolean = logIfRuleReadWasTruncated({
+      ruleKind: "MonitorLabelRule",
+      projectId: PROJECT_ID,
+      rulesRead: MAX_RULES_EVALUATED_PER_PROJECT - 1,
+    });
+
+    expect(wasTruncated).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A read that comes back exactly full is indistinguishable from a truncated
+   * one - the row that would have been 10,001st was never fetched to be
+   * counted. It has to be reported, even though a project sitting at exactly
+   * the cap has in fact lost nothing.
+   */
+  it("reports a read that comes back exactly at the ceiling", () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    const wasTruncated: boolean = logIfRuleReadWasTruncated({
+      ruleKind: "MonitorLabelRule",
+      projectId: PROJECT_ID,
+      rulesRead: MAX_RULES_EVALUATED_PER_PROJECT,
+    });
+
+    expect(wasTruncated).toBe(true);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the rule kind and the project so the config can be found", () => {
+    const errorSpy: jest.SpyInstance = jest
+      .spyOn(logger, "error")
+      .mockImplementation(() => {});
+
+    logIfRuleReadWasTruncated({
+      ruleKind: "MonitorLabelRule",
+      projectId: PROJECT_ID,
+      rulesRead: 100000,
+    });
+
+    const message: string = errorSpy.mock.calls[0]![0] as string;
+    const attributes: { projectId?: string } = errorSpy.mock.calls[0]![1] as {
+      projectId?: string;
+    };
+
+    expect(message).toContain("MonitorLabelRule");
+    expect(message).toContain(String(MAX_RULES_EVALUATED_PER_PROJECT));
+    expect(message).toContain("NOT being evaluated");
+    expect(attributes.projectId).toBe(PROJECT_ID.toString());
+  });
+
+  // The guard reports; it never throws. A partial evaluation beats none.
+  it("does not throw when the project has no id", () => {
+    jest.spyOn(logger, "error").mockImplementation(() => {});
+
+    expect(() => {
+      return logIfRuleReadWasTruncated({
+        ruleKind: "MonitorLabelRule",
+        projectId: undefined,
+        rulesRead: 100000,
+      });
+    }).not.toThrow();
+  });
+});

--- a/Common/Utils/Rules/RuleEngineLimits.ts
+++ b/Common/Utils/Rules/RuleEngineLimits.ts
@@ -1,0 +1,32 @@
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+
+/*
+ * How many of a project's automation rules one engine run reads.
+ *
+ * Every rule engine — label, owner, on-call, privacy, auto-remediation,
+ * runbook — answers the same question when a resource is created: "which of
+ * this project's enabled rules match it?". That read used to be written as
+ * `limit: 100, skip: 0`, which is not a page of a paged walk but the whole
+ * evaluation: rule 101 and beyond were fetched by nobody and therefore
+ * matched nothing, forever.
+ *
+ * Nothing surfaced it. The engines have no queue, no cursor and no counter;
+ * they run inline in the resource's onCreateSuccess and log only what they
+ * attached. A project with 1,243 monitor label rules imported 1,000+ monitors
+ * and watched ~50-100 of them get labelled while the rest stayed bare, which
+ * reads exactly like a backlog draining slowly and is in fact 92% of the
+ * rules never being consulted at all (OneUptime/oneuptime#3506).
+ *
+ * The default sort on these reads is createdAt DESC, so the 100 that DID run
+ * were the newest — which is why a rule written early, against a naming
+ * convention the estate was later built on, is precisely the kind of rule
+ * that went quiet.
+ *
+ * LIMIT_PER_PROJECT is the codebase's existing bound for "every row of this
+ * kind in one project". Rules are hand-authored configuration, so this is a
+ * ceiling rather than a page size: a project would need 10,000 enabled rules
+ * of a single kind to reach it.
+ */
+export const MAX_RULES_EVALUATED_PER_PROJECT: number = LIMIT_PER_PROJECT;
+
+export default MAX_RULES_EVALUATED_PER_PROJECT;


### PR DESCRIPTION
## The report

[#3506](https://github.com/OneUptime/oneuptime/issues/3506): a self-hosted project with **1,243 monitor label rules** bulk-imported 1,000+ monitors through Discovery Scan + Auto Import. A day later only ~50-100 of them carried labels. The rest read "No labels attached" — including monitors that plainly matched an existing rule, e.g. `Unit Label - WB1396` against a monitor named `WB1396`.

The report reads this as a queue draining slowly. It isn't one, and waiting longer would never have helped.

## What is actually happening

`MonitorLabelRuleEngineService.applyRulesToMonitor` runs inline inside `MonitorService.onCreateSuccess`. There is no worker, no queue and nothing to drain. It read the project's rules like this:

```ts
const rules = await MonitorLabelRuleService.findBy({
  query: { projectId, isEnabled: true },
  ...
  limit: 100,
  skip: 0,
});
```

`limit: 100, skip: 0` with no second page is not a page of a paged walk — it is the entire evaluation. In a project with 1,243 enabled rules, 1,143 of them were fetched by nobody and matched nothing. Permanently, not eventually.

The default sort on these reads is `createdAt DESC`, so the 100 that *did* run were the newest. That is why a rule written early — against the naming convention the estate was later built on — is exactly the kind of rule that went quiet.

~8% of the rules running is what produces ~50-100 labelled monitors out of 1,000+, which is what the reporter measured.

The same line had been copy-pasted into **62 rule engines**: label, owner, on-call, privacy, auto-remediation and runbook rules, across monitors, incidents, alerts, hosts, clusters, status pages and the rest. Every one of them stopped at 100 rules, and none of them said so.

## The fix

One shared, documented constant — `MAX_RULES_EVALUATED_PER_PROJECT` in `Common/Utils/Rules/RuleEngineLimits.ts`, which is the codebase's existing `LIMIT_PER_PROJECT` (10,000) — replaces the bare `100` in all 62 engines.

`StatusPageMonitorRuleEngineService`, `ServiceLevelObjectiveMonitorRuleEngineService` and `NetworkDeviceAutoImportRuleEngineService` already read whole-project limits; this brings the rest in line with them rather than inventing a new convention.

Nothing else about evaluation changes. Rules still run inline at create, matching is still O(rules) per resource, labels are still only ever added, and re-running is still idempotent.

## Tests

`Common/Tests/Server/Services/MonitorLabelRuleEngineScale.test.ts` — the reporter's numbers, driven through the real engine against a rule-read mock that honours the `limit` it is given (so a query asking for 100 rules gets 100 rules and the bug stays visible):

- a monitor is labelled by a rule sitting at position 1,200 of 1,243
- the engine asks for the whole rule set in one read (`limit` = the constant, `skip` = 0)
- the counterfactual: under the old 100-rule limit, that same project and monitor attach nothing
- a rule at the very last position of a project sitting at the ceiling still fires
- labels from several matching rules are unioned and each attached once
- a monitor already carrying its matched labels produces no insert
- one unparseable regex among 1,243 rules does not stop the rest being evaluated
- the in-memory monitor is synced with labels a late rule added, so the owner-rule engine that runs next in the same chain can key on them
- the feed item names the rule that fired
- a project with no rules never reads the monitor

`Common/Tests/Server/Services/RuleEngineRuleFetchLimit.test.ts` — the guard, because the bug was a copy-paste that reached 62 files and the next engine will be copied from a sibling too. It scans `Common/Server/Services/*RuleEngineService.ts` and fails on any bare numeric cap below the whole-project limit, and pins the constant itself (132 assertions).

## What this does not fix

Rules only ever fire when a resource is created. The reporter's 1,000+ monitors already exist, so this labels everything imported from here on but does not reach back over what is already there.

Network device label rules got a "Run now" for exactly that gap ([#3191](https://github.com/OneUptime/oneuptime/issues/3191)); monitor label rules have no equivalent yet. That is worth a follow-up issue rather than folding a new endpoint and dashboard surface into a fix a customer is currently blocked on.

Fixes #3506

---

## Follow-up in this PR: making 10,000 a ceiling rather than a further-away cliff

Raising the cap does not, on its own, remove the failure mode. `limit: <cap>, skip: 0` with no second page returns a full page whether or not more rows exist, so at 10,001 enabled rules the oldest rule goes quiet in exactly the way 1,143 rules did at the old cap. Second commit closes that:

- **`logIfRuleReadWasTruncated`** — every rule read now logs an error naming the rule kind and the project when it comes back full. It reports rather than throws: a project past the ceiling still wants the 10,000 rules that matched to be applied.
- **Six more reads** that the first pass missed because it was scoped by filename. Same create-time chain, same `limit: 100, skip: 0`, no `*RuleEngineService.ts` suffix: `IncidentGroupingEngineService`, `AlertGroupingEngineService`, `IncidentSlaRuleService`, `IncidentReminderRuleService`, `AlertReminderRuleService`, `ScheduledMaintenanceReminderRuleService`. These sort by the user's own `priority`/`order`, so what went dark was the bottom of a list the user themselves ordered.
- **`StatusPageMonitorRuleEngineService`** gets the same report — it already read a whole-project limit, but in a single un-paged read.
- **`NetworkDeviceAutoImportRuleEngineService` is deliberately untouched**: its `loadEnabledRules` pages to exhaustion, so it cannot truncate. The guard test now asserts *page-to-exhaustion OR report-the-ceiling*, which is what surfaced the two engines above.

Verified at 100,000 rules by reading the query TypeORM actually emits: `skip`/`take` alongside `relations` takes the two-query DISTINCT-subquery path where **LIMIT sits on the outer select and the inner join is unbounded** (`typeorm/query-builder/SelectQueryBuilder.js:1988`). Explained against a live Postgres with 100,000 rules × 3 `monitorLabels` × 3 `labelsToAdd`: `Merge Right Join (rows=900000) -> HashAggregate (rows=100000) -> Limit (rows=10000)`. You pay to join and de-duplicate all 100,000 to evaluate 10,000 — which is the argument for the log, not for a larger number.

### Known and deliberately not in this PR

- **`StatusPageSubscriberNotificationTemplateService` reads templates with `limit: 100` and no `projectId` filter** (`:59-77`, `props: { isRoot: true }` so no tenant scoping is injected). Its truncation is *install-wide*, not per-project, and the default `createdAt DESC` sort evicts the oldest rows — so on a multi-tenant deployment roughly the 100th customer to configure a template for an `(eventType, notificationMethod)` pair silently pushes the longest-standing customer's template off the end, permanently. That is a cross-tenant bug of a different kind and wants its own issue.
- `RunbookRuleEngineService` has no per-subject execution budget (its sibling `AutoRemediationRuleEngineService` has `MAX_SUGGESTIONS_PER_SUBJECT` and a circuit breaker). Ceiling is distinct runbook count, so the widened read is at worst ~4x, not 100x — but the guardrail is missing.
- `IncidentService.ts:1643` maps the merged on-call policy set straight into `Promise.allSettled` with no concurrency bound.
- The `MonitorLabelRuleEngineService` label attach is unchunked and breaks at 32,768 distinct labels on one monitor (Postgres 65,535 bind parameters, 2 per pair); `NetworkDeviceLabelRuleEngineService` chunks at 500 for exactly this reason.
- No rule read is cached between resource creates, and `MonitorService.onCreateSuccess` fires four engines per monitor. At the reporter's 1,243 rules this is ~3.7 ms CPU per monitor (measured); it only becomes interesting near the ceiling.
