### PR TITLE
fix(slug): derive slugs from the column each model means

### DIFF
--- a/Common/Models/DatabaseModels/AlertState.ts
+++ b/Common/Models/DatabaseModels/AlertState.ts
@@ -14,7 +14,6 @@ import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableMCP from "../../Types/Database/EnableMCP";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
 import ColorField from "../../Types/Database/ColorField";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -71,7 +70,6 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   read: true,
 })
 @CrudApiEndpoint(new Route("/alert-state"))
-@SlugifyColumn("name", "slug")
 @TableMetadata({
   tableName: "AlertState",
   singularName: "Alert State",

--- a/Common/Models/DatabaseModels/Domain.ts
+++ b/Common/Models/DatabaseModels/Domain.ts
@@ -50,7 +50,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   ],
 })
 @CrudApiEndpoint(new Route("/domain"))
-@SlugifyColumn("name", "slug")
+@SlugifyColumn("domain", "slug")
 @TableMetadata({
   tableName: "Domain",
   singularName: "Domain",

--- a/Common/Models/DatabaseModels/Incident.ts
+++ b/Common/Models/DatabaseModels/Incident.ts
@@ -101,7 +101,7 @@ import NotificationRuleWorkspaceChannel from "../../Types/Workspace/Notification
   ],
 })
 @CrudApiEndpoint(new Route("/incident"))
-@SlugifyColumn("name", "slug")
+@SlugifyColumn("title", "slug")
 @Entity({
   name: "Incident",
 })

--- a/Common/Models/DatabaseModels/IncidentTemplate.ts
+++ b/Common/Models/DatabaseModels/IncidentTemplate.ts
@@ -88,7 +88,7 @@ import { PlanType } from "../../Types/Billing/SubscriptionPlan";
   ],
 })
 @CrudApiEndpoint(new Route("/incident-templates"))
-@SlugifyColumn("name", "slug")
+@SlugifyColumn("templateName", "slug")
 @Entity({
   name: "IncidentTemplate",
 })

--- a/Common/Models/DatabaseModels/MetricType.ts
+++ b/Common/Models/DatabaseModels/MetricType.ts
@@ -8,7 +8,6 @@ import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -72,7 +71,6 @@ import { AggregationTemporality } from "../AnalyticsModels/Metric";
   read: false,
 })
 @CrudApiEndpoint(new Route("/metric-type"))
-@SlugifyColumn("name", "slug")
 @TableMetadata({
   tableName: "MetricType",
   singularName: "Metric Type",

--- a/Common/Models/DatabaseModels/MonitorStatusTimeline.ts
+++ b/Common/Models/DatabaseModels/MonitorStatusTimeline.ts
@@ -13,7 +13,6 @@ import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableMCP from "../../Types/Database/EnableMCP";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -73,7 +72,6 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   read: true,
 })
 @CrudApiEndpoint(new Route("/monitor-status-timeline"))
-@SlugifyColumn("name", "slug")
 @OwnedThrough("monitorId", Monitor)
 @Entity({
   name: "MonitorStatusTimeline",

--- a/Common/Models/DatabaseModels/MonitorTest.ts
+++ b/Common/Models/DatabaseModels/MonitorTest.ts
@@ -10,7 +10,6 @@ import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -70,7 +69,6 @@ import Monitor from "./Monitor";
   read: true,
 })
 @CrudApiEndpoint(new Route("/monitor-test"))
-@SlugifyColumn("name", "slug")
 @OwnedThrough("monitorId", Monitor)
 @Entity({
   name: "MonitorTest",

--- a/Common/Models/DatabaseModels/ScheduledMaintenance.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenance.ts
@@ -94,7 +94,7 @@ import NotificationRuleWorkspaceChannel from "../../Types/Workspace/Notification
   ],
 })
 @CrudApiEndpoint(new Route("/scheduled-maintenance"))
-@SlugifyColumn("name", "slug")
+@SlugifyColumn("title", "slug")
 @Entity({
   name: "ScheduledMaintenance",
 })

--- a/Common/Models/DatabaseModels/ScheduledMaintenanceTemplate.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenanceTemplate.ts
@@ -90,7 +90,7 @@ import { PlanType } from "../../Types/Billing/SubscriptionPlan";
   ],
 })
 @CrudApiEndpoint(new Route("/scheduled-maintenance-template"))
-@SlugifyColumn("name", "slug")
+@SlugifyColumn("templateName", "slug")
 @Entity({
   name: "ScheduledMaintenanceTemplate",
 })

