### PR TITLE
feat(dashboard): State Timeline view for the Monitor List widget (#3503)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import DashboardMonitorListComponent from "Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent";
@@ -12,15 +13,30 @@ import DashboardResourceListBase, {
   ResourceListViewMode,
 } from "./DashboardResourceListBase";
 import { HoneycombTile } from "./DashboardResourceHoneycomb";
+import {
+  StateTimelineAxisTick,
+  StateTimelineLegendItem,
+  StateTimelineRow,
+  StateTimelineSegment,
+  StateTimelineTooltipDetail,
+} from "./DashboardResourceStateTimeline";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import DashboardResourceList from "../Utils/DashboardResourceList";
+import MonitorStateTimelineWidgetData from "../Utils/MonitorStateTimelineWidgetData";
+import {
+  getDashboardDateTimeLabel,
+  getDashboardTimelineAxisLabel,
+} from "../Utils/DashboardDateTime";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorStatusTimeline from "Common/Models/DatabaseModels/MonitorStatusTimeline";
 import API from "Common/UI/Utils/API/API";
 import IconProp from "Common/Types/Icon/IconProp";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import Query from "Common/Types/BaseDatabase/Query";
 import Includes from "Common/Types/BaseDatabase/Includes";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
 import JSONFunctions from "Common/Types/JSONFunctions";
+import OneUptimeDate from "Common/Types/Date";
 import ProjectUtil from "Common/UI/Utils/Project";
 import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
 import PageMap from "../../../Utils/PageMap";
@@ -28,6 +44,15 @@ import AppLink from "../../AppLink/AppLink";
 import Route from "Common/Types/API/Route";
 import ObjectID from "Common/Types/ObjectID";
 import Color from "Common/Types/Color";
+import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEndDateTime";
+import MonitorStateTimelineUtil, {
+  MonitorStateTimelineLegendItem,
+  MonitorStateTimelineRow,
+  MonitorStateTimelineSegment,
+} from "Common/Utils/Monitor/MonitorStateTimelineUtil";
+import MonitorStateTimelineTooltipField, {
+  MonitorStateTimelineTooltipFieldUtil,
+} from "Common/Types/Dashboard/MonitorStateTimelineTooltipField";
 
 export interface ComponentProps extends DashboardBaseComponentProps {
   component: DashboardMonitorListComponent;
@@ -39,16 +64,37 @@ const COLUMNS: Array<ResourceListColumn> = [
   { label: "Type", widthPct: "15%" },
 ];
 
+const NO_VALUE_LABEL: string = "—";
+
+/*
+ * Labels stop being time-only once the window is longer than a day, so a
+ * long window gets fewer, wider ticks and a short one gets more.
+ */
+const ONE_DAY_IN_MS: number = 24 * 60 * 60 * 1000;
+const TICK_COUNT_FOR_SHORT_WINDOW: number = 4;
+const TICK_COUNT_FOR_LONG_WINDOW: number = 3;
+
 const DashboardMonitorListComponentElement: FunctionComponent<
   ComponentProps
 > = (props: ComponentProps): ReactElement => {
   const [monitors, setMonitors] = useState<Array<Monitor>>([]);
+  const [statusTimelines, setStatusTimelines] = useState<
+    Array<MonitorStatusTimeline>
+  >([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const maxRows: number = props.component.arguments.maxRows || 25;
+
   const viewMode: ResourceListViewMode =
-    props.component.arguments.viewMode === "honeycomb" ? "honeycomb" : "list";
+    props.component.arguments.viewMode === "honeycomb"
+      ? "honeycomb"
+      : props.component.arguments.viewMode === "timeline"
+        ? "timeline"
+        : "list";
+
+  const isTimelineView: boolean = viewMode === "timeline";
+
   const statusFilter: string | undefined =
     props.component.arguments.statusFilter;
   const monitorStatusIds: Array<string> | undefined =
@@ -61,6 +107,23 @@ const DashboardMonitorListComponentElement: FunctionComponent<
   const monitorStatusIdsKey: string = (monitorStatusIds || []).join(",");
   const monitorTypesKey: string = (monitorTypes || []).join(",");
   const labelIdsKey: string = (labelIds || []).join(",");
+
+  /*
+   * Re-resolved on every refresh tick as well as on a range change: a
+   * relative range like "Past 1 hour" means something different each time the
+   * dashboard refreshes, and a timeline that kept the first window would
+   * silently stop advancing.
+   */
+  const timelineWindow: InBetween<Date> = useMemo(() => {
+    return RangeStartAndEndDateTimeUtil.getStartAndEndDate(
+      props.dashboardStartAndEndDate,
+    );
+    /*
+     * refreshTick is a deliberate extra dependency, not an oversight: on a
+     * relative range the resolver reads the wall clock, so the window has to
+     * be recomputed on every auto-refresh or the timeline stops advancing.
+     */
+  }, [props.dashboardStartAndEndDate, props.refreshTick]);
 
   const fetchMonitors: () => Promise<void> = useCallback(async () => {
     setIsLoading(true);
@@ -126,6 +189,33 @@ const DashboardMonitorListComponentElement: FunctionComponent<
       });
 
       setMonitors(listResult.data);
+
+      /*
+       * The timeline is a second read, and only in the mode that draws it —
+       * a list or honeycomb widget must not pay for status history it never
+       * renders.
+       */
+      if (isTimelineView) {
+        setStatusTimelines(
+          await MonitorStateTimelineWidgetData.fetchStatusTimelines({
+            componentId: props.componentId,
+            monitorIds: listResult.data
+              .map((monitor: Monitor) => {
+                return monitor.id;
+              })
+              .filter((id: ObjectID | null): id is ObjectID => {
+                return id !== null;
+              }),
+            projectId: projectId,
+            startDate: timelineWindow.startValue,
+            endDate: timelineWindow.endValue,
+            variables: props.variables,
+          }),
+        );
+      } else {
+        setStatusTimelines([]);
+      }
+
       setError(null);
     } catch (err: unknown) {
       setError(API.getFriendlyErrorMessage(err as Error));
@@ -138,6 +228,8 @@ const DashboardMonitorListComponentElement: FunctionComponent<
     monitorStatusIdsKey,
     monitorTypesKey,
     labelIdsKey,
+    isTimelineView,
+    timelineWindow,
     props.componentId,
     props.variables,
   ]);
@@ -145,6 +237,21 @@ const DashboardMonitorListComponentElement: FunctionComponent<
   useEffect(() => {
     fetchMonitors();
   }, [fetchMonitors, props.refreshTick]);
+
+  type GetMonitorRouteFunction = (monitorId: string) => Route | undefined;
+
+  const getMonitorRoute: GetMonitorRouteFunction = (
+    monitorId: string,
+  ): Route | undefined => {
+    if (!monitorId) {
+      return undefined;
+    }
+
+    return RouteUtil.populateRouteParams(
+      RouteMap[PageMap.MONITOR_VIEW] as Route,
+      { modelId: new ObjectID(monitorId) },
+    );
+  };
 
   const honeycombTiles: Array<HoneycombTile> = monitors.map(
     (monitor: Monitor): HoneycombTile => {
@@ -156,18 +263,11 @@ const DashboardMonitorListComponentElement: FunctionComponent<
         ?.color as Color | undefined;
       const monitorType: string = (monitor.monitorType as string) || "—";
 
-      const detailRoute: Route | undefined = monitorId
-        ? RouteUtil.populateRouteParams(
-            RouteMap[PageMap.MONITOR_VIEW] as Route,
-            { modelId: new ObjectID(monitorId) },
-          )
-        : undefined;
-
       return {
         id: monitorId || name,
         status: statusName,
         color: statusColor ? statusColor.toString() : "#9ca3af",
-        route: detailRoute,
+        route: getMonitorRoute(monitorId),
         tooltip: {
           title: name,
           details: [{ label: "Type", value: monitorType }],
@@ -175,6 +275,183 @@ const DashboardMonitorListComponentElement: FunctionComponent<
       };
     },
   );
+
+  // ── state timeline ────────────────────────────────────────────────────
+
+  const timelineRows: Array<MonitorStateTimelineRow> = useMemo(() => {
+    if (!isTimelineView) {
+      return [];
+    }
+
+    return MonitorStateTimelineUtil.buildRows({
+      monitors: monitors.map((monitor: Monitor) => {
+        return {
+          monitorId: (monitor._id as string) || "",
+          monitorName: (monitor.name as string) || "Unnamed",
+        };
+      }),
+      statusTimelines: statusTimelines,
+      startDate: timelineWindow.startValue,
+      endDate: timelineWindow.endValue,
+    });
+  }, [isTimelineView, monitors, statusTimelines, timelineWindow]);
+
+  const tooltipFields: Array<MonitorStateTimelineTooltipField> = useMemo(() => {
+    return MonitorStateTimelineTooltipFieldUtil.resolveFields(
+      props.component.arguments.timelineTooltipFields,
+    );
+  }, [props.component.arguments.timelineTooltipFields]);
+
+  type GetTooltipValueFunction = (data: {
+    field: MonitorStateTimelineTooltipField;
+    row: MonitorStateTimelineRow;
+    segment: MonitorStateTimelineSegment;
+    monitorType: string;
+  }) => string;
+
+  const getTooltipValue: GetTooltipValueFunction = (data: {
+    field: MonitorStateTimelineTooltipField;
+    row: MonitorStateTimelineRow;
+    segment: MonitorStateTimelineSegment;
+    monitorType: string;
+  }): string => {
+    const { field, row, segment, monitorType } = data;
+
+    switch (field) {
+      case MonitorStateTimelineTooltipField.Status:
+        return segment.label;
+      case MonitorStateTimelineTooltipField.StartedAt:
+        return getDashboardDateTimeLabel(segment.startDate);
+      case MonitorStateTimelineTooltipField.EndedAt:
+        return getDashboardDateTimeLabel(segment.endDate);
+      case MonitorStateTimelineTooltipField.Duration:
+        return OneUptimeDate.secondsToFormattedFriendlyTimeString(
+          segment.durationInSeconds,
+        );
+      case MonitorStateTimelineTooltipField.UptimePercent:
+        return row.uptimePercent === null
+          ? NO_VALUE_LABEL
+          : `${row.uptimePercent}%`;
+      case MonitorStateTimelineTooltipField.CurrentStatus:
+        return row.currentStatusName || NO_VALUE_LABEL;
+      case MonitorStateTimelineTooltipField.LastStatusChange:
+        return row.lastStatusChangeAt
+          ? getDashboardDateTimeLabel(row.lastStatusChangeAt)
+          : NO_VALUE_LABEL;
+      case MonitorStateTimelineTooltipField.MonitorType:
+        return monitorType;
+      default:
+        return NO_VALUE_LABEL;
+    }
+  };
+
+  const timelineViewRows: Array<StateTimelineRow> = useMemo(() => {
+    const monitorTypeById: Map<string, string> = new Map<string, string>(
+      monitors.map((monitor: Monitor): [string, string] => {
+        return [
+          (monitor._id as string) || "",
+          (monitor.monitorType as string) || NO_VALUE_LABEL,
+        ];
+      }),
+    );
+
+    return timelineRows.map(
+      (row: MonitorStateTimelineRow): StateTimelineRow => {
+        const monitorType: string =
+          monitorTypeById.get(row.monitorId) || NO_VALUE_LABEL;
+
+        const segments: Array<StateTimelineSegment> = row.segments.map(
+          (
+            segment: MonitorStateTimelineSegment,
+            index: number,
+          ): StateTimelineSegment => {
+            const tooltipDetails: Array<StateTimelineTooltipDetail> =
+              tooltipFields.map(
+                (
+                  field: MonitorStateTimelineTooltipField,
+                ): StateTimelineTooltipDetail => {
+                  return {
+                    label: MonitorStateTimelineTooltipFieldUtil.getTitle(field),
+                    value: getTooltipValue({
+                      field,
+                      row,
+                      segment,
+                      monitorType,
+                    }),
+                  };
+                },
+              );
+
+            return {
+              /*
+               * Index, not status id: a monitor that flaps between two statuses
+               * produces repeated status ids in one lane, and React would
+               * collapse them into one key.
+               */
+              id: `${row.monitorId}-${index}`,
+              label: segment.label,
+              color: segment.color,
+              startPercent: segment.startPercent,
+              widthPercent: segment.widthPercent,
+              tooltipDetails: tooltipDetails,
+            };
+          },
+        );
+
+        const uptimeLabel: string | undefined =
+          row.uptimePercent === null ? undefined : `${row.uptimePercent}%`;
+
+        const ariaLabel: string =
+          row.segments.length === 0
+            ? `${row.monitorName}: no status history in this time range.`
+            : `${row.monitorName}: currently ${row.currentStatusName}, ${uptimeLabel} uptime in this time range.`;
+
+        return {
+          id: row.monitorId,
+          label: row.monitorName,
+          route: getMonitorRoute(row.monitorId),
+          segments: segments,
+          ...(uptimeLabel === undefined ? {} : { trailingLabel: uptimeLabel }),
+          ariaLabel: ariaLabel,
+        };
+      },
+    );
+  }, [timelineRows, monitors, tooltipFields]);
+
+  const timelineAxisTicks: Array<StateTimelineAxisTick> = useMemo(() => {
+    if (!isTimelineView) {
+      return [];
+    }
+
+    const isLongWindow: boolean =
+      timelineWindow.endValue.getTime() - timelineWindow.startValue.getTime() >
+      ONE_DAY_IN_MS;
+
+    return MonitorStateTimelineUtil.getAxisTicks({
+      startDate: timelineWindow.startValue,
+      endDate: timelineWindow.endValue,
+      tickCount: isLongWindow
+        ? TICK_COUNT_FOR_LONG_WINDOW
+        : TICK_COUNT_FOR_SHORT_WINDOW,
+    }).map((tick: { date: Date; percent: number }): StateTimelineAxisTick => {
+      return {
+        label: getDashboardTimelineAxisLabel(tick.date, {
+          includeDate: isLongWindow,
+        }),
+        percent: tick.percent,
+      };
+    });
+  }, [isTimelineView, timelineWindow]);
+
+  const timelineLegend: Array<StateTimelineLegendItem> = useMemo(() => {
+    return MonitorStateTimelineUtil.getLegend(timelineRows).map(
+      (item: MonitorStateTimelineLegendItem): StateTimelineLegendItem => {
+        return { label: item.label, color: item.color };
+      },
+    );
+  }, [timelineRows]);
+
+  // ── list ──────────────────────────────────────────────────────────────
 
   const rows: Array<ReactElement> = monitors.map(
     (monitor: Monitor): ReactElement => {
@@ -244,6 +521,10 @@ const DashboardMonitorListComponentElement: FunctionComponent<
       emptyIcon={IconProp.AltGlobe}
       viewMode={viewMode}
       honeycombTiles={honeycombTiles}
+      timelineRows={timelineViewRows}
+      timelineAxisTicks={timelineAxisTicks}
+      timelineLegend={timelineLegend}
+      timelineNoDataLabel="No status history"
     >
       {rows}
     </DashboardResourceListBase>
@@ -258,6 +539,20 @@ function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
     prev.isSelected !== next.isSelected ||
     prev.dashboardComponentWidthInPx !== next.dashboardComponentWidthInPx ||
     prev.dashboardComponentHeightInPx !== next.dashboardComponentHeightInPx
+  ) {
+    return false;
+  }
+
+  /*
+   * The State Timeline is the one view mode whose data depends on the
+   * dashboard's time range, so unlike the other list widgets this one has to
+   * re-render when the range changes.
+   */
+  if (
+    !JSONFunctions.deepEqual(
+      prev.dashboardStartAndEndDate as unknown as Record<string, unknown>,
+      next.dashboardStartAndEndDate as unknown as Record<string, unknown>,
+    )
   ) {
     return false;
   }

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import DashboardMonitorListComponent from "Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent";
@@ -65,6 +66,7 @@ const COLUMNS: Array<ResourceListColumn> = [
 ];
 
 const NO_VALUE_LABEL: string = "—";
+const ONGOING_LABEL: string = "Ongoing";
 
 /*
  * Labels stop being time-only once the window is longer than a day, so a
@@ -83,6 +85,15 @@ const DashboardMonitorListComponentElement: FunctionComponent<
   >([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  /*
+   * Which fetch is the current one. The timeline mode issues two sequential
+   * requests, so a range change part way through leaves an older, narrower
+   * window still in flight; without this guard its late response overwrites
+   * the newer one and the lanes render a truncated history and a wrong uptime
+   * against the window the axis is labelled with.
+   */
+  const fetchGeneration: React.MutableRefObject<number> = useRef<number>(0);
 
   const maxRows: number = props.component.arguments.maxRows || 25;
 
@@ -114,10 +125,22 @@ const DashboardMonitorListComponentElement: FunctionComponent<
    * dashboard refreshes, and a timeline that kept the first window would
    * silently stop advancing.
    */
-  const timelineWindow: InBetween<Date> = useMemo(() => {
-    return RangeStartAndEndDateTimeUtil.getStartAndEndDate(
-      props.dashboardStartAndEndDate,
-    );
+  const timelineWindow: { startDate: Date; endDate: Date } = useMemo(() => {
+    const range: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(
+        props.dashboardStartAndEndDate,
+      );
+
+    /*
+     * Clamped BEFORE anything is drawn or requested. The public route applies
+     * the same ceiling server side; without matching it here, an over-long
+     * CUSTOM range would draw an axis spanning months against history the
+     * server only returned the tail of.
+     */
+    return MonitorStateTimelineUtil.clampWindow({
+      startDate: range.startValue,
+      endDate: range.endValue,
+    });
     /*
      * refreshTick is a deliberate extra dependency, not an oversight: on a
      * relative range the resolver reads the wall clock, so the window has to
@@ -125,7 +148,19 @@ const DashboardMonitorListComponentElement: FunctionComponent<
      */
   }, [props.dashboardStartAndEndDate, props.refreshTick]);
 
+  /*
+   * What the monitor fetch actually depends on. In list and honeycomb mode the
+   * query is time-independent, so keying the fetch on the window itself would
+   * refire every Monitor List widget on the board on every range change, for
+   * data that cannot have changed.
+   */
+  const timelineWindowKey: string = isTimelineView
+    ? `${timelineWindow.startDate.getTime()}-${timelineWindow.endDate.getTime()}`
+    : "";
+
   const fetchMonitors: () => Promise<void> = useCallback(async () => {
+    const generation: number = ++fetchGeneration.current;
+
     setIsLoading(true);
 
     const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
@@ -188,15 +223,15 @@ const DashboardMonitorListComponentElement: FunctionComponent<
         },
       });
 
-      setMonitors(listResult.data);
-
       /*
        * The timeline is a second read, and only in the mode that draws it —
        * a list or honeycomb widget must not pay for status history it never
        * renders.
        */
+      let nextStatusTimelines: Array<MonitorStatusTimeline> = [];
+
       if (isTimelineView) {
-        setStatusTimelines(
+        nextStatusTimelines =
           await MonitorStateTimelineWidgetData.fetchStatusTimelines({
             componentId: props.componentId,
             monitorIds: listResult.data
@@ -207,21 +242,38 @@ const DashboardMonitorListComponentElement: FunctionComponent<
                 return id !== null;
               }),
             projectId: projectId,
-            startDate: timelineWindow.startValue,
-            endDate: timelineWindow.endValue,
+            startDate: timelineWindow.startDate,
+            endDate: timelineWindow.endDate,
             variables: props.variables,
-          }),
-        );
-      } else {
-        setStatusTimelines([]);
+          });
       }
 
+      if (generation !== fetchGeneration.current) {
+        // A newer fetch started while this one was in flight; it owns the state.
+        return;
+      }
+
+      /*
+       * Both together, after both reads. Committing the monitors first would
+       * end the skeleton (its guard is isLoading && count === 0) and paint a
+       * full set of "No status history" lanes for the whole of the second
+       * round trip, then jump the track narrower when the uptime column
+       * finally appears.
+       */
+      setMonitors(listResult.data);
+      setStatusTimelines(nextStatusTimelines);
       setError(null);
     } catch (err: unknown) {
-      setError(API.getFriendlyErrorMessage(err as Error));
-    }
+      if (generation !== fetchGeneration.current) {
+        return;
+      }
 
-    setIsLoading(false);
+      setError(API.getFriendlyErrorMessage(err as Error));
+    } finally {
+      if (generation === fetchGeneration.current) {
+        setIsLoading(false);
+      }
+    }
   }, [
     maxRows,
     statusFilter,
@@ -229,7 +281,7 @@ const DashboardMonitorListComponentElement: FunctionComponent<
     monitorTypesKey,
     labelIdsKey,
     isTimelineView,
-    timelineWindow,
+    timelineWindowKey,
     props.componentId,
     props.variables,
   ]);
@@ -291,8 +343,8 @@ const DashboardMonitorListComponentElement: FunctionComponent<
         };
       }),
       statusTimelines: statusTimelines,
-      startDate: timelineWindow.startValue,
-      endDate: timelineWindow.endValue,
+      startDate: timelineWindow.startDate,
+      endDate: timelineWindow.endDate,
     });
   }, [isTimelineView, monitors, statusTimelines, timelineWindow]);
 
@@ -323,7 +375,14 @@ const DashboardMonitorListComponentElement: FunctionComponent<
       case MonitorStateTimelineTooltipField.StartedAt:
         return getDashboardDateTimeLabel(segment.startDate);
       case MonitorStateTimelineTooltipField.EndedAt:
