### PR TITLE
fix(workers): select endsAt so {{scheduledEndTime}} renders in subscriber notifications

### DIFF
--- a/App/FeatureSet/Workers/Jobs/ScheduledMaintenance/SendNotificationToSubscribers.ts
+++ b/App/FeatureSet/Workers/Jobs/ScheduledMaintenance/SendNotificationToSubscribers.ts
@@ -28,6 +28,7 @@ RunCron(
           title: true,
           description: true,
           startsAt: true,
+          endsAt: true,
           projectId: true,
           monitors: {
             _id: true,

--- a/App/FeatureSet/Workers/Jobs/ScheduledMaintenance/SendSubscriberRemindersOnEventScheduled.ts
+++ b/App/FeatureSet/Workers/Jobs/ScheduledMaintenance/SendSubscriberRemindersOnEventScheduled.ts
@@ -32,6 +32,7 @@ RunCron(
           title: true,
           description: true,
           startsAt: true,
+          endsAt: true,
           projectId: true,
           monitors: {
             _id: true,

--- a/App/Tests/Workers/Jobs/ScheduledMaintenance/SendNotificationToSubscribers.test.ts
+++ b/App/Tests/Workers/Jobs/ScheduledMaintenance/SendNotificationToSubscribers.test.ts
@@ -1,0 +1,282 @@
+import ScheduledMaintenance from "Common/Models/DatabaseModels/ScheduledMaintenance";
+import ObjectID from "Common/Types/ObjectID";
+import StatusPageSubscriberNotificationStatus from "Common/Types/StatusPage/StatusPageSubscriberNotificationStatus";
+
+/*
+ * Subscriber notifications for a newly created scheduled maintenance are
+ * rendered from the event models this job hands to
+ * `notififySubscribersOnEventScheduled`. That service reads `event.endsAt`
+ * straight off them to fill `{{scheduledEndTime}}`.
+ *
+ * This job's select listed `startsAt` but not `endsAt`, so every event arrived
+ * with `endsAt` undefined and the service's `event.endsAt ? ... : ""` branch
+ * silently rendered an empty string. `{{scheduledStartTime}}` worked, which is
+ * exactly why the hole went unnoticed for so long: the mail looked correct
+ * apart from a blank end time. (GitHub issue #3545.)
+ *
+ * `endsAt` is never read inside this job's own body, so no assertion about
+ * what the job DOES can catch its absence. The fake below therefore behaves
+ * like the database it stands in for: it projects each row through the select
+ * the job actually asked for, so an unselected column arrives undefined here
+ * for the same reason it does in production. That is what makes the
+ * pass-through tests real regression tests rather than restatements of the
+ * fixture.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler — the same recorder the other
+ * App/Tests/Workers/Jobs suites use — and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ScheduledMaintenanceService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      getScheduledMaintenanceLinkInDashboard: jest.fn(),
+      notififySubscribersOnEventScheduled: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ScheduledMaintenanceFeedService", () => {
+  return {
+    __esModule: true,
+    default: { createScheduledMaintenanceFeedItem: jest.fn() },
+  };
+});
+
+import ScheduledMaintenanceService from "Common/Server/Services/ScheduledMaintenanceService";
+import ScheduledMaintenanceFeedService from "Common/Server/Services/ScheduledMaintenanceFeedService";
+import URL from "Common/Types/API/URL";
+import "../../../../FeatureSet/Workers/Jobs/ScheduledMaintenance/SendNotificationToSubscribers";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const JOB_NAME: string = "ScheduledMaintenance:SendNotificationToSubscribers";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+const STARTS_AT: Date = new Date("2024-03-04T06:08:00.000Z");
+const ENDS_AT: Date = new Date("2024-03-04T08:00:00.000Z");
+
+// A full database row — every column the table has that this job could ask for.
+function storedEvent(overrides?: {
+  id?: string;
+  endsAt?: Date | undefined;
+  isVisibleOnStatusPage?: boolean;
+}): ScheduledMaintenance {
+  const event: ScheduledMaintenance = new ScheduledMaintenance();
+
+  event._id = overrides?.id || "22222222-2222-4222-8222-222222222222";
+  event.projectId = PROJECT_ID;
+  event.title = "Quarterly database failover drill";
+  event.description = "Failing over the primary.";
+  event.startsAt = STARTS_AT;
+  event.endsAt =
+    overrides && "endsAt" in overrides
+      ? (overrides.endsAt as Date)
+      : new Date(ENDS_AT);
+  event.isVisibleOnStatusPage = overrides?.isVisibleOnStatusPage !== false;
+  event.scheduledMaintenanceNumber = 7;
+  event.scheduledMaintenanceNumberWithPrefix = "SM-7";
+
+  return event;
+}
+
+/*
+ * Stands in for the database's column projection: a column the caller did not
+ * select is simply not on the model that comes back.
+ */
+function project(
+  row: ScheduledMaintenance,
+  select: Record<string, unknown>,
+): ScheduledMaintenance {
+  const projected: ScheduledMaintenance = new ScheduledMaintenance();
+  const source: Record<string, unknown> = row as unknown as Record<
+    string,
+    unknown
+  >;
+  const target: Record<string, unknown> = projected as unknown as Record<
+    string,
+    unknown
+  >;
+
+  for (const [column, isSelected] of Object.entries(select)) {
+    if (!isSelected) {
+      continue;
+    }
+
+    target[column] = source[column];
+  }
+
+  return projected;
+}
+
+let storedEvents: Array<ScheduledMaintenance> = [];
+
+function findAllBySelect(): Record<string, unknown> {
+  const args: { select: Record<string, unknown> } = (
+    ScheduledMaintenanceService.findAllBy as unknown as jest.Mock
+  ).mock.calls[0]![0] as { select: Record<string, unknown> };
+
+  return args.select;
+}
+
+function notifiedEvents(): Array<ScheduledMaintenance> {
+  const calls: Array<Array<unknown>> = (
+    ScheduledMaintenanceService.notififySubscribersOnEventScheduled as unknown as jest.Mock
+  ).mock.calls as Array<Array<unknown>>;
+
+  return (calls[0]?.[0] as Array<ScheduledMaintenance>) || [];
+}
+
+describe("ScheduledMaintenance:SendNotificationToSubscribers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    storedEvents = [storedEvent()];
+
+    (
+      ScheduledMaintenanceService.findAllBy as unknown as jest.Mock
+    ).mockImplementation(
+      async (args: unknown): Promise<Array<ScheduledMaintenance>> => {
+        const select: Record<string, unknown> = (
+          args as { select: Record<string, unknown> }
+        ).select;
+
+        return storedEvents.map((row: ScheduledMaintenance) => {
+          return project(row, select);
+        });
+      },
+    );
+
+    (
+      ScheduledMaintenanceService.updateOneById as unknown as jest.Mock
+    ).mockResolvedValue(undefined as never);
+
+    (
+      ScheduledMaintenanceService.getScheduledMaintenanceLinkInDashboard as unknown as jest.Mock
+    ).mockResolvedValue(
+      URL.fromString("https://oneuptime.com/dashboard/sm-1") as never,
+    );
+
+    (
+      ScheduledMaintenanceService.notififySubscribersOnEventScheduled as unknown as jest.Mock
+    ).mockResolvedValue(undefined as never);
+
+    (
+      ScheduledMaintenanceFeedService.createScheduledMaintenanceFeedItem as unknown as jest.Mock
+    ).mockResolvedValue(undefined as never);
+  });
+
+  test("selects endsAt so {{scheduledEndTime}} has a value to render", async () => {
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(findAllBySelect()["endsAt"]).toBe(true);
+    expect(findAllBySelect()["startsAt"]).toBe(true);
+  });
+
+  test("hands the end time through to the notification service", async () => {
+    await mockCapturedJobs[JOB_NAME]!();
+
+    const events: Array<ScheduledMaintenance> = notifiedEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.endsAt).toEqual(ENDS_AT);
+    expect(events[0]!.startsAt).toEqual(STARTS_AT);
+  });
+
+  test("keeps an absent end time absent rather than inventing one", async () => {
+    /*
+     * An event with no end time is legitimate — the service renders
+     * `{{scheduledEndTime}}` as an empty string for it. The fix must not
+     * paper over that case with a fabricated date.
+     */
+    storedEvents = [storedEvent({ endsAt: undefined })];
+
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]!.endsAt).toBeUndefined();
+  });
+
+  test("carries the end time on every event of a multi-event tick", async () => {
+    const second: ScheduledMaintenance = storedEvent({
+      id: "44444444-4444-4444-8444-444444444444",
+    });
+    second.endsAt = new Date("2024-03-05T09:30:00.000Z");
+
+    storedEvents = [
+      storedEvent({ id: "33333333-3333-4333-8333-333333333333" }),
+      second,
+    ];
+
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(
+      notifiedEvents().map((event: ScheduledMaintenance) => {
+        return event.endsAt;
+      }),
+    ).toEqual([ENDS_AT, new Date("2024-03-05T09:30:00.000Z")]);
+  });
+
+  test("still excludes events hidden from the status page", async () => {
+    /*
+     * Guards the filter the end-time fix sits next to: a hidden event is
+     * marked Skipped and never reaches the notification service.
+     */
+    storedEvents = [storedEvent({ isVisibleOnStatusPage: false })];
+
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(
+      ScheduledMaintenanceService.notififySubscribersOnEventScheduled,
+    ).not.toHaveBeenCalled();
+
+    const skipped: boolean = (
+      ScheduledMaintenanceService.updateOneById as unknown as jest.Mock
+    ).mock.calls.some((call: Array<unknown>) => {
+      const args: {
+        data: { subscriberNotificationStatusOnEventScheduled?: string };
+      } = call[0] as {
+        data: { subscriberNotificationStatusOnEventScheduled?: string };
+      };
+
+      return (
+        args.data.subscriberNotificationStatusOnEventScheduled ===
+        StatusPageSubscriberNotificationStatus.Skipped
+      );
+    });
+
+    expect(skipped).toBe(true);
+  });
+});

