### PR TITLE
fix(ci): the two flakes that failed master at 12.0.31

### DIFF
--- a/Common/Tests/Models/DatabaseModels/ModelRegistryInvariants.test.ts
+++ b/Common/Tests/Models/DatabaseModels/ModelRegistryInvariants.test.ts
@@ -44,14 +44,49 @@ const MODEL_TYPES: Array<ModelType> = AllModelTypes as Array<ModelType>;
 const ANALYTICS_MODEL_TYPES: Array<AnalyticsModelType> =
   AllAnalyticsModelTypes as unknown as Array<AnalyticsModelType>;
 
+/*
+ * A flat snapshot of the declarations, NOT the model instances.
+ *
+ * The first version of this file kept all 416 constructed models alive for the
+ * lifetime of the file, which is a large object graph resident in a Jest
+ * worker whose heap ceiling is deliberately tight (see the note in
+ * .github/workflows/test.common.yaml: 2 workers x 4 GB, live set peaking near
+ * 3.5 GB). This file shares a shard with the isolated-vm SSRF suite, which
+ * needs CPU and memory of its own and reports starvation as a script timeout
+ * rather than as an out-of-memory.
+ *
+ * Every assertion below is about scalar declarations, so the instances exist
+ * only long enough to read those off and are collectable immediately after.
+ */
 interface RegisteredModel {
   className: string;
-  model: BaseModel;
+  tableName: string | null;
+  crudApiPath: string | null;
+  singularName: string | null;
+  pluralName: string | null;
+  enableDocumentation: boolean;
+  tableDescription: string | null;
+  slugifyColumn: string | null;
+  saveSlugToColumn: string | null;
+  columns: Array<string>;
 }
 
 const REGISTERED_MODELS: Array<RegisteredModel> = MODEL_TYPES.map(
   (ModelClass: ModelType): RegisteredModel => {
-    return { className: ModelClass.name, model: new ModelClass() };
+    const model: BaseModel = new ModelClass();
+
+    return {
+      className: ModelClass.name,
+      tableName: model.tableName,
+      crudApiPath: model.crudApiPath ? model.crudApiPath.toString() : null,
+      singularName: model.singularName,
+      pluralName: model.pluralName,
+      enableDocumentation: Boolean(model.enableDocumentation),
+      tableDescription: model.tableDescription,
+      slugifyColumn: model.slugifyColumn,
+      saveSlugToColumn: model.saveSlugToColumn,
+      columns: model.getTableColumns().columns,
+    };
   },
 );
 