-        return getDashboardDateTimeLabel(segment.endDate);
+        /*
+         * A run that had not ended when the window closed has no end to
+         * report — printing the clipped one reads as "Ended: <now>" over an
+         * outage that is still happening.
+         */
+        return segment.continuesAfterWindow
+          ? ONGOING_LABEL
+          : getDashboardDateTimeLabel(segment.endDate);
       case MonitorStateTimelineTooltipField.Duration:
         return OneUptimeDate.secondsToFormattedFriendlyTimeString(
           segment.durationInSeconds,
@@ -401,10 +460,15 @@ const DashboardMonitorListComponentElement: FunctionComponent<
         const uptimeLabel: string | undefined =
           row.uptimePercent === null ? undefined : `${row.uptimePercent}%`;
 
+        /*
+         * "at the end of this time range", not "currently": on a custom range
+         * that ends in the past the last bar is not the monitor's status now,
+         * and the same widget's list mode would announce a different one.
+         */
         const ariaLabel: string =
           row.segments.length === 0
             ? `${row.monitorName}: no status history in this time range.`
-            : `${row.monitorName}: currently ${row.currentStatusName}, ${uptimeLabel} uptime in this time range.`;
+            : `${row.monitorName}: ${row.currentStatusName} at the end of this time range, ${uptimeLabel} uptime.`;
 
         return {
           id: row.monitorId,
@@ -424,12 +488,12 @@ const DashboardMonitorListComponentElement: FunctionComponent<
     }
 
     const isLongWindow: boolean =
-      timelineWindow.endValue.getTime() - timelineWindow.startValue.getTime() >
+      timelineWindow.endDate.getTime() - timelineWindow.startDate.getTime() >
       ONE_DAY_IN_MS;
 
     return MonitorStateTimelineUtil.getAxisTicks({
-      startDate: timelineWindow.startValue,
-      endDate: timelineWindow.endValue,
+      startDate: timelineWindow.startDate,
+      endDate: timelineWindow.endDate,
       tickCount: isLongWindow
         ? TICK_COUNT_FOR_LONG_WINDOW
         : TICK_COUNT_FOR_SHORT_WINDOW,
@@ -546,15 +610,23 @@ function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
   /*
    * The State Timeline is the one view mode whose data depends on the
    * dashboard's time range, so unlike the other list widgets this one has to
-   * re-render when the range changes.
+   * re-render when the range changes — but ONLY in that mode. Comparing it
+   * unconditionally would re-render (and refetch) every list-mode Monitor List
+   * widget on the board on every range change, for a query that does not read
+   * the range at all.
    */
   if (
-    !JSONFunctions.deepEqual(
-      prev.dashboardStartAndEndDate as unknown as Record<string, unknown>,
-      next.dashboardStartAndEndDate as unknown as Record<string, unknown>,
-    )
+    next.component.arguments.viewMode === "timeline" ||
+    prev.component.arguments.viewMode === "timeline"
   ) {
-    return false;
+    if (
+      !JSONFunctions.deepEqual(
+        prev.dashboardStartAndEndDate as unknown as Record<string, unknown>,
+        next.dashboardStartAndEndDate as unknown as Record<string, unknown>,
+      )
+    ) {
+      return false;
+    }
   }
 
   return JSONFunctions.deepEqual(

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceHoneycomb.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceHoneycomb.tsx
@@ -85,8 +85,7 @@ interface HexProps {
 
 const Hex: FunctionComponent<HexProps> = (props: HexProps): ReactElement => {
   const { tile, width, height, onHoverStart, onHoverEnd } = props;
-  const ref: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const ref: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
   const textColor: string =
     tile.textColor || getReadableTextColor(tile.color || "#9ca3af");
@@ -176,8 +175,7 @@ const HoneycombTooltip: FunctionComponent<{ state: TooltipState }> = ({
     top: number;
     placement: "above" | "below";
   }>({ left: 0, top: 0, placement: "above" });
-  const ref: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const ref: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     setPosition(
@@ -247,8 +245,8 @@ const HoneycombTooltip: FunctionComponent<{ state: TooltipState }> = ({
 const DashboardResourceHoneycomb: FunctionComponent<
   DashboardResourceHoneycombProps
 > = (props: DashboardResourceHoneycombProps): ReactElement => {
-  const containerRef: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const containerRef: React.RefObject<HTMLDivElement> =
+    useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
 

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceHoneycomb.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceHoneycomb.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import Route from "Common/Types/API/Route";
 import Navigation from "Common/UI/Utils/Navigation";
+import getHoverCardPosition from "../Utils/HoverCardPosition";
 
 export interface HoneycombTileDetail {
   label: string;
@@ -179,27 +180,17 @@ const HoneycombTooltip: FunctionComponent<{ state: TooltipState }> = ({
     useRef<HTMLDivElement | null>(null);
 
   useLayoutEffect(() => {
-    const tooltipHeight: number = ref.current?.offsetHeight || 100;
-    const viewportWidth: number = window.innerWidth;
-    const viewportHeight: number = window.innerHeight;
-
-    let left: number =
-      state.rect.left + state.rect.width / 2 - TOOLTIP_WIDTH / 2;
-    left = Math.max(8, Math.min(viewportWidth - TOOLTIP_WIDTH - 8, left));
-
-    const spaceAbove: number = state.rect.top;
-    const placement: "above" | "below" =
-      spaceAbove < tooltipHeight + TOOLTIP_OFFSET + 8 ? "below" : "above";
-
-    const top: number =
-      placement === "above"
-        ? Math.max(8, state.rect.top - tooltipHeight - TOOLTIP_OFFSET)
-        : Math.min(
-            viewportHeight - tooltipHeight - 8,
-            state.rect.top + state.rect.height + TOOLTIP_OFFSET,
-          );
-
-    setPosition({ left, top, placement });
+    setPosition(
+      getHoverCardPosition({
+        rect: state.rect,
+        cardWidth: TOOLTIP_WIDTH,
+        // 100 is the first-pass guess, before the card has ever been laid out.
+        cardHeight: ref.current?.offsetHeight || 100,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        offset: TOOLTIP_OFFSET,
+      }),
+    );
   }, [state.rect.left, state.rect.top, state.rect.width, state.rect.height]);
 
   const details: Array<HoneycombTileDetail> = state.tile.tooltip.details || [];

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceListBase.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceListBase.tsx
@@ -5,6 +5,11 @@ import DashboardResourceHoneycomb, {
   HoneycombLegendItem,
   HoneycombTile,
 } from "./DashboardResourceHoneycomb";
+import DashboardResourceStateTimeline, {
+  StateTimelineAxisTick,
+  StateTimelineLegendItem,
+  StateTimelineRow,
+} from "./DashboardResourceStateTimeline";
 
 export interface ResourceListColumn {
   label: string;
@@ -12,7 +17,7 @@ export interface ResourceListColumn {
   alignRight?: boolean;
 }
 
-export type ResourceListViewMode = "list" | "honeycomb";
+export type ResourceListViewMode = "list" | "honeycomb" | "timeline";
 
 export interface DashboardResourceListBaseProps {
   title?: string | undefined;
@@ -28,6 +33,15 @@ export interface DashboardResourceListBaseProps {
   viewMode?: ResourceListViewMode | undefined;
   honeycombTiles?: Array<HoneycombTile> | undefined;
   honeycombLegend?: Array<HoneycombLegendItem> | undefined;
+  /*
+   * State-timeline mode. Supplied only by widgets whose entries have a stored
+   * status history; every other widget leaves these undefined and never
+   * selects the mode.
+   */
+  timelineRows?: Array<StateTimelineRow> | undefined;
+  timelineAxisTicks?: Array<StateTimelineAxisTick> | undefined;
+  timelineLegend?: Array<StateTimelineLegendItem> | undefined;
+  timelineNoDataLabel?: string | undefined;
 }
 
 const DashboardResourceListBase: FunctionComponent<
@@ -108,12 +122,19 @@ const DashboardResourceListBase: FunctionComponent<
           </span>
         </div>
       )}
-      {viewMode === "honeycomb" ? (
+      {viewMode === "honeycomb" || viewMode === "timeline" ? (
         <div className="flex-1 overflow-hidden rounded-md border border-gray-100">
           {props.isEmpty ? (
             <div className="h-full flex items-center justify-center px-4 py-8 text-center text-gray-400 text-sm">
               {props.emptyMessage}
             </div>
+          ) : viewMode === "timeline" ? (
+            <DashboardResourceStateTimeline
+              rows={props.timelineRows || []}
+              axisTicks={props.timelineAxisTicks || []}
+              legend={props.timelineLegend}
+              noDataLabel={props.timelineNoDataLabel || "No data"}
+            />
           ) : (
             <DashboardResourceHoneycomb
               tiles={props.honeycombTiles || []}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceStateTimeline.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceStateTimeline.tsx
@@ -1,0 +1,393 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import Route from "Common/Types/API/Route";
+import Navigation from "Common/UI/Utils/Navigation";
+import getHoverCardPosition, {
+  HoverCardPosition,
+  HoverCardTriggerRect,
+} from "../Utils/HoverCardPosition";
+
+/*
+ * A Grafana / Zabbix style "state timeline": one lane per resource, and inside
+ * each lane a run of coloured bars showing which state it was in, and for how
+ * long, across the dashboard's selected time range.
+ *
+ * Everything here is positioned in PERCENTAGES supplied by the caller — the
+ * component never measures itself. That is deliberate: the arithmetic that
+ * decides where a bar starts and how wide it is is the part worth testing, so
+ * it lives in a pure util (Common/Utils/Monitor/MonitorStateTimelineUtil), and
+ * this file is left as presentation that renders identically at any width.
+ */
+
+export interface StateTimelineTooltipDetail {
+  label: string;
+  value: string;
+}
+
+export interface StateTimelineSegment {
+  /** Unique within its row. */
+  id: string;
+  /** Status name, shown in the hover card's header. */
+  label: string;
+  color: string;
+  /** 0-100, left edge as a percentage of the visible range. */
+  startPercent: number;
+  /** 0-100, width as a percentage of the visible range. */
+  widthPercent: number;
+  tooltipDetails: Array<StateTimelineTooltipDetail>;
+}
+
+export interface StateTimelineRow {
+  id: string;
+  label: string;
+  route?: Route | undefined;
+  segments: Array<StateTimelineSegment>;
+  /** Short text at the right of the lane, e.g. an uptime percentage. */
+  trailingLabel?: string | undefined;
+  /** Screen-reader summary of the whole lane. */
+  ariaLabel: string;
+}
+
+export interface StateTimelineAxisTick {
+  label: string;
+  percent: number;
+}
+
+export interface StateTimelineLegendItem {
+  label: string;
+  color: string;
+}
+
+export interface DashboardResourceStateTimelineProps {
+  rows: Array<StateTimelineRow>;
+  axisTicks: Array<StateTimelineAxisTick>;
+  legend?: Array<StateTimelineLegendItem> | undefined;
+  /** Shown inside an otherwise-empty lane. */
+  noDataLabel: string;
+}
+
+const TOOLTIP_WIDTH: number = 240;
+const TOOLTIP_OFFSET: number = 8;
+const LANE_HEIGHT_IN_PX: number = 18;
+
+/*
+ * A bar narrower than this is invisible and unhoverable, so a brief outage
+ * inside a long window would vanish entirely — the single most important thing
+ * this widget exists to show. Short segments are widened to it; they overlap
+ * their neighbour by a hair rather than disappear.
+ */
+const MIN_SEGMENT_WIDTH_IN_PX: number = 2;
+
+interface TooltipState {
+  rowLabel: string;
+  segment: StateTimelineSegment;
+  rect: HoverCardTriggerRect;
+}
+
+interface SegmentBarProps {
+  rowLabel: string;
+  segment: StateTimelineSegment;
+  onHoverStart: (state: TooltipState) => void;
+  onHoverEnd: () => void;
+}
+
+const SegmentBar: FunctionComponent<SegmentBarProps> = (
+  props: SegmentBarProps,
+): ReactElement => {
+  const { rowLabel, segment, onHoverStart, onHoverEnd } = props;
+
+  const ref: React.RefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement | null>(null);
+
+  const onMouseEnter: () => void = (): void => {
+    if (!ref.current) {
+      return;
+    }
+
+    const rect: DOMRect = ref.current.getBoundingClientRect();
+
+    onHoverStart({
+      rowLabel: rowLabel,
+      segment: segment,
+      rect: {
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+      },
+    });
+  };
+
+  return (
+    <div
+      ref={ref}
+      data-testid="state-timeline-segment"
+      aria-hidden={true}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onHoverEnd}
+      className="absolute top-0 bottom-0 transition-opacity duration-100 hover:opacity-80"
+      style={{
+        left: `${segment.startPercent}%`,
+        width: `${segment.widthPercent}%`,
+        minWidth: `${MIN_SEGMENT_WIDTH_IN_PX}px`,
+        backgroundColor: segment.color,
+      }}
+    />
+  );
+};
+
+const StateTimelineTooltip: FunctionComponent<{ state: TooltipState }> = ({
+  state,
+}: {
+  state: TooltipState;
+}): ReactElement => {
+  const [position, setPosition] = useState<HoverCardPosition>({
+    left: 0,
+    top: 0,
+    placement: "above",
+  });
+
+  const ref: React.RefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    setPosition(
+      getHoverCardPosition({
+        rect: state.rect,
+        cardWidth: TOOLTIP_WIDTH,
+        // 100 is the first-pass guess, before the card has ever been laid out.
+        cardHeight: ref.current?.offsetHeight || 100,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        offset: TOOLTIP_OFFSET,
+      }),
+    );
+  }, [state.rect.left, state.rect.top, state.rect.width, state.rect.height]);
+
+  return (
+    <div
+      ref={ref}
+      role="tooltip"
+      className="fixed z-50 pointer-events-none rounded-lg border border-gray-200 bg-white shadow-xl"
+      style={{
+        left: `${position.left}px`,
+        top: `${position.top}px`,
+        width: `${TOOLTIP_WIDTH}px`,
+      }}
+    >
+      <div className="px-3 py-2 border-b border-gray-100 flex items-center gap-2">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+          style={{ backgroundColor: state.segment.color }}
+        ></span>
+        <span className="text-xs font-semibold text-gray-800 truncate">
+          {state.rowLabel}
+        </span>
+      </div>
+      {state.segment.tooltipDetails.length > 0 && (
+        <div className="px-3 py-2 space-y-1">
+          {state.segment.tooltipDetails.map(
+            (detail: StateTimelineTooltipDetail, index: number) => {
+              return (
+                <div
+                  key={index}
+                  className="flex items-center justify-between gap-2 text-xs"
+                >
+                  <span className="text-gray-400">{detail.label}</span>
+                  <span className="font-medium text-gray-700 truncate">
+                    {detail.value}
+                  </span>
+                </div>
+              );
+            },
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DashboardResourceStateTimeline: FunctionComponent<
+  DashboardResourceStateTimelineProps
+> = (props: DashboardResourceStateTimelineProps): ReactElement => {
+  const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
+
+  const onHoverEnd: () => void = (): void => {
+    setTooltipState(null);
+  };
+
+  /*
+   * Decided once for the whole widget, not per lane: if only the lanes that
+   * HAVE a trailing label reserved room for one, a monitor with no history
+   * would get a wider track than the monitor above it and the bars would stop
+   * lining up down the column.
+   */
+  const hasTrailingLabels: boolean = props.rows.some(
+    (row: StateTimelineRow) => {
+      return row.trailingLabel !== undefined;
+    },
+  );
+
+  type GetLaneFunction = (row: StateTimelineRow) => ReactElement;
+
+  const getLane: GetLaneFunction = (row: StateTimelineRow): ReactElement => {
+    const isClickable: boolean = Boolean(row.route);
+
+    const onLabelClick: () => void = (): void => {
+      if (row.route) {
+        Navigation.navigate(row.route);
+      }
+    };
+
+    return (
+      <div
+        key={row.id}
+        data-testid="state-timeline-row"
+        className="flex items-center gap-2 px-2 py-1 group"
+      >
+        <div
+          className="flex-shrink-0 truncate text-xs text-gray-700"
+          style={{ width: "34%", maxWidth: "180px", minWidth: "64px" }}
+          title={row.label}
+        >
+          {isClickable ? (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={onLabelClick}
+              onKeyDown={(event: React.KeyboardEvent) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onLabelClick();
+                }
+              }}
+              className="cursor-pointer hover:underline group-hover:text-blue-600"
+            >
+              {row.label}
+            </span>
+          ) : (
+            <span>{row.label}</span>
+          )}
+        </div>
+
+        <div
+          role="img"
+          data-testid="state-timeline-lane"
+          aria-label={row.ariaLabel}
+          className="relative flex-1 rounded-sm overflow-hidden bg-gray-100"
+          style={{ height: `${LANE_HEIGHT_IN_PX}px` }}
+        >
+          {row.segments.length === 0 ? (
+            <span
+              data-testid="state-timeline-no-data"
+              className="absolute inset-0 flex items-center justify-center text-[10px] text-gray-400"
+            >
+              {props.noDataLabel}
+            </span>
+          ) : (
+            row.segments.map((segment: StateTimelineSegment) => {
+              return (
+                <SegmentBar
+                  key={segment.id}
+                  rowLabel={row.label}
+                  segment={segment}
+                  onHoverStart={setTooltipState}
+                  onHoverEnd={onHoverEnd}
+                />
+              );
+            })
+          )}
+        </div>
+
+        {hasTrailingLabels && (
+          <div
+            data-testid="state-timeline-trailing-label"
+            className="flex-shrink-0 text-[10px] text-gray-500 tabular-nums text-right w-12"
+          >
+            {row.trailingLabel ?? ""}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
+        {props.rows.map(getLane)}
+      </div>
+
+      {props.axisTicks.length > 0 && (
+        <div className="flex items-center gap-2 px-2 pb-1">
+          <div
+            className="flex-shrink-0"
+            style={{ width: "34%", maxWidth: "180px", minWidth: "64px" }}
+          ></div>
+          <div className="relative flex-1 h-4">
+            {props.axisTicks.map(
+              (tick: StateTimelineAxisTick, index: number) => {
+                /*
+                 * The first and last labels are anchored to their edge rather
+                 * than centred on it, so neither is clipped by the lane.
+                 */
+                const isFirst: boolean = index === 0;
+                const isLast: boolean = index === props.axisTicks.length - 1;
+
+                let transform: string = "translateX(-50%)";
+                if (isFirst) {
+                  transform = "translateX(0)";
+                } else if (isLast) {
+                  transform = "translateX(-100%)";
+                }
+
+                return (
+                  <span
+                    key={index}
+                    data-testid="state-timeline-axis-tick"
+                    className="absolute top-0 text-[10px] text-gray-400 whitespace-nowrap tabular-nums"
+                    style={{
+                      left: `${tick.percent}%`,
+                      transform: transform,
+                    }}
+                  >
+                    {tick.label}
+                  </span>
+                );
+              },
+            )}
+          </div>
+          {hasTrailingLabels && <div className="flex-shrink-0 w-12"></div>}
+        </div>
+      )}
+
+      {props.legend && props.legend.length > 0 && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 pb-2 pt-1 border-t border-gray-100 bg-gray-50/50">
+          {props.legend.map((item: StateTimelineLegendItem, index: number) => {
+            return (
+              <div
+                key={index}
+                data-testid="state-timeline-legend-item"
+                className="flex items-center gap-1.5"
+              >
+                <span
+                  className="inline-block w-2 h-2 rounded-full"
+                  style={{ backgroundColor: item.color }}
+                ></span>
+                <span className="text-[10px] text-gray-500">{item.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {tooltipState && <StateTimelineTooltip state={tooltipState} />}
+    </div>
+  );
+};
+
+export default DashboardResourceStateTimeline;

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceStateTimeline.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceStateTimeline.tsx
@@ -119,8 +119,7 @@ const SegmentBar: FunctionComponent<SegmentBarProps> = (
 ): ReactElement => {
   const { rowLabel, segment, onHoverStart, onHoverEnd } = props;
 
-  const ref: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const ref: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
   const onMouseEnter: () => void = (): void => {
     if (!ref.current) {
@@ -171,8 +170,7 @@ const StateTimelineTooltip: FunctionComponent<{ state: TooltipState }> = ({
     placement: "above",
   });
 
-  const ref: React.RefObject<HTMLDivElement | null> =
-    useRef<HTMLDivElement | null>(null);
+  const ref: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     setPosition(

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceStateTimeline.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardResourceStateTimeline.tsx
@@ -1,6 +1,7 @@
 import React, {
   FunctionComponent,
   ReactElement,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -83,6 +84,23 @@ const LANE_HEIGHT_IN_PX: number = 18;
  */
 const MIN_SEGMENT_WIDTH_IN_PX: number = 2;
 
+/*
+ * Segments are absolutely positioned siblings, so without this the LAST one in
+ * the lane paints over every earlier one it overlaps — which is exactly the
+ * pixels the min-width above just bought a brief outage. Stacking them
+ * narrowest-on-top makes the widening real for both painting and hit testing,
+ * and it costs nothing when nothing overlaps. widthPercent is 0-100, so this
+ * is always a non-negative integer and a wider bar can never outrank a
+ * narrower one.
+ */
+type GetSegmentZIndexFunction = (widthPercent: number) => number;
+
+const getSegmentZIndex: GetSegmentZIndexFunction = (
+  widthPercent: number,
+): number => {
+  return Math.max(0, Math.round(100 - widthPercent));
+};
+
 interface TooltipState {
   rowLabel: string;
   segment: StateTimelineSegment;
@@ -135,6 +153,7 @@ const SegmentBar: FunctionComponent<SegmentBarProps> = (
         left: `${segment.startPercent}%`,
         width: `${segment.widthPercent}%`,
         minWidth: `${MIN_SEGMENT_WIDTH_IN_PX}px`,
+        zIndex: getSegmentZIndex(segment.widthPercent),
         backgroundColor: segment.color,
       }}
     />
@@ -220,6 +239,32 @@ const DashboardResourceStateTimeline: FunctionComponent<
   const onHoverEnd: () => void = (): void => {
     setTooltipState(null);
   };
+
+  /*
+   * React dispatches no mouseleave for an element it unmounts, so a refresh
+   * tick that drops the hovered bar (the window slid, an event fell out of
+   * range) would otherwise leave its fixed-position card pinned to the screen
+   * for good. Hovering is not cleared on every refresh — only when the bar
+   * under the pointer is actually gone — so a card over a bar that survived
+   * the refresh does not flicker.
+   */
+  useEffect(() => {
+    setTooltipState((current: TooltipState | null): TooltipState | null => {
+      if (!current) {
+        return current;
+      }
+
+      const stillRendered: boolean = props.rows.some(
+        (row: StateTimelineRow) => {
+          return row.segments.some((segment: StateTimelineSegment) => {
+            return segment.id === current.segment.id;
+          });
+        },
+      );
+
+      return stillRendered ? current : null;
+    });
+  }, [props.rows]);
 
   /*
    * Decided once for the whole widget, not per lane: if only the lanes that
@@ -318,52 +363,59 @@ const DashboardResourceStateTimeline: FunctionComponent<
 
   return (
     <div className="h-full w-full flex flex-col">
+      {/*
+       * The axis lives INSIDE the scrolling container, stuck to its bottom.
+       * As a sibling it would be laid out against a containing block wider by
+       * the scrollbar, and its 34%-plus-flex-1 split would no longer line up
+       * with the lanes' — so every tick would sit a few pixels away from the
+       * instant it names, on exactly the tall widgets where the axis matters.
+       */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
         {props.rows.map(getLane)}
-      </div>
 
-      {props.axisTicks.length > 0 && (
-        <div className="flex items-center gap-2 px-2 pb-1">
-          <div
-            className="flex-shrink-0"
-            style={{ width: "34%", maxWidth: "180px", minWidth: "64px" }}
-          ></div>
-          <div className="relative flex-1 h-4">
-            {props.axisTicks.map(
-              (tick: StateTimelineAxisTick, index: number) => {
-                /*
-                 * The first and last labels are anchored to their edge rather
-                 * than centred on it, so neither is clipped by the lane.
-                 */
-                const isFirst: boolean = index === 0;
-                const isLast: boolean = index === props.axisTicks.length - 1;
+        {props.axisTicks.length > 0 && (
+          <div className="sticky bottom-0 flex items-center gap-2 px-2 pt-1 pb-1 bg-white">
+            <div
+              className="flex-shrink-0"
+              style={{ width: "34%", maxWidth: "180px", minWidth: "64px" }}
+            ></div>
+            <div className="relative flex-1 h-4">
+              {props.axisTicks.map(
+                (tick: StateTimelineAxisTick, index: number) => {
+                  /*
+                   * The first and last labels are anchored to their edge rather
+                   * than centred on it, so neither is clipped by the lane.
+                   */
+                  const isFirst: boolean = index === 0;
+                  const isLast: boolean = index === props.axisTicks.length - 1;
 
-                let transform: string = "translateX(-50%)";
-                if (isFirst) {
-                  transform = "translateX(0)";
-                } else if (isLast) {
-                  transform = "translateX(-100%)";
-                }
+                  let transform: string = "translateX(-50%)";
+                  if (isFirst) {
+                    transform = "translateX(0)";
+                  } else if (isLast) {
+                    transform = "translateX(-100%)";
+                  }
 
-                return (
-                  <span
-                    key={index}
-                    data-testid="state-timeline-axis-tick"
-                    className="absolute top-0 text-[10px] text-gray-400 whitespace-nowrap tabular-nums"
-                    style={{
-                      left: `${tick.percent}%`,
-                      transform: transform,
-                    }}
-                  >
-                    {tick.label}
-                  </span>
-                );
-              },
-            )}
+                  return (
+                    <span
+                      key={index}
+                      data-testid="state-timeline-axis-tick"
+                      className="absolute top-0 text-[10px] text-gray-400 whitespace-nowrap tabular-nums"
+                      style={{
+                        left: `${tick.percent}%`,
+                        transform: transform,
+                      }}
+                    >
+                      {tick.label}
+                    </span>
+                  );
+                },
+              )}
+            </div>
+            {hasTrailingLabels && <div className="flex-shrink-0 w-12"></div>}
           </div>
-          {hasTrailingLabels && <div className="flex-shrink-0 w-12"></div>}
-        </div>
-      )}
+        )}
+      </div>
 
       {props.legend && props.legend.length > 0 && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 pb-2 pt-1 border-t border-gray-100 bg-gray-50/50">

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts
@@ -344,7 +344,8 @@ export const WIDGET_CATALOG: ReadonlyArray<WidgetCatalogCategory> = [
         type: DashboardComponentType.MonitorList,
         label: "Monitor List",
         icon: IconProp.AltGlobe,
-        description: "Monitors with current operational status.",
+        description:
+          "Monitors with current operational status — as a list, a honeycomb, or a state timeline showing when each one went down and for how long.",
         keywords: [
           "uptime",
           "probe",
@@ -352,6 +353,11 @@ export const WIDGET_CATALOG: ReadonlyArray<WidgetCatalogCategory> = [
           "status",
           "health",
           "availability",
+          "state timeline",
+          "status history",
+          "downtime",
+          "outage",
+          "history",
         ],
       },
     ],

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime.ts
@@ -111,3 +111,34 @@ export function getDashboardDateTimeLabel(
 ): string {
   return getDashboardDateTime(date, options).label;
 }
+
+/**
+ * The label under one tick of a state-timeline axis.
+ *
+ * The axis is the one dashboard surface where a bare clock reading is right:
+ * on a window of a day or less the axis as a whole says which day is on
+ * screen, so there is no date half for a time half to disagree with, and a
+ * repeated date on every tick is noise in a lane only a few hundred pixels
+ * wide. A longer window has to name the day, because consecutive ticks are no
+ * longer on the same one.
+ *
+ * It lives here rather than in the widget for the same reason every other
+ * dashboard timestamp does: both halves resolve through OneUptimeDate's
+ * current-timezone helpers, so a user who picked a timezone in User Settings
+ * reads that wall clock on the axis too.
+ */
+export function getDashboardTimelineAxisLabel(
+  date: Date,
+  options?: { includeDate?: boolean | undefined } | undefined,
+): string {
+  const timeLabel: string = OneUptimeDate.getLocalTimeString(date, {
+    includeMinutes: true,
+    includeSeconds: false,
+  });
+
+  if (options?.includeDate !== true) {
+    return timeLabel;
+  }
+
+  return `${OneUptimeDate.getDateAsLocalFormattedString(date, true)} ${timeLabel}`;
+}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/HoverCardPosition.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/HoverCardPosition.ts
@@ -1,0 +1,72 @@
+/*
+ * Where a fixed-position hover card should sit relative to the thing it
+ * describes.
+ *
+ * Widgets render inside a scrolling, clipped dashboard tile, so their hover
+ * cards are `position: fixed` and placed from the trigger's viewport rect
+ * rather than laid out next to it. That placement is the same arithmetic for
+ * every widget that does it — centre horizontally, clamp inside the viewport,
+ * and flip above→below when there is not enough room above — so it lives here
+ * once, as a pure function that can be tested without a DOM.
+ */
+
+export interface HoverCardTriggerRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface HoverCardPositionInput {
+  rect: HoverCardTriggerRect;
+  cardWidth: number;
+  /*
+   * The card's measured height. Callers pass a guess on the first pass, before
+   * the card has ever been laid out; the placement is corrected on the next.
+   */
+  cardHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  /** Gap between the trigger and the card, and the minimum viewport margin. */
+  offset: number;
+}
+
+export interface HoverCardPosition {
+  left: number;
+  top: number;
+  placement: "above" | "below";
+}
+
+/** The viewport margin the card is never allowed to cross. */
+export const HOVER_CARD_VIEWPORT_MARGIN: number = 8;
+
+export default function getHoverCardPosition(
+  input: HoverCardPositionInput,
+): HoverCardPosition {
+  const { rect, cardWidth, cardHeight, viewportWidth, viewportHeight, offset } =
+    input;
+
+  const margin: number = HOVER_CARD_VIEWPORT_MARGIN;
+
+  /*
+   * Centre on the trigger, then clamp. Math.max wins the tie on a viewport
+   * narrower than the card, so the card is pinned to the left edge and stays
+   * partly readable rather than being pushed off-screen to the left.
+   */
+  let left: number = rect.left + rect.width / 2 - cardWidth / 2;
+  left = Math.max(margin, Math.min(viewportWidth - cardWidth - margin, left));
+
+  const spaceAbove: number = rect.top;
+  const placement: "above" | "below" =
+    spaceAbove < cardHeight + offset + margin ? "below" : "above";
+
+  const top: number =
+    placement === "above"
+      ? Math.max(margin, rect.top - cardHeight - offset)
+      : Math.min(
+          viewportHeight - cardHeight - margin,
+          rect.top + rect.height + offset,
+        );
+
+  return { left, top, placement };
+}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/MonitorStateTimelineWidgetData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/MonitorStateTimelineWidgetData.ts
@@ -1,0 +1,167 @@
+import {
+  getPublicDashboardContext,
+  PublicDashboardContext,
+} from "./PublicDashboardContext";
+import MonitorStatusTimeline from "Common/Models/DatabaseModels/MonitorStatusTimeline";
+import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import GreaterThanOrNull from "Common/Types/BaseDatabase/GreaterThanOrNull";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import LessThanOrEqual from "Common/Types/BaseDatabase/LessThanOrEqual";
+import Query from "Common/Types/BaseDatabase/Query";
+import Select from "Common/Types/BaseDatabase/Select";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+
+/*
+ * Data access for the Monitor List widget's State Timeline view, on both an
+ * authenticated dashboard and an anonymous public one.
+ *
+ * The two paths are deliberately NOT symmetrical. The authenticated path
+ * queries MonitorStatusTimeline directly for the monitor ids the widget just
+ * listed. The public path cannot: monitor ids sent by an anonymous caller
+ * would be a selector the server has to trust, and the whole public-dashboard
+ * design refuses to trust client-supplied selectors. So the public route takes
+ * only the componentId and the window, re-derives the monitor set from the
+ * STORED widget, and returns the timelines for exactly those monitors.
+ */
+
+/*
+ * Everything the timeline draws, and nothing else. The public endpoint pins
+ * its own copy of this select server-side and ignores whatever the client
+ * sends, so this list is the widget's contract, never its access control.
+ *
+ * monitorStatus._id is not cosmetic: UptimeUtil keys an event's status off it,
+ * and without it every segment would collapse into one indistinguishable
+ * status and the uptime percentage would count no downtime at all.
+ */
+export const MONITOR_STATE_TIMELINE_SELECT: Select<MonitorStatusTimeline> = {
+  monitorId: true,
+  startsAt: true,
+  endsAt: true,
+  monitorStatus: {
+    _id: true,
+    name: true,
+    color: true,
+    isOperationalState: true,
+    priority: true,
+  },
+};
+
+export default class MonitorStateTimelineWidgetData {
+  /**
+   * The status history overlapping [startDate, endDate] for the given
+   * monitors, oldest first.
+   */
+  public static async fetchStatusTimelines(data: {
+    componentId: ObjectID;
+    monitorIds: Array<ObjectID>;
+    projectId: ObjectID | null;
+    startDate: Date;
+    endDate: Date;
+    variables?: Array<DashboardVariable> | undefined;
+  }): Promise<Array<MonitorStatusTimeline>> {
+    const context: PublicDashboardContext | null = getPublicDashboardContext();
+
+    if (context) {
+      return MonitorStateTimelineWidgetData.fetchPublicStatusTimelines({
+        context,
+        componentId: data.componentId,
+        startDate: data.startDate,
+        endDate: data.endDate,
+        variables: data.variables,
+      });
+    }
+
+    if (data.monitorIds.length === 0 || !data.projectId) {
+      return [];
+    }
+
+    const listResult: ListResult<MonitorStatusTimeline> =
+      await ModelAPI.getList<MonitorStatusTimeline>({
+        modelType: MonitorStatusTimeline,
+        query: {
+          /*
+           * Every row that OVERLAPS the window, not just the rows that began
+           * inside it. A monitor that went Offline before the window opened
+           * and is still Offline has exactly one row, and it started in the
+           * past — without this the lane would render empty for a monitor
+           * that has been down the whole time.
+           */
+          startsAt: new LessThanOrEqual(data.endDate),
+          endsAt: new GreaterThanOrNull(data.startDate),
+          monitorId: new Includes(data.monitorIds),
+          projectId: data.projectId,
+        } as Query<MonitorStatusTimeline>,
+        select: MONITOR_STATE_TIMELINE_SELECT,
+        sort: {
+          /*
+           * startsAt, not createdAt: they are different clocks (DB now() vs
+           * worker moment()) with real skew, and startsAt is the one the
+           * timeline math orders by.
+           */
+          startsAt: SortOrder.Ascending,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+      });
+
+    return listResult.data;
+  }
+
+  private static async fetchPublicStatusTimelines(data: {
+    context: PublicDashboardContext;
+    componentId: ObjectID;
+    startDate: Date;
+    endDate: Date;
+    variables?: Array<DashboardVariable> | undefined;
+  }): Promise<Array<MonitorStatusTimeline>> {
+    const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await data.context.postJSON(
+        `/monitor-status-timeline/${data.context.dashboardId.toString()}`,
+        {
+          componentId: data.componentId.toString(),
+          /*
+           * Selections only — the same projection the resource-list route
+           * takes. The server resolves each id against the dashboard's stored
+           * variables, including its trusted type and attribute key.
+           */
+          variables: (data.variables || []).map(
+            (variable: DashboardVariable): JSONObject => {
+              return {
+                id: variable.id,
+                selectedValue: variable.selectedValue ?? null,
+                selectedValues: variable.selectedValues || [],
+              };
+            },
+          ) as JSONArray,
+          /*
+           * toJSON(), NOT JSONFunctions.serialize(): serialize would wrap each
+           * bound as {_type: "DateTime", value}, and InBetween.fromJSON copies
+           * its bounds across verbatim — so the server would receive an
+           * InBetween holding two objects where it expects two dates, and
+           * reject the window. toJSON leaves the raw Dates, which JSON
+           * stringification turns into the ISO strings the server parses.
+           */
+          startAndEndDate: new InBetween<Date>(
+            data.startDate,
+            data.endDate,
+          ).toJSON(),
+        },
+      );
+
+    if (response instanceof HTTPErrorResponse) {
+      throw response;
+    }
+
+    const list: JSONArray = (response.data["data"] || []) as JSONArray;
+
+    return BaseModel.fromJSONArray(list, MonitorStatusTimeline);
+  }
+}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/MonitorStateTimelineWidgetData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/MonitorStateTimelineWidgetData.ts
@@ -67,6 +67,17 @@ export default class MonitorStateTimelineWidgetData {
     endDate: Date;
     variables?: Array<DashboardVariable> | undefined;
   }): Promise<Array<MonitorStatusTimeline>> {
+    /*
+     * No monitors, nothing to ask about — on either path. The public route
+     * re-derives the monitor set itself and never trusts these ids, but their
+     * COUNT is still a safe hint: it can only skip a request whose answer
+     * provably has nowhere to render, since the lanes are built from the
+     * monitor list this count came from.
+     */
+    if (data.monitorIds.length === 0) {
+      return [];
+    }
+
     const context: PublicDashboardContext | null = getPublicDashboardContext();
 
     if (context) {
@@ -79,7 +90,7 @@ export default class MonitorStateTimelineWidgetData {
       });
     }
 
-    if (data.monitorIds.length === 0 || !data.projectId) {
+    if (!data.projectId) {
       return [];
     }
 
@@ -105,8 +116,15 @@ export default class MonitorStateTimelineWidgetData {
            * startsAt, not createdAt: they are different clocks (DB now() vs
            * worker moment()) with real skew, and startsAt is the one the
            * timeline math orders by.
+           *
+           * DESCENDING, because this read is capped. A flapping fleet can
+           * produce more rows than the cap, and ascending would hand back the
+           * OLDEST of them — silently dropping the newest, which is exactly
+           * where the lane reads its current status and last change from.
+           * Newest-first degrades the far left of the chart instead. Order
+           * does not otherwise matter: UptimeUtil sorts the rows it is given.
            */
-          startsAt: SortOrder.Ascending,
+          startsAt: SortOrder.Descending,
         },
         limit: LIMIT_PER_PROJECT,
         skip: 0,

--- a/App/Tests/Dashboard/DashboardDateTime.test.ts
+++ b/App/Tests/Dashboard/DashboardDateTime.test.ts
@@ -17,6 +17,7 @@ import {
   NO_DATE_LABEL,
   getDashboardDateTime,
   getDashboardDateTimeLabel,
+  getDashboardTimelineAxisLabel,
 } from "../../FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime";
 
 const NY: Timezone = Timezone.AmericaNew_York;
@@ -492,5 +493,83 @@ describe("DashboardDateTime", () => {
       expect(morning).toContain("Jul 16, 2026");
       expect(evening).toContain("Jul 16, 2026");
     });
+  });
+});
+
+describe("getDashboardTimelineAxisLabel", () => {
+  afterEach(() => {
+    // Never leak a timezone override into another test.
+    OneUptimeDate.setUserTimezone(null);
+  });
+
+  it("is a bare clock reading on a window that fits inside one day", () => {
+    /*
+     * The one dashboard surface where a date-less timestamp is right: the
+     * state-timeline axis as a whole says which day is on screen, and a
+     * repeated date on every tick is noise in a lane a few hundred pixels
+     * wide.
+     */
+    OneUptimeDate.setUserTimezone(LA);
+
+    expect(getDashboardTimelineAxisLabel(INSTANT)).toBe("14:32");
+  });
+
+  it("names the day as well when the caller says the window spans days", () => {
+    OneUptimeDate.setUserTimezone(LA);
+
+    expect(getDashboardTimelineAxisLabel(INSTANT, { includeDate: true })).toBe(
+      "Jul 16, 2026 14:32",
+    );
+  });
+
+  it("treats an absent or explicitly false option as time-only", () => {
+    OneUptimeDate.setUserTimezone(LA);
+
+    expect(getDashboardTimelineAxisLabel(INSTANT, {})).toBe("14:32");
+    expect(getDashboardTimelineAxisLabel(INSTANT, { includeDate: false })).toBe(
+      "14:32",
+    );
+    expect(
+      getDashboardTimelineAxisLabel(INSTANT, { includeDate: undefined }),
+    ).toBe("14:32");
+  });
+
+  it("reads the wall clock of the timezone the user picked in settings", () => {
+    OneUptimeDate.setUserTimezone(KOLKATA);
+    expect(getDashboardTimelineAxisLabel(INSTANT)).toBe("03:02");
+
+    OneUptimeDate.setUserTimezone(NY);
+    expect(getDashboardTimelineAxisLabel(INSTANT)).toBe("17:32");
+  });
+
+  it("resolves both halves in the SAME zone when it names the day", () => {
+    /*
+     * The failure this guards against is a label reading "Jul 16, 2026 03:02"
+     * — the UTC date next to the Kolkata time — which is 21:32 UTC rendered
+     * half in one zone and half in another.
+     */
+    OneUptimeDate.setUserTimezone(KOLKATA);
+
+    expect(getDashboardTimelineAxisLabel(INSTANT, { includeDate: true })).toBe(
+      "Jul 17, 2026 03:02",
+    );
+  });
+
+  it("never shows seconds — a tick is a coarse reading", () => {
+    OneUptimeDate.setUserTimezone(UTC);
+
+    expect(
+      getDashboardTimelineAxisLabel(new Date("2026-07-16T09:05:37.000Z")),
+    ).toBe("09:05");
+  });
+
+  it("distinguishes consecutive ticks inside one hour", () => {
+    OneUptimeDate.setUserTimezone(UTC);
+
+    expect(
+      getDashboardTimelineAxisLabel(new Date("2026-07-16T09:05:00.000Z")),
+    ).not.toBe(
+      getDashboardTimelineAxisLabel(new Date("2026-07-16T09:20:00.000Z")),
+    );
   });
 });

--- a/App/Tests/Dashboard/HoverCardPosition.test.ts
+++ b/App/Tests/Dashboard/HoverCardPosition.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "@jest/globals";
+import getHoverCardPosition, {
+  HoverCardPosition,
+  HoverCardTriggerRect,
+  HOVER_CARD_VIEWPORT_MARGIN,
+} from "../../FeatureSet/Dashboard/src/Components/Dashboard/Utils/HoverCardPosition";
+
+/*
+ * Dashboard widgets render inside a clipped, scrolling tile, so their hover
+ * cards are position: fixed and placed from the trigger's viewport rect. That
+ * arithmetic is what decides whether the card is readable or half off-screen,
+ * and it cannot be checked by rendering: jsdom reports every rect as zero, and
+ * a real browser only shows the failure at particular viewport sizes.
+ *
+ * The two widgets that use it (the honeycomb and the state timeline) sit in
+ * the corners of a dashboard as often as the middle, so the edge cases below
+ * are the normal cases.
+ */
+
+const CARD_WIDTH: number = 240;
+const CARD_HEIGHT: number = 120;
+const OFFSET: number = 8;
+
+const VIEWPORT_WIDTH: number = 1280;
+const VIEWPORT_HEIGHT: number = 800;
+
+type PositionFunction = (
+  rect: HoverCardTriggerRect,
+  overrides?:
+    | {
+        cardWidth?: number | undefined;
+        cardHeight?: number | undefined;
+        viewportWidth?: number | undefined;
+        viewportHeight?: number | undefined;
+      }
+    | undefined,
+) => HoverCardPosition;
+
+const positionFor: PositionFunction = (
+  rect: HoverCardTriggerRect,
+  overrides?:
+    | {
+        cardWidth?: number | undefined;
+        cardHeight?: number | undefined;
+        viewportWidth?: number | undefined;
+        viewportHeight?: number | undefined;
+      }
+    | undefined,
+): HoverCardPosition => {
+  return getHoverCardPosition({
+    rect: rect,
+    cardWidth: overrides?.cardWidth ?? CARD_WIDTH,
+    cardHeight: overrides?.cardHeight ?? CARD_HEIGHT,
+    viewportWidth: overrides?.viewportWidth ?? VIEWPORT_WIDTH,
+    viewportHeight: overrides?.viewportHeight ?? VIEWPORT_HEIGHT,
+    offset: OFFSET,
+  });
+};
+
+// A trigger comfortably in the middle of the viewport.
+const CENTRED_TRIGGER: HoverCardTriggerRect = {
+  left: 600,
+  top: 400,
+  width: 40,
+  height: 20,
+};
+
+describe("getHoverCardPosition", () => {
+  describe("horizontal placement", () => {
+    test("centres the card on the trigger", () => {
+      // 600 + 20 (half the trigger) - 120 (half the card)
+      expect(positionFor(CENTRED_TRIGGER).left).toBe(500);
+    });
+
+    test("pins the card inside the left margin rather than letting it overhang", () => {
+      const position: HoverCardPosition = positionFor({
+        left: 4,
+        top: 400,
+        width: 40,
+        height: 20,
+      });
+
+      expect(position.left).toBe(HOVER_CARD_VIEWPORT_MARGIN);
+    });
+
+    test("pins the card inside the right margin", () => {
+      const position: HoverCardPosition = positionFor({
+        left: VIEWPORT_WIDTH - 44,
+        top: 400,
+        width: 40,
+        height: 20,
+      });
+
+      expect(position.left).toBe(
+        VIEWPORT_WIDTH - CARD_WIDTH - HOVER_CARD_VIEWPORT_MARGIN,
+      );
+      expect(position.left + CARD_WIDTH).toBeLessThanOrEqual(
+        VIEWPORT_WIDTH - HOVER_CARD_VIEWPORT_MARGIN,
+      );
+    });
+
+    test("keeps the card on-screen on a viewport narrower than the card itself", () => {
+      /*
+       * A phone in portrait is narrower than the 240px card. Clamping to the
+       * RIGHT edge first would push the card off to the left and hide its
+       * label; the left margin has to win the tie.
+       */
+      const position: HoverCardPosition = positionFor(
+        { left: 10, top: 400, width: 40, height: 20 },
+        { viewportWidth: 200 },
+      );
+
+      expect(position.left).toBe(HOVER_CARD_VIEWPORT_MARGIN);
+    });
+  });
+
+  describe("vertical placement", () => {
+    test("prefers above the trigger when there is room", () => {
+      const position: HoverCardPosition = positionFor(CENTRED_TRIGGER);
+
+      expect(position.placement).toBe("above");
+      expect(position.top).toBe(400 - CARD_HEIGHT - OFFSET);
+    });
+
+    test("flips below when the trigger is near the top of the viewport", () => {
+      /*
+       * The top row of a dashboard tile is exactly where this happens, and an
+       * unflipped card would be clipped by the top of the window.
+       */
+      const position: HoverCardPosition = positionFor({
+        left: 600,
+        top: 40,
+        width: 40,
+        height: 20,
+      });
+
+      expect(position.placement).toBe("below");
+      expect(position.top).toBe(40 + 20 + OFFSET);
+    });
+
+    test("flips at the exact boundary where the card would no longer fit", () => {
+      const justFits: number =
+        CARD_HEIGHT + OFFSET + HOVER_CARD_VIEWPORT_MARGIN;
+
+      expect(
+        positionFor({ left: 600, top: justFits, width: 40, height: 20 })
+          .placement,
+      ).toBe("above");
+      expect(
+        positionFor({ left: 600, top: justFits - 1, width: 40, height: 20 })
+          .placement,
+      ).toBe("below");
+    });
+
+    test("keeps a below-placed card inside the bottom margin", () => {
+      const position: HoverCardPosition = positionFor(
+        { left: 600, top: 10, width: 40, height: 20 },
+        { viewportHeight: 100 },
+      );
+
+      expect(position.placement).toBe("below");
+      expect(position.top).toBe(100 - CARD_HEIGHT - HOVER_CARD_VIEWPORT_MARGIN);
+    });
+
+    test("never places an above-card past the top margin", () => {
+      /*
+       * The flip already handles the common case; this is the belt-and-braces
+       * clamp for a tall card in a short viewport, where neither side fits.
+       */
+      const position: HoverCardPosition = positionFor(
+        { left: 600, top: 300, width: 40, height: 20 },
+        { cardHeight: 600 },
+      );
+
+      expect(position.top).toBeGreaterThanOrEqual(HOVER_CARD_VIEWPORT_MARGIN);
+    });
+  });
+
+  describe("first-pass behaviour", () => {
+    test("produces a usable placement before the card has been measured", () => {
+      /*
+       * The caller passes a guessed height on the first layout pass, because
+       * the card has not rendered yet. The result still has to be a real
+       * position — a NaN would drop the card into the top-left corner.
+       */
+      const position: HoverCardPosition = positionFor(CENTRED_TRIGGER, {
+        cardHeight: 100,
+      });
+
+      expect(Number.isFinite(position.left)).toBe(true);
+      expect(Number.isFinite(position.top)).toBe(true);
+    });
+
+    test("handles a zero-sized trigger without producing a NaN", () => {
+      // jsdom reports every getBoundingClientRect as zero.
+      const position: HoverCardPosition = positionFor({
+        left: 0,
+        top: 0,
+        width: 0,
+        height: 0,
+      });
+
+      expect(Number.isFinite(position.left)).toBe(true);
+      expect(Number.isFinite(position.top)).toBe(true);
+      expect(position.placement).toBe("below");
+    });
+  });
+});

--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -86,6 +86,13 @@ import PublicDashboardSloHistoryPolicy, {
 import AggregationType from "../../Types/BaseDatabase/AggregationType";
 import InBetween from "../../Types/BaseDatabase/InBetween";
 import { applyIncidentSelfPrivacyFilter } from "../Utils/Incident/IncidentPrivacyFilter";
+import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
+import MonitorStatusTimelineService from "../Services/MonitorStatusTimelineService";
+import QueryHelper from "../Types/Database/QueryHelper";
+import PublicDashboardMonitorStateTimelinePolicy, {
+  MAX_PUBLIC_STATE_TIMELINE_ROWS,
+  PUBLIC_STATE_TIMELINE_SELECT,
+} from "../Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy";
 import { applyAlertSelfPrivacyFilter } from "../Utils/Alert/AlertPrivacyFilter";
 
 /*
@@ -122,6 +129,20 @@ const PUBLIC_DASHBOARD_SLO_RESOURCE: PublicDashboardResourceConfig = {
   },
 };
 
+/*
+ * Named rather than inlined below: the state-timeline route selects its
+ * widget through the same registry entry as the resource-list route, so both
+ * must agree on which stored widgets count as "a Monitor List on this
+ * dashboard".
+ */
+const PUBLIC_DASHBOARD_MONITOR_RESOURCE: PublicDashboardResourceConfig = {
+  modelType: Monitor,
+  service: MonitorService,
+  widgets: {
+    [DashboardComponentType.MonitorList]: null,
+  },
+};
+
 const PUBLIC_DASHBOARD_RESOURCES: Record<
   string,
   PublicDashboardResourceConfig
@@ -140,13 +161,7 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
       [DashboardComponentType.AlertList]: null,
     },
   },
-  monitor: {
-    modelType: Monitor,
-    service: MonitorService,
-    widgets: {
-      [DashboardComponentType.MonitorList]: null,
-    },
-  },
+  monitor: PUBLIC_DASHBOARD_MONITOR_RESOURCE,
   "network-site": {
     modelType: NetworkSite,
     service: NetworkSiteService,
@@ -1446,6 +1461,184 @@ export default class DashboardAPI extends BaseAPI<
         } catch (err) {
           next(err);
         }
+      },
+    );
+
+    /*
+     * Public monitor status history for the Monitor List widget's State
+     * Timeline view.
+     *
+     * This is a dedicated route rather than another PUBLIC_DASHBOARD_RESOURCES
+     * entry because the timeline is a read ABOUT a set of monitors, and that
+     * set is a selector. The resource-list route rebuilds a widget's query
+     * server side precisely so a public caller never supplies one; letting the
+     * caller post monitor ids here would hand that back. So the monitor set is
+     * re-derived from the STORED Monitor List widget with the same policy the
+     * resource-list route uses, and the only caller-supplied input that
+     * survives is the time window — validated and length-capped by
+     * PublicDashboardMonitorStateTimelinePolicy.
+     *
+     * Authorization reuses DashboardService.hasReadAccess.
+     */
+    this.router.post(
+      `${new this.entityType()
+        .getCrudApiPath()
+        ?.toString()}/monitor-status-timeline/:dashboardId`,
+      publicDashboardRateLimit,
+      UserMiddleware.getUserMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const dashboardId: ObjectID = new ObjectID(
+            req.params["dashboardId"] as string,
+          );
+
+          const accessResult: {
+            hasReadAccess: boolean;
+            error?: NotAuthenticatedException | ForbiddenException;
+          } = await DashboardService.hasReadAccess({
+            dashboardId,
+            req,
+          });
+
+          if (!accessResult.hasReadAccess) {
+            throw (
+              accessResult.error ||
+              new BadDataException("Access denied to this dashboard.")
+            );
+          }
+
+          const dashboard: Dashboard | null =
+            await DashboardService.findOneById({
+              id: dashboardId,
+              select: {
+                _id: true,
+                projectId: true,
+                dashboardViewConfig: true,
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          if (!dashboard || !dashboard.projectId) {
+            throw new NotFoundException("Dashboard not found");
+          }
+
+          const widget: JSONObject = DashboardAPI.selectPublicResourceWidget({
+            dashboardViewConfig: dashboard.dashboardViewConfig,
+            config: PUBLIC_DASHBOARD_MONITOR_RESOURCE,
+            requestedComponentId: req.body
+              ? req.body["componentId"]
+              : undefined,
+          });
+
+          const window: InBetween<Date> =
+            PublicDashboardMonitorStateTimelinePolicy.resolveWindowFromBody(
+              req.body as JSONObject | undefined,
+            );
+
+          const policy: PublicDashboardResourceListPolicyResult =
+            PublicDashboardResourceListPolicy.build({
+              widget,
+              dashboardViewConfig: dashboard.dashboardViewConfig,
+              requestedVariables: req.body ? req.body["variables"] : undefined,
+              /*
+               * The Monitor List policy reads its whole query out of the
+               * stored widget, so there is nothing for a caller to contribute
+               * here — unlike the log and trace policies, which take their
+               * time window through this argument.
+               */
+              requestedQuery: {},
+            });
+
+          /*
+           * The same monitor set the widget's own list call resolves, in the
+           * same order and under the same row cap — so the lanes the browser
+           * draws and the history it gets back describe the same monitors.
+           */
+          const monitors: Array<Monitor> = (await MonitorService.findBy({
+            query: {
+              ...policy.query,
+              // Never redirect this root read to another project.
+              projectId: dashboard.projectId,
+            },
+            select: {
+              _id: true,
+            },
+            sort: policy.sort,
+            limit: policy.limit,
+            skip: 0,
+            props: {
+              isRoot: true,
+            },
+          })) as Array<Monitor>;
+
+          const monitorIds: Array<ObjectID> = monitors
+            .map((monitor: Monitor) => {
+              return monitor.id;
+            })
+            .filter((id: ObjectID | null): id is ObjectID => {
+              return id !== null;
+            });
+
+          if (monitorIds.length === 0) {
+            return Response.sendEntityArrayResponse(
+              req,
+              res,
+              [],
+              new PositiveNumber(0),
+              MonitorStatusTimeline,
+            );
+          }
+
+          const statusTimelines: Array<MonitorStatusTimeline> =
+            await MonitorStatusTimelineService.findBy({
+              query: {
+                projectId: dashboard.projectId,
+                monitorId: QueryHelper.any(monitorIds),
+                /*
+                 * Every row that OVERLAPS the window: it started on or before
+                 * the window ends, and it either ended on or after the window
+                 * started or is still open.
+                 *
+                 * The browser's own query says `endsAt > start` rather than
+                 * `>=`. The difference is a row that ends exactly at the
+                 * window start, which contributes a zero-length event that
+                 * UptimeUtil discards and a zero-width bar the renderer skips
+                 * — so the two paths draw the same timeline either way, and
+                 * the inclusive form here is the one the rest of the server
+                 * uses for this predicate.
+                 */
+                startsAt: QueryHelper.lessThanEqualTo(window.endValue),
+                endsAt: QueryHelper.greaterThanEqualToOrNull(window.startValue),
+              },
+              select: PUBLIC_STATE_TIMELINE_SELECT,
+              sort: {
+                startsAt: SortOrder.Ascending,
+              },
+              limit: MAX_PUBLIC_STATE_TIMELINE_ROWS,
+              skip: 0,
+              /*
+               * Run as root: authorization is already enforced by
+               * hasReadAccess above, the monitor set comes from the stored
+               * widget, and the project is pinned in the query.
+               */
+              props: {
+                isRoot: true,
+              },
+            });
+
+          return Response.sendEntityArrayResponse(
+            req,
+            res,
+            statusTimelines,
+            new PositiveNumber(statusTimelines.length),
+            MonitorStatusTimeline,
+          );
+        } catch (err) {
+          next(err);
+        }
+        return undefined;
       },
     );
 

--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -1532,6 +1532,10 @@ export default class DashboardAPI extends BaseAPI<
               : undefined,
           });
 
+          PublicDashboardMonitorStateTimelinePolicy.assertWidgetDrawsTimeline(
+            widget,
+          );
+
           const window: InBetween<Date> =
             PublicDashboardMonitorStateTimelinePolicy.resolveWindowFromBody(
               req.body as JSONObject | undefined,
@@ -1613,8 +1617,15 @@ export default class DashboardAPI extends BaseAPI<
                 endsAt: QueryHelper.greaterThanEqualToOrNull(window.startValue),
               },
               select: PUBLIC_STATE_TIMELINE_SELECT,
+              /*
+               * Newest first, matching the authenticated path: this read is
+               * capped, and ascending would drop the most recent rows — the
+               * ones the lane reads its current status from — rather than the
+               * far left of the chart. The timeline math sorts what it is
+               * given, so order is otherwise immaterial.
+               */
               sort: {
-                startsAt: SortOrder.Ascending,
+                startsAt: SortOrder.Descending,
               },
               limit: MAX_PUBLIC_STATE_TIMELINE_ROWS,
               skip: 0,

--- a/Common/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.ts
@@ -4,6 +4,9 @@ import { JSONObject, JSONValue } from "../../../Types/JSON";
 import JSONFunctions from "../../../Types/JSONFunctions";
 import Select from "../../Types/Database/Select";
 import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import MonitorStateTimelineUtil, {
+  MAX_STATE_TIMELINE_WINDOW_IN_DAYS,
+} from "../../../Utils/Monitor/MonitorStateTimelineUtil";
 
 /*
  * The server-owned policy for the public Monitor List "State Timeline" read.
@@ -16,16 +19,13 @@ import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusT
  */
 
 /*
- * Hard ceiling on the window a public viewer may request, independent of the
- * range picker's own options. A timeline row is written on every status
- * CHANGE, so an unbounded window on a flapping monitor is an unbounded read
- * — and unlike the authenticated app there is no session to attribute it to.
- * 3 months matches the longest range the dashboard time picker offers
- * (TimeRange.PAST_THREE_MONTHS).
+ * Re-exported so this module reads as the complete public-route policy, but
+ * OWNED by the shared timeline util: the browser applies the same ceiling
+ * before it draws, so an over-long range narrows identically on both sides of
+ * the wire instead of the axis labelling a span the server never queried.
  */
-export const MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS: number = 92;
-
-const MS_PER_DAY: number = 24 * 60 * 60 * 1000;
+export const MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS: number =
+  MAX_STATE_TIMELINE_WINDOW_IN_DAYS;
 
 /*
  * Enough rows to draw a busy window, far below LIMIT_PER_PROJECT. A widget
@@ -57,6 +57,34 @@ export const PUBLIC_STATE_TIMELINE_SELECT: Select<MonitorStatusTimeline> = {
 
 export default class PublicDashboardMonitorStateTimelinePolicy {
   /**
+   * Refuse a widget that does not draw a state timeline.
+   *
+   * Only the timeline view mode publishes status HISTORY. A Monitor List left
+   * in list or honeycomb mode publishes each monitor's name, type and CURRENT
+   * status and nothing more — the resource-list policy's select says exactly
+   * that — so serving 92 days of every status change for one would hand out
+   * history its author never put on the page. Adding a widget to a public
+   * dashboard is the owner's only opt-in to exposing data, and the view mode
+   * is part of what they opted into.
+   */
+  public static assertWidgetDrawsTimeline(widget: JSONObject): void {
+    const widgetArguments: unknown = widget["arguments"];
+
+    const viewMode: unknown =
+      widgetArguments &&
+      typeof widgetArguments === "object" &&
+      !Array.isArray(widgetArguments)
+        ? (widgetArguments as Record<string, unknown>)["viewMode"]
+        : undefined;
+
+    if (viewMode !== "timeline") {
+      throw new BadDataException(
+        "This dashboard widget does not show a monitor state timeline.",
+      );
+    }
+  }
+
+  /**
    * The validated, bounded window for a public state-timeline read.
    *
    * A window longer than the ceiling is CLAMPED (its start is moved forward)
@@ -87,17 +115,13 @@ export default class PublicDashboardMonitorStateTimelinePolicy {
       );
     }
 
-    const maxWindowInMs: number =
-      MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY;
+    const clamped: { startDate: Date; endDate: Date } =
+      MonitorStateTimelineUtil.clampWindow({
+        startDate: startDate,
+        endDate: endDate,
+      });
 
-    if (endDate.getTime() - startDate.getTime() > maxWindowInMs) {
-      return new InBetween<Date>(
-        new Date(endDate.getTime() - maxWindowInMs),
-        endDate,
-      );
-    }
-
-    return new InBetween<Date>(startDate, endDate);
+    return new InBetween<Date>(clamped.startDate, clamped.endDate);
   }
 
   private static validDate(value: unknown): Date {

--- a/Common/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.ts
@@ -1,0 +1,138 @@
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import Select from "../../Types/Database/Select";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+
+/*
+ * The server-owned policy for the public Monitor List "State Timeline" read.
+ *
+ * Nothing a public caller sends selects data. Which monitors are in scope
+ * comes from the STORED widget (through PublicDashboardResourceListPolicy),
+ * the project comes from the dashboard, and the columns come from the fixed
+ * select below. The only caller-supplied input that survives is the time
+ * window, and this module is what bounds and validates it.
+ */
+
+/*
+ * Hard ceiling on the window a public viewer may request, independent of the
+ * range picker's own options. A timeline row is written on every status
+ * CHANGE, so an unbounded window on a flapping monitor is an unbounded read
+ * — and unlike the authenticated app there is no session to attribute it to.
+ * 3 months matches the longest range the dashboard time picker offers
+ * (TimeRange.PAST_THREE_MONTHS).
+ */
+export const MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS: number = 92;
+
+const MS_PER_DAY: number = 24 * 60 * 60 * 1000;
+
+/*
+ * Enough rows to draw a busy window, far below LIMIT_PER_PROJECT. A widget
+ * showing 25 monitors would need each of them to change status 200 times in
+ * the window to reach this.
+ */
+export const MAX_PUBLIC_STATE_TIMELINE_ROWS: number = 5000;
+
+/*
+ * Exactly the columns the timeline draws.
+ *
+ * This read runs as root after only a dashboard read-access check, so this
+ * projection is the ONLY thing keeping the rest of the row out of an
+ * anonymous response — `rootCause` and `statusChangeLog` in particular can
+ * carry probe output and internal error detail, and must never appear here.
+ */
+export const PUBLIC_STATE_TIMELINE_SELECT: Select<MonitorStatusTimeline> = {
+  monitorId: true,
+  startsAt: true,
+  endsAt: true,
+  monitorStatus: {
+    _id: true,
+    name: true,
+    color: true,
+    isOperationalState: true,
+    priority: true,
+  },
+};
+
+export default class PublicDashboardMonitorStateTimelinePolicy {
+  /**
+   * The validated, bounded window for a public state-timeline read.
+   *
+   * A window longer than the ceiling is CLAMPED (its start is moved forward)
+   * rather than rejected: the widget then draws a shorter range, which is a
+   * better answer for a wall display than an error card.
+   */
+  public static resolveWindow(requestedWindow: unknown): InBetween<Date> {
+    const deserialized: JSONValue = JSONFunctions.deserializeValue(
+      requestedWindow as JSONValue,
+    );
+
+    if (!(deserialized instanceof InBetween)) {
+      throw new BadDataException(
+        "Public dashboard state timeline requires a startAndEndDate range.",
+      );
+    }
+
+    const startDate: Date = PublicDashboardMonitorStateTimelinePolicy.validDate(
+      deserialized.startValue,
+    );
+    const endDate: Date = PublicDashboardMonitorStateTimelinePolicy.validDate(
+      deserialized.endValue,
+    );
+
+    if (startDate.getTime() >= endDate.getTime()) {
+      throw new BadDataException(
+        "Public dashboard state timeline range is invalid.",
+      );
+    }
+
+    const maxWindowInMs: number =
+      MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY;
+
+    if (endDate.getTime() - startDate.getTime() > maxWindowInMs) {
+      return new InBetween<Date>(
+        new Date(endDate.getTime() - maxWindowInMs),
+        endDate,
+      );
+    }
+
+    return new InBetween<Date>(startDate, endDate);
+  }
+
+  private static validDate(value: unknown): Date {
+    if (value instanceof Date && Number.isFinite(value.getTime())) {
+      return new Date(value.getTime());
+    }
+
+    if (typeof value === "string" && value.length <= 128) {
+      const date: Date = new Date(value);
+      if (Number.isFinite(date.getTime())) {
+        return date;
+      }
+    }
+
+    throw new BadDataException(
+      "Public dashboard state timeline range contains an invalid date.",
+    );
+  }
+
+  /**
+   * Pulls the requested window off a public request body. Kept next to
+   * resolveWindow so the body key ("startAndEndDate") is stated once and the
+   * client and server cannot drift on it.
+   */
+  public static resolveWindowFromBody(
+    body: JSONObject | undefined,
+  ): InBetween<Date> {
+    if (!body || body["startAndEndDate"] === undefined) {
+      throw new BadDataException(
+        "Public dashboard state timeline requires a startAndEndDate range.",
+      );
+    }
+
+    return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+      body["startAndEndDate"],
+    );
+  }
+}

--- a/Common/Tests/App/Dashboard/MonitorListStateTimeline.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorListStateTimeline.test.tsx
@@ -79,6 +79,7 @@ import {
   PublicDashboardContext,
   setPublicDashboardContext,
 } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
@@ -93,9 +94,10 @@ import Color from "../../../Types/Color";
 import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
 import DashboardMonitorListComponent from "../../../Types/Dashboard/DashboardComponents/DashboardMonitorListComponent";
 import MonitorStateTimelineTooltipField from "../../../Types/Dashboard/MonitorStateTimelineTooltipField";
+import { MAX_STATE_TIMELINE_WINDOW_IN_DAYS } from "../../../Utils/Monitor/MonitorStateTimelineUtil";
 import PublicDashboardMonitorStateTimelinePolicy from "../../../Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy";
 import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
-import { JSONObject, ObjectType } from "../../../Types/JSON";
+import { JSONArray, JSONObject, ObjectType } from "../../../Types/JSON";
 import MonitorType from "../../../Types/Monitor/MonitorType";
 import ObjectID from "../../../Types/ObjectID";
 import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
@@ -151,6 +153,7 @@ interface PublicRequest {
 }
 
 let publicRequests: Array<PublicRequest> = [];
+let publicTimelinePayload: JSONArray = [];
 
 const PUBLIC_DASHBOARD_CONTEXT: PublicDashboardContext = {
   dashboardId: DASHBOARD_ID,
@@ -162,7 +165,7 @@ const PUBLIC_DASHBOARD_CONTEXT: PublicDashboardContext = {
   postJSON: (route: string, body: JSONObject) => {
     publicRequests.push({ route, body });
     return Promise.resolve({
-      data: { data: [] },
+      data: { data: publicTimelinePayload },
     } as unknown as HTTPResponse<JSONObject>);
   },
 } as unknown as PublicDashboardContext;
@@ -327,14 +330,14 @@ const buildBaseProps: BuildPropsFunction = (
   };
 };
 
-type RenderWidgetFunction = (
+type BuildComponentFunction = (
   args?: DashboardMonitorListComponent["arguments"] | undefined,
-) => RenderResult;
+) => DashboardMonitorListComponent;
 
-const renderWidget: RenderWidgetFunction = (
+const buildComponent: BuildComponentFunction = (
   args?: DashboardMonitorListComponent["arguments"] | undefined,
-): RenderResult => {
-  const component: DashboardMonitorListComponent = {
+): DashboardMonitorListComponent => {
+  return {
     _type: ObjectType.DashboardComponent,
     componentId: COMPONENT_ID,
     componentType: DashboardComponentType.MonitorList,
@@ -346,6 +349,16 @@ const renderWidget: RenderWidgetFunction = (
     minHeightInDashboardUnits: 3,
     arguments: args || { viewMode: "timeline" },
   } as unknown as DashboardMonitorListComponent;
+};
+
+type RenderWidgetFunction = (
+  args?: DashboardMonitorListComponent["arguments"] | undefined,
+) => RenderResult;
+
+const renderWidget: RenderWidgetFunction = (
+  args?: DashboardMonitorListComponent["arguments"] | undefined,
+): RenderResult => {
+  const component: DashboardMonitorListComponent = buildComponent(args);
 
   /*
    * The list view links each monitor with AppLink, which needs a router in
@@ -381,6 +394,7 @@ const segmentStyles: SegmentStyleFunction = (): Array<{
 beforeEach((): void => {
   jest.clearAllMocks();
   publicRequests = [];
+  publicTimelinePayload = [];
   monitorsResponse = [
     buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
     buildMonitor({
@@ -487,7 +501,7 @@ describe("Monitor List widget — State Timeline", () => {
       ).toEqual(START_DATE);
     });
 
-    test("orders history by startsAt, the clock the timeline math uses", async (): Promise<void> => {
+    test("orders history newest-first by startsAt, so a row cap cannot eat the current status", async (): Promise<void> => {
       renderWidget({ viewMode: "timeline" });
 
       await waitFor((): void => {
@@ -495,12 +509,17 @@ describe("Monitor List widget — State Timeline", () => {
       });
 
       /*
-       * startsAt and createdAt are different clocks (DB now() vs worker
-       * moment()) with real skew; sorting by createdAt can put segments out
-       * of order and make the last one — the "current status" — wrong.
+       * startsAt, not createdAt: they are different clocks (DB now() vs worker
+       * moment()) with real skew, and startsAt is the one the timeline math
+       * orders by.
+       *
+       * DESCENDING because the read is capped. A flapping fleet can produce
+       * more rows than the cap, and ascending would hand back the OLDEST of
+       * them — silently dropping the newest, which is exactly where the lane
+       * reads its current status and last change from.
        */
       expect(callsFor(MonitorStatusTimeline)[0]!.sort).toEqual({
-        startsAt: SortOrder.Ascending,
+        startsAt: SortOrder.Descending,
       });
     });
 
@@ -661,7 +680,9 @@ describe("Monitor List widget — State Timeline", () => {
        * than A's and the bars would stop lining up down the column — which is
        * the entire point of stacking them.
        */
-      timelinesResponse = [operational(MONITOR_A_ID, "2026-09-01T08:00:00.000Z")];
+      timelinesResponse = [
+        operational(MONITOR_A_ID, "2026-09-01T08:00:00.000Z"),
+      ];
 
       renderWidget({ viewMode: "timeline" });
 
@@ -695,7 +716,7 @@ describe("Monitor List widget — State Timeline", () => {
       );
       expect(lane).toHaveAttribute(
         "aria-label",
-        "core-switch-01: currently Offline, 0% uptime in this time range.",
+        "core-switch-01: Offline at the end of this time range, 0% uptime.",
       );
     });
 
@@ -962,6 +983,175 @@ describe("Monitor List widget — State Timeline", () => {
       });
 
       expect(screen.queryAllByTestId("state-timeline-no-data")).toHaveLength(2);
+    });
+  });
+
+  describe("reacting to a time range change", () => {
+    type RerenderWithRangeFunction = (
+      result: RenderResult,
+      range: RangeStartAndEndDateTime,
+    ) => void;
+
+    const rerenderWithRange: RerenderWithRangeFunction = (
+      result: RenderResult,
+      range: RangeStartAndEndDateTime,
+    ): void => {
+      result.rerender(
+        <MemoryRouter>
+          <DashboardMonitorListComponentElement
+            {...buildBaseProps({ dashboardStartAndEndDate: range })}
+            component={buildComponent({ viewMode: "timeline" })}
+          />
+        </MemoryRouter>,
+      );
+    };
+
+    test("refetches history for the new window when the range changes", async (): Promise<void> => {
+      const result: RenderResult = renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(1);
+      });
+
+      const widerStart: Date = new Date("2026-09-01T04:00:00.000Z");
+      rerenderWithRange(result, {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(widerStart, END_DATE),
+      });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(2);
+      });
+
+      /*
+       * The memo comparator has to let a range change through in timeline
+       * mode, and the fetch has to key on the new window — otherwise the axis
+       * is relabelled while the bars still describe the old one.
+       */
+      const second: ListArgs = callsFor(MonitorStatusTimeline)[1]!;
+      expect(
+        (second.query["endsAt"] as unknown as GreaterThanOrNull<Date>).value,
+      ).toEqual(widerStart);
+    });
+
+    test("does NOT refetch in list view when only the range changes", async (): Promise<void> => {
+      /*
+       * A list-mode Monitor List query does not read the range at all. Every
+       * such widget on a board refiring on every range change is pure waste,
+       * and the memo comparator is the only thing standing between them.
+       */
+      const result: RenderResult = render(
+        <MemoryRouter>
+          <DashboardMonitorListComponentElement
+            {...buildBaseProps()}
+            component={buildComponent({})}
+          />
+        </MemoryRouter>,
+      );
+
+      await screen.findByText("core-switch-01");
+      expect(callsFor(Monitor)).toHaveLength(1);
+
+      result.rerender(
+        <MemoryRouter>
+          <DashboardMonitorListComponentElement
+            {...buildBaseProps({
+              dashboardStartAndEndDate: {
+                range: TimeRange.CUSTOM,
+                startAndEndDate: new InBetween<Date>(
+                  new Date("2026-09-01T04:00:00.000Z"),
+                  END_DATE,
+                ),
+              },
+            })}
+            component={buildComponent({})}
+          />
+        </MemoryRouter>,
+      );
+
+      await waitFor((): void => {
+        expect(callsFor(Monitor)).toHaveLength(1);
+      });
+      expect(callsFor(MonitorStatusTimeline)).toHaveLength(0);
+    });
+
+    test("clamps an over-long custom range to what the server will serve", async (): Promise<void> => {
+      /*
+       * The public route caps the window at 92 days. If the browser drew the
+       * range it asked for rather than the one it can get, the axis would
+       * label months of chart against history the server only returned the
+       * tail of.
+       */
+      const result: RenderResult = renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(1);
+      });
+
+      rerenderWithRange(result, {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date("2020-01-01T00:00:00.000Z"),
+          END_DATE,
+        ),
+      });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(2);
+      });
+
+      const requestedStart: Date = (
+        callsFor(MonitorStatusTimeline)[1]!.query[
+          "endsAt"
+        ] as unknown as GreaterThanOrNull<Date>
+      ).value;
+
+      expect(END_DATE.getTime() - requestedStart.getTime()).toBe(
+        MAX_STATE_TIMELINE_WINDOW_IN_DAYS * 24 * 60 * 60 * 1000,
+      );
+    });
+  });
+
+  describe("reading a real public payload", () => {
+    beforeEach((): void => {
+      setPublicDashboardContext(PUBLIC_DASHBOARD_CONTEXT);
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+    });
+
+    test("renders lanes from the serialized rows the route actually returns", async (): Promise<void> => {
+      /*
+       * The public path goes through BaseModel.fromJSONArray rather than
+       * ModelAPI, so nothing else in this suite exercises the deserialization
+       * the widget depends on. The payload below is what the route's
+       * sendEntityArrayResponse produces for two rows.
+       */
+      publicTimelinePayload = BaseModel.toJSONArray(
+        [
+          operational(
+            MONITOR_A_ID,
+            "2026-09-01T08:00:00.000Z",
+            "2026-09-01T10:00:00.000Z",
+          ),
+          offline(MONITOR_A_ID, "2026-09-01T10:00:00.000Z"),
+        ],
+        MonitorStatusTimeline,
+      );
+
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(segmentStyles()).toHaveLength(2);
+      });
+
+      expect(segmentStyles()).toEqual([
+        { left: "0%", width: "50%" },
+        { left: "50%", width: "50%" },
+      ]);
+      expect(
+        await screen.findByTestId("state-timeline-trailing-label"),
+      ).toHaveTextContent("50%");
     });
   });
 

--- a/Common/Tests/App/Dashboard/MonitorListStateTimeline.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorListStateTimeline.test.tsx
@@ -1,0 +1,988 @@
+/** @timezone UTC */
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  RenderResult,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import { MemoryRouter } from "react-router-dom";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The Monitor List widget's State Timeline view (issue #3503): one lane per
+ * monitor, each lane a run of status-coloured bars across the dashboard's time
+ * range.
+ *
+ * Two things are asserted here that nothing else can catch.
+ *
+ * The REQUESTS: the timeline is a second read, and it must only happen in the
+ * mode that draws it (a list or honeycomb widget must not pay for status
+ * history), it must be ONE query for all monitors rather than one per monitor,
+ * and on a public dashboard it must go through the dashboard-scoped endpoint
+ * rather than the private CRUD route whose 401 sends the viewer to
+ * /accounts/login.
+ *
+ * The GEOMETRY: the bars are positioned in percentages, so a wrong percentage
+ * is a wrong answer on a wall display rather than a crash. jsdom measures
+ * every element as 0x0, which is exactly why the widget computes percentages
+ * instead of pixels — and why they can be asserted here at all.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+const getCurrentProjectIdMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the compiled
+ * requires, so the mock variables above are still unassigned when the factory
+ * runs. Dereferencing them lazily, at call time, is what makes this work.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      getCommonHeaders: () => {
+        return {};
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: (...args: Array<any>) => {
+        return getCurrentProjectIdMock(...args);
+      },
+    },
+  };
+});
+
+import DashboardMonitorListComponentElement from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent";
+import { DashboardBaseComponentProps } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent";
+import {
+  PublicDashboardContext,
+  setPublicDashboardContext,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import GreaterThanOrNull from "../../../Types/BaseDatabase/GreaterThanOrNull";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import LessThanOrEqual from "../../../Types/BaseDatabase/LessThanOrEqual";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { Green, Red } from "../../../Types/BrandColors";
+import Color from "../../../Types/Color";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardMonitorListComponent from "../../../Types/Dashboard/DashboardComponents/DashboardMonitorListComponent";
+import MonitorStateTimelineTooltipField from "../../../Types/Dashboard/MonitorStateTimelineTooltipField";
+import PublicDashboardMonitorStateTimelinePolicy from "../../../Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { JSONObject, ObjectType } from "../../../Types/JSON";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+const COMPONENT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const DASHBOARD_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const MONITOR_A_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const MONITOR_B_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+const OPERATIONAL_STATUS_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+
+/*
+ * A CUSTOM range pins the window to fixed instants; a relative range would
+ * resolve against the wall clock and make every percentage in this file drift.
+ * Four hours, so the fractions below are round numbers.
+ */
+const START_DATE: Date = new Date("2026-09-01T08:00:00.000Z");
+const END_DATE: Date = new Date("2026-09-01T12:00:00.000Z");
+
+const DASHBOARD_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(START_DATE, END_DATE),
+};
+
+const DASHBOARD_VIEW_CONFIG: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [],
+  heightInDashboardUnits: 60,
+};
+
+/** Every postJSON call the public dashboard client received. */
+interface PublicRequest {
+  route: string;
+  body: JSONObject;
+}
+
+let publicRequests: Array<PublicRequest> = [];
+
+const PUBLIC_DASHBOARD_CONTEXT: PublicDashboardContext = {
+  dashboardId: DASHBOARD_ID,
+  apiUrl: {
+    toString: (): string => {
+      return "http://localhost/public-dashboard-api";
+    },
+  },
+  postJSON: (route: string, body: JSONObject) => {
+    publicRequests.push({ route, body });
+    return Promise.resolve({
+      data: { data: [] },
+    } as unknown as HTTPResponse<JSONObject>);
+  },
+} as unknown as PublicDashboardContext;
+
+type BuildMonitorFunction = (data: {
+  id: ObjectID;
+  name: string;
+  statusName?: string | undefined;
+  statusColor?: Color | undefined;
+}) => Monitor;
+
+const buildMonitor: BuildMonitorFunction = (data: {
+  id: ObjectID;
+  name: string;
+  statusName?: string | undefined;
+  statusColor?: Color | undefined;
+}): Monitor => {
+  const monitor: Monitor = new Monitor();
+  monitor.id = data.id;
+  monitor.name = data.name;
+  monitor.monitorType = MonitorType.Ping;
+
+  const status: MonitorStatus = new MonitorStatus();
+  status.name = data.statusName || "Operational";
+  status.color = data.statusColor || Green;
+  monitor.currentMonitorStatus = status;
+
+  return monitor;
+};
+
+type BuildTimelineFunction = (data: {
+  monitorId: ObjectID;
+  statusId: ObjectID;
+  statusName: string;
+  color: Color;
+  isOperationalState: boolean;
+  priority: number;
+  startsAt: string;
+  endsAt?: string | undefined;
+}) => MonitorStatusTimeline;
+
+const buildTimeline: BuildTimelineFunction = (data: {
+  monitorId: ObjectID;
+  statusId: ObjectID;
+  statusName: string;
+  color: Color;
+  isOperationalState: boolean;
+  priority: number;
+  startsAt: string;
+  endsAt?: string | undefined;
+}): MonitorStatusTimeline => {
+  const status: MonitorStatus = new MonitorStatus();
+  status.id = data.statusId;
+  status.name = data.statusName;
+  status.color = data.color;
+  status.isOperationalState = data.isOperationalState;
+  status.priority = data.priority;
+
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+  timeline.monitorId = data.monitorId;
+  timeline.monitorStatusId = data.statusId;
+  timeline.monitorStatus = status;
+  timeline.startsAt = new Date(data.startsAt);
+  if (data.endsAt) {
+    timeline.endsAt = new Date(data.endsAt);
+  }
+
+  return timeline;
+};
+
+type OperationalFunction = (
+  monitorId: ObjectID,
+  startsAt: string,
+  endsAt?: string | undefined,
+) => MonitorStatusTimeline;
+
+const operational: OperationalFunction = (
+  monitorId: ObjectID,
+  startsAt: string,
+  endsAt?: string | undefined,
+): MonitorStatusTimeline => {
+  return buildTimeline({
+    monitorId,
+    statusId: OPERATIONAL_STATUS_ID,
+    statusName: "Operational",
+    color: Green,
+    isOperationalState: true,
+    priority: 1,
+    startsAt,
+    endsAt,
+  });
+};
+
+const offline: OperationalFunction = (
+  monitorId: ObjectID,
+  startsAt: string,
+  endsAt?: string | undefined,
+): MonitorStatusTimeline => {
+  return buildTimeline({
+    monitorId,
+    statusId: OFFLINE_STATUS_ID,
+    statusName: "Offline",
+    color: Red,
+    isOperationalState: false,
+    priority: 3,
+    startsAt,
+    endsAt,
+  });
+};
+
+/*
+ * The widget makes up to two list calls. They are told apart by modelType, not
+ * by call order, so a future reordering does not silently retarget the stubs.
+ */
+type ListArgs = { modelType: unknown; query: JSONObject; sort: JSONObject };
+
+let monitorsResponse: Array<Monitor> = [];
+let timelinesResponse: Array<MonitorStatusTimeline> = [];
+
+type CallsForFunction = (modelType: { new (): unknown }) => Array<ListArgs>;
+
+const callsFor: CallsForFunction = (modelType: {
+  new (): unknown;
+}): Array<ListArgs> => {
+  return (getListMock.mock.calls as Array<Array<ListArgs>>)
+    .map((call: Array<ListArgs>): ListArgs => {
+      return call[0] as ListArgs;
+    })
+    .filter((args: ListArgs) => {
+      return args.modelType === modelType;
+    });
+};
+
+type BuildPropsFunction = (
+  overrides?: Partial<DashboardBaseComponentProps>,
+) => DashboardBaseComponentProps;
+
+const buildBaseProps: BuildPropsFunction = (
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): DashboardBaseComponentProps => {
+  return {
+    componentId: COMPONENT_ID,
+    isEditMode: false,
+    isSelected: false,
+    key: "monitor-list-widget",
+    onComponentUpdate: (): void => {
+      // The widget never writes back through this.
+    },
+    totalCurrentDashboardWidthInPx: 1200,
+    dashboardCanvasTopInPx: 0,
+    dashboardCanvasLeftInPx: 0,
+    dashboardCanvasWidthInPx: 1200,
+    dashboardCanvasHeightInPx: 800,
+    dashboardComponentHeightInPx: 320,
+    dashboardComponentWidthInPx: 480,
+    dashboardViewConfig: DASHBOARD_VIEW_CONFIG,
+    dashboardStartAndEndDate: DASHBOARD_RANGE,
+    metricTypes: [],
+    refreshTick: 0,
+    variables: undefined,
+    ...overrides,
+  };
+};
+
+type RenderWidgetFunction = (
+  args?: DashboardMonitorListComponent["arguments"] | undefined,
+) => RenderResult;
+
+const renderWidget: RenderWidgetFunction = (
+  args?: DashboardMonitorListComponent["arguments"] | undefined,
+): RenderResult => {
+  const component: DashboardMonitorListComponent = {
+    _type: ObjectType.DashboardComponent,
+    componentId: COMPONENT_ID,
+    componentType: DashboardComponentType.MonitorList,
+    topInDashboardUnits: 0,
+    leftInDashboardUnits: 0,
+    widthInDashboardUnits: 6,
+    heightInDashboardUnits: 4,
+    minWidthInDashboardUnits: 6,
+    minHeightInDashboardUnits: 3,
+    arguments: args || { viewMode: "timeline" },
+  } as unknown as DashboardMonitorListComponent;
+
+  /*
+   * The list view links each monitor with AppLink, which needs a router in
+   * context. The timeline view does not, but the widget builds both trees, so
+   * every render goes through the router.
+   */
+  return render(
+    <MemoryRouter>
+      <DashboardMonitorListComponentElement
+        {...buildBaseProps()}
+        component={component}
+      />
+    </MemoryRouter>,
+  );
+};
+
+type SegmentStyleFunction = () => Array<{ left: string; width: string }>;
+
+const segmentStyles: SegmentStyleFunction = (): Array<{
+  left: string;
+  width: string;
+}> => {
+  return screen
+    .queryAllByTestId("state-timeline-segment")
+    .map((element: HTMLElement): { left: string; width: string } => {
+      return {
+        left: element.style.left,
+        width: element.style.width,
+      };
+    });
+};
+
+beforeEach((): void => {
+  jest.clearAllMocks();
+  publicRequests = [];
+  monitorsResponse = [
+    buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+    buildMonitor({
+      id: MONITOR_B_ID,
+      name: "ap-lobby-02",
+      statusName: "Offline",
+      statusColor: Red,
+    }),
+  ];
+  timelinesResponse = [];
+  getCurrentProjectIdMock.mockReturnValue(PROJECT_ID);
+
+  getListMock.mockImplementation((...args: Array<any>) => {
+    const request: ListArgs = args[0] as ListArgs;
+
+    if (request.modelType === MonitorStatusTimeline) {
+      return Promise.resolve({
+        data: timelinesResponse,
+        count: timelinesResponse.length,
+      });
+    }
+
+    return Promise.resolve({
+      data: monitorsResponse,
+      count: monitorsResponse.length,
+    });
+  });
+});
+
+afterEach((): void => {
+  cleanup();
+  setPublicDashboardContext(null);
+});
+
+describe("Monitor List widget — State Timeline", () => {
+  describe("when to read status history at all", () => {
+    test("does not read status history in the default list view", async (): Promise<void> => {
+      renderWidget({});
+
+      await screen.findByText("core-switch-01");
+
+      /*
+       * The list view renders only the CURRENT status, which the monitor row
+       * already carries. A second read here would double every list widget's
+       * cost for data it never draws.
+       */
+      expect(callsFor(MonitorStatusTimeline)).toHaveLength(0);
+    });
+
+    test("does not read status history in honeycomb view", async (): Promise<void> => {
+      renderWidget({ viewMode: "honeycomb" });
+
+      await waitFor((): void => {
+        expect(callsFor(Monitor).length).toBeGreaterThan(0);
+      });
+
+      expect(callsFor(MonitorStatusTimeline)).toHaveLength(0);
+    });
+
+    test("reads status history once for every monitor in timeline view", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(1);
+      });
+
+      /*
+       * One IN query, not one request per monitor: a widget showing 25
+       * devices on a wall display would otherwise blow the public
+       * dashboard's per-IP rate limit on its own.
+       */
+      const query: JSONObject = callsFor(MonitorStatusTimeline)[0]!.query;
+      const monitorId: Includes = query["monitorId"] as unknown as Includes;
+
+      expect(monitorId).toBeInstanceOf(Includes);
+      expect(
+        monitorId.values.map((value: unknown) => {
+          return String(value);
+        }),
+      ).toEqual([MONITOR_A_ID.toString(), MONITOR_B_ID.toString()]);
+    });
+
+    test("asks for every row overlapping the window, not just rows inside it", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(1);
+      });
+
+      const call: ListArgs = callsFor(MonitorStatusTimeline)[0]!;
+
+      /*
+       * A device that went Offline yesterday has exactly ONE row and it
+       * starts before the window. Querying `startsAt BETWEEN` would render an
+       * empty lane for the device that has been down the whole time.
+       */
+      expect(call.query["startsAt"]).toBeInstanceOf(LessThanOrEqual);
+      expect(
+        (call.query["startsAt"] as unknown as LessThanOrEqual<Date>).value,
+      ).toEqual(END_DATE);
+      expect(call.query["endsAt"]).toBeInstanceOf(GreaterThanOrNull);
+      expect(
+        (call.query["endsAt"] as unknown as GreaterThanOrNull<Date>).value,
+      ).toEqual(START_DATE);
+    });
+
+    test("orders history by startsAt, the clock the timeline math uses", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(1);
+      });
+
+      /*
+       * startsAt and createdAt are different clocks (DB now() vs worker
+       * moment()) with real skew; sorting by createdAt can put segments out
+       * of order and make the last one — the "current status" — wrong.
+       */
+      expect(callsFor(MonitorStatusTimeline)[0]!.sort).toEqual({
+        startsAt: SortOrder.Ascending,
+      });
+    });
+
+    test("scopes the history read to the current project", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(callsFor(MonitorStatusTimeline)).toHaveLength(1);
+      });
+
+      expect(callsFor(MonitorStatusTimeline)[0]!.query["projectId"]).toEqual(
+        PROJECT_ID,
+      );
+    });
+  });
+
+  describe("lane geometry", () => {
+    test("draws one lane per monitor, labelled with its name", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-row")).toHaveLength(2);
+      });
+
+      expect(screen.getByText("core-switch-01")).toBeInTheDocument();
+      expect(screen.getByText("ap-lobby-02")).toBeInTheDocument();
+    });
+
+    test("positions each bar by its share of the visible window", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [
+        operational(
+          MONITOR_A_ID,
+          "2026-09-01T08:00:00.000Z",
+          "2026-09-01T10:00:00.000Z",
+        ),
+        offline(
+          MONITOR_A_ID,
+          "2026-09-01T10:00:00.000Z",
+          "2026-09-01T11:00:00.000Z",
+        ),
+        operational(MONITOR_A_ID, "2026-09-01T11:00:00.000Z"),
+      ];
+
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(segmentStyles()).toHaveLength(3);
+      });
+
+      // 2h operational, 1h offline, 1h operational, in a 4h window.
+      expect(segmentStyles()).toEqual([
+        { left: "0%", width: "50%" },
+        { left: "50%", width: "25%" },
+        { left: "75%", width: "25%" },
+      ]);
+    });
+
+    test("fills the lane for a monitor that was down before the window opened", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({
+          id: MONITOR_A_ID,
+          name: "core-switch-01",
+          statusName: "Offline",
+          statusColor: Red,
+        }),
+      ];
+      timelinesResponse = [offline(MONITOR_A_ID, "2026-08-30T00:00:00.000Z")];
+
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(segmentStyles()).toHaveLength(1);
+      });
+
+      expect(segmentStyles()[0]).toEqual({ left: "0%", width: "100%" });
+    });
+
+    test("paints each bar with the status's configured colour", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [
+        operational(
+          MONITOR_A_ID,
+          "2026-09-01T08:00:00.000Z",
+          "2026-09-01T10:00:00.000Z",
+        ),
+        offline(MONITOR_A_ID, "2026-09-01T10:00:00.000Z"),
+      ];
+
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-segment")).toHaveLength(
+          2,
+        );
+      });
+
+      /*
+       * Monitor status colours are a per-project setting (Monitors →
+       * Settings → Monitor Status). A literal palette here would silently
+       * override whatever the operator configured.
+       */
+      const colors: Array<string> = screen
+        .getAllByTestId("state-timeline-segment")
+        .map((element: HTMLElement): string => {
+          return element.style.backgroundColor;
+        });
+
+      expect(colors[0]).toBe("rgb(42, 181, 125)");
+      expect(colors[1]).toBe("rgb(253, 98, 94)");
+    });
+
+    test("says so, rather than drawing nothing, when a monitor has no history", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [];
+
+      renderWidget({ viewMode: "timeline" });
+
+      expect(
+        await screen.findByTestId("state-timeline-no-data"),
+      ).toHaveTextContent("No status history");
+      expect(
+        screen.queryAllByTestId("state-timeline-trailing-label"),
+      ).toHaveLength(0);
+    });
+
+    test("shows the uptime for the visible range beside the lane", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [
+        operational(
+          MONITOR_A_ID,
+          "2026-09-01T06:00:00.000Z",
+          "2026-09-01T11:00:00.000Z",
+        ),
+        offline(MONITOR_A_ID, "2026-09-01T11:00:00.000Z"),
+      ];
+
+      renderWidget({ viewMode: "timeline" });
+
+      // 1 hour offline out of the 4 hour window.
+      expect(
+        await screen.findByTestId("state-timeline-trailing-label"),
+      ).toHaveTextContent("75%");
+    });
+
+    test("reserves the same trailing column on every lane, even the empty ones", async (): Promise<void> => {
+      /*
+       * Only monitor A has history, so only monitor A has an uptime figure.
+       * If the trailing slot were rendered per-lane, B's track would be wider
+       * than A's and the bars would stop lining up down the column — which is
+       * the entire point of stacking them.
+       */
+      timelinesResponse = [operational(MONITOR_A_ID, "2026-09-01T08:00:00.000Z")];
+
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-row")).toHaveLength(2);
+      });
+
+      const trailing: Array<HTMLElement> = screen.getAllByTestId(
+        "state-timeline-trailing-label",
+      );
+
+      expect(trailing).toHaveLength(2);
+      expect(trailing[0]).toHaveTextContent("100%");
+      expect(trailing[1]?.textContent).toBe("");
+    });
+
+    test("summarises the lane for a screen reader", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [offline(MONITOR_A_ID, "2026-09-01T08:00:00.000Z")];
+
+      renderWidget({ viewMode: "timeline" });
+
+      /*
+       * The bars themselves are aria-hidden — a screen reader reading out
+       * fifty coloured divs is noise — so the lane carries the summary.
+       */
+      const lane: HTMLElement = await screen.findByTestId(
+        "state-timeline-lane",
+      );
+      expect(lane).toHaveAttribute(
+        "aria-label",
+        "core-switch-01: currently Offline, 0% uptime in this time range.",
+      );
+    });
+
+    test("labels the axis at both edges of the window", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(
+          screen.queryAllByTestId("state-timeline-axis-tick").length,
+        ).toBeGreaterThan(1);
+      });
+
+      const ticks: Array<HTMLElement> = screen.getAllByTestId(
+        "state-timeline-axis-tick",
+      );
+
+      expect(ticks[0]).toHaveTextContent("08:00");
+      expect(ticks[ticks.length - 1]).toHaveTextContent("12:00");
+    });
+
+    test("explains only the statuses actually drawn", async (): Promise<void> => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [
+        operational(
+          MONITOR_A_ID,
+          "2026-09-01T08:00:00.000Z",
+          "2026-09-01T10:00:00.000Z",
+        ),
+        offline(MONITOR_A_ID, "2026-09-01T10:00:00.000Z"),
+      ];
+
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(
+          screen.queryAllByTestId("state-timeline-legend-item"),
+        ).toHaveLength(2);
+      });
+
+      expect(
+        screen
+          .getAllByTestId("state-timeline-legend-item")
+          .map((element: HTMLElement): string | null => {
+            return element.textContent;
+          }),
+      ).toEqual(["Operational", "Offline"]);
+    });
+  });
+
+  describe("the hover card", () => {
+    beforeEach((): void => {
+      monitorsResponse = [
+        buildMonitor({ id: MONITOR_A_ID, name: "core-switch-01" }),
+      ];
+      timelinesResponse = [
+        operational(
+          MONITOR_A_ID,
+          "2026-09-01T08:00:00.000Z",
+          "2026-09-01T10:00:00.000Z",
+        ),
+        offline(MONITOR_A_ID, "2026-09-01T10:00:00.000Z"),
+      ];
+    });
+
+    test("shows nothing until a bar is hovered", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-segment")).toHaveLength(
+          2,
+        );
+      });
+
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    test("names the monitor and the default rows when a bar is hovered", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-segment")).toHaveLength(
+          2,
+        );
+      });
+
+      fireEvent.mouseEnter(
+        screen.getAllByTestId("state-timeline-segment")[1] as HTMLElement,
+      );
+
+      const tooltip: HTMLElement = await screen.findByRole("tooltip");
+
+      expect(tooltip).toHaveTextContent("core-switch-01");
+      expect(tooltip).toHaveTextContent("Status");
+      expect(tooltip).toHaveTextContent("Offline");
+      expect(tooltip).toHaveTextContent("Started");
+      expect(tooltip).toHaveTextContent("Ended");
+      expect(tooltip).toHaveTextContent("Duration");
+      expect(tooltip).toHaveTextContent("2 hours");
+
+      // Not in the default set.
+      expect(tooltip).not.toHaveTextContent("Uptime in range");
+    });
+
+    test("shows exactly the rows the widget was configured with", async (): Promise<void> => {
+      renderWidget({
+        viewMode: "timeline",
+        timelineTooltipFields: [
+          MonitorStateTimelineTooltipField.UptimePercent,
+          MonitorStateTimelineTooltipField.MonitorType,
+        ],
+      });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-segment")).toHaveLength(
+          2,
+        );
+      });
+
+      fireEvent.mouseEnter(
+        screen.getAllByTestId("state-timeline-segment")[1] as HTMLElement,
+      );
+
+      const tooltip: HTMLElement = await screen.findByRole("tooltip");
+
+      expect(tooltip).toHaveTextContent("Uptime in range");
+      expect(tooltip).toHaveTextContent("50%");
+      expect(tooltip).toHaveTextContent("Monitor type");
+      expect(tooltip).toHaveTextContent(MonitorType.Ping);
+      expect(tooltip).not.toHaveTextContent("Duration");
+    });
+
+    test("honours an explicitly emptied selection instead of restoring defaults", async (): Promise<void> => {
+      /*
+       * Clearing the field is a choice. Falling back to the defaults here
+       * would make the control look broken — clear it, save, and every row
+       * comes straight back.
+       */
+      renderWidget({ viewMode: "timeline", timelineTooltipFields: [] });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-segment")).toHaveLength(
+          2,
+        );
+      });
+
+      fireEvent.mouseEnter(
+        screen.getAllByTestId("state-timeline-segment")[0] as HTMLElement,
+      );
+
+      const tooltip: HTMLElement = await screen.findByRole("tooltip");
+
+      expect(tooltip).toHaveTextContent("core-switch-01");
+      expect(tooltip).not.toHaveTextContent("Duration");
+      expect(tooltip).not.toHaveTextContent("Started");
+    });
+
+    test("disappears when the pointer leaves the bar", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-segment")).toHaveLength(
+          2,
+        );
+      });
+
+      const segment: HTMLElement = screen.getAllByTestId(
+        "state-timeline-segment",
+      )[0] as HTMLElement;
+
+      fireEvent.mouseEnter(segment);
+      expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+      fireEvent.mouseLeave(segment);
+      await waitFor((): void => {
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("on a public dashboard", () => {
+    beforeEach((): void => {
+      setPublicDashboardContext(PUBLIC_DASHBOARD_CONTEXT);
+    });
+
+    test("reads status history through the dashboard-scoped endpoint", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(publicRequests).toHaveLength(1);
+      });
+
+      /*
+       * Never the private CRUD route: its 401 redirects an anonymous viewer
+       * to /accounts/login instead of showing the dashboard they were sent.
+       */
+      expect(publicRequests[0]!.route).toBe(
+        `/monitor-status-timeline/${DASHBOARD_ID.toString()}`,
+      );
+      expect(callsFor(MonitorStatusTimeline)).toHaveLength(0);
+    });
+
+    test("sends the component id and the window, and no monitor ids", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(publicRequests).toHaveLength(1);
+      });
+
+      const body: JSONObject = publicRequests[0]!.body;
+
+      /*
+       * The monitor set is a SELECTOR, and the public route re-derives it
+       * from the stored widget precisely so an anonymous caller never gets to
+       * choose it. Sending ids from here would hand that back.
+       */
+      expect(body["componentId"]).toBe(COMPONENT_ID.toString());
+      expect(body["monitorIds"]).toBeUndefined();
+
+      const window: JSONObject = body["startAndEndDate"] as JSONObject;
+      expect(window["_type"]).toBe(ObjectType.InBetween);
+      expect(new Date(window["startValue"] as string)).toEqual(START_DATE);
+      expect(new Date(window["endValue"] as string)).toEqual(END_DATE);
+    });
+
+    test("sends a window the server-side policy actually accepts", async (): Promise<void> => {
+      /*
+       * The one assertion that spans the wire. The body is round-tripped
+       * through JSON first, because that is what an HTTP request does to it,
+       * and then handed to the real policy the public route runs.
+       *
+       * This is not hypothetical: wrapping the window in
+       * JSONFunctions.serialize (as the other public widget bodies do) encodes
+       * each bound as {_type: "DateTime", value}, InBetween.fromJSON copies
+       * those objects across verbatim, and the route rejects every request
+       * with "range contains an invalid date". Nothing on either side of the
+       * wire catches that alone.
+       */
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(publicRequests).toHaveLength(1);
+      });
+
+      const overTheWire: JSONObject = JSON.parse(
+        JSON.stringify(publicRequests[0]!.body),
+      ) as JSONObject;
+
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindowFromBody(
+          overTheWire,
+        );
+
+      expect(window.startValue).toEqual(START_DATE);
+      expect(window.endValue).toEqual(END_DATE);
+    });
+
+    test("still renders lanes when the public endpoint returns no history", async (): Promise<void> => {
+      renderWidget({ viewMode: "timeline" });
+
+      await waitFor((): void => {
+        expect(screen.queryAllByTestId("state-timeline-row")).toHaveLength(2);
+      });
+
+      expect(screen.queryAllByTestId("state-timeline-no-data")).toHaveLength(2);
+    });
+  });
+
+  describe("the other view modes still work", () => {
+    test("renders the table rows in list view", async (): Promise<void> => {
+      renderWidget({});
+
+      expect(await screen.findByText("core-switch-01")).toBeInTheDocument();
+      expect(screen.queryAllByTestId("state-timeline-row")).toHaveLength(0);
+    });
+
+    test("treats an unknown stored viewMode as the list view", async (): Promise<void> => {
+      /*
+       * A dashboard saved by a newer version could name a mode this build
+       * does not have; falling through to the list is the one mode that
+       * always has something to draw.
+       */
+      renderWidget({ viewMode: "heatmap" as "list" });
+
+      expect(await screen.findByText("core-switch-01")).toBeInTheDocument();
+      expect(callsFor(MonitorStatusTimeline)).toHaveLength(0);
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/WidgetCatalog.test.ts
+++ b/Common/Tests/App/Dashboard/WidgetCatalog.test.ts
@@ -334,9 +334,30 @@ describe("WidgetCatalog", () => {
     });
 
     test("matches text that only appears in the description", () => {
-      expect(getMatchedTypes("honeycomb")).toEqual([
-        DashboardComponentType.CephOsdList,
-      ]);
+      /*
+       * Two widgets name the honeycomb in their copy: the Ceph OSD list, which
+       * defaults to it, and the Monitor List, which offers it alongside the
+       * list and the state timeline.
+       */
+      expect(getMatchedTypes("honeycomb").sort()).toEqual(
+        [
+          DashboardComponentType.CephOsdList,
+          DashboardComponentType.MonitorList,
+        ].sort(),
+      );
+    });
+
+    test("finds the Monitor List by what its timeline mode is for", () => {
+      /*
+       * The reason someone opens this picker at all (issue #3503) is to see
+       * when a device went down and for how long, so those are the words that
+       * have to lead there.
+       */
+      for (const term of ["state timeline", "status history", "downtime"]) {
+        expect(getMatchedTypes(term)).toContain(
+          DashboardComponentType.MonitorList,
+        );
+      }
     });
 
     test("matches keywords that are not in the visible copy", () => {

--- a/Common/Tests/Server/API/DashboardPublicRateLimit.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicRateLimit.test.ts
@@ -216,6 +216,11 @@ const buildPublicRoutes: (dashboardId: string) => Array<PublicRoute> = (
     },
     {
       method: "POST",
+      uri: "/dashboard/monitor-status-timeline/:dashboardId",
+      params: { dashboardId },
+    },
+    {
+      method: "POST",
       uri: "/dashboard/master-password/:dashboardId",
       params: { dashboardId },
     },

--- a/Common/Tests/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.test.ts
+++ b/Common/Tests/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.test.ts
@@ -1,0 +1,305 @@
+import PublicDashboardMonitorStateTimelinePolicy, {
+  MAX_PUBLIC_STATE_TIMELINE_ROWS,
+  MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS,
+  PUBLIC_STATE_TIMELINE_SELECT,
+} from "../../../../Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject, ObjectType } from "../../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The state-timeline route is unauthenticated. Which monitors it reads comes
+ * from the stored widget and the project comes from the dashboard, so the time
+ * window is the ONLY thing a caller still controls — and this policy is the
+ * whole boundary around it. Everything below is written from that angle: what
+ * a caller can move, what it provably cannot, and what the response may carry.
+ */
+
+const RANGE_START: Date = new Date("2026-08-09T00:00:00.000Z");
+const RANGE_END: Date = new Date("2026-08-09T06:00:00.000Z");
+
+const MS_PER_DAY: number = 24 * 60 * 60 * 1000;
+
+type SerializedRangeFunction = (
+  startValue: unknown,
+  endValue: unknown,
+) => JSONObject;
+
+/*
+ * The wire form of an InBetween, exactly as JSONFunctions.serialize produces
+ * it on the browser side — dates as ISO strings, not Date instances.
+ */
+const serializedRange: SerializedRangeFunction = (
+  startValue: unknown,
+  endValue: unknown,
+): JSONObject => {
+  return {
+    _type: ObjectType.InBetween,
+    startValue: startValue,
+    endValue: endValue,
+  } as JSONObject;
+};
+
+describe("PublicDashboardMonitorStateTimelinePolicy", () => {
+  describe("resolveWindow", () => {
+    it("accepts a well-formed range sent as ISO strings", () => {
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(RANGE_START.toISOString(), RANGE_END.toISOString()),
+        );
+
+      expect(window.startValue).toEqual(RANGE_START);
+      expect(window.endValue).toEqual(RANGE_END);
+    });
+
+    it("accepts a range that already carries real Dates", () => {
+      /*
+       * The deserializer may hand back either shape depending on how the body
+       * was encoded, so both have to work.
+       */
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(RANGE_START, RANGE_END),
+        );
+
+      expect(window.startValue).toEqual(RANGE_START);
+      expect(window.endValue).toEqual(RANGE_END);
+    });
+
+    it("returns a copy rather than the caller's Date objects", () => {
+      const mutableStart: Date = new Date(RANGE_START.getTime());
+
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(mutableStart, RANGE_END),
+        );
+
+      mutableStart.setFullYear(1999);
+
+      expect(window.startValue.getFullYear()).toBe(2026);
+    });
+
+    it("rejects a body that is not a range at all", () => {
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.resolveWindow({
+          startValue: RANGE_START.toISOString(),
+          endValue: RANGE_END.toISOString(),
+        } as JSONObject);
+      }).toThrow(BadDataException);
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["a bare string", "2026-08-09"],
+      ["a number", 1754697600000],
+      ["an array", []],
+    ])("rejects %s in place of a range", (_label: string, value: unknown) => {
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(value);
+      }).toThrow(BadDataException);
+    });
+
+    it.each([
+      ["an unparseable string", "not-a-date"],
+      ["a number", 1754697600000],
+      ["null", null],
+      ["an object", {}],
+    ])(
+      "rejects a range whose start is %s",
+      (_label: string, value: unknown) => {
+        expect(() => {
+          return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+            serializedRange(value, RANGE_END.toISOString()),
+          );
+        }).toThrow(BadDataException);
+      },
+    );
+
+    it("rejects a range whose end is unparseable", () => {
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(RANGE_START.toISOString(), "not-a-date"),
+        );
+      }).toThrow(BadDataException);
+    });
+
+    it("rejects an absurdly long date string rather than parsing it", () => {
+      /*
+       * Date parsing is the one place a caller controls the length of a string
+       * this route will work on, so it is bounded before it reaches the parser.
+       */
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(
+            "2026-08-09T00:00:00.000Z".padEnd(200, " "),
+            RANGE_END,
+          ),
+        );
+      }).toThrow(BadDataException);
+    });
+
+    it("rejects an inverted range", () => {
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(RANGE_END.toISOString(), RANGE_START.toISOString()),
+        );
+      }).toThrow(BadDataException);
+    });
+
+    it("rejects a zero-length range", () => {
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(RANGE_START.toISOString(), RANGE_START.toISOString()),
+        );
+      }).toThrow(BadDataException);
+    });
+
+    it("leaves a range at the ceiling exactly as it is", () => {
+      const start: Date = new Date(
+        RANGE_END.getTime() -
+          MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY,
+      );
+
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(start.toISOString(), RANGE_END.toISOString()),
+        );
+
+      expect(window.startValue).toEqual(start);
+      expect(window.endValue).toEqual(RANGE_END);
+    });
+
+    it("clamps a range longer than the ceiling instead of rejecting it", () => {
+      /*
+       * A wall display asking for too much should draw a shorter range, not an
+       * error card. The END is what the viewer is looking at, so the START is
+       * the side that moves.
+       */
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(
+            new Date("2020-01-01T00:00:00.000Z").toISOString(),
+            RANGE_END.toISOString(),
+          ),
+        );
+
+      expect(window.endValue).toEqual(RANGE_END);
+      expect(window.endValue.getTime() - window.startValue.getTime()).toBe(
+        MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY,
+      );
+    });
+
+    it("bounds the window a caller can reach however far back it asks", () => {
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindow(
+          serializedRange(
+            new Date("1970-01-01T00:00:00.000Z").toISOString(),
+            RANGE_END.toISOString(),
+          ),
+        );
+
+      expect(
+        window.endValue.getTime() - window.startValue.getTime(),
+      ).toBeLessThanOrEqual(
+        MAX_PUBLIC_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY,
+      );
+    });
+  });
+
+  describe("resolveWindowFromBody", () => {
+    it("reads the range out of the startAndEndDate key", () => {
+      const window: InBetween<Date> =
+        PublicDashboardMonitorStateTimelinePolicy.resolveWindowFromBody({
+          componentId: "ignored",
+          startAndEndDate: serializedRange(
+            RANGE_START.toISOString(),
+            RANGE_END.toISOString(),
+          ),
+        } as JSONObject);
+
+      expect(window.startValue).toEqual(RANGE_START);
+      expect(window.endValue).toEqual(RANGE_END);
+    });
+
+    it.each([
+      ["an absent body", undefined],
+      ["an empty body", {}],
+      ["a body with no range", { componentId: "abc" }],
+    ])(
+      "refuses to guess a window given %s",
+      (_label: string, body: JSONObject | undefined) => {
+        /*
+         * Defaulting the window here would mean an anonymous request with no
+         * range at all still produced a read; the route requires one.
+         */
+        expect(() => {
+          return PublicDashboardMonitorStateTimelinePolicy.resolveWindowFromBody(
+            body,
+          );
+        }).toThrow(BadDataException);
+      },
+    );
+  });
+
+  describe("the response projection", () => {
+    it("selects only what the timeline draws", () => {
+      expect(PUBLIC_STATE_TIMELINE_SELECT).toEqual({
+        monitorId: true,
+        startsAt: true,
+        endsAt: true,
+        monitorStatus: {
+          _id: true,
+          name: true,
+          color: true,
+          isOperationalState: true,
+          priority: true,
+        },
+      });
+    });
+
+    it("never exposes the operator-facing columns of a timeline row", () => {
+      /*
+       * This read runs as root after only a dashboard read-access check, so
+       * this projection is the only thing keeping the rest of the row out of
+       * an anonymous response. rootCause and statusChangeLog carry probe
+       * output and internal error detail.
+       */
+      for (const column of [
+        "rootCause",
+        "statusChangeLog",
+        "isOwnerNotified",
+        "createdByUserId",
+        "createdByUser",
+        "projectId",
+      ]) {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            PUBLIC_STATE_TIMELINE_SELECT,
+            column,
+          ),
+        ).toBe(false);
+      }
+    });
+
+    it("selects the status id the uptime math keys off", () => {
+      /*
+       * UptimeUtil matches an event against the downtime statuses by
+       * monitorStatus.id. Without _id every segment collapses into one
+       * indistinguishable status and the lane reports 100% uptime through an
+       * outage.
+       */
+      expect(
+        (PUBLIC_STATE_TIMELINE_SELECT.monitorStatus as JSONObject)["_id"],
+      ).toBe(true);
+    });
+  });
+
+  describe("the row ceiling", () => {
+    it("bounds a single response well below the project list limit", () => {
+      expect(MAX_PUBLIC_STATE_TIMELINE_ROWS).toBeGreaterThan(0);
+      expect(MAX_PUBLIC_STATE_TIMELINE_ROWS).toBeLessThan(10000);
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.test.ts
+++ b/Common/Tests/Server/Utils/Dashboard/PublicDashboardMonitorStateTimelinePolicy.test.ts
@@ -42,6 +42,63 @@ const serializedRange: SerializedRangeFunction = (
 };
 
 describe("PublicDashboardMonitorStateTimelinePolicy", () => {
+  describe("assertWidgetDrawsTimeline", () => {
+    type WidgetFunction = (viewMode?: unknown) => JSONObject;
+
+    const widget: WidgetFunction = (viewMode?: unknown): JSONObject => {
+      return {
+        componentType: "MonitorList",
+        arguments: viewMode === undefined ? {} : ({ viewMode } as JSONObject),
+      } as JSONObject;
+    };
+
+    it("accepts a widget that is actually in timeline mode", () => {
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.assertWidgetDrawsTimeline(
+          widget("timeline"),
+        );
+      }).not.toThrow();
+    });
+
+    it.each([
+      ["list", "list"],
+      ["honeycomb", "honeycomb"],
+      ["an unset view mode", undefined],
+      ["a mode from a newer version", "heatmap"],
+      ["a non-string", 7],
+      ["null", null],
+    ])("refuses a widget in %s", (_label: string, viewMode: unknown) => {
+      /*
+       * A Monitor List in list or honeycomb mode publishes each monitor's
+       * name, type and CURRENT status and nothing more. Serving 92 days of
+       * every status change for one would hand out history its author never
+       * put on the page — adding the widget is the owner's ONLY opt-in, and
+       * the view mode is part of what they opted into.
+       */
+      expect(() => {
+        return PublicDashboardMonitorStateTimelinePolicy.assertWidgetDrawsTimeline(
+          widget(viewMode),
+        );
+      }).toThrow(BadDataException);
+    });
+
+    it.each([
+      ["no arguments object at all", {}],
+      ["a null arguments object", { arguments: null }],
+      ["an arguments array", { arguments: [] }],
+      ["a string arguments value", { arguments: "timeline" }],
+    ])(
+      "refuses a widget with %s rather than reading through it",
+      (_label: string, malformed: JSONObject) => {
+        expect(() => {
+          return PublicDashboardMonitorStateTimelinePolicy.assertWidgetDrawsTimeline(
+            { componentType: "MonitorList", ...malformed } as JSONObject,
+          );
+        }).toThrow(BadDataException);
+      },
+    );
+  });
+
   describe("resolveWindow", () => {
     it("accepts a well-formed range sent as ISO strings", () => {
       const window: InBetween<Date> =

--- a/Common/Tests/Types/Dashboard/MonitorStateTimelineTooltipField.test.ts
+++ b/Common/Tests/Types/Dashboard/MonitorStateTimelineTooltipField.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "@jest/globals";
+import MonitorStateTimelineTooltipField, {
+  DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS,
+  MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS,
+  MonitorStateTimelineTooltipFieldProps,
+  MonitorStateTimelineTooltipFieldUtil,
+} from "../../../Types/Dashboard/MonitorStateTimelineTooltipField";
+
+/*
+ * These values are persisted inside a saved dashboard's widget arguments, so
+ * this file is really pinning a stored config format: rename a value and every
+ * dashboard already configured with it silently loses that tooltip row, with
+ * nothing in the UI to say why.
+ *
+ * resolveFields is the boundary between "whatever is stored" and "what the
+ * tooltip renders", so it has to be total: an unset value, an empty selection,
+ * a value from a newer version, and a hand-edited config all have to land
+ * somewhere sensible.
+ */
+
+const ALL_FIELD_VALUES: Array<MonitorStateTimelineTooltipField> = Object.values(
+  MonitorStateTimelineTooltipField,
+);
+
+describe("MonitorStateTimelineTooltipField", () => {
+  describe("the declared field list", () => {
+    test("covers every member of the enum", () => {
+      /*
+       * A field in the enum but not in this list is unreachable: it can never
+       * be picked in the settings form and resolveFields would drop it.
+       */
+      expect(
+        MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+          (props: MonitorStateTimelineTooltipFieldProps) => {
+            return props.field;
+          },
+        ).sort(),
+      ).toEqual([...ALL_FIELD_VALUES].sort());
+    });
+
+    test("names every field exactly once", () => {
+      const fields: Array<MonitorStateTimelineTooltipField> =
+        MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+          (props: MonitorStateTimelineTooltipFieldProps) => {
+            return props.field;
+          },
+        );
+
+      expect(new Set<string>(fields).size).toBe(fields.length);
+    });
+
+    test("gives every field a distinct, non-empty title", () => {
+      const titles: Array<string> = MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+        (props: MonitorStateTimelineTooltipFieldProps) => {
+          return props.title;
+        },
+      );
+
+      for (const title of titles) {
+        expect(title.length).toBeGreaterThan(0);
+      }
+      expect(new Set<string>(titles).size).toBe(titles.length);
+    });
+
+    test("keeps the segment's own facts ahead of the whole-row ones", () => {
+      /*
+       * The hover card describes the bar under the cursor first, then widens
+       * out to the monitor. Reversing that reads as if the row-level numbers
+       * belong to the hovered segment.
+       */
+      const order: Array<MonitorStateTimelineTooltipField> =
+        MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+          (props: MonitorStateTimelineTooltipFieldProps) => {
+            return props.field;
+          },
+        );
+
+      expect(
+        order.indexOf(MonitorStateTimelineTooltipField.Duration),
+      ).toBeLessThan(
+        order.indexOf(MonitorStateTimelineTooltipField.UptimePercent),
+      );
+    });
+  });
+
+  describe("the default selection", () => {
+    test("is a subset of the declared fields", () => {
+      for (const field of DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS) {
+        expect(ALL_FIELD_VALUES).toContain(field);
+      }
+    });
+
+    test("describes the hovered segment: what, when, and for how long", () => {
+      expect([...DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS]).toEqual([
+        MonitorStateTimelineTooltipField.Status,
+        MonitorStateTimelineTooltipField.StartedAt,
+        MonitorStateTimelineTooltipField.EndedAt,
+        MonitorStateTimelineTooltipField.Duration,
+      ]);
+    });
+  });
+
+  describe("resolveFields", () => {
+    test("falls back to the defaults when nothing is stored", () => {
+      /*
+       * undefined means "never configured" — a freshly dropped widget — and it
+       * must show something useful rather than an empty card.
+       */
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields(undefined),
+      ).toEqual([...DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS]);
+    });
+
+    test("returns nothing when the operator cleared the selection", () => {
+      /*
+       * An empty array is a CHOICE, not an absence. Falling back to the
+       * defaults here would make the control look broken: clear it, save, and
+       * the rows come straight back.
+       */
+      expect(MonitorStateTimelineTooltipFieldUtil.resolveFields([])).toEqual(
+        [],
+      );
+    });
+
+    test("keeps exactly the stored fields", () => {
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields([
+          MonitorStateTimelineTooltipField.UptimePercent,
+          MonitorStateTimelineTooltipField.Status,
+        ]),
+      ).toEqual([
+        MonitorStateTimelineTooltipField.Status,
+        MonitorStateTimelineTooltipField.UptimePercent,
+      ]);
+    });
+
+    test("renders in the canonical order, not the order they were ticked", () => {
+      /*
+       * Two widgets configured with the same rows in a different click order
+       * must produce identical hover cards.
+       */
+      const clickedOneWay: Array<MonitorStateTimelineTooltipField> =
+        MonitorStateTimelineTooltipFieldUtil.resolveFields([
+          MonitorStateTimelineTooltipField.MonitorType,
+          MonitorStateTimelineTooltipField.Duration,
+          MonitorStateTimelineTooltipField.Status,
+        ]);
+
+      const clickedAnother: Array<MonitorStateTimelineTooltipField> =
+        MonitorStateTimelineTooltipFieldUtil.resolveFields([
+          MonitorStateTimelineTooltipField.Status,
+          MonitorStateTimelineTooltipField.MonitorType,
+          MonitorStateTimelineTooltipField.Duration,
+        ]);
+
+      expect(clickedOneWay).toEqual(clickedAnother);
+      expect(clickedOneWay).toEqual([
+        MonitorStateTimelineTooltipField.Status,
+        MonitorStateTimelineTooltipField.Duration,
+        MonitorStateTimelineTooltipField.MonitorType,
+      ]);
+    });
+
+    test("drops a value it does not recognise", () => {
+      /*
+       * A dashboard saved by a newer version, or a hand-edited config, would
+       * otherwise render a row with a blank label and a blank value.
+       */
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields([
+          "responseTime",
+          MonitorStateTimelineTooltipField.Status,
+        ]),
+      ).toEqual([MonitorStateTimelineTooltipField.Status]);
+    });
+
+    test("returns nothing when every stored value is unrecognised", () => {
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields([
+          "nope",
+          "also-nope",
+        ]),
+      ).toEqual([]);
+    });
+
+    test("collapses a duplicated selection to one row", () => {
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields([
+          MonitorStateTimelineTooltipField.Status,
+          MonitorStateTimelineTooltipField.Status,
+        ]),
+      ).toEqual([MonitorStateTimelineTooltipField.Status]);
+    });
+
+    test("accepts every declared field", () => {
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields(ALL_FIELD_VALUES),
+      ).toEqual(
+        MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+          (props: MonitorStateTimelineTooltipFieldProps) => {
+            return props.field;
+          },
+        ),
+      );
+    });
+
+    test("does not hand back the shared default array", () => {
+      /*
+       * The caller renders and sometimes maps over this list; sharing the
+       * module-level constant would let one widget's render corrupt the
+       * default for every other widget on the board.
+       */
+      const first: Array<MonitorStateTimelineTooltipField> =
+        MonitorStateTimelineTooltipFieldUtil.resolveFields(undefined);
+
+      first.pop();
+
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.resolveFields(undefined),
+      ).toHaveLength(DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.length);
+    });
+  });
+
+  describe("getTitle", () => {
+    test("returns the declared title for every field", () => {
+      for (const props of MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS) {
+        expect(MonitorStateTimelineTooltipFieldUtil.getTitle(props.field)).toBe(
+          props.title,
+        );
+      }
+    });
+
+    test("falls back to the raw value for an unknown field", () => {
+      /*
+       * A blank label would render an anonymous row; the raw value at least
+       * tells whoever is looking what got stored.
+       */
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.getTitle(
+          "responseTime" as MonitorStateTimelineTooltipField,
+        ),
+      ).toBe("responseTime");
+    });
+  });
+});