--- a/App/Tests/Workers/Jobs/ScheduledMaintenance/SendSubscriberRemindersOnEventScheduled.test.ts
+++ b/App/Tests/Workers/Jobs/ScheduledMaintenance/SendSubscriberRemindersOnEventScheduled.test.ts
@@ -1,0 +1,277 @@
+import ScheduledMaintenance from "Common/Models/DatabaseModels/ScheduledMaintenance";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * The reminder job — the "your maintenance window starts soon" mail — hands
+ * its events to the same `notififySubscribersOnEventScheduled` the creation
+ * job does, and that service fills `{{scheduledEndTime}}` from `event.endsAt`.
+ *
+ * Like its sibling, this job selected `startsAt` but not `endsAt`, so the end
+ * time reached the template renderer as undefined and came out as an empty
+ * string. (GitHub issue #3545.)
+ *
+ * The fake `findAllBy` below projects each row through the select the job
+ * actually asked for, exactly as the database does, so an unselected column
+ * arrives undefined here for the same reason it did in production.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler and each test drives one full
+ * tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ScheduledMaintenanceService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      getNextTimeToNotify: jest.fn(),
+      getScheduledMaintenanceLinkInDashboard: jest.fn(),
+      notififySubscribersOnEventScheduled: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ScheduledMaintenanceFeedService", () => {
+  return {
+    __esModule: true,
+    default: { createScheduledMaintenanceFeedItem: jest.fn() },
+  };
+});
+
+import ScheduledMaintenanceService from "Common/Server/Services/ScheduledMaintenanceService";
+import ScheduledMaintenanceFeedService from "Common/Server/Services/ScheduledMaintenanceFeedService";
+import URL from "Common/Types/API/URL";
+import "../../../../FeatureSet/Workers/Jobs/ScheduledMaintenance/SendSubscriberRemindersOnEventScheduled";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const JOB_NAME: string =
+  "ScheduledMaintenance:SendSubscriberRemindersOnEventScheduled";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+const STARTS_AT: Date = new Date("2024-03-04T06:08:00.000Z");
+const ENDS_AT: Date = new Date("2024-03-04T08:00:00.000Z");
+
+// A full database row — every column the table has that this job could ask for.
+function storedEvent(overrides?: {
+  id?: string;
+  endsAt?: Date | undefined;
+}): ScheduledMaintenance {
+  const event: ScheduledMaintenance = new ScheduledMaintenance();
+
+  event._id = overrides?.id || "22222222-2222-4222-8222-222222222222";
+  event.projectId = PROJECT_ID;
+  event.title = "Quarterly database failover drill";
+  event.description = "Failing over the primary.";
+  event.startsAt = STARTS_AT;
+  event.endsAt =
+    overrides && "endsAt" in overrides
+      ? (overrides.endsAt as Date)
+      : new Date(ENDS_AT);
+  event.sendSubscriberNotificationsOnBeforeTheEvent = [];
+  event.nextSubscriberNotificationBeforeTheEventAt = new Date(
+    "2024-03-04T05:08:00.000Z",
+  );
+  event.scheduledMaintenanceNumber = 7;
+  event.scheduledMaintenanceNumberWithPrefix = "SM-7";
+
+  return event;
+}
+
+/*
+ * Stands in for the database's column projection: a column the caller did not
+ * select is simply not on the model that comes back.
+ */
+function project(
+  row: ScheduledMaintenance,
+  select: Record<string, unknown>,
+): ScheduledMaintenance {
+  const projected: ScheduledMaintenance = new ScheduledMaintenance();
+  const source: Record<string, unknown> = row as unknown as Record<
+    string,
+    unknown
+  >;
+  const target: Record<string, unknown> = projected as unknown as Record<
+    string,
+    unknown
+  >;
+
+  for (const [column, isSelected] of Object.entries(select)) {
+    if (!isSelected) {
+      continue;
+    }
+
+    target[column] = source[column];
+  }
+
+  return projected;
+}
+
+let storedEvents: Array<ScheduledMaintenance> = [];
+
+function findAllBySelect(): Record<string, unknown> {
+  const args: { select: Record<string, unknown> } = (
+    ScheduledMaintenanceService.findAllBy as unknown as jest.Mock
+  ).mock.calls[0]![0] as { select: Record<string, unknown> };
+
+  return args.select;
+}
+
+function notifiedEvents(): Array<ScheduledMaintenance> {
+  const calls: Array<Array<unknown>> = (
+    ScheduledMaintenanceService.notififySubscribersOnEventScheduled as unknown as jest.Mock
+  ).mock.calls as Array<Array<unknown>>;
+
+  return (calls[0]?.[0] as Array<ScheduledMaintenance>) || [];
+}
+
+describe("ScheduledMaintenance:SendSubscriberRemindersOnEventScheduled", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    storedEvents = [storedEvent()];
+
+    (
+      ScheduledMaintenanceService.findAllBy as unknown as jest.Mock
+    ).mockImplementation(
+      async (args: unknown): Promise<Array<ScheduledMaintenance>> => {
+        const select: Record<string, unknown> = (
+          args as { select: Record<string, unknown> }
+        ).select;
+
+        return storedEvents.map((row: ScheduledMaintenance) => {
+          return project(row, select);
+        });
+      },
+    );
+
+    (
+      ScheduledMaintenanceService.updateOneById as unknown as jest.Mock
+    ).mockResolvedValue(undefined as never);
+
+    (
+      ScheduledMaintenanceService.getNextTimeToNotify as unknown as jest.Mock
+    ).mockReturnValue(null);
+
+    (
+      ScheduledMaintenanceService.getScheduledMaintenanceLinkInDashboard as unknown as jest.Mock
+    ).mockResolvedValue(
+      URL.fromString("https://oneuptime.com/dashboard/sm-1") as never,
+    );
+
+    (
+      ScheduledMaintenanceService.notififySubscribersOnEventScheduled as unknown as jest.Mock
+    ).mockResolvedValue(undefined as never);
+
+    (
+      ScheduledMaintenanceFeedService.createScheduledMaintenanceFeedItem as unknown as jest.Mock
+    ).mockResolvedValue(undefined as never);
+  });
+
+  test("selects endsAt so {{scheduledEndTime}} has a value to render", async () => {
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(findAllBySelect()["endsAt"]).toBe(true);
+    expect(findAllBySelect()["startsAt"]).toBe(true);
+  });
+
+  test("hands the end time through to the notification service", async () => {
+    await mockCapturedJobs[JOB_NAME]!();
+
+    const events: Array<ScheduledMaintenance> = notifiedEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.endsAt).toEqual(ENDS_AT);
+    expect(events[0]!.startsAt).toEqual(STARTS_AT);
+  });
+
+  test("keeps an absent end time absent rather than inventing one", async () => {
+    storedEvents = [storedEvent({ endsAt: undefined })];
+
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(notifiedEvents()).toHaveLength(1);
+    expect(notifiedEvents()[0]!.endsAt).toBeUndefined();
+  });
+
+  test("carries the end time on every event of a multi-event tick", async () => {
+    const second: ScheduledMaintenance = storedEvent({
+      id: "44444444-4444-4444-8444-444444444444",
+    });
+    second.endsAt = new Date("2024-03-05T09:30:00.000Z");
+
+    storedEvents = [
+      storedEvent({ id: "33333333-3333-4333-8333-333333333333" }),
+      second,
+    ];
+
+    await mockCapturedJobs[JOB_NAME]!();
+
+    expect(
+      notifiedEvents().map((event: ScheduledMaintenance) => {
+        return event.endsAt;
+      }),
+    ).toEqual([ENDS_AT, new Date("2024-03-05T09:30:00.000Z")]);
+  });
+
+  test("still reschedules the next reminder off the start time", async () => {
+    /*
+     * The reminder cadence is driven by `startsAt`, not `endsAt`; widening the
+     * select must not disturb it.
+     */
+    const nextAt: Date = new Date("2024-03-04T05:38:00.000Z");
+
+    (
+      ScheduledMaintenanceService.getNextTimeToNotify as unknown as jest.Mock
+    ).mockReturnValue(nextAt);
+
+    await mockCapturedJobs[JOB_NAME]!();
+
+    const nextTimeArgs: { eventScheduledDate: Date } = (
+      ScheduledMaintenanceService.getNextTimeToNotify as unknown as jest.Mock
+    ).mock.calls[0]![0] as { eventScheduledDate: Date };
+
+    expect(nextTimeArgs.eventScheduledDate).toEqual(STARTS_AT);
+
+    const updateArgs: {
+      data: { nextSubscriberNotificationBeforeTheEventAt?: Date };
+    } = (ScheduledMaintenanceService.updateOneById as unknown as jest.Mock).mock
+      .calls[0]![0] as {
+      data: { nextSubscriberNotificationBeforeTheEventAt?: Date };
+    };
+
+    expect(updateArgs.data.nextSubscriberNotificationBeforeTheEventAt).toEqual(
+      nextAt,
+    );
+  });
+});

