### PR TITLE
fix(monitor): stop captureMetric attributes from claiming another resource's identity

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Service/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Service/View/Index.tsx
@@ -632,10 +632,19 @@ const ServiceView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             },
             stepId: "service-info",
             title: "Tech Stack",
+            /*
+             * Optional, like the same field on Service > Settings and like
+             * the create form, which does not offer it at all. It used to be
+             * required here, which meant renaming a service that ingest had
+             * auto-created forced the editor to invent a language for it —
+             * and `detectServiceLanguage` then reported that guess as the
+             * service's detected "Technology", indistinguishable in the UI
+             * from a real telemetry.sdk.language reading.
+             */
             description:
-              "The language or framework used to build this service.",
+              "Optional. The language or framework used to build this service. Leave blank to use the language detected from this service's telemetry.",
             fieldType: FormFieldSchemaType.MultiSelectDropdown,
-            required: true,
+            required: false,
             placeholder: "Tech Stack",
             dropdownOptions: DropdownUtil.getDropdownOptionsFromEnum(TechStack),
           },

--- a/App/FeatureSet/Docs/Content/en/monitor/custom-code-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/custom-code-monitor.md
@@ -58,7 +58,7 @@ oneuptime.captureMetric(name, value, attributes);
 
 - `name` (string, required): The metric name (e.g. `"api.response.time"`). It will be stored with a `custom.monitor.` prefix automatically.
 - `value` (number, required): The numeric metric value.
-- `attributes` (object, optional): Key-value pairs for additional context.
+- `attributes` (object, optional): Key-value pairs for additional context. String, number and boolean values are recorded (numbers and booleans are stored as text, because metric attributes are dimensions rather than measurements). Values of any other type are ignored.
 
 #### Example
 