--- a/Common/Tests/Types/Dashboard/MonitorStateTimelineTooltipField.test.ts
+++ b/Common/Tests/Types/Dashboard/MonitorStateTimelineTooltipField.test.ts
@@ -100,6 +100,31 @@ describe("MonitorStateTimelineTooltipField", () => {
     });
   });
 
+  describe("the titles a viewer reads", () => {
+    test("does not call the end-of-range status 'current'", () => {
+      /*
+       * On a custom range that ends in the past, the value is the status the
+       * monitor was in when the chart stops — not the one it is in now, which
+       * the same widget's list mode would show. A title claiming otherwise
+       * makes the two view modes contradict each other.
+       */
+      const title: string = MonitorStateTimelineTooltipFieldUtil.getTitle(
+        MonitorStateTimelineTooltipField.CurrentStatus,
+      );
+
+      expect(title.toLowerCase()).not.toContain("current");
+      expect(title).toBe("Status at range end");
+    });
+
+    test("scopes the uptime row to the visible range", () => {
+      expect(
+        MonitorStateTimelineTooltipFieldUtil.getTitle(
+          MonitorStateTimelineTooltipField.UptimePercent,
+        ).toLowerCase(),
+      ).toContain("range");
+    });
+  });
+
   describe("resolveFields", () => {
     test("falls back to the defaults when nothing is stored", () => {
       /*
@@ -203,6 +228,36 @@ describe("MonitorStateTimelineTooltipField", () => {
         ),
       );
     });
+
+    test.each([
+      ["a string", "status"],
+      ["a number", 3],
+      ["an object", { status: true }],
+      ["null", null],
+      ["a boolean", true],
+    ])(
+      "falls back to the defaults rather than throwing on %s",
+      (_label: string, stored: unknown) => {
+        /*
+         * Widget arguments are untyped JSONB, so the declared Array<string> is
+         * a promise the database never enforced — a hand-edited config or an
+         * older writer can put anything here. resolveFields runs inside a
+         * render memo, so a TypeError from `new Set(notIterable)` would blank
+         * the dashboard tile rather than lose one tooltip row.
+         */
+        expect(() => {
+          return MonitorStateTimelineTooltipFieldUtil.resolveFields(
+            stored as Array<string> | undefined,
+          );
+        }).not.toThrow();
+
+        expect(
+          MonitorStateTimelineTooltipFieldUtil.resolveFields(
+            stored as Array<string> | undefined,
+          ),
+        ).toEqual([...DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS]);
+      },
+    );
 
     test("does not hand back the shared default array", () => {
       /*

--- a/Common/Tests/Utils/Dashboard/Components/DashboardListSharedArgs.test.ts
+++ b/Common/Tests/Utils/Dashboard/Components/DashboardListSharedArgs.test.ts
@@ -19,11 +19,16 @@ import DashboardBaseComponent from "../../../../Types/Dashboard/DashboardCompone
  * The contract that matters at runtime is machine-readable, not cosmetic. The
  * `id` is the key the chosen value is persisted under, the `type` decides which
  * editor the form renders, and the dropdown option `value`s are the exact
- * strings ("list" / "honeycomb") the rendering code later switches on. If any
- * of those drift, a widget silently renders the wrong view or stores a value no
- * consumer understands, with no compiler error to catch it. This suite pins
- * that contract, and also verifies the factory passes the caller's section
- * through untouched and hands back independent objects on every call.
+ * strings ("list" / "honeycomb" / "timeline") the rendering code later switches
+ * on. If any of those drift, a widget silently renders the wrong view or stores
+ * a value no consumer understands, with no compiler error to catch it. This
+ * suite pins that contract, and also verifies the factory passes the caller's
+ * section through untouched and hands back independent objects on every call.
+ *
+ * The state-timeline mode is OPT-IN. Most list widgets only know an entry's
+ * CURRENT status, so offering them a timeline would hand the operator a
+ * permanently empty widget; only a widget with a stored status history (the
+ * Monitor List) asks for it. Both shapes of the factory call are pinned below.
  */
 
 /*
@@ -39,11 +44,14 @@ const SAMPLE_SECTION: ComponentArgumentSection = {
 };
 
 /*
- * The complete set of view modes the DashboardListViewMode union permits. Each
- * dropdown option value must be one of these and, together, the options must
- * cover all of them.
+ * The complete set of view modes the DashboardListViewMode union permits. Every
+ * dropdown option value must be one of these, whichever call shape produced it.
  */
 const VALID_VIEW_MODES: Set<DashboardListViewMode> =
+  new Set<DashboardListViewMode>(["list", "honeycomb", "timeline"]);
+
+// What a caller that does not opt in to the timeline is offered.
+const DEFAULT_VIEW_MODES: Set<DashboardListViewMode> =
   new Set<DashboardListViewMode>(["list", "honeycomb"]);
 
 describe("getViewModeArgument", () => {
@@ -156,8 +164,118 @@ describe("getViewModeArgument", () => {
       const uniqueValues: Set<string> = new Set<string>(values);
       expect(uniqueValues.size).toBe(values.length);
       expect(uniqueValues).toEqual(
-        new Set<string>(Array.from(VALID_VIEW_MODES)),
+        new Set<string>(Array.from(DEFAULT_VIEW_MODES)),
       );
+    });
+  });
+
+  describe("timeline opt-in", () => {
+    test("adds the State Timeline option only when asked for it", () => {
+      const withTimeline: ComponentArgument<DashboardBaseComponent> =
+        getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION, {
+          includeTimeline: true,
+        });
+
+      expect(withTimeline.dropdownOptions).toEqual([
+        { label: "List", value: "list" },
+        { label: "Honeycomb", value: "honeycomb" },
+        { label: "State Timeline", value: "timeline" },
+      ]);
+    });
+
+    test("keeps the timeline last so the default view stays first", () => {
+      /*
+       * The picker's first option is what an operator reads as the default,
+       * and "list" is what an unset viewMode actually renders.
+       */
+      const options: Array<{ value: unknown }> =
+        (getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION, {
+          includeTimeline: true,
+        }).dropdownOptions ?? []) as Array<{ value: unknown }>;
+
+      expect(options[0]?.value).toBe("list");
+      expect(options[options.length - 1]?.value).toBe("timeline");
+    });
+
+    test.each([
+      ["no options object", undefined],
+      ["an empty options object", {}],
+      ["an explicit false", { includeTimeline: false }],
+      ["an explicit undefined", { includeTimeline: undefined }],
+    ])(
+      "withholds the timeline option given %s",
+      (
+        _label: string,
+        options: { includeTimeline?: boolean | undefined } | undefined,
+      ) => {
+        /*
+         * Only an explicit `true` opts in. Anything else — including a widget
+         * that simply forwards an absent flag — must get the two-option list,
+         * because offering a timeline for data that has no history renders an
+         * empty widget with no explanation.
+         */
+        const values: Array<unknown> = (
+          getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION, options)
+            .dropdownOptions ?? []
+        ).map((option: { value: unknown }): unknown => {
+          return option.value;
+        });
+
+        expect(values).toEqual(["list", "honeycomb"]);
+      },
+    );
+
+    test("describes the timeline in its own words when it is offered", () => {
+      const description: string = getViewModeArgument<DashboardBaseComponent>(
+        SAMPLE_SECTION,
+        { includeTimeline: true },
+      ).description.toLowerCase();
+
+      expect(description).toContain("list");
+      expect(description).toContain("honeycomb");
+      expect(description).toContain("timeline");
+    });
+
+    test("does not mention the timeline when it is not offered", () => {
+      /*
+       * A description that promises a mode the dropdown does not carry sends
+       * the operator looking for a control that is not there.
+       */
+      expect(
+        getViewModeArgument<DashboardBaseComponent>(
+          SAMPLE_SECTION,
+        ).description.toLowerCase(),
+      ).not.toContain("timeline");
+    });
+
+    test("keeps every other part of the argument identical either way", () => {
+      const withoutTimeline: ComponentArgument<DashboardBaseComponent> =
+        getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION);
+      const withTimeline: ComponentArgument<DashboardBaseComponent> =
+        getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION, {
+          includeTimeline: true,
+        });
+
+      expect(withTimeline.id).toBe(withoutTimeline.id);
+      expect(withTimeline.type).toBe(withoutTimeline.type);
+      expect(withTimeline.name).toBe(withoutTimeline.name);
+      expect(withTimeline.required).toBe(withoutTimeline.required);
+      expect(withTimeline.section).toBe(withoutTimeline.section);
+    });
+
+    test("hands back an independent options array when the timeline is included", () => {
+      const first: ComponentArgument<DashboardBaseComponent> =
+        getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION, {
+          includeTimeline: true,
+        });
+
+      first.dropdownOptions?.push({ label: "Injected", value: "list" });
+
+      expect(
+        getViewModeArgument<DashboardBaseComponent>(SAMPLE_SECTION, {
+          includeTimeline: true,
+        }).dropdownOptions,
+      ).toHaveLength(3);
     });
   });
 

