### PR TITLE
fix(rum): stop session replay destroying the snapshot it needs to be playable

### DIFF
--- a/App/FeatureSet/BrowserRecorder/Tests/Chunker.test.ts
+++ b/App/FeatureSet/BrowserRecorder/Tests/Chunker.test.ts
@@ -1,9 +1,12 @@
 import Chunker, {
   PendingChunk,
   SESSION_REPLAY_TRUNCATED_NOTICE,
-  splitByUtf8Bytes,
   utf8ByteLength,
 } from "../src/Chunker";
+import {
+  SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES,
+  SessionReplayFidelityNotice,
+} from "Common/Types/Rum/SessionReplay";
 import { BufferedEvent } from "../src/RollingBuffer";
 
 describe("Chunker", (): void => {
@@ -309,14 +312,26 @@ describe("Chunker", (): void => {
     expect(chunks).toHaveLength(0);
   });
 
-  describe("oversized snapshot splitting", (): void => {
-    /*
-     * A FullSnapshot is one indivisible rrweb event. It cannot be split across
-     * chunks and still parse, so the parts carry raw slices and only the LAST
-     * part claims hasFullSnapshot - otherwise a seek anchor would point into
-     * the middle of a snapshot and the player would rebuild a partial DOM.
-     */
-    it("splits one oversized event into parts, anchoring only the last", (): void => {
+  /*
+   * REGRESSION: github.com/OneUptime/oneuptime/issues/3527.
+   *
+   * An oversized indivisible snapshot used to be CUT into raw slices of the
+   * array text, each posted as its own chunk index with snapshotPart
+   * {index, total}, on the stated understanding that the receiving side would
+   * concatenate them before parsing. Nothing ever did: the ingest worker
+   * JSON.parses every frame on its own, so every slice threw and was dropped,
+   * and the chunk indexes they had already consumed stayed missing forever.
+   *
+   * The user-visible result was a session list reporting "8 chunks missing",
+   * a scrubber drawing gaps, and a recording with no seek anchor - on every
+   * page whose DOM serialises to more than the flush threshold, which is any
+   * large enterprise page.
+   *
+   * Every test here is about ONE property: each chunk this class emits must
+   * be independently decodable, and the chunk sequence must stay contiguous.
+   */
+  describe("oversized indivisible events", (): void => {
+    it("emits ONE whole chunk, never fragments", (): void => {
       const chunker: Chunker = makeChunker(50);
       const big: string = `{"type":2,"data":"${"x".repeat(200)}"}`;
 
@@ -324,24 +339,190 @@ describe("Chunker", (): void => {
         event({ type: 2, json: big, bytes: big.length, isCheckout: true }),
       );
 
-      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.payload).toBe(`[${big}]`);
+      expect(chunks[0]?.eventCount).toBe(1);
+      expect(chunks[0]?.rawBytes).toBe(utf8ByteLength(`[${big}]`));
+    });
 
-      const total: number = chunks.length;
+    it("emits a payload that parses on its own, exactly as the worker parses it", (): void => {
+      const chunker: Chunker = makeChunker(50);
+      const big: string = `{"type":2,"data":"${"x".repeat(200)}"}`;
 
-      chunks.forEach((chunk: PendingChunk, index: number): void => {
-        expect(chunk.snapshotPart).toEqual({ index: index, total: total });
-        expect(chunk.hasFullSnapshot).toBe(index === total - 1);
-        expect(chunk.eventCount).toBe(index === total - 1 ? 1 : 0);
+      chunker.add(
+        event({ type: 2, json: big, bytes: big.length, isCheckout: true }),
+      );
+
+      for (const chunk of chunks) {
+        const parsed: unknown = JSON.parse(chunk.payload);
+
+        expect(Array.isArray(parsed)).toBe(true);
+      }
+
+      expect(JSON.parse(chunks[0]?.payload as string)).toEqual([
+        JSON.parse(big),
+      ]);
+    });
+
+    it("anchors the oversized snapshot, because nothing replayable precedes it", (): void => {
+      const chunker: Chunker = makeChunker(50);
+      const big: string = `{"type":2,"data":"${"x".repeat(200)}"}`;
+
+      chunker.add(
+        event({ type: 2, json: big, bytes: big.length, isCheckout: true }),
+      );
+
+      expect(chunks[0]?.hasFullSnapshot).toBe(true);
+    });
+
+    it("does not anchor an oversized event that is not a full snapshot", (): void => {
+      const chunker: Chunker = makeChunker(50);
+      const big: string = `{"type":3,"data":"${"x".repeat(200)}"}`;
+
+      chunker.add(event({ type: 3, json: big, bytes: big.length }));
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.hasFullSnapshot).toBe(false);
+    });
+
+    it("seals whatever was open first, so the snapshot is alone in its chunk", (): void => {
+      const chunker: Chunker = makeChunker(500);
+
+      chunker.add(event({ json: '{"type":3,"a":1}', bytes: 16 }));
+
+      const big: string = `{"type":2,"data":"${"x".repeat(600)}"}`;
+
+      chunker.add(
+        event({ type: 2, json: big, bytes: big.length, isCheckout: true }),
+      );
+
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0]?.payload).toBe('[{"type":3,"a":1}]');
+      expect(chunks[0]?.hasFullSnapshot).toBe(false);
+      expect(chunks[1]?.payload).toBe(`[${big}]`);
+      expect(chunks[1]?.hasFullSnapshot).toBe(true);
+    });
+
+    /*
+     * A non-ASCII snapshot is what broke loudest under the old slicing: each
+     * part was UTF-8 encoded independently, so a surrogate pair cut in half
+     * became two U+FFFD. Emitting whole cannot corrupt anything, and this
+     * pins that.
+     */
+    it("keeps an emoji-bearing snapshot byte-identical", (): void => {
+      const chunker: Chunker = makeChunker(40);
+      const big: string = `{"type":2,"data":"${"😀".repeat(60)}"}`;
+
+      chunker.add({
+        json: big,
+        bytes: utf8ByteLength(big),
+        timestampMs: SESSION_START + 10,
+        isCheckout: true,
+        type: 2,
       });
 
-      /* Concatenating every part reproduces the exact JSON array. */
-      const rejoined: string = chunks
-        .map((chunk: PendingChunk): string => {
-          return chunk.payload;
-        })
-        .join("");
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.payload).toBe(`[${big}]`);
+      expect(chunks[0]?.payload).not.toContain("�");
+      expect(JSON.parse(chunks[0]?.payload as string)).toEqual([
+        JSON.parse(big),
+      ]);
+    });
 
-      expect(rejoined).toBe(`[${big}]`);
+    it("keeps the chunk sequence contiguous across a mixed stream", (): void => {
+      const chunker: Chunker = makeChunker(100);
+      const big: string = `{"type":2,"data":"${"x".repeat(400)}"}`;
+
+      chunker.add(event({ json: '{"type":3,"a":1}', bytes: 16 }));
+      chunker.add(
+        event({ type: 2, json: big, bytes: big.length, isCheckout: true }),
+      );
+      chunker.add(event({ json: '{"type":3,"a":2}', bytes: 16 }));
+      chunker.close(true);
+
+      /*
+       * One chunk index per emitted chunk, and every one of them decodable —
+       * which is what "no missing chunks" means on the other end.
+       */
+      expect(chunks).toHaveLength(3);
+
+      for (const chunk of chunks) {
+        expect(Array.isArray(JSON.parse(chunk.payload))).toBe(true);
+      }
+    });
+
+    /*
+     * Above the ceiling the ingest worker will actually inflate
+     * (SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES), posting the chunk would
+     * mint an index for something that can only ever be dropped at decode
+     * time — the exact shape of the bug. Dropping BEFORE the sink keeps the
+     * sequence contiguous, and the notice tells the viewer.
+     */
+    it("drops an event past the worker's ceiling, without minting a chunk index", (): void => {
+      const chunker: Chunker = makeChunker(50);
+      const huge: string = `{"type":2,"data":"${"x".repeat(
+        SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES + 10,
+      )}"}`;
+
+      chunker.add(
+        event({
+          type: 2,
+          json: huge,
+          bytes: utf8ByteLength(huge),
+          isCheckout: true,
+        }),
+      );
+
+      expect(chunks).toHaveLength(0);
+      expect(chunker.getDroppedEventCount()).toBe(1);
+    });
+
+    it("discloses the dropped snapshot on the next chunk that closes", (): void => {
+      const chunker: Chunker = makeChunker(50);
+      const huge: string = `{"type":2,"data":"${"x".repeat(
+        SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES + 10,
+      )}"}`;
+
+      chunker.add(
+        event({
+          type: 2,
+          json: huge,
+          bytes: utf8ByteLength(huge),
+          isCheckout: true,
+        }),
+      );
+      chunker.add(event());
+      chunker.close(false);
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.fidelityNotices).toContain(
+        SessionReplayFidelityNotice.SnapshotTooLarge,
+      );
+    });
+
+    it("still emits an event that sits exactly on the ceiling", (): void => {
+      const chunker: Chunker = makeChunker(50);
+
+      /* `[` + json + `]` must land on the ceiling exactly. */
+      const padding: number =
+        SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES -
+        utf8ByteLength('[{"type":2,"data":""}]');
+      const atCeiling: string = `{"type":2,"data":"${"x".repeat(padding)}"}`;
+
+      chunker.add(
+        event({
+          type: 2,
+          json: atCeiling,
+          bytes: utf8ByteLength(atCeiling),
+          isCheckout: true,
+        }),
+      );
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.rawBytes).toBe(
+        SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES,
+      );
+      expect(chunker.getDroppedEventCount()).toBe(0);
     });
   });
 
@@ -500,83 +681,5 @@ describe("utf8ByteLength", (): void => {
     const lone: string = "\ud83d";
 
     expect(utf8ByteLength(lone)).toBe(new TextEncoder().encode(lone).length);
-  });
-});
-
-describe("splitByUtf8Bytes", (): void => {
-  it("never cuts a surrogate pair in half", (): void => {
-    /* Ten ASCII, one emoji, ten ASCII - the exact shape that used to corrupt. */
-    const body: string = `${"x".repeat(10)}😀${"y".repeat(10)}`;
-
-    for (let limit: number = 4; limit <= 24; limit++) {
-      const parts: Array<string> = splitByUtf8Bytes(body, limit);
-
-      /* Round-tripping each part independently must reproduce the input. */
-      const decoder: TextDecoder = new TextDecoder();
-      const rejoined: string = parts
-        .map((part: string): string => {
-          return decoder.decode(new TextEncoder().encode(part));
-        })
-        .join("");
-
-      expect(rejoined).toBe(body);
-      expect(rejoined).not.toContain("�");
-    }
-  });
-
-  it("keeps every part inside the byte budget", (): void => {
-    const body: string = "日本語のページ".repeat(20);
-    const parts: Array<string> = splitByUtf8Bytes(body, 32);
-
-    for (const part of parts) {
-      expect(utf8ByteLength(part)).toBeLessThanOrEqual(32);
-    }
-
-    expect(parts.join("")).toBe(body);
-  });
-
-  it("returns one part when the whole string fits", (): void => {
-    expect(splitByUtf8Bytes("short", 1000)).toEqual(["short"]);
-    expect(splitByUtf8Bytes("", 1000)).toEqual([""]);
-  });
-});
-
-describe("Chunker oversized non-ASCII snapshot", (): void => {
-  const SESSION_START: number = 1_700_000_000_000;
-
-  it("splits an emoji-bearing snapshot without corrupting it", (): void => {
-    const chunks: Array<PendingChunk> = [];
-
-    const chunker: Chunker = new Chunker({
-      sessionStartUnixMs: SESSION_START,
-      sink: (chunk: PendingChunk): void => {
-        chunks.push(chunk);
-      },
-      maxPayloadBytes: 40,
-    });
-
-    const big: string = `{"type":2,"data":"${"😀".repeat(60)}"}`;
-
-    chunker.add({
-      json: big,
-      bytes: utf8ByteLength(big),
-      timestampMs: SESSION_START + 10,
-      isCheckout: true,
-      type: 2,
-    });
-
-    expect(chunks.length).toBeGreaterThan(1);
-
-    const decoder: TextDecoder = new TextDecoder();
-    const rejoined: string = chunks
-      .map((chunk: PendingChunk): string => {
-        /* Exactly what the wire does to each part: encode it on its own. */
-        return decoder.decode(new TextEncoder().encode(chunk.payload));
-      })
-      .join("");
-
-    expect(rejoined).toBe(`[${big}]`);
-    expect(rejoined).not.toContain("�");
-    expect(JSON.parse(rejoined)).toHaveLength(1);
   });
 });

