### PR TITLE
Make source map limits configurable and bound resolution by bytes

### DIFF
--- a/App/FeatureSet/Docs/Content/en/telemetry/source-maps.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/source-maps.md
@@ -58,7 +58,18 @@ Details:
 - Each uploaded file's bundle path is its file name with the trailing `.map` stripped — `main.a8f1b2.js.map` becomes `main.a8f1b2.js`. If your map file name does not follow that convention, upload one file per request and pass an explicit `bundlePath` field.
 - Re-uploading the same bundle for the same service and version replaces the previous map, so CI retries are safe.
 - Files must be [source map v3](https://tc39.es/ecma426/) JSON (which is what every modern bundler emits — indexed maps with `sections` are supported too).
-- Limits: each `.map` file may be up to 50 MB, but the ingress also caps the **whole request body** at 50 MB — so upload large maps one per request. Up to 50 files are accepted per request, and one release (service + version) can hold at most 100 maps in total; an upload that would exceed that is rejected.
+- Limits: each `.map` file may be up to 50 MB, but the ingress also caps the **whole request body** at 50 MB — so upload large maps one per request. Up to 50 files are accepted per request, and one release (service + version) can hold at most 1,000 maps in total; an upload that would exceed that is rejected with a message naming the limit. A build that emits more maps than one request accepts should simply send several requests — uploads for the same release accumulate.
+- Self-hosted installations can change these. All five are ordinary environment variables, and the Helm chart exposes them under `sourceMaps` in `values.yaml`:
+
+  | `values.yaml` | Environment variable | Default |
+  | --- | --- | --- |
+  | `sourceMaps.maxMapsPerRelease` | `SOURCE_MAP_MAX_MAPS_PER_RELEASE` | `1000` |
+  | `sourceMaps.maxFilesPerRequest` | `SOURCE_MAP_MAX_FILES_PER_REQUEST` | `50` |
+  | `sourceMaps.maxFileSizeBytes` | `SOURCE_MAP_MAX_FILE_SIZE_BYTES` | `52428800` |
+  | `sourceMaps.maxBytesPerResolve` | `SOURCE_MAP_MAX_BYTES_PER_RESOLVE` | `536870912` |
+  | `sourceMaps.retentionDays` | `SOURCE_MAP_RETENTION_DAYS` | `90` |
+
+  `maxMapsPerRelease` is the one to raise if your build outgrows the default; it is a storage-shape limit and nothing more, because resolution is bounded by `maxBytesPerResolve` rather than by how many maps a release holds. `maxFilesPerRequest` and `maxFileSizeBytes` can only be **lowered** — the multipart body is parsed before the request is authenticated, so the shared ceilings above them are what an unauthenticated caller is held to, and a larger value is narrowed rather than applied.
 - Build with `sourcesContent` included (the default for most bundlers) to get original source snippets around each resolved frame in the dashboard.
 - If your self-hosted operator has disabled telemetry ingestion (`DISABLE_TELEMETRY_INGESTION`), uploads return an empty success response and nothing is stored — the same behavior every telemetry ingest endpoint has in that mode. A successful upload always returns a JSON body listing the stored maps, so CI can assert on that.
 

--- a/App/FeatureSet/Telemetry/API/SourceMapIngest.ts
+++ b/App/FeatureSet/Telemetry/API/SourceMapIngest.ts
@@ -7,10 +7,22 @@ import Express, {
   NextFunction,
   RequestHandler,
 } from "Common/Server/Utils/Express";
-import MultipartFormDataMiddleware from "Common/Server/Middleware/MultipartFormData";
+import { getMultipartFormDataMiddleware } from "Common/Server/Middleware/MultipartFormData";
+import { SourceMapMaxFilesPerRequest } from "Common/Server/EnvironmentConfig";
 import SourceMapIngestService from "../Services/SourceMapIngestService";
 
 const router: ExpressRouter = Express.getRouter();
+
+/*
+ * Built once at module scope, not per request — each call constructs a multer
+ * instance. SOURCE_MAP_MAX_FILES_PER_REQUEST can only narrow the shared
+ * default, so this never widens the pre-auth parse that every route mounting
+ * the multipart middleware shares.
+ */
+const sourceMapMultipartMiddleware: RequestHandler =
+  getMultipartFormDataMiddleware({
+    maxFiles: SourceMapMaxFilesPerRequest,
+  });
 
 /*
  * Map Authorization: Bearer <token> to x-oneuptime-token so CI tools that
@@ -44,7 +56,7 @@ const mapBearerTokenMiddleware: RequestHandler = (
 router.post(
   "/source-maps/v1/upload",
   TelemetryIngestionDisabled.middleware,
-  MultipartFormDataMiddleware,
+  sourceMapMultipartMiddleware,
   mapBearerTokenMiddleware,
   TelemetryIngest.isAuthorizedServiceMiddleware,
   async (

--- a/App/FeatureSet/Telemetry/Services/SourceMapIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/SourceMapIngestService.ts
@@ -8,7 +8,7 @@ import TelemetrySourceMapService, {
 import SourceMapResolver, {
   MAX_SOURCE_MAP_SIZE_IN_BYTES,
 } from "Common/Server/Utils/Telemetry/SourceMapResolver";
-import { MAX_MULTIPART_FILES } from "Common/Server/Middleware/MultipartFormData";
+import { SourceMapMaxFilesPerRequest } from "Common/Server/EnvironmentConfig";
 import TelemetrySourceMap from "Common/Models/DatabaseModels/TelemetrySourceMap";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import ColumnLength from "Common/Types/Database/ColumnLength";
@@ -107,13 +107,13 @@ export default class SourceMapIngestService {
       }
 
       /*
-       * The multipart middleware already 413s past MAX_MULTIPART_FILES, so
-       * this branch is defense in depth — and the message states the real
-       * per-request limit rather than the (higher) per-release one.
+       * The multipart middleware already 413s past this count, so the branch
+       * is defense in depth — and the message states the real per-request
+       * limit rather than the (higher) per-release one.
        */
-      if (files.length > MAX_MULTIPART_FILES) {
+      if (files.length > SourceMapMaxFilesPerRequest) {
         throw new BadDataException(
-          `At most ${MAX_MULTIPART_FILES} source maps can be uploaded in one request. Split the upload across requests — up to ${MAX_SOURCE_MAPS_PER_RELEASE} maps are kept per release.`,
+          `At most ${SourceMapMaxFilesPerRequest} source maps can be uploaded in one request. Split the upload across requests — up to ${MAX_SOURCE_MAPS_PER_RELEASE} maps are kept per release.`,
         );
       }
 
@@ -216,9 +216,10 @@ export default class SourceMapIngestService {
 
       /*
        * Per-release ceiling: what is already stored, minus bundles this
-       * request replaces, plus this request's bundles must fit. Without
-       * this, maps past the resolver's read limit would store fine but
-       * silently never resolve.
+       * request replaces, plus this request's bundles must fit. This is a
+       * storage-shape limit the operator chooses, not a resolver constraint —
+       * resolveFramesForService bounds itself by bytes, so everything that
+       * fits this ceiling resolves.
        */
       const existingBundlePaths: Array<string> =
         await TelemetrySourceMapService.getStoredBundlePathsForRelease({
@@ -234,7 +235,7 @@ export default class SourceMapIngestService {
 
       if (bundlePathsAfterUpload.size > MAX_SOURCE_MAPS_PER_RELEASE) {
         throw new BadDataException(
-          `This release already has ${existingBundlePaths.length} source maps and this upload would take it past the limit of ${MAX_SOURCE_MAPS_PER_RELEASE} per release. Delete unused maps or use a new serviceVersion.`,
+          `This release already has ${existingBundlePaths.length} source maps and this upload would take it past the limit of ${MAX_SOURCE_MAPS_PER_RELEASE} per release. Delete unused maps, use a new serviceVersion, or raise SOURCE_MAP_MAX_MAPS_PER_RELEASE.`,
         );
       }
 

--- a/App/Tests/Telemetry/SourceMapIngestAPI.test.ts
+++ b/App/Tests/Telemetry/SourceMapIngestAPI.test.ts
@@ -52,14 +52,114 @@ jest.mock("Common/Server/Middleware/TelemetryIngestionDisabled", () => {
   };
 });
 
+/*
+ * The two source map knobs, read from the REAL config module rather than
+ * repeated as literals: this suite is about the route and the ingest service
+ * honouring whatever an operator configured, and
+ * Common/Tests/Server/Utils/Telemetry/SourceMapLimits.test.ts is what pins the
+ * numbers themselves.
+ */
+interface SourceMapConfigShape {
+  SourceMapMaxFilesPerRequest: number;
+  SourceMapMaxMapsPerRelease: number;
+}
+
+const realEnvironmentConfig: SourceMapConfigShape = jest.requireActual(
+  "Common/Server/EnvironmentConfig",
+) as SourceMapConfigShape;
+
+/*
+ * Both knobs are served through live accessors, so one file can cover several
+ * differently configured deployments. That works because the ingest service
+ * reads each constant at call time. The ROUTE reads the per-request one once,
+ * at import time, so reassigning these never re-mounts the middleware —
+ * SourceMapIngestRouteMultipart.test.ts covers that side.
+ */
+let mockMaxFilesPerRequest: number =
+  realEnvironmentConfig.SourceMapMaxFilesPerRequest;
+let mockMaxMapsPerRelease: number =
+  realEnvironmentConfig.SourceMapMaxMapsPerRelease;
+
+/*
+ * Only SOURCE_MAP_MAX_FILES_PER_REQUEST is replaced; every other export stays
+ * real, because SourceMapResolver — deliberately unmocked so content
+ * validation runs for real — reads its own size ceiling from this module.
+ *
+ * It has to be an accessor installed with defineProperty rather than a getter
+ * in an object literal: object spread compiles to Object.assign, which READS
+ * every accessor it copies and flattens it to whatever it returned at that
+ * moment.
+ */
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  const mocked: Record<string, unknown> = {
+    ...actual,
+    __esModule: true,
+  };
+
+  Object.defineProperty(mocked, "SourceMapMaxFilesPerRequest", {
+    get: (): number => {
+      return mockMaxFilesPerRequest;
+    },
+  });
+
+  return mocked;
+});
+
 const multipartMiddleware: unknown = jest.fn();
+
+/*
+ * Real value from the middleware: the shared ceiling every route that mounts
+ * the multipart parser is held to. Before this change it was ALSO the ingest
+ * service's per-request file guard.
+ */
+const MAX_MULTIPART_FILES: number = 50;
+
+interface MultipartMiddlewareBuild {
+  maxFiles: number;
+  middleware: unknown;
+}
+
+/*
+ * Every getMultipartFormDataMiddleware() call the route module made. A plain
+ * array rather than a jest.fn's call log: the route builds its middleware once,
+ * at import time, and the jest.clearAllMocks() in beforeEach would wipe that
+ * single call long before any test could read it.
+ */
+const multipartMiddlewareBuilds: Array<MultipartMiddlewareBuild> = [];
 
 jest.mock("Common/Server/Middleware/MultipartFormData", () => {
   return {
     __esModule: true,
     default: multipartMiddleware,
-    // Real value from the middleware — the per-request file guard uses it.
-    MAX_MULTIPART_FILES: 50,
+    MAX_MULTIPART_FILES: MAX_MULTIPART_FILES,
+    /*
+     * Mirrors the real builder closely enough that identity means the same
+     * thing here as in production: maxFiles is clamped into
+     * [1, MAX_MULTIPART_FILES], and a caller that narrows nothing gets the
+     * SHARED default instance back rather than a second multer.
+     */
+    getMultipartFormDataMiddleware: (options: {
+      maxFiles: number;
+    }): unknown => {
+      const clampedMaxFiles: number = Math.max(
+        1,
+        Math.min(options.maxFiles, MAX_MULTIPART_FILES),
+      );
+
+      const middleware: unknown =
+        clampedMaxFiles === MAX_MULTIPART_FILES ? multipartMiddleware : jest.fn();
+
+      multipartMiddlewareBuilds.push({
+        maxFiles: options.maxFiles,
+        middleware: middleware,
+      });
+
+      return middleware;
+    },
   };
 });
 
@@ -114,19 +214,36 @@ jest.mock("Common/Server/Services/OpenTelemetryIngestService", () => {
  * (no DB), so it is deliberately NOT mocked here.
  */
 jest.mock("Common/Server/Services/TelemetrySourceMapService", () => {
-  return {
+  const mocked: Record<string, unknown> = {
     __esModule: true,
     default: {
       replaceSourceMap: jest.fn(),
       getStoredBundlePathsForRelease: jest.fn(),
     },
-    MAX_SOURCE_MAPS_PER_RELEASE: 100,
   };
+
+  /*
+   * = SourceMapMaxMapsPerRelease in the real service, so it defaults to the
+   * shipped ceiling. A live accessor, so this file can also exercise a
+   * deployment that configured the ceiling LOWER — the only shape in which
+   * "re-upload every bundle this release holds" is a request small enough to
+   * send.
+   */
+  Object.defineProperty(mocked, "MAX_SOURCE_MAPS_PER_RELEASE", {
+    get: (): number => {
+      return mockMaxMapsPerRelease;
+    },
+  });
+
+  return mocked;
 });
 
 import Response from "Common/Server/Utils/Response";
 import OTelIngestService from "Common/Server/Services/OpenTelemetryIngestService";
-import TelemetrySourceMapService from "Common/Server/Services/TelemetrySourceMapService";
+import TelemetrySourceMapService, {
+  MAX_SOURCE_MAPS_PER_RELEASE,
+} from "Common/Server/Services/TelemetrySourceMapService";
+import { SourceMapMaxFilesPerRequest } from "Common/Server/EnvironmentConfig";
 import SourceMapIngestService from "../../FeatureSet/Telemetry/Services/SourceMapIngestService";
 // Importing the router module registers the routes on the mocked router.
 import "../../FeatureSet/Telemetry/API/SourceMapIngest";
@@ -171,6 +288,32 @@ const makeFile: MakeFileFunction = (
     originalname: originalname,
     buffer: Buffer.from(content ?? VALID_MAP, "utf8"),
   };
+};
+
+type BundlePathsFunction = (prefix: string, count: number) => Array<string>;
+
+/*
+ * `count` distinct bundle paths under one prefix — "chunk" for what a release
+ * already holds, "new" for what a request is adding. Route-split builds are
+ * exactly this shape, and the prefix is what keeps "replaces an existing
+ * bundle" and "adds a bundle" unambiguous in the per-release arithmetic.
+ */
+const bundlePaths: BundlePathsFunction = (
+  prefix: string,
+  count: number,
+): Array<string> => {
+  return Array.from({ length: count }, (_: unknown, index: number): string => {
+    return `${prefix}-${index}.js`;
+  });
+};
+
+type FilesForFunction = (paths: Array<string>) => Array<FilePart>;
+
+// The upload parts a CI job would send for those bundles: <bundlePath>.map.
+const filesFor: FilesForFunction = (paths: Array<string>): Array<FilePart> => {
+  return paths.map((path: string): FilePart => {
+    return makeFile(`${path}.map`);
+  });
 };
 
 type MakeRequestFunction = (data: {
@@ -227,6 +370,13 @@ const invokeHandler: InvokeHandlerFunction = async (
 beforeEach(() => {
   jest.clearAllMocks();
 
+  /*
+   * Back to the shipped configuration: a case that moves a knob is describing
+   * a different deployment, and must not leak that into the next one.
+   */
+  mockMaxFilesPerRequest = realEnvironmentConfig.SourceMapMaxFilesPerRequest;
+  mockMaxMapsPerRelease = realEnvironmentConfig.SourceMapMaxMapsPerRelease;
+
   telemetryServiceFromNameMock.mockResolvedValue({
     serviceName: "my-web-app",
     primaryEntityId: SERVICE_ID,
@@ -253,6 +403,46 @@ describe("route registration", () => {
     expect(handlers[1]).toBe(multipartMiddleware);
     // handlers[2] is the local bearer-token adapter (asserted behaviourally below)
     expect(handlers[3]).toBe(authMiddleware);
+  });
+
+  test("the mounted multipart middleware is built from SOURCE_MAP_MAX_FILES_PER_REQUEST", () => {
+    /*
+     * The route asks the middleware module for an instance sized to the knob
+     * instead of mounting the shared default export directly. At the shipped
+     * default the builder hands that very instance back — so what matters here
+     * is that the knob is what was passed, because that is what makes lowering
+     * it narrow the mount. SourceMapIngestRouteMultipart.test.ts loads the
+     * route at other values and asserts the mount actually changes.
+     */
+    expect(multipartMiddlewareBuilds).toHaveLength(1);
+    expect(multipartMiddlewareBuilds[0]!.maxFiles).toBe(
+      realEnvironmentConfig.SourceMapMaxFilesPerRequest,
+    );
+    expect(registeredPostHandlers[UPLOAD_ROUTE]![1]).toBe(
+      multipartMiddlewareBuilds[0]!.middleware,
+    );
+  });
+
+  test("the multipart middleware is built once at module load, not per request", async () => {
+    /*
+     * Every build constructs a multer instance. Building it inside the request
+     * handler would allocate one per upload, which is why the route hoists the
+     * call to module scope.
+     */
+    await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: [makeFile("main.js.map")],
+      }),
+    );
+    await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: [makeFile("vendor.js.map")],
+      }),
+    );
+
+    expect(multipartMiddlewareBuilds).toHaveLength(1);
   });
 
   test("the bearer adapter copies Authorization: Bearer into x-oneuptime-token", () => {
@@ -366,11 +556,9 @@ describe("uploadSourceMaps", () => {
   });
 
   test("rejects an upload that would take the release past the per-release map limit", async () => {
-    // 100 distinct bundles already stored; this upload adds a new one.
+    // A release already at the ceiling; this upload adds a new bundle.
     getStoredBundlePathsMock.mockResolvedValue(
-      Array.from({ length: 100 }, (_: unknown, i: number) => {
-        return `chunk-${i}.js`;
-      }) as never,
+      bundlePaths("chunk", MAX_SOURCE_MAPS_PER_RELEASE) as never,
     );
 
     const error: Error | null = await invokeHandler(
@@ -386,11 +574,13 @@ describe("uploadSourceMaps", () => {
 
   test("replacing an already-stored bundle does not count against the per-release limit", async () => {
     // At the limit, but the upload replaces an existing bundle.
-    getStoredBundlePathsMock.mockResolvedValue(
-      Array.from({ length: 100 }, (_: unknown, i: number) => {
-        return i === 0 ? "main.abc123.js" : `chunk-${i}.js`;
-      }) as never,
+    const storedPaths: Array<string> = bundlePaths(
+      "chunk",
+      MAX_SOURCE_MAPS_PER_RELEASE,
     );
+    storedPaths[0] = "main.abc123.js";
+
+    getStoredBundlePathsMock.mockResolvedValue(storedPaths as never);
 
     const error: Error | null = await invokeHandler(
       makeRequest({
@@ -513,6 +703,330 @@ describe("uploadSourceMaps", () => {
     );
 
     expect(error).toBeInstanceOf(BadDataException);
+  });
+});
+
+/*
+ * The per-request file cap.
+ *
+ * It used to be MAX_MULTIPART_FILES — the shared multipart ceiling every route
+ * that parses a multipart body is held to. It is SOURCE_MAP_MAX_FILES_PER_REQUEST
+ * now. The two are the same number by default (the knob is clamped to that
+ * ceiling and can only be lowered), so the boundary cases below pin the edge at
+ * the knob's value and the lowered case is what proves WHICH of the two the
+ * service reads.
+ */
+describe("per-request file cap", () => {
+  test("accepts exactly SOURCE_MAP_MAX_FILES_PER_REQUEST files in one request", async () => {
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("chunk", SourceMapMaxFilesPerRequest)),
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(
+      SourceMapMaxFilesPerRequest,
+    );
+  });
+
+  test("rejects one file more than SOURCE_MAP_MAX_FILES_PER_REQUEST", async () => {
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("chunk", SourceMapMaxFilesPerRequest + 1)),
+      }),
+    );
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(replaceSourceMapMock).not.toHaveBeenCalled();
+  });
+
+  test("the rejection names the per-request limit and the per-release one, so splitting the upload reads as the fix", async () => {
+    /*
+     * These are different numbers now — 50 per request, a thousand per release
+     * — and a message that quoted only one of them would read as "your release
+     * is full" for a CI job that simply sent too many files at once.
+     */
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("chunk", SourceMapMaxFilesPerRequest + 1)),
+      }),
+    );
+
+    const message: string = (error as BadDataException).message;
+
+    expect(message).toContain(
+      `At most ${SourceMapMaxFilesPerRequest} source maps can be uploaded in one request.`,
+    );
+    expect(message).toContain("Split the upload across requests");
+    expect(message).toContain(
+      `up to ${MAX_SOURCE_MAPS_PER_RELEASE} maps are kept per release.`,
+    );
+  });
+
+  test("an over-sized request is rejected before any service lookup, so it costs no database work", async () => {
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("chunk", SourceMapMaxFilesPerRequest + 1)),
+      }),
+    );
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(telemetryServiceFromNameMock).not.toHaveBeenCalled();
+    expect(getStoredBundlePathsMock).not.toHaveBeenCalled();
+  });
+
+  test("a lowered SOURCE_MAP_MAX_FILES_PER_REQUEST caps the request, not the shared multipart ceiling", async () => {
+    /*
+     * The regression this guards: six files is comfortably under
+     * MAX_MULTIPART_FILES, which is what the guard used to read, so an operator
+     * who narrowed the knob would have seen it ignored.
+     */
+    mockMaxFilesPerRequest = 5;
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("chunk", 6)),
+      }),
+    );
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect((error as BadDataException).message).toContain(
+      "At most 5 source maps can be uploaded in one request.",
+    );
+    expect(replaceSourceMapMock).not.toHaveBeenCalled();
+  });
+
+  test("a lowered SOURCE_MAP_MAX_FILES_PER_REQUEST still accepts a request exactly at it", async () => {
+    mockMaxFilesPerRequest = 5;
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("chunk", 5)),
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(5);
+  });
+
+  test("the per-request cap does not cap the release: a later request tops the same release up past it", async () => {
+    /*
+     * "Split the upload across requests" has to actually work, which it only
+     * does because the per-request cap and the per-release ceiling are separate
+     * limits.
+     */
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", SourceMapMaxFilesPerRequest) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("later", SourceMapMaxFilesPerRequest)),
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(
+      SourceMapMaxFilesPerRequest,
+    );
+  });
+});
+
+/*
+ * The per-release ceiling.
+ *
+ * It was a hardcoded 100 that also bounded what the resolver would READ, so it
+ * could not safely be raised: more stored maps than the reader would look at
+ * meant maps that uploaded fine and then silently never resolved. It is an
+ * operator knob with a far higher default now, and a byte budget bounds the
+ * read path instead — so the arithmetic below is the whole of what decides
+ * whether a route-split build's CI upload succeeds.
+ */
+describe("per-release ceiling", () => {
+  test("a release holding the old hardcoded 100 maps now accepts more", async () => {
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", 100) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: [makeFile("brand-new.js.map")],
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a release one under the ceiling accepts one more bundle", async () => {
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", MAX_SOURCE_MAPS_PER_RELEASE - 1) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: [makeFile("brand-new.js.map")],
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("stored plus new that lands exactly on the ceiling is accepted", async () => {
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", MAX_SOURCE_MAPS_PER_RELEASE - 10) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("new", 10)),
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(10);
+  });
+
+  test("one bundle past the ceiling is rejected, and nothing from that request is stored", async () => {
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", MAX_SOURCE_MAPS_PER_RELEASE - 10) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(bundlePaths("new", 11)),
+      }),
+    );
+
+    expect(error).toBeInstanceOf(BadDataException);
+    // The ten that would have fit are not written either — the gate is all or nothing.
+    expect(replaceSourceMapMock).not.toHaveBeenCalled();
+  });
+
+  test("re-uploading bundles the release already holds does not count them twice", async () => {
+    /*
+     * The common case for a rebuild of an unchanged release: at the ceiling,
+     * every file in the request replaces a stored bundle, so the release's
+     * distinct-bundle count does not move.
+     */
+    const storedPaths: Array<string> = bundlePaths(
+      "chunk",
+      MAX_SOURCE_MAPS_PER_RELEASE,
+    );
+    getStoredBundlePathsMock.mockResolvedValue(storedPaths as never);
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(storedPaths.slice(0, SourceMapMaxFilesPerRequest)),
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(
+      SourceMapMaxFilesPerRequest,
+    );
+  });
+
+  test("a request that mixes replacements with one new bundle is rejected at the ceiling", async () => {
+    const storedPaths: Array<string> = bundlePaths(
+      "chunk",
+      MAX_SOURCE_MAPS_PER_RELEASE,
+    );
+    getStoredBundlePathsMock.mockResolvedValue(storedPaths as never);
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor([...storedPaths.slice(0, 9), "brand-new.js"]),
+      }),
+    );
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(replaceSourceMapMock).not.toHaveBeenCalled();
+  });
+
+  test("at a lower configured ceiling, re-uploading every stored bundle still succeeds", async () => {
+    // Small enough that "every bundle this release holds" fits in one request.
+    mockMaxMapsPerRelease = 3;
+
+    const storedPaths: Array<string> = bundlePaths("chunk", 3);
+    getStoredBundlePathsMock.mockResolvedValue(storedPaths as never);
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: filesFor(storedPaths),
+      }),
+    );
+
+    expect(error).toBeNull();
+    expect(replaceSourceMapMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("at a lower configured ceiling, one bundle past it is rejected", async () => {
+    mockMaxMapsPerRelease = 3;
+
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", 3) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: [makeFile("brand-new.js.map")],
+      }),
+    );
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect((error as BadDataException).message).toContain(
+      "past the limit of 3 per release",
+    );
+  });
+
+  test("the rejection names the env var an operator raises to make room", async () => {
+    /*
+     * The ceiling is configuration now, so the 400 has to say so — otherwise
+     * the only readings left are "delete maps" and "this product cannot hold
+     * my build", neither of which is true.
+     */
+    getStoredBundlePathsMock.mockResolvedValue(
+      bundlePaths("chunk", MAX_SOURCE_MAPS_PER_RELEASE) as never,
+    );
+
+    const error: Error | null = await invokeHandler(
+      makeRequest({
+        body: { serviceName: "my-web-app", serviceVersion: "1.4.2" },
+        files: [makeFile("brand-new.js.map")],
+      }),
+    );
+
+    const message: string = (error as BadDataException).message;
+
+    expect(message).toContain(
+      `This release already has ${MAX_SOURCE_MAPS_PER_RELEASE} source maps`,
+    );
+    expect(message).toContain(
+      `past the limit of ${MAX_SOURCE_MAPS_PER_RELEASE} per release.`,
+    );
+    expect(
+      message.endsWith(
+        "Delete unused maps, use a new serviceVersion, or raise SOURCE_MAP_MAX_MAPS_PER_RELEASE.",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/App/Tests/Telemetry/SourceMapIngestRouteMultipart.test.ts
+++ b/App/Tests/Telemetry/SourceMapIngestRouteMultipart.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * What the source map upload route mounts for multipart parsing.
+ *
+ * It used to mount the SHARED middleware — the module's default export, one
+ * multer instance every route that parses a multipart body shares. It now
+ * mounts one built for SOURCE_MAP_MAX_FILES_PER_REQUEST, so an operator who
+ * lowers that knob narrows what multer will accept on this route.
+ *
+ * The direction is the whole point: the parse runs BEFORE the route's auth
+ * check, so the shared ceiling is the limit an unauthenticated caller is held
+ * to across every route that mounts it. A per-route knob that could raise it
+ * would widen that surface, so the builder clamps and the route can only
+ * narrow.
+ *
+ * The route reads the knob once, at module load, so each case here loads the
+ * module afresh inside jest.isolateModules with a different configured value.
+ */
+
+// Router-capture pattern, as in SourceMapIngestAPI.test.ts.
+let registeredPostHandlers: Record<string, Array<unknown>> = {};
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: () => {
+        return {
+          post: (uri: string, ...handlers: Array<unknown>) => {
+            registeredPostHandlers[uri] = handlers;
+          },
+        };
+      },
+    },
+  };
+});
+
+const authMiddleware: unknown = jest.fn();
+
+jest.mock("Common/Server/Middleware/TelemetryIngest", () => {
+  return {
+    __esModule: true,
+    default: {
+      isAuthorizedServiceMiddleware: authMiddleware,
+    },
+  };
+});
+
+const ingestionDisabledMiddleware: unknown = jest.fn();
+
+jest.mock("Common/Server/Middleware/TelemetryIngestionDisabled", () => {
+  return {
+    __esModule: true,
+    default: {
+      middleware: ingestionDisabledMiddleware,
+      isDisabled: jest.fn().mockReturnValue(false),
+    },
+  };
+});
+
+interface MultipartModuleShape {
+  default: unknown;
+  MAX_MULTIPART_FILES: number;
+  getMultipartFormDataMiddleware: (options: { maxFiles: number }) => unknown;
+}
+
+/*
+ * The REAL middleware module, not a hand-written stand-in.
+ *
+ * A local re-implementation of the clamp would make every "cannot widen"
+ * assertion below a statement about this file rather than about the shipped
+ * builder: it would keep passing if the real clamp were deleted, and it would
+ * have to be kept in step with it by hand. Delegating means the clamp under
+ * test is the one that ships, and the shared instance these tests compare
+ * against by identity is the actual default export the other routes mount.
+ *
+ * Safe to pull in here even though this file mocks Common/Server/Utils/Express:
+ * MultipartFormData uses that module for types only, so the import is erased
+ * and the real multer instances it builds are never driven by this suite.
+ */
+const actualMultipartModule: MultipartModuleShape = jest.requireActual(
+  "Common/Server/Middleware/MultipartFormData",
+) as MultipartModuleShape;
+
+/* The shared ceiling the builder clamps to, read rather than repeated. */
+const MAX_MULTIPART_FILES: number = actualMultipartModule.MAX_MULTIPART_FILES;
+
+/*
+ * The module's default export — the ONE shared instance every route that
+ * parses a multipart body mounts. Every assertion below about "the shared
+ * middleware" is an identity check against it, which is exactly what the real
+ * builder's fast path returns.
+ */
+const sharedMultipartMiddleware: unknown = actualMultipartModule.default;
+
+interface MultipartMiddlewareBuild {
+  maxFiles: number;
+  middleware: unknown;
+}
+
+const multipartMiddlewareBuilds: Array<MultipartMiddlewareBuild> = [];
+
+jest.mock("Common/Server/Middleware/MultipartFormData", () => {
+  return {
+    __esModule: true,
+    default: sharedMultipartMiddleware,
+    MAX_MULTIPART_FILES: MAX_MULTIPART_FILES,
+    /*
+     * Pass-through to the real builder, recording what the route asked for.
+     * The clamp, and the fast path that returns the shared instance, are the
+     * shipped ones.
+     */
+    getMultipartFormDataMiddleware: (options: {
+      maxFiles: number;
+    }): unknown => {
+      const middleware: unknown =
+        actualMultipartModule.getMultipartFormDataMiddleware(options);
+
+      multipartMiddlewareBuilds.push({
+        maxFiles: options.maxFiles,
+        middleware: middleware,
+      });
+
+      return middleware;
+    },
+  };
+});
+
+let mockMaxFilesPerRequest: number = MAX_MULTIPART_FILES;
+
+/*
+ * A minimal stand-in rather than a spread of the real module: with the ingest
+ * service mocked below, SOURCE_MAP_MAX_FILES_PER_REQUEST is the only export
+ * anything in this graph reads.
+ */
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  const mocked: Record<string, unknown> = {
+    __esModule: true,
+  };
+
+  Object.defineProperty(mocked, "SourceMapMaxFilesPerRequest", {
+    get: (): number => {
+      return mockMaxFilesPerRequest;
+    },
+  });
+
+  return mocked;
+});
+
+/*
+ * Mocked so loading the route does not drag in the database-backed service
+ * graph. This file is about the middleware chain the route mounts; what the
+ * terminal handler does with a request is SourceMapIngestAPI.test.ts's job.
+ */
+jest.mock("../../FeatureSet/Telemetry/Services/SourceMapIngestService", () => {
+  return {
+    __esModule: true,
+    default: {
+      uploadSourceMaps: jest.fn(),
+    },
+  };
+});
+
+const UPLOAD_ROUTE: string = "/source-maps/v1/upload";
+
+type LoadRouteFunction = (maxFilesPerRequest: number) => Array<unknown>;
+
+/*
+ * Loads the route module with SOURCE_MAP_MAX_FILES_PER_REQUEST configured to
+ * `maxFilesPerRequest` and returns the middleware chain it mounted.
+ * isolateModules gives the require a private module registry, so the module
+ * body — where the knob is read and the middleware built — runs again per case
+ * instead of being served from cache.
+ */
+const loadRoute: LoadRouteFunction = (
+  maxFilesPerRequest: number,
+): Array<unknown> => {
+  mockMaxFilesPerRequest = maxFilesPerRequest;
+  multipartMiddlewareBuilds.length = 0;
+  registeredPostHandlers = {};
+
+  jest.isolateModules(() => {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../../FeatureSet/Telemetry/API/SourceMapIngest");
+    /* eslint-enable @typescript-eslint/no-var-requires */
+  });
+
+  return registeredPostHandlers[UPLOAD_ROUTE]!;
+};
+
+describe("POST /source-maps/v1/upload multipart mount", () => {
+  test("mounts a middleware built from SOURCE_MAP_MAX_FILES_PER_REQUEST rather than the shared default export", () => {
+    const handlers: Array<unknown> = loadRoute(10);
+
+    expect(multipartMiddlewareBuilds).toHaveLength(1);
+    expect(multipartMiddlewareBuilds[0]!.maxFiles).toBe(10);
+    expect(handlers[1]).toBe(multipartMiddlewareBuilds[0]!.middleware);
+    expect(handlers[1]).not.toBe(sharedMultipartMiddleware);
+  });
+
+  test("a narrowed route mounts the shared default export nowhere in its chain", () => {
+    const handlers: Array<unknown> = loadRoute(1);
+
+    expect(handlers).not.toContain(sharedMultipartMiddleware);
+  });
+
+  test("at the shipped default the knob resolves to the shared instance, so no second multer is built", () => {
+    /*
+     * SOURCE_MAP_MAX_FILES_PER_REQUEST defaults to the shared ceiling. Going
+     * through the builder still matters — it is what makes lowering the knob
+     * take effect — but at the default it must not cost a duplicate multer,
+     * because every instance buffers uploads in this process's memory.
+     */
+    const handlers: Array<unknown> = loadRoute(MAX_MULTIPART_FILES);
+
+    expect(multipartMiddlewareBuilds).toHaveLength(1);
+    expect(multipartMiddlewareBuilds[0]!.maxFiles).toBe(MAX_MULTIPART_FILES);
+    /*
+     * Both halves matter. The first says the mounted handler is what the
+     * builder returned — without it this passes just as well for a route that
+     * mounted the default export directly and never called the builder at
+     * all. The second says what the builder returned at the default IS the
+     * shared instance.
+     */
+    expect(handlers[1]).toBe(multipartMiddlewareBuilds[0]!.middleware);
+    expect(handlers[1]).toBe(sharedMultipartMiddleware);
+  });
+
+  test("a knob set above the shared ceiling cannot widen this route's pre-auth parse", () => {
+    /*
+     * EnvironmentConfig already clamps the knob, so this is the second of two
+     * clamps. It is the one that holds if the config ever stops clamping: the
+     * parse runs before authentication, so widening it here would widen what an
+     * unauthenticated caller can make the process buffer.
+     */
+    const handlers: Array<unknown> = loadRoute(MAX_MULTIPART_FILES * 100);
+
+    /*
+     * The route handed the builder the raw, over-ceiling value — it does no
+     * clamping of its own — and the builder is what refused to widen. Pinning
+     * both is what stops this reading as a pass for a route that quietly
+     * mounted the shared export without consulting the knob at all.
+     */
+    expect(multipartMiddlewareBuilds).toHaveLength(1);
+    expect(multipartMiddlewareBuilds[0]!.maxFiles).toBe(
+      MAX_MULTIPART_FILES * 100,
+    );
+    expect(handlers[1]).toBe(multipartMiddlewareBuilds[0]!.middleware);
+    expect(handlers[1]).toBe(sharedMultipartMiddleware);
+  });
+
+  test("builds exactly one middleware per module load", () => {
+    // Each build constructs a multer instance, so the route hoists the call.
+    loadRoute(10);
+
+    expect(multipartMiddlewareBuilds).toHaveLength(1);
+  });
+
+  test("the narrowed parse still sits between the ingestion-disabled gate and the auth check", () => {
+    /*
+     * Order is what makes the clamp necessary in the first place: multipart
+     * parsing happens before isAuthorizedServiceMiddleware, so swapping in a
+     * per-route instance must not move it later (which would parse
+     * unauthenticated bodies with different limits than the gate expects) or
+     * earlier than the disabled gate (which would parse for a project that has
+     * ingestion switched off).
+     */
+    const handlers: Array<unknown> = loadRoute(10);
+
+    expect(handlers).toHaveLength(5);
+    expect(handlers[0]).toBe(ingestionDisabledMiddleware);
+    expect(handlers[1]).toBe(multipartMiddlewareBuilds[0]!.middleware);
+    expect(handlers[3]).toBe(authMiddleware);
+  });
+});

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -14,7 +14,9 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import TelemetryType from "../../Types/Telemetry/TelemetryType";
 import TelemetryAttributeService from "../Services/TelemetryAttributeService";
 import TelemetrySourceMapService from "../Services/TelemetrySourceMapService";