--- a/Common/Tests/Utils/Dashboard/Components/DashboardMonitorListComponent.test.ts
+++ b/Common/Tests/Utils/Dashboard/Components/DashboardMonitorListComponent.test.ts
@@ -14,6 +14,10 @@ import {
   MonitorTypeHelper,
   MonitorTypeProps,
 } from "../../../../Types/Monitor/MonitorType";
+import {
+  MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS,
+  MonitorStateTimelineTooltipFieldProps,
+} from "../../../../Types/Dashboard/MonitorStateTimelineTooltipField";
 
 /*
  * DashboardMonitorListComponentUtil is a pure factory with two
@@ -51,6 +55,7 @@ const EXPECTED_ARGUMENT_IDS: Array<ArgumentId> = [
   "title",
   "maxRows",
   "viewMode",
+  "timelineTooltipFields",
   "statusFilter",
   "monitorStatusIds",
   "monitorTypes",
@@ -61,6 +66,7 @@ const DISPLAY_SECTION_ARGUMENT_IDS: Array<ArgumentId> = [
   "title",
   "maxRows",
   "viewMode",
+  "timelineTooltipFields",
 ];
 
 const FILTER_SECTION_ARGUMENT_IDS: Array<ArgumentId> = [
@@ -153,6 +159,7 @@ describe("DashboardMonitorListComponentUtil", () => {
        */
       expect(component.arguments.title).toBeUndefined();
       expect(component.arguments.viewMode).toBeUndefined();
