### PR TITLE
fix(ci): bound Common Test's heap across Jest's worker pool

### DIFF
--- a/.github/workflows/test.common.yaml
+++ b/.github/workflows/test.common.yaml
@@ -27,6 +27,19 @@ jobs:
   # gate; it never changed a pass into a fail. `npm run debug:test` still has
   # it for when a leak needs chasing.
   #
+  # Moving off runInBand is also why the test script now pins --maxWorkers and
+  # a smaller heap. --max-old-space-size is a per-process ceiling, and
+  # jest-worker forwards the parent's execArgv to every worker it forks
+  # (ChildProcessWorker only strips --debug/--inspect), so the old
+  # --max-old-space-size=6144 stopped describing one process and started
+  # describing each of them. On a 4-vCPU runner Jest defaults to three workers,
+  # which is an 18 GB ceiling on a 16 GB box: the workers grew until the VM
+  # itself died, and every shard failed with "the runner has received a
+  # shutdown signal" rather than a test failure. A shard's live set measures
+  # ~2 GB per worker and peaks near 3.5 GB, so 2 workers x 4 GB keeps the hard
+  # ceiling at 8 GB with room to spare for the postgres and redis containers
+  # test-setup.sh starts alongside.
+  #
   # Type checking is deliberately left on. App's suite could go transpile-only
   # (App/jest.config.json, isolatedModules) because the compile-app job takes
   # every App test file as a tsc program root, so nothing went unchecked.

--- a/Common/package.json
+++ b/Common/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "cd .. && export $(grep -v '^#' config.env | xargs) && cd Common && node --max-old-space-size=6144 node_modules/.bin/jest ./Tests --forceExit",
+    "test": "cd .. && export $(grep -v '^#' config.env | xargs) && cd Common && node --max-old-space-size=4096 node_modules/.bin/jest ./Tests --forceExit --maxWorkers=2",
     "test-file": "cd .. && export $(grep -v '^#' config.env | xargs) && cd Common && node node_modules/.bin/jest --runInBand $1 --detectOpenHandles",
     "coverage": "jest --detectOpenHandles --coverage",
     "compile": "tsc",


### PR DESCRIPTION
## What's broken

Every `Common Test` shard on master has been failing since the suite moved off `runInBand` in 701ba43a61. The jobs don't report a test failure — they report:

```
##[error]The runner has received a shutdown signal...
##[error]Process completed with exit code 143.
```

Each shard dies a few minutes into *its own* run rather than all at one wall-clock instant, and the workflow sets `fail-fast: false`, so this is not the concurrency group or fail-fast cancelling anything. It's the runner VM dying underneath the job.

## Root cause

`--max-old-space-size` is a **per-process** ceiling, and `jest-worker` forwards the parent's `execArgv` to every worker it forks — `ChildProcessWorker` filters only `--debug`/`--inspect`:

```js
execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
```

A worker's own command line carries the flag verbatim:

```
node --max-old-space-size=8192 .../jest-worker/build/workers/processChild.js
```

While the script passed `--detectOpenHandles`, Jest's scheduler forced `runInBand`, so `--max-old-space-size=6144` described the single process that existed. Dropping that flag turned the pool on and turned the same number into a *per-worker* ceiling. Three workers on a 4-vCPU runner is an **18 GB ceiling on a 16 GB box**, and the workers grow into it until the VM is gone.

## Sizing

Measured on a shard, mimicking the runner's worker count:

| per-worker ceiling | result |
|---|---|
| 2048 MB | workers genuinely OOM (`FATAL ERROR: Reached heap limit`), live set ~2038 MB at collection |
| 8192 MB | no OOM; ~3.5 GB peak per worker, ~10 GB across three |

So the memory is real, not V8 declining to collect. Two workers at 4 GB holds the hard ceiling at **8 GB**, leaves each worker roughly twice its live set, and keeps room for the postgres and redis containers `test-setup.sh` starts alongside. It's still a worker pool, so the wall-clock win over `runInBand` stays.

Type checking is untouched, and so is `--forceExit`.

## Follow-up (not in this PR)

`App/package.json` has the same shape — `NODE_OPTIONS=--max-old-space-size=4096` (inherited by every child through the environment) with no worker cap. It isn't failing, because App's suite is transpile-only via `isolatedModules`, so its workers are far smaller. Worth bounding on its own.