### PR TITLE
Enforce the enterprise license user limit, and let admins refresh it

### DIFF
--- a/Common/Server/API/GlobalConfigAPI.ts
+++ b/Common/Server/API/GlobalConfigAPI.ts
@@ -26,6 +26,11 @@ import {
 import EnterpriseLicenseInstanceSummary from "../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
 import VersionUtil from "../../Utils/VersionUtil";
 import UserMiddleware from "../Middleware/UserAuthorization";
+import MasterAdminAuthorization from "../Middleware/MasterAdminAuthorization";
+import EnterpriseLicenseSeatUtil from "../Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil";
+import { SeatUsage } from "../../Utils/EnterpriseLicense/EnterpriseLicenseSeats";
+import UserService from "../Services/UserService";
+import PositiveNumber from "../../Types/PositiveNumber";
 
 export default class GlobalConfigAPI extends BaseAPI<
   GlobalConfig,
@@ -104,6 +109,22 @@ export default class GlobalConfigAPI extends BaseAPI<
               config.enterpriseLicenseExpiresAt.getTime() > Date.now(),
           );
 
+          /*
+           * What the seat limit actually means on this installation right now,
+           * as opposed to what oneuptime.com last reported. Only for signed-in
+           * callers: it is derived from the live User table, and an anonymous
+           * visitor on the login page has no business being told how close this
+           * server is to refusing new accounts.
+           */
+          const seatUsage: SeatUsage | null = isAuthenticatedUser
+            ? await EnterpriseLicenseSeatUtil.getSeatUsageForLoadedGlobalConfig(
+                {
+                  config: config,
+                  getLocalUserCount: GlobalConfigAPI.getLocalUserCount,
+                },
+              )
+            : null;
+
           const responseBody: JSONObject = {
             companyName: config?.enterpriseCompanyName || null,
             expiresAt: config?.enterpriseLicenseExpiresAt
@@ -174,6 +195,7 @@ export default class GlobalConfigAPI extends BaseAPI<
             isUpdateCheckDisabled: isAuthenticatedUser
               ? DisableUpdateCheck
               : false,
+            ...GlobalConfigAPI.getSeatUsageResponseFields(seatUsage),
           };
 
           return Response.sendJsonObjectResponse(req, res, responseBody);
@@ -183,9 +205,19 @@ export default class GlobalConfigAPI extends BaseAPI<
       },
     );
 
+    /*
+     * Activating (or replacing) the license key for the whole installation.
+     *
+     * Master admin only. This writes the terms that bound how many users the
+     * installation may have, so anyone who can reach it can change the seat
+     * limit UserService now enforces. It used to run on
+     * UserMiddleware.getUserMiddleware, which lets anonymous callers through
+     * (it has to — the GET above serves the signed-out login page), so the
+     * route was in practice unauthenticated.
+     */
     this.router.post(
       `${new this.entityType().getCrudApiPath()?.toString()}/license`,
-      UserMiddleware.getUserMiddleware,
+      MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
       async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
         try {
           const licenseKey: string =
@@ -195,205 +227,352 @@ export default class GlobalConfigAPI extends BaseAPI<
             throw new BadDataException("License key is required");
           }
 
-          const globalConfigId: ObjectID = ObjectID.getZeroObjectID();
+          const responseBody: JSONObject =
+            await this.validateAndStoreLicenseKey(licenseKey);
 
-          const existingConfig: GlobalConfig | null =
-            await GlobalConfigService.findOneById({
-              id: globalConfigId,
-              select: {
-                _id: true,
-                instanceId: true,
-              },
-              props: {
-                isRoot: true,
-                ignoreHooks: true,
-              },
-            });
-
-          /*
-           * Send this instance's id and host along with the key so the
-           * license server registers this instance against the license and
-           * it shows up in the instance list on all instances that share
-           * the license.
-           */
-          const instanceId: ObjectID =
-            existingConfig?.instanceId || ObjectID.generate();
-
-          const validationResponse:
-            | HTTPResponse<JSONObject>
-            | HTTPErrorResponse = await API.post<JSONObject>({
-            url: EnterpriseLicenseValidationUrl,
-            data: {
-              licenseKey,
-              instanceId: instanceId.toString(),
-              host: Host,
-              /*
-               * Sent here as well as from the daily report job so the version
-               * lands on the license server the moment the key is validated,
-               * rather than up to 24 hours later.
-               */
-              version: AppVersion,
-            },
-          });
-
-          if (!validationResponse.isSuccess()) {
-            const errorMessage: string =
-              validationResponse instanceof HTTPErrorResponse
-                ? validationResponse.message ||
-                  "Failed to validate license key."
-                : "Failed to validate license key.";
-            throw new BadDataException(errorMessage);
-          }
-
-          const payload: JSONObject = validationResponse.data as JSONObject;
-
-          const companyNameRaw: string =
-            (payload["companyName"] as string | undefined)?.trim() || "";
-          const expiresAtRaw: string =
-            (payload["expiresAt"] as string | undefined) || "";
-          const licenseKeyRaw: string =
-            (payload["licenseKey"] as string | undefined)?.trim() || licenseKey;
-          const licenseToken: string =
-            (payload["token"] as string | undefined) || "";
-
-          let licenseExpiry: Date | undefined = undefined;
-          if (expiresAtRaw) {
-            const parsedDate: Date = new Date(expiresAtRaw);
-
-            if (Number.isNaN(parsedDate.getTime())) {
-              throw new BadDataException(
-                "License expiration returned from server is invalid.",
-              );
-            }
-
-            licenseExpiry = parsedDate;
-          }
-
-          const userLimitRaw: unknown = payload["userLimit"];
-          const userLimit: number | null =
-            typeof userLimitRaw === "number" && Number.isFinite(userLimitRaw)
-              ? userLimitRaw
-              : null;
-
-          const currentUserCountRaw: unknown = payload["currentUserCount"];
-          const currentUserCount: number | null =
-            typeof currentUserCountRaw === "number" &&
-            Number.isFinite(currentUserCountRaw)
-              ? currentUserCountRaw
-              : null;
-
-          const userCountUpdatedAtRaw: string | undefined = payload[
-            "userCountUpdatedAt"
-          ] as string | undefined;
-          let userCountUpdatedAt: Date | null = null;
-          if (userCountUpdatedAtRaw) {
-            const parsedReportedAt: Date = new Date(userCountUpdatedAtRaw);
-            if (!Number.isNaN(parsedReportedAt.getTime())) {
-              userCountUpdatedAt = parsedReportedAt;
-            }
-          }
-
-          const isEvaluationLicense: boolean =
-            payload["isEvaluationLicense"] === true;
-
-          const instances: Array<EnterpriseLicenseInstanceSummary> =
-            Array.isArray(payload["instances"])
-              ? (payload[
-                  "instances"
-                ] as Array<EnterpriseLicenseInstanceSummary>)
-              : [];
-
-          const updatePayload: PartialEntity<GlobalConfig> = {
-            enterpriseCompanyName: companyNameRaw || null,
-            enterpriseLicenseKey: licenseKeyRaw || null,
-            enterpriseLicenseExpiresAt: licenseExpiry || null,
-            enterpriseLicenseToken: licenseToken || null,
-            enterpriseLicenseIsEvaluation: isEvaluationLicense,
-            enterpriseLicenseUserLimit: userLimit,
-            enterpriseLicenseCurrentUserCount: currentUserCount,
-            enterpriseLicenseUserCountUpdatedAt: userCountUpdatedAt,
-            enterpriseLicenseInstances: instances,
-          };
-
-          if (!existingConfig?.instanceId) {
-            // Installs that predate instance ids: persist the one we generated.
-            updatePayload.instanceId = instanceId;
-          }
-
-          if (existingConfig) {
-            await GlobalConfigService.updateOneById({
-              id: globalConfigId,
-              data: updatePayload,
-              props: {
-                isRoot: true,
-                ignoreHooks: true,
-              },
-            });
-          } else {
-            const newConfig: GlobalConfig = new GlobalConfig();
-            newConfig.id = globalConfigId;
-
-            if (companyNameRaw) {
-              newConfig.enterpriseCompanyName = companyNameRaw;
-            }
-
-            if (licenseKeyRaw) {
-              newConfig.enterpriseLicenseKey = licenseKeyRaw;
-            }
-
-            if (licenseToken) {
-              newConfig.enterpriseLicenseToken = licenseToken;
-            }
-
-            newConfig.enterpriseLicenseIsEvaluation = isEvaluationLicense;
-
-            if (licenseExpiry) {
-              newConfig.enterpriseLicenseExpiresAt = licenseExpiry;
-            }
-
-            if (userLimit !== null) {
-              newConfig.enterpriseLicenseUserLimit = userLimit;
-            }
-
-            if (currentUserCount !== null) {
-              newConfig.enterpriseLicenseCurrentUserCount = currentUserCount;
-            }
-
-            if (userCountUpdatedAt) {
-              newConfig.enterpriseLicenseUserCountUpdatedAt =
-                userCountUpdatedAt;
-            }
-
-            newConfig.enterpriseLicenseInstances = instances;
-            newConfig.instanceId = instanceId;
-
-            await GlobalConfigService.create({
-              data: newConfig,
-              props: {
-                isRoot: true,
-                ignoreHooks: true,
-              },
-            });
-          }
-
-          return Response.sendJsonObjectResponse(req, res, {
-            companyName: companyNameRaw || null,
-            expiresAt: licenseExpiry ? licenseExpiry.toISOString() : null,
-            licenseKey: licenseKeyRaw || null,
-            token: licenseToken || null,
-            isEvaluationLicense: isEvaluationLicense,
-            userLimit: userLimit,
-            currentUserCount: currentUserCount,
-            userCountUpdatedAt: userCountUpdatedAt
-              ? userCountUpdatedAt.toISOString()
-              : null,
-            instances: instances,
-            instanceId: instanceId.toString(),
-          });
+          return Response.sendJsonObjectResponse(req, res, responseBody);
         } catch (err) {
           next(err);
         }
       },
     );
