### PR TITLE
Fix prettier formatting in SourceMapIngestAPI.test.ts

### DIFF
--- a/App/Tests/Telemetry/SourceMapIngestAPI.test.ts
+++ b/App/Tests/Telemetry/SourceMapIngestAPI.test.ts
@@ -151,7 +151,9 @@ jest.mock("Common/Server/Middleware/MultipartFormData", () => {
       );
 
       const middleware: unknown =
-        clampedMaxFiles === MAX_MULTIPART_FILES ? multipartMiddleware : jest.fn();
+        clampedMaxFiles === MAX_MULTIPART_FILES
+          ? multipartMiddleware
+          : jest.fn();
 
       multipartMiddlewareBuilds.push({
         maxFiles: options.maxFiles,


### PR DESCRIPTION
`js-lint` is failing on `master` since #3538 with a single `prettier/prettier` error:

```
App/Tests/Telemetry/SourceMapIngestAPI.test.ts
  154:48  error  Replace `·?·multipartMiddleware` with `⏎··········?·multipartMiddleware⏎·········`  prettier/prettier
```

A ternary that needs wrapping. Purely cosmetic — no behaviour change, and the suite's 40 tests are unaffected.

**Why it got through:** the lint run before #3538 merged covered the implementation files and `Common/Tests/Server/Middleware/MultipartFormData.test.ts`, but not the App-side test files. `eslint` has now been run over all fourteen files that change touched — implementation and tests, both packages — and this was the only finding.