### PR TITLE
fix(docs): name the env var the Docker Swarm inventory cutoff actually reads

### DIFF
--- a/App/FeatureSet/Workers/Jobs/DockerSwarm/CleanupStaleResources.ts
+++ b/App/FeatureSet/Workers/Jobs/DockerSwarm/CleanupStaleResources.ts
@@ -26,8 +26,8 @@ import ObjectID from "Common/Types/ObjectID";
  *      threshold. Threshold and delete both live in
  *      DockerSwarmResourceService (getStaleThresholdDate /
  *      deleteStaleForCluster — default 15 minutes = 3x the snapshot
- *      interval; override with PVE_INVENTORY_STALE_MINUTES, minimum
- *      5) so this cron carries no duplicate policy. The cutoff is
+ *      interval; override with DOCKER_SWARM_INVENTORY_STALE_MINUTES,
+ *      minimum 5) so this cron carries no duplicate policy. The cutoff is
  *      anchored to each cluster's own lastSeenAt rather than wall-clock
  *      now: inventory rows ride the slower snapshot clock, so with the
  *      disconnect and prune thresholds both at 15 minutes a wall-clock

--- a/App/FeatureSet/Workers/Jobs/Kubernetes/CleanupStaleResources.ts
+++ b/App/FeatureSet/Workers/Jobs/Kubernetes/CleanupStaleResources.ts
@@ -18,7 +18,8 @@ import ObjectID from "Common/Types/ObjectID";
  *      ingest maintenance fence TTL so healthy clusters never flap).
  *   2. For each CONNECTED cluster, hard-delete KubernetesResource
  *      rows whose last snapshot is older than the stale threshold
- *      (default 15 minutes = 3x snapshot interval).
+ *      (default 15 minutes = 3x snapshot interval; override with
+ *      K8S_INVENTORY_STALE_MINUTES, minimum 5).
  *
  * Skipping disconnected clusters is deliberate: during a transient
  * agent outage we want to preserve the last-known inventory rather


### PR DESCRIPTION
## What

Two comment-only fixes to the stale-inventory cleanup crons. No behaviour change.

**1. Docker Swarm points at the wrong env var (the actual bug)**

`App/FeatureSet/Workers/Jobs/DockerSwarm/CleanupStaleResources.ts:29` told operators to override the prune threshold with `PVE_INVENTORY_STALE_MINUTES`. That line was copied verbatim from `Proxmox/CleanupStaleResources.ts:29`, where the identical sentence is correct.

`DockerSwarmResourceService.getStaleThresholdMinutes` (`Common/Server/Services/DockerSwarmResourceService.ts:419`) reads `DOCKER_SWARM_INVENTORY_STALE_MINUTES`. Nothing in the Docker Swarm path reads the PVE name, so an operator following the comment set a variable that did nothing and silently kept the 15-minute default.

Same class of bug as e3de6f9 (#3519) fixed for Kubernetes.

**2. Kubernetes named no env var at all**

`Kubernetes/CleanupStaleResources.ts:21` said only "(default 15 minutes = 3x snapshot interval)", while its four documented siblings — Ceph:28, DockerSwarm:29, IoT:31, Proxmox:29 — all spell out "override with \<VAR\>, minimum 5" in that position. Added the clause naming `K8S_INVENTORY_STALE_MINUTES`, which is what `KubernetesResourceService.ts:964` reads.

## Verification

Every documented job comment now matches the variable its service reads:

| Job | Comment says | Service reads |
|---|---|---|
| Ceph | `CEPH_INVENTORY_STALE_MINUTES` | `CEPH_INVENTORY_STALE_MINUTES` |
| DockerSwarm | `DOCKER_SWARM_INVENTORY_STALE_MINUTES` | `DOCKER_SWARM_INVENTORY_STALE_MINUTES` |
| IoT | `IOT_INVENTORY_STALE_MINUTES` | `IOT_INVENTORY_STALE_MINUTES` |
| Kubernetes | `K8S_INVENTORY_STALE_MINUTES` | `K8S_INVENTORY_STALE_MINUTES` |
| Proxmox | `PVE_INVENTORY_STALE_MINUTES` | `PVE_INVENTORY_STALE_MINUTES` |

The "minimum 5" wording holds in both files: each service ignores a parsed value below 5 and falls back to the 15-minute default.

`npx prettier --check` and `npx eslint` both pass clean on the two touched files.