### PR TITLE
test(common): give the suite a per-test timeout it can survive off runInBand

### DIFF
--- a/Common/jest.config.json
+++ b/Common/jest.config.json
@@ -48,6 +48,7 @@
   "testEnvironment": "<rootDir>/Tests/Utils/TimezoneEnvironment.js",
   "setupFilesAfterEnv": ["<rootDir>/Tests/jest.setup.ts"],
   "collectCoverage": false,
+  "testTimeout": 60000,
   "coverageReporters": ["text", "lcov"],
   "testRegex": "./Tests/(.*)\\.test\\.(ts|tsx)$",
   "collectCoverageFrom": ["./**/*.{ts,tsx}"],


### PR DESCRIPTION
Prerequisite for #3509.

#3509 drops `--detectOpenHandles` from Common's test script, which is what was forcing Jest into `runInBand`. With the suite on the worker pool, 25 tests in `Common/Tests/App/StatusPage/StatusPageResourceExplorer.test.tsx` fail on shard 5 — every one of them `Exceeded timeout of 5000 ms`.

`Common/jest.config.json` is the only Jest project in the repo with no `testTimeout`, so it runs on Jest's 5-second default. `App`, `CLI`, `BrowserRecorder` and `Scripts/TerraformProvider` all set one; `runInBand` is what hid the gap here. Nothing in the explorer suite is new or slower than it was — its own helpers already budget 15s per `waitFor`, and its 1506-group test already carries `}, 60000)`. The file was written knowing five seconds was not the right ceiling; it just never had to be said out loud while it had a whole runner to itself.

One of the 25 failures was not a timeout — `a group with none of them says none of them` found the `collapsed-by-default` badge it asserts is absent. Same bug, different hat: Jest reports a timed-out test but does not stop it, so the previous test's `waitFor` kept polling and its leftover `selectGroup("Published Quietly")` landed on the DOM the *next* test had just rendered. Fixing the ceiling removes the cascade.

## Why 60000 and not the 30000 the other configs use

Common is the only suite where ts-jest type-checks every file, and the measurement says 30000 is not enough.

Reproduced by running `Tests/App` on the worker pool: **8 files fail, 43 timeouts**. With a ceiling in place all 8 pass — **383 tests** — and the slowest individual tests land at **25.6s** and **25.1s** (in `LoginTwoFactorRecovery` and `OnCallReadinessSurfaces`, not the explorer).

| | baseline | with ceiling |
| --- | --- | --- |
| `Tests/App` suites failing | 8 | 0 |
| `Exceeded timeout of 5000 ms` | 43 | 0 |
| slowest single test | — | 25.6s |

That verification run was ~1.3x faster than CI on the one file we can compare directly (124.9s local against 160s on shard 5), which puts those tests around 33s on a runner. 30000 would have traded one flake for another.

## Note

This is inert on master, where the suite still runs in band — nothing currently reaches the 5s ceiling. It only starts mattering when #3509 lands.