@@ -86,6 +86,17 @@ Once captured, these metrics appear in the Metric Explorer under names like `cus
 - Maximum 100 metrics per script execution.
 - Metric names are limited to 200 characters.
 - Values must be numeric.
+- Maximum 50 attributes per metric. Attribute keys are limited to 200 characters and attribute values to 1000 characters.
+
+**Reserved attribute keys:**
+
+Some attribute names are OneUptime's own, and a script cannot write them. If your script sets one, the attribute is dropped — the metric itself is still recorded — and a warning naming the key is written to the OneUptime server logs. They are:
+
+- The monitor's identity: `monitorId`, `projectId`, `monitorName`, `probeName`, `probeId`, `isCustomMetric`.
+- Anything in the `oneuptime.` or `resource.` namespaces — these carry the identifiers OneUptime stamps at ingest.
+- Resource identity attributes: `service.name`, `host.name`, `k8s.cluster.name`, `iot.fleet.name`, `proxmox.cluster.name`, `ceph.cluster.name` and `docker.swarm.cluster.name`.
+
+The reason is that these names are not just labels — OneUptime reads them back as a claim about which resource a datapoint belongs to. A metric tagged `service.name: payments-api` would show up on that service's Metrics tab, and if you later built a metric monitor grouped by `service.name`, its alerts would be linked to that service, would page that service's owners, and would fall silent during a maintenance window on it. To associate a monitor with a service or host, use the monitor's own labels instead.
 
 ### Modules available in the script
 

--- a/Common/Server/Utils/Monitor/CapturedMetricAttributeUtil.ts
+++ b/Common/Server/Utils/Monitor/CapturedMetricAttributeUtil.ts
@@ -1,0 +1,245 @@
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import { AllResourceIdentityLabelKeys } from "./SeriesResourceLabels";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Attributes a monitor SCRIPT chose, on their way into ClickHouse
+ * ---------------------------------------------------------------------------
+ *
+ * Custom code and synthetic monitors let a user's script name its own metric
+ * dimensions:
+ *
+ *   oneuptime.captureMetric("api.queue.depth", 12, { region: "us-east-1" })
+ *
+ * Everything else that writes a metric row picks its own attribute keys from a
+ * fixed vocabulary. This is the one writer where the KEY is user input, so it
+ * is the one writer that needs a guard, and this module is it.
+ *
+ * Two classes of key are refused.
+ *
+ *  1. RESOURCE IDENTITY. A metric row is not just a datapoint — it is a claim
+ *     about which resource the datapoint describes. `SeriesResourceLabels`
+ *     lists the attribute names that carry that claim (`service.name`,
+ *     `oneuptime.host.id`, `k8s.cluster.name`, ...), and the consumers take
+ *     them at face value.
+ *
+ *     Two consequences, one immediate and one a step removed. Immediately, the
+ *     resource detail pages scope their charts by the raw attribute rather
+ *     than by the owning entity's id — Service > Metrics pins
+ *     `resource.service.name = <the service's name>` — so a script stamping
+ *     that key files its monitor's datapoints onto an unrelated Service's
+ *     page. A step removed, ANY metric monitor grouped by one of these keys
+ *     turns it into a series label, and from there `SeriesResourceLinker`
+ *     attaches the named resource to every alert and incident that series
+ *     opens, `AlertOwnerRuleEngineService` pages that resource's owners
+ *     through owner inheritance, and `MonitorMaintenanceSuppression` silences
+ *     the series for the duration of a maintenance window on it. (A custom
+ *     code monitor's OWN alerts carry no series labels, so that second chain
+ *     needs a metric monitor over the `custom.monitor.*` series — which is an
+ *     ordinary thing for the same user to build.)
+ *
+ *     The blocklist is DERIVED from `AllResourceIdentityLabelKeys` so a key
+ *     added to the read side cannot be forgotten here.
+ *
+ *     The whole `oneuptime.` and `resource.` namespaces go with them.
+ *     `oneuptime.*` is what ingest stamps (ids, names, labels, custom fields);
+ *     `resource.*` is the ClickHouse spelling of an OTel resource attribute,
+ *     and a monitor metric has no OTel resource — so a script writing there is
+ *     always impersonating something. Blocking the namespaces rather than the
+ *     individual keys is what makes this hold for stamps added later.
+ *
+ *  2. PROTOTYPE-WALKING SEGMENTS. Dotted keys are read back as nested paths
+ *     (`{{host.name}}` in an alert template walks `host` then `name`), so a
+ *     segment of `__proto__` / `constructor` / `prototype` aims that walk at
+ *     `Object.prototype`. `MonitorTemplateUtil` refuses to walk them, and this
+ *     keeps them out of the store in the first place.
+ *
+ * Values are coerced rather than filtered. The sandbox hands over whatever
+ * JSON the script passed, and the ClickHouse column is Map(String, String), so
+ * a number or a boolean is a perfectly good dimension once stringified — which
+ * is what the synthetic runtime already does in-sandbox. The custom code path
+ * used to drop them on the floor server-side instead, so
+ * `captureMetric("queue.depth", n, { shard: 3 })` silently recorded no `shard`
+ * at all. Anything with no useful string form (objects, arrays, null, NaN,
+ * Infinity) is still dropped.
+ *
+ * The caps match the synthetic runtime's in-sandbox caps exactly. They are
+ * re-applied here because a probe is a separately deployed process: the server
+ * must not take the probe's word for how much a script was allowed to write.
+ */
+
+/** Most attributes kept on one captured metric. Matches the synthetic runtime. */
+export const MaxCapturedMetricAttributes: number = 50;
+
+/** Longest attribute key kept. Matches the synthetic runtime. */
+export const MaxCapturedMetricAttributeKeyLength: number = 200;
+
+/** Longest attribute value kept. Matches the synthetic runtime. */
+export const MaxCapturedMetricAttributeValueLength: number = 1000;
+
+/*
+ * The monitor's own identity, stamped by `buildMonitorMetricAttributes` and by
+ * the custom-metric block itself. A script that could overwrite these would be
+ * able to file its datapoints under a different monitor, or hide them from the
+ * Custom Metrics tab.
+ */
+const MonitorIdentityAttributeKeys: ReadonlyArray<string> = [
+  "monitorId",
+  "projectId",
+  "monitorName",
+  "probeName",
+  "probeId",
+  "isCustomMetric",
+];
+
+/*
+ * Namespace prefixes reserved for OneUptime's own stamps. `oneuptime.` covers
+ * every id / name / label / customField stamp; `resource.` covers the
+ * ClickHouse spelling of OTel resource attributes.
+ */
+const ReservedAttributeKeyPrefixes: ReadonlyArray<string> = [
+  "oneuptime.",
+  "resource.",
+];
+
+/*
+ * Path segments that make a dotted key resolve to the object prototype when a
+ * consumer walks it as a nested property path.
+ */
+const PrototypeWalkingKeySegments: ReadonlySet<string> = new Set<string>([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+const ReservedAttributeKeys: ReadonlySet<string> = new Set<string>([
+  ...MonitorIdentityAttributeKeys,
+  ...AllResourceIdentityLabelKeys,
+]);
+
+/** One captured metric's attributes after the guard has run. */
+export interface SanitizedCapturedMetricAttributes {
+  /** The attributes that survived, ready to merge into the metric row. */
+  attributes: JSONObject;
+  /**
+   * Keys refused because they are reserved. Surfaced so the caller can tell
+   * the user why an attribute they wrote is not on their chart — a silent drop
+   * is indistinguishable from a bug in their script.
+   */
+  droppedReservedKeys: Array<string>;
+}
+
+export default class CapturedMetricAttributeUtil {
+  /**
+   * True when a monitor script must not be allowed to write this attribute
+   * key, either because OneUptime owns its meaning or because reading it back
+   * as a nested path would walk the object prototype.
+   *
+   * Compared case-sensitively, exactly as the read side compares
+   * (`SeriesResourceLabels.collectLabelValues` does a plain lookup), so this
+   * refuses precisely the spellings that would actually be honoured.
+   */
+  public static isReservedAttributeKey(key: string): boolean {
+    if (ReservedAttributeKeys.has(key)) {
+      return true;
+    }
+
+    for (const prefix of ReservedAttributeKeyPrefixes) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+
+    for (const segment of key.split(".")) {
+      if (PrototypeWalkingKeySegments.has(segment)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * The attributes of one captured metric, filtered, coerced and capped.
+   *
+   * First key wins on a post-trim collision, so the result does not depend on
+   * how the script happened to order two keys that differ only in whitespace.
+   */
+  public static sanitize(
+    attributes: JSONObject | undefined | null,
+  ): SanitizedCapturedMetricAttributes {
+    const sanitized: JSONObject = {};
+    const droppedReservedKeys: Array<string> = [];
+
+    if (!attributes || typeof attributes !== "object") {
+      return { attributes: sanitized, droppedReservedKeys };
+    }
+
+    let kept: number = 0;
+
+    for (const rawKey of Object.keys(attributes)) {
+      if (kept >= MaxCapturedMetricAttributes) {
+        break;
+      }
+
+      /*
+       * An empty or whitespace-only key would store as an attribute no filter
+       * could ever select — the same thing MetricResourceAttributeUtil refuses
+       * to form for labels and custom fields.
+       */
+      const key: string = rawKey
+        .trim()
+        .substring(0, MaxCapturedMetricAttributeKeyLength);
+
+      if (key.length === 0) {
+        continue;
+      }
+
+      if (this.isReservedAttributeKey(key)) {
+        if (!droppedReservedKeys.includes(key)) {
+          droppedReservedKeys.push(key);
+        }
+        continue;
+      }
+
+      if (sanitized[key] !== undefined) {
+        continue;
+      }
+
+      const value: string | null = this.toAttributeValue(
+        attributes[rawKey] as JSONValue,
+      );
+
+      if (value === null) {
+        continue;
+      }
+
+      sanitized[key] = value;
+      kept++;
+    }
+
+    return { attributes: sanitized, droppedReservedKeys };
+  }
+
+  /*
+   * One attribute value as the string the Map(String, String) column stores.
+   * Returns null for anything that carries no usable dimension — an object, an
+   * array, null/undefined, or a non-finite number, which would record as the
+   * text "NaN" and chart as a category.
+   */
+  private static toAttributeValue(value: JSONValue | undefined): string | null {
+    if (typeof value === "string") {
+      return value.substring(0, MaxCapturedMetricAttributeValueLength);
+    }
+
+    if (typeof value === "number") {
+      return isFinite(value) ? String(value) : null;
+    }
+
+    if (typeof value === "boolean") {
+      return value ? "true" : "false";
+    }
+
+    return null;
+  }
+}

--- a/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
@@ -2,6 +2,9 @@ import logger from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
 import TelemetryUtil from "../Telemetry/Telemetry";
 import MetricResourceAttributeUtil from "../../../Utils/Metrics/MetricResourceAttributeUtil";
+import CapturedMetricAttributeUtil, {
+  SanitizedCapturedMetricAttributes,
+} from "./CapturedMetricAttributeUtil";
 import MetricService from "../../Services/MetricService";
 import GlobalConfigService from "../../Services/GlobalConfigService";
 import GlobalConfig from "../../../Models/DatabaseModels/GlobalConfig";
@@ -245,9 +248,14 @@ export default class MonitorMetricUtil {
    * same monitor, so there is nothing per-metric to decide, and one pass is
    * far easier to keep correct than thirty call sites.
    *
-   * Resource attributes are merged LAST. Custom code monitors let a user
-   * supply their own attribute names, and those must not be able to shadow the
-   * oneuptime.* namespace.
+   * Resource attributes are merged LAST, so a resource attribute wins any
+   * collision. That merge is NOT what keeps the oneuptime.* namespace safe
+   * from a monitor script, though — it only ever writes the handful of keys
+   * this monitor's own labels and custom fields produce, and it does not run
+   * at all for a monitor that has neither. Script-supplied attribute keys are
+   * refused at the point they are read instead, by
+   * CapturedMetricAttributeUtil, which rejects the whole oneuptime.* and
+   * resource.* namespaces rather than the keys that happen to collide today.
    */
   public static applyResourceAttributesToMetricRows(data: {
     metricRows: Array<JSONObject>;
@@ -1327,13 +1335,13 @@ export default class MonitorMetricUtil {
       );
     }
 
-    const reservedAttributeKeys: Set<string> = new Set([
-      "monitorId",
-      "projectId",
-      "monitorName",
-      "probeName",
-      "probeId",
-    ]);
+    /*
+     * Keys a script tried to write but is not allowed to own, collected
+     * across the whole check so the operator gets one line naming them
+     * rather than one per datapoint. Without it, an attribute that silently
+     * never reaches a chart is indistinguishable from a bug in the script.
+     */
+    const droppedReservedAttributeKeys: Set<string> = new Set<string>();
 
     for (const customMetric of allCustomMetrics) {
       if (
@@ -1347,7 +1355,20 @@ export default class MonitorMetricUtil {
 
       const prefixedName: string = `custom.monitor.${customMetric.name}`;
 
+      /*
+       * Script-supplied attributes first, OneUptime's own stamps after, so
+       * the stamps are written onto a set the guard has already cleared of
+       * every key OneUptime owns.
+       */
+      const sanitized: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize(customMetric.attributes);
+
+      for (const droppedKey of sanitized.droppedReservedKeys) {
+        droppedReservedAttributeKeys.add(droppedKey);
+      }
+
       const extraAttributes: JSONObject = {
+        ...sanitized.attributes,
         isCustomMetric: "true",
       };
 
@@ -1355,14 +1376,6 @@ export default class MonitorMetricUtil {
         extraAttributes["probeId"] = (
           data.dataToProcess as ProbeMonitorResponse
         ).probeId.toString();
-      }
-
-      if (customMetric.attributes) {
-        for (const [key, val] of Object.entries(customMetric.attributes)) {
-          if (typeof val === "string" && !reservedAttributeKeys.has(key)) {
-            extraAttributes[key] = val;
-          }
-        }
       }
 
       const attributes: JSONObject = this.buildMonitorMetricAttributes({
@@ -1390,6 +1403,16 @@ export default class MonitorMetricUtil {
       metricType.unit = "";
 
       metricNameServiceNameMap[prefixedName] = metricType;
+    }
+
+    if (droppedReservedAttributeKeys.size > 0) {
+      logger.warn(
+        `${data.monitorId.toString()} - Custom metric attributes dropped, these keys are reserved by OneUptime: ${Array.from(
+          droppedReservedAttributeKeys,
+        )
+          .sort()
+          .join(", ")}`,
+      );
     }
 
     this.applyResourceAttributesToMetricRows({

--- a/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
@@ -33,6 +33,18 @@ import VMUtil from "../VM/VMAPI";
 import DataToProcess from "./DataToProcess";
 import logger from "../Logger";
 
+/*
+ * Path segments that resolve to the object prototype when a dotted series
+ * label key is walked as a nested property path. See the fold in
+ * `getStorageMap`, and the matching write-side guard in
+ * `CapturedMetricAttributeUtil`.
+ */
+const PrototypeWalkingKeySegments: ReadonlySet<string> = new Set<string>([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 /**
  * Utility for building template variable storage map and processing dynamic placeholders
  * shared between Incident and Alert auto-creation.
@@ -534,6 +546,26 @@ export default class MonitorTemplateUtil {
           continue;
         }
         const parts: Array<string> = key.split(".");
+        /*
+         * Series label keys are attacker-adjacent: they are whatever
+         * attribute names the emitting telemetry chose, and a monitor
+         * script picks them outright via oneuptime.captureMetric(). Walking
+         * `__proto__` here would hand the loop Object.prototype — it is
+         * truthy, an object, and not an Array, so the reset below would be
+         * skipped and the final assignment would land on the prototype
+         * itself, polluting every object in the shared Workers process that
+         * renders every project's alert templates. `constructor` and
+         * `prototype` are refused with it so no spelling of the same walk
+         * survives. The whole label is skipped rather than partially
+         * folded, and it is still reachable in full under `seriesLabels`.
+         */
+        if (
+          parts.some((part: string) => {
+            return PrototypeWalkingKeySegments.has(part);
+          })
+        ) {
+          continue;
+        }
         let cursor: JSONObject = storageMap;
         for (let i: number = 0; i < parts.length - 1; i++) {
           const part: string = parts[i]!;

--- a/Common/Server/Utils/Monitor/SeriesResourceLabels.ts
+++ b/Common/Server/Utils/Monitor/SeriesResourceLabels.ts
@@ -161,6 +161,40 @@ export const ServiceNameLabelKeys: ReadonlyArray<string> = [
 ];
 
 /*
+ * Every label key above, in one list: the complete set of attribute
+ * names that make a series claim to belong to a specific Host / cluster
+ * / Service.
+ *
+ * `extractResourceRefs` below is the READ side of these keys. Writers
+ * that accept attribute names from a user — the custom code and
+ * synthetic monitors, whose scripts choose their own
+ * `oneuptime.captureMetric()` attribute keys — need the same list to
+ * decide what a script must NOT be allowed to stamp, because a series
+ * label saying `service.name = payments-api` is taken at face value
+ * downstream: alerts and incidents get linked to that Service, its
+ * owners are paged through owner inheritance, and a maintenance window
+ * on it silences the series. Deriving the write-side guard from this
+ * array is what stops the two sides from drifting apart the way the
+ * alert and incident linkers once did.
+ */
+export const AllResourceIdentityLabelKeys: ReadonlyArray<string> = [
+  ...HostIdLabelKeys,
+  ...HostNameLabelKeys,
+  ...DockerHostIdLabelKeys,
+  ...DockerHostNameLabelKeys,
+  ...PodmanHostIdLabelKeys,
+  ...PodmanHostNameLabelKeys,
+  ...DockerSwarmClusterNameLabelKeys,
+  ...KubernetesClusterIdLabelKeys,
+  ...KubernetesClusterNameLabelKeys,
+  ...ProxmoxClusterNameLabelKeys,
+  ...CephClusterNameLabelKeys,
+  ...IoTFleetNameLabelKeys,
+  ...ServiceIdLabelKeys,
+  ...ServiceNameLabelKeys,
+];
+
+/*
  * The identifiers carried by one series, split by resource type and by
  * id-vs-name. Ids are OneUptime database ids (the `oneuptime.*.id`
  * stamps); names are the human/telemetry identifiers (host.name,

--- a/Common/Tests/Server/Utils/Monitor/CapturedMetricAttributeUtil.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/CapturedMetricAttributeUtil.test.ts
@@ -1,0 +1,284 @@
+import CapturedMetricAttributeUtil, {
+  MaxCapturedMetricAttributes,
+  MaxCapturedMetricAttributeKeyLength,
+  MaxCapturedMetricAttributeValueLength,
+  SanitizedCapturedMetricAttributes,
+} from "../../../../Server/Utils/Monitor/CapturedMetricAttributeUtil";
+import {
+  AllResourceIdentityLabelKeys,
+  ServiceNameLabelKeys,
+} from "../../../../Server/Utils/Monitor/SeriesResourceLabels";
+import { JSONObject } from "../../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The guard in front of the ONE metric writer whose attribute KEYS are user
+ * input: `oneuptime.captureMetric(name, value, attributes)` inside a custom
+ * code or synthetic monitor script.
+ *
+ * The stakes are not cosmetic. An attribute such as `service.name` is read
+ * back as a claim about which resource the datapoint describes: Service >
+ * Metrics scopes its charts by the raw `resource.service.name` string, and
+ * once any metric monitor groups by one of these keys it becomes a series
+ * label, from where SeriesResourceLinker attaches the named Service to the
+ * alerts and incidents that series opens, AlertOwnerRuleEngineService pages
+ * that Service's owners, and MonitorMaintenanceSuppression silences the series
+ * for the duration of a maintenance window on it.
+ */
+describe("CapturedMetricAttributeUtil", () => {
+  describe("isReservedAttributeKey", () => {
+    test("refuses every key the series-label resolver treats as resource identity", () => {
+      // Derived from the read side so the two can never disagree.
+      for (const key of AllResourceIdentityLabelKeys) {
+        expect(CapturedMetricAttributeUtil.isReservedAttributeKey(key)).toBe(
+          true,
+        );
+      }
+    });
+
+    test("refuses the monitor's own identity attributes", () => {
+      for (const key of [
+        "monitorId",
+        "projectId",
+        "monitorName",
+        "probeName",
+        "probeId",
+        "isCustomMetric",
+      ]) {
+        expect(CapturedMetricAttributeUtil.isReservedAttributeKey(key)).toBe(
+          true,
+        );
+      }
+    });
+
+    test("refuses the whole oneuptime.* namespace, not just the keys that collide today", () => {
+      for (const key of [
+        "oneuptime.service.id",
+        "oneuptime.host.name",
+        "oneuptime.label.product",
+        "oneuptime.customField.team",
+        "oneuptime.something.invented.later",
+      ]) {
+        expect(CapturedMetricAttributeUtil.isReservedAttributeKey(key)).toBe(
+          true,
+        );
+      }
+    });
+
+    test("refuses the whole resource.* namespace — a monitor metric has no OTel resource", () => {
+      for (const key of [
+        "resource.service.name",
+        "resource.host.name",
+        "resource.telemetry.sdk.language",
+        "resource.anything",
+      ]) {
+        expect(CapturedMetricAttributeUtil.isReservedAttributeKey(key)).toBe(
+          true,
+        );
+      }
+    });
+
+    test("refuses dotted keys whose segments would walk the object prototype", () => {
+      for (const key of [
+        "__proto__",
+        "__proto__.polluted",
+        "constructor.prototype.polluted",
+        "a.__proto__.b",
+        "prototype",
+      ]) {
+        expect(CapturedMetricAttributeUtil.isReservedAttributeKey(key)).toBe(
+          true,
+        );
+      }
+    });
+
+    test("allows ordinary script-chosen dimensions", () => {
+      for (const key of [
+        "region",
+        "environment",
+        "ai.tool",
+        "cursor.team.id",
+        "queue",
+        "service_name",
+        "myservice.name",
+        "serviceName",
+      ]) {
+        expect(CapturedMetricAttributeUtil.isReservedAttributeKey(key)).toBe(
+          false,
+        );
+      }
+    });
+  });
+
+  describe("sanitize", () => {
+    test("keeps ordinary attributes untouched", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          region: "us-east-1",
+          environment: "production",
+          "ai.tool": "cursor",
+        });
+
+      expect(result.attributes).toEqual({
+        region: "us-east-1",
+        environment: "production",
+        "ai.tool": "cursor",
+      });
+      expect(result.droppedReservedKeys).toEqual([]);
+    });
+
+    test("drops every resource-identity spelling of service.name and reports it", () => {
+      const attributes: JSONObject = {};
+      for (const key of ServiceNameLabelKeys) {
+        attributes[key] = "payments-api";
+      }
+      attributes["region"] = "us-east-1";
+
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize(attributes);
+
+      expect(result.attributes).toEqual({ region: "us-east-1" });
+      expect(result.droppedReservedKeys.sort()).toEqual(
+        [...ServiceNameLabelKeys].sort(),
+      );
+    });
+
+    test("drops the host, kubernetes, iot and cluster identity keys too", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          "host.name": "web-01",
+          "oneuptime.host.id": "9c3a0c3e-0000-4000-8000-000000000001",
+          "k8s.cluster.name": "prod",
+          "iot.fleet.name": "fleet-a",
+          "proxmox.cluster.name": "pve",
+          "ceph.cluster.name": "ceph",
+          "docker.swarm.cluster.name": "swarm",
+          keep: "yes",
+        });
+
+      expect(result.attributes).toEqual({ keep: "yes" });
+      expect(result.droppedReservedKeys).toHaveLength(7);
+    });
+
+    test("records numbers and booleans as text instead of dropping them", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          shard: 3,
+          ratio: 0.5,
+          negative: -1,
+          zero: 0,
+          primary: true,
+          replica: false,
+        });
+
+      expect(result.attributes).toEqual({
+        shard: "3",
+        ratio: "0.5",
+        negative: "-1",
+        zero: "0",
+        primary: "true",
+        replica: "false",
+      });
+    });
+
+    test("drops values with no usable string form", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          nested: { a: 1 },
+          list: [1, 2],
+          nothing: null,
+          notANumber: Number.NaN,
+          unbounded: Number.POSITIVE_INFINITY,
+          kept: "yes",
+        } as unknown as JSONObject);
+
+      expect(result.attributes).toEqual({ kept: "yes" });
+    });
+
+    test("drops empty and whitespace-only keys, which no filter could ever select", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          "": "a",
+          "   ": "b",
+          ok: "c",
+        });
+
+      expect(result.attributes).toEqual({ ok: "c" });
+    });
+
+    test("trims keys, so a padded spelling cannot slip past the reserved list", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          "  service.name  ": "payments-api",
+          "  region  ": "us-east-1",
+        });
+
+      expect(result.attributes).toEqual({ region: "us-east-1" });
+      expect(result.droppedReservedKeys).toEqual(["service.name"]);
+    });
+
+    test("first key wins when two keys collide after trimming", () => {
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          region: "first",
+          " region": "second",
+        });
+
+      expect(result.attributes).toEqual({ region: "first" });
+    });
+
+    test("caps the attribute count, key length and value length", () => {
+      const attributes: JSONObject = {};
+      for (let i: number = 0; i < MaxCapturedMetricAttributes + 25; i++) {
+        attributes[`key${i}`] = "value";
+      }
+      attributes["x".repeat(MaxCapturedMetricAttributeKeyLength + 50)] = "y";
+
+      const result: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize(attributes);
+
+      expect(Object.keys(result.attributes)).toHaveLength(
+        MaxCapturedMetricAttributes,
+      );
+
+      const longValue: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          long: "z".repeat(MaxCapturedMetricAttributeValueLength + 100),
+        });
+
+      expect((longValue.attributes["long"] as string).length).toBe(
+        MaxCapturedMetricAttributeValueLength,
+      );
+
+      const longKey: SanitizedCapturedMetricAttributes =
+        CapturedMetricAttributeUtil.sanitize({
+          ["k".repeat(MaxCapturedMetricAttributeKeyLength + 100)]: "v",
+        });
+
+      expect(Object.keys(longKey.attributes)[0]!.length).toBe(
+        MaxCapturedMetricAttributeKeyLength,
+      );
+    });
+
+    test("returns an empty set for absent or non-object attributes", () => {
+      expect(
+        CapturedMetricAttributeUtil.sanitize(undefined).attributes,
+      ).toEqual({});
+      expect(CapturedMetricAttributeUtil.sanitize(null).attributes).toEqual({});
+      expect(
+        CapturedMetricAttributeUtil.sanitize(
+          "not an object" as unknown as JSONObject,
+        ).attributes,
+      ).toEqual({});
+    });
+
+    test("does not pollute Object.prototype through a __proto__ key", () => {
+      CapturedMetricAttributeUtil.sanitize({
+        __proto__: "pwned",
+        "__proto__.polluted": "pwned",
+      } as unknown as JSONObject);
+
+      expect(({} as JSONObject)["polluted"]).toBeUndefined();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorCustomMetricAttributes.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorCustomMetricAttributes.test.ts
@@ -1,0 +1,503 @@
+import Label from "../../../../Models/DatabaseModels/Label";
+import MetricType from "../../../../Models/DatabaseModels/MetricType";
+import GlobalConfigService from "../../../../Server/Services/GlobalConfigService";
+import MetricService from "../../../../Server/Services/MetricService";
+import ServiceService from "../../../../Server/Services/ServiceService";
+import { getJestSpyOn } from "../../../Spy";
+import MonitorMetricUtil from "../../../../Server/Utils/Monitor/MonitorMetricUtil";
+import logger from "../../../../Server/Utils/Logger";
+import { MaxCapturedMetricAttributes } from "../../../../Server/Utils/Monitor/CapturedMetricAttributeUtil";
+import { AllResourceIdentityLabelKeys } from "../../../../Server/Utils/Monitor/SeriesResourceLabels";
+import TelemetryUtil from "../../../../Server/Utils/Telemetry/Telemetry";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
+import CapturedMetric from "../../../../Types/Monitor/CustomCodeMonitor/CapturedMetric";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import ServiceType from "../../../../Types/Telemetry/ServiceType";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Regression suite for GitHub issue #3514
+ * ---------------------------------------------------------------------------
+ *
+ * The report was that a Custom JavaScript Code Monitor calling only
+ * `oneuptime.captureMetric()` auto-created a phantom Service row. It does not,
+ * and the first block below pins that down end to end: everything this path
+ * writes is a ClickHouse Metric row owned by the MONITOR
+ * (primaryEntityType = ServiceType.Monitor, primaryEntityId = the monitor id),
+ * and the MetricType it catalogues is never associated with any Service.
+ *
+ * What the investigation DID find in that path is the inverse problem, and it
+ * is the reason the rest of this file exists. Script-supplied attribute keys
+ * were copied into the metric row with only five names reserved, so a script
+ * could stamp `service.name` / `oneuptime.host.id` / `k8s.cluster.name` on its
+ * own datapoints. Those are not decoration — SeriesResourceLabels treats them
+ * as the series' resource identity. A stamped `resource.service.name` files
+ * the monitor's datapoints straight onto an unrelated Service's Metrics tab,
+ * which pins that raw attribute rather than the owning entity id; and any
+ * metric monitor grouped by one of these keys turns it into a series label,
+ * from where SeriesResourceLinker attaches the named resource to the alerts
+ * and incidents that series opens, AlertOwnerRuleEngineService pages that
+ * resource's owners, and MonitorMaintenanceSuppression silences the series
+ * during a maintenance window on it.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROBE_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+
+const CUSTOM_METRIC_NAME: string = "cursor.usage.lines_accepted";
+const CUSTOM_ROW_NAME: string = `custom.monitor.${CUSTOM_METRIC_NAME}`;
+
+function makeLabel(name: string): Label {
+  const label: Label = new Label();
+  label.name = name;
+  return label;
+}
+
+describe("MonitorMetricUtil custom metric attributes (issue #3514)", () => {
+  let insertedRows: Array<JSONObject>;
+  let indexedMetricNames: Dictionary<MetricType>;
+
+  beforeEach(() => {
+    insertedRows = [];
+    indexedMetricNames = {};
+
+    jest
+      .spyOn(GlobalConfigService, "findOneBy")
+      .mockResolvedValue(null as never);
+    jest
+      .spyOn(MetricService, "insertJsonRows")
+      .mockImplementation(async (rows: Array<JSONObject>): Promise<void> => {
+        insertedRows.push(...rows);
+      });
+    jest
+      .spyOn(TelemetryUtil, "indexMetricNameServiceNameMap")
+      .mockImplementation(
+        async (data: {
+          projectId: ObjectID;
+          metricNameServiceNameMap: Dictionary<MetricType>;
+        }): Promise<void> => {
+          Object.assign(indexedMetricNames, data.metricNameServiceNameMap);
+          return undefined;
+        },
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function captureMetrics(
+    capturedMetrics: Array<CapturedMetric>,
+    options: {
+      monitorLabels?: Array<Label>;
+      monitorCustomFields?: JSONObject;
+    } = {},
+  ): Promise<void> {
+    const response: ProbeMonitorResponse = {
+      projectId: PROJECT_ID,
+      monitorId: MONITOR_ID,
+      monitorStepId: ObjectID.generate(),
+      probeId: PROBE_ID,
+      failureCause: "",
+      monitoredAt: new Date("2026-08-10T12:00:00.000Z"),
+      customCodeMonitorResponse: {
+        logMessages: [],
+        scriptError: undefined,
+        result: undefined,
+        executionTimeInMS: 10,
+        capturedMetrics: capturedMetrics,
+      },
+    } as unknown as ProbeMonitorResponse;
+
+    await MonitorMetricUtil.saveMonitorMetrics({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      dataToProcess: response,
+      monitorName: "Cursor usage ingest — daily",
+      probeName: "London Probe",
+      monitorLabels: options.monitorLabels,
+      monitorCustomFields: options.monitorCustomFields,
+    });
+  }
+
+  function customMetricRow(): JSONObject {
+    const row: JSONObject | undefined = insertedRows.find(
+      (candidate: JSONObject) => {
+        return candidate["name"] === CUSTOM_ROW_NAME;
+      },
+    );
+
+    expect(row).toBeDefined();
+
+    return row as JSONObject;
+  }
+
+  function customMetricAttributes(): JSONObject {
+    return customMetricRow()["attributes"] as JSONObject;
+  }
+
+  describe("the reported behaviour: captureMetric and Service rows", () => {
+    test("owns its metric rows by MONITOR, never by a Service", async () => {
+      await captureMetrics([
+        { name: CUSTOM_METRIC_NAME, value: 1234, attributes: {} },
+      ]);
+
+      const row: JSONObject = customMetricRow();
+
+      expect(row["primaryEntityType"]).toBe(ServiceType.Monitor);
+      expect(row["primaryEntityId"]).toBe(MONITOR_ID.toString());
+
+      /*
+       * The columns ingest fills in for an OTLP resource. A monitor metric has
+       * no OTel resource, so leaving them unset is what keeps this row out of
+       * the entity registry — and out of the Services list.
+       */
+      expect(row["entityKeys"]).toBeUndefined();
+      expect(row["serviceEntityKey"]).toBeUndefined();
+    });
+
+    test("catalogues the metric name without associating any Service", async () => {
+      await captureMetrics([
+        { name: CUSTOM_METRIC_NAME, value: 1234, attributes: {} },
+      ]);
+
+      const metricType: MetricType | undefined =
+        indexedMetricNames[CUSTOM_ROW_NAME];
+
+      expect(metricType).toBeDefined();
+      expect(metricType?.name).toBe(CUSTOM_ROW_NAME);
+
+      /*
+       * `services` left unset is what makes TelemetryUtil's junction insert a
+       * no-op. A Service attached here would be the closest this path could
+       * ever come to the reported phantom service.
+       */
+      expect(metricType?.services).toBeUndefined();
+    });
+
+    test("stamps no attribute that names a Service, even when the script tries", async () => {
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1234,
+          attributes: {
+            "service.name": "Cursor",
+            "resource.service.name": "Cursor",
+            "oneuptime.service.name": "Cursor",
+            "oneuptime.service.id": "44444444-4444-4444-8444-444444444444",
+            "ai.tool": "cursor",
+          },
+        },
+      ]);
+
+      const attributes: JSONObject = customMetricAttributes();
+
+      expect(attributes["service.name"]).toBeUndefined();
+      expect(attributes["resource.service.name"]).toBeUndefined();
+      expect(attributes["oneuptime.service.name"]).toBeUndefined();
+      expect(attributes["oneuptime.service.id"]).toBeUndefined();
+
+      // The script's own dimension is untouched.
+      expect(attributes["ai.tool"]).toBe("cursor");
+    });
+
+    test("creates no Service row — the literal claim in the issue", async () => {
+      /*
+       * The narrowest possible statement of what was reported. Postgres has
+       * exactly one automatic Service creator
+       * (OpenTelemetryIngestService.findOrCreateTelemetryService, itself the
+       * only production caller of ServiceService.create), so a spy on that
+       * one method is a complete assertion for this path.
+       */
+      const create: jest.SpyInstance<any, any> = getJestSpyOn(
+        ServiceService,
+        "create",
+      );
+
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1234,
+          attributes: { "service.name": "Cursor", "ai.tool": "cursor" },
+        },
+      ]);
+
+      expect(create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resource identity cannot be claimed by a script", () => {
+    test("drops every key the series-label resolver reads as resource identity", async () => {
+      const attributes: JSONObject = {};
+      for (const key of AllResourceIdentityLabelKeys) {
+        attributes[key] = "borrowed";
+      }
+      attributes["region"] = "us-east-1";
+
+      await captureMetrics([
+        { name: CUSTOM_METRIC_NAME, value: 1, attributes: attributes },
+      ]);
+
+      const recorded: JSONObject = customMetricAttributes();
+
+      for (const key of AllResourceIdentityLabelKeys) {
+        expect(recorded[key]).toBeUndefined();
+      }
+
+      expect(recorded["region"]).toBe("us-east-1");
+    });
+
+    test("drops the monitor's own identity attributes so a script cannot re-file its data", async () => {
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: {
+            monitorId: "99999999-9999-4999-8999-999999999999",
+            projectId: "88888888-8888-4888-8888-888888888888",
+            monitorName: "Some Other Monitor",
+            probeName: "Some Other Probe",
+            probeId: "77777777-7777-4777-8777-777777777777",
+            isCustomMetric: "false",
+          },
+        },
+      ]);
+
+      const attributes: JSONObject = customMetricAttributes();
+
+      expect(attributes["monitorId"]).toBe(MONITOR_ID.toString());
+      expect(attributes["projectId"]).toBe(PROJECT_ID.toString());
+      expect(attributes["monitorName"]).toBe("Cursor usage ingest — daily");
+      expect(attributes["probeName"]).toBe("London Probe");
+      expect(attributes["probeId"]).toBe(PROBE_ID.toString());
+      expect(attributes["isCustomMetric"]).toBe("true");
+    });
+
+    test("drops a spoofed oneuptime.label.* even when the monitor has NO labels of its own", async () => {
+      /*
+       * The old guarantee came from merging the monitor's real labels last,
+       * which does nothing at all for a monitor that has none — so this case
+       * used to record the spoofed value verbatim.
+       */
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: { "oneuptime.label.product": "spoofed" },
+        },
+      ]);
+
+      expect(
+        customMetricAttributes()["oneuptime.label.product"],
+      ).toBeUndefined();
+    });
+
+    test("still lets the monitor's real labels through", async () => {
+      await captureMetrics(
+        [{ name: CUSTOM_METRIC_NAME, value: 1, attributes: { q: "1" } }],
+        { monitorLabels: [makeLabel("product:checkout")] },
+      );
+
+      const attributes: JSONObject = customMetricAttributes();
+
+      expect(attributes["oneuptime.label.product"]).toBe("checkout");
+      expect(attributes["q"]).toBe("1");
+    });
+
+    test("names every dropped key in ONE log line for the whole check", async () => {
+      /*
+       * The diagnostic is the whole reason a user can tell a refused
+       * attribute from a bug in their script. One line per check, not one per
+       * datapoint, or a script emitting 100 metrics floods the log.
+       */
+      const warn: jest.SpyInstance<any, any> = getJestSpyOn(
+        logger,
+        "warn",
+      ).mockImplementation((): void => {
+        return undefined;
+      });
+
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: { "service.name": "Cursor", region: "us-east-1" },
+        },
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 2,
+          attributes: { "service.name": "Cursor", "host.name": "web-01" },
+        },
+      ]);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      const message: string = String(warn.mock.calls[0]?.[0]);
+
+      expect(message).toContain(MONITOR_ID.toString());
+      // Deduped across the two metrics, and sorted so the line is stable.
+      expect(message).toContain("host.name, service.name");
+      expect(message).not.toContain("region");
+    });
+
+    test("says nothing when the script writes only attributes it owns", async () => {
+      const warn: jest.SpyInstance<any, any> = getJestSpyOn(
+        logger,
+        "warn",
+      ).mockImplementation((): void => {
+        return undefined;
+      });
+
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: { region: "us-east-1", "ai.tool": "cursor" },
+        },
+      ]);
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    test("republishes attributeKeys so a dropped key is not left behind in the filter list", async () => {
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: { "service.name": "Cursor", region: "us-east-1" },
+        },
+      ]);
+
+      const row: JSONObject = customMetricRow();
+      const attributes: JSONObject = row["attributes"] as JSONObject;
+      const attributeKeys: Array<string> = row[
+        "attributeKeys"
+      ] as Array<string>;
+
+      expect(attributeKeys).toEqual(Object.keys(attributes).sort());
+      expect(attributeKeys).not.toContain("service.name");
+      expect(attributeKeys).toContain("region");
+    });
+  });
+
+  describe("values and limits", () => {
+    test("records numbers and booleans instead of silently dropping them", async () => {
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: {
+            seats: 42,
+            active: true,
+            suspended: false,
+            tool: "cursor",
+          },
+        },
+      ]);
+
+      const attributes: JSONObject = customMetricAttributes();
+
+      expect(attributes["seats"]).toBe("42");
+      expect(attributes["active"]).toBe("true");
+      expect(attributes["suspended"]).toBe("false");
+      expect(attributes["tool"]).toBe("cursor");
+    });
+
+    test("caps the number of script-supplied attributes on one metric", async () => {
+      const attributes: JSONObject = {};
+      for (let i: number = 0; i < MaxCapturedMetricAttributes + 30; i++) {
+        attributes[`dimension${i}`] = "value";
+      }
+
+      await captureMetrics([
+        { name: CUSTOM_METRIC_NAME, value: 1, attributes: attributes },
+      ]);
+
+      const recorded: JSONObject = customMetricAttributes();
+      const scriptKeys: Array<string> = Object.keys(recorded).filter(
+        (key: string) => {
+          return key.startsWith("dimension");
+        },
+      );
+
+      expect(scriptKeys).toHaveLength(MaxCapturedMetricAttributes);
+    });
+
+    test("does not pollute Object.prototype through a dotted __proto__ key", async () => {
+      await captureMetrics([
+        {
+          name: CUSTOM_METRIC_NAME,
+          value: 1,
+          attributes: {
+            "__proto__.polluted": "pwned",
+            region: "us-east-1",
+          },
+        },
+      ]);
+
+      expect(({} as JSONObject)["polluted"]).toBeUndefined();
+      expect(customMetricAttributes()["region"]).toBe("us-east-1");
+    });
+
+    test("the guard applies to synthetic monitor captured metrics too", async () => {
+      /*
+       * Probes are separately deployed processes. The synthetic runtime caps
+       * and coerces in-sandbox, but the server must not take a probe's word
+       * for what a script was allowed to write.
+       */
+      const response: ProbeMonitorResponse = {
+        projectId: PROJECT_ID,
+        monitorId: MONITOR_ID,
+        monitorStepId: ObjectID.generate(),
+        probeId: PROBE_ID,
+        failureCause: "",
+        monitoredAt: new Date("2026-08-10T12:00:00.000Z"),
+        syntheticMonitorResponse: [
+          {
+            logMessages: [],
+            scriptError: undefined,
+            result: undefined,
+            executionTimeInMS: 10,
+            browserType: "Chromium",
+            screenSizeType: "Desktop",
+            capturedMetrics: [
+              {
+                name: CUSTOM_METRIC_NAME,
+                value: 5,
+                attributes: { "host.name": "web-01", page: "checkout" },
+              },
+            ],
+          },
+        ],
+      } as unknown as ProbeMonitorResponse;
+
+      await MonitorMetricUtil.saveMonitorMetrics({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        dataToProcess: response,
+        monitorName: "Checkout journey",
+        probeName: "London Probe",
+      });
+
+      const attributes: JSONObject = customMetricAttributes();
+
+      expect(attributes["host.name"]).toBeUndefined();
+      expect(attributes["page"]).toBe("checkout");
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorTemplatePrototypePollution.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorTemplatePrototypePollution.test.ts
@@ -1,0 +1,106 @@
+import MonitorTemplateUtil from "../../../../Server/Utils/Monitor/MonitorTemplateUtil";
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * A grouped metric monitor renders its incident/alert title per series, and
+ * the series' labels are folded onto the template storage map so
+ * `{{host.name}}` resolves as a nested path. The fold therefore walks
+ * attacker-adjacent input: series label keys are whatever attribute names the
+ * emitting telemetry chose, and for a custom code or synthetic monitor a
+ * script picks them outright via `oneuptime.captureMetric()`.
+ *
+ * A key of `__proto__.polluted` used to aim that walk at Object.prototype —
+ * `storageMap["__proto__"]` is truthy, an object and not an Array, so the
+ * "reset to a fresh object" branch was skipped and the final assignment landed
+ * on the prototype itself. This runs in the shared Workers process that
+ * renders every project's templates, so one series label polluted every object
+ * in it.
+ */
+describe("MonitorTemplateUtil series label fold", () => {
+  const monitorId: ObjectID = new ObjectID(
+    "22222222-2222-4222-8222-222222222222",
+  );
+
+  function buildStorageMap(seriesLabels: JSONObject): JSONObject {
+    return MonitorTemplateUtil.buildTemplateStorageMap({
+      monitorType: MonitorType.Metrics,
+      dataToProcess: {
+        monitorId: monitorId,
+        projectId: new ObjectID("11111111-1111-4111-8111-111111111111"),
+      } as unknown as ProbeMonitorResponse,
+      seriesLabels: seriesLabels,
+    });
+  }
+
+  afterEach(() => {
+    // Never leave a polluted prototype behind for the rest of the suite.
+    delete (Object.prototype as unknown as JSONObject)["polluted"];
+  });
+
+  test("does not pollute Object.prototype through a __proto__ segment", () => {
+    buildStorageMap({ "__proto__.polluted": "pwned" });
+
+    expect(({} as JSONObject)["polluted"]).toBeUndefined();
+    expect(
+      (Object.prototype as unknown as JSONObject)["polluted"],
+    ).toBeUndefined();
+  });
+
+  test("does not pollute Object.prototype through a constructor.prototype segment", () => {
+    buildStorageMap({ "constructor.prototype.polluted": "pwned" });
+
+    expect(({} as JSONObject)["polluted"]).toBeUndefined();
+  });
+
+  test("does not pollute through a __proto__ segment buried mid-path", () => {
+    buildStorageMap({ "host.__proto__.polluted": "pwned" });
+
+    expect(({} as JSONObject)["polluted"]).toBeUndefined();
+  });
+
+  test("still exposes a refused label under seriesLabels, so nothing is lost", () => {
+    const storageMap: JSONObject = buildStorageMap({
+      "__proto__.polluted": "pwned",
+      "host.name": "web-01",
+    });
+
+    const seriesLabels: JSONObject = storageMap["seriesLabels"] as JSONObject;
+
+    expect(seriesLabels["__proto__.polluted"]).toBe("pwned");
+    expect(seriesLabels["host.name"]).toBe("web-01");
+  });
+
+  test("still folds ordinary dotted labels into nested paths", () => {
+    const storageMap: JSONObject = buildStorageMap({
+      "host.name": "web-01",
+      "k8s.pod.name": "checkout-abc",
+      region: "us-east-1",
+    });
+
+    expect((storageMap["host"] as JSONObject)["name"]).toBe("web-01");
+    expect(
+      ((storageMap["k8s"] as JSONObject)["pod"] as JSONObject)["name"],
+    ).toBe("checkout-abc");
+    expect(storageMap["region"]).toBe("us-east-1");
+  });
+
+  test("renders a template against a folded label, with the refused one inert", () => {
+    const storageMap: JSONObject = buildStorageMap({
+      "host.name": "web-01",
+      "__proto__.polluted": "pwned",
+    });
+
+    expect(
+      MonitorTemplateUtil.processTemplateString({
+        value: "Host {{host.name}} is down",
+        storageMap: storageMap,
+      }),
+    ).toBe("Host web-01 is down");
+
+    expect(({} as JSONObject)["polluted"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What this is

Investigation of #3514, plus a fix for the real defect the investigation turned up in the code path the reporter named.

## First: the reported behaviour is not what happens

A Custom JavaScript Code Monitor that only calls `oneuptime.captureMetric()` **cannot create a `Service` row.** Four independent reasons, each sufficient on its own:

1. **There is exactly one automatic `Service` creator in the repo** — `ServiceService.create()` at [OpenTelemetryIngestService.ts:775](Common/Server/Services/OpenTelemetryIngestService.ts:775), inside the private `findOrCreateTelemetryService`. Its only caller is `telemetryServiceFromName`, whose 11 production callers are all ingest sinks (OTLP, syslog, fluent, SNMP, source maps, security events, change events, and three security-event utils). `MonitorMetricUtil.ts` and `MonitorResource.ts` import neither `OTelIngestService` nor `ServiceService`.

2. **`captureMetric` never leaves the process.** The sandbox shim ([VMRunner.ts:272-292](Common/Server/Utils/VM/VMRunner.ts:272)) marshals to a host callback that does nothing but push onto a plain array. The captured metrics ride the `ProbeMonitorResponse` to `MonitorMetricUtil.saveMonitorMetrics`, which writes ClickHouse rows hard-stamped `primaryEntityType: ServiceType.Monitor`, `primaryEntityId: <monitorId>` ([MonitorMetricUtil.ts:152-153](Common/Server/Utils/Monitor/MonitorMetricUtil.ts:152)).

3. **The one Postgres write on that path creates a `MetricType`, and cannot cascade.** `MonitorMetricUtil` never assigns `metricType.services`, so `servicesInMap` is always `[]` and the junction insert is a no-op; the relation declares no `cascade`, and `attachServices` is a raw `INSERT ... ON CONFLICT DO NOTHING` that would FK-fail rather than create.

4. **"Technology: Python" is affirmative counter-evidence.** `Service.telemetrySdkLanguage` and `runtimeName` are `@ColumnAccessControl({create: [], update: []})` and are written only by `ServiceService.updateLastSeen`, fed only by `buildServiceMetadataFromAttributes`. Of the 11 callers of `telemetryServiceFromName`, exactly one passes `resourceAttributes` — the OTLP path.

Also decisive: the screenshot shows "Last seen 6 days ago", and `ResourceOverview` prints the literal `"never"` when `lastSeenAt` is null. A non-null `lastSeenAt` can only come from `updateLastSeen`, which is called from inside `telemetryServiceFromName`. So an ingest sink resolved the name "Cursor" for that project. It was not the monitor.

**Most likely origin:** Cursor's own server-side OpenTelemetry Export destination, which OneUptime ships first-class support for ([Docs/.../telemetry/cursor.md](App/FeatureSet/Docs/Content/en/telemetry/cursor.md)). It is enabled by a Cursor *team admin* in the Cursor web dashboard — no SDK, nothing on any developer machine, which is exactly why the reporter can truthfully say "no OTel SDK". It sends `service.name = cursor` and **metrics and logs but never traces**, which is precisely why Requests reads 0 and every APM panel is empty at any time range. The 6-day staleness matches Cursor's no-backfill, at-most-once export. Separately, "Python" may not be from telemetry at all — see the `techStack` fix below.

## Second: the real defect, in the same code path

`MonitorMetricUtil`'s custom-metric block is **the only metric writer in the codebase where the attribute _key_ is user input**. It reserved five names (`monitorId`, `projectId`, `monitorName`, `probeName`, `probeId`) and copied every other string attribute verbatim. So a script could stamp `service.name`, `resource.service.name`, `oneuptime.service.id`, `host.name`, `k8s.cluster.name`, `iot.fleet.name`, `proxmox.cluster.name`, … on its own datapoints.

Those are not decoration — they are how OneUptime decides which resource a datapoint describes:

- **Immediately:** resource detail pages scope their charts by the raw attribute, not the entity id. `Service > Metrics` pins `resource.service.name = <the service's name>` ([Metrics.tsx:88-96](App/FeatureSet/Dashboard/src/Pages/Service/View/Metrics.tsx:88)), so a stamped key filed a monitor's datapoints onto an unrelated Service's page. Eight sibling Metrics views (Host, Kubernetes, Ceph, Proxmox, Docker Swarm, IoT, Cloud, Serverless) pin the same way.
- **One step removed:** the metric-monitor query is scoped by `{projectId, time, name}` with no `primaryEntityType` predicate, so a Metrics monitor can select `custom.monitor.*` rows. Group it by the injected key and it becomes a series label — from where `SeriesResourceLinker` attaches the named resource to the alerts and incidents that series opens, `AlertOwnerRuleEngineService` **pages that resource's owners** through owner inheritance, and `MonitorMaintenanceSuppression` **silences the series** for the duration of a maintenance window on it.

Scope, stated honestly: the second chain needs a second monitor (a custom code monitor's own alerts never carry series labels), and it is within-project only. It is co-tenant impersonation, not a tenant-boundary break.

The doc comment on `applyResourceAttributesToMetricRows` claimed the merge-last ordering kept the `oneuptime.*` namespace safe. It did not: it only ever writes the handful of keys the monitor's own labels and custom fields produce, and it early-returns entirely for a monitor that has neither.

**Also fixed here, reachable from the same user-controlled keys: `Object.prototype` pollution.** `MonitorTemplateUtil` folds dotted series-label keys into a nested object for alert/incident templating. For `__proto__.polluted`, `cursor["__proto__"]` returns `Object.prototype` — truthy, an object, not an Array — so the reset branch is skipped and the assignment lands on the prototype. This runs in the shared Workers process that renders every project's templates. Verified by executing the exact loop body.

## The fix

**New `Common/Server/Utils/Monitor/CapturedMetricAttributeUtil.ts`** — a guard at the one writer whose keys are user input:

- Blocklist **derived** from `AllResourceIdentityLabelKeys`, not hand-copied, so a key added to the read side cannot be forgotten on the write side.
- Refuses the whole `oneuptime.` and `resource.` namespaces rather than the keys that collide today — `oneuptime.*` is what ingest stamps, and a monitor metric has no OTel resource, so a script writing `resource.*` is always impersonating something.
- Refuses `__proto__` / `constructor` / `prototype` path segments.
- Keys trimmed **before** the reserved check, so `"  service.name  "` cannot slip past; empty keys dropped (no filter could ever select them).
- **Coerces rather than drops** finite numbers and booleans, matching what the synthetic runtime already does in-sandbox. `captureMetric("queue.depth", n, { shard: 3 })` used to record no `shard` at all, silently — which contradicted the documented contract.
- Re-applies the synthetic runtime's 50 / 200 / 1000 caps server-side. A probe is a separately deployed process; the server should not take its word for how much a script was allowed to write.

**`SeriesResourceLabels.ts`** — purely additive: exports `AllResourceIdentityLabelKeys`, the concatenation of the fourteen existing key arrays. No existing array or resolver changed.

**`MonitorMetricUtil.ts`** — calls the guard; script attributes go in first so OneUptime's own stamps land on an already-cleared set. Dropped keys are deduped across the whole check and surfaced as **one** operator log line naming them, because a silently-missing attribute is indistinguishable from a bug in the user's script.

**`MonitorTemplateUtil.ts`** — skips prototype-walking label keys before the fold. The label stays fully reachable under `seriesLabels`, so nothing is lost.

**`Service/View/Index.tsx`** — `techStack` `required: true` → `false`. This is directly relevant to the report: the overview edit form was the only one of the three that made Tech Stack mandatory (Settings has it optional; the create form does not offer it), so **anyone who opened an auto-discovered service and saved any edit — a rename, a description — was forced to invent a language**, which the tile then labels "detected from telemetry". That is a plausible source of the "Python" in the screenshot.

**Docs** — the reserved namespaces, the value coercion, and the caps.

### Intended behaviour deliberately untouched

No ingest file is modified. Docker/Podman container-name services and Kubernetes autodiscovery route through `OtelIngestBaseService` and are unaffected, as is OTLP `service.name` → Service creation.

## Tests

Three new suites, 40 tests. Ran locally with the four adjacent pre-existing suites: **all pass.**

- **`CapturedMetricAttributeUtil.test.ts`** (17) — the guard contract. The most valuable one loops over `AllResourceIdentityLabelKeys` itself, so it fails automatically if the read side gains a key the write side does not follow. Also pins that ordinary dimensions (`region`, `ai.tool`, `service_name`, `myservice.name`) are *not* over-blocked.
- **`MonitorCustomMetricAttributes.test.ts`** (16) — end-to-end through the real `saveMonitorMetrics`, titled for the issue. `"owns its metric rows by MONITOR, never by a Service"`, `"catalogues the metric name without associating any Service"`, `"creates no Service row — the literal claim in the issue"` (spies `ServiceService.create`) are the regression lock for #3514 itself. Also covers the spoofed `oneuptime.label.*` on a monitor with no labels — the case the old merge-last ordering could never have caught — and that the guard applies to synthetic monitors too.
- **`MonitorTemplatePrototypePollution.test.ts`** (6) — `__proto__`, `constructor.prototype`, and a segment buried mid-path; plus proof that ordinary dotted labels still fold and the refused label is still reachable under `seriesLabels`.

Regression-checked against `MonitorMetricResourceAttributes`, `MonitorMetricUtilPortTimings`, `SeriesResourceLinker`, `MonitorMaintenanceSuppression`, `MonitorAlertResourceLinking`, `MonitorIncidentResourceLinking` — 89 tests, all pass. `tsc --noEmit` clean in both `Common` and `App`; eslint clean on every changed file.

## For the reporter

`ServiceService.onCreateSuccess` writes a `ServiceCreated` feed item recording `createdByUserId` — ingest creates carry none, every human/API create does. **Opening the "Cursor" service's Feed tab already answers whether that row was ingest-discovered or added by a person.** If ingest-discovered, widening the Metrics range to 30 days should surface the data (it is very likely still in ClickHouse, just outside the default 1-hour window), and the Cursor team admin panel is worth checking for an OpenTelemetry Export destination.

## Related defects found in passing — not folded in

Filed for separate tickets rather than widening this diff: the synthetic 100-metric cap is re-applied across the concatenation of all browser×screen-size responses (silently discarding later combinations); `Service > Metrics` scoping by `resource.service.name` instead of the drift-free `oneuptime.service.id`; `findWithSameText` trimming the query but not the column; custom monitor metric names not lowercased unlike OTLP; syslog creating a Service before drop filters run.

Closes #3514
