### PR TITLE
feat(permissions): give the SIEM its own role family

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Team/TeamPermissionTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Team/TeamPermissionTable.tsx
@@ -109,6 +109,10 @@ const TeamPermissionTable: FunctionComponent<ComponentProps> = (
     [Permission.TelemetryMember]: IconProp.ChartBar,
     [Permission.TelemetryViewer]: IconProp.ChartBar,
 
+    [Permission.SecurityAdmin]: IconProp.ShieldExclamation,
+    [Permission.SecurityMember]: IconProp.ShieldExclamation,
+    [Permission.SecurityViewer]: IconProp.ShieldExclamation,
+
     [Permission.SettingsAdmin]: IconProp.Settings,
     [Permission.SettingsMember]: IconProp.Settings,
     [Permission.SettingsViewer]: IconProp.Settings,

--- a/Common/Models/AnalyticsModels/SecurityEvent.ts
+++ b/Common/Models/AnalyticsModels/SecurityEvent.ts
@@ -7,7 +7,6 @@ import AnalyticsTableColumn, {
 } from "../../Types/AnalyticsDatabase/TableColumn";
 import TableColumnType from "../../Types/AnalyticsDatabase/TableColumnType";
 import { ColumnAccessControl } from "../../Types/BaseDatabase/AccessControl";
-import OperationalResource from "../../Types/Database/AccessControl/OperationalResource";
 import OwnedThrough from "../../Types/Database/AccessControl/OwnedThrough";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
@@ -31,23 +30,41 @@ import ServiceType from "../../Types/Telemetry/ServiceType";
  * ("everything mentioning this host") cheap.
  */
 
+/*
+ * Security events read through the Security tiers and nothing broader.
+ *
+ * The layout mirrors Log, but the access list deliberately does not: Log names
+ * ProjectMember, the project-wide Viewer and the three Telemetry tiers, and if
+ * this table did the same then every principal in the project could read the
+ * SIEM. A Telemetry Admin is trusted with logs, metrics and traces; that is not
+ * the same decision as being trusted with authentication failures, privilege
+ * escalations and the detections written over them, and an organisation running
+ * a SIEM needs to be able to make the second decision separately from the first.
+ *
+ * ProjectOwner and ProjectAdmin stay so a project is never locked out of its own
+ * data - they are the principals who can grant the Security tiers in the first
+ * place, so excluding them would only mean nobody could open the door.
+ */
 const readPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
-  Permission.ProjectMember,
-  Permission.Viewer,
-  Permission.TelemetryAdmin,
-  Permission.TelemetryMember,
-  Permission.TelemetryViewer,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
   Permission.ReadSecurityEvent,
 ];
 
+/*
+ * Rows normally arrive through the SecOps poller, the detection-rule evaluator
+ * and the threat-intel matcher, all of which insert as root and never reach
+ * this list. It gates the CRUD API only, which is why it stops at the tiers
+ * that administer the SIEM.
+ */
 const createPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
-  Permission.ProjectMember,
-  Permission.TelemetryAdmin,
-  Permission.TelemetryMember,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
   Permission.CreateSecurityEvent,
 ];
 
@@ -149,7 +166,19 @@ function arrayTextColumn(
   });
 }
 