-import SourceMapResolver from "../Utils/Telemetry/SourceMapResolver";
+import SourceMapResolver, {
+  MAX_FRAMES_PER_RESOLVE_REQUEST,
+} from "../Utils/Telemetry/SourceMapResolver";
 import {
   MinifiedStackFrame,
   ResolveStackTraceResult,
@@ -361,6 +363,24 @@ router.post(
           req,
           res,
           new BadDataException("frames must be an array of stack frames"),
+        );
+      }
+
+      /*
+       * Bound the array before sanitizing it. sanitizeMinifiedStackFrames
+       * never throws and never truncates, so without this the only limit on
+       * the work a caller can ask for is the body-size cap.
+       */
+      if (
+        (body["frames"] as Array<unknown>).length >
+        MAX_FRAMES_PER_RESOLVE_REQUEST
+      ) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException(
+            `frames must contain at most ${MAX_FRAMES_PER_RESOLVE_REQUEST} stack frames.`,
+          ),
         );
       }
 

--- a/Common/Server/EnvironmentConfig.ts
+++ b/Common/Server/EnvironmentConfig.ts
@@ -15,6 +15,7 @@ import Route from "../Types/API/Route";
 import SubscriptionPlan from "../Types/Billing/SubscriptionPlan";
 import Email from "../Types/Email";
 import { JSONObject } from "../Types/JSON";
+import LIMIT_MAX from "../Types/Database/LimitMax";
 import ObjectID from "../Types/ObjectID";
 import Port from "../Types/Port";
 import Hostname from "../Types/API/Hostname";
@@ -128,6 +129,20 @@ const parsePositiveIntegerFromEnv: (
   }
 
   return parsedValue;
+};
+
+/*
+ * parsePositiveIntegerFromEnv with a ceiling the rest of the system can
+ * actually honour. A configured value the app would silently fail to enforce
+ * is worse than a visibly clamped one -- so this clamps rather than trusting
+ * the operator, and every call site documents WHY its ceiling exists.
+ */
+const parseClampedIntegerFromEnv: (
+  envKey: string,
+  fallback: number,
+  ceiling: number,
+) => number = (envKey: string, fallback: number, ceiling: number): number => {
+  return Math.min(parsePositiveIntegerFromEnv(envKey, fallback), ceiling);
 };
 
 export const IsBillingEnabled: boolean = BillingConfig.IsBillingEnabled;
@@ -862,6 +877,103 @@ export const OnCallCalendarFeedRateLimitPerIpPerWindow: number =
     "ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_IP_PER_WINDOW",
     3000,
   );
+
+/*
+ * Source map ingestion and resolution limits.
+ *
+ * These were fixed constants, sized on the assumption that "a build rarely
+ * emits more than a few dozen chunks with maps". That assumption does not
+ * survive route-level code splitting: a Nuxt/Vite/Next app with a hundred
+ * routes emits hundreds of chunk .map files per release, and the maps that
+ * did not fit simply never resolved. They are operator knobs now, and the
+ * Helm chart exposes each one.
+ *
+ * The division of labour matters, because it is what makes raising the
+ * ceiling safe:
+ *
+ *   - SourceMapMaxMapsPerRelease is purely a WRITE gate. An upload past it is
+ *     rejected with a 400 that names the limit. It is no longer the
+ *     resolver's read limit, so raising it can never turn stored maps into
+ *     maps that store fine and then silently never resolve.
+ *   - SourceMapMaxBytesPerResolve is what bounds the READ path. Resolution
+ *     loads whole maps into memory, so a byte budget -- not a row count -- is
+ *     the invariant that actually protects the process.
+ */
+
+/*
+ * Distinct bundles one (project, service, release) may hold.
+ *
+ * Clamped to LIMIT_MAX because the gate reads the release's existing bundle
+ * paths with LIMIT_MAX; a configured value above that could not be enforced
+ * and would be a lie.
+ */
+export const SourceMapMaxMapsPerRelease: number = parseClampedIntegerFromEnv(
+  "SOURCE_MAP_MAX_MAPS_PER_RELEASE",
+  1000,
+  LIMIT_MAX,
+);
+
+/*
+ * How long uploaded maps are kept. A map is only useful while exceptions from
+ * its release are still within telemetry retention, and the default
+ * comfortably exceeds it.
+ */
+export const SourceMapRetentionInDays: number = parsePositiveIntegerFromEnv(
+  "SOURCE_MAP_RETENTION_DAYS",
+  90,
+);
+
+/*
+ * Hard ceiling on ONE map, enforced on the raw upload and again on the
+ * decoded string.
+ *
+ * The ceiling is MAX_MULTIPART_FILE_BYTES from
+ * Common/Server/Middleware/MultipartFormData.ts, repeated as a literal
+ * because that module pulls in multer and express and has no business being
+ * imported by config. The two are pinned to each other by
+ * Common/Tests/Server/Utils/Telemetry/SourceMapLimits.test.ts. Configuring
+ * past it would not raise anything: multer aborts the request first, turning
+ * the 400 this ceiling is meant to give into a confusing 413.
+ */
+export const SourceMapMaxFileSizeInBytes: number = parseClampedIntegerFromEnv(
+  "SOURCE_MAP_MAX_FILE_SIZE_BYTES",
+  50 * 1024 * 1024,
+  50 * 1024 * 1024,
+);
+
+/*
+ * Source map files accepted in ONE upload request.
+ *
+ * Separate from the per-release ceiling: a release may hold far more maps
+ * than any single request may carry, and CI splits the upload. Clamped to
+ * MAX_MULTIPART_FILES, which is the shared middleware default and runs
+ * BEFORE authentication on every route that mounts it -- so this knob only
+ * ever narrows the source map route, never widens the pre-auth surface that
+ * Pyroscope and inbound email sit behind.
+ */
+export const SourceMapMaxFilesPerRequest: number = parseClampedIntegerFromEnv(
+  "SOURCE_MAP_MAX_FILES_PER_REQUEST",
+  50,
+  50,
+);
+
+/*
+ * Total map bytes one resolve request may pull into memory.
+ *
+ * This is the bound that used to be implied by the per-release count, and it
+ * is a much tighter one: resolution materialises whole maps, each up to
+ * SourceMapMaxFileSizeInBytes, and the set it loads is chosen by a
+ * caller-supplied frames array. Maps that do not fit the budget are skipped
+ * in match-quality order and REPORTED on the response, so a skip is visible
+ * rather than looking like "no map was uploaded".
+ *
+ * 512 MiB is roughly ten maps at the per-file ceiling, or every map of a
+ * realistically sized release many times over.
+ */
+export const SourceMapMaxBytesPerResolve: number = parsePositiveIntegerFromEnv(
+  "SOURCE_MAP_MAX_BYTES_PER_RESOLVE",
+  512 * 1024 * 1024,
+);
 
 export const EnableProfiling: boolean =
   process.env["ENABLE_PROFILING"] === "true";

--- a/Common/Server/Middleware/MultipartFormData.ts
+++ b/Common/Server/Middleware/MultipartFormData.ts
@@ -32,6 +32,29 @@ export const MAX_MULTIPART_FILES: number = 50;
 export const MAX_MULTIPART_FIELDS: number = 200;
 
 /*
+ * busboy's SIZE limits and its `parts` counter are EXCLUSIVE: each fires
+ * the moment the counter REACHES the limit, so handing it N admits only
+ * N-1. Its `files` and `fields` counters are INCLUSIVE -- N admits N.
+ *
+ * That asymmetry is undocumented and easy to lose, so the constants above
+ * stay the INCLUSIVE maxima this app documents and that callers
+ * range-check against (`file.buffer.length > MAX_SOURCE_MAP_SIZE_IN_BYTES`
+ * and friends), and only the three exclusive limits are converted here.
+ *
+ * Both halves of this were live bugs. A file of exactly 50 MiB -- a size
+ * the source map endpoint means to accept, and whose 400 message says it
+ * accepts -- was truncated by the parser into a 413 the endpoint never
+ * saw. And `parts`, whose whole job is to allow the file and field
+ * allowances in full, rejected a body carrying exactly both with
+ * LIMIT_PART_COUNT.
+ */
+const exclusive: (inclusiveMax: number) => number = (
+  inclusiveMax: number,
+): number => {
+  return inclusiveMax + 1;
+};
+
+/*
  * Configure multer for handling multipart/form-data
  * Uses memory storage to store files in memory as Buffer objects
  */
