### PR TITLE
fix(test): give Testing Library's waits room for the lazy markdown boundary

### DIFF
--- a/Common/Tests/jest.setup.ts
+++ b/Common/Tests/jest.setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+import { configure } from "@testing-library/react";
 import { jest } from "@jest/globals";
 import { TextEncoder, TextDecoder } from "util";
 import { webcrypto, randomUUID } from "crypto";
@@ -31,3 +32,21 @@ Object.defineProperty(window, "scrollTo", {
   value: jest.fn(),
   writable: true,
 });
+
+/*
+ * Testing Library waits a default of one second for findBy/waitFor. That is a
+ * generous budget for a state update and a hopeless one for a React.lazy
+ * boundary: the first component to render LazyMarkdownViewer has to resolve
+ * the dynamic import and put MarkdownViewer (plus its mermaid mock) through
+ * ts-jest before any assertion on the markdown text can pass. Locally that is
+ * ~400 ms; on a CI runner with the other shard workers competing for the same
+ * cores it goes past a second, and the test fails having rendered the Suspense
+ * fallback -- a timeout wearing the costume of a missing element.
+ *
+ * ~20 components reach the viewer through that wrapper (FeedItem, EventItem,
+ * Detail, BaseModelTable and the rest), so this is a whole class of flake
+ * rather than one test, and it belongs here rather than at one call site.
+ * Five seconds is still short enough that a genuinely broken assertion fails
+ * promptly instead of sitting out the 60 s testTimeout.
+ */
+configure({ asyncUtilTimeout: 5000 });


### PR DESCRIPTION
## What failed

`Common Test` shard 5 on master (`dfde365e94`), 7/8 shards green, one test red:

```
● ResourceFeed › renders the items it is given
  Unable to find an element with the text: /cluster was created automatically/
Tests: 1 failed, 5594 passed, 5595 total
```

## It wasn't a missing element

The DOM dump in that failure shows the feed rendering correctly — card, heading, icon, `3 years ago` timestamp — with `LazyMarkdownViewer`'s Suspense fallback where the markdown should be:

```html
<span role="status" aria-live="polite" class="block space-y-2">
  <span class="block h-4 w-3/4 animate-pulse rounded bg-gray-100" />
  <span class="block h-4 w-1/2 animate-pulse rounded bg-gray-100" />
  <span class="sr-only">Loading content</span>
</span>
```

The component was still suspended. The element hadn't arrived yet.

## Why

Testing Library waits a default of **one second** for `waitFor`/`findBy`. That's generous for a state update and hopeless for a `React.lazy` boundary: the first component to render `LazyMarkdownViewer` has to resolve the dynamic import and put `MarkdownViewer` (plus its mermaid mock) through ts-jest before any assertion on the markdown text can pass.

On an idle machine that's ~400 ms — comfortably inside the default. On a runner with the other shard workers competing for the same cores it goes past a second.

## Confirmed by moving the budget, not the code

| `asyncUtilTimeout` | result |
|---|---|
| 30 ms | reproduces master's error message **exactly** |
| 5000 ms | passes — with `FeedItemSafeMode` and `InvestigationPanel`, 64 tests, under a load average near 100 |

So the failure is bounded by the wait, not by anything the component does.

## Why it's in the shared setup

About twenty components reach the viewer through that wrapper — `FeedItem`, `EventItem`, `Detail`, `BaseModelTable`, `Accordion`, `ResourceGroupSection` and the rest — so this is a class of flake rather than one test. There was no `configure()` anywhere in the suite, so the 1 s default applied everywhere.

Five seconds still fails a genuinely broken assertion promptly rather than sitting out the 60 s `testTimeout`.

## Why now

This surfaced only after [#3524](https://github.com/OneUptime/oneuptime/pull/3524): until then every shard died of an OOM before it could report a test result, so the flake had nothing to fail in.