+      expect(component.arguments.timelineTooltipFields).toBeUndefined();
       expect(component.arguments.statusFilter).toBeUndefined();
       expect(component.arguments.monitorStatusIds).toBeUndefined();
       expect(component.arguments.monitorTypes).toBeUndefined();
@@ -188,7 +195,7 @@ describe("DashboardMonitorListComponentUtil", () => {
   });
 
   describe("getComponentConfigArguments", () => {
-    test("declares exactly the seven documented arguments, in form order", () => {
+    test("declares exactly the eight documented arguments, in form order", () => {
       expect(
         getArguments().map((arg: MonitorListArgument) => {
           return arg.id;
@@ -250,7 +257,7 @@ describe("DashboardMonitorListComponentUtil", () => {
   });
 
   describe("Display Options section", () => {
-    test("groups the title, maxRows and viewMode fields under 'Display Options' at order 1", () => {
+    test("groups the title, maxRows, viewMode and tooltip fields under 'Display Options' at order 1", () => {
       for (const id of DISPLAY_SECTION_ARGUMENT_IDS) {
         const arg: MonitorListArgument = getArgumentById(id);
         expect(arg.section?.name).toBe("Display Options");
@@ -273,15 +280,69 @@ describe("DashboardMonitorListComponentUtil", () => {
       expect(arg.placeholder).toBe("25");
     });
 
-    test("wires in the shared viewMode dropdown offering list and honeycomb", () => {
+    test("wires in the shared viewMode dropdown, opting in to the state timeline", () => {
       const arg: MonitorListArgument = getArgumentById("viewMode");
 
+      /*
+       * The monitor list is the one list widget whose entries have a stored
+       * status HISTORY (MonitorStatusTimeline), so it is the one that opts in
+       * to the third mode. The exact strings are what the renderer switches
+       * on and what a saved dashboard persists.
+       */
       expect(arg.type).toBe(ComponentInputType.Dropdown);
       expect(
         getOptions("viewMode").map((option: OptionShape) => {
           return option.value;
         }),
-      ).toEqual(["list", "honeycomb"]);
+      ).toEqual(["list", "honeycomb", "timeline"]);
+    });
+
+    test("offers the timeline tooltip rows as a multi-select", () => {
+      const arg: MonitorListArgument = getArgumentById("timelineTooltipFields");
+
+      expect(arg.type).toBe(ComponentInputType.MultiSelectDropdown);
+      expect(arg.required).toBe(false);
+      expect(arg.entityFilterModelType).toBeUndefined();
+    });
+
+    test("offers exactly one tooltip option per known field, in display order", () => {
+      /*
+       * Order is not cosmetic here: the tooltip renders its rows in the
+       * canonical order regardless of the order they were ticked, so a picker
+       * that sorted them differently would misrepresent the result.
+       */
+      expect(getOptions("timelineTooltipFields")).toEqual(
+        MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+          (props: MonitorStateTimelineTooltipFieldProps): OptionShape => {
+            return { label: props.title, value: props.field };
+          },
+        ),
+      );
+    });
+
+    test("gives every tooltip option a distinct, non-empty value", () => {
+      const values: Array<string> = getOptions("timelineTooltipFields").map(
+        (option: OptionShape): string => {
+          return String(option.value);
+        },
+      );
+
+      expect(values.length).toBeGreaterThan(0);
+      expect(new Set<string>(values).size).toBe(values.length);
+      for (const value of values) {
+        expect(value.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("hints the default tooltip rows in its placeholder", () => {
+      /*
+       * The field is optional and an unset value falls back to a default set;
+       * the placeholder is the only place a viewer learns what that default
+       * is before touching the control.
+       */
+      expect(getArgumentById("timelineTooltipFields").placeholder).toBe(
+        "Status, Started, Ended, Duration",
+      );
     });
   });
 

--- a/Common/Tests/Utils/Monitor/MonitorStateTimelineUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorStateTimelineUtil.test.ts
@@ -1,6 +1,7 @@
 /** @timezone UTC */
 import { describe, expect, jest, test } from "@jest/globals";
 import MonitorStateTimelineUtil, {
+  MAX_STATE_TIMELINE_WINDOW_IN_DAYS,
   MonitorStateTimelineAxisTick,
   MonitorStateTimelineLegendItem,
   MonitorStateTimelineRow,
@@ -803,7 +804,7 @@ describe("MonitorStateTimelineUtil", () => {
       );
     });
 
-    test("reports the CLIPPED change time when the status last changed before the window", () => {
+    test("reports NO last change when the status did not change inside the window", () => {
       const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
         createTimeline({
           monitorId: MONITOR_A,
@@ -813,11 +814,34 @@ describe("MonitorStateTimelineUtil", () => {
       ]);
 
       /*
-       * Everything in a lane is expressed in the window's own terms, so the
-       * "last change" a viewer reads matches the bar they are looking at
-       * rather than a moment off the left of the chart.
+       * The one segment is clipped to the window start, but nothing happened
+       * there. Reporting that boundary would tell an operator a monitor that
+       * has been Offline for two days changed status an hour ago — and the
+       * reported moment would march forward on every auto-refresh, because a
+       * relative window is re-resolved each tick.
        */
-      expect(rows[0]?.lastStatusChangeAt).toEqual(WINDOW_START);
+      expect(rows[0]?.lastStatusChangeAt).toBeNull();
+      expect(rows[0]?.currentStatusName).toBe("Offline");
+    });
+
+    test("reports the change time when the status DID change inside the window", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-08-30T09:00:00.000Z",
+          endsAt: "2026-09-01T11:20:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:20:00.000Z",
+        }),
+      ]);
+
+      expect(rows[0]?.lastStatusChangeAt).toEqual(
+        new Date("2026-09-01T11:20:00.000Z"),
+      );
     });
 
     test("does not report uptime when the window is degenerate", () => {
@@ -849,6 +873,430 @@ describe("MonitorStateTimelineUtil", () => {
             omitStatusRelation: true,
           }),
         ]);
+      }).not.toThrow();
+    });
+  });
+
+  describe("clampWindow", () => {
+    const MS_PER_DAY: number = 24 * 60 * 60 * 1000;
+
+    test("leaves a window inside the ceiling exactly as it is", () => {
+      const clamped: { startDate: Date; endDate: Date } =
+        MonitorStateTimelineUtil.clampWindow({
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+        });
+
+      expect(clamped.startDate).toEqual(WINDOW_START);
+      expect(clamped.endDate).toEqual(WINDOW_END);
+    });
+
+    test("leaves a window exactly at the ceiling alone", () => {
+      const startDate: Date = new Date(
+        WINDOW_END.getTime() - MAX_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY,
+      );
+
+      expect(
+        MonitorStateTimelineUtil.clampWindow({
+          startDate: startDate,
+          endDate: WINDOW_END,
+        }).startDate,
+      ).toEqual(startDate);
+    });
+
+    test("moves the START forward on an over-long window, keeping the end", () => {
+      /*
+       * The end is the edge the viewer is looking at, so that is the one that
+       * survives. The same ceiling is enforced by the public route, which is
+       * why the browser has to apply it BEFORE it draws — otherwise the axis
+       * would label months the server was never asked about.
+       */
+      const clamped: { startDate: Date; endDate: Date } =
+        MonitorStateTimelineUtil.clampWindow({
+          startDate: new Date("2020-01-01T00:00:00.000Z"),
+          endDate: WINDOW_END,
+        });
+
+      expect(clamped.endDate).toEqual(WINDOW_END);
+      expect(clamped.endDate.getTime() - clamped.startDate.getTime()).toBe(
+        MAX_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY,
+      );
+    });
+
+    test("leaves a degenerate or inverted window for the caller to reject", () => {
+      /*
+       * Clamping is about length, not validity — isWindowValid is what refuses
+       * to draw, and swallowing an inverted range here would hide it.
+       */
+      expect(
+        MonitorStateTimelineUtil.clampWindow({
+          startDate: WINDOW_END,
+          endDate: WINDOW_START,
+        }),
+      ).toEqual({ startDate: WINDOW_END, endDate: WINDOW_START });
+    });
+  });
+
+  describe("isStillInStateAtWindowEnd", () => {
+    test("is true for a monitor whose live row is still open", () => {
+      expect(
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd(
+          [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T11:30:00.000Z",
+            }),
+          ],
+          WINDOW_END,
+        ),
+      ).toBe(true);
+    });
+
+    test("is true for a row that only closes AFTER the window", () => {
+      /*
+       * A past window: the run had not ended by the time the chart stops, so
+       * the last bar is still clipped even though the row is closed today.
+       */
+      expect(
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd(
+          [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T11:30:00.000Z",
+              endsAt: "2026-09-01T13:00:00.000Z",
+            }),
+          ],
+          WINDOW_END,
+        ),
+      ).toBe(true);
+    });
+
+    test("is false when the run ended inside the window", () => {
+      expect(
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd(
+          [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T11:00:00.000Z",
+              endsAt: "2026-09-01T11:30:00.000Z",
+            }),
+          ],
+          WINDOW_END,
+        ),
+      ).toBe(false);
+    });
+
+    test("takes the LATEST covering row, so an orphaned open row cannot claim the end", () => {
+      /*
+       * The documented production hazard: a write race left rows with
+       * endsAt = NULL and a later successor. A naive "any open row" test
+       * would report a status the monitor left long ago as still running.
+       */
+      expect(
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd(
+          [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T10:00:00.000Z",
+            }),
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OPERATIONAL,
+              startsAt: "2026-09-01T11:00:00.000Z",
+              endsAt: "2026-09-01T11:30:00.000Z",
+            }),
+          ],
+          WINDOW_END,
+        ),
+      ).toBe(false);
+    });
+
+    test("ignores rows that start after the window closes", () => {
+      expect(
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd(
+          [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-02T00:00:00.000Z",
+            }),
+          ],
+          WINDOW_END,
+        ),
+      ).toBe(false);
+    });
+
+    test("is false when there is nothing covering the window end at all", () => {
+      expect(
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd([], WINDOW_END),
+      ).toBe(false);
+    });
+  });
+
+  describe("continuesAfterWindow", () => {
+    test("marks only the last bar of a lane, and only while the run is open", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:30:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:30:00.000Z",
+        }),
+      ]);
+
+      expect(
+        segments.map((segment: MonitorStateTimelineSegment) => {
+          return segment.continuesAfterWindow;
+        }),
+      ).toEqual([false, true]);
+    });
+
+    test("does not mark a lane whose last run ended before the window closed", () => {
+      /*
+       * A monitor that recovered and has been Operational since: the last bar
+       * IS still running, so this checks the negative case properly — a run
+       * that closed inside the window and was never replaced.
+       */
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:30:00.000Z",
+        }),
+      ]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.continuesAfterWindow).toBe(false);
+    });
+  });
+
+  describe("windows that do not end at now", () => {
+    // A whole day, a fortnight before "now".
+    const PAST_START: Date = new Date("2026-08-18T00:00:00.000Z");
+    const PAST_END: Date = new Date("2026-08-19T00:00:00.000Z");
+
+    type BuildPastRowsFunction = (
+      statusTimelines: Array<MonitorStatusTimeline>,
+    ) => Array<MonitorStateTimelineRow>;
+
+    const buildPastRows: BuildPastRowsFunction = (
+      statusTimelines: Array<MonitorStatusTimeline>,
+    ): Array<MonitorStateTimelineRow> => {
+      return MonitorStateTimelineUtil.buildRows({
+        monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+        statusTimelines: statusTimelines,
+        startDate: PAST_START,
+        endDate: PAST_END,
+      });
+    };
+
+    test("draws the state the monitor was in THEN, not the one it is in now", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildPastRows([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-08-18T06:00:00.000Z",
+          endsAt: "2026-08-18T12:00:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-08-18T12:00:00.000Z",
+        }),
+      ]);
+
+      /*
+       * The open row runs to the end of the WINDOW, not to now — otherwise a
+       * one-day chart from a fortnight ago would be drawn as if it covered
+       * the fortnight since.
+       */
+      expect(
+        rows[0]?.segments.map((segment: MonitorStateTimelineSegment) => {
+          return [segment.label, segment.startPercent, segment.widthPercent];
+        }),
+      ).toEqual([
+        ["Offline", 25, 25],
+        ["Operational", 50, 50],
+      ]);
+    });
+
+    test("measures uptime over the period it has data for, not the whole window", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildPastRows([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-08-18T06:00:00.000Z",
+          endsAt: "2026-08-18T12:00:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-08-18T12:00:00.000Z",
+        }),
+      ]);
+
+      /*
+       * 6 hours offline out of the 18 hours from the first recorded event to
+       * the end of the window — 66.66%, NOT 75% of the 24 hour window. The
+       * denominator is clamped forward to the monitor's first event by
+       * UptimeUtil, deliberately, so a monitor younger than the window is
+       * measured from when it started existing rather than diluted by time it
+       * did not. Every uptime figure in the product (monitor page, status
+       * page, SLOs) is computed that way; this widget agreeing with them
+       * matters more than agreeing with the width of its own empty track, so
+       * the behaviour is pinned here rather than special-cased.
+       */
+      expect(rows[0]?.uptimePercent).toBe(66.66);
+    });
+
+    test("marks the last bar of a past window as still running when it was", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildPastRows([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-08-18T12:00:00.000Z",
+        }),
+      ]);
+
+      /*
+       * The run had not ended by the time the chart stops, so the bar's right
+       * edge is where the chart stops — the hover card must not print it as
+       * an end time.
+       */
+      expect(rows[0]?.segments[0]?.continuesAfterWindow).toBe(true);
+      expect(rows[0]?.segments[0]?.endDate).toEqual(PAST_END);
+    });
+
+    test("stops the bars at now when the window reaches into the future", () => {
+      const rows: Array<MonitorStateTimelineRow> =
+        MonitorStateTimelineUtil.buildRows({
+          monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+          statusTimelines: [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OPERATIONAL,
+              startsAt: "2026-09-01T11:00:00.000Z",
+            }),
+          ],
+          startDate: WINDOW_START,
+          // One hour of past, one hour that has not happened yet.
+          endDate: new Date("2026-09-01T13:00:00.000Z"),
+        });
+
+      /*
+       * Painting to the right edge would claim a status for time that has not
+       * happened. The unlived half of the window stays empty.
+       */
+      expect(rows[0]?.segments).toHaveLength(1);
+      expect(rows[0]?.segments[0]?.startPercent).toBe(0);
+      expect(rows[0]?.segments[0]?.widthPercent).toBe(50);
+    });
+  });
+
+  describe("data that is not a clean contiguous run", () => {
+    test("leaves a gap in the lane where the monitor has no rows", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:15:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:45:00.000Z",
+        }),
+      ]);
+
+      /*
+       * The half hour with no rows is drawn as empty track rather than being
+       * filled by whichever neighbour happens to be adjacent — the widget must
+       * not invent a status for a period it has no record of.
+       */
+      expect(
+        segments.map((segment: MonitorStateTimelineSegment) => {
+          return [segment.startPercent, segment.widthPercent];
+        }),
+      ).toEqual([
+        [0, 25],
+        [75, 25],
+      ]);
+    });
+
+    test("never draws bars that overlap or exceed the lane", () => {
+      /*
+       * Two rows for one monitor that overlap in time — a data anomaly the
+       * write path serializes against, but one the reader has to survive. The
+       * bars are built from the same de-overlapped event list the uptime
+       * number comes from, so the two can never disagree about the same rows.
+       */
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:50:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:10:00.000Z",
+          endsAt: "2026-09-01T12:00:00.000Z",
+        }),
+      ]);
+
+      let cursor: number = 0;
+      let total: number = 0;
+      for (const segment of segments) {
+        expect(segment.startPercent).toBeGreaterThanOrEqual(cursor);
+        cursor = segment.startPercent + segment.widthPercent;
+        total += segment.widthPercent;
+      }
+
+      expect(total).toBeLessThanOrEqual(100.000001);
+      expect(cursor).toBeLessThanOrEqual(100.000001);
+    });
+
+    test("survives a status relation that carries no id", () => {
+      /*
+       * buildRows runs inside a render memo, not the widget's fetch
+       * try/catch, so an unguarded throw here blanks the whole dashboard tile
+       * rather than one lane. UptimeUtil dereferences monitorStatus.id without
+       * a guard, so the presence of the relation is not enough.
+       */
+      const timeline: MonitorStatusTimeline = createTimeline({
+        monitorId: MONITOR_A,
+        status: OPERATIONAL,
+        startsAt: "2026-09-01T11:00:00.000Z",
+      });
+      /*
+       * `id` is a getter over `_id`; clearing the backing column is what a
+       * partially-selected relation actually looks like on the wire. The cast
+       * is the point of the test — the type says it cannot happen, the API
+       * response says otherwise.
+       */
+      delete (timeline.monitorStatus as unknown as Record<string, unknown>)[
+        "_id"
+      ];
+
+      expect(() => {
+        return MonitorStateTimelineUtil.buildRows({
+          monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+          statusTimelines: [timeline],
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+        });
       }).not.toThrow();
     });
   });