--- a/App/FeatureSet/BrowserRecorder/src/Chunker.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Chunker.ts
@@ -1,6 +1,7 @@
 import {
   MAX_SESSION_REPLAY_CHUNKS_PER_SESSION,
   SESSION_REPLAY_FLUSH_BYTES,
+  SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES,
   SessionReplayFidelityNotice,
   SessionReplaySignalCounts,
 } from "Common/Types/Rum/SessionReplay";
@@ -96,62 +97,15 @@ export function utf8ByteLength(value: string): number {
   return bytes;
 }
 
-/*
- * Cut a string into pieces of at most maxBytes UTF-8 bytes each, never
- * between the two halves of a surrogate pair.
- *
- * Slicing by code unit split emoji and other astral characters down the
- * middle, and because each part is UTF-8 encoded INDEPENDENTLY before it goes
- * on the wire, both halves of a broken pair became U+FFFD - so the server's
- * reassembled snapshot was silently corrupted rather than failing loudly.
- * Cutting on code-point boundaries keeps every part independently valid,
- * which makes the reassembly correct whether the server concatenates the
- * decoded strings or the raw bytes.
- */
-export function splitByUtf8Bytes(
-  value: string,
-  maxBytes: number,
-): Array<string> {
-  if (value.length === 0) {
-    return [""];
-  }
-
-  const parts: Array<string> = [];
-  let start: number = 0;
-  let bytes: number = 0;
-  let index: number = 0;
-
-  while (index < value.length) {
-    const code: number = value.charCodeAt(index);
-    const isHighSurrogate: boolean =
-      code >= 0xd800 && code <= 0xdbff && index + 1 < value.length;
-    const next: number = isHighSurrogate ? value.charCodeAt(index + 1) : 0;
-    const isPair: boolean = isHighSurrogate && next >= 0xdc00 && next <= 0xdfff;
-
-    const width: number = isPair ? 2 : 1;
-    const cost: number = utf8ByteLength(value.slice(index, index + width));
-
-    if (bytes + cost > maxBytes && index > start) {
-      parts.push(value.slice(start, index));
-      start = index;
-      bytes = 0;
-    }
-
-    bytes += cost;
-    index += width;
-  }
-
-  parts.push(value.slice(start));
-
-  return parts;
-}
-
 export interface PendingChunk {
   /*
-   * The chunk body before compression. Normally a complete JSON array of
-   * rrweb events. For a split snapshot (see below) it is a FRAGMENT of that
-   * array's text, and the receiving side must concatenate the parts by
-   * chunkIndex before parsing.
+   * The chunk body before compression: always a COMPLETE JSON array of rrweb
+   * events, so a chunk can be decoded on its own.
+   *
+   * It used to be allowed to be a raw fragment of that array's text, for the
+   * one case of an oversized indivisible snapshot, on the understanding that
+   * the receiving side would concatenate the parts by chunkIndex before
+   * parsing. Nothing ever did — see emitOversizedEvent.
    */
   payload: string;
 
@@ -163,11 +117,6 @@ export interface PendingChunk {
 
   hasFullSnapshot: boolean;
   isFinal: boolean;
-
-  snapshotPart?: {
-    index: number;
-    total: number;
-  };
 
   signals: SessionReplaySignalCounts;
   fidelityNotices: Array<string>;
@@ -280,16 +229,16 @@ export default class Chunker {
     }
 
     /*
-     * A FullSnapshot is ONE indivisible rrweb event: it cannot be split
-     * across chunks and still parse. On a large DOM it can exceed the flush
-     * threshold on its own, so it gets its own multi-part chunk sequence
-     * with hasFullSnapshot set on the final part only. Without this, a seek
-     * anchor would point at a chunk holding half a snapshot and the player
-     * would rebuild a partial DOM.
+     * A FullSnapshot is ONE indivisible rrweb event: it cannot be cut in half
+     * and still parse. On a large DOM it can exceed the flush threshold on its
+     * own, so it gets a chunk to ITSELF, over the threshold. The threshold is
+     * a flush cadence, not a wire limit — the wire limits are
+     * MAX_SESSION_REPLAY_CHUNK_BYTES post-compression and
+     * SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES raw, and the recorder gzips.
      */
     if (event.bytes + 2 > this.maxPayloadBytes) {
       this.close(false);
-      this.emitSplitEvent(event);
+      this.emitOversizedEvent(event);
       return;
     }
 
@@ -407,54 +356,75 @@ export default class Chunker {
   }
 
   /*
-   * Split one oversized event across as many chunks as it needs.
+   * Emit one indivisible event that is bigger than the flush threshold, whole,
+   * in a chunk of its own.
    *
-   * The parts carry raw slices of the array text, so only the concatenation
-   * of all parts is valid JSON. snapshotPart tells the receiving side how
-   * many to expect, and hasFullSnapshot is set only on the last one so no
-   * seek anchor ever points into the middle of a snapshot.
+   * This used to CUT the event into `maxPayloadBytes` slices of raw array
+   * text, tagged with snapshotPart {index, total}, on the stated
+   * understanding that "the receiving side must concatenate the parts by
+   * chunkIndex before parsing". Nothing on the receiving side ever did.
+   * SessionReplayIngestService.decodePayload JSON.parses every frame on its
+   * own, so each part threw and was dropped as an undecodable payload — and
+   * because the recorder had already minted a chunk index for each one, the
+   * indexes stayed missing forever. The dashboard reported them honestly ("8
+   * chunks missing", gaps on the scrubber) and the recording lost precisely
+   * the FullSnapshot it needed to be replayable, on every page whose DOM
+   * serialises to more than the flush threshold. Splitting could not be
+   * repaired in the recorder alone either: the parts arrive in separate
+   * requests, and a fragment cannot be scrubbed, so the server could not
+   * safely store one even if it did reassemble them.
+   *
+   * So: no fragments. A complete chunk over the flush threshold costs one
+   * larger POST and is decodable on its own. Past the ceiling the worker will
+   * actually inflate, the event is dropped WITH a disclosure — a snapshot the
+   * viewer is told about is strictly better than a hole nothing reports.
    */
-  private emitSplitEvent(event: BufferedEvent): void {
-    const body: string = `[${event.json}]`;
-    const slices: Array<string> = splitByUtf8Bytes(body, this.maxPayloadBytes);
-    const partCount: number = slices.length;
+  private emitOversizedEvent(event: BufferedEvent): void {
+    if (this.hasReachedSessionChunkCap()) {
+      this.droppedEvents++;
+      this.emitTruncationChunk();
+      return;
+    }
+
+    const payload: string = `[${event.json}]`;
+    const rawBytes: number = utf8ByteLength(payload);
+
+    if (rawBytes > SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES) {
+      /*
+       * No chunk index is minted here: add() has not called the sink, so the
+       * sequence stays contiguous and the session simply has one fewer seek
+       * anchor. The notice rides the next chunk that closes.
+       */
+      this.droppedEvents++;
+      this.addFidelityNotice(SessionReplayFidelityNotice.SnapshotTooLarge);
+      return;
+    }
+
     const offsetMs: number = this.getOffset(event.timestampMs);
 
-    for (let index: number = 0; index < partCount; index++) {
-      if (this.hasReachedSessionChunkCap()) {
-        this.droppedEvents++;
-        this.emitTruncationChunk();
-        return;
-      }
+    this.closedChunkCount++;
 
-      const slice: string = slices[index] as string;
+    this.sink({
+      payload: payload,
+      rawBytes: rawBytes,
+      eventCount: 1,
+      chunkStartOffsetMs: offsetMs,
+      chunkEndOffsetMs: offsetMs,
 
-      const isLastPart: boolean = index === partCount - 1;
+      /*
+       * The event is alone in this chunk, so nothing replayable precedes the
+       * snapshot and it is a valid seek anchor - the property the old
+       * last-part-only rule was reaching for.
+       */
+      hasFullSnapshot: event.type === EVENT_TYPE_FULL_SNAPSHOT,
+      isFinal: false,
+      signals: this.signals,
+      fidelityNotices: Array.from(this.fidelityNotices),
+      traceIds: Array.from(this.traceIds),
+      routes: Array.from(this.routes),
+    });
 
-      this.closedChunkCount++;
-
-      this.sink({
-        payload: slice,
-        rawBytes: utf8ByteLength(slice),
-
-        /*
-         * Only the last part reports the event, so summing eventCount over
-         * the session does not multiply-count one snapshot.
-         */
-        eventCount: isLastPart ? 1 : 0,
-        chunkStartOffsetMs: offsetMs,
-        chunkEndOffsetMs: offsetMs,
-        hasFullSnapshot: isLastPart && event.type === EVENT_TYPE_FULL_SNAPSHOT,
-        isFinal: false,
-        snapshotPart: { index: index, total: partCount },
-        signals: this.signals,
-        fidelityNotices: Array.from(this.fidelityNotices),
-        traceIds: Array.from(this.traceIds),
-        routes: Array.from(this.routes),
-      });
-
-      this.resetPerChunkCounters();
-    }
+    this.resetPerChunkCounters();
   }
 
   /*

--- a/App/FeatureSet/BrowserRecorder/src/Recorder.ts
+++ b/App/FeatureSet/BrowserRecorder/src/Recorder.ts
@@ -1431,9 +1431,14 @@ export default class Recorder {
       flushFailures: this.transport.getFlushFailureCount(),
     };
 
-    if (chunk.snapshotPart) {
-      envelope.snapshotPart = chunk.snapshotPart;
-    }
+    /*
+     * snapshotPart is deliberately never set any more. The chunker no longer
+     * cuts an oversized snapshot into fragments, because nothing on the
+     * receiving side ever reassembled them - see Chunker.emitOversizedEvent.
+     * The wire field stays on SessionReplayChunkEnvelope so the server can
+     * still recognise, and refuse cleanly, a frame from a recorder built
+     * before this.
+     */
 
     if (chunk.traceIds.length > 0) {
       envelope.traceIds = chunk.traceIds;

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/RumInstrumentation.ts
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/RumInstrumentation.ts
@@ -1,0 +1,70 @@
+/*
+ * "Session replay works, but every other tile on the Overview reads zero."
+ *
+ * That is a real and entirely reasonable configuration - the replay snippet
+ * and the OpenTelemetry browser SDK are two separate installs, and replay does
+ * not need the SDK - but it looks exactly like a broken application: page
+ * views, error rate, p95 duration and clients all sit at zero or a dash with
+ * nothing saying why. It is what issue #3527 reported alongside the recording
+ * faults, and the reporter had no way to tell the two apart.
+ *
+ * A pure function rather than an inline expression on the page so the
+ * condition can be tested for the cases that matter, several of which are
+ * about NOT showing a banner.
+ */
+
+export interface RumInstrumentationSignals {
+  /*
+   * Written by the replay ingest path when a chunk is accepted. Its presence
+   * is the whole "replay is reporting" half of the question.
+   */
+  sessionReplayLastChunkReceivedAt?: Date | string | null | undefined;
+
+  /*
+   * All three are written ONLY by the OTel ingest path, harvested from the
+   * resource attributes the browser SDK sends (browser.*, telemetry.sdk.*).
+   * The replay paths never touch them - replay's own liveness write carries no
+   * metadata precisely so this signal stays clean - so all three being empty
+   * means the SDK has never reported for this application.
+   */
+  clientType?: string | null | undefined;
+  sdkLanguage?: string | null | undefined;
+  agentVersion?: string | null | undefined;
+}
+
+function isPresent(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  return true;
+}
+
+/*
+ * Deliberately NOT "no spans in the selected time range", which would fire on
+ * any quiet hour and turn the banner into noise the moment somebody narrowed
+ * the time picker. This answer is a property of the INSTALL, so it does not
+ * change with the range, and it goes away by itself the first time the SDK
+ * reports.
+ */
+export default function isReplayOnlyInstrumented(
+  app: RumInstrumentationSignals | null | undefined,
+): boolean {
+  if (!app) {
+    return false;
+  }
+
+  if (!isPresent(app.sessionReplayLastChunkReceivedAt)) {
+    return false;
+  }
+
+  return (
+    !isPresent(app.clientType) &&
+    !isPresent(app.sdkLanguage) &&
+    !isPresent(app.agentVersion)
+  );
+}

--- a/App/FeatureSet/Dashboard/src/Pages/Rum/View/Overview.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Rum/View/Overview.tsx
@@ -18,6 +18,7 @@ import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import API from "Common/UI/Utils/API/API";
 import PageLoader from "Common/UI/Components/Loader/PageLoader";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
 import OneUptimeDate from "Common/Types/Date";
 import TelemetryTimeRangePicker from "Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker";
 import RangeStartAndEndDateTime, {
@@ -50,6 +51,7 @@ import {
   fetchSessionReplayList,
   SessionReplayListResult,
 } from "../../../Components/SessionReplay/SessionReplayTable";
+import isReplayOnlyInstrumented from "../../../Components/SessionReplay/RumInstrumentation";
 
 const DEFAULT_RANGE: RangeStartAndEndDateTime = {
   range: TimeRange.PAST_ONE_HOUR,
@@ -119,6 +121,11 @@ const RumApplicationOverview: FunctionComponent<
           otelCollectorStatus: true,
           lastSeenAt: true,
           agentVersion: true,
+          /*
+           * Read for the instrumentation banner below, not for a tile. See
+           * isReplayOnlyInstrumented.
+           */
+          sessionReplayLastChunkReceivedAt: true,
           labels: { name: true, color: true },
         },
       });
@@ -413,8 +420,36 @@ const RumApplicationOverview: FunctionComponent<
     { label: "SDK Version", value: a.agentVersion },
   ];
 
+  /*
+   * Recordings are arriving but the OpenTelemetry browser SDK has never
+   * reported, so every tile on this page except "sessions recorded" is
+   * honestly zero. See RumInstrumentation for why the signal is the SDK
+   * metadata columns rather than "no spans in the selected range".
+   */
+  const showRumSdkMissingNotice: boolean = isReplayOnlyInstrumented(a);
+
   return (
     <Fragment>
+      {showRumSdkMissingNotice && (
+        <Alert
+          type={AlertType.INFO}
+          strongTitle="Session replay is reporting, the RUM SDK is not"
+          title={
+            <span>
+              Recordings are arriving for this application, so the replay
+              snippet and your ingestion key are working. Page views, error
+              rate, p95 duration and clients come from a different install — the
+              OpenTelemetry browser SDK — and nothing has reported through it
+              yet, which is why those tiles read zero. Add the SDK with{" "}
+              <code>service.name</code> set to{" "}
+              <code>{(a.appIdentifier as string) || ""}</code> to fill them in;
+              the steps are on this application&apos;s Documentation tab.
+              Session replay does not need it.
+            </span>
+          }
+        />
+      )}
+
       <ResourceOverview
         icon={IconProp.Globe}
         title={(a.name as string) || "RUM Application"}

--- a/App/FeatureSet/Docs/Content/en/rum/session-replay-troubleshooting.md
+++ b/App/FeatureSet/Docs/Content/en/rum/session-replay-troubleshooting.md
@@ -227,6 +227,22 @@ Work down this list; it is ordered by how often each one is the answer.
 3. **Is there no chunk `POST`?** Read the `recording` line. `uploading: false` under `OnErrorOrFrustration` is normal — call `OneUptimeReplay.captureSession()` to force one and confirm the path works.
 4. **Still nothing after `captureSession()`?** Look for `upload-blocked-consent` (call `grantConsent()`), `not-sampled`, or `transport-disabled`.
 
+## The session list says "N chunks missing", or the player draws gaps
+
+A recording is uploaded as a numbered sequence of chunks per tab. The finalizer reports any index that never arrived as a missing chunk, and the player draws a gap wherever the sequence skips — deliberately, because the alternative is playing mutations across a hole and rendering a DOM the user never saw.
+
+So the number is always telling the truth. What it means depends on where the hole is:
+
+- **A hole at the very end** is the usual, benign one: the browser was closed or navigated away mid-flush. Look for `final-chunk-too-large` in the console.
+- **A hole in the middle** is a chunk the server refused or never received. `chunk-refused`, `chunk-post-failed` and `chunk-not-recorded` in the console each name a different cause, and the `server-directive` line beside them carries the server's reason.
+- **The same gap in the same place on every session, on a page with a large DOM**, was a defect in recorders up to 12.0.x. An rrweb full-page snapshot bigger than the 256 KB flush threshold was cut into fragments the ingest worker could never parse, so the snapshot — and every chunk index it occupied — was dropped, on every page load. Nothing on the customer's page could work around it. Upgrade OneUptime; browsers pick up the new recorder within one config cache TTL (5 minutes). Recordings already taken stay as they are.
+
+## The RUM application says "Disconnected"
+
+The status pill and Last Seen on _Real User Monitoring → your application_ report when telemetry last arrived for that application. Session replay counts: both a recorder fetching its policy and an accepted chunk refresh it, so an application instrumented with the replay snippet alone stays Connected. In older versions only OpenTelemetry RUM telemetry did, so a replay-only application read "Disconnected" with a Last Seen days old while its recorders were working perfectly.
+
+"Connected" therefore means *something* is reporting — not that everything is. Page views, error rate, p95 duration and clients come from the OpenTelemetry browser SDK, which is a separate install; when those read zero while recordings are arriving, the application's Overview page says so directly.
+
 ## RUM telemetry is separate
 
 Session replay and RUM traces are two independent pipelines with two independent failure modes. A working recorder does not imply RUM telemetry is arriving, and a working RUM application is not a prerequisite for the recorder to load.

--- a/App/FeatureSet/Telemetry/API/SessionReplayIngest.ts
+++ b/App/FeatureSet/Telemetry/API/SessionReplayIngest.ts
@@ -271,6 +271,41 @@ function readCountryCode(req: ExpressRequest): string {
 }
 
 /*
+ * Session replay traffic is telemetry, so it keeps the application ALIVE.
+ *
+ * RumApplicationService.updateLastSeen used to be reachable only from the
+ * OTel path (OtelIngestBaseService), so an application instrumented with the
+ * replay snippet alone never had its lastSeenAt refreshed at all:
+ * markDisconnectedApplications flipped it to "disconnected" fifteen minutes
+ * after whatever OTel batch last touched it, and the Dashboard showed
+ * "Disconnected" with a Last Seen days old while recorders on the customer's
+ * site were talking to this very process. That is issue #3527's headline
+ * symptom, and it is not a cosmetic one: "Disconnected" is what somebody
+ * reads before concluding their install is broken and giving up.
+ *
+ * Called from BOTH replay entry points, and the config fetch is the
+ * load-bearing one. Under the shipped default policy - capture trigger
+ * OnErrorOrFrustration, sample percentage 0 - a perfectly healthy page makes
+ * exactly ONE request per page load and posts no chunk unless something goes
+ * wrong, so a chunk-only heartbeat would leave a working installation looking
+ * dead for as long as nothing went wrong.
+ *
+ * Fire-and-forget, and throttled to one Postgres write per application per
+ * minute inside ResourceHeartbeat. It must never delay or fail a response on
+ * either path.
+ */
+function markApplicationAlive(rumApplicationId: ObjectID): void {
+  RumApplicationService.updateLastSeen(rumApplicationId).catch(
+    (err: unknown) => {
+      logger.warn(
+        "Could not refresh RUM application liveness from session replay:",
+      );
+      logger.warn(err);
+    },
+  );
+}
+
+/*
  * Stamp a disabled config with WHY, and with the debug flag.
  *
  * A helper rather than five inline spreads so no future disabled branch can
@@ -563,6 +598,8 @@ router.post(
           logger.warn("Could not record replay chunk receipt:");
           logger.warn(err);
         });
+
+        markApplicationAlive(decision.policy.rumApplicationId);
       }
 
       sendChunkDirective(req, res, 202, decision);
@@ -723,6 +760,14 @@ router.get(
         );
         return;
       }
+
+      /*
+       * A recorder asked this application for its policy, so a recorder is
+       * running on it right now. See markApplicationAlive: for the default
+       * policy this is the ONLY request a healthy page makes, and therefore
+       * the only honest liveness signal replay has.
+       */
+      markApplicationAlive(policy.rumApplicationId);
 
       const config: SessionReplayConfigResponse = {
         enabled: true,

--- a/App/FeatureSet/Telemetry/Services/SessionReplayIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/SessionReplayIngestService.ts
@@ -21,6 +21,7 @@ import SessionReplayTriggerReason from "Common/Types/Rum/SessionReplayTriggerRea
 import {
   MAX_SESSION_REPLAY_CHUNKS_PER_SESSION,
   SESSION_REPLAY_ALLOWED_RETENTION_DAYS,
+  SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES,
   SESSION_REPLAY_SCHEMA_VERSION,
   SESSION_REPLAY_WIRE_VERSION,
   SessionReplayChunkEnvelope,
@@ -92,11 +93,14 @@ const ACTIVE_SESSION_TTL_SECONDS: number = 6 * 60 * 60;
  * guard fires during inflation rather than after we have already allocated
  * the memory.
  *
- * 8 MiB is deliberately close to the recorder's actual behaviour (it flushes
- * at a 256 KB pre-compression threshold) rather than to what a Buffer can
- * hold, so a legitimate frame never comes near it.
+ * Imported from Common rather than declared here because the recorder's
+ * chunker enforces the SAME number as its ceiling for an indivisible event it
+ * posts whole. Two independently-maintained copies of that number is a chunk
+ * the recorder is willing to send and the worker refuses to inflate, which
+ * shows up as a permanent hole in a recording.
  */
-const MAX_DECOMPRESSED_FRAME_BYTES: number = 8 * 1024 * 1024;
+const MAX_DECOMPRESSED_FRAME_BYTES: number =
+  SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES;
 
 /*
  * Decompressed-payload ceiling for the WHOLE job, which is the number that
@@ -560,6 +564,42 @@ export default class SessionReplayIngestService {
 
     for (const frame of parsed.frames) {
       const envelope: SessionReplayChunkEnvelope = frame.envelope;
+
+      /*
+       * A FRAGMENT of a snapshot, from a recorder built before this file's
+       * sibling change.
+       *
+       * Recorders up to 12.0.x cut an oversized FullSnapshot into raw slices
+       * of the array text and posted each as its own chunk, tagged
+       * snapshotPart {index, total}, on the understanding that the receiving
+       * side would concatenate them before parsing. Nothing here ever did, so
+       * every part fell through decodePayload's JSON.parse and was dropped as
+       * "payload-undecodable" - a misleading label for a frame that is
+       * exactly as it was sent, and one that hid the real fault (every page
+       * with a DOM over the flush threshold lost its snapshot, and the chunk
+       * indexes with it) for as long as it existed.
+       *
+       * They cannot be accepted retroactively: the parts arrive in SEPARATE
+       * requests, so no single job ever holds the whole snapshot, and a
+       * fragment cannot be run through the scrubber - storing one would mean
+       * writing unscrubbed end-user content. So they are refused, by name, and
+       * the recorder that produced them is named in the log. Recorders are
+       * version-pinned by the config endpoint, so this drains within one
+       * config TTL of a deploy.
+       */
+      if (envelope.snapshotPart && envelope.snapshotPart.total > 1) {
+        this.recordDrop("snapshot-fragment-unsupported");
+        logger.warn(
+          `SessionReplayIngestService: refused snapshot fragment ${
+            envelope.snapshotPart.index + 1
+          }/${envelope.snapshotPart.total} of chunk ${
+            envelope.chunkIndex
+          } (session ${envelope.sessionId}, recorder ${
+            envelope.recorderVersion
+          }). Fragments are never reassembled; upgrade the recorder artifact.`,
+        );
+        continue;
+      }
 
       /*
        * Consent is asserted by the recorder and verified here, so a

--- a/App/Tests/Dashboard/RumInstrumentationNotice.test.ts
+++ b/App/Tests/Dashboard/RumInstrumentationNotice.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "@jest/globals";
+import isReplayOnlyInstrumented from "../../FeatureSet/Dashboard/src/Components/SessionReplay/RumInstrumentation";
+
+/*
+ * The "session replay is reporting, the RUM SDK is not" banner on the RUM
+ * application Overview.
+ *
+ * From github.com/OneUptime/oneuptime/issues/3527: the reporter had session
+ * replay working and every other tile on the page reading zero, with nothing
+ * anywhere saying that page views, error rate, p95 and clients come from a
+ * SECOND install they had not done. Two separate faults looked like one broken
+ * feature.
+ *
+ * Half of these cases are about NOT showing the banner. A diagnostic that
+ * appears on a healthy application is worse than none, because the next real
+ * one is ignored.
+ */
+describe("isReplayOnlyInstrumented", () => {
+  const REPLAY_SEEN: Date = new Date("2026-09-01T09:54:00.000Z");
+
+  test("fires when replay is arriving and the SDK has never reported", () => {
+    expect(
+      isReplayOnlyInstrumented({
+        sessionReplayLastChunkReceivedAt: REPLAY_SEEN,
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * The reporter's exact row: replay chunks accepted hours ago, and a Client
+   * Type column rendering an em dash.
+   */
+  test("fires when the SDK columns are empty strings, not just absent", () => {
+    expect(
+      isReplayOnlyInstrumented({
+        sessionReplayLastChunkReceivedAt: REPLAY_SEEN,
+        clientType: "",
+        sdkLanguage: "   ",
+        agentVersion: "",
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts the date as the ISO string an API response carries", () => {
+    expect(
+      isReplayOnlyInstrumented({
+        sessionReplayLastChunkReceivedAt: "2026-09-01T09:54:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * An application with the SDK installed is fully instrumented; zeroes there
+   * mean a quiet time range, which the banner must not misdiagnose.
+   */
+  for (const field of ["clientType", "sdkLanguage", "agentVersion"] as const) {
+    test(`stays silent when ${field} says the SDK has reported`, () => {
+      expect(
+        isReplayOnlyInstrumented({
+          sessionReplayLastChunkReceivedAt: REPLAY_SEEN,
+          [field]: "browser",
+        }),
+      ).toBe(false);
+    });
+  }
+
+  /*
+   * No replay either. This is an application with nothing installed at all,
+   * and telling it about the OTel SDK alone would be actively misleading -
+   * the empty session list has its own setup guide for that case.
+   */
+  test("stays silent when replay has not reported either", () => {
+    expect(isReplayOnlyInstrumented({})).toBe(false);
+    expect(
+      isReplayOnlyInstrumented({ sessionReplayLastChunkReceivedAt: null }),
+    ).toBe(false);
+  });
+
+  test("stays silent while the application is still loading", () => {
+    expect(isReplayOnlyInstrumented(null)).toBe(false);
+    expect(isReplayOnlyInstrumented(undefined)).toBe(false);
+  });
+});

--- a/App/Tests/Telemetry/SessionReplayConfigDeploymentAnswers.test.ts
+++ b/App/Tests/Telemetry/SessionReplayConfigDeploymentAnswers.test.ts
@@ -168,6 +168,7 @@ jest.mock("Common/Server/Services/RumApplicationService", () => {
     __esModule: true,
     default: {
       markSessionReplayChunkReceived: jest.fn(),
+      updateLastSeen: jest.fn(),
       markSessionReplayBudgetExceeded: jest.fn(),
     },
   };

--- a/App/Tests/Telemetry/SessionReplayConfigEndpoint.test.ts
+++ b/App/Tests/Telemetry/SessionReplayConfigEndpoint.test.ts
@@ -165,6 +165,7 @@ jest.mock("Common/Server/Services/RumApplicationService", () => {
     __esModule: true,
     default: {
       markSessionReplayChunkReceived: jest.fn(),
+      updateLastSeen: jest.fn(),
       markSessionReplayBudgetExceeded: jest.fn(),
     },
   };
@@ -240,6 +241,7 @@ jest.mock("../../FeatureSet/BrowserRecorder/Manifest", () => {
 });
 
 import Response from "Common/Server/Utils/Response";
+import RumApplicationService from "Common/Server/Services/RumApplicationService";
 import SessionReplayGateCache from "Common/Server/Utils/SessionReplay/SessionReplayGateCache";
 import SessionReplayTargeting from "Common/Server/Utils/SessionReplay/SessionReplayTargeting";
 // Importing the router module registers the routes on the mocked router.
@@ -253,6 +255,8 @@ const consumeTargetMock: MockedFn =
   SessionReplayTargeting.consumeTarget as unknown as MockedFn;
 const sendJsonMock: MockedFn =
   Response.sendJsonObjectResponse as unknown as MockedFn;
+const updateLastSeenMock: MockedFn =
+  RumApplicationService.updateLastSeen as unknown as MockedFn;
 
 const PROJECT_ID: ObjectID = ObjectID.generate();
 const RUM_APPLICATION_ID: ObjectID = ObjectID.generate();
@@ -343,6 +347,69 @@ describe("GET /session-replay/v1/config (wave 4 fields)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consumeTargetMock.mockResolvedValue(false as never);
+    updateLastSeenMock.mockResolvedValue(undefined as never);
+  });
+
+  /*
+   * REGRESSION: github.com/OneUptime/oneuptime/issues/3527.
+   *
+   * The config fetch is the ONLY request a healthy recorder makes under the
+   * shipped default policy - capture trigger OnErrorOrFrustration, sample
+   * percentage 0 - because nothing uploads until something goes wrong. So it
+   * is the only honest liveness signal replay has, and without it an
+   * application instrumented with the replay snippet alone sat on the
+   * Dashboard as "Disconnected" with a Last Seen days old while its recorders
+   * were fetching policy from this very route.
+   */
+  describe("RUM application liveness", () => {
+    test("an enabled application is kept connected by the policy fetch alone", async () => {
+      getPolicyMock.mockResolvedValue(buildPolicy() as never);
+
+      await callConfigRoute(buildRequest(), buildResponse());
+
+      expect(updateLastSeenMock).toHaveBeenCalledTimes(1);
+      expect(updateLastSeenMock).toHaveBeenCalledWith(RUM_APPLICATION_ID);
+    });
+
+    /*
+     * A sample percentage of 0 is the SHIPPED DEFAULT, and it is what the
+     * reporter on #3527 was running. It must not make the application look
+     * dead: the recorder is running, it is just not uploading yet.
+     */
+    test("a 0% sample percentage still counts as alive", async () => {
+      getPolicyMock.mockResolvedValue(
+        buildPolicy({ samplePercentage: 0 }) as never,
+      );
+
+      await callConfigRoute(buildRequest(), buildResponse());
+
+      expect(updateLastSeenMock).toHaveBeenCalledWith(RUM_APPLICATION_ID);
+    });
+
+    /*
+     * No policy means no application resolved at all, so there is nothing to
+     * mark alive - and nothing to auto-create from an unauthenticated-shaped
+     * identifier either.
+     */
+    test("a disabled or unknown application is not marked alive", async () => {
+      getPolicyMock.mockResolvedValue(null as never);
+
+      await callConfigRoute(buildRequest(), buildResponse());
+
+      expect(updateLastSeenMock).not.toHaveBeenCalled();
+    });
+
+    test("a failed liveness write still returns a usable config", async () => {
+      getPolicyMock.mockResolvedValue(buildPolicy() as never);
+      updateLastSeenMock.mockRejectedValue(new Error("postgres down") as never);
+
+      const body: JSONObject = await callConfigRoute(
+        buildRequest(),
+        buildResponse(),
+      );
+
+      expect(body["enabled"]).toBe(true);
+    });
   });
 
   test("the live config mirrors the correlation and performance policy verbatim", async () => {

--- a/App/Tests/Telemetry/SessionReplayIngestAPI.test.ts
+++ b/App/Tests/Telemetry/SessionReplayIngestAPI.test.ts
@@ -161,6 +161,7 @@ jest.mock("Common/Server/Services/RumApplicationService", () => {
     __esModule: true,
     default: {
       markSessionReplayChunkReceived: jest.fn(),
+      updateLastSeen: jest.fn(),
       markSessionReplayBudgetExceeded: jest.fn(),
     },
   };
@@ -225,6 +226,8 @@ const markChunkReceivedMock: MockedFn =
   RumApplicationService.markSessionReplayChunkReceived as unknown as MockedFn;
 const markBudgetExceededMock: MockedFn =
   RumApplicationService.markSessionReplayBudgetExceeded as unknown as MockedFn;
+const updateLastSeenMock: MockedFn =
+  RumApplicationService.updateLastSeen as unknown as MockedFn;
 
 const PROJECT_ID: ObjectID = ObjectID.generate();
 const RUM_APPLICATION_ID: ObjectID = ObjectID.generate();
@@ -404,6 +407,7 @@ describe("POST /session-replay/v1/chunk", () => {
     addJobMock.mockResolvedValue(undefined as never);
     markChunkReceivedMock.mockResolvedValue(undefined as never);
     markBudgetExceededMock.mockResolvedValue(undefined as never);
+    updateLastSeenMock.mockResolvedValue(undefined as never);
     gateMock.mockResolvedValue({
       outcome: SessionReplayGateOutcome.Accepted,
       directive: "continue",
@@ -494,6 +498,66 @@ describe("POST /session-replay/v1/chunk", () => {
     expect(markChunkReceivedMock).toHaveBeenCalledTimes(1);
     expect(markChunkReceivedMock).toHaveBeenCalledWith(RUM_APPLICATION_ID);
     expect(markBudgetExceededMock).not.toHaveBeenCalled();
+  });
+
+  /*
+   * REGRESSION: github.com/OneUptime/oneuptime/issues/3527.
+   *
+   * updateLastSeen used to be reachable only from the OTel ingest path, so an
+   * application instrumented with the replay snippet alone was flipped to
+   * "disconnected" by markDisconnectedApplications fifteen minutes after
+   * whatever OTel batch last touched it - while its recorders were posting
+   * chunks to this very route. The Dashboard showed "Disconnected" and a Last
+   * Seen days old, which is what somebody reads before concluding their
+   * install is broken.
+   */
+  test("an accepted chunk keeps the RUM application connected", async () => {
+    const { res } = await invokeChunkRoute({ body: buildBody() });
+
+    expect(getStatus(res)).toBe(202);
+    expect(updateLastSeenMock).toHaveBeenCalledTimes(1);
+    expect(updateLastSeenMock).toHaveBeenCalledWith(RUM_APPLICATION_ID);
+  });
+
+  /*
+   * Liveness is written AFTER the enqueue, for the same reason recording
+   * health is: a chunk that could not be staged did not land, and a 503 that
+   * still refreshed lastSeenAt would report a storage outage as health.
+   */
+  test("does not refresh liveness when staging failed", async () => {
+    addJobMock.mockRejectedValue(new Error("redis down") as never);
+
+    const { res } = await invokeChunkRoute({ body: buildBody() });
+
+    expect(getStatus(res)).toBe(503);
+    expect(updateLastSeenMock).not.toHaveBeenCalled();
+  });
+
+  test("a refused chunk does not refresh liveness", async () => {
+    gateMock.mockResolvedValue({
+      outcome: SessionReplayGateOutcome.Stop,
+      directive: "stop",
+      configEpoch: 7,
+      reason: "not-sampled",
+      policy: { samplePercentage: 0, rumApplicationId: RUM_APPLICATION_ID },
+    } as never);
+
+    const { res } = await invokeChunkRoute({ body: buildBody() });
+
+    expect(res.statusCode).toBe(204);
+    expect(updateLastSeenMock).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A liveness write that throws must never reach the response. It is
+   * bookkeeping; the chunk has already been staged.
+   */
+  test("a failed liveness write still answers 202", async () => {
+    updateLastSeenMock.mockRejectedValue(new Error("postgres down") as never);
+
+    const { res } = await invokeChunkRoute({ body: buildBody() });
+
+    expect(getStatus(res)).toBe(202);
   });
 
   test("records budget exhaustion on the application so the Dashboard can explain the silence", async () => {

--- a/App/Tests/Telemetry/SessionReplayIngestService.test.ts
+++ b/App/Tests/Telemetry/SessionReplayIngestService.test.ts
@@ -704,6 +704,66 @@ describe("SessionReplayIngestService.processFromQueue", () => {
     (isSessionErased as jest.Mock).mockResolvedValue(false as never);
   });
 
+  /*
+   * REGRESSION: github.com/OneUptime/oneuptime/issues/3527.
+   *
+   * Recorders up to 12.0.x cut an oversized FullSnapshot into raw slices of
+   * the array text and posted each slice as its own chunk index, tagged
+   * snapshotPart {index, total}. Nothing here ever concatenated them, so every
+   * slice fell through decodePayload's JSON.parse and was dropped as
+   * "payload-undecodable" - a label that described the parse and hid the
+   * cause. The recorder no longer produces fragments at all (Chunker
+   * .emitOversizedEvent); these tests pin what happens to the ones still in
+   * flight from a cached bundle.
+   */
+  describe("legacy split-snapshot fragments", () => {
+    test("refuses a fragment rather than storing an unparseable slice", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 3, snapshotPart: { index: 0, total: 2 } }]),
+        ),
+      );
+
+      expect(getSubmittedRows("RumSessionChunkV1")).toHaveLength(0);
+    });
+
+    /*
+     * Only a MULTI-part tag means a fragment. total 1 is a whole event that a
+     * recorder happened to label, and refusing it would throw away a chunk
+     * that decodes perfectly well.
+     */
+    test("accepts a single-part chunk, which is not a fragment", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([{ chunkIndex: 0, snapshotPart: { index: 0, total: 1 } }]),
+        ),
+      );
+
+      expect(getSubmittedRows("RumSessionChunkV1")).toHaveLength(1);
+    });
+
+    test("refuses the fragment WITHOUT losing the whole chunks beside it", async () => {
+      await SessionReplayIngestService.processFromQueue(
+        buildJobData(
+          buildBody([
+            { chunkIndex: 0 },
+            { chunkIndex: 1, snapshotPart: { index: 0, total: 2 } },
+            { chunkIndex: 2, snapshotPart: { index: 1, total: 2 } },
+            { chunkIndex: 3 },
+          ]),
+        ),
+      );
+
+      const rows: Array<JSONObject> = getSubmittedRows("RumSessionChunkV1");
+
+      expect(
+        rows.map((row: JSONObject): unknown => {
+          return row["chunkIndex"];
+        }),
+      ).toEqual([0, 3]);
+    });
+  });
+
   describe("erasure tombstone", () => {
     /*
      * A chunk can be staged in Redis, or sitting in the queue, at the moment

--- a/App/Tests/Telemetry/SessionReplayOversizedSnapshot.test.ts
+++ b/App/Tests/Telemetry/SessionReplayOversizedSnapshot.test.ts
@@ -1,0 +1,573 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import SessionReplayCaptureTrigger from "Common/Types/Rum/SessionReplayCaptureTrigger";
+import SessionReplayConsentMode from "Common/Types/Rum/SessionReplayConsentMode";
+import SessionReplayMaskingMode from "Common/Types/Rum/SessionReplayMaskingMode";
+import SessionReplayTriggerReason from "Common/Types/Rum/SessionReplayTriggerReason";
+import {
+  SESSION_REPLAY_FLUSH_BYTES,
+  SESSION_REPLAY_SCHEMA_VERSION,
+  SESSION_REPLAY_WIRE_VERSION,
+  SessionReplayChunkEnvelope,
+} from "Common/Types/Rum/SessionReplay";
+import zlib from "zlib";
+
+/*
+ * THE END-TO-END REGRESSION FOR github.com/OneUptime/oneuptime/issues/3527.
+ *
+ * This file exists because the bug it pins was invisible from either side.
+ *
+ * The recorder's chunker used to cut an oversized indivisible FullSnapshot
+ * into raw slices of the array text, one chunk index per slice, tagged
+ * snapshotPart {index, total}, "and the receiving side must concatenate the
+ * parts by chunkIndex before parsing". The ingest worker never learned to.
+ * decodePayload JSON.parses every frame on its own, so every slice threw and
+ * was dropped - and because the recorder had already minted a chunk index for
+ * each one, those indexes were missing from the session forever.
+ *
+ * Both sides had thorough unit tests. The recorder's proved the slices
+ * rejoined into the original JSON; the worker's proved a well-formed frame
+ * decoded. Nothing anywhere ran the REAL chunker's output through the REAL
+ * worker, which is the only place the contract lived - so on any page whose
+ * DOM serialises to more than SESSION_REPLAY_FLUSH_BYTES (a Dynamics portal,
+ * a large admin console, any enterprise app) the snapshot was destroyed on
+ * every single page load, the dashboard reported "N chunks missing" and drew
+ * gaps on the scrubber, and playback had no anchor to rebuild the DOM from.
+ *
+ * So this test crosses the boundary on purpose: it drives the actual Chunker,
+ * puts each chunk it emits on the wire the way Transport does, and hands the
+ * result to the actual processFromQueue.
+ */
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    getLogAttributesFromRequest: jest.fn(),
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry/CaptureSpan", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return (): void => {
+        /* The real decorator needs a live tracer provider. */
+      };
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry/AppMetrics", () => {
+  const counter: { add: unknown } = { add: jest.fn() };
+  const histogram: { record: unknown } = { record: jest.fn() };
+
+  return {
+    __esModule: true,
+    default: {
+      getIngestCounter: () => {
+        return counter;
+      },
+      getIngestDuration: () => {
+        return histogram;
+      },
+      getIngestPayloadBytes: () => {
+        return histogram;
+      },
+    },
+  };
+});
+
+jest.mock("../../FeatureSet/Telemetry/Config", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../FeatureSet/Telemetry/Config",
+  ) as Record<string, unknown>;
+
+  return {
+    __esModule: true,
+    ...actual,
+    SESSION_REPLAY_INGEST_ENABLED: true,
+    SESSION_REPLAY_ENABLED_BY_DEFAULT: true,
+  };
+});
+
+jest.mock("Common/Server/Infrastructure/Redis", () => {
+  return {
+    __esModule: true,
+    default: {
+      getClient: (): unknown => {
+        return { zadd: jest.fn(), expire: jest.fn() };
+      },
+      isConnected: (): boolean => {
+        return true;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/RumSessionService", () => {
+  return {
+    __esModule: true,
+    default: { model: { tableName: "RumSessionV1" } },
+  };
+});
+
+jest.mock("Common/Server/Services/RumSessionChunkService", () => {
+  return {
+    __esModule: true,
+    default: { model: { tableName: "RumSessionChunkV1" } },
+  };
+});
+
+jest.mock("Common/Server/Utils/SessionReplay/SessionReplayGateCache", () => {
+  return {
+    __esModule: true,
+    default: {
+      getPolicy: jest.fn(),
+      isOriginAllowed: jest.fn().mockReturnValue(true),
+      markProjectDisabled: jest.fn(),
+      clearCache: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Telemetry/TelemetryFanInWriter", () => {
+  return {
+    __esModule: true,
+    default: { submit: jest.fn() },
+    pushObservedAck: (
+      pendingAcks: Array<Promise<void>>,
+      flushed: Promise<void>,
+    ): void => {
+      pendingAcks.push(flushed);
+    },
+  };
+});
+
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/SessionReplayScrubService",
+  () => {
+    return {
+      __esModule: true,
+      default: { loadRules: jest.fn(), scrubEvents: jest.fn() },
+    };
+  },
+);
+
+jest.mock("../../FeatureSet/Telemetry/Utils/SessionReplayChunkStore", () => {
+  return {
+    __esModule: true,
+    default: {
+      storeBody: jest.fn(),
+      readBody: jest.fn(),
+      deleteBody: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../FeatureSet/Telemetry/Utils/SessionReplayRateLimiter", () => {
+  return {
+    __esModule: true,
+    default: {
+      consumeChunkAllowance: jest.fn(),
+      consumeByteBudget: jest.fn(),
+      consumeApplicationMonthlyBudget: jest.fn(),
+      getBytesUsedToday: jest.fn(),
+    },
+    SessionReplayLimitOutcome: {
+      Allowed: "allowed",
+      RateLimited: "rate-limited",
+      BudgetExhausted: "budget-exhausted",
+      CounterUnavailable: "counter-unavailable",
+    },
+  };
+});
+
+jest.mock(
+  "Common/Server/Utils/SessionReplay/SessionReplayErasureTombstone",
+  () => {
+    class FakeErasureTombstoneUnavailableError extends Error {}
+
+    return {
+      __esModule: true,
+      isSessionErased: jest.fn(),
+      ErasureTombstoneUnavailableError: FakeErasureTombstoneUnavailableError,
+    };
+  },
+);
+
+import { isSessionErased } from "Common/Server/Utils/SessionReplay/SessionReplayErasureTombstone";
+import SessionReplayGateCache, {
+  SessionReplayGatePolicy,
+} from "Common/Server/Utils/SessionReplay/SessionReplayGateCache";
+import TelemetryFanInWriter from "Common/Server/Utils/Telemetry/TelemetryFanInWriter";
+import SessionReplayScrubService from "../../FeatureSet/Telemetry/Services/SessionReplayScrubService";
+import SessionReplayIngestService from "../../FeatureSet/Telemetry/Services/SessionReplayIngestService";
+import { SessionReplayIngestJobData } from "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+
+/* The REAL recorder chunker, not a stand-in for it. */
+import Chunker, {
+  PendingChunk,
+} from "../../FeatureSet/BrowserRecorder/src/Chunker";
+import { BufferedEvent } from "../../FeatureSet/BrowserRecorder/src/RollingBuffer";
+
+type MockedFn = ReturnType<typeof jest.fn>;
+
+const getPolicyMock: MockedFn =
+  SessionReplayGateCache.getPolicy as unknown as MockedFn;
+const submitMock: MockedFn = TelemetryFanInWriter.submit as unknown as MockedFn;
+const loadRulesMock: MockedFn =
+  SessionReplayScrubService.loadRules as unknown as MockedFn;
+const scrubEventsMock: MockedFn =
+  SessionReplayScrubService.scrubEvents as unknown as MockedFn;
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const RUM_APPLICATION_ID: ObjectID = ObjectID.generate();
+const APP_IDENTIFIER: string = "dynamics-portal";
+const SESSION_ID: string = "a".repeat(32);
+const TAB_ID: string = "b".repeat(32);
+const SESSION_START: number = 1_800_000_000_000;
+
+function buildPolicy(): SessionReplayGatePolicy {
+  return {
+    projectId: PROJECT_ID,
+    rumApplicationId: RUM_APPLICATION_ID,
+    isProjectAllowed: true,
+    isAppEnabled: true,
+    allowedOrigins: [],
+    maskingMode: SessionReplayMaskingMode.MaskSensitiveInputsOnly,
+    consentMode: SessionReplayConsentMode.NotRequired,
+    captureTrigger: SessionReplayCaptureTrigger.OnErrorOrFrustration,
+    samplePercentage: 0,
+    maskSelectors: [],
+    blockSelectors: [],
+    recordCanvas: false,
+    captureUserIdentity: false,
+    captureGeo: true,
+    retentionInDays: 7,
+    monthlyBudgetInGB: null,
+    ignoreErrorPatterns: [],
+    tracePropagationOrigins: [],
+    lcpBudgetMs: 0,
+    longTaskBudgetMs: 0,
+    slowRequestBudgetMs: 0,
+    configEpoch: 1,
+  };
+}
+
+/*
+ * A serialised rrweb FullSnapshot of the given size. The shape is what
+ * matters, not the content: ONE event, bigger than the flush threshold, that
+ * cannot be cut in half and still parse.
+ */
+function buildFullSnapshotEvent(bytes: number): BufferedEvent {
+  const prefix: string = '{"type":2,"timestamp":1,"data":{"node":"';
+  const suffix: string = '"}}';
+  const json: string = `${prefix}${"n".repeat(
+    Math.max(0, bytes - prefix.length - suffix.length),
+  )}${suffix}`;
+
+  return {
+    json: json,
+    bytes: Buffer.byteLength(json, "utf-8"),
+    timestampMs: SESSION_START + 500,
+    isCheckout: true,
+    type: 2,
+  };
+}
+
+function buildIncrementalEvent(index: number): BufferedEvent {
+  const json: string = `{"type":3,"timestamp":${
+    SESSION_START + 1000 + index
+  },"data":{"source":2,"id":${index}}}`;
+
+  return {
+    json: json,
+    bytes: Buffer.byteLength(json, "utf-8"),
+    timestampMs: SESSION_START + 1000 + index,
+    isCheckout: false,
+    type: 3,
+  };
+}
+
+/*
+ * Everything the recorder does to a chunk between the chunker's sink and the
+ * server: mint the next index, build the envelope, gzip the payload, and lay
+ * the two out as `envelope JSON`, newline, payload bytes.
+ *
+ * One frame per body, because that is what Transport.post does - which is
+ * exactly why a fragmented snapshot could never be reassembled by a worker
+ * that only ever sees one job at a time.
+ */
+function putOnTheWire(chunks: Array<PendingChunk>): Array<Buffer> {
+  return chunks.map((chunk: PendingChunk, chunkIndex: number): Buffer => {
+    const payload: Buffer = zlib.gzipSync(
+      new Uint8Array(Buffer.from(chunk.payload, "utf-8")),
+    );
+
+    const envelope: SessionReplayChunkEnvelope = {
+      v: SESSION_REPLAY_WIRE_VERSION,
+      appIdentifier: APP_IDENTIFIER,
+      sessionId: SESSION_ID,
+      tabId: TAB_ID,
+      chunkIndex: chunkIndex,
+      sessionStartUnixMs: SESSION_START,
+      clientSendUnixMs: SESSION_START + 20_000,
+      chunkStartOffsetMs: chunk.chunkStartOffsetMs,
+      chunkEndOffsetMs: chunk.chunkEndOffsetMs,
+      eventCount: chunk.eventCount,
+      hasFullSnapshot: chunk.hasFullSnapshot,
+      isFinal: chunk.isFinal,
+      recorderKind: "dom",
+      schemaVersion: SESSION_REPLAY_SCHEMA_VERSION,
+      rrwebVersion: "2.1.1",
+      recorderVersion: "12.0.30",
+      maskingMode: SessionReplayMaskingMode.MaskSensitiveInputsOnly,
+      consentState: "NotRequired",
+      triggerReason: SessionReplayTriggerReason.Frustration,
+      payloadEncoding: "gzip",
+      payloadBytes: payload.length,
+      url: "https://portal.example.com/Account/Login",
+      routes: chunk.routes,
+      signals: chunk.signals,
+      fidelityNotices: chunk.fidelityNotices,
+      droppedEvents: 0,
+      flushFailures: 0,
+    };
+
+    return Buffer.concat([
+      new Uint8Array(Buffer.from(`${JSON.stringify(envelope)}\n`)),
+      new Uint8Array(payload),
+    ]);
+  });
+}
+
+function buildJobData(body: Buffer): SessionReplayIngestJobData {
+  return {
+    projectId: PROJECT_ID.toString(),
+    appIdentifier: APP_IDENTIFIER,
+    inlineBodyBase64: body.toString("base64"),
+    serverReceiveUnixMs: SESSION_START + 25_000,
+    samplePercentageAtCapture: 0,
+    countryCode: "GB",
+  };
+}
+
+function getStoredChunkRows(): Array<JSONObject> {
+  const rows: Array<JSONObject> = [];
+
+  for (const call of submitMock.mock.calls) {
+    const target: { model: { tableName: string } } = call[0] as {
+      model: { tableName: string };
+    };
+
+    if (target.model.tableName === "RumSessionChunkV1") {
+      rows.push(...(call[1] as Array<JSONObject>));
+    }
+  }
+
+  return rows;
+}
+
+/* Drive the real chunker over one page load's worth of events. */
+function recordPageLoad(snapshotBytes: number): Array<PendingChunk> {
+  const chunks: Array<PendingChunk> = [];
+
+  const chunker: Chunker = new Chunker({
+    sessionStartUnixMs: SESSION_START,
+    sink: (chunk: PendingChunk): void => {
+      chunks.push(chunk);
+    },
+  });
+
+  chunker.addRoute("https://portal.example.com/Account/Login");
+
+  /*
+   * rrweb's opening Meta, then the FullSnapshot, then a few mutations - the
+   * order every real page load produces.
+   */
+  chunker.add({
+    json: '{"type":4,"timestamp":1,"data":{"href":"https://portal.example.com/","width":1440,"height":900}}',
+    bytes: 97,
+    timestampMs: SESSION_START + 400,
+    isCheckout: true,
+    type: 4,
+  });
+
+  chunker.add(buildFullSnapshotEvent(snapshotBytes));
+
+  for (let index: number = 0; index < 5; index++) {
+    chunker.add(buildIncrementalEvent(index));
+  }
+
+  /* The page-hide flush that seals the recording. */
+  chunker.close(true);
+
+  return chunks;
+}
+
+async function ingestAll(bodies: Array<Buffer>): Promise<void> {
+  for (const body of bodies) {
+    await SessionReplayIngestService.processFromQueue(buildJobData(body));
+  }
+}
+
+describe("an oversized full snapshot survives the round trip (issue #3527)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getPolicyMock.mockResolvedValue(buildPolicy() as never);
+    loadRulesMock.mockResolvedValue([] as never);
+    scrubEventsMock.mockResolvedValue({
+      isComplete: true,
+      nodesVisited: 1,
+      stringsScrubbed: 0,
+      skippedOversizedStrings: 0,
+      truncatedAtDepth: false,
+    } as never);
+    submitMock.mockResolvedValue({ flushed: Promise.resolve() } as never);
+    (isSessionErased as jest.Mock).mockResolvedValue(false as never);
+  });
+
+  /*
+   * 4x the flush threshold. Under the old slicing this became four fragments,
+   * every one of them undecodable, and four permanently missing chunk indexes.
+   */
+  const OVERSIZED_SNAPSHOT_BYTES: number = SESSION_REPLAY_FLUSH_BYTES * 4;
+
+  test("every chunk the recorder emits is stored - none is dropped at decode", async () => {
+    const chunks: Array<PendingChunk> = recordPageLoad(
+      OVERSIZED_SNAPSHOT_BYTES,
+    );
+
+    await ingestAll(putOnTheWire(chunks));
+
+    expect(getStoredChunkRows()).toHaveLength(chunks.length);
+  });
+
+  /*
+   * The property the dashboard actually reports on. FinalizeSessions computes
+   * missingChunkCount as the set difference between the indexes it stored and
+   * 0..max, and the player draws a gap wherever the sequence skips - so a
+   * contiguous run here IS "0 chunks missing, no gaps" on the session list.
+   */
+  test("the stored chunk indexes are contiguous from zero", async () => {
+    const chunks: Array<PendingChunk> = recordPageLoad(
+      OVERSIZED_SNAPSHOT_BYTES,
+    );
+
+    await ingestAll(putOnTheWire(chunks));
+
+    const storedIndexes: Array<number> = getStoredChunkRows()
+      .map((row: JSONObject): number => {
+        return row["chunkIndex"] as number;
+      })
+      .sort((a: number, b: number): number => {
+        return a - b;
+      });
+
+    expect(storedIndexes).toEqual(
+      chunks.map((_chunk: PendingChunk, index: number): number => {
+        return index;
+      }),
+    );
+  });
+
+  /*
+   * Storing the chunks is not enough: the snapshot has to survive INTACT,
+   * because it is the only thing the player can rebuild the DOM from. The old
+   * slicing lost it whole; a subtly wrong reassembly would lose it silently,
+   * which is worse.
+   */
+  test("the snapshot is stored whole, in one chunk, byte for byte", async () => {
+    const chunks: Array<PendingChunk> = recordPageLoad(
+      OVERSIZED_SNAPSHOT_BYTES,
+    );
+
+    await ingestAll(putOnTheWire(chunks));
+
+    const snapshotRows: Array<JSONObject> = getStoredChunkRows().filter(
+      (row: JSONObject): boolean => {
+        return row["hasFullSnapshot"] === true;
+      },
+    );
+
+    expect(snapshotRows).toHaveLength(1);
+
+    const events: Array<JSONObject> = JSON.parse(
+      snapshotRows[0]?.["payload"] as string,
+    ) as Array<JSONObject>;
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.["type"]).toBe(2);
+    expect(
+      ((events[0]?.["data"] as JSONObject)?.["node"] as string).length,
+    ).toBeGreaterThan(SESSION_REPLAY_FLUSH_BYTES);
+  });
+
+  /*
+   * The seek anchor. Playback restarts from a full-snapshot chunk, so a
+   * recording whose only snapshot chunk was dropped cannot be played from any
+   * position at all - which is what "the recording does not behave as
+   * expected" meant on the report.
+   */
+  test("the recording keeps a seek anchor", async () => {
+    const chunks: Array<PendingChunk> = recordPageLoad(
+      OVERSIZED_SNAPSHOT_BYTES,
+    );
+
+    await ingestAll(putOnTheWire(chunks));
+
+    expect(
+      getStoredChunkRows().some((row: JSONObject): boolean => {
+        return row["hasFullSnapshot"] === true;
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * The same page recorded four times, which is exactly what refresh rage -
+   * the frustration signal that TRIGGERS the upload in the first place -
+   * produces. Each page load mints a fresh tab id and its own chunk sequence,
+   * so the bug multiplied by the number of reloads: the report showed four
+   * tabs, four gaps and eight missing chunks.
+   */
+  test("a reload storm loses nothing on any of its page loads", async () => {
+    let expectedChunks: number = 0;
+
+    for (let pageLoad: number = 0; pageLoad < 4; pageLoad++) {
+      const chunks: Array<PendingChunk> = recordPageLoad(
+        OVERSIZED_SNAPSHOT_BYTES,
+      );
+
+      expectedChunks += chunks.length;
+
+      await ingestAll(putOnTheWire(chunks));
+    }
+
+    expect(getStoredChunkRows()).toHaveLength(expectedChunks);
+  });
+
+  /*
+   * A page small enough to fit the flush threshold never went near the split
+   * path, which is why the bug looked like "session replay is broken for SOME
+   * customers". Pinned so the fix cannot regress the case that always worked.
+   */
+  test("an ordinary page is unaffected", async () => {
+    const chunks: Array<PendingChunk> = recordPageLoad(1024);
+
+    await ingestAll(putOnTheWire(chunks));
+
+    expect(getStoredChunkRows()).toHaveLength(chunks.length);
+    expect(
+      getStoredChunkRows().some((row: JSONObject): boolean => {
+        return row["hasFullSnapshot"] === true;
+      }),
+    ).toBe(true);
+  });
+});

--- a/Common/Types/Rum/SessionReplay.ts
+++ b/Common/Types/Rum/SessionReplay.ts
@@ -36,6 +36,27 @@ export const MAX_SESSION_REPLAY_CHUNK_BYTES: number = 2 * 1024 * 1024;
 export const MAX_SESSION_REPLAY_CHUNKS_PER_REQUEST: number = 8;
 
 /*
+ * Largest DECOMPRESSED payload the ingest worker will inflate for one frame,
+ * and therefore the largest single indivisible rrweb event the recorder may
+ * put on the wire.
+ *
+ * The two numbers have to be the same number, which is why this lives in
+ * Common rather than in either side. A FullSnapshot is one rrweb event: it
+ * cannot be cut in half and still parse, so when it is bigger than the flush
+ * threshold the recorder posts it whole in a chunk of its own rather than
+ * cutting it. That is only safe while the recorder's ceiling is exactly the
+ * worker's — a recorder willing to send more than the worker will inflate
+ * produces a chunk that is accepted, queued, and then dropped at decode time,
+ * leaving a hole in the chunk sequence with nothing anywhere reporting it.
+ *
+ * Compression is what makes the number affordable: a snapshot this size gzips
+ * to a small fraction of MAX_SESSION_REPLAY_CHUNK_BYTES, which is the cap on
+ * the bytes actually posted.
+ */
+export const SESSION_REPLAY_MAX_DECOMPRESSED_FRAME_BYTES: number =
+  8 * 1024 * 1024;
+
+/*
  * Hard stop per session. At the 15s flush cadence this is ~2 hours of
  * continuous recording, comfortably past the 4-hour session cap once
  * idle gaps are accounted for. Prevents one pathological tab from


### PR DESCRIPTION
Fixes #3527.

Two independent defects were reported together, plus one genuine configuration
issue that had nothing telling the reporter it was one.

## 1. The recording: an oversized snapshot was destroyed, and its chunk indexes with it

An rrweb `FullSnapshot` is **one indivisible event**, and on a large DOM it
exceeds the recorder's 256 KB flush threshold on its own. `Chunker.emitSplitEvent`
cut it into raw slices of the array text — minting a chunk index for each —
tagged `snapshotPart {index, total}`, on the stated understanding that
*"the receiving side must concatenate the parts by chunkIndex before parsing"*.

Nothing on the receiving side ever did. `SessionReplayIngestService.decodePayload`
`JSON.parse`s every frame on its own, so every slice threw and was dropped as
`payload-undecodable` — a label describing the parse, not the cause. The chunk
indexes the recorder had already spent stayed missing forever, so the finalizer
counted them as missing chunks, the player drew gaps, and the recording lost
exactly the `FullSnapshot` it needed as a seek anchor.

On **every page load**, on **any** page whose DOM serialises past the threshold —
which is any large enterprise app, the reporter's Dynamics/Power Apps portal
included. Their screenshots pin it exactly: 4 tabs, 4 gaps, 8 chunks missing —
one snapshot cut into two fragments, once per reload.

Both sides had thorough unit tests. The recorder's proved the slices rejoined
into the original JSON; the worker's proved a well-formed frame decoded. Nothing
ran the real chunker's output through the real worker, and the contract lived
only in the gap between them.

**Fix.** Splitting could not be repaired where it was: the parts go out in
separate requests, so no ingest job ever holds a whole snapshot, and a fragment
cannot be run through the scrubber, so the server could not safely store one even
if it did reassemble them. So the recorder no longer fragments — an oversized
indivisible event gets a chunk to **itself**, over the flush threshold, which is
a flush cadence rather than a wire limit (the wire limits are the 2 MiB
post-compression frame cap and the worker's decompressed-frame ceiling, and the
recorder gzips). Past that ceiling the event is dropped *before* a chunk index is
minted, with the existing `snapshot-too-large` fidelity notice, so the viewer is
told rather than the sequence being poisoned. The ceiling now lives in `Common`
and both sides import it — a recorder willing to send more than the worker will
inflate reintroduces the same silent hole.

The worker refuses fragments from recorders still cached in browsers by name
(`snapshot-fragment-unsupported`) and logs the recorder version, instead of
mislabelling them.

## 2. "Disconnected" while recorders were talking to the server

`RumApplicationService.updateLastSeen` was reachable only from the OTel ingest
path, so an application instrumented with the replay snippet alone never had
`lastSeenAt` refreshed at all: `markDisconnectedApplications` flipped it fifteen
minutes after whatever OTel batch last touched it. The Dashboard then showed
`Disconnected` with a Last Seen days old while recorders on the customer's site
were talking to the very process serving that page.

Both replay entry points now refresh liveness, and **the config fetch is the
load-bearing one**: under the shipped default policy (`OnErrorOrFrustration`, 0%
sample) a healthy page makes exactly one request per load and posts no chunk
unless something goes wrong, so a chunk-only heartbeat would leave a working
install looking dead for as long as nothing went wrong.

## 3. The configuration issue, surfaced

Page views, error rate, p95 and clients come from the OpenTelemetry browser SDK,
which is a **separate install** from the replay snippet. Having only the snippet
is a real and reasonable configuration — and it reads as a broken application:
five tiles at zero with nothing saying why.

The Overview now says so when replay is reporting and the SDK never has. The
signal is deliberately the SDK metadata columns (`clientType`, `sdkLanguage`,
`agentVersion` — written only by the OTel path) rather than "no spans in the
selected range", so it cannot fire on a quiet hour and does not change with the
time picker.

Both symptoms also get a section in the session replay troubleshooting doc: what
"N chunks missing" means depending on where the hole is, and what Connected now
means.

## Tests

The regression that would have caught this crosses the boundary neither side's
own suite covers. `App/Tests/Telemetry/SessionReplayOversizedSnapshot.test.ts`
drives the **real** `Chunker`, puts each chunk on the wire the way `Transport`
does, and hands the result to the **real** `processFromQueue` — asserting
contiguous chunk indexes, a surviving seek anchor, a byte-identical snapshot, and
a four-reload storm losing nothing. Verified to fail on the pre-fix `Chunker`
(5 of its 6 cases).

Also added: chunker unit tests for the whole-chunk path, the ceiling boundary and
the disclosed drop; worker tests for refused legacy fragments (including that
whole chunks beside them still land); liveness tests on both replay routes,
including that a failed liveness write never affects the response and that a
refused chunk does not refresh it; and unit tests for the Overview banner
condition, half of which are about *not* showing it.

| suite | result |
| --- | --- |
| `App` (full) | 461 suites, 12,675 tests passed |
| `App/FeatureSet/BrowserRecorder` | 29 suites, 557 tests passed |
| `Common` (session replay + RUM) | 13 suites, 189 tests passed |

`tsc --noEmit` clean in `App`, `Common` and `BrowserRecorder`; eslint clean.

## Deploying

Recorders are version-pinned by the config endpoint, so browsers pick up the
fixed artifact within one config cache TTL (5 minutes) of a deploy. Recordings
already taken keep their gaps — the fragments were never stored and cannot be
recovered.
