### PR TITLE
fix(ui): eight usability papercuts across the shared table and header

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Header/Header.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/Header.tsx
@@ -8,6 +8,7 @@ import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
  */
 import AskAI from "./AskAI";
 import Help from "./Help";
+import Search from "./Search";
 import Logo from "./Logo";
 import ProjectPicker from "./ProjectPicker";
 import Upgrade from "./Upgrade";
@@ -880,6 +881,7 @@ const DashboardHeader: FunctionComponent<ComponentProps> = (
             ) : (
               <></>
             )}
+            <Search />
             <AskAI />
             <NotificationBell
               items={buildNotificationItems()}

--- a/App/FeatureSet/Dashboard/src/Components/Header/Search.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/Search.tsx
@@ -1,0 +1,46 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import HeaderIconDropdownButton from "Common/UI/Components/Header/HeaderIconDropdownButton";
+import KeyboardKey from "Common/UI/Components/KeyboardShortcut/KeyboardKey";
+import GlobalEvents from "Common/UI/Utils/GlobalEvents";
+import React, { ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import EventName from "../../Utils/EventName";
+
+/*
+ * The command palette - every page in the product, plus the create actions and
+ * a live search over monitors, incidents, alerts, status pages and on-call -
+ * had exactly one way in: knowing to press Cmd/Ctrl+K. Nothing on screen said
+ * so, so the whole surface was invisible to anyone who had not been told about
+ * it.
+ *
+ * This is the visible door. It sits beside Ask AI, which advertises its own
+ * chord the same way, so the keycaps also teach the shortcut to whoever
+ * reaches for the mouse first.
+ */
+const Search: () => JSX.Element = (): ReactElement => {
+  /*
+   * t(key, default) rather than a locale entry: en.json is the source of truth
+   * the other 15 locales must mirror key-for-key (Scripts/I18n/ValidateLocales),
+   * so adding the key to English alone would fail validation, and inventing
+   * fifteen translations here would be worse. Same pattern
+   * DashboardCommandPalette already uses for its own strings.
+   */
+  const { t } = useTranslation();
+  const label: string = t("header.search", "Search");
+
+  return (
+    <HeaderIconDropdownButton
+      icon={IconProp.Search}
+      name={label}
+      title={label}
+      // DashboardCommandPalette listens for meta-or-ctrl + K.
+      shortcut={[KeyboardKey.Mod, "K"]}
+      showDropdown={false}
+      onClick={() => {
+        GlobalEvents.dispatchEvent(EventName.COMMAND_PALETTE_TOGGLE);
+      }}
+    />
+  );
+};
+
+export default Search;

--- a/App/FeatureSet/Dashboard/src/Components/User/RemoveUserFromProject.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/User/RemoveUserFromProject.tsx
@@ -17,7 +17,7 @@ export interface ComponentProps {
   onError: (error: string) => void;
 }
 
-const ResetObjectID: (props: ComponentProps) => ReactElement = (
+const RemoveUserFromProject: (props: ComponentProps) => ReactElement = (
   props: ComponentProps,
 ): ReactElement => {
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -87,7 +87,7 @@ const ResetObjectID: (props: ComponentProps) => ReactElement = (
 
       {showModal ? (
         <ConfirmModal
-          description={`Are you sure you want to reset remove this user?`}
+          description={`Are you sure you want to remove this user from the project? They will immediately lose access to it, and to every team in it.`}
           title={`Remove User`}
           onSubmit={async () => {
             await removeUserFromProject();
@@ -121,4 +121,4 @@ const ResetObjectID: (props: ComponentProps) => ReactElement = (
   );
 };
 
-export default ResetObjectID;
+export default RemoveUserFromProject;

--- a/Common/Tests/App/Dashboard/OnCallReadinessSurfaces.test.tsx
+++ b/Common/Tests/App/Dashboard/OnCallReadinessSurfaces.test.tsx
@@ -1293,7 +1293,7 @@ describe("ResponderReadinessCard", () => {
       expect(
         await screen.findByText("Could not load readiness"),
       ).toBeInTheDocument();
-      expect(screen.getByRole("refresh-button")).toBeInTheDocument();
+      expect(screen.getByTestId("refresh-button")).toBeInTheDocument();
     });
 
     test("retrying issues another request", async () => {
@@ -1305,7 +1305,7 @@ describe("ResponderReadinessCard", () => {
 
       const callsBefore: number = getMock.mock.calls.length;
 
-      fireEvent.click(screen.getByRole("refresh-button"));
+      fireEvent.click(screen.getByTestId("refresh-button"));
 
       await waitFor((): void => {
         expect(getMock.mock.calls.length).toBeGreaterThan(callsBefore);
@@ -1784,7 +1784,7 @@ describe("On-call readiness page", () => {
       expect(
         await screen.findByText("Could not load readiness"),
       ).toBeInTheDocument();
-      expect(screen.getByRole("refresh-button")).toBeInTheDocument();
+      expect(screen.getByTestId("refresh-button")).toBeInTheDocument();
     });
 
     test("the card chrome survives a failed request", async () => {

--- a/Common/Tests/UI/Components/ErrorMessageRefreshControl.test.tsx
+++ b/Common/Tests/UI/Components/ErrorMessageRefreshControl.test.tsx
@@ -1,0 +1,83 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+
+/*
+ * ErrorMessage is the app-wide "this went wrong" and "there is nothing here"
+ * surface - 89 call sites pass onRefreshClick - and its recovery control used
+ * to be a <div role="refresh-button">. A div is not in the tab order and does
+ * not answer Enter or Space, so the only way out of a failed table was the
+ * mouse. It is a real <button> now, which is what these assertions pin down:
+ * reachable by keyboard, and operable by the keys a button responds to.
+ */
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import ErrorMessage from "../../../UI/Components/ErrorMessage/ErrorMessage";
+
+describe("ErrorMessage refresh control", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders the refresh control as a real button", () => {
+    render(
+      <ErrorMessage message="Something went wrong" onRefreshClick={() => {}} />,
+    );
+
+    const refresh: HTMLElement = screen.getByTestId("refresh-button");
+
+    expect(refresh.tagName).toBe("BUTTON");
+    // A submit button inside a form would navigate instead of refetching.
+    expect(refresh).toHaveAttribute("type", "button");
+    expect(refresh).toHaveTextContent("Refresh?");
+  });
+
+  test("the refresh control is focusable and fires on Enter and on Space", () => {
+    let refreshCount: number = 0;
+
+    render(
+      <ErrorMessage
+        message="Something went wrong"
+        onRefreshClick={() => {
+          refreshCount++;
+        }}
+      />,
+    );
+
+    const refresh: HTMLElement = screen.getByTestId("refresh-button");
+
+    refresh.focus();
+    expect(refresh).toHaveFocus();
+
+    /*
+     * jsdom does not synthesise the click a real browser derives from Enter or
+     * Space on a button, so the assertion that matters here is the one above -
+     * that this is a button at all, and therefore gets that behaviour from the
+     * platform. The click below confirms the handler is still wired.
+     */
+    fireEvent.click(refresh);
+    expect(refreshCount).toBe(1);
+  });
+
+  test("renders no control at all when there is nothing to refresh", () => {
+    render(<ErrorMessage message="Nothing here" />);
+
+    expect(screen.queryByTestId("refresh-button")).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableDeleteAndEmptyStates.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableDeleteAndEmptyStates.test.tsx
@@ -1,0 +1,341 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Two sentences a table shows constantly, both of which used to say less than
+ * they knew.
+ *
+ * The per-row delete confirmation said "Are you sure you want to delete this
+ * monitor?" - equally true of the row that was clicked and of the twenty
+ * either side of it, which is exactly the wrong moment to be vague. The table
+ * has the row in hand when it renders that dialog.
+ *
+ * And an empty table said "No monitor" whether the project had nothing in it
+ * or a search had simply missed, so a typo in the search box was
+ * indistinguishable from an empty account.
+ */
+
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return [];
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return true;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import PermissionGate from "../../../../UI/Utils/PermissionGate";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+const MONITOR_ROWS: Array<JSONObject> = [
+  { _id: "monitor-1", name: "Checkout API", description: "Payments" },
+  { _id: "monitor-2", name: "Billing Worker", description: "Invoices" },
+];
+
+// Incidents key on `title`, not `name` - the deriver has to know both.
+const INCIDENT_ROWS: Array<JSONObject> = [
+  { _id: "incident-1", title: "Checkout is down", description: "Sev1" },
+];
+
+// Neither `name` nor `title`, so the generic wording has to survive.
+const UNNAMED_ROWS: Array<JSONObject> = [
+  { _id: "monitor-9", description: "No name on this one" },
+];
+
+interface TableOptions {
+  rows?: Array<JSONObject> | undefined;
+  initialFilterData?: JSONObject | undefined;
+  nameColumnTitle?: string | undefined;
+  nameColumnField?: string | undefined;
+  singularName?: string | undefined;
+  pluralName?: string | undefined;
+  noItemsMessage?: string | undefined;
+}
+
+type MakePropsFunction = (
+  options: TableOptions,
+) => BaseModelTableProps<Monitor>;
+
+const makeProps: MakePropsFunction = (
+  options: TableOptions,
+): BaseModelTableProps<Monitor> => {
+  const rows: Array<JSONObject> = options.rows ?? MONITOR_ROWS;
+
+  const callbacks: BaseTableCallbacks<Monitor> = {
+    deleteItem: async (): Promise<void> => {
+      return undefined;
+    },
+    getModelFromJSON: (item: JSONObject): Monitor => {
+      return item as unknown as Monitor;
+    },
+    getJSONFromModel: (item: Monitor): JSONObject => {
+      return item as unknown as JSONObject;
+    },
+    addSlugToSelect: (select: unknown): unknown => {
+      return select;
+    },
+    getList: async (data: {
+      skip: number;
+      limit: number;
+    }): Promise<ListResult<Monitor>> => {
+      return {
+        data: rows as unknown as Array<Monitor>,
+        count: rows.length,
+        skip: data.skip,
+        limit: data.limit,
+      };
+    },
+    toJSONArray: (): Array<JSONObject> => {
+      return [];
+    },
+    updateById: async (): Promise<void> => {
+      return undefined;
+    },
+    showCreateEditModal: (): React.ReactElement => {
+      return <div data-testid="create-edit-modal" />;
+    },
+  } as unknown as BaseTableCallbacks<Monitor>;
+
+  return {
+    modelType: options.nameColumnField === "title" ? Incident : Monitor,
+    id: "monitors-table",
+    name: "Monitors",
+    singularName: options.singularName ?? "Monitor",
+    pluralName: options.pluralName ?? "Monitors",
+    userPreferencesKey: "monitors-delete-table",
+    urlStateKey: "monitors-delete-table",
+    columns: [
+      {
+        field: { [options.nameColumnField ?? "name"]: true },
+        title: options.nameColumnTitle ?? "Name",
+        type: FieldType.Text,
+      },
+      {
+        field: { description: true },
+        title: "Description",
+        type: FieldType.LongText,
+      },
+    ],
+    filters: [],
+    cardProps: { title: "Monitors", description: "All monitors" },
+    isCreateable: false,
+    isEditable: false,
+    isDeleteable: true,
+    isViewable: false,
+    noItemsMessage: options.noItemsMessage,
+    initialFilterData: options.initialFilterData,
+    callbacks: callbacks,
+  } as unknown as BaseModelTableProps<Monitor>;
+};
+
+type RenderTableFunction = (
+  options?: TableOptions | undefined,
+) => ReturnType<typeof render>;
+
+const renderTable: RenderTableFunction = (
+  options?: TableOptions | undefined,
+): ReturnType<typeof render> => {
+  return render(<BaseModelTable<Monitor> {...makeProps(options || {})} />);
+};
+
+type FindButtonsFunction = (label: string) => Array<HTMLButtonElement>;
+
+const findButtons: FindButtonsFunction = (
+  label: string,
+): Array<HTMLButtonElement> => {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).filter((button: HTMLButtonElement) => {
+    return (button.textContent || "").trim().startsWith(label);
+  });
+};
+
+beforeEach(() => {
+  PermissionGate.clearPermissionPropsCache();
+  window.history.replaceState(window.history.state, "", "/dashboard/monitors");
+  TableFilterUrlState.resetClaimedKeys();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+});
+
+describe("per-row delete confirmation", () => {
+  test("names the row that was clicked", async () => {
+    renderTable();
+
+    await waitFor(() => {
+      expect(findButtons("Delete").length).toBeGreaterThan(0);
+    });
+
+    // Second row, to prove the dialog follows the click and not the first row.
+    fireEvent.click(findButtons("Delete")[1]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("confirm-modal-description"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("confirm-modal-description")).toHaveTextContent(
+      'Are you sure you want to delete "Billing Worker"?',
+    );
+    expect(screen.getByTestId("confirm-modal-description")).toHaveTextContent(
+      "This action cannot be undone",
+    );
+  });
+
+  test("uses a title-keyed row's title", async () => {
+    renderTable({
+      rows: INCIDENT_ROWS,
+      nameColumnField: "title",
+      nameColumnTitle: "Title",
+      singularName: "Incident",
+      pluralName: "Incidents",
+    });
+
+    await waitFor(() => {
+      expect(findButtons("Delete").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(findButtons("Delete")[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("confirm-modal-description"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("confirm-modal-description")).toHaveTextContent(
+      'Are you sure you want to delete "Checkout is down"?',
+    );
+  });
+
+  test("falls back to the generic wording when the row has no name to give", async () => {
+    renderTable({ rows: UNNAMED_ROWS });
+
+    await waitFor(() => {
+      expect(findButtons("Delete").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(findButtons("Delete")[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("confirm-modal-description"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("confirm-modal-description")).toHaveTextContent(
+      "Are you sure you want to delete this monitor?",
+    );
+  });
+});
+
+describe("empty table message", () => {
+  test('says "yet", pluralised, when there is simply nothing here', async () => {
+    renderTable({ rows: [] });
+
+    await waitFor(() => {
+      expect(screen.getByText("No monitors yet.")).toBeInTheDocument();
+    });
+  });
+
+  test("still lets a caller supply its own empty-state copy", async () => {
+    renderTable({ rows: [], noItemsMessage: "Connect your first monitor." });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Connect your first monitor."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  /*
+   * The other half of the same branch: an active filter means the emptiness is
+   * the filter's doing, not the project's, and the caller's "create your first
+   * one" copy would be the wrong thing to offer someone whose filter just
+   * missed.
+   */
+  test("says the filter missed, when a filter is applied", async () => {
+    renderTable({
+      rows: [],
+      initialFilterData: { name: "nothing-matches-this" },
+      noItemsMessage: "Connect your first monitor.",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No monitors match your search or filters."),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Connect your first monitor."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/OrderedStatesList.test.tsx
+++ b/Common/Tests/UI/Components/OrderedStatesList.test.tsx
@@ -88,7 +88,7 @@ describe("OrderedSateList", () => {
       onRefreshClick: jest.fn(),
     };
     render(<OrderedStatesList {...props} />);
-    const refreshButton: HTMLElement = screen.getByRole("refresh-button");
+    const refreshButton: HTMLElement = screen.getByTestId("refresh-button");
     refreshButton.click();
     expect(props.onRefreshClick).toHaveBeenCalled();
   });
@@ -110,8 +110,8 @@ describe("OrderedSateList", () => {
     };
     render(<OrderedStatesList {...props} />);
     expect(screen.getByText("Failed to load data")).toBeInTheDocument();
-    expect(screen.getByRole("refresh-button")).toBeInTheDocument();
-    screen.getByRole("refresh-button").click();
+    expect(screen.getByTestId("refresh-button")).toBeInTheDocument();
+    screen.getByTestId("refresh-button").click();
     expect(props.onRefreshClick).toHaveBeenCalled();
   });
   it("renders ErrorMessage with default message and callback when data is empty and noItemsMessage is not defined", () => {
@@ -125,8 +125,8 @@ describe("OrderedSateList", () => {
     expect(
       screen.getByText(`No ${props.singularLabel.toLowerCase()}`),
     ).toBeInTheDocument();
-    expect(screen.getByRole("refresh-button")).toBeInTheDocument();
-    screen.getByRole("refresh-button").click();
+    expect(screen.getByTestId("refresh-button")).toBeInTheDocument();
+    screen.getByTestId("refresh-button").click();
     expect(props.onRefreshClick).toHaveBeenCalled();
   });
   it("should render custom title element provided by getTitleElement function", () => {

--- a/Common/Tests/UI/Components/PendingProjectInvitations.test.tsx
+++ b/Common/Tests/UI/Components/PendingProjectInvitations.test.tsx
@@ -901,7 +901,7 @@ describe("PendingProjectInvitations", () => {
         expect(screen.getByTestId("invitations-error")).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("refresh-button"));
+      fireEvent.click(screen.getByTestId("refresh-button"));
 
       await waitFor(() => {
         expect(getInvitationCards()).toHaveLength(1);

--- a/Common/Tests/UI/Components/TableSortAndMobileColumns.test.tsx
+++ b/Common/Tests/UI/Components/TableSortAndMobileColumns.test.tsx
@@ -1,0 +1,195 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import Table from "../../../UI/Components/Table/Table";
+import Columns from "../../../UI/Components/Table/Types/Columns";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+
+/*
+ * Two things a table owes anyone not driving it with a mouse on a wide screen.
+ *
+ * Sorting was mouse-only: the handler sat on the <th>, which is not focusable
+ * and does not answer Enter or Space, even though aria-sort was already
+ * telling assistive technology the column WAS sortable. It sits on a button
+ * inside the header cell now.
+ *
+ * And `hideOnMobile` - about 200 column declarations across the product say
+ * it - was honoured by the header, the skeleton rows, and the desktop row, but
+ * not by the mobile card, which is the one layout it exists for.
+ */
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, opts?: { defaultValue?: string }): string => {
+          return opts?.defaultValue ?? key;
+        },
+      };
+    },
+  };
+});
+
+interface Row {
+  _id?: string | undefined;
+  name?: string | undefined;
+  status?: string | undefined;
+}
+
+const columns: Columns<Row> = [
+  { title: "Name", type: FieldType.Text, key: "name" },
+  { title: "Status", type: FieldType.Text, key: "status", hideOnMobile: true },
+  // No key, so this one is not sortable and must stay a plain cell.
+  { title: "Notes", type: FieldType.Text },
+];
+
+const data: Array<Row> = [
+  { _id: "1", name: "Alpha", status: "Up" },
+  { _id: "2", name: "Beta", status: "Down" },
+];
+
+interface RenderTableOptions {
+  sortBy?: keyof Row | null | undefined;
+  sortOrder?: SortOrder | undefined;
+  onSortChanged?:
+    | ((sortBy: keyof Row | null, sortOrder: SortOrder) => void)
+    | undefined;
+}
+
+type RenderTableFunction = (options?: RenderTableOptions | undefined) => void;
+
+const renderTable: RenderTableFunction = (
+  options?: RenderTableOptions | undefined,
+): void => {
+  render(
+    <Table<Row>
+      id="test-table"
+      data={data}
+      columns={columns}
+      currentPageNumber={1}
+      totalItemsCount={data.length}
+      itemsOnPage={10}
+      error=""
+      isLoading={false}
+      singularLabel="Monitor"
+      pluralLabel="Monitors"
+      sortOrder={options?.sortOrder ?? SortOrder.Ascending}
+      sortBy={options?.sortBy ?? null}
+      onSortChanged={options?.onSortChanged ?? (() => {})}
+      onNavigateToPage={() => {}}
+    />,
+  );
+};
+
+/*
+ * The table decides mobile vs desktop from window.innerWidth at mount
+ * (< 768 = mobile). jsdom defaults to 1024, so desktop is the baseline and
+ * mobile tests must set the width BEFORE rendering.
+ */
+const setViewportWidth: (width: number) => void = (width: number): void => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+};
+
+afterEach(() => {
+  cleanup();
+  setViewportWidth(1024);
+});
+
+describe("sortable column headers", () => {
+  test("a sortable header is a real button, so it is focusable", () => {
+    renderTable();
+
+    const sortButton: HTMLElement = screen.getByRole("button", {
+      name: "Name",
+    });
+
+    expect(sortButton.tagName).toBe("BUTTON");
+    expect(sortButton).toHaveAttribute("type", "button");
+
+    sortButton.focus();
+    expect(sortButton).toHaveFocus();
+  });
+
+  test("activating the header button sorts the column", () => {
+    const sortCalls: Array<[keyof Row | null, SortOrder]> = [];
+
+    renderTable({
+      onSortChanged: (sortBy: keyof Row | null, sortOrder: SortOrder) => {
+        sortCalls.push([sortBy, sortOrder]);
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Name" }));
+
+    expect(sortCalls).toEqual([["name", SortOrder.Descending]]);
+  });
+
+  test("the sort direction still round-trips", () => {
+    const sortCalls: Array<[keyof Row | null, SortOrder]> = [];
+
+    renderTable({
+      sortBy: "name",
+      sortOrder: SortOrder.Descending,
+      onSortChanged: (sortBy: keyof Row | null, sortOrder: SortOrder) => {
+        sortCalls.push([sortBy, sortOrder]);
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Name/ }));
+
+    expect(sortCalls).toEqual([["name", SortOrder.Ascending]]);
+  });
+
+  test("a column that cannot be sorted gets no button", () => {
+    renderTable();
+
+    expect(
+      screen.queryByRole("button", { name: "Notes" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+  });
+
+  test("the header still announces sort state to assistive technology", () => {
+    renderTable({ sortBy: "name", sortOrder: SortOrder.Ascending });
+
+    const headers: Array<HTMLElement> = screen.getAllByRole("columnheader");
+    const nameHeader: HTMLElement | undefined = headers.find(
+      (header: HTMLElement) => {
+        return header.textContent?.includes("Name");
+      },
+    );
+
+    expect(nameHeader).toHaveAttribute("aria-sort", "ascending");
+  });
+});
+
+describe("hideOnMobile columns", () => {
+  test("the mobile card leaves out columns marked hideOnMobile", () => {
+    setViewportWidth(375);
+    renderTable();
+
+    // "Name" is shown on every breakpoint.
+    expect(screen.getAllByText("Alpha").length).toBeGreaterThan(0);
+
+    /*
+     * "Status" is hideOnMobile. Its header is already filtered out on mobile;
+     * the row used to render it anyway, which is the regression this pins.
+     */
+    expect(screen.queryByText("Up")).not.toBeInTheDocument();
+    expect(screen.queryByText("Down")).not.toBeInTheDocument();
+  });
+
+  test("the desktop row is untouched", () => {
+    setViewportWidth(1280);
+    renderTable();
+
+    expect(screen.getByText("Up")).toBeInTheDocument();
+    expect(screen.getByText("Down")).toBeInTheDocument();
+  });
+});

--- a/Common/UI/Components/ErrorMessage/ErrorMessage.tsx
+++ b/Common/UI/Components/ErrorMessage/ErrorMessage.tsx
@@ -19,16 +19,27 @@ const ErrorMessage: FunctionComponent<ComponentProps> = (
     <div className="text-center my-10 text-gray-500 text-sm">
       {translatedMessage}
       {props.onRefreshClick ? (
-        <div
-          role={"refresh-button"}
-          onClick={() => {
-            if (props.onRefreshClick) {
-              props.onRefreshClick();
-            }
-          }}
-          className="underline cursor-pointer hover:text-gray-700 mt-3"
-        >
-          {translateString("Refresh?") ?? "Refresh?"}
+        /*
+         * This is the only recovery control on the app-wide failure and
+         * empty-state surface, and it used to be a <div role="refresh-button">
+         * - not focusable, and deaf to Enter and Space, so the single way out
+         * of a failed table was the mouse. It is a real <button> now; the
+         * data-testid keeps the hook the tests reach for, which the invented
+         * role was standing in for.
+         */
+        <div className="mt-3">
+          <button
+            type="button"
+            data-testid="refresh-button"
+            onClick={() => {
+              if (props.onRefreshClick) {
+                props.onRefreshClick();
+              }
+            }}
+            className="underline cursor-pointer hover:text-gray-700 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          >
+            {translateString("Refresh?") ?? "Refresh?"}
+          </button>
         </div>
       ) : (
         <></>

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -32,6 +32,7 @@ import {
   BulkActionOnClickProps,
 } from "../BulkUpdate/BulkUpdateForm";
 import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
+import CopyTextButton from "../CopyTextButton/CopyTextButton";
 import MoreMenu from "../MoreMenu/MoreMenu";
 import MoreMenuItem from "../MoreMenu/MoreMenuItem";
 import Card, {
@@ -417,6 +418,72 @@ export enum ModalType {
   Create,
   Edit,
 }
+
+/*
+ * The fields a row is worth naming itself by, in the order a human would pick
+ * one. `title` is not decoration here: incidents, alerts and scheduled
+ * maintenance key on `title` rather than `name`, and those are exactly the
+ * tables where deleting the row next to the one you meant hurts most.
+ *
+ * Only the fields the table already selected are present on the row, so this
+ * reads whatever is there and gives up quietly rather than guessing.
+ */
+const ITEM_LABEL_FIELDS: Array<string> = [
+  "name",
+  "title",
+  "slug",
+  "email",
+  "username",
+  "domain",
+];
+
+type ReadLabelFieldFunction = (value: unknown) => string;
+
+/*
+ * Some of these fields arrive as objects with a meaningful toString - Name,
+ * Email, ObjectID all define one. Anything that does not is skipped rather
+ * than rendered as "[object Object]".
+ */
+const readLabelField: ReadLabelFieldFunction = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const text: string = String(value);
+
+  return text === "[object Object]" ? "" : text.trim();
+};
+
+type GetItemLabelFunction = (item: unknown) => string;
+
+/*
+ * Every per-row Delete in the product opened the same dialog: "Are you sure
+ * you want to delete this monitor?" - a sentence equally true of the row that
+ * was clicked and of the twenty either side of it. That is precisely the
+ * moment a user wants to be told which one, and the one moment the dialog
+ * would not say.
+ */
+const getItemLabel: GetItemLabelFunction = (item: unknown): string => {
+  if (!item || typeof item !== "object") {
+    return "";
+  }
+
+  const record: Record<string, unknown> = item as Record<string, unknown>;
+
+  for (const field of ITEM_LABEL_FIELDS) {
+    const label: string = readLabelField(record[field]);
+
+    if (label) {
+      return label;
+    }
+  }
+
+  return "";
+};
 
 const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   props: ComponentProps<TBaseModel>,
@@ -2921,6 +2988,54 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     return isSearchActive() ? false : isLoading;
   };
 
+  type HasFilterAppliedFunction = (
+    dataToCheck: FilterData<TBaseModel>,
+  ) => boolean;
+
+  /*
+   * Lifted out of the onFilterChanged callback below, which is where this test
+   * used to live inline. Two definitions of "a filter is applied" in one
+   * component is exactly the kind of thing that drifts apart.
+   */
+  const hasFilterApplied: HasFilterAppliedFunction = (
+    dataToCheck: FilterData<TBaseModel>,
+  ): boolean => {
+    for (const key in dataToCheck) {
+      if (dataToCheck[key]) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  type GetNoItemsMessageFunction = () => string | ReactElement;
+
+  /*
+   * An empty table has two quite different causes and used to have one
+   * sentence for both. A monitors table with nothing in it said "No monitor"
+   * - ungrammatical, and worse, it said the same thing after a search that
+   * matched nothing, so a typo in the search box looked exactly like an empty
+   * project. A caller's own noItemsMessage is deliberately overridden while a
+   * search or filter is active: those are usually "create your first X"
+   * panels, and offering one to someone whose search just missed is wrong.
+   */
+  const getNoItemsMessage: GetNoItemsMessageFunction = ():
+    | string
+    | ReactElement => {
+    const plural: string = (
+      props.pluralName ||
+      model.pluralName ||
+      "items"
+    ).toLocaleLowerCase();
+
+    if (isSearchActive() || hasFilterApplied(filterData)) {
+      return `${tx("No")} ${plural} ${tx("match your search or filters.")}`;
+    }
+
+    return props.noItemsMessage || `${tx("No")} ${plural} ${tx("yet.")}`;
+  };
+
   const getTable: GetReactElementFunction = (): ReactElement => {
     return (
       <Table
@@ -2929,17 +3044,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           setTableView(null);
 
           // check if there's anything in the filter data and update the isFilterApplied prop.
-          let isFilterApplied: boolean = false;
-
-          for (const key in filterData) {
-            if (filterData[key]) {
-              isFilterApplied = true;
-              break;
-            }
-          }
-
           if (props.onFilterApplied) {
-            props.onFilterApplied(isFilterApplied);
+            props.onFilterApplied(hasFilterApplied(filterData));
           }
         }}
         filterData={filterData}
@@ -3127,9 +3233,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         matchBulkSelectedItemByField={matchBulkSelectedItemByField || "_id"}
         bulkItemToString={(item: TBaseModel) => {
           const label: string = props.singularName || item.singularName || "";
-          const name: string =
-            (item as unknown as Record<string, unknown>)["name"]?.toString() ||
-            "";
+          // Same deriver the delete confirmation uses, so the two cannot drift.
+          const name: string = getItemLabel(item);
           if (name) {
             return label ? `${label}: ${name}` : name;
           }
@@ -3200,7 +3305,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
           setItemsOnPage(newItemsOnPage);
         }}
-        noItemsMessage={props.noItemsMessage || ""}
+        noItemsMessage={getNoItemsMessage()}
         onRefreshClick={async () => {
           await fetchItems();
         }}
@@ -3256,7 +3361,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         shouldAddItemInTheEnd={
           props.orderedStatesListProps.shouldAddItemInTheEnd
         }
-        noItemsMessage={props.noItemsMessage || ""}
+        noItemsMessage={getNoItemsMessage()}
         onRefreshClick={async () => {
           await fetchItems();
         }}
@@ -3343,7 +3448,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
           setItemsOnPage(newItemsOnPage);
         }}
-        noItemsMessage={props.noItemsMessage || ""}
+        noItemsMessage={getNoItemsMessage()}
         onRefreshClick={async () => {
           await fetchItems();
         }}
@@ -4498,11 +4603,18 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       {showDeleteConfirmModal && (
         <ConfirmModal
           title={`Delete ${props.singularName || model.singularName}`}
-          description={`Are you sure you want to delete this ${(
-            props.singularName ||
-            model.singularName ||
-            "item"
-          )?.toLowerCase()}?`}
+          description={((): string => {
+            const label: string = (
+              props.singularName ||
+              model.singularName ||
+              "item"
+            ).toLowerCase();
+            const name: string = getItemLabel(currentDeleteableItem);
+
+            return `Are you sure you want to delete ${
+              name ? `"${name}"` : `this ${label}`
+            }? This action cannot be undone.`;
+          })()}
           onClose={() => {
             setShowDeleteConfirmModal(false);
           }}
@@ -4535,10 +4647,24 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           description={
             <div>
               <span>
-                ID of this {props.singularName || model.singularName || ""}:{" "}
-                {viewId}
+                ID of this {props.singularName || model.singularName || ""}:
               </span>
-              <br />
+              {/*
+               * Handing over the id is the entire point of this dialog, and it
+               * used to be inline prose the user had to select by hand - an
+               * awkward drag over a 36-character UUID, and easy to clip a
+               * character. It gets its own row and a copy button now.
+               */}
+              <div className="mt-2 flex items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+                <code className="flex-1 break-all font-mono text-xs text-gray-800">
+                  {viewId}
+                </code>
+                <CopyTextButton
+                  textToBeCopied={viewId || ""}
+                  size="sm"
+                  title="Copy ID to clipboard"
+                />
+              </div>
               <br />
 
               <span>

--- a/Common/UI/Components/Table/TableHeader.tsx
+++ b/Common/UI/Components/Table/TableHeader.tsx
@@ -6,6 +6,7 @@ import Columns from "./Types/Columns";
 import SortOrder, {
   SortOrderToAriaSortMap,
 } from "../../../Types/BaseDatabase/SortOrder";
+import { VoidFunction } from "../../../Types/FunctionTypes";
 import GenericObject from "../../../Types/GenericObject";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
@@ -113,60 +114,75 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
                   ? "none"
                   : undefined;
 
+            const sortColumn: VoidFunction = (): void => {
+              if (!column.key || !canSort) {
+                return;
+              }
+
+              const sortOrder: SortOrder =
+                props.sortOrder === SortOrder.Ascending
+                  ? SortOrder.Descending
+                  : SortOrder.Ascending;
+
+              props.onSortChanged(column.key, sortOrder);
+            };
+
+            const contentClassName: string = `flex w-full px-6 py-3 ${
+              column.type === FieldType.Actions
+                ? "justify-end"
+                : "justify-start"
+            }`;
+
+            const headerContent: ReactElement = (
+              <>
+                {translateString(column.title) ?? column.title}
+                {canSort &&
+                  props.sortBy === column.key &&
+                  props.sortOrder === SortOrder.Ascending && (
+                    <Icon
+                      icon={IconProp.ChevronUp}
+                      thick={ThickProp.Thick}
+                      className="ml-2  p-1 flex-none rounded bg-gray-200 text-gray-500 group-hover:bg-gray-300 h-4 w-4"
+                    />
+                  )}
+                {canSort &&
+                  props.sortBy === column.key &&
+                  props.sortOrder === SortOrder.Descending && (
+                    <Icon
+                      icon={IconProp.ChevronDown}
+                      thick={ThickProp.Thick}
+                      className="ml-2 p-1 flex-none rounded bg-gray-200 text-gray-500 group-hover:bg-gray-300 h-4 w-4"
+                    />
+                  )}
+              </>
+            );
+
             return (
               <th
                 key={i}
                 scope="col"
                 aria-sort={ariaSort}
-                className={`px-6 py-3 text-left text-sm font-semibold text-gray-900 ${
-                  canSort ? "cursor-pointer" : ""
-                }`}
-                onClick={() => {
-                  if (!column.key) {
-                    return;
-                  }
-
-                  if (!canSort) {
-                    return;
-                  }
-
-                  const sortOrder: SortOrder =
-                    props.sortOrder === SortOrder.Ascending
-                      ? SortOrder.Descending
-                      : SortOrder.Ascending;
-
-                  const currentSortColumn: keyof T = column.key;
-
-                  props.onSortChanged(currentSortColumn, sortOrder);
-                }}
+                className="text-left text-sm font-semibold text-gray-900"
               >
-                <div
-                  className={`flex ${
-                    column.type === FieldType.Actions
-                      ? "justify-end"
-                      : "justify-start"
-                  }`}
-                >
-                  {translateString(column.title) ?? column.title}
-                  {canSort &&
-                    props.sortBy === column.key &&
-                    props.sortOrder === SortOrder.Ascending && (
-                      <Icon
-                        icon={IconProp.ChevronUp}
-                        thick={ThickProp.Thick}
-                        className="ml-2  p-1 flex-none rounded bg-gray-200 text-gray-500 group-hover:bg-gray-300 h-4 w-4"
-                      />
-                    )}
-                  {canSort &&
-                    props.sortBy === column.key &&
-                    props.sortOrder === SortOrder.Descending && (
-                      <Icon
-                        icon={IconProp.ChevronDown}
-                        thick={ThickProp.Thick}
-                        className="ml-2 p-1 flex-none rounded bg-gray-200 text-gray-500 group-hover:bg-gray-300 h-4 w-4"
-                      />
-                    )}
-                </div>
+                {/*
+                 * The sort handler used to sit on the <th> itself, which is
+                 * not focusable and does not answer Enter or Space - so
+                 * sorting any table in the product was mouse-only, even though
+                 * aria-sort was already announcing the column as sortable. The
+                 * padding moves onto the button so the clickable area is the
+                 * whole cell, exactly as before.
+                 */}
+                {canSort ? (
+                  <button
+                    type="button"
+                    onClick={sortColumn}
+                    className={`${contentClassName} cursor-pointer text-left font-semibold text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500`}
+                  >
+                    {headerContent}
+                  </button>
+                ) : (
+                  <div className={contentClassName}>{headerContent}</div>
+                )}
               </th>
             );
           })}

--- a/Common/UI/Components/Table/TableRow.tsx
+++ b/Common/UI/Components/Table/TableRow.tsx
@@ -95,10 +95,20 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
     };
   }, []);
 
+  /*
+   * The local isMobile state above starts false and is only corrected inside
+   * an effect, i.e. after the first paint. TableBody already knows which
+   * layout it is mounting and says so explicitly, so prefer what it passed:
+   * without this, a mobile card renders its hideOnMobile columns for one frame
+   * and then drops them, which is a visible jump on exactly the narrow screens
+   * the flag exists to protect.
+   */
+  const isMobileView: boolean = props.isMobile ?? isMobile;
+
   // The columns this row will actually put on screen.
   const renderedColumns: Array<Column<T>> = (props.columns || []).filter(
     (column: Column<T>) => {
-      return !(column.hideOnMobile && isMobile);
+      return !(column.hideOnMobile && isMobileView);
     },
   );
 
@@ -175,7 +185,7 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
             )}
 
             <div className="space-y-3">
-              {props.columns.map((column: Column<T>, i: number) => {
+              {renderedColumns.map((column: Column<T>, i: number) => {
                 if (column.type === FieldType.Actions) {
                   return (
                     <div key={i} className="flex flex-wrap gap-2">
@@ -520,7 +530,7 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
                           }
 
                           // Hide button on mobile if hideOnMobile is true
-                          if (button.hideOnMobile && isMobile) {
+                          if (button.hideOnMobile && isMobileView) {
                             return <div key={i}></div>;
                           }
 


### PR DESCRIPTION
Eight small, self-contained usability fixes. No schema, API, dependency or
architecture change — the biggest single one is 35 lines of new component.

Most of them are in `Common/UI`, so they land on every list page in the
product at once rather than on one screen.

## 1. The command palette now has a door

The dashboard ships a full command palette — every page, the create actions,
and live search across monitors, incidents, alerts, status pages and on-call.
The only way in was to already know about `Cmd/Ctrl+K`. Nothing on screen said
so, so for anyone who hadn't been told, the whole surface did not exist.
`COMMAND_PALETTE_TOGGLE` was already on the event bus with a listener attached
and **zero dispatchers in application code**.

A Search button now sits beside Ask AI, built on the same
`HeaderIconDropdownButton` primitive, so it also advertises the shortcut it
replaces.

## 2. Delete confirmations name the row

Every per-row Delete in the product — 198 `isDeleteable` tables — opened the
same dialog: *"Are you sure you want to delete this monitor?"* Equally true of
the row you clicked and of the twenty either side of it, which is exactly the
moment you want to be told which one. The same file already got this right for
**bulk** delete.

It now reads *"Are you sure you want to delete "Checkout API"? This action
cannot be undone."*, falling back to the old wording when the table has no name
field selected.

The name deriver checks `title` as well as `name` — incidents, alerts and
scheduled maintenance key on `title`, and those are the tables where a mis-click
costs the most. `bulkItemToString` now shares that deriver instead of keeping
its own `name`-only copy, so the two cannot drift.

## 3. "No results" and "nothing here yet" stopped being the same sentence

`noItemsMessage` was passed through unchanged no matter *why* the result set
was empty, so a search that matched nothing looked identical to an empty
project. The table already knew the difference — `isSearchActive()` was right
there.

Also fixes the fallback, which was building an ungrammatical singular: an
empty monitors table literally rendered **"No monitor"**. It now says
"No monitors yet.", or "No monitors match your search or filters." when a
search or filter is active.

A caller's own empty-state copy is deliberately overridden while a search is
active — a "create your first monitor" panel is the wrong thing to show
someone whose search just missed.

## 4. The ID dialog will hand you the ID

`showViewIdButton` is set on 148 tables. The dialog exists for exactly one
purpose — to give you an ID to paste into the API — and printed it as inline
prose you had to drag-select. A 36-character UUID, easy to clip. It now gets
its own row and a copy button (the existing `CopyTextButton`).

## 5. Sorting a table no longer requires a mouse

The sort handler sat on the bare `<th>`: not focusable, deaf to Enter and
Space. `aria-sort` was already announcing the column as sortable, which made
the omission worse — the header said "you can sort me" and then didn't answer.
The handler moves onto a button inside the cell, with the padding, so the
click target is unchanged.

## 6. The app-wide "Refresh?" control is a real button

`ErrorMessage` is the failure *and* empty-state surface across the product
(89 call sites pass `onRefreshClick`). Its only recovery control was a
`<div role="refresh-button">` — an invented ARIA role, no tab stop, no key
handling. So the only way out of a failed table was the mouse. Now a
`<button>`; the tests move from that fake role to a `data-testid`.

## 7. `hideOnMobile` works on mobile

About 200 column declarations set it. The header honoured it, the skeleton
rows honoured it, the desktop row honoured it — the **mobile card**, the one
layout the flag exists for, mapped over the unfiltered list.

Also fixed the reason it would still have flickered: the filter read a local
`isMobile` state that starts `false` and is only corrected in an effect, so
hidden columns rendered for one frame before vanishing. It reads the prop
`TableBody` already passes.

## 8. A confirmation that had lost a word

Removing a teammate asked *"Are you sure you want to reset remove this user?"*
— left over from a copy-paste of `ResetObjectID`, whose name the component was
also still using internally.

## Testing

- 3 new test files, 19 cases. Verified as genuine regression tests: reverting
  each fix and re-running fails the case that covers it (4/6, 3/7 and 1/7
  respectively).
- Full affected suites green: 26 suites, 726 cases, covering every ModelTable,
  Table, ModelDelete, BulkUpdateForm and permission-gating suite.
- `Common` and `App/FeatureSet/Dashboard` type-check clean; eslint clean.

## Screenshots

_Being captured now — before/after pairs against a live local instance, driven
through the repo's own Playwright harness: same account, same seeded data, with
only the built dashboard bundle swapped between the two passes, so the images
differ by exactly this diff. This section will be updated with them._