@@ -41,15 +64,15 @@ const buildUploadAny: (maxFiles: number) => RequestHandler = (
   const upload: multer.Multer = multer({
     storage: multer.memoryStorage(),
     limits: {
-      fileSize: MAX_MULTIPART_FILE_BYTES,
-      fieldSize: MAX_MULTIPART_FIELD_BYTES,
+      fileSize: exclusive(MAX_MULTIPART_FILE_BYTES),
+      fieldSize: exclusive(MAX_MULTIPART_FIELD_BYTES),
       files: maxFiles,
       fields: MAX_MULTIPART_FIELDS,
       /*
        * Parts are files + fields, so this has to allow both in full or it
        * would be the effective limit and the two above would never fire.
        */
-      parts: maxFiles + MAX_MULTIPART_FIELDS,
+      parts: exclusive(maxFiles + MAX_MULTIPART_FIELDS),
     },
   });
 

--- a/Common/Server/Middleware/MultipartFormData.ts
+++ b/Common/Server/Middleware/MultipartFormData.ts
@@ -35,22 +35,28 @@ export const MAX_MULTIPART_FIELDS: number = 200;
  * Configure multer for handling multipart/form-data
  * Uses memory storage to store files in memory as Buffer objects
  */
-const upload: multer.Multer = multer({
-  storage: multer.memoryStorage(),
-  limits: {
-    fileSize: MAX_MULTIPART_FILE_BYTES,
-    fieldSize: MAX_MULTIPART_FIELD_BYTES,
-    files: MAX_MULTIPART_FILES,
-    fields: MAX_MULTIPART_FIELDS,
-    /*
-     * Parts are files + fields, so this has to allow both in full or it
-     * would be the effective limit and the two above would never fire.
-     */
-    parts: MAX_MULTIPART_FILES + MAX_MULTIPART_FIELDS,
-  },
-});
+const buildUploadAny: (maxFiles: number) => RequestHandler = (
+  maxFiles: number,
+): RequestHandler => {
+  const upload: multer.Multer = multer({
+    storage: multer.memoryStorage(),
+    limits: {
+      fileSize: MAX_MULTIPART_FILE_BYTES,
+      fieldSize: MAX_MULTIPART_FIELD_BYTES,
+      files: maxFiles,
+      fields: MAX_MULTIPART_FIELDS,
+      /*
+       * Parts are files + fields, so this has to allow both in full or it
+       * would be the effective limit and the two above would never fire.
+       */
+      parts: maxFiles + MAX_MULTIPART_FIELDS,
+    },
+  });
 
-const uploadAny: RequestHandler = upload.any() as unknown as RequestHandler;
+  return upload.any() as unknown as RequestHandler;
+};
+
+const uploadAny: RequestHandler = buildUploadAny(MAX_MULTIPART_FILES);
 
 /*
  * The LIMIT_* codes that mean "you sent too much". LIMIT_UNEXPECTED_FILE
@@ -69,14 +75,32 @@ const TOO_LARGE_CODES: Set<string> = new Set<string>([
 ]);
 
 /*
+ * A limit breach must answer 413 rather than 500. multer signals every limit
+ * with a MulterError whose `code` is one of the LIMIT_* values, and nothing
+ * downstream knows what those mean - the generic error handler would turn a
+ * caller's oversized upload into a server error and page whoever is on call
+ * for it. Shared by every middleware this module builds.
+ */
+const handleMulterError: (err: unknown, next: NextFunction) => void = (
+  err: unknown,
+  next: NextFunction,
+): void => {
+  if (err instanceof multer.MulterError) {
+    const message: string = `Multipart request rejected: ${err.code}.`;
+
+    return next(
+      TOO_LARGE_CODES.has(err.code)
+        ? new PayloadTooLargeException(message)
+        : new BadRequestException(message),
+    );
+  }
+
+  return next(err);
+};
+
+/*
  * Middleware for handling any file uploads (multipart/form-data)
  * This is useful for webhooks that send data as multipart/form-data (e.g., SendGrid inbound email)
- *
- * Wrapped so a limit breach answers 413 rather than 500. multer signals
- * every limit with a MulterError whose `code` is one of the LIMIT_*
- * values, and nothing downstream knows what those mean - the generic
- * error handler would turn a caller's oversized upload into a server
- * error and page whoever is on call for it.
  */
 const MultipartFormDataMiddleware: RequestHandler = (
   req: ExpressRequest,
@@ -84,18 +108,57 @@ const MultipartFormDataMiddleware: RequestHandler = (
   next: NextFunction,
 ): void => {
   uploadAny(req, res, (err: unknown): void => {
-    if (err instanceof multer.MulterError) {
-      const message: string = `Multipart request rejected: ${err.code}.`;
-
-      return next(
-        TOO_LARGE_CODES.has(err.code)
-          ? new PayloadTooLargeException(message)
-          : new BadRequestException(message),
-      );
-    }
-
-    return next(err);
+    return handleMulterError(err, next);
   });
+};
+
+/**
+ * A multipart middleware for a route that wants a LOWER file count than the
+ * shared default.
+ *
+ * Only downward: maxFiles is clamped to MAX_MULTIPART_FILES. Every route that
+ * mounts this middleware parses the body before its own auth check runs, so
+ * the shared ceiling is the limit an unauthenticated caller is held to across
+ * all of them. A per-route knob that could raise it would widen the pre-auth
+ * memory surface of every OTHER route's neighbours by proxy of a config
+ * change made for one — so it cannot.
+ *
+ * Routes that are happy with the default should keep using the default
+ * export; this builds a second multer instance, so call it once at module
+ * scope and never per request.
+ */
+export const getMultipartFormDataMiddleware: (options: {
+  maxFiles: number;
+}) => RequestHandler = (options: { maxFiles: number }): RequestHandler => {
+  /*
+   * Clamp the DOMAIN as well as the range. busboy compares `files === limit`,
+   * which never matches a fractional or NaN limit — so a non-integer would
+   * not narrow anything, it would remove the file bound entirely and leave
+   * the pre-auth parse unbounded. That is the exact widening this function
+   * exists to prevent, so anything not a finite number falls back to the
+   * shared ceiling rather than being passed through.
+   */
+  const requestedMaxFiles: number = options.maxFiles;
+
+  const maxFiles: number = Number.isFinite(requestedMaxFiles)
+    ? Math.max(1, Math.min(Math.floor(requestedMaxFiles), MAX_MULTIPART_FILES))
+    : MAX_MULTIPART_FILES;
+
+  if (maxFiles === MAX_MULTIPART_FILES) {
+    return MultipartFormDataMiddleware;
+  }
+
+  const scopedUploadAny: RequestHandler = buildUploadAny(maxFiles);
+
+  return (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): void => {
+    scopedUploadAny(req, res, (err: unknown): void => {
+      return handleMulterError(err, next);
+    });
+  };
 };
 
 export default MultipartFormDataMiddleware;

--- a/Common/Server/Services/TelemetrySourceMapService.ts
+++ b/Common/Server/Services/TelemetrySourceMapService.ts
@@ -6,12 +6,20 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
+import PositiveNumber from "../../Types/PositiveNumber";
 import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import logger from "../Utils/Logger";
 import SourceMapResolver, {
+  MAX_FRAMES_TO_RESOLVE,
   MAX_SOURCE_MAP_SIZE_IN_BYTES,
   SourceMapBundle,
 } from "../Utils/Telemetry/SourceMapResolver";
+import {
+  SourceMapMaxBytesPerResolve,
+  SourceMapMaxMapsPerRelease,
+  SourceMapRetentionInDays,
+} from "../EnvironmentConfig";
 import {
   MinifiedStackFrame,
   ResolvedStackFrame,
@@ -23,17 +31,24 @@ export { MAX_SOURCE_MAP_SIZE_IN_BYTES };
 /*
  * How long uploaded maps are kept. Old releases age out automatically —
  * a map is only useful while exceptions from its release are still within
- * telemetry retention, and 90 days comfortably exceeds the default.
+ * telemetry retention, and the default comfortably exceeds it.
+ * SOURCE_MAP_RETENTION_DAYS overrides it.
  */
-export const SOURCE_MAP_RETENTION_DAYS: number = 90;
+export const SOURCE_MAP_RETENTION_DAYS: number = SourceMapRetentionInDays;
 
 /*
- * How many maps one (service, release) pair may hold. Enforced by the
- * upload endpoint (existing bundles + new bundles must fit) and used as
- * the resolver's read limit, so nothing stored is ever silently ignored.
- * A build rarely emits more than a few dozen chunks with maps.
+ * How many distinct bundles one (service, release) pair may hold, from
+ * SOURCE_MAP_MAX_MAPS_PER_RELEASE.
+ *
+ * This is a WRITE gate and nothing else: the upload endpoint checks that
+ * existing bundles + new bundles fit, and rejects with a 400 naming the
+ * limit. It used to double as the resolver's read limit, which coupled two
+ * different quantities — distinct bundle paths on the write side, rows on
+ * the read side — and made raising it dangerous. resolveFramesForService now
+ * bounds itself by BYTES loaded (SourceMapMaxBytesPerResolve), so a release
+ * that fits this ceiling always resolves in full.
  */
-export const MAX_SOURCE_MAPS_PER_RELEASE: number = 100;
+export const MAX_SOURCE_MAPS_PER_RELEASE: number = SourceMapMaxMapsPerRelease;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -74,9 +89,114 @@ export class Service extends DatabaseService<Model> {
       throw new BadDataException("Service version is required.");
     }
 
+    await this.assertReleaseHasRoomFor(createBy);
+
     createBy.data.sizeInBytes = Buffer.byteLength(content, "utf8");
 
     return { createBy, carryForward: null };
+  }
+
+  /**
+   * Enforce the per-release ceiling on the create path itself.
+   *
+   * The upload endpoint checks the whole batch up front, which is where the
+   * useful error message lives — but TelemetrySourceMap is a full CRUD
+   * resource, so POST /api/telemetry-source-map reaches create() without ever
+   * passing that check. Without this the configured ceiling was advisory on
+   * that path, and a release could quietly grow past what the operator set.
+   *
+   * Two steps, so the common case stays cheap: an indexed COUNT on every
+   * insert, and the exact distinct-bundle answer only once that COUNT says
+   * the release is at the boundary. A release is written once per CI run, and
+   * on the upload path the batch check has already passed, so the second step
+   * is effectively unreachable there.
+   */
+  @CaptureSpan()
+  private async assertReleaseHasRoomFor(
+    createBy: CreateBy<Model>,
+  ): Promise<void> {
+    const projectId: ObjectID | undefined =
+      createBy.data.projectId || createBy.props.tenantId || undefined;
+    const serviceId: ObjectID | undefined =
+      createBy.data.serviceId || undefined;
+    const serviceVersion: string | undefined = createBy.data.serviceVersion;
+
+    /*
+     * Not a silent pass: a create missing any of these cannot be scoped to a
+     * release, and the tenant column / required-column checks reject it on
+     * their own with a better message than a count could give.
+     */
+    if (!projectId || !serviceId || !serviceVersion) {
+      return;
+    }
+
+    /*
+     * Cheap check first, and it is the one that runs in practice: a COUNT of
+     * ROWS on the (projectId, serviceId, serviceVersion) index. Below the
+     * ceiling there is nothing to decide, whatever the rows contain.
+     */
+    const existingRowCount: PositiveNumber = await this.countBy({
+      query: {
+        projectId: projectId,
+        serviceId: serviceId,
+        serviceVersion: serviceVersion,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (existingRowCount.toNumber() < MAX_SOURCE_MAPS_PER_RELEASE) {
+      return;
+    }
+
+    /*
+     * At or above the ceiling on rows — but rows are not the unit the ceiling
+     * is expressed in. The model deliberately allows more than one row per
+     * bundle (a racing double upload must not fail CI), so rejecting on the
+     * row count would fail a legitimate re-upload of a full release purely
+     * because a duplicate row exists. Pay for the exact answer only here,
+     * where the fast path has already established this is the boundary.
+     */
+    const storedBundlePaths: Array<string> =
+      await this.getStoredBundlePathsForRelease({
+        projectId: projectId,
+        serviceId: serviceId,
+        serviceVersion: serviceVersion,
+      });
+
+    const distinctBundlePaths: Set<string> = new Set(
+      storedBundlePaths.map((bundlePath: string) => {
+        return SourceMapResolver.normalizePath(bundlePath);
+      }),
+    );
+
+    /*
+     * Normalized, which makes this backstop slightly MORE permissive than the
+     * upload endpoint's raw-path gate. That is the right direction for a
+     * backstop: it must never be the thing that fails a request the primary
+     * gate already approved.
+     */
+    const incomingBundlePath: string = SourceMapResolver.normalizePath(
+      createBy.data.bundlePath || "",
+    );
+
+    /*
+     * Adding a row for a bundle the release already holds does not grow the
+     * release, so it stays allowed even at the ceiling. Only a NEW distinct
+     * bundle is refused.
+     */
+    if (distinctBundlePaths.has(incomingBundlePath)) {
+      return;
+    }
+
+    if (distinctBundlePaths.size >= MAX_SOURCE_MAPS_PER_RELEASE) {
+      throw new BadDataException(
+        `This release already holds ${distinctBundlePaths.size} source maps, which is the limit of ${MAX_SOURCE_MAPS_PER_RELEASE} per release. Delete unused maps, use a new serviceVersion, or raise SOURCE_MAP_MAX_MAPS_PER_RELEASE.`,
+      );
+    }
   }
 
   /**
@@ -182,15 +302,26 @@ export class Service extends DatabaseService<Model> {
         }),
         resolvedCount: 0,
         sourceMapCount: 0,
+        sourceMapsSkippedForSize: 0,
       };
     }
 
     /*
-     * Two-step fetch: list bundle paths first (cheap), then pull content
-     * only for bundles that at least one frame can match. Maps can be tens
-     * of megabytes each and a release may store up to
-     * MAX_SOURCE_MAPS_PER_RELEASE of them — loading them all for every
-     * exception view would be a memory hazard for no benefit.
+     * Two-step fetch: list bundle paths first (cheap — no content), then pull
+     * content only for the bundles a frame can match, and only as many of
+     * those as the byte budget allows. Maps can be tens of megabytes each, so
+     * loading a whole release for every exception view would be a memory
+     * hazard for no benefit.
+     *
+     * The listing reads with LIMIT_MAX rather than the per-release ceiling.
+     * The ceiling counts distinct bundle PATHS, while a read limit counts
+     * ROWS, and duplicate rows for one bundle are deliberately allowed (see
+     * the model: a racing double upload must not fail CI). With the two
+     * numbers equal, one duplicate row was enough to push a distinct bundle
+     * out of resolution — it stored fine, showed in the dashboard, and
+     * silently never resolved. Reading everything and deduping afterwards
+     * removes that coupling; memory is bounded below by bytes, not by how
+     * many rows a content-free listing returns.
      */
     const sourceMapRows: Array<Model> = await this.findBy({
       query: {
@@ -202,11 +333,12 @@ export class Service extends DatabaseService<Model> {
         _id: true,
         bundlePath: true,
         createdAt: true,
+        sizeInBytes: true,
       },
       sort: {
         createdAt: SortOrder.Descending,
       },
-      limit: MAX_SOURCE_MAPS_PER_RELEASE,
+      limit: LIMIT_MAX,
       skip: 0,
       props: {
         isRoot: true,
@@ -237,16 +369,121 @@ export class Service extends DatabaseService<Model> {
       dedupedRows.push(row);
     }
 
-    const matchedRows: Array<Model> = dedupedRows.filter((row: Model) => {
-      return data.frames.some((frame: MinifiedStackFrame) => {
-        return (
-          SourceMapResolver.getMatchScore(
-            frame.fileName,
-            row.bundlePath || "",
-          ) > 0
+    /*
+     * Only the frames resolveFrames will actually attempt can pull a map in.
+     * Matching against every frame would let a caller-supplied array drive an
+     * O(rows x frames) scan and select maps that could never be used anyway —
+     * the frames array is parsed from client-supplied stack trace text, so it
+     * is capped rather than trusted (the API rejects absurd lengths outright).
+     */
+    const framesForMatching: Array<MinifiedStackFrame> = data.frames.slice(
+      0,
+      MAX_FRAMES_TO_RESOLVE,
+    );
+
+    /*
+     * Score every candidate against those frames. The score is how many
+     * trailing path segments the frame and the bundle share, so a frame
+     * "static/main.a8f1.js" prefers the bundle that agrees on "static/" over
+     * one that only agrees on the file name. That ordering is what makes the
+     * byte budget below defensible: when not everything fits, what gets
+     * dropped is the weakest match, not an arbitrary row.
+     */
+    const scoredRows: Array<{
+      row: Model;
+      score: number;
+      sizeInBytes: number;
+    }> = [];
+
+    for (const row of dedupedRows) {
+      let bestScore: number = 0;
+
+      for (const frame of framesForMatching) {
+        const score: number = SourceMapResolver.getMatchScore(
+          frame.fileName,
+          row.bundlePath || "",
         );
-      });
-    });
+
+        if (score > bestScore) {
+          bestScore = score;
+        }
+      }
+
+      if (bestScore > 0) {
+        scoredRows.push({
+          row: row,
+          score: bestScore,
+          /*
+           * onBeforeCreate stamps sizeInBytes on every insert, so a missing
+           * value means a row written straight to the database. Charge it the
+           * per-map ceiling rather than nothing: an unknown size must not be
+           * the way to slip past a budget meant to bound memory.
+           */
+          sizeInBytes:
+            typeof row.sizeInBytes === "number" &&
+            Number.isFinite(row.sizeInBytes) &&
+            row.sizeInBytes > 0
+              ? row.sizeInBytes
+              : MAX_SOURCE_MAP_SIZE_IN_BYTES,
+        });
+      }
+    }
+
+    scoredRows.sort(
+      (
+        a: { row: Model; score: number; sizeInBytes: number },
+        b: { row: Model; score: number; sizeInBytes: number },
+      ) => {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+
+        // Same match quality: prefer the newer upload, as the dedupe does.
+        const aTime: number = a.row.createdAt
+          ? new Date(a.row.createdAt).getTime()
+          : 0;
+        const bTime: number = b.row.createdAt
+          ? new Date(b.row.createdAt).getTime()
+          : 0;
+
+        return bTime - aTime;
+      },
+    );
+
+    /*
+     * The byte budget. This is the bound that used to be implied by the
+     * per-release count and is a far tighter one, because it measures the
+     * thing that actually consumes memory. Lower-scoring maps that still fit
+     * are kept (hence continue, not break) so a single oversized map does not
+     * cost the rest of the stack trace its symbols.
+     *
+     * The best-scoring map is always attempted even if it alone exceeds the
+     * budget: a budget configured below the per-map ceiling should degrade to
+     * "one map at a time", not to "nothing ever resolves". Peak is therefore
+     * max(SourceMapMaxBytesPerResolve, MAX_SOURCE_MAP_SIZE_IN_BYTES).
+     */
+    const matchedRows: Array<Model> = [];
+    let budgetUsedInBytes: number = 0;
+    let sourceMapsSkippedForSize: number = 0;
+
+    for (const scored of scoredRows) {
+      const wouldExceedBudget: boolean =
+        budgetUsedInBytes + scored.sizeInBytes > SourceMapMaxBytesPerResolve;
+
+      if (wouldExceedBudget && matchedRows.length > 0) {
+        sourceMapsSkippedForSize++;
+        continue;
+      }
+
+      budgetUsedInBytes += scored.sizeInBytes;
+      matchedRows.push(scored.row);
+    }
+
+    if (sourceMapsSkippedForSize > 0) {
+      logger.warn(
+        `Source map resolution skipped ${sourceMapsSkippedForSize} matching map(s) for service ${data.serviceId.toString()} release ${data.serviceVersion}: loading them would exceed SOURCE_MAP_MAX_BYTES_PER_RESOLVE (${SourceMapMaxBytesPerResolve} bytes).`,
+      );
+    }
 
     const bundles: Array<SourceMapBundle> = [];
 
@@ -269,7 +506,7 @@ export class Service extends DatabaseService<Model> {
           bundlePath: true,
           content: true,
         },
-        limit: MAX_SOURCE_MAPS_PER_RELEASE,
+        limit: matchedRows.length,
         skip: 0,
         props: {
           isRoot: true,
@@ -300,6 +537,12 @@ export class Service extends DatabaseService<Model> {
        * distinguishable from "no maps uploaded".
        */
       sourceMapCount: dedupedRows.length,
+      /*
+       * Non-zero means symbols are missing because of the byte budget, not
+       * because the maps were never uploaded — the one distinction a user
+       * staring at a half-resolved stack trace cannot make for themselves.
+       */
+      sourceMapsSkippedForSize: sourceMapsSkippedForSize,
     };
   }
 }

--- a/Common/Server/Utils/Telemetry/SourceMapResolver.ts
+++ b/Common/Server/Utils/Telemetry/SourceMapResolver.ts
@@ -14,6 +14,7 @@ import {
   SourceCodeSnippet,
 } from "../../../Types/Telemetry/SourceMap";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import { SourceMapMaxFileSizeInBytes } from "../../EnvironmentConfig";
 import {
   AnyMap,
   TraceMap,
@@ -28,11 +29,12 @@ export interface SourceMapBundle {
 }
 
 /*
- * Hard ceiling on one map. Matches MAX_MULTIPART_FILE_BYTES on the upload
- * path; also enforced on the decoded string (invalid UTF-8 bytes expand to
- * 3-byte U+FFFD on decode, so the string can outgrow the raw file).
+ * Hard ceiling on one map, from SOURCE_MAP_MAX_FILE_SIZE_BYTES. Clamped to
+ * MAX_MULTIPART_FILE_BYTES on the upload path by the config layer; also
+ * enforced on the decoded string (invalid UTF-8 bytes expand to 3-byte
+ * U+FFFD on decode, so the string can outgrow the raw file).
  */
-export const MAX_SOURCE_MAP_SIZE_IN_BYTES: number = 50 * 1024 * 1024;
+export const MAX_SOURCE_MAP_SIZE_IN_BYTES: number = SourceMapMaxFileSizeInBytes;
 
 /** Lines of context shown on each side of the resolved line. */
 const SNIPPET_CONTEXT_LINES: number = 3;
@@ -51,7 +53,16 @@ const MAX_SNIPPET_LINE_LENGTH: number = 512;
  * through unresolved so the output length always equals the input length,
  * which the dashboard overlay relies on.
  */
-const MAX_FRAMES_TO_RESOLVE: number = 500;
+export const MAX_FRAMES_TO_RESOLVE: number = 500;
+
+/*
+ * Hard ceiling on the frames array ONE resolve request may carry. Well above
+ * anything a runtime produces — browsers truncate stack traces long before
+ * this — so it never rejects a real trace; it exists so the request body
+ * cannot be used to drive work proportional to a caller-chosen length. The
+ * per-call resolution cap above is the tighter, non-rejecting bound.
+ */
+export const MAX_FRAMES_PER_RESOLVE_REQUEST: number = 10000;
 
 interface ParsedBundle {
   bundlePath: string;

--- a/Common/Tests/Server/API/TelemetryResolveStackTraceAPI.test.ts
+++ b/Common/Tests/Server/API/TelemetryResolveStackTraceAPI.test.ts
@@ -1,0 +1,805 @@
+import CommonAPI from "../../../Server/API/CommonAPI";
+import ProjectService from "../../../Server/Services/ProjectService";
+import TelemetrySourceMapService from "../../../Server/Services/TelemetrySourceMapService";
+import SourceMapResolver, {
+  MAX_FRAMES_PER_RESOLVE_REQUEST,
+  MAX_FRAMES_TO_RESOLVE,
+} from "../../../Server/Utils/Telemetry/SourceMapResolver";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "../../../Types/Dictionary";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Exception from "../../../Types/Exception/Exception";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import {
+  MinifiedStackFrame,
+  ResolveStackTraceResult,
+} from "../../../Types/Telemetry/SourceMap";
+import UserType from "../../../Types/UserType";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * POST /telemetry/exceptions/resolve-stack-trace — the frames-array cap
+ * ---------------------------------------------------------------------------
+ *
+ * The handler takes a caller-supplied `frames` array and hands it to
+ * SourceMapResolver.sanitizeMinifiedStackFrames, which never throws and never
+ * truncates: it walks every element and returns one output frame per object it
+ * sees. Downstream, resolveFramesForService only *resolves* the first
+ * MAX_FRAMES_TO_RESOLVE frames, but it still copies the whole array into the
+ * response. So before this cap existed, the only bound on the work (and the
+ * response size) a single request could ask for was the body-size limit —
+ * ~200k frames of `{}` fit inside a few megabytes of JSON.
+ *
+ * MAX_FRAMES_PER_RESOLVE_REQUEST closes that. The cases below pin the three
+ * things that make it correct rather than merely present: it is a `>` bound
+ * (a full 10000-frame trace still resolves), it sits AFTER the Array.isArray
+ * guard (so a non-array keeps its own precise error), and it sits BEFORE
+ * sanitize (so an oversized array is refused instead of being quietly walked
+ * end to end and reduced to []).
+ */
+
+type RouterFunction = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+type RecordedRoute = {
+  method: string;
+  uri: string;
+  handlers: Array<RouterFunction>;
+};
+
+const recordedRoutes: Array<RecordedRoute> = [];
+
+type RecordRouteFunction = (
+  method: string,
+) => (uri: string, ...handlers: Array<RouterFunction>) => void;
+
+const recordRoute: RecordRouteFunction = (method: string) => {
+  return (uri: string, ...handlers: Array<RouterFunction>): void => {
+    recordedRoutes.push({
+      method: method.toUpperCase(),
+      uri: uri,
+      handlers: handlers,
+    });
+  };
+};
+
+const telemetryRouter: JSONObject = {
+  get: recordRoute("get"),
+  post: recordRoute("post"),
+  put: recordRoute("put"),
+  delete: recordRoute("delete"),
+} as unknown as JSONObject;
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return telemetryRouter;
+    },
+    getClientIp: () => {
+      return "203.0.113.7";
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+  };
+});
+
+const RESOLVE_ROUTE: string = "/telemetry/exceptions/resolve-stack-trace";
+
+type FindRouteFunction = (uri: string) => RecordedRoute;
+
+const findRoute: FindRouteFunction = (uri: string): RecordedRoute => {
+  const route: RecordedRoute | undefined = recordedRoutes.find(
+    (candidate: RecordedRoute): boolean => {
+      return candidate.method === "POST" && candidate.uri === uri;
+    },
+  );
+
+  if (!route) {
+    throw new Error(`Route not registered: ${uri}`);
+  }
+
+  return route;
+};
+
+type CallResult = {
+  /* Exception handed to Response.sendErrorResponse by a guard or the handler. */
+  deniedWith: Exception | undefined;
+  /* Exception thrown out of the handler into express' error path. */
+  thrownToNext: unknown;
+  /* True when the final route handler was actually entered. */
+  reachedHandler: boolean;
+  jsonBody: JSONObject | undefined;
+};
+
+/*
+ * Runs the recorded route's middleware chain for real, starting at
+ * requireUserAuthentication. Index 0 is getUserMiddleware, whose only job is
+ * to populate the session fields these fixtures set directly — running it
+ * would need a live session store and would prove nothing about the cap.
+ */
+type CallRouteFunction = (data: {
+  request: JSONObject;
+  body: unknown;
+}) => Promise<CallResult>;
+
+const callRoute: CallRouteFunction = async (data: {
+  request: JSONObject;
+  body: unknown;
+}): Promise<CallResult> => {
+  const route: RecordedRoute = findRoute(RESOLVE_ROUTE);
+
+  const req: ExpressRequest = {
+    ...data.request,
+    body: data.body,
+    params: {},
+    query: {},
+    headers: { "user-agent": "jest-agent" },
+  } as unknown as ExpressRequest;
+
+  const res: ExpressResponse = {
+    setHeader: (): void => {
+      // no-op
+    },
+    send: (): void => {
+      // no-op
+    },
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as ExpressResponse;
+
+  const outcome: { thrownToNext: unknown; reachedHandler: boolean } = {
+    thrownToNext: undefined,
+    reachedHandler: false,
+  };
+
+  for (let index: number = 1; index < route.handlers.length; index++) {
+    const handler: RouterFunction | undefined = route.handlers[index];
+
+    if (!handler) {
+      break;
+    }
+
+    if (index === route.handlers.length - 1) {
+      outcome.reachedHandler = true;
+    }
+
+    const step: { calledNext: boolean } = { calledNext: false };
+
+    const next: NextFunction = ((error?: unknown): void => {
+      step.calledNext = true;
+
+      if (error) {
+        outcome.thrownToNext = error;
+      }
+    }) as unknown as NextFunction;
+
+    await handler(req, res, next);
+
+    // A guard (or the handler) that answered the request never calls next.
+    if (!step.calledNext) {
+      break;
+    }
+  }
+
+  const sendErrorResponse: jest.Mock =
+    Response.sendErrorResponse as unknown as jest.Mock;
+  const sendJsonObjectResponse: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+
+  const errorCall: Array<unknown> | undefined = sendErrorResponse.mock
+    .calls[0] as Array<unknown> | undefined;
+  const jsonCall: Array<unknown> | undefined = sendJsonObjectResponse.mock
+    .calls[0] as Array<unknown> | undefined;
+
+  return {
+    deniedWith: errorCall ? (errorCall[2] as Exception) : undefined,
+    thrownToNext: outcome.thrownToNext,
+    reachedHandler: outcome.reachedHandler,
+    jsonBody: jsonCall ? (jsonCall[2] as JSONObject) : undefined,
+  };
+};
+
+type BuildPrincipalFunction = (data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+}) => JSONObject;
+
+const buildPrincipal: BuildPrincipalFunction = (data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+}): JSONObject => {
+  /*
+   * isBlockPermission must be an explicit false: getUserPermissions filters
+   * tenant permissions with a strict `=== false`, so undefined would silently
+   * drop the permission this fixture grants and every case below would fail
+   * at the guard instead of exercising the handler.
+   */
+  const userPermissions: Array<UserPermission> = [
+    Permission.ReadTelemetryException,
+  ].map((permission: Permission): UserPermission => {
+    return {
+      _type: "UserPermission",
+      permission: permission,
+      labelIds: [],
+      isBlockPermission: false,
+    };
+  });
+
+  const tenantPermission: UserTenantAccessPermission = {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: userPermissions,
+  };
+
+  const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+  permissionMap[data.projectId.toString()] = tenantPermission;
+
+  return {
+    userType: UserType.User,
+    tenantId: data.projectId,
+    userTenantAccessPermission: permissionMap,
+    userAuthorization: { userId: data.userId },
+  } as unknown as JSONObject;
+};
+
+/*
+ * Well-formed frames. Every one is a distinct object so nothing about the
+ * cap can be an artifact of array element identity.
+ */
+type MakeFramesFunction = (count: number) => Array<JSONObject>;
+
+const makeFrames: MakeFramesFunction = (count: number): Array<JSONObject> => {
+  return Array.from(
+    { length: count },
+    (_unused: unknown, index: number): JSONObject => {
+      return {
+        functionName: `minified${index}`,
+        fileName: "https://app.example.com/assets/main.abc123.js",
+        lineNumber: 1,
+        columnNumber: index,
+        inApp: true,
+      };
+    },
+  );
+};
+
+/*
+ * Elements sanitize throws away entirely (null, primitives, nested arrays):
+ * a payload of these sanitizes to [] no matter how long it is, which is
+ * exactly the shape that has to be rejected on length rather than quietly
+ * accepted as an empty resolve.
+ */
+type MakeJunkFramesFunction = (count: number) => Array<unknown>;
+
+const makeJunkFrames: MakeJunkFramesFunction = (
+  count: number,
+): Array<unknown> => {
+  return Array.from({ length: count }, (_unused: unknown, index: number) => {
+    if (index % 3 === 0) {
+      return null;
+    }
+
+    if (index % 3 === 1) {
+      return "not-a-frame";
+    }
+
+    return [index];
+  });
+};
+
+const EMPTY_RESULT: ResolveStackTraceResult = {
+  frames: [],
+  resolvedCount: 0,
+  sourceMapCount: 0,
+  sourceMapsSkippedForSize: 0,
+};
+
+const TOO_MANY_FRAMES_MESSAGE: string = `frames must contain at most ${MAX_FRAMES_PER_RESOLVE_REQUEST} stack frames.`;
+const NOT_AN_ARRAY_MESSAGE: string = "frames must be an array of stack frames";
+
+describe("POST /telemetry/exceptions/resolve-stack-trace frames cap", () => {
+  let projectId: ObjectID;
+  let userId: ObjectID;
+  let serviceId: ObjectID;
+
+  interface Spy {
+    mock: { calls: Array<Array<unknown>> };
+    mockResolvedValue: (value: ResolveStackTraceResult) => unknown;
+    mockRejectedValue: (value: unknown) => unknown;
+  }
+
+  let resolveFramesForService: Spy;
+  let sanitizeMinifiedStackFrames: Spy;
+
+  beforeAll(() => {
+    recordedRoutes.length = 0;
+    /*
+     * Loaded lazily rather than with a top-level import: TelemetryAPI calls
+     * Express.getRouter() at module scope, so a static import would run the
+     * mock factory before `telemetryRouter` is initialised and die in the
+     * temporal dead zone.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../../../Server/API/TelemetryAPI");
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    projectId = ObjectID.generate();
+    userId = ObjectID.generate();
+    serviceId = ObjectID.generate();
+
+    /*
+     * CI runs the Common suite with BILLING_ENABLED=true (see test-setup.sh),
+     * so getDatabaseCommonInteractionProps resolves the caller's plan through
+     * ProjectService.getCurrentPlan. These fixtures use a project that never
+     * exists in the database, so the real lookup throws and the handler's
+     * catch swallows the request before it reaches the frames guard. Billing
+     * is orthogonal to the cap, so stub the plan lookup and let the rest run.
+     */
+    jest
+      .spyOn(ProjectService, "getCurrentPlan")
+      .mockResolvedValue({ plan: null, isSubscriptionUnpaid: false });
+
+    resolveFramesForService = jest.spyOn(
+      TelemetrySourceMapService,
+      "resolveFramesForService" as never,
+    ) as unknown as Spy;
+    resolveFramesForService.mockResolvedValue(EMPTY_RESULT);
+
+    /*
+     * Spied, not stubbed: the real implementation still runs, so the cases
+     * that assert what the handler forwards are exercising real sanitize
+     * output while the call log proves whether sanitize ran at all.
+     */
+    sanitizeMinifiedStackFrames = jest.spyOn(
+      SourceMapResolver,
+      "sanitizeMinifiedStackFrames" as never,
+    ) as unknown as Spy;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  type CallFunction = (body: unknown) => Promise<CallResult>;
+
+  const call: CallFunction = (body: unknown): Promise<CallResult> => {
+    return callRoute({
+      request: buildPrincipal({ projectId: projectId, userId: userId }),
+      body: body,
+    });
+  };
+
+  type BodyWithFramesFunction = (frames: unknown) => JSONObject;
+
+  const bodyWithFrames: BodyWithFramesFunction = (
+    frames: unknown,
+  ): JSONObject => {
+    return {
+      serviceId: serviceId.toString(),
+      serviceVersion: "1.4.2",
+      frames: frames,
+    } as JSONObject;
+  };
+
+  type ForwardedFramesFunction = () => Array<MinifiedStackFrame>;
+
+  const forwardedFrames: ForwardedFramesFunction =
+    (): Array<MinifiedStackFrame> => {
+      const argument: JSONObject = resolveFramesForService.mock
+        .calls[0]![0] as JSONObject;
+
+      return argument["frames"] as unknown as Array<MinifiedStackFrame>;
+    };
+
+  describe("route registration", () => {
+    test("the route is registered as POST behind the exception-read guard chain", () => {
+      const route: RecordedRoute = findRoute(RESOLVE_ROUTE);
+
+      expect(route.uri).toBe(RESOLVE_ROUTE);
+      // getUserMiddleware, requireUserAuthentication, requirePermission, handler.
+      expect(route.handlers).toHaveLength(4);
+    });
+  });
+
+  describe("the limit itself", () => {
+    test("MAX_FRAMES_PER_RESOLVE_REQUEST is 10000", () => {
+      expect(MAX_FRAMES_PER_RESOLVE_REQUEST).toBe(10000);
+    });
+
+    /*
+     * The two bounds do different jobs and must not be confused for each
+     * other: MAX_FRAMES_TO_RESOLVE is how many frames get *resolved* against
+     * a map, this one is how many a caller may *submit*. If the request cap
+     * ever slid down to the resolve cap, browsers that send deep async traces
+     * would start getting 400s instead of a partially-resolved trace, so the
+     * gap between them is deliberate and worth pinning.
+     */
+    test("the request cap sits far above the per-request resolve cap", () => {
+      expect(MAX_FRAMES_PER_RESOLVE_REQUEST).toBeGreaterThan(
+        MAX_FRAMES_TO_RESOLVE,
+      );
+      expect(MAX_FRAMES_PER_RESOLVE_REQUEST).toBeGreaterThanOrEqual(
+        MAX_FRAMES_TO_RESOLVE * 10,
+      );
+    });
+  });
+
+  describe("accepted sizes", () => {
+    test("a single frame resolves", async () => {
+      const result: CallResult = await call(bodyWithFrames(makeFrames(1)));
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(resolveFramesForService.mock.calls).toHaveLength(1);
+      expect(forwardedFrames()).toHaveLength(1);
+    });
+
+    test("one frame under the cap is accepted", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST - 1)),
+      );
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(resolveFramesForService.mock.calls).toHaveLength(1);
+      expect(forwardedFrames()).toHaveLength(
+        MAX_FRAMES_PER_RESOLVE_REQUEST - 1,
+      );
+    });
+
+    /*
+     * The boundary. The guard is a `>` comparison, so a trace of exactly the
+     * cap is a legal request; an off-by-one here would reject the very
+     * payload the constant advertises as the maximum.
+     */
+    test("exactly MAX_FRAMES_PER_RESOLVE_REQUEST frames is accepted, not rejected by the cap", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST)),
+      );
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(result.thrownToNext).toBeUndefined();
+      expect(resolveFramesForService.mock.calls).toHaveLength(1);
+    });
+
+    /*
+     * And it is accepted in full. sanitize does not truncate, and the handler
+     * does not either — which is precisely why the cap has to exist at this
+     * layer rather than being left to a downstream slice.
+     */
+    test("an at-cap request forwards all 10000 frames — nothing truncates on the way through", async () => {
+      await call(bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST)));
+
+      expect(forwardedFrames()).toHaveLength(MAX_FRAMES_PER_RESOLVE_REQUEST);
+      expect(forwardedFrames()).not.toHaveLength(MAX_FRAMES_TO_RESOLVE);
+    });
+
+    test("an empty frames array is accepted — the cap only bounds the top end", async () => {
+      const result: CallResult = await call(bodyWithFrames([]));
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(resolveFramesForService.mock.calls).toHaveLength(1);
+      expect(forwardedFrames()).toHaveLength(0);
+    });
+
+    test("an accepted request returns the resolver's result to the caller", async () => {
+      const resolved: ResolveStackTraceResult = {
+        frames: [],
+        resolvedCount: 3,
+        sourceMapCount: 2,
+        sourceMapsSkippedForSize: 1,
+      };
+      resolveFramesForService.mockResolvedValue(resolved);
+
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST)),
+      );
+
+      expect(result.jsonBody).toMatchObject({
+        resolvedCount: 3,
+        sourceMapCount: 2,
+        sourceMapsSkippedForSize: 1,
+      });
+    });
+
+    test("the accepted request is scoped to the caller's tenant and body service", async () => {
+      await call(bodyWithFrames(makeFrames(10)));
+
+      const argument: JSONObject = resolveFramesForService.mock
+        .calls[0]![0] as JSONObject;
+
+      expect((argument["projectId"] as ObjectID).toString()).toBe(
+        projectId.toString(),
+      );
+      expect((argument["serviceId"] as ObjectID).toString()).toBe(
+        serviceId.toString(),
+      );
+      expect(argument["serviceVersion"]).toBe("1.4.2");
+    });
+  });
+
+  describe("rejected sizes", () => {
+    /*
+     * One over the boundary. This is the case the cap exists for, and the
+     * only place the off-by-one can be caught from the outside.
+     */
+    test("one frame over the cap is rejected with a BadDataException", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.deniedWith).toBeInstanceOf(BadDataException);
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+
+    /*
+     * The message has to name the limit: the caller is a build tool or a
+     * browser SDK batching frames, and "too many frames" without the number
+     * gives it nothing to clamp to.
+     */
+    test("the rejection message names the limit", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.deniedWith?.message).toBe(TOO_MANY_FRAMES_MESSAGE);
+      expect(result.deniedWith?.message).toContain(
+        String(MAX_FRAMES_PER_RESOLVE_REQUEST),
+      );
+    });
+
+    test("a wildly oversized array is rejected the same way, not merely trimmed", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST * 2)),
+      );
+
+      expect(result.deniedWith).toBeInstanceOf(BadDataException);
+      expect(result.deniedWith?.message).toBe(TOO_MANY_FRAMES_MESSAGE);
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+
+    test("no response body is produced for a rejected request", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.jsonBody).toBeUndefined();
+      expect(result.thrownToNext).toBeUndefined();
+    });
+  });
+
+  describe("guard ordering: the cap runs AFTER the Array.isArray check", () => {
+    /*
+     * A non-array `frames` must keep its own precise error. If the length
+     * check were hoisted above the type check it would read `.length` off
+     * whatever the caller sent — and a string, or any array-like object,
+     * has a length — so a plainly malformed body would come back complaining
+     * about a limit it never approached.
+     */
+    test("a non-array frames value gets the array error, not the length error", async () => {
+      const result: CallResult = await call(bodyWithFrames({ zero: "frame" }));
+
+      expect(result.deniedWith).toBeInstanceOf(BadDataException);
+      expect(result.deniedWith?.message).toBe(NOT_AN_ARRAY_MESSAGE);
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+
+    test("an array-like object longer than the cap still gets the array error", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames({ length: MAX_FRAMES_PER_RESOLVE_REQUEST + 1 }),
+      );
+
+      expect(result.deniedWith?.message).toBe(NOT_AN_ARRAY_MESSAGE);
+      expect(result.deniedWith?.message).not.toBe(TOO_MANY_FRAMES_MESSAGE);
+    });
+
+    test("a string longer than the cap still gets the array error", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames("f".repeat(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.deniedWith?.message).toBe(NOT_AN_ARRAY_MESSAGE);
+      expect(result.deniedWith?.message).not.toBe(TOO_MANY_FRAMES_MESSAGE);
+    });
+
+    test("a missing frames field gets the array error", async () => {
+      const result: CallResult = await call({
+        serviceId: serviceId.toString(),
+        serviceVersion: "1.4.2",
+      });
+
+      expect(result.deniedWith?.message).toBe(NOT_AN_ARRAY_MESSAGE);
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+
+    test("a null frames field gets the array error", async () => {
+      const result: CallResult = await call(bodyWithFrames(null));
+
+      expect(result.deniedWith?.message).toBe(NOT_AN_ARRAY_MESSAGE);
+    });
+  });
+
+  describe("guard ordering: the cap runs BEFORE sanitize", () => {
+    /*
+     * The regression this ordering fixes. sanitize walks every element and
+     * silently drops the ones that are not objects, so an oversized array of
+     * pure junk sanitizes to [] — and a cap placed after sanitize would see
+     * a length of 0, wave the request through, and only then have done the
+     * per-element work the cap was supposed to prevent. The caller would get
+     * a cheerful empty resolve for a payload the server should have refused.
+     */
+    test("an oversized array of junk is rejected on length, not silently sanitized to []", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeJunkFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.deniedWith).toBeInstanceOf(BadDataException);
+      expect(result.deniedWith?.message).toBe(TOO_MANY_FRAMES_MESSAGE);
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+
+    test("sanitize is never invoked for an oversized array", async () => {
+      await call(
+        bodyWithFrames(makeJunkFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(sanitizeMinifiedStackFrames.mock.calls).toHaveLength(0);
+    });
+
+    test("sanitize is never invoked for an oversized array of well-formed frames either", async () => {
+      await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(sanitizeMinifiedStackFrames.mock.calls).toHaveLength(0);
+    });
+
+    /*
+     * The other half of the ordering: under the cap, sanitize still runs and
+     * still does its filtering. The guard bounds the work; it does not
+     * replace the type coercion.
+     */
+    test("an under-cap array of junk does reach sanitize and comes out empty", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeJunkFrames(MAX_FRAMES_PER_RESOLVE_REQUEST)),
+      );
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(sanitizeMinifiedStackFrames.mock.calls).toHaveLength(1);
+      expect(forwardedFrames()).toHaveLength(0);
+    });
+
+    test("an at-cap mixed array forwards only the object frames sanitize kept", async () => {
+      const mixed: Array<unknown> = [
+        ...makeFrames(4),
+        ...makeJunkFrames(MAX_FRAMES_PER_RESOLVE_REQUEST - 4),
+      ];
+
+      const result: CallResult = await call(bodyWithFrames(mixed));
+
+      expect(result.deniedWith).toBeUndefined();
+      expect(forwardedFrames()).toHaveLength(4);
+    });
+  });
+
+  describe("guard ordering: serviceId and serviceVersion are checked first", () => {
+    /*
+     * The identity checks stay in front of the cap. A request that is both
+     * oversized and missing its serviceId is not a limits problem — telling
+     * the caller about the frame limit would send them off trimming a trace
+     * when the actual defect is an unset field, and they would hit the same
+     * wall again with a shorter payload.
+     */
+    test("an oversized request missing serviceId is refused for serviceId", async () => {
+      const result: CallResult = await call({
+        serviceVersion: "1.4.2",
+        frames: makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1),
+      } as unknown as JSONObject);
+
+      expect(result.deniedWith?.message).toBe("serviceId is required");
+      expect(result.deniedWith?.message).not.toBe(TOO_MANY_FRAMES_MESSAGE);
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+
+    test("an oversized request with a non-string serviceId is refused for serviceId", async () => {
+      const result: CallResult = await call({
+        serviceId: 42,
+        serviceVersion: "1.4.2",
+        frames: makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1),
+      } as unknown as JSONObject);
+
+      expect(result.deniedWith?.message).toBe("serviceId is required");
+    });
+
+    test("an oversized request missing serviceVersion is refused for serviceVersion", async () => {
+      const result: CallResult = await call({
+        serviceId: serviceId.toString(),
+        frames: makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1),
+      } as unknown as JSONObject);
+
+      expect(result.deniedWith?.message).toBe("serviceVersion is required");
+      expect(result.deniedWith?.message).not.toBe(TOO_MANY_FRAMES_MESSAGE);
+    });
+
+    /*
+     * And the tenant check stays in front of everything: an unscoped request
+     * must never get as far as reporting anything about its payload.
+     */
+    test("an oversized request without a tenant is refused for the project, not the frames", async () => {
+      jest
+        .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+        .mockResolvedValue({
+          tenantId: undefined,
+          userType: UserType.User,
+        } as unknown as DatabaseCommonInteractionProps);
+
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.deniedWith?.message).toBe("Invalid Project ID");
+      expect(resolveFramesForService.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe("the cap is a request guard, not an error handler", () => {
+    /*
+     * A rejected request answers the caller directly; it must not fall
+     * through to express' error path, which would turn a 400 into a 500.
+     */
+    test("an oversized request is answered, not thrown to next", async () => {
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST + 1)),
+      );
+
+      expect(result.thrownToNext).toBeUndefined();
+      expect(result.deniedWith).toBeDefined();
+    });
+
+    // A failure below the guard still goes to next, as it always did.
+    test("a resolver failure on an accepted request still reaches the error handler", async () => {
+      resolveFramesForService.mockRejectedValue(
+        new Error("clickhouse said no"),
+      );
+
+      const result: CallResult = await call(
+        bodyWithFrames(makeFrames(MAX_FRAMES_PER_RESOLVE_REQUEST)),
+      );
+
+      expect(result.thrownToNext).toBeDefined();
+      expect(result.jsonBody).toBeUndefined();
+    });
+  });
+});

