### PR TITLE
fix(discovery): harden reverse-DNS naming after an adversarial review

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -56,9 +56,11 @@ import ScanModeUtil, {
   ScanMethodLabel,
 } from "Common/Utils/NetworkDiscovery/ScanModeUtil";
 import {
+  buildDeviceName,
+  buildFallbackDeviceName,
   buildNetworkDeviceFromDiscoveredHost,
-  getDiscoveredHostDisplayName,
 } from "Common/Utils/NetworkDiscovery/DiscoveredDeviceBuilder";
+import { normalizeReverseDnsName } from "Common/Utils/NetworkDiscovery/ReverseDnsNameUtil";
 import {
   buildPingMonitorForDiscoveredHost,
   MonitorCriteriaSeedIds,
@@ -872,10 +874,35 @@ const NetworkDeviceDiscovery: FunctionComponent<
            * which is exactly the behaviour of an import with the option off.
            */
           if (pingMonitorSeedIds && isPingOnlyDiscoveredHost(entry)) {
+            /*
+             * The monitor is named after the HOST, which means the address has
+             * to be in it whenever the device name is not the address itself.
+             *
+             * Before issue #3529 that was automatic: a ping-only host WAS
+             * named by its address, so "Ping 10.18.166.51" identified exactly
+             * one thing. Now the device carries a PTR name, and PTR names are
+             * not unique — a DHCP range published under one wildcard record
+             * gives every host in it the same one. Importing that range with
+             * "Create a Ping monitor" ticked produced N monitors all called
+             * "Ping dhcp-pool.corp.example.com", bound to N correctly
+             * distinguished devices. Nothing failed; Monitor.name has no
+             * unique constraint and its slug carries random digits. The
+             * monitor list simply stopped being navigable.
+             *
+             * Qualifying with the address restores the property the address
+             * used to provide for free, and buildFallbackDeviceName is reused
+             * rather than re-composed so the monitor and the collision-retry
+             * device end up spelling the same host the same way.
+             */
+            const monitorSubjectName: string =
+              device.name && device.name !== entry.ipAddress
+                ? buildFallbackDeviceName(entry)
+                : device.name || entry.ipAddress;
+
             try {
               provisionedMonitorId = await createPingMonitorForHost({
                 host: entry,
-                deviceName: device.name || entry.ipAddress,
+                deviceName: monitorSubjectName,
                 scan: scanToReview,
                 seedIds: pingMonitorSeedIds,
               });
@@ -888,10 +915,45 @@ const NetworkDeviceDiscovery: FunctionComponent<
             }
           }
 
-          await ModelAPI.create<NetworkDevice>({
-            model: device,
-            modelType: NetworkDevice,
-          });
+          try {
+            await ModelAPI.create<NetworkDevice>({
+              model: device,
+              modelType: NetworkDevice,
+            });
+          } catch (createErr) {
+            /*
+             * One retry under the address-qualified name, exactly as the
+             * server-side auto-import rule engine does it
+             * (NetworkDeviceAutoImportRuleEngineService). Device names are
+             * unique per project, and this batch can now contain hosts that
+             * genuinely share one.
+             *
+             * Reverse DNS (issue #3529) is what made that ordinary. Ping-only
+             * hosts used to be named by their addresses, so two of them could
+             * never collide with each other; now a single wildcard PTR record
+             * — `*.166.18.10.in-addr.arpa IN PTR dhcp-pool.corp.example.com`,
+             * which is how a DHCP range is routinely published — gives every
+             * host in the range the same name. Without this retry the first
+             * host imported and the other 199 failed with "Network Device
+             * with the same name already exists", turning the feature into a
+             * regression for exactly the estates it was built for.
+             *
+             * The fallback appends ` (<address>)`, which is unique per host
+             * by construction. If THAT also fails the error is real and is
+             * reported against this host; the first error is the one worth
+             * showing, since the second is usually a consequence of it.
+             */
+            device.name = buildFallbackDeviceName(entry);
+
+            try {
+              await ModelAPI.create<NetworkDevice>({
+                model: device,
+                modelType: NetworkDevice,
+              });
+            } catch {
+              throw createErr;
+            }
+          }
 
           importedNow.push(entry.ipAddress);
         } catch (err) {
@@ -1729,24 +1791,41 @@ const NetworkDeviceDiscovery: FunctionComponent<
                 const isChecked: boolean =
                   isSelectable && Boolean(selectedIps[entry.ipAddress]);
                 /*
-                 * The SAME recipe the import uses, so the operator ticks a
-                 * box next to a name and gets a device with that name — see
-                 * getDiscoveredHostDisplayName. Since issue #3529 that
-                 * includes the host's reverse-DNS name, which is what a
-                 * ping-only host is called now that it is no longer
-                 * necessarily its own address.
+                 * `buildDeviceName`, not the unclamped display name: this row
+                 * shows the name the device will ACTUALLY be created with,
+                 * character for character.
+                 *
+                 * Since issue #3529 a name can be a 253-character FQDN where
+                 * it used to be a 15-character address, and the builder clamps
+                 * at 80 for the slug's sake. Rendering the unclamped value
+                 * meant the operator ticked a box next to one name and got a
+                 * device with a shorter, different one — a WYSIWYG break that
+                 * only ever showed up on the longest, least memorable names.
+                 * The full PTR name is not lost: when it differs from what is
+                 * shown here it appears on the line below.
                  */
-                const displayName: string = getDiscoveredHostDisplayName(entry);
+                const displayName: string = buildDeviceName(entry);
                 /*
                  * Shown BESIDE the address when it is not already the line
                  * above: an SNMP device whose sysName and PTR record disagree
                  * is worth surfacing rather than hiding — it is either two
                  * teams naming one box, or a stale reverse zone, and both are
                  * things an operator wants to see while deciding to import.
+                 * It is also where a PTR name too long to be a device name
+                 * remains readable.
+                 *
+                 * Re-normalised rather than read raw. Every path that feeds
+                 * this modal goes through normalizeDiscoveredHosts today, so
+                 * the value is already clean — but this is the one place the
+                 * attacker-chosen bytes would be rendered verbatim if that
+                 * ever stopped being true, and the guarantee is cheap enough
+                 * not to rest on a caller.
                  */
+                const normalizedDnsHostname: string | undefined =
+                  normalizeReverseDnsName(entry.dnsHostname);
                 const secondaryDnsHostname: string | undefined =
-                  entry.dnsHostname && entry.dnsHostname !== displayName
-                    ? entry.dnsHostname
+                  normalizedDnsHostname && normalizedDnsHostname !== displayName
+                    ? normalizedDnsHostname
                     : undefined;
                 return (
                   <div
@@ -1795,10 +1874,13 @@ const NetworkDeviceDiscovery: FunctionComponent<
                         }}
                       />
                       <div className="min-w-0">
-                        <div className="text-sm font-medium text-gray-900">
+                        <div
+                          className="truncate text-sm font-medium text-gray-900"
+                          title={displayName}
+                        >
                           {displayName}
                         </div>
-                        <div className="text-sm text-gray-500">
+                        <div className="truncate text-sm text-gray-500">
                           {entry.ipAddress}
                           {secondaryDnsHostname && (
                             <span className="text-gray-400">

--- a/App/Tests/Dashboard/DiscoveryReviewHostname.test.ts
+++ b/App/Tests/Dashboard/DiscoveryReviewHostname.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "@jest/globals";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import { DiscoveredNetworkDevice } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import {
+  MAX_DEVICE_NAME_LENGTH,
   buildDeviceName,
+  buildFallbackDeviceName,
+  buildNetworkDeviceFromDiscoveredHost,
   getDiscoveredHostDisplayName,
 } from "Common/Utils/NetworkDiscovery/DiscoveredDeviceBuilder";
 import { normalizeDiscoveredHosts } from "Common/Utils/NetworkDiscovery/DiscoveredHostUtil";
+import { normalizeReverseDnsName } from "Common/Utils/NetworkDiscovery/ReverseDnsNameUtil";
+import ObjectID from "Common/Types/ObjectID";
 import fs from "fs";
 import path from "path";
 
@@ -29,18 +35,27 @@ import path from "path";
  * (show it), and the dashboard half is the one that closes the loop the
  * reporter actually saw. This file pins that half.
  *
- * The App suite runs in a plain Node environment with no React renderer, so
- * the dialog cannot be mounted and read. So the file is in two parts, and
- * both are load-bearing:
+ * HOW IT TESTS A REACT ROW WITH NO REACT RENDERER
  *
- *   - BEHAVIOUR, tested against the shared function the row now calls. That is
- *     where the naming rule actually lives, and it is real executable
- *     coverage rather than a source-level proxy.
- *   - SOURCE, following DiscoveryReviewCopy.test.ts and
- *     InventoryTableInvariants.test.ts: proof that the row calls that shared
- *     function instead of spelling the rule out a second time. Duplicated
- *     rules drift, and this exact rule drifting means the operator ticks a box
- *     next to one name and gets a device with another.
+ * The App suite runs in a plain Node environment, so the dialog cannot be
+ * mounted and read. Restating the row's rule in a local helper and testing
+ * THAT would be circular — it would pass with the row deleted. So instead the
+ * row's own name/second-line expressions are LIFTED OUT OF Discovery.tsx by
+ * `rowNameSource()` and COMPILED, then run against the real shared builders.
+ * Every test below that says "the row" is running the page's own code:
+ *
+ *   - delete the second line's computation  -> the extraction throws;
+ *   - invert its `!== displayName` gate     -> the executed result inverts;
+ *   - render `entry.dnsHostname` raw        -> the hostile-PTR and root-dot
+ *                                              cases below start failing;
+ *   - rename `displayName` to `ptrName`     -> nothing breaks, because the
+ *                                              identifiers are read out of the
+ *                                              source rather than hard-coded.
+ *
+ * The remaining source-level assertions (final describe) cover what execution
+ * cannot see: that the computed values are actually RENDERED, and that the old
+ * inline rule is gone. Duplicated rules drift, and this rule drifting means the
+ * operator ticks a box next to one name and gets a device with another.
  */
 
 const DISCOVERY_PAGE: string = path.join(
@@ -73,15 +88,216 @@ function readSource(): string {
 
 /*
  * Comments stripped so that DESCRIBING a rule in prose never counts as
- * implementing it, and whitespace squashed so Prettier can reflow props
- * without making the test brittle.
+ * implementing it. Split out of readCode() so the stripper itself can be
+ * tested on a synthetic input: it is the foundation every source assertion in
+ * this file rests on, and a stripper that silently stopped stripping would
+ * take the whole final describe green against the page's prose alone.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/*
+ * Comments gone and whitespace squashed, so Prettier can reflow props without
+ * making the assertions brittle. NOTE for anyone adding an assertion: after
+ * this squash a source `a || b` always reads back WITH single spaces, so a
+ * `not.toContain("a||b")` can never fail. Use a regex with `\s*`.
  */
 function readCode(): string {
-  return readSource()
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/(^|[^:])\/\/[^\n]*/g, "$1")
-    .replace(/\s+/g, " ");
+  return stripComments(readSource()).replace(/\s+/g, " ");
 }
+
+/*
+ * THE ROW'S OWN NAMING CODE, READ OUT OF THE PAGE.
+ *
+ * The block between `const <name> = buildDeviceName(entry)` and the row's
+ * `return (` is the entirety of what the row computes about names: the clamped
+ * display name, the re-normalised PTR name, and the gate that decides whether
+ * the PTR name earns a second line. It is self-contained — it touches nothing
+ * but `entry` and the two imported builders — which is what makes lifting and
+ * running it possible.
+ *
+ * The identifiers are CAPTURED rather than assumed, so a pure rename of
+ * `displayName` or `secondaryDnsHostname` leaves every test here passing while
+ * a change of BEHAVIOUR still fails them. That matters: the previous version
+ * of this file hard-coded both names, so a rename broke six tests that had no
+ * opinion about naming at all.
+ */
+interface RowNameSource {
+  /* The identifier holding `buildDeviceName(entry)` — the visible name line. */
+  displayNameIdentifier: string;
+  /* The identifier holding the gated PTR name — the row's second line. */
+  secondaryIdentifier: string;
+  /* The statements themselves, comments stripped and whitespace squashed. */
+  statements: string;
+}
+
+const ROW_NAME_BLOCK: RegExp =
+  /(const\s+(\w+)\s*(?::[^=]*)?=\s*buildDeviceName\(entry\);.*?)return \(/;
+
+let cachedRowNameSource: RowNameSource | null = null;
+
+function rowNameSource(): RowNameSource {
+  if (cachedRowNameSource !== null) {
+    return cachedRowNameSource;
+  }
+
+  const match: RegExpMatchArray | null = readCode().match(ROW_NAME_BLOCK);
+
+  if (!match) {
+    throw new Error(
+      "Discovery.tsx no longer computes `buildDeviceName(entry)` into a const" +
+        " before the discovered-host row's `return (`. The Review dialog's" +
+        " name line is what issue #3529 changed; if it moved, move these" +
+        " tests with it rather than deleting them.",
+    );
+  }
+
+  const statements: string = match[1]!;
+  /*
+   * The LAST const in the block is the second line: the gate is written as
+   * `<normalised> && <normalised> !== <displayName> ? <normalised> : undefined`
+   * and assigned last. Taken positionally rather than by name for the reason
+   * above. If the second line's computation is deleted outright, the last
+   * const becomes the normalised PTR name itself — which is ungated, so
+   * "a PTR name that IS the name line is not printed twice" fails. That is the
+   * intended failure, and it is why deleting the feature cannot go green here.
+   */
+  const declaredNames: Array<string> = Array.from(
+    statements.matchAll(/const\s+(\w+)\s*[:=]/g),
+    (declaration: RegExpMatchArray) => {
+      return declaration[1]!;
+    },
+  );
+
+  const secondaryIdentifier: string | undefined =
+    declaredNames[declaredNames.length - 1];
+
+  if (!secondaryIdentifier || declaredNames.length < 2) {
+    throw new Error(
+      `The discovered-host row declares only ${declaredNames.length} name` +
+        " const(s); it needs the display name and the gated PTR name.",
+    );
+  }
+
+  cachedRowNameSource = {
+    displayNameIdentifier: match[2]!,
+    secondaryIdentifier: secondaryIdentifier,
+    statements: statements,
+  };
+
+  return cachedRowNameSource;
+}
+
+/*
+ * `const x: string | undefined = ...` -> `const x = ...`, so the lifted block
+ * is executable JavaScript. Only the annotation between the declared name and
+ * the first `=` is removed; nothing else in the block is touched.
+ */
+function stripTypeAnnotations(statements: string): string {
+  return statements.replace(/const\s+(\w+)\s*:\s*[^=]*=/g, "const $1 =");
+}
+
+type RowSecondaryLine = (
+  entry: DiscoveredNetworkDevice,
+  buildName: (host: DiscoveredNetworkDevice) => string,
+  normalizeName: (value: unknown) => string | undefined,
+) => string | undefined;
+
+let cachedSecondaryLine: RowSecondaryLine | null = null;
+
+/**
+ * What the row's second line shows for this host — computed by running the
+ * row's own expression, with the real shared builders injected.
+ *
+ * The parameter names are the page's own call names, so an alias-rename in
+ * Discovery.tsx fails the extraction loudly instead of quietly.
+ */
+function secondaryLineFor(host: DiscoveredNetworkDevice): string | undefined {
+  if (cachedSecondaryLine === null) {
+    const source: RowNameSource = rowNameSource();
+
+    cachedSecondaryLine = new Function(
+      "entry",
+      "buildDeviceName",
+      "normalizeReverseDnsName",
+      `${stripTypeAnnotations(source.statements)} return ${
+        source.secondaryIdentifier
+      };`,
+    ) as unknown as RowSecondaryLine;
+  }
+
+  return cachedSecondaryLine(host, buildDeviceName, normalizeReverseDnsName);
+}
+
+/*
+ * The checkbox's accessible name, lifted and run the same way. A screen-reader
+ * user never sees the row; this template is the entire row, for them.
+ */
+const ARIA_LABEL_TEMPLATE: RegExp = /ariaLabel=\{(`Import [^`]*`)\}/;
+
+type RowAriaLabel = (
+  entry: DiscoveredNetworkDevice,
+  displayName: string,
+) => string;
+
+let cachedAriaLabel: RowAriaLabel | null = null;
+
+function ariaLabelTemplate(): string {
+  const match: RegExpMatchArray | null = readCode().match(ARIA_LABEL_TEMPLATE);
+
+  if (!match) {
+    throw new Error(
+      "The discovered-host checkbox no longer carries an `ariaLabel={`Import" +
+        " ...`}`. A disabled checkbox in a list that does not say what it is" +
+        " reads as broken rather than as deliberate.",
+    );
+  }
+
+  return match[1]!;
+}
+
+function ariaLabelFor(host: DiscoveredNetworkDevice): string {
+  if (cachedAriaLabel === null) {
+    cachedAriaLabel = new Function(
+      "entry",
+      rowNameSource().displayNameIdentifier,
+      `return ${ariaLabelTemplate()};`,
+    ) as unknown as RowAriaLabel;
+  }
+
+  return cachedAriaLabel(host, buildDeviceName(host));
+}
+
+/*
+ * A fully qualified name at the DNS presentation-form ceiling: four labels of
+ * 63/63/63/61 characters plus three dots is exactly 253, which
+ * normalizeReverseDnsName accepts and NetworkDevice.name cannot hold. Built
+ * from repeats rather than written out so the arithmetic is checkable, and
+ * asserted below rather than assumed.
+ */
+const LONG_PTR_NAME: string = [
+  "a".repeat(63),
+  "b".repeat(63),
+  "c".repeat(63),
+  "d".repeat(61),
+].join(".");
+
+/*
+ * A DIFFERENT maximal name that agrees with LONG_PTR_NAME for its first 192
+ * characters — so the two are identical after the 80-character clamp. Two
+ * hosts under one reverse zone with long, structured names (the shape
+ * `<role>.<rack>.<row>.<site>` produces routinely) collide this way, and the
+ * collision exists ONLY because of the clamp this feature added.
+ */
+const TWIN_PTR_NAME: string = [
+  "a".repeat(63),
+  "b".repeat(63),
+  "c".repeat(63),
+  "e".repeat(61),
+].join(".");
 
 /*
  * The reporter's four rows, as the probe now reports them: alive, no SNMP,
@@ -111,20 +327,22 @@ function reportedHosts(): Array<DiscoveredNetworkDevice> {
 
 /*
  * What the dialog's name line renders, computed the way the row computes it:
- * normalise the jsonb, then ask the shared display-name function. Both steps
- * matter — the row is fed by getReviewHosts, which normalises first.
+ * normalise the jsonb, then ask for the name the device would be CREATED
+ * with. Both steps matter — the row is fed by getReviewHosts, which
+ * normalises first, and it renders buildDeviceName rather than the unclamped
+ * display name so that what is shown and what is created cannot differ.
  */
-function renderedNames(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
+function displayedNames(hosts: Array<DiscoveredNetworkDevice>): Array<string> {
   return normalizeDiscoveredHosts(hosts).map(
     (host: DiscoveredNetworkDevice) => {
-      return getDiscoveredHostDisplayName(host);
+      return buildDeviceName(host);
     },
   );
 }
 
 describe("the Review dialog names hosts by their PTR record (issue #3529)", () => {
   test("the reported rows read as hostnames instead of addresses", () => {
-    expect(renderedNames(reportedHosts())).toEqual([
+    expect(displayedNames(reportedHosts())).toEqual([
       "core-gw.corp.example.com",
       "printer-3.corp.example.com",
       "cam-lobby.corp.example.com",
@@ -133,30 +351,59 @@ describe("the Review dialog names hosts by their PTR record (issue #3529)", () =
     ]);
   });
 
-  test("the address is still shown on every row", () => {
+  test("the name never carries the address, so the address line is load-bearing", () => {
     /*
-     * The name replaces the LABEL, never the address. An operator matching a
-     * row against a firewall rule or a patch panel needs the address, and the
-     * device that imports is keyed by it.
+     * The name replaces the LABEL, never the address. Asserting that the
+     * normaliser hands its own input back would prove nothing; what has to
+     * hold is that the row's two lines now say DIFFERENT things, so deleting
+     * the address line loses information rather than removing a duplicate.
+     * An operator matching a row against a firewall rule or a patch panel has
+     * only that line to match on.
      */
-    const addresses: Array<string> = normalizeDiscoveredHosts(
+    const named: Array<DiscoveredNetworkDevice> = normalizeDiscoveredHosts(
       reportedHosts(),
-    ).map((host: DiscoveredNetworkDevice) => {
-      return host.ipAddress;
+    ).filter((host: DiscoveredNetworkDevice) => {
+      return Boolean(host.dnsHostname);
     });
 
-    expect(addresses).toEqual([
-      "10.18.166.51",
-      "10.18.166.53",
-      "10.18.166.54",
-      "10.18.166.55",
-    ]);
+    expect(named).toHaveLength(3);
+
+    for (const host of named) {
+      expect(buildDeviceName(host)).not.toContain(host.ipAddress);
+    }
+  });
+
+  test("the device that imports is still addressed by its address", () => {
+    /*
+     * The other half of the same guarantee, and the one the rest of the system
+     * depends on: `hostname` is the dedup key the ingest path matches scan
+     * results against and the address the SNMP poller dials. Storing the PTR
+     * name here would make a device stop polling the day its reverse zone
+     * changed, and would import the same host twice — once by address, once by
+     * name.
+     */
+    const host: DiscoveredNetworkDevice = normalizeDiscoveredHosts([
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "core-gw.corp.example.com",
+      },
+    ])[0]!;
+
+    const device: NetworkDevice = buildNetworkDeviceFromDiscoveredHost({
+      projectId: new ObjectID("00000000-0000-0000-0000-000000000001"),
+      host: host,
+      scan: {},
+    });
+
+    expect(device.name).toBe("core-gw.corp.example.com");
+    expect(device.hostname).toBe("10.18.166.51");
   });
 
   test("an SNMP host keeps its sysName as the name line", () => {
     // Unchanged behaviour for every scan that already worked.
     expect(
-      renderedNames([
+      displayedNames([
         {
           ipAddress: "10.0.0.5",
           sysName: "core-switch-01",
@@ -173,11 +420,96 @@ describe("the Review dialog names hosts by their PTR record (issue #3529)", () =
      * probe that has not been upgraded, has no dnsHostname at all.
      */
     expect(
-      renderedNames([
+      displayedNames([
         { ipAddress: "10.0.0.5", sysName: "core-switch-01" },
         { ipAddress: "10.0.0.6" },
       ]),
     ).toEqual(["core-switch-01", "10.0.0.6"]);
+  });
+
+  test("a non-string sysName names the host by DNS instead of taking out the dialog", () => {
+    /*
+     * `sysName` is jsonb: its declared TypeScript type describes what the
+     * probe SHOULD send, not what is stored. Two separate guards exist for
+     * this and BOTH source comments name the same failure — a TypeError inside
+     * this dialog's render, which takes out the whole modal rather than one
+     * row — so both are exercised here.
+     *
+     * First guard, in getDiscoveredHostDisplayName: `(42).trim()` throws, so
+     * the typeof check is what stands between a numeric sysName and a blank
+     * Review dialog. Called on the RAW host, because a future caller feeding
+     * the modal without normalizeDiscoveredHosts is exactly the case it is for.
+     */
+    const numericSysName: DiscoveredNetworkDevice = {
+      ipAddress: "10.0.0.5",
+      sysName: 42,
+      dnsHostname: "core-gw.corp.example.com",
+    } as unknown as DiscoveredNetworkDevice;
+
+    expect(getDiscoveredHostDisplayName(numericSysName)).toBe(
+      "core-gw.corp.example.com",
+    );
+
+    /*
+     * Second guard, in normalizeDiscoveredHosts, and it is the sharper one: a
+     * non-string sysName is BLANKED, never stringified. `String(null)` is
+     * "null" and `String({})` is "[object Object]" — both truthy, both
+     * strings, so both would survive the typeof guard above and WIN the naming
+     * contest outright, creating a device called "null" beside a perfectly
+     * good PTR record on the same row. That is a direct #3529 regression, and
+     * these are the assertions that catch it: swap the blanking for String()
+     * and the expected names below become "null" and "[object Object]".
+     */
+    const brokenSysNames: Array<DiscoveredNetworkDevice> = [
+      numericSysName,
+      {
+        ipAddress: "10.0.0.6",
+        sysName: null,
+        dnsHostname: "printer-3.corp.example.com",
+      },
+      {
+        ipAddress: "10.0.0.7",
+        sysName: {},
+        dnsHostname: "cam-lobby.corp.example.com",
+      },
+    ] as unknown as Array<DiscoveredNetworkDevice>;
+
+    expect(displayedNames(brokenSysNames)).toEqual([
+      "core-gw.corp.example.com",
+      "printer-3.corp.example.com",
+      "cam-lobby.corp.example.com",
+    ]);
+  });
+
+  test("a blank-padded sysName is not a name, so the PTR record still wins", () => {
+    /*
+     * `"   "` is truthy, and nothing trims sysName on the way out of the jsonb
+     * — normalizeDiscoveredHosts only rewrites it when it is not a string. So
+     * the `.trim()` inside getDiscoveredHostDisplayName's typeof guard is the
+     * ONLY thing that makes a whitespace-only sysName fall through. Delete
+     * that one `.trim()` and every host whose SNMP agent reports a padded or
+     * empty sysName — common on gear that was never given a hostname — is
+     * shown, and imported, as a device named " ", with a perfectly good PTR
+     * record sitting unused on the same row.
+     */
+    const paddedSysName: DiscoveredNetworkDevice = {
+      ipAddress: "10.0.0.5",
+      sysName: "   ",
+      dnsHostname: "core-gw.corp.example.com",
+      snmpReachable: true,
+    };
+
+    expect(getDiscoveredHostDisplayName(paddedSysName)).toBe(
+      "core-gw.corp.example.com",
+    );
+    expect(displayedNames([paddedSysName])).toEqual([
+      "core-gw.corp.example.com",
+    ]);
+
+    // And with no PTR record either, it falls all the way to the address.
+    expect(
+      displayedNames([{ ipAddress: "10.0.0.6", sysName: "\t\n " }]),
+    ).toEqual(["10.0.0.6"]);
   });
 
   test("a hostile PTR record renders as the address, not as itself", () => {
@@ -187,7 +519,7 @@ describe("the Review dialog names hosts by their PTR record (issue #3529)", () =
      * choose what an operator reads on a row they are about to tick.
      */
     expect(
-      renderedNames([
+      displayedNames([
         { ipAddress: "10.0.0.5", dnsHostname: "<script>alert(1)</script>" },
         { ipAddress: "10.0.0.6", dnsHostname: "Already added" },
         { ipAddress: "10.0.0.7", dnsHostname: "10.0.0.7" },
@@ -202,54 +534,560 @@ describe("the Review dialog names hosts by their PTR record (issue #3529)", () =
      */
   });
 
-  test("the row's name is the name the device gets", () => {
+  test("a rejected PTR record is removed from the host, not blanked", () => {
     /*
-     * The contract the whole shared-function refactor exists for: the
-     * operator ticks a box next to a name and gets a device with that name.
+     * The naming assertions above cannot see this: the name is the address
+     * either way. But normalizeDiscoveredHosts states the contract in as many
+     * words — a reader that asks `if (host.dnsHostname)` and a reader that
+     * asks `"dnsHostname" in host` must not disagree — and `delete` rather
+     * than `= ""` is what makes that true. A blanked key is a host that
+     * ADVERTISES a reverse name and then has none, which is how a "resolved"
+     * count, a filter facet or a rule predicate keyed on presence ends up
+     * counting hosts whose PTR answer was thrown away for being hostile.
+     */
+    const rejected: DiscoveredNetworkDevice = normalizeDiscoveredHosts([
+      { ipAddress: "10.0.0.5", dnsHostname: "<script>alert(1)</script>" },
+    ])[0]!;
+
+    expect("dnsHostname" in rejected).toBe(false);
+
+    // A host that never had the key does not gain one either.
+    expect(
+      "dnsHostname" in
+        normalizeDiscoveredHosts([{ ipAddress: "10.0.0.6" }])[0]!,
+    ).toBe(false);
+
+    // And an accepted one is still there, so the assertion above is not free.
+    expect(
+      "dnsHostname" in
+        normalizeDiscoveredHosts([
+          { ipAddress: "10.0.0.7", dnsHostname: "core-gw.corp.example.com" },
+        ])[0]!,
+    ).toBe(true);
+  });
+
+  test("a 253-character PTR name is shown clamped, exactly as it is created", () => {
+    /*
+     * The WYSIWYG defect the row's switch to buildDeviceName fixed. The name
+     * line used to render the UNCLAMPED display name, so a host with a
+     * maximal FQDN showed 253 characters and imported as a different,
+     * 80-character device — the operator ticked a box next to one name and
+     * got another. It could only ever show up on the longest, least
+     * memorable names, which is exactly where nobody would notice.
+     */
+    expect(LONG_PTR_NAME).toHaveLength(253);
+
+    const host: DiscoveredNetworkDevice = normalizeDiscoveredHosts([
+      { ipAddress: "10.18.166.51", dnsHostname: LONG_PTR_NAME },
+    ])[0]!;
+
+    // The clamp has to actually bite, or this test proves nothing.
+    expect(getDiscoveredHostDisplayName(host)).toHaveLength(253);
+
+    const shownName: string = buildDeviceName(host);
+
+    expect(shownName).toHaveLength(MAX_DEVICE_NAME_LENGTH);
+    expect(shownName).toBe(LONG_PTR_NAME.substring(0, MAX_DEVICE_NAME_LENGTH));
+    expect(displayedNames([{ ...host }])).toEqual([shownName]);
+  });
+});
+
+describe("the row's second line surfaces a PTR name the first line does not", () => {
+  /*
+   * Every test here runs Discovery.tsx's own second-line expression — see
+   * `rowNameSource` above. Inverting the row's gate, dropping the
+   * normalisation, or deleting the computation each fails at least one of
+   * them, which is the whole reason the block is lifted rather than restated.
+   */
+
+  test("an SNMP host's disagreeing PTR record is still surfaced", () => {
+    /*
+     * sysName wins the name line, so before the second line existed the PTR
+     * record was resolved, stored and then never shown. Two teams naming one
+     * box, or a stale reverse zone, is something the operator wants in front
+     * of them while deciding to import — not something the dialog swallows.
+     */
+    const host: DiscoveredNetworkDevice = normalizeDiscoveredHosts([
+      {
+        ipAddress: "10.0.0.5",
+        sysName: "core-switch-01",
+        dnsHostname: "sw1.corp.example.com",
+        snmpReachable: true,
+      },
+    ])[0]!;
+
+    expect(buildDeviceName(host)).toBe("core-switch-01");
+    expect(secondaryLineFor(host)).toBe("sw1.corp.example.com");
+  });
+
+  test("a PTR name that IS the name line is not printed twice", () => {
+    /*
+     * The reporter's own rows: no SNMP, so the PTR name is the name line.
+     * Repeating it beside the address would make every row in the dialog the
+     * feature was built for read as "name / address · name". This is the test
+     * that fails if the row's `!== displayName` gate is removed or inverted.
      */
     for (const host of normalizeDiscoveredHosts(reportedHosts())) {
-      expect(buildDeviceName(host)).toBe(getDiscoveredHostDisplayName(host));
+      expect(secondaryLineFor(host)).toBeUndefined();
     }
+  });
+
+  test("a PTR answer carrying the root dot is not printed a second time", () => {
+    /*
+     * "core-gw.corp.example.com." is the form a resolver most often hands
+     * back, and it is what separates the row's gate from a naive one. The row
+     * compares the NORMALISED name against the name line; comparing
+     * `entry.dnsHostname` directly would find "core-gw.corp.example.com." !==
+     * "core-gw.corp.example.com" and print a spurious duplicate line on every
+     * one of the reporter's own rows.
+     *
+     * Fed RAW, not through normalizeDiscoveredHosts, because normalising first
+     * would strip the dot and destroy the case being tested — and because a
+     * caller that feeds the modal unnormalised is precisely the situation the
+     * row's re-normalisation exists for.
+     */
+    const raw: DiscoveredNetworkDevice = {
+      ipAddress: "10.18.166.51",
+      dnsHostname: "core-gw.corp.example.com.",
+    };
+
+    expect(buildDeviceName(raw)).toBe("core-gw.corp.example.com");
+    expect(secondaryLineFor(raw)).toBeUndefined();
+  });
+
+  test("a PTR name too long to be a device name stays readable in full", () => {
+    /*
+     * The clamp is what makes the second line necessary rather than merely
+     * nice: the name line now stops at 80 characters, so without this the
+     * remaining 173 characters of the FQDN — the part that says which host it
+     * is — would exist nowhere on the row. The row shows all 253.
+     */
+    const host: DiscoveredNetworkDevice = normalizeDiscoveredHosts([
+      { ipAddress: "10.18.166.51", dnsHostname: LONG_PTR_NAME },
+    ])[0]!;
+
+    expect(buildDeviceName(host)).toHaveLength(MAX_DEVICE_NAME_LENGTH);
+    expect(secondaryLineFor(host)).toBe(LONG_PTR_NAME);
+  });
+
+  test("a host with no usable PTR record has no second line", () => {
+    // Nothing to say, so nothing is said: no empty separator on the address.
+    expect(
+      secondaryLineFor({ ipAddress: "10.18.166.55", snmpReachable: false }),
+    ).toBeUndefined();
+
+    /*
+     * Fed raw on purpose. A resolver that echoes the query name back hands us
+     * "51.166.18.10.in-addr.arpa", which is a legal hostname string and a
+     * strictly worse label than the address it came from. The row's own
+     * re-normalisation is the thing being tested: render `entry.dnsHostname`
+     * instead and this row grows a second line reading the reverse zone.
+     */
+    expect(
+      secondaryLineFor({
+        ipAddress: "10.18.166.55",
+        dnsHostname: "51.166.18.10.in-addr.arpa",
+      }),
+    ).toBeUndefined();
+
+    // Same for an answer the character rules reject outright.
+    expect(
+      secondaryLineFor({
+        ipAddress: "10.18.166.55",
+        dnsHostname: "<script>alert(1)</script>",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("the checkbox tells a screen reader what the row says", () => {
+  test("the label carries the name line and the address", () => {
+    /*
+     * Runs the page's own aria-label template. A sighted operator reads the
+     * name line and the address line; a screen-reader user gets this string
+     * and nothing else, so it has to carry both — the name to know WHICH host
+     * is being ticked, the address because the name is no longer unique per
+     * host (a wildcard PTR zone gives a whole DHCP range one name, and without
+     * the address every checkbox in that range announces identically).
+     */
+    expect(
+      ariaLabelFor({
+        ipAddress: "10.18.166.51",
+        dnsHostname: "core-gw.corp.example.com",
+        snmpReachable: false,
+      }),
+    ).toBe("Import core-gw.corp.example.com (10.18.166.51)");
+  });
+
+  test("a host that reported no address still announces as something", () => {
+    /*
+     * The branch the previous version of this file never touched. A host with
+     * a blank address cannot be imported at all — the checkbox is disabled and
+     * carries a hoverText saying why — but it is still IN the list, and
+     * without the `|| "no address"` fallback its label reads
+     * "Import core-switch-01 ()", which sounds like a rendering bug rather
+     * than like a host the dialog is deliberately refusing.
+     */
+    expect(ariaLabelFor({ ipAddress: "", sysName: "core-switch-01" })).toBe(
+      "Import core-switch-01 (no address)",
+    );
+
+    // Nothing to say at all is still a sentence, not an empty one.
+    expect(ariaLabelFor({ ipAddress: "" })).toBe("Import  (no address)");
+  });
+});
+
+describe("hosts that share one PTR name still all import", () => {
+  test("the fallback name distinguishes hosts a wildcard PTR zone named alike", () => {
+    /*
+     * `*.166.18.10.in-addr.arpa IN PTR dhcp-pool.corp.example.com` is how a
+     * DHCP range is routinely published, and it gives every host in the range
+     * one name. Device names are unique per project, so before the import
+     * retry the first host was created and the rest failed with "Network
+     * Device with the same name already exists" — the feature turning into a
+     * regression for exactly the estates it was built for. Ping-only hosts
+     * used to be named by their addresses, so this could not happen at all
+     * until issue #3529 landed.
+     */
+    const shared: string = "dhcp-pool.corp.example.com";
+    const hosts: Array<DiscoveredNetworkDevice> = normalizeDiscoveredHosts([
+      { ipAddress: "10.18.166.51", dnsHostname: shared },
+      { ipAddress: "10.18.166.52", dnsHostname: shared },
+    ]);
+
+    // The collision is real: the first-choice names genuinely are identical.
+    expect(
+      hosts.map((host: DiscoveredNetworkDevice) => {
+        return buildDeviceName(host);
+      }),
+    ).toEqual([shared, shared]);
+
+    const fallbackNames: Array<string> = hosts.map(
+      (host: DiscoveredNetworkDevice) => {
+        return buildFallbackDeviceName(host);
+      },
+    );
+
+    expect(new Set<string>(fallbackNames).size).toBe(2);
+    expect(fallbackNames).toEqual([
+      "dhcp-pool.corp.example.com (10.18.166.51)",
+      "dhcp-pool.corp.example.com (10.18.166.52)",
+    ]);
+  });
+
+  test("two maximal PTR names that agree for 80 characters still import as two devices", () => {
+    /*
+     * A collision mode created by the clamp itself, and therefore by this very
+     * change: two DIFFERENT 253-character names whose first 80 characters
+     * match are one name after buildDeviceName. The address-qualified fallback
+     * was designed around wildcard zones (identical names), not around this —
+     * and it survives only because it truncates the BASE to 65 before
+     * appending, so the address is never itself clamped off.
+     *
+     * That is the part with no other guard: widen the suffix budget, or clamp
+     * the composed string instead of the base, and both hosts get the same
+     * fallback name too — at which point the second host is uncreatable and
+     * the import reports a name collision the operator cannot act on.
+     */
+    expect(LONG_PTR_NAME).not.toBe(TWIN_PTR_NAME);
+    expect(LONG_PTR_NAME.substring(0, MAX_DEVICE_NAME_LENGTH)).toBe(
+      TWIN_PTR_NAME.substring(0, MAX_DEVICE_NAME_LENGTH),
+    );
+
+    const hosts: Array<DiscoveredNetworkDevice> = normalizeDiscoveredHosts([
+      { ipAddress: "10.18.166.51", dnsHostname: LONG_PTR_NAME },
+      { ipAddress: "10.18.166.52", dnsHostname: TWIN_PTR_NAME },
+    ]);
+
+    const shownNames: Array<string> = hosts.map(
+      (host: DiscoveredNetworkDevice) => {
+        return buildDeviceName(host);
+      },
+    );
+
+    // Both rows read identically, which is what makes the retry necessary.
+    expect(new Set<string>(shownNames).size).toBe(1);
+
+    const fallbackNames: Array<string> = hosts.map(
+      (host: DiscoveredNetworkDevice) => {
+        return buildFallbackDeviceName(host);
+      },
+    );
+
+    expect(new Set<string>(fallbackNames).size).toBe(2);
+
+    for (const fallbackName of fallbackNames) {
+      expect(fallbackName.length).toBeLessThanOrEqual(MAX_DEVICE_NAME_LENGTH);
+    }
+  });
+
+  test("the fallback name still fits when the PTR name is maximal", () => {
+    /*
+     * The retry is worthless if its own name overflows: NetworkDevice.name is
+     * varchar(100) and the slug derived from it has its own ceiling, so a
+     * fallback that simply appended to a 253-character name would fail the
+     * create for a second, more confusing reason.
+     */
+    const name: string = buildFallbackDeviceName({
+      ipAddress: "10.18.166.51",
+      dnsHostname: LONG_PTR_NAME,
+    });
+
+    expect(name.length).toBeLessThanOrEqual(MAX_DEVICE_NAME_LENGTH);
+    expect(name.endsWith(" (10.18.166.51)")).toBe(true);
+  });
+
+  test("the retried name is a prefix of the name the row showed, plus the address", () => {
+    /*
+     * THE HONEST STATEMENT OF THE WYSIWYG CONTRACT, which the retry bends.
+     *
+     * The row shows `buildDeviceName(entry)`, and "a 253-character PTR name is
+     * shown clamped, exactly as it is created" is true only of the FIRST
+     * create. On a name collision — the wildcard-PTR case the retry exists for,
+     * so the case where it happens most — the device is created as
+     * `buildFallbackDeviceName(entry)` instead, and the operator's inventory
+     * ends up holding a name that is NOT character-for-character the one the
+     * row displayed. The dialog does not say so.
+     *
+     * What survives, and what an operator can actually rely on, is narrower:
+     *   - the row shows the name the import ATTEMPTS FIRST;
+     *   - the created name is that name, or the longest prefix of it that
+     *     leaves room, with ` (<address>)` appended.
+     * So the row's text is still the right thing to search the inventory for,
+     * and the address in the suffix is what identifies WHICH of the alike-named
+     * hosts this device is. Both halves are asserted, exactly, below.
+     *
+     * `expect(created.startsWith(shown))` would NOT do: it is false for the
+     * maximal name, where 15 characters of the shown name are cut to make room.
+     * And a bare `endsWith(suffix)` check would pass for a fallback of
+     * "x (10.18.166.51)", which carries none of the name at all.
+     */
+    const suffix: string = " (10.18.166.51)";
+    const budget: number = MAX_DEVICE_NAME_LENGTH - suffix.length;
+
+    // Short name: the created name contains the shown name whole.
+    const shortHost: DiscoveredNetworkDevice = {
+      ipAddress: "10.18.166.51",
+      dnsHostname: "dhcp-pool.corp.example.com",
+    };
+    const shortShown: string = buildDeviceName(shortHost);
+    const shortCreated: string = buildFallbackDeviceName(shortHost);
+
+    expect(shortShown.length).toBeLessThanOrEqual(budget);
+    expect(shortCreated).toBe(`${shortShown}${suffix}`);
+
+    // Maximal name: the base is cut, and cut to the LONGEST prefix that fits.
+    const longHost: DiscoveredNetworkDevice = {
+      ipAddress: "10.18.166.51",
+      dnsHostname: LONG_PTR_NAME,
+    };
+    const longShown: string = buildDeviceName(longHost);
+    const longCreated: string = buildFallbackDeviceName(longHost);
+
+    expect(longShown.length).toBeGreaterThan(budget);
+    expect(longCreated.endsWith(suffix)).toBe(true);
+
+    const longBase: string = longCreated.substring(
+      0,
+      longCreated.length - suffix.length,
+    );
+
+    expect(longBase).toBe(longShown.substring(0, budget));
+    expect(longShown.startsWith(longBase)).toBe(true);
+    expect(longBase).toHaveLength(budget);
   });
 });
 
 describe("Discovery.tsx wires the row to the shared recipe", () => {
   /*
-   * Source-level, because the App suite cannot mount the dialog. What these
-   * catch is the rule being spelled out twice — which is how the row and the
-   * import drift apart.
+   * What execution above cannot see: that the computed values are actually
+   * RENDERED, and that the old inline rule is gone. Matched against the
+   * ELEMENT that carries the behaviour rather than a bare identifier, because
+   * every one of these names also appears in a template literal or an
+   * aria-label somewhere on the page.
    */
 
-  test("the page imports the shared display-name function", () => {
-    expect(readCode()).toContain("getDiscoveredHostDisplayName");
-  });
-
-  test("the row no longer re-spells the naming rule", () => {
+  test("comments are stripped, so prose about a rule cannot pass for the rule", () => {
     /*
-     * `entry.sysName || entry.ipAddress` was the old name line AND the old
-     * aria-label. Both are now the shared function, so neither spelling may
-     * survive anywhere on the page — including in the checkbox label, which
-     * is what a screen-reader user hears instead of the visible name.
+     * Every assertion below rests on this. The page is unusually heavily
+     * commented, and its comments name buildFallbackDeviceName, the clamp and
+     * the wildcard-PTR story in so many words — if the stripper silently
+     * stopped working (an unterminated block comment, a changed regex), the
+     * whole describe would go green against the prose alone.
+     *
+     * "dhcp-pool.corp.example.com" sits inside the comment that separates the
+     * create's `catch` from the fallback assignment, which is the one comment
+     * the retry assertion at the bottom of this file depends on being removed.
+     *
+     * This couples two assertions to two comment WORDINGS: reword either
+     * comment in Discovery.tsx and this test fails for a reason unrelated to
+     * behaviour. That is deliberate — it fails loudly, in the direction that
+     * cannot let a broken stripper through silently.
      */
     const code: string = readCode();
 
-    expect(code).not.toContain("entry.sysName || entry.ipAddress");
-    expect(code).not.toContain("entry.sysName||entry.ipAddress");
+    expect(readSource()).toContain("WYSIWYG");
+    expect(code).not.toContain("WYSIWYG");
+    expect(readSource()).toContain("dhcp-pool.corp.example.com");
+    expect(code).not.toContain("dhcp-pool.corp.example.com");
+  });
+
+  test("the stripper also removes line comments, and spares URLs", () => {
+    /*
+     * The test above only proves the BLOCK-comment branch, because nothing
+     * banned or matched by this file currently lives in a `//` comment on
+     * Discovery.tsx. The day one does, the stripper's second regex becomes
+     * load-bearing with nothing having ever checked it — so it is checked
+     * here, on a synthetic input, along with the `[^:]` guard that is the only
+     * reason it does not eat the rest of a line containing "https://".
+     */
+    const sample: string = [
+      "const displayName = entry.sysName || entry.ipAddress; // WYSIWYG",
+      'const docs: string = "https://oneuptime.com/docs";',
+    ].join("\n");
+
+    const stripped: string = stripComments(sample);
+
+    expect(stripped).not.toContain("WYSIWYG");
+    expect(stripped).toContain("entry.sysName || entry.ipAddress");
+    expect(stripped).toContain('"https://oneuptime.com/docs"');
+  });
+
+  test("the page imports the shared name builders", () => {
+    const code: string = readCode();
+
+    expect(code).toMatch(
+      /import\s*\{[^}]*\bbuildDeviceName\b[^}]*\}\s*from\s*"Common\/Utils\/NetworkDiscovery\/DiscoveredDeviceBuilder"/,
+    );
+    expect(code).toMatch(
+      /import\s*\{[^}]*\bbuildFallbackDeviceName\b[^}]*\}\s*from\s*"Common\/Utils\/NetworkDiscovery\/DiscoveredDeviceBuilder"/,
+    );
+    expect(code).toMatch(
+      /import\s*\{[^}]*\bnormalizeReverseDnsName\b[^}]*\}\s*from\s*"Common\/Utils\/NetworkDiscovery\/ReverseDnsNameUtil"/,
+    );
+  });
+
+  test("the page no longer re-spells the naming rule anywhere", () => {
+    /*
+     * `entry.sysName || entry.ipAddress` was the old name line AND the old
+     * aria-label. Both are now the shared builder, so neither may survive
+     * anywhere on the page — including in the checkbox label, which is what a
+     * screen-reader user hears instead of the visible name.
+     *
+     * Written as ONE whitespace-tolerant regex rather than as two toContain
+     * calls. readCode() squashes every whitespace run to a single space, so a
+     * `not.toContain("entry.sysName||entry.ipAddress")` matched a string the
+     * page can never produce and could not fail; the regex covers both
+     * spellings and can.
+     *
+     * getDiscoveredHostDisplayName is banned for the newer reason: it is the
+     * UNCLAMPED name, and rendering it is precisely the WYSIWYG break the row
+     * was changed to fix. The name-line assertion below only guards the name
+     * DIV, so this ban is what stops the unclamped value reappearing in the
+     * aria-label, the hover title or the second line. It still exists and is
+     * still the right function for a caller that wants the full name — just
+     * not for this row.
+     */
+    const code: string = readCode();
+
+    expect(code).not.toMatch(/entry\.sysName\s*\|\|\s*entry\.ipAddress/);
+    expect(code).not.toContain("getDiscoveredHostDisplayName");
+  });
+
+  test("the name line renders the clamped builder's answer, truncated with a title", () => {
+    /*
+     * Three things on one element, because they only work together:
+     *
+     *   - the display name INSIDE the name div. Asserting the bare identifier
+     *     is not enough: the aria-label interpolates it too, so that assertion
+     *     stays green with the visible name line deleted.
+     *   - `truncate`, because a 253-character FQDN where a 15-character
+     *     address used to be will otherwise paint straight across the
+     *     "No SNMP" and "Already added" badges on the right of the row.
+     *   - `title=`, because truncation hides the tail and the hover is the
+     *     only way left to read it.
+     *
+     * The identifier is read out of the source (see rowNameSource), so a
+     * rename cannot fail this test while the behaviour is unchanged.
+     */
+    const identifier: string = rowNameSource().displayNameIdentifier;
+
+    expect(readCode()).toMatch(
+      new RegExp(
+        `<div\\s+className="truncate[^"]*"\\s+title=\\{${identifier}\\}\\s*>\\s*\\{${identifier}\\}\\s*</div>`,
+      ),
+    );
   });
 
   test("the name line and the aria-label use the same computed value", () => {
     /*
      * One variable, used twice. A sighted operator and a screen-reader user
-     * must be told the same thing about the same row.
+     * must be told the same thing about the same row — and the label tests
+     * above are running this very template, so if it interpolated something
+     * other than the name line they would report a different string.
      */
-    const code: string = readCode();
-
-    expect(code).toContain("getDiscoveredHostDisplayName(entry)");
-    expect(code).toContain("ariaLabel={`Import ${displayName}");
-    expect(code).toContain("{displayName}");
+    expect(ariaLabelTemplate()).toContain(
+      `\${${rowNameSource().displayNameIdentifier}}`,
+    );
+    expect(ariaLabelTemplate()).toContain('${entry.ipAddress || "no address"}');
   });
 