--- a/Common/Tests/Utils/Monitor/MonitorStateTimelineUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorStateTimelineUtil.test.ts
@@ -1,0 +1,993 @@
+/** @timezone UTC */
+import { describe, expect, jest, test } from "@jest/globals";
+import MonitorStateTimelineUtil, {
+  MonitorStateTimelineAxisTick,
+  MonitorStateTimelineLegendItem,
+  MonitorStateTimelineRow,
+  MonitorStateTimelineSegment,
+} from "../../../Utils/Monitor/MonitorStateTimelineUtil";
+import { Green, Red, Yellow } from "../../../Types/BrandColors";
+import Color from "../../../Types/Color";
+import ObjectID from "../../../Types/ObjectID";
+import UptimePrecision from "../../../Types/StatusPage/UptimePrecision";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+
+/*
+ * MonitorStateTimelineUtil turns MonitorStatusTimeline rows into the geometry
+ * a state-timeline widget draws. Everything asserted here is arithmetic the
+ * renderer cannot check for itself: a bar in the wrong place, a bar of the
+ * wrong width, or an uptime figure that disagrees with the bars is a silent
+ * wrong answer on a wall display, not a crash.
+ *
+ * "Now" is pinned, because the util resolves open (endsAt = null) rows against
+ * the wall clock through UptimeUtil, and a floating clock would make every
+ * percentage in this file drift.
+ */
+
+const NOW: Date = new Date("2026-09-01T12:00:00.000Z");
+
+// A one-hour window ending at "now" — the dashboard's default range.
+const WINDOW_START: Date = new Date("2026-09-01T11:00:00.000Z");
+const WINDOW_END: Date = NOW;
+
+const MONITOR_A: string = "11111111-1111-4111-8111-111111111111";
+const MONITOR_B: string = "22222222-2222-4222-8222-222222222222";
+
+const OPERATIONAL_STATUS_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const DEGRADED_STATUS_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+interface StatusSpec {
+  id: ObjectID;
+  name: string;
+  color: Color;
+  priority: number;
+  isOperationalState: boolean;
+}
+
+const OPERATIONAL: StatusSpec = {
+  id: OPERATIONAL_STATUS_ID,
+  name: "Operational",
+  color: Green,
+  priority: 1,
+  isOperationalState: true,
+};
+
+const DEGRADED: StatusSpec = {
+  id: DEGRADED_STATUS_ID,
+  name: "Degraded",
+  color: Yellow,
+  priority: 2,
+  isOperationalState: false,
+};
+
+const OFFLINE: StatusSpec = {
+  id: OFFLINE_STATUS_ID,
+  name: "Offline",
+  color: Red,
+  priority: 3,
+  isOperationalState: false,
+};
+
+type CreateTimelineFunction = (data: {
+  monitorId: string;
+  status: StatusSpec;
+  startsAt: string;
+  endsAt?: string | undefined;
+  omitStatusRelation?: boolean | undefined;
+}) => MonitorStatusTimeline;
+
+const createTimeline: CreateTimelineFunction = (data: {
+  monitorId: string;
+  status: StatusSpec;
+  startsAt: string;
+  endsAt?: string | undefined;
+  omitStatusRelation?: boolean | undefined;
+}): MonitorStatusTimeline => {
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+  timeline.monitorId = new ObjectID(data.monitorId);
+  timeline.monitorStatusId = data.status.id;
+  timeline.startsAt = new Date(data.startsAt);
+
+  // endsAt is left unset for the live row, which is how the database stores it.
+  if (data.endsAt) {
+    timeline.endsAt = new Date(data.endsAt);
+  }
+
+  if (!data.omitStatusRelation) {
+    const monitorStatus: MonitorStatus = new MonitorStatus();
+    monitorStatus.id = data.status.id;
+    monitorStatus.name = data.status.name;
+    monitorStatus.color = data.status.color;
+    monitorStatus.priority = data.status.priority;
+    monitorStatus.isOperationalState = data.status.isOperationalState;
+    timeline.monitorStatus = monitorStatus;
+  }
+
+  return timeline;
+};
+
+type BuildSegmentsFunction = (
+  statusTimelines: Array<MonitorStatusTimeline>,
+  monitorId?: string | undefined,
+) => Array<MonitorStateTimelineSegment>;
+
+const buildSegments: BuildSegmentsFunction = (
+  statusTimelines: Array<MonitorStatusTimeline>,
+  monitorId?: string | undefined,
+): Array<MonitorStateTimelineSegment> => {
+  return MonitorStateTimelineUtil.buildSegments({
+    monitorId: monitorId || MONITOR_A,
+    statusTimelines: statusTimelines,
+    startDate: WINDOW_START,
+    endDate: WINDOW_END,
+  });
+};
+
+describe("MonitorStateTimelineUtil", () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ now: NOW });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe("isWindowValid", () => {
+    test("accepts a window whose end is after its start", () => {
+      expect(
+        MonitorStateTimelineUtil.isWindowValid(WINDOW_START, WINDOW_END),
+      ).toBe(true);
+    });
+
+    test("rejects a zero-length window", () => {
+      /*
+       * A zero-length window is what the CUSTOM range resolves to before the
+       * user has picked anything; every percentage would divide by zero.
+       */
+      expect(MonitorStateTimelineUtil.isWindowValid(NOW, NOW)).toBe(false);
+    });
+
+    test("rejects an inverted window", () => {
+      expect(
+        MonitorStateTimelineUtil.isWindowValid(WINDOW_END, WINDOW_START),
+      ).toBe(false);
+    });
+  });
+
+  describe("getPercentOfWindow", () => {
+    type PercentFunction = (date: Date) => number;
+
+    const percentOf: PercentFunction = (date: Date): number => {
+      return MonitorStateTimelineUtil.getPercentOfWindow({
+        date: date,
+        startDate: WINDOW_START,
+        endDate: WINDOW_END,
+      });
+    };
+
+    test("puts the window start at 0 and the window end at 100", () => {
+      expect(percentOf(WINDOW_START)).toBe(0);
+      expect(percentOf(WINDOW_END)).toBe(100);
+    });
+
+    test("puts the midpoint at 50", () => {
+      expect(percentOf(new Date("2026-09-01T11:30:00.000Z"))).toBe(50);
+    });
+
+    test("is linear across the window", () => {
+      expect(percentOf(new Date("2026-09-01T11:15:00.000Z"))).toBe(25);
+      expect(percentOf(new Date("2026-09-01T11:45:00.000Z"))).toBe(75);
+    });
+
+    test("clamps a date before the window to 0", () => {
+      /*
+       * Callers pass event dates that UptimeUtil has already clipped, but a
+       * clamp here is what guarantees the renderer never receives a negative
+       * left offset — which CSS would draw outside the lane.
+       */
+      expect(percentOf(new Date("2020-01-01T00:00:00.000Z"))).toBe(0);
+    });
+
+    test("clamps a date after the window to 100", () => {
+      expect(percentOf(new Date("2030-01-01T00:00:00.000Z"))).toBe(100);
+    });
+
+    test("returns 0 for every date when the window is degenerate", () => {
+      expect(
+        MonitorStateTimelineUtil.getPercentOfWindow({
+          date: NOW,
+          startDate: NOW,
+          endDate: NOW,
+        }),
+      ).toBe(0);
+    });
+  });
+
+  describe("getDowntimeStatuses", () => {
+    test("collects the statuses explicitly marked non-operational", () => {
+      const statuses: Array<MonitorStatus> =
+        MonitorStateTimelineUtil.getDowntimeStatuses([
+          createTimeline({
+            monitorId: MONITOR_A,
+            status: OPERATIONAL,
+            startsAt: "2026-09-01T11:00:00.000Z",
+            endsAt: "2026-09-01T11:30:00.000Z",
+          }),
+          createTimeline({
+            monitorId: MONITOR_A,
+            status: OFFLINE,
+            startsAt: "2026-09-01T11:30:00.000Z",
+          }),
+        ]);
+
+      expect(
+        statuses.map((status: MonitorStatus) => {
+          return status.name;
+        }),
+      ).toEqual(["Offline"]);
+    });
+
+    test("returns one entry per status however many rows carry it", () => {
+      const statuses: Array<MonitorStatus> =
+        MonitorStateTimelineUtil.getDowntimeStatuses([
+          createTimeline({
+            monitorId: MONITOR_A,
+            status: OFFLINE,
+            startsAt: "2026-09-01T11:05:00.000Z",
+            endsAt: "2026-09-01T11:10:00.000Z",
+          }),
+          createTimeline({
+            monitorId: MONITOR_B,
+            status: OFFLINE,
+            startsAt: "2026-09-01T11:20:00.000Z",
+            endsAt: "2026-09-01T11:25:00.000Z",
+          }),
+        ]);
+
+      /*
+       * UptimeUtil matches an event against this list by id, so duplicates
+       * would only make the match slower — but a dashboard showing 25 flapping
+       * monitors would build a list hundreds of entries long.
+       */
+      expect(statuses).toHaveLength(1);
+    });
+
+    test("treats a status with an unselected isOperationalState as operational", () => {
+      const timeline: MonitorStatusTimeline = createTimeline({
+        monitorId: MONITOR_A,
+        status: OFFLINE,
+        startsAt: "2026-09-01T11:00:00.000Z",
+      });
+      delete timeline.monitorStatus?.isOperationalState;
+
+      /*
+       * Under-reporting downtime is the safe direction: inventing an outage
+       * from a column that simply was not selected would page someone.
+       */
+      expect(MonitorStateTimelineUtil.getDowntimeStatuses([timeline])).toEqual(
+        [],
+      );
+    });
+
+    test("ignores rows whose status did not come back joined", () => {
+      expect(
+        MonitorStateTimelineUtil.getDowntimeStatuses([
+          createTimeline({
+            monitorId: MONITOR_A,
+            status: OFFLINE,
+            startsAt: "2026-09-01T11:00:00.000Z",
+            omitStatusRelation: true,
+          }),
+        ]),
+      ).toEqual([]);
+    });
+  });
+
+  describe("getTimelinesForMonitor", () => {
+    const rows: Array<MonitorStatusTimeline> = [
+      createTimeline({
+        monitorId: MONITOR_A,
+        status: OPERATIONAL,
+        startsAt: "2026-09-01T11:00:00.000Z",
+      }),
+      createTimeline({
+        monitorId: MONITOR_B,
+        status: OPERATIONAL,
+        startsAt: "2026-09-01T11:00:00.000Z",
+      }),
+    ];
+
+    test("keeps only the rows belonging to the requested monitor", () => {
+      expect(
+        MonitorStateTimelineUtil.getTimelinesForMonitor(rows, MONITOR_A),
+      ).toHaveLength(1);
+      expect(
+        MonitorStateTimelineUtil.getTimelinesForMonitor(
+          rows,
+          MONITOR_A,
+        )[0]?.monitorId?.toString(),
+      ).toBe(MONITOR_A);
+    });
+
+    test("returns nothing for a monitor with no rows", () => {
+      expect(
+        MonitorStateTimelineUtil.getTimelinesForMonitor(
+          rows,
+          "99999999-9999-4999-8999-999999999999",
+        ),
+      ).toEqual([]);
+    });
+
+    test("drops a row whose status relation is missing", () => {
+      /*
+       * UptimeUtil dereferences `monitorStatus.id` without a guard, so one
+       * such row thrown at it takes down the whole widget. This filter is the
+       * only thing standing between a deleted MonitorStatus and a blank tile.
+       */
+      expect(
+        MonitorStateTimelineUtil.getTimelinesForMonitor(
+          [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OPERATIONAL,
+              startsAt: "2026-09-01T11:00:00.000Z",
+              omitStatusRelation: true,
+            }),
+          ],
+          MONITOR_A,
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("buildSegments", () => {
+    test("places a segment that spans the whole window across the whole lane", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+        }),
+      ]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.startPercent).toBe(0);
+      expect(segments[0]?.widthPercent).toBe(100);
+      expect(segments[0]?.label).toBe("Operational");
+    });
+
+    test("clips a row that started before the window to the window's left edge", () => {
+      /*
+       * The single most important case for this widget: a device that went
+       * Offline yesterday has exactly ONE row, and it starts in the past. If
+       * it were not clipped in, the lane would render empty for the device
+       * that has been down the entire time.
+       */
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-08-30T09:00:00.000Z",
+        }),
+      ]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.startPercent).toBe(0);
+      expect(segments[0]?.widthPercent).toBe(100);
+      expect(segments[0]?.startDate).toEqual(WINDOW_START);
+    });
+
+    test("positions and sizes a segment that starts inside the window", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:30:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:30:00.000Z",
+          endsAt: "2026-09-01T11:45:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:45:00.000Z",
+        }),
+      ]);
+
+      expect(
+        segments.map((segment: MonitorStateTimelineSegment) => {
+          return [segment.label, segment.startPercent, segment.widthPercent];
+        }),
+      ).toEqual([
+        ["Operational", 0, 50],
+        ["Offline", 50, 25],
+        ["Operational", 75, 25],
+      ]);
+    });
+
+    test("runs the live (endsAt = null) row up to now", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:45:00.000Z",
+        }),
+      ]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0]?.endDate).toEqual(NOW);
+      expect(segments[0]?.widthPercent).toBe(25);
+    });
+
+    test("closes an orphaned open row at its successor rather than running it to now", () => {
+      /*
+       * A documented production hazard: a write race left ~67.5k rows with
+       * endsAt = NULL and a later successor. Rendered naively, that stale row
+       * paints the entire lane with a status the monitor left long ago.
+       */
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:00:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:30:00.000Z",
+        }),
+      ]);
+
+      expect(
+        segments.map((segment: MonitorStateTimelineSegment) => {
+          return [segment.label, segment.startPercent, segment.widthPercent];
+        }),
+      ).toEqual([
+        ["Offline", 0, 50],
+        ["Operational", 50, 50],
+      ]);
+    });
+
+    test("drops a row that ends before the window opens", () => {
+      expect(
+        buildSegments([
+          createTimeline({
+            monitorId: MONITOR_A,
+            status: OFFLINE,
+            startsAt: "2026-08-01T00:00:00.000Z",
+            endsAt: "2026-08-01T01:00:00.000Z",
+          }),
+        ]),
+      ).toEqual([]);
+    });
+
+    test("ignores rows belonging to another monitor", () => {
+      expect(
+        buildSegments([
+          createTimeline({
+            monitorId: MONITOR_B,
+            status: OFFLINE,
+            startsAt: "2026-09-01T11:00:00.000Z",
+          }),
+        ]),
+      ).toEqual([]);
+    });
+
+    test("returns nothing for a degenerate window", () => {
+      expect(
+        MonitorStateTimelineUtil.buildSegments({
+          monitorId: MONITOR_A,
+          statusTimelines: [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OPERATIONAL,
+              startsAt: "2026-09-01T11:00:00.000Z",
+            }),
+          ],
+          startDate: NOW,
+          endDate: NOW,
+        }),
+      ).toEqual([]);
+    });
+
+    test("carries the configured status colour through, not a hardcoded one", () => {
+      /*
+       * Monitor status colours are a per-project setting. The widget's whole
+       * colour scheme is whatever the operator configured there, so a literal
+       * leaking in here would silently override their choice.
+       */
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: DEGRADED,
+          startsAt: "2026-09-01T11:00:00.000Z",
+        }),
+      ]);
+
+      expect(segments[0]?.color).toBe(Yellow.toString());
+      expect(segments[0]?.monitorStatusId).toBe(DEGRADED_STATUS_ID.toString());
+    });
+
+    test("reports each segment's real duration in seconds", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:30:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:30:00.000Z",
+        }),
+      ]);
+
+      expect(segments[0]?.durationInSeconds).toBe(1800);
+      expect(segments[1]?.durationInSeconds).toBe(1800);
+    });
+
+    test("returns segments in chronological order whatever order the rows arrive in", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:30:00.000Z",
+          endsAt: "2026-09-01T11:45:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:30:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:45:00.000Z",
+        }),
+      ]);
+
+      /*
+       * Order is not cosmetic: the renderer takes the LAST segment as the
+       * monitor's current status and as the moment it last changed.
+       */
+      expect(
+        segments.map((segment: MonitorStateTimelineSegment) => {
+          return segment.startPercent;
+        }),
+      ).toEqual([0, 50, 75]);
+    });
+
+    test("never emits a zero-width segment", () => {
+      /*
+       * A row that ends exactly when the window opens overlaps it by nothing.
+       * The server's overlap predicate is inclusive and returns such a row, so
+       * the geometry has to be the thing that discards it.
+       */
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T10:00:00.000Z",
+          endsAt: "2026-09-01T11:00:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+        }),
+      ]);
+
+      for (const segment of segments) {
+        expect(segment.widthPercent).toBeGreaterThan(0);
+      }
+      expect(
+        segments.map((segment: MonitorStateTimelineSegment) => {
+          return segment.label;
+        }),
+      ).toEqual(["Operational"]);
+    });
+
+    test("segments tile the window without gaps or overlap", () => {
+      const segments: Array<MonitorStateTimelineSegment> = buildSegments([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T10:00:00.000Z",
+          endsAt: "2026-09-01T11:12:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: DEGRADED,
+          startsAt: "2026-09-01T11:12:00.000Z",
+          endsAt: "2026-09-01T11:36:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:36:00.000Z",
+        }),
+      ]);
+
+      let cursor: number = 0;
+      for (const segment of segments) {
+        expect(segment.startPercent).toBeCloseTo(cursor, 6);
+        cursor = segment.startPercent + segment.widthPercent;
+      }
+      expect(cursor).toBeCloseTo(100, 6);
+    });
+  });
+
+  describe("buildRows", () => {
+    type BuildRowsFunction = (
+      statusTimelines: Array<MonitorStatusTimeline>,
+    ) => Array<MonitorStateTimelineRow>;
+
+    const buildTwoLanes: BuildRowsFunction = (
+      statusTimelines: Array<MonitorStatusTimeline>,
+    ): Array<MonitorStateTimelineRow> => {
+      return MonitorStateTimelineUtil.buildRows({
+        monitors: [
+          { monitorId: MONITOR_A, monitorName: "core-switch-01" },
+          { monitorId: MONITOR_B, monitorName: "ap-lobby-02" },
+        ],
+        statusTimelines: statusTimelines,
+        startDate: WINDOW_START,
+        endDate: WINDOW_END,
+      });
+    };
+
+    test("emits one lane per monitor, in the order the monitors were given", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([]);
+
+      expect(
+        rows.map((row: MonitorStateTimelineRow) => {
+          return row.monitorName;
+        }),
+      ).toEqual(["core-switch-01", "ap-lobby-02"]);
+    });
+
+    test("gives a monitor with no history an empty lane and no uptime figure", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([]);
+
+      /*
+       * null, not 0 and not 100: "we have no data for this device in this
+       * window" is a third answer, and rendering it as either number would be
+       * a claim the data does not support.
+       */
+      expect(rows[0]?.segments).toEqual([]);
+      expect(rows[0]?.uptimePercent).toBeNull();
+      expect(rows[0]?.currentStatusName).toBeUndefined();
+      expect(rows[0]?.lastStatusChangeAt).toBeNull();
+    });
+
+    test("keeps each monitor's rows in its own lane", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_B,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:00:00.000Z",
+        }),
+      ]);
+
+      expect(rows[0]?.currentStatusName).toBe("Operational");
+      expect(rows[1]?.currentStatusName).toBe("Offline");
+    });
+
+    test("reports 100% uptime for a monitor that was operational throughout", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T10:00:00.000Z",
+        }),
+      ]);
+
+      expect(rows[0]?.uptimePercent).toBe(100);
+    });
+
+    test("reports uptime that matches the share of the window spent down", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T10:00:00.000Z",
+          endsAt: "2026-09-01T11:45:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:45:00.000Z",
+        }),
+      ]);
+
+      // 15 minutes offline out of a 60 minute window.
+      expect(rows[0]?.uptimePercent).toBe(75);
+    });
+
+    test("counts only non-operational statuses as downtime", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T10:00:00.000Z",
+          endsAt: "2026-09-01T11:30:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: DEGRADED,
+          startsAt: "2026-09-01T11:30:00.000Z",
+        }),
+      ]);
+
+      /*
+       * Degraded is seeded as a non-operational state, so half a window spent
+       * degraded is half a window of downtime.
+       */
+      expect(rows[0]?.uptimePercent).toBe(50);
+    });
+
+    test("honours the requested uptime precision", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T10:00:00.000Z",
+          endsAt: "2026-09-01T11:59:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:59:00.000Z",
+        }),
+      ];
+
+      const twoDecimals: Array<MonitorStateTimelineRow> =
+        MonitorStateTimelineUtil.buildRows({
+          monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+          statusTimelines: timelines,
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+        });
+
+      const noDecimals: Array<MonitorStateTimelineRow> =
+        MonitorStateTimelineUtil.buildRows({
+          monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+          statusTimelines: timelines,
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+          uptimePrecision: UptimePrecision.NO_DECIMAL,
+        });
+
+      expect(twoDecimals[0]?.uptimePercent).toBe(98.33);
+      expect(noDecimals[0]?.uptimePercent).toBe(98);
+    });
+
+    test("takes the current status and last change from the final segment", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OPERATIONAL,
+          startsAt: "2026-09-01T11:00:00.000Z",
+          endsAt: "2026-09-01T11:20:00.000Z",
+        }),
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-09-01T11:20:00.000Z",
+        }),
+      ]);
+
+      expect(rows[0]?.currentStatusName).toBe("Offline");
+      expect(rows[0]?.currentStatusColor).toBe(Red.toString());
+      expect(rows[0]?.lastStatusChangeAt).toEqual(
+        new Date("2026-09-01T11:20:00.000Z"),
+      );
+    });
+
+    test("reports the CLIPPED change time when the status last changed before the window", () => {
+      const rows: Array<MonitorStateTimelineRow> = buildTwoLanes([
+        createTimeline({
+          monitorId: MONITOR_A,
+          status: OFFLINE,
+          startsAt: "2026-08-30T09:00:00.000Z",
+        }),
+      ]);
+
+      /*
+       * Everything in a lane is expressed in the window's own terms, so the
+       * "last change" a viewer reads matches the bar they are looking at
+       * rather than a moment off the left of the chart.
+       */
+      expect(rows[0]?.lastStatusChangeAt).toEqual(WINDOW_START);
+    });
+
+    test("does not report uptime when the window is degenerate", () => {
+      const rows: Array<MonitorStateTimelineRow> =
+        MonitorStateTimelineUtil.buildRows({
+          monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+          statusTimelines: [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T10:00:00.000Z",
+            }),
+          ],
+          startDate: NOW,
+          endDate: NOW,
+        });
+
+      expect(rows[0]?.segments).toEqual([]);
+      expect(rows[0]?.uptimePercent).toBeNull();
+    });
+
+    test("survives a row whose status was deleted out from under it", () => {
+      expect(() => {
+        return buildTwoLanes([
+          createTimeline({
+            monitorId: MONITOR_A,
+            status: OPERATIONAL,
+            startsAt: "2026-09-01T11:00:00.000Z",
+            omitStatusRelation: true,
+          }),
+        ]);
+      }).not.toThrow();
+    });
+  });
+
+  describe("getAxisTicks", () => {
+    test("returns the requested number of ticks, spanning both edges", () => {
+      const ticks: Array<MonitorStateTimelineAxisTick> =
+        MonitorStateTimelineUtil.getAxisTicks({
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+          tickCount: 5,
+        });
+
+      expect(ticks).toHaveLength(5);
+      expect(ticks[0]?.percent).toBe(0);
+      expect(ticks[4]?.percent).toBe(100);
+      expect(ticks[0]?.date).toEqual(WINDOW_START);
+      expect(ticks[4]?.date).toEqual(WINDOW_END);
+    });
+
+    test("spaces the ticks evenly", () => {
+      const ticks: Array<MonitorStateTimelineAxisTick> =
+        MonitorStateTimelineUtil.getAxisTicks({
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+          tickCount: 3,
+        });
+
+      expect(
+        ticks.map((tick: MonitorStateTimelineAxisTick) => {
+          return tick.percent;
+        }),
+      ).toEqual([0, 50, 100]);
+      expect(ticks[1]?.date).toEqual(new Date("2026-09-01T11:30:00.000Z"));
+    });
+
+    test("returns nothing when asked for fewer than two ticks", () => {
+      /*
+       * One tick has no defined position — the fraction would divide by zero —
+       * and an axis of one label is not an axis.
+       */
+      expect(
+        MonitorStateTimelineUtil.getAxisTicks({
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+          tickCount: 1,
+        }),
+      ).toEqual([]);
+      expect(
+        MonitorStateTimelineUtil.getAxisTicks({
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+          tickCount: 0,
+        }),
+      ).toEqual([]);
+    });
+
+    test("returns nothing for a degenerate window", () => {
+      expect(
+        MonitorStateTimelineUtil.getAxisTicks({
+          startDate: NOW,
+          endDate: NOW,
+          tickCount: 4,
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("getLegend", () => {
+    test("lists each distinct status once, in first-appearance order", () => {
+      const rows: Array<MonitorStateTimelineRow> =
+        MonitorStateTimelineUtil.buildRows({
+          monitors: [
+            { monitorId: MONITOR_A, monitorName: "core-switch-01" },
+            { monitorId: MONITOR_B, monitorName: "ap-lobby-02" },
+          ],
+          statusTimelines: [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OPERATIONAL,
+              startsAt: "2026-09-01T11:00:00.000Z",
+              endsAt: "2026-09-01T11:30:00.000Z",
+            }),
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T11:30:00.000Z",
+            }),
+            createTimeline({
+              monitorId: MONITOR_B,
+              status: OFFLINE,
+              startsAt: "2026-09-01T11:00:00.000Z",
+              endsAt: "2026-09-01T11:15:00.000Z",
+            }),
+            createTimeline({
+              monitorId: MONITOR_B,
+              status: DEGRADED,
+              startsAt: "2026-09-01T11:15:00.000Z",
+            }),
+          ],
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+        });
+
+      expect(
+        MonitorStateTimelineUtil.getLegend(rows).map(
+          (item: MonitorStateTimelineLegendItem) => {
+            return item.label;
+          },
+        ),
+      ).toEqual(["Operational", "Offline", "Degraded"]);
+    });
+
+    test("carries each status's configured colour", () => {
+      const rows: Array<MonitorStateTimelineRow> =
+        MonitorStateTimelineUtil.buildRows({
+          monitors: [{ monitorId: MONITOR_A, monitorName: "core-switch-01" }],
+          statusTimelines: [
+            createTimeline({
+              monitorId: MONITOR_A,
+              status: OFFLINE,
+              startsAt: "2026-09-01T11:00:00.000Z",
+            }),
+          ],
+          startDate: WINDOW_START,
+          endDate: WINDOW_END,
+        });
+
+      expect(MonitorStateTimelineUtil.getLegend(rows)).toEqual([
+        {
+          monitorStatusId: OFFLINE_STATUS_ID.toString(),
+          label: "Offline",
+          color: Red.toString(),
+        },
+      ]);
+    });
+
+    test("explains nothing when nothing is drawn", () => {
+      expect(MonitorStateTimelineUtil.getLegend([])).toEqual([]);
+    });
+  });
+});

--- a/Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent.ts
+++ b/Common/Types/Dashboard/DashboardComponents/DashboardMonitorListComponent.ts
@@ -8,7 +8,14 @@ export default interface DashboardMonitorListComponent extends BaseComponent {
   arguments: {
     title?: string | undefined;
     maxRows?: number | undefined;
-    viewMode?: "list" | "honeycomb" | undefined;
+    viewMode?: "list" | "honeycomb" | "timeline" | undefined;
+    /*
+     * Which rows the State Timeline's hover card shows. Stored as plain
+     * strings because that is what the MultiSelectDropdown editor writes;
+     * MonitorStateTimelineTooltipFieldUtil.resolveFields is what turns them
+     * back into known fields, dropping anything it does not recognise.
+     */
+    timelineTooltipFields?: Array<string> | undefined;
     statusFilter?: string | undefined;
     monitorStatusIds?: Array<string> | undefined;
     monitorTypes?: Array<string> | undefined;

--- a/Common/Types/Dashboard/MonitorStateTimelineTooltipField.ts
+++ b/Common/Types/Dashboard/MonitorStateTimelineTooltipField.ts
@@ -19,7 +19,11 @@ enum MonitorStateTimelineTooltipField {
   Duration = "duration",
   /** Uptime for this monitor across the whole visible window. */
   UptimePercent = "uptimePercent",
-  /** The status the monitor is in at the end of the visible window. */
+  /*
+   * The status the monitor is in at the END of the visible window — which is
+   * "now" only while the range ends now. The stored value keeps its original
+   * name; the title below is what a viewer reads.
+   */
   CurrentStatus = "currentStatus",
   /** When the monitor last changed status inside the visible window. */
   LastStatusChange = "lastStatusChange",
@@ -66,7 +70,7 @@ export const MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS: ReadonlyArray<MonitorStateTi
     },
     {
       field: MonitorStateTimelineTooltipField.CurrentStatus,
-      title: "Current status",
+      title: "Status at range end",
     },
     {
       field: MonitorStateTimelineTooltipField.LastStatusChange,
@@ -89,6 +93,17 @@ export class MonitorStateTimelineTooltipFieldUtil {
     storedFields: Array<string> | undefined,
   ): Array<MonitorStateTimelineTooltipField> {
     if (storedFields === undefined) {
+      return [...DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS];
+    }
+
+    /*
+     * Widget arguments are stored as untyped JSONB, so the declared
+     * Array<string> is a promise the database never enforced. Anything that is
+     * not an array is treated as "never configured" rather than fed to
+     * `new Set`, which throws on a non-iterable — and this runs inside a
+     * render memo, so the throw would blank the tile.
+     */
+    if (!Array.isArray(storedFields)) {
       return [...DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS];
     }
 

--- a/Common/Types/Dashboard/MonitorStateTimelineTooltipField.ts
+++ b/Common/Types/Dashboard/MonitorStateTimelineTooltipField.ts
@@ -1,0 +1,116 @@
+/*
+ * The rows an operator can put in the hover card of a Monitor List widget's
+ * State Timeline. The header (monitor name + status colour) is always there;
+ * these are the detail rows underneath it, and the widget stores the selected
+ * subset verbatim in its `timelineTooltipFields` argument.
+ *
+ * The values are persisted in a saved dashboard, so they are part of the
+ * stored config format: renaming one silently drops that row from every
+ * dashboard already configured with it.
+ */
+enum MonitorStateTimelineTooltipField {
+  /** Name of the status the hovered segment represents. */
+  Status = "status",
+  /** When the hovered segment began (clipped to the visible window). */
+  StartedAt = "startedAt",
+  /** When the hovered segment ended (clipped to the visible window, or now). */
+  EndedAt = "endedAt",
+  /** How long the hovered segment lasted. */
+  Duration = "duration",
+  /** Uptime for this monitor across the whole visible window. */
+  UptimePercent = "uptimePercent",
+  /** The status the monitor is in at the end of the visible window. */
+  CurrentStatus = "currentStatus",
+  /** When the monitor last changed status inside the visible window. */
+  LastStatusChange = "lastStatusChange",
+  /** The monitor's type (Ping, Website, SNMP, …). */
+  MonitorType = "monitorType",
+}
+
+export default MonitorStateTimelineTooltipField;
+
+/*
+ * What a widget shows when the operator has never touched the setting. An
+ * EMPTY selection is honoured as "no detail rows" rather than falling back to
+ * this — clearing the field is a choice, and silently re-adding rows would
+ * make the control look broken.
+ */
+export const DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS: ReadonlyArray<MonitorStateTimelineTooltipField> =
+  [
+    MonitorStateTimelineTooltipField.Status,
+    MonitorStateTimelineTooltipField.StartedAt,
+    MonitorStateTimelineTooltipField.EndedAt,
+    MonitorStateTimelineTooltipField.Duration,
+  ];
+
+export interface MonitorStateTimelineTooltipFieldProps {
+  field: MonitorStateTimelineTooltipField;
+  title: string;
+}
+
+/*
+ * Declared as an ordered list rather than derived from the enum so the
+ * settings dropdown and the rendered tooltip agree on ORDER: the rows appear
+ * in this order regardless of the order the operator ticked them, which keeps
+ * one widget's hover card readable next to another's.
+ */
+export const MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS: ReadonlyArray<MonitorStateTimelineTooltipFieldProps> =
+  [
+    { field: MonitorStateTimelineTooltipField.Status, title: "Status" },
+    { field: MonitorStateTimelineTooltipField.StartedAt, title: "Started" },
+    { field: MonitorStateTimelineTooltipField.EndedAt, title: "Ended" },
+    { field: MonitorStateTimelineTooltipField.Duration, title: "Duration" },
+    {
+      field: MonitorStateTimelineTooltipField.UptimePercent,
+      title: "Uptime in range",
+    },
+    {
+      field: MonitorStateTimelineTooltipField.CurrentStatus,
+      title: "Current status",
+    },
+    {
+      field: MonitorStateTimelineTooltipField.LastStatusChange,
+      title: "Last status change",
+    },
+    {
+      field: MonitorStateTimelineTooltipField.MonitorType,
+      title: "Monitor type",
+    },
+  ];
+
+export class MonitorStateTimelineTooltipFieldUtil {
+  /**
+   * The fields a widget should render, given whatever is stored in its
+   * arguments. Unknown values (a dashboard saved by a newer version, or a
+   * hand-edited config) are dropped rather than rendered as blank rows, and
+   * the result is always in the canonical display order with no duplicates.
+   */
+  public static resolveFields(
+    storedFields: Array<string> | undefined,
+  ): Array<MonitorStateTimelineTooltipField> {
+    if (storedFields === undefined) {
+      return [...DEFAULT_MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS];
+    }
+
+    const selected: Set<string> = new Set<string>(storedFields);
+
+    return MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.filter(
+      (props: MonitorStateTimelineTooltipFieldProps) => {
+        return selected.has(props.field);
+      },
+    ).map((props: MonitorStateTimelineTooltipFieldProps) => {
+      return props.field;
+    });
+  }
+
+  /** The human label for one field. */
+  public static getTitle(field: MonitorStateTimelineTooltipField): string {
+    return (
+      MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.find(
+        (props: MonitorStateTimelineTooltipFieldProps) => {
+          return props.field === field;
+        },
+      )?.title || field
+    );
+  }
+}

--- a/Common/Utils/Dashboard/Components/DashboardListSharedArgs.ts
+++ b/Common/Utils/Dashboard/Components/DashboardListSharedArgs.ts
@@ -4,28 +4,54 @@ import {
   ComponentInputType,
 } from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
 import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
 
-export type DashboardListViewMode = "list" | "honeycomb";
+export type DashboardListViewMode = "list" | "honeycomb" | "timeline";
+
+export interface ViewModeArgumentOptions {
+  /*
+   * Offer the "State Timeline" mode as well.
+   *
+   * Opt-in rather than universal: a timeline needs a per-entity status
+   * history to draw, and most list widgets only have the entity's CURRENT
+   * status. Offering the mode where there is nothing to plot would hand the
+   * operator a permanently empty widget.
+   */
+  includeTimeline?: boolean | undefined;
+}
 
 /**
  * Returns the `viewMode` dropdown argument used by every dashboard list
  * component to switch between the default table view and a status-colored
- * honeycomb view.
+ * honeycomb view — plus, for widgets that pass `includeTimeline`, a state
+ * timeline that plots each entry's status over the dashboard's time range.
  */
 export function getViewModeArgument<T extends DashboardBaseComponent>(
   section: ComponentArgumentSection,
+  options?: ViewModeArgumentOptions | undefined,
 ): ComponentArgument<T> {
+  const includeTimeline: boolean = options?.includeTimeline === true;
+
+  const dropdownOptions: Array<DropdownOption> = [
+    { label: "List", value: "list" },
+    { label: "Honeycomb", value: "honeycomb" },
+  ];
+
+  if (includeTimeline) {
+    dropdownOptions.push({ label: "State Timeline", value: "timeline" });
+  }
+
+  const description: string = includeTimeline
+    ? "Show entries as a list (default), as a honeycomb where each cell is colored by status, or as a state timeline where each row is a bar colored by status across the dashboard's time range."
+    : "Show entries as a list (default) or as a honeycomb where each cell is colored by status.";
+
   return {
     name: "View Mode",
-    description:
-      "Show entries as a list (default) or as a honeycomb where each cell is colored by status.",
+    description: description,
     required: false,
     type: ComponentInputType.Dropdown,
     id: "viewMode" as keyof T["arguments"],
     section: section,
-    dropdownOptions: [
-      { label: "List", value: "list" },
-      { label: "Honeycomb", value: "honeycomb" },
-    ],
+    dropdownOptions: dropdownOptions,
   };
 }

--- a/Common/Utils/Dashboard/Components/DashboardMonitorListComponent.ts
+++ b/Common/Utils/Dashboard/Components/DashboardMonitorListComponent.ts
@@ -15,6 +15,10 @@ import {
 } from "../../../Types/Monitor/MonitorType";
 import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
 import { getViewModeArgument } from "./DashboardListSharedArgs";
+import {
+  MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS,
+  MonitorStateTimelineTooltipFieldProps,
+} from "../../../Types/Dashboard/MonitorStateTimelineTooltipField";
 
 const DisplaySection: ComponentArgumentSection = {
   name: "Display Options",
@@ -45,6 +49,23 @@ function getMonitorTypeDropdownOptions(): Array<DropdownOption> {
   });
 
   return options;
+}
+
+/*
+ * Kept in the canonical display order of
+ * MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS (NOT sorted alphabetically like the
+ * monitor-type list above): the tooltip renders its rows in that same order,
+ * so a picker that reordered them would misrepresent the result.
+ */
+function getTimelineTooltipFieldOptions(): Array<DropdownOption> {
+  return MONITOR_STATE_TIMELINE_TOOLTIP_FIELDS.map(
+    (props: MonitorStateTimelineTooltipFieldProps): DropdownOption => {
+      return {
+        label: props.title,
+        value: props.field,
+      };
+    },
+  );
 }
 
 export default class DashboardMonitorListComponentUtil extends DashboardBaseComponentUtil {
@@ -92,8 +113,27 @@ export default class DashboardMonitorListComponentUtil extends DashboardBaseComp
     });
 
     componentArguments.push(
-      getViewModeArgument<DashboardMonitorListComponent>(DisplaySection),
+      getViewModeArgument<DashboardMonitorListComponent>(DisplaySection, {
+        /*
+         * The monitor list is the one list widget whose entries have a stored
+         * status HISTORY (MonitorStatusTimeline), so it is the one that can
+         * plot a state timeline rather than only a current-status snapshot.
+         */
+        includeTimeline: true,
+      }),
     );
+
+    componentArguments.push({
+      name: "Timeline Tooltip",
+      description:
+        "Which details the State Timeline shows when you hover a bar. Applies to the State Timeline view mode only.",
+      required: false,
+      type: ComponentInputType.MultiSelectDropdown,
+      id: "timelineTooltipFields",
+      placeholder: "Status, Started, Ended, Duration",
+      section: DisplaySection,
+      dropdownOptions: getTimelineTooltipFieldOptions(),
+    });
 
     componentArguments.push({
       name: "Operational Status",

--- a/Common/Utils/Monitor/MonitorStateTimelineUtil.ts
+++ b/Common/Utils/Monitor/MonitorStateTimelineUtil.ts
@@ -1,0 +1,392 @@
+import OneUptimeDate from "../../Types/Date";
+import ObjectID from "../../Types/ObjectID";
+import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
+import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
+import MonitorEvent from "../Uptime/MonitorEvent";
+import UptimeUtil, { UptimeWindow } from "../Uptime/UptimeUtil";
+
+/*
+ * Turns MonitorStatusTimeline rows into the geometry a "state timeline"
+ * renders: one lane per monitor, and inside each lane a run of coloured
+ * segments positioned as percentages of the visible window.
+ *
+ * Deliberately pure — no React, no database, no clock of its own beyond what
+ * UptimeUtil already consults — so the arithmetic that decides where a bar
+ * starts, how wide it is, and what uptime it reports can be tested directly.
+ *
+ * The event math itself is NOT re-implemented here. UptimeUtil already owns
+ * the hard parts (clipping an event to a window, resolving an open row with
+ * endsAt = null against the next row or "now", and computing an uptime
+ * percentage whose denominator does not count time before a monitor's first
+ * recorded event). This module only converts those events into geometry.
+ */
+
+/**
+ * A segment is one contiguous run of a single status inside the window,
+ * already clipped to it. `startPercent` and `widthPercent` are percentages of
+ * the window's width, so a renderer can place them without knowing any dates.
+ */
+export interface MonitorStateTimelineSegment {
+  monitorStatusId: string;
+  label: string;
+  color: string;
+  startDate: Date;
+  endDate: Date;
+  durationInSeconds: number;
+  startPercent: number;
+  widthPercent: number;
+}
+
+/** One lane of the timeline: a single monitor and everything it did. */
+export interface MonitorStateTimelineRow {
+  monitorId: string;
+  monitorName: string;
+  segments: Array<MonitorStateTimelineSegment>;
+  /*
+   * Uptime over the visible window, or null when this monitor has no status
+   * history inside it at all — which is not the same as 0%, and must not be
+   * rendered as if it were.
+   */
+  uptimePercent: number | null;
+  /** The status the monitor is in at the END of the window. */
+  currentStatusName: string | undefined;
+  currentStatusColor: string | undefined;
+  /** Start of the last segment, i.e. when the status last changed. */
+  lastStatusChangeAt: Date | null;
+}
+
+/** One label under the timeline axis. */
+export interface MonitorStateTimelineAxisTick {
+  date: Date;
+  percent: number;
+}
+
+/** A distinct status shown in the timeline, for the legend. */
+export interface MonitorStateTimelineLegendItem {
+  monitorStatusId: string;
+  label: string;
+  color: string;
+}
+
+export interface MonitorStateTimelineInput {
+  /*
+   * The monitors to render, in the order they should appear. A monitor with
+   * no timeline rows still gets a lane — an empty lane is the honest answer
+   * to "this device has no recorded history in this window".
+   */
+  monitors: Array<{
+    monitorId: string;
+    monitorName: string;
+  }>;
+  statusTimelines: Array<MonitorStatusTimeline>;
+  startDate: Date;
+  endDate: Date;
+  uptimePrecision?: UptimePrecision | undefined;
+}
+
+export default class MonitorStateTimelineUtil {
+  /**
+   * True when the window is usable — a zero-length or inverted window has no
+   * geometry, and every percentage computed from it would divide by zero.
+   */
+  public static isWindowValid(startDate: Date, endDate: Date): boolean {
+    return endDate.getTime() > startDate.getTime();
+  }
+
+  /**
+   * Where `date` falls inside the window, as a 0-100 percentage, clamped to
+   * the window at both ends. An invalid window pins everything to 0.
+   */
+  public static getPercentOfWindow(data: {
+    date: Date;
+    startDate: Date;
+    endDate: Date;
+  }): number {
+    const { date, startDate, endDate } = data;
+
+    if (!MonitorStateTimelineUtil.isWindowValid(startDate, endDate)) {
+      return 0;
+    }
+
+    const windowMs: number = endDate.getTime() - startDate.getTime();
+    const offsetMs: number = date.getTime() - startDate.getTime();
+
+    const percent: number = (offsetMs / windowMs) * 100;
+
+    return Math.min(100, Math.max(0, percent));
+  }
+
+  /**
+   * The non-operational statuses appearing anywhere in `statusTimelines`.
+   *
+   * Derived from the rows the widget already fetched rather than from a
+   * second query for the project's status list: every row carries its status,
+   * and a status that never appears in the window cannot contribute downtime
+   * to it either. A row whose status did not select `isOperationalState` is
+   * treated as operational, so a missing column can only ever under-report
+   * downtime, never invent it.
+   */
+  public static getDowntimeStatuses(
+    statusTimelines: Array<MonitorStatusTimeline>,
+  ): Array<MonitorStatus> {
+    const byId: Map<string, MonitorStatus> = new Map<string, MonitorStatus>();
+
+    for (const timeline of statusTimelines) {
+      const status: MonitorStatus | undefined = timeline.monitorStatus;
+
+      if (!status || !status.id) {
+        continue;
+      }
+
+      if (status.isOperationalState === false) {
+        byId.set(status.id.toString(), status);
+      }
+    }
+
+    return Array.from(byId.values());
+  }
+
+  /**
+   * The timeline rows belonging to one monitor. Callers hand us every row for
+   * every monitor in one fetch (one query beats N), so each lane filters.
+   */
+  public static getTimelinesForMonitor(
+    statusTimelines: Array<MonitorStatusTimeline>,
+    monitorId: string,
+  ): Array<MonitorStatusTimeline> {
+    return statusTimelines.filter((timeline: MonitorStatusTimeline) => {
+      /*
+       * A row whose status did not come back joined is dropped rather than
+       * passed on: UptimeUtil reads `monitorStatus.id` unguarded, so one such
+       * row would throw and take the whole widget down. It happens when the
+       * status was deleted out from under the row, and a lane that is missing
+       * one segment is a far better outcome than a blank dashboard tile.
+       */
+      return (
+        timeline.monitorId?.toString() === monitorId &&
+        Boolean(timeline.monitorStatus)
+      );
+    });
+  }
+
+  /**
+   * One monitor's clipped events turned into positioned segments.
+   *
+   * Segments come back in chronological order. Zero-width segments are kept
+   * out: UptimeUtil already drops events that do not overlap the window, and
+   * a segment that rounds to no width is noise a renderer cannot draw.
+   */
+  public static buildSegments(data: {
+    monitorId: string;
+    statusTimelines: Array<MonitorStatusTimeline>;
+    startDate: Date;
+    endDate: Date;
+  }): Array<MonitorStateTimelineSegment> {
+    const { monitorId, statusTimelines, startDate, endDate } = data;
+
+    if (!MonitorStateTimelineUtil.isWindowValid(startDate, endDate)) {
+      return [];
+    }
+
+    const window: UptimeWindow = {
+      startDate: startDate,
+      endDate: endDate,
+    };
+
+    const events: Array<MonitorEvent> = UptimeUtil.getMonitorEventsForId(
+      new ObjectID(monitorId),
+      /*
+       * Filtered here as well as in buildRows so this stays safe when called
+       * on its own with every monitor's rows: the filter is what drops rows
+       * with no joined status, which UptimeUtil would throw on.
+       */
+      MonitorStateTimelineUtil.getTimelinesForMonitor(
+        statusTimelines,
+        monitorId,
+      ),
+      window,
+    );
+
+    const segments: Array<MonitorStateTimelineSegment> = [];
+
+    for (const event of events) {
+      const startPercent: number = MonitorStateTimelineUtil.getPercentOfWindow({
+        date: event.startDate,
+        startDate: startDate,
+        endDate: endDate,
+      });
+
+      const endPercent: number = MonitorStateTimelineUtil.getPercentOfWindow({
+        date: event.endDate,
+        startDate: startDate,
+        endDate: endDate,
+      });
+
+      const widthPercent: number = endPercent - startPercent;
+
+      if (widthPercent <= 0) {
+        continue;
+      }
+
+      segments.push({
+        monitorStatusId: event.eventStatusId.toString(),
+        label: event.label,
+        color: event.color.toString(),
+        startDate: event.startDate,
+        endDate: event.endDate,
+        durationInSeconds: OneUptimeDate.getSecondsBetweenDates(
+          event.startDate,
+          event.endDate,
+        ),
+        startPercent: startPercent,
+        widthPercent: widthPercent,
+      });
+    }
+
+    /*
+     * UptimeUtil sorts by start date already, but it sorts the timeline rows
+     * rather than the produced events, and an event list built from rows with
+     * equal startsAt is only as ordered as its input. Sorting here keeps
+     * "last segment == current status" true regardless.
+     */
+    segments.sort(
+      (a: MonitorStateTimelineSegment, b: MonitorStateTimelineSegment) => {
+        return a.startDate.getTime() - b.startDate.getTime();
+      },
+    );
+
+    return segments;
+  }
+
+  /**
+   * The complete set of lanes for a state timeline widget.
+   */
+  public static buildRows(
+    input: MonitorStateTimelineInput,
+  ): Array<MonitorStateTimelineRow> {
+    const { monitors, statusTimelines, startDate, endDate } = input;
+
+    const precision: UptimePrecision =
+      input.uptimePrecision ?? UptimePrecision.TWO_DECIMAL;
+
+    const downtimeStatuses: Array<MonitorStatus> =
+      MonitorStateTimelineUtil.getDowntimeStatuses(statusTimelines);
+
+    const isValidWindow: boolean = MonitorStateTimelineUtil.isWindowValid(
+      startDate,
+      endDate,
+    );
+
+    return monitors.map(
+      (monitor: {
+        monitorId: string;
+        monitorName: string;
+      }): MonitorStateTimelineRow => {
+        const timelinesForMonitor: Array<MonitorStatusTimeline> =
+          MonitorStateTimelineUtil.getTimelinesForMonitor(
+            statusTimelines,
+            monitor.monitorId,
+          );
+
+        const segments: Array<MonitorStateTimelineSegment> =
+          MonitorStateTimelineUtil.buildSegments({
+            monitorId: monitor.monitorId,
+            statusTimelines: timelinesForMonitor,
+            startDate: startDate,
+            endDate: endDate,
+          });
+
+        const lastSegment: MonitorStateTimelineSegment | undefined =
+          segments[segments.length - 1];
+
+        /*
+         * No segments means no recorded history inside the window. Reporting
+         * 100% there would claim an uptime the data does not support, and 0%
+         * would invent an outage, so the row reports nothing at all.
+         */
+        const uptimePercent: number | null =
+          segments.length > 0 && isValidWindow
+            ? UptimeUtil.calculateUptimePercentage(
+                timelinesForMonitor,
+                precision,
+                downtimeStatuses,
+                { startDate: startDate, endDate: endDate },
+              )
+            : null;
+
+        return {
+          monitorId: monitor.monitorId,
+          monitorName: monitor.monitorName,
+          segments: segments,
+          uptimePercent: uptimePercent,
+          currentStatusName: lastSegment?.label,
+          currentStatusColor: lastSegment?.color,
+          lastStatusChangeAt: lastSegment ? lastSegment.startDate : null,
+        };
+      },
+    );
+  }
+
+  /**
+   * Evenly spaced tick positions across the window, oldest first, including
+   * both edges. `tickCount` is the number of ticks, so 2 gives just the two
+   * edges. An invalid window, or fewer than two ticks, yields nothing to draw.
+   */
+  public static getAxisTicks(data: {
+    startDate: Date;
+    endDate: Date;
+    tickCount: number;
+  }): Array<MonitorStateTimelineAxisTick> {
+    const { startDate, endDate, tickCount } = data;
+
+    if (
+      !MonitorStateTimelineUtil.isWindowValid(startDate, endDate) ||
+      tickCount < 2
+    ) {
+      return [];
+    }
+
+    const windowMs: number = endDate.getTime() - startDate.getTime();
+    const ticks: Array<MonitorStateTimelineAxisTick> = [];
+
+    for (let i: number = 0; i < tickCount; i++) {
+      const fraction: number = i / (tickCount - 1);
+
+      ticks.push({
+        date: new Date(startDate.getTime() + windowMs * fraction),
+        percent: fraction * 100,
+      });
+    }
+
+    return ticks;
+  }
+
+  /**
+   * Every distinct status drawn across all lanes, in first-appearance order,
+   * so the legend explains exactly the colours on screen and nothing else.
+   */
+  public static getLegend(
+    rows: Array<MonitorStateTimelineRow>,
+  ): Array<MonitorStateTimelineLegendItem> {
+    const seen: Set<string> = new Set<string>();
+    const legend: Array<MonitorStateTimelineLegendItem> = [];
+
+    for (const row of rows) {
+      for (const segment of row.segments) {
+        if (seen.has(segment.monitorStatusId)) {
+          continue;
+        }
+
+        seen.add(segment.monitorStatusId);
+        legend.push({
+          monitorStatusId: segment.monitorStatusId,
+          label: segment.label,
+          color: segment.color,
+        });
+      }
+    }
+
+    return legend;
+  }
+}

--- a/Common/Utils/Monitor/MonitorStateTimelineUtil.ts
+++ b/Common/Utils/Monitor/MonitorStateTimelineUtil.ts
@@ -1,9 +1,8 @@
 import OneUptimeDate from "../../Types/Date";
-import ObjectID from "../../Types/ObjectID";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
-import MonitorEvent from "../Uptime/MonitorEvent";
+import Event from "../Uptime/Event";
 import UptimeUtil, { UptimeWindow } from "../Uptime/UptimeUtil";
 
 /*
@@ -36,6 +35,18 @@ export interface MonitorStateTimelineSegment {
   durationInSeconds: number;
   startPercent: number;
   widthPercent: number;
+  /*
+   * The monitor was STILL in this state at the right edge of the window, so
+   * the segment's end is where the chart stops, not where the state did.
+   * Only the last segment of a lane can carry it.
+   */
+  continuesAfterWindow: boolean;
+  /*
+   * The monitor was ALREADY in this state when the window opened, so the
+   * segment's start is where the chart begins, not where the state did. Only
+   * the first segment of a lane can carry it.
+   */
+  beganBeforeWindow: boolean;
 }
 
 /** One lane of the timeline: a single monitor and everything it did. */
@@ -55,6 +66,23 @@ export interface MonitorStateTimelineRow {
   /** Start of the last segment, i.e. when the status last changed. */
   lastStatusChangeAt: Date | null;
 }
+
+/*
+ * The longest range a state timeline will draw.
+ *
+ * A timeline row is written on every status CHANGE, so an unbounded window on
+ * a flapping fleet is an unbounded read, and a lane thousands of segments deep
+ * is unreadable anyway. 92 days matches the longest range the dashboard's own
+ * time picker offers (TimeRange.PAST_THREE_MONTHS); a longer CUSTOM range is
+ * clamped to it.
+ *
+ * Both ends of the wire share this number. The public route enforces it, and
+ * the browser applies it BEFORE it draws, so the axis never labels a span the
+ * server was never asked about.
+ */
+export const MAX_STATE_TIMELINE_WINDOW_IN_DAYS: number = 92;
+
+const MS_PER_DAY: number = 24 * 60 * 60 * 1000;
 
 /** One label under the timeline axis. */
 export interface MonitorStateTimelineAxisTick {
@@ -92,6 +120,30 @@ export default class MonitorStateTimelineUtil {
    */
   public static isWindowValid(startDate: Date, endDate: Date): boolean {
     return endDate.getTime() > startDate.getTime();
+  }
+
+  /**
+   * The window a timeline may actually draw, given the one the dashboard asked
+   * for. A range longer than the ceiling keeps its END — that is the edge the
+   * viewer is looking at — and has its start moved forward.
+   */
+  public static clampWindow(data: { startDate: Date; endDate: Date }): {
+    startDate: Date;
+    endDate: Date;
+  } {
+    const { startDate, endDate } = data;
+
+    const maxWindowInMs: number =
+      MAX_STATE_TIMELINE_WINDOW_IN_DAYS * MS_PER_DAY;
+
+    if (endDate.getTime() - startDate.getTime() > maxWindowInMs) {
+      return {
+        startDate: new Date(endDate.getTime() - maxWindowInMs),
+        endDate: endDate,
+      };
+    }
+
+    return { startDate: startDate, endDate: endDate };
   }
 
   /**
@@ -157,15 +209,89 @@ export default class MonitorStateTimelineUtil {
   ): Array<MonitorStatusTimeline> {
     return statusTimelines.filter((timeline: MonitorStatusTimeline) => {
       /*
-       * A row whose status did not come back joined is dropped rather than
-       * passed on: UptimeUtil reads `monitorStatus.id` unguarded, so one such
-       * row would throw and take the whole widget down. It happens when the
-       * status was deleted out from under the row, and a lane that is missing
-       * one segment is a far better outcome than a blank dashboard tile.
+       * A row whose status did not come back fully joined is dropped rather
+       * than passed on: UptimeUtil reads `monitorStatus.id` unguarded, so one
+       * such row throws and takes the whole widget down — and buildRows runs
+       * inside a render memo, not the fetch's try/catch, so the throw blanks
+       * the dashboard rather than the lane. The `id` is checked, not merely
+       * the relation: a status object present but without one fails in exactly
+       * the same place, and getDowntimeStatuses below already tests for it.
        */
       return (
         timeline.monitorId?.toString() === monitorId &&
-        Boolean(timeline.monitorStatus)
+        Boolean(timeline.monitorStatus?.id)
+      );
+    });
+  }
+
+  /**
+   * Whether the monitor was still in whatever state it was in when the window
+   * closed — i.e. the run the last bar draws had not ended by then.
+   *
+   * Read off the RAW rows rather than the clipped events, because a clipped
+   * event always ends at the window edge and so cannot tell the difference.
+   * The row that covers the window end is the latest one starting at or before
+   * it; if that row is open, or closes after the window, the state was still
+   * running. Taking the LATEST such row is also what makes this immune to the
+   * orphaned open rows (endsAt = NULL with a later successor) that
+   * MonitorStatusTimelineReconciler exists to repair — an orphan is superseded
+   * by the row that starts after it.
+   */
+  public static isStillInStateAtWindowEnd(
+    statusTimelines: Array<MonitorStatusTimeline>,
+    endDate: Date,
+  ): boolean {
+    let covering: MonitorStatusTimeline | null = null;
+
+    for (const timeline of statusTimelines) {
+      if (
+        !timeline.startsAt ||
+        timeline.startsAt.getTime() > endDate.getTime()
+      ) {
+        continue;
+      }
+
+      if (
+        !covering ||
+        !covering.startsAt ||
+        timeline.startsAt.getTime() >= covering.startsAt.getTime()
+      ) {
+        covering = timeline;
+      }
+    }
+
+    if (!covering) {
+      return false;
+    }
+
+    return !covering.endsAt || covering.endsAt.getTime() > endDate.getTime();
+  }
+
+  /**
+   * Whether the monitor was already in some state before the window opened —
+   * i.e. the run the first bar draws started earlier than the chart does.
+   *
+   * Same shape as isStillInStateAtWindowEnd and read off the RAW rows for the
+   * same reason: a clipped event always starts at the window edge, so it
+   * cannot tell a status change that happened at that instant from one that
+   * happened a year earlier.
+   */
+  public static beganBeforeWindowStart(
+    statusTimelines: Array<MonitorStatusTimeline>,
+    startDate: Date,
+  ): boolean {
+    return statusTimelines.some((timeline: MonitorStatusTimeline) => {
+      if (!timeline.startsAt) {
+        return false;
+      }
+
+      if (timeline.startsAt.getTime() >= startDate.getTime()) {
+        return false;
+      }
+
+      // Still running when the window opened.
+      return (
+        !timeline.endsAt || timeline.endsAt.getTime() > startDate.getTime()
       );
     });
   }
@@ -194,17 +320,26 @@ export default class MonitorStateTimelineUtil {
       endDate: endDate,
     };
 
-    const events: Array<MonitorEvent> = UptimeUtil.getMonitorEventsForId(
-      new ObjectID(monitorId),
-      /*
-       * Filtered here as well as in buildRows so this stays safe when called
-       * on its own with every monitor's rows: the filter is what drops rows
-       * with no joined status, which UptimeUtil would throw on.
-       */
+    /*
+     * Filtered here as well as in buildRows so this stays safe when called on
+     * its own with every monitor's rows: the filter is what drops rows with no
+     * usable status, which UptimeUtil would throw on.
+     */
+    const timelinesForMonitor: Array<MonitorStatusTimeline> =
       MonitorStateTimelineUtil.getTimelinesForMonitor(
         statusTimelines,
         monitorId,
-      ),
+      );
+
+    /*
+     * The NON-overlapping event list, which is the same one
+     * UptimeUtil.calculateUptimePercentage derives its number from. Drawing
+     * the raw list instead would let two overlapping rows paint bars summing
+     * past the width of the lane while the percentage beside them was computed
+     * from a different, split interpretation of the same rows.
+     */
+    const events: Array<Event> = UptimeUtil.getNonOverlappingMonitorEvents(
+      timelinesForMonitor,
       window,
     );
 
@@ -241,6 +376,9 @@ export default class MonitorStateTimelineUtil {
         ),
         startPercent: startPercent,
         widthPercent: widthPercent,
+        // Both decided once the whole run is known — below.
+        continuesAfterWindow: false,
+        beganBeforeWindow: false,
       });
     }
 