--- a/Common/Tests/Server/Services/ScheduledMaintenanceSubscriberEndTime.test.ts
+++ b/Common/Tests/Server/Services/ScheduledMaintenanceSubscriberEndTime.test.ts
@@ -1,0 +1,369 @@
+import ScheduledMaintenance from "../../../Models/DatabaseModels/ScheduledMaintenance";
+import ProjectCallSMSConfig from "../../../Models/DatabaseModels/ProjectCallSMSConfig";
+import ProjectSmtpConfig from "../../../Models/DatabaseModels/ProjectSmtpConfig";
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import StatusPageSubscriber from "../../../Models/DatabaseModels/StatusPageSubscriber";
+import StatusPageSubscriberNotificationTemplate from "../../../Models/DatabaseModels/StatusPageSubscriberNotificationTemplate";
+import DatabaseConfig from "../../../Server/DatabaseConfig";
+import MailService from "../../../Server/Services/MailService";
+import ProjectCallSMSConfigService from "../../../Server/Services/ProjectCallSMSConfigService";
+import ProjectSmtpConfigService from "../../../Server/Services/ProjectSmtpConfigService";
+import ScheduledMaintenanceService from "../../../Server/Services/ScheduledMaintenanceService";
+import SmsService from "../../../Server/Services/SmsService";
+import StatusPageResourceService from "../../../Server/Services/StatusPageResourceService";
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import StatusPageSubscriberNotificationTemplateService from "../../../Server/Services/StatusPageSubscriberNotificationTemplateService";
+import StatusPageSubscriberService from "../../../Server/Services/StatusPageSubscriberService";
+import Markdown from "../../../Server/Types/Markdown";
+import SlackUtil from "../../../Server/Utils/Workspace/Slack/Slack";
+import StatusPageSubscriberWebhookUtil from "../../../Server/Utils/StatusPageSubscriberWebhook";
+import Hostname from "../../../Types/API/Hostname";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import Protocol from "../../../Types/API/Protocol";
+import URL from "../../../Types/API/URL";
+import OneUptimeDate from "../../../Types/Date";
+import { JSONObject } from "../../../Types/JSON";
+import Email from "../../../Types/Email";
+import Phone from "../../../Types/Phone";
+import ObjectID from "../../../Types/ObjectID";
+import StatusPageSubscriberNotificationMethod from "../../../Types/StatusPage/StatusPageSubscriberNotificationMethod";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The other half of GitHub issue #3545.
+ *
+ * The worker jobs did not select `endsAt`, so this service received events
+ * with the end time missing and rendered `{{scheduledEndTime}}` as an empty
+ * string — while `{{scheduledStartTime}}` rendered fine, which is what made
+ * the bug look like a template problem rather than a query problem.
+ *
+ * The worker suites pin that `endsAt` now arrives. This suite pins the
+ * consequence: given an event that carries `endsAt`, every channel that
+ * advertises `{{scheduledEndTime}}` to template authors — custom email, SMS
+ * and Slack templates, plus the subscriber webhook payload — actually renders
+ * the end time; and given an event without one, they degrade to an empty
+ * string rather than printing "undefined" at a subscriber.
+ *
+ * Everything the service talks to is a `jest.spyOn`: no database, no mail
+ * server, no Slack. What is under test is this service's own rendering, driven
+ * through the real `compileTemplate`.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SUBSCRIBER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const EVENT_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+
+const STARTS_AT: Date = new Date("2024-03-04T06:08:00.000Z");
+const ENDS_AT: Date = new Date("2024-03-04T08:00:00.000Z");
+
+const TEMPLATE_BODY: string =
+  "Start: {{scheduledStartTime}} | End: {{scheduledEndTime}}";
+
+// What the template author expects to see rendered, in the service's own format.
+const EXPECTED_END: string =
+  OneUptimeDate.getDateAsUserFriendlyFormattedString(ENDS_AT);
+const EXPECTED_START: string =
+  OneUptimeDate.getDateAsUserFriendlyFormattedString(STARTS_AT);
+
+// Every outbound channel here resolves an HTTPResponse rather than throwing.
+function accepted(): HTTPResponse<JSONObject> {
+  return new HTTPResponse<JSONObject>(200, {}, {});
+}
+
+function scheduledEvent(endsAt?: Date): ScheduledMaintenance {
+  const event: ScheduledMaintenance = new ScheduledMaintenance();
+
+  event._id = EVENT_ID.toString();
+  event.projectId = PROJECT_ID;
+  event.title = "Quarterly database failover drill";
+  event.description = "Failing over the primary.";
+  event.startsAt = STARTS_AT;
+
+  if (endsAt) {
+    event.endsAt = endsAt;
+  }
+
+  const statusPage: StatusPage = new StatusPage();
+  statusPage._id = STATUS_PAGE_ID.toString();
+  event.statusPages = [statusPage];
+
+  return event;
+}
+
+function statusPageWithCustomProviders(): StatusPage {
+  const statusPage: StatusPage = new StatusPage();
+
+  statusPage._id = STATUS_PAGE_ID.toString();
+  statusPage.projectId = PROJECT_ID;
+  statusPage.name = "Acme Status";
+  statusPage.pageTitle = "Acme Status";
+  statusPage.isPublicStatusPage = true;
+  statusPage.showScheduledMaintenanceEventsOnStatusPage = true;
+  statusPage.allowSubscribersToChooseResources = false;
+  statusPage.allowSubscribersToChooseEventTypes = false;
+  statusPage.subscriberTimezones = [];
+
+  /*
+   * Custom email and SMS templates are only honoured when the status page
+   * brings its own SMTP/Twilio credentials, so both configs are required for
+   * this suite to exercise the custom-template path at all.
+   */
+  const smtpConfig: ProjectSmtpConfig = new ProjectSmtpConfig();
+  smtpConfig._id = "55555555-5555-4555-8555-555555555555";
+  statusPage.smtpConfig = smtpConfig;
+
+  const callSmsConfig: ProjectCallSMSConfig = new ProjectCallSMSConfig();
+  callSmsConfig._id = "66666666-6666-4666-8666-666666666666";
+  statusPage.callSmsConfig = callSmsConfig;
+
+  return statusPage;
+}
+
+function subscriberOnEveryChannel(): StatusPageSubscriber {
+  const subscriber: StatusPageSubscriber = new StatusPageSubscriber();
+
+  subscriber._id = SUBSCRIBER_ID.toString();
+  subscriber.statusPageId = STATUS_PAGE_ID;
+  subscriber.isUnsubscribed = false;
+  subscriber.isSubscribedToAllResources = true;
+  subscriber.isSubscribedToAllEventTypes = true;
+  subscriber.subscriberEmail = new Email("subscriber@example.com");
+  subscriber.subscriberPhone = new Phone("+15558675309");
+  subscriber.slackIncomingWebhookUrl = URL.fromString(
+    "https://hooks.slack.com/services/T/B/X",
+  );
+  subscriber.subscriberWebhook = URL.fromString(
+    "https://hooks.example.com/subscriber",
+  );
+
+  return subscriber;
+}
+
+function customTemplate(
+  method: StatusPageSubscriberNotificationMethod,
+): StatusPageSubscriberNotificationTemplate {
+  const template: StatusPageSubscriberNotificationTemplate =
+    new StatusPageSubscriberNotificationTemplate();
+
+  template._id = `template-${method}`;
+  template.templateBody = TEMPLATE_BODY;
+  template.emailSubject = "Window ends {{scheduledEndTime}}";
+  template.notificationMethod = method;
+
+  return template;
+}
+
+// The rendered body of the one custom email this run produced.
+function sentEmailBody(): string {
+  const call: Array<unknown> = (MailService.sendMail as unknown as jest.Mock)
+    .mock.calls[0]!;
+
+  return String((call[0] as { vars: { body: string } }).vars.body);
+}
+
+function sentEmailSubject(): string {
+  const call: Array<unknown> = (MailService.sendMail as unknown as jest.Mock)
+    .mock.calls[0]!;
+
+  return String((call[0] as { subject: string }).subject);
+}
+
+function sentSmsMessage(): string {
+  const call: Array<unknown> = (SmsService.sendSms as unknown as jest.Mock).mock
+    .calls[0]!;
+
+  return String((call[0] as { message: string }).message);
+}
+
+function sentSlackMessage(): string {
+  return String(
+    (SlackUtil.convertMarkdownToSlackRichText as unknown as jest.Mock).mock
+      .calls[0]![0],
+  );
+}
+
+function sentWebhookPayload(): Record<string, string> {
+  const call: Array<unknown> = (
+    StatusPageSubscriberWebhookUtil.sendWebhookNotification as unknown as jest.Mock
+  ).mock.calls[0]!;
+
+  return (call[0] as { payload: { data: Record<string, string> } }).payload
+    .data;
+}
+
+describe("scheduled maintenance subscriber notifications: {{scheduledEndTime}}", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(DatabaseConfig, "getHost")
+      .mockResolvedValue(new Hostname("oneuptime.com"));
+    jest
+      .spyOn(DatabaseConfig, "getHttpProtocol")
+      .mockResolvedValue(Protocol.HTTPS);
+
+    jest
+      .spyOn(StatusPageResourceService, "findByMonitors")
+      .mockResolvedValue([]);
+
+    jest
+      .spyOn(StatusPageSubscriberService, "getStatusPagesToSendNotification")
+      .mockResolvedValue([statusPageWithCustomProviders()]);
+
+    jest
+      .spyOn(StatusPageSubscriberService, "getSubscribersByStatusPage")
+      .mockResolvedValue([subscriberOnEveryChannel()]);
+
+    jest
+      .spyOn(StatusPageService, "getStatusPageURL")
+      .mockResolvedValue("https://status.example.com");
+
+    jest
+      .spyOn(
+        StatusPageSubscriberNotificationTemplateService,
+        "getTemplateForStatusPage",
+      )
+      .mockImplementation(
+        async (data: {
+          notificationMethod: StatusPageSubscriberNotificationMethod;
+        }): Promise<StatusPageSubscriberNotificationTemplate | null> => {
+          return customTemplate(data.notificationMethod);
+        },
+      );
+
+    jest
+      .spyOn(ProjectSmtpConfigService, "toEmailServer")
+      .mockReturnValue(undefined);
+    jest
+      .spyOn(ProjectCallSMSConfigService, "toTwilioConfig")
+      .mockReturnValue(undefined);
+
+    jest
+      .spyOn(Markdown, "convertToHTML")
+      .mockImplementation(async (markdown: string): Promise<string> => {
+        return markdown;
+      });
+
+    jest.spyOn(MailService, "sendMail").mockResolvedValue(accepted());
+    jest.spyOn(SmsService, "sendSms").mockResolvedValue(accepted());
+    jest
+      .spyOn(SlackUtil, "sendMessageToChannelViaIncomingWebhook")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(SlackUtil, "convertMarkdownToSlackRichText")
+      .mockImplementation((markdown: string): string => {
+        return markdown;
+      });
+    jest
+      .spyOn(StatusPageSubscriberWebhookUtil, "sendWebhookNotification")
+      .mockResolvedValue(accepted());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders the end time in a custom email body", async () => {
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(ENDS_AT),
+    ]);
+
+    /*
+     * Guards the fixture itself: an empty EXPECTED_END would make every
+     * assertion in this file pass on the very bug it exists to catch.
+     */
+    expect(EXPECTED_END).not.toBe("");
+
+    expect(MailService.sendMail).toHaveBeenCalledTimes(1);
+    expect(sentEmailBody()).toBe(
+      `Start: ${EXPECTED_START} | End: ${EXPECTED_END}`,
+    );
+  });
+
+  test("renders the end time in a custom email subject", async () => {
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(ENDS_AT),
+    ]);
+
+    expect(sentEmailSubject()).toBe(`Window ends ${EXPECTED_END}`);
+  });
+
+  test("renders the end time in a custom SMS template", async () => {
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(ENDS_AT),
+    ]);
+
+    expect(SmsService.sendSms).toHaveBeenCalledTimes(1);
+    expect(sentSmsMessage()).toBe(
+      `Start: ${EXPECTED_START} | End: ${EXPECTED_END}`,
+    );
+  });
+
+  test("renders the end time in a custom Slack template", async () => {
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(ENDS_AT),
+    ]);
+
+    expect(sentSlackMessage()).toBe(
+      `Start: ${EXPECTED_START} | End: ${EXPECTED_END}`,
+    );
+  });
+
+  test("sends the end time in the subscriber webhook payload", async () => {
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(ENDS_AT),
+    ]);
+
+    expect(sentWebhookPayload()["scheduledEndTime"]).toBe(EXPECTED_END);
+    expect(sentWebhookPayload()["scheduledStartTime"]).toBe(EXPECTED_START);
+  });
+
+  test("renders an empty end time — never 'undefined' — for an open-ended event", async () => {
+    /*
+     * An event with no end time is legitimate. The subscriber should see a
+     * blank, not the string "undefined": this is the behaviour the bug made
+     * universal, and it has to survive as the genuine no-end-time case.
+     */
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(undefined),
+    ]);
+
+    expect(sentEmailBody()).toBe(`Start: ${EXPECTED_START} | End: `);
+    expect(sentSmsMessage()).toBe(`Start: ${EXPECTED_START} | End: `);
+    expect(sentWebhookPayload()["scheduledEndTime"]).toBe("");
+  });
+
+  test("renders each event's own end time when several are notified at once", async () => {
+    const laterEnd: Date = new Date("2024-03-05T09:30:00.000Z");
+
+    await ScheduledMaintenanceService.notififySubscribersOnEventScheduled([
+      scheduledEvent(ENDS_AT),
+      scheduledEvent(laterEnd),
+    ]);
+
+    const bodies: Array<string> = (
+      MailService.sendMail as unknown as jest.Mock
+    ).mock.calls.map((call: Array<unknown>) => {
+      return String((call[0] as { vars: { body: string } }).vars.body);
+    });
+
+    expect(bodies).toEqual([
+      `Start: ${EXPECTED_START} | End: ${EXPECTED_END}`,
+      `Start: ${EXPECTED_START} | End: ${OneUptimeDate.getDateAsUserFriendlyFormattedString(
+        laterEnd,
+      )}`,
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #3545

## The bug

`ScheduledMaintenanceService.notififySubscribersOnEventScheduled` fills the `{{scheduledEndTime}}` template variable straight from `event.endsAt`:

```ts
scheduledEndTime: event.endsAt
  ? OneUptimeDate.getDateAsUserFriendlyFormattedString(event.endsAt)
  : "",
```

Both worker jobs that call it selected `startsAt` but not `endsAt`, so every event reached the renderer with `endsAt` undefined and `{{scheduledEndTime}}` came out empty. `{{scheduledStartTime}}` rendered fine, which is exactly why this read as a template problem rather than a query problem.

These are the only two callers of that service, so the diagnosis in the issue is complete.

## The fix

`endsAt: true` added to the select in:

- `App/FeatureSet/Workers/Jobs/ScheduledMaintenance/SendNotificationToSubscribers.ts`
- `App/FeatureSet/Workers/Jobs/ScheduledMaintenance/SendSubscriberRemindersOnEventScheduled.ts`

## Tests

17 new tests across three suites.

**Worker suites** (`App/Tests/Workers/Jobs/ScheduledMaintenance/`) drive one full cron tick each. `endsAt` is never read inside either job's own body, so no assertion about what the job *does* can catch its absence — the `findAllBy` fake therefore behaves like the database it stands in for and projects each row through the select the job actually asked for. An unselected column arrives undefined in the test for the same reason it did in production, which is what makes the pass-through assertions real regression tests rather than restatements of the fixture.

Verified against the unfixed code: 3 of 5 tests in each suite fail.

**Service suite** (`Common/Tests/Server/Services/ScheduledMaintenanceSubscriberEndTime.test.ts`) drives the real `notififySubscribersOnEventScheduled` through the real `compileTemplate`, with every collaborator a `jest.spyOn` — no database, no mail server, no Slack. It asserts the end time reaches every channel that advertises `{{scheduledEndTime}}` to template authors: custom email body, email subject, SMS, Slack, and the subscriber webhook payload. It also pins the genuine open-ended case — an event with no end time renders blank, never the string `"undefined"` — since that is the behaviour the bug made universal and it has to survive as the real no-end-time path.

## Checks

- `npm run fix` — clean, no files rewritten
- `npx tsc --noEmit` in `Common` — clean
- `npx tsc --noEmit` in `App` — the 7 errors it reports are in `FeatureSet/BaseAPI/Index.ts` and `FeatureSet/Telemetry/Services/ChangeEventsIngestService.ts`, untouched by this change. They are a local git-worktree artifact: `App/node_modules` symlinks into the main checkout, so `App/node_modules/Common` and the relative imports resolve to two different copies of `Common` and tsc sees two identities for the same types. Does not occur in CI or a normal checkout.
- Relevant suites: 13 App worker tests + 21 Common tests, all passing