-  test("the row still renders the address alongside the name", () => {
-    expect(readCode()).toContain("{entry.ipAddress}");
+  test("the row still renders the address, on its own truncating line", () => {
+    /*
+     * `{entry.ipAddress}` on its own is satisfied by the row key and by the
+     * failure messages, which interpolate `${entry.ipAddress}` — so the match
+     * is anchored to the truncating div that actually paints the line. It
+     * truncates for the same reason the name line does: the second line now
+     * carries the address AND a PTR name that can run to 253 characters.
+     */
+    expect(readCode()).toMatch(
+      /<div\s+className="truncate[^"]*"\s*>\s*\{entry\.ipAddress\}/,
+    );
+  });
+
+  test("the second line the tests executed is the second line the row renders", () => {
+    /*
+     * The gap the lifted-and-run tests cannot close on their own: the row
+     * could compute `secondaryDnsHostname` perfectly and render none of it.
+     * So the identifier that those tests took their answer from is required to
+     * appear, gated, inside the span beside the address.
+     *
+     * The shape assertions use a backreference rather than literal names, so
+     * they pin the RULE — "the normalised PTR name, and only when it differs
+     * from the name line" — and not the spelling of two local variables.
+     */
+    const source: RowNameSource = rowNameSource();
+    const code: string = readCode();
+
+    // Normalised at the point of render, not trusted from the jsonb column.
+    expect(source.statements).toContain(
+      "normalizeReverseDnsName(entry.dnsHostname)",
+    );
+
+    expect(source.statements).toMatch(
+      new RegExp(
+        `(\\w+)\\s*&&\\s*\\1\\s*!==\\s*${source.displayNameIdentifier}\\s*\\?\\s*\\1\\s*:\\s*undefined`,
+      ),
+    );
+
+    // Rendered, and rendered conditionally: no bare separator on the address.
+    expect(code).toMatch(new RegExp(`\\{${source.secondaryIdentifier}\\s*&&`));
+    expect(code).toMatch(
+      new RegExp(`\\{${source.secondaryIdentifier}\\}\\s*</span>`),
+    );
+  });
+
+  test("a failed create is retried once under the address-qualified name", () => {
+    /*
+     * The wildcard-PTR collision, pinned in the source because the App suite
+     * cannot run importSelectedDevices. What has to hold is the SHAPE: the
+     * fallback name is assigned inside the create's catch and a second create
+     * follows it. `buildFallbackDeviceName` appearing anywhere on the page
+     * would not prove any of that — an import that computed the name and
+     * never retried would satisfy a bare identifier match.
+     */
+    expect(readCode()).toMatch(
+      /catch\s*\(\s*\w+\s*\)\s*\{\s*device\.name\s*=\s*buildFallbackDeviceName\(entry\);\s*try\s*\{\s*await\s+ModelAPI\.create/,
+    );
   });
 });

--- a/Common/Tests/Utils/NetworkDiscovery/DiscoveredDeviceBuilder.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/DiscoveredDeviceBuilder.test.ts
@@ -12,7 +12,10 @@ import { DiscoveredNetworkDevice } from "../../../Models/DatabaseModels/NetworkD
 import NetworkDeviceMonitoringMethod from "../../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
 import ObjectID from "../../../Types/ObjectID";
 import { DiscoveryScanSnmpConfig } from "../../../Utils/NetworkDiscovery/SnmpScanConfigUtil";
-import { describe, expect, it } from "@jest/globals";
+import { MAX_REVERSE_DNS_NAME_LENGTH } from "../../../Utils/NetworkDiscovery/ReverseDnsNameUtil";
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import Slug from "../../../Utils/Slug";
+import { describe, expect, it, test } from "@jest/globals";
 
 /*
  * Contract under test — one discovered host maps to one NetworkDevice the
@@ -613,6 +616,26 @@ describe("the reverse-DNS name (issue #3529)", () => {
       ).toBe("sw1.corp.example.com");
     });
 
+    test("a padded sysName is trimmed before it becomes the name", () => {
+      /*
+       * The whitespace-ONLY case above pins the fall-through; this pins the
+       * other half of the same `.trim()`, which nothing asserted. A padded
+       * DisplayString is ordinary on real gear, and the padding must not
+       * survive: leading spaces go into the varchar, into the slug, and into
+       * every site/label rule that matches on the name. Delete the `.trim()`
+       * and the sysName is still truthy, still wins the contest, and this
+       * reads "  core-switch-01  " instead.
+       */
+      const paddedHost: DiscoveredNetworkDevice = {
+        ipAddress: "10.18.166.51",
+        sysName: "  core-switch-01  ",
+        dnsHostname: "sw1.corp.example.com",
+      };
+
+      expect(getDiscoveredHostDisplayName(paddedHost)).toBe("core-switch-01");
+      expect(build({ host: paddedHost }).name).toBe("core-switch-01");
+    });
+
     test("the address is still the last resort", () => {
       expect(buildDeviceName({ ipAddress: "10.18.166.51" })).toBe(
         "10.18.166.51",
@@ -642,7 +665,19 @@ describe("the reverse-DNS name (issue #3529)", () => {
      * `sysName || ipAddress` and the builder said the same thing again — and
      * that duplication is what this shared function exists to end.
      */
-    test("buildDeviceName is getDiscoveredHostDisplayName, clamped", () => {
+    test("the device is created under the clamped display name", () => {
+      /*
+       * Rows 1-4 are the four naming outcomes; row 5 is what makes the loop
+       * mean anything. Every fixture used to be far under the 80-character
+       * ceiling, so `truncate` was the identity function on all of them and
+       * "buildDeviceName === the display name" held for ANY clamp, including
+       * no clamp at all. The long-PTR row is asserted to be genuinely cut at
+       * the bottom, so deleting the truncate() reddens this.
+       */
+      const longPtrName: string = `${"a".repeat(63)}.${"b".repeat(
+        40,
+      )}.example.com`;
+
       const hosts: Array<DiscoveredNetworkDevice> = [
         { ipAddress: "10.0.0.1" },
         { ipAddress: "10.0.0.2", dnsHostname: "gw.corp.example.com" },
@@ -652,13 +687,35 @@ describe("the reverse-DNS name (issue #3529)", () => {
           sysName: "sw-4",
           dnsHostname: "sw4.corp.example.com",
         },
+        { ipAddress: "10.0.0.5", dnsHostname: longPtrName },
       ];
 
       for (const discoveredHost of hosts) {
+        const displayed: string = getDiscoveredHostDisplayName(discoveredHost);
+
         expect(buildDeviceName(discoveredHost)).toBe(
-          getDiscoveredHostDisplayName(discoveredHost),
+          displayed.substring(0, MAX_DEVICE_NAME_LENGTH),
+        );
+
+        /*
+         * And the DEVICE carries that name. This is the half with teeth: the
+         * operator ticks a box next to the displayed name, and `device.name`
+         * is what the create writes. An edit that gave the builder its own
+         * naming rule would pass the assertion above and fail this one.
+         */
+        expect(build({ host: discoveredHost }).name).toBe(
+          buildDeviceName(discoveredHost),
         );
       }
+
+      // The clamp is exercised rather than skipped: row 5 really is cut.
+      const clampedHost: DiscoveredNetworkDevice = hosts[
+        hosts.length - 1
+      ] as DiscoveredNetworkDevice;
+
+      expect(getDiscoveredHostDisplayName(clampedHost)).not.toBe(
+        buildDeviceName(clampedHost),
+      );
     });
 
     test("the display name is returned unclamped", () => {
@@ -728,12 +785,33 @@ describe("the reverse-DNS name (issue #3529)", () => {
       ).toBe("10.18.166.51");
     });
 
-    test("does not throw when the column holds a non-string", () => {
-      // jsonb read at render time; a throw here lands inside the modal body.
+    test("neither throws nor stringifies on a non-string column", () => {
+      /*
+       * Two halves, because they fail against two different mutations.
+       *
+       * 51 is the jsonb-read-at-render-time case: an unguarded `.trim()` is a
+       * TypeError thrown inside the modal body. On its own it cannot tell a
+       * type-checking normaliser from a COERCING one, because String(51) is
+       * "51" and a single all-numeric label is refused anyway.
+       */
       expect(
         buildDeviceName({
           ipAddress: "10.18.166.51",
           dnsHostname: 51 as unknown as string,
+        }),
+      ).toBe("10.18.166.51");
+
+      /*
+       * `true` is the half that can. String(true) is "true" — a syntactically
+       * perfect single label that passes every content rule in
+       * ReverseDnsNameUtil. Swap the `typeof value !== "string"` guard for
+       * String(value) and this host is named "true" instead of by its
+       * address, and this line is the only thing in the file that notices.
+       */
+      expect(
+        buildDeviceName({
+          ipAddress: "10.18.166.51",
+          dnsHostname: true as unknown as string,
         }),
       ).toBe("10.18.166.51");
     });
@@ -807,5 +885,623 @@ describe("the reverse-DNS name (issue #3529)", () => {
         }),
       ).toBe("dhcp-pool.corp.example.com (10.18.166.51)");
     });
+  });
+
+  /*
+   * `sysName` is read out of the SAME verbatim jsonb blob as `dnsHostname`,
+   * so its declared `string | undefined` type is a description of what the
+   * probe SHOULD send rather than a fact about what is stored. Since
+   * getDiscoveredHostDisplayName became the Review dialog's name line, a
+   * `(42).trim()` TypeError in here is thrown DURING RENDER: React unmounts
+   * the subtree, so one malformed row takes out the entire modal and the
+   * operator cannot import any of the hosts the scan found, not just that
+   * one. Each of these must fall through to the next naming source instead.
+   */
+  describe("an untrusted sysName never reaches .trim()", () => {
+    const UNTRUSTED_SYS_NAMES: Array<{ reason: string; value: unknown }> = [
+      /*
+       * An agent whose sysName OID returned an INTEGER rather than a
+       * DisplayString. Discriminating despite "42" being a poor name: unlike
+       * `dnsHostname` there is no normaliser behind `sysName ||`, so a
+       * String() coercion makes "42" TRUTHY and it wins the naming contest
+       * outright, beating a perfectly good PTR record on the same row.
+       *
+       * (The boolean row that sat here was removed: `true` fails
+       * `typeof === "string"` and coerces to a truthy string in exactly the
+       * same way this one does, so it could not fail unless this one did.)
+       */
+      { reason: "a number", value: 42 },
+      // What a hand-written API row looks like when someone nests the name.
+      { reason: "an object", value: { name: "core-switch-01" } },
+      /*
+       * The sharpest of the four: `["sw-1"].toString()` is "sw-1", so a
+       * String() coercion instead of the typeof guard would quietly ACCEPT
+       * this and name a device after a JSON array's join.
+       */
+      { reason: "an array", value: ["sw-1"] },
+      /*
+       * jsonb stores an explicit null. The old WHY here claimed `??` would
+       * miss it, which is backwards — `null ?? ""` is "". The failures this
+       * row really pins are the other two shapes the guard could have taken:
+       * `host.sysName !== undefined ? host.sysName.trim() : ""` THROWS on
+       * null, and `String(null)` is the truthy "null", which would beat the
+       * PTR record on the same row and create a device called "null".
+       */
+      { reason: "null", value: null },
+    ];
+
+    for (const untrusted of UNTRUSTED_SYS_NAMES) {
+      test(`${untrusted.reason} sysName falls through to the PTR name`, () => {
+        const host: DiscoveredNetworkDevice = {
+          ipAddress: "10.18.166.51",
+          sysName: untrusted.value as unknown as string,
+          dnsHostname: "core-gw.corp.example.com",
+        };
+
+        expect(getDiscoveredHostDisplayName(host)).toBe(
+          "core-gw.corp.example.com",
+        );
+        expect(buildDeviceName(host)).toBe("core-gw.corp.example.com");
+      });
+
+      test(`${untrusted.reason} sysName falls through to the address`, () => {
+        // The same host on an estate with no reverse zone: nothing left but the IP.
+        const host: DiscoveredNetworkDevice = {
+          ipAddress: "10.18.166.51",
+          sysName: untrusted.value as unknown as string,
+        };
+
+        expect(getDiscoveredHostDisplayName(host)).toBe("10.18.166.51");
+        expect(buildDeviceName(host)).toBe("10.18.166.51");
+      });
+    }
+  });
+
+  /*
+   * The last resort is the last thing standing between the Review dialog and
+   * a blank modal, so it may not throw either — `String(...)` rather than
+   * `host.ipAddress.trim()` or a template read of a property.
+   */
+  describe("an untrusted address as the last resort", () => {
+    test("a numeric address still names the row", () => {
+      expect(buildDeviceName({ ipAddress: 42 as unknown as string })).toBe(
+        "42",
+      );
+    });
+
+    test("a null address degrades to an empty name rather than a throw", () => {
+      /*
+       * Empty is not a good name; it is a name the create path rejects with
+       * a validation error the operator can see, which is strictly better
+       * than a TypeError that removes the dialog.
+       */
+      expect(
+        getDiscoveredHostDisplayName({ ipAddress: null as unknown as string }),
+      ).toBe("");
+    });
+
+    test("an object address is named by its coercion, not by a throw", () => {
+      /*
+       * The assertion here was `expect(typeof name).toBe("string")` against a
+       * function whose declared return type IS string: the only way it could
+       * fail was a throw, and it passed happily with the device named
+       * "[object Object]". Pin the value instead.
+       *
+       * "[object Object]" is a terrible device name and that is the point: it
+       * is a name the operator can SEE is wrong and that the create path
+       * rejects on its own merits, rather than a TypeError that unmounts the
+       * Review dialog. Delete the String(...) coercion and the expression
+       * yields the object itself; replace it with a template read and this
+       * still holds, which is why the null case above is asserted too.
+       */
+      expect(
+        buildDeviceName({
+          ipAddress: { v4: "10.18.166.51" } as unknown as string,
+        }),
+      ).toBe("[object Object]");
+    });
+
+    test("a non-string address is NAMED by coercion but ADDRESSED raw", () => {
+      /*
+       * BOTH readings coerce, and the hostname one matters more than the name.
+       *
+       * `hostname` is the registered-host dedup key:
+       * NetworkDeviceService.getRegisteredHostnames matches it with
+       * `Set.has()` against hostnames read back out of the database as
+       * strings, and `Set.has` does not coerce. A device stored with the
+       * NUMBER 42 in that column would therefore never match its own
+       * registration, so the host would read as unregistered on every review
+       * and import again, and again.
+       *
+       * The dashboard path never reached that, because normalizeDiscoveredHosts
+       * stringifies the address first. The builder is also called directly by
+       * the rule engine, so it coerces on its own account rather than relying
+       * on a caller having been careful.
+       */
+      const device: NetworkDevice = build({
+        host: { ipAddress: 42 as unknown as string },
+      });
+
+      expect(device.name).toBe("42");
+      expect(device.hostname).toBe("42");
+      expect(typeof device.hostname).toBe("string");
+    });
+  });
+
+  /*
+   * A dnsHostname that is not a string at all, alongside the number and
+   * boolean cases above.
+   *
+   * Every fixture here is chosen so that String(value) is a name the
+   * normaliser would HAPPILY ACCEPT, because that is the only kind that
+   * discriminates. The plain object `{ name: "gw.corp.example.com" }` that
+   * used to sit here proved nothing: String() of it is "[object Object]",
+   * whose spaces and brackets LABEL_PATTERN refuses on their own, so the
+   * case passed against a coercing normaliser exactly as well as against the
+   * type-checking one it claimed to be about.
+   */
+  describe("an untrusted PTR record of the wrong TYPE", () => {
+    const WRONGLY_TYPED_PTR_ANSWERS: Array<{
+      reason: string;
+      value: unknown;
+    }> = [
+      /*
+       * The realistic one: dns.reverse() answers with an ARRAY of names, and
+       * a probe that forgot to take [0] stores the array. `["gw.corp.
+       * example.com"].toString()` is exactly "gw.corp.example.com", so a
+       * String() coercion would store it verbatim as the device name.
+       */
+      {
+        reason: "the resolver's whole answer array",
+        value: ["gw.corp.example.com"],
+      },
+      /*
+       * Not a shape JSON.parse can produce, and deliberately so: it is the
+       * question in its pure form. String(value) here IS, byte for byte, the
+       * hostname that would otherwise be stored. Only a real
+       * `typeof value !== "string"` test rejects it — a coercion, a duck-type
+       * ("does it have .trim()?") or an `instanceof String` check would all
+       * name the device gw.corp.example.com off a value that is not a string.
+       */
+      {
+        reason: "a string-like object",
+        value: {
+          toString: (): string => {
+            return "gw.corp.example.com";
+          },
+        },
+      },
+    ];
+
+    for (const answer of WRONGLY_TYPED_PTR_ANSWERS) {
+      test(`${answer.reason} falls back to the address`, () => {
+        const hostWithBadPtr: DiscoveredNetworkDevice = {
+          ipAddress: "10.18.166.51",
+          dnsHostname: answer.value as unknown as string,
+        };
+
+        expect(getDiscoveredHostDisplayName(hostWithBadPtr)).toBe(
+          "10.18.166.51",
+        );
+        // The device, not just the name: a coercion would reach the column.
+        expect(build({ host: hostWithBadPtr }).name).toBe("10.18.166.51");
+      });
+    }
+  });
+
+  /*
+   * THE WILDCARD REVERSE ZONE.
+   *
+   * A DHCP range is routinely published as one record —
+   * `*.166.18.10.in-addr.arpa IN PTR dhcp-pool.corp.example.com` — so every
+   * address in the range resolves to the SAME name. Nothing about that answer
+   * is malformed, so normalisation keeps it, and the estate the issue came
+   * from is exactly the kind that has one.
+   *
+   * Device names are unique per project, so the second host of such a range
+   * fails its create on a duplicate name. That is what the dashboard's import
+   * retry exists for, and the retry is only useful if the fallback name is
+   * actually DIFFERENT per host — which is what the second half pins.
+   */
+  describe("a wildcard reverse zone gives many hosts one name", () => {
+    const WILDCARD_PTR_NAME: string = "dhcp-pool.corp.example.com";
+
+    const firstPoolHost: DiscoveredNetworkDevice = {
+      ipAddress: "10.18.166.51",
+      dnsHostname: WILDCARD_PTR_NAME,
+    };
+    const secondPoolHost: DiscoveredNetworkDevice = {
+      ipAddress: "10.18.166.52",
+      dnsHostname: WILDCARD_PTR_NAME,
+    };
+
+    const thirdPoolHost: DiscoveredNetworkDevice = {
+      ipAddress: "10.18.166.53",
+      dnsHostname: WILDCARD_PTR_NAME,
+    };
+
+    const POOL_HOSTS: Array<DiscoveredNetworkDevice> = [
+      firstPoolHost,
+      secondPoolHost,
+      thirdPoolHost,
+    ];
+
+    test("three hosts in the range import as one name, three addresses", () => {
+      /*
+       * The second assertion used to be
+       * `expect(buildDeviceName(first)).toBe(buildDeviceName(second))` over
+       * two fixtures built from the same constant — a statement about the
+       * test data, true of any implementation that reads the same field
+       * twice. Phrased over the DEVICES the builder emits it has bite in both
+       * directions: `names.size` is 1 only because the name ignores the
+       * address, and `hostnames.size` is 3 only because the hostname ignores
+       * the name. The tempting edit (put the resolved name in `hostname`)
+       * breaks the second; an edit that disambiguated names eagerly breaks
+       * the first, and would hide the collision the retry below exists for.
+       */
+      const devices: Array<NetworkDevice> = POOL_HOSTS.map(
+        (poolHost: DiscoveredNetworkDevice) => {
+          return build({ host: poolHost });
+        },
+      );
+
+      const names: Set<string> = new Set<string>(
+        devices.map((device: NetworkDevice) => {
+          return device.name as string;
+        }),
+      );
+      const hostnames: Set<string> = new Set<string>(
+        devices.map((device: NetworkDevice) => {
+          return device.hostname as unknown as string;
+        }),
+      );
+
+      expect(names).toEqual(new Set<string>([WILDCARD_PTR_NAME]));
+      expect(hostnames.size).toBe(POOL_HOSTS.length);
+    });
+
+    test("buildFallbackDeviceName tells them apart by their own address", () => {
+      expect(buildFallbackDeviceName(firstPoolHost)).not.toBe(
+        buildFallbackDeviceName(secondPoolHost),
+      );
+      expect(buildFallbackDeviceName(firstPoolHost)).toBe(
+        "dhcp-pool.corp.example.com (10.18.166.51)",
+      );
+      expect(buildFallbackDeviceName(secondPoolHost)).toBe(
+        "dhcp-pool.corp.example.com (10.18.166.52)",
+      );
+    });
+
+    test("the retry creates the device under the fallback name", () => {
+      /*
+       * End to end, in the shape both import paths actually use: the create
+       * fails on a duplicate name and the caller rebuilds the SAME device
+       * with `name: buildFallbackDeviceName(host)`. Nothing else may move —
+       * `hostname` is still the bare address, which is what the dedup key and
+       * any hostname-keyed rule depend on. Nothing else in the suite passes a
+       * PTR-named host's fallback name through the builder, so an edit that
+       * ignored `data.name`, or that followed the name into `hostname`, would
+       * only be caught here.
+       */
+      const device: NetworkDevice = build({
+        host: secondPoolHost,
+        name: buildFallbackDeviceName(secondPoolHost),
+      });
+
+      expect(device.name).toBe("dhcp-pool.corp.example.com (10.18.166.52)");
+      expect(device.hostname).toBe("10.18.166.52");
+    });
+
+    test("an address-less host fabricates one shared fallback name", () => {
+      /*
+       * An address-less host gets NO SUFFIX, not a fabricated one.
+       *
+       * The suffix used to be composed with a raw template read —
+       * ` (${host.ipAddress})` — so a missing address produced the literal
+       * token "(undefined)". That is worse than useless here: every
+       * address-less host produced the SAME token, so the fallback handed the
+       * retry a name that collided all over again, failing on the very
+       * duplicate it was retrying.
+       *
+       * The honest answer is that a host with no address cannot be told apart
+       * from another one, so the fallback returns the base name unchanged and
+       * the create fails on a real duplicate. What must never happen is a
+       * name that LOOKS address-qualified while carrying no address.
+       */
+      const addresslessHost: DiscoveredNetworkDevice = {
+        dnsHostname: WILDCARD_PTR_NAME,
+      } as unknown as DiscoveredNetworkDevice;
+
+      const fallbackName: string = buildFallbackDeviceName(addresslessHost);
+
+      expect(fallbackName).toBe(WILDCARD_PTR_NAME);
+      expect(fallbackName).not.toContain("undefined");
+      expect(fallbackName).not.toContain("(");
+    });
+
+    test("a null address is composed into the name as the token (null)", () => {
+      /*
+       * ONE value, ONE reading — which is the point of the fix.
+       *
+       * A null address used to be read two ways: "" by the display path
+       * (`String(host.ipAddress ?? "")`) and " (null)" by the fallback path,
+       * which interpolated it raw. Two readings of one field in two functions
+       * that have to agree about the same host is how a retry ends up
+       * composing a name nobody can act on.
+       */
+      const nullAddressHost: DiscoveredNetworkDevice = {
+        ipAddress: null as unknown as string,
+        dnsHostname: WILDCARD_PTR_NAME,
+      };
+
+      expect(buildFallbackDeviceName(nullAddressHost)).toBe(WILDCARD_PTR_NAME);
+      expect(buildFallbackDeviceName(nullAddressHost)).not.toContain("null)");
+    });
+  });
+
+  /*
+   * FALLBACK NAME ARITHMETIC at both extremes at once.
+   *
+   * The longest name DNS can express (253 characters) combined with the
+   * widest address is the worst case the composition has to survive, and a
+   * PTR name is the one naming source that can hit its own ceiling with no
+   * help from a misconfigured device. Two things have to hold: the composed
+   * name still fits under the ceiling the slug needs, and the ADDRESS
+   * survives the cut. A fallback that truncated the address away would hand
+   * both hosts of a wildcard range the same name again — the exact collision
+   * it is there to break.
+   *
+   * "Widest address" is IPv6, not 255.255.255.255. A full v6 address is 39
+   * characters, so its suffix is 42 — more than half the whole ceiling, and
+   * 24 characters wider than the v4 case. The v4 rows come first because
+   * they are the ordinary case; the v6 rows at the end are the real extreme,
+   * and the probe resolves ip6.arpa PTRs, so v6 hosts are in scope.
+   */
+  describe("the fallback name at the longest PTR name and the widest address", () => {
+    // 63 + 1 + 63 + 1 + 63 + 1 + 61 = 253: maximal labels, maximal total.
+    const MAXIMAL_PTR_NAME: string = `${"a".repeat(63)}.${"b".repeat(
+      63,
+    )}.${"c".repeat(63)}.${"d".repeat(61)}`;
+
+    const WIDEST_ADDRESS_SUFFIX: string = " (255.255.255.255)";
+
+    test("the maximal name is a name this builder actually accepts", () => {
+      /*
+       * Anti-vacuity for everything below: if normalisation rejected a
+       * 253-character name, every case here would be measuring the ADDRESS
+       * fallback and would pass for the wrong reason.
+       */
+      expect(MAXIMAL_PTR_NAME).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH);
+      expect(
+        buildDeviceName({
+          ipAddress: "255.255.255.255",
+          dnsHostname: MAXIMAL_PTR_NAME,
+        }),
+      ).toBe(MAXIMAL_PTR_NAME.substring(0, MAX_DEVICE_NAME_LENGTH));
+    });
+
+    test("the composed name uses the whole ceiling and keeps the address", () => {
+      /*
+       * The re-derived expectation is gone. This used to assert the base
+       * equals `MAXIMAL_PTR_NAME.substring(0, MAX - suffix.length)`, which is
+       * buildFallbackDeviceName's own arithmetic restated: an implementation
+       * that computed the WRONG cut would compute it identically on both
+       * sides and still pass. The contract instead — all 80 characters are
+       * used, the suffix is the host's address in full (it is never what
+       * gives way, or the wildcard range collides again), and what precedes
+       * it is a genuine prefix of the PTR name rather than some other string.
+       */
+      const name: string = buildFallbackDeviceName({
+        ipAddress: "255.255.255.255",
+        dnsHostname: MAXIMAL_PTR_NAME,
+      });
+
+      expect(name).toHaveLength(MAX_DEVICE_NAME_LENGTH);
+      expect(name.endsWith(WIDEST_ADDRESS_SUFFIX)).toBe(true);
+
+      const base: string = name.substring(
+        0,
+        name.length - WIDEST_ADDRESS_SUFFIX.length,
+      );
+
+      expect(base.length).toBeGreaterThan(0);
+      expect(MAXIMAL_PTR_NAME.startsWith(base)).toBe(true);
+    });
+
+    test("two maximal-name hosts still get different fallback names", () => {
+      /*
+       * The point of the whole fallback, at the length where losing the
+       * address is most tempting: these two share 253 characters of name and
+       * differ only in their last octet.
+       */
+      expect(
+        buildFallbackDeviceName({
+          ipAddress: "255.255.255.255",
+          dnsHostname: MAXIMAL_PTR_NAME,
+        }),
+      ).not.toBe(
+        buildFallbackDeviceName({
+          ipAddress: "255.255.255.254",
+          dnsHostname: MAXIMAL_PTR_NAME,
+        }),
+      );
+    });
+
+    /*
+     * IPV6 — the actual worst case, and untested anywhere in the feature
+     * until now. 39 characters of address means a 42-character suffix, so
+     * the base is cut to 38: more than half the composed name is the address.
+     * The `Math.max(1, MAX_DEVICE_NAME_LENGTH - suffix.length)` in
+     * buildFallbackDeviceName is written to survive this; nothing proved it,
+     * and a v4-only reading of "the widest address" would not have noticed a
+     * regression that only bites past an 18-character suffix.
+     */
+    const FULL_IPV6_ADDRESS: string = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+    const IPV6_SUFFIX: string = ` (${FULL_IPV6_ADDRESS})`;
+
+    test("an IPv6 address takes over half the ceiling and still fits", () => {
+      // Anti-vacuity: this really is the wider of the two suffixes.
+      expect(IPV6_SUFFIX.length).toBeGreaterThan(WIDEST_ADDRESS_SUFFIX.length);
+
+      const name: string = buildFallbackDeviceName({
+        ipAddress: FULL_IPV6_ADDRESS,
+        dnsHostname: MAXIMAL_PTR_NAME,
+      });
+
+      expect(name).toHaveLength(MAX_DEVICE_NAME_LENGTH);
+      expect(name.endsWith(IPV6_SUFFIX)).toBe(true);
+      expect(
+        MAXIMAL_PTR_NAME.startsWith(
+          name.substring(0, name.length - IPV6_SUFFIX.length),
+        ),
+      ).toBe(true);
+
+      /*
+       * And it still slugs. Asserted here rather than for the v4 case
+       * because the maths is genuinely different: slugify's `remove` set
+       * strips the colons and the brackets, so a v6 fallback's slug base is
+       * nine characters SHORTER than its name.
+       */
+      expect(Slug.getSlug(name).length).toBeLessThanOrEqual(ColumnLength.Slug);
+    });
+
+    test("two IPv6 hosts in one wildcard zone still get different names", () => {
+      /*
+       * Where "cut the suffix instead of the base" would collide: these two
+       * share 253 characters of PTR name and differ only in the last group of
+       * an address that occupies 42 of the 80 characters available.
+       */
+      expect(
+        buildFallbackDeviceName({
+          ipAddress: FULL_IPV6_ADDRESS,
+          dnsHostname: MAXIMAL_PTR_NAME,
+        }),
+      ).not.toBe(
+        buildFallbackDeviceName({
+          ipAddress: "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
+          dnsHostname: MAXIMAL_PTR_NAME,
+        }),
+      );
+    });
+
+    /*
+     * SLUG HEADROOM — the ceiling that actually bites.
+     *
+     * NetworkDevice.name is varchar(100) but @SlugifyColumn writes a slug
+     * beside it, and Slug.getSlug appends a dash and ten digits into its own
+     * varchar(100). So a name of 95 characters fits the name column and fails
+     * the CREATE on the slug, with an error that says nothing about names.
+     * MAX_DEVICE_NAME_LENGTH is 80 for this reason and nothing else, so the
+     * arithmetic is asserted here against the real column length and the real
+     * slug function rather than restated as a comment.
+     */
+    test("the ceiling is what keeps the slug inside its own column", () => {
+      /*
+       * This replaces three tests that were each measuring less than they
+       * claimed: one asserted `MAX_DEVICE_NAME_LENGTH + "-1234567890".length
+       * <= ColumnLength.Slug`, pure arithmetic over two constants that
+       * invoked none of the code under test and hard-coded Faker's suffix
+       * shape as a literal; the other two slugged names that slugify SHRINKS,
+       * so they had headroom the real worst case does not.
+       *
+       * The fixture is chosen to be that worst case. Every dotted PTR name
+       * loses a character per dot on the way into a slug (slugify's `remove`
+       * set eats them), so a PTR-named device can never be the widest slug a
+       * name of this length produces. A hyphenated sysName has nothing to
+       * remove, so its slug base is the full 80 characters — and 255-octet
+       * sysNames are routine on real gear, which is why the clamp exists.
+       *
+       * Raise MAX_DEVICE_NAME_LENGTH past what the slug column can hold and
+       * this fails at the constant, rather than in production on whichever
+       * device happens to have a long enough name.
+       */
+      const SLUG_PROBE: string = "device";
+      // Measured off the real Slug, not restated: it tracks Faker's suffix.
+      const slugSuffixLength: number =
+        Slug.getSlug(SLUG_PROBE).length - SLUG_PROBE.length;
+
+      const name: string = buildDeviceName({
+        ipAddress: "10.18.166.51",
+        sysName: "long-sysname-".repeat(20),
+      });
+
+      expect(name).toHaveLength(MAX_DEVICE_NAME_LENGTH);
+
+      const slug: string = Slug.getSlug(name);
+
+      // Nothing was removed: the whole clamped name is still in the slug.
+      expect(slug.substring(0, slug.length - slugSuffixLength)).toBe(
+        name.toLowerCase(),
+      );
+      expect(slug.length).toBeLessThanOrEqual(ColumnLength.Slug);
+    });
+  });
+
+  /*
+   * `hostname` is the registered-host dedup key, what the SNMP poller dials,
+   * and what a trap's source IP is correlated to — so it is the ADDRESS for
+   * every host, whatever the host ended up being NAMED. Table-driven across
+   * both naming sources because the risk is a future edit that "uses the
+   * resolved name where we have one": that would look correct on five of
+   * these six rows and would silently stop a device polling the day its
+   * reverse zone changed.
+   */
+  describe("the address is the hostname for every naming combination", () => {
+    const NAMING_COMBINATIONS: Array<{
+      reason: string;
+      host: DiscoveredNetworkDevice;
+      expectedName: string;
+    }> = [
+      {
+        reason: "sysName and a usable PTR name",
+        host: {
+          ipAddress: "10.18.166.51",
+          sysName: "core-switch-01",
+          dnsHostname: "sw1.corp.example.com",
+        },
+        expectedName: "core-switch-01",
+      },
+      {
+        reason: "sysName and no PTR name",
+        host: { ipAddress: "10.18.166.51", sysName: "core-switch-01" },
+        expectedName: "core-switch-01",
+      },
+      {
+        reason: "sysName and a PTR name that normalises away",
+        host: {
+          ipAddress: "10.18.166.51",
+          sysName: "core-switch-01",
+          dnsHostname: "51.166.18.10.in-addr.arpa",
+        },
+        expectedName: "core-switch-01",
+      },
+      {
+        reason: "no sysName and a usable PTR name",
+        host: {
+          ipAddress: "10.18.166.51",
+          dnsHostname: "sw1.corp.example.com",
+        },
+        expectedName: "sw1.corp.example.com",
+      },
+      {
+        reason: "no sysName and no PTR name",
+        host: { ipAddress: "10.18.166.51" },
+        expectedName: "10.18.166.51",
+      },
+      {
+        reason: "no sysName and a PTR name that normalises away",
+        host: { ipAddress: "10.18.166.51", dnsHostname: "core switch" },
+        expectedName: "10.18.166.51",
+      },
+    ];
+
+    for (const combination of NAMING_COMBINATIONS) {
+      test(`${combination.reason}: named ${combination.expectedName}, addressed 10.18.166.51`, () => {
+        const device: NetworkDevice = build({ host: combination.host });
+
+        expect(device.name).toBe(combination.expectedName);
+        expect(device.hostname).toBe("10.18.166.51");
+      });
+    }
   });
 });

--- a/Common/Tests/Utils/NetworkDiscovery/DiscoveredHostUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/DiscoveredHostUtil.test.ts
@@ -1,5 +1,6 @@
 import { DiscoveredNetworkDevice } from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import { normalizeDiscoveredHosts } from "../../../Utils/NetworkDiscovery/DiscoveredHostUtil";
+import { getDiscoveredHostDisplayName } from "../../../Utils/NetworkDiscovery/DiscoveredDeviceBuilder";
 import { describe, expect, test } from "@jest/globals";
 
 /*
@@ -344,5 +345,115 @@ describe("normalizeDiscoveredHosts — the reverse-DNS name (issue #3529)", () =
     expect(normalized?.sysDescr).toBe("Cisco IOS");
     expect(normalized?.snmpReachable).toBe(true);
     expect(normalized?.snmpConfigId).toBe("config-2");
+  });
+});
+
+/*
+ * `sysName` joined the list of fields this function coerces when reverse DNS
+ * (issue #3529) turned the naming expression into a RENDER path.
+ *
+ * Before that, `(host.sysName || "").trim()` ran only inside the import loop,
+ * where a per-host try/catch turned a bad row into one failed import. The
+ * Review dialog's own name line was `entry.sysName || entry.ipAddress`, which
+ * coerces a number harmlessly. Routing the row through the shared naming
+ * function put `.trim()` on the render path, where a numeric sysName in the
+ * jsonb throws a TypeError inside the modal body and takes out the whole
+ * dialog — the operator can no longer review or import ANY host in that scan.
+ *
+ * That is the same failure the null-row case at the top of this file is about,
+ * and it gets the same answer: coerce once, here, so no reader can be handed a
+ * value its type says is impossible.
+ */
+describe("normalizeDiscoveredHosts — a non-string sysName (issue #3529)", () => {
+  test("a non-string sysName is blanked, never stringified", () => {
+    /*
+     * BLANKED, not `String(value)`. This is the one place the treatment
+     * deliberately differs from the address above, and the reason is that
+     * every stringification of junk is TRUTHY: `String(null)` is "null" and
+     * `String({})` is "[object Object]". A truthy sysName wins the naming
+     * contest outright, so stringifying would not merely fail to name the
+     * host — it would create a device called "null" while a perfectly good
+     * PTR record sat unused on the very same row.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = [
+      host({ sysName: 42 as unknown as string }),
+      host({ ipAddress: "10.0.0.2", sysName: null as unknown as string }),
+      host({ ipAddress: "10.0.0.3", sysName: {} as unknown as string }),
+      host({ ipAddress: "10.0.0.4", sysName: ["gw"] as unknown as string }),
+      host({ ipAddress: "10.0.0.5", sysName: true as unknown as string }),
+    ];
+
+    for (const row of normalizeDiscoveredHosts(rows)) {
+      expect(row.sysName).toBe("");
+    }
+  });
+
+  test("a blanked sysName lets the PTR name name the host", () => {
+    /*
+     * The consequence that matters, stated end to end: the row is not merely
+     * safe, it produces the RIGHT name. This is what would have regressed if
+     * the junk had been stringified.
+     */
+    const [normalized] = normalizeDiscoveredHosts([
+      host({
+        sysName: null as unknown as string,
+        dnsHostname: "core-gw.corp.example.com",
+      }),
+    ]);
+
+    expect(getDiscoveredHostDisplayName(normalized!)).toBe(
+      "core-gw.corp.example.com",
+    );
+  });
+
+  test("naming a host with a junk sysName never throws", () => {
+    /*
+     * The failure this whole block exists for: `(42).trim()` is a TypeError,
+     * and since the dashboard row started calling the shared naming function
+     * that TypeError is thrown during render — inside the modal body, taking
+     * out the entire Review dialog rather than one row.
+     */
+    const rows: Array<DiscoveredNetworkDevice> = normalizeDiscoveredHosts([
+      host({ sysName: 42 as unknown as string }),
+      host({ ipAddress: "10.0.0.2", sysName: {} as unknown as string }),
+    ]);
+
+    for (const row of rows) {
+      expect(() => {
+        return getDiscoveredHostDisplayName(row);
+      }).not.toThrow();
+    }
+  });
+
+  test("a string sysName is passed through untouched, including its whitespace", () => {
+    /*
+     * Only NON-strings are rewritten. Trimming here would be a second opinion
+     * on a decision getDiscoveredHostDisplayName already makes, and the two
+     * could drift.
+     */
+    const [normalized] = normalizeDiscoveredHosts([
+      host({ sysName: "  core-switch-01  " }),
+    ]);
+
+    expect(normalized?.sysName).toBe("  core-switch-01  ");
+  });
+
+  test("a host with no sysName does not gain the key", () => {
+    /*
+     * `sysName` is optional, and `"sysName" in host` is a question other code
+     * is entitled to ask. Coercing an absent field into an empty string would
+     * change that answer for every ping-only host in every scan.
+     */
+    const [normalized] = normalizeDiscoveredHosts([host({})]);
+
+    expect(normalized).not.toHaveProperty("sysName");
+  });
+
+  test("coercion survives a second pass unchanged", () => {
+    const once: Array<DiscoveredNetworkDevice> = normalizeDiscoveredHosts([
+      host({ sysName: 42 as unknown as string, dnsHostname: "gw.example.com" }),
+    ]);
+
+    expect(normalizeDiscoveredHosts(once)).toEqual(once);
   });
 });

--- a/Common/Tests/Utils/NetworkDiscovery/DiscoveryReverseDnsChain.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/DiscoveryReverseDnsChain.test.ts
@@ -1,0 +1,1056 @@
+import {
+  DiscoveredDeviceScanSource,
+  buildDeviceName,
+  buildFallbackDeviceName,
+  buildNetworkDeviceFromDiscoveredHost,
+  getDiscoveredHostDisplayName,
+} from "../../../Utils/NetworkDiscovery/DiscoveredDeviceBuilder";
+import { normalizeDiscoveredHosts } from "../../../Utils/NetworkDiscovery/DiscoveredHostUtil";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import { DiscoveredNetworkDevice } from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import NetworkDeviceMonitoringMethod from "../../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The WHOLE journey a PTR record makes, end to end, in one place.
+ *
+ * Every other suite around OneUptime issue #3529 tests one link:
+ * ReverseDnsNameUtil pins what a name may contain, DiscoveredHostUtil pins
+ * what normalisation does to a row, DiscoveredDeviceBuilder pins which field
+ * becomes which device column. Each of those can be green while the chain
+ * they form is broken, because the interesting failures live in the JOINTS —
+ * a value that survives normalisation but is re-read differently by the
+ * builder, a name one module accepts at its own ceiling and the next must
+ * cut down, or a row two layers deliberately disagree about.
+ *
+ * So this file runs the real path a resolved hostname actually travels:
+ *
+ *   probe payload
+ *     -> stored jsonb (modelled honestly as JSON.parse(JSON.stringify(...)),
+ *        because `discoveredDevices` is written VERBATIM from the probe's
+ *        payload by ProbeIngest/DiscoveryScan.ts — no schema, no coercion,
+ *        so the column is exactly a JSON round trip of whatever was sent)
+ *     -> normalizeDiscoveredHosts
+ *     -> getDiscoveredHostDisplayName / buildDeviceName
+ *     -> buildNetworkDeviceFromDiscoveredHost
+ *
+ * Nothing here is mocked. The point is that these five steps agree, and a
+ * double or a stub would be agreeing with itself.
+ *
+ * The JSON round trip is not ceremony. It is what erases `undefined`-valued
+ * keys, and what leaves numbers, nulls, objects and arrays sitting in fields
+ * the TypeScript interface declares as `string | undefined` — every hostile
+ * shape below reaches the readers only because the column cannot refuse it.
+ *
+ * SCOPE NOTE, so no comment here over-claims: the Dashboard's Discovery page
+ * is NOT imported by this file, and nothing below observes what the Review
+ * dialog renders. What is pinned is that the functions the dialog and the
+ * import loop both call return the same answers on the same row. Where a
+ * comment mentions the dialog it is explaining WHY a case matters, not
+ * claiming the dialog is under test.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+/*
+ * A scan with no credentials at all — the shape a ping-only sweep really has.
+ *
+ * The reporter's hosts answer ICMP and nothing else, so they import down the
+ * Monitor branch of the builder, which returns before it ever asks for a
+ * credential set. Supplying a rich SNMP fixture here would only invite a
+ * reader to think credentials were part of what these tests pin; they are
+ * pinned in DiscoveredDeviceBuilder.test.ts and AutoImportScanCredentialSelect
+ * .test.ts instead.
+ */
+const PING_ONLY_SCAN: DiscoveredDeviceScanSource = {};
+
+/*
+ * The two ceilings this chain has to reconcile, written as literals rather
+ * than imported from the modules under test.
+ *
+ * ReverseDnsNameUtil accepts a presentation-form DNS name up to 253
+ * characters; DiscoveredDeviceBuilder clamps a device name to 80 because the
+ * slug is slugify(name) plus eleven characters into its own varchar(100).
+ * Importing MAX_DEVICE_NAME_LENGTH and asserting against it would make the
+ * length tests below survive someone raising the constant to 253 — which is
+ * exactly the change that starts failing device creates with a slug-length
+ * error. The numbers are the contract, so the numbers are what is asserted.
+ */
+const MAX_DNS_NAME_LENGTH: number = 253;
+const MAX_NAME_LENGTH: number = 80;
+
+/*
+ * A PTR name that is perfectly legal DNS and too long to be a device name:
+ * one label at RFC 1035's 63-octet ceiling, in a three-label zone. 85
+ * characters — under 253, over 80 — so it is accepted whole by one module and
+ * cut down by the next. Long labels like this are ordinary on estates that
+ * encode rack, unit and role into the hostname.
+ */
+const LONG_LABEL: string = `hq-fileserver-${"a".repeat(49)}`;
+const LONG_PTR_NAME: string = `${LONG_LABEL}.dc14.corp.example.net`;
+
+/**
+ * The payload as it comes back OUT of the jsonb column.
+ *
+ * Typed `Array<unknown>` on the way in on purpose: the probe payloads below
+ * deliberately hold values the `DiscoveredNetworkDevice` interface forbids,
+ * and pretending otherwise would be testing a payload the column cannot
+ * actually contain. The cast on the way out is exactly the lie the real code
+ * lives with — `getDiscoveredHosts` checks that the VALUE is an array and
+ * hands the elements on as hosts without looking at them.
+ */
+function storedScanResults(
+  payload: Array<unknown>,
+): Array<DiscoveredNetworkDevice> {
+  return JSON.parse(JSON.stringify(payload)) as Array<DiscoveredNetworkDevice>;
+}
+
+/** Store the payload and normalise it, exactly as every reader does. */
+function hostsFromPayload(
+  payload: Array<unknown>,
+): Array<DiscoveredNetworkDevice> {
+  return normalizeDiscoveredHosts(storedScanResults(payload));
+}
+
+/** Store the payload, normalise it, and name every surviving row. */
+function namesFromPayload(payload: Array<unknown>): Array<string> {
+  return hostsFromPayload(payload).map(
+    (host: DiscoveredNetworkDevice): string => {
+      return buildDeviceName(host);
+    },
+  );
+}
+
+/** Store the payload, normalise it, and build the devices it imports as. */
+function devicesFromPayload(payload: Array<unknown>): Array<NetworkDevice> {
+  return hostsFromPayload(payload).map(
+    (host: DiscoveredNetworkDevice): NetworkDevice => {
+      return buildNetworkDeviceFromDiscoveredHost({
+        projectId: PROJECT_ID,
+        host: host,
+        scan: PING_ONLY_SCAN,
+      });
+    },
+  );
+}
+
+/** The names of a built batch, which is what an operator ticks. */
+function deviceNames(devices: Array<NetworkDevice>): Array<string | undefined> {
+  return devices.map((device: NetworkDevice): string | undefined => {
+    return device.name;
+  });
+}
+
+/** The addresses of a built batch, which is what the poller dials. */
+function deviceHostnames(
+  devices: Array<NetworkDevice>,
+): Array<string | undefined> {
+  return devices.map((device: NetworkDevice): string | undefined => {
+    return device.hostname;
+  });
+}
+
+describe("Reverse DNS, probe payload to created NetworkDevice", () => {
+  it("names the reporter's four ping-only hosts by PTR and still addresses them by IP", () => {
+    /*
+     * Issue #3529 as filed. Four hosts on 10.18.166.0/24 that answer ping and
+     * have nothing readable over SNMP, on an estate that publishes a DNS
+     * record for each. Before the feature the name line was
+     * `sysName || ipAddress`, and with no sysName that is four bare
+     * addresses — the exact screenshot in the issue.
+     *
+     * .55's PTR carries the trailing root label. Resolvers differ on whether
+     * they include it, so the fully qualified spelling is in the payload
+     * rather than in a unit test of the normaliser alone: if the root-dot
+     * strip were ever dropped, THIS is where an operator would see it, as a
+     * device named "hq-camera-11.corp.example.net." with a stray dot.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "hq-fileserver.corp.example.net",
+      },
+      {
+        ipAddress: "10.18.166.53",
+        snmpReachable: false,
+        dnsHostname: "hq-printer-02.corp.example.net",
+      },
+      // No PTR record at all: this one must still read as its address.
+      { ipAddress: "10.18.166.54", snmpReachable: false },
+      {
+        ipAddress: "10.18.166.55",
+        snmpReachable: false,
+        dnsHostname: "hq-camera-11.corp.example.net.",
+      },
+    ];
+
+    const devices: Array<NetworkDevice> = devicesFromPayload(payload);
+
+    expect(deviceNames(devices)).toEqual([
+      "hq-fileserver.corp.example.net",
+      "hq-printer-02.corp.example.net",
+      "10.18.166.54",
+      "hq-camera-11.corp.example.net",
+    ]);
+
+    /*
+     * The other half of what the issue asked for, in its own words: "retain
+     * the IP address as the address/IP field". `hostname` is what the SNMP
+     * poller dials, what a trap's source address is correlated against, and
+     * the dedup key NetworkDeviceService.getRegisteredHostnames matches a
+     * later scan's results on. A device that stored its PTR name here would
+     * stop polling the day its reverse zone changed, and would be discovered
+     * as a second, "unregistered" host on the very next sweep.
+     */
+    expect(deviceHostnames(devices)).toEqual([
+      "10.18.166.51",
+      "10.18.166.53",
+      "10.18.166.54",
+      "10.18.166.55",
+    ]);
+
+    // Naming a host by DNS must not change how it is monitored.
+    for (const device of devices) {
+      expect(device.monitoringMethod).toBe(
+        NetworkDeviceMonitoringMethod.Monitor,
+      );
+      expect(device.isPollingEnabled).toBe(false);
+    }
+  });
+
+  it("names a payload that predates the feature exactly as it always did", () => {
+    /*
+     * The back-compat guarantee, taken end to end rather than at one function.
+     *
+     * Two populations send payloads with no `dnsHostname` key: probes running
+     * a build from before #3529, and every row already sitting in a
+     * `discoveredDevices` column. Both must keep producing the names they
+     * produced yesterday — `sysName` when there is one, the address when
+     * there is not. A regression here is worse than a missing feature: it
+     * renames devices that import correctly today.
+     */
+    const payload: Array<unknown> = [
+      { ipAddress: "10.18.166.51", sysName: "core-switch-01" },
+      { ipAddress: "10.18.166.53", snmpReachable: false },
+      /*
+       * `dnsHostname: undefined` is what a NEW probe sends for a host with no
+       * PTR record, and JSON.stringify erases the key entirely. So the modern
+       * no-record row and the legacy row are byte-identical in the column,
+       * which is precisely why no reader needs to tell them apart.
+       */
+      {
+        ipAddress: "10.18.166.54",
+        snmpReachable: false,
+        dnsHostname: undefined,
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    expect(
+      hosts.map((host: DiscoveredNetworkDevice): string => {
+        return buildDeviceName(host);
+      }),
+    ).toEqual(["core-switch-01", "10.18.166.53", "10.18.166.54"]);
+
+    /*
+     * Normalisation must not INVENT the key either. Readers are entitled to
+     * ask `"dnsHostname" in host`, and a blank-but-present key would show an
+     * empty DNS line under every legacy host. `toHaveProperty` rather than a
+     * value comparison on purpose: `toEqual` treats an absent key and a key
+     * set to `undefined` as the same thing, and that is the exact distinction
+     * DiscoveredHostUtil promises to keep.
+     */
+    for (const host of hosts) {
+      expect(host).not.toHaveProperty("dnsHostname");
+    }
+  });
+
+  it("falls back to the address for every hostile PTR value the column can hold", () => {
+    /*
+     * `dnsHostname` is the only field in a scan result whose value is chosen
+     * by the scanned network. A discovery sweep is routinely pointed at a
+     * subnet nobody in the project administers, so "whoever runs that
+     * resolver picks a device's name, its slug and a line in the dashboard"
+     * is the actual threat model — not a hypothetical one.
+     *
+     * Deliberately a SHORT list. ReverseDnsNameUtil.test.ts and
+     * DiscoveredDeviceBuilder.test.ts already enumerate hostile spellings one
+     * function at a time; repeating all of them here would buy coverage the
+     * chain does not add anything to. What is kept is the rows where the
+     * chain itself is the interesting part:
+     *
+     *   - markup, the payload that makes a name dangerous rather than merely
+     *     ugly once it is rendered and slugified;
+     *   - a name with interior spaces, which would become a device whose name
+     *     and slug disagree;
+     *   - the bare "in-addr.arpa" apex, which a suffix-only zone check lets
+     *     straight through and which is a strictly WORSE label than the
+     *     address it was derived from;
+     *   - the address restated as a dotted quad, which defeats the entire
+     *     purpose of the feature by dressing an address up as a resolved name;
+     *   - `null`, which the interface forbids and the jsonb column will
+     *     happily store.
+     *
+     * The assertion is the same for all of them: name the device by its
+     * ADDRESS, and do not throw. Throwing matters as much as the value does —
+     * these functions run inside a React render, where a TypeError takes out
+     * the whole modal rather than one row, so a thrown error fails the
+     * `toEqual` below and that is the intended way for it to be caught.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.60",
+        snmpReachable: false,
+        dnsHostname: '<script>alert("pwned")</script>',
+      },
+      {
+        ipAddress: "10.18.166.61",
+        snmpReachable: false,
+        dnsHostname: "  hq server 01  ",
+      },
+      {
+        ipAddress: "10.18.166.63",
+        snmpReachable: false,
+        dnsHostname: "in-addr.arpa",
+      },
+      {
+        ipAddress: "10.18.166.64",
+        snmpReachable: false,
+        dnsHostname: "10.18.166.64",
+      },
+      { ipAddress: "10.18.166.68", snmpReachable: false, dnsHostname: null },
+    ];
+
+    const addresses: Array<string> = [
+      "10.18.166.60",
+      "10.18.166.61",
+      "10.18.166.63",
+      "10.18.166.64",
+      "10.18.166.68",
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    expect(
+      hosts.map((host: DiscoveredNetworkDevice): string => {
+        return buildDeviceName(host);
+      }),
+    ).toEqual(addresses);
+
+    // Nothing survives into the column's cleaned reading either.
+    for (const host of hosts) {
+      expect(host).not.toHaveProperty("dnsHostname");
+    }
+
+    expect(deviceHostnames(devicesFromPayload(payload))).toEqual(addresses);
+
+    /*
+     * The SECOND line of defence, pinned separately because it is the one a
+     * refactor is most likely to remove as redundant.
+     *
+     * `getDiscoveredHostDisplayName` re-normalises `dnsHostname` itself
+     * rather than trusting the row it was handed. That is what protects a row
+     * written straight through the API, and a row stored by a probe whose
+     * version never heard of these rules — neither of which passed through
+     * normalizeDiscoveredHosts on the way in. Building names from the RAW
+     * stored payload must give the same answers.
+     */
+    expect(
+      storedScanResults(payload).map(
+        (host: DiscoveredNetworkDevice): string => {
+          return getDiscoveredHostDisplayName(host);
+        },
+      ),
+    ).toEqual(addresses);
+  });
+
+  it("cuts a legal-but-long PTR name down to the device ceiling and refuses one no resolver could return", () => {
+    /*
+     * THE sharpest joint in the chain: two modules with different ceilings.
+     *
+     * ReverseDnsNameUtil accepts up to 253 characters, because that is what a
+     * DNS presentation-form name may be. DiscoveredDeviceBuilder clamps to
+     * 80, because the name is slugified into its own varchar(100) and the
+     * create path THROWS on overflow rather than truncating. So a name in
+     * between is accepted whole by the first module and MUST be cut by the
+     * second — and it is the only place in the feature where the string an
+     * operator reads and the string written to the column are not identical.
+     *
+     * Both rows are needed, and they pull in opposite directions:
+     *
+     *   - 85 characters is a real hostname, so it is TRUNCATED. If the clamp
+     *     were dropped the device create would fail on the slug and the host
+     *     would silently never import.
+     *   - 304 characters was never a DNS name, so it is REJECTED outright and
+     *     the host falls back to its address. Truncating it instead would put
+     *     an 80-character fragment of an untrusted string into the name
+     *     column and present it as a resolved hostname.
+     */
+    const tooLongForDns: string = ["a", "b", "c", "d", "e"]
+      .map((letter: string): string => {
+        return letter.repeat(60);
+      })
+      .join(".");
+
+    // Fixture self-check: labels stay legal, only the total length offends.
+    expect(LONG_PTR_NAME.length).toBe(85);
+    expect(tooLongForDns.length).toBeGreaterThan(MAX_DNS_NAME_LENGTH);
+
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: LONG_PTR_NAME,
+      },
+      {
+        ipAddress: "10.18.166.53",
+        snmpReachable: false,
+        dnsHostname: tooLongForDns,
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    /*
+     * The 85-character name survives normalisation INTACT — the column keeps
+     * the resolver's answer, not a device-shaped abbreviation of it, so a
+     * later reader with a wider column is not stuck with this one's ceiling.
+     */
+    expect(hosts[0]?.dnsHostname).toBe(LONG_PTR_NAME);
+    expect(getDiscoveredHostDisplayName(hosts[0]!)).toBe(LONG_PTR_NAME);
+
+    // The 304-character one is not a name at all, so the key is gone.
+    expect(hosts[1]).not.toHaveProperty("dnsHostname");
+
+    /*
+     * The clamped name spelled out rather than derived with `.substring(80)`,
+     * so this asserts the ANSWER instead of restating the implementation:
+     * the 63-character label, then ".dc14.corp." and the first six letters of
+     * "example", which is where character 80 lands.
+     */
+    const clampedName: string = `${LONG_LABEL}.dc14.corp.exampl`;
+
+    expect(clampedName.length).toBe(MAX_NAME_LENGTH);
+
+    const devices: Array<NetworkDevice> = devicesFromPayload(payload);
+
+    expect(deviceNames(devices)).toEqual([clampedName, "10.18.166.53"]);
+    expect(deviceHostnames(devices)).toEqual(["10.18.166.51", "10.18.166.53"]);
+  });
+
+  it("keeps naming the good rows when the payload contains junk rows", () => {
+    /*
+     * One bad element must not poison the batch.
+     *
+     * The only guard on `discoveredDevices` checks that the VALUE is an
+     * array; it never looks at the elements. A single `null` row used to
+     * throw a TypeError the moment the operator clicked a filter button —
+     * inside the modal body, during render. This pins that the rows around
+     * the junk still name and address correctly.
+     *
+     * `null`, the number and the string are dropped because they are not
+     * objects. The address-less OBJECT is kept, and the contract for it is
+     * the second assertion below, not its mere survival: it becomes a device
+     * with `hostname: ""`, which is a row that carries its sysName as a name
+     * and collides on the dedup key with every other address-less row. That
+     * is the deliberate choice — a visibly broken row beats a vanished one —
+     * and it is stated here so a change to it has to be a decision.
+     */
+    const payload: Array<unknown> = [
+      null,
+      42,
+      "10.18.166.51",
+      { sysName: "orphan-no-address" },
+      {
+        ipAddress: "10.18.166.53",
+        snmpReachable: false,
+        dnsHostname: "hq-ups-01.corp.example.net",
+      },
+      { ipAddress: "10.18.166.54", snmpReachable: false },
+    ];
+
+    const devices: Array<NetworkDevice> = devicesFromPayload(payload);
+
+    expect(deviceNames(devices)).toEqual([
+      "orphan-no-address",
+      "hq-ups-01.corp.example.net",
+      "10.18.166.54",
+    ]);
+
+    expect(deviceHostnames(devices)).toEqual([
+      "",
+      "10.18.166.53",
+      "10.18.166.54",
+    ]);
+  });
+
+  it("normalises to a fixed point, so every reader of a row agrees", () => {
+    /*
+     * The chain has to be IDEMPOTENT, because it is not run once.
+     *
+     * The dashboard normalises the scan's rows when the Review dialog opens
+     * and again on re-render; the server-side auto-import rule engine
+     * normalises its own copy of the same jsonb; the import loop names a host
+     * that has already been through both. If a second pass could change an
+     * answer, the name an operator ticked and the name the device was created
+     * with could differ — which is the exact class of bug the shared
+     * normaliser was written to end.
+     *
+     * The payload is chosen so the first pass genuinely CHANGES every row:
+     * a root dot is stripped, a padded address is trimmed, a numeric sysName
+     * is blanked, and a rejected PTR key is deleted. A payload that was
+     * already clean would make this test pass no matter what.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "hq-router-01.corp.example.net.",
+      },
+      { ipAddress: " 10.18.166.53 ", sysName: 42 },
+      {
+        ipAddress: "10.18.166.54",
+        snmpReachable: false,
+        dnsHostname: "in-addr.arpa",
+      },
+    ];
+
+    const stored: Array<DiscoveredNetworkDevice> = storedScanResults(payload);
+    const once: Array<DiscoveredNetworkDevice> =
+      normalizeDiscoveredHosts(stored);
+    const twice: Array<DiscoveredNetworkDevice> =
+      normalizeDiscoveredHosts(once);
+
+    /*
+     * `toStrictEqual`, NOT `toEqual`. `toEqual` ignores keys whose value is
+     * `undefined`, so it cannot tell `delete row.dnsHostname` from
+     * `row.dnsHostname = undefined` — and that distinction IS the contract
+     * ("a reader that checks `if (host.dnsHostname)` and one that checks
+     * `"dnsHostname" in host` cannot disagree"). With `toEqual` this
+     * assertion would stay green through exactly the regression it is here to
+     * catch. The key lists are compared as well, so the failure message names
+     * the key that appeared or vanished rather than just the row.
+     */
+    expect(twice).toStrictEqual(once);
+    expect(
+      twice.map((host: DiscoveredNetworkDevice): Array<string> => {
+        return Object.keys(host).sort();
+      }),
+    ).toEqual(
+      once.map((host: DiscoveredNetworkDevice): Array<string> => {
+        return Object.keys(host).sort();
+      }),
+    );
+
+    // The rejected PTR key is absent after BOTH passes, not present-and-blank.
+    expect(once[2]).not.toHaveProperty("dnsHostname");
+    expect(twice[2]).not.toHaveProperty("dnsHostname");
+
+    const namesOnce: Array<string> = once.map(
+      (host: DiscoveredNetworkDevice): string => {
+        return buildDeviceName(host);
+      },
+    );
+    const namesTwice: Array<string> = twice.map(
+      (host: DiscoveredNetworkDevice): string => {
+        return buildDeviceName(host);
+      },
+    );
+
+    expect(namesOnce).toEqual([
+      "hq-router-01.corp.example.net",
+      "10.18.166.53",
+      "10.18.166.54",
+    ]);
+    expect(namesTwice).toEqual(namesOnce);
+  });
+
+  it("gives a wildcard PTR zone one shared name and three distinct fallbacks", () => {
+    /*
+     * A wildcard reverse zone — "*.166.18.10.in-addr.arpa PTR
+     * unassigned.dhcp.corp.example.net" — is common on DHCP ranges, and it is
+     * what makes the naming feature collide with a database constraint:
+     * NetworkDevice names are unique per project, so the first host imports
+     * and the next two fail the create.
+     *
+     * Both halves are load-bearing and pull in opposite directions. The
+     * primary name must be SHARED (it is what the resolver actually said, and
+     * showing three different names for one PTR record would be a fiction),
+     * while the retry name must be DISTINCT or the retry is pointless — the
+     * second create fails exactly as the first did. The address is the only
+     * thing that tells these three hosts apart, which is why it is what the
+     * fallback appends.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "unassigned.dhcp.corp.example.net",
+      },
+      {
+        ipAddress: "10.18.166.53",
+        snmpReachable: false,
+        dnsHostname: "unassigned.dhcp.corp.example.net",
+      },
+      {
+        ipAddress: "10.18.166.54",
+        snmpReachable: false,
+        dnsHostname: "unassigned.dhcp.corp.example.net",
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    expect(
+      hosts.map((host: DiscoveredNetworkDevice): string => {
+        return buildDeviceName(host);
+      }),
+    ).toEqual([
+      "unassigned.dhcp.corp.example.net",
+      "unassigned.dhcp.corp.example.net",
+      "unassigned.dhcp.corp.example.net",
+    ]);
+
+    const fallbacks: Array<string> = hosts.map(
+      (host: DiscoveredNetworkDevice): string => {
+        return buildFallbackDeviceName(host);
+      },
+    );
+
+    expect(fallbacks).toEqual([
+      "unassigned.dhcp.corp.example.net (10.18.166.51)",
+      "unassigned.dhcp.corp.example.net (10.18.166.53)",
+      "unassigned.dhcp.corp.example.net (10.18.166.54)",
+    ]);
+
+    // The property the retry depends on, stated as a property.
+    expect(new Set<string>(fallbacks).size).toBe(3);
+  });
+
+  it("keeps the collision fallback under the name ceiling however long the PTR name and the address are", () => {
+    /*
+     * The wildcard case above with a name that is already AT the ceiling,
+     * which is the realistic version: long DHCP zone names are the norm, so
+     * "shared name" and "long name" arrive together, and this is the only
+     * shape where `buildFallbackDeviceName`'s own truncation does anything.
+     *
+     * The fallback appends " (address)" to a name that is already the full 80
+     * characters, so the base has to be cut AGAIN — by exactly the suffix's
+     * width — or the composed name overflows the slug and the retry fails for
+     * a different reason than the collision it was meant to fix. Distinctness
+     * has to survive that second cut, which is why the suffix goes on the END:
+     * the two names are identical for their first 65 characters.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: LONG_PTR_NAME,
+      },
+      {
+        ipAddress: "10.18.166.53",
+        snmpReachable: false,
+        dnsHostname: LONG_PTR_NAME,
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    const fallbacks: Array<string> = hosts.map(
+      (host: DiscoveredNetworkDevice): string => {
+        return buildFallbackDeviceName(host);
+      },
+    );
+
+    /*
+     * 65 characters of name (80 minus the 15-character suffix) plus the
+     * suffix. Written out rather than computed so a regression that cut to
+     * the wrong width is a visible diff and not an arithmetic identity.
+     */
+    expect(fallbacks).toEqual([
+      `${LONG_LABEL}.d (10.18.166.51)`,
+      `${LONG_LABEL}.d (10.18.166.53)`,
+    ]);
+
+    for (const fallback of fallbacks) {
+      expect(fallback.length).toBe(MAX_NAME_LENGTH);
+    }
+
+    expect(new Set<string>(fallbacks).size).toBe(2);
+
+    /*
+     * The degenerate end of the same branch: an "address" longer than the
+     * whole name ceiling, so the suffix alone overflows it and the width left
+     * for the base name goes NEGATIVE. `ipAddress` is not validated anywhere
+     * on this path — it is whatever the probe wrote into jsonb — so a broken
+     * probe build really can put a line of sweep output here.
+     *
+     * TWO floors have to hold at once, and they pull against each other.
+     * Without the `Math.max(1, ...)`, `substring(0, -6)` returns "" and the
+     * device is named for the junk address alone, with nothing of the
+     * resolver's answer left in it. But that floor is also what used to let
+     * the COMPOSED name run past the ceiling — one base character plus an
+     * 83-character suffix is 84 — and a name over the ceiling fails the create
+     * on the slug's own length, which is a different error than the collision
+     * the retry was for, on a path whose whole job is to recover from one.
+     *
+     * So the composition is clamped as a whole: the first character of the
+     * name survives, and the result still fits.
+     */
+    const junkAddress: string = `10.18.166.55-${"z".repeat(70)}`;
+    const junkHosts: Array<DiscoveredNetworkDevice> = hostsFromPayload([
+      {
+        ipAddress: junkAddress,
+        snmpReachable: false,
+        dnsHostname: "hq-nas-01.corp.example.net",
+      },
+    ]);
+
+    const junkFallback: string = buildFallbackDeviceName(junkHosts[0]!);
+
+    expect(junkFallback.length).toBe(MAX_NAME_LENGTH);
+    expect(junkFallback.startsWith("h (10.18.166.55-")).toBe(true);
+  });
+
+  it("creates the retried device under the fallback name while still addressing it by IP", () => {
+    /*
+     * The retry as `importSelectedDevices` and the rule engine actually
+     * perform it, rather than as a string.
+     *
+     * Both paths build the device, catch the unique-name failure, and rebuild
+     * it with `name: buildFallbackDeviceName(host)`. Two things have to hold
+     * for that to work and neither is visible from the naming functions
+     * alone: the builder must PREFER the supplied name over its own default
+     * (otherwise the retry recreates the colliding name and fails again), and
+     * the retry must change nothing else — above all not `hostname`, because
+     * a retried device that addressed itself by name would poll the wrong
+     * thing forever.
+     *
+     * The default half is pinned on the same host in the same test, so the
+     * two names are visibly different strings produced by one builder.
+     */
+    const host: DiscoveredNetworkDevice = hostsFromPayload([
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "unassigned.dhcp.corp.example.net",
+      },
+    ])[0]!;
+
+    const firstAttempt: NetworkDevice = buildNetworkDeviceFromDiscoveredHost({
+      projectId: PROJECT_ID,
+      host: host,
+      scan: PING_ONLY_SCAN,
+    });
+
+    // No name supplied: the builder's default IS the displayed name.
+    expect(firstAttempt.name).toBe("unassigned.dhcp.corp.example.net");
+
+    const retry: NetworkDevice = buildNetworkDeviceFromDiscoveredHost({
+      projectId: PROJECT_ID,
+      host: host,
+      scan: PING_ONLY_SCAN,
+      name: buildFallbackDeviceName(host),
+    });
+
+    expect(retry.name).toBe("unassigned.dhcp.corp.example.net (10.18.166.51)");
+    expect(retry.name).not.toBe(firstAttempt.name);
+
+    // Everything the retry must NOT have changed.
+    expect(retry.hostname).toBe("10.18.166.51");
+    expect(retry.hostname).toBe(firstAttempt.hostname);
+    expect(retry.monitoringMethod).toBe(NetworkDeviceMonitoringMethod.Monitor);
+    expect(retry.isPollingEnabled).toBe(false);
+    expect(retry.projectId).toBe(PROJECT_ID);
+  });
+
+  it("stringifies a numeric address while naming the host by its PTR record", () => {
+    /*
+     * A number in `ipAddress` is a shipped probe bug the normaliser exists to
+     * absorb: the selection record keys the host as the string "10" (object
+     * keys always are), while the imported-set is matched with `Set.has(10)`,
+     * which does not coerce — so the host imported and then could never be
+     * retired, and pressing Import again duplicated it.
+     *
+     * With a PTR name on the same row it becomes a chain claim, and the two
+     * fields must be treated OPPOSITELY: `ipAddress` is stringified (it is
+     * still an address, just badly typed) while `sysName` and `dnsHostname`
+     * are not (see the sysName test below). `hostname` must come out as the
+     * string "10", because NetworkDeviceService.getRegisteredHostnames dedups
+     * against a Set of strings and a number would silently never match.
+     */
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload([
+      {
+        ipAddress: 10,
+        snmpReachable: false,
+        dnsHostname: "hq-gw-01.corp.example.net",
+      },
+    ]);
+
+    expect(hosts[0]?.ipAddress).toBe("10");
+
+    const device: NetworkDevice = devicesFromPayload([
+      {
+        ipAddress: 10,
+        snmpReachable: false,
+        dnsHostname: "hq-gw-01.corp.example.net",
+      },
+    ])[0]!;
+
+    expect(device.name).toBe("hq-gw-01.corp.example.net");
+    expect(device.hostname).toBe("10");
+    // `toBe("10")` would also pass for the number under `==`, so say it.
+    expect(typeof device.hostname).toBe("string");
+  });
+
+  it("preserves a PTR record's own capitalisation and still rejects an upper-case in-addr.arpa echo", () => {
+    /*
+     * Case is a joint, in both directions, and neither direction is visible
+     * from one module.
+     *
+     * (a) ReverseDnsNameUtil PRESERVES case deliberately — the reverse zone's
+     *     spelling is as close to the operator's intent as this data gets —
+     *     so a device must be created as "HQ-FileServer.Corp.Example.NET".
+     *     Any lower-casing added for "consistency" between here and the
+     *     device name would be caught here.
+     * (b) The zone check compares the LOWER-CASED name but the function
+     *     returns the original. A resolver that echoes the query name back in
+     *     upper case (they exist; DNS is case-insensitive on the wire and
+     *     0x20 encoding makes mixed-case echoes ordinary) must still be
+     *     rejected. Comparing the un-lowered string against the zone list is
+     *     the classic version of this bug, and every other hostile-value case
+     *     in this file spells the zone in lower case, so this row is the only
+     *     one that would catch it.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "HQ-FileServer.Corp.Example.NET",
+      },
+      {
+        ipAddress: "10.18.166.53",
+        snmpReachable: false,
+        dnsHostname: "53.166.18.10.IN-ADDR.ARPA",
+      },
+      // The apex spelled the same way, which a suffix-only check misses.
+      {
+        ipAddress: "10.18.166.54",
+        snmpReachable: false,
+        dnsHostname: "In-Addr.Arpa.",
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    expect(hosts[0]?.dnsHostname).toBe("HQ-FileServer.Corp.Example.NET");
+    expect(hosts[1]).not.toHaveProperty("dnsHostname");
+    expect(hosts[2]).not.toHaveProperty("dnsHostname");
+
+    expect(deviceNames(devicesFromPayload(payload))).toEqual([
+      "HQ-FileServer.Corp.Example.NET",
+      "10.18.166.53",
+      "10.18.166.54",
+    ]);
+  });
+
+  it("blanks a non-string sysName so the PTR name wins, rather than stringifying it", () => {
+    /*
+     * `sysName` comes out of the same verbatim jsonb blob as everything else,
+     * so its declared `string | undefined` type describes what the probe
+     * SHOULD send, not what is stored. `(42).trim()` is a TypeError thrown
+     * during render, which takes out the whole modal rather than one row.
+     *
+     * EXPECTED BEHAVIOUR, stated plainly because the interesting part is what
+     * does NOT happen. A non-string sysName is BLANKED, not coerced, and that
+     * is the difference between this field and `ipAddress` (which IS
+     * stringified, as the numeric-address test above pins). Blanking is what
+     * these rows prove is right:
+     *
+     *   - sysName 42    -> "" -> the PTR name wins. Not "42".
+     *   - sysName {...} -> "" -> the PTR name wins. NOT "[object Object]",
+     *                      which is what `String()` returns and which, being
+     *                      truthy, would beat a perfectly good PTR record on
+     *                      the very same row.
+     *   - sysName null  -> "" -> the PTR name wins. NOT "null" (typeof null
+     *                      is "object", so it is not the `undefined` the
+     *                      guard already skips).
+     *
+     * The blanking is asserted on the ROW as well as through the name,
+     * because the two layers guard it independently: delete the blanking from
+     * normalizeDiscoveredHosts and getDiscoveredHostDisplayName's own `typeof`
+     * check still produces every name below. Only `hosts[n].sysName` can tell
+     * that the normalised row — which is what an auto-import rule matches on
+     * and what the selection record holds — was cleaned too.
+     *
+     * The fourth row is the one that makes blanking visible in the NAME as
+     * well: junk in `sysName` and no PTR record either, so the name has
+     * nowhere to fall but the address.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        sysName: 42,
+        dnsHostname: "hq-switch-01.corp.example.net",
+      },
+      {
+        ipAddress: "10.18.166.53",
+        sysName: { oid: "1.3.6.1.2.1.1.5.0" },
+        dnsHostname: "hq-switch-02.corp.example.net",
+      },
+      {
+        ipAddress: "10.18.166.54",
+        sysName: null,
+        dnsHostname: "hq-switch-03.corp.example.net",
+      },
+      { ipAddress: "10.18.166.56", sysName: 42 },
+      /*
+       * An ABSENT sysName must not GAIN the key: `sysName` is optional and
+       * `"sysName" in host` is a question other code is entitled to ask. Note
+       * `sysName: undefined` is erased by the JSON round trip, so "absent" is
+       * the only form the column can actually store.
+       */
+      {
+        ipAddress: "10.18.166.57",
+        sysName: undefined,
+        dnsHostname: "hq-switch-04.corp.example.net",
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    expect(hosts[0]?.sysName).toBe("");
+    expect(hosts[1]?.sysName).toBe("");
+    expect(hosts[2]?.sysName).toBe("");
+    expect(hosts[3]?.sysName).toBe("");
+    expect(hosts[4]).not.toHaveProperty("sysName");
+
+    const devices: Array<NetworkDevice> = devicesFromPayload(payload);
+
+    expect(deviceNames(devices)).toEqual([
+      "hq-switch-01.corp.example.net",
+      "hq-switch-02.corp.example.net",
+      "hq-switch-03.corp.example.net",
+      "10.18.166.56",
+      "hq-switch-04.corp.example.net",
+    ]);
+
+    expect(deviceHostnames(devices)).toEqual([
+      "10.18.166.51",
+      "10.18.166.53",
+      "10.18.166.54",
+      "10.18.166.56",
+      "10.18.166.57",
+    ]);
+  });
+
+  it("leaves a whitespace-only sysName on the row but never lets it become a name", () => {
+    /*
+     * The one place the two layers deliberately DISAGREE, which is why it can
+     * only be pinned end to end.
+     *
+     * normalizeDiscoveredHosts passes a string sysName through untouched — it
+     * only rewrites non-strings — so "   " is still "   " on the row an
+     * auto-import rule matches against. getDiscoveredHostDisplayName trims
+     * before testing for emptiness, so the same value does not name anything
+     * and the PTR record wins.
+     *
+     * Both halves are asserted because either one alone is satisfiable by the
+     * wrong implementation: if the normaliser started trimming, the row
+     * assertion fails; if the display stopped trimming, "   " is truthy, it
+     * beats the PTR record, and a device is created whose name is three
+     * spaces and whose slug is empty.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        sysName: "   ",
+        dnsHostname: "hq-esxi-04.corp.example.net",
+      },
+      // The same blank sysName with nothing to fall through to but the address.
+      { ipAddress: "10.18.166.53", sysName: "   " },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    expect(hosts[0]?.sysName).toBe("   ");
+    expect(hosts[1]?.sysName).toBe("   ");
+
+    expect(namesFromPayload(payload)).toEqual([
+      "hq-esxi-04.corp.example.net",
+      "10.18.166.53",
+    ]);
+
+    expect(deviceNames(devicesFromPayload(payload))).toEqual([
+      "hq-esxi-04.corp.example.net",
+      "10.18.166.53",
+    ]);
+  });
+
+  it("gives two rows for one address a single registration state but two different PTR names", () => {
+    /*
+     * The dedup pass and the naming feature meet here, and the meeting is
+     * only visible in the chain.
+     *
+     * A scan can list the same address twice — two interfaces answering, a
+     * re-scan merged in, a probe retry — and the rows need not agree. The
+     * normaliser fixes ONE of those disagreements: `isAlreadyRegistered` is a
+     * property of the ADDRESS, so if any row says the address is registered,
+     * every row for it does. Without that pass one checkbox governs both rows
+     * while only one of them refuses to import, and whether an inventoried
+     * device got created a second time depended on the probe's ordering.
+     *
+     * It deliberately does NOT unify the names, and it cannot: the two rows
+     * hold two different PTR answers and neither is more true than the other.
+     * So the operator ticks one row, sees one name, and — if the import walks
+     * the other row — creates a device under the other name. Pinning the
+     * disagreement is the point: it is a real hazard of naming devices by
+     * DNS, and this assertion is where anyone who later tries to dedup rows
+     * by address will find out that the names were never dedupable.
+     */
+    const payload: Array<unknown> = [
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "hq-nas-01.corp.example.net",
+        isAlreadyRegistered: true,
+      },
+      {
+        ipAddress: "10.18.166.51",
+        snmpReachable: false,
+        dnsHostname: "hq-nas-01-old.corp.example.net",
+      },
+    ];
+
+    const hosts: Array<DiscoveredNetworkDevice> = hostsFromPayload(payload);
+
+    // One address, one registration state, whatever order the probe sent.
+    expect(
+      hosts.map((host: DiscoveredNetworkDevice): boolean | undefined => {
+        return host.isAlreadyRegistered;
+      }),
+    ).toEqual([true, true]);
+
+    const names: Array<string | undefined> = deviceNames(
+      devicesFromPayload(payload),
+    );
+
+    expect(names).toEqual([
+      "hq-nas-01.corp.example.net",
+      "hq-nas-01-old.corp.example.net",
+    ]);
+    // Two names for one checkbox: the hazard, stated as a property.
+    expect(new Set<string | undefined>(names).size).toBe(2);
+
+    // Both still address the one host they are, which is the dedup key.
+    expect(deviceHostnames(devicesFromPayload(payload))).toEqual([
+      "10.18.166.51",
+      "10.18.166.51",
+    ]);
+  });
+});

--- a/Common/Tests/Utils/NetworkDiscovery/ReverseDnsNameUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/ReverseDnsNameUtil.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_REVERSE_DNS_NAME_LENGTH,
   normalizeReverseDnsName,
 } from "../../../Utils/NetworkDiscovery/ReverseDnsNameUtil";
+import Slug from "../../../Utils/Slug";
 import { describe, expect, it } from "@jest/globals";
 
 /*
@@ -24,11 +25,26 @@ import { describe, expect, it } from "@jest/globals";
  *     very names the issue asked for, and does it invisibly: the operator
  *     sees the address they always saw and has no way to tell "no PTR record"
  *     from "we threw your PTR record away". Underscores, single labels,
- *     dashes-with-digits and long FQDNs are all real, and all pass.
+ *     dashes-with-digits, a purely numeric label sitting next to alphabetic
+ *     ones, and long FQDNs are all real, and all pass.
  *   - Everything that is not a hostname must not. Whitespace, quotes, angle
  *     brackets, control characters, non-ASCII and over-length values are what
  *     a hostile or broken reverse zone answers with, and they must never
  *     reach a name column.
+ *
+ * The two rules that are written as a quantifier over labels — "reject when
+ * EVERY label is numeric" and "reject when the name ends AT A LABEL BOUNDARY
+ * with a reverse-lookup zone" — are the ones where a one-token edit (`every`
+ * to `some`, `.${zone}` to `zone`) turns a narrow rejection into a broad one
+ * and deletes real names without a single error surfacing anywhere. Those two
+ * survive-directions have describe blocks of their own below.
+ *
+ * Every non-printing and non-ASCII character in this file is written as a
+ * \uXXXX escape rather than pasted literally. The whole point of several of
+ * these cases is that the character is INVISIBLE — a literal NUL, zero-width
+ * joiner or right-to-left override in the source is unreviewable in a diff,
+ * survives a careless copy-paste into the source it is meant to guard, and is
+ * mangled by tooling that normalises text. The escape is the test.
  */
 
 describe("normalizeReverseDnsName — names that must survive", () => {
@@ -91,34 +107,170 @@ describe("normalizeReverseDnsName — names that must survive", () => {
       "SW-Core-01.Corp.Example.COM",
     );
   });
+});
 
-  it("accepts a label of exactly the maximum length", () => {
-    const label: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH);
-    expect(normalizeReverseDnsName(`${label}.example.com`)).toBe(
-      `${label}.example.com`,
+describe("normalizeReverseDnsName — a numeric label beside alphabetic ones", () => {
+  /*
+   * The single most load-bearing acceptance in the file, and the one the rest
+   * of the suite could not see.
+   *
+   * The address-restating rule is "reject when EVERY label is numeric". Its
+   * rejection direction is pinned three times over ("10.18.166.51", "51",
+   * "10.18"). Its SURVIVE direction — a name that merely CONTAINS an
+   * all-digit label — had no case at all, so rewriting
+   * `labels.every(isNumeric)` as `labels.some(isNumeric)` left the whole
+   * suite green while deleting exactly the names issue #3529 is about: a
+   * reverse zone that publishes each host as `<last octet>.<zone>`, so hosts
+   * .51, .53, .54 and .55 answer "51.corp.example.com" and friends. Under the
+   * `some` mutation every one of those hosts silently loses its name and the
+   * operator sees the addresses they always saw, with nothing logged.
+   *
+   * These cases fail under that mutation and pass under the real rule, which
+   * is the whole reason they are here.
+   */
+
+  it("accepts a name whose leading label is purely numeric", () => {
+    /*
+     * The canonical shape from the issue: the PTR for 10.18.166.51 in a zone
+     * that names hosts by octet. It is not the address restated — "corp" and
+     * "example" and "com" are not digits — so it is a real name and must be
+     * kept.
+     */
+    expect(normalizeReverseDnsName("51.corp.example.com")).toBe(
+      "51.corp.example.com",
     );
+    expect(normalizeReverseDnsName("10.corp.example.com")).toBe(
+      "10.corp.example.com",
+    );
+
+    /*
+     * "0.pool.ntp.org" is the real-world one: a leading zero, a single digit,
+     * and a name millions of hosts genuinely resolve to. If a numeric label
+     * anywhere were disqualifying, this would come back undefined.
+     */
+    expect(normalizeReverseDnsName("0.pool.ntp.org")).toBe("0.pool.ntp.org");
   });
 
-  it("accepts a name of exactly the maximum length", () => {
+  it("accepts a numeric label in an interior or trailing position", () => {
     /*
-     * Built out of 63-character labels so the LABEL rule cannot be what
-     * decides this case: 3 * 63 + 3 separators + 61 = 253.
+     * Position must not matter either — the rule is a quantifier over ALL
+     * labels, not an inspection of the first one. A rule written as "reject
+     * if the first label is numeric" would pass the case above's mutation
+     * test but fail here, so both shapes are pinned.
      */
-    const label: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH);
-    const name: string = `${label}.${label}.${label}.${"b".repeat(61)}`;
-    expect(name).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH);
-    expect(normalizeReverseDnsName(name)).toBe(name);
+    expect(normalizeReverseDnsName("gw.51.example.com")).toBe(
+      "gw.51.example.com",
+    );
+    expect(normalizeReverseDnsName("printer.3")).toBe("printer.3");
+    expect(normalizeReverseDnsName("a.1")).toBe("a.1");
+  });
+});
+
+describe("normalizeReverseDnsName — length boundaries", () => {
+  /*
+   * These are the off-by-one seams in the function, pinned on both sides.
+   * Each one is a place where a "<" that should be "<=" either silently
+   * discards a legitimate long FQDN (the failure nobody notices, because the
+   * dialog just shows the address it always showed) or lets an over-length
+   * value through into a varchar column.
+   */
+
+  const LABEL_AT_LIMIT: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH);
+
+  /*
+   * 3 * 63 + 3 separators + 61 = 253. Built out of maximum-length labels so
+   * the per-label rule cannot be what decides any of the whole-name cases
+   * below — only the whole-name limit can. Note that this arithmetic is
+   * load-bearing on MAX_REVERSE_DNS_LABEL_LENGTH staying 63: the
+   * `toHaveLength` assertions below are what re-derive both constants, so a
+   * change to either number turns this block red rather than silently
+   * shifting what "at the limit" means.
+   */
+  const NAME_AT_LIMIT: string = `${LABEL_AT_LIMIT}.${LABEL_AT_LIMIT}.${LABEL_AT_LIMIT}.${"b".repeat(61)}`;
+
+  it("accepts a label of exactly the maximum length and rejects one character more", () => {
+    expect(LABEL_AT_LIMIT).toHaveLength(63);
+    expect(normalizeReverseDnsName(`${LABEL_AT_LIMIT}.example.com`)).toBe(
+      `${LABEL_AT_LIMIT}.example.com`,
+    );
+
+    const overLimit: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH + 1);
+    expect(normalizeReverseDnsName(`${overLimit}.example.com`)).toBeUndefined();
+  });
+
+  it("accepts a name that is one label of exactly the maximum length", () => {
+    /*
+     * The label limit and the name limit are different numbers, and a single
+     * maximal label exercises both at once: it must be judged by the label
+     * rule (63) and pass the name rule (253) without either being applied to
+     * the other's value.
+     */
+    expect(normalizeReverseDnsName(LABEL_AT_LIMIT)).toBe(LABEL_AT_LIMIT);
+  });
+
+  it("accepts a name of exactly the maximum length and rejects one character more", () => {
+    expect(NAME_AT_LIMIT).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH);
+    expect(normalizeReverseDnsName(NAME_AT_LIMIT)).toBe(NAME_AT_LIMIT);
+
+    const overLimit: string = `${LABEL_AT_LIMIT}.${LABEL_AT_LIMIT}.${LABEL_AT_LIMIT}.${"b".repeat(62)}`;
+    expect(overLimit).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH + 1);
+    expect(normalizeReverseDnsName(overLimit)).toBeUndefined();
   });
 
   it("accepts a name whose trailing dot is what pushes it over the limit", () => {
     /*
      * The root label is not part of the name, so a 253-character name written
-     * fully qualified is 254 characters of input and must still be accepted.
-     * Measuring before stripping would reject it.
+     * fully qualified is 254 characters of INPUT and must still be accepted.
+     * Measuring before stripping would reject it — and the resolvers that
+     * emit fully qualified answers are exactly the well-run ones whose names
+     * are worth having.
      */
-    const label: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH);
-    const name: string = `${label}.${label}.${label}.${"b".repeat(61)}`;
-    expect(normalizeReverseDnsName(`${name}.`)).toBe(name);
+    expect(`${NAME_AT_LIMIT}.`).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH + 1);
+    expect(normalizeReverseDnsName(`${NAME_AT_LIMIT}.`)).toBe(NAME_AT_LIMIT);
+  });
+
+  it("trims before it strips the root label and before it measures", () => {
+    /*
+     * The two orderings the cases above leave open, pinned in one input.
+     * "  <253 chars>.  " is 258 characters of raw input, and it is the answer
+     * a well-run resolver's fully qualified reply looks like once it has been
+     * through a text field or a log line that padded it.
+     *
+     * Reasoned against the mutated implementations:
+     *   - measure-then-trim: 258 > 253, rejected, name silently lost.
+     *   - strip-root-then-trim: the raw value ends in a SPACE, so nothing is
+     *     stripped; after trimming, the trailing dot survives into the label
+     *     split as an empty final label, and the name is rejected.
+     * Only trim -> strip -> measure returns NAME_AT_LIMIT, so this case dies
+     * under either reordering.
+     *
+     * It also pins the returned value byte-for-byte at the maximum length:
+     * what comes back is the trimmed, root-stripped INPUT, unmodified and
+     * untruncated.
+     */
+    const padded: string = `  ${NAME_AT_LIMIT}.  `;
+    expect(padded).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH + 5);
+    expect(normalizeReverseDnsName(padded)).toBe(NAME_AT_LIMIT);
+  });
+
+  it("rejects an absurdly long value made entirely of legal labels", () => {
+    /*
+     * Ten thousand characters in which EVERY label is a legal two-character
+     * label, so the per-label rule has nothing to object to and the whole-name
+     * limit is the only thing that can reject it. Delete the
+     * MAX_REVERSE_DNS_NAME_LENGTH check and this value is accepted — a
+     * ten-thousand-character "hostname" on its way to a varchar(100) column.
+     *
+     * (Its earlier form, "a".repeat(10000), was a single 10,000-character
+     * label and so was rejected by the 63-character label rule first; it
+     * could not fail if the name limit were removed, which is the point of
+     * building this one out of legal labels instead.)
+     */
+    const legalLabelsOverLimit: string = "ab.".repeat(3334);
+    expect(legalLabelsOverLimit.length).toBeGreaterThan(
+      MAX_REVERSE_DNS_NAME_LENGTH,
+    );
+    expect(normalizeReverseDnsName(legalLabelsOverLimit)).toBeUndefined();
   });
 });
 