@@ -255,6 +393,37 @@ export default class MonitorStateTimelineUtil {
         return a.startDate.getTime() - b.startDate.getTime();
       },
     );
+
+    /*
+     * Only the last bar can still be running: every earlier one is bounded by
+     * the bar after it. Without this the hover card reads "Ended: <the current
+     * time>" over an outage that is still happening.
+     */
+    const lastSegment: MonitorStateTimelineSegment | undefined =
+      segments[segments.length - 1];
+
+    if (lastSegment) {
+      lastSegment.continuesAfterWindow =
+        MonitorStateTimelineUtil.isStillInStateAtWindowEnd(
+          timelinesForMonitor,
+          endDate,
+        );
+    }
+
+    /*
+     * Likewise only the first bar can have been cut off at the left. It is
+     * what tells the caller that the run it draws is older than the chart, so
+     * the clipped start is not a status change that happened.
+     */
+    const firstSegment: MonitorStateTimelineSegment | undefined = segments[0];
+
+    if (firstSegment) {
+      firstSegment.beganBeforeWindow =
+        MonitorStateTimelineUtil.beganBeforeWindowStart(
+          timelinesForMonitor,
+          startDate,
+        );
+    }
 
     return segments;
   }
@@ -322,7 +491,18 @@ export default class MonitorStateTimelineUtil {
           uptimePercent: uptimePercent,
           currentStatusName: lastSegment?.label,
           currentStatusColor: lastSegment?.color,
-          lastStatusChangeAt: lastSegment ? lastSegment.startDate : null,
+          /*
+           * null when nothing CHANGED inside the window. A monitor that has
+           * sat in one status since before the window opened has exactly one
+           * segment, clipped to the window start — reporting that boundary as
+           * a status change would tell an operator a seven-year-old
+           * Operational monitor changed status an hour ago, and would move
+           * forward on every auto-refresh.
+           */
+          lastStatusChangeAt:
+            lastSegment && !lastSegment.beganBeforeWindow
+              ? lastSegment.startDate
+              : null,
         };
       },
     );