--- a/Common/Tests/Server/Middleware/MultipartFormData.test.ts
+++ b/Common/Tests/Server/Middleware/MultipartFormData.test.ts
@@ -43,15 +43,21 @@ jest.setTimeout(180_000);
  */
 
 import MultipartFormDataMiddleware, {
+  getMultipartFormDataMiddleware,
   MAX_MULTIPART_FIELDS,
   MAX_MULTIPART_FIELD_BYTES,
   MAX_MULTIPART_FILES,
   MAX_MULTIPART_FILE_BYTES,
 } from "../../../Server/Middleware/MultipartFormData";
 import {
+  SourceMapMaxFilesPerRequest,
+  SourceMapMaxFileSizeInBytes,
+} from "../../../Server/EnvironmentConfig";
+import {
   ExpressRequest,
   ExpressResponse,
   NextFunction,
+  RequestHandler,
 } from "../../../Server/Utils/Express";
 import Exception from "../../../Types/Exception/Exception";
 import ExceptionCode from "../../../Types/Exception/ExceptionCode";
@@ -95,11 +101,33 @@ interface Outcome {
   nextCalls: number;
 }
 
+interface RunOptions {
+  /*
+   * Which handler to drive. Defaults to the shared export, so every call
+   * written before getMultipartFormDataMiddleware existed still reads as
+   * "the middleware".
+   */
+  middleware?: RequestHandler;
+  /*
+   * Override the Content-Type header, for the one case that needs a
+   * multipart request busboy cannot parse at all.
+   */
+  contentType?: string;
+}
+
 /*
  * Drive the middleware with a real multipart body over a real Readable, so
  * busboy does the parsing it does in production rather than being faked.
  */