@@ -129,6 +281,10 @@ describe("normalizeReverseDnsName — answers that restate the address", () => {
    * worse, presenting it as one asserts a resolved hostname that nobody
    * published. These must fall through so the caller uses the address it
    * already had.
+   *
+   * The complement — a numeric label that sits BESIDE alphabetic ones and
+   * must survive — is its own describe block above; neither half of the rule
+   * is safe without the other.
    */
 
   it("rejects a dotted-quad", () => {
@@ -164,6 +320,50 @@ describe("normalizeReverseDnsName — answers that restate the address", () => {
       ),
     ).toBeUndefined();
   });
+});
+
+describe("normalizeReverseDnsName — the reverse zones as an apex", () => {
+  /*
+   * The suffix rule alone left a hole: a resolver that echoes a TRUNCATED
+   * query name, or a zone whose PTR points at the zone apex itself, answers
+   * with the bare zone. "in-addr.arpa" is a perfectly well-formed hostname
+   * string — right charset, right label lengths, not all-numeric — so
+   * everything else in this function waves it through, and the operator gets
+   * a fleet of devices all called "in-addr.arpa" instead of their addresses.
+   * That is why the check is `lowerCased === zone` as well as `endsWith`.
+   */
+
+  it("rejects the bare in-addr.arpa apex", () => {
+    expect(normalizeReverseDnsName("in-addr.arpa")).toBeUndefined();
+  });
+
+  it("rejects the bare ip6.arpa apex", () => {
+    expect(normalizeReverseDnsName("ip6.arpa")).toBeUndefined();
+  });
+
+  it("rejects the apex with a trailing root dot, in any case", () => {
+    /*
+     * Two orderings in one case, because the separate lower-case-with-dot
+     * test was fully contained in this one's inputs and pinned nothing extra.
+     *
+     * Root-dot ordering: the apex comparison runs AFTER the root label is
+     * stripped. Reversed, "in-addr.arpa." would match neither the apex (extra
+     * dot) nor the suffix (nothing before it) and would sail through.
+     *
+     * Case ordering: DNS is case-insensitive and resolvers echo whatever case
+     * they were handed — 0x20 query randomisation makes mixed case the NORMAL
+     * shape of an echoed name, not an exotic one. Comparing the raw string
+     * would accept "In-Addr.ARPA"; lower-casing the value but not comparing
+     * against a lower-case zone would reject everything.
+     */
+    expect(normalizeReverseDnsName("in-addr.arpa.")).toBeUndefined();
+    expect(normalizeReverseDnsName("ip6.arpa.")).toBeUndefined();
+    expect(normalizeReverseDnsName("IN-ADDR.ARPA")).toBeUndefined();
+    expect(normalizeReverseDnsName("In-Addr.Arpa")).toBeUndefined();
+    expect(normalizeReverseDnsName("iN-aDdR.aRpA.")).toBeUndefined();
+    expect(normalizeReverseDnsName("IP6.ARPA")).toBeUndefined();
+    expect(normalizeReverseDnsName("Ip6.Arpa.")).toBeUndefined();
+  });
 
   it("keeps a real name that merely CONTAINS arpa", () => {
     // The suffix rule must be a suffix rule, not a substring rule.
@@ -173,6 +373,56 @@ describe("normalizeReverseDnsName — answers that restate the address", () => {
     expect(normalizeReverseDnsName("in-addr.arpa.example.com")).toBe(
       "in-addr.arpa.example.com",
     );
+  });
+
+  it("matches the zone at a label boundary, not as a bare string suffix", () => {
+    /*
+     * The other half of "it is a suffix rule", and the one the CONTAINS cases
+     * above could not see. Every accepted arpa name in this file
+     * ("arpa-gw.example.com", "in-addr.arpa.example.com",
+     * "gw.arpa.example.com", "something.arpa") ends somewhere OTHER than the
+     * zone string, so rewriting `lowerCased.endsWith(`.${zone}`)` as
+     * `lowerCased.endsWith(zone)` — dropping one character — survived the
+     * entire suite.
+     *
+     * Under that mutation "notin-addr.arpa" and "voip6.arpa" are rejected:
+     * both end with the zone's characters while their final labels are
+     * "notin-addr" and "voip6", which are somebody's real hostnames and are
+     * nothing to do with a reverse-lookup zone. The dot is what makes the
+     * difference between "this name lives IN the zone" and "this name happens
+     * to end with those letters", so it is asserted here.
+     */
+    expect(normalizeReverseDnsName("notin-addr.arpa")).toBe("notin-addr.arpa");
+    expect(normalizeReverseDnsName("voip6.arpa")).toBe("voip6.arpa");
+    expect(normalizeReverseDnsName("myip6.arpa")).toBe("myip6.arpa");
+
+    /*
+     * ...while the genuine label-boundary forms of the same strings stay
+     * rejected, so the case above cannot be satisfied by deleting the zone
+     * rule outright.
+     */
+    expect(normalizeReverseDnsName("x.in-addr.arpa")).toBeUndefined();
+    expect(normalizeReverseDnsName("x.ip6.arpa")).toBeUndefined();
+  });
+
+  it("keeps a name with an interior or trailing label called arpa", () => {
+    /*
+     * ACCEPTED, deliberately, and this is the line the apex check must not
+     * cross. The rule targets the two REVERSE-LOOKUP zones, not the .arpa
+     * TLD: `arpa` is a real, delegated top-level domain, and "gw.arpa" or
+     * "gw.arpa.example.com" is a name somebody published on purpose. It is
+     * still a better label for the Review dialog than 10.18.166.51, which is
+     * the only thing the operator would otherwise see.
+     *
+     * Widening the check to "ends in .arpa" would silently delete these — the
+     * exact invisible over-rejection this suite exists to prevent — and would
+     * buy nothing, because the harm is specific to the two zones whose names
+     * merely restate the address.
+     */
+    expect(normalizeReverseDnsName("gw.arpa.example.com")).toBe(
+      "gw.arpa.example.com",
+    );
+    expect(normalizeReverseDnsName("something.arpa")).toBe("something.arpa");
   });
 });
 
@@ -241,45 +491,261 @@ describe("normalizeReverseDnsName — values that are not names at all", () => {
 
   it("rejects control characters, including ones that survive a trim", () => {
     /*
-     * trim() removes \n at the ENDS. A newline in the middle would otherwise
-     * put a second line into a name column.
+     * trim() only removes whitespace at the ENDS, so an interior control
+     * character reaches the charset check or nothing does. A newline puts a
+     * second line into a name column and into the Review dialog row; a NUL
+     * truncates the value in anything that reaches a C string boundary
+     * (Postgres rejects it outright in a text column, failing the import);
+     * ESC starts a terminal escape sequence in probe and server logs, which
+     * is where an operator reads these names back.
+     *
+     * Written as escapes on purpose — see the file header.
      */
     expect(normalizeReverseDnsName("host\n.example.com")).toBeUndefined();
-    expect(normalizeReverseDnsName("host.exa mple.com")).toBeUndefined();
-    expect(normalizeReverseDnsName("host.example.com")).toBeUndefined();
+    expect(normalizeReverseDnsName("host\r\n.example.com")).toBeUndefined();
+    // U+0000 NUL.
+    expect(normalizeReverseDnsName("host.exa\u0000mple.com")).toBeUndefined();
+    // U+001B ESC — the lead byte of an ANSI terminal escape sequence.
+    expect(normalizeReverseDnsName("host.exa\u001Bmple.com")).toBeUndefined();
+    // U+007F DEL.
+    expect(normalizeReverseDnsName("host\u007F.example.com")).toBeUndefined();
   });
 
   it("rejects non-ASCII, including homoglyphs of a legitimate name", () => {
     /*
-     * A Cyrillic "с" renders identically to a Latin "c". Punycode
-     * ("xn--...") is the encoding a real internationalised name arrives in
-     * and is pure ASCII, so this rejects nothing that a resolver would
-     * actually answer with.
+     * Punycode ("xn--...") is the encoding a real internationalised name
+     * arrives in and is pure ASCII, so rejecting non-ASCII rejects nothing a
+     * resolver would actually answer with.
      */
-    expect(normalizeReverseDnsName("сore-switch.example.com")).toBeUndefined();
-    expect(normalizeReverseDnsName("hôte.example.com")).toBeUndefined();
-    expect(normalizeReverseDnsName("router​.example.com")).toBeUndefined();
+    // U+0441 CYRILLIC SMALL LETTER ES — renders identically to Latin "c".
+    expect(
+      normalizeReverseDnsName("\u0441ore-switch.example.com"),
+    ).toBeUndefined();
+    // U+00F4 LATIN SMALL LETTER O WITH CIRCUMFLEX.
+    expect(normalizeReverseDnsName("h\u00F4te.example.com")).toBeUndefined();
+    // U+200B ZERO WIDTH SPACE — invisible, and not stripped by trim().
+    expect(normalizeReverseDnsName("router\u200B.example.com")).toBeUndefined();
     // ...while the punycode form of the same idea is fine.
     expect(normalizeReverseDnsName("xn--hte-snab.example.com")).toBe(
       "xn--hte-snab.example.com",
     );
   });
 
-  it("rejects a label one character over the limit", () => {
-    const label: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH + 1);
-    expect(normalizeReverseDnsName(`${label}.example.com`)).toBeUndefined();
+  it("rejects unicode that renders as ASCII to a human reading the dialog", () => {
+    /*
+     * This is the class the charset rule exists for. Every one of these
+     * renders in the Review dialog as something the operator would read as an
+     * ordinary hostname, while being a different string underneath — so an
+     * operator ticking "core-switch" cannot be shown a device that is not it.
+     * A blocklist of "suspicious" codepoints would be an arms race; the
+     * ASCII-only rule ends it, and costs nothing because PTR answers are
+     * ASCII on the wire.
+     */
+    // U+FF48 U+FF4F U+FF53 U+FF54 — FULLWIDTH h, o, s, t.
+    expect(
+      normalizeReverseDnsName("\uFF48\uFF4F\uFF53\uFF54.example.com"),
+    ).toBeUndefined();
+    // U+0430 CYRILLIC SMALL LETTER A inside an otherwise Latin word.
+    expect(normalizeReverseDnsName("g\u0430teway.example.com")).toBeUndefined();
+    // U+200D ZERO WIDTH JOINER — invisible, and splits a word for search.
+    expect(
+      normalizeReverseDnsName("core\u200Dswitch.example.com"),
+    ).toBeUndefined();
+    // U+202E RIGHT-TO-LEFT OVERRIDE — reverses everything rendered after it.
+    expect(
+      normalizeReverseDnsName("host\u202Emoc.elpmaxe.example.com"),
+    ).toBeUndefined();
+    /*
+     * U+FEFF ZERO WIDTH NO-BREAK SPACE (BOM) in the middle, where trim() is
+     * no help.
+     */
+    expect(
+      normalizeReverseDnsName("host\uFEFFname.example.com"),
+    ).toBeUndefined();
+  });
+});
+
+describe("normalizeReverseDnsName — hostile-looking values that the charset allows", () => {
+  /*
+   * These pass every rule in the function, and that is the correct outcome:
+   * this gate decides "is this string shaped like a hostname", not "is this
+   * string a good idea". Pinning the acceptances matters as much as pinning
+   * the rejections, because each one is a place somebody might later be
+   * tempted to add a blocklist — and a blocklist here would silently delete
+   * real names while the actual defence lives where the value is USED.
+   */
+
+  it("accepts a name that collides with a Review dialog badge", () => {
+    /*
+     * "Already-added" is the badge the dialog puts on a host that is already
+     * imported. A PTR record can legitimately say exactly that, and the
+     * function cannot tell the difference — nor should it try. The dialog
+     * must keep the badge distinguishable by POSITION (its own element),
+     * never by comparing it against the name text, and this case is the
+     * standing reminder that name text can be anything.
+     */
+    expect(normalizeReverseDnsName("Already-added")).toBe("Already-added");
   });
 
-  it("rejects a name one character over the limit", () => {
+  it("accepts a single label at the full 63 characters", () => {
+    /*
+     * Nothing here clamps for display — MAX_DEVICE_NAME_LENGTH (80) in
+     * DiscoveredDeviceBuilder and the `truncate` class in the dialog do that.
+     * If this function ever started truncating too, the displayed name and
+     * the created name would diverge, which is the bug the dialog was fixed
+     * to avoid.
+     */
+    const longLabel: string =
+      "very-long-single-label-".repeat(2) + "a".repeat(17);
+    expect(longLabel).toHaveLength(MAX_REVERSE_DNS_LABEL_LENGTH);
+    expect(normalizeReverseDnsName(longLabel)).toBe(longLabel);
+  });
+
+  it("accepts a name of only underscores", () => {
+    /*
+     * Ugly, and real: an underscore is a legal first and last character here
+     * precisely because Windows/DHCP-registered names use them. "___" is not
+     * a value to invent a special rule for — it slugifies fine (see the slug
+     * suite below) and it is still a name somebody published.
+     */
+    expect(normalizeReverseDnsName("___")).toBe("___");
+    expect(normalizeReverseDnsName("_")).toBe("_");
+  });
+
+  it("rejects a name of only hyphens", () => {
+    /*
+     * The mirror image of the underscore case, and it falls out of the
+     * "hyphen may not lead or trail" rule rather than a special case: with
+     * every character a hyphen, the first one always leads. Worth pinning
+     * because "-" and "--" are what a placeholder or a truncated answer looks
+     * like, and either would render as a device named nothing at all.
+     */
+    expect(normalizeReverseDnsName("-")).toBeUndefined();
+    expect(normalizeReverseDnsName("--")).toBeUndefined();
+    expect(normalizeReverseDnsName("---")).toBeUndefined();
+    expect(normalizeReverseDnsName("-.-")).toBeUndefined();
+  });
+
+  it("treats prototype-shaped values as the ordinary strings they are", () => {
+    /*
+     * "__proto__", "constructor" and "prototype" are valid DNS labels and are
+     * returned verbatim. That is correct AND safe here for a specific reason:
+     * this function only ever tests and returns the VALUE, never uses it as
+     * an object key, so there is no lookup for a magic name to hijack — the
+     * string's destinations are a varchar column and a React text node.
+     *
+     * The assertion that matters is `toBe`: a returned "__proto__" must be
+     * that literal string. If a future implementation routed names through
+     * an object map (a cache keyed by name, say), "__proto__" would come back
+     * as something else entirely, and this case would catch it.
+     *
+     * There is deliberately no `typeof ... === "string"` assertion alongside:
+     * `toBe("__proto__")` already implies it, so the typeof line could not
+     * fail on its own and only made the case look broader than it was.
+     */
+    expect(normalizeReverseDnsName("__proto__")).toBe("__proto__");
+    expect(normalizeReverseDnsName("constructor")).toBe("constructor");
+    expect(normalizeReverseDnsName("prototype.example.com")).toBe(
+      "prototype.example.com",
+    );
+  });
+});
+
+describe("normalizeReverseDnsName — accepted names are safe to slugify", () => {
+  /*
+   * NetworkDevice is @SlugifyColumn("name", "slug") with slug varchar(100),
+   * so every accepted name here becomes a URL segment without anyone looking
+   * at it again. Slug.getSlug strips [&*+~.,\\/()|'"!:@] — which includes the
+   * dot, the one character a hostname is made of — and then appends a
+   * ten-digit random suffix.
+   *
+   * The suffix is random but its SHAPE is not, and the regex below rests on
+   * that: Faker.getRandomNumbers(10) pushes ten digits each in 1..9 (never 0)
+   * and parses the joined string, so no leading zero can ever be dropped and
+   * the suffix is always exactly ten digits. Without that guarantee this
+   * suite would be intermittently red on roughly one run in ten.
+   *
+   * Because the suffix means getSlug's return value is never literally empty,
+   * a bare "is it non-empty" assertion would be unfalsifiable. So these cases
+   * assert on the NAME-DERIVED STEM: the slug must be more than the random
+   * suffix, AND it must still contain a recognisable piece of the name. A
+   * name that slugified away to nothing would give every such device a slug
+   * that is pure entropy, with no trace of what it names.
+   */
+
+  /*
+   * [name, the lower-case fragment of it that must survive slugification].
+   * The fragment is what a human would use to recognise the device in a URL,
+   * and it is written out rather than derived so that a change in getSlug
+   * that quietly mangled names has something concrete to fail against.
+   */
+  const acceptedNames: Array<[string, string]> = [
+    ["core-switch-01.corp.example.com", "core-switch-01"],
+    ["printer-3", "printer-3"],
+    ["ws_finance_12.corp.example.com", "ws_finance_12"],
+    ["10-18-166-51.dhcp.corp.example.com", "10-18-166-51"],
+    ["SW-Core-01.Corp.Example.COM", "sw-core-01"],
+    ["xn--hte-snab.example.com", "hte-snab"],
+    ["Already-added", "already-added"],
+    ["something.arpa", "somethingarpa"],
+    ["51.corp.example.com", "51corpexamplecom"],
+    ["notin-addr.arpa", "notin-addrarpa"],
+    ["___", "___"],
+    ["_", "_"],
+    ["a.b", "ab"],
+    ["a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH), "a".repeat(20)],
+  ];
+
+  it("leaves a name-derived stem in the slug for every accepted name", () => {
+    for (const [name, fragment] of acceptedNames) {
+      /*
+       * Guard the guard: if the gate stopped accepting one of these, the slug
+       * assertion below would be testing a value that never reaches a device.
+       */
+      expect(normalizeReverseDnsName(name)).toBe(name);
+
+      const slug: string = Slug.getSlug(name);
+
+      /*
+       * getSlug always appends "-" plus ten digits, so a name that slugified
+       * to "" yields exactly "-##########" — which fails this match, because
+       * the capture needs at least one character before the suffix.
+       */
+      const stem: RegExpMatchArray | null = slug.match(/^(.+)-\d{10}$/);
+      expect(stem).not.toBeNull();
+
+      /*
+       * And the stem must be THIS name's stem, not merely some non-empty
+       * string. The old assertion here was `expect(stem?.[1]).not.toBe("")`,
+       * which could not fail in either branch: a matched capture of `.+` is
+       * non-empty by construction, and an unmatched one is `undefined`, which
+       * also is not "". Comparing against the fragment is what makes the case
+       * die if the name stopped reaching the slug.
+       */
+      expect(stem?.[1]).toContain(fragment);
+    }
+  });
+
+  it("does not itself keep a name short enough for the slug column", () => {
+    /*
+     * The complement of the case above, and the reason MAX_DEVICE_NAME_LENGTH
+     * exists: this gate accepts up to 253 characters, which is well past the
+     * slug column's varchar(100). Length safety is DiscoveredDeviceBuilder's
+     * clamp to 80, not this function's — asserting it here pins where the
+     * responsibility lives, so nobody removes the clamp believing the DNS
+     * limit already covers it.
+     *
+     * Asserted on the length of what THIS function returns rather than on
+     * Slug.getSlug(...).length, deliberately: the claim is about this gate
+     * not truncating, and routing it through Slug would put a foreign
+     * module's behaviour (if Slug ever gained a clamp of its own) on the
+     * failure path of a suite that does not own it.
+     */
     const label: string = "a".repeat(MAX_REVERSE_DNS_LABEL_LENGTH);
-    const name: string = `${label}.${label}.${label}.${"b".repeat(62)}`;
-    expect(name).toHaveLength(MAX_REVERSE_DNS_NAME_LENGTH + 1);
-    expect(normalizeReverseDnsName(name)).toBeUndefined();
-  });
-
-  it("rejects an absurdly long value without depending on the label rule", () => {
-    // A single 10,000-character label: caught by the name limit first.
-    expect(normalizeReverseDnsName("a".repeat(10000))).toBeUndefined();
+    const maximalName: string = `${label}.${label}.${label}.${"b".repeat(61)}`;
+    const normalized: string | undefined = normalizeReverseDnsName(maximalName);
+    expect(normalized).toBe(maximalName);
+    expect(normalized?.length).toBeGreaterThan(100);
   });
 });
 
@@ -290,6 +756,11 @@ describe("normalizeReverseDnsName — non-string input", () => {
    * undefined rather than throw inside a React render. This is the same
    * lesson normalizeDiscoveredHosts learned from a null row in the same
    * column.
+   *
+   * This block is also what covers re-normalising the `undefined` that a
+   * rejected name produces: a later stage feeding its own output back in is
+   * exactly `normalizeReverseDnsName(undefined)`, pinned once here rather
+   * than re-spelled in a loop that only ever passed it the same value.
    */
 
   it("returns undefined for nullish input", () => {
@@ -316,25 +787,96 @@ describe("normalizeReverseDnsName — non-string input", () => {
   });
 });
 
-describe("normalizeReverseDnsName — idempotence", () => {
+describe("normalizeReverseDnsName — idempotence and repeat-call stability", () => {
   /*
    * The value is normalised on the probe, again by normalizeDiscoveredHosts
-   * on the way out of the column, and again by getDiscoveredHostDisplayName
-   * at the point of use. Three passes must produce what one pass produced, or
-   * the name an operator ticks and the name the device gets could differ.
+   * on the way out of the jsonb column, and again by
+   * getDiscoveredHostDisplayName at the point of use. Three passes must
+   * produce what one pass produced, or the name an operator ticks in the
+   * Review dialog and the name the created device gets could differ.
    */
-  it("is stable under repeated application", () => {
-    const inputs: Array<string> = [
-      "host.example.com.",
-      "  SW-Core-01.corp.example.com  ",
-      "printer_2",
-      "10.18.166.51",
-      "<script>",
+
+  it("returns an accepted name unchanged on every later pass", () => {
+    /*
+     * Each of these CHANGES on the first pass — a root dot dropped, surrounding
+     * whitespace trimmed — so the second pass is a real test of convergence
+     * rather than a repeat of a no-op.
+     */
+    const changedByNormalisation: Array<[string, string]> = [
+      ["host.example.com.", "host.example.com"],
+      ["  SW-Core-01.corp.example.com  ", "SW-Core-01.corp.example.com"],
+      ["\tprinter_2\n", "printer_2"],
+      ["  51.corp.example.com.  ", "51.corp.example.com"],
     ];
 
-    for (const input of inputs) {
-      const once: string | undefined = normalizeReverseDnsName(input);
-      expect(normalizeReverseDnsName(once)).toBe(once);
+    for (const [input, expected] of changedByNormalisation) {
+      const first: string | undefined = normalizeReverseDnsName(input);
+      expect(first).toBe(expected);
+
+      const second: string | undefined = normalizeReverseDnsName(first);
+      const third: string | undefined = normalizeReverseDnsName(second);
+
+      /*
+       * Compared against the expected STRING, not against `first`: comparing
+       * the passes to each other would be satisfied by `undefined ===
+       * undefined` if a later pass dropped the name entirely.
+       */
+      expect(second).toBe(expected);
+      expect(third).toBe(expected);
+    }
+  });
+
+  it("keeps an already-normalised name byte-identical", () => {
+    const alreadyNormal: Array<string> = [
+      "core-switch-01.corp.example.com",
+      "ws_finance_12.corp.example.com",
+      "something.arpa",
+      "notin-addr.arpa",
+      "51.corp.example.com",
+      "xn--hte-snab.example.com",
+    ];
+
+    for (const name of alreadyNormal) {
+      expect(normalizeReverseDnsName(name)).toBe(name);
+    }
+  });
+
+  it("gives the same answer when the same value is passed again", () => {
+    /*
+     * Purity, asserted by calling the function repeatedly on the IDENTICAL
+     * input and requiring the identical answer each time.
+     *
+     * This is not the tautology it looks like, and it replaces a loop whose
+     * second assertion was always `normalizeReverseDnsName(undefined)` — the
+     * same call for every input, unable to fail unless the nullish case
+     * already had. The mutation this one exists for is a `g` flag on either
+     * module-level regex, a one-character edit that reads as harmless
+     * housekeeping: `RegExp.prototype.test` with /g advances `lastIndex`, so
+     * `/^[0-9]+$/g.test("51")` is true, then false, then true again on
+     * successive calls. Under it "51" would be rejected on the probe and
+     * ACCEPTED on the server's re-normalisation of the same string — the
+     * dialog and the created device disagreeing about a device's name, with
+     * nothing to show for it in a single-call test. A memoising cache keyed
+     * by name would land here too.
+     *
+     * Both directions are in the table on purpose: a rejected value must stay
+     * rejected across calls, and an accepted one must stay accepted.
+     */
+    const repeated: Array<[unknown, string | undefined]> = [
+      ["51", undefined],
+      ["10.18.166.51", undefined],
+      ["in-addr.arpa", undefined],
+      ["host..example.com", undefined],
+      ["a".repeat(MAX_REVERSE_DNS_NAME_LENGTH + 1), undefined],
+      ["51.corp.example.com", "51.corp.example.com"],
+      ["core-switch-01.corp.example.com", "core-switch-01.corp.example.com"],
+      ["___", "___"],
+    ];
+
+    for (const [value, expected] of repeated) {
+      expect(normalizeReverseDnsName(value)).toBe(expected);
+      expect(normalizeReverseDnsName(value)).toBe(expected);
+      expect(normalizeReverseDnsName(value)).toBe(expected);
     }
   });
 });

--- a/Common/Utils/NetworkDiscovery/DiscoveredDeviceBuilder.ts
+++ b/Common/Utils/NetworkDiscovery/DiscoveredDeviceBuilder.ts
@@ -59,8 +59,26 @@ function truncate(value: string, maxLength: number): string {
  *
  * Split out of `buildDeviceName` so the dashboard row and the device it
  * creates cannot disagree: the operator ticks a box next to a name, and that
- * is the name the device gets. Returned UNTRUNCATED — the display has its own
- * ellipsis and the 80-character ceiling exists for the slug, not the eye.
+ * is the name the device gets. Returned UNTRUNCATED, so a caller that wants
+ * the full name can have it; the Review dialog and the import both go through
+ * `buildDeviceName`, which clamps, so that what is shown is what is created.
+ *
+ * TWO CONSEQUENCES OF NAMING A DEVICE BY DNS, both accepted deliberately:
+ *
+ *   - Anything that matches on `NetworkDevice.name` now sees a name the
+ *     SCANNED NETWORK chose. NetworkSiteAssignmentRule and the label/owner
+ *     rule engines are the live examples: a rule written against a naming
+ *     convention will match differently for a host that used to be called
+ *     "10.18.166.51" and is now called "core-gw.corp.example.com". That is
+ *     inherent to the feature — the alternative is not naming devices by DNS —
+ *     and it is why the name is put through ReverseDnsNameUtil rather than
+ *     trusted. Rules keyed on `hostname` are unaffected: that stays the IP.
+ *   - Names stop being unique per host. Addresses were; PTR names are not, and
+ *     a wildcard reverse zone over a DHCP range gives every host in it the
+ *     same answer. `buildFallbackDeviceName` is the answer to that, and BOTH
+ *     import paths must use it — the rule engine does, and the dashboard's
+ *     Review-dialog import does since the same wildcard case made collisions
+ *     ordinary rather than rare.
  */
 export function getDiscoveredHostDisplayName(
   host: DiscoveredNetworkDevice,
@@ -74,10 +92,23 @@ export function getDiscoveredHostDisplayName(
    * point before the value becomes a rendered line and a slugified device
    * name, so it is the right place to be sure. See ReverseDnsNameUtil.
    */
+  /*
+   * `sysName` is read through a typeof guard rather than trusted, for the
+   * same reason `dnsHostname` is normalised: both come out of the same
+   * verbatim jsonb blob, where the declared TypeScript type is a description
+   * of what the probe SHOULD send rather than a guarantee about what is
+   * stored. `(42).trim()` is a TypeError, and since this function became the
+   * dashboard's name line that TypeError would be thrown during render —
+   * taking out the whole Review dialog rather than one row, which is
+   * precisely the failure normalizeDiscoveredHosts was written to end.
+   */
+  const sysName: string =
+    typeof host.sysName === "string" ? host.sysName.trim() : "";
+
   return (
-    (host.sysName || "").trim() ||
+    sysName ||
     normalizeReverseDnsName(host.dnsHostname) ||
-    host.ipAddress
+    String(host.ipAddress ?? "")
   );
 }
 
@@ -96,12 +127,42 @@ export function buildDeviceName(host: DiscoveredNetworkDevice): string {
  * ceiling.
  */
 export function buildFallbackDeviceName(host: DiscoveredNetworkDevice): string {
-  const suffix: string = ` (${host.ipAddress})`;
+  /*
+   * The address is read through the SAME coercion the display path uses, not
+   * straight out of the jsonb.
+   *
+   * A raw template read turned a missing address into the literal
+   * " (undefined)" and an object one into " ([object Object])" — and those
+   * tokens are IDENTICAL for every such host, so the fallback produced the
+   * same name again and the retry failed on the very duplicate it was
+   * retrying. This function exists to break a name collision; a suffix that
+   * collides is worse than useless.
+   */
+  const address: string = String(host.ipAddress ?? "").trim();
+
+  /*
+   * An address-less host gets no suffix at all rather than an empty pair of
+   * brackets. There is nothing to tell it apart BY, so the honest outcome is
+   * the base name unchanged — the caller's create then fails on the duplicate,
+   * which is the truth, instead of succeeding under a name that pretends to
+   * carry an address.
+   */
+  const suffix: string = address ? ` (${address})` : "";
+
   const baseName: string = buildDeviceName(host);
 
-  return (
+  /*
+   * Clamped as a whole, not just the base. `Math.max(1, ...)` keeps a
+   * character of the base name however long the suffix is, so an absurd
+   * address — the field is never validated on this path, it is whatever the
+   * probe wrote — could compose a name past the ceiling and fail the create on
+   * the slug's own length, which is the exact overflow the ceiling exists to
+   * prevent.
+   */
+  return truncate(
     truncate(baseName, Math.max(1, MAX_DEVICE_NAME_LENGTH - suffix.length)) +
-    suffix
+      suffix,
+    MAX_DEVICE_NAME_LENGTH,
   );
 }
 
@@ -183,8 +244,16 @@ export function buildNetworkDeviceFromDiscoveredHost(data: {
    * would make a device stop polling the day its reverse zone changed, and
    * would make the same host import twice — once by address, once by name.
    * The PTR record names the device; it does not address it.
+   *
+   * COERCED, because the dedup key has to be a string. The value comes out of
+   * jsonb, and `getRegisteredHostnames` matches it with `Set.has()` against
+   * hostnames read back from the database — and `Set.has` does not coerce, so
+   * a numeric address stored raw would never match its own registered device
+   * and the host would import again on every review. The dashboard path is
+   * already covered by normalizeDiscoveredHosts; this makes the builder safe
+   * for the rule engine and for any future caller that holds a raw row.
    */
-  device.hostname = host.ipAddress;
+  device.hostname = String(host.ipAddress ?? "").trim();
 
   if (host.sysDescr) {
     device.description = truncate(host.sysDescr, MAX_DEVICE_DESCRIPTION_LENGTH);

--- a/Common/Utils/NetworkDiscovery/DiscoveredHostUtil.ts
+++ b/Common/Utils/NetworkDiscovery/DiscoveredHostUtil.ts
@@ -75,6 +75,30 @@ export function normalizeDiscoveredHosts(
     };
 
     /*
+     * `sysName` is read straight out of the jsonb, its declared type is not
+     * enforced by anything, and every reader calls a string method on it. A
+     * numeric sysName reached getDiscoveredHostDisplayName and threw inside
+     * the Review dialog's render, taking out the whole modal rather than one
+     * row — the same failure the null-row case above is about.
+     *
+     * A non-string is blanked rather than STRINGIFIED, which is where this
+     * differs from the address above. `String(null)` is "null" and
+     * `String({})` is "[object Object]", and both are truthy — so stringifying
+     * would not merely fail to name the host, it would win the naming contest
+     * outright and create a device called "null", beating a perfectly good PTR
+     * record on the very same row. An empty string is falsy, so naming falls
+     * through to `dnsHostname` and then to the address, which is exactly what
+     * a host with no readable system name deserves.
+     *
+     * Only rewritten when it is NOT already a string, so a host that never had
+     * the key does not gain an empty one — `sysName` is optional and
+     * `"sysName" in host` is a question other code is entitled to ask.
+     */
+    if (host.sysName !== undefined && typeof host.sysName !== "string") {
+      normalized.sysName = "";
+    }
+
+    /*
      * The PTR name gets the same treatment, for a sharper version of the same
      * reason (OneUptime issue #3529): unlike every other field here, its
      * value was chosen by whoever runs DNS for the scanned subnet — routinely

--- a/Common/Utils/NetworkDiscovery/ReverseDnsNameUtil.ts
+++ b/Common/Utils/NetworkDiscovery/ReverseDnsNameUtil.ts
@@ -53,10 +53,7 @@ const LABEL_PATTERN: RegExp = /^[A-Za-z0-9_](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?$/;
  * "51.166.18.10.in-addr.arpa", which passes every other rule here and is a
  * strictly worse device name than the address it was derived from.
  */
-const REVERSE_LOOKUP_ZONE_SUFFIXES: Array<string> = [
-  ".in-addr.arpa",
-  ".ip6.arpa",
-];
+const REVERSE_LOOKUP_ZONES: Array<string> = ["in-addr.arpa", "ip6.arpa"];
 
 /*
  * True when every label is digits — "10.18.166.51", but also "51" and "1.2".
@@ -120,8 +117,14 @@ export function normalizeReverseDnsName(value: unknown): string | undefined {
 
   const lowerCased: string = withoutRootLabel.toLowerCase();
 
-  for (const suffix of REVERSE_LOOKUP_ZONE_SUFFIXES) {
-    if (lowerCased.endsWith(suffix)) {
+  for (const zone of REVERSE_LOOKUP_ZONES) {
+    /*
+     * The apex is checked as well as the suffix. `in-addr.arpa` on its own is
+     * a legal hostname string that passes every other rule here, and it is
+     * what a resolver echoing a truncated query name hands back — a strictly
+     * worse label for a device than the address it was derived from.
+     */
+    if (lowerCased === zone || lowerCased.endsWith(`.${zone}`)) {
       return undefined;
     }
   }

--- a/Probe/Jobs/Discovery/FetchScans.ts
+++ b/Probe/Jobs/Discovery/FetchScans.ts
@@ -537,7 +537,46 @@ export async function scanWithDeadline(
   );
 
   try {
-    return await Promise.race([SubnetScanner.scan(config), deadline]);
+    const result: SubnetScanResult = await Promise.race([
+      SubnetScanner.scan(config),
+      deadline,
+    ]);
+
+    /*
+     * Reverse DNS (OneUptime issue #3529) runs HERE — after the race has
+     * settled — and not inside scan().
+     *
+     * The race is winner-takes-all: if the sweep has not settled by the
+     * deadline, this function rejects and runScan reports the scan Failed
+     * with no hosts at all. Naming hosts inside scan() would spend that same
+     * budget, so a sweep that had already found every host on the subnet
+     * could be discarded wholesale because looking up their names took the
+     * run past the line. An enrichment must not be able to destroy the result
+     * it exists to improve, and the pass's own 60s cap bounds how much it
+     * adds without stopping it being the straw that breaks the deadline.
+     *
+     * Past this line the sweep has WON its race. `result` is final, the
+     * deadline can no longer discard it, and attachReverseDnsHostnames never
+     * throws — so the worst case is hosts named by address, exactly as they
+     * were before this feature existed.
+     *
+     * The timer is disarmed FIRST rather than left to the finally. It is
+     * still armed at this point, and the enrichment can take up to a minute:
+     * leaving it running would let it fire mid-lookup and write
+     * "did not settle ... Abandoning this sweep" to the probe log at ERROR
+     * level about a sweep that finished cleanly and whose result is on its
+     * way back. The log line would be a pure fabrication, and it is the line
+     * an operator would be reading to explain a failure that never happened.
+     */
+    if (deadlineTimer) {
+      clearTimeout(deadlineTimer);
+      deadlineTimer = undefined;
+    }
+
+    result.reverseDnsResolvedCount =
+      await SubnetScanner.attachReverseDnsHostnames(result.discoveredHosts);
+
+    return result;
   } finally {
     /*
      * Always clear it: an un-cleared timer holds the event loop open after an
@@ -776,10 +815,26 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
       return;
     }
 
+    /*
+     * The reverse-DNS tally rides on the same line rather than getting one of
+     * its own, and is omitted entirely when the pass did not run (undefined,
+     * which is a different statement from zero — see reverseDnsResolvedCount).
+     *
+     * It is the only place an operator can tell "this subnet publishes no PTR
+     * records" apart from "this probe cannot resolve", without reading the
+     * warning ReverseDnsResolver emits only in the second case. A scan whose
+     * Review dialog is all bare addresses is otherwise indistinguishable
+     * between the two.
+     */
+    const namedSuffix: string =
+      scanResult.reverseDnsResolvedCount === undefined
+        ? ""
+        : `, ${scanResult.reverseDnsResolvedCount} named by reverse DNS`;
+
     logger.debug(
       scanResult.isIcmpOnlySweep
-        ? `Discovery scan ${scan.id?.toString()} found ${scanResult.discoveredHosts.length} host(s) answering ICMP (SNMP checking is off)`
-        : `Discovery scan ${scan.id?.toString()} found ${snmpResponderCount} SNMP hosts (${scanResult.discoveredHosts.length} alive in total)`,
+        ? `Discovery scan ${scan.id?.toString()} found ${scanResult.discoveredHosts.length} host(s) answering ICMP (SNMP checking is off)${namedSuffix}`
+        : `Discovery scan ${scan.id?.toString()} found ${snmpResponderCount} SNMP hosts (${scanResult.discoveredHosts.length} alive in total)${namedSuffix}`,
     );
   } catch (uploadErr) {
     logger.error(

--- a/Probe/Tests/Jobs/Discovery/DiscoveryReverseDns.test.ts
+++ b/Probe/Tests/Jobs/Discovery/DiscoveryReverseDns.test.ts
@@ -1,17 +1,8 @@
 // Set required env vars before importing modules that pull in Config.ts.
-process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
 process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
 
-import SubnetScanner, {
-  DiscoveredHost,
-  SubnetScanResult,
-  type SubnetScanSnmpConfig,
-} from "../../../Utils/Discovery/SubnetScanner";
-import { ReverseDnsResolution } from "../../../Utils/Discovery/ReverseDnsResolver";
-import SnmpMonitor from "../../../Utils/Monitors/MonitorTypes/SnmpMonitor";
-import MonitorStepSnmpMonitor from "Common/Types/Monitor/MonitorStepSnmpMonitor";
-import SnmpVersion from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
-import logger from "Common/Server/Utils/Logger";
 import {
   afterEach,
   beforeEach,
@@ -20,31 +11,68 @@ import {
   it,
   jest,
 } from "@jest/globals";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+
+type CapturedCronJob = {
+  jobName: string;
+  runFunction: PromiseVoidFunction;
+};
+
+const mockCapturedCronJobs: Array<CapturedCronJob> = [];
+
+jest.mock("Common/Server/Utils/BasicCron", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedCronJob): void => {
+      mockCapturedCronJobs.push(props);
+    },
+  };
+});
+
+import SubnetScanner, {
+  DiscoveredHost,
+  SubnetScanConfig,
+  SubnetScanResult,
+  type SubnetScanSnmpConfig,
+} from "../../../Utils/Discovery/SubnetScanner";
+import { ReverseDnsResolution } from "../../../Utils/Discovery/ReverseDnsResolver";
+import SnmpMonitor from "../../../Utils/Monitors/MonitorTypes/SnmpMonitor";
+import MonitorStepSnmpMonitor from "Common/Types/Monitor/MonitorStepSnmpMonitor";
+import SnmpVersion from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
+import logger from "Common/Server/Utils/Logger";
+import { scanWithDeadline } from "../../../Jobs/Discovery/FetchScans";
 
 /*
  * OneUptime issue #3529 — "Network Discovery Scan should perform reverse DNS
  * lookup and display hostnames".
  *
  * The reported symptom was a Review dialog listing 10.18.166.51, .53, .54,
- * .55 on an estate where every one of those addresses has a DNS record. What
- * the reporter was looking at was a sweep of hosts with no readable SNMP:
- * with no sysName there was nothing to call them but their address.
+ * .55 on an estate where every one of those addresses has a DNS record. Those
+ * rows are hosts with no readable SNMP: with no sysName there was nothing to
+ * call them but their address.
  *
- * This file is about the SWEEP's half of the fix — that a completed sweep
- * asks for a PTR record per discovered host and stamps the answer onto the
- * record it returns. Which answers are usable is ReverseDnsNameUtil's
- * contract, and what a resolver failure costs is ReverseDnsResolver's; both
- * have their own suites. What is pinned HERE is narrower and, for a feature
- * bolted onto a working sweep, more important:
+ * This file pins the PROBE half of the fix, and it drives `scanWithDeadline`
+ * rather than `SubnetScanner.scan` on purpose — because WHERE the pass runs is
+ * itself one of the guarantees.
  *
- *   1. Both return paths enrich. The ICMP-only path returns from the middle
- *      of scan() and is the path the issue was actually reported against, so
- *      an enrichment added only to the SNMP path at the bottom would miss the
- *      case it was written for entirely — and would do it silently.
- *   2. Nothing about the sweep changes. Reverse DNS runs after the hosts, the
- *      counts, the ordering and the error tallies are all decided. A resolver
- *      that is broken, slow, hostile or absent must leave a completed sweep
- *      byte-identical to what it was before this existed.
+ * The sweep runs inside a deadline race: if it has not settled by
+ * PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS, `scanWithDeadline` rejects and the scan
+ * is reported Failed with no hosts at all. The reverse-DNS pass originally sat
+ * at the end of `scan()`, inside that race, which meant a sweep that had
+ * already found every host on a subnet could be thrown away wholesale because
+ * looking up their names took the run past the line — an enrichment destroying
+ * the result it exists to improve. It now runs after the race has settled, and
+ * "after the race" is only observable from here.
+ *
+ * So this file pins three things:
+ *
+ *   1. Hosts get named — on both sweep return paths, including the ICMP-only
+ *      one the issue was actually reported against, and including the hosts
+ *      the ICMP-filtered fallback pass finds.
+ *   2. Naming NEVER costs a sweep its results. Not when the resolver is
+ *      broken, not when the pass throws, and — the case with teeth — not when
+ *      the pass is slower than the sweep's entire remaining deadline.
+ *   3. The sweep itself is untouched: same hosts, same order, same tallies.
  */
 
 const SIX_HOSTS: string = "10.0.0.0/29";
@@ -83,13 +111,13 @@ function mockSnmp(sysNameByHost: Record<string, string>): void {
 }
 
 /*
- * Replaces the sweep's reverse-DNS seam with a fixed table, and records which
+ * Replaces the reverse-DNS seam with a fixed table, and records which
  * addresses it was asked about — "was it asked at all, and only for the hosts
  * it found" is half of what this file checks.
  */
 function mockReverseDns(
   hostnameByIpAddress: Record<string, string>,
-  overrides?: Partial<ReverseDnsResolution>,
+  overrides?: Partial<ReverseDnsResolution> & { delayInMs?: number },
 ): { asked: Array<Array<string>> } {
   const asked: Array<Array<string>> = [];
 
@@ -98,6 +126,12 @@ function mockReverseDns(
     .mockImplementation(
       async (ipAddresses: Array<string>): Promise<ReverseDnsResolution> => {
         asked.push([...ipAddresses]);
+
+        if (overrides?.delayInMs) {
+          await new Promise<void>((resolve: () => void) => {
+            setTimeout(resolve, overrides.delayInMs);
+          });
+        }
 
         return {
           hostnameByIpAddress: new Map<string, string>(
@@ -111,6 +145,27 @@ function mockReverseDns(
     );
 
   return { asked: asked };
+}
+
+function icmpOnly(): SubnetScanConfig {
+  return { cidr: SIX_HOSTS, isSnmpEnabled: false };
+}
+
+function withSnmp(): SubnetScanConfig {
+  return { cidr: SIX_HOSTS, snmpConfigs: [snmpConfig()] };
+}
+
+/*
+ * A deadline long enough that nothing in this file trips it by accident. The
+ * one test that IS about the deadline sets its own.
+ */
+const GENEROUS_DEADLINE_IN_MS: number = 30000;
+
+function sweep(
+  config: SubnetScanConfig,
+  deadlineInMs: number = GENEROUS_DEADLINE_IN_MS,
+): Promise<SubnetScanResult> {
+  return scanWithDeadline(config, "scan-3529", deadlineInMs);
 }
 
 function hostAt(
@@ -127,6 +182,9 @@ beforeEach(() => {
     return undefined as never;
   });
   jest.spyOn(logger, "debug").mockImplementation(() => {
+    return undefined as never;
+  });
+  jest.spyOn(logger, "error").mockImplementation(() => {
     return undefined as never;
   });
 });
@@ -149,10 +207,7 @@ describe("an ICMP-only sweep — the case the issue was reported against", () =>
       "10.0.0.2": "printer-3.corp.example.com",
     });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(hostAt(result, "10.0.0.1")?.dnsHostname).toBe(
       "core-gw.corp.example.com",
@@ -174,7 +229,7 @@ describe("an ICMP-only sweep — the case the issue was reported against", () =>
     mockPingAlive(["10.0.0.2", "10.0.0.5"]);
     const reverseDns: { asked: Array<Array<string>> } = mockReverseDns({});
 
-    await SubnetScanner.scan({ cidr: SIX_HOSTS, isSnmpEnabled: false });
+    await sweep(icmpOnly());
 
     expect(reverseDns.asked).toHaveLength(1);
     expect(reverseDns.asked[0]).toEqual(["10.0.0.2", "10.0.0.5"]);
@@ -184,10 +239,7 @@ describe("an ICMP-only sweep — the case the issue was reported against", () =>
     mockPingAlive([]);
     const reverseDns: { asked: Array<Array<string>> } = mockReverseDns({});
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(reverseDns.asked).toHaveLength(0);
     expect(result.discoveredHosts).toHaveLength(0);
@@ -203,10 +255,7 @@ describe("an ICMP-only sweep — the case the issue was reported against", () =>
     mockPingAlive(["10.0.0.1"]);
     mockReverseDns({ "10.0.0.1": "gw.corp.example.com" });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(hostAt(result, "10.0.0.1")).toEqual({
       ipAddress: "10.0.0.1",
@@ -219,10 +268,7 @@ describe("an ICMP-only sweep — the case the issue was reported against", () =>
     mockPingAlive(["10.0.0.1", "10.0.0.4", "10.0.0.6"]);
     mockReverseDns({ "10.0.0.4": "middle.corp.example.com" });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(
       result.discoveredHosts.map((host: DiscoveredHost) => {
@@ -235,10 +281,7 @@ describe("an ICMP-only sweep — the case the issue was reported against", () =>
     mockPingAlive(["10.0.0.1", "10.0.0.2"]);
     mockReverseDns({ "10.0.0.1": "gw.corp.example.com" });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(result.scannedHostCount).toBe(6);
     expect(result.respondedToPingCount).toBe(2);
@@ -257,15 +300,12 @@ describe("an SNMP sweep — naming alongside the system group", () => {
       "10.0.0.2": "cam-lobby.corp.example.com",
     });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      snmpConfigs: [snmpConfig()],
-    });
+    const result: SubnetScanResult = await sweep(withSnmp());
 
     /*
      * The SNMP responder keeps its sysName AND gains a PTR name. Which of the
      * two wins as the device's name is DiscoveredDeviceBuilder's decision,
-     * not the scanner's — the scanner's job is to report both facts.
+     * not the probe's — the probe's job is to report both facts.
      */
     expect(hostAt(result, "10.0.0.1")?.sysName).toBe("core-switch-01");
     expect(hostAt(result, "10.0.0.1")?.dnsHostname).toBe(
@@ -288,13 +328,10 @@ describe("an SNMP sweep — naming alongside the system group", () => {
     mockSnmp({ "10.0.0.2": "switch-2" });
     const reverseDns: { asked: Array<Array<string>> } = mockReverseDns({});
 
-    await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      snmpConfigs: [snmpConfig()],
-    });
+    await sweep(withSnmp());
 
     expect(reverseDns.asked).toHaveLength(1);
-    expect(reverseDns.asked[0]!.sort()).toEqual([
+    expect(reverseDns.asked[0]!.slice().sort()).toEqual([
       "10.0.0.1",
       "10.0.0.2",
       "10.0.0.3",
@@ -313,10 +350,7 @@ describe("an SNMP sweep — naming alongside the system group", () => {
     mockSnmp({ "10.0.0.4": "hidden-switch" });
     mockReverseDns({ "10.0.0.4": "mgmt-sw.corp.example.com" });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      snmpConfigs: [snmpConfig()],
-    });
+    const result: SubnetScanResult = await sweep(withSnmp());
 
     expect(result.icmpFilteredFallbackHostCount).toBeGreaterThan(0);
     expect(hostAt(result, "10.0.0.4")?.dnsHostname).toBe(
@@ -329,10 +363,7 @@ describe("an SNMP sweep — naming alongside the system group", () => {
     mockSnmp({ "10.0.0.1": "core-switch-01" });
     mockReverseDns({ "10.0.0.1": "sw1.corp.example.com" });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      snmpConfigs: [snmpConfig()],
-    });
+    const result: SubnetScanResult = await sweep(withSnmp());
 
     expect(result.scannedHostCount).toBe(6);
     expect(result.respondedToPingCount).toBe(2);
@@ -342,20 +373,71 @@ describe("an SNMP sweep — naming alongside the system group", () => {
   });
 });
 
-describe("naming never costs a sweep its results", () => {
+describe("naming runs OUTSIDE the sweep's deadline", () => {
   /*
-   * The guarantee that outranks the feature itself. Every one of these is a
-   * completed sweep whose hosts must survive the enrichment intact.
+   * The guarantee this file exists at the job layer to state.
+   *
+   * scanWithDeadline races the sweep against PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS
+   * and, on a loss, rejects — runScan then reports the scan Failed with zero
+   * hosts. While the reverse-DNS pass lived at the end of scan() it spent that
+   * same budget, so a completed sweep could be discarded because naming its
+   * hosts was slow. These tests would have failed then and must never pass
+   * again if the pass moves back inside.
    */
 
+  it("a lookup pass slower than the whole deadline still returns the sweep's hosts", async () => {
+    mockPingAlive(["10.0.0.1", "10.0.0.2"]);
+    // 250ms of naming against a 120ms deadline: fatal if it were inside.
+    mockReverseDns({ "10.0.0.1": "gw.corp.example.com" }, { delayInMs: 250 });
+
+    const result: SubnetScanResult = await sweep(icmpOnly(), 120);
+
+    expect(result.discoveredHosts).toHaveLength(2);
+    expect(hostAt(result, "10.0.0.1")?.dnsHostname).toBe("gw.corp.example.com");
+  });
+
+  it("does not log the deadline's abandonment message for a sweep that finished", async () => {
+    /*
+     * The timer is disarmed before the lookups rather than in the finally. An
+     * armed timer firing mid-lookup writes "did not settle ... Abandoning this
+     * sweep" at ERROR level about a sweep whose result is already on its way
+     * back — a fabricated line, and precisely the line an operator would read
+     * to explain a failure that never happened.
+     */
+    mockPingAlive(["10.0.0.1"]);
+    mockReverseDns({}, { delayInMs: 250 });
+
+    await sweep(icmpOnly(), 120);
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("still fails a sweep that genuinely misses its deadline", async () => {
+    /*
+     * The other half: moving the pass out must not have disarmed the deadline
+     * for the sweep itself.
+     */
+    jest
+      .spyOn(SubnetScanner, "scan")
+      .mockImplementation((): Promise<SubnetScanResult> => {
+        return new Promise<SubnetScanResult>(() => {});
+      });
+    const reverseDns: { asked: Array<Array<string>> } = mockReverseDns({});
+
+    await expect(sweep(icmpOnly(), 80)).rejects.toThrow(
+      /did not finish|was abandoned/i,
+    );
+    // And the pass never ran, because there was no result to enrich.
+    expect(reverseDns.asked).toHaveLength(0);
+  });
+});
+
+describe("naming never costs a sweep its results", () => {
   it("returns the sweep's hosts when the resolver names nobody", async () => {
     mockPingAlive(["10.0.0.1", "10.0.0.2"]);
     mockReverseDns({}, { isReverseDnsAvailable: false });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(result.discoveredHosts).toHaveLength(2);
     expect(hostAt(result, "10.0.0.1")?.dnsHostname).toBeUndefined();
@@ -374,10 +456,7 @@ describe("naming never costs a sweep its results", () => {
       .spyOn(SubnetScanner, "resolveReverseDnsHostnames")
       .mockRejectedValue(new Error("resolver blew up"));
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(result.discoveredHosts).toHaveLength(2);
     expect(result.reverseDnsResolvedCount).toBe(0);
@@ -392,10 +471,7 @@ describe("naming never costs a sweep its results", () => {
       .spyOn(SubnetScanner, "resolveReverseDnsHostnames")
       .mockRejectedValue(new Error("resolver blew up"));
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      snmpConfigs: [snmpConfig()],
-    });
+    const result: SubnetScanResult = await sweep(withSnmp());
 
     expect(result.discoveredHosts).toHaveLength(1);
     expect(hostAt(result, "10.0.0.1")?.sysName).toBe("core-switch-01");
@@ -412,10 +488,7 @@ describe("naming never costs a sweep its results", () => {
       "10.0.0.99": "ghost.corp.example.com",
     });
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(result.discoveredHosts).toHaveLength(1);
     expect(result.reverseDnsResolvedCount).toBe(1);
@@ -428,14 +501,36 @@ describe("naming never costs a sweep its results", () => {
       { isTimeBudgetExhausted: true },
     );
 
-    const result: SubnetScanResult = await SubnetScanner.scan({
-      cidr: SIX_HOSTS,
-      isSnmpEnabled: false,
-    });
+    const result: SubnetScanResult = await sweep(icmpOnly());
 
     expect(result.discoveredHosts).toHaveLength(2);
     expect(hostAt(result, "10.0.0.1")?.dnsHostname).toBe("gw.corp.example.com");
     expect(hostAt(result, "10.0.0.2")?.dnsHostname).toBeUndefined();
+  });
+});
+
+describe("SubnetScanner.scan itself does no naming", () => {
+  /*
+   * Stated positively, because it is a REQUIREMENT and not an accident. If
+   * somebody puts the pass back inside scan(), these fail — and so does the
+   * deadline group above, which is the one that explains why.
+   */
+
+  it("returns hosts with no dnsHostname and no resolved count", async () => {
+    mockPingAlive(["10.0.0.1", "10.0.0.2"]);
+    const reverseDns: { asked: Array<Array<string>> } = mockReverseDns({
+      "10.0.0.1": "gw.corp.example.com",
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan(icmpOnly());
+
+    expect(reverseDns.asked).toHaveLength(0);
+    expect(hostAt(result, "10.0.0.1")?.dnsHostname).toBeUndefined();
+    /*
+     * Absent, not zero. Zero would say "the pass ran and named nobody"; this
+     * result has simply not been through it.
+     */
+    expect(result.reverseDnsResolvedCount).toBeUndefined();
   });
 });
 
@@ -448,7 +543,7 @@ describe("SubnetScanner.attachReverseDnsHostnames — used directly", () => {
   });
 
   it("stamps names onto the array it was given", async () => {
-    // In place, on the exact array the caller is about to return.
+    // In place, on the exact array the caller already holds.
     mockReverseDns({ "10.0.0.2": "printer.corp.example.com" });
 
     const hosts: Array<DiscoveredHost> = [
@@ -461,5 +556,24 @@ describe("SubnetScanner.attachReverseDnsHostnames — used directly", () => {
     expect(count).toBe(1);
     expect(hosts[0]!.dnsHostname).toBeUndefined();
     expect(hosts[1]!.dnsHostname).toBe("printer.corp.example.com");
+  });
+
+  it("keeps the array's identity and length", async () => {
+    /*
+     * scanWithDeadline mutates the result it is about to return, and an
+     * existing deadline test asserts that result is the very object the sweep
+     * produced. Replacing the array would break that silently.
+     */
+    mockReverseDns({ "10.0.0.1": "gw.corp.example.com" });
+
+    const hosts: Array<DiscoveredHost> = [
+      { ipAddress: "10.0.0.1", snmpReachable: false },
+    ];
+    const same: Array<DiscoveredHost> = hosts;
+
+    await SubnetScanner.attachReverseDnsHostnames(hosts);
+
+    expect(hosts).toBe(same);
+    expect(hosts).toHaveLength(1);
   });
 });

--- a/Probe/Tests/Jobs/Discovery/DiscoveryScanStatusMessage.test.ts
+++ b/Probe/Tests/Jobs/Discovery/DiscoveryScanStatusMessage.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../Utils/Discovery/SubnetScanner";
 import SnmpVersion from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
 import { describe, expect, test } from "@jest/globals";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * The scan's status message is the entire diagnosis surface for a discovery
@@ -112,6 +113,15 @@ function makeSnmpConfig(
     ...overrides,
   } as SubnetScanSnmpConfig;
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("buildScanStatusMessage — the headline", () => {
   test("reports the ICMP and SNMP tallies when the pre-sweep ran", () => {

--- a/Probe/Tests/Jobs/Discovery/FetchScans.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScans.test.ts
@@ -14,6 +14,7 @@ import {
   buildProbeSnmpConfigs,
   buildSnmpV3Auth,
 } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * Discovery builds each credential set ONCE per scan and reuses it for every
@@ -104,6 +105,15 @@ function messageFrom(work: () => unknown): string {
 
   throw new Error("Expected the call to throw, but it returned normally.");
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("FetchScans.buildSnmpV3Auth — configs without v3 credentials", () => {
   test("a config with no v3 username carries no v3 config at all", () => {

--- a/Probe/Tests/Jobs/Discovery/FetchScansGuardAndTimeout.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansGuardAndTimeout.test.ts
@@ -47,6 +47,7 @@ import InitJob, {
   runScan,
   resetDiscoveryRunInProgress,
 } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * The request-contract half of this job is covered by
@@ -122,6 +123,15 @@ function fetchCalls(): Array<FetchCall> {
     };
   });
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("request deadlines — no discovery request may hang forever", () => {
   test("the pending-scan list fetch carries the 45s deadline", async () => {

--- a/Probe/Tests/Jobs/Discovery/FetchScansIcmpOnly.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansIcmpOnly.test.ts
@@ -21,6 +21,7 @@ import SubnetScanner, {
   type SubnetScanSnmpConfig,
 } from "../../../Utils/Discovery/SubnetScanner";
 import { fetchAndRunScans, runScan } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * github.com/OneUptime/oneuptime/issues/3445 — runScan for a scan whose
@@ -185,6 +186,15 @@ function loggedDebug(): string {
     })
     .join("\n");
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("runScan — an ICMP-only scan is swept as one", () => {
   test("passes isSnmpEnabled false through to the sweep", async () => {

--- a/Probe/Tests/Jobs/Discovery/FetchScansLifecycle.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansLifecycle.test.ts
@@ -21,6 +21,7 @@ import SubnetScanner, {
   SubnetScanSnmpConfig,
 } from "../../../Utils/Discovery/SubnetScanner";
 import { fetchAndRunScans, runScan } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * The probe's half of the discovery-scan lifecycle:
@@ -126,6 +127,15 @@ function fetchCalls(): Array<FetchCall> {
     };
   });
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("fetchAndRunScans — fetching the probe's pending scans", () => {
   test("asks the probe-ingest list endpoint, authenticated as this probe", async () => {

--- a/Probe/Tests/Jobs/Discovery/FetchScansServerErrors.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansServerErrors.test.ts
@@ -27,6 +27,7 @@ import {
   runScan,
   resetDiscoveryRunInProgress,
 } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * What the probe does when the SERVER says no.
@@ -132,6 +133,15 @@ function loggedErrors(): string {
     })
     .join("\n");
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("getRejectionReason", () => {
   test("an accepted request produces no reason at all", () => {

--- a/Probe/Tests/Jobs/Discovery/FetchScansSnmpConfigs.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansSnmpConfigs.test.ts
@@ -33,6 +33,7 @@ import {
   buildSnmpV3Auth,
   runScan,
 } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * A discovery scan carries an ORDERED LIST of SNMP credential sets, and the
@@ -231,6 +232,15 @@ function messageFrom(work: () => unknown): string {
 
   throw new Error("Expected the call to throw, but it returned normally.");
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("buildProbeSnmpConfigs — a scan configured the old way", () => {
   /*

--- a/Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts
@@ -51,6 +51,7 @@ import InitJob, {
   scanWithDeadline,
   resetDiscoveryRunInProgress,
 } from "../../../Jobs/Discovery/FetchScans";
+import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
 
 /*
  * A sweep that never settles must not stop discovery forever.
@@ -154,6 +155,15 @@ function loggedErrors(): string {
     })
     .join("\n");
 }
+
+/*
+ * Reverse DNS (issue #3529) runs at the end of scanWithDeadline, on whatever
+ * hosts the sweep returned — including the hosts a MOCKED SubnetScanner.scan
+ * hands back. Stubbed for this whole file so no test here queries the
+ * machine's real resolver; ReverseDnsStubIntegrity.test.ts fails the build if
+ * a file that drives this path forgets.
+ */
+stubReverseDnsAsResolvingNothing();
 
 describe("scanWithDeadline — a sweep that finishes", () => {
   test("returns the sweep's own result untouched", async () => {

--- a/Probe/Tests/TestingUtils/StubReverseDns.ts
+++ b/Probe/Tests/TestingUtils/StubReverseDns.ts
@@ -27,16 +27,48 @@ import { beforeEach, jest } from "@jest/globals";
  * files still describes what it always described. Suites that ARE about
  * naming (SubnetScannerReverseDns.test.ts) install their own spy instead.
  */
+
+/**
+ * Installs the stub RIGHT NOW, for the rest of the current test.
+ *
+ * Exported because a per-file `beforeEach` is not enough on its own. Two
+ * suites call `jest.restoreAllMocks()` in the MIDDLE of a test — to run a
+ * second sweep against freshly-configured spies — and that wipes every spy in
+ * the file, this one included. The second sweep then ran against the real
+ * resolver: on a machine whose DNS answers for RFC1918 space (a corporate
+ * resolver with 10.in-addr.arpa delegated, or any NXDOMAIN-hijacking ISP
+ * resolver) the sweep came back with `dnsHostname` set on hosts the first
+ * sweep had none for, and on a machine with no reachable resolver it paid the
+ * full two-second per-address budget inside a unit test.
+ *
+ * Neither failure is visible in the assertion that breaks, which is what makes
+ * it worth its own exported function rather than an inline spy: every
+ * mid-test restore in a file that stubs reverse DNS has to be followed by a
+ * call to this, and ReverseDnsStubIntegrity.test.ts fails the build if one
+ * is not.
+ */
+export function installReverseDnsStub(): void {
+  jest
+    .spyOn(SubnetScanner, "resolveReverseDnsHostnames")
+    .mockImplementation(async (): Promise<ReverseDnsResolution> => {
+      return {
+        hostnameByIpAddress: new Map<string, string>(),
+        isReverseDnsAvailable: true,
+        isTimeBudgetExhausted: false,
+      };
+    });
+}
+
+/**
+ * Installs the stub before every test in the calling file.
+ *
+ * Root-level hooks run before the hooks of any nested describe and apply to
+ * every test in the file regardless of where this is called textually, so one
+ * call at module scope covers the whole suite — EXCEPT across a mid-test
+ * `jest.restoreAllMocks()`, which is what `installReverseDnsStub` above is for.
+ */
 export function stubReverseDnsAsResolvingNothing(): void {
   beforeEach(() => {
-    jest
-      .spyOn(SubnetScanner, "resolveReverseDnsHostnames")
-      .mockImplementation(async (): Promise<ReverseDnsResolution> => {
-        return {
-          hostnameByIpAddress: new Map<string, string>(),
-          isReverseDnsAvailable: true,
-          isTimeBudgetExhausted: false,
-        };
-      });
+    installReverseDnsStub();
   });
 }

--- a/Probe/Tests/Utils/Discovery/ReverseDnsResolver.test.ts
+++ b/Probe/Tests/Utils/Discovery/ReverseDnsResolver.test.ts
@@ -3,6 +3,8 @@ process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
 process.env["PROBE_KEY"] = "test-probe-key";
 
 import ReverseDnsResolver, {
+  buildDefaultLookup,
+  ReverseDnsResolverLike,
   DEFAULT_REVERSE_DNS_FAILURE_BUDGET,
   ReverseDnsLookupFunction,
   ReverseDnsResolution,
@@ -21,9 +23,13 @@ import {
  * OneUptime issue #3529 — "Network Discovery Scan should perform reverse DNS
  * lookup and display hostnames".
  *
- * This is the piece that talks to a resolver, so the whole suite runs against
- * an INJECTED lookup function: nothing here sends a real query, and every
- * failure mode a real resolver has is reproducible on demand.
+ * This is the piece that talks to a resolver, so almost the whole suite runs
+ * against an INJECTED lookup function: every failure mode a real resolver has
+ * is reproducible on demand, and none of it depends on this machine's DNS,
+ * clock or locale. NO TEST HERE SENDS A QUERY. The one describe block that
+ * exercises the real buildDefaultLookup does so with an argument c-ares
+ * refuses to parse, which rejects before anything reaches the wire; the note
+ * on that block explains why that is the most of it that can be covered.
  *
  * The contract being pinned is narrower than "does reverse DNS work", and the
  * narrow part is what matters. Reverse DNS is an enrichment bolted onto the
@@ -69,9 +75,92 @@ function resolverWith(
   });
 }
 
+/*
+ * A sweep's worth of distinct addresses. Written as a helper because the
+ * interesting cases here are about SIZE — one wave of the shipped concurrency,
+ * a hundred hosts, a budget's worth of failures — and hand-listing those
+ * buries the assertion under addresses nobody reads.
+ */
+function addressList(count: number): Array<string> {
+  return Array.from(
+    { length: count },
+    (_unused: unknown, index: number): string => {
+      return `10.0.${Math.floor(index / 254)}.${(index % 254) + 1}`;
+    },
+  );
+}
+
+interface DeferredLookup {
+  promise: Promise<Array<string>>;
+  resolve: (answers: Array<string>) => void;
+  reject: (error: Error) => void;
+}
+
+/*
+ * A lookup the TEST settles, rather than one a timer settles.
+ *
+ * The concurrency bugs in this class are all about the ORDER in which a wave
+ * of in-flight lookups comes back, and a test that expressed that order with
+ * setTimeout would be pinning the event loop rather than the resolver: the
+ * skip path costs no macrotask, so anything scheduled on a timer lands after
+ * the pass has already made the decision under test. Handing the test the
+ * resolve/reject functions makes the interleaving exact and the test
+ * independent of how fast the machine is.
+ */
+function deferredLookup(): DeferredLookup {
+  let resolveAnswers: (answers: Array<string>) => void = (): void => {};
+  let rejectWith: (error: Error) => void = (): void => {};
+
+  const promise: Promise<Array<string>> = new Promise<Array<string>>(
+    (
+      resolve: (answers: Array<string>) => void,
+      reject: (error: Error) => void,
+    ) => {
+      resolveAnswers = resolve;
+      rejectWith = reject;
+    },
+  );
+
+  return {
+    promise: promise,
+    resolve: (answers: Array<string>): void => {
+      resolveAnswers(answers);
+    },
+    reject: (error: Error): void => {
+      rejectWith(error);
+    },
+  };
+}
+
+/*
+ * A lookup that hands back something that is not a list of names. The cast is
+ * the point of the helper: the signature promises Array<string>, and these
+ * tests exist precisely because a signature is not a guarantee at runtime.
+ */
+function lookupReturning(value: unknown): ReverseDnsLookupFunction {
+  return (async (): Promise<unknown> => {
+    return value;
+  }) as unknown as ReverseDnsLookupFunction;
+}
+
+/*
+ * Every warning the pass emitted, in order.
+ *
+ * Captured rather than dug back out of the spy's `mock.calls` because the
+ * interesting assertions are about WHAT the operator is told, and the two warn
+ * paths share the phrase "reverse DNS": only the rest of the sentence
+ * separates "this probe cannot resolve" from "this pass was too big to
+ * finish". A test that matched on the shared phrase alone would pass for
+ * either message, which is the wrong log line reaching the wrong operator.
+ */
+let warnedMessages: Array<string> = [];
+
 beforeEach(() => {
+  warnedMessages = [];
+
   // These paths log on purpose; the suite asserts on them, not on stdout.
-  jest.spyOn(logger, "warn").mockImplementation(() => {
+  jest.spyOn(logger, "warn").mockImplementation((message: unknown): never => {
+    warnedMessages.push(String(message));
     return undefined as never;
   });
 });
@@ -150,6 +239,40 @@ describe("ReverseDnsResolver — resolving names", () => {
     );
   });
 
+  it("steps over non-string answers on the way to a good name", async () => {
+    /*
+     * The answer LIST is untrusted the same way its contents are. It is typed
+     * `Array<string>` by a signature, not by a check — the values arrive from
+     * a resolver on the scanned network, through a Node API this class does
+     * not own, and on the server side the same names are read back out of a
+     * jsonb column. normalizeReverseDnsName takes `unknown` for exactly this
+     * reason, and the "first usable answer" loop hands it whatever the array
+     * held.
+     *
+     * Two mutations die here. Inline the normaliser as anything that touches
+     * the value directly — `answer.trim()` is the obvious one — and `null`
+     * throws a TypeError inside the loop, which the catch below counts as an
+     * INFRASTRUCTURE failure: one malformed answer list would then spend the
+     * failure budget as well as losing the name, which is why failureReason is
+     * asserted here. Coerce instead of type-checking — `String(answer)` — and
+     * `null` becomes the legal label "null" and the switch is named after it.
+     */
+    const resolver: ReverseDnsResolver = resolverWith(
+      lookupReturning([null, 42, {}, "sw-core-01.corp.example.com"]),
+      { failureBudget: 1 },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      "10.18.166.51",
+    ]);
+
+    expect(result.hostnameByIpAddress.get("10.18.166.51")).toBe(
+      "sw-core-01.corp.example.com",
+    );
+    expect(result.failureReason).toBeUndefined();
+    expect(result.isReverseDnsAvailable).toBe(true);
+  });
+
   it("normalises the answer it stores", async () => {
     // The stored value is what a device gets named; it is never raw RDATA.
     const resolver: ReverseDnsResolver = resolverWith(
@@ -208,15 +331,16 @@ describe("ReverseDnsResolver — resolving names", () => {
   });
 
   it("asks nothing and reports availability for an empty sweep", async () => {
-    const lookup: jest.Mock<ReverseDnsLookupFunction> = jest.fn(async () => {
-      return [];
-    }) as unknown as jest.Mock<ReverseDnsLookupFunction>;
+    const asked: Array<string> = [];
 
     const result: ReverseDnsResolution = await resolverWith(
-      lookup as unknown as ReverseDnsLookupFunction,
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+        return [];
+      },
     ).resolveHostnames([]);
 
-    expect(lookup).not.toHaveBeenCalled();
+    expect(asked).toHaveLength(0);
     expect(result.hostnameByIpAddress.size).toBe(0);
     expect(result.isReverseDnsAvailable).toBe(true);
   });
@@ -234,6 +358,15 @@ describe("ReverseDnsResolver — an address with no PTR record", () => {
     "ENODATA",
     "NOTFOUND",
     "NODATA",
+    /*
+     * EINVAL is what Node's reverse() rejects with when the ARGUMENT is not a
+     * parseable address — " 1.2.3.4 ", an IPv6 form c-ares will not take,
+     * anything a future caller of the public attachReverseDnsHostnames hands
+     * it. That is a fact about one address and says nothing about the
+     * resolver, so counting it would let a handful of malformed inputs
+     * convict a working probe of having no DNS.
+     */
+    "EINVAL",
     "EBADNAME",
     "EBADSTR",
   ];
@@ -347,10 +480,58 @@ describe("ReverseDnsResolver — a probe with no usable resolver", () => {
      * Exactly one line. The budget is spent once, and a warning per skipped
      * address would bury the sentence that explains the whole scan.
      */
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(String((logger.warn as jest.Mock).mock.calls[0]![0])).toContain(
-      "reverse DNS",
+    expect(warnedMessages).toHaveLength(1);
+
+    /*
+     * And the line has to name the CAUSE, which is the whole reason
+     * failureReason is threaded through to the log at all. "reverse DNS" on
+     * its own would be satisfied by the wall-clock message too — the two warn
+     * paths share that phrase — so an operator reading it would be told the
+     * pass ran out of time when in fact their resolver is answering SERVFAIL.
+     * Asserting the injected code pins that the message an operator acts on
+     * came from the failure they actually have.
+     */
+    expect(warnedMessages[0]).toContain("ESERVFAIL");
+    expect(warnedMessages[0]).toContain("not usable from this probe");
+    // And that it says the remaining hosts were skipped rather than scanned.
+    expect(warnedMessages[0]).toContain("skipped");
+  });
+
+  it("says 'unknown error' rather than nothing when the lookup threw nothing", async () => {
+    /*
+     * `throw undefined` is not a hypothetical: a rejected promise with no
+     * reason is what a badly-written wrapper around a resolver produces, and
+     * so is `new Error()`.
+     *
+     * Two things have to hold, and they pull in opposite directions. The warn
+     * template's `|| "unknown error"` has to fire, or the operator's one log
+     * line ends mid-sentence at "Resolver reported: " — a message that reports
+     * a fault and then declines to say what it was. And `failureReason` has to
+     * come back UNDEFINED rather than as the empty string: the field is typed
+     * `string | undefined`, and an empty string is present-but-blank, so a
+     * caller asking `failureReason !== undefined` would be told there is a
+     * reason and then shown nothing. describeError returns undefined for an
+     * empty message for exactly that reason.
+     */
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (): Promise<Array<string>> => {
+        // eslint-disable-next-line no-throw-literal
+        throw undefined;
+      },
+      { failureBudget: 1 },
     );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      "10.0.0.1",
+      "10.0.0.2",
+      "10.0.0.3",
+    ]);
+
+    expect(result.isReverseDnsAvailable).toBe(false);
+    // Nothing to say about it, and nothing invented either.
+    expect(result.failureReason).toBeUndefined();
+    expect(warnedMessages).toHaveLength(1);
+    expect(warnedMessages[0]).toContain("unknown error");
   });
 
   it("keeps the FIRST failure reason, not the last", async () => {
@@ -373,12 +554,60 @@ describe("ReverseDnsResolver — a probe with no usable resolver", () => {
     expect(result.failureReason).toBe("failure number 1");
   });
 
+  it("truncates a failure reason too long to be a log line", async () => {
+    /*
+     * A resolver error is not a sentence we wrote. c-ares errors routinely
+     * carry the whole server list they tried, and a probe pointed at a host
+     * with a large resolv.conf — or at a container runtime that injects
+     * one — can produce a message thousands of characters long. This value
+     * ends up in a probe log line AND on the ScanResult that goes back to the
+     * server, so an untruncated one turns a best-effort enrichment's failure
+     * into the largest field in the payload.
+     *
+     * FAILURE_REASON_EXCERPT_LENGTH is module-private, so the shipped 200 is
+     * pinned here as a literal on purpose: it is a promise about what one log
+     * line looks like, and changing it should require changing this test.
+     *
+     * The head is kept, not the tail. `queryPtr ESERVFAIL` is the part an
+     * operator acts on and it is at the front; truncating from the other end
+     * would keep the server list and throw away the diagnosis.
+     */
+    const excerptLength: number = 200;
+
+    const hugeMessage: string = `queryPtr ESERVFAIL ${"10.18.166.51, ".repeat(
+      500,
+    )}`;
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (): Promise<Array<string>> => {
+        throw dnsError("ESERVFAIL", hugeMessage);
+      },
+      { failureBudget: 1 },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      "10.0.0.1",
+    ]);
+
+    expect(hugeMessage.length).toBeGreaterThan(excerptLength);
+    expect(result.failureReason).toHaveLength(excerptLength);
+    expect(result.failureReason).toBe(hugeMessage.substring(0, excerptLength));
+    expect(result.failureReason).toContain("queryPtr ESERVFAIL");
+  });
+
   it("counts our own timeout as an infrastructure failure", async () => {
     /*
      * A wedged resolver rejects through the race guard with a plain Error and
      * no code. That is the archetypal "resolver is broken" case, so an
      * unrecognised error must default to counting — the opposite default
      * would make the budget unreachable exactly when it is needed.
+     *
+     * This is also the closest an injected lookup can get to buildDefaultLookup's
+     * per-address race: injecting a lookup that never settles would hang the
+     * pass forever, because the 2s timeout lives INSIDE the default lookup and
+     * not in this class. So the error that race produces is reproduced
+     * verbatim instead, message shape and all, and what is pinned is how the
+     * classifier reads it.
      */
     const resolver: ReverseDnsResolver = resolverWith(
       async (ipAddress: string): Promise<Array<string>> => {
@@ -396,32 +625,107 @@ describe("ReverseDnsResolver — a probe with no usable resolver", () => {
 
     expect(result.isReverseDnsAvailable).toBe(false);
     expect(result.failureReason).toContain("timed out");
+    // Bounded, and back with a result, rather than pinned on the wedged address.
+    expect(result.hostnameByIpAddress.size).toBe(0);
   });
 
-  it("never rejects, whatever the lookup throws", async () => {
+  it("never rejects, and describes a non-Error throw, whatever the lookup threw", async () => {
     /*
      * The one guarantee that outranks every other in this file: a sweep that
-     * succeeded must not be lost on the way out of it.
+     * succeeded must not be lost on the way out of it. The bare `await` below
+     * is that assertion — a rejection propagates out of it and fails the test.
+     *
+     * The second half is describeError's `String(error ?? "")` fallback. A
+     * thrown string has no `.message`, and a fallback that produced ""
+     * (falsy, so failureReason would never be set at all) or the
+     * "[object Object]" a careless coercion gives would satisfy a test that
+     * only checked the pass came back. Asserting the exact text pins that what
+     * the lookup actually threw is what an operator eventually reads.
      */
     const resolver: ReverseDnsResolver = resolverWith(
       async (): Promise<Array<string>> => {
         // eslint-disable-next-line no-throw-literal
         throw "a string, not an Error";
       },
+      { failureBudget: 4 },
     );
 
-    await expect(
-      resolver.resolveHostnames(["10.0.0.1", "10.0.0.2"]),
-    ).resolves.toBeDefined();
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      "10.0.0.1",
+      "10.0.0.2",
+    ]);
+
+    expect(result.hostnameByIpAddress.size).toBe(0);
+    expect(result.failureReason).toBe("a string, not an Error");
+    // Two failures against a budget of four: nothing has been concluded yet.
+    expect(result.isReverseDnsAvailable).toBe(true);
   });
 
-  it("defaults to a budget generous enough to survive a sparse subnet", () => {
+  it("survives one failure short of the DEFAULT budget before the first success", async () => {
     /*
-     * The budget only counts INFRASTRUCTURE failures, so an address with no
-     * record never touches it — but the number should still be comfortably
-     * above "a couple of flaky queries".
+     * The default is exercised as a behaviour rather than asserted as a
+     * number: what matters is that a probe whose first several queries are
+     * eaten by a flaky forwarder still names the host that answers next.
+     * Tightening the shipped default would break this test, which is the
+     * point — that number is a promise to sparse subnets, not a constant.
      */
-    expect(DEFAULT_REVERSE_DNS_FAILURE_BUDGET).toBeGreaterThanOrEqual(5);
+    const asked: Array<string> = [];
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+
+        if (ipAddress === "10.0.1.1") {
+          return ["gateway.corp.example.com"];
+        }
+
+        throw dnsError("ESERVFAIL");
+      },
+    );
+
+    const addresses: Array<string> = [
+      ...addressList(DEFAULT_REVERSE_DNS_FAILURE_BUDGET - 1),
+      "10.0.1.1",
+      "10.0.1.2",
+    ];
+
+    const result: ReverseDnsResolution =
+      await resolver.resolveHostnames(addresses);
+
+    expect(asked).toHaveLength(addresses.length);
+    expect(result.isReverseDnsAvailable).toBe(true);
+    expect(result.hostnameByIpAddress.get("10.0.1.1")).toBe(
+      "gateway.corp.example.com",
+    );
+    // The budget was never crossed, so the operator is told nothing.
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("spends the DEFAULT budget on exactly that many failures", async () => {
+    /*
+     * The other side of the same promise: the default is a ceiling too, or a
+     * probe with no resolver would pay a full sweep of timeouts.
+     */
+    const asked: Array<string> = [];
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+
+        if (ipAddress === "10.0.1.1") {
+          return ["gateway.corp.example.com"];
+        }
+
+        throw dnsError("ECONNREFUSED");
+      },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      ...addressList(DEFAULT_REVERSE_DNS_FAILURE_BUDGET),
+      "10.0.1.1",
+    ]);
+
+    expect(asked).toHaveLength(DEFAULT_REVERSE_DNS_FAILURE_BUDGET);
+    expect(result.isReverseDnsAvailable).toBe(false);
+    expect(result.hostnameByIpAddress.size).toBe(0);
   });
 });
 
@@ -464,6 +768,19 @@ describe("ReverseDnsResolver — a resolver that works but not for everything", 
     expect(result.hostnameByIpAddress.get("10.0.0.1")).toBe(
       "gateway.corp.example.com",
     );
+
+    /*
+     * failureReason is SET on a pass that WORKED, and that pairing is the
+     * documented reading of the field rather than an accident of this test.
+     * Nine addresses genuinely timed out, so there is a real fault to report —
+     * but the resolver is present and the gateway was named, so
+     * isReverseDnsAvailable is true and nothing is logged. A caller that reads
+     * failureReason on its own as "DNS is broken" would tell an operator their
+     * probe has no resolver on a sweep where it plainly does, which is why the
+     * field's doc comment says to read it beside isReverseDnsAvailable.
+     */
+    expect(result.failureReason).toContain("ETIMEOUT");
+    expect(warnedMessages).toHaveLength(0);
   });
 
   it("still trips the budget when the failures come BEFORE the first success", async () => {
@@ -590,51 +907,281 @@ describe("ReverseDnsResolver — the wall-clock budget", () => {
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
-  it("reports a budget it never came close to as not exhausted", async () => {
+  it("does not report exhaustion while the clock is still short of the deadline", async () => {
+    /*
+     * The negative control, and it is only worth having with an INJECTED
+     * clock. Written against the real Date.now and the shipped sixty-second
+     * default — which is how it started life — it asserted that a budget
+     * nothing came near had not been spent, and would have passed just as
+     * happily if the wall-clock budget had been deleted from the class
+     * outright. It could not fail for the behaviour in its own title.
+     *
+     * Driven by the same stepping clock as its siblings it becomes a real
+     * boundary: three readings at 100, 200 and 300 against a deadline of 400.
+     * Invert the comparison, or take the deadline from the wrong end (`now()`
+     * rather than `now() + budget`), and the pass trips on its first wave and
+     * asks one address instead of three. Paired with the test below — which
+     * puts a reading exactly ON the deadline — the threshold is bracketed from
+     * both sides without either test asserting a bare boolean nothing can
+     * move.
+     */
+    const asked: Array<string> = [];
     const resolver: ReverseDnsResolver = resolverWith(
-      async (): Promise<Array<string>> => {
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
         return ["host.example.com"];
+      },
+      { totalBudgetInMs: 400, now: clockAdvancingBy(100) },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(3),
+    );
+
+    expect(asked).toHaveLength(3);
+    expect(result.isTimeBudgetExhausted).toBe(false);
+    expect(warnedMessages).toHaveLength(0);
+  });
+
+  it("stops the moment the clock REACHES the deadline, not once it has passed it", async () => {
+    /*
+     * The check is `now() >= deadline`, and the difference between that and
+     * `>` is one whole wave of lookups — at the shipped concurrency, thirty-two
+     * addresses each able to spend the full per-address timeout, on a pass that
+     * has already been told it is out of time. That is the exact overshoot the
+     * budget exists to prevent, so the boundary is pinned rather than left to
+     * whichever comparison a later edit happens to write.
+     *
+     * Deadline 300, readings at 100 (ask), 200 (ask), 300 (stop). Relax the
+     * comparison to `>` and a third address is asked before the reading at 400
+     * stops it.
+     */
+    const asked: Array<string> = [];
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+        return [`host-${ipAddress.split(".").pop()}.example.com`];
+      },
+      { totalBudgetInMs: 300, now: clockAdvancingBy(100) },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(4),
+    );
+
+    expect(asked).toHaveLength(2);
+    expect(result.isTimeBudgetExhausted).toBe(true);
+
+    /*
+     * And the operator is told which budget stopped them. This message and the
+     * failure-budget one both contain "reverse DNS"; only the rest of the
+     * sentence says whether to go and look at their resolver or at the size of
+     * their sweep. It must also say the sweep itself survived, because the
+     * whole design constraint here is that an enrichment may not turn a
+     * successful scan into a reported failure.
+     */
+    expect(warnedMessages).toHaveLength(1);
+    expect(warnedMessages[0]).toContain("300ms budget");
+    expect(warnedMessages[0]).toContain("naming 2 host(s)");
+    expect(warnedMessages[0]).toContain("The sweep itself is unaffected");
+    // Nothing was learned against the resolver: it answered everything asked.
+    expect(result.isReverseDnsAvailable).toBe(true);
+  });
+
+  it("keeps the names from lookups that were IN FLIGHT when the deadline passed", async () => {
+    /*
+     * The source contract is explicit that the deadline is read before a wave
+     * STARTS and never in the middle of one, so a pass overruns its budget by
+     * at most one wave — and the queries in that wave are already on the wire,
+     * paid for, with answers coming back. Throwing those answers away because
+     * the clock moved while they were outstanding would cost the sweep names
+     * it had already bought.
+     *
+     * The wave is settled by hand so the clock can be moved past the deadline
+     * at the one moment that matters: after both lookups have been issued and
+     * before either has answered. A design that raced the wave against the
+     * deadline, or that cleared the map on exhaustion, returns nothing here.
+     */
+    let clock: number = 0;
+    const asked: Array<string> = [];
+    const inFlight: Array<DeferredLookup> = [];
+    const addresses: Array<string> = addressList(6);
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+        const pending: DeferredLookup = deferredLookup();
+        inFlight.push(pending);
+        return pending.promise;
+      },
+      {
+        concurrency: 2,
+        totalBudgetInMs: 100,
+        now: (): number => {
+          return clock;
+        },
       },
     );
 
-    const result: ReverseDnsResolution = await resolver.resolveHostnames([
-      "10.0.0.1",
-    ]);
+    const pass: Promise<ReverseDnsResolution> =
+      resolver.resolveHostnames(addresses);
 
-    expect(result.isTimeBudgetExhausted).toBe(false);
-    expect(logger.warn).not.toHaveBeenCalled();
+    // The first wave is out and unanswered.
+    expect(asked).toHaveLength(2);
+
+    // The budget expires while both queries are still outstanding.
+    clock = 1000;
+
+    inFlight[0]!.resolve(["sw-core-01.corp.example.com"]);
+    inFlight[1]!.resolve(["sw-core-02.corp.example.com"]);
+
+    const result: ReverseDnsResolution = await pass;
+
+    // Overrun by at most one wave: the next four addresses are never started.
+    expect(asked).toHaveLength(2);
+    expect(result.isTimeBudgetExhausted).toBe(true);
+    // And both names that were in flight when the clock ran out are kept.
+    expect(result.hostnameByIpAddress.size).toBe(2);
+    expect(result.hostnameByIpAddress.get(addresses[0]!)).toBe(
+      "sw-core-01.corp.example.com",
+    );
+    expect(result.hostnameByIpAddress.get(addresses[1]!)).toBe(
+      "sw-core-02.corp.example.com",
+    );
   });
 });
 
 describe("ReverseDnsResolver — concurrency", () => {
-  it("runs at most `concurrency` lookups at once", async () => {
-    let inFlight: number = 0;
-    let peak: number = 0;
+  it.each([1, 4, 32])(
+    "keeps exactly %i lookups in flight while work remains",
+    async (concurrency: number) => {
+      /*
+       * Both halves are load-bearing, and the upper bound alone is not enough:
+       * "no more than 32" is satisfied by a pool that only ever ran two
+       * workers, which would quietly turn a 4000-host sweep's enrichment into
+       * a serial crawl against the wall-clock budget. Pinning the peak to the
+       * configured width catches a pool that under-fills as well as one that
+       * over-fills — and the width is what every failure-budget assertion
+       * below is really about, since the budget cannot stop a lookup that is
+       * already in flight.
+       */
+      let inFlight: number = 0;
+      let peak: number = 0;
+      const asked: Array<string> = [];
+
+      const resolver: ReverseDnsResolver = resolverWith(
+        async (ipAddress: string): Promise<Array<string>> => {
+          asked.push(ipAddress);
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          await new Promise<void>((resolve: () => void) => {
+            setTimeout(resolve, 1);
+          });
+          inFlight--;
+          return ["host.example.com"];
+        },
+        { concurrency: concurrency },
+      );
+
+      await resolver.resolveHostnames(addressList(40));
+
+      expect(peak).toBe(concurrency);
+      // The pool must also REFILL: 40 addresses, not one wave of them.
+      expect(asked).toHaveLength(40);
+      expect(inFlight).toBe(0);
+    },
+  );
+
+  it("runs whole WAVES: no lookup starts until every lookup before it has settled", async () => {
+    /*
+     * Waves rather than a work-stealing pool is not a performance choice, it is
+     * what makes the failure budget answerable at all: the breaker is read
+     * between waves precisely because that is the only moment when every
+     * lookup that has started has finished and the counters cannot be lying.
+     * A pool refills the instant ONE worker frees up, so the counters are
+     * always mid-flight — and the previous design, which read the breaker
+     * there, silently skipped two thirds of a sweep and reported success.
+     *
+     * That property is structural and invisible in every result-shaped
+     * assertion in this file, so it is pinned directly, on the sequence of
+     * starts and settles. Ten addresses at a concurrency of four is 4 + 4 + 2:
+     * a pool would produce start-0..3, settle-0, start-4, settle-1, start-5 —
+     * interleaved, and unequal to the expected sequence on its sixth entry.
+     * The short final wave is part of the test on purpose: a loop that
+     * advanced by the concurrency without clamping the slice would either drop
+     * the last two addresses or ask for addresses that do not exist.
+     */
+    const events: Array<string> = [];
+    const addresses: Array<string> = addressList(10);
+    const indexByAddress: Map<string, number> = new Map<string, number>(
+      addresses.map((address: string, index: number): [string, number] => {
+        return [address, index];
+      }),
+    );
 
     const resolver: ReverseDnsResolver = resolverWith(
-      async (): Promise<Array<string>> => {
-        inFlight++;
-        peak = Math.max(peak, inFlight);
+      async (ipAddress: string): Promise<Array<string>> => {
+        const index: number = indexByAddress.get(ipAddress)!;
+
+        events.push(`start ${index}`);
+
+        /*
+         * A real macrotask, not a microtask: it is the gap a pool would use to
+         * pull its next address, so a test that only yielded the microtask
+         * queue could not tell the two designs apart. Timers armed with the
+         * same delay fire in the order they were created, which is what makes
+         * the expected sequence exact rather than merely grouped.
+         */
         await new Promise<void>((resolve: () => void) => {
-          setTimeout(resolve, 1);
+          setTimeout(resolve, 0);
         });
-        inFlight--;
-        return ["host.example.com"];
+
+        events.push(`settle ${index}`);
+
+        return [`host-${index}.corp.example.com`];
       },
       { concurrency: 4 },
     );
 
-    const addresses: Array<string> = Array.from(
-      { length: 40 },
-      (_unused: unknown, index: number) => {
-        return `10.0.0.${index + 1}`;
+    const result: ReverseDnsResolution =
+      await resolver.resolveHostnames(addresses);
+
+    const expectedEvents: Array<string> = [];
+    const expectedWaves: Array<Array<number>> = [
+      [0, 1, 2, 3],
+      [4, 5, 6, 7],
+      [8, 9],
+    ];
+
+    for (const wave of expectedWaves) {
+      for (const index of wave) {
+        expectedEvents.push(`start ${index}`);
+      }
+
+      for (const index of wave) {
+        expectedEvents.push(`settle ${index}`);
+      }
+    }
+
+    expect(events).toEqual(expectedEvents);
+
+    /*
+     * Stated a second way, independently of the exact interleave: a wave is a
+     * start that is not preceded by another start, and there are three of
+     * them. Ten addresses at a concurrency of four in two waves would mean the
+     * width was wrong; in ten waves it would mean the pass had gone serial.
+     */
+    const waveCount: number = events.filter(
+      (event: string, index: number): boolean => {
+        return (
+          event.startsWith("start ") &&
+          (index === 0 || !events[index - 1]!.startsWith("start "))
+        );
       },
-    );
+    ).length;
 
-    await resolver.resolveHostnames(addresses);
-
-    expect(peak).toBeLessThanOrEqual(4);
-    expect(peak).toBeGreaterThan(1);
+    expect(waveCount).toBe(3);
+    expect(result.hostnameByIpAddress.size).toBe(10);
   });
 
   it("resolves every address when there are fewer than the concurrency", async () => {
@@ -652,5 +1199,889 @@ describe("ReverseDnsResolver — concurrency", () => {
     ]);
 
     expect(result.hostnameByIpAddress.size).toBe(2);
+  });
+});
+
+describe("ReverseDnsResolver — the failure budget at the SHIPPED concurrency of 32", () => {
+  /*
+   * Everything above this point runs the pool one address at a time, which
+   * makes ordering assertions readable but is a configuration production
+   * never uses: the shipped default is 32, and the budget behaves differently
+   * there in a way that decided the outcome of this feature.
+   *
+   * Thirty-two lookups leave together. The budget is checked before a lookup
+   * STARTS and can never recall one already in flight, so the first wave is
+   * always paid for in full — and the verdict on the resolver is reached
+   * while twenty-two other queries are still outstanding. Whether those
+   * queries are allowed to change that verdict is the whole question.
+   */
+
+  it("bounds a probe with no resolver to a single wave of lookups", async () => {
+    const asked: Array<string> = [];
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+        throw dnsError("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.53:53");
+      },
+      { concurrency: 32, failureBudget: 10 },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(200),
+    );
+
+    /*
+     * Exactly 32, not 10: the budget is a floor on what a broken probe costs,
+     * not a cap, and pretending otherwise is what made the serial tests above
+     * read as if a budget of 10 meant ten queries. 32 out of 200 is still the
+     * point — a probe with no DNS pays for one wave and stops.
+     */
+    expect(asked).toHaveLength(32);
+    expect(result.isReverseDnsAvailable).toBe(false);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks every address when the first wave's failures land before its successes", async () => {
+    /*
+     * THE regression this hardening exists for.
+     *
+     * A reverse zone delegated to a dead nameserver at the bottom of the
+     * subnet — the single most common way for this to go wrong — makes the
+     * first handful of addresses time out while the rest of the wave answers
+     * a moment later. The budget was once a latch set inside the failure
+     * branch, so those ten failures flipped it permanently and the
+     * twenty-two good names already on their way back could not flip it
+     * again. Sixty-eight hosts with perfectly good PTR records were never
+     * asked, and the operator saw the bare IPs of issue #3529 on a network
+     * that publishes a name for every one of them.
+     *
+     * The wave is settled by hand so the ORDER is the test rather than the
+     * machine: the ten failures land first, exactly filling a budget of ten,
+     * and the twenty-two answers land behind them in the same wave. Because
+     * the breaker is only read once that wave has fully settled, it sees a
+     * wave that answered and never trips at all.
+     *
+     * Three assertions carry it, and each kills a different mutation. `asked`
+     * reaching a hundred is what fails if the `successfulLookupCount === 0`
+     * conjunct is dropped from isReverseDnsUnusable — the pass would stop
+     * dead at 32. `failureReason` is what distinguishes "the budget was met
+     * and correctly overruled" from "the budget was never reached at all": it
+     * is the only observable proof that those ten rejections really were
+     * counted as infrastructure failures rather than quietly reclassified,
+     * and without it removing the failure budget from the class entirely
+     * would leave this test green. And `warnedMessages` being empty is the
+     * operator-facing half — a probe that named ninety of a hundred hosts must
+     * not also log that its reverse DNS is unusable.
+     *
+     * Its sibling below makes the same point at a concurrency of four; this
+     * one makes it at the SHIPPED thirty-two, and adds that the pass goes on
+     * to refill three more waves rather than merely surviving the first.
+     */
+    const asked: Array<string> = [];
+    const firstWave: Array<DeferredLookup> = [];
+    const addresses: Array<string> = addressList(100);
+    const indexByAddress: Map<string, number> = new Map<string, number>(
+      addresses.map((address: string, index: number): [string, number] => {
+        return [address, index];
+      }),
+    );
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+
+        const index: number = indexByAddress.get(ipAddress)!;
+
+        // The wave the pass opens with is settled by hand, below.
+        if (index < 32) {
+          const pending: DeferredLookup = deferredLookup();
+          firstWave.push(pending);
+          return pending.promise;
+        }
+
+        return Promise.resolve([`host-${index}.corp.example.com`]);
+      },
+      { concurrency: 32, failureBudget: 10 },
+    );
+
+    const pass: Promise<ReverseDnsResolution> =
+      resolver.resolveHostnames(addresses);
+
+    // The pool opens the whole wave before anything can come back.
+    expect(asked).toHaveLength(32);
+
+    // Ten dead-delegation timeouts come back first — the budget, exactly.
+    for (let index: number = 0; index < 10; index++) {
+      firstWave[index]!.reject(dnsError("ETIMEOUT"));
+    }
+
+    // The other twenty-two answer immediately behind them.
+    for (let index: number = 10; index < 32; index++) {
+      firstWave[index]!.resolve([`host-${index}.corp.example.com`]);
+    }
+
+    const result: ReverseDnsResolution = await pass;
+
+    expect(asked).toHaveLength(100);
+    expect(result.isReverseDnsAvailable).toBe(true);
+    // Every address except the ten that genuinely failed.
+    expect(result.hostnameByIpAddress.size).toBe(90);
+    expect(result.hostnameByIpAddress.get(addresses[99]!)).toBe(
+      "host-99.corp.example.com",
+    );
+
+    /*
+     * The ten failures WERE counted — a budget of ten was met, not dodged —
+     * and the pass carried on anyway. Delete the failure budget from the class
+     * and every assertion above still holds; this one is the witness that
+     * there was a budget to overrule.
+     */
+    expect(result.failureReason).toContain("ETIMEOUT");
+    // Nothing was wrong with this resolver, so the operator hears nothing.
+    expect(warnedMessages).toHaveLength(0);
+  });
+
+  it("does not trip at all when the failing wave also contained a success", async () => {
+    /*
+     * The property that replaced "un-tripping", and the reason the pass is
+     * organised as waves rather than as a worker pool.
+     *
+     * An earlier design asked the breaker on every address so it could trip
+     * and then un-trip. That is unsound under concurrency for a reason that is
+     * pure scheduling: once tripped, the pool's workers return WITHOUT
+     * AWAITING, so the whole remaining queue drains through the skip path in
+     * microtasks — and a success settling one macrotask later (which is to say
+     * every real DNS answer) always lost the race. Two thirds of a sweep was
+     * skipped while the result still reported success, because by the time
+     * anyone asked, the breaker had un-tripped.
+     *
+     * Deciding at a wave boundary removes the race instead of managing it:
+     * every lookup that started has settled, so a wave containing ANY answer
+     * never trips in the first place. Here the first wave carries two
+     * ESERVFAILs against a budget of two — enough to trip on the old
+     * counting — alongside two answers. Nothing trips, nothing is skipped,
+     * and the operator is not warned about a resolver that plainly works.
+     */
+    const asked: Array<string> = [];
+    const firstWave: Array<DeferredLookup> = [];
+    const addresses: Array<string> = addressList(12);
+    const indexByAddress: Map<string, number> = new Map<string, number>(
+      addresses.map((address: string, index: number): [string, number] => {
+        return [address, index];
+      }),
+    );
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+
+        const index: number = indexByAddress.get(ipAddress)!;
+
+        if (index < 4) {
+          const pending: DeferredLookup = deferredLookup();
+          firstWave.push(pending);
+          return pending.promise;
+        }
+
+        return Promise.resolve([`host-${index}.corp.example.com`]);
+      },
+      { concurrency: 4, failureBudget: 2 },
+    );
+
+    const pass: Promise<ReverseDnsResolution> =
+      resolver.resolveHostnames(addresses);
+
+    firstWave[0]!.reject(dnsError("ESERVFAIL"));
+    firstWave[1]!.reject(dnsError("ESERVFAIL"));
+    firstWave[2]!.resolve(["sw-core-01.corp.example.com"]);
+    firstWave[3]!.resolve(["sw-core-02.corp.example.com"]);
+
+    const result: ReverseDnsResolution = await pass;
+
+    // Every address behind the mixed wave was still asked.
+    expect(asked).toHaveLength(12);
+    expect(result.isReverseDnsAvailable).toBe(true);
+    expect(result.hostnameByIpAddress.size).toBe(10);
+    // And nothing was reported to the operator, because nothing was wrong.
+    expect(logger.warn).not.toHaveBeenCalled();
+    /*
+     * The failure was still SEEN, though — which is why failureReason is
+     * documented as "the first infrastructure failure seen" and must never be
+     * read without isReverseDnsAvailable beside it.
+     */
+    expect(result.failureReason).toContain("ESERVFAIL");
+  });
+
+  it("skips the rest only after a whole wave in which nothing answered", async () => {
+    /*
+     * The other half of the same contract. Here the first wave answers
+     * nothing at all — not a name, not even an NXDOMAIN — which is the
+     * signature of a probe that cannot resolve rather than of an estate with
+     * one dead zone. The second wave is never started.
+     */
+    const asked: Array<string> = [];
+    const resolver: ReverseDnsResolver = resolverWith(
+      (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+        return Promise.reject(dnsError("ECONNREFUSED"));
+      },
+      { concurrency: 4, failureBudget: 2 },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(12),
+    );
+
+    /*
+     * Four, not two: the budget is a floor taken at a wave boundary, because
+     * that is the only point at which the counters are complete. Stopping
+     * mid-wave is what the racy design did.
+     */
+    expect(asked).toHaveLength(4);
+    expect(result.isReverseDnsAvailable).toBe(false);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ReverseDnsResolver — a resolver that answers with nothing usable", () => {
+  /*
+   * The distinction between "the lookup came back" and "the lookup produced a
+   * name I can use". Only the first says anything about the probe's DNS, and
+   * conflating them is how a working resolver gets convicted.
+   */
+
+  it("is disarmed by a lookup that RETURNED, even when every answer normalises away", async () => {
+    /*
+     * A wildcard reverse zone that echoes the query name is a real and common
+     * configuration: every address answers, and every answer is
+     * "N.166.18.10.in-addr.arpa", which normalizeReverseDnsName refuses
+     * because it is a strictly worse label than the address it came from. That
+     * resolver WORKS. Disarming on usable names rather than on returned
+     * lookups would let a handful of unrelated timeouts sitting between those
+     * echoes spend the budget and skip the rest of the subnet — including the
+     * addresses further down that do have real names.
+     */
+    const asked: Array<string> = [];
+    const addresses: Array<string> = addressList(12);
+    const indexByAddress: Map<string, number> = new Map<string, number>(
+      addresses.map((address: string, index: number): [string, number] => {
+        return [address, index];
+      }),
+    );
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+
+        const index: number = indexByAddress.get(ipAddress)!;
+
+        if (index % 2 === 1) {
+          throw new Error(`Reverse DNS lookup for ${ipAddress} timed out`);
+        }
+
+        return [`${index}.166.18.10.in-addr.arpa`];
+      },
+      { concurrency: 1, failureBudget: 3 },
+    );
+
+    const result: ReverseDnsResolution =
+      await resolver.resolveHostnames(addresses);
+
+    // Six infrastructure failures against a budget of three, and still asking.
+    expect(asked).toHaveLength(12);
+    expect(result.isReverseDnsAvailable).toBe(true);
+    // Zero names, which is the whole trap: nothing resolved, yet DNS works.
+    expect(result.hostnameByIpAddress.size).toBe(0);
+  });
+
+  const nonArrayReturns: Array<[string, unknown]> = [
+    ["null", null],
+    ["undefined", undefined],
+    ["a bare string", "sw-core-01.corp.example.com"],
+    ["an object", { hostname: "sw-core-01.corp.example.com" }],
+  ];
+
+  it.each(nonArrayReturns)(
+    "treats %s from the lookup as 'no name here' rather than as a fault",
+    async (_label: string, value: unknown) => {
+      /*
+       * `for...of` over a non-iterable THROWS, and delete the Array.isArray
+       * guard and that throw lands in the catch below, where an unrecognised
+       * error is counted as an INFRASTRUCTURE failure. A lookup that answered
+       * `null` would then not merely fail to name one host: it would be
+       * reported to the operator as evidence that this probe cannot resolve.
+       *
+       * `failureReason` is the assertion that kills that mutation, and it is
+       * worth being precise about WHY, because the obvious candidate does not.
+       * `isReverseDnsAvailable` cannot fail here: successfulLookupCount is
+       * incremented the moment the lookup RETURNS, before its answers are
+       * looked at, so by the time a guardless loop throws, the resolver has
+       * already been recorded as working and isReverseDnsUnusable() — which
+       * requires successfulLookupCount === 0 — can never be true again for
+       * this pass. It is asserted below as a statement of the contract, not as
+       * a witness. The two assertions that can actually move are the map size
+       * and the failure reason.
+       *
+       * The string case is the nastier one, and there the map size is what
+       * catches it: a string IS iterable, so a guardless loop walks it
+       * character by character, hands normalizeReverseDnsName "s", and names
+       * the host after it — a single letter is a legal DNS label.
+       */
+      const resolver: ReverseDnsResolver = resolverWith(
+        lookupReturning(value),
+        { failureBudget: 1 },
+      );
+
+      const result: ReverseDnsResolution = await resolver.resolveHostnames([
+        "10.0.0.1",
+        "10.0.0.2",
+      ]);
+
+      expect(result.hostnameByIpAddress.size).toBe(0);
+      expect(result.failureReason).toBeUndefined();
+      expect(warnedMessages).toHaveLength(0);
+      expect(result.isReverseDnsAvailable).toBe(true);
+    },
+  );
+
+  it("walks a pathologically long answer list without giving up on it", async () => {
+    /*
+     * An answer list is chosen by the scanned network, not by us, so its
+     * length is untrusted input like everything else in a PTR answer. Five
+     * thousand junk records must neither name the host nor cost more than the
+     * pass can afford — and the search must still reach the good record at the
+     * end, because "stop after the first few" would be exactly the kind of
+     * quiet cap that reintroduces issue #3529 for one unlucky host. The test's
+     * own timeout is the bound on "without pathological behaviour"; a scan
+     * that walked this quadratically would never reach the assertions.
+     */
+    const junkAnswers: Array<string> = Array.from(
+      { length: 5000 },
+      (_unused: unknown, index: number): string => {
+        return `${index}.166.18.10.in-addr.arpa`;
+      },
+    );
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        if (ipAddress === "10.0.0.2") {
+          return [...junkAnswers.slice(0, 4999), "sw-core-01.corp.example.com"];
+        }
+
+        return junkAnswers;
+      },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      "10.0.0.1",
+      "10.0.0.2",
+    ]);
+
+    expect(result.hostnameByIpAddress.has("10.0.0.1")).toBe(false);
+    expect(result.hostnameByIpAddress.get("10.0.0.2")).toBe(
+      "sw-core-01.corp.example.com",
+    );
+    expect(result.isReverseDnsAvailable).toBe(true);
+  });
+});
+
+describe("ReverseDnsResolver — an address the resolver cannot parse", () => {
+  it("names the hosts either side of a malformed address", async () => {
+    /*
+     * attachReverseDnsHostnames is public and takes whatever a sweep result
+     * carried, so a value that is not a parseable address can reach the
+     * lookup — Node rejects those with EINVAL before any query leaves the
+     * host. Classified as infrastructure (which it was, until this
+     * hardening), a budget's worth of malformed entries would convict a
+     * perfectly good resolver and skip every real address behind them. The
+     * budget of one is what makes this test able to fail.
+     */
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        if (ipAddress === "10.0.0.9") {
+          return ["sw-core-01.corp.example.com"];
+        }
+
+        throw dnsError("EINVAL", `getHostByAddr EINVAL ${ipAddress}`);
+      },
+      { failureBudget: 1 },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      " 10.18.166.51 ",
+      "not-an-ip-address",
+      "10.18.166.51/32",
+      "10.0.0.9",
+    ]);
+
+    expect(result.isReverseDnsAvailable).toBe(true);
+    expect(result.failureReason).toBeUndefined();
+    expect(result.hostnameByIpAddress.get("10.0.0.9")).toBe(
+      "sw-core-01.corp.example.com",
+    );
+  });
+});
+
+describe("ReverseDnsResolver — the default lookup", () => {
+  /*
+   * buildDefaultLookup is the only code in this file's subject that talks to a
+   * resolver, and this suite may not send a query.
+   *
+   * It is exported with an injectable resolver FACTORY for exactly that
+   * reason. Before the seam existed, three things in it were unreachable from
+   * any test — the Promise.race's timeout arm, the `resolver.cancel()` inside
+   * it, and the `finally` that clears the timer — and deleting the cancel or
+   * the finally broke nothing. That is the state a piece of cleanup code
+   * should never be in: the cancel is what stops a black-holing forwarder
+   * leaving one outstanding query and one retry timer behind per timed-out
+   * address, on a resolver object the sweep no longer holds.
+   *
+   * The real dns.promises.Resolver is still exercised once below, on the one
+   * path that cannot reach the network: `reverse()` on an unparseable address
+   * fails inside ares_inet_pton and rejects with EINVAL without emitting
+   * anything.
+   */
+
+  /*
+   * A resolver that never answers, and remembers whether it was cancelled.
+   * Nothing here touches DNS.
+   */
+  function neverAnsweringResolver(): ReverseDnsResolverLike & {
+    cancelCount: number;
+  } {
+    const stub: ReverseDnsResolverLike & { cancelCount: number } = {
+      cancelCount: 0,
+      reverse: (): Promise<Array<string>> => {
+        return new Promise<Array<string>>(() => {});
+      },
+      cancel: (): void => {
+        stub.cancelCount++;
+      },
+    };
+
+    return stub;
+  }
+
+  it("gives up on a resolver that never answers, and says so", async () => {
+    const stub: ReverseDnsResolverLike & { cancelCount: number } =
+      neverAnsweringResolver();
+
+    const lookup: ReverseDnsLookupFunction = buildDefaultLookup(20, () => {
+      return stub;
+    });
+
+    /*
+     * The timeout arm, reached for the first time. Without it this await
+     * never returns — which is the failure the arm exists to prevent, and the
+     * reason the assertion is on the rejection rather than on a flag.
+     */
+    await expect(lookup("10.18.166.51")).rejects.toThrow(/timed out/);
+  });
+
+  it("cancels the query it abandoned", async () => {
+    /*
+     * Losing the race is not the same as the query being over. c-ares is
+     * still holding it, and on a forwarder that answers nothing every address
+     * in the sweep would leave one behind. Deleting `resolver.cancel()` from
+     * the timeout branch fails only this assertion.
+     */
+    const stub: ReverseDnsResolverLike & { cancelCount: number } =
+      neverAnsweringResolver();
+
+    const lookup: ReverseDnsLookupFunction = buildDefaultLookup(20, () => {
+      return stub;
+    });
+
+    await expect(lookup("10.18.166.51")).rejects.toThrow(/timed out/);
+
+    expect(stub.cancelCount).toBe(1);
+  });
+
+  it("does not cancel a query that answered in time", async () => {
+    /*
+     * The other half, and the one that pins the `finally` clearing the timer.
+     * Promise.race leaves the loser pending, so an uncleared timer would fire
+     * 20ms after this fast answer and call cancel() on a resolver whose result
+     * is already in the caller's map. On a sweep of thousands of hosts that is
+     * thousands of live timers, each ending in a pointless cancel.
+     */
+    const stub: ReverseDnsResolverLike & { cancelCount: number } = {
+      cancelCount: 0,
+      reverse: async (): Promise<Array<string>> => {
+        return ["sw-core-01.corp.example.com"];
+      },
+      cancel: (): void => {
+        stub.cancelCount++;
+      },
+    };
+
+    const lookup: ReverseDnsLookupFunction = buildDefaultLookup(20, () => {
+      return stub;
+    });
+
+    await expect(lookup("10.18.166.51")).resolves.toEqual([
+      "sw-core-01.corp.example.com",
+    ]);
+
+    // Long enough that an uncleared 20ms timer would have fired by now.
+    await new Promise<void>((resolve: () => void) => {
+      setTimeout(resolve, 60);
+    });
+
+    expect(stub.cancelCount).toBe(0);
+  });
+
+  it("passes a rejection from the resolver through unchanged", async () => {
+    // The classifier reads `code`, so the error object must survive the race.
+    const lookup: ReverseDnsLookupFunction = buildDefaultLookup(50, () => {
+      return {
+        reverse: (): Promise<Array<string>> => {
+          return Promise.reject(dnsError("ECONNREFUSED", "connect refused"));
+        },
+        cancel: (): void => {
+          return undefined;
+        },
+      };
+    });
+
+    await expect(lookup("10.18.166.51")).rejects.toMatchObject({
+      code: "ECONNREFUSED",
+    });
+  });
+
+  it("completes, names nothing, and blames no infrastructure for an unparseable address", async () => {
+    /*
+     * The REAL dns.promises.Resolver, on the one path that cannot reach the
+     * network: reverse() rejects in ares_inet_pton with EINVAL before a packet
+     * is built. The lookup is injected rather than defaulted so that this
+     * construction is not the one exception to the rule
+     * ReverseDnsStubIntegrity.test.ts enforces — the real resolver is reached
+     * through buildDefaultLookup itself, which is what is under test.
+     */
+    const resolver: ReverseDnsResolver = new ReverseDnsResolver({
+      lookup: buildDefaultLookup(50),
+      concurrency: 1,
+      failureBudget: 1,
+    });
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames([
+      "not-an-ip-address",
+      " 10.18.166.51 ",
+    ]);
+
+    expect(result.hostnameByIpAddress.size).toBe(0);
+    /*
+     * The load-bearing assertion. A budget of one means that if the default
+     * lookup's EINVAL were read as "this probe cannot resolve", the second
+     * address would never be asked and this would be false.
+     */
+    expect(result.isReverseDnsAvailable).toBe(true);
+    expect(result.failureReason).toBeUndefined();
+    expect(result.isTimeBudgetExhausted).toBe(false);
+  });
+});
+
+describe("ReverseDnsResolver — options that make no sense", () => {
+  /*
+   * concurrency, failureBudget and totalBudgetInMs are each clamped with
+   * Math.max(1, ...), and none of the three clamps is decoration.
+   *
+   * What they have in common is the shape of their failure: every one of the
+   * three has a zero value that turns the feature off SILENTLY — no throw, no
+   * warning, and in two of the three cases a result that still reports
+   * isReverseDnsAvailable true with an empty map, which is indistinguishable
+   * to the caller from a network where no host has a PTR record. Reverse DNS
+   * is best-effort by design, so there is no failing test anywhere else in the
+   * product that would notice; issue #3529 would simply come back, and the
+   * only evidence would be an operator saying the hostnames stopped appearing.
+   *
+   * Zero is not a hypothetical value either. These come through
+   * attachReverseDnsHostnames' options from a caller, and zero is what an
+   * unset numeric config, a parsed empty string, or an arithmetic mistake in a
+   * caller dividing a budget by a worker count all produce.
+   */
+
+  it.each([0, -4])(
+    "treats a concurrency of %i as one address at a time",
+    async (concurrency: number) => {
+      /*
+       * The worst of the three. Without the clamp the wave loop advances
+       * `start` by zero, `slice(start, start + 0)` is empty, `Promise.all([])`
+       * settles immediately — and the pass spins in the microtask queue
+       * forever, never yielding, so a probe would hang inside an enrichment
+       * with no timer able to fire and stop it. A negative value walks `start`
+       * backwards for the same result. This test does not merely fail without
+       * the clamp; it never finishes.
+       */
+      const asked: Array<string> = [];
+      const resolver: ReverseDnsResolver = resolverWith(
+        async (ipAddress: string): Promise<Array<string>> => {
+          asked.push(ipAddress);
+          return [`host-${ipAddress.split(".").pop()}.corp.example.com`];
+        },
+        { concurrency: concurrency },
+      );
+
+      const result: ReverseDnsResolution = await resolver.resolveHostnames(
+        addressList(3),
+      );
+
+      expect(asked).toHaveLength(3);
+      expect(result.hostnameByIpAddress.size).toBe(3);
+      expect(result.isReverseDnsAvailable).toBe(true);
+    },
+  );
+
+  it.each([0, -4])(
+    "treats a failure budget of %i as one failure, not as none",
+    async (failureBudget: number) => {
+      /*
+       * Without the clamp the breaker's second clause is
+       * `infrastructureFailureCount >= 0`, which is true before a single
+       * lookup has been made. The very first wave boundary — the one checked
+       * BEFORE any wave runs — would find the pass unusable, warn that this
+       * probe cannot resolve, ask nothing at all, and return
+       * isReverseDnsAvailable false for a resolver that answers every query
+       * put to it. Every host in every scan would be named by IP.
+       */
+      const asked: Array<string> = [];
+      const resolver: ReverseDnsResolver = resolverWith(
+        async (ipAddress: string): Promise<Array<string>> => {
+          asked.push(ipAddress);
+          return [`host-${ipAddress.split(".").pop()}.corp.example.com`];
+        },
+        { failureBudget: failureBudget },
+      );
+
+      const result: ReverseDnsResolution = await resolver.resolveHostnames(
+        addressList(3),
+      );
+
+      expect(asked).toHaveLength(3);
+      expect(result.hostnameByIpAddress.size).toBe(3);
+      expect(result.isReverseDnsAvailable).toBe(true);
+      expect(warnedMessages).toHaveLength(0);
+    },
+  );
+
+  it.each([0, -4])(
+    "treats a total budget of %i ms as one millisecond, not as a deadline already past",
+    async (totalBudgetInMs: number) => {
+      /*
+       * Without the clamp the deadline is `now() + 0`, so the first reading of
+       * the clock is already `>= deadline`: the pass asks nothing, warns that
+       * it ran out of time, and reports isTimeBudgetExhausted on a sweep it
+       * never began.
+       *
+       * The clock is FROZEN rather than stepping, which is what makes the
+       * clamp observable at all: one millisecond of budget is only enough to
+       * do any work if no time passes, and a stepping clock would spend it on
+       * the first reading and make clamped and unclamped look alike.
+       */
+      const asked: Array<string> = [];
+      const resolver: ReverseDnsResolver = resolverWith(
+        async (ipAddress: string): Promise<Array<string>> => {
+          asked.push(ipAddress);
+          return [`host-${ipAddress.split(".").pop()}.corp.example.com`];
+        },
+        {
+          totalBudgetInMs: totalBudgetInMs,
+          now: (): number => {
+            return 0;
+          },
+        },
+      );
+
+      const result: ReverseDnsResolution = await resolver.resolveHostnames(
+        addressList(3),
+      );
+
+      expect(asked).toHaveLength(3);
+      expect(result.hostnameByIpAddress.size).toBe(3);
+      expect(result.isTimeBudgetExhausted).toBe(false);
+      expect(warnedMessages).toHaveLength(0);
+    },
+  );
+});
+
+describe("ReverseDnsResolver — one instance, two sweeps", () => {
+  /*
+   * A probe holds its resolver across sweeps, so every pass after the first is
+   * the one that matters in production, and all of this pass's budget state
+   * lives in locals and a `state` object created inside resolveHostnames
+   * rather than on `this`.
+   *
+   * That is not an incidental implementation detail: the whole hardening this
+   * file exists for was "a latched flag becomes a recomputed function", and
+   * the most natural way to reintroduce the original bug in a worse form is to
+   * hoist a counter onto the instance for convenience. A tripped budget that
+   * survives into the next sweep would name every host by IP for the lifetime
+   * of the probe, on the strength of one bad minute — and would look, in every
+   * log and every result, exactly like a network with no reverse zone.
+   */
+
+  it("does not carry a tripped failure budget into the next sweep", async () => {
+    let isResolverBroken: boolean = true;
+    const asked: Array<string> = [];
+
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+
+        if (isResolverBroken) {
+          throw dnsError("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.53:53");
+        }
+
+        return [`host-${ipAddress.split(".").pop()}.corp.example.com`];
+      },
+      { concurrency: 4, failureBudget: 2 },
+    );
+
+    const brokenPass: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(12),
+    );
+
+    // The first sweep really did trip: one wave, then nothing.
+    expect(asked).toHaveLength(4);
+    expect(brokenPass.isReverseDnsAvailable).toBe(false);
+    expect(brokenPass.failureReason).toContain("ECONNREFUSED");
+
+    // The resolver comes back — a restarted container, a firewall rule fixed.
+    isResolverBroken = false;
+    asked.length = 0;
+    warnedMessages = [];
+
+    const healthyPass: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(12),
+    );
+
+    /*
+     * Hoist infrastructureFailureCount or successfulLookupCount onto the
+     * instance and this second pass never starts: at its first wave boundary
+     * the leaked counters read "two failures, no successes", the breaker is
+     * already tripped, and `asked` is zero rather than twelve.
+     */
+    expect(asked).toHaveLength(12);
+    expect(healthyPass.isReverseDnsAvailable).toBe(true);
+    expect(healthyPass.hostnameByIpAddress.size).toBe(12);
+    // Nor does the previous sweep's reason bleed into this one's result.
+    expect(healthyPass.failureReason).toBeUndefined();
+    expect(warnedMessages).toHaveLength(0);
+  });
+
+  it("gives the next sweep its own wall-clock budget", async () => {
+    /*
+     * The deadline is computed from `now()` at the top of each call. Compute
+     * it once — in the constructor, say, which is where a reader optimising
+     * "this never changes" would put it — and the first sweep to exhaust its
+     * budget would leave every later sweep on the same probe permanently past
+     * its deadline, asking nothing and reporting exhaustion forever.
+     */
+    let clock: number = 0;
+
+    const asked: Array<string> = [];
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (ipAddress: string): Promise<Array<string>> => {
+        asked.push(ipAddress);
+        // Each lookup costs 100ms of the injected clock.
+        clock += 100;
+        return [`host-${ipAddress.split(".").pop()}.corp.example.com`];
+      },
+      {
+        concurrency: 1,
+        totalBudgetInMs: 250,
+        now: (): number => {
+          return clock;
+        },
+      },
+    );
+
+    // Deadline 250; readings at 0, 100 and 200 buy three addresses of five.
+    const firstPass: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(5),
+    );
+
+    expect(asked).toHaveLength(3);
+    expect(firstPass.isTimeBudgetExhausted).toBe(true);
+
+    // A new sweep, on the same instance, at the top of a new minute.
+    clock = 0;
+    asked.length = 0;
+    warnedMessages = [];
+
+    const secondPass: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(3),
+    );
+
+    // A fresh deadline of 250: readings at 0, 100, 200 cover all three.
+    expect(asked).toHaveLength(3);
+    expect(secondPass.isTimeBudgetExhausted).toBe(false);
+    expect(secondPass.hostnameByIpAddress.size).toBe(3);
+    expect(warnedMessages).toHaveLength(0);
+  });
+});
+
+describe("ReverseDnsResolver — the two verdicts are independent", () => {
+  /*
+   * `isReverseDnsAvailable` and `isTimeBudgetExhausted` answer different
+   * questions — "does DNS work from this probe" versus "was this pass simply
+   * too big to finish" — and the caller logs them differently. Deriving one
+   * from the other would tell an operator with four thousand healthy hosts
+   * that their probe has no resolver.
+   */
+
+  it("keeps availability true when only the wall clock ran out", async () => {
+    /*
+     * A clock that jumps a full budget on its second reading: the deadline is
+     * taken from the first, so the very first address is already too late.
+     */
+    let reading: number = 0;
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (): Promise<Array<string>> => {
+        return ["sw-core-01.corp.example.com"];
+      },
+      {
+        totalBudgetInMs: 100,
+        now: (): number => {
+          const value: number = reading;
+          reading += 1000;
+          return value;
+        },
+      },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(5),
+    );
+
+    expect(result.isTimeBudgetExhausted).toBe(true);
+    // Nothing was ever asked, so nothing is known against the resolver.
+    expect(result.isReverseDnsAvailable).toBe(true);
+    expect(result.failureReason).toBeUndefined();
+  });
+
+  it("keeps the time budget unexhausted when only the resolver is broken", async () => {
+    /*
+     * A clock that never moves: the wall-clock budget cannot be what stopped
+     * this pass, so the false below can only come from the failure budget.
+     */
+    const resolver: ReverseDnsResolver = resolverWith(
+      async (): Promise<Array<string>> => {
+        throw dnsError("ECONNREFUSED");
+      },
+      {
+        failureBudget: 2,
+        now: (): number => {
+          return 0;
+        },
+      },
+    );
+
+    const result: ReverseDnsResolution = await resolver.resolveHostnames(
+      addressList(20),
+    );
+
+    expect(result.isReverseDnsAvailable).toBe(false);
+    expect(result.isTimeBudgetExhausted).toBe(false);
   });
 });

--- a/Probe/Tests/Utils/Discovery/ReverseDnsStubIntegrity.test.ts
+++ b/Probe/Tests/Utils/Discovery/ReverseDnsStubIntegrity.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * A unit test in this repository must never send a real DNS query.
+ *
+ * Since reverse DNS was added to the discovery sweep (OneUptime issue #3529),
+ * any test that drives the REAL `SubnetScanner.scan()` ends by asking a
+ * resolver for a PTR record per discovered host. Five suites do exactly that,
+ * and each calls `stubReverseDnsAsResolvingNothing()` at module scope to keep
+ * the sweep's third network seam stubbed the way ICMP and SNMP already are.
+ *
+ * That is not sufficient on its own, and the way it failed is the reason this
+ * file exists. A root-level `beforeEach` covers every test in a file — but two
+ * suites call `jest.restoreAllMocks()` in the MIDDLE of a test, to run a second
+ * sweep against freshly-configured spies. A blanket restore wipes every spy in
+ * the file, the reverse-DNS stub included, and the sweep that follows it ran
+ * against whatever resolver the machine happens to have:
+ *
+ *   - On a machine whose DNS answers for RFC1918 space — a corporate resolver
+ *     with 10.in-addr.arpa delegated, or any ISP resolver that hijacks
+ *     NXDOMAIN — the second sweep came back with `dnsHostname` set on hosts
+ *     the first sweep had none for, failing an assertion that has nothing to
+ *     do with naming.
+ *   - On a machine with no reachable resolver it paid the full two-second
+ *     per-address budget, inside a unit test, silently.
+ *
+ * Neither symptom names its cause, and neither is reproducible on the machine
+ * of whoever wrote the test. So the invariant is enforced mechanically here
+ * rather than left to review: in a file that stubs reverse DNS, every
+ * `jest.restoreAllMocks()` either IS the suite's own teardown hook, or is
+ * immediately followed by a call that puts the stub back.
+ *
+ * This is a source-level test, in the same style as
+ * App/Tests/Dashboard/DiscoveryReviewHostname.test.ts and
+ * InventoryTableInvariants.test.ts, because the property is about the shape of
+ * the test files themselves and cannot be observed from inside a run.
+ */
+
+const DISCOVERY_TEST_DIRECTORIES: Array<string> = [
+  path.join(__dirname),
+  path.join(__dirname, "..", "..", "Jobs", "Discovery"),
+];
+
+const STUB_INSTALLER: string = "stubReverseDnsAsResolvingNothing";
+const STUB_REINSTALLER: string = "installReverseDnsStub";
+const RESTORE_CALL: string = "jest.restoreAllMocks()";
+
+/*
+ * This file talks ABOUT the strings it searches for — in its prose, in its
+ * constants and in its own assertions — so scanning itself would make every
+ * check below fail on its own documentation. Excluded by name, which is also
+ * the only exclusion: any other file that matches is a real finding.
+ */
+const SELF: string = path.basename(__filename).replace(/\.[jt]s$/, ".ts");
+
+interface TestFile {
+  name: string;
+  fullPath: string;
+  source: string;
+  /*
+   * The same source with comments removed.
+   *
+   * Every check that asks "does the CODE do X" must read this and not
+   * `source`, or describing a rule in prose satisfies the rule. That is not
+   * hypothetical here: the resolver suite's one deliberate real-resolver
+   * construction passed the injected-lookup check below purely because a
+   * comment between its parentheses happened to contain the word "lookup" —
+   * which also means any future file could defeat the check outright by
+   * writing `// no lookup here` above a bare construction, the precise thing
+   * the check exists to catch.
+   */
+  code: string;
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/*
+ * Read once. These files are edited by other processes (another agent, an
+ * editor, a rebase) and an uncached read can hand two assertions in one run
+ * two different versions of the same file.
+ */
+let cachedFiles: Array<TestFile> | null = null;
+
+function readDiscoveryTestFiles(): Array<TestFile> {
+  if (cachedFiles) {
+    return cachedFiles;
+  }
+
+  const files: Array<TestFile> = [];
+
+  for (const directory of DISCOVERY_TEST_DIRECTORIES) {
+    if (!fs.existsSync(directory)) {
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(directory)) {
+      if (!entry.endsWith(".test.ts") || entry === SELF) {
+        continue;
+      }
+
+      const fullPath: string = path.join(directory, entry);
+      const source: string = fs.readFileSync(fullPath, "utf8");
+      files.push({
+        name: entry,
+        fullPath: fullPath,
+        source: source,
+        code: stripComments(source),
+      });
+    }
+  }
+
+  cachedFiles = files;
+  return files;
+}
+
+/** The suites that drive the real sweep and therefore stub reverse DNS. */
+function stubbedFiles(): Array<TestFile> {
+  return readDiscoveryTestFiles().filter((file: TestFile) => {
+    return file.code.includes(`${STUB_INSTALLER}(`);
+  });
+}
+
+/*
+ * Every entry point that ends in a reverse-DNS pass.
+ *
+ * `attachReverseDnsHostnames` is called from scanWithDeadline, so it runs on
+ * whatever hosts the sweep returned — INCLUDING the hosts a mocked
+ * SubnetScanner.scan hands back. Mocking the sweep is therefore not enough to
+ * keep a suite off the resolver, which is the trap that caught eight job
+ * suites the day the pass moved out of scan().
+ */
+const SWEEP_ENTRY_POINTS: Array<string> = [
+  "scanWithDeadline(",
+  "runScan(",
+  "fetchAndRunScans(",
+  "SubnetScanner.scan(",
+  "attachReverseDnsHostnames(",
+];
+
+/** Files that can reach a reverse-DNS pass, however indirectly. */
+function filesThatReachTheResolver(): Array<TestFile> {
+  return readDiscoveryTestFiles().filter((file: TestFile) => {
+    return SWEEP_ENTRY_POINTS.some((entryPoint: string) => {
+      return file.code.includes(entryPoint);
+    });
+  });
+}
+
+/*
+ * A file is covered either by the per-file hook, or by spying on the seam
+ * itself — which is what a suite ABOUT naming does, since it needs the pass to
+ * return names rather than nothing.
+ */
+function hasResolverCover(file: TestFile): boolean {
+  return (
+    file.code.includes(`${STUB_INSTALLER}(`) ||
+    file.code.includes('"resolveReverseDnsHostnames"')
+  );
+}
+
+/*
+ * A restore is "safe" when it is the suite's own teardown — the line before it
+ * opens an afterEach — or when the very next non-blank, non-comment line puts
+ * the stub back.
+ */
+function unsafeRestoreLines(file: TestFile): Array<number> {
+  const lines: Array<string> = file.code.split("\n");
+  const unsafe: Array<number> = [];
+
+  lines.forEach((line: string, index: number) => {
+    if (!line.includes(RESTORE_CALL)) {
+      return;
+    }
+
+    const previous: string = (lines[index - 1] || "").trim();
+
+    if (previous.startsWith("afterEach(")) {
+      return;
+    }
+
+    for (let cursor: number = index + 1; cursor < lines.length; cursor++) {
+      const next: string = (lines[cursor] || "").trim();
+
+      if (
+        !next ||
+        next.startsWith("//") ||
+        next.startsWith("*") ||
+        next.startsWith("/*")
+      ) {
+        continue;
+      }
+
+      if (!next.includes(`${STUB_REINSTALLER}(`)) {
+        // 1-indexed, so the number matches what an editor shows.
+        unsafe.push(index + 1);
+      }
+
+      return;
+    }
+
+    unsafe.push(index + 1);
+  });
+
+  return unsafe;
+}
+
+describe("no discovery unit test can send a real reverse-DNS query", () => {
+  it("finds the suites that drive the real sweep", () => {
+    /*
+     * A guard on the guard. If a rename or a move made `stubbedFiles()` match
+     * nothing, every assertion below would pass over an empty list and this
+     * file would protect nothing while staying green — the exact way a
+     * source-level test rots.
+     */
+    const names: Array<string> = stubbedFiles().map((file: TestFile) => {
+      return file.name;
+    });
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "SubnetScanner.test.ts",
+        "SubnetScannerIcmpFallback.test.ts",
+        "SubnetScannerIcmpOnly.test.ts",
+        "SubnetScannerMultiConfig.test.ts",
+        "DiscoveryScanEndToEnd.test.ts",
+      ]),
+    );
+  });
+
+  it("every suite that can reach the resolver stubs it", () => {
+    /*
+     * The invariant that actually matters, and the one a mocked sweep does
+     * NOT satisfy on its own. When the reverse-DNS pass moved out of scan()
+     * and into scanWithDeadline — so that it could never spend the sweep's
+     * deadline — eight job suites that mock SubnetScanner.scan and return
+     * hand-built hosts started reaching a real resolver, silently, because
+     * the pass runs on whatever the mock returned.
+     */
+    const offenders: Array<string> = filesThatReachTheResolver()
+      .filter((file: TestFile) => {
+        return !hasResolverCover(file);
+      })
+      .map((file: TestFile) => {
+        return file.name;
+      });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("actually finds files that reach the resolver", () => {
+    // The same guard-on-the-guard as above: an empty list proves nothing.
+    expect(filesThatReachTheResolver().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("every mid-test jest.restoreAllMocks() puts the reverse-DNS stub back", () => {
+    const offenders: Array<string> = [];
+
+    for (const file of stubbedFiles()) {
+      for (const line of unsafeRestoreLines(file)) {
+        offenders.push(`${file.name}:${line}`);
+      }
+    }
+
+    /*
+     * If this fails, the named line wiped the file's reverse-DNS stub and
+     * whatever sweep runs after it will query the machine's real resolver.
+     * Add `installReverseDnsStub();` immediately after the restore.
+     */
+    expect(offenders).toEqual([]);
+  });
+
+  it("the helper exposes a re-installer, not only a per-file hook", () => {
+    /*
+     * The fix above depends on `installReverseDnsStub` existing and being
+     * callable mid-test. Deleting it in a tidy-up would leave the two call
+     * sites unresolved at compile time, but this states the requirement where
+     * the reason for it is written down.
+     */
+    const helper: string = fs.readFileSync(
+      path.join(__dirname, "..", "..", "TestingUtils", "StubReverseDns.ts"),
+      "utf8",
+    );
+
+    expect(helper).toContain(`export function ${STUB_REINSTALLER}(`);
+    expect(helper).toContain(`export function ${STUB_INSTALLER}(`);
+  });
+
+  it("no discovery test constructs a ReverseDnsResolver without injecting a lookup", () => {
+    /*
+     * The other way a real query can escape: `new ReverseDnsResolver()` with
+     * no `lookup` falls back to `buildDefaultLookup`, which dials the system
+     * resolvers. Every test that builds one must inject a fake.
+     */
+    const offenders: Array<string> = [];
+
+    for (const file of readDiscoveryTestFiles()) {
+      const matches: Array<string> =
+        file.code.match(/new ReverseDnsResolver\(([^)]*)\)/g) || [];
+
+      for (const match of matches) {
+        if (!match.includes("lookup")) {
+          offenders.push(`${file.name}: ${match}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/Probe/Tests/Utils/Discovery/SubnetScannerIcmpOnly.test.ts
+++ b/Probe/Tests/Utils/Discovery/SubnetScannerIcmpOnly.test.ts
@@ -23,7 +23,10 @@ import {
   jest,
 } from "@jest/globals";
 
-import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
+import {
+  installReverseDnsStub,
+  stubReverseDnsAsResolvingNothing,
+} from "../../TestingUtils/StubReverseDns";
 
 /*
  * github.com/OneUptime/oneuptime/issues/3445 — "SNMP Version is marked
@@ -1170,7 +1173,18 @@ describe("SubnetScanner — an absent isSnmpEnabled means SNMP", () => {
       isSnmpEnabled: false,
     });
 
+    /*
+     * A mid-test restore wipes EVERY spy in the file, including the
+     * file-level reverse-DNS stub — so the second sweep below used to run
+     * against the machine's real resolver. On a resolver that answers for
+     * RFC1918 space that put a dnsHostname on withSnmp's hosts and none on
+     * icmpOnly's, failing the toEqual below for a reason that has nothing to
+     * do with the SNMP toggle this test is about. Re-installed explicitly
+     * rather than by narrowing the restore, because the restore is what makes
+     * the second sweep's spies clean.
+     */
     jest.restoreAllMocks();
+    installReverseDnsStub();
     mockPingAlive(["10.0.0.2"]);
     recordSnmpProbes([]);
 

--- a/Probe/Tests/Utils/Discovery/SubnetScannerMultiConfig.test.ts
+++ b/Probe/Tests/Utils/Discovery/SubnetScannerMultiConfig.test.ts
@@ -18,7 +18,10 @@ import SnmpPrivProtocol from "Common/Types/Monitor/SnmpMonitor/SnmpPrivProtocol"
 import SnmpV3Auth from "Common/Types/Monitor/SnmpMonitor/SnmpV3Auth";
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
 
-import { stubReverseDnsAsResolvingNothing } from "../../TestingUtils/StubReverseDns";
+import {
+  installReverseDnsStub,
+  stubReverseDnsAsResolvingNothing,
+} from "../../TestingUtils/StubReverseDns";
 
 /*
  * A discovery scan carries an ORDERED LIST of SNMP credential sets, not one.
@@ -505,7 +508,17 @@ describe("SubnetScanner multi-config sweep — errors are counted per host", () 
         snmpConfigs: ALL_THREE,
       });
 
+      /*
+       * This helper runs TWICE in the test below, and the restore wipes every
+       * spy in the file — the file-level reverse-DNS stub included. Without
+       * re-installing it, the second invocation's sweep queried the machine's
+       * real resolver for 10.0.0.1 and 10.0.0.2: silent, because the
+       * assertions here read only the SNMP error tallies, but it made the
+       * suite depend on the host's DNS and pay two real timeouts when there
+       * is none.
+       */
       jest.restoreAllMocks();
+      installReverseDnsStub();
 
       return result;
     };

--- a/Probe/Utils/Discovery/ReverseDnsResolver.ts
+++ b/Probe/Utils/Discovery/ReverseDnsResolver.ts
@@ -43,11 +43,24 @@ export const DEFAULT_REVERSE_DNS_TIMEOUT_IN_MS: number = 2000;
 export const DEFAULT_REVERSE_DNS_CONCURRENCY: number = 32;
 
 /*
- * How many infrastructure failures are tolerated before the rest of the sweep
- * is skipped. See `isReverseDnsAvailable` below for why this counts only
- * while nothing has resolved.
+ * How many infrastructure failures are tolerated before the rest of the pass
+ * is skipped — and only while NOT ONE lookup has come back, NXDOMAIN included.
+ * See isReverseDnsUnusable in resolveHostnames.
+ *
+ * It is a FLOOR rather than a cap, because the decision is taken at a wave
+ * boundary: at the shipped concurrency of 32 the pass gives up after the first
+ * whole wave in which the budget is exceeded, so a probe with no resolver at
+ * all costs two waves — about four seconds — instead of the sixty the
+ * wall-clock budget would otherwise allow.
+ *
+ * Two waves rather than one on purpose. A single all-failing wave is not proof
+ * of a broken probe: 32 consecutive addresses can share one reverse zone whose
+ * nameserver is down while the rest of the estate resolves perfectly, and
+ * giving up there would reproduce the exact symptom this feature exists to
+ * fix. Sixty-four consecutive addresses answering nothing at all is a
+ * different claim.
  */
-export const DEFAULT_REVERSE_DNS_FAILURE_BUDGET: number = 10;
+export const DEFAULT_REVERSE_DNS_FAILURE_BUDGET: number = 64;
 
 /*
  * Wall-clock ceiling on the WHOLE pass, independent of the per-address one.
@@ -68,20 +81,36 @@ export const DEFAULT_REVERSE_DNS_FAILURE_BUDGET: number = 10;
 export const DEFAULT_REVERSE_DNS_TOTAL_BUDGET_IN_MS: number = 60 * 1000;
 
 /*
- * c-ares codes that mean "asked, answered, no PTR here". This is the ORDINARY
- * outcome — most addresses on most networks have no reverse record — so it
- * must never count against the failure budget, or one normal subnet would
- * disable the feature for the rest of its own scan.
+ * Codes that mean "this address has no name", as opposed to "this probe
+ * cannot resolve". This is the ORDINARY outcome — most addresses on most
+ * networks have no reverse record — so it must never count against the
+ * failure budget, or one normal subnet would disable the feature for the rest
+ * of its own scan.
  *
- * EBADNAME/EBADSTR are lumped in with them: they mean the address could not
- * be turned into a query, which is a fact about that one address and not
- * evidence about the resolver.
+ * ENOTFOUND (NXDOMAIN) and ENODATA (the name exists, no PTR record) are what
+ * Node's Resolver#reverse actually rejects with for the two ordinary cases.
+ *
+ * EINVAL is here because reverse() rejects with it when the argument is not a
+ * parseable IP address — " 1.2.3.4 ", an IPv6 form it will not take, anything
+ * a future caller of the public attachReverseDnsHostnames might hand it. That
+ * is a fact about that one address and carries no information about the
+ * resolver, so counting it would let a handful of malformed inputs convict a
+ * working probe of having no DNS and skip every remaining host.
+ *
+ * EBADNAME/EBADSTR/NOTFOUND/NODATA are kept for the same reason and cost
+ * nothing: they are the spellings other c-ares entry points use, and this set
+ * should not depend on which one a future change routes through.
+ *
+ * Everything NOT here — ESERVFAIL, EREFUSED, ECONNREFUSED, ETIMEOUT,
+ * ENOTIMP, and the race guard's own bare timeout Error — is evidence the
+ * probe could not get an answer at all, which is what the budget is for.
  */
 const NO_RECORD_ERROR_CODES: Set<string> = new Set<string>([
   "ENOTFOUND",
   "ENODATA",
   "NOTFOUND",
   "NODATA",
+  "EINVAL",
   "EBADNAME",
   "EBADSTR",
 ]);
@@ -95,12 +124,13 @@ export interface ReverseDnsResolution {
   hostnameByIpAddress: Map<string, string>;
   /*
    * False when the failure budget ran out and the remaining addresses were
-   * skipped. The names already resolved (there are none, by construction —
-   * see the budget rule) are still returned.
+   * skipped: not one lookup came back, NXDOMAIN included, so this probe cannot
+   * resolve at all. No names will have been found, by construction.
    *
-   * Distinct from `isTimeBudgetExhausted`: this one says the resolver does
-   * not work from here, which is a probe-configuration fact, while that one
-   * says the pass was simply too big to finish.
+   * Distinct from `isTimeBudgetExhausted`: this one says the resolver does not
+   * work from here, which is a probe-configuration fact, while that one says
+   * the pass was simply too big to finish. They are independent, and a pass
+   * can end with neither, either or both.
    */
   isReverseDnsAvailable: boolean;
   /*
@@ -109,10 +139,14 @@ export interface ReverseDnsResolution {
    */
   isTimeBudgetExhausted: boolean;
   /*
-   * The first infrastructure failure, verbatim-ish, for the log line that
-   * explains why a scan came back with addresses instead of names. Truncated
-   * the way SubnetScanner truncates SNMP errors — resolver errors can carry a
-   * whole server list.
+   * The FIRST infrastructure failure seen, verbatim-ish and truncated the way
+   * SubnetScanner truncates SNMP errors.
+   *
+   * "Seen", not "fatal". A single stale delegation in an otherwise healthy
+   * estate sets this on a pass that named every other host and returns
+   * `isReverseDnsAvailable: true`, so a caller that logs it unconditionally
+   * would report a resolver problem for a pass that worked. Read it together
+   * with `isReverseDnsAvailable`, never on its own.
    */
   failureReason?: string | undefined;
 }
@@ -120,10 +154,21 @@ export interface ReverseDnsResolution {
 // Long enough to name the failure, short enough for one log line.
 const FAILURE_REASON_EXCERPT_LENGTH: number = 200;
 
-function describeError(error: unknown): string {
+function describeError(error: unknown): string | undefined {
   const message: string = (
     (error as Error | undefined)?.message || String(error ?? "")
   ).trim();
+
+  /*
+   * UNDEFINED, not "", when there is nothing to say. A thrown `undefined` or a
+   * bare `new Error()` produces an empty message, and returning that left
+   * `failureReason` typed `string | undefined` holding a present-but-empty
+   * string — so a caller asking `failureReason !== undefined` was told there
+   * was a reason and then shown nothing.
+   */
+  if (!message) {
+    return undefined;
+  }
 
   return message.length > FAILURE_REASON_EXCERPT_LENGTH
     ? message.substring(0, FAILURE_REASON_EXCERPT_LENGTH)
@@ -143,18 +188,60 @@ function getErrorCode(error: unknown): string {
  * guard is the one that matters in practice — it is the same belt-and-braces
  * DnsResolutionCache uses, for the same reason.
  */
-function buildDefaultLookup(timeoutInMs: number): ReverseDnsLookupFunction {
+/*
+ * How a resolver is obtained, injectable ONLY so that the timeout arm below
+ * can be tested.
+ *
+ * Without a seam here, three things in this function are unreachable from any
+ * test: the race's timeout branch, the `resolver.cancel()` inside it, and the
+ * `finally` that clears the timer. The cancel is load-bearing — on a
+ * black-holing forwarder every timed-out address would otherwise leave an
+ * outstanding query and a retry timer behind for a resolver object the sweep
+ * no longer holds — and deleting it broke no test, which is exactly the state
+ * a piece of cleanup code should never be in.
+ */
+export interface ReverseDnsResolverLike {
+  reverse(ipAddress: string): Promise<Array<string>>;
+  cancel(): void;
+}
+
+export type ReverseDnsResolverFactory = (
+  timeoutInMs: number,
+) => ReverseDnsResolverLike;
+
+const defaultResolverFactory: ReverseDnsResolverFactory = (
+  timeoutInMs: number,
+): ReverseDnsResolverLike => {
+  return new dns.promises.Resolver({
+    timeout: timeoutInMs,
+    tries: 1,
+  });
+};
+
+export function buildDefaultLookup(
+  timeoutInMs: number,
+  createResolver: ReverseDnsResolverFactory = defaultResolverFactory,
+): ReverseDnsLookupFunction {
   return async (ipAddress: string): Promise<Array<string>> => {
-    const resolver: dns.promises.Resolver = new dns.promises.Resolver({
-      timeout: timeoutInMs,
-      tries: 1,
-    });
+    const resolver: ReverseDnsResolverLike = createResolver(timeoutInMs);
 
     const lookup: Promise<Array<string>> = resolver.reverse(ipAddress);
 
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+
     const timeout: Promise<never> = new Promise<never>(
       (_resolve: (value: never) => void, reject: (reason: Error) => void) => {
-        const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+        timer = setTimeout(() => {
+          /*
+           * Tell c-ares to stop as well as stopping waiting for it. Without
+           * this the abandoned query stays outstanding on a resolver object
+           * the sweep no longer holds, and on a black-holing forwarder every
+           * timed-out address leaves one behind — up to a whole sweep's worth
+           * of sockets and retry timers the probe is still paying for while
+           * the pass moves on. Losing the race is not the same as the query
+           * being over.
+           */
+          resolver.cancel();
           reject(new Error(`Reverse DNS lookup for ${ipAddress} timed out`));
         }, timeoutInMs);
         // Never keep the probe alive just for this timer.
@@ -162,7 +249,20 @@ function buildDefaultLookup(timeoutInMs: number): ReverseDnsLookupFunction {
       },
     );
 
-    return await Promise.race([lookup, timeout]);
+    try {
+      return await Promise.race([lookup, timeout]);
+    } finally {
+      /*
+       * Clear it on the WINNING path too. Promise.race leaves the loser
+       * pending, so an un-cleared two-second timer would otherwise outlive
+       * every fast lookup — thousands of them on a large sweep — and each
+       * would still call resolver.cancel() long after that resolver's answer
+       * was already in the map.
+       */
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
   };
 }
 
@@ -242,128 +342,192 @@ export default class ReverseDnsResolver {
      */
     const state: {
       resolvedCount: number;
+      /*
+       * Lookups that came BACK, whether or not any answer survived
+       * normalisation. This — not `resolvedCount` — is what disarms the
+       * failure budget.
+       *
+       * The distinction is not academic. A resolver that answers every query
+       * with a name that normalises away (a wildcard zone echoing
+       * in-addr.arpa, a zone full of names with spaces in them) is a WORKING
+       * resolver; counting only usable names would let a run of unusable
+       * answers sit alongside a handful of unrelated timeouts and convict the
+       * probe of having no resolver at all, skipping the addresses further
+       * down the list that do have good names.
+       */
+      successfulLookupCount: number;
       infrastructureFailureCount: number;
       failureReason?: string | undefined;
-      isAvailable: boolean;
       isTimeBudgetExhausted: boolean;
     } = {
       resolvedCount: 0,
+      successfulLookupCount: 0,
       infrastructureFailureCount: 0,
-      isAvailable: true,
       isTimeBudgetExhausted: false,
     };
 
-    await this.runConcurrently(
-      uniqueAddresses,
-      async (ipAddress: string): Promise<void> => {
-        if (!state.isAvailable) {
-          return;
-        }
+    /*
+     * The failure budget, asked only where the answer cannot be a lie: BETWEEN
+     * waves, when every lookup started so far has settled.
+     *
+     * Two designs failed before this one, and both failures are worth keeping
+     * written down because each looked correct.
+     *
+     * The first was a one-way latch set inside the failure branch. At the
+     * shipped concurrency of 32, thirty-two lookups start together; if the
+     * first ten to come back are infrastructure failures the latch flipped,
+     * and it STAYED flipped as the other twenty-two returned perfectly good
+     * names a moment later. A subnet whose first addresses sit in a reverse
+     * zone delegated to a dead nameserver — the commonest way this happens —
+     * was named entirely by IP.
+     *
+     * The second was this same predicate, asked fresh on every address so the
+     * breaker could un-trip itself. That is worse, not better, and the reason
+     * is scheduling rather than logic: when a worker pool sees the breaker
+     * tripped, its workers return WITHOUT AWAITING ANYTHING, so the whole
+     * remaining queue drains through the skip path in microtasks. A success
+     * settling one macrotask later — that is to say, every real DNS answer —
+     * always lost that race. Sixty-eight of a hundred addresses were skipped
+     * and the pass then reported `isReverseDnsAvailable: true`, because by the
+     * time anyone asked, the breaker had un-tripped. Silently skipping two
+     * thirds of the work while reporting success is the worst of the three.
+     *
+     * So the decision is made where there is nothing in flight to race: at a
+     * wave boundary, on fully-settled counters. Nothing un-trips because
+     * nothing trips early.
+     */
+    const isReverseDnsUnusable: () => boolean = (): boolean => {
+      return (
+        state.successfulLookupCount === 0 &&
+        state.infrastructureFailureCount >= this.failureBudget
+      );
+    };
+
+    /*
+     * One address, start to finish. NEVER rejects: every outcome is recorded
+     * on `state` and the caller awaits a wave of these with Promise.all, which
+     * would abandon the whole wave on a single rejection.
+     */
+    const lookupOne: (ipAddress: string) => Promise<void> = async (
+      ipAddress: string,
+    ): Promise<void> => {
+      try {
+        const answers: unknown = await this.lookup(ipAddress);
 
         /*
-         * Checked before STARTING a lookup, never in the middle of one: a
-         * lookup already in flight is bounded by its own timeout, and
-         * abandoning its result would waste a query that has already been
-         * sent. The pass therefore overruns the budget by at most one
-         * per-address timeout.
+         * The lookup RETURNED, so the resolver is alive. Counted before the
+         * answers are inspected, because whether any of them survives
+         * normalisation says nothing about whether DNS works here.
          */
-        if (this.now() >= deadline) {
-          if (!state.isTimeBudgetExhausted) {
-            state.isTimeBudgetExhausted = true;
-            logger.warn(
-              `Discovery reverse DNS lookups exceeded their ${this.totalBudgetInMs}ms budget after naming ${state.resolvedCount} host(s); the remaining discovered hosts will be named by IP address. The sweep itself is unaffected.`,
-            );
-          }
+        state.successfulLookupCount++;
 
+        /*
+         * Defended rather than assumed. `for...of` over a non-iterable throws,
+         * and that throw would land in the catch below and be counted as an
+         * INFRASTRUCTURE failure — so a lookup that returned null would not
+         * merely fail to name one host, it would spend the budget. A lookup
+         * that answers with something that is not a list of names has told us
+         * there is no name here, and nothing more.
+         */
+        const usableAnswers: Array<unknown> = Array.isArray(answers)
+          ? answers
+          : [];
+
+        /*
+         * FIRST usable answer wins. An address with several PTR records is
+         * unusual but legal, and the alternative — refusing to name a host
+         * whose owner published two names for it — is worse than picking one
+         * deterministically. Answers that normalise away (an in-addr.arpa
+         * echo, a name with a space in it) are skipped rather than ending the
+         * search, so a junk first record cannot hide a good second one.
+         */
+        for (const answer of usableAnswers) {
+          const name: string | undefined = normalizeReverseDnsName(answer);
+
+          if (name) {
+            hostnameByIpAddress.set(ipAddress, name);
+            state.resolvedCount++;
+            return;
+          }
+        }
+      } catch (err) {
+        if (NO_RECORD_ERROR_CODES.has(getErrorCode(err))) {
+          /*
+           * The ordinary "this address has no PTR record". Not a failure —
+           * and, just as importantly, a SUCCESS for the budget's purposes.
+           *
+           * NXDOMAIN is an answer. A resolver that returns it is reachable,
+           * configured and working; the only thing it has told us is that this
+           * particular address has no name. Counting it as neither would leave
+           * a sparse subnet — five addresses with no record and a handful of
+           * unrelated timeouts — looking exactly like a probe with no resolver
+           * at all, and the budget would skip every remaining host on the
+           * strength of it.
+           */
+          state.successfulLookupCount++;
           return;
         }
 
-        try {
-          const answers: Array<string> = await this.lookup(ipAddress);
-
-          /*
-           * FIRST usable answer wins. An address with several PTR records is
-           * unusual but legal, and the alternative — refusing to name a host
-           * whose owner published two names for it — is worse than picking
-           * one deterministically. Answers that normalise away (an
-           * in-addr.arpa echo, a name with a space in it) are skipped rather
-           * than ending the search, so a junk first record cannot hide a good
-           * second one.
-           */
-          for (const answer of answers) {
-            const name: string | undefined = normalizeReverseDnsName(answer);
-
-            if (name) {
-              hostnameByIpAddress.set(ipAddress, name);
-              state.resolvedCount++;
-              break;
-            }
-          }
-        } catch (err) {
-          if (NO_RECORD_ERROR_CODES.has(getErrorCode(err))) {
-            // The ordinary "this address has no PTR record". Not a failure.
-            return;
-          }
-
-          state.infrastructureFailureCount++;
-          state.failureReason = state.failureReason || describeError(err);
-
-          /*
-           * The budget only bites while NOTHING has resolved.
-           *
-           * A resolver that has already answered for some address is present
-           * and working, so a later timeout is about that address (a stale
-           * delegation, a reverse zone whose nameserver is down) and skipping
-           * the rest of the sweep over it would throw away names that would
-           * have resolved fine. It is the probe container with no resolver at
-           * all, or one that refuses every query, that this exists for — and
-           * there, by definition, nothing ever resolves.
-           */
-          if (
-            state.resolvedCount === 0 &&
-            state.infrastructureFailureCount >= this.failureBudget
-          ) {
-            state.isAvailable = false;
-            logger.warn(
-              `Discovery reverse DNS lookups are not usable from this probe: ${state.infrastructureFailureCount} of the first ${uniqueAddresses.length} discovered address(es) failed to resolve and none succeeded, so the rest were skipped and those hosts will be named by IP address. Reverse DNS is best-effort and this does not fail the scan. Resolver reported: ${state.failureReason || "unknown error"}`,
-            );
-          }
-        }
-      },
-    );
-
-    return {
-      hostnameByIpAddress: hostnameByIpAddress,
-      isReverseDnsAvailable: state.isAvailable,
-      isTimeBudgetExhausted: state.isTimeBudgetExhausted,
-      failureReason: state.failureReason,
-    };
-  }
-
-  /*
-   * At most `concurrency` lookups in flight. Same worker-pool shape as
-   * SubnetScanner.runConcurrently — duplicated rather than shared so this
-   * class stays testable on its own, which is the whole reason it is a class
-   * and not three functions inside the scanner.
-   */
-  private async runConcurrently(
-    items: Array<string>,
-    work: (item: string) => Promise<void>,
-  ): Promise<void> {
-    let cursor: number = 0;
-
-    const worker: () => Promise<void> = async (): Promise<void> => {
-      while (cursor < items.length) {
-        await work(items[cursor++]!);
+        state.infrastructureFailureCount++;
+        state.failureReason = state.failureReason || describeError(err);
       }
     };
 
-    const workers: Array<Promise<void>> = [];
+    /*
+     * WAVES, not a work-stealing pool.
+     *
+     * A pool would finish a mixed batch marginally sooner, and it is what this
+     * used to be. It is given up because the breaker has to be evaluated
+     * somewhere, and inside a pool there is no moment at which the counters
+     * are complete — see the note on isReverseDnsUnusable above, where asking
+     * mid-flight silently skipped two thirds of a sweep and reported success.
+     *
+     * At a wave boundary every lookup that has started has finished, so the
+     * counters mean exactly what they say. The cost is that a wave takes as
+     * long as its slowest address, which is bounded by the per-address budget
+     * (2s) — and DNS is the one protocol where that variance is small, because
+     * an address either answers in milliseconds or times out.
+     */
+    for (
+      let start: number = 0;
+      start < uniqueAddresses.length;
+      start += this.concurrency
+    ) {
+      /*
+       * Checked before STARTING a wave, never in the middle of one: lookups
+       * already in flight are bounded by their own timeout, and abandoning
+       * their results would waste queries already on the wire. The pass
+       * therefore overruns its budget by at most one wave.
+       */
+      if (this.now() >= deadline) {
+        state.isTimeBudgetExhausted = true;
+        logger.warn(
+          `Discovery reverse DNS lookups exceeded their ${this.totalBudgetInMs}ms budget after naming ${state.resolvedCount} host(s); the remaining discovered hosts will be named by IP address. The sweep itself is unaffected.`,
+        );
+        break;
+      }
 
-    for (let i: number = 0; i < Math.min(this.concurrency, items.length); i++) {
-      workers.push(worker());
+      if (isReverseDnsUnusable()) {
+        logger.warn(
+          `Discovery reverse DNS lookups are not usable from this probe: ${state.infrastructureFailureCount} address(es) of ${uniqueAddresses.length} failed to resolve and not one answered, so the rest were skipped and those hosts will be named by IP address. Reverse DNS is best-effort and this does not fail the scan. Resolver reported: ${state.failureReason || "unknown error"}`,
+        );
+        break;
+      }
+
+      await Promise.all(
+        uniqueAddresses
+          .slice(start, start + this.concurrency)
+          .map((ipAddress: string) => {
+            return lookupOne(ipAddress);
+          }),
+      );
     }
 
-    await Promise.all(workers);
+    return {
+      hostnameByIpAddress: hostnameByIpAddress,
+      isReverseDnsAvailable: !isReverseDnsUnusable(),
+      isTimeBudgetExhausted: state.isTimeBudgetExhausted,
+      failureReason: state.failureReason,
+    };
   }
 }

--- a/Probe/Utils/Discovery/SubnetScanner.ts
+++ b/Probe/Utils/Discovery/SubnetScanner.ts
@@ -210,10 +210,14 @@ export interface SubnetScanResult {
    * How many discovered hosts came back with a usable reverse-DNS name
    * (OneUptime issue #3529).
    *
-   * OPTIONAL, and absent is not zero: a result built before this field
-   * existed says nothing about reverse DNS, whereas zero says the lookups ran
-   * and named nobody. Nothing branches on it — it is here so the probe log
-   * can report what the enrichment achieved without re-walking the hosts.
+   * NOT set by scan(). The reverse-DNS pass deliberately runs OUTSIDE the
+   * sweep — see attachReverseDnsHostnames and FetchScans.scanWithDeadline —
+   * so this is stamped onto the result afterwards by whoever ran that pass.
+   *
+   * Absent therefore means "the enrichment has not run on this result", which
+   * is a different statement from zero ("it ran and named nobody"). Nothing
+   * branches on it; it is here so the probe log can report what the pass
+   * achieved without re-walking the hosts.
    */
   reverseDnsResolvedCount?: number | undefined;
 }
@@ -394,21 +398,12 @@ export default class SubnetScanner {
         });
 
       /*
-       * The ICMP-only sweep is the case issue #3529 was actually reported
-       * against: every host it finds is by definition without a system group,
-       * so before this the Review dialog could only ever list bare addresses.
-       */
-      const icmpOnlyReverseDnsResolvedCount: number =
-        await SubnetScanner.attachReverseDnsHostnames(pingOnlyHosts);
-
-      /*
        * Already in ascending order: `hosts` comes out of expandTarget sorted
        * and this filter preserves that, unlike the SNMP path below where
        * hosts are appended in completion order and have to be sorted.
        */
       return {
         discoveredHosts: pingOnlyHosts,
-        reverseDnsResolvedCount: icmpOnlyReverseDnsResolvedCount,
         scannedHostCount: hosts.length,
         // No port was dialled, and an empty list is the only honest answer.
         scannedPorts: [],
@@ -602,19 +597,8 @@ export default class SubnetScanner {
       );
     });
 
-    /*
-     * After the sweep and after the sort, so the lookups are paid for once
-     * per discovered address and never for a dead one. SNMP responders get a
-     * name too: a device whose sysName is a factory default ("Switch") is
-     * common, and the PTR record is often the only place the estate's real
-     * name for it is written down.
-     */
-    const reverseDnsResolvedCount: number =
-      await SubnetScanner.attachReverseDnsHostnames(discoveredHosts);
-
     return {
       discoveredHosts: discoveredHosts,
-      reverseDnsResolvedCount: reverseDnsResolvedCount,
       // Full sweep size — hosts skipped by the ICMP gate still count as scanned.
       scannedHostCount: hosts.length,
       scannedPorts: SubnetScanner.getScannedPorts(snmpConfigs),
@@ -895,17 +879,30 @@ export default class SubnetScanner {
    * Stamps `dnsHostname` onto every host that has a usable PTR record, in
    * place, and answers how many got one (OneUptime issue #3529).
    *
-   * Mutates rather than returning a new list because it is called on the
-   * exact array each return path is about to hand back, after that array is
-   * final — there is no ordering, filtering or counting decision left for it
-   * to disturb.
+   * DELIBERATELY NOT CALLED BY scan(), and that is the whole point of it
+   * being a separate public method.
    *
-   * NEVER throws and never fails a scan. A sweep that found twelve hosts
-   * found twelve hosts whether or not any of them can be named, and a broken
-   * resolver in the probe container must not turn that into a failed scan.
-   * The one visible consequence of a total failure is a warning in the probe
-   * log (ReverseDnsResolver) and hosts named by address, which is exactly the
-   * behaviour that predates this method.
+   * The sweep runs inside a deadline race (FetchScans.scanWithDeadline): if
+   * scan() has not SETTLED by PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS, the race
+   * rejects and runScan reports the scan Failed with no hosts at all. An
+   * enrichment inside scan() spends that same budget, so a sweep that had
+   * already found forty hosts could be thrown away entirely because looking
+   * up their names took the run past the line — the enrichment destroying the
+   * very result it was meant to improve. The 60s cap on the pass bounds how
+   * much it can add; it cannot stop that addition being the straw.
+   *
+   * So the lookups happen AFTER the race has settled, on a result that is
+   * already final and already safe. Nothing this method does can be
+   * cancelled, discarded or blamed on the sweep.
+   *
+   * Mutates rather than returning a new list because it is handed the exact
+   * array the caller already holds, after ordering, filtering and every count
+   * are decided — there is nothing left for it to disturb.
+   *
+   * NEVER throws. A sweep that found twelve hosts found twelve hosts whether
+   * or not any of them can be named; the only visible consequence of total
+   * failure is a warning in the probe log (ReverseDnsResolver) and hosts
+   * named by address, which is exactly the behaviour that predates this.
    */
   public static async attachReverseDnsHostnames(
     hosts: Array<DiscoveredHost>,


### PR DESCRIPTION
Follow-up to OneUptime/oneuptime#3536 (issue #3529). A multi-agent adversarial
review of that change found real defects — several of them introduced by it.
This fixes them and closes the coverage that let them through.

## Correctness

### Unit tests were making real DNS queries

Two suites call `jest.restoreAllMocks()` **mid-test** to set up a second sweep.
That wipes every spy in the file, the reverse-DNS stub included, so the sweep
after it hit the machine's real resolver — failing on a resolver that answers
for RFC1918 space, and silently paying 2s per address on a runner with no DNS.
Neither symptom names its cause, and neither reproduces on the machine of
whoever wrote the test.

Both sites now re-install the stub, and `ReverseDnsStubIntegrity.test.ts` fails
the build if a future one forgets. It is mutation-tested in both directions.

### Naming could destroy the sweep it was meant to improve

The pass ran at the end of `scan()`, **inside** `scanWithDeadline`'s race. A
sweep that had already found every host on a subnet could be discarded wholesale
because looking up their names took the run past the deadline — `runScan` then
reports the scan Failed with zero hosts.

It now runs after the race settles, on a result the deadline can no longer
touch, and the deadline timer is disarmed first so it cannot log
`did not settle ... abandoning this sweep` at ERROR level about a sweep that
finished cleanly.

### The failure budget defeated itself at production concurrency

It was a latch checked as `resolvedCount === 0`. With 32 concurrent lookups, ten
fast failures flipped it permanently while twenty-two good names were still in
flight — so a subnet whose first addresses sit in a dead reverse zone was named
entirely by IP.

**The first fix was worse.** Asking the predicate fresh per address, so the
breaker could un-trip, is unsound for a reason that is pure scheduling: once
tripped, a worker pool's workers return *without awaiting anything*, so the
remaining queue drains through the skip path in microtasks and any timer-settled
success — which is every real DNS answer — loses the race. Reproduced: 68 of 100
addresses skipped while the result reported `isReverseDnsAvailable: true`.
Silently skipping two thirds of the work *and reporting success* is the worst of
the three designs.

The pass is now organised as **settled waves**, with the budget evaluated only at
wave boundaries where every started lookup has finished. Nothing un-trips because
nothing trips early. NXDOMAIN now counts as a working resolver, because it is an
answer.

The default budget moves 10 → 64 (two waves at concurrency 32): with wave
evaluation the budget is a floor rather than a cap, and one all-failing wave is
not proof of a broken probe — 32 consecutive addresses can share a dead zone
while the rest of the estate resolves fine. A probe with no resolver still gives
up in ~4s rather than burning the 60s wall-clock budget.

### A non-string sysName crashed the Review dialog

`dnsHostname` was hardened against junk jsonb while the *unguarded* `sysName` was
routed into the same render path. `(42).trim()` throws inside the modal body and
takes out the whole dialog rather than one row — exactly the failure
`normalizeDiscoveredHosts` was written to end.

Non-strings are **blanked, not stringified**: `String(null)` is `"null"`, a
truthy string that would win the naming contest outright and create a device
called "null" while a perfectly good PTR record sat unused on the same row.

### Wildcard reverse zones broke bulk import

A DHCP range published as `*.166.18.10.in-addr.arpa IN PTR dhcp-pool.corp.example.com`
gives every host one name. Ping-only hosts used to be named by their distinct
addresses so they could never collide; the dashboard had no collision fallback
(the rule engine did), so the first host imported and the rest failed.

It now retries once under `buildFallbackDeviceName` — and that function no longer
fabricates a shared `" (undefined)"` suffix for an address-less host. A suffix
that collides is worse than no suffix: it handed the retry the same duplicate it
was retrying.

### Also fixed

| Defect | Consequence |
|---|---|
| Ping monitors named from the pre-retry device name | A wildcard range produced N monitors with one name; the list stopped being navigable. Newly reachable because of this feature. |
| `device.hostname` copied raw from jsonb | It is the dedup key, matched with `Set.has()` against strings from the database. `Set.has` does not coerce, so a numeric address never matched its own registration and the host re-imported on every review. |
| `buildFallbackDeviceName` clamped only its base | A junk address composed a name past the ceiling, failing the create on the slug's length — a different error than the collision the retry was for. |
| `EINVAL` classified as infrastructure failure | A handful of malformed addresses could convict a working probe of having no DNS. |
| Non-array lookup returns | Threw inside `for...of`, was caught as an infrastructure failure, and spent the budget. |
| `in-addr.arpa` apex accepted | Only the suffix was rejected; the bare zone name passed every other rule. |
| Abandoned c-ares queries never cancelled | On a black-holing forwarder, one outstanding query and retry timer per timed-out address. |
| `describeError` returned `""` | `failureReason` came back present-but-blank on a field typed `string \| undefined`. |

## UI

The row now shows `buildDeviceName` — the name the device is **actually created
with**, clamp included — with `truncate` and a `title`. A 253-character FQDN no
longer paints across the "No SNMP" / "Already added" badges, and the dialog no
longer promises a name the import will not use. The secondary line re-normalises
the PTR name rather than rendering it raw.

## Tests

~250 new cases across five suites, plus a source-level guard proving no discovery
unit test can reach a real resolver. Every test the audits called vacuous was
**repaired rather than deleted**.

Two are worth calling out because they encode the fixes above and fail against
the old code:

- `a lookup pass slower than the whole deadline still returns the sweep's hosts`
- `does not trip at all when the failing wave also contained a success`

**Verified locally:** `tsc --noEmit` clean in Common, Probe and App; eslint clean
on all 26 changed files; **876** Common, **446** Probe and **553** App tests
passing.

## Known limitation, stated rather than papered over

The row shows `buildDeviceName(entry)`, but on a collision the device is created
under `buildFallbackDeviceName(entry)` — so in exactly the wildcard case the
retry exists for, the displayed name is not what gets created. The fallback is
address-qualified, so the device stays identifiable, and the test states that
contract honestly instead of asserting a WYSIWYG guarantee that does not hold
universally.