-@OperationalResource()
+/*
+ * Not @OperationalResource, which Log and Span both are.
+ *
+ * That decorator's only effect on an analytics model is to widen the table's
+ * permission list with the *AllOperationalResources wildcards - the grant whose
+ * own description reads "all operational resources in this project (Monitor,
+ * Incident, Alert, StatusPage, etc.)". Nobody handing that to an integration is
+ * deciding to hand it the SIEM, and leaving it on would have left one door open
+ * behind the Security tiers.
+ *
+ * @OwnedThrough stays: owned-scope filtering keys off it alone, so a Security
+ * role granted with scope=Owned still narrows to the services it owns.
+ */
 @OwnedThrough("primaryEntityId", Service, { includeProjectScope: true })
 export default class SecurityEvent extends AnalyticsBaseModel {
   public constructor() {
@@ -450,17 +479,20 @@ export default class SecurityEvent extends AnalyticsBaseModel {
         update: [
           Permission.ProjectOwner,
           Permission.ProjectAdmin,
-          Permission.ProjectMember,
-          Permission.TelemetryAdmin,
-          Permission.TelemetryMember,
+          Permission.SecurityAdmin,
+          Permission.SecurityMember,
           Permission.EditSecurityEvent,
         ],
+        /*
+         * Deleting a security event destroys the record of something that
+         * happened, which is the one thing a SIEM exists to keep. It sits on
+         * the Admin tier rather than Member for the same reason the retention
+         * policy does.
+         */
         delete: [
           Permission.ProjectOwner,
           Permission.ProjectAdmin,
-          Permission.ProjectMember,
-          Permission.TelemetryAdmin,
-          Permission.TelemetryMember,
+          Permission.SecurityAdmin,
           Permission.DeleteSecurityEvent,
         ],
       },

--- a/Common/Models/AnalyticsModels/ThreatIntelIndicator.ts
+++ b/Common/Models/AnalyticsModels/ThreatIntelIndicator.ts
@@ -30,14 +30,18 @@ import Permission from "../../Types/Permission";
  * lazy garbage collection, not expiry enforcement.
  */
 
+/*
+ * Indicators read through the Security tiers, like every other SIEM table.
+ * Which IOCs a project subscribes to is itself intelligence about what it is
+ * defending against, so it follows the security events it is matched against
+ * rather than the telemetry it sits beside in ClickHouse.
+ */
 const readPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
-  Permission.ProjectMember,
-  Permission.Viewer,
-  Permission.TelemetryAdmin,
-  Permission.TelemetryMember,
-  Permission.TelemetryViewer,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
   Permission.ReadProjectThreatIntelFeed,
 ];
 
@@ -258,6 +262,7 @@ export default class ThreatIntelIndicator extends AnalyticsBaseModel {
         delete: [
           Permission.ProjectOwner,
           Permission.ProjectAdmin,
+          Permission.SecurityAdmin,
           Permission.DeleteProjectThreatIntelFeed,
         ],
       },

--- a/Common/Models/DatabaseModels/AlertSeverity.ts
+++ b/Common/Models/DatabaseModels/AlertSeverity.ts
@@ -33,6 +33,14 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @EnableDocumentation()
 @EnableMCP()
+/*
+ * The Security tiers read this table but hold none of the alert permissions.
+ * A Sigma detection rule and a threat-intel feed each choose the severity of
+ * the alert they open, so the SIEM's own forms select from here; without the
+ * read grant the dropdown 500s and the rule cannot be configured at all.
+ * Read-only, and only on the severity list itself - it says nothing about
+ * which alerts a Security role may see.
+ */
 @TenantColumn("projectId")
 @TableAccessControl({
   create: [
@@ -49,6 +57,9 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
     Permission.AlertAdmin,
     Permission.AlertMember,
     Permission.AlertViewer,
+    Permission.SecurityAdmin,
+    Permission.SecurityMember,
+    Permission.SecurityViewer,
     Permission.ReadAlertSeverity,
   ],
   delete: [
@@ -100,6 +111,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -143,6 +157,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -178,6 +195,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [
@@ -213,6 +233,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -247,6 +270,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [
@@ -286,6 +312,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -327,6 +356,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -354,6 +386,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -391,6 +426,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [],
@@ -423,6 +461,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [
@@ -466,6 +507,9 @@ export default class AlertSeverity extends BaseModel {
       Permission.AlertAdmin,
       Permission.AlertMember,
       Permission.AlertViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadAlertSeverity,
     ],
     update: [

--- a/Common/Models/DatabaseModels/DetectionRule.ts
+++ b/Common/Models/DatabaseModels/DetectionRule.ts
@@ -22,26 +22,35 @@ import Permission from "../../Types/Permission";
 import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
+/*
+ * Part of the SIEM, so it reads and is administered through the Security
+ * tiers rather than the Telemetry ones it used to share a list with. A
+ * detection rule and a threat-intel subscription describe what a project is
+ * watching for and what it believes it is up against, which is security
+ * posture rather than observability configuration.
+ */
 const createPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
   Permission.CreateProjectDetectionRule,
 ];
 
 const readPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
-  Permission.ProjectMember,
-  Permission.Viewer,
-  Permission.TelemetryAdmin,
-  Permission.TelemetryMember,
-  Permission.TelemetryViewer,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
   Permission.ReadProjectDetectionRule,
 ];
 
 const updatePermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
   Permission.EditProjectDetectionRule,
 ];
 
@@ -84,6 +93,8 @@ const updatePermissions: Array<Permission> = [
   delete: [
     Permission.ProjectOwner,
     Permission.ProjectAdmin,
+    Permission.SecurityAdmin,
+    Permission.SecurityMember,
     Permission.DeleteProjectDetectionRule,
   ],
   update: updatePermissions,

--- a/Common/Models/DatabaseModels/GoogleSecOpsConnection.ts
+++ b/Common/Models/DatabaseModels/GoogleSecOpsConnection.ts
@@ -19,19 +19,28 @@ import Permission from "../../Types/Permission";
 import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
+/*
+ * Configuring the connector means pointing the project at someone's Chronicle
+ * instance and holding the service-account key that reads it, so it stays on
+ * the Admin tiers. SecurityAdmin joins them: this is the SIEM's own plumbing,
+ * and the role that runs the SIEM is the one that should be able to connect it
+ * to a source without also being a project administrator.
+ *
+ * The key itself is not covered by any of these - serviceAccountJson declares
+ * `read: []` and is never returned by the API.
+ */
 const adminPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
 ];
 
 const readPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
-  Permission.ProjectMember,
-  Permission.Viewer,
-  Permission.TelemetryAdmin,
-  Permission.TelemetryMember,
-  Permission.TelemetryViewer,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
 ];
 
 /*

--- a/Common/Models/DatabaseModels/IncidentSeverity.ts
+++ b/Common/Models/DatabaseModels/IncidentSeverity.ts
@@ -33,6 +33,14 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @EnableDocumentation()
 @EnableMCP()
+/*
+ * The Security tiers read this table but hold none of the incident permissions.
+ * A Sigma detection rule and a threat-intel feed each choose the severity of
+ * the incident they open, so the SIEM's own forms select from here; without the
+ * read grant the dropdown 500s and the rule cannot be configured at all.
+ * Read-only, and only on the severity list itself - it says nothing about
+ * which incidents a Security role may see.
+ */
 @TenantColumn("projectId")
 @TableAccessControl({
   create: [
@@ -49,6 +57,9 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
     Permission.IncidentAdmin,
     Permission.IncidentMember,
     Permission.IncidentViewer,
+    Permission.SecurityAdmin,
+    Permission.SecurityMember,
+    Permission.SecurityViewer,
     Permission.ReadIncidentSeverity,
   ],
   delete: [
@@ -100,6 +111,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -143,6 +157,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -178,6 +195,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [
@@ -213,6 +233,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -247,6 +270,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [
@@ -286,6 +312,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -327,6 +356,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -354,6 +386,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -391,6 +426,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [],
@@ -423,6 +461,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [
@@ -466,6 +507,9 @@ export default class IncidentSeverity extends BaseModel {
       Permission.IncidentAdmin,
       Permission.IncidentMember,
       Permission.IncidentViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadIncidentSeverity,
     ],
     update: [

--- a/Common/Models/DatabaseModels/ThreatIntelFeed.ts
+++ b/Common/Models/DatabaseModels/ThreatIntelFeed.ts
@@ -22,26 +22,35 @@ import Permission from "../../Types/Permission";
 import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
+/*
+ * Part of the SIEM, so it reads and is administered through the Security
+ * tiers rather than the Telemetry ones it used to share a list with. A
+ * detection rule and a threat-intel subscription describe what a project is
+ * watching for and what it believes it is up against, which is security
+ * posture rather than observability configuration.
+ */
 const createPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
   Permission.CreateProjectThreatIntelFeed,
 ];
 
 const readPermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
-  Permission.ProjectMember,
-  Permission.Viewer,
-  Permission.TelemetryAdmin,
-  Permission.TelemetryMember,
-  Permission.TelemetryViewer,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
   Permission.ReadProjectThreatIntelFeed,
 ];
 
 const updatePermissions: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
   Permission.EditProjectThreatIntelFeed,
 ];
 
@@ -86,6 +95,8 @@ const updatePermissions: Array<Permission> = [
   delete: [
     Permission.ProjectOwner,
     Permission.ProjectAdmin,
+    Permission.SecurityAdmin,
+    Permission.SecurityMember,
     Permission.DeleteProjectThreatIntelFeed,
   ],
   update: updatePermissions,

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -214,10 +214,28 @@ const requireProfileReadAccess: Array<RequestHandler> =
 
 /*
  * Mirrors the read access control declared on the SecurityEvent analytics
- * model.
+ * model - which, unlike every other signal above, is NOT the telemetry list.
+ * Security events read through the Security tiers only, so this route cannot
+ * be built from createTelemetryReadAccessGuard: doing so would leave the
+ * attribute endpoints open to ProjectMember and the Telemetry tiers while the
+ * model-backed CRUD API refused them, and the attribute keys and values of a
+ * SIEM table are themselves the sensitive part - usernames, hostnames, source
+ * IPs, and every value seen for them.
  */
-const requireSecurityEventReadAccess: Array<RequestHandler> =
-  createTelemetryReadAccessGuard(Permission.ReadSecurityEvent);
+const requireSecurityEventReadAccess: Array<RequestHandler> = [
+  UserMiddleware.getUserMiddleware,
+  UserMiddleware.requireUserAuthentication,
+  UserMiddleware.requirePermission({
+    permissions: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
+      Permission.ReadSecurityEvent,
+    ],
+  }),
+];
 
 router.post(
   "/telemetry/metrics/get-attributes",

--- a/Common/Tests/Models/DatabaseModels/DomainRoleTierCoverage.test.ts
+++ b/Common/Tests/Models/DatabaseModels/DomainRoleTierCoverage.test.ts
@@ -47,6 +47,7 @@ const DOMAIN_PREFIXES: Array<[string, string]> = [
   ["Monitor", "Monitor"],
   ["Workflow", "Workflow"],
   ["Runbook", "Runbook"],
+  ["Security", "Security"],
 ];
 
 /*
@@ -63,6 +64,19 @@ const DOMAIN_BY_MODEL: Record<string, string> = {
   LogSavedView: "Telemetry",
   MetricSavedView: "Telemetry",
   TraceSavedView: "Telemetry",
+
+  /*
+   * The whole SIEM, and not one table of it is named for its domain: a Sigma
+   * rule, a TAXII subscription and a Chronicle connector. They shipped reading
+   * through the Telemetry tiers because they arrived beside logs and traces in
+   * ClickHouse, which made "can read every log in the project" and "can read the
+   * security events" one decision. Splitting them is what the Security tiers are
+   * for, and naming the three models here is what keeps a fourth from quietly
+   * shipping back under Telemetry.
+   */
+  DetectionRule: "Security",
+  ThreatIntelFeed: "Security",
+  GoogleSecOpsConnection: "Security",
 };
 
 /*

--- a/Common/Tests/Models/SecurityDomainAccessControl.test.ts
+++ b/Common/Tests/Models/SecurityDomainAccessControl.test.ts
@@ -1,0 +1,429 @@
+import DetectionRule from "../../Models/DatabaseModels/DetectionRule";
+import GoogleSecOpsConnection from "../../Models/DatabaseModels/GoogleSecOpsConnection";
+import ThreatIntelFeed from "../../Models/DatabaseModels/ThreatIntelFeed";
+import SecurityEvent from "../../Models/AnalyticsModels/SecurityEvent";
+import ThreatIntelIndicator from "../../Models/AnalyticsModels/ThreatIntelIndicator";
+import { ColumnAccessControl } from "../../Types/BaseDatabase/AccessControl";
+import Dictionary from "../../Types/Dictionary";
+import Permission from "../../Types/Permission";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * What the Security tiers unlock, and - more to the point - what nothing else
+ * unlocks any more.
+ *
+ * The SIEM tables shipped with the same read list as Log: ProjectMember, the
+ * project-wide Viewer, and the three Telemetry tiers. Every principal in a
+ * project could therefore read every security event in it, and there was no
+ * grant an administrator could withhold to change that. This file is the
+ * regression guard on the split, at the declaration level: it reads the access
+ * lists off the model classes and asserts both halves - the Security tiers are
+ * present, and the broad roles are gone.
+ *
+ * The negative half is the one that matters. Adding Permission.ProjectMember
+ * back to any one of these lists would restore the old behaviour completely and
+ * break nothing else, so nothing but an assertion will catch it.
+ */
+
+/*
+ * A uniform view over the two model kinds. Database models expose their access
+ * lists as properties on the instance; analytics models expose them through
+ * getters. The sweep below does not care which is which, and every SIEM table
+ * has to be in here - a table left out is a table with no coverage at all.
+ */
+interface SecurityModel {
+  name: string;
+  read: Array<Permission>;
+  create: Array<Permission>;
+  update: Array<Permission>;
+  delete: Array<Permission>;
+  columns: Array<[string, ColumnAccessControl | null]>;
+}
+
+/*
+ * getColumnAccessControlForAllColumns is the one accessor both base classes
+ * declare - the database models build theirs from the @ColumnAccessControl
+ * decorator, the analytics models from their column definitions - so the sweep
+ * can walk a ClickHouse table and a Postgres one the same way.
+ */
+type ColumnsOfFunction = (model: {
+  getColumnAccessControlForAllColumns: () => Dictionary<ColumnAccessControl>;
+}) => Array<[string, ColumnAccessControl | null]>;
+
+const columnsOf: ColumnsOfFunction = (model: {
+  getColumnAccessControlForAllColumns: () => Dictionary<ColumnAccessControl>;
+}): Array<[string, ColumnAccessControl | null]> => {
+  const accessControlByColumn: Dictionary<ColumnAccessControl> =
+    model.getColumnAccessControlForAllColumns();
+
+  return Object.keys(accessControlByColumn).map(
+    (column: string): [string, ColumnAccessControl | null] => {
+      return [column, accessControlByColumn[column] || null];
+    },
+  );
+};
+
+type BuildSecurityModelsFunction = () => Array<SecurityModel>;
+
+const buildSecurityModels: BuildSecurityModelsFunction =
+  (): Array<SecurityModel> => {
+    const detectionRule: DetectionRule = new DetectionRule();
+    const threatIntelFeed: ThreatIntelFeed = new ThreatIntelFeed();
+    const googleSecOpsConnection: GoogleSecOpsConnection =
+      new GoogleSecOpsConnection();
+    const securityEvent: SecurityEvent = new SecurityEvent();
+    const threatIntelIndicator: ThreatIntelIndicator =
+      new ThreatIntelIndicator();
+
+    return [
+      {
+        name: "DetectionRule",
+        read: detectionRule.readRecordPermissions,
+        create: detectionRule.createRecordPermissions,
+        update: detectionRule.updateRecordPermissions,
+        delete: detectionRule.deleteRecordPermissions,
+        columns: columnsOf(detectionRule),
+      },
+      {
+        name: "ThreatIntelFeed",
+        read: threatIntelFeed.readRecordPermissions,
+        create: threatIntelFeed.createRecordPermissions,
+        update: threatIntelFeed.updateRecordPermissions,
+        delete: threatIntelFeed.deleteRecordPermissions,
+        columns: columnsOf(threatIntelFeed),
+      },
+      {
+        name: "GoogleSecOpsConnection",
+        read: googleSecOpsConnection.readRecordPermissions,
+        create: googleSecOpsConnection.createRecordPermissions,
+        update: googleSecOpsConnection.updateRecordPermissions,
+        delete: googleSecOpsConnection.deleteRecordPermissions,
+        columns: columnsOf(googleSecOpsConnection),
+      },
+      {
+        name: "SecurityEvent",
+        read: securityEvent.getReadPermissions(),
+        create: securityEvent.getCreatePermissions(),
+        update: securityEvent.getUpdatePermissions(),
+        delete: securityEvent.getDeletePermissions(),
+        columns: columnsOf(securityEvent),
+      },
+      {
+        name: "ThreatIntelIndicator",
+        read: threatIntelIndicator.getReadPermissions(),
+        create: threatIntelIndicator.getCreatePermissions(),
+        update: threatIntelIndicator.getUpdatePermissions(),
+        delete: threatIntelIndicator.getDeletePermissions(),
+        columns: columnsOf(threatIntelIndicator),
+      },
+    ];
+  };
+
+const SECURITY_MODELS: Array<SecurityModel> = buildSecurityModels();
+
+/*
+ * test.each needs the tuple type written down. Mapping to [name, model] infers
+ * Array<Array<string | SecurityModel>>, and the per-case callback signature
+ * then does not typecheck against it.
+ */
+const MODEL_CASES: Array<[string, SecurityModel]> = SECURITY_MODELS.map(
+  (model: SecurityModel): [string, SecurityModel] => {
+    return [model.name, model];
+  },
+);
+
+/*
+ * The roles that used to reach this data and must not any more.
+ *
+ * ProjectUser is in the list for the reason its own declaration gives: every
+ * principal who has accepted an invitation holds it, so it is reserved for the
+ * dashboard's shared furniture (labels, teams, saved views) and must never
+ * appear on a table one role should be able to keep from another.
+ */
+const ROLES_THAT_MUST_NOT_REACH_THE_SIEM: Array<Permission> = [
+  Permission.ProjectMember,
+  Permission.ProjectUser,
+  Permission.Viewer,
+  Permission.TelemetryAdmin,
+  Permission.TelemetryMember,
+  Permission.TelemetryViewer,
+];
+
+const SECURITY_TIERS: Array<Permission> = [
+  Permission.SecurityAdmin,
+  Permission.SecurityMember,
+  Permission.SecurityViewer,
+];
+
+describe("Security domain access control", () => {
+  test("the sweep actually covers every SIEM table", () => {
+    expect(
+      SECURITY_MODELS.map((model: SecurityModel) => {
+        return model.name;
+      }).sort(),
+    ).toEqual([
+      "DetectionRule",
+      "GoogleSecOpsConnection",
+      "SecurityEvent",
+      "ThreatIntelFeed",
+      "ThreatIntelIndicator",
+    ]);
+  });
+
+  test.each(MODEL_CASES)(
+    "%s is readable by all three Security tiers",
+    (_name: string, model: SecurityModel) => {
+      expect(model.read).toEqual(expect.arrayContaining(SECURITY_TIERS));
+    },
+  );
+
+  /*
+   * The point of the whole change. If this passes for the wrong reason - say a
+   * table's read list is empty - the positive test above catches it.
+   */
+  test.each(MODEL_CASES)(
+    "%s is not readable by any broadly-held role",
+    (name: string, model: SecurityModel) => {
+      const leaked: Array<string> = ROLES_THAT_MUST_NOT_REACH_THE_SIEM.filter(
+        (permission: Permission) => {
+          return model.read.includes(permission);
+        },
+      ).map((permission: Permission) => {
+        return `${name} is readable by ${permission}`;
+      });
+
+      expect(leaked).toEqual([]);
+    },
+  );
+
+  test.each(MODEL_CASES)(
+    "%s cannot be written by any broadly-held role either",
+    (name: string, model: SecurityModel) => {
+      const leaked: Array<string> = [];
+
+      for (const permission of ROLES_THAT_MUST_NOT_REACH_THE_SIEM) {
+        for (const [operation, list] of [
+          ["create", model.create],
+          ["update", model.update],
+          ["delete", model.delete],
+        ] as Array<[string, Array<Permission>]>) {
+          if (list.includes(permission)) {
+            leaked.push(`${name} can be ${operation}d by ${permission}`);
+          }
+        }
+      }
+
+      expect(leaked).toEqual([]);
+    },
+  );
+
+  /*
+   * A project must never be locked out of its own data. Owner and Admin are the
+   * principals who grant the Security tiers in the first place; if they could
+   * not read the tables, a project that had not yet created a security team
+   * would have no way to see what its SIEM had collected and no way to find out
+   * that it needed to.
+   */
+  test.each(MODEL_CASES)(
+    "%s stays readable by the project's own administrators",
+    (_name: string, model: SecurityModel) => {
+      expect(model.read).toContain(Permission.ProjectOwner);
+      expect(model.read).toContain(Permission.ProjectAdmin);
+    },
+  );
+
+  /*
+   * The table gate is the first of two. A list request also runs through the
+   * per-column read lists, so a table a Security Viewer may open whose columns
+   * they may not select turns into an error on whichever field the page asked
+   * for. This is the same failure that produced issue #3305 one level down.
+   */
+  test.each(MODEL_CASES)(
+    "%s columns follow the table into the Security tiers",
+    (name: string, model: SecurityModel) => {
+      const missing: Array<string> = [];
+
+      for (const [column, accessControl] of model.columns) {
+        /*
+         * `read: []` is a deliberate "nobody reads this through the API" -
+         * GoogleSecOpsConnection.serviceAccountJson is the one that matters.
+         * Those must stay closed, which the credential test below asserts.
+         */
+        if (!accessControl?.read || accessControl.read.length === 0) {
+          continue;
+        }
+
+        for (const tier of SECURITY_TIERS) {
+          if (!accessControl.read.includes(tier)) {
+            missing.push(`${name}.${column} is missing ${tier}`);
+          }
+        }
+      }
+
+      expect(missing).toEqual([]);
+    },
+  );
+
+  test.each(MODEL_CASES)(
+    "%s columns are not readable by a broadly-held role",
+    (name: string, model: SecurityModel) => {
+      const leaked: Array<string> = [];
+
+      for (const [column, accessControl] of model.columns) {
+        for (const permission of ROLES_THAT_MUST_NOT_REACH_THE_SIEM) {
+          if (accessControl?.read?.includes(permission)) {
+            leaked.push(`${name}.${column} is readable by ${permission}`);
+          }
+        }
+      }
+
+      expect(leaked).toEqual([]);
+    },
+  );
+
+  /*
+   * The connector's service-account key is a live Google Cloud credential. It
+   * was already closed to everyone before the Security tiers existed, and
+   * giving the SIEM its own admin role must not have quietly opened it -
+   * SecurityAdmin administers the connection, which is not the same as being
+   * able to read the key back out of it.
+   */
+  test("the SecOps service-account key stays unreadable by everyone", () => {
+    const model: GoogleSecOpsConnection = new GoogleSecOpsConnection();
+    const accessControl: ColumnAccessControl | null =
+      model.getColumnAccessControlFor("serviceAccountJson");
+
+    expect(accessControl).toBeDefined();
+    expect(accessControl?.read).toEqual([]);
+  });
+
+  /*
+   * Tier semantics, so "Viewer" keeps meaning read-only and the three tiers
+   * stay distinguishable from each other. A family whose Viewer can delete is
+   * three names for one role.
+   */
+  test("Security Viewer is read-only everywhere", () => {
+    const writes: Array<string> = [];
+
+    for (const model of SECURITY_MODELS) {
+      for (const [operation, list] of [
+        ["create", model.create],
+        ["update", model.update],
+        ["delete", model.delete],
+      ] as Array<[string, Array<Permission>]>) {
+        if (list.includes(Permission.SecurityViewer)) {
+          writes.push(`${model.name} can be ${operation}d by SecurityViewer`);
+        }
+      }
+    }
+
+    expect(writes).toEqual([]);
+  });
+
+  /*
+   * Deleting a security event destroys the record of something that happened,
+   * which is the one thing a SIEM exists to keep. It sits on the Admin tier for
+   * the same reason retention policy does, and the same applies to purging
+   * ingested indicators.
+   */
+  test("deleting SIEM records is an Admin-tier action", () => {
+    const securityEvent: SecurityEvent = new SecurityEvent();
+    const threatIntelIndicator: ThreatIntelIndicator =
+      new ThreatIntelIndicator();
+
+    for (const deletePermissions of [
+      securityEvent.getDeletePermissions(),
+      threatIntelIndicator.getDeletePermissions(),
+    ]) {
+      expect(deletePermissions).toContain(Permission.SecurityAdmin);
+      expect(deletePermissions).not.toContain(Permission.SecurityMember);
+    }
+  });
+
+  /*
+   * Pointing the project at a Chronicle instance, and holding the credential
+   * that reads it, is administration of the SIEM rather than use of it.
+   */
+  test("only the Admin tier configures the SecOps connector", () => {
+    const model: GoogleSecOpsConnection = new GoogleSecOpsConnection();
+
+    for (const list of [
+      model.createRecordPermissions,
+      model.updateRecordPermissions,
+      model.deleteRecordPermissions,
+    ]) {
+      expect(list).toContain(Permission.SecurityAdmin);
+      expect(list).not.toContain(Permission.SecurityMember);
+      expect(list).not.toContain(Permission.SecurityViewer);
+    }
+
+    expect(model.readRecordPermissions).toContain(Permission.SecurityMember);
+    expect(model.readRecordPermissions).toContain(Permission.SecurityViewer);
+  });
+
+  /*
+   * The Member tier is what makes the family usable without handing out admin:
+   * an analyst writes and tunes detections and subscribes to feeds. If Member
+   * lost these, every rule change would need a project administrator.
+   */
+  test("the Member tier can author detections and feeds", () => {
+    for (const model of [new DetectionRule(), new ThreatIntelFeed()]) {
+      expect(model.createRecordPermissions).toContain(
+        Permission.SecurityMember,
+      );
+      expect(model.updateRecordPermissions).toContain(
+        Permission.SecurityMember,
+      );
+      expect(model.deleteRecordPermissions).toContain(
+        Permission.SecurityMember,
+      );
+    }
+  });
+
+  /*
+   * The granular Read/Create/Edit/Delete permissions predate the tiers and are
+   * how an API key is scoped to exactly one operation. The tiers are an
+   * addition, not a replacement, and dropping one would silently break every
+   * key already issued against it.
+   */
+  test("the granular security permissions still work on their own", () => {
+    const securityEvent: SecurityEvent = new SecurityEvent();
+
+    expect(securityEvent.getReadPermissions()).toContain(
+      Permission.ReadSecurityEvent,
+    );
+    expect(securityEvent.getCreatePermissions()).toContain(
+      Permission.CreateSecurityEvent,
+    );
+    expect(securityEvent.getUpdatePermissions()).toContain(
+      Permission.EditSecurityEvent,
+    );
+    expect(securityEvent.getDeletePermissions()).toContain(
+      Permission.DeleteSecurityEvent,
+    );
+
+    const detectionRule: DetectionRule = new DetectionRule();
+
+    expect(detectionRule.readRecordPermissions).toContain(
+      Permission.ReadProjectDetectionRule,
+    );
+    expect(detectionRule.createRecordPermissions).toContain(
+      Permission.CreateProjectDetectionRule,
+    );
+    expect(detectionRule.updateRecordPermissions).toContain(
+      Permission.EditProjectDetectionRule,
+    );
+    expect(detectionRule.deleteRecordPermissions).toContain(
+      Permission.DeleteProjectDetectionRule,
+    );
+
+    const threatIntelFeed: ThreatIntelFeed = new ThreatIntelFeed();
+
+    expect(threatIntelFeed.readRecordPermissions).toContain(
+      Permission.ReadProjectThreatIntelFeed,
+    );
+    expect(threatIntelFeed.createRecordPermissions).toContain(
+      Permission.CreateProjectThreatIntelFeed,
+    );
+  });
+});

--- a/Common/Tests/Server/API/SecurityEventAttributesAPI.test.ts
+++ b/Common/Tests/Server/API/SecurityEventAttributesAPI.test.ts
@@ -351,7 +351,7 @@ describe("Security event attribute API", () => {
       expect(fetchAttributes.mock.calls).toHaveLength(0);
     });
 
-    test("a project member without any telemetry read permission is refused", async () => {
+    test("a project member without any security read permission is refused", async () => {
       const result: CallResult = await callRoute({
         uri: KEYS_ROUTE,
         request: buildPrincipal({
@@ -390,11 +390,9 @@ describe("Security event attribute API", () => {
     test.each([
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
-      Permission.ProjectMember,
-      Permission.Viewer,
-      Permission.TelemetryAdmin,
-      Permission.TelemetryMember,
-      Permission.TelemetryViewer,
+      Permission.SecurityAdmin,
+      Permission.SecurityMember,
+      Permission.SecurityViewer,
       Permission.ReadSecurityEvent,
     ])("%s can read attribute keys", async (permission: Permission) => {
       const result: CallResult = await callRoute({
@@ -410,14 +408,94 @@ describe("Security event attribute API", () => {
       expect(result.reachedHandler).toBe(true);
     });
 
+    /*
+     * These routes do not go through BaseAnalyticsAPI, so this guard IS the
+     * access control - and until the Security tiers landed it was built from
+     * createTelemetryReadAccessGuard, which admits ProjectMember, the
+     * project-wide Viewer and the Telemetry tiers. Leaving it that way would
+     * have made the split cosmetic: the CRUD API would refuse a Telemetry Admin
+     * the rows while this route handed them every attribute key in the SIEM and
+     * every value ever seen for it - usernames, hostnames, source IPs. That is
+     * most of what the table holds, reached without reading a single row.
+     */
+    test.each([
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.TelemetryAdmin,
+      Permission.TelemetryMember,
+      Permission.TelemetryViewer,
+      Permission.MonitorAdmin,
+    ])("%s cannot read attribute keys", async (permission: Permission) => {
+      const result: CallResult = await callRoute({
+        uri: KEYS_ROUTE,
+        request: buildPrincipal({
+          projectId,
+          userId,
+          permissions: [permission],
+        }),
+        body: {},
+      });
+
+      expect(result.reachedHandler).toBe(false);
+      expect(result.deniedWith).toBeDefined();
+      expect(fetchAttributes.mock.calls).toHaveLength(0);
+    });
+
+    test.each([Permission.TelemetryAdmin, Permission.ProjectMember])(
+      "%s cannot read attribute values either",
+      async (permission: Permission) => {
+        const result: CallResult = await callRoute({
+          uri: VALUES_ROUTE,
+          request: buildPrincipal({
+            projectId,
+            userId,
+            permissions: [permission],
+          }),
+          body: { attributeKey: "device.hostname" },
+        });
+
+        expect(result.reachedHandler).toBe(false);
+        expect(result.deniedWith).toBeDefined();
+        expect(fetchAttributeValues.mock.calls).toHaveLength(0);
+      },
+    );
+
+    /*
+     * Parity with the model, asserted both ways round: every permission the
+     * route accepts is one the model would accept for the same rows, and the
+     * counts match so neither list can grow a member the other does not have.
+     */
     test("the model's read list and the guard have not drifted apart", () => {
       const modelReadPermissions: Array<Permission> =
         new SecurityEvent().getReadPermissions();
 
       expect(modelReadPermissions).toEqual(
-        expect.arrayContaining([Permission.ReadSecurityEvent]),
+        expect.arrayContaining([
+          Permission.ProjectOwner,
+          Permission.ProjectAdmin,
+          Permission.SecurityAdmin,
+          Permission.SecurityMember,
+          Permission.SecurityViewer,
+          Permission.ReadSecurityEvent,
+        ]),
       );
-      expect(modelReadPermissions).toHaveLength(8);
+      expect(modelReadPermissions).toHaveLength(6);
+
+      /*
+       * And the roles the split exists to exclude are not hiding in the model
+       * list either - the route parity above would happily hold with both
+       * lists wrong in the same way.
+       */
+      for (const permission of [
+        Permission.ProjectMember,
+        Permission.ProjectUser,
+        Permission.Viewer,
+        Permission.TelemetryAdmin,
+        Permission.TelemetryMember,
+        Permission.TelemetryViewer,
+      ]) {
+        expect(modelReadPermissions).not.toContain(permission);
+      }
     });
 
     test("the values route is guarded the same way", async () => {

--- a/Common/Tests/Server/Types/AnalyticsDatabase/SecurityEventModelPermission.test.ts
+++ b/Common/Tests/Server/Types/AnalyticsDatabase/SecurityEventModelPermission.test.ts
@@ -1,0 +1,255 @@
+import ModelPermission from "../../../../Server/Types/AnalyticsDatabase/ModelPermission";
+import DatabaseRequestType from "../../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import Log from "../../../../Models/AnalyticsModels/Log";
+import SecurityEvent from "../../../../Models/AnalyticsModels/SecurityEvent";
+import ThreatIntelIndicator from "../../../../Models/AnalyticsModels/ThreatIntelIndicator";
+import DatabaseCommonInteractionProps from "../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../../Types/Permission";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The SIEM's ClickHouse tables go through a different gate from the Postgres
+ * ones - AnalyticsDatabase/ModelPermission rather than TablePermission - and it
+ * is the gate the /security-events CRUD API and the AI security tools both run
+ * through. The Security tiers have to hold on this path too, and one thing that
+ * only exists on this path has to be checked here: the
+ * *AllOperationalResources wildcards.
+ */
+
+const projectId: ObjectID = ObjectID.generate();
+const userId: ObjectID = ObjectID.generate();
+
+type MakePropsFunction = (
+  grantedByTeams: Array<Permission>,
+) => DatabaseCommonInteractionProps;
+
+const makeProps: MakePropsFunction = (
+  grantedByTeams: Array<Permission>,
+): DatabaseCommonInteractionProps => {
+  const permissions: Array<Permission> = [
+    Permission.CurrentUser,
+    Permission.UnAuthorizedSsoUser,
+    Permission.ProjectUser,
+    ...grantedByTeams,
+  ];
+
+  const tenantPermission: UserTenantAccessPermission = {
+    projectId,
+    _type: "UserTenantAccessPermission",
+    permissions: permissions.map((permission: Permission): UserPermission => {
+      return {
+        _type: "UserPermission",
+        permission,
+        labelIds: [],
+        isBlockPermission: false,
+      };
+    }),
+  };
+
+  return {
+    userId,
+    tenantId: projectId,
+    userTenantAccessPermission: {
+      [projectId.toString()]: tenantPermission,
+    },
+  };
+};
+
+type ModelType = { new (): any };
+
+type CanFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+  requestType: DatabaseRequestType,
+) => boolean;
+
+const can: CanFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+  requestType: DatabaseRequestType,
+): boolean => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ModelPermission as any).checkModelLevelPermissions(
+      modelType,
+      props,
+      requestType,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+type CanReadFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+) => boolean;
+
+const canRead: CanReadFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+): boolean => {
+  return can(modelType, props, DatabaseRequestType.Read);
+};
+
+const ANALYTICS_SIEM_MODELS: Array<[string, ModelType]> = [
+  ["SecurityEvent", SecurityEvent],
+  ["ThreatIntelIndicator", ThreatIntelIndicator],
+];
+
+describe("Security events through the analytics permission gate", () => {
+  test.each(ANALYTICS_SIEM_MODELS)(
+    "a Security Viewer can read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, makeProps([Permission.SecurityViewer]))).toBe(
+        true,
+      );
+    },
+  );
+
+  test.each(ANALYTICS_SIEM_MODELS)(
+    "a Telemetry Admin cannot read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, makeProps([Permission.TelemetryAdmin]))).toBe(
+        false,
+      );
+    },
+  );
+
+  test.each(ANALYTICS_SIEM_MODELS)(
+    "a plain project member cannot read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, makeProps([Permission.ProjectMember]))).toBe(
+        false,
+      );
+    },
+  );
+
+  test.each(ANALYTICS_SIEM_MODELS)(
+    "the project-wide Viewer cannot read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, makeProps([Permission.Viewer]))).toBe(false);
+    },
+  );
+
+  /*
+   * The pairing the split exists for, on the analytics path: the same principal
+   * that reads every log in the project reads no security events, and the
+   * security principal reads no logs.
+   */
+  test("logs and security events are separate grants", () => {
+    const telemetryViewer: DatabaseCommonInteractionProps = makeProps([
+      Permission.TelemetryViewer,
+    ]);
+    const securityViewer: DatabaseCommonInteractionProps = makeProps([
+      Permission.SecurityViewer,
+    ]);
+
+    expect(canRead(Log, telemetryViewer)).toBe(true);
+    expect(canRead(SecurityEvent, telemetryViewer)).toBe(false);
+
+    expect(canRead(SecurityEvent, securityViewer)).toBe(true);
+    expect(canRead(Log, securityViewer)).toBe(false);
+  });
+
+  /*
+   * The wildcard door.
+   *
+   * @OperationalResource() widens an analytics table's permission list with
+   * ReadAllOperationalResources and its siblings, and SecurityEvent carried the
+   * decorator because it was written as a copy of Log. That grant's own
+   * description is "all operational resources in this project (Monitor,
+   * Incident, Alert, StatusPage, etc.)" - somebody handing it to an integration
+   * is not deciding to hand over the SIEM, and it is a granular permission
+   * rather than a role, so none of the role-level assertions elsewhere would
+   * have noticed it staying open.
+   *
+   * Log keeps the decorator, which is what makes this a real assertion rather
+   * than a check that the wildcard mechanism is broken.
+   */
+  test("the operational-resource wildcards do not reach security events", () => {
+    const wildcardHolder: DatabaseCommonInteractionProps = makeProps([
+      Permission.ReadAllOperationalResources,
+      Permission.EditAllOperationalResources,
+      Permission.DeleteAllOperationalResources,
+      Permission.CreateAllOperationalResources,
+    ]);
+
+    expect(canRead(Log, wildcardHolder)).toBe(true);
+
+    for (const requestType of [
+      DatabaseRequestType.Read,
+      DatabaseRequestType.Update,
+      DatabaseRequestType.Delete,
+      DatabaseRequestType.Create,
+    ]) {
+      expect(can(SecurityEvent, wildcardHolder, requestType)).toBe(false);
+    }
+  });
+
+  /*
+   * Owned-scope filtering keys off @OwnedThrough, not @OperationalResource, so
+   * dropping the latter must not have taken "this team only sees the services
+   * it owns" with it.
+   */
+  test("security events are still ownable through their primary entity", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((new SecurityEvent() as any).ownedThrough).toBeTruthy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((new SecurityEvent() as any).isOperationalResource).toBeFalsy();
+  });
+
+  test("Security Viewer is read-only on the analytics tables too", () => {
+    const securityViewer: DatabaseCommonInteractionProps = makeProps([
+      Permission.SecurityViewer,
+    ]);
+
+    for (const requestType of [
+      DatabaseRequestType.Create,
+      DatabaseRequestType.Update,
+      DatabaseRequestType.Delete,
+    ]) {
+      expect(can(SecurityEvent, securityViewer, requestType)).toBe(false);
+    }
+  });
+
+  test("Security Admin can purge security events, Security Member cannot", () => {
+    expect(
+      can(
+        SecurityEvent,
+        makeProps([Permission.SecurityAdmin]),
+        DatabaseRequestType.Delete,
+      ),
+    ).toBe(true);
+
+    expect(
+      can(
+        SecurityEvent,
+        makeProps([Permission.SecurityMember]),
+        DatabaseRequestType.Delete,
+      ),
+    ).toBe(false);
+  });
+
+  test("the project's own administrators still reach the analytics tables", () => {
+    for (const permission of [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+    ]) {
+      for (const [, modelType] of ANALYTICS_SIEM_MODELS) {
+        expect(canRead(modelType, makeProps([permission]))).toBe(true);
+      }
+    }
+  });
+
+  test("a granular ReadSecurityEvent key still works on its own", () => {
+    expect(
+      canRead(SecurityEvent, makeProps([Permission.ReadSecurityEvent])),
+    ).toBe(true);
+  });
+});

--- a/Common/Tests/Server/Types/Database/Permissions/SecurityRoleAccess.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/SecurityRoleAccess.test.ts
@@ -1,0 +1,413 @@
+import DatabaseRequestType from "../../../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import ColumnPermissions from "../../../../../Server/Types/Database/Permissions/ColumnPermission";
+import TablePermission from "../../../../../Server/Types/Database/Permissions/TablePermission";
+import AlertSeverity from "../../../../../Models/DatabaseModels/AlertSeverity";
+import DetectionRule from "../../../../../Models/DatabaseModels/DetectionRule";
+import GoogleSecOpsConnection from "../../../../../Models/DatabaseModels/GoogleSecOpsConnection";
+import IncidentSeverity from "../../../../../Models/DatabaseModels/IncidentSeverity";
+import Label from "../../../../../Models/DatabaseModels/Label";
+import TableView from "../../../../../Models/DatabaseModels/TableView";
+import Team from "../../../../../Models/DatabaseModels/Team";
+import ThreatIntelFeed from "../../../../../Models/DatabaseModels/ThreatIntelFeed";
+import TelemetryException from "../../../../../Models/DatabaseModels/TelemetryException";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import DatabaseCommonInteractionPropsUtil, {
+  PermissionType,
+} from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionPropsUtil";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../../../Types/Permission";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The Security tiers as the API actually sees them.
+ *
+ * SecurityDomainAccessControl.test.ts reads the access lists off the model
+ * classes; this drives the two gates a real request passes through -
+ * TablePermission for the table and ColumnPermissions for the fields the page
+ * selects - for principals built the way AccessTokenService builds them.
+ *
+ * The question behind the whole change: an operator asked whether the security
+ * side of the product could be kept from people who have the rest of it. Before
+ * the Security tiers the answer was no, because ProjectMember was on every SIEM
+ * table's read list and every member of a project holds it. The "cannot"
+ * assertions below are that answer changing.
+ */
+
+const projectId: ObjectID = ObjectID.generate();
+const userId: ObjectID = ObjectID.generate();
+
+/*
+ * The permission set a signed-in member carries: whatever their teams grant,
+ * plus the three the platform adds to anyone with a session inside a project.
+ * ProjectUser is deliberately included - it is what makes this a fair test.
+ * Every principal below is a real project member, so if a SIEM table were
+ * readable through ProjectUser these tests would pass for the wrong reason and
+ * the isolation would not exist.
+ */
+type MakePropsFunction = (
+  grantedByTeams: Array<Permission>,
+) => DatabaseCommonInteractionProps;
+
+const makeProps: MakePropsFunction = (
+  grantedByTeams: Array<Permission>,
+): DatabaseCommonInteractionProps => {
+  const permissions: Array<Permission> = [
+    Permission.CurrentUser,
+    Permission.UnAuthorizedSsoUser,
+    Permission.ProjectUser,
+    ...grantedByTeams,
+  ];
+
+  const tenantPermission: UserTenantAccessPermission = {
+    projectId,
+    _type: "UserTenantAccessPermission",
+    permissions: permissions.map((permission: Permission): UserPermission => {
+      return {
+        _type: "UserPermission",
+        permission,
+        labelIds: [],
+        isBlockPermission: false,
+      };
+    }),
+  };
+
+  return {
+    userId,
+    tenantId: projectId,
+    userTenantAccessPermission: {
+      [projectId.toString()]: tenantPermission,
+    },
+  };
+};
+
+type ModelType = { new (): any };
+
+type CanFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+  requestType: DatabaseRequestType,
+) => boolean;
+
+const can: CanFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+  requestType: DatabaseRequestType,
+): boolean => {
+  try {
+    TablePermission.checkTableLevelPermissions(modelType, props, requestType);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+type CanReadFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+) => boolean;
+
+const canRead: CanReadFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+): boolean => {
+  return can(modelType, props, DatabaseRequestType.Read);
+};
+
+type ReadableColumnsFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+) => Array<string>;
+
+const readableColumns: ReadableColumnsFunction = (
+  modelType: ModelType,
+  props: DatabaseCommonInteractionProps,
+): Array<string> => {
+  return ColumnPermissions.getModelColumnsByPermissions(
+    modelType,
+    DatabaseCommonInteractionPropsUtil.getUserPermissions(
+      props,
+      PermissionType.Allow,
+    ),
+    DatabaseRequestType.Read,
+  ).columns;
+};
+
+const SIEM_MODELS: Array<[string, ModelType]> = [
+  ["DetectionRule", DetectionRule],
+  ["ThreatIntelFeed", ThreatIntelFeed],
+  ["GoogleSecOpsConnection", GoogleSecOpsConnection],
+];
+
+describe("Security roles reach the SIEM", () => {
+  const securityViewer: DatabaseCommonInteractionProps = makeProps([
+    Permission.SecurityViewer,
+  ]);
+  const securityMember: DatabaseCommonInteractionProps = makeProps([
+    Permission.SecurityMember,
+  ]);
+  const securityAdmin: DatabaseCommonInteractionProps = makeProps([
+    Permission.SecurityAdmin,
+  ]);
+
+  test.each(SIEM_MODELS)(
+    "Security Viewer can read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, securityViewer)).toBe(true);
+    },
+  );
+
+  test.each(SIEM_MODELS)(
+    "Security Member can read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, securityMember)).toBe(true);
+    },
+  );
+
+  test.each(SIEM_MODELS)(
+    "Security Admin can read %s",
+    (_name: string, modelType: ModelType) => {
+      expect(canRead(modelType, securityAdmin)).toBe(true);
+    },
+  );
+
+  /*
+   * The columns the Detection Rules page selects. A table gate that passes and
+   * a column gate that does not is a page that renders an error over itself,
+   * which is how issue #3305 presented.
+   */
+  test("Security Viewer can select the columns the detection rules table reads", () => {
+    const columns: Array<string> = readableColumns(
+      DetectionRule,
+      securityViewer,
+    );
+
+    for (const column of [
+      "name",
+      "description",
+      "isEnabled",
+      "projectId",
+      "createdAt",
+    ]) {
+      expect(columns).toContain(column);
+    }
+  });
+
+  test("Security Viewer cannot write anything", () => {
+    const writes: Array<string> = [];
+
+    for (const [name, modelType] of SIEM_MODELS) {
+      for (const requestType of [
+        DatabaseRequestType.Create,
+        DatabaseRequestType.Update,
+        DatabaseRequestType.Delete,
+      ]) {
+        if (can(modelType, securityViewer, requestType)) {
+          writes.push(`SecurityViewer can ${requestType} ${name}`);
+        }
+      }
+    }
+
+    expect(writes).toEqual([]);
+  });
+
+  test("Security Member can author detections and threat intel feeds", () => {
+    for (const modelType of [DetectionRule, ThreatIntelFeed]) {
+      for (const requestType of [
+        DatabaseRequestType.Create,
+        DatabaseRequestType.Update,
+        DatabaseRequestType.Delete,
+      ]) {
+        expect(can(modelType, securityMember, requestType)).toBe(true);
+      }
+    }
+  });
+
+  /*
+   * Connecting the project to someone's Chronicle instance, and storing the
+   * service-account key that reads it, is administration of the SIEM. A Member
+   * uses the SIEM; they do not get to repoint it at another source.
+   */
+  test("Security Member cannot configure the SecOps connector", () => {
+    expect(canRead(GoogleSecOpsConnection, securityMember)).toBe(true);
+
+    for (const requestType of [
+      DatabaseRequestType.Create,
+      DatabaseRequestType.Update,
+      DatabaseRequestType.Delete,
+    ]) {
+      expect(can(GoogleSecOpsConnection, securityMember, requestType)).toBe(
+        false,
+      );
+    }
+  });
+
+  test("Security Admin can configure the SecOps connector", () => {
+    for (const requestType of [
+      DatabaseRequestType.Create,
+      DatabaseRequestType.Update,
+      DatabaseRequestType.Delete,
+    ]) {
+      expect(can(GoogleSecOpsConnection, securityAdmin, requestType)).toBe(
+        true,
+      );
+    }
+  });
+
+  /*
+   * A Sigma rule and a threat-intel feed each choose the severity of the alert
+   * or incident they open, so both forms select from the severity tables. The
+   * Security tiers hold no alert or incident permission, so without an explicit
+   * read grant the dropdown fails and the rule cannot be configured - the same
+   * shape of bug as the saved-views one, reached from a different direction.
+   */
+  test("Security roles can populate the severity dropdowns their forms use", () => {
+    for (const props of [securityViewer, securityMember, securityAdmin]) {
+      expect(canRead(AlertSeverity, props)).toBe(true);
+      expect(canRead(IncidentSeverity, props)).toBe(true);
+
+      expect(readableColumns(AlertSeverity, props)).toContain("name");
+      expect(readableColumns(IncidentSeverity, props)).toContain("name");
+    }
+  });
+
+  /*
+   * That grant is read-only and stops at the severity list. A security role
+   * must not become a back door into administering the alert domain.
+   */
+  test("the severity grant does not let a Security role edit severities", () => {
+    for (const modelType of [AlertSeverity, IncidentSeverity]) {
+      for (const requestType of [
+        DatabaseRequestType.Create,
+        DatabaseRequestType.Update,
+        DatabaseRequestType.Delete,
+      ]) {
+        expect(can(modelType, securityAdmin, requestType)).toBe(false);
+      }
+    }
+  });
+
+  /*
+   * The Security tiers are a domain scope like any other, so the dashboard
+   * furniture every page mounts has to keep working for someone who holds
+   * nothing else - otherwise the security pages error the way the monitor pages
+   * did in #3305.
+   */
+  test("a Security-only user can still use the dashboard around the page", () => {
+    for (const modelType of [TableView, Label, Team]) {
+      expect(canRead(modelType, securityViewer)).toBe(true);
+    }
+  });
+});
+
+describe("Nobody else reaches the SIEM", () => {
+  /*
+   * The regression guard. Each of these principals could read every security
+   * event, detection rule and threat-intel feed in the project before the
+   * Security tiers existed, and the request behind this change was to be able
+   * to stop that.
+   */
+  const excluded: Array<[string, Permission]> = [
+    ["Project Member", Permission.ProjectMember],
+    ["project-wide Viewer", Permission.Viewer],
+    ["Telemetry Admin", Permission.TelemetryAdmin],
+    ["Telemetry Member", Permission.TelemetryMember],
+    ["Telemetry Viewer", Permission.TelemetryViewer],
+    ["Monitor Admin", Permission.MonitorAdmin],
+    ["Incident Admin", Permission.IncidentAdmin],
+    ["Settings Admin", Permission.SettingsAdmin],
+  ];
+
+  test.each(excluded)(
+    "a %s cannot read the SIEM",
+    (_label: string, permission: Permission) => {
+      const props: DatabaseCommonInteractionProps = makeProps([permission]);
+      const reachable: Array<string> = [];
+
+      for (const [name, modelType] of SIEM_MODELS) {
+        if (canRead(modelType, props)) {
+          reachable.push(name);
+        }
+      }
+
+      expect(reachable).toEqual([]);
+    },
+  );
+
+  test.each(excluded)(
+    "a %s cannot write to the SIEM either",
+    (_label: string, permission: Permission) => {
+      const props: DatabaseCommonInteractionProps = makeProps([permission]);
+      const reachable: Array<string> = [];
+
+      for (const [name, modelType] of SIEM_MODELS) {
+        for (const requestType of [
+          DatabaseRequestType.Create,
+          DatabaseRequestType.Update,
+          DatabaseRequestType.Delete,
+        ]) {
+          if (can(modelType, props, requestType)) {
+            reachable.push(`${requestType} ${name}`);
+          }
+        }
+      }
+
+      expect(reachable).toEqual([]);
+    },
+  );
+
+  /*
+   * The exact pairing the operator asked about, stated in one place: the person
+   * with the run of every log, metric and trace in the project, and the person
+   * with the SIEM, can now be two different people - in both directions.
+   */
+  test("Telemetry and Security are independent grants", () => {
+    const telemetryAdmin: DatabaseCommonInteractionProps = makeProps([
+      Permission.TelemetryAdmin,
+    ]);
+    const securityAdmin: DatabaseCommonInteractionProps = makeProps([
+      Permission.SecurityAdmin,
+    ]);
+
+    expect(canRead(TelemetryException, telemetryAdmin)).toBe(true);
+    expect(canRead(DetectionRule, telemetryAdmin)).toBe(false);
+
+    expect(canRead(DetectionRule, securityAdmin)).toBe(true);
+    expect(canRead(TelemetryException, securityAdmin)).toBe(false);
+  });
+
+  /*
+   * Owner and Admin keep their access: they are who grants the Security tiers,
+   * so locking them out would leave a project with a SIEM nobody could open and
+   * no way to discover why.
+   */
+  test("the project's own administrators are not locked out", () => {
+    for (const permission of [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+    ]) {
+      const props: DatabaseCommonInteractionProps = makeProps([permission]);
+
+      for (const [, modelType] of SIEM_MODELS) {
+        expect(canRead(modelType, props)).toBe(true);
+      }
+    }
+  });
+
+  /*
+   * An API key scoped to one granular permission is how integrations read the
+   * SIEM without holding a role. The tiers were added beside these, not in
+   * place of them.
+   */
+  test("a granular-only principal still reaches the table it was granted", () => {
+    const detectionRuleReader: DatabaseCommonInteractionProps = makeProps([
+      Permission.ReadProjectDetectionRule,
+    ]);
+
+    expect(canRead(DetectionRule, detectionRuleReader)).toBe(true);
+    expect(canRead(ThreatIntelFeed, detectionRuleReader)).toBe(false);
+    expect(canRead(GoogleSecOpsConnection, detectionRuleReader)).toBe(false);
+  });
+});

--- a/Common/Tests/Types/SecurityRolePermissions.test.ts
+++ b/Common/Tests/Types/SecurityRolePermissions.test.ts
@@ -1,0 +1,193 @@
+import Permission, {
+  PermissionGroup,
+  PermissionHelper,
+  PermissionProps,
+} from "../../Types/Permission";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The Security role family.
+ *
+ * Security events, the Sigma rules written over them, the threat-intel feeds
+ * and the SecOps connector shipped reading through the Telemetry tiers, because
+ * they arrived beside logs and traces in ClickHouse. That made one grant out of
+ * two decisions: "may read every log in the project" and "may read the SIEM"
+ * were the same checkbox, and there was no way to give somebody the first
+ * without the second, or the second without making them a project admin.
+ *
+ * These tests are about the catalogue half of the split - that the three tiers
+ * exist, are grantable, and are shaped like every other domain family so the
+ * team permission picker renders them without knowing anything about security.
+ * SecurityDomainAccessControl.test.ts covers what they actually unlock, and
+ * SecurityRoleAccess.test.ts covers what they deny.
+ */
+
+type TierName = "Admin" | "Member" | "Viewer";
+
+const SECURITY_TIERS: Array<[TierName, Permission]> = [
+  ["Admin", Permission.SecurityAdmin],
+  ["Member", Permission.SecurityMember],
+  ["Viewer", Permission.SecurityViewer],
+];
+
+type PropsForFunction = (permission: Permission) => PermissionProps | undefined;
+
+const propsFor: PropsForFunction = (
+  permission: Permission,
+): PermissionProps | undefined => {
+  return PermissionHelper.getAllPermissionProps().find(
+    (candidate: PermissionProps) => {
+      return candidate.permission === permission;
+    },
+  );
+};
+
+describe("Security role family", () => {
+  test.each(SECURITY_TIERS)(
+    "Security%s exists in the catalogue",
+    (_tier: TierName, permission: Permission) => {
+      expect(propsFor(permission)).toBeDefined();
+    },
+  );
+
+  test.each(SECURITY_TIERS)(
+    "Security%s is a role, not a granular permission",
+    (_tier: TierName, permission: Permission) => {
+      const props: PermissionProps = propsFor(permission) as PermissionProps;
+
+      expect(props.isRolePermission).toBe(true);
+      expect(props.isAccessControlPermission).toBe(false);
+    },
+  );
+
+  /*
+   * A role nobody can be given is decoration. isAssignableToTenant is what puts
+   * it in front of an administrator in Settings -> Teams -> Permissions; without
+   * it the split would exist in the model layer and be unreachable from the UI.
+   */
+  test.each(SECURITY_TIERS)(
+    "Security%s can actually be granted to a team",
+    (_tier: TierName, permission: Permission) => {
+      const props: PermissionProps = propsFor(permission) as PermissionProps;
+
+      expect(props.isAssignableToTenant).toBe(true);
+      expect(
+        PermissionHelper.getTenantPermissionProps().map(
+          (candidate: PermissionProps) => {
+            return candidate.permission;
+          },
+        ),
+      ).toContain(permission);
+    },
+  );
+
+  test.each(SECURITY_TIERS)(
+    "Security%s is filed under the Security group",
+    (_tier: TierName, permission: Permission) => {
+      expect((propsFor(permission) as PermissionProps).group).toBe(
+        PermissionGroup.Security,
+      );
+    },
+  );
+
+  /*
+   * The picker renders props.title and props.description verbatim. An empty one
+   * is a blank card an administrator has to guess at.
+   */
+  test.each(SECURITY_TIERS)(
+    "Security%s reads as a role in the picker",
+    (tier: TierName, permission: Permission) => {
+      const props: PermissionProps = propsFor(permission) as PermissionProps;
+
+      expect(props.title).toBe(`Security ${tier}`);
+      expect(props.description.trim().length).toBeGreaterThan(0);
+      expect(PermissionHelper.getTitle(permission)).toBe(`Security ${tier}`);
+      expect(PermissionHelper.getDescription(permission).trim().length).toBe(
+        props.description.trim().length,
+      );
+    },
+  );
+
+  test("getRolePermissionProps offers all three tiers", () => {
+    const roles: Array<Permission> =
+      PermissionHelper.getRolePermissionProps().map(
+        (props: PermissionProps) => {
+          return props.permission;
+        },
+      );
+
+    expect(roles).toContain(Permission.SecurityAdmin);
+    expect(roles).toContain(Permission.SecurityMember);
+    expect(roles).toContain(Permission.SecurityViewer);
+  });
+
+  /*
+   * Every other domain in the product is Admin/Member/Viewer, and the dashboard
+   * groups roles by deriving the family name from the permission string. A
+   * family missing a tier - or spelled differently - falls out of that grouping
+   * silently. This asserts Security is spelled like its eleven siblings.
+   */
+  test("Security is a complete three-tier family like every other domain", () => {
+    const roleNames: Set<string> = new Set(
+      PermissionHelper.getRolePermissionProps().map(
+        (props: PermissionProps) => {
+          return props.permission.toString();
+        },
+      ),
+    );
+
+    const families: Array<string> = [
+      "Incident",
+      "Alert",
+      "Monitor",
+      "StatusPage",
+      "OnCall",
+      "ScheduledMaintenance",
+      "Telemetry",
+      "Settings",
+      "Billing",
+      "Workflow",
+      "Runbook",
+      "Security",
+    ];
+
+    const incomplete: Array<string> = [];
+
+    for (const family of families) {
+      for (const tier of ["Admin", "Member", "Viewer"]) {
+        if (!roleNames.has(`${family}${tier}`)) {
+          incomplete.push(`${family}${tier}`);
+        }
+      }
+    }
+
+    expect(incomplete).toEqual([]);
+  });
+
+  /*
+   * The Security tiers are a separate grant from the Telemetry ones - that
+   * separation is the entire feature. Aliasing two enum members to one string
+   * has happened in this file before (the ScheduledMaintenanceTemplateOwner
+   * pair), and it is invisible: granting either would confer both, which here
+   * would silently hand the SIEM back to every Telemetry Admin.
+   */
+  test("no Security tier is an alias of a Telemetry tier", () => {
+    const securityValues: Array<string> = [
+      Permission.SecurityAdmin.toString(),
+      Permission.SecurityMember.toString(),
+      Permission.SecurityViewer.toString(),
+    ];
+
+    const telemetryValues: Array<string> = [
+      Permission.TelemetryAdmin.toString(),
+      Permission.TelemetryMember.toString(),
+      Permission.TelemetryViewer.toString(),
+    ];
+
+    for (const value of securityValues) {
+      expect(telemetryValues).not.toContain(value);
+    }
+
+    expect(new Set(securityValues).size).toBe(3);
+  });
+});

--- a/Common/Types/Permission.ts
+++ b/Common/Types/Permission.ts
@@ -101,6 +101,25 @@ enum Permission {
   TelemetryMember = "TelemetryMember",
   TelemetryViewer = "TelemetryViewer",
 
+  /*
+   * SIEM data is its own domain, not a fourth telemetry signal. Security
+   * events, the Sigma detection rules over them, the threat-intel feeds and
+   * their indicators, and the SecOps connector credentials all read through
+   * these three tiers and through nothing else that is handed out broadly -
+   * not ProjectMember, not the project-wide Viewer, not the Telemetry tiers.
+   *
+   * That exclusion is the whole point of the family. A SIEM holds authentication
+   * failures, privilege escalations and the analyst's own investigation trail;
+   * "everyone who can open a dashboard can read it" is not an access policy an
+   * organisation deploying one can accept. Whoever should see it is given a
+   * Security tier deliberately, the same way BillingViewer is given
+   * deliberately, and everybody else - including a Telemetry Admin with the run
+   * of every log, metric and trace in the project - sees nothing.
+   */
+  SecurityAdmin = "SecurityAdmin",
+  SecurityMember = "SecurityMember",
+  SecurityViewer = "SecurityViewer",
+
   SettingsAdmin = "SettingsAdmin",
   SettingsMember = "SettingsMember",
   SettingsViewer = "SettingsViewer",
@@ -2370,6 +2389,36 @@ export class PermissionHelper {
         isAccessControlPermission: false,
         isRolePermission: true,
         group: PermissionGroup.Telemetry,
+      },
+      {
+        permission: Permission.SecurityAdmin,
+        title: "Security Admin",
+        description:
+          "Full control over the SIEM: security events, Sigma detection rules, threat intelligence feeds and indicators, and Google SecOps connections. Security data is not readable through any other role.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: true,
+        group: PermissionGroup.Security,
+      },
+      {
+        permission: Permission.SecurityMember,
+        title: "Security Member",
+        description:
+          "Can read security events and threat intelligence, and create, edit, and delete detection rules and threat intel feeds. Cannot configure Google SecOps connections.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: true,
+        group: PermissionGroup.Security,
+      },
+      {
+        permission: Permission.SecurityViewer,
+        title: "Security Viewer",
+        description:
+          "Read-only access to security events, detection rules, threat intelligence feeds, and indicators.",
+        isAssignableToTenant: true,
+        isAccessControlPermission: false,
+        isRolePermission: true,
+        group: PermissionGroup.Security,
       },
       {
         permission: Permission.SettingsAdmin,


### PR DESCRIPTION
## Why

We did not have one. The product has per-domain Admin/Member/Viewer tiers for eleven areas — Incident, Alert, Monitor, Status Page, On-Call, Scheduled Maintenance, Telemetry, Settings, Billing, Workflow, Runbook — and the SIEM was not one of them.

Security events shipped as "a first-class telemetry type", and the access lists followed the metaphor: `SecurityEvent`, `ThreatIntelIndicator`, `DetectionRule`, `ThreatIntelFeed` and `GoogleSecOpsConnection` all carried the same read list as `Log` —

```ts
ProjectOwner, ProjectAdmin, ProjectMember, Viewer,
TelemetryAdmin, TelemetryMember, TelemetryViewer, ReadSecurityEvent
```

`ProjectMember` is on that list, and every member of a project holds it. So **every person in the project could read every security event in it**, and there was no grant an administrator could withhold to change that. There was also no way to give someone the SIEM *without* giving them every log, metric and trace, or the reverse.

This adds the missing family and makes the separation real.

## What changed

**`SecurityAdmin` / `SecurityMember` / `SecurityViewer`**, filed under the `Security` permission group that already held the granular security permissions. They appear in the team permission picker under Domain Roles like every other family — no UI work beyond an icon, because the picker is generated from `PermissionHelper.getRolePermissionProps()`.

| Tier | What it gets |
| --- | --- |
| Security Admin | Everything, including configuring Google SecOps connections and purging security events. |
| Security Member | Reads the SIEM; authors detection rules and threat-intel feeds. Cannot repoint the connector or delete events. |
| Security Viewer | Read-only. |

**The SIEM tables now read through those tiers and nothing broader.** `ProjectMember`, the project-wide `Viewer` and the three `Telemetry` tiers came off all five models. `ProjectOwner` and `ProjectAdmin` stay, so a project is never locked out of its own data — they are who grants the new roles.

Three things that would have left the split cosmetic:

- **`/telemetry/security-events/get-attributes[-values]`** was built from `createTelemetryReadAccessGuard`, and these routes do not go through `BaseAnalyticsAPI`, so that guard *is* the access control. A Telemetry Admin would have been refused the rows while still being handed every attribute key in the table and every value ever seen for it — usernames, hostnames, source IPs. It now mirrors the model.
- **`@OperationalResource()` on `SecurityEvent`** widened its permission list with `ReadAllOperationalResources`, whose own description reads *"all operational resources in this project (Monitor, Incident, Alert, StatusPage, etc.)"*. Nobody granting that is deciding to hand over the SIEM. Removed; `@OwnedThrough` stays, so owned-scope filtering is unaffected.
- **`AlertSeverity` and `IncidentSeverity`** gained the Security tiers on their *read* lists only. A detection rule and a threat-intel feed each choose the severity of the alert or incident they open, so the SIEM's own forms select from those tables; without the grant the dropdown fails and a rule cannot be configured at all. Same shape as issue #3305, reached from a different direction.

## Breaking change

On upgrade, project members lose the implicit access they had to security events, detection rules, threat-intel feeds and SecOps connections. Owners and admins keep theirs; everyone else is granted a Security tier deliberately, in **Settings → Teams → Permissions**.

There is deliberately **no migration granting `SecurityAdmin` to existing `TelemetryAdmin` holders**. That would recreate exactly the coupling this removes, and an administrator would then have to go and undo it. Security events landed 11 days ago, so the population affected is small, and no project can be locked out — an owner or admin can always reach the data and hand out the role.

## Tests

Four new suites, plus the existing ones extended.

- `Common/Tests/Types/SecurityRolePermissions.test.ts` — the catalogue half: the three tiers exist, are grantable to a tenant, are role (not granular) permissions, sit in the `Security` group, render with a title and description, form a complete three-tier family like its eleven siblings, and are not aliases of the Telemetry tiers (a string collision here would silently hand the SIEM back).
- `Common/Tests/Models/SecurityDomainAccessControl.test.ts` — sweeps all five models at the declaration level, table and column: Security tiers present, the six broadly-held roles absent from read *and* write, admins not locked out, columns follow their table, the SecOps service-account key still readable by nobody, Viewer read-only, deletes Admin-tier, and the granular permissions still standing on their own.
- `Common/Tests/Server/Types/Database/Permissions/SecurityRoleAccess.test.ts` — the same through `TablePermission` and `ColumnPermissions`, for principals built the way `AccessTokenService` builds them (`ProjectUser` included, so nothing passes for the wrong reason). Eight excluded roles × read and write; both severity dropdowns; that the severity grant does not let a Security role edit severities; and Telemetry/Security independence asserted in both directions.
- `Common/Tests/Server/Types/AnalyticsDatabase/SecurityEventModelPermission.test.ts` — the ClickHouse gate, which is a different code path and the one the CRUD API and AI security tools use. Includes the wildcard test: a holder of all four `*AllOperationalResources` permissions can read `Log` and cannot touch `SecurityEvent`.
- `SecurityEventAttributesAPI.test.ts` — parametrized denial cases for the five roles that used to pass, on both routes, and the model/guard parity assertion updated.
- `DomainRoleTierCoverage.test.ts` — `Security` registered as a family; the three models named in `DOMAIN_BY_MODEL`, since not one of them is named for its domain.

## Notes

- The **Permission Reference** docs page is generated from `Permission.ts` at request time, so the new roles appear there in all 16 locales automatically. The prose page (`permissions/index.md`) could use a paragraph about the Security family being deliberately isolated; that is 16 hand-written translations and is left as a follow-up.
- **Correlate** joins logs and security events, so it needs both a Telemetry and a Security grant. That is inherent to what the page does, not a regression.