@@ -98,7 +133,7 @@ describe("Database model registry", () => {
   it("gives every model a table name", () => {
     const missing: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        return !entry.model.tableName;
+        return !entry.tableName;
       },
     ).map((entry: RegisteredModel) => {
       return entry.className;
@@ -113,7 +148,7 @@ describe("Database model registry", () => {
   it("gives every model its own table", () => {
     expect(
       groupBy((entry: RegisteredModel) => {
-        return entry.model.tableName;
+        return entry.tableName;
       }),
     ).toEqual([]);
   });
@@ -125,9 +160,7 @@ describe("Database model registry", () => {
   it("gives every model its own CRUD path", () => {
     expect(
       groupBy((entry: RegisteredModel) => {
-        return entry.model.crudApiPath
-          ? entry.model.crudApiPath.toString()
-          : null;
+        return entry.crudApiPath;
       }),
     ).toEqual([]);
   });
@@ -135,7 +168,7 @@ describe("Database model registry", () => {
   it("gives every model a singular and a plural display name", () => {
     const missing: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        return !entry.model.singularName || !entry.model.pluralName;
+        return !entry.singularName || !entry.pluralName;
       },
     ).map((entry: RegisteredModel) => {
       return entry.className;
@@ -152,7 +185,7 @@ describe("Database model registry", () => {
   it("describes every model it publishes documentation for", () => {
     const undescribed: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        return entry.model.enableDocumentation && !entry.model.tableDescription;
+        return entry.enableDocumentation && !entry.tableDescription;
       },
     ).map((entry: RegisteredModel) => {
       return entry.className;
@@ -169,7 +202,7 @@ describe("Database model registry", () => {
   it("gives every documented model a CRUD path to document", () => {
     const undocumentable: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        return entry.model.enableDocumentation && !entry.model.crudApiPath;
+        return entry.enableDocumentation && !entry.crudApiPath;
       },
     ).map((entry: RegisteredModel) => {
       return entry.className;
@@ -245,10 +278,10 @@ describe("Database model registry", () => {
     const dangling: Array<string> = [];
 
     for (const entry of REGISTERED_MODELS) {
-      const columns: Array<string> = entry.model.getTableColumns().columns;
+      const columns: Array<string> = entry.columns;
 
-      const source: string | null = entry.model.slugifyColumn;
-      const destination: string | null = entry.model.saveSlugToColumn;
+      const source: string | null = entry.slugifyColumn;
+      const destination: string | null = entry.saveSlugToColumn;
 
       if (source && !columns.includes(source)) {
         dangling.push(`${entry.className}.slugifyColumn = ${source}`);
@@ -296,10 +329,7 @@ describe("Database model registry", () => {
   it("pairs a slug source with a slug destination", () => {
     const unpaired: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        return (
-          Boolean(entry.model.slugifyColumn) !==
-          Boolean(entry.model.saveSlugToColumn)
-        );
+        return Boolean(entry.slugifyColumn) !== Boolean(entry.saveSlugToColumn);
       },
     ).map((entry: RegisteredModel) => {
       return entry.className;
@@ -311,7 +341,7 @@ describe("Database model registry", () => {
   it("declares at least one column on every model", () => {
     const empty: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        return entry.model.getTableColumns().columns.length === 0;
+        return entry.columns.length === 0;
       },
     ).map((entry: RegisteredModel) => {
       return entry.className;
@@ -323,9 +353,7 @@ describe("Database model registry", () => {
   it("starts every CRUD path with a slash", () => {
     const malformed: Array<string> = REGISTERED_MODELS.filter(
       (entry: RegisteredModel) => {
-        const path: string | null = entry.model.crudApiPath
-          ? entry.model.crudApiPath.toString()
-          : null;
+        const path: string | null = entry.crudApiPath;
 
         return path !== null && !path.startsWith("/");
       },
@@ -338,14 +366,24 @@ describe("Database model registry", () => {
 });
 
 describe("Analytics model registry", () => {
+  /* Flattened for the same reason as the database models above. */
   interface RegisteredAnalyticsModel {
     className: string;
-    model: AnalyticsBaseModel;
+    tableName: string | null;
+    crudApiPath: string | null;
+    columnCount: number;
   }
 
   const REGISTERED: Array<RegisteredAnalyticsModel> = ANALYTICS_MODEL_TYPES.map(
     (ModelClass: AnalyticsModelType): RegisteredAnalyticsModel => {
-      return { className: ModelClass.name, model: new ModelClass() };
+      const model: AnalyticsBaseModel = new ModelClass();
+
+      return {
+        className: ModelClass.name,
+        tableName: model.tableName,
+        crudApiPath: model.crudApiPath ? model.crudApiPath.toString() : null,
+        columnCount: (model.tableColumns || []).length,
+      };
     },
   );
 
@@ -356,7 +394,7 @@ describe("Analytics model registry", () => {
   it("gives every analytics model a table name", () => {
     const missing: Array<string> = REGISTERED.filter(
       (entry: RegisteredAnalyticsModel) => {
-        return !entry.model.tableName;
+        return !entry.tableName;
       },
     ).map((entry: RegisteredAnalyticsModel) => {
       return entry.className;
@@ -373,7 +411,7 @@ describe("Analytics model registry", () => {
     const claimants: Map<string, Array<string>> = new Map();
 
     for (const entry of REGISTERED) {
-      const key: string | null = entry.model.tableName;
+      const key: string | null = entry.tableName;
 
       if (!key) {
         continue;
@@ -397,9 +435,7 @@ describe("Analytics model registry", () => {
     const claimants: Map<string, Array<string>> = new Map();
 
     for (const entry of REGISTERED) {
-      const key: string | undefined = entry.model.crudApiPath
-        ? entry.model.crudApiPath.toString()
-        : undefined;
+      const key: string | null = entry.crudApiPath;
 
       if (!key) {
         continue;
@@ -422,7 +458,7 @@ describe("Analytics model registry", () => {
   it("declares at least one column on every analytics model", () => {
     const empty: Array<string> = REGISTERED.filter(
       (entry: RegisteredAnalyticsModel) => {
-        return (entry.model.tableColumns || []).length === 0;
+        return entry.columnCount === 0;
       },
     ).map((entry: RegisteredAnalyticsModel) => {
       return entry.className;

--- a/MobileApp/src/hooks/useOnCallCalendarFeed.test.tsx
+++ b/MobileApp/src/hooks/useOnCallCalendarFeed.test.tsx
@@ -141,8 +141,33 @@ describe("useOnCallCalendarFeed", () => {
     expect(fetchSpy()).not.toHaveBeenCalled();
   });
 
+  /*
+   * The fetch is held open by the test rather than pre-resolved, because the
+   * loading assertion below is otherwise a race that this test lost about one
+   * run in six.
+   *
+   * `mockResolvedValue` hands back an ALREADY-resolved promise, so between
+   * mounting the hook and reading `isLoading` there is a window in which that
+   * promise, react-query's state update and the re-render can all land. The
+   * `await` on renderHook is what opens it -- and it cannot simply be dropped,
+   * because renderHook is async here and `result` would be undefined. Whether
+   * the chain finishes inside that window comes down to how many microtask
+   * ticks it happens to need, which is why this failed intermittently rather
+   * than never or always.
+   *
+   * Holding the promise open removes the timing question instead of narrowing
+   * it: no number of ticks can move the hook off `isLoading` until the test
+   * resolves it, so the assertion is about the hook rather than about the
+   * scheduler.
+   */
   test("loads the feed for the given project", async () => {
-    fetchSpy().mockResolvedValue(status() as never);
+    let resolveFetch: (value: OnCallCalendarFeedStatus) => void = () => {};
+
+    fetchSpy().mockReturnValue(
+      new Promise((resolve: (value: OnCallCalendarFeedStatus) => void) => {
+        resolveFetch = resolve;
+      }) as never,
+    );
 
     const { result } = await renderHook(
       (): UseOnCallCalendarFeedResult => {
@@ -153,10 +178,15 @@ describe("useOnCallCalendarFeed", () => {
 
     expect(result.current.isLoading).toBe(true);
 
+    await act(async () => {
+      resolveFetch(status());
+    });
+
     await waitFor(() => {
       expect(result.current.status?.exists).toBe(true);
     });
 
+    expect(result.current.isLoading).toBe(false);
     expect(fetchSpy()).toHaveBeenCalledWith("project-1");
     expect(result.current.isError).toBe(false);
     expect(result.current.isUnsupported).toBe(false);


### PR DESCRIPTION
Master at `41fbc05b` (the 12.0.31 bump) failed two jobs. Both are fixed here.

---

## 1. MobileApp Test — `useOnCallCalendarFeed` raced its own mock

`useOnCallCalendarFeed › loads the feed for the given project` reproduces locally about **one run in six**.

The assertion is `expect(result.current.isLoading).toBe(true)` immediately after mounting the hook, while the fetch is mocked with `mockResolvedValue` — an **already-resolved** promise. Between mounting and reading `isLoading` there is a window in which that promise, react-query's state update and the re-render can all land, and then the hook is legitimately no longer loading.

The `await` on `renderHook` is what opens that window, and it cannot simply be dropped: `renderHook` is async in this version of the library, so `result` would be `undefined`. Whether the chain finishes inside the window comes down to how many microtask ticks it happens to need — hence intermittent rather than never or always.

**Fix:** hold the fetch open on a promise the test resolves. That removes the timing question rather than narrowing it — no number of ticks can move the hook off `isLoading` until the test lets it. This is the pattern the rest of the suite already uses (the same file does it in "each user gets their own cache entry"; so does `useAllProjectIncidents` for its in-flight case). The test now also asserts `isLoading` returns to `false`, which the racy version could not meaningfully check.

Every other `isLoading).toBe(true)` in MobileApp was checked and is already safe — they either hold the promise open the same way, or the loading state comes from synchronous project-context state with no promise in play.

## 2. Common Test shard 6/8 — a heap hog starving the isolate suite

Every test in `Tests/Server/Utils/VM/VMRunnerSsrf.test.ts` reported `"Script execution timed out"` against its 15s sandbox budget, and the file took **523s**. Those tests need no network — the SSRF guard refuses before a socket opens — so a 15s budget only runs out if the isolate is starved of CPU, and the whole file degrading together points at shard pressure rather than at the guard.

`ModelRegistryInvariants`, added an hour earlier, shards into 6/8 alongside it (`jest --listTests --shard=6/8` names both), and it held **all 416 constructed database models** plus every analytics model alive at module scope for the lifetime of the file. That is a large graph resident in a worker whose heap ceiling is deliberately tight: `test.common.yaml` pins 2 workers × 4 GB because a shard's live set already peaks near 3.5 GB.

**Fix:** every assertion in that file is about scalar declarations — table name, CRUD path, display names, description, slug source/destination, column names — so the instances only need to live long enough to read those off. They are now flattened into a plain snapshot and dropped.

Nothing in the VM suite is touched. `VMRunnerSsrf` had not failed before this commit, and the same shard composition passed on both PRs that carried it, so this is a contention fix rather than a diagnosis of that suite.

---

## Test plan

- `npx jest src/hooks/useOnCallCalendarFeed.test.tsx` in `MobileApp` — ran 10×, green every time (it failed within 6 runs before the fix).
- `npx jest` in `MobileApp` — 289 suites, 6519 tests, all pass.
- `npx jest Tests/Models/DatabaseModels/ModelRegistryInvariants.test.ts` in `Common` — 17 pass, unchanged.
- `npx tsc --noEmit` in `Common` — clean. prettier + eslint clean.