--- a/Common/Models/DatabaseModels/StatusPageAnnouncement.ts
+++ b/Common/Models/DatabaseModels/StatusPageAnnouncement.ts
@@ -16,7 +16,6 @@ import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableMCP from "../../Types/Database/EnableMCP";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -88,7 +87,6 @@ import {
   read: true,
 })
 @CrudApiEndpoint(new Route("/status-page-announcement"))
-@SlugifyColumn("name", "slug")
 @TableMetadata({
   tableName: "StatusPageAnnouncement",
   singularName: "Status Page Announcement",

--- a/Common/Models/DatabaseModels/StatusPageAnnouncementTemplate.ts
+++ b/Common/Models/DatabaseModels/StatusPageAnnouncementTemplate.ts
@@ -14,7 +14,6 @@ import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -84,7 +83,6 @@ import {
   read: true,
 })
 @CrudApiEndpoint(new Route("/status-page-announcement-template"))
-@SlugifyColumn("templateName", "slug")
 @TableMetadata({
   tableName: "StatusPageAnnouncementTemplate",
   singularName: "Status Page Announcement Template",

--- a/Common/Models/DatabaseModels/StatusPagePrivateUser.ts
+++ b/Common/Models/DatabaseModels/StatusPagePrivateUser.ts
@@ -14,7 +14,6 @@ import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -78,7 +77,6 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   read: true,
 })
 @CrudApiEndpoint(new Route("/status-page-private-user"))
-@SlugifyColumn("name", "slug")
 @TableMetadata({
   tableName: "StatusPagePrivateUser",
   singularName: "Status Page Private User",

--- a/Common/Models/DatabaseModels/StatusPageResource.ts
+++ b/Common/Models/DatabaseModels/StatusPageResource.ts
@@ -15,7 +15,6 @@ import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -72,7 +71,6 @@ import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
   read: true,
 })
 @CrudApiEndpoint(new Route("/status-page-resource"))
-@SlugifyColumn("name", "slug")
 @TableMetadata({
   tableName: "StatusPageResource",
   singularName: "Status Page Resource",

--- a/Common/Models/DatabaseModels/StatusPageSubscriber.ts
+++ b/Common/Models/DatabaseModels/StatusPageSubscriber.ts
@@ -14,7 +14,6 @@ import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import EnableWorkflow from "../../Types/Database/EnableWorkflow";
-import SlugifyColumn from "../../Types/Database/SlugifyColumn";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -82,7 +81,6 @@ import StatusPageEventType from "../../Types/StatusPage/StatusPageEventType";
   ],
 })
 @CrudApiEndpoint(new Route("/status-page-subscriber"))