-function run(parts: Array<MultipartPart>): Promise<Outcome> {
+function run(
+  parts: Array<MultipartPart>,
+  options?: RunOptions,
+): Promise<Outcome> {
+  const middleware: RequestHandler =
+    options && options.middleware
+      ? options.middleware
+      : MultipartFormDataMiddleware;
+
   const body: Buffer = buildMultipartBody(parts);
 
   const req: Readable & {
@@ -109,7 +137,10 @@ function run(parts: Array<MultipartPart>): Promise<Outcome> {
   } = Readable.from([body]) as never;
 
   req.headers = {
-    "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+    "content-type":
+      options && options.contentType
+        ? options.contentType
+        : `multipart/form-data; boundary=${BOUNDARY}`,
     "content-length": String(body.length),
   };
 
@@ -123,7 +154,7 @@ function run(parts: Array<MultipartPart>): Promise<Outcome> {
   return new Promise<Outcome>((resolve: (value: Outcome) => void): void => {
     let nextCalls: number = 0;
 
-    MultipartFormDataMiddleware(req as unknown as ExpressRequest, res, ((
+    middleware(req as unknown as ExpressRequest, res, ((
       err?: unknown,
     ): void => {
       nextCalls++;
@@ -134,6 +165,23 @@ function run(parts: Array<MultipartPart>): Promise<Outcome> {
       });
     }) as NextFunction);
   });
+}
+
+/*
+ * `count` one-byte files. The count limits are what these fixtures probe, so
+ * the payload per file is deliberately trivial.
+ */
+function tinyFiles(count: number): Array<MultipartPart> {
+  return Array.from(
+    { length: count },
+    (_v: unknown, i: number): MultipartPart => {
+      return {
+        name: `f${i}`,
+        value: Buffer.from("x"),
+        filename: `f${i}.bin`,
+      };
+    },
+  );
 }
 
 function files(outcome: Outcome): Array<{ fieldname: string; buffer: Buffer }> {
@@ -154,6 +202,24 @@ describe("MultipartFormData - the limits are set where they were reasoned about"
     expect(MAX_MULTIPART_FIELDS).toBe(200);
     expect(Number.isFinite(MAX_MULTIPART_FILES)).toBe(true);
     expect(Number.isFinite(MAX_MULTIPART_FIELDS)).toBe(true);
+  });
+
+  test("the source map env knobs cannot be configured past these two ceilings", () => {
+    /*
+     * Common/Server/EnvironmentConfig.ts clamps SOURCE_MAP_MAX_FILES_PER_REQUEST
+     * to 50 and SOURCE_MAP_MAX_FILE_SIZE_BYTES to 50 MiB, and repeats both as
+     * literals rather than importing them - config has no business pulling in
+     * multer and express. That copy is the thing this pins: if either constant
+     * here moves DOWN, the config default silently becomes unenforceable and
+     * multer starts aborting requests the config layer thought it had accepted
+     * (a 413 where the operator was promised a 400).
+     */
+    expect(SourceMapMaxFilesPerRequest).toBeLessThanOrEqual(
+      MAX_MULTIPART_FILES,
+    );
+    expect(SourceMapMaxFileSizeInBytes).toBeLessThanOrEqual(
+      MAX_MULTIPART_FILE_BYTES,
+    );
   });
 });
 
@@ -294,5 +360,525 @@ describe("MultipartFormData - breaches answer 413, not 500", () => {
     ]);
 
     expect(outcome.nextCalls).toBe(1);
+  });
+});
+
+/*
+ * getMultipartFormDataMiddleware exists so the source map upload route can
+ * hold itself to SOURCE_MAP_MAX_FILES_PER_REQUEST files instead of the shared
+ * 50. Two properties matter more than the count itself:
+ *
+ *   - it is DOWNWARD only. Every route mounting this parses before its own
+ *     auth check, so MAX_MULTIPART_FILES is the ceiling an unauthenticated
+ *     caller is held to across all of them. A knob that could raise it would
+ *     widen the pre-auth memory surface of routes that never asked for it.
+ *   - narrowing is per route. It builds a SECOND multer instance rather than
+ *     reconfiguring the shared one, so a tighter source map route must not
+ *     make Pyroscope ingest or inbound email tighter by proxy.
+ */
+describe("getMultipartFormDataMiddleware - nothing to narrow means the shared instance", () => {
+  test("asking for exactly the shared ceiling hands back the default export itself", () => {
+    /*
+     * Identity, not equivalence: a fresh middleware here would be a second
+     * multer with a second memoryStorage for no behavioural difference, and
+     * this function is documented as build-once-at-module-scope precisely
+     * because instances are not free.
+     */
+    expect(
+      getMultipartFormDataMiddleware({ maxFiles: MAX_MULTIPART_FILES }),
+    ).toBe(MultipartFormDataMiddleware);
+  });
+
+  test("one file above the ceiling is clamped back onto the default export", () => {
+    expect(
+      getMultipartFormDataMiddleware({ maxFiles: MAX_MULTIPART_FILES + 1 }),
+    ).toBe(MultipartFormDataMiddleware);
+  });
+
+  test("absurd, unbounded and fractional requests above the ceiling all clamp onto the default export", () => {
+    /*
+     * The clamp is what turns a misconfigured SOURCE_MAP_MAX_FILES_PER_REQUEST
+     * into a no-op instead of a widened pre-auth surface, so every shape an
+     * operator could plausibly produce has to land on the shared instance.
+     *
+     * Written against MAX_MULTIPART_FILES rather than the number it happens
+     * to hold, so raising the shared ceiling does not quietly turn these into
+     * assertions about a value that is no longer above it.
+     */
+    for (const attempted of [
+      MAX_MULTIPART_FILES + 1,
+      MAX_MULTIPART_FILES + 0.5,
+      MAX_MULTIPART_FILES * 2,
+      1000,
+      Number.MAX_SAFE_INTEGER,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(getMultipartFormDataMiddleware({ maxFiles: attempted })).toBe(
+        MultipartFormDataMiddleware,
+      );
+    }
+  });
+
+  test("no attempted value yields a middleware that accepts more than MAX_MULTIPART_FILES files", async () => {
+    /*
+     * The identity checks above prove the fast path was taken; this proves
+     * the property those checks are a proxy for. If the clamp were ever
+     * dropped, an instance built for 1000 files would happily buffer 51 of
+     * them before auth - so drive the returned handler with one file more
+     * than the shared ceiling and require the 413 either way.
+     */
+    for (const attempted of [
+      MAX_MULTIPART_FILES + 1,
+      MAX_MULTIPART_FILES * 2,
+      MAX_MULTIPART_FILES * 10,
+      Number.MAX_SAFE_INTEGER,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      const middleware: RequestHandler = getMultipartFormDataMiddleware({
+        maxFiles: attempted,
+      });
+
+      const outcome: Outcome = await run(tinyFiles(MAX_MULTIPART_FILES + 1), {
+        middleware: middleware,
+      });
+
+      expect((outcome.error as Exception).code).toBe(
+        ExceptionCode.PayloadTooLargeException,
+      );
+      expect((outcome.error as Exception).message).toContain(
+        "LIMIT_FILE_COUNT",
+      );
+    }
+  });
+});
+
+describe("getMultipartFormDataMiddleware - a narrowed instance is narrower, and only for itself", () => {
+  const narrow: RequestHandler = getMultipartFormDataMiddleware({
+    maxFiles: 2,
+  });
+
+  test("a genuinely narrower request builds its own handler, not the shared one", () => {
+    expect(narrow).not.toBe(MultipartFormDataMiddleware);
+  });
+
+  test("exactly its own file limit is accepted", async () => {
+    const outcome: Outcome = await run(tinyFiles(2), { middleware: narrow });
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(2);
+  });
+
+  test("one file under its limit is accepted", async () => {
+    const outcome: Outcome = await run(tinyFiles(1), { middleware: narrow });
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(1);
+  });
+
+  test("one file over its limit answers 413, not the shared 50-file limit", async () => {
+    const outcome: Outcome = await run(tinyFiles(3), { middleware: narrow });
+
+    expect(outcome.error).toBeInstanceOf(Exception);
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).code).toBe(413);
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+
+  test("the very same three files still pass the default middleware", async () => {
+    /*
+     * The regression this guards: narrowing one route by mutating the shared
+     * multer's limits would look identical in the test above and quietly cut
+     * Pyroscope ingest and SendGrid inbound email down to two files each.
+     */
+    const outcome: Outcome = await run(tinyFiles(3));
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(3);
+  });
+
+  test("the default middleware still accepts a full 50 files after a narrower one exists", async () => {
+    const outcome: Outcome = await run(tinyFiles(MAX_MULTIPART_FILES));
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(MAX_MULTIPART_FILES);
+  });
+
+  test("the narrowed instance stays narrow after the default has been used", async () => {
+    /*
+     * The mirror image of the leak: two multer instances sharing mutable
+     * limits would drift in whichever direction ran last, so re-drive the
+     * narrow one after the 50-file body above.
+     */
+    const outcome: Outcome = await run(tinyFiles(3), { middleware: narrow });
+
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+});
+
+describe("getMultipartFormDataMiddleware - the low end clamps up to 1, never to zero", () => {
+  test("maxFiles: 0 still accepts a file", async () => {
+    /*
+     * multer reads `files: 0` as "no files at all", which would turn a
+     * misconfigured SOURCE_MAP_MAX_FILES_PER_REQUEST into a route that 413s
+     * every upload. Clamping up to 1 keeps the route working, degraded, and
+     * the parse still bounded.
+     */
+    const middleware: RequestHandler = getMultipartFormDataMiddleware({
+      maxFiles: 0,
+    });
+
+    const outcome: Outcome = await run(tinyFiles(1), {
+      middleware: middleware,
+    });
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(1);
+  });
+
+  test("maxFiles: 0 rejects the second file, so it clamped to 1 rather than to the default", async () => {
+    const middleware: RequestHandler = getMultipartFormDataMiddleware({
+      maxFiles: 0,
+    });
+
+    const outcome: Outcome = await run(tinyFiles(2), {
+      middleware: middleware,
+    });
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+
+  test("a negative maxFiles behaves exactly like 1", async () => {
+    const middleware: RequestHandler = getMultipartFormDataMiddleware({
+      maxFiles: -5,
+    });
+
+    const accepted: Outcome = await run(tinyFiles(1), {
+      middleware: middleware,
+    });
+    const rejected: Outcome = await run(tinyFiles(2), {
+      middleware: middleware,
+    });
+
+    expect(accepted.error).toBeUndefined();
+    expect(files(accepted)).toHaveLength(1);
+    expect((rejected.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+  });
+
+  test("clamped-up values are still their own handler, not the shared one", () => {
+    expect(getMultipartFormDataMiddleware({ maxFiles: 0 })).not.toBe(
+      MultipartFormDataMiddleware,
+    );
+    expect(getMultipartFormDataMiddleware({ maxFiles: -5 })).not.toBe(
+      MultipartFormDataMiddleware,
+    );
+  });
+});
+
+/*
+ * The DOMAIN is clamped, not only the range.
+ *
+ * busboy's file-count check is `files === filesLimit` - an equality against a
+ * counter that only ever holds whole numbers. A fractional or NaN limit
+ * therefore never matches anything: it does not narrow the parse, it removes
+ * the file bound outright and leaves an unauthenticated caller free to send as
+ * many files as it likes. That is the precise widening this function exists to
+ * prevent, so Math.floor and the finite check are load-bearing rather than
+ * defensive tidiness.
+ *
+ * Latent as things stand - the only caller passes the value through
+ * parsePositiveIntegerFromEnv, which rejects "1.5" and garbage before it gets
+ * here. Pinned anyway, because the function is exported and the next caller
+ * may not come through the config layer at all.
+ */
+describe("getMultipartFormDataMiddleware - a non-integer maxFiles cannot unbound the parse", () => {
+  test("a fractional maxFiles narrows to the whole number below it", async () => {
+    const middleware: RequestHandler = getMultipartFormDataMiddleware({
+      maxFiles: 2.5,
+    });
+
+    const accepted: Outcome = await run(tinyFiles(2), {
+      middleware: middleware,
+    });
+    const rejected: Outcome = await run(tinyFiles(3), {
+      middleware: middleware,
+    });
+
+    expect(accepted.error).toBeUndefined();
+    expect(files(accepted)).toHaveLength(2);
+    /*
+     * The half is what matters: handed 2.5 straight to multer, this third
+     * file arrives with no error at all.
+     */
+    expect((rejected.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((rejected.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+
+  test("a fractional maxFiles above the ceiling is still bounded by the ceiling", async () => {
+    const middleware: RequestHandler = getMultipartFormDataMiddleware({
+      maxFiles: MAX_MULTIPART_FILES + 0.5,
+    });
+
+    const outcome: Outcome = await run(tinyFiles(MAX_MULTIPART_FILES + 1), {
+      middleware: middleware,
+    });
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+
+  test("NaN falls back to the shared ceiling rather than removing the file bound", async () => {
+    /*
+     * NaN survives every comparison a naive clamp makes - Math.min(NaN, 50)
+     * and Math.max(1, NaN) are both NaN - so it would reach multer intact and
+     * silently uncap the route. It has to land on the shared instance instead.
+     */
+    const middleware: RequestHandler = getMultipartFormDataMiddleware({
+      maxFiles: Number.NaN,
+    });
+
+    expect(middleware).toBe(MultipartFormDataMiddleware);
+
+    const outcome: Outcome = await run(tinyFiles(MAX_MULTIPART_FILES + 1), {
+      middleware: middleware,
+    });
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
+  });
+});
+
+describe("getMultipartFormDataMiddleware - narrowing files changes nothing else", () => {
+  const narrow: RequestHandler = getMultipartFormDataMiddleware({
+    maxFiles: 2,
+  });
+
+  test("its own file-count limit does not relax the shared size ceiling", async () => {
+    const outcome: Outcome = await run(
+      [
+        {
+          name: "big",
+          value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES + 1),
+          filename: "big.bin",
+        },
+      ],
+      { middleware: narrow },
+    );
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_SIZE");
+  });
+
+  test("the shared size ceiling is exclusive, and a narrowed instance lands on the same byte", async () => {
+    /*
+     * busboy truncates a file the moment its byte count REACHES fileSize
+     * (`fileSize === fileSizeLimit`), so the largest body that survives is
+     * one byte under the constant, not the constant itself.
+     *
+     * Worth pinning rather than glossing: EnvironmentConfig clamps
+     * SOURCE_MAP_MAX_FILE_SIZE_BYTES to exactly MAX_MULTIPART_FILE_BYTES and
+     * SourceMapIngestService rejects only what is STRICTLY over it, so a map
+     * of precisely that many bytes is one the service means to accept and the
+     * parser kills first. Whatever that boundary is, narrowing the file COUNT
+     * must not move it.
+     */
+    const underCeiling: Outcome = await run(
+      [
+        {
+          name: "justunder",
+          value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES - 1),
+          filename: "justunder.bin",
+        },
+      ],
+      { middleware: narrow },
+    );
+
+    expect(underCeiling.error).toBeUndefined();
+    expect(files(underCeiling)[0]!.buffer.length).toBe(
+      MAX_MULTIPART_FILE_BYTES - 1,
+    );
+
+    const atCeiling: Outcome = await run(
+      [
+        {
+          name: "atlimit",
+          value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES),
+          filename: "atlimit.bin",
+        },
+      ],
+      { middleware: narrow },
+    );
+
+    expect((atCeiling.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((atCeiling.error as Exception).message).toContain("LIMIT_FILE_SIZE");
+  });
+
+  test("the shared field-value ceiling still applies", async () => {
+    const outcome: Outcome = await run(
+      [{ name: "html", value: Buffer.alloc(MAX_MULTIPART_FIELD_BYTES + 1) }],
+      { middleware: narrow },
+    );
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FIELD_VALUE");
+  });
+
+  test("the whole shared field allowance still parses alongside its files", async () => {
+    /*
+     * `parts` is files + fields, so a narrowed instance has to carry the
+     * field allowance over rather than deriving the part budget from its own
+     * file count. Leaving parts at 2 - or at anything near it - would make
+     * the part count the effective limit, and the source map route would
+     * start 413ing bodies whose field count the shared config says are fine.
+     */
+    const outcome: Outcome = await run(
+      [
+        ...Array.from(
+          { length: MAX_MULTIPART_FIELDS },
+          (_v: unknown, i: number): MultipartPart => {
+            return { name: `k${i}`, value: Buffer.from("v") };
+          },
+        ),
+        ...tinyFiles(1),
+      ],
+      { middleware: narrow },
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(
+      Object.keys(outcome.req.body as Record<string, unknown>),
+    ).toHaveLength(MAX_MULTIPART_FIELDS);
+    expect(files(outcome)).toHaveLength(1);
+  });
+
+  test("its full file count fits alongside one field short of the allowance", async () => {
+    const outcome: Outcome = await run(
+      [
+        ...Array.from(
+          { length: MAX_MULTIPART_FIELDS - 1 },
+          (_v: unknown, i: number): MultipartPart => {
+            return { name: `k${i}`, value: Buffer.from("v") };
+          },
+        ),
+        ...tinyFiles(2),
+      ],
+      { middleware: narrow },
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(files(outcome)).toHaveLength(2);
+  });
+
+  test("the maximal body trips the same parts off-by-one the default instance has", async () => {
+    /*
+     * busboy starts its part counter at -1 to account for the opening
+     * boundary and then fires partsLimit when the counter REACHES the limit,
+     * so `parts: n` admits n - 1 real parts. A body carrying the file limit
+     * AND the field limit in full is therefore rejected with
+     * LIMIT_PART_COUNT even though neither of those two limits was breached.
+     *
+     * This is inherited, not introduced: the same expression produced the
+     * same result before the per-route knob existed. It is pinned on BOTH
+     * instances so the narrowed one is provably no tighter than the shared
+     * one - a narrowing that also stole a part or two would show up here as
+     * the 199-field case above failing while this one still passed.
+     */
+    const fields: (count: number) => Array<MultipartPart> = (
+      count: number,
+    ): Array<MultipartPart> => {
+      return Array.from(
+        { length: count },
+        (_v: unknown, i: number): MultipartPart => {
+          return { name: `k${i}`, value: Buffer.from("v") };
+        },
+      );
+    };
+
+    const narrowed: Outcome = await run(
+      [...fields(MAX_MULTIPART_FIELDS), ...tinyFiles(2)],
+      { middleware: narrow },
+    );
+
+    expect((narrowed.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((narrowed.error as Exception).message).toContain("LIMIT_PART_COUNT");
+
+    const shared: Outcome = await run([
+      ...fields(MAX_MULTIPART_FIELDS),
+      ...tinyFiles(MAX_MULTIPART_FILES),
+    ]);
+
+    expect((shared.error as Exception).message).toContain("LIMIT_PART_COUNT");
+  });
+
+  test("one field too many is still LIMIT_FIELD_COUNT, not LIMIT_PART_COUNT", async () => {
+    const outcome: Outcome = await run(
+      Array.from(
+        { length: MAX_MULTIPART_FIELDS + 1 },
+        (_v: unknown, i: number): MultipartPart => {
+          return { name: `k${i}`, value: Buffer.from("v") };
+        },
+      ),
+      { middleware: narrow },
+    );
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FIELD_COUNT");
+  });
+
+  test("next() is called exactly once on a breach here too", async () => {
+    const outcome: Outcome = await run(tinyFiles(3), { middleware: narrow });
+
+    expect(outcome.nextCalls).toBe(1);
+  });
+
+  test("a non-multer error passes straight through instead of becoming a 413", async () => {
+    /*
+     * A multipart Content-Type with no boundary makes busboy throw during
+     * construction, which multer hands to next() as a plain Error. That is a
+     * malformed request, not an oversized one, and the error mapping both
+     * instances share must not launder it into a PayloadTooLargeException -
+     * doing so would report every parser failure as "you sent too much".
+     */
+    const outcome: Outcome = await run(tinyFiles(1), {
+      middleware: narrow,
+      contentType: "multipart/form-data",
+    });
+
+    expect(outcome.error).toBeInstanceOf(Error);
+    expect(outcome.error).not.toBeInstanceOf(Exception);
+    expect((outcome.error as Error).message).toContain("Boundary not found");
+    expect(outcome.nextCalls).toBe(1);
+  });
+
+  test("the default middleware treats that same non-multer error identically", async () => {
+    const outcome: Outcome = await run(tinyFiles(1), {
+      contentType: "multipart/form-data",
+    });
+
+    expect(outcome.error).toBeInstanceOf(Error);
+    expect(outcome.error).not.toBeInstanceOf(Exception);
+    expect((outcome.error as Error).message).toContain("Boundary not found");
   });
 });

--- a/Common/Tests/Server/Middleware/MultipartFormData.test.ts
+++ b/Common/Tests/Server/Middleware/MultipartFormData.test.ts
@@ -683,50 +683,58 @@ describe("getMultipartFormDataMiddleware - narrowing files changes nothing else"
     expect((outcome.error as Exception).message).toContain("LIMIT_FILE_SIZE");
   });
 
-  test("the shared size ceiling is exclusive, and a narrowed instance lands on the same byte", async () => {
+  test("the shared size ceiling is INCLUSIVE, and a narrowed instance lands on the same byte", async () => {
     /*
-     * busboy truncates a file the moment its byte count REACHES fileSize
-     * (`fileSize === fileSizeLimit`), so the largest body that survives is
-     * one byte under the constant, not the constant itself.
+     * busboy truncates a file the moment its byte count REACHES fileSize,
+     * so the middleware hands it MAX_MULTIPART_FILE_BYTES + 1 to make the
+     * constant itself an inclusive maximum.
      *
      * Worth pinning rather than glossing: EnvironmentConfig clamps
      * SOURCE_MAP_MAX_FILE_SIZE_BYTES to exactly MAX_MULTIPART_FILE_BYTES and
      * SourceMapIngestService rejects only what is STRICTLY over it, so a map
-     * of precisely that many bytes is one the service means to accept and the
-     * parser kills first. Whatever that boundary is, narrowing the file COUNT
-     * must not move it.
+     * of precisely that many bytes is one the service means to accept -- and
+     * before the +1 the parser killed it first, turning the 400 the endpoint
+     * documents into a 413 it never saw. Narrowing the file COUNT must not
+     * move that boundary either.
      */
-    const underCeiling: Outcome = await run(
-      [
-        {
-          name: "justunder",
-          value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES - 1),
-          filename: "justunder.bin",
-        },
-      ],
-      { middleware: narrow },
-    );
-
-    expect(underCeiling.error).toBeUndefined();
-    expect(files(underCeiling)[0]!.buffer.length).toBe(
-      MAX_MULTIPART_FILE_BYTES - 1,
-    );
+    // One allocation, driven through both instances - it is 50 MiB.
+    const atLimit: Buffer = Buffer.alloc(MAX_MULTIPART_FILE_BYTES);
 
     const atCeiling: Outcome = await run(
+      [{ name: "atlimit", value: atLimit, filename: "atlimit.bin" }],
+      { middleware: narrow },
+    );
+
+    expect(atCeiling.error).toBeUndefined();
+    expect(files(atCeiling)[0]!.buffer.length).toBe(MAX_MULTIPART_FILE_BYTES);
+
+    // The shared instance is the baseline the narrowed one must match.
+    const sharedAtCeiling: Outcome = await run([
+      { name: "atlimit", value: atLimit, filename: "atlimit.bin" },
+    ]);
+
+    expect(sharedAtCeiling.error).toBeUndefined();
+    expect(files(sharedAtCeiling)[0]!.buffer.length).toBe(
+      MAX_MULTIPART_FILE_BYTES,
+    );
+
+    const overCeiling: Outcome = await run(
       [
         {
-          name: "atlimit",
-          value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES),
-          filename: "atlimit.bin",
+          name: "overlimit",
+          value: Buffer.alloc(MAX_MULTIPART_FILE_BYTES + 1),
+          filename: "overlimit.bin",
         },
       ],
       { middleware: narrow },
     );
 
-    expect((atCeiling.error as Exception).code).toBe(
+    expect((overCeiling.error as Exception).code).toBe(
       ExceptionCode.PayloadTooLargeException,
     );
-    expect((atCeiling.error as Exception).message).toContain("LIMIT_FILE_SIZE");
+    expect((overCeiling.error as Exception).message).toContain(
+      "LIMIT_FILE_SIZE",
+    );
   });
 
   test("the shared field-value ceiling still applies", async () => {
@@ -787,19 +795,19 @@ describe("getMultipartFormDataMiddleware - narrowing files changes nothing else"
     expect(files(outcome)).toHaveLength(2);
   });
 
-  test("the maximal body trips the same parts off-by-one the default instance has", async () => {
+  test("the maximal body - the full file AND field allowance - is accepted", async () => {
     /*
      * busboy starts its part counter at -1 to account for the opening
      * boundary and then fires partsLimit when the counter REACHES the limit,
-     * so `parts: n` admits n - 1 real parts. A body carrying the file limit
-     * AND the field limit in full is therefore rejected with
-     * LIMIT_PART_COUNT even though neither of those two limits was breached.
+     * so a raw `parts: n` admits only n - 1. That used to reject a body
+     * carrying the file limit AND the field limit in full with
+     * LIMIT_PART_COUNT, though neither of those limits was breached -- the
+     * exact thing the comment on `parts` says must not happen. The
+     * middleware now converts it, so the maximal body parses.
      *
-     * This is inherited, not introduced: the same expression produced the
-     * same result before the per-route knob existed. It is pinned on BOTH
-     * instances so the narrowed one is provably no tighter than the shared
-     * one - a narrowing that also stole a part or two would show up here as
-     * the 199-field case above failing while this one still passed.
+     * Pinned on BOTH instances so the narrowed one is provably no tighter
+     * than the shared one: a narrowing that also stole a part would show up
+     * here rather than in production.
      */
     const fields: (count: number) => Array<MultipartPart> = (
       count: number,
@@ -817,17 +825,38 @@ describe("getMultipartFormDataMiddleware - narrowing files changes nothing else"
       { middleware: narrow },
     );
 
-    expect((narrowed.error as Exception).code).toBe(
-      ExceptionCode.PayloadTooLargeException,
-    );
-    expect((narrowed.error as Exception).message).toContain("LIMIT_PART_COUNT");
+    expect(narrowed.error).toBeUndefined();
+    expect(files(narrowed)).toHaveLength(2);
 
     const shared: Outcome = await run([
       ...fields(MAX_MULTIPART_FIELDS),
       ...tinyFiles(MAX_MULTIPART_FILES),
     ]);
 
-    expect((shared.error as Exception).message).toContain("LIMIT_PART_COUNT");
+    expect(shared.error).toBeUndefined();
+    expect(files(shared)).toHaveLength(MAX_MULTIPART_FILES);
+  });
+
+  test("one file past the maximal body is LIMIT_FILE_COUNT, not LIMIT_PART_COUNT", async () => {
+    /*
+     * The counts stay the limits that actually speak. Raising `parts` to
+     * admit the maximal body must not push the parts limit down onto a body
+     * that breaches the file allowance -- the caller needs to be told which
+     * allowance they exceeded.
+     */
+    const outcome: Outcome = await run(
+      Array.from(
+        { length: MAX_MULTIPART_FIELDS },
+        (_v: unknown, i: number): MultipartPart => {
+          return { name: `k${i}`, value: Buffer.from("v") };
+        },
+      ).concat(tinyFiles(MAX_MULTIPART_FILES + 1)),
+    );
+
+    expect((outcome.error as Exception).code).toBe(
+      ExceptionCode.PayloadTooLargeException,
+    );
+    expect((outcome.error as Exception).message).toContain("LIMIT_FILE_COUNT");
   });
 
   test("one field too many is still LIMIT_FIELD_COUNT, not LIMIT_PART_COUNT", async () => {

--- a/Common/Tests/Server/Services/TelemetrySourceMapService.test.ts
+++ b/Common/Tests/Server/Services/TelemetrySourceMapService.test.ts
@@ -1,3 +1,43 @@
+/*
+ * The per-release ceiling used to be a hardcoded 100 that also bounded what
+ * resolveFramesForService would READ. This suite pins the two apart:
+ *
+ *   - the ceiling is an operator knob (SOURCE_MAP_MAX_MAPS_PER_RELEASE) that
+ *     gates WRITES, enforced on the create path itself;
+ *   - the read path bounds itself by BYTES loaded
+ *     (SOURCE_MAP_MAX_BYTES_PER_RESOLVE), so a release that fits the write
+ *     gate always resolves in full.
+ *
+ * SourceMapMaxBytesPerResolve is read at call time, so a getter over the real
+ * config lets a case pick a budget measured in tens of bytes while every
+ * other value stays production-real. bytesPerResolve === null means "use the
+ * configured value", which is what every non-budget case runs with.
+ */
+const mockResolveBudget: { bytesPerResolve: number | null } = {
+  bytesPerResolve: null,
+};
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const actualConfig: Record<string, unknown> = jest.requireActual(
+    "../../../Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  const mockedConfig: Record<string, unknown> = { ...actualConfig };
+
+  Object.defineProperty(mockedConfig, "SourceMapMaxBytesPerResolve", {
+    configurable: true,
+    enumerable: true,
+    get: (): number => {
+      return (
+        mockResolveBudget.bytesPerResolve ??
+        (actualConfig["SourceMapMaxBytesPerResolve"] as number)
+      );
+    },
+  });
+
+  return mockedConfig;
+});
+
 import TelemetrySourceMapService, {
   MAX_SOURCE_MAP_SIZE_IN_BYTES,
   MAX_SOURCE_MAPS_PER_RELEASE,
@@ -7,7 +47,18 @@ import CreateBy from "../../../Server/Types/Database/CreateBy";
 import TelemetrySourceMap from "../../../Models/DatabaseModels/TelemetrySourceMap";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
-import { ResolveStackTraceResult } from "../../../Types/Telemetry/SourceMap";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import logger from "../../../Server/Utils/Logger";
+import { MAX_FRAMES_TO_RESOLVE } from "../../../Server/Utils/Telemetry/SourceMapResolver";
+import {
+  SourceMapMaxMapsPerRelease,
+  SourceMapRetentionInDays,
+} from "../../../Server/EnvironmentConfig";
+import {
+  MinifiedStackFrame,
+  ResolveStackTraceResult,
+} from "../../../Types/Telemetry/SourceMap";
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
 
 /*
@@ -76,6 +127,25 @@ const invokeOnBeforeCreate: InvokeOnBeforeCreateFunction = async (
   ).onBeforeCreate(createBy);
 };
 
+type CaptureOnBeforeCreateRejectionFunction = (
+  createBy: CreateBy<TelemetrySourceMap>,
+) => Promise<Error>;
+
+/*
+ * The rejection itself, not just its type: the per-release message has to
+ * name the knob an operator would raise, so the message is asserted on.
+ */
+const captureOnBeforeCreateRejection: CaptureOnBeforeCreateRejectionFunction =
+  async (createBy: CreateBy<TelemetrySourceMap>): Promise<Error> => {
+    try {
+      await invokeOnBeforeCreate(createBy);
+    } catch (err) {
+      return err as Error;
+    }
+
+    throw new Error("Expected onBeforeCreate to reject, but it resolved.");
+  };
+
 type MakeRowFunction = (
   bundlePath: string,
   content?: string,
@@ -94,8 +164,144 @@ const makeRow: MakeRowFunction = (
   return row;
 };
 
+type MakeListingRowFunction = (data: {
+  bundlePath: string;
+  sizeInBytes?: number | null | undefined;
+  createdAt?: Date | undefined;
+}) => TelemetrySourceMap;
+
+/*
+ * A row as the resolver's FIRST findBy returns it: no content, but the two
+ * columns the byte budget reads — the stored size, and the timestamp that
+ * breaks ties between maps that match a frame equally well.
+ */
+const makeListingRow: MakeListingRowFunction = (data: {
+  bundlePath: string;
+  sizeInBytes?: number | null | undefined;
+  createdAt?: Date | undefined;
+}): TelemetrySourceMap => {
+  const row: TelemetrySourceMap = makeRow(data.bundlePath);
+
+  if (data.sizeInBytes !== undefined) {
+    /*
+     * Widened deliberately: the column is typed number, but a row written
+     * outside the create hook can hold null or a nonsense count, and the
+     * budget has to charge those something.
+     */
+    (row as unknown as { sizeInBytes: number | null | undefined }).sizeInBytes =
+      data.sizeInBytes;
+  }
+
+  if (data.createdAt) {
+    row.createdAt = data.createdAt;
+  }
+
+  return row;
+};
+
+type MakeFrameFunction = (fileName: string) => MinifiedStackFrame;
+
+/*
+ * A frame that the fixture map can actually resolve (line 1, column 46 maps
+ * to onSelect), so "did this map get loaded" and "did this frame resolve" are
+ * the same question.
+ */
+const makeFrame: MakeFrameFunction = (fileName: string): MinifiedStackFrame => {
+  return {
+    functionName: "e.onSelect",
+    fileName: fileName,
+    lineNumber: 1,
+    columnNumber: 46,
+    inApp: true,
+  };
+};
+
+type FindBySpy = ReturnType<typeof jest.spyOn>;
+
+type ContentFetchArgsFunction = (findBySpy: FindBySpy) => {
+  query: Record<string, unknown>;
+  limit: number;
+};
+
+/** Arguments of the SECOND findBy — the content fetch. */
+const contentFetchArgs: ContentFetchArgsFunction = (
+  findBySpy: FindBySpy,
+): { query: Record<string, unknown>; limit: number } => {
+  return findBySpy.mock.calls[1]![0] as never;
+};
+
+type RequestedContentIdsFunction = (findBySpy: FindBySpy) => Array<string>;
+
+/*
+ * The ids the content fetch actually asked for. QueryHelper.any produces a
+ * TypeORM Raw operator whose parameters object holds the id list under a
+ * random key, so it is dug out rather than compared structurally.
+ */
+const requestedContentIds: RequestedContentIdsFunction = (
+  findBySpy: FindBySpy,
+): Array<string> => {
+  const idOperator: { objectLiteralParameters?: Record<string, unknown> } =
+    contentFetchArgs(findBySpy).query["_id"] as never;
+
+  const idList: Array<unknown> = Object.values(
+    idOperator.objectLiteralParameters || {},
+  )[0] as Array<unknown>;
+
+  return idList.map((id: unknown) => {
+    return String(id);
+  });
+};
+
+type MockReleaseRowCountFunction = (count: number) => FindBySpy;
+
+const mockReleaseRowCount: MockReleaseRowCountFunction = (
+  count: number,
+): FindBySpy => {
+  return jest
+    .spyOn(TelemetrySourceMapService, "countBy")
+    .mockResolvedValue(new PositiveNumber(count) as never);
+};
+
+type MockStoredBundlePathsFunction = (bundlePaths: Array<string>) => FindBySpy;
+
+const mockStoredBundlePaths: MockStoredBundlePathsFunction = (
+  bundlePaths: Array<string>,
+): FindBySpy => {
+  return jest
+    .spyOn(TelemetrySourceMapService, "getStoredBundlePathsForRelease")
+    .mockResolvedValue(bundlePaths as never);
+};
+
+type MakeBundlePathsFunction = (count: number) => Array<string>;
+
+const makeBundlePaths: MakeBundlePathsFunction = (
+  count: number,
+): Array<string> => {
+  const bundlePaths: Array<string> = [];
+
+  for (let index: number = 0; index < count; index++) {
+    bundlePaths.push(`chunk-${index}.js`);
+  }
+
+  return bundlePaths;
+};
+
+/*
+ * One frame, three stored bundles that match it at three different strengths.
+ * The score is the number of trailing path segments the frame and the bundle
+ * share, so "x/y/main.abc123.js" (3) beats "y/main.abc123.js" (2) beats
+ * "main.abc123.js" (1). That ordering is what the byte budget spends: when
+ * not everything fits, the weakest match is what goes.
+ */
+const SCORED_FRAME_FILE_NAME: string =
+  "https://cdn.example.com/x/y/main.abc123.js";
+const STRONG_MATCH_PATH: string = "x/y/main.abc123.js";
+const MEDIUM_MATCH_PATH: string = "y/main.abc123.js";
+const WEAK_MATCH_PATH: string = "main.abc123.js";
+
 afterEach(() => {
   jest.restoreAllMocks();
+  mockResolveBudget.bytesPerResolve = null;
 });
 
 describe("retention configuration", () => {
@@ -107,10 +313,91 @@ describe("retention configuration", () => {
       SOURCE_MAP_RETENTION_DAYS,
     );
   });
+
+  it("drives retention from the SOURCE_MAP_RETENTION_DAYS knob rather than a literal", () => {
+    /*
+     * The service must not re-declare the number. If the constant ever drifts
+     * from the config, an operator who sets SOURCE_MAP_RETENTION_DAYS gets a
+     * sweep interval they did not ask for — silently, since nothing else
+     * reports the effective value.
+     */
+    expect(SOURCE_MAP_RETENTION_DAYS).toBe(SourceMapRetentionInDays);
+    expect(TelemetrySourceMapService.hardDeleteItemsOlderThanDays).toBe(
+      SourceMapRetentionInDays,
+    );
+  });
+
+  it("drives the per-release ceiling from the SOURCE_MAP_MAX_MAPS_PER_RELEASE knob", () => {
+    expect(MAX_SOURCE_MAPS_PER_RELEASE).toBe(SourceMapMaxMapsPerRelease);
+  });
+
+  /*
+   * The two assertions above are only as strong as the environment they run
+   * in: with nothing configured, SourceMapRetentionInDays IS 90 and
+   * SourceMapMaxMapsPerRelease IS 1000, so a service that went back to
+   * hardcoding those two literals would satisfy both of them and every other
+   * case in this file.
+   *
+   * The only way to tell "reads the knob" from "happens to equal the knob's
+   * default" is to configure something the defaults are not, and re-enter the
+   * module — both constants are evaluated once, at import, and
+   * hardDeleteItemsOlderThanDays is stamped from one of them in the
+   * constructor, so a fresh registry is what it takes to observe them at all.
+   */
+  it("picks up configured values rather than the defaults it happens to match", async () => {
+    const originalEnv: NodeJS.ProcessEnv = { ...process.env };
+
+    // Two numbers no default in this system is, so neither can coincide.
+    process.env["SOURCE_MAP_MAX_MAPS_PER_RELEASE"] = "4242";
+    process.env["SOURCE_MAP_RETENTION_DAYS"] = "17";
+
+    try {
+      /*
+       * resetModules rather than isolateModules: the mock factory reaches for
+       * the real EnvironmentConfig with requireActual, and an isolated
+       * registry still serves that from the copy loaded when this file was
+       * imported — so the module would come back holding the defaults and the
+       * case would prove nothing. This is the same reload the config suite
+       * uses.
+       */
+      jest.resetModules();
+
+      /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      const reloaded: {
+        default: { hardDeleteItemsOlderThanDays: number };
+        MAX_SOURCE_MAPS_PER_RELEASE: number;
+        SOURCE_MAP_RETENTION_DAYS: number;
+      } = require("../../../Server/Services/TelemetrySourceMapService");
+      /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+
+      expect(reloaded.MAX_SOURCE_MAPS_PER_RELEASE).toBe(4242);
+      expect(reloaded.SOURCE_MAP_RETENTION_DAYS).toBe(17);
+      /*
+       * And the configured retention reaches the sweep the worker actually
+       * reads, not just the exported constant.
+       */
+      expect(reloaded.default.hardDeleteItemsOlderThanDays).toBe(17);
+    } finally {
+      process.env = originalEnv;
+      /*
+       * Leave the registry as it was found. Every other case in this file
+       * works against the singleton captured by the imports at the top, which
+       * this does not disturb.
+       */
+      jest.resetModules();
+    }
+  });
 });
 
 describe("onBeforeCreate", () => {
   it("stamps sizeInBytes from the content", async () => {
+    /*
+     * Every create that survives validation now counts the release's rows, so
+     * the count is mocked here rather than reaching a database that no unit
+     * test connects to.
+     */
+    mockReleaseRowCount(0);
+
     const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy();
 
     await invokeOnBeforeCreate(createBy);
@@ -176,6 +463,232 @@ describe("onBeforeCreate", () => {
     await expect(invokeOnBeforeCreate(createBy)).rejects.toThrow(
       BadDataException,
     );
+  });
+});
+
+/*
+ * The per-release ceiling on the create path.
+ *
+ * The upload endpoint checks a whole batch up front, but TelemetrySourceMap
+ * is a full CRUD resource: POST /api/telemetry-source-map reaches create()
+ * without ever passing that check, so without this hook the configured
+ * ceiling was advisory on that path.
+ */
+describe("onBeforeCreate per-release ceiling", () => {
+  it("counts the release's rows scoped to the tenant, service and version, as root", async () => {
+    const countBySpy: FindBySpy = mockReleaseRowCount(0);
+
+    await invokeOnBeforeCreate(makeCreateBy());
+
+    const countArgs: {
+      query: Record<string, unknown>;
+      props: Record<string, unknown>;
+      skip: number;
+      limit: number;
+    } = countBySpy.mock.calls[0]![0] as never;
+
+    expect(countArgs.query["projectId"]).toBe(PROJECT_ID);
+    expect(countArgs.query["serviceId"]).toBe(SERVICE_ID);
+    expect(countArgs.query["serviceVersion"]).toBe("1.4.2");
+    expect(countArgs.skip).toBe(0);
+    expect(countArgs.limit).toBe(LIMIT_MAX);
+    // The hook runs inside create, before permissions are re-derived.
+    expect(countArgs.props["isRoot"]).toBe(true);
+  });
+
+  it("admits a create one map under the ceiling without paying for the distinct-bundle listing", async () => {
+    mockReleaseRowCount(MAX_SOURCE_MAPS_PER_RELEASE - 1);
+    const bundlePathsSpy: FindBySpy = mockStoredBundlePaths([]);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy();
+
+    await invokeOnBeforeCreate(createBy);
+
+    /*
+     * Below the ceiling there is nothing to decide, whatever the rows hold —
+     * so the second, more expensive query must not run. This is what keeps a
+     * bulk upload paying one indexed COUNT per insert and no more.
+     */
+    expect(bundlePathsSpy).not.toHaveBeenCalled();
+    expect(createBy.data.sizeInBytes).toBe(
+      Buffer.byteLength(FIXTURE_MAP, "utf8"),
+    );
+  });
+
+  it("rejects a new bundle when the release already holds the ceiling in distinct bundles", async () => {
+    mockReleaseRowCount(MAX_SOURCE_MAPS_PER_RELEASE);
+    mockStoredBundlePaths(makeBundlePaths(MAX_SOURCE_MAPS_PER_RELEASE));
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      bundlePath: "brand-new-chunk.js",
+    });
+
+    const error: Error = await captureOnBeforeCreateRejection(createBy);
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toContain(
+      `limit of ${MAX_SOURCE_MAPS_PER_RELEASE} per release`,
+    );
+    /*
+     * The message has to name the knob: the only fix a self-hosted operator
+     * has for a full release is raising it (or deleting maps), and nothing
+     * else in the response says what it is called.
+     */
+    expect(error.message).toContain("SOURCE_MAP_MAX_MAPS_PER_RELEASE");
+  });
+
+  it("rejects a new bundle when the release is already above the ceiling", async () => {
+    const overCeiling: number = MAX_SOURCE_MAPS_PER_RELEASE + 7;
+
+    mockReleaseRowCount(overCeiling);
+    mockStoredBundlePaths(makeBundlePaths(overCeiling));
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      bundlePath: "brand-new-chunk.js",
+    });
+
+    const error: Error = await captureOnBeforeCreateRejection(createBy);
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toContain("SOURCE_MAP_MAX_MAPS_PER_RELEASE");
+  });
+
+  it("refuses the full release before stamping sizeInBytes, so nothing half-processed is handed on", async () => {
+    mockReleaseRowCount(MAX_SOURCE_MAPS_PER_RELEASE);
+    mockStoredBundlePaths(makeBundlePaths(MAX_SOURCE_MAPS_PER_RELEASE));
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      bundlePath: "brand-new-chunk.js",
+    });
+
+    await captureOnBeforeCreateRejection(createBy);
+
+    expect(createBy.data.sizeInBytes).toBeUndefined();
+  });
+
+  it("still admits a re-upload of a bundle the release already holds when it is at the ceiling", async () => {
+    /*
+     * A CI re-run replaces every bundle of a release. Rejecting a path the
+     * release already contains would fail that re-run outright, even though
+     * it does not grow the release by a single bundle.
+     */
+    mockReleaseRowCount(MAX_SOURCE_MAPS_PER_RELEASE);
+    mockStoredBundlePaths(makeBundlePaths(MAX_SOURCE_MAPS_PER_RELEASE));
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      bundlePath: "chunk-0.js",
+    });
+
+    await invokeOnBeforeCreate(createBy);
+
+    expect(createBy.data.sizeInBytes).toBe(
+      Buffer.byteLength(FIXTURE_MAP, "utf8"),
+    );
+  });
+
+  it("compares the incoming bundle against stored paths after normalization", async () => {
+    /*
+     * "/main.abc123.js" and "main.abc123.js" are the same bundle to the
+     * resolver, so they must be the same bundle to the gate too — otherwise a
+     * release at the ceiling rejects a re-upload purely over a leading slash.
+     */
+    mockReleaseRowCount(MAX_SOURCE_MAPS_PER_RELEASE);
+    mockStoredBundlePaths([
+      "/main.abc123.js",
+      ...makeBundlePaths(MAX_SOURCE_MAPS_PER_RELEASE - 1),
+    ]);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      bundlePath: "main.abc123.js",
+    });
+
+    await invokeOnBeforeCreate(createBy);
+
+    expect(createBy.data.sizeInBytes).toBe(
+      Buffer.byteLength(FIXTURE_MAP, "utf8"),
+    );
+  });
+
+  it("admits a new bundle when duplicate rows, not distinct bundles, reached the row count", async () => {
+    /*
+     * The model deliberately allows more than one row per bundle (a racing
+     * double upload must not fail CI). Rejecting on the ROW count alone would
+     * therefore refuse a legitimate new bundle purely because a duplicate row
+     * exists somewhere in the release — the ceiling counts distinct bundles.
+     */
+    mockReleaseRowCount(MAX_SOURCE_MAPS_PER_RELEASE);
+    mockStoredBundlePaths([
+      ...makeBundlePaths(MAX_SOURCE_MAPS_PER_RELEASE - 1),
+      "chunk-0.js",
+    ]);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      bundlePath: "brand-new-chunk.js",
+    });
+
+    await invokeOnBeforeCreate(createBy);
+
+    expect(createBy.data.sizeInBytes).toBe(
+      Buffer.byteLength(FIXTURE_MAP, "utf8"),
+    );
+  });
+
+  it("falls back to the tenant on props when the row itself carries no projectId", async () => {
+    /*
+     * A tenant-scoped create leaves projectId to the tenant column, so the
+     * gate has to read props.tenantId — otherwise the whole check silently
+     * no-ops on exactly the path most creates take.
+     */
+    const countBySpy: FindBySpy = mockReleaseRowCount(0);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy();
+    delete createBy.data.projectId;
+    createBy.props.tenantId = PROJECT_ID;
+
+    await invokeOnBeforeCreate(createBy);
+
+    const countArgs: { query: Record<string, unknown> } = countBySpy.mock
+      .calls[0]![0] as never;
+    expect(countArgs.query["projectId"]).toBe(PROJECT_ID);
+  });
+
+  it("does not count when the create can be scoped to no project at all", async () => {
+    const countBySpy: FindBySpy = mockReleaseRowCount(0);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy();
+    delete createBy.data.projectId;
+
+    await invokeOnBeforeCreate(createBy);
+
+    /*
+     * Not a silent pass: the tenant column check rejects this create on its
+     * own, with a better message than a count could give.
+     */
+    expect(countBySpy).not.toHaveBeenCalled();
+  });
+
+  it("does not count when the create carries no serviceId", async () => {
+    const countBySpy: FindBySpy = mockReleaseRowCount(0);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy();
+    delete createBy.data.serviceId;
+
+    await invokeOnBeforeCreate(createBy);
+
+    expect(countBySpy).not.toHaveBeenCalled();
+  });
+
+  it("does not count when the release version is missing, because validation rejects first", async () => {
+    const countBySpy: FindBySpy = mockReleaseRowCount(0);
+
+    const createBy: CreateBy<TelemetrySourceMap> = makeCreateBy({
+      serviceVersion: "",
+    });
+
+    await expect(invokeOnBeforeCreate(createBy)).rejects.toThrow(
+      BadDataException,
+    );
+    expect(countBySpy).not.toHaveBeenCalled();
   });
 });
 
@@ -305,9 +818,23 @@ describe("resolveFramesForService", () => {
     expect(listArgs.query["projectId"]).toBe(PROJECT_ID);
     expect(listArgs.query["serviceId"]).toBe(SERVICE_ID);
     expect(listArgs.query["serviceVersion"]).toBe("1.4.2");
-    expect(listArgs.limit).toBe(MAX_SOURCE_MAPS_PER_RELEASE);
+    /*
+     * LIMIT_MAX, deliberately NOT the per-release ceiling. The ceiling counts
+     * distinct bundle PATHS while a read limit counts ROWS; tying the read to
+     * it made duplicate rows push real bundles out of resolution (see the
+     * duplicate-row case below). Memory is bounded by the byte budget now.
+     */
+    expect(listArgs.limit).toBe(LIMIT_MAX);
     // The listing must not pull content.
     expect(listArgs.select["content"]).toBeUndefined();
+    /*
+     * It must pull the size, though: the byte budget charges each candidate
+     * its stored size, and a listing that did not select the column would
+     * charge every row the per-map ceiling instead.
+     */
+    expect(listArgs.select["sizeInBytes"]).toBe(true);
+    expect(listArgs.select["createdAt"]).toBe(true);
+    expect(listArgs.select["bundlePath"]).toBe(true);
 
     // The content fetch stays tenant-scoped too.
     const contentArgs: {
@@ -360,6 +887,37 @@ describe("resolveFramesForService", () => {
     )[0] as Array<unknown>;
     expect(idList).toHaveLength(1);
     expect(String(idList[0])).toBe(matchedRow.id!.toString());
+  });
+
+  it("asks the content fetch for exactly as many rows as it selected", async () => {
+    /*
+     * The content limit used to be the per-release ceiling, which asked the
+     * database for room for a thousand rows to fetch two. It is the size of
+     * the selected set now, so the query cannot return more than was chosen.
+     */
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([
+        makeListingRow({ bundlePath: STRONG_MATCH_PATH, sizeInBytes: 100 }),
+        makeListingRow({ bundlePath: WEAK_MATCH_PATH, sizeInBytes: 100 }),
+        makeListingRow({ bundlePath: "admin.f00baa.js", sizeInBytes: 100 }),
+      ] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+        makeRow(WEAK_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(result.sourceMapCount).toBe(3);
+    expect(requestedContentIds(findBySpy)).toHaveLength(2);
+    expect(contentFetchArgs(findBySpy).limit).toBe(2);
   });
 
   it("skips the content fetch entirely when no stored bundle matches any frame", async () => {
@@ -426,6 +984,87 @@ describe("resolveFramesForService", () => {
     expect(result.frames[0]!.originalFunctionName).toBe("newest");
   });
 
+  it("still resolves the last distinct bundle of a full release when a duplicate row exists", async () => {
+    /*
+     * THE REGRESSION THIS FIXES.
+     *
+     * A release holding the maximum number of distinct bundles, plus one
+     * duplicate row of an early bundle — which the model allows, because a
+     * racing double upload must not fail CI. That is one row MORE than the
+     * per-release ceiling.
+     *
+     * The listing used to read with limit = MAX_SOURCE_MAPS_PER_RELEASE, so
+     * the duplicate consumed the slot of the last distinct bundle: the map
+     * uploaded fine, showed in the dashboard, and then silently never
+     * resolved, with nothing anywhere saying why. The listing reads LIMIT_MAX
+     * and dedupes afterwards now, so a release that fits the write gate is
+     * fully reachable however many duplicate rows it accumulated.
+     *
+     * The findBy mock honours the limit it is handed, exactly as the database
+     * would — otherwise this case would pass under the old code too.
+     */
+    const listingRows: Array<TelemetrySourceMap> = [];
+
+    for (let index: number = 0; index < MAX_SOURCE_MAPS_PER_RELEASE; index++) {
+      listingRows.push(
+        makeListingRow({ bundlePath: `chunk-${index}.js`, sizeInBytes: 1024 }),
+      );
+
+      if (index === 0) {
+        // The duplicate row, newest-first next to the bundle it duplicates.
+        listingRows.push(
+          makeListingRow({ bundlePath: "chunk-0.js", sizeInBytes: 1024 }),
+        );
+      }
+    }
+
+    const lastDistinctBundlePath: string = `chunk-${
+      MAX_SOURCE_MAPS_PER_RELEASE - 1
+    }.js`;
+    const lastDistinctRow: TelemetrySourceMap =
+      listingRows[listingRows.length - 1]!;
+
+    expect(listingRows).toHaveLength(MAX_SOURCE_MAPS_PER_RELEASE + 1);
+    expect(lastDistinctRow.bundlePath).toBe(lastDistinctBundlePath);
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+      TelemetrySourceMapService,
+      "findBy",
+    );
+
+    findBySpy.mockImplementationOnce((async (listQuery: {
+      limit: number;
+      skip: number;
+    }): Promise<Array<TelemetrySourceMap>> => {
+      return listingRows.slice(
+        listQuery.skip,
+        listQuery.skip + listQuery.limit,
+      );
+    }) as never);
+
+    findBySpy.mockResolvedValueOnce([
+      makeRow(lastDistinctBundlePath, FIXTURE_MAP),
+    ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(lastDistinctBundlePath)],
+      });
+
+    // The duplicate collapsed away, leaving every distinct bundle listed.
+    expect(result.sourceMapCount).toBe(MAX_SOURCE_MAPS_PER_RELEASE);
+    expect(requestedContentIds(findBySpy)).toEqual([
+      lastDistinctRow.id!.toString(),
+    ]);
+    expect(result.resolvedCount).toBe(1);
+    expect(result.frames[0]!.resolved).toBe(true);
+    expect(result.frames[0]!.originalFunctionName).toBe("onSelect");
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+  });
+
   it("returns unresolved frames without querying when the release is empty", async () => {
     const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
       TelemetrySourceMapService,
@@ -453,6 +1092,32 @@ describe("resolveFramesForService", () => {
     expect(result.resolvedCount).toBe(0);
     expect(result.frames).toHaveLength(1);
     expect(result.frames[0]!.resolved).toBe(false);
+    /*
+     * Zero, never undefined: the field is required on the response, and the
+     * dashboard reads it to decide whether to tell the user that symbols are
+     * missing for a reason an operator can fix.
+     */
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+  });
+
+  it("returns nothing skipped when there are no frames to resolve", async () => {
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+      TelemetrySourceMapService,
+      "findBy",
+    );
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [],
+      });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(result.frames).toHaveLength(0);
+    expect(result.sourceMapCount).toBe(0);
+    expect(result.sourceMapsSkippedForSize).toBe(0);
   });
 
   it("returns unresolved frames when no maps exist for the release", async () => {
@@ -479,5 +1144,548 @@ describe("resolveFramesForService", () => {
     expect(result.sourceMapCount).toBe(0);
     expect(result.resolvedCount).toBe(0);
     expect(result.frames[0]!.resolved).toBe(false);
+  });
+});
+
+/*
+ * The byte budget: the bound that used to be implied by the per-release
+ * count, and a far tighter one, because it measures the thing that actually
+ * consumes memory. Resolution materialises whole maps (up to 50 MB each) and
+ * the set it loads is chosen by a caller-supplied frames array.
+ */
+describe("resolveFramesForService byte budget", () => {
+  it("loads every matching map when the whole matched set fits", async () => {
+    const warnSpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(logger, "warn")
+      .mockImplementation((): void => {});
+
+    mockResolveBudget.bytesPerResolve = 1024 * 1024;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const mediumRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: MEDIUM_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const weakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow, mediumRow, weakRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy).sort()).toEqual(
+      [
+        strongRow.id!.toString(),
+        mediumRow.id!.toString(),
+        weakRow.id!.toString(),
+      ].sort(),
+    );
+    expect(contentFetchArgs(findBySpy).limit).toBe(3);
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+    // Nothing was dropped, so there is nothing for an operator to hear about.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips the maps that do not fit and reports them on the response", async () => {
+    const warnSpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(logger, "warn")
+      .mockImplementation((): void => {});
+
+    // Room for two of the three 100-byte maps.
+    mockResolveBudget.bytesPerResolve = 250;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const mediumRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: MEDIUM_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const weakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow, mediumRow, weakRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy).sort()).toEqual(
+      [strongRow.id!.toString(), mediumRow.id!.toString()].sort(),
+    );
+    expect(contentFetchArgs(findBySpy).limit).toBe(2);
+    /*
+     * The count is the whole point of the field: a half-resolved stack trace
+     * looks identical to "the maps were never uploaded" without it.
+     */
+    expect(result.sourceMapsSkippedForSize).toBe(1);
+
+    // One warning for the whole request, naming the knob that would fix it.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain(
+      "SOURCE_MAP_MAX_BYTES_PER_RESOLVE",
+    );
+  });
+
+  it("keeps the best-matching map and drops the weakest when only one fits", async () => {
+    /*
+     * What gets dropped must be the weakest match, not an arbitrary row —
+     * that is what makes a budget defensible at all. The frame shares three
+     * trailing segments with the strong bundle and one with the weak one.
+     */
+    mockResolveBudget.bytesPerResolve = 100;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const mediumRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: MEDIUM_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const weakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      // Listed weakest-first, so only the score can explain the choice.
+      .mockResolvedValueOnce([weakRow, mediumRow, strongRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy)).toEqual([strongRow.id!.toString()]);
+    expect(result.sourceMapsSkippedForSize).toBe(2);
+    // The one map that was worth loading still resolved the frame.
+    expect(result.resolvedCount).toBe(1);
+  });
+
+  it("still fits a smaller lower-scoring map after skipping a big one", async () => {
+    /*
+     * The budget loop continues rather than breaking. One oversized map in
+     * the middle of the ranking must not cost the rest of the stack trace its
+     * symbols — a break here would drop the small map that still fits.
+     */
+    mockResolveBudget.bytesPerResolve = 1000;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const oversizedMediumRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: MEDIUM_MATCH_PATH,
+      sizeInBytes: 5000,
+    });
+    const smallWeakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 50,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([
+        strongRow,
+        oversizedMediumRow,
+        smallWeakRow,
+      ] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+        makeRow(WEAK_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy).sort()).toEqual(
+      [strongRow.id!.toString(), smallWeakRow.id!.toString()].sort(),
+    );
+    expect(contentFetchArgs(findBySpy).limit).toBe(2);
+    expect(result.sourceMapsSkippedForSize).toBe(1);
+  });
+
+  it("attempts the single best map even when it alone exceeds the budget", async () => {
+    /*
+     * A budget configured below the per-map ceiling should degrade to "one
+     * map at a time", not to "nothing ever resolves". Peak memory is
+     * therefore max(budget, one map) — bounded either way.
+     */
+    mockResolveBudget.bytesPerResolve = 10;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 5000,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy)).toEqual([strongRow.id!.toString()]);
+    // It was loaded, not skipped: nothing to report and nothing to warn about.
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+    expect(result.resolvedCount).toBe(1);
+  });
+
+  it("skips everything after the over-budget best map, having already spent the budget", async () => {
+    mockResolveBudget.bytesPerResolve = 10;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 5000,
+    });
+    const tinyWeakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 5,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow, tinyWeakRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy)).toEqual([strongRow.id!.toString()]);
+    expect(result.sourceMapsSkippedForSize).toBe(1);
+  });
+
+  it("loads a map that lands exactly on the budget", async () => {
+    // Boundary: the check is "over budget", not "at budget".
+    mockResolveBudget.bytesPerResolve = 200;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const weakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow, weakRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+        makeRow(WEAK_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy)).toHaveLength(2);
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+  });
+
+  it("skips a map that lands one byte over the budget", async () => {
+    mockResolveBudget.bytesPerResolve = 199;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const weakRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: WEAK_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow, weakRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy)).toEqual([strongRow.id!.toString()]);
+    expect(result.sourceMapsSkippedForSize).toBe(1);
+  });
+
+  it("prefers the newer upload when two maps match equally well and only one fits", async () => {
+    /*
+     * Same match quality, so the tie-break decides — and it is the same
+     * newest-wins rule the dedupe uses, rather than whatever order the rows
+     * happened to arrive in.
+     */
+    mockResolveBudget.bytesPerResolve = 100;
+
+    const olderRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: "a.abc123.js",
+      sizeInBytes: 100,
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    });
+    const newerRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: "b.abc123.js",
+      sizeInBytes: 100,
+      createdAt: new Date("2024-06-01T00:00:00.000Z"),
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([olderRow, newerRow] as never)
+      .mockResolvedValueOnce([makeRow("b.abc123.js", FIXTURE_MAP)] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame("a.abc123.js"), makeFrame("b.abc123.js")],
+      });
+
+    expect(requestedContentIds(findBySpy)).toEqual([newerRow.id!.toString()]);
+    expect(result.sourceMapsSkippedForSize).toBe(1);
+  });
+
+  /*
+   * Every shape of "no usable size" a row can carry. onBeforeCreate stamps
+   * sizeInBytes on every insert, so these belong to rows written straight to
+   * the database — and an unknown size must not become the way to slip past a
+   * budget that exists to bound memory. Each is charged the per-map ceiling.
+   */
+  const UNKNOWN_SIZE_CASES: Array<{
+    label: string;
+    sizeInBytes: number | null | undefined;
+  }> = [
+    { label: "undefined", sizeInBytes: undefined },
+    { label: "null", sizeInBytes: null },
+    { label: "zero", sizeInBytes: 0 },
+    { label: "NaN", sizeInBytes: Number.NaN },
+    { label: "negative", sizeInBytes: -1 },
+  ];
+
+  for (const unknownSizeCase of UNKNOWN_SIZE_CASES) {
+    it(`charges a row whose sizeInBytes is ${unknownSizeCase.label} the per-map ceiling, not zero`, async () => {
+      mockResolveBudget.bytesPerResolve = 1000;
+
+      const strongRow: TelemetrySourceMap = makeListingRow({
+        bundlePath: STRONG_MATCH_PATH,
+        sizeInBytes: 100,
+      });
+      const unknownSizeRow: TelemetrySourceMap = makeListingRow({
+        bundlePath: MEDIUM_MATCH_PATH,
+        sizeInBytes: unknownSizeCase.sizeInBytes,
+      });
+
+      const findBySpy: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(TelemetrySourceMapService, "findBy")
+        .mockResolvedValueOnce([strongRow, unknownSizeRow] as never)
+        .mockResolvedValueOnce([
+          makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+        ] as never);
+
+      const result: ResolveStackTraceResult =
+        await TelemetrySourceMapService.resolveFramesForService({
+          projectId: PROJECT_ID,
+          serviceId: SERVICE_ID,
+          serviceVersion: "1.4.2",
+          frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+        });
+
+      /*
+       * Charged 50 MB against a 1000-byte budget, so it cannot fit — where a
+       * zero charge would have let it through unmetered.
+       */
+      expect(requestedContentIds(findBySpy)).toEqual([
+        strongRow.id!.toString(),
+      ]);
+      expect(result.sourceMapsSkippedForSize).toBe(1);
+    });
+  }
+
+  it("still loads an unknown-size map when the budget can absorb the per-map ceiling", async () => {
+    /*
+     * The ceiling is a charge, not a ban: a budget with room for a
+     * worst-case map still loads a row whose size was never stamped.
+     */
+    mockResolveBudget.bytesPerResolve = MAX_SOURCE_MAP_SIZE_IN_BYTES + 100;
+
+    const strongRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: STRONG_MATCH_PATH,
+      sizeInBytes: 100,
+    });
+    const unknownSizeRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: MEDIUM_MATCH_PATH,
+      sizeInBytes: undefined,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([strongRow, unknownSizeRow] as never)
+      .mockResolvedValueOnce([
+        makeRow(STRONG_MATCH_PATH, FIXTURE_MAP),
+        makeRow(MEDIUM_MATCH_PATH, FIXTURE_MAP),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: [makeFrame(SCORED_FRAME_FILE_NAME)],
+      });
+
+    expect(requestedContentIds(findBySpy).sort()).toEqual(
+      [strongRow.id!.toString(), unknownSizeRow.id!.toString()].sort(),
+    );
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+  });
+});
+
+/*
+ * Only the frames resolveFrames will actually attempt can pull a map in. The
+ * frames array is parsed from client-supplied stack trace text, so matching
+ * against all of it would let a caller drive an O(rows x frames) scan and
+ * select maps that could never be used anyway.
+ */
+describe("resolveFramesForService frame budget", () => {
+  it("loads a map for a bundle referenced by the last resolvable frame", async () => {
+    const frames: Array<MinifiedStackFrame> = [];
+
+    for (let index: number = 0; index < MAX_FRAMES_TO_RESOLVE - 1; index++) {
+      frames.push(makeFrame("unrelated-chunk.js"));
+    }
+
+    // The 500th frame — the last one resolveFrames will attempt.
+    frames.push(makeFrame("main.abc123.js"));
+    expect(frames).toHaveLength(MAX_FRAMES_TO_RESOLVE);
+
+    const listRow: TelemetrySourceMap = makeListingRow({
+      bundlePath: "main.abc123.js",
+      sizeInBytes: 100,
+    });
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([listRow] as never)
+      .mockResolvedValueOnce([makeRow("main.abc123.js", FIXTURE_MAP)] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: frames,
+      });
+
+    expect(requestedContentIds(findBySpy)).toEqual([listRow.id!.toString()]);
+    expect(result.resolvedCount).toBe(1);
+    expect(result.frames[MAX_FRAMES_TO_RESOLVE - 1]!.resolved).toBe(true);
+  });
+
+  it("does not load a map for a bundle referenced only past the frame budget", async () => {
+    const frames: Array<MinifiedStackFrame> = [];
+
+    for (let index: number = 0; index < MAX_FRAMES_TO_RESOLVE; index++) {
+      frames.push(makeFrame("unrelated-chunk.js"));
+    }
+
+    /*
+     * The 501st frame. Its bundle IS stored — but the frame is past what
+     * resolveFrames will attempt, so loading its map would spend the budget
+     * on symbols that can never be handed back.
+     */
+    frames.push(makeFrame("main.abc123.js"));
+
+    const findBySpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(TelemetrySourceMapService, "findBy")
+      .mockResolvedValueOnce([
+        makeListingRow({ bundlePath: "main.abc123.js", sizeInBytes: 100 }),
+      ] as never);
+
+    const result: ResolveStackTraceResult =
+      await TelemetrySourceMapService.resolveFramesForService({
+        projectId: PROJECT_ID,
+        serviceId: SERVICE_ID,
+        serviceVersion: "1.4.2",
+        frames: frames,
+      });
+
+    // No content fetch at all: nothing matched a frame that counts.
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(result.sourceMapCount).toBe(1);
+    expect(result.resolvedCount).toBe(0);
+    expect(result.sourceMapsSkippedForSize).toBe(0);
+
+    /*
+     * One output frame per input frame regardless — the dashboard overlay
+     * discards length-mismatched responses wholesale.
+     */
+    expect(result.frames).toHaveLength(MAX_FRAMES_TO_RESOLVE + 1);
+    expect(result.frames[MAX_FRAMES_TO_RESOLVE]!.resolved).toBe(false);
   });
 });

