### PR TITLE
fix(docs): name the env var the Kubernetes inventory cutoff actually …

### DIFF
--- a/Common/Server/Services/KubernetesResourceService.ts
+++ b/Common/Server/Services/KubernetesResourceService.ts
@@ -946,7 +946,10 @@ export class Service extends DatabaseService<Model> {
 
   /**
    * Helper for the cleanup worker: snapshot-interval aware cutoff.
-   * 3× the 5-minute snapshot interval. Tune via CLEANUP_THRESHOLD_MINUTES.
+   * 3× the 5-minute snapshot interval. Tune via K8S_INVENTORY_STALE_MINUTES,
+   * which is floored at 5 — a smaller value is ignored and the default of 15
+   * applies, so raising the agent's resourceSpecs interval past a third of
+   * this threshold deletes live inventory rows.
    */
   public getStaleThresholdDate(nowOverride?: Date): Date {
     const minutes: number = this.getStaleThresholdMinutes();

--- a/Common/Server/Services/KubernetesResourceService.ts
+++ b/Common/Server/Services/KubernetesResourceService.ts
@@ -946,10 +946,11 @@ export class Service extends DatabaseService<Model> {
 
   /**
    * Helper for the cleanup worker: snapshot-interval aware cutoff.
-   * 3× the 5-minute snapshot interval. Tune via K8S_INVENTORY_STALE_MINUTES,
-   * which is floored at 5 — a smaller value is ignored and the default of 15
-   * applies, so raising the agent's resourceSpecs interval past a third of
-   * this threshold deletes live inventory rows.
+   * 3× the 5-minute snapshot interval by default. Tune via
+   * K8S_INVENTORY_STALE_MINUTES — a value below 5 is ignored and the
+   * 15-minute default applies, so it is not clamped to the floor. Keep the
+   * threshold above the agent's resourceSpecs interval: CleanupStaleResources
+   * hard-deletes inventory rows whose lastSeenAt is older than this cutoff.
    */
   public getStaleThresholdDate(nowOverride?: Date): Date {
     const minutes: number = this.getStaleThresholdMinutes();


### PR DESCRIPTION
The comment on KubernetesResourceService.getStaleThresholdDate says "Tune via CLEANUP_THRESHOLD_MINUTES". Nothing in the repo reads that name — getStaleThresholdMinutes reads K8S_INVENTORY_STALE_MINUTES, which is also the convention its Ceph, Docker, Docker Swarm, IoT, Podman and Proxmox siblings follow (<SYSTEM>_INVENTORY_STALE_MINUTES). Kubernetes was the only outlier, so anyone who set the documented name got the default of 15 minutes and no error.

While correcting the name, the comment now also states two things it left out: a value below 5 is ignored rather than applied, and this threshold is what bounds the agent's resourceSpecs pull interval, because CleanupStaleResources hard-deletes inventory rows whose lastSeenAt is older than it — raise the interval past a third of the threshold and rows for live objects get deleted.

Comment only, no behaviour change.