### PR DESCRIPTION
Closes #3503.

## What the issue asked for, and what this actually does

The customer runs per-unit NOC dashboards filtered by Label and wants to see
**when** a device went down and **for how long**, not just its status right now.
That is the real ask, and it is what this PR ships.

Their four bullets, checked against the codebase:

| Asked for | Verdict | What this PR does |
|---|---|---|
| **State Timeline view mode** | Missing — genuinely | Ships it. |
| **Configurable status→colour mapping** | Already configurable | Monitor status colours are a per-project setting (**Monitors → Settings → Monitor Status**), and both existing view modes already render them. The timeline does the same. No second place to set the same colour. |
| **Configurable tooltip metrics** | Partly cheap | Ships a "Timeline Tooltip" multi-select for everything that is free once the timeline rows are fetched. Response time is not — see below. |
| **"The product's own picker already lists Time series / Stat / Heatmap / Status history / …"** | Not ours | That screenshot is Grafana's visualization picker. OneUptime's picker is the **Add Widget** modal (`WidgetCatalog.ts`, 48 widgets / 19 categories) and has none of those. Building ten Grafana panel types for monitor data is a different, much larger piece of work, and most of them (histogram, heatmap of what?) do not describe monitor status. |
| Grouped multi-section dashboards | Already possible | Text widgets are Markdown, the Monitor List already filters by `labelIds` and carries its own title, and the grid is free placement. The shipped "Monitor Dashboard" template already uses Text widgets as section headings. |

**Response time is deliberately not a tooltip row.** It is a ClickHouse metric
(`oneuptime.monitor.response.time`) with its own 30-day retention, emitted only
for probe monitors, and it would need a third fetch that the public dashboard
path has no route for. The metric Chart widget already plots it.

## The feature

Monitor List gains a third **View Mode: State Timeline** — one lane per monitor,
bars coloured by status across the dashboard's selected time range, an axis, a
legend of the statuses actually drawn, and the uptime for that range beside each
lane. Hovering a bar opens a card whose rows are configurable via a new
**Timeline Tooltip** multi-select (status, started, ended, duration, uptime in
range, current status, last status change, monitor type).

It works with every filter the widget already has, so the customer's
"per-unit network" dashboard is a Text widget plus three label-filtered Monitor
List widgets in State Timeline mode.

## How it is built

`Common/Utils/Monitor/MonitorStateTimelineUtil.ts` holds all of the arithmetic
and is pure — a bar in the wrong place is a test failure, not a wrong answer on
a wall display. It does **not** re-implement the event math: `UptimeUtil` already
owns clipping an event to a window, resolving an open (`endsAt = null`) row
against its successor or "now" — including the orphaned-open-row case
`MonitorStatusTimelineReconciler` exists to repair — and computing an uptime
percentage. This only turns those events into geometry, expressed in
percentages, so the renderer never measures itself and reads identically at any
width (which is also why it is testable in jsdom).

Data comes from one `monitorId IN (…)` query over rows that **overlap** the
window (`startsAt <= end AND (endsAt >= start OR endsAt IS NULL)`), not rows
that started inside it — a device that went Offline yesterday has exactly one
row and it starts in the past. The read only happens in the mode that draws it.

**Public dashboards** get a dedicated route,
`POST /dashboard/monitor-status-timeline/:dashboardId`, rather than another
`PUBLIC_DASHBOARD_RESOURCES` entry: the timeline is a read *about a set of
monitors*, and that set is a selector. The resource-list route rebuilds a
widget's query server-side precisely so an anonymous caller never supplies one,
so this route re-derives the monitor set from the stored widget through the same
policy, pins the project, fixes the select, and lets only the time window
through — validated, and clamped to 92 days rather than rejected.

## Tests

- `MonitorStateTimelineUtil.test.ts` — 47 tests: clipping, tiling without gaps
  or overlap, the orphaned-open-row case, degenerate windows, uptime agreeing
  with the bars, legend and axis.
- `MonitorListStateTimeline.test.tsx` — 27 render tests: which reads happen in
  which view mode, the overlap predicate and sort, bar geometry, the hover card,
  lane alignment, and the public path. Includes a **cross-wire contract test**
  that round-trips the request body through JSON and feeds it to the real
  server-side policy — that test caught a real serialization bug during
  development (`JSONFunctions.serialize` wraps each bound as
  `{_type: "DateTime"}`, which `InBetween.fromJSON` copies across verbatim, so
  the server would have rejected every request).
- `PublicDashboardMonitorStateTimelinePolicy.test.ts` — 28 tests on the window
  boundary and the response projection.
- `MonitorStateTimelineTooltipField.test.ts` — 17 tests on the stored config
  format.
- `HoverCardPosition.test.ts` — 11 tests; the honeycomb's inline placement
  arithmetic is now a shared, tested util that both widgets use.
- Existing suites updated: `DashboardListSharedArgs`, `DashboardMonitorListComponent`,
  `DashboardDateTime`.

Verified green: `Common/Tests/{Utils/Dashboard,Types/Dashboard,Utils/Uptime,Utils/Monitor,Server/Utils/Dashboard,App/Dashboard}`,
the touched `App/Tests/Dashboard` suites, plus `tsc` on Common, App and the
Dashboard feature set, and eslint on every changed file.

## Screens

The timeline is percentage-positioned and has no measurement step, so it renders
the same at any widget width. Reviewers can drop a Monitor List widget, set
**View Mode → State Timeline**, and pick a range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShS3Q16ksQ3mMoWw4TgtGr