-@SlugifyColumn("name", "slug")
 @TableMetadata({
   tableName: "StatusPageSubscriber",
   singularName: "Status Page Subscriber",

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -616,19 +616,49 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     throw PostgresErrorTranslator.translateException(error);
   }
 
+  /*
+   * Both halves of @SlugifyColumn are resolved BY NAME off the object rather
+   * than through the schema, so a name matching no declared column misfires
+   * silently: a missing source reads `undefined` and Slug.getSlug answers with
+   * a random Faker name, and a missing destination is assigned to a property
+   * TypeORM drops on insert. ModelRegistryInvariants sweeps every model for
+   * both, so the pairing is guaranteed by a test rather than by this code.
+   *
+   * The ceiling comes from the DESTINATION column, not from Slug: getSlug
+   * appends a dash and ten random digits, and checkMaxLengthOfFields -- which
+   * runs later in the same create -- THROWS on overflow rather than
+   * truncating. Sources are routinely wider than the slug they feed
+   * (Incident.title is varchar(500) against a varchar(100) slug), so without
+   * this a long title would be a failed insert rather than a long slug.
+   */
   private generateSlug(createBy: CreateBy<TBaseModel>): CreateBy<TBaseModel> {
-    if (createBy.data.getSlugifyColumn()) {
-      (createBy.data as any)[createBy.data.getSaveSlugToColumn() as string] =
-        Slug.getSlug(
-          (createBy.data as any)[createBy.data.getSlugifyColumn() as string]
-            ? ((createBy.data as any)[
-                createBy.data.getSlugifyColumn() as string
-              ] as string)
-            : null,
-        );
+    const slugifyColumn: string | null = createBy.data.getSlugifyColumn();
+    const saveSlugToColumn: string | null = createBy.data.getSaveSlugToColumn();
+
+    if (!slugifyColumn || !saveSlugToColumn) {
+      return createBy;
     }
 
+    const source: JSONValue = (createBy.data as any)[slugifyColumn];
+
+    (createBy.data as any)[saveSlugToColumn] = Slug.getSlug(
+      source ? String(source) : null,
+      this.getMaxLengthOfColumn(saveSlugToColumn),
+    );
+
     return createBy;
+  }
+
+  /*
+   * The declared width of a column, or undefined for a column that declares
+   * none -- including a name that is not a column at all, which is what
+   * getTableColumnMetadata answers for.
+   */
+  private getMaxLengthOfColumn(columnName: string): number | undefined {
+    const columnType: TableColumnType | undefined =
+      this.model.getTableColumnMetadata(columnName)?.type;
+
+    return columnType ? getMaxLengthFromTableColumnType(columnType) : undefined;
   }
 
   private async sanitizeCreateOrUpdate(

--- a/Common/Tests/Models/DatabaseModels/ModelRegistryInvariants.test.ts
+++ b/Common/Tests/Models/DatabaseModels/ModelRegistryInvariants.test.ts
@@ -217,62 +217,47 @@ describe("Database model registry", () => {
    * than through the schema -- so a name that matches no declared column is a
    * silent misfire rather than an error.
    *
-   * Both halves misfire differently and both are live today:
+   * Both halves misfire differently:
    *
    *  - A source that does not exist reads `undefined`, and Slug.getSlug(null)
    *    answers with a slug built from Faker.generateName(). The row still gets
    *    a unique, non-null slug, so nothing fails -- the slug is simply a
-   *    random pair of words instead of the object's own name. Incident is the
-   *    clearest case: it slugifies "name" while its title column is `title`,
+   *    random pair of words instead of the object's own name. Incident was the
+   *    clearest case: it slugified "name" while its title column is `title`,
    *    and its own slug column documents the example
    *    "database-connection-failure-in-production", which is a slugified
-   *    TITLE. Every incident URL in the product is a random name instead.
+   *    TITLE. Every incident created before the fix carries a random name.
    *
    *  - A destination that does not exist has the slug assigned to a property
    *    the table has no column for, and TypeORM drops it on insert. The whole
    *    decorator is dead configuration.
    *
-   * The fourteen below are pre-existing and are recorded as a baseline rather
-   * than fixed here, because each needs its own judgement: the four that mean
-   * `title` are a rename, but the nine with no slug column at all are either a
-   * missing column (which needs a migration) or a decorator that should be
-   * deleted, and picking wrong is a schema change made on a guess.
+   * Fourteen models were recorded here as a baseline and have all since been
+   * fixed, so the list is empty. It is kept, rather than deleted along with
+   * its last entry, because the pair of tests below it is the ratchet: the
+   * first fails on a new misfire, the second fails on an entry left behind
+   * after a fix.
+   *
+   * Where each of the fourteen went, and why:
+   *
+   *  - The four event models (Incident, ScheduledMaintenance and the two
+   *    templates) had a real slug column and a source naming a column they do
+   *    not have, so the slug landed and was random. Their intended sources
+   *    are pinned in EXPECTED_SLUG_SOURCES below and asserted behaviourally
+   *    in Tests/Server/Services/DatabaseServiceGenerateSlug.test.ts.
+   *
+   *  - Domain, likewise, but its identity is the `domain` column.
+   *
+   *  - The nine with no slug column had their decorator deleted rather than a
+   *    column added. Nothing in the product reads any of these slugs -- the
+   *    only slug consumed anywhere is Monitor's, as a template variable --
+   *    and the alternative was adding a NOT NULL column to a live table with
+   *    a backfill, for a value with no reader.
    *
    * THIS LIST MUST ONLY EVER SHRINK. A new entry means a new misfire; a stale
    * entry means somebody fixed one and this test says so.
    */
-  const KNOWN_SLUG_MISFIRES: Array<string> = [
-    /*
-     * Source should almost certainly be `title` -- each of these has a title
-     * column and a real slug column, so the slug lands but is random.
-     */
-    "Incident.slugifyColumn = name",
-    "IncidentTemplate.slugifyColumn = name",
-    "ScheduledMaintenance.slugifyColumn = name",
-    "ScheduledMaintenanceTemplate.slugifyColumn = name",
-
-    /* No name column and no title column; the slug source is `domain`. */
-    "Domain.slugifyColumn = name",
-
-    /* Has the source column, but no slug column to write to. */
-    "AlertState.saveSlugToColumn = slug",
-    "MetricType.saveSlugToColumn = slug",
-    "StatusPageAnnouncementTemplate.saveSlugToColumn = slug",
-
-    /* Neither column exists: the decorator does nothing at all. */
-    "MonitorStatusTimeline.slugifyColumn = name",
-    "MonitorStatusTimeline.saveSlugToColumn = slug",
-    "MonitorTest.slugifyColumn = name",
-    "MonitorTest.saveSlugToColumn = slug",
-    "StatusPageAnnouncement.slugifyColumn = name",
-    "StatusPageAnnouncement.saveSlugToColumn = slug",
-    "StatusPagePrivateUser.slugifyColumn = name",
-    "StatusPagePrivateUser.saveSlugToColumn = slug",
-    "StatusPageResource.slugifyColumn = name",
-    "StatusPageResource.saveSlugToColumn = slug",
-    "StatusPageSubscriber.slugifyColumn = name",
-    "StatusPageSubscriber.saveSlugToColumn = slug",
-  ];
+  const KNOWN_SLUG_MISFIRES: Array<string> = [];
 
   const findSlugMisfires: () => Array<string> = (): Array<string> => {
     const dangling: Array<string> = [];
@@ -319,6 +304,95 @@ describe("Database model registry", () => {
     );
 
     expect(stale).toEqual([]);
+  });
+
+  /*
+   * The sweep above only proves a slug source names a column that EXISTS. It
+   * cannot see the other half of the same mistake: a decorator naming a real
+   * column that is not the one the model means. Incident, before the fix,
+   * would have passed such a sweep the moment "name" were changed to
+   * "description".
+   *
+   * So the models whose source was corrected are pinned by name, with the
+   * evidence for each choice. Behaviour is asserted separately in
+   * Tests/Server/Services/DatabaseServiceGenerateSlug.test.ts; this is the
+   * declaration.
+   */
+  const EXPECTED_SLUG_SOURCES: Record<string, string> = {
+    /*
+     * The slug column's documented example is
+     * "database-connection-failure-in-production" -- the title column's
+     * example, slugified.
+     */
+    Incident: "title",
+    ScheduledMaintenance: "title",
+
+    /*
+     * Both template models carry a title AND a templateName, so this is a
+     * choice between two real columns rather than the only one available.
+     * They mean templateName: each documents a slug example that is its
+     * templateName example slugified ("Server Outage Template" ->
+     * "server-outage-template", "Database Upgrade Template" ->
+     * "database-upgrade-template"), and the title is the incident or event
+     * the template produces rather than anything unique to the template.
+     */
+    IncidentTemplate: "templateName",
+    ScheduledMaintenanceTemplate: "templateName",
+
+    /* Domain has neither a name nor a title; the domain is its identity. */
+    Domain: "domain",
+  };
+
+  it("slugifies the column each model actually means", () => {
+    const declared: Record<string, string | null> = {};
+
+    for (const className of Object.keys(EXPECTED_SLUG_SOURCES)) {
+      const entry: RegisteredModel | undefined = REGISTERED_MODELS.find(
+        (candidate: RegisteredModel) => {
+          return candidate.className === className;
+        },
+      );
+
+      /*
+       * A renamed or unregistered model shows up as a null rather than as a
+       * silently skipped expectation.
+       */
+      declared[className] = entry ? entry.slugifyColumn : null;
+    }
+
+    expect(declared).toEqual(EXPECTED_SLUG_SOURCES);
+  });
+
+  /*
+   * The nine models whose decorator named columns they do not have at all.
+   * Deleting the decorator is what fixed them, so a copy-paste that puts one
+   * back has to fail here as well as in the sweep above.
+   */
+  const MODELS_WITH_NO_SLUG: Array<string> = [
+    "AlertState",
+    "MetricType",
+    "MonitorStatusTimeline",
+    "MonitorTest",
+    "StatusPageAnnouncement",
+    "StatusPageAnnouncementTemplate",
+    "StatusPagePrivateUser",
+    "StatusPageResource",
+    "StatusPageSubscriber",
+  ];
+
+  it("leaves the models with no slug column unslugified", () => {
+    const configured: Array<string> = REGISTERED_MODELS.filter(
+      (entry: RegisteredModel) => {
+        return (
+          MODELS_WITH_NO_SLUG.includes(entry.className) &&
+          Boolean(entry.slugifyColumn || entry.saveSlugToColumn)
+        );
+      },
+    ).map((entry: RegisteredModel) => {
+      return entry.className;
+    });
+
+    expect(configured).toEqual([]);
   });
 
   /*

--- a/Common/Tests/Server/Services/DatabaseServiceGenerateSlug.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceGenerateSlug.test.ts
@@ -1,0 +1,215 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentTemplate from "../../../Models/DatabaseModels/IncidentTemplate";
+import ScheduledMaintenance from "../../../Models/DatabaseModels/ScheduledMaintenance";
+import ScheduledMaintenanceTemplate from "../../../Models/DatabaseModels/ScheduledMaintenanceTemplate";
+import Domain from "../../../Models/DatabaseModels/Domain";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import DomainType from "../../../Types/Domain";
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import { SLUG_SUFFIX_LENGTH } from "../../../Utils/Slug";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Regression tests for the slug sources fixed alongside the baseline in
+ * Tests/Models/DatabaseModels/ModelRegistryInvariants.test.ts.
+ *
+ * generateSlug resolves both halves of @SlugifyColumn BY NAME off the object
+ * rather than through the schema, so a source naming no column reads
+ * `undefined` and Slug.getSlug(null) answers with a slug built from
+ * Faker.generateName(). Nothing throws and nothing is null -- the row simply
+ * carries two random words as its public identity. That is why the fix has to
+ * be pinned behaviourally here and not only as a declaration in the registry
+ * sweep: the sweep proves the column EXISTS, these prove the slug is actually
+ * derived from it.
+ *
+ * Every assertion is on the derivation, never on the whole string: getSlug
+ * appends ten random digits to keep slugs unique.
+ */
+
+const TEN_DIGIT_TAIL: RegExp = /^[\d]{10}$/;
+
+/*
+ * Runs the real private hook the create path calls, and answers with whatever
+ * landed on `slug`.
+ */
+const slugFor: (
+  modelType: { new (): BaseModel },
+  data: BaseModel,
+) => string | undefined = (
+  modelType: { new (): BaseModel },
+  data: BaseModel,
+): string | undefined => {
+  const service: DatabaseService<BaseModel> = new DatabaseService<BaseModel>(
+    modelType,
+  );
+
+  const createBy: CreateBy<BaseModel> = {
+    data,
+    props: { isRoot: true },
+  };
+
+  const result: CreateBy<BaseModel> = service["generateSlug"](createBy);
+
+  return (result.data as unknown as Record<string, string | undefined>)["slug"];
+};
+
+/*
+ * Asserts the slug reads as `<expected>-<ten digits>` without pinning the
+ * digits.
+ */
+const expectSlugDerivedFrom: (
+  slug: string | undefined,
+  expected: string,
+) => void = (slug: string | undefined, expected: string): void => {
+  expect(slug).toBeDefined();
+  expect(slug!.substring(0, expected.length + 1)).toBe(`${expected}-`);
+  expect(slug!.substring(expected.length + 1)).toMatch(TEN_DIGIT_TAIL);
+};
+
+describe("DatabaseService.generateSlug — the slug comes from the column the model means", () => {
+  /*
+   * Incident's slug column documents the example
+   * "database-connection-failure-in-production", which is exactly its title
+   * column's example slugified. It slugified `name` -- a column Incident does
+   * not have -- so every incident URL in the product was a random name.
+   */
+  test("Incident slugifies its title", () => {
+    const incident: Incident = new Incident();
+    incident.title = "Database connection failure in production";
+
+    expectSlugDerivedFrom(
+      slugFor(Incident, incident),
+      "database-connection-failure-in-production",
+    );
+  });
+
+  test("ScheduledMaintenance slugifies its title", () => {
+    const event: ScheduledMaintenance = new ScheduledMaintenance();
+    event.title = "Database Migration and Server Upgrade";
+
+    expectSlugDerivedFrom(
+      slugFor(ScheduledMaintenance, event),
+      "database-migration-and-server-upgrade",
+    );
+  });
+
+  /*
+   * The two template models carry BOTH a title and a templateName, so which
+   * one they mean is a real choice rather than the only column available.
+   * They mean templateName: each documents a slug example that is its
+   * TEMPLATE NAME example slugified ("Server Outage Template" ->
+   * "server-outage-template"), and StatusPageAnnouncementTemplate -- the one
+   * template model whose source column was never mis-copied -- names
+   * templateName too. The title is the incident or event the template
+   * produces, and is not unique to the template.
+   */
+  test("IncidentTemplate slugifies its template name, not the incident title it produces", () => {
+    const template: IncidentTemplate = new IncidentTemplate();
+    template.templateName = "Server Outage Template";
+    template.title = "Production Server Outage - Database Connection Issue";
+
+    expectSlugDerivedFrom(
+      slugFor(IncidentTemplate, template),
+      "server-outage-template",
+    );
+  });
+
+  test("ScheduledMaintenanceTemplate slugifies its template name, not the event title it produces", () => {
+    const template: ScheduledMaintenanceTemplate =
+      new ScheduledMaintenanceTemplate();
+    template.templateName = "Database Upgrade Template";
+    template.title = "Scheduled Database Maintenance - PostgreSQL Upgrade";
+
+    expectSlugDerivedFrom(
+      slugFor(ScheduledMaintenanceTemplate, template),
+      "database-upgrade-template",
+    );
+  });
+
+  /*
+   * Domain has neither a name nor a title column; the domain IS its identity.
+   * getSlug strips dots along with the rest of [&*+~.,\\/()|'"!:@].
+   */
+  test("Domain slugifies the domain itself", () => {
+    const domain: Domain = new Domain();
+    domain.domain = new DomainType("status.example.com");
+
+    expectSlugDerivedFrom(slugFor(Domain, domain), "statusexamplecom");
+  });
+
+  /*
+   * States the failure mode the five tests above are guarding against, rather
+   * than leaving it to be inferred from a prefix that happens to match.
+   */
+  test("an unset source column falls back to a random name rather than failing", () => {
+    const slug: string | undefined = slugFor(Incident, new Incident());
+
+    expect(slug).toBeDefined();
+    expect(slug).toMatch(/^[a-z0-9-]+-[\d]{10}$/);
+    expect(slug!.startsWith("database-connection-failure")).toBe(false);
+  });
+
+  /*
+   * Incident.title is varchar(500) against a varchar(100) slug, so pointing
+   * the decorator at it is only safe because generateSlug clamps to the
+   * DESTINATION column. checkMaxLengthOfFields runs later in the same create
+   * and THROWS on overflow rather than truncating, so without the clamp a
+   * long incident title would be a failed insert instead of a long slug.
+   */
+  test("clamps an over-wide source down to the slug column", () => {
+    const title: string = "Database connection failure in production ".repeat(
+      12,
+    );
+
+    expect(title.length).toBeGreaterThan(ColumnLength.Slug);
+
+    const incident: Incident = new Incident();
+    incident.title = title;
+
+    const slug: string | undefined = slugFor(Incident, incident);
+
+    expect(slug).toBeDefined();
+    expect(slug!.length).toBeLessThanOrEqual(ColumnLength.Slug);
+
+    /* The readable half is what gets cut; the unique tail survives whole. */
+    expect(slug!.substring(slug!.length - SLUG_SUFFIX_LENGTH)).toMatch(
+      /^-[\d]{10}$/,
+    );
+    expect(slug!.startsWith("database-connection-failure-in-production")).toBe(
+      true,
+    );
+
+    /* And never a dash left dangling where the cut fell. */
+    expect(slug).not.toMatch(/--[\d]{10}$/);
+  });
+
+  /*
+   * The other half of the sweep's fourteen: models whose decorator named
+   * columns they do not have at all. Their slug was assigned to a property
+   * with no column and dropped by TypeORM on insert, so the decorator was
+   * dead configuration and was removed rather than backed by a new column and
+   * a migration for a value nothing in the product reads.
+   */
+  test("a model with no slug configuration is left untouched", () => {
+    for (const model of [
+      new StatusPageResource(),
+      new MonitorStatusTimeline(),
+    ]) {
+      expect(model.getSlugifyColumn()).toBeFalsy();
+      expect(model.getSaveSlugToColumn()).toBeFalsy();
+
+      const ownPropertiesBefore: Array<string> = Object.keys(model).sort();
+
+      slugFor(
+        model.constructor as { new (): BaseModel },
+        model as unknown as BaseModel,
+      );
+
+      expect(Object.keys(model).sort()).toEqual(ownPropertiesBefore);
+    }
+  });
+});

--- a/Common/Tests/Utils/Slug.test.ts
+++ b/Common/Tests/Utils/Slug.test.ts
@@ -1,4 +1,5 @@
-import Slug from "../../Utils/Slug";
+import Slug, { SLUG_SUFFIX_LENGTH } from "../../Utils/Slug";
+import ColumnLength from "../../Types/Database/ColumnLength";
 
 describe("Slug.getSlug()", () => {
   test("should return empty string, if name is empty ", () => {
@@ -19,5 +20,64 @@ describe("Slug.getSlug()", () => {
     expect(Slug.getSlug(" *+~.,\\/()'\"!:@slug is awesome")).toMatch(
       /^slug-is-awesome-+[\d]{10}$/,
     );
+  });
+});
+
+/*
+ * The ceiling exists because the create path THROWS on an oversized value
+ * rather than truncating it (DatabaseService.checkMaxLengthOfFields), and slug
+ * sources are routinely wider than the slug column they feed: Incident.title
+ * is varchar(500) against a varchar(100) slug. DatabaseService.generateSlug
+ * passes the destination column's declared width in.
+ */
+describe("Slug.getSlug() — clamped to a destination column", () => {
+  const LONG_NAME: string = "a very long incident title indeed ".repeat(10);
+
+  test("leaves a name that already fits alone", () => {
+    expect(Slug.getSlug("short name", ColumnLength.Slug)).toMatch(
+      /^short-name-[\d]{10}$/,
+    );
+  });
+
+  test("fits the result inside the ceiling", () => {
+    expect(
+      Slug.getSlug(LONG_NAME, ColumnLength.Slug).length,
+    ).toBeLessThanOrEqual(ColumnLength.Slug);
+  });
+
+  test("cuts the readable half and keeps the unique tail whole", () => {
+    const slug: string = Slug.getSlug(LONG_NAME, ColumnLength.Slug);
+
+    expect(slug.substring(slug.length - SLUG_SUFFIX_LENGTH)).toMatch(
+      /^-[\d]{10}$/,
+    );
+    expect(slug.startsWith("a-very-long-incident-title-indeed")).toBe(true);
+  });
+
+  test("leaves no dash dangling where the cut fell", () => {
+    /*
+     * 44 puts the ceiling exactly on the dash after the second "indeed",
+     * which is the case that would otherwise read `...indeed--0123456789`.
+     */
+    expect(Slug.getSlug(LONG_NAME, 45)).not.toMatch(/--[\d]{10}$/);
+
+    /* Every nearby ceiling, so the case above is not the only one covered. */
+    for (let ceiling: number = 20; ceiling <= 100; ceiling++) {
+      const slug: string = Slug.getSlug(LONG_NAME, ceiling);
+
+      expect(slug.length).toBeLessThanOrEqual(ceiling);
+      expect(slug).not.toMatch(/--[\d]{10}$/);
+    }
+  });
+
+  test("still answers with a random name for a null source", () => {
+    const slug: string = Slug.getSlug(null, ColumnLength.Slug);
+
+    expect(slug).toMatch(/^[a-z0-9-]+-[\d]{10}$/);
+    expect(slug.length).toBeLessThanOrEqual(ColumnLength.Slug);
+  });
+
+  test("still answers with an empty string for an empty name", () => {
+    expect(Slug.getSlug("", ColumnLength.Slug)).toEqual("");
   });
 });

--- a/Common/Utils/Slug.ts
+++ b/Common/Utils/Slug.ts
@@ -1,8 +1,30 @@
 import Faker from "./Faker";
 import slugify from "slugify";
 
+/*
+ * The tail every slug carries: a dash plus ten random digits.
+ *
+ * It is what keeps two objects of the same name apart, so it is the half that
+ * survives when a slug has to be cut down to fit its column.
+ */
+export const SLUG_SUFFIX_LENGTH: number = 11;
+
 export default class Slug {
-  public static getSlug(name: string | null): string {
+  /*
+   * `maxLength`, when given, is the width of the column the slug is about to
+   * be written to.
+   *
+   * It exists because the create path THROWS on an oversized value rather
+   * than truncating it (DatabaseService.checkMaxLengthOfFields), and a slug
+   * source is routinely wider than the slug column: Incident.title is
+   * varchar(500) against a varchar(100) slug. Without a ceiling, slugifying
+   * such a column turns a long title into a failed insert.
+   *
+   * Only the readable half is trimmed; the random tail is never touched. A
+   * `maxLength` narrower than SLUG_SUFFIX_LENGTH therefore cannot be honoured
+   * -- the tail wins -- but no column is anywhere near that narrow.
+   */
+  public static getSlug(name: string | null, maxLength?: number): string {
     if (name === null) {
       name = Faker.generateName();
     }
@@ -13,6 +35,17 @@ export default class Slug {
     }
 
     let slug: string = slugify(name, { remove: /[&*+~.,\\/()|'"!:@]+/g });
+
+    if (maxLength !== undefined) {
+      /*
+       * Cut to what the tail leaves, then drop any dash the cut left
+       * dangling so the result does not read as `something--0123456789`.
+       */
+      slug = slug
+        .substring(0, Math.max(0, maxLength - SLUG_SUFFIX_LENGTH))
+        .replace(/-+$/, "");
+    }
+
     slug = `${slug}-${Faker.getRandomNumbers(10).toString()}`;
     slug = slug.toLowerCase();
 


### PR DESCRIPTION
### Title of this pull request?

fix(slug): derive slugs from the column each model means

### Small Description?

`@SlugifyColumn` is resolved BY NAME off the object at save time (`DatabaseService.generateSlug`) rather than through the schema, so a name matching no declared column misfires silently. Fourteen models did:

- **A missing source** reads `undefined`, and `Slug.getSlug(null)` answers with a slug built from `Faker.generateName()`. The row still gets a unique, non-null slug — it is simply two random words instead of the object's own name.
- **A missing destination** is assigned to a property the table has no column for, and TypeORM drops it on insert. The decorator was dead configuration.

These were recorded as `KNOWN_SLUG_MISFIRES` in `ModelRegistryInvariants.test.ts`. That list is now empty, with its ratchet kept intact.

#### Sources corrected

| model | was | now |
|---|---|---|
| `Incident`, `ScheduledMaintenance` | `name` | `title` |
| `IncidentTemplate`, `ScheduledMaintenanceTemplate` | `name` | `templateName` |
| `Domain` | `name` | `domain` |

Each is what the model's own slug example documents. `Incident` pairs the slug example `database-connection-failure-in-production` with a title example of "Database connection failure in production". Both template models pair their slug example with their **templateName** example — "Server Outage Template" → `server-outage-template`, "Database Upgrade Template" → `database-upgrade-template` — and `StatusPageAnnouncementTemplate`, the one template model whose source was never mis-copied, names `templateName` too.

#### The nine with no slug column

`AlertState`, `MetricType`, `StatusPageAnnouncementTemplate`, `MonitorStatusTimeline`, `MonitorTest`, `StatusPageAnnouncement`, `StatusPagePrivateUser`, `StatusPageResource`, `StatusPageSubscriber` had the decorator **deleted** rather than a column added. Nothing in the product reads their slugs — the only slug consumed anywhere is Monitor's, as a template variable — so the alternative was a `NOT NULL` column plus a backfill on nine live tables for a value with no reader. `Domain` was the exception: its `slug` column is `NOT NULL`, so it had to keep generating.

**No schema change, so no migration.** Existing rows keep their slugs; only newly created rows are affected.

#### The clamp this needed first

Pointing `Incident` at `title` is only safe with a ceiling. `Incident.title` is `varchar(500)` against a `varchar(100)` slug, and `checkMaxLengthOfFields` runs *after* `generateSlug` in the same create and **throws** rather than truncating — so unguarded, any incident titled longer than ~89 characters would have failed to insert.

`Slug.getSlug` now takes the destination column's declared width, trimming the readable half and never the random tail. That also closes the pre-existing hazard `NetworkDeviceMonitorTemplateUtil` works around by clamping monitor names to 88.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission? (`npm run fix` at root, exit 0; `npx tsc --noEmit` in `Common`, clean)
- [x] Did you write tests where appropriate?

Tests added:

- `Common/Tests/Server/Services/DatabaseServiceGenerateSlug.test.ts` — new behavioural suite exercising the real create-path hook, one case per corrected model plus the clamp and the random-fallback failure mode.
- `ModelRegistryInvariants.test.ts` — declaration pins for the intended source per model, and for the nine that must stay unconfigured.
- `Slug.test.ts` — the clamp, including that no dash is left dangling where the cut falls, swept across every ceiling from 20 to 100.

Verified the ratchet actually bites: reverting `Incident` to `"name"` fails 4 tests, and neutering the clamp fails the clamp test on its own. 1,579 tests across the registry, schema, model, `DatabaseService`, and slug-adjacent NetworkDiscovery suites pass.

### Related Issue?

None.