--- a/Common/Tests/Server/Utils/Telemetry/SourceMapLimits.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/SourceMapLimits.test.ts
@@ -1,0 +1,656 @@
+import LIMIT_MAX from "../../../../Types/Database/LimitMax";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * The five operator knobs that size source map ingestion and resolution.
+ *
+ * These used to be one hardcoded 100 that did two unrelated jobs: it gated
+ * uploads AND bounded what the resolver would read. Raising it was therefore
+ * unsafe (more maps stored than the reader would ever look at), and leaving it
+ * meant route-split builds — a Vite/Next app emitting hundreds of chunk maps
+ * per release — silently lost the maps that did not fit. The count is now a
+ * pure WRITE gate with a much higher default, and a byte budget bounds the
+ * READ path instead.
+ *
+ * EnvironmentConfig reads process.env once at module load, so every case here
+ * sets the environment, resets the module registry, and imports afresh.
+ */
+
+interface SourceMapConfigShape {
+  SourceMapMaxMapsPerRelease: number;
+  SourceMapRetentionInDays: number;
+  SourceMapMaxFileSizeInBytes: number;
+  SourceMapMaxFilesPerRequest: number;
+  SourceMapMaxBytesPerResolve: number;
+}
+
+interface SourceMapResolverShape {
+  MAX_SOURCE_MAP_SIZE_IN_BYTES: number;
+  MAX_FRAMES_TO_RESOLVE: number;
+  MAX_FRAMES_PER_RESOLVE_REQUEST: number;
+}
+
+interface MultipartLimitsShape {
+  MAX_MULTIPART_FILE_BYTES: number;
+  MAX_MULTIPART_FILES: number;
+}
+
+const MEGABYTE: number = 1024 * 1024;
+
+/* The ceilings EnvironmentConfig hardcodes, named once. */
+const FIFTY_MEGABYTES: number = 50 * MEGABYTE;
+const FIFTY_FILES: number = 50;
+
+/* Defaults, named so a change to one is a deliberate edit here too. */
+const DEFAULT_MAPS_PER_RELEASE: number = 1000;
+const DEFAULT_RETENTION_DAYS: number = 90;
+const DEFAULT_BYTES_PER_RESOLVE: number = 512 * MEGABYTE;
+
+const MANAGED_KEYS: Array<string> = [
+  "SOURCE_MAP_MAX_MAPS_PER_RELEASE",
+  "SOURCE_MAP_RETENTION_DAYS",
+  "SOURCE_MAP_MAX_FILE_SIZE_BYTES",
+  "SOURCE_MAP_MAX_FILES_PER_REQUEST",
+  "SOURCE_MAP_MAX_BYTES_PER_RESOLVE",
+];
+
+/*
+ * Every shape of value an operator can get wrong. "" and "   " are what
+ * Docker Compose's ${VAR:-} and a Helm value left blank actually pass
+ * through, so they must read as unset rather than as zero.
+ */
+const INVALID_VALUES: Array<string> = [
+  "",
+  "   ",
+  "0",
+  "-5",
+  "1.5",
+  "abc",
+  "NaN",
+  "Infinity",
+];
+
+const originalEnv: NodeJS.ProcessEnv = { ...process.env };
+
+/*
+ * Clears every knob first, so a value that happens to be set in the shell
+ * running the suite cannot make a "default" case pass for the wrong reason.
+ */
+async function loadConfig(
+  overrides: Record<string, string | undefined>,
+): Promise<SourceMapConfigShape> {
+  for (const key of MANAGED_KEYS) {
+    delete process.env[key];
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  jest.resetModules();
+
+  return (await import(
+    "../../../../Server/EnvironmentConfig"
+  )) as unknown as SourceMapConfigShape;
+}
+
+/*
+ * Loads the resolver against the same freshly-read config, so the two are
+ * observed from one module registry rather than from separate loads that
+ * could disagree.
+ */
+async function loadConfigAndResolver(
+  overrides: Record<string, string | undefined>,
+): Promise<{
+  config: SourceMapConfigShape;
+  resolver: SourceMapResolverShape;
+}> {
+  const config: SourceMapConfigShape = await loadConfig(overrides);
+
+  const resolver: SourceMapResolverShape = (await import(
+    "../../../../Server/Utils/Telemetry/SourceMapResolver"
+  )) as unknown as SourceMapResolverShape;
+
+  return { config, resolver };
+}
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  jest.resetModules();
+});
+
+describe("SOURCE_MAP_MAX_MAPS_PER_RELEASE", () => {
+  it("defaults to 1000 distinct bundles per release", async () => {
+    /*
+     * The old value was 100. A route-split build blows past that on its own,
+     * which is the whole reason this knob exists.
+     */
+    const config: SourceMapConfigShape = await loadConfig({});
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(DEFAULT_MAPS_PER_RELEASE);
+  });
+
+  it("honours an operator's raised value", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: "4000",
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(4000);
+  });
+
+  it("can be lowered below the default", async () => {
+    /*
+     * The gate is also a cost control: an operator who wants a tighter cap
+     * than the default must be able to set one.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: "25",
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(25);
+  });
+
+  it("accepts exactly LIMIT_MAX, the highest value it can enforce", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: String(LIMIT_MAX),
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(LIMIT_MAX);
+  });
+
+  it("clamps one over LIMIT_MAX back down to LIMIT_MAX", async () => {
+    /*
+     * The write gate counts a release's existing maps with limit LIMIT_MAX.
+     * A configured cap above that could never be reached by the count, so it
+     * would be a limit the app silently failed to enforce. Clamping makes the
+     * effective value honest.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: String(LIMIT_MAX + 1),
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(LIMIT_MAX);
+  });
+
+  it("clamps an absurd value rather than trusting it", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: "999999999",
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(LIMIT_MAX);
+  });
+
+  it("falls back to the default for anything that is not a positive whole number", async () => {
+    for (const value of INVALID_VALUES) {
+      const config: SourceMapConfigShape = await loadConfig({
+        SOURCE_MAP_MAX_MAPS_PER_RELEASE: value,
+      });
+
+      expect({ value, resolved: config.SourceMapMaxMapsPerRelease }).toEqual({
+        value,
+        resolved: DEFAULT_MAPS_PER_RELEASE,
+      });
+    }
+  });
+
+  it("tolerates surrounding whitespace on an otherwise valid value", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: "  2500 ",
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(2500);
+  });
+});
+
+describe("SOURCE_MAP_RETENTION_DAYS", () => {
+  it("defaults to 90 days", async () => {
+    const config: SourceMapConfigShape = await loadConfig({});
+
+    expect(config.SourceMapRetentionInDays).toBe(DEFAULT_RETENTION_DAYS);
+  });
+
+  it("honours an operator's value in both directions", async () => {
+    const shortened: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_RETENTION_DAYS: "7",
+    });
+
+    expect(shortened.SourceMapRetentionInDays).toBe(7);
+
+    const lengthened: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_RETENTION_DAYS: "365",
+    });
+
+    expect(lengthened.SourceMapRetentionInDays).toBe(365);
+  });
+
+  it("is not clamped, so a long-retention install can keep maps for years", async () => {
+    /*
+     * Retention has no in-code ceiling to honour — nothing reads a bounded
+     * page of days — so unlike the count and size knobs it passes any
+     * positive integer straight through.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_RETENTION_DAYS: "36500",
+    });
+
+    expect(config.SourceMapRetentionInDays).toBe(36500);
+  });
+
+  it("falls back to 90 days for anything that is not a positive whole number", async () => {
+    for (const value of INVALID_VALUES) {
+      const config: SourceMapConfigShape = await loadConfig({
+        SOURCE_MAP_RETENTION_DAYS: value,
+      });
+
+      expect({ value, resolved: config.SourceMapRetentionInDays }).toEqual({
+        value,
+        resolved: DEFAULT_RETENTION_DAYS,
+      });
+    }
+  });
+});
+
+describe("SOURCE_MAP_MAX_FILE_SIZE_BYTES", () => {
+  it("defaults to 50 MiB for a single map", async () => {
+    const config: SourceMapConfigShape = await loadConfig({});
+
+    expect(config.SourceMapMaxFileSizeInBytes).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("can be lowered to a tighter per-file ceiling", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(5 * MEGABYTE),
+    });
+
+    expect(config.SourceMapMaxFileSizeInBytes).toBe(5 * MEGABYTE);
+  });
+
+  it("accepts exactly 50 MiB, the multipart per-file ceiling", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(FIFTY_MEGABYTES),
+    });
+
+    expect(config.SourceMapMaxFileSizeInBytes).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("clamps one byte over 50 MiB back down to 50 MiB", async () => {
+    /*
+     * Raising this past what multer accepts would not raise anything: multer
+     * aborts the request first, so the clear 400 this ceiling is meant to
+     * produce becomes a confusing 413. The knob can only ever be lowered.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(FIFTY_MEGABYTES + 1),
+    });
+
+    expect(config.SourceMapMaxFileSizeInBytes).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("clamps an operator who asks for gigabyte maps", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(2 * 1024 * MEGABYTE),
+    });
+
+    expect(config.SourceMapMaxFileSizeInBytes).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("falls back to 50 MiB for anything that is not a positive whole number", async () => {
+    for (const value of INVALID_VALUES) {
+      const config: SourceMapConfigShape = await loadConfig({
+        SOURCE_MAP_MAX_FILE_SIZE_BYTES: value,
+      });
+
+      expect({ value, resolved: config.SourceMapMaxFileSizeInBytes }).toEqual({
+        value,
+        resolved: FIFTY_MEGABYTES,
+      });
+    }
+  });
+});
+
+describe("SOURCE_MAP_MAX_FILES_PER_REQUEST", () => {
+  it("defaults to 50 files in one upload request", async () => {
+    const config: SourceMapConfigShape = await loadConfig({});
+
+    expect(config.SourceMapMaxFilesPerRequest).toBe(FIFTY_FILES);
+  });
+
+  it("can be lowered so CI splits the upload into smaller batches", async () => {
+    /*
+     * This is deliberately separate from the per-release cap: a release may
+     * hold 1000 maps while no single request may carry more than a handful.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: "10",
+    });
+
+    expect(config.SourceMapMaxFilesPerRequest).toBe(10);
+  });
+
+  it("accepts exactly 50, the shared multipart file ceiling", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: String(FIFTY_FILES),
+    });
+
+    expect(config.SourceMapMaxFilesPerRequest).toBe(FIFTY_FILES);
+  });
+
+  it("clamps 51 back down to 50", async () => {
+    /*
+     * The multipart middleware runs BEFORE authentication on every route that
+     * mounts it. Letting this knob widen it would widen the pre-auth surface
+     * that Pyroscope and inbound email also sit behind, so it narrows only.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: String(FIFTY_FILES + 1),
+    });
+
+    expect(config.SourceMapMaxFilesPerRequest).toBe(FIFTY_FILES);
+  });
+
+  it("clamps a large value rather than widening the pre-auth upload surface", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: "5000",
+    });
+
+    expect(config.SourceMapMaxFilesPerRequest).toBe(FIFTY_FILES);
+  });
+
+  it("falls back to 50 for anything that is not a positive whole number", async () => {
+    for (const value of INVALID_VALUES) {
+      const config: SourceMapConfigShape = await loadConfig({
+        SOURCE_MAP_MAX_FILES_PER_REQUEST: value,
+      });
+
+      expect({ value, resolved: config.SourceMapMaxFilesPerRequest }).toEqual({
+        value,
+        resolved: FIFTY_FILES,
+      });
+    }
+  });
+});
+
+describe("SOURCE_MAP_MAX_BYTES_PER_RESOLVE", () => {
+  it("defaults to 512 MiB of map bytes per resolve request", async () => {
+    /*
+     * Roughly ten maps at the per-file ceiling, or every map of a
+     * realistically sized release many times over.
+     */
+    const config: SourceMapConfigShape = await loadConfig({});
+
+    expect(config.SourceMapMaxBytesPerResolve).toBe(DEFAULT_BYTES_PER_RESOLVE);
+  });
+
+  it("honours an operator's value in both directions", async () => {
+    const tightened: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_BYTES_PER_RESOLVE: String(64 * MEGABYTE),
+    });
+
+    expect(tightened.SourceMapMaxBytesPerResolve).toBe(64 * MEGABYTE);
+
+    const loosened: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_BYTES_PER_RESOLVE: String(2048 * MEGABYTE),
+    });
+
+    expect(loosened.SourceMapMaxBytesPerResolve).toBe(2048 * MEGABYTE);
+  });
+
+  it("is not clamped, because it is the knob that replaced the row count", async () => {
+    /*
+     * This is the bound that actually protects the process now, and it is the
+     * one an operator with lots of memory has a legitimate reason to raise a
+     * long way. Clamping it to any of the other ceilings would recreate the
+     * exact coupling this change removed.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_BYTES_PER_RESOLVE: String(1024 * 1024 * MEGABYTE),
+    });
+
+    expect(config.SourceMapMaxBytesPerResolve).toBe(1024 * 1024 * MEGABYTE);
+  });
+
+  it("falls back to 512 MiB for anything that is not a positive whole number", async () => {
+    for (const value of INVALID_VALUES) {
+      const config: SourceMapConfigShape = await loadConfig({
+        SOURCE_MAP_MAX_BYTES_PER_RESOLVE: value,
+      });
+
+      expect({ value, resolved: config.SourceMapMaxBytesPerResolve }).toEqual({
+        value,
+        resolved: DEFAULT_BYTES_PER_RESOLVE,
+      });
+    }
+  });
+});
+
+describe("the five knobs together", () => {
+  it("reads each variable independently", async () => {
+    /*
+     * They are five separate settings that happen to share a prefix; setting
+     * one must not move another.
+     */
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: "2000",
+      SOURCE_MAP_RETENTION_DAYS: "30",
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(8 * MEGABYTE),
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: "12",
+      SOURCE_MAP_MAX_BYTES_PER_RESOLVE: String(256 * MEGABYTE),
+    });
+
+    expect({
+      maps: config.SourceMapMaxMapsPerRelease,
+      days: config.SourceMapRetentionInDays,
+      size: config.SourceMapMaxFileSizeInBytes,
+      files: config.SourceMapMaxFilesPerRequest,
+      bytes: config.SourceMapMaxBytesPerResolve,
+    }).toEqual({
+      maps: 2000,
+      days: 30,
+      size: 8 * MEGABYTE,
+      files: 12,
+      bytes: 256 * MEGABYTE,
+    });
+  });
+
+  it("does not let one misconfigured variable disturb the others", async () => {
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: "not-a-number",
+      SOURCE_MAP_RETENTION_DAYS: "45",
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: "20",
+    });
+
+    expect({
+      maps: config.SourceMapMaxMapsPerRelease,
+      days: config.SourceMapRetentionInDays,
+      files: config.SourceMapMaxFilesPerRequest,
+    }).toEqual({
+      maps: DEFAULT_MAPS_PER_RELEASE,
+      days: 45,
+      files: 20,
+    });
+  });
+
+  it("gives every knob a positive whole number, whatever the environment says", async () => {
+    /*
+     * Each of these feeds a database limit, a multer limit or a byte budget.
+     * A fractional, zero or negative value reaching any of them would be a
+     * different class of failure than a rejected upload, so the invariant is
+     * asserted across the whole set rather than per-variable.
+     */
+    for (const value of INVALID_VALUES) {
+      const config: SourceMapConfigShape = await loadConfig({
+        SOURCE_MAP_MAX_MAPS_PER_RELEASE: value,
+        SOURCE_MAP_RETENTION_DAYS: value,
+        SOURCE_MAP_MAX_FILE_SIZE_BYTES: value,
+        SOURCE_MAP_MAX_FILES_PER_REQUEST: value,
+        SOURCE_MAP_MAX_BYTES_PER_RESOLVE: value,
+      });
+
+      const resolved: Array<number> = [
+        config.SourceMapMaxMapsPerRelease,
+        config.SourceMapRetentionInDays,
+        config.SourceMapMaxFileSizeInBytes,
+        config.SourceMapMaxFilesPerRequest,
+        config.SourceMapMaxBytesPerResolve,
+      ];
+
+      for (const number of resolved) {
+        expect({ value, number, integer: Number.isInteger(number) }).toEqual({
+          value,
+          number,
+          integer: true,
+        });
+        expect(number).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("keeps the per-request file cap at or below the per-release cap's default", async () => {
+    /*
+     * Sanity on the division of labour: one request may never carry more maps
+     * than a release is allowed to hold, or the upload path could accept a
+     * batch the write gate must then reject wholesale.
+     */
+    const config: SourceMapConfigShape = await loadConfig({});
+
+    expect(config.SourceMapMaxFilesPerRequest).toBeLessThanOrEqual(
+      config.SourceMapMaxMapsPerRelease,
+    );
+  });
+});
+
+describe("MAX_SOURCE_MAP_SIZE_IN_BYTES in SourceMapResolver", () => {
+  it("equals the configured per-file ceiling by default", async () => {
+    const { config, resolver } = await loadConfigAndResolver({});
+
+    expect(resolver.MAX_SOURCE_MAP_SIZE_IN_BYTES).toBe(
+      config.SourceMapMaxFileSizeInBytes,
+    );
+    expect(resolver.MAX_SOURCE_MAP_SIZE_IN_BYTES).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("tracks a lowered SOURCE_MAP_MAX_FILE_SIZE_BYTES", async () => {
+    /*
+     * The resolver's own ceiling used to be an independent literal. If it
+     * stops tracking the config, an operator who lowers the knob gets maps
+     * rejected on upload but still decoded at read time — the two halves of
+     * one limit disagreeing.
+     */
+    const { config, resolver } = await loadConfigAndResolver({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(3 * MEGABYTE),
+    });
+
+    expect(resolver.MAX_SOURCE_MAP_SIZE_IN_BYTES).toBe(3 * MEGABYTE);
+    expect(resolver.MAX_SOURCE_MAP_SIZE_IN_BYTES).toBe(
+      config.SourceMapMaxFileSizeInBytes,
+    );
+  });
+
+  it("tracks the clamp too, so it never exceeds what multer accepts", async () => {
+    const { resolver } = await loadConfigAndResolver({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(FIFTY_MEGABYTES * 4),
+    });
+
+    expect(resolver.MAX_SOURCE_MAP_SIZE_IN_BYTES).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("exposes the frame ceilings the API layer needs to enforce", async () => {
+    /*
+     * MAX_FRAMES_TO_RESOLVE was module-private and is now exported, and
+     * MAX_FRAMES_PER_RESOLVE_REQUEST is new: TelemetryAPI rejects a frames
+     * array larger than the latter before sanitizing it. Both are fixed, not
+     * configurable — the frames array is caller-supplied, so its bounds are
+     * not an operator's to raise.
+     */
+    const { resolver } = await loadConfigAndResolver({});
+
+    expect(resolver.MAX_FRAMES_TO_RESOLVE).toBe(500);
+    expect(resolver.MAX_FRAMES_PER_RESOLVE_REQUEST).toBe(10000);
+    expect(resolver.MAX_FRAMES_PER_RESOLVE_REQUEST).toBeGreaterThan(
+      resolver.MAX_FRAMES_TO_RESOLVE,
+    );
+  });
+});
+
+describe("the ceilings EnvironmentConfig duplicates as literals", () => {
+  /*
+   * EnvironmentConfig cannot import MultipartFormData — that module pulls in
+   * multer and express, and config has no business dragging those in — so it
+   * repeats MAX_MULTIPART_FILE_BYTES and MAX_MULTIPART_FILES as bare literals
+   * in its clamps.
+   *
+   * These two cases are the only thing keeping that duplication honest. If
+   * someone raises a multipart limit and does not touch EnvironmentConfig,
+   * the clamp silently becomes the tighter of the two and the knob stops
+   * reaching the value the middleware would now allow; if someone lowers one,
+   * the clamp lets through a value multer will reject with a 413. Either way
+   * these fail here rather than in production.
+   */
+
+  it("pins the per-file byte clamp to MAX_MULTIPART_FILE_BYTES", async () => {
+    jest.resetModules();
+
+    const multipart: MultipartLimitsShape = (await import(
+      "../../../../Server/Middleware/MultipartFormData"
+    )) as unknown as MultipartLimitsShape;
+
+    expect(multipart.MAX_MULTIPART_FILE_BYTES).toBe(FIFTY_MEGABYTES);
+  });
+
+  it("pins the per-request file clamp to MAX_MULTIPART_FILES", async () => {
+    jest.resetModules();
+
+    const multipart: MultipartLimitsShape = (await import(
+      "../../../../Server/Middleware/MultipartFormData"
+    )) as unknown as MultipartLimitsShape;
+
+    expect(multipart.MAX_MULTIPART_FILES).toBe(FIFTY_FILES);
+  });
+
+  it("cannot be configured above either middleware limit", async () => {
+    /*
+     * Stated as the behaviour an operator sees, against the middleware's own
+     * exported values rather than against the literals repeated above.
+     */
+    jest.resetModules();
+
+    const multipart: MultipartLimitsShape = (await import(
+      "../../../../Server/Middleware/MultipartFormData"
+    )) as unknown as MultipartLimitsShape;
+
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_FILE_SIZE_BYTES: String(
+        multipart.MAX_MULTIPART_FILE_BYTES * 10,
+      ),
+      SOURCE_MAP_MAX_FILES_PER_REQUEST: String(
+        multipart.MAX_MULTIPART_FILES * 10,
+      ),
+    });
+
+    expect(config.SourceMapMaxFileSizeInBytes).toBe(
+      multipart.MAX_MULTIPART_FILE_BYTES,
+    );
+    expect(config.SourceMapMaxFilesPerRequest).toBe(
+      multipart.MAX_MULTIPART_FILES,
+    );
+  });
+
+  it("pins the per-release count clamp to LIMIT_MAX", async () => {
+    /*
+     * Same duplication hazard, different ceiling: the write gate's countBy
+     * uses LIMIT_MAX, so a change to LIMIT_MAX must be a deliberate change
+     * to the reachable range of this knob.
+     */
+    expect(LIMIT_MAX).toBe(10000);
+
+    const config: SourceMapConfigShape = await loadConfig({
+      SOURCE_MAP_MAX_MAPS_PER_RELEASE: String(LIMIT_MAX * 10),
+    });
+
+    expect(config.SourceMapMaxMapsPerRelease).toBe(LIMIT_MAX);
+  });
+});

--- a/Common/Types/Telemetry/SourceMap.ts
+++ b/Common/Types/Telemetry/SourceMap.ts
@@ -53,4 +53,12 @@ export interface ResolveStackTraceResult {
   resolvedCount: number;
   /** Number of source maps found for the (service, release) pair. */
   sourceMapCount: number;
+  /**
+   * Maps that a frame matched but that were not loaded, because loading them
+   * would have exceeded the resolver's per-request byte budget
+   * (SOURCE_MAP_MAX_BYTES_PER_RESOLVE). Non-zero means symbols are missing
+   * for a reason an operator can fix by raising the budget — as opposed to
+   * the maps simply never having been uploaded.
+   */
+  sourceMapsSkippedForSize: number;
 }

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -808,6 +808,36 @@ GLOBAL_LLM_PROVIDER_API_KEY is rendered only when an API key is configured.
 - name: ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_IP_PER_WINDOW
   value: {{ default 3000 $.Values.onCallCalendarFeed.rateLimit.perIpPerWindow | squote }}
 
+{{/*
+  Source map ingestion and resolution limits. `default` is safe on all of
+  these because 0 is not a valid value for any of them -- the app falls back
+  to its own default too -- and every one is clamped app-side, so a value the
+  chart cannot honour is narrowed rather than silently ignored.
+
+  `int64` before quoting is NOT decoration. Helm parses values.yaml through
+  JSON, so a number arrives as a float64, and Go prints a float64 above 1e6 in
+  exponent form: the 52428800 an operator wrote in a values file would reach
+  the container as '5.24288e+07'. The same value passed with --set goes
+  through strvals as an int64 and renders plainly, so without this the env var
+  depends on HOW it was set, not what it was set to. Node's Number() happens
+  to accept exponent notation, which is the only reason that was not already a
+  bug -- and not a property to rely on.
+*/}}
+- name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+  value: {{ default 1000 $.Values.sourceMaps.maxMapsPerRelease | int64 | squote }}
+
+- name: SOURCE_MAP_MAX_FILES_PER_REQUEST
+  value: {{ default 50 $.Values.sourceMaps.maxFilesPerRequest | int64 | squote }}
+
+- name: SOURCE_MAP_MAX_FILE_SIZE_BYTES
+  value: {{ default 52428800 $.Values.sourceMaps.maxFileSizeBytes | int64 | squote }}
+
+- name: SOURCE_MAP_MAX_BYTES_PER_RESOLVE
+  value: {{ default 536870912 $.Values.sourceMaps.maxBytesPerResolve | int64 | squote }}
+
+- name: SOURCE_MAP_RETENTION_DAYS
+  value: {{ default 90 $.Values.sourceMaps.retentionDays | int64 | squote }}
+
 - name: WORKFLOW_SCRIPT_TIMEOUT_IN_MS
   value: {{ $.Values.script.workflowScriptTimeoutInMs | squote }}
 

--- a/HelmChart/Public/oneuptime/tests/source-map-limits_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/source-map-limits_test.yaml
@@ -1,0 +1,350 @@
+# Browser source maps used to be governed by hardcoded constants sized for "a
+# few dozen chunks per build". Route-level code splitting broke that
+# assumption, so the five limits are operator settings now -- and settings are
+# only settings if they actually reach the container. Every one of these fails
+# silently when the wiring breaks, which is what makes them worth pinning:
+#
+#   - SOURCE_MAP_MAX_MAPS_PER_RELEASE is the one that gets RAISED. An operator
+#     whose build emits 400 chunks raises it, the value never arrives, and CI
+#     keeps getting the same 400 at upload 1001. The symptom is identical to
+#     not having raised it at all, so the operator blames the app.
+#   - SOURCE_MAP_MAX_FILES_PER_REQUEST and SOURCE_MAP_MAX_FILE_SIZE_BYTES only
+#     ever get LOWERED (both are clamped app-side to the chart default, since
+#     the multipart body is parsed before authentication). A lowering that
+#     never lands leaves an unauthenticated route wider open than the operator
+#     believes it is -- the dangerous direction to fail in.
+#   - SOURCE_MAP_MAX_BYTES_PER_RESOLVE is what bounds resolver memory now that
+#     the map COUNT no longer does. If it never arrives, raising the map count
+#     is the unsafe change it was specifically made safe by.
+#   - SOURCE_MAP_RETENTION_DAYS decides how long maps are kept. Silently
+#     keeping 90 days of maps for every release is a storage bill.
+#
+# And they have to reach EVERY workload that boots the server, not just app:
+# the ingest route and the resolve route live in the same image, and the
+# shared `oneuptime.env.runtime` helper is what puts them there. worker,
+# telemetry-writer, runner and the workloads built from the shared
+# `oneuptime.deployment` helper all pull that same block in, so a refactor
+# that drops the include from one of them is a real and invisible regression.
+suite: source map limits
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  - it: ships the documented default caps
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "1000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILES_PER_REQUEST
+            value: "50"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_RETENTION_DAYS
+            value: "90"
+
+  # Helm parses values.yaml through JSON, so every number in it arrives as a
+  # float64, and Go prints a float64 in exponent form once it reaches 1e6.
+  # Without the `int64` pipe in _helpers.tpl the two byte-valued limits would
+  # reach the container as '5.24288e+07' and '5.36870912e+08'.
+  #
+  # That mattered for two reasons. It is only harmless to the app by luck --
+  # it parses with Number(), which accepts exponent notation; anything using
+  # parseInt() reads '5.24288e+07' as 5, turning a 50 MiB cap into a 5 BYTE
+  # cap. And it was not even consistent per value: only the values.yaml / `-f`
+  # path goes through JSON, so `--set sourceMaps.maxFileSizeBytes=10485760`
+  # rendered '10485760' while the same number in a `-f` file rendered
+  # '1.048576e+07'. Same operator intent, two different env values.
+  #
+  # These assertions are what keeps the `int64` pipes in place.
+  - it: renders the byte-valued limits as plain integers, never in exponent form
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILE_SIZE_BYTES
+            value: "52428800"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_BYTES_PER_RESOLVE
+            value: "536870912"
+
+  - it: passes a raised per-release map cap through
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxMapsPerRelease: 5000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "5000"
+
+  # The app clamps this to 10000, so the chart must be able to express the
+  # exact ceiling -- an operator who asks for the maximum and silently gets
+  # the 1000 default has no way to tell the difference from the rejection they
+  # were trying to avoid.
+  - it: passes the per-release map cap through at its 10000 ceiling
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxMapsPerRelease: 10000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "10000"
+
+  # maxFilesPerRequest and maxFileSizeBytes can only ever be lowered, so
+  # lowering is the ONLY direction that needs to work for them.
+  - it: passes a lowered per-request file cap through
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxFilesPerRequest: 10
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILES_PER_REQUEST
+            value: "10"
+
+  # 1 is the schema minimum and the narrowest an operator can go: one map per
+  # request. `default` would eat a 0 here, but the schema rejects 0 before the
+  # template ever runs, so 1 is the real edge and it has to survive.
+  - it: passes the per-request file cap through at its minimum of 1
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxFilesPerRequest: 1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILES_PER_REQUEST
+            value: "1"
+
+  - it: passes a lowered maximum file size through
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxFileSizeBytes: 1048576
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILE_SIZE_BYTES
+            value: "1048576"
+
+  - it: passes a raised resolve byte budget through
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxBytesPerResolve: 1073741824
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_BYTES_PER_RESOLVE
+            value: "1073741824"
+
+  # The same knob below 1e6, where a float64 would not have reached exponent
+  # form anyway. Paired with the gigabyte case above, this pins the rendering
+  # on BOTH sides of the magnitude where the formatting used to change.
+  - it: renders a sub-megabyte resolve budget as a plain integer
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxBytesPerResolve: 999999
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_BYTES_PER_RESOLVE
+            value: "999999"
+
+  - it: passes a shortened retention window through
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.retentionDays: 7
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_RETENTION_DAYS
+            value: "7"
+
+  - it: passes every knob through at once
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxMapsPerRelease: 4000
+      sourceMaps.maxFilesPerRequest: 25
+      sourceMaps.maxFileSizeBytes: 999999
+      sourceMaps.maxBytesPerResolve: 888888
+      sourceMaps.retentionDays: 30
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "4000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILES_PER_REQUEST
+            value: "25"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILE_SIZE_BYTES
+            value: "999999"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_BYTES_PER_RESOLVE
+            value: "888888"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_RETENTION_DAYS
+            value: "30"
+
+  # The worker boots the same server image as app and reads the same config,
+  # so a limit that reaches only app is a split brain: an upload accepted by
+  # one pod and rejected by another depending on which one the gateway picked.
+  - it: reaches the worker
+    templates:
+      - templates/worker.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      # Off by default; the worker Deployment renders nothing without this.
+      worker.enabled: true
+      sourceMaps.maxMapsPerRelease: 5000
+      sourceMaps.retentionDays: 14
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "5000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_RETENTION_DAYS
+            value: "14"
+
+  - it: reaches the telemetry writer
+    templates:
+      - templates/telemetry-writer.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      # Explicit opt-in tier; renders nothing without this.
+      telemetryWriter.enabled: true
+      sourceMaps.maxMapsPerRelease: 6000
+      sourceMaps.maxFilesPerRequest: 20
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "6000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_FILES_PER_REQUEST
+            value: "20"
+
+  - it: reaches the runner
+    templates:
+      - templates/runner.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sourceMaps.maxMapsPerRelease: 7000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "7000"
+
+  # test-server does not include the env helper itself -- it is built from the
+  # shared `oneuptime.deployment` helper, which is a second, independent path
+  # to the same env block. A regression there is invisible to every assertion
+  # above, because app, worker, telemetry-writer and runner all inline the
+  # include directly.
+  - it: reaches workloads built from the shared deployment helper
+    templates:
+      - templates/test-server.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      testServer.enabled: true
+      sourceMaps.maxMapsPerRelease: 8000
+      sourceMaps.retentionDays: 3
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_MAX_MAPS_PER_RELEASE
+            value: "8000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_MAP_RETENTION_DAYS
+            value: "3"

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -1744,6 +1744,35 @@
             },
             "additionalProperties": false
         },
+        "sourceMaps": {
+            "type": "object",
+            "properties": {
+                "maxMapsPerRelease": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10000
+                },
+                "maxFilesPerRequest": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50
+                },
+                "maxFileSizeBytes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 52428800
+                },
+                "maxBytesPerResolve": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "retentionDays": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "additionalProperties": false
+        },
         "updateCheck": {
             "type": "object",
             "properties": {

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1060,6 +1060,42 @@ alerts:
 telemetry:
   disableIngestion: false
 
+# Browser source maps, uploaded from CI so exception stack traces can be shown
+# with original file names and line numbers instead of minified ones.
+#
+# These were fixed constants sized for "a few dozen chunks per build". Route
+# level code splitting broke that assumption -- a Nuxt / Vite / Next app with a
+# hundred routes emits hundreds of chunk .map files per release -- so they are
+# operator settings now. The defaults are safe for every deployment; raise
+# maxMapsPerRelease if your build emits more maps than fit.
+sourceMaps:
+  # Distinct bundles one release (service + service.version) may hold. An
+  # upload past this is rejected with a clear 400 rather than being accepted
+  # and then silently failing to resolve. Cannot exceed 10000.
+  maxMapsPerRelease: 1000
+
+  # Source map files accepted in ONE upload request. CI splits a large release
+  # across several requests. This can only be LOWERED: the request is parsed
+  # before authentication, and the shared 50-file ceiling is the limit an
+  # unauthenticated caller is held to on every route that parses multipart
+  # bodies, so raising it here would not be safe and has no effect.
+  maxFilesPerRequest: 50
+
+  # Largest single .map file accepted, in bytes (50 MiB). Also cannot be
+  # raised: the multipart parser aborts larger bodies first, so a higher value
+  # would only turn a clear 400 into a confusing 413.
+  maxFileSizeBytes: 52428800
+
+  # Total map bytes ONE stack trace resolution may load into memory (512 MiB).
+  # This -- not the map count -- is what bounds the resolver, which is why
+  # maxMapsPerRelease can be raised safely. Maps that do not fit are skipped
+  # worst-match-first and reported on the response, never dropped silently.
+  maxBytesPerResolve: 536870912
+
+  # How long uploaded maps are kept. A map is only useful while exceptions
+  # from its release are still within telemetry retention.
+  retentionDays: 90
+
 # Once a day this installation asks the GitHub API which OneUptime version is
 # the latest release, so admins are told in the dashboard when an upgrade is
 # available. No usage data is sent — GitHub sees your public IP and a

--- a/config.example.env
+++ b/config.example.env
@@ -285,6 +285,23 @@ ON_CALL_CALENDAR_FEED_RATE_LIMIT_WINDOW_SECONDS=60
 ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_TOKEN_PER_WINDOW=60
 ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_IP_PER_WINDOW=3000
 
+# Browser source maps, uploaded from CI so exception stack traces show original
+# file names and line numbers instead of minified ones.
+#
+# Raise SOURCE_MAP_MAX_MAPS_PER_RELEASE if your build emits more .map files per
+# release than the default holds -- route-level code splitting routinely emits
+# hundreds. It is a storage-shape limit only: resolution is bounded by
+# SOURCE_MAP_MAX_BYTES_PER_RESOLVE, so anything that fits the ceiling resolves.
+#
+# The two request-shaped limits can only be LOWERED. The multipart body is
+# parsed before authentication, so the shared 50-file / 50 MiB ceilings are
+# what an unauthenticated caller is held to; values above them are narrowed.
+SOURCE_MAP_MAX_MAPS_PER_RELEASE=1000
+SOURCE_MAP_MAX_FILES_PER_REQUEST=50
+SOURCE_MAP_MAX_FILE_SIZE_BYTES=52428800
+SOURCE_MAP_MAX_BYTES_PER_RESOLVE=536870912
+SOURCE_MAP_RETENTION_DAYS=90
+
 # If you're using an extrenal open telemetry collector, you can set the endpoint here - both server and client endpoint can be the same in this case. 
 
 # You can set the env var to an OTLP endpoint if you want instrumentation to be exported.

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -140,6 +140,16 @@ x-common-runtime-variables: &common-runtime-variables
   ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_TOKEN_PER_WINDOW: ${ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_TOKEN_PER_WINDOW:-}
   ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_IP_PER_WINDOW: ${ON_CALL_CALENDAR_FEED_RATE_LIMIT_PER_IP_PER_WINDOW:-}
 
+  # Browser source map upload / symbolication limits. Blank means "use the
+  # built-in default", so a config.env upgraded in place keeps today's
+  # behaviour. maxFilesPerRequest and maxFileSizeBytes can only be lowered --
+  # the multipart parser's shared, pre-auth ceilings sit above them.
+  SOURCE_MAP_MAX_MAPS_PER_RELEASE: ${SOURCE_MAP_MAX_MAPS_PER_RELEASE:-}
+  SOURCE_MAP_MAX_FILES_PER_REQUEST: ${SOURCE_MAP_MAX_FILES_PER_REQUEST:-}
+  SOURCE_MAP_MAX_FILE_SIZE_BYTES: ${SOURCE_MAP_MAX_FILE_SIZE_BYTES:-}
+  SOURCE_MAP_MAX_BYTES_PER_RESOLVE: ${SOURCE_MAP_MAX_BYTES_PER_RESOLVE:-}
+  SOURCE_MAP_RETENTION_DAYS: ${SOURCE_MAP_RETENTION_DAYS:-}
+
   # How many appending proxies of your own sit in front of the app. Decides
   # which X-Forwarded-For entry counts as the client for IP allowlists and rate
   # limits. Defaulted because an existing config.env upgraded in place will not


### PR DESCRIPTION
Fixes #3515.

## Why the 100 existed, and why it could not just be raised

`MAX_SOURCE_MAPS_PER_RELEASE` was not an upload policy — it was the *same constant* at three sites, two of them on the read path:

| Site | Role |
|---|---|
| `SourceMapIngestService.ts:235` | write gate |
| `TelemetrySourceMapService.ts:209` | read limit — bundle-path listing |
| `TelemetrySourceMapService.ts:272` | read limit — the **content** fetch |

It was the only bound on peak memory of `POST /telemetry/exceptions/resolve-stack-trace`: that fetch materialises every matched row's full `content`, each map may be 50 MiB, and there was no cumulative byte budget anywhere. Row count was the sole quantity between a request and the heap.

Its stated premise — *"a build rarely emits more than a few dozen chunks with maps"* — does not survive route-level code splitting. A Nuxt/Vite/Next app with a hundred routes emits hundreds of chunk `.map` files per release, which is exactly what #3515 describes.

Simply deleting the constant is not expressible: `limit` is required on `FindBy`, so it would become an undocumented, unconfigurable `LIMIT_MAX` (10000) — worse than the ask on every axis, and 500 GiB of theoretical worst case.

## What this does

Splits the two roles so raising the ceiling is safe:

- **`SOURCE_MAP_MAX_MAPS_PER_RELEASE`** is now purely a **write gate**, default raised **100 → 1000**, clamped to `LIMIT_MAX`. An upload past it is rejected with a 400 naming the limit.
- **`SOURCE_MAP_MAX_BYTES_PER_RESOLVE`** bounds the **read path** instead. Maps that do not fit are skipped worst-match-first, logged, and reported as `sourceMapsSkippedForSize` on the response — never dropped silently.

Five knobs, exposed through the Helm chart under `sourceMaps` and through env for docker-compose self-hosters:

| `values.yaml` | Env var | Default |
| --- | --- | --- |
| `sourceMaps.maxMapsPerRelease` | `SOURCE_MAP_MAX_MAPS_PER_RELEASE` | `1000` |
| `sourceMaps.maxFilesPerRequest` | `SOURCE_MAP_MAX_FILES_PER_REQUEST` | `50` |
| `sourceMaps.maxFileSizeBytes` | `SOURCE_MAP_MAX_FILE_SIZE_BYTES` | `52428800` |
| `sourceMaps.maxBytesPerResolve` | `SOURCE_MAP_MAX_BYTES_PER_RESOLVE` | `536870912` |
| `sourceMaps.retentionDays` | `SOURCE_MAP_RETENTION_DAYS` | `90` |

`maxFilesPerRequest` and `maxFileSizeBytes` can only be **lowered**. The multipart body is parsed *before* authentication, so the shared ceilings above them are what an unauthenticated caller is held to on every route mounting that middleware; a larger value is narrowed rather than applied.

## Three regressions fixed along the way

1. **Duplicate rows silently cost a bundle its resolution.** The listing used the per-release ceiling as a *row* limit, while the ceiling counts distinct bundle *paths* — and duplicate rows are allowed by design (`TelemetrySourceMap.ts:64-71`). Since the gate is `> N`, one duplicate row was enough. The listing now reads with `LIMIT_MAX` and dedupes after.
2. **The CRUD path bypassed the ceiling.** `POST /api/telemetry-source-map` reached `create()` without passing the upload endpoint's batch check. `onBeforeCreate` now enforces it in two steps — an indexed COUNT on every insert, and the exact distinct-bundle answer only once that COUNT says the release is at the boundary, so a legitimate re-upload of a full release still succeeds.
3. **The chart rendered byte values in exponent form.** Helm parses `values.yaml` through JSON, so `52428800` reached the container as `'5.24288e+07'` — and only on that path, so `--set` and `-f` disagreed for the same number. `| int64` before quoting fixes both.

Also bounds the `frames` array at the resolve endpoint (it was validated only by `Array.isArray`, and `sanitizeMinifiedStackFrames` never truncates), and hardens the new per-route multipart builder against non-integer limits — busboy compares `files === limit`, so a fractional or `NaN` limit would *remove* the bound rather than narrow it.

## Testing

**222 tests** across 7 suites (≈180 new), all passing:

- `Common/Tests/Server/Utils/Telemetry/SourceMapLimits.test.ts` — 40 (new): defaults, overrides, clamp boundaries, 8 invalid-value shapes per knob, and a pin tying the config layer's hardcoded ceilings to the multipart constants they duplicate.
- `Common/Tests/Server/Services/TelemetrySourceMapService.test.ts` — 50: byte budget, unknown-size handling, frame-matching bound, the duplicate-row regression, and the new create-path ceiling.
- `Common/Tests/Server/Middleware/MultipartFormData.test.ts` — 41: per-route narrowing, identity of the shared instance, domain clamping.
- `Common/Tests/Server/API/TelemetryResolveStackTraceAPI.test.ts` — 30 (new): the frames cap, driven through the real route. This endpoint had no coverage before.
- `App/Tests/Telemetry/SourceMapIngestAPI.test.ts` — 40, and `SourceMapIngestRouteMultipart.test.ts` — 6 (new).
- `HelmChart/.../tests/source-map-limits_test.yaml` — 15 (new). Full chart suite: 18 suites / 203 tests pass.

Every regression above was **mutation-verified**: the implementation was reverted toward the old behaviour and the relevant tests were confirmed to fail. That pass also caught and fixed two hollow tests (one comparing values equal by default, one asserting its own mock) and one uncovered hardening path.

## Two pre-existing off-by-ones in the shared multipart middleware, also fixed

busboy's SIZE limits and its `parts` counter are **exclusive** — each fires the moment the counter *reaches* the limit, so handing it N admits only N−1. Its `files` and `fields` counters are **inclusive** — N admits N. That asymmetry is undocumented, and both exclusive halves were live bugs:

1. **A file of exactly `MAX_MULTIPART_FILE_BYTES` was 413'd.** The source map endpoint clamps its own ceiling to exactly that constant and rejects only what is *strictly* over it — so a map of precisely 50 MiB is one the endpoint means to accept, and whose 400 message says it accepts, and the parser killed it before the endpoint ever saw it. The documented "each `.map` file may be up to 50 MB" is now actually true.
2. **`parts` rejected the maximal body.** Its whole job, per the comment above it, is to allow the file and field allowances in full — but a body carrying exactly 50 files *and* 200 fields was rejected with `LIMIT_PART_COUNT` though neither allowance was breached.

The exported constants stay the inclusive maxima the app documents and that callers range-check against; only the three exclusive limits are converted at the multer call site. The two inclusive counters are left alone, so `files` and `fields` remain the limits that actually speak — one file past the maximal body is still `LIMIT_FILE_COUNT`, not `LIMIT_PART_COUNT`.

Both boundaries were measured against real multer/busboy before and after the change, and the tests that previously pinned the broken behaviour now pin the fixed behaviour on both the shared instance and a narrowed one.

## Verification after the fix

- `Common/Tests/Server/Middleware/MultipartFormData.test.ts` — **42 passed**
- `Common/Tests/Server/{Utils/Telemetry,Services,API}` source-map suites — **25 suites / 940 passed**
- `App/Tests/Telemetry` — **70 suites / 1146 passed**
- eslint clean on both changed files