+
+    /*
+     * Re-fetch the license this installation already holds.
+     *
+     * The seat limit and the expiry live on oneuptime.com and can change on
+     * any day — a customer buys ten more seats at noon. The daily report job
+     * picks that up eventually; this is the button an administrator presses
+     * when "eventually" is not good enough, and it is the only way to apply a
+     * change without re-typing the key.
+     *
+     * Deliberately takes no license key: it uses the stored one. A refresh
+     * that accepted a key would be an activation with a friendlier name, and
+     * would let a mistyped key replace a working license by accident.
+     */
+    this.router.post(
+      `${new this.entityType().getCrudApiPath()?.toString()}/license/refresh`,
+      MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const config: GlobalConfig | null =
+            await GlobalConfigService.findOneById({
+              id: ObjectID.getZeroObjectID(),
+              select: {
+                enterpriseLicenseKey: true,
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          const licenseKey: string = config?.enterpriseLicenseKey?.trim() || "";
+
+          if (!licenseKey) {
+            throw new BadDataException(
+              "This installation does not have an enterprise license key yet. Enter a license key to activate it first.",
+            );
+          }
+
+          const responseBody: JSONObject =
+            await this.validateAndStoreLicenseKey(licenseKey);
+
+          return Response.sendJsonObjectResponse(req, res, responseBody);
+        } catch (err) {
+          next(err);
+        }
+      },
+    );
+  }
+
+  /*
+   * Ask oneuptime.com what this license key is worth today, and mirror the
+   * answer into GlobalConfig.
+   *
+   * Shared by activation and refresh so the two cannot drift: the whole point
+   * of refresh is that it applies exactly what activation would have applied,
+   * and a second hand-written copy of this mapping is how the seat limit came
+   * to be dropped on the floor by the daily report job before.
+   */
+  private async validateAndStoreLicenseKey(
+    licenseKey: string,
+  ): Promise<JSONObject> {
+    const globalConfigId: ObjectID = ObjectID.getZeroObjectID();
+
+    const existingConfig: GlobalConfig | null =
+      await GlobalConfigService.findOneById({
+        id: globalConfigId,
+        select: {
+          _id: true,
+          instanceId: true,
+        },
+        props: {
+          isRoot: true,
+          ignoreHooks: true,
+        },
+      });
+
+    /*
+     * Send this instance's id and host along with the key so the
+     * license server registers this instance against the license and
+     * it shows up in the instance list on all instances that share
+     * the license.
+     */
+    const instanceId: ObjectID =
+      existingConfig?.instanceId || ObjectID.generate();
+
+    const validationResponse: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await API.post<JSONObject>({
+        url: EnterpriseLicenseValidationUrl,
+        data: {
+          licenseKey,
+          instanceId: instanceId.toString(),
+          host: Host,
+          /*
+           * Sent here as well as from the daily report job so the version
+           * lands on the license server the moment the key is validated,
+           * rather than up to 24 hours later.
+           */
+          version: AppVersion,
+        },
+      });
+
+    if (!validationResponse.isSuccess()) {
+      const errorMessage: string =
+        validationResponse instanceof HTTPErrorResponse
+          ? validationResponse.message || "Failed to validate license key."
+          : "Failed to validate license key.";
+      throw new BadDataException(errorMessage);
+    }
+
+    const payload: JSONObject = validationResponse.data as JSONObject;
+
+    const companyNameRaw: string =
+      (payload["companyName"] as string | undefined)?.trim() || "";
+    const expiresAtRaw: string =
+      (payload["expiresAt"] as string | undefined) || "";
+    const licenseKeyRaw: string =
+      (payload["licenseKey"] as string | undefined)?.trim() || licenseKey;
+    const licenseToken: string = (payload["token"] as string | undefined) || "";
+
+    let licenseExpiry: Date | undefined = undefined;
+    if (expiresAtRaw) {
+      const parsedDate: Date = new Date(expiresAtRaw);
+
+      if (Number.isNaN(parsedDate.getTime())) {
+        throw new BadDataException(
+          "License expiration returned from server is invalid.",
+        );
+      }
+
+      licenseExpiry = parsedDate;
+    }
+
+    const userLimitRaw: unknown = payload["userLimit"];
+    const userLimit: number | null =
+      typeof userLimitRaw === "number" && Number.isFinite(userLimitRaw)
+        ? userLimitRaw
+        : null;
+
+    const currentUserCountRaw: unknown = payload["currentUserCount"];
+    const currentUserCount: number | null =
+      typeof currentUserCountRaw === "number" &&
+      Number.isFinite(currentUserCountRaw)
+        ? currentUserCountRaw
+        : null;
+
+    const userCountUpdatedAtRaw: string | undefined = payload[
+      "userCountUpdatedAt"
+    ] as string | undefined;
+    let userCountUpdatedAt: Date | null = null;
+    if (userCountUpdatedAtRaw) {
+      const parsedReportedAt: Date = new Date(userCountUpdatedAtRaw);
+      if (!Number.isNaN(parsedReportedAt.getTime())) {
+        userCountUpdatedAt = parsedReportedAt;
+      }
+    }
+
+    const isEvaluationLicense: boolean =
+      payload["isEvaluationLicense"] === true;
+
+    const instances: Array<EnterpriseLicenseInstanceSummary> = Array.isArray(
+      payload["instances"],
+    )
+      ? (payload["instances"] as Array<EnterpriseLicenseInstanceSummary>)
+      : [];
+
+    const updatePayload: PartialEntity<GlobalConfig> = {
+      enterpriseCompanyName: companyNameRaw || null,
+      enterpriseLicenseKey: licenseKeyRaw || null,
+      enterpriseLicenseExpiresAt: licenseExpiry || null,
+      enterpriseLicenseToken: licenseToken || null,
+      enterpriseLicenseIsEvaluation: isEvaluationLicense,
+      enterpriseLicenseUserLimit: userLimit,
+      enterpriseLicenseCurrentUserCount: currentUserCount,
+      enterpriseLicenseUserCountUpdatedAt: userCountUpdatedAt,
+      enterpriseLicenseInstances: instances,
+    };
+
+    if (!existingConfig?.instanceId) {
+      // Installs that predate instance ids: persist the one we generated.
+      updatePayload.instanceId = instanceId;
+    }
+
+    if (existingConfig) {
+      await GlobalConfigService.updateOneById({
+        id: globalConfigId,
+        data: updatePayload,
+        props: {
+          isRoot: true,
+          ignoreHooks: true,
+        },
+      });
+    } else {
+      const newConfig: GlobalConfig = new GlobalConfig();
+      newConfig.id = globalConfigId;
+
+      if (companyNameRaw) {
+        newConfig.enterpriseCompanyName = companyNameRaw;
+      }
+
+      if (licenseKeyRaw) {
+        newConfig.enterpriseLicenseKey = licenseKeyRaw;
+      }
+
+      if (licenseToken) {
+        newConfig.enterpriseLicenseToken = licenseToken;
+      }
+
+      newConfig.enterpriseLicenseIsEvaluation = isEvaluationLicense;
+
+      if (licenseExpiry) {
+        newConfig.enterpriseLicenseExpiresAt = licenseExpiry;
+      }
+
+      if (userLimit !== null) {
+        newConfig.enterpriseLicenseUserLimit = userLimit;
+      }
+
+      if (currentUserCount !== null) {
+        newConfig.enterpriseLicenseCurrentUserCount = currentUserCount;
+      }
+
+      if (userCountUpdatedAt) {
+        newConfig.enterpriseLicenseUserCountUpdatedAt = userCountUpdatedAt;
+      }
+
+      newConfig.enterpriseLicenseInstances = instances;
+      newConfig.instanceId = instanceId;
+
+      await GlobalConfigService.create({
+        data: newConfig,
+        props: {
+          isRoot: true,
+          ignoreHooks: true,
+        },
+      });
+    }
+
+    /*
+     * Seat usage recomputed from what was just stored, so the dialog that
+     * triggered this can show the new limit against the real user count
+     * without a second round trip - and so an administrator who just bought
+     * seats sees them land.
+     */
+    const seatUsage: SeatUsage | null =
+      await GlobalConfigAPI.getSeatUsageForResponse({
+        userLimit: userLimit,
+        currentUserCount: currentUserCount,
+        instances: instances,
+        instanceId: instanceId,
+      });
+
+    return {
+      companyName: companyNameRaw || null,
+      expiresAt: licenseExpiry ? licenseExpiry.toISOString() : null,
+      licenseKey: licenseKeyRaw || null,
+      token: licenseToken || null,
+      isEvaluationLicense: isEvaluationLicense,
+      userLimit: userLimit,
+      currentUserCount: currentUserCount,
+      userCountUpdatedAt: userCountUpdatedAt
+        ? userCountUpdatedAt.toISOString()
+        : null,
+      instances: instances,
+      instanceId: instanceId.toString(),
+      ...GlobalConfigAPI.getSeatUsageResponseFields(seatUsage),
+    };
+  }
+
+  /*
+   * Seat usage built from license terms held in memory rather than re-read
+   * from the database. Used right after a write, where re-reading would race
+   * the write it is describing.
+   */
+  private static async getSeatUsageForResponse(data: {
+    userLimit: number | null;
+    currentUserCount: number | null;
+    instances: Array<EnterpriseLicenseInstanceSummary>;
+    instanceId: ObjectID;
+  }): Promise<SeatUsage | null> {
+    const config: GlobalConfig = new GlobalConfig();
+    config.instanceId = data.instanceId;
+    config.enterpriseLicenseInstances = data.instances;
+
+    if (data.userLimit !== null) {
+      config.enterpriseLicenseUserLimit = data.userLimit;
+    }
+
+    if (data.currentUserCount !== null) {
+      config.enterpriseLicenseCurrentUserCount = data.currentUserCount;
+    }
+
+    return EnterpriseLicenseSeatUtil.getSeatUsageForLoadedGlobalConfig({
+      config: config,
+      getLocalUserCount: GlobalConfigAPI.getLocalUserCount,
+    });
+  }
+
+  /*
+   * How many users exist on this installation right now. Deliberately the live
+   * count rather than the last reported one: the number an administrator is
+   * about to act on is the number that decides whether the next invitation
+   * goes through.
+   */
+  private static async getLocalUserCount(): Promise<number> {
+    const userCount: PositiveNumber = await UserService.countBy({
+      query: {},
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return userCount.toNumber();
+  }
+
+  /*
+   * The seat-enforcement half of a license response. Always the same keys, so
+   * a client never has to tell "this build does not report seats" apart from
+   * "this installation does not enforce them" by which fields are missing:
+   * isSeatLimitEnforced is the single flag that answers that.
+   */
+  private static getSeatUsageResponseFields(
+    seatUsage: SeatUsage | null,
+  ): JSONObject {
+    if (!seatUsage || !seatUsage.isEnforced) {
+      return {
+        isSeatLimitEnforced: false,
+        seatsInUse: null,
+        seatsRemaining: null,
+        canAddMoreUsers: true,
+      };
+    }
+
+    return {
+      isSeatLimitEnforced: true,
+      seatsInUse: seatUsage.seatsInUse,
+      seatsRemaining: seatUsage.seatsRemaining,
+      canAddMoreUsers: seatUsage.hasSeatForNewUser,
+    };
   }
 }

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -58,6 +58,7 @@ import Name from "../../Types/Name";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import Timezone from "../../Types/Timezone";
 import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+import EnterpriseLicenseSeatUtil from "../Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil";
 
 /*
  * Names the Redis mutex that serializes the first-Master-Admin election across
@@ -184,6 +185,32 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeCreate(
     createBy: CreateBy<Model>,
   ): Promise<OnCreate<Model>> {
+    /*
+     * The enterprise seat limit, enforced here because this is the one place
+     * every new user passes through: team invitations, self-service signup,
+     * SSO/OIDC just-in-time provisioning, SCIM, and the Admin Dashboard all
+     * end up in `create`. Enforcing on the invitation instead would leave
+     * signup and SSO as open doors around it.
+     *
+     * No isRoot exemption on purpose — invitations create the invited user as
+     * root, so exempting root would exempt invitations, which is the exact
+     * thing this is here to bound. It is a no-op on Community Edition and on
+     * oneuptime.com (see EnterpriseLicenseSeatUtil.isSeatLimitEnforceable),
+     * and it never counts the User table on a licence with no seat limit.
+     */
+    await EnterpriseLicenseSeatUtil.assertSeatAvailableForNewUser({
+      getLocalUserCount: async (): Promise<number> => {
+        const userCount: PositiveNumber = await this.countBy({
+          query: {},
+          props: {
+            isRoot: true,
+          },
+        });
+
+        return userCount.toNumber();
+      },
+    });
+
     /*
      * clickIds / firstTouchAttribution are publicly creatable jsonb columns
      * (set during signup). Unlike the varchar(500) utm columns they have no

--- a/Common/Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil.ts
+++ b/Common/Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil.ts
@@ -1,0 +1,186 @@
+import GlobalConfig from "../../../Models/DatabaseModels/GlobalConfig";
+import EnterpriseLicenseInstanceSummary from "../../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import EnterpriseLicenseSeatsUtil, {
+  SeatUsage,
+} from "../../../Utils/EnterpriseLicense/EnterpriseLicenseSeats";
+import { IsBillingEnabled, IsEnterpriseEdition } from "../../EnvironmentConfig";
+import GlobalConfigService from "../../Services/GlobalConfigService";
+
+/*
+ * Counts the users on THIS installation. Passed in rather than called
+ * directly so this util never has to import UserService — and, more usefully,
+ * so the count is only paid for on the installations that actually enforce a
+ * limit. On Community Edition and on oneuptime.com itself the callbacks below
+ * are never invoked.
+ */
+export type GetLocalUserCountFunction = () => Promise<number>;
+
+/*
+ * Enforcement of the enterprise license seat limit on a self-hosted
+ * installation.
+ *
+ * The limit itself is set on oneuptime.com and mirrored into GlobalConfig by
+ * the daily report job (and by validating or refreshing the license by hand).
+ * This is the half that acts on it: it is the only thing standing between a
+ * customer's license terms and an unbounded User table.
+ *
+ * The seat arithmetic lives in Common/Utils/EnterpriseLicense/EnterpriseLicenseSeats
+ * as a pure function; everything here is about reading the license state and
+ * deciding whether the installation is one that enforces at all.
+ */
+export default class EnterpriseLicenseSeatUtil {
+  /*
+   * Whether this process is an installation whose users are governed by an
+   * enterprise license at all.
+   *
+   * Community Edition has no license and no limit. oneuptime.com runs with
+   * billing enabled and bounds seats through subscriptions instead
+   * (TeamMemberService.onBeforeCreate) — enforcing a license limit there as
+   * well would be a second, wrong answer to the same question.
+   */
+  public static isSeatLimitEnforceable(): boolean {
+    return IsEnterpriseEdition && !IsBillingEnabled;
+  }
+
+  /*
+   * Seat usage derived from an already-loaded GlobalConfig row. Kept separate
+   * from the loading so a caller that has the row in hand — the license
+   * endpoint, which has just read it — does not read it a second time.
+   *
+   * A null config (a fresh installation whose GlobalConfig has not been seeded
+   * yet) yields no limit, which is the same answer as a licence with no seat
+   * limit set.
+   */
+  public static getSeatUsageFromGlobalConfig(data: {
+    config: GlobalConfig | null;
+    localUserCount: number;
+  }): SeatUsage {
+    const config: GlobalConfig | null = data.config;
+
+    const instances: Array<EnterpriseLicenseInstanceSummary> = Array.isArray(
+      config?.enterpriseLicenseInstances,
+    )
+      ? config.enterpriseLicenseInstances
+      : [];
+
+    return EnterpriseLicenseSeatsUtil.getSeatUsage({
+      userLimit: config?.enterpriseLicenseUserLimit,
+      localUserCount: data.localUserCount,
+      aggregatedUserCount: config?.enterpriseLicenseCurrentUserCount,
+      instances: instances,
+      thisInstanceId: config?.instanceId ? config.instanceId.toString() : null,
+    });
+  }
+
+  /*
+   * Seat usage for this installation right now, or null on an installation
+   * that does not enforce a seat limit.
+   *
+   * Null rather than an unenforced SeatUsage so callers cannot accidentally
+   * present Community Edition with a seat report it has no business having,
+   * and so the user count is never queried there.
+   */
+  public static async getSeatUsage(data: {
+    getLocalUserCount: GetLocalUserCountFunction;
+  }): Promise<SeatUsage | null> {
+    if (!this.isSeatLimitEnforceable()) {
+      return null;
+    }
+
+    const config: GlobalConfig | null = await GlobalConfigService.findOneById({
+      id: ObjectID.getZeroObjectID(),
+      select: {
+        enterpriseLicenseUserLimit: true,
+        enterpriseLicenseCurrentUserCount: true,
+        enterpriseLicenseInstances: true,
+        instanceId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return this.getSeatUsageForLoadedGlobalConfig({
+      config: config,
+      getLocalUserCount: data.getLocalUserCount,
+    });
+  }
+
+  /*
+   * The same answer as getSeatUsage, for a caller that has already loaded the
+   * GlobalConfig row (the license endpoint reads it to build its response, and
+   * reading it twice per request would be silly).
+   *
+   * The row must have been selected with enterpriseLicenseUserLimit,
+   * enterpriseLicenseCurrentUserCount, enterpriseLicenseInstances and
+   * instanceId, or the numbers here are a fiction built from missing columns.
+   */
+  public static async getSeatUsageForLoadedGlobalConfig(data: {
+    config: GlobalConfig | null;
+    getLocalUserCount: GetLocalUserCountFunction;
+  }): Promise<SeatUsage | null> {
+    if (!this.isSeatLimitEnforceable()) {
+      return null;
+    }
+
+    /*
+     * The seat limit is read before the users are counted, and the count is
+     * skipped entirely when there is no limit. An unlimited licence is the
+     * common case on a large installation, and that is exactly the
+     * installation where counting the User table on every user creation would
+     * be worth avoiding.
+     */
+    const withoutLocalUsers: SeatUsage = this.getSeatUsageFromGlobalConfig({
+      config: data.config,
+      localUserCount: 0,
+    });
+
+    if (!withoutLocalUsers.isEnforced) {
+      return withoutLocalUsers;
+    }
+
+    return this.getSeatUsageFromGlobalConfig({
+      config: data.config,
+      localUserCount: await data.getLocalUserCount(),
+    });
+  }
+
+  /*
+   * Throws if this installation cannot take another user.
+   *
+   * Called from UserService.onBeforeCreate, which every path that creates a
+   * user goes through — team invitations, self-service signup, SSO and OIDC
+   * just-in-time provisioning, SCIM, and the Admin Dashboard. Enforcing on the
+   * User row rather than on the invitation is what makes that true: a seat is
+   * consumed by a person existing on the installation, not by the particular
+   * door they came through.
+   *
+   * It is also why this deliberately does NOT exempt root/internal writes.
+   * Team invitations create the invited user with `isRoot: true`, so an
+   * isRoot escape hatch here would exempt the single most important path.
+   */
+  public static async assertSeatAvailableForNewUser(data: {
+    getLocalUserCount: GetLocalUserCountFunction;
+  }): Promise<void> {
+    const seatUsage: SeatUsage | null = await this.getSeatUsage({
+      getLocalUserCount: data.getLocalUserCount,
+    });
+
+    if (!seatUsage || !seatUsage.isEnforced) {
+      return;
+    }
+
+    if (seatUsage.hasSeatForNewUser) {
+      return;
+    }
+
+    throw new BadDataException(
+      EnterpriseLicenseSeatsUtil.getSeatLimitReachedMessage({
+        seatsInUse: seatUsage.seatsInUse,
+        userLimit: seatUsage.userLimit as number,
+      }),
+    );
+  }
+}

--- a/Common/Tests/Server/API/GlobalConfigLicense.test.ts
+++ b/Common/Tests/Server/API/GlobalConfigLicense.test.ts
@@ -1,0 +1,657 @@
+import GlobalConfigAPI from "../../../Server/API/GlobalConfigAPI";
+import MasterAdminAuthorization from "../../../Server/Middleware/MasterAdminAuthorization";
+import GlobalConfigService from "../../../Server/Services/GlobalConfigService";
+import UserService from "../../../Server/Services/UserService";
+import Response from "../../../Server/Utils/Response";
+import GlobalConfig from "../../../Models/DatabaseModels/GlobalConfig";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import API from "../../../Utils/API";
+import {
+  NextFunction,
+  OneUptimeRequest,
+  OneUptimeResponse,
+} from "../../../Server/Utils/Express";
+import { mockRouter } from "./Helpers";
+import { beforeEach, afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * The self-hosted half of the licence: activating a key, refreshing the key
+ * the installation already holds, and reporting what the seat limit means
+ * right now.
+ *
+ * Two things brought this suite into being.
+ *
+ * The seat limit is set on oneuptime.com and changes on any day — a customer
+ * buys ten more seats at noon. It reaches the installation through the daily
+ * report job, so until now the only way to apply it sooner was for somebody to
+ * re-type the licence key into a box that is HIDDEN while the licence is
+ * valid. /license/refresh is that missing button, and it exists precisely
+ * because the installation now refuses users above the limit: waiting a day to
+ * learn about seats you have already paid for is a different feature when the
+ * old number is being enforced.
+ *
+ * And both writes used to run on UserMiddleware.getUserMiddleware, which lets
+ * anonymous callers through — it has to, because the GET on the same path
+ * serves the signed-out login page. That made the route that decides this
+ * installation's seat ceiling reachable without signing in at all.
+ */
+
+/*
+ * PasswordHash carries a pre-existing TS diagnostic that fails any suite whose
+ * require graph reaches it, and BaseAPI's graph still reaches it. Replaced with
+ * a factory rather than automocked, because an automock still type-checks the
+ * real file.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+// Same story as PasswordHash: a local-only diagnostic in a module dragged in.
+jest.mock("../../../Server/Utils/VerificationCode", () => {
+  return {
+    __esModule: true,
+    default: {
+      generate: jest.fn(),
+      hashCode: jest.fn(),
+      isHashEqual: jest.fn(),
+      generateUnusableHash: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendJsonObjectResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendErrorResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+  };
+});
+
+/*
+ * The deployment flags live on globalThis rather than in module-scope
+ * variables, and the getters below reference nothing but globalThis.
+ *
+ * jest hoists the mock factory above every declaration in this file, and
+ * BaseAPI's import graph reaches IncidentFeedService, which reads
+ * IsBillingEnabled at module scope. That read lands inside these getters
+ * during the import — before a `let` in this file has initialised — and a
+ * getter that closed over one would throw a temporal-dead-zone
+ * ReferenceError before a single test ran. Absent flags read as false, which
+ * is a fine thing for an unrelated service to see on its way past.
+ *
+ * They are also live accessors rather than values: the routes read the flags
+ * when they run, and object spread would flatten them at import time.
+ */
+const BILLING_FLAG_KEY: string = "__oneUptimeTestIsBillingEnabled";
+const ENTERPRISE_FLAG_KEY: string = "__oneUptimeTestIsEnterpriseEdition";
+
+type SetDeploymentFlagFunction = (key: string, value: boolean) => void;
+
+const setDeploymentFlag: SetDeploymentFlagFunction = (
+  key: string,
+  value: boolean,
+): void => {
+  (globalThis as unknown as Record<string, unknown>)[key] = value;
+};
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../../Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  const mocked: Record<string, unknown> = {
+    ...actual,
+    __esModule: true,
+  };
+
+  Object.defineProperty(mocked, "IsBillingEnabled", {
+    get: (): boolean => {
+      return (
+        (globalThis as unknown as Record<string, unknown>)[
+          "__oneUptimeTestIsBillingEnabled"
+        ] === true
+      );
+    },
+  });
+
+  Object.defineProperty(mocked, "IsEnterpriseEdition", {
+    get: (): boolean => {
+      return (
+        (globalThis as unknown as Record<string, unknown>)[
+          "__oneUptimeTestIsEnterpriseEdition"
+        ] === true
+      );
+    },
+  });
+
+  return mocked;
+});
+
+/*
+ * Factories rather than automocks. An automock still loads the real module to
+ * copy its shape, and loading UserService drags in most of the service graph -
+ * some of which reads IsBillingEnabled at module scope, before the flags above
+ * have initialised. Nothing here needs the real implementations.
+ */
+jest.mock("../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+      updateOneById: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      countBy: jest.fn(),
+    },
+  };
+});
+
+const LICENSE_ROUTE: string = "/global-config/license";
+const REFRESH_ROUTE: string = "/global-config/license/refresh";
+
+const STORED_LICENSE_KEY: string = "acme-stored-license-key";
+const INSTANCE_ID: ObjectID = ObjectID.generate();
+
+type MakeStoredConfigFunction = (
+  overrides?: Record<string, unknown>,
+) => GlobalConfig;
+
+const makeStoredConfig: MakeStoredConfigFunction = (
+  overrides?: Record<string, unknown>,
+): GlobalConfig => {
+  const config: GlobalConfig = new GlobalConfig();
+  config.id = ObjectID.getZeroObjectID();
+  config.instanceId = INSTANCE_ID;
+  config.enterpriseLicenseKey = STORED_LICENSE_KEY;
+
+  return Object.assign(config, overrides || {});
+};
+
+type LicenseServerPayloadFunction = (
+  overrides?: Record<string, unknown>,
+) => JSONObject;
+
+const licenseServerPayload: LicenseServerPayloadFunction = (
+  overrides?: Record<string, unknown>,
+): JSONObject => {
+  return {
+    companyName: "Acme Inc",
+    expiresAt: "2030-01-01T00:00:00.000Z",
+    licenseKey: STORED_LICENSE_KEY,
+    token: "signed.jwt.token",
+    isEvaluationLicense: false,
+    userLimit: 150,
+    currentUserCount: 42,
+    userCountUpdatedAt: "2026-01-01T00:00:00.000Z",
+    instances: [],
+    ...overrides,
+  };
+};
+
+type GetResponseBodyFunction = () => JSONObject;
+
+const getResponseBody: GetResponseBodyFunction = (): JSONObject => {
+  const calls: Array<Array<unknown>> = (
+    Response.sendJsonObjectResponse as unknown as jest.Mock
+  ).mock.calls as Array<Array<unknown>>;
+
+  expect(calls).toHaveLength(1);
+
+  return calls[0]![2] as JSONObject;
+};
+
+type GetStoredUpdateFunction = () => JSONObject;
+
+const getStoredUpdate: GetStoredUpdateFunction = (): JSONObject => {
+  const calls: Array<Array<unknown>> = (
+    GlobalConfigService.updateOneById as unknown as jest.Mock
+  ).mock.calls as Array<Array<unknown>>;
+
+  expect(calls.length).toBeGreaterThan(0);
+
+  return (calls[0]![0] as Record<string, unknown>)["data"] as JSONObject;
+};
+
+describe("GlobalConfigAPI licence routes", () => {
+  let mockRequest: OneUptimeRequest;
+  let mockResponse: OneUptimeResponse;
+  let nextFunction: NextFunction;
+
+  type CallRouteFunction = (route: string) => Promise<void>;
+
+  const callRoute: CallRouteFunction = async (route: string): Promise<void> => {
+    await mockRouter
+      .match("post", route)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+  };
+
+  type NextErrorFunction = () => Error;
+
+  const nextError: NextErrorFunction = (): Error => {
+    const calls: Array<Array<unknown>> = (nextFunction as unknown as jest.Mock)
+      .mock.calls as Array<Array<unknown>>;
+
+    expect(calls).toHaveLength(1);
+
+    return calls[0]![0] as Error;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouter.routes = [];
+    setDeploymentFlag(BILLING_FLAG_KEY, false);
+    setDeploymentFlag(ENTERPRISE_FLAG_KEY, true);
+
+    new GlobalConfigAPI();
+
+    GlobalConfigService.findOneById = jest
+      .fn()
+      .mockResolvedValue(makeStoredConfig());
+    GlobalConfigService.updateOneById = jest.fn().mockResolvedValue(undefined);
+    GlobalConfigService.create = jest.fn().mockResolvedValue(undefined);
+
+    UserService.countBy = jest.fn().mockResolvedValue(new PositiveNumber(42));
+
+    (API.post as unknown as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, licenseServerPayload(), {}),
+      );
+
+    mockRequest = {
+      body: {},
+    } as unknown as OneUptimeRequest;
+
+    mockResponse = {
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as OneUptimeResponse;
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("who is allowed to write the licence", () => {
+    /*
+     * The seat limit these routes store is the number UserService refuses new
+     * users against. UserMiddleware.getUserMiddleware — which the GET on the
+     * same path uses, and has to, because it serves the signed-out login page —
+     * lets anonymous callers straight through, so it is not a guard here.
+     */
+    it.each([
+      ["activating a licence key", LICENSE_ROUTE],
+      ["refreshing the stored licence", REFRESH_ROUTE],
+    ])("requires a master admin for %s", (_label: string, route: string) => {
+      expect(mockRouter.match("post", route).middlewares).toContain(
+        MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+      );
+    });
+
+    it("still serves the licence GET to anyone, so the login page keeps working", () => {
+      expect(mockRouter.match("get", LICENSE_ROUTE).middlewares).not.toContain(
+        MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+      );
+    });
+  });
+
+  describe("POST /global-config/license - activating a key", () => {
+    it("rejects a request with no licence key", async () => {
+      mockRequest.body = {};
+
+      await callRoute(LICENSE_ROUTE);
+
+      expect(nextError()).toBeInstanceOf(BadDataException);
+      expect(API.post).not.toHaveBeenCalled();
+    });
+
+    it("rejects a licence key that is only whitespace", async () => {
+      mockRequest.body = { licenseKey: "   " };
+
+      await callRoute(LICENSE_ROUTE);
+
+      expect(nextError()).toBeInstanceOf(BadDataException);
+    });
+
+    it("validates the supplied key against oneuptime.com", async () => {
+      mockRequest.body = { licenseKey: "  a-new-key  " };
+
+      await callRoute(LICENSE_ROUTE);
+
+      const sent: JSONObject = (
+        (API.post as unknown as jest.Mock).mock.calls[0]![0] as Record<
+          string,
+          JSONObject
+        >
+      )["data"] as JSONObject;
+
+      expect(sent["licenseKey"]).toBe("a-new-key");
+      expect(sent["instanceId"]).toBe(INSTANCE_ID.toString());
+    });
+
+    it("stores the seat limit the licence server reported", async () => {
+      mockRequest.body = { licenseKey: STORED_LICENSE_KEY };
+
+      await callRoute(LICENSE_ROUTE);
+
+      expect(getStoredUpdate()["enterpriseLicenseUserLimit"]).toBe(150);
+    });
+  });
+
+  describe("POST /global-config/license/refresh", () => {
+    /*
+     * The whole point of the route: no key in the body. A refresh that
+     * accepted one would be an activation with a friendlier name, and a
+     * mistyped key would be able to replace a working licence by accident.
+     */
+    it("refreshes using the stored key and ignores anything in the body", async () => {
+      mockRequest.body = { licenseKey: "somebody-elses-key" };
+
+      await callRoute(REFRESH_ROUTE);
+
+      const sent: JSONObject = (
+        (API.post as unknown as jest.Mock).mock.calls[0]![0] as Record<
+          string,
+          JSONObject
+        >
+      )["data"] as JSONObject;
+
+      expect(sent["licenseKey"]).toBe(STORED_LICENSE_KEY);
+    });
+
+    it("refuses to refresh an installation that has no licence key yet", async () => {
+      GlobalConfigService.findOneById = jest
+        .fn()
+        .mockResolvedValue(
+          makeStoredConfig({ enterpriseLicenseKey: undefined }),
+        );
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(nextError()).toBeInstanceOf(BadDataException);
+      expect(API.post).not.toHaveBeenCalled();
+    });
+
+    it("refuses to refresh when there is no config row at all", async () => {
+      GlobalConfigService.findOneById = jest.fn().mockResolvedValue(null);
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(nextError()).toBeInstanceOf(BadDataException);
+      expect(API.post).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The reason the button exists. The customer raised the limit on
+     * oneuptime.com; the stored 50 is what this installation is refusing users
+     * against until something writes the new number down.
+     */
+    it("applies a seat limit that has been raised on oneuptime.com", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          licenseServerPayload({ userLimit: 500 }),
+          {},
+        ),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(getStoredUpdate()["enterpriseLicenseUserLimit"]).toBe(500);
+      expect(getResponseBody()["userLimit"]).toBe(500);
+    });
+
+    it("applies a seat limit that has been lowered on oneuptime.com", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          licenseServerPayload({ userLimit: 5 }),
+          {},
+        ),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(getStoredUpdate()["enterpriseLicenseUserLimit"]).toBe(5);
+    });
+
+    it("clears the seat limit when the licence no longer carries one", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          licenseServerPayload({ userLimit: null }),
+          {},
+        ),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(getStoredUpdate()["enterpriseLicenseUserLimit"]).toBeNull();
+    });
+
+    it("refreshes the expiry as well as the seat limit", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          licenseServerPayload({ expiresAt: "2031-06-01T00:00:00.000Z" }),
+          {},
+        ),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(
+        (
+          getStoredUpdate()["enterpriseLicenseExpiresAt"] as unknown as Date
+        ).toISOString(),
+      ).toBe("2031-06-01T00:00:00.000Z");
+    });
+
+    /*
+     * An installation that cannot reach oneuptime.com must be told so rather
+     * than quietly keeping the old terms and reporting success — the
+     * administrator pressed this button precisely because they believe the old
+     * terms are wrong.
+     */
+    it("surfaces a failure from the licence server instead of storing anything", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPErrorResponse(500, { message: "License key is invalid" }, {}),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      const error: Error = nextError();
+
+      expect(error).toBeInstanceOf(BadDataException);
+      expect(error.message).toBe("License key is invalid");
+      expect(GlobalConfigService.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("does not store anything when the returned expiry is not a date", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          licenseServerPayload({ expiresAt: "the-first-of-never" }),
+          {},
+        ),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      expect(nextError()).toBeInstanceOf(BadDataException);
+      expect(GlobalConfigService.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the seat enforcement the response reports", () => {
+    it("reports the seats in use against the freshly refreshed limit", async () => {
+      UserService.countBy = jest.fn().mockResolvedValue(new PositiveNumber(42));
+
+      await callRoute(REFRESH_ROUTE);
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["isSeatLimitEnforced"]).toBe(true);
+      expect(body["seatsInUse"]).toBe(42);
+      expect(body["seatsRemaining"]).toBe(108);
+      expect(body["canAddMoreUsers"]).toBe(true);
+    });
+
+    /*
+     * The live count is what enforcement uses, and it is allowed to be higher
+     * than the licence-wide figure oneuptime.com last computed — that figure is
+     * up to a day old.
+     */
+    it("prefers the live user count over the licence server's stale one", async () => {
+      UserService.countBy = jest
+        .fn()
+        .mockResolvedValue(new PositiveNumber(150));
+
+      await callRoute(REFRESH_ROUTE);
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["seatsInUse"]).toBe(150);
+      expect(body["seatsRemaining"]).toBe(0);
+      expect(body["canAddMoreUsers"]).toBe(false);
+    });
+
+    it("says the limit is not enforced when the licence has none", async () => {
+      (API.post as unknown as jest.Mock).mockResolvedValue(
+        new HTTPResponse<JSONObject>(
+          200,
+          licenseServerPayload({ userLimit: null }),
+          {},
+        ),
+      );
+
+      await callRoute(REFRESH_ROUTE);
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["isSeatLimitEnforced"]).toBe(false);
+      expect(body["seatsInUse"]).toBeNull();
+      expect(body["canAddMoreUsers"]).toBe(true);
+    });
+
+    it("says the limit is not enforced on Community Edition", async () => {
+      setDeploymentFlag(ENTERPRISE_FLAG_KEY, false);
+
+      await callRoute(REFRESH_ROUTE);
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["isSeatLimitEnforced"]).toBe(false);
+      expect(body["canAddMoreUsers"]).toBe(true);
+      expect(UserService.countBy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /global-config/license", () => {
+    type CallGetFunction = () => Promise<void>;
+
+    const callGet: CallGetFunction = async (): Promise<void> => {
+      await mockRouter
+        .match("get", LICENSE_ROUTE)
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+    };
+
+    beforeEach(() => {
+      GlobalConfigService.findOneById = jest.fn().mockResolvedValue(
+        makeStoredConfig({
+          enterpriseLicenseUserLimit: 150,
+          enterpriseLicenseCurrentUserCount: 42,
+          enterpriseLicenseInstances: [],
+        }),
+      );
+    });
+
+    it("tells a signed-in administrator how close the installation is to refusing users", async () => {
+      (mockRequest as unknown as Record<string, unknown>)["userAuthorization"] =
+        {
+          userId: ObjectID.generate(),
+        };
+      UserService.countBy = jest
+        .fn()
+        .mockResolvedValue(new PositiveNumber(149));
+
+      await callGet();
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["isSeatLimitEnforced"]).toBe(true);
+      expect(body["seatsInUse"]).toBe(149);
+      expect(body["seatsRemaining"]).toBe(1);
+      expect(body["canAddMoreUsers"]).toBe(true);
+    });
+
+    /*
+     * The same route serves the signed-out login page. How near this server is
+     * to refusing new accounts is operational detail, and counting its users
+     * for an anonymous visitor would be a free query on an unauthenticated
+     * endpoint besides.
+     */
+    it("tells an anonymous visitor nothing about seat enforcement", async () => {
+      await callGet();
+
+      const body: JSONObject = getResponseBody();
+
+      expect(body["isSeatLimitEnforced"]).toBe(false);
+      expect(body["seatsInUse"]).toBeNull();
+      expect(body["seatsRemaining"]).toBeNull();
+      expect(body["canAddMoreUsers"]).toBe(true);
+      expect(UserService.countBy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Services/UserServiceSeatLimit.test.ts
+++ b/Common/Tests/Server/Services/UserServiceSeatLimit.test.ts
@@ -1,0 +1,182 @@
+import UserService from "../../../Server/Services/UserService";
+import EnterpriseLicenseSeatUtil from "../../../Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import User from "../../../Models/DatabaseModels/User";
+import Email from "../../../Types/Email";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import { beforeEach, afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Where the enterprise seat limit is actually enforced.
+ *
+ * The limit is bought per user and shared by every instance on the licence,
+ * and a seat is consumed by a person EXISTING on the installation — not by the
+ * particular door they walked through. There are eight of those doors: team
+ * invitations, self-service signup, SAML and OIDC just-in-time provisioning
+ * (project-level and global), three SCIM routes, the Admin Dashboard user
+ * form, and the master API key posting to /api/user. Every one of them ends up
+ * in UserService.create, so the check belongs in its create hook and nowhere
+ * else; a check on the invitation would have left signup and SSO as open doors
+ * beside it.
+ *
+ * The single most important assertion in this file is the isRoot one. Team
+ * invitations create the invited user with `props: { isRoot: true }`
+ * (TeamMemberService.onBeforeCreate), so the usual "internal writes bypass
+ * this" instinct would exempt invitations — the exact path this feature was
+ * asked for.
+ */
+
+jest.mock(
+  "../../../Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        assertSeatAvailableForNewUser: jest.fn(),
+      },
+    };
+  },
+);
+
+type OnBeforeCreateFunction = (createBy: CreateBy<User>) => Promise<unknown>;
+
+/*
+ * onBeforeCreate is protected, which is exactly the right shape for it and
+ * exactly the wrong shape for a test. Reached through the instance rather than
+ * re-implemented, so this suite breaks if the hook is renamed or removed.
+ */
+const onBeforeCreate: OnBeforeCreateFunction = (
+  createBy: CreateBy<User>,
+): Promise<unknown> => {
+  return (
+    UserService as unknown as {
+      onBeforeCreate: OnBeforeCreateFunction;
+    }
+  ).onBeforeCreate(createBy);
+};
+
+type MakeCreateByFunction = (props?: Record<string, unknown>) => CreateBy<User>;
+
+const makeCreateBy: MakeCreateByFunction = (
+  props?: Record<string, unknown>,
+): CreateBy<User> => {
+  const user: User = new User();
+  user.email = new Email("someone@acme.com");
+
+  return {
+    data: user,
+    props: props || {},
+  } as unknown as CreateBy<User>;
+};
+
+type AssertSeatMockFunction = () => jest.Mock;
+
+const assertSeatMock: AssertSeatMockFunction = (): jest.Mock => {
+  return EnterpriseLicenseSeatUtil.assertSeatAvailableForNewUser as unknown as jest.Mock;
+};
+
+describe("UserService - the enterprise seat limit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertSeatMock().mockResolvedValue(undefined);
+    UserService.countBy = jest.fn().mockResolvedValue(new PositiveNumber(7));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("checks the seat limit before creating a user", async () => {
+    await onBeforeCreate(makeCreateBy());
+
+    expect(assertSeatMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses the create when there is no seat for the new user", async () => {
+    assertSeatMock().mockRejectedValue(new BadDataException("No seats left"));
+
+    await expect(onBeforeCreate(makeCreateBy())).rejects.toBeInstanceOf(
+      BadDataException,
+    );
+  });
+
+  /*
+   * The one that matters. TeamMemberService creates the invited user as root,
+   * so an isRoot exemption would exempt invitations — and inviting users past
+   * the licence is the thing being prevented.
+   */
+  it.each([
+    ["a root write, which is how invitations create users", { isRoot: true }],
+    ["a master admin acting from the Admin Dashboard", { isMasterAdmin: true }],
+    ["an ordinary tenant write", { userId: ObjectID.generate() }],
+  ])(
+    "still checks the limit for %s",
+    async (_label: string, props: Record<string, unknown>) => {
+      await onBeforeCreate(makeCreateBy(props));
+
+      expect(assertSeatMock()).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("checks the limit before anything else the hook does", async () => {
+    /*
+     * The hook also sanitizes attribution columns. If a refusal came after
+     * that, a rejected create would still have done work; more importantly the
+     * ordering pins that nothing was inserted ahead of the check later on.
+     */
+    assertSeatMock().mockRejectedValue(new BadDataException("No seats left"));
+
+    const createBy: CreateBy<User> = makeCreateBy();
+    (createBy.data as unknown as Record<string, unknown>)["clickIds"] = {
+      gclid: "abc",
+    };
+
+    await expect(onBeforeCreate(createBy)).rejects.toBeInstanceOf(
+      BadDataException,
+    );
+  });
+
+  describe("the user count it enforces against", () => {
+    type GetLocalUserCountFunction = () => Promise<number>;
+
+    type CapturedCallbackFunction = () => GetLocalUserCountFunction;
+
+    const capturedCallback: CapturedCallbackFunction =
+      (): GetLocalUserCountFunction => {
+        const call: Record<string, unknown> = assertSeatMock().mock
+          .calls[0]![0] as Record<string, unknown>;
+
+        return call["getLocalUserCount"] as GetLocalUserCountFunction;
+      };
+
+    it("counts every user on this installation, not just the caller's project", async () => {
+      await onBeforeCreate(makeCreateBy());
+
+      const count: number = await capturedCallback()();
+
+      expect(count).toBe(7);
+
+      const countCall: Record<string, unknown> = (
+        UserService.countBy as unknown as jest.Mock
+      ).mock.calls[0]![0] as Record<string, unknown>;
+
+      expect(countCall["query"]).toEqual({});
+      expect((countCall["props"] as Record<string, unknown>)["isRoot"]).toBe(
+        true,
+      );
+    });
+
+    /*
+     * The count is deliberately behind a callback rather than passed in: on
+     * Community Edition, and on a licence with no seat limit, it must never
+     * run at all. This is the create path of every user on the installation.
+     */
+    it("does not count users unless the seat check asks for it", async () => {
+      await onBeforeCreate(makeCreateBy());
+
+      expect(UserService.countBy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil.test.ts
+++ b/Common/Tests/Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil.test.ts
@@ -1,0 +1,495 @@
+import GlobalConfig from "../../../../Models/DatabaseModels/GlobalConfig";
+import GlobalConfigService from "../../../../Server/Services/GlobalConfigService";
+import EnterpriseLicenseSeatUtil from "../../../../Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../Types/ObjectID";
+import { SeatUsage } from "../../../../Utils/EnterpriseLicense/EnterpriseLicenseSeats";
+import {
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * The half of seat enforcement that decides whether this installation
+ * enforces at all, and reads the license state it enforces against.
+ *
+ * Three things have to hold, and each of them is a way the feature could be
+ * quietly wrong rather than loudly broken:
+ *
+ *   1. It runs on self-hosted Enterprise and nowhere else. oneuptime.com bounds
+ *      seats through subscriptions, and Community Edition has no license — a
+ *      second, different answer on either of those would be a regression that
+ *      nobody notices until a customer cannot sign up.
+ *   2. It never counts the User table when there is no limit to compare it
+ *      against. That query runs on the create path of every user on the
+ *      installation.
+ *   3. It does not exempt root. Team invitations create the invited user with
+ *      isRoot: true, so an isRoot exemption would exempt invitations — the one
+ *      path this was asked for.
+ */
+
+let mockBillingEnabled: boolean = false;
+let mockEnterpriseEdition: boolean = true;
+
+/*
+ * Live accessors rather than plain values: the util reads these when it runs,
+ * and object spread would flatten them to whatever they were at import time.
+ */
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../../../Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  const mocked: Record<string, unknown> = {
+    ...actual,
+    __esModule: true,
+  };
+
+  Object.defineProperty(mocked, "IsBillingEnabled", {
+    get: (): boolean => {
+      return mockBillingEnabled;
+    },
+  });
+
+  Object.defineProperty(mocked, "IsEnterpriseEdition", {
+    get: (): boolean => {
+      return mockEnterpriseEdition;
+    },
+  });
+
+  return mocked;
+});
+
+jest.mock("../../../../Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+/*
+ * Both @types/jest and @jest/globals are installed, and their Mock types are
+ * not assignable to each other. Taking the type from jest.fn keeps fresh mocks
+ * on whichever one is actually in scope.
+ */
+type MockFunction = ReturnType<typeof jest.fn>;
+
+const INSTANCE_ID: ObjectID = ObjectID.generate();
+
+type MakeConfigFunction = (overrides?: Record<string, unknown>) => GlobalConfig;
+
+const makeConfig: MakeConfigFunction = (
+  overrides?: Record<string, unknown>,
+): GlobalConfig => {
+  const config: GlobalConfig = new GlobalConfig();
+  config.instanceId = INSTANCE_ID;
+  config.enterpriseLicenseUserLimit = 10;
+  config.enterpriseLicenseCurrentUserCount = 4;
+  config.enterpriseLicenseInstances = [];
+
+  return Object.assign(config, overrides || {});
+};
+
+type SetStoredConfigFunction = (config: GlobalConfig | null) => void;
+
+const setStoredConfig: SetStoredConfigFunction = (
+  config: GlobalConfig | null,
+): void => {
+  (GlobalConfigService.findOneById as unknown as jest.Mock).mockResolvedValue(
+    config as never,
+  );
+};
+
+describe("EnterpriseLicenseSeatUtil - which installations enforce", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBillingEnabled = false;
+    mockEnterpriseEdition = true;
+    setStoredConfig(makeConfig());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("enforces on a self-hosted enterprise installation", () => {
+    expect(EnterpriseLicenseSeatUtil.isSeatLimitEnforceable()).toBe(true);
+  });
+
+  it("does not enforce on Community Edition", () => {
+    mockEnterpriseEdition = false;
+
+    expect(EnterpriseLicenseSeatUtil.isSeatLimitEnforceable()).toBe(false);
+  });
+
+  /*
+   * oneuptime.com runs with billing on and bounds seats per project through
+   * subscriptions (TeamMemberService.onBeforeCreate). Enforcing an enterprise
+   * license limit there as well would be a second answer to the same question.
+   */
+  it("does not enforce where billing is doing the bounding", () => {
+    mockBillingEnabled = true;
+
+    expect(EnterpriseLicenseSeatUtil.isSeatLimitEnforceable()).toBe(false);
+  });
+
+  it.each([
+    ["Community Edition", false, false],
+    ["billing enabled", true, true],
+  ])(
+    "returns no seat usage at all on %s, and never reads the config",
+    async (
+      _label: string,
+      billingEnabled: boolean,
+      enterpriseEdition: boolean,
+    ) => {
+      mockBillingEnabled = billingEnabled;
+      mockEnterpriseEdition = enterpriseEdition;
+
+      const getLocalUserCount: MockFunction = jest.fn();
+
+      const usage: SeatUsage | null =
+        await EnterpriseLicenseSeatUtil.getSeatUsage({
+          getLocalUserCount:
+            getLocalUserCount as unknown as () => Promise<number>,
+        });
+
+      expect(usage).toBeNull();
+      expect(GlobalConfigService.findOneById).not.toHaveBeenCalled();
+      expect(getLocalUserCount).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("EnterpriseLicenseSeatUtil - reading the licence", () => {
+  let getLocalUserCount: MockFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBillingEnabled = false;
+    mockEnterpriseEdition = true;
+    getLocalUserCount = jest.fn(async (): Promise<number> => {
+      return 4;
+    }) as unknown as MockFunction;
+    setStoredConfig(makeConfig());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  type UsageFunction = () => Promise<SeatUsage | null>;
+
+  const usage: UsageFunction = (): Promise<SeatUsage | null> => {
+    return EnterpriseLicenseSeatUtil.getSeatUsage({
+      getLocalUserCount: getLocalUserCount as unknown as () => Promise<number>,
+    });
+  };
+
+  it("reads the licence columns it needs off the singleton config row", async () => {
+    await usage();
+
+    const call: Record<string, unknown> = (
+      GlobalConfigService.findOneById as unknown as jest.Mock
+    ).mock.calls[0]![0] as Record<string, unknown>;
+
+    expect((call["id"] as ObjectID).toString()).toBe(
+      ObjectID.getZeroObjectID().toString(),
+    );
+    expect(
+      Object.keys(call["select"] as Record<string, unknown>).sort(),
+    ).toEqual([
+      "enterpriseLicenseCurrentUserCount",
+      "enterpriseLicenseInstances",
+      "enterpriseLicenseUserLimit",
+      "instanceId",
+    ]);
+    expect((call["props"] as Record<string, unknown>)["isRoot"]).toBe(true);
+  });
+
+  it("combines the stored licence with the live user count", async () => {
+    getLocalUserCount = jest.fn(async (): Promise<number> => {
+      return 9;
+    }) as unknown as MockFunction;
+
+    const seatUsage: SeatUsage | null = await usage();
+
+    expect(seatUsage?.isEnforced).toBe(true);
+    expect(seatUsage?.userLimit).toBe(10);
+    expect(seatUsage?.seatsInUse).toBe(9);
+    expect(seatUsage?.hasSeatForNewUser).toBe(true);
+  });
+
+  /*
+   * Counting the User table on a licence that has no limit would be a query
+   * per user creation bought for nothing — and an unlimited licence is exactly
+   * the kind a large installation holds.
+   */
+  it("does not count users when the licence has no seat limit", async () => {
+    setStoredConfig(
+      makeConfig({ enterpriseLicenseUserLimit: undefined } as Record<
+        string,
+        unknown
+      >),
+    );
+
+    const seatUsage: SeatUsage | null = await usage();
+
+    expect(seatUsage?.isEnforced).toBe(false);
+    expect(seatUsage?.hasSeatForNewUser).toBe(true);
+    expect(getLocalUserCount).not.toHaveBeenCalled();
+  });
+
+  it("counts users exactly once when the licence does have a limit", async () => {
+    await usage();
+
+    expect(getLocalUserCount).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * A fresh installation whose GlobalConfig row has not been seeded yet. There
+   * is no licence, so there is no limit — and certainly no reason to refuse the
+   * very first user.
+   */
+  it("enforces nothing when there is no config row at all", async () => {
+    setStoredConfig(null);
+
+    const seatUsage: SeatUsage | null = await usage();
+
+    expect(seatUsage?.isEnforced).toBe(false);
+    expect(seatUsage?.hasSeatForNewUser).toBe(true);
+    expect(getLocalUserCount).not.toHaveBeenCalled();
+  });
+
+  it("attributes the licence-wide overflow to the customer's other instances", async () => {
+    setStoredConfig(
+      makeConfig({
+        enterpriseLicenseUserLimit: 100,
+        enterpriseLicenseCurrentUserCount: 80,
+        enterpriseLicenseInstances: [
+          {
+            instanceId: INSTANCE_ID.toString(),
+            host: "prod.acme.internal",
+            userCount: 60,
+            lastReportedAt: "2026-01-01T00:00:00.000Z",
+            version: "12.0.30",
+          },
+          {
+            instanceId: "another-instance",
+            host: "staging.acme.internal",
+            userCount: 30,
+            lastReportedAt: "2026-01-01T00:00:00.000Z",
+            version: "12.0.30",
+          },
+        ],
+      }),
+    );
+
+    getLocalUserCount = jest.fn(async (): Promise<number> => {
+      return 60;
+    }) as unknown as MockFunction;
+
+    const seatUsage: SeatUsage | null = await usage();
+
+    expect(seatUsage?.seatsUsedByOtherInstances).toBe(20);
+    expect(seatUsage?.seatsInUse).toBe(80);
+  });
+
+  it("survives an instance list stored as something other than an array", async () => {
+    setStoredConfig(
+      makeConfig({
+        enterpriseLicenseInstances: "not-an-array",
+      } as unknown as Record<string, unknown>),
+    );
+
+    const seatUsage: SeatUsage | null = await usage();
+
+    expect(seatUsage?.seatsUsedByOtherInstances).toBe(0);
+    expect(seatUsage?.isEnforced).toBe(true);
+  });
+});
+
+describe("EnterpriseLicenseSeatUtil - refusing a new user", () => {
+  let localUserCount: number;
+
+  type AssertFunction = () => Promise<void>;
+
+  const assertSeat: AssertFunction = (): Promise<void> => {
+    return EnterpriseLicenseSeatUtil.assertSeatAvailableForNewUser({
+      getLocalUserCount: async (): Promise<number> => {
+        return localUserCount;
+      },
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBillingEnabled = false;
+    mockEnterpriseEdition = true;
+    localUserCount = 4;
+    setStoredConfig(makeConfig());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("allows a user while seats are free", async () => {
+    localUserCount = 9;
+
+    await expect(assertSeat()).resolves.toBeUndefined();
+  });
+
+  it("refuses the user that would step past the limit", async () => {
+    localUserCount = 10;
+
+    await expect(assertSeat()).rejects.toBeInstanceOf(BadDataException);
+  });
+
+  it("explains the refusal in terms the administrator can act on", async () => {
+    localUserCount = 10;
+
+    let message: string = "";
+
+    try {
+      await assertSeat();
+    } catch (err) {
+      message = (err as BadDataException).message;
+    }
+
+    expect(message).toContain("10");
+    expect(message).toContain("enterprise license");
+    expect(message).toContain("sales@oneuptime.com");
+  });
+
+  it("keeps refusing once the installation is already over the limit", async () => {
+    localUserCount = 40;
+
+    await expect(assertSeat()).rejects.toBeInstanceOf(BadDataException);
+  });
+
+  it("allows everything on a licence with no seat limit", async () => {
+    setStoredConfig(
+      makeConfig({ enterpriseLicenseUserLimit: undefined } as Record<
+        string,
+        unknown
+      >),
+    );
+    localUserCount = 100_000;
+
+    await expect(assertSeat()).resolves.toBeUndefined();
+  });
+
+  it("allows everything on Community Edition", async () => {
+    mockEnterpriseEdition = false;
+    localUserCount = 100_000;
+
+    await expect(assertSeat()).resolves.toBeUndefined();
+  });
+
+  it("allows everything where billing does the bounding", async () => {
+    mockBillingEnabled = true;
+    localUserCount = 100_000;
+
+    await expect(assertSeat()).resolves.toBeUndefined();
+  });
+
+  /*
+   * The seats already spoken for on the customer's other instances count
+   * against this one. Otherwise two instances on a 10-seat licence would each
+   * happily fill up to 10.
+   */
+  it("refuses when the licence is full because of another instance", async () => {
+    setStoredConfig(
+      makeConfig({
+        enterpriseLicenseUserLimit: 10,
+        enterpriseLicenseCurrentUserCount: 10,
+        enterpriseLicenseInstances: [
+          {
+            instanceId: INSTANCE_ID.toString(),
+            host: "prod.acme.internal",
+            userCount: 2,
+            lastReportedAt: "2026-01-01T00:00:00.000Z",
+            version: "12.0.30",
+          },
+          {
+            instanceId: "another-instance",
+            host: "staging.acme.internal",
+            userCount: 8,
+            lastReportedAt: "2026-01-01T00:00:00.000Z",
+            version: "12.0.30",
+          },
+        ],
+      }),
+    );
+
+    localUserCount = 2;
+
+    await expect(assertSeat()).rejects.toBeInstanceOf(BadDataException);
+  });
+});
+
+describe("EnterpriseLicenseSeatUtil - usage from an already-loaded config", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBillingEnabled = false;
+    mockEnterpriseEdition = true;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The license endpoint has just read GlobalConfig to build its response.
+   * Reading it a second time to answer the same question would be silly, so
+   * there is an entry point that takes the row — and it has to agree exactly
+   * with the one that loads it.
+   */
+  it("does not go back to the database for a config it was handed", async () => {
+    const seatUsage: SeatUsage | null =
+      await EnterpriseLicenseSeatUtil.getSeatUsageForLoadedGlobalConfig({
+        config: makeConfig({ enterpriseLicenseUserLimit: 10 }),
+        getLocalUserCount: async (): Promise<number> => {
+          return 10;
+        },
+      });
+
+    expect(GlobalConfigService.findOneById).not.toHaveBeenCalled();
+    expect(seatUsage?.hasSeatForNewUser).toBe(false);
+    expect(seatUsage?.seatsRemaining).toBe(0);
+  });
+
+  it("returns null on an installation that does not enforce", async () => {
+    mockEnterpriseEdition = false;
+
+    const seatUsage: SeatUsage | null =
+      await EnterpriseLicenseSeatUtil.getSeatUsageForLoadedGlobalConfig({
+        config: makeConfig(),
+        getLocalUserCount: async (): Promise<number> => {
+          return 10;
+        },
+      });
+
+    expect(seatUsage).toBeNull();
+  });
+
+  it("handles a null config the same way as a licence with no limit", async () => {
+    const seatUsage: SeatUsage | null =
+      await EnterpriseLicenseSeatUtil.getSeatUsageForLoadedGlobalConfig({
+        config: null,
+        getLocalUserCount: async (): Promise<number> => {
+          return 10;
+        },
+      });
+
+    expect(seatUsage?.isEnforced).toBe(false);
+    expect(seatUsage?.hasSeatForNewUser).toBe(true);
+  });
+});

--- a/Common/Tests/UI/Components/EditionLabelLicenseRefresh.test.tsx
+++ b/Common/Tests/UI/Components/EditionLabelLicenseRefresh.test.tsx
@@ -1,0 +1,405 @@
+import EditionLabel from "../../../UI/Components/EditionLabel/EditionLabel";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../Types/JSON";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * The "Refresh license" button, and who is allowed to see it.
+ *
+ * The seat limit is set on oneuptime.com and can change on any day. It reaches
+ * a self-hosted installation through a job that runs once a day — which was
+ * merely slow while nothing acted on the number, and is a real problem now that
+ * the installation refuses users above it. An administrator who has just bought
+ * ten seats should not have to wait until tomorrow, and should not have to
+ * re-type the license key into a box the dialog hides while the license is
+ * valid. This button is the answer, so these tests pin that it:
+ *
+ *   - is offered only to a master admin, matching the server, which now
+ *     requires one on both license writes;
+ *   - sends no license key, so it can only ever refresh the key already
+ *     stored and never replace a working license with a typo;
+ *   - shows the new limit afterwards;
+ *   - says so when it fails, rather than looking like it worked. The whole
+ *     reason it was pressed is a belief that the stored terms are stale.
+ */
+
+let isEnterpriseEdition: boolean = true;
+let billingEnabled: boolean = false;
+let isMasterAdmin: boolean = true;
+
+/*
+ * Object.defineProperty rather than getters in an object literal: this file is
+ * down-levelled, so `{ ...actual, get X() {} }` becomes Object.assign, which
+ * reads each getter once and freezes it at module-load time.
+ */
+jest.mock("../../../UI/Config", () => {
+  const actualConfig: Record<string, unknown> = jest.requireActual(
+    "../../../UI/Config",
+  ) as Record<string, unknown>;
+
+  const mockedConfig: Record<string, unknown> = { ...actualConfig };
+
+  Object.defineProperty(mockedConfig, "IS_ENTERPRISE_EDITION", {
+    get: (): boolean => {
+      return isEnterpriseEdition;
+    },
+  });
+
+  Object.defineProperty(mockedConfig, "BILLING_ENABLED", {
+    get: (): boolean => {
+      return billingEnabled;
+    },
+  });
+
+  return mockedConfig;
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdmin;
+      },
+    },
+  };
+});
+
+interface FetchCall {
+  method: string;
+  url: string;
+  data: JSONObject | undefined;
+}
+
+const fetchCalls: Array<FetchCall> = [];
+
+type FetchResponder = (
+  call: FetchCall,
+) => HTTPResponse<JSONObject> | HTTPErrorResponse;
+
+let respond: FetchResponder;
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      fetch: (options: {
+        method: { toString: () => string };
+        url: { toString: () => string };
+        data?: JSONObject | undefined;
+      }): Promise<HTTPResponse<JSONObject> | HTTPErrorResponse> => {
+        const call: FetchCall = {
+          method: options.method.toString(),
+          url: options.url.toString(),
+          data: options.data,
+        };
+
+        fetchCalls.push(call);
+
+        return Promise.resolve(respond(call));
+      },
+      getFriendlyMessage: (err: unknown): string => {
+        if (err instanceof HTTPErrorResponse) {
+          return err.message;
+        }
+
+        return String(err);
+      },
+    },
+  };
+});
+
+const EXPIRES_AT: string = "2031-01-01T00:00:00.000Z";
+
+type LicensePayloadFunction = (
+  overrides?: Record<string, unknown>,
+) => JSONObject;
+
+const licensePayload: LicensePayloadFunction = (
+  overrides?: Record<string, unknown>,
+): JSONObject => {
+  return {
+    companyName: "Acme Inc",
+    expiresAt: EXPIRES_AT,
+    licenseKey: "acme-license-key",
+    token: "signed.jwt.token",
+    licenseValid: true,
+    isEvaluationLicense: false,
+    userLimit: 50,
+    currentUserCount: 50,
+    userCountUpdatedAt: "2026-01-01T00:00:00.000Z",
+    instances: [],
+    instanceId: "instance-1",
+    currentVersion: "12.0.30",
+    latestVersion: "12.0.30",
+    isUpdateAvailable: false,
+    isUpdateCheckDisabled: false,
+    isSeatLimitEnforced: true,
+    seatsInUse: 50,
+    seatsRemaining: 0,
+    canAddMoreUsers: false,
+    ...overrides,
+  };
+};
+
+type OpenDialogFunction = () => Promise<void>;
+
+const openDialog: OpenDialogFunction = async (): Promise<void> => {
+  render(<EditionLabel />);
+
+  // The pill only knows what to say once the license GET has come back.
+  await waitFor(() => {
+    expect(fetchCalls.length).toBeGreaterThan(0);
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /Enterprise Edition/i }));
+};
+
+describe("EditionLabel - refreshing the license", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    isEnterpriseEdition = true;
+    billingEnabled = false;
+    isMasterAdmin = true;
+    respond = (): HTTPResponse<JSONObject> => {
+      return new HTTPResponse<JSONObject>(200, licensePayload(), {});
+    };
+  });
+
+  it("offers the button to a master admin once the license is valid", async () => {
+    await openDialog();
+
+    expect(
+      await screen.findByTestId("refresh-enterprise-license"),
+    ).toBeInTheDocument();
+  });
+
+  /*
+   * The server requires a master admin on both license writes, so offering the
+   * button to anyone else would only ever produce a permission error.
+   */
+  it("does not offer the button to a user who is not a master admin", async () => {
+    isMasterAdmin = false;
+
+    await openDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Licensed seats")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("refresh-enterprise-license"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Change license key")).not.toBeInTheDocument();
+  });
+
+  it("asks a non-admin to find one when the license needs activating", async () => {
+    isMasterAdmin = false;
+    respond = (): HTTPResponse<JSONObject> => {
+      return new HTTPResponse<JSONObject>(
+        200,
+        licensePayload({ licenseValid: false, token: null }),
+        {},
+      );
+    };
+
+    await openDialog();
+
+    expect(
+      await screen.findByText("A master admin has to activate this license"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Enter your enterprise license key"),
+    ).not.toBeInTheDocument();
+  });
+
+  /*
+   * No license key in the body. A refresh that carried one would be an
+   * activation with a friendlier name.
+   */
+  it("refreshes the stored license without sending a key", async () => {
+    await openDialog();
+
+    fireEvent.click(await screen.findByTestId("refresh-enterprise-license"));
+
+    await waitFor(() => {
+      expect(
+        fetchCalls.some((call: FetchCall): boolean => {
+          return call.url.includes("/global-config/license/refresh");
+        }),
+      ).toBe(true);
+    });
+
+    const refreshCall: FetchCall = fetchCalls.find(
+      (call: FetchCall): boolean => {
+        return call.url.includes("/global-config/license/refresh");
+      },
+    ) as FetchCall;
+
+    expect(refreshCall.method).toBe("POST");
+    expect(refreshCall.data).toBeUndefined();
+  });
+
+  it("shows the new seat limit after a refresh", async () => {
+    await openDialog();
+
+    await screen.findByTestId("refresh-enterprise-license");
+
+    // Ten more seats bought on oneuptime.com since the page loaded.
+    respond = (): HTTPResponse<JSONObject> => {
+      return new HTTPResponse<JSONObject>(
+        200,
+        licensePayload({
+          userLimit: 60,
+          seatsRemaining: 10,
+          canAddMoreUsers: true,
+        }),
+        {},
+      );
+    };
+
+    fireEvent.click(screen.getByTestId("refresh-enterprise-license"));
+
+    expect(
+      await screen.findByText(/License refreshed from OneUptime/),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/60 seats/)).toBeInTheDocument();
+  });
+
+  /*
+   * A refresh that quietly kept the old terms and said nothing would be worse
+   * than no button at all: the administrator pressed it precisely because they
+   * think the stored terms are wrong.
+   */
+  it("reports a failed refresh instead of looking like it worked", async () => {
+    await openDialog();
+
+    await screen.findByTestId("refresh-enterprise-license");
+
+    respond = (
+      call: FetchCall,
+    ): HTTPResponse<JSONObject> | HTTPErrorResponse => {
+      if (call.url.includes("/refresh")) {
+        return new HTTPErrorResponse(
+          500,
+          { message: "Could not reach OneUptime." },
+          {},
+        );
+      }
+
+      return new HTTPResponse<JSONObject>(200, licensePayload(), {});
+    };
+
+    fireEvent.click(screen.getByTestId("refresh-enterprise-license"));
+
+    expect(
+      await screen.findByText(/Could not reach OneUptime/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/License refreshed from OneUptime/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("EditionLabel - what an exhausted seat limit looks like", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    isEnterpriseEdition = true;
+    billingEnabled = false;
+    isMasterAdmin = true;
+    respond = (): HTTPResponse<JSONObject> => {
+      return new HTTPResponse<JSONObject>(200, licensePayload(), {});
+    };
+  });
+
+  /*
+   * 50 of 50 is not over the limit, so the old arithmetic called it "nearly
+   * full" — an amber nudge in front of a door that is already shut. Once the
+   * limit is enforced, being exactly on it is the thing the administrator has
+   * to act on.
+   */
+  it("treats a full license as a breach rather than a nudge", async () => {
+    await openDialog();
+
+    expect(
+      await screen.findByText("Every licensed seat is in use"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Limit exceeded")).toBeInTheDocument();
+  });
+
+  it("says plainly that no more users can be added", async () => {
+    await openDialog();
+
+    expect(
+      await screen.findByText(
+        /New users cannot be invited, signed up or provisioned/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  /*
+   * seatsInUse is computed from the live User table; currentUserCount is the
+   * licence-wide figure oneuptime.com last computed, up to a day ago. The card
+   * has to show the one enforcement uses, or it contradicts the invitation that
+   * just bounced.
+   */
+  it("shows the live enforced usage rather than the last reported count", async () => {
+    respond = (): HTTPResponse<JSONObject> => {
+      return new HTTPResponse<JSONObject>(
+        200,
+        licensePayload({
+          currentUserCount: 40,
+          seatsInUse: 50,
+        }),
+        {},
+      );
+    };
+
+    await openDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Licensed seats")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.queryByText("40")).not.toBeInTheDocument();
+  });
+
+  /*
+   * A build or a deployment that reports no enforcement must not be rendered as
+   * one that is refusing users.
+   */
+  it("says nothing about enforcement when the server reports none", async () => {
+    respond = (): HTTPResponse<JSONObject> => {
+      return new HTTPResponse<JSONObject>(
+        200,
+        licensePayload({
+          isSeatLimitEnforced: false,
+          seatsInUse: null,
+          seatsRemaining: null,
+          canAddMoreUsers: true,
+          currentUserCount: 10,
+          userLimit: 50,
+        }),
+        {},
+      );
+    };
+
+    await openDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Licensed seats")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/New users cannot be invited/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/This installation enforces the seat limit/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/Utils/EnterpriseLicenseSeats.test.ts
+++ b/Common/Tests/Utils/EnterpriseLicenseSeats.test.ts
@@ -1,0 +1,507 @@
+import EnterpriseLicenseInstanceSummary from "../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+import EnterpriseLicenseSeatsUtil, {
+  SeatUsage,
+  SeatUsageInput,
+} from "../../Utils/EnterpriseLicense/EnterpriseLicenseSeats";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The arithmetic behind "you cannot add another user".
+ *
+ * An enterprise license is bought for a number of users and shared by every
+ * instance the customer runs on that key. Until now nothing on the customer's
+ * side acted on that number — the limit was mirrored into GlobalConfig, drawn
+ * on a progress bar, and otherwise ignored, so a 50-seat license and a 5000-
+ * seat license behaved identically.
+ *
+ * Deciding whether one more user fits is not a comparison, because neither
+ * number this installation holds is the answer:
+ *
+ *   localUserCount      live, and blind to the customer's other instances.
+ *   aggregatedUserCount deduplicated across every instance, and up to a day
+ *                       old — so it does not know about the person being
+ *                       invited right now, which is the only person the check
+ *                       is about.
+ *
+ * These tests pin how those are combined, and — at least as importantly — pin
+ * which way every "cannot tell" case is allowed to fall. Under-enforcing is
+ * corrected by the next daily report. Over-enforcing locks a paying customer
+ * out of their own installation, so no missing, malformed or contradictory
+ * field is allowed to invent seats that are not there.
+ */
+
+type MakeInstanceFunction = (
+  overrides?: Partial<EnterpriseLicenseInstanceSummary>,
+) => EnterpriseLicenseInstanceSummary;
+
+const makeInstance: MakeInstanceFunction = (
+  overrides?: Partial<EnterpriseLicenseInstanceSummary>,
+): EnterpriseLicenseInstanceSummary => {
+  return {
+    instanceId: "instance-1",
+    host: "oneuptime.acme.internal",
+    userCount: 10,
+    lastReportedAt: "2026-01-01T00:00:00.000Z",
+    version: "12.0.30",
+    ...overrides,
+  };
+};
+
+type SeatsFunction = (input: Partial<SeatUsageInput>) => SeatUsage;
+
+const seats: SeatsFunction = (input: Partial<SeatUsageInput>): SeatUsage => {
+  return EnterpriseLicenseSeatsUtil.getSeatUsage({
+    localUserCount: 0,
+    ...input,
+  } as SeatUsageInput);
+};
+
+describe("EnterpriseLicenseSeatsUtil - is there a limit at all", () => {
+  it("does not enforce when the license carries no seat limit", () => {
+    const usage: SeatUsage = seats({ userLimit: null, localUserCount: 9999 });
+
+    expect(usage.isEnforced).toBe(false);
+    expect(usage.userLimit).toBeNull();
+    expect(usage.seatsRemaining).toBeNull();
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it("does not enforce when the seat limit was never set", () => {
+    expect(seats({ localUserCount: 9999 }).isEnforced).toBe(false);
+    expect(
+      seats({ userLimit: undefined, localUserCount: 9999 }).isEnforced,
+    ).toBe(false);
+  });
+
+  /*
+   * Zero is read as "no limit", matching the license modal and the breach
+   * notification job, both of which treat userLimit <= 0 as nothing to measure
+   * against. Reading it as "nobody may have an account" would leave a stray
+   * zero — a bad import, a half-filled form on oneuptime.com — unable to create
+   * even the first user of an installation.
+   */
+  it("treats a zero seat limit as no limit rather than no seats", () => {
+    const usage: SeatUsage = seats({ userLimit: 0, localUserCount: 0 });
+
+    expect(usage.isEnforced).toBe(false);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it("ignores a negative seat limit", () => {
+    expect(seats({ userLimit: -10, localUserCount: 5 }).isEnforced).toBe(false);
+  });
+
+  it.each([
+    ["a fractional limit", 10.5],
+    ["infinity", Number.POSITIVE_INFINITY],
+    ["NaN", Number.NaN],
+  ])("ignores %s as a seat limit", (_label: string, userLimit: number) => {
+    expect(seats({ userLimit: userLimit, localUserCount: 5 }).isEnforced).toBe(
+      false,
+    );
+  });
+
+  it("ignores a seat limit that is not a number at all", () => {
+    expect(
+      seats({
+        userLimit: "150" as unknown as number,
+        localUserCount: 5,
+      }).isEnforced,
+    ).toBe(false);
+  });
+
+  it("enforces the smallest real limit there is", () => {
+    expect(seats({ userLimit: 1, localUserCount: 0 }).hasSeatForNewUser).toBe(
+      true,
+    );
+    expect(seats({ userLimit: 1, localUserCount: 1 }).hasSeatForNewUser).toBe(
+      false,
+    );
+  });
+});
+
+describe("EnterpriseLicenseSeatsUtil - a single instance", () => {
+  it("has room while users are below the limit", () => {
+    const usage: SeatUsage = seats({ userLimit: 10, localUserCount: 7 });
+
+    expect(usage.isEnforced).toBe(true);
+    expect(usage.seatsInUse).toBe(7);
+    expect(usage.seatsRemaining).toBe(3);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  /*
+   * The boundary the whole feature turns on. A license bought for 10 users
+   * covers the 10th; it is the 11th that has to be refused.
+   */
+  it("refuses the user that would step past the limit", () => {
+    expect(seats({ userLimit: 10, localUserCount: 9 }).hasSeatForNewUser).toBe(
+      true,
+    );
+    expect(seats({ userLimit: 10, localUserCount: 10 }).hasSeatForNewUser).toBe(
+      false,
+    );
+  });
+
+  it("reports no seats remaining rather than a negative number when over the limit", () => {
+    const usage: SeatUsage = seats({ userLimit: 10, localUserCount: 25 });
+
+    expect(usage.seatsInUse).toBe(25);
+    expect(usage.seatsRemaining).toBe(0);
+    expect(usage.hasSeatForNewUser).toBe(false);
+  });
+
+  it("still reports usage on an unlimited license, it just never blocks", () => {
+    const usage: SeatUsage = seats({ userLimit: null, localUserCount: 25 });
+
+    expect(usage.seatsInUse).toBe(25);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it.each([
+    ["a negative count", -5],
+    ["a fractional count", 4.5],
+    ["NaN", Number.NaN],
+  ])(
+    "falls back to zero local users for %s",
+    (_label: string, localUserCount: number) => {
+      expect(
+        seats({ userLimit: 10, localUserCount: localUserCount }).seatsInUse,
+      ).toBe(0);
+    },
+  );
+});
+
+describe("EnterpriseLicenseSeatsUtil - the licence-wide count", () => {
+  /*
+   * The aggregate is the only number that knows about the customer's other
+   * instances, so it has to be able to exhaust the limit on its own — even
+   * though this installation has barely any users of its own.
+   */
+  it("blocks on the licence-wide count even when this instance is nearly empty", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 3,
+      aggregatedUserCount: 100,
+    });
+
+    expect(usage.seatsInUse).toBe(100);
+    expect(usage.hasSeatForNewUser).toBe(false);
+  });
+
+  /*
+   * And the live local count has to be able to exhaust it on its own too: the
+   * aggregate is up to a day old, so it is systematically behind on exactly
+   * the users this check exists to catch.
+   */
+  it("blocks on the live local count even when the last report was lower", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 100,
+      aggregatedUserCount: 12,
+    });
+
+    expect(usage.seatsInUse).toBe(100);
+    expect(usage.hasSeatForNewUser).toBe(false);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a negative number", -1],
+    ["a fraction", 12.5],
+    ["a string", "12" as unknown as number],
+  ])(
+    "ignores a licence-wide count of %s and falls back to the local one",
+    (_label: string, aggregatedUserCount: number | null | undefined) => {
+      const usage: SeatUsage = seats({
+        userLimit: 100,
+        localUserCount: 40,
+        aggregatedUserCount: aggregatedUserCount,
+      });
+
+      expect(usage.seatsInUse).toBe(40);
+      expect(usage.hasSeatForNewUser).toBe(true);
+    },
+  );
+});
+
+describe("EnterpriseLicenseSeatsUtil - several instances on one licence", () => {
+  /*
+   * The case the whole instance breakdown exists for. Two instances share a
+   * 100-seat license: this one has 60 users, the other 30, and 10 people have
+   * accounts on both. oneuptime.com deduplicates that to 80.
+   *
+   * Neither number alone is right here — 60 lets the customer overshoot, 80 is
+   * a day stale. Subtracting this instance's last reported count from the
+   * aggregate leaves the 20 seats that are somebody else's, and adding the
+   * live local count back gives a figure that is current here and complete
+   * everywhere else.
+   */
+  it("adds this instance's live users to the seats other instances hold", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 60,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({ instanceId: "instance-1", userCount: 60 }),
+        makeInstance({ instanceId: "instance-2", userCount: 30 }),
+      ],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(20);
+    expect(usage.seatsInUse).toBe(80);
+    expect(usage.seatsRemaining).toBe(20);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it("sees users added here since the last report, which the aggregate cannot", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      // 25 people signed up since the report that said 60.
+      localUserCount: 85,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({ instanceId: "instance-1", userCount: 60 }),
+        makeInstance({ instanceId: "instance-2", userCount: 30 }),
+      ],
+    });
+
+    expect(usage.seatsInUse).toBe(105);
+    expect(usage.seatsRemaining).toBe(0);
+    expect(usage.hasSeatForNewUser).toBe(false);
+  });
+
+  it("counts users deleted here since the last report back off the total", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 40,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({ instanceId: "instance-1", userCount: 60 }),
+        makeInstance({ instanceId: "instance-2", userCount: 30 }),
+      ],
+    });
+
+    // 20 seats elsewhere + 40 live here. The stale 80 no longer decides it.
+    expect(usage.seatsInUse).toBe(60);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  /*
+   * Complete overlap: the same 60 people on both instances is 60 seats, not
+   * 120. Subtracting our own reported count is what stops this instance being
+   * charged twice for its own users.
+   */
+  it("does not double-count users who exist on more than one instance", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 60,
+      aggregatedUserCount: 60,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({ instanceId: "instance-1", userCount: 60 }),
+        makeInstance({ instanceId: "instance-2", userCount: 60 }),
+      ],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(0);
+    expect(usage.seatsInUse).toBe(60);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  /*
+   * The stale licence-wide figure is deliberately NOT allowed to outvote the
+   * live local count once the breakdown makes it decomposable. Freeing seats by
+   * deleting users has to free them now, not at the next daily report - which
+   * is the difference between a limit and a lockout.
+   */
+  it("does not let the stale licence-wide figure hold seats that were just freed", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 80,
+      localUserCount: 40,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({ instanceId: "instance-1", userCount: 60 }),
+        makeInstance({ instanceId: "instance-2", userCount: 30 }),
+      ],
+    });
+
+    expect(usage.seatsInUse).toBe(60);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it("never lets other instances hold a negative number of seats", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 70,
+      // Our own last report is somehow larger than the licence-wide total.
+      aggregatedUserCount: 40,
+      thisInstanceId: "instance-1",
+      instances: [makeInstance({ instanceId: "instance-1", userCount: 70 })],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(0);
+    expect(usage.seatsInUse).toBe(70);
+  });
+});
+
+describe("EnterpriseLicenseSeatsUtil - when the topology cannot be read", () => {
+  /*
+   * Every branch here resolves to "assume nothing is held elsewhere". That is
+   * the under-enforcing direction on purpose: the daily report corrects an
+   * undercount, and nothing corrects an installation that has wrongly locked
+   * its administrator out of adding users.
+   */
+  it.each([
+    ["there is no instance list", undefined],
+    ["the instance list is null", null],
+    ["the instance list is empty", []],
+  ])(
+    "attributes nothing to other instances when %s",
+    (
+      _label: string,
+      instances: Array<EnterpriseLicenseInstanceSummary> | null | undefined,
+    ) => {
+      const usage: SeatUsage = seats({
+        userLimit: 100,
+        localUserCount: 20,
+        aggregatedUserCount: 80,
+        thisInstanceId: "instance-1",
+        instances: instances,
+      });
+
+      expect(usage.seatsUsedByOtherInstances).toBe(0);
+      expect(usage.seatsInUse).toBe(80);
+    },
+  );
+
+  it("attributes nothing to other instances when this instance has no id", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 20,
+      aggregatedUserCount: 80,
+      thisInstanceId: null,
+      instances: [makeInstance({ instanceId: "instance-2", userCount: 80 })],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(0);
+    expect(usage.seatsInUse).toBe(80);
+  });
+
+  /*
+   * The dangerous reading of "we are not in the list" is "then the whole
+   * aggregate belongs to somebody else". It is right for an instance that has
+   * genuinely never registered, and catastrophic for one whose instance id
+   * changed after its users had already been counted under the old one — that
+   * installation would be charged twice for every user it has and could lock
+   * itself out. It is not taken.
+   */
+  it("does not assume the whole aggregate is somebody else's when this instance is missing from the list", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 80,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-that-was-renamed",
+      instances: [makeInstance({ instanceId: "instance-1", userCount: 80 })],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(0);
+    expect(usage.seatsInUse).toBe(80);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it.each([
+    ["null", null],
+    ["a fraction", 12.5 as unknown as number],
+    ["a string", "60" as unknown as number],
+  ])(
+    "attributes nothing to other instances when our own reported count is %s",
+    (_label: string, userCount: number | null) => {
+      const usage: SeatUsage = seats({
+        userLimit: 100,
+        localUserCount: 20,
+        aggregatedUserCount: 80,
+        thisInstanceId: "instance-1",
+        instances: [
+          makeInstance({ instanceId: "instance-1", userCount: userCount }),
+        ],
+      });
+
+      expect(usage.seatsUsedByOtherInstances).toBe(0);
+      expect(usage.seatsInUse).toBe(80);
+    },
+  );
+
+  it("survives a malformed entry in the instance list", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 60,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-1",
+      instances: [
+        null as unknown as EnterpriseLicenseInstanceSummary,
+        makeInstance({ instanceId: "instance-1", userCount: 60 }),
+      ],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(20);
+    expect(usage.seatsInUse).toBe(80);
+  });
+
+  it("matches this instance by its id even with surrounding whitespace", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 60,
+      aggregatedUserCount: 80,
+      thisInstanceId: "  instance-1  ",
+      instances: [makeInstance({ instanceId: "instance-1", userCount: 60 })],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(20);
+  });
+});
+
+describe("EnterpriseLicenseSeatsUtil - the message an administrator reads", () => {
+  it("names the limit, the usage and what to do about it", () => {
+    const message: string =
+      EnterpriseLicenseSeatsUtil.getSeatLimitReachedMessage({
+        seatsInUse: 150,
+        userLimit: 150,
+      });
+
+    expect(message).toContain("150");
+    expect(message).toContain("sales@oneuptime.com");
+    expect(message).toContain("Refresh license");
+  });
+
+  it("does not say 1 users", () => {
+    const message: string =
+      EnterpriseLicenseSeatsUtil.getSeatLimitReachedMessage({
+        seatsInUse: 1,
+        userLimit: 1,
+      });
+
+    expect(message).toContain("1-user limit");
+    expect(message).not.toContain("1 users");
+  });
+
+  /*
+   * The message is shown to a person who is being told no. It must not read
+   * like a bug, so it always states both halves of the arithmetic.
+   */
+  it("states the usage even when it exceeds the limit", () => {
+    const message: string =
+      EnterpriseLicenseSeatsUtil.getSeatLimitReachedMessage({
+        seatsInUse: 212,
+        userLimit: 150,
+      });
+
+    expect(message).toContain("150");
+    expect(message).toContain("212");
+  });
+});

--- a/Common/UI/Components/EditionLabel/EditionLabel.tsx
+++ b/Common/UI/Components/EditionLabel/EditionLabel.tsx
@@ -29,6 +29,7 @@ import {
 import Alert, { AlertType } from "../Alerts/Alert";
 import EnterpriseLicenseInstanceSummary from "../../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
 import VersionUtil from "../../../Utils/VersionUtil";
+import UserUtil from "../../Utils/User";
 
 export interface ComponentProps {
   className?: string | undefined;
@@ -136,7 +137,24 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
   const [validationError, setValidationError] = useState<string>("");
   const [successMessage, setSuccessMessage] = useState<string>("");
   const [isValidating, setIsValidating] = useState<boolean>(false);
+  const [isRefreshingLicense, setIsRefreshingLicense] =
+    useState<boolean>(false);
   const [isChangingLicense, setIsChangingLicense] = useState<boolean>(false);
+  /*
+   * The seat limit as this installation actually enforces it, rather than as
+   * oneuptime.com last reported it. The server computes it from the live User
+   * table, so it knows about everybody added since the last daily report -
+   * including the person whose invitation is about to be refused.
+   *
+   * Only returned to a signed-in caller, so all four stay at their "nothing to
+   * say" values on the login page.
+   */
+  const [isSeatLimitEnforced, setIsSeatLimitEnforced] =
+    useState<boolean>(false);
+  const [enforcedSeatsInUse, setEnforcedSeatsInUse] = useState<number | null>(
+    null,
+  );
+  const [canAddMoreUsers, setCanAddMoreUsers] = useState<boolean>(true);
   const [licenseInstances, setLicenseInstances] = useState<
     Array<EnterpriseLicenseInstanceSummary>
   >([]);
@@ -177,6 +195,29 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
   if (BILLING_ENABLED) {
     return <></>;
   }
+
+  /*
+   * Both the license GET and the two license POSTs answer with the same seat
+   * fields, so the three responses are unpacked in one place.
+   * isSeatLimitEnforced is what tells "this installation does not enforce a
+   * seat limit" apart from "this build did not report one" - without it, an
+   * older server's silence would read as a limit of zero.
+   */
+  const applySeatEnforcementPayload: (payload: JSONObject) => void =
+    useCallback((payload: JSONObject): void => {
+      setIsSeatLimitEnforced(payload["isSeatLimitEnforced"] === true);
+      setEnforcedSeatsInUse(
+        typeof payload["seatsInUse"] === "number"
+          ? (payload["seatsInUse"] as number)
+          : null,
+      );
+      /*
+       * Defaults to true, so a build or a response that says nothing about
+       * enforcement never renders a "you cannot add users" warning it has no
+       * evidence for.
+       */
+      setCanAddMoreUsers(payload["canAddMoreUsers"] !== false);
+    }, []);
 
   /*
    * Runs on Community Edition too. The license half of the response is empty
@@ -278,6 +319,7 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
         );
         setIsUpdateAvailable(payload["isUpdateAvailable"] === true);
         setIsUpdateCheckDisabled(payload["isUpdateCheckDisabled"] === true);
+        applySeatEnforcementPayload(payload);
 
         if (!licenseInputEditedRef.current) {
           setLicenseKeyInput(configModel.enterpriseLicenseKey || "");
@@ -293,11 +335,14 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
         setLatestVersionCheckedAt("");
         setIsUpdateAvailable(false);
         setIsUpdateCheckDisabled(false);
+        setIsSeatLimitEnforced(false);
+        setEnforcedSeatsInUse(null);
+        setCanAddMoreUsers(true);
         setConfigError(API.getFriendlyMessage(err));
       } finally {
         setIsConfigLoading(false);
       }
-    }, []);
+    }, [applySeatEnforcementPayload]);
 
   /*
    * Only Enterprise Edition needs this on mount — its pill reports license
@@ -468,6 +513,25 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
       : null;
   }, [globalConfig?.enterpriseLicenseCurrentUserCount]);
 
+  /*
+   * The seat figure everything below is measured against.
+   *
+   * currentUserCount is what oneuptime.com last computed across every instance
+   * on this license, which is up to a day old. On an installation that
+   * enforces a seat limit the server also sends seatsInUse: the same
+   * cross-instance figure reconciled with the live User table here, and the
+   * number invitations are actually refused on. Showing anything else would
+   * leave the card reading "98 of 100" next to an invitation that had just
+   * bounced.
+   */
+  const effectiveUserCount: number | null = useMemo(() => {
+    if (isSeatLimitEnforced && typeof enforcedSeatsInUse === "number") {
+      return enforcedSeatsInUse;
+    }
+
+    return currentUserCount;
+  }, [isSeatLimitEnforced, enforcedSeatsInUse, currentUserCount]);
+
   const userCountUpdatedAtText: string | null = useMemo(() => {
     if (!globalConfig?.enterpriseLicenseUserCountUpdatedAt) {
       return null;
@@ -493,12 +557,12 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
       return false;
     }
 
-    if (typeof currentUserCount !== "number") {
+    if (typeof effectiveUserCount !== "number") {
       return false;
     }
 
-    return currentUserCount > userLimit;
-  }, [licenseValid, userLimit, currentUserCount]);
+    return effectiveUserCount > userLimit;
+  }, [licenseValid, userLimit, effectiveUserCount]);
 
   /*
    * Unclamped and unrounded. The only value that can tell 120/120 apart from
@@ -510,12 +574,12 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
       return null;
     }
 
-    if (typeof currentUserCount !== "number") {
+    if (typeof effectiveUserCount !== "number") {
       return null;
     }
 
-    return Math.max(0, (currentUserCount / userLimit) * 100);
-  }, [userLimit, currentUserCount]);
+    return Math.max(0, (effectiveUserCount / userLimit) * 100);
+  }, [userLimit, effectiveUserCount]);
 
   /*
    * The percent the admin reads, and the one the warning fires on. May exceed
@@ -558,12 +622,12 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
       return null;
     }
 
-    if (typeof currentUserCount !== "number") {
+    if (typeof effectiveUserCount !== "number") {
       return null;
     }
 
-    return userLimit - currentUserCount;
-  }, [userLimit, currentUserCount]);
+    return userLimit - effectiveUserCount;
+  }, [userLimit, effectiveUserCount]);
 
   const seatsRemainingText: string = useMemo(() => {
     if (typeof seatsRemaining !== "number") {
@@ -600,6 +664,16 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
       return "breached";
     }
 
+    /*
+     * Exactly at the limit is not over it, but it is the point where the
+     * installation starts refusing new users - so it gets the red treatment
+     * rather than the amber "nearly full" nudge, which would understate a
+     * door that is already shut.
+     */
+    if (isSeatLimitEnforced && !canAddMoreUsers) {
+      return "breached";
+    }
+
     if (
       typeof seatUsageDisplayPercent === "number" &&
       seatUsageDisplayPercent >= SEAT_WARNING_PERCENT
@@ -608,7 +682,13 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
     }
 
     return "healthy";
-  }, [licenseValid, isUserLimitBreached, seatUsageDisplayPercent]);
+  }, [
+    licenseValid,
+    isUserLimitBreached,
+    isSeatLimitEnforced,
+    canAddMoreUsers,
+    seatUsageDisplayPercent,
+  ]);
 
   /*
    * Copy containing apostrophes lives in string literals rather than JSX text,
@@ -617,6 +697,14 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
   const seatAdvisoryTitle: string = useMemo(() => {
     if (seatTone === "breached") {
       const over: number = Math.abs(seatsRemaining || 0);
+
+      /*
+       * Reachable now that "every seat taken" is a breach in its own right:
+       * an installation sitting exactly on its limit is not "0 users over".
+       */
+      if (over === 0) {
+        return "Every licensed seat is in use";
+      }
 
       return over === 1
         ? "1 user over your licensed seats"
@@ -638,9 +726,19 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
 
   const seatAdvisoryBody: string = useMemo(() => {
     const limitText: string = (userLimit || 0).toLocaleString();
-    const inUse: string = `${(currentUserCount || 0).toLocaleString()} of ${limitText}`;
+    const inUse: string = `${(effectiveUserCount || 0).toLocaleString()} of ${limitText}`;
 
     if (seatTone === "breached") {
+      /*
+       * When the limit is being enforced this is no longer advice, it is a
+       * description of what the installation is already doing to invitations
+       * and signups - so it says so plainly rather than suggesting an upgrade
+       * as though adding people were still an option.
+       */
+      if (isSeatLimitEnforced && !canAddMoreUsers) {
+        return `This installation is using ${inUse} licensed seats. New users cannot be invited, signed up or provisioned until a seat is freed up or the license is expanded.`;
+      }
+
       return `This installation is using ${inUse} licensed seats. Expand your license so it covers everyone on the platform.`;
     }
 
@@ -649,7 +747,13 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
     }
 
     return "";
-  }, [seatTone, currentUserCount, userLimit]);
+  }, [
+    seatTone,
+    effectiveUserCount,
+    userLimit,
+    isSeatLimitEnforced,
+    canAddMoreUsers,
+  ]);
 
   const seatUsageAriaValueText: string = useMemo(() => {
     if (typeof seatUsageDisplayPercent !== "number") {
@@ -878,7 +982,7 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
         "We would like to expand the seat count on our enterprise license.",
         "",
         `Company: ${globalConfig?.enterpriseCompanyName || "Not specified"}`,
-        `Seats in use: ${(currentUserCount || 0).toLocaleString()} of ${(
+        `Seats in use: ${(effectiveUserCount || 0).toLocaleString()} of ${(
           userLimit || 0
         ).toLocaleString()}`,
         `Instances on this license: ${licenseInstances.length}`,
@@ -958,14 +1062,96 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
     void runLicenseValidation(licenseKeyInput, setIsValidating);
   };
 
+  /*
+   * Re-ask oneuptime.com about the license this installation already holds.
+   *
+   * The seat limit and the expiry are changed on oneuptime.com, and the daily
+   * report job is what normally carries them here - so without this, an
+   * administrator who has just bought seats waits up to a day before the
+   * installation stops refusing invitations. Deliberately sends no key: the
+   * server refreshes the stored one.
+   */
+  const handleRefreshLicense: () => void = useCallback((): void => {
+    if (isRefreshingLicense) {
+      return;
+    }
+
+    const refresh: () => Promise<void> = async (): Promise<void> => {
+      setValidationError("");
+      setSuccessMessage("");
+      setIsRefreshingLicense(true);
+
+      try {
+        const refreshUrl: URL = URL.fromURL(APP_API_URL).addRoute(
+          new Route("/global-config/license/refresh"),
+        );
+
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.fetch<JSONObject>({
+            method: HTTPMethod.POST,
+            url: refreshUrl,
+          });
+
+        if (!response.isSuccess()) {
+          throw response;
+        }
+
+        applySeatEnforcementPayload(response.data as JSONObject);
+
+        setSuccessMessage("License refreshed from OneUptime.");
+
+        /*
+         * The POST already returned the new terms, but the modal renders from
+         * what the GET reports - re-reading keeps one source of truth for the
+         * whole dialog instead of two that can disagree.
+         */
+        await fetchGlobalConfig();
+      } catch (err) {
+        setValidationError(API.getFriendlyMessage(err));
+      } finally {
+        setIsRefreshingLicense(false);
+      }
+    };
+
+    void refresh();
+  }, [isRefreshingLicense, fetchGlobalConfig, applySeatEnforcementPayload]);
+
   const handleRetryFetch: () => void = () => {
     if (!isConfigLoading) {
       void fetchGlobalConfig();
     }
   };
 
+  /*
+   * Activating, replacing and refreshing the license are master-admin actions:
+   * the license is instance-wide, and its seat limit is what UserService
+   * enforces against, so being able to rewrite it is being able to raise the
+   * ceiling on the whole installation. The server enforces this
+   * (MasterAdminAuthorization on both POSTs); hiding the controls here just
+   * stops everyone else being offered a button that can only fail.
+   *
+   * False for a signed-out visitor, which is what keeps the license key input
+   * off the login page where this same component renders the edition pill.
+   */
+  const canManageLicense: boolean = useMemo(() => {
+    return Boolean(UserUtil.isMasterAdmin());
+  }, []);
+
   const showLicenseKeyInput: boolean =
-    IS_ENTERPRISE_EDITION && (!licenseValid || isChangingLicense);
+    IS_ENTERPRISE_EDITION &&
+    canManageLicense &&
+    (!licenseValid || isChangingLicense);
+
+  /*
+   * Someone who cannot fix the license still needs to be told why the
+   * installation is behaving like an unlicensed one, and who can fix it.
+   */
+  const showLicenseAdminRequiredNotice: boolean =
+    IS_ENTERPRISE_EDITION &&
+    !configError &&
+    !isConfigLoading &&
+    !licenseValid &&
+    !canManageLicense;
 
   const shouldShowEnterpriseValidationButton: boolean = showLicenseKeyInput;
 
@@ -1066,13 +1252,34 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
   ) : undefined;
 
   const modalLeftFooterElement: ReactElement | undefined =
-    showLicenseDetails && !isChangingLicense ? (
-      <Button
-        title="Change license key"
-        icon={IconProp.Edit}
-        buttonStyle={ButtonStyleType.NORMAL}
-        onClick={handleStartChangingLicense}
-      />
+    showLicenseDetails && !isChangingLicense && canManageLicense ? (
+      <div className="flex flex-wrap items-center gap-2">
+        {/*
+         * The seat limit and the expiry are changed on oneuptime.com and reach
+         * this installation through the daily report job. This is the button
+         * for the administrator who has just bought seats and would rather not
+         * wait a day for the installation to stop refusing invitations.
+         */}
+        <Button
+          title="Refresh license"
+          icon={IconProp.Refresh}
+          buttonStyle={ButtonStyleType.NORMAL}
+          onClick={handleRefreshLicense}
+          isLoading={isRefreshingLicense}
+          disabled={isRefreshingLicense || isConfigLoading}
+          tooltip="Fetch the latest seat limit and expiry for this license from OneUptime."
+          dataTestId="refresh-enterprise-license"
+          className="!mt-0 md:!ml-0"
+        />
+        <Button
+          title="Change license key"
+          icon={IconProp.Edit}
+          buttonStyle={ButtonStyleType.NORMAL}
+          onClick={handleStartChangingLicense}
+          disabled={isRefreshingLicense}
+          className="!mt-0 md:!ml-0"
+        />
+      </div>
     ) : undefined;
 
   const pillClassName: string =
@@ -1320,6 +1527,16 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
                   <Alert type={AlertType.SUCCESS} title={successMessage} />
                 )}
 
+                {/*
+                 * A failed refresh has nowhere else to go: the license key
+                 * section carries its own copy of this alert, but that
+                 * section is not rendered at all while the license is valid,
+                 * which is exactly when refreshing is worth doing.
+                 */}
+                {!configError && validationError && !showLicenseKeyInput && (
+                  <Alert type={AlertType.DANGER} title={validationError} />
+                )}
+
                 {configError && (
                   <div className="rounded-xl border border-red-200 bg-red-50 p-4">
                     <div className="flex items-start gap-2.5">
@@ -1412,15 +1629,15 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
                       <p className="flex items-baseline gap-1.5">
                         <span
                           className={`text-3xl font-semibold leading-none tabular-nums ${
-                            typeof currentUserCount !== "number"
+                            typeof effectiveUserCount !== "number"
                               ? "text-gray-300"
                               : seatTone === "breached"
                                 ? "text-red-700"
                                 : "text-gray-900"
                           }`}
                         >
-                          {typeof currentUserCount === "number"
-                            ? currentUserCount.toLocaleString()
+                          {typeof effectiveUserCount === "number"
+                            ? effectiveUserCount.toLocaleString()
                             : "—"}
                         </span>
                         <span className="text-sm tabular-nums text-gray-500">
@@ -1568,6 +1785,28 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
                         {userCountUpdatedAtText
                           ? `Last reported to OneUptime on ${userCountUpdatedAtText}.`
                           : "User count has not been reported to OneUptime yet. The first report will be sent within 24 hours."}
+                        {isSeatLimitEnforced && (
+                          <>
+                            {" "}
+                            This installation enforces the seat limit: users
+                            above it cannot be invited, signed up or
+                            provisioned.
+                          </>
+                        )}
+                        {/*
+                         * Only pointed at somebody who can actually press it.
+                         * The refresh button is master-admin only, so telling
+                         * everyone else to use it would be an instruction they
+                         * cannot follow.
+                         */}
+                        {isSeatLimitEnforced && canManageLicense && (
+                          <>
+                            {" "}
+                            Bought more seats? Use &quot;Refresh license&quot;
+                            below to apply the new limit without waiting for the
+                            next daily report.
+                          </>
+                        )}
                       </p>
                     </div>
                   </section>
@@ -1729,6 +1968,19 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
                     </div>
                   )}
 
+                {showLicenseAdminRequiredNotice && (
+                  <section className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+                    <h4 className="text-sm font-semibold text-amber-900">
+                      A master admin has to activate this license
+                    </h4>
+                    <p className="mt-1 text-xs leading-relaxed text-amber-800">
+                      This installation does not have a valid enterprise
+                      license. Ask a master admin of this OneUptime installation
+                      to enter or refresh the license key from this dialog.
+                    </p>
+                  </section>
+                )}
+
                 {!configError && showLicenseKeyInput && (
                   <section className="rounded-xl border border-gray-200 bg-white p-5">
                     <div className="flex items-start justify-between gap-4">
@@ -1801,7 +2053,9 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
                       What your license unlocks
                     </h4>
                     <p className="mt-0.5 text-xs text-indigo-700">
-                      Validate your key above to turn these on immediately.
+                      {canManageLicense
+                        ? "Validate your key above to turn these on immediately."
+                        : "A master admin can activate the license to turn these on."}
                     </p>
                     <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                       {enterpriseFeatures.map(

--- a/Common/Utils/EnterpriseLicense/EnterpriseLicenseSeats.ts
+++ b/Common/Utils/EnterpriseLicense/EnterpriseLicenseSeats.ts
@@ -1,0 +1,271 @@
+import EnterpriseLicenseInstanceSummary from "../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+
+/*
+ * Everything the seat calculation needs, taken as plain values so this file
+ * stays a pure function the tests can drive directly. The server reads these
+ * off GlobalConfig; the browser reads them off the /global-config/license
+ * response.
+ */
+export interface SeatUsageInput {
+  /*
+   * The seat limit mirrored from oneuptime.com. Null, undefined or anything
+   * that is not a positive whole number means "no limit to enforce" — see
+   * getSeatUsage for why zero is included in that.
+   */
+  userLimit?: number | null | undefined;
+
+  /*
+   * Users that exist on THIS installation right now. The live number, counted
+   * at the moment of the check rather than taken from the last daily report,
+   * because the whole point of enforcement is to catch the user who is being
+   * added a second after the report was sent.
+   */
+  localUserCount: number;
+
+  /*
+   * Unique users across every instance sharing this license, as oneuptime.com
+   * last computed it. Up to a day stale, and only meaningful for a customer
+   * running more than one instance on one key.
+   */
+  aggregatedUserCount?: number | null | undefined;
+
+  /*
+   * Per-instance breakdown from the same report. Used only to work out how
+   * much of aggregatedUserCount belongs to OTHER instances.
+   */
+  instances?: Array<EnterpriseLicenseInstanceSummary> | null | undefined;
+
+  // This installation's own instance id, so it can find itself in `instances`.
+  thisInstanceId?: string | null | undefined;
+}
+
+export interface SeatUsage {
+  /*
+   * False when the license carries no usable seat limit. Every other field is
+   * still filled in — a caller that wants to display usage can, it just must
+   * not block anything.
+   */
+  isEnforced: boolean;
+
+  // The limit actually being enforced, or null when there is none.
+  userLimit: number | null;
+
+  /*
+   * The best estimate of how many licensed seats are consumed right now,
+   * across every instance on this license. See getSeatUsage for how it is
+   * derived and which way it is allowed to be wrong.
+   */
+  seatsInUse: number;
+
+  // Null when there is no limit. Never negative — a breach reads as 0 free.
+  seatsRemaining: number | null;
+
+  /*
+   * The single question enforcement asks. True whenever there is no limit, so
+   * a caller can use this on its own without re-checking isEnforced.
+   */
+  hasSeatForNewUser: boolean;
+
+  /*
+   * How many of seatsInUse are users this installation has never seen. Zero
+   * whenever the topology is not known well enough to say, which is the
+   * conservative answer — see getSeatUsage.
+   */
+  seatsUsedByOtherInstances: number;
+}
+
+export default class EnterpriseLicenseSeatsUtil {
+  /*
+   * How many seats are in use, and whether one more user fits.
+   *
+   * The awkward part is that a license is shared by every instance the
+   * customer runs, and only oneuptime.com can deduplicate users across them —
+   * the same person on staging and production is one seat. So this instance
+   * has two numbers and neither one is the answer on its own:
+   *
+   *   localUserCount      live, but blind to the customer's other instances.
+   *   aggregatedUserCount complete, but up to a day old, so it does not know
+   *                       about anyone added since the last daily report —
+   *                       including the user being added right now.
+   *
+   * Combining them needs to know how much of the aggregate is NOT ours, which
+   * is what the per-instance breakdown is for: subtract our own last reported
+   * count from the aggregate and what is left is other instances. Add the live
+   * local count back and the result is current on this instance and complete
+   * on the others.
+   *
+   * When the breakdown does not say — an older license server that sends no
+   * instance list, an instance that has never registered — there is nothing to
+   * subtract, and the fallback is the larger of the two numbers on their own.
+   * That is the only case where the stale aggregate decides anything: with a
+   * usable breakdown it is deliberately NOT maxed in, because it would then
+   * outvote the live count in the one direction that hurts. Free twenty seats
+   * by deleting twenty users and a stale aggregate would go on refusing new
+   * ones until the next daily report.
+   *
+   * Which way it is allowed to be wrong: under-enforcing is recoverable (the
+   * next daily report corrects the count, and the breach emails already go
+   * out), over-enforcing locks a paying customer out of their own instance.
+   * So every "I cannot tell" branch below resolves towards under-enforcing.
+   */
+  public static getSeatUsage(input: SeatUsageInput): SeatUsage {
+    const userLimit: number | null = this.parseUserLimit(input.userLimit);
+    const localUserCount: number = this.parseCount(input.localUserCount) ?? 0;
+    const aggregatedUserCount: number | null = this.parseCount(
+      input.aggregatedUserCount,
+    );
+
+    /*
+     * Null means the report is not complete enough to attribute seats to
+     * anybody, which is a different thing from attributing zero to them.
+     */
+    const otherInstanceSeats: number | null = this.getSeatsUsedByOtherInstances(
+      {
+        aggregatedUserCount: aggregatedUserCount,
+        instances: input.instances,
+        thisInstanceId: input.thisInstanceId,
+      },
+    );
+
+    const seatsUsedByOtherInstances: number = otherInstanceSeats ?? 0;
+
+    const seatsInUse: number =
+      otherInstanceSeats === null
+        ? Math.max(localUserCount, aggregatedUserCount ?? 0)
+        : otherInstanceSeats + localUserCount;
+
+    if (userLimit === null) {
+      return {
+        isEnforced: false,
+        userLimit: null,
+        seatsInUse: seatsInUse,
+        seatsRemaining: null,
+        hasSeatForNewUser: true,
+        seatsUsedByOtherInstances: seatsUsedByOtherInstances,
+      };
+    }
+
+    return {
+      isEnforced: true,
+      userLimit: userLimit,
+      seatsInUse: seatsInUse,
+      seatsRemaining: Math.max(0, userLimit - seatsInUse),
+      hasSeatForNewUser: seatsInUse < userLimit,
+      seatsUsedByOtherInstances: seatsUsedByOtherInstances,
+    };
+  }
+
+  /*
+   * The message an administrator reads when a seat could not be taken. Built
+   * here rather than at each throw site so the invite form, the signup form
+   * and SSO/SCIM provisioning all explain the same thing the same way, and so
+   * the tests can assert on it without copying the wording.
+   */
+  public static getSeatLimitReachedMessage(data: {
+    seatsInUse: number;
+    userLimit: number;
+  }): string {
+    return (
+      `This OneUptime installation has reached the ${data.userLimit.toLocaleString()}-user ` +
+      `limit of its enterprise license (${data.seatsInUse.toLocaleString()} in use). New users ` +
+      `cannot be invited, signed up or provisioned until a seat is freed up or the license is ` +
+      `expanded. Contact sales@oneuptime.com to add seats, then use "Refresh license" in the ` +
+      `edition dialog to apply the new limit.`
+    );
+  }
+
+  /*
+   * The part of the aggregate that belongs to instances other than this one,
+   * or null when the report does not say.
+   *
+   * Null rather than zero, because the two lead somewhere different: zero means
+   * "this installation is the only one holding seats", and null means "the
+   * report cannot be decomposed, fall back to comparing the two totals". Every
+   * missing or unusable field lands on null.
+   *
+   * In particular, an instance list that does not contain us is NOT treated as
+   * "then all of the aggregate is somebody else's". That reading is right for a
+   * genuinely unregistered instance, and catastrophic for an instance whose id
+   * changed after its users were already counted under the old one: it would
+   * count this installation's users twice and lock it out.
+   */
+  private static getSeatsUsedByOtherInstances(data: {
+    aggregatedUserCount: number | null;
+    instances?: Array<EnterpriseLicenseInstanceSummary> | null | undefined;
+    thisInstanceId?: string | null | undefined;
+  }): number | null {
+    const aggregatedUserCount: number | null = data.aggregatedUserCount;
+
+    if (aggregatedUserCount === null) {
+      return null;
+    }
+
+    if (!Array.isArray(data.instances) || data.instances.length === 0) {
+      return null;
+    }
+
+    const thisInstanceId: string =
+      typeof data.thisInstanceId === "string" ? data.thisInstanceId.trim() : "";
+
+    if (!thisInstanceId) {
+      return null;
+    }
+
+    const thisInstance: EnterpriseLicenseInstanceSummary | undefined =
+      data.instances.find(
+        (instance: EnterpriseLicenseInstanceSummary): boolean => {
+          return Boolean(instance) && instance.instanceId === thisInstanceId;
+        },
+      );
+
+    if (!thisInstance) {
+      return null;
+    }
+
+    const ownReportedCount: number | null = this.parseCount(
+      thisInstance.userCount,
+    );
+
+    if (ownReportedCount === null) {
+      return null;
+    }
+
+    return Math.max(0, aggregatedUserCount - ownReportedCount);
+  }
+
+  /*
+   * A limit is only a limit when it is a positive whole number.
+   *
+   * Zero is deliberately read as "no limit" rather than "no seats at all",
+   * matching every other place in the product that measures seat usage
+   * (the license modal, the breach notification job). A license that really
+   * grants nobody an account is not a thing OneUptime issues, and reading a
+   * stray zero the other way would leave an installation unable to create even
+   * its first user.
+   */
+  private static parseUserLimit(value: unknown): number | null {
+    if (
+      typeof value !== "number" ||
+      !Number.isFinite(value) ||
+      !Number.isInteger(value) ||
+      value <= 0
+    ) {
+      return null;
+    }
+
+    return value;
+  }
+
+  private static parseCount(value: unknown): number | null {
+    if (
+      typeof value !== "number" ||
+      !Number.isFinite(value) ||
+      !Number.isInteger(value) ||
+      value < 0
+    ) {
+      return null;
+    }
+
+    return value;
+  }
+}


### PR DESCRIPTION
## Enforce the enterprise license user limit on self-hosted installations

Enterprise licenses are sold for a number of users, and until now nothing on the
customer's side acted on that number. The limit was fetched from oneuptime.com,
mirrored into `GlobalConfig`, drawn on a progress bar in the edition dialog — and
then ignored. A 50-seat license and a 5000-seat license behaved identically:
invitations, signups, SSO and SCIM all went through regardless.

This makes the limit real, and gives administrators a way to apply a limit change
without waiting a day for it.

### 1. Enforcement at the one chokepoint that covers every door

`UserService.onBeforeCreate` — every path that creates a user ends up in
`UserService.create`:

| Path | Entry point |
| --- | --- |
| Team invitation | `TeamMemberService.onBeforeCreate` → `UserService.createByEmail` |
| Self-service signup | `Identity/API/Authentication.ts` → `createUserOnSignup` |
| SAML / OIDC JIT provisioning | `SSO.ts`, `OIDC.ts`, `GlobalSSO.ts`, `GlobalOIDC.ts` |
| SCIM | three routes in `Identity/API/SCIM.ts` |
| Admin Dashboard user form | `POST /api/user` |
| Master API key | `POST /api/user` |

Enforcing on the invitation alone would have left signup and SSO as open doors
beside it. The check deliberately does **not** exempt `isRoot` — team invitations
create the invited user as root, so an `isRoot` escape hatch would exempt the
single path this was asked for.

It is a no-op on Community Edition and on oneuptime.com itself (which bounds
seats through subscriptions), and it never counts the `User` table on a license
with no seat limit.

### 2. The seat arithmetic

A license is shared by every instance the customer runs, and only oneuptime.com
can deduplicate users across them. So the installation holds two numbers, and
neither is the answer on its own:

- **local user count** — live, but blind to the customer's other instances.
- **license-wide count** — deduplicated, but up to a day old, so it does not know
  about the person being invited right now.

`EnterpriseLicenseSeatsUtil.getSeatUsage` combines them: subtract this instance's
last reported count from the license-wide total to get the seats other instances
hold, then add the live local count back. When the report is not decomposable
(older license server, unregistered instance) it falls back to the larger of the
two totals.

Every "cannot tell" branch resolves towards under-enforcing. Under-enforcing is
corrected by the next daily report; over-enforcing locks a paying customer out of
their own installation.

### 3. A "Refresh license" button

`POST /global-config/license/refresh` re-fetches the stored license key's terms
from oneuptime.com and applies them — the seat limit, the expiry, the company
name, the instance list. Surfaced as a **Refresh license** button in the edition
dialog next to "Change license key".

It deliberately takes no license key in the body: a refresh that accepted one
would be an activation with a friendlier name, and would let a typo replace a
working license.

### 4. Security fix along the way

`POST /global-config/license` ran on `UserMiddleware.getUserMiddleware`, which
lets anonymous callers through — it has to, because the `GET` on the same path
serves the signed-out login page. So the route that sets this installation's
license (and now its seat ceiling) was in practice unauthenticated.

Both license writes now require a master admin
(`MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware`), and the dialog
hides the license controls from everyone else, showing them who to ask instead.

### 5. UI

- The seat card shows the figure enforcement actually uses, not the up-to-a-day-old
  license-wide one — otherwise it would read "98 of 100" next to an invitation
  that had just bounced.
- A full license (100/100) is now shown as a breach rather than an amber
  "nearly full" nudge: it is the point where the door is already shut.
- The advisory says plainly that new users cannot be invited, signed up or
  provisioned.

### Tests

| Suite | What it covers |
| --- | --- |
| `Common/Tests/Utils/EnterpriseLicenseSeats.test.ts` | the seat arithmetic — limits, boundaries, multi-instance overlap, and every malformed-input branch |
| `Common/Tests/Server/Utils/EnterpriseLicense/EnterpriseLicenseSeatUtil.test.ts` | which installations enforce, what is read, when users are counted, when a user is refused |
| `Common/Tests/Server/Services/UserServiceSeatLimit.test.ts` | the hook is wired in, and does not exempt root |
| `Common/Tests/Server/API/GlobalConfigLicense.test.ts` | both license routes: master-admin guard, refresh semantics, upstream failures, seat fields |
| `Common/Tests/UI/Components/EditionLabelLicenseRefresh.test.tsx` | the button — who sees it, what it sends, what it shows |

No database migration: every column this uses already exists.
