### PR TITLE
feat(dashboard): drag-to-zoom retimes the whole dashboard, double-click resets

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx
@@ -44,6 +44,17 @@ export interface ComponentProps {
   refreshTick?: number | undefined;
   chartSyncId?: string | undefined;
   variables?: Array<DashboardVariable> | undefined;
+  /*
+   * Board-wide drag-to-zoom, owned by the dashboard shell above this
+   * canvas: a time-series widget hands up the window the user dragged,
+   * and a double-click on any of them hands up the undo. Both must be
+   * identity-stable — widgets below are React.memo'd.
+   */
+  onDashboardTimeRangeSelect?:
+    | ((startTime: Date, endTime: Date) => void)
+    | undefined;
+  onDashboardTimeRangeReset?: (() => void) | undefined;
+  isDashboardTimeRangeZoomed?: boolean | undefined;
 }
 
 /** Extra empty rows kept below the lowest widget while editing. */
@@ -264,6 +275,9 @@ const DashboardCanvas: FunctionComponent<ComponentProps> = (
           refreshTick={props.refreshTick}
           chartSyncId={props.chartSyncId}
           variables={props.variables}
+          onDashboardTimeRangeSelect={props.onDashboardTimeRangeSelect}
+          onDashboardTimeRangeReset={props.onDashboardTimeRangeReset}
+          isDashboardTimeRangeZoomed={props.isDashboardTimeRangeZoomed}
           onClick={() => {
             props.onComponentSelected(componentId);
           }}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
@@ -89,6 +89,26 @@ export interface DashboardBaseComponentProps {
    */
   chartSyncId?: string | undefined;
   variables?: Array<DashboardVariable> | undefined;
+  /*
+   * Drag-to-zoom on a time-series widget retimes the WHOLE dashboard —
+   * a spike is investigated across every panel at once, the way Traces
+   * and Logs already work. The shell owns the range, so the widget hands
+   * the selected window up rather than narrowing itself.
+   */
+  onDashboardTimeRangeSelect?:
+    | ((startTime: Date, endTime: Date) => void)
+    | undefined;
+  /*
+   * Double-click on a time-series widget: undo the zoom and put the
+   * dashboard back on the range it had before the first drag.
+   */
+  onDashboardTimeRangeReset?: (() => void) | undefined;
+  /*
+   * True while a drag-selection is narrowing the board. Widgets use it to
+   * decide whether a reset gesture has anything to undo — see the chart
+   * library's onTimeRangeReset for why an idle handler is not free.
+   */
+  isDashboardTimeRangeZoomed?: boolean | undefined;
 }
 
 export interface ComponentProps extends DashboardBaseComponentProps {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
@@ -120,13 +120,14 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
   }, [props.dashboardStartAndEndDate, props.refreshTick]);
 
   /*
-   * Drag-to-zoom: a widget-local window narrowed by drag-selecting a
-   * range on the chart. It overrides the dashboard's window for THIS
-   * widget only (spike investigation shouldn't retime every other
-   * widget), survives auto-refresh ticks (the user is mid-investigation;
-   * a rolling re-anchor would yank the window away), and clears when the
-   * dashboard's own time range changes — an explicit range pick is a
-   * statement about what the user wants to see everywhere.
+   * Drag-to-zoom FALLBACK: a widget-local window, used only when the host
+   * did not hand down onDashboardTimeRangeSelect. On a real dashboard the
+   * gesture retimes the whole board (that is the point — a spike is read
+   * across every panel at once), so this path only runs where the widget
+   * is mounted standalone. It survives auto-refresh ticks (the user is
+   * mid-investigation; a rolling re-anchor would yank the window away)
+   * and clears when the dashboard's own time range changes — an explicit
+   * range pick is a statement about what the user wants to see.
    */
   const [zoomWindow, setZoomWindow] = useState<InBetween<Date> | null>(null);
 
@@ -322,13 +323,50 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
    * Drag-to-zoom is a view-mode affordance: in edit mode the drag gesture
    * belongs to widget move/resize, and mid-edit navigation state (the
    * zoom bar's explorer link) would invite losing unsaved changes.
+   *
+   * The selected window goes to the DASHBOARD when the shell offers to
+   * take it, so every panel re-queries the same range; the widget-local
+   * zoom is only the standalone fallback.
    */
+  const onDashboardTimeRangeSelect:
+    | ((startTime: Date, endTime: Date) => void)
+    | undefined = props.onDashboardTimeRangeSelect;
+  const onDashboardTimeRangeReset: (() => void) | undefined =
+    props.onDashboardTimeRangeReset;
+
   const handleChartTimeRangeSelect: (startTime: Date, endTime: Date) => void =
-    useCallback((startTime: Date, endTime: Date): void => {
-      setZoomWindow(new InBetween<Date>(startTime, endTime));
-    }, []);
+    useCallback(
+      (startTime: Date, endTime: Date): void => {
+        if (onDashboardTimeRangeSelect) {
+          onDashboardTimeRangeSelect(startTime, endTime);
+          return;
+        }
+        setZoomWindow(new InBetween<Date>(startTime, endTime));
+      },
+      [onDashboardTimeRangeSelect],
+    );
+
+  const handleChartTimeRangeReset: () => void = useCallback((): void => {
+    if (onDashboardTimeRangeReset) {
+      onDashboardTimeRangeReset();
+      return;
+    }
+    setZoomWindow(null);
+  }, [onDashboardTimeRangeReset]);
 
   const enableChartZoom: boolean = !props.isEditMode;
+
+  /*
+   * Only offer double-click-to-reset while there is a zoom to undo. The
+   * chart library delays single clicks to tell them apart from a
+   * double-click, so an always-on handler would tax every bucket click
+   * for a gesture that could not do anything.
+   */
+  const canResetChartZoom: boolean =
+    enableChartZoom &&
+    (onDashboardTimeRangeReset
+      ? Boolean(props.isDashboardTimeRangeZoomed)
+      : Boolean(zoomWindow));
 
   /*
    * Series investigate menus navigate to explorer/telemetry pages, so
@@ -411,21 +449,46 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
             )}
           </div>
           {/*
-           * Icon-only control: text-gray-500 idle (>= 3:1 contrast on the
+           * Icon-only controls: text-gray-500 idle (>= 3:1 contrast on the
            * white widget surface per WCAG 1.4.11 — gray-300/400 fail),
            * aria-label for the accessible name, and the focus-visible
            * ring shared by the branch's other icon-only buttons.
            */}
           {showOpenInExplorer && (
-            <button
-              type="button"
-              className="inline-flex items-center justify-center rounded-full w-5 h-5 flex-shrink-0 text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
-              title="Open in Metric Explorer"
-              aria-label="Open in Metric Explorer"
-              onClick={handleOpenInExplorer}
-            >
-              <Icon icon={IconProp.ExternalLink} className="h-3.5 w-3.5" />
-            </button>
+            <div className="flex flex-shrink-0 items-center gap-0.5">
+              {/*
+               * Investigate lives in the header, not in the zoom pill: a
+               * drag-selection now retimes the whole dashboard, so the
+               * pill only ever renders for the standalone fallback and an
+               * Investigate button inside it would be unreachable on a
+               * real board. It always investigates the window the widget
+               * is actually charting.
+               */}
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-full w-5 h-5 flex-shrink-0 text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                title="Investigate this window — logs, traces, exceptions"
+                aria-label="Investigate this time window in a side panel"
+                onClick={(event: React.MouseEvent<HTMLButtonElement>): void => {
+                  event.stopPropagation();
+                  setInvestigationWindow(effectiveStartAndEndDate);
+                }}
+              >
+                <Icon
+                  icon={IconProp.MagnifyingGlassPlus}
+                  className="h-3.5 w-3.5"
+                />
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-full w-5 h-5 flex-shrink-0 text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                title="Open in Metric Explorer"
+                aria-label="Open in Metric Explorer"
+                onClick={handleOpenInExplorer}
+              >
+                <Icon icon={IconProp.ExternalLink} className="h-3.5 w-3.5" />
+              </button>
+            </div>
           )}
         </div>
       )}
@@ -499,6 +562,9 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
           onTimeRangeSelect={
             enableChartZoom ? handleChartTimeRangeSelect : undefined
           }
+          onTimeRangeReset={
+            canResetChartZoom ? handleChartTimeRangeReset : undefined
+          }
         />
       </div>
     </div>
@@ -518,6 +584,20 @@ function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
     prev.refreshTick !== next.refreshTick ||
     prev.isEditMode !== next.isEditMode ||
     prev.isSelected !== next.isSelected ||
+    Boolean(prev.isDashboardTimeRangeZoomed) !==
+      Boolean(next.isDashboardTimeRangeZoomed) ||
+    /*
+     * Only whether the shell offers the gesture, not the identity of the
+     * handler: the dashboard hands down identity-stable callbacks (see
+     * useDashboardTimeRangeZoom), and comparing references here would
+     * re-render every chart on every parent tick if one ever came through
+     * as an inline lambda — the exact cost this comparator exists to
+     * avoid.
+     */
+    Boolean(prev.onDashboardTimeRangeSelect) !==
+      Boolean(next.onDashboardTimeRangeSelect) ||
+    Boolean(prev.onDashboardTimeRangeReset) !==
+      Boolean(next.onDashboardTimeRangeReset) ||
     prev.dashboardComponentWidthInPx !== next.dashboardComponentWidthInPx ||
     prev.dashboardComponentHeightInPx !== next.dashboardComponentHeightInPx
   ) {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
@@ -78,6 +78,9 @@ import { PromiseVoidFunction, VoidFunction } from "Common/Types/FunctionTypes";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import MetricUtil from "../Metrics/Utils/Metrics";
 import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import useDashboardTimeRangeZoom, {
+  DashboardTimeRangeZoom,
+} from "Common/UI/Utils/UseDashboardTimeRangeZoom";
 import TimeRange from "Common/Types/Time/TimeRange";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
 import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
@@ -94,10 +97,16 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
     DashboardMode.View,
   );
 
-  const [startAndEndDate, setStartAndEndDate] =
-    useState<RangeStartAndEndDateTime>({
-      range: TimeRange.PAST_ONE_HOUR,
-    });
+  /*
+   * The board's one time range, plus the undo that makes drag-to-zoom on a
+   * panel reversible. A drag-selection on any time-series widget retimes
+   * every widget; a double-click on one puts them all back.
+   */
+  const timeRangeZoom: DashboardTimeRangeZoom = useDashboardTimeRangeZoom({
+    range: TimeRange.PAST_ONE_HOUR,
+  });
+  const startAndEndDate: RangeStartAndEndDateTime =
+    timeRangeZoom.startAndEndDate;
 
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
@@ -462,14 +471,23 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
         onStartAndEndDateChange={(
           newStartAndEndDate: RangeStartAndEndDateTime,
         ) => {
-          setStartAndEndDate(newStartAndEndDate);
+          timeRangeZoom.setStartAndEndDate(newStartAndEndDate);
         }}
+        isTimeRangeZoomed={timeRangeZoom.isZoomed}
+        onResetTimeRangeZoom={timeRangeZoom.resetZoom}
         onCancelEditClick={async () => {
           // load the dashboard view config again
           setDashboardMode(DashboardMode.View);
           await fetchDashboardViewConfig();
         }}
         onEditClick={() => {
+          /*
+           * Editing hides the time-range picker and the reset button, so a
+           * board left zoomed would be stranded on a Custom window with no
+           * way out until the user leaves edit mode. Drop the zoom on the
+           * way in.
+           */
+          timeRangeZoom.resetZoom();
           /*
            * Heal any layout corruption (overlapping or out-of-bounds
            * widgets saved by older builds) before editing starts, so
@@ -833,6 +851,9 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
           refreshTick={refreshTick}
           variables={dashboardVariables}
           chartSyncId={props.dashboardId.toString()}
+          onDashboardTimeRangeSelect={timeRangeZoom.zoomToTimeRange}
+          onDashboardTimeRangeReset={timeRangeZoom.resetZoom}
+          isDashboardTimeRangeZoomed={timeRangeZoom.isZoomed}
         />
       </div>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx
@@ -39,6 +39,14 @@ export interface ComponentProps {
   dashboardDescription?: string | undefined;
   startAndEndDate: RangeStartAndEndDateTime;
   onStartAndEndDateChange: (startAndEndDate: RangeStartAndEndDateTime) => void;
+  /*
+   * A drag-selection on a time-series widget has narrowed the whole board.
+   * The picker then reads "Custom", which says nothing about there being a
+   * way back — so the toolbar spells one out next to it, alongside the
+   * double-click gesture on the panels themselves.
+   */
+  isTimeRangeZoomed?: boolean | undefined;
+  onResetTimeRangeZoom?: (() => void) | undefined;
   dashboardViewConfig: DashboardViewConfig;
   autoRefreshInterval: AutoRefreshInterval;
   onAutoRefreshIntervalChange: (interval: AutoRefreshInterval) => void;
@@ -353,6 +361,24 @@ const DashboardToolbar: FunctionComponent<ComponentProps> = (
                     props.onStartAndEndDateChange(startAndEndDate);
                   }}
                 />
+
+                {props.isTimeRangeZoomed && props.onResetTimeRangeZoom && (
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-medium text-indigo-600 transition-colors hover:bg-indigo-50 hover:text-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                    title="Reset the dashboard to the time range it had before the zoom"
+                    aria-label="Reset zoom"
+                    onClick={() => {
+                      props.onResetTimeRangeZoom?.();
+                    }}
+                  >
+                    <Icon
+                      icon={IconProp.MagnifyingGlassMinus}
+                      className="h-3.5 w-3.5"
+                    />
+                    Reset zoom
+                  </button>
+                )}
 
                 {/* Auto-refresh section */}
                 <AutoRefreshDropdown

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -132,6 +132,13 @@ export interface ComponentProps {
    */
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
   /*
+   * Double-click-to-reset: the way back out of a zoom. Supplied only while
+   * a reset is actually possible — the chart library slows single clicks
+   * down to tell them apart from a double-click, so an always-on handler
+   * would tax every bucket click on the page for nothing.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
+  /*
    * Time-anchored annotations rendered on EVERY panel (query and formula
    * charts alike): vertical event markers (e.g. incident/alert created)
    * and shaded regions (e.g. incident open windows).
@@ -2926,6 +2933,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
           referenceLines:
             referenceLines.length > 0 ? referenceLines : undefined,
           onTimeRangeSelect: props.onTimeRangeSelect,
+          onTimeRangeReset: props.onTimeRangeReset,
           onBucketClick: showSeriesActions
             ? (
                 bucketStart: Date,
@@ -3219,6 +3227,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
               ? formulaReferenceLines
               : undefined,
           onTimeRangeSelect: props.onTimeRangeSelect,
+          onTimeRangeReset: props.onTimeRangeReset,
           onBucketClick: showSeriesActions
             ? (
                 bucketStart: Date,

--- a/App/FeatureSet/Docs/Content/en/dashboards/authoring.md
+++ b/App/FeatureSet/Docs/Content/en/dashboards/authoring.md
@@ -51,6 +51,27 @@ At the top of the dashboard, two controls affect every time-based telemetry widg
 
 Widgets that don't use the time range (like a Text widget) ignore both controls.
 
+### Zooming into a spike
+
+You don't have to reach for the time-range picker to look at a spike. Drag
+across the interesting stretch of any line or area chart and the **whole
+dashboard** moves to that window — every other panel re-queries alongside it,
+so you're reading one moment across the board instead of one chart at a
+different scale from its neighbours.
+
+**Double-click any chart** to undo it: the dashboard goes back to the range it
+had before you started zooming, however many times you drilled in. A **Reset
+zoom** button appears next to the time-range picker while a zoom is active, and
+double-clicking a dashboard that isn't zoomed does nothing.
+
+A zoomed window is a fixed one, so it stops rolling forward while auto-refresh
+is on — that's deliberate, since a window that slid out from under you
+mid-investigation would be worse. Reset the zoom to start rolling again.
+
+Zooming works in View mode only; in Edit mode dragging moves and resizes
+widgets instead. Bar charts can't originate a zoom (there's nothing to drag
+across), but double-clicking one still resets the dashboard.
+
 ## Saving
 
 The canvas saves on its own as you work. A small indicator in the header tells you when the latest change is saved. If you're making a big change, duplicate the dashboard first so you have a safe copy.

--- a/App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardViewPage.tsx
+++ b/App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardViewPage.tsx
@@ -25,6 +25,9 @@ import DefaultDashboardSize from "Common/Types/Dashboard/DashboardSize";
 import { PromiseVoidFunction, VoidFunction } from "Common/Types/FunctionTypes";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import useDashboardTimeRangeZoom, {
+  DashboardTimeRangeZoom,
+} from "Common/UI/Utils/UseDashboardTimeRangeZoom";
 import TimeRange from "Common/Types/Time/TimeRange";
 import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
 import DashboardVariableUrlState from "Common/Utils/Dashboard/VariableUrlState";
@@ -46,19 +49,22 @@ export interface ComponentProps {
 const DashboardViewPage: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [startAndEndDate, setStartAndEndDate] =
-    useState<RangeStartAndEndDateTime>({
-      range: TimeRange.PAST_ONE_HOUR,
-    });
+  /*
+   * The board's one time range plus the undo behind drag-to-zoom, shared
+   * with the authenticated dashboard so a panel gesture means the same
+   * thing on both surfaces.
+   */
+  const timeRangeZoom: DashboardTimeRangeZoom = useDashboardTimeRangeZoom({
+    range: TimeRange.PAST_ONE_HOUR,
+  });
+  const startAndEndDate: RangeStartAndEndDateTime =
+    timeRangeZoom.startAndEndDate;
 
   const [autoRefreshInterval, setAutoRefreshInterval] =
     useState<AutoRefreshInterval>(AutoRefreshInterval.OFF);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [dashboardVariables, setDashboardVariables] = useState<
     Array<DashboardVariable>
-  >([]);
-  const [timeRangeStack, setTimeRangeStack] = useState<
-    Array<RangeStartAndEndDateTime>
   >([]);
   const autoRefreshTimerRef: React.MutableRefObject<ReturnType<
     typeof setInterval
@@ -313,20 +319,15 @@ const DashboardViewPage: FunctionComponent<ComponentProps> = (
                   </span>
                 )}
 
-              {timeRangeStack.length > 0 && (
+              {timeRangeZoom.isZoomed && (
                 <Button
-                  icon={IconProp.Refresh}
+                  icon={IconProp.MagnifyingGlassMinus}
                   title="Reset Zoom"
                   buttonStyle={ButtonStyleType.HOVER_PRIMARY_OUTLINE}
                   onClick={() => {
-                    const previousRange: RangeStartAndEndDateTime | undefined =
-                      timeRangeStack[0];
-                    if (previousRange) {
-                      setStartAndEndDate(previousRange);
-                      setTimeRangeStack([]);
-                    }
+                    timeRangeZoom.resetZoom();
                   }}
-                  tooltip="Reset to original time range"
+                  tooltip="Reset to the time range before the zoom"
                 />
               )}
 
@@ -382,8 +383,12 @@ const DashboardViewPage: FunctionComponent<ComponentProps> = (
                 <RangeStartAndEndDateView
                   dashboardStartAndEndDate={startAndEndDate}
                   onChange={(newRange: RangeStartAndEndDateTime) => {
-                    setTimeRangeStack([...timeRangeStack, startAndEndDate]);
-                    setStartAndEndDate(newRange);
+                    /*
+                     * An explicit pick is a new baseline, not a zoom — it
+                     * retires the "reset" affordance instead of offering
+                     * to jump back to a range the user just left.
+                     */
+                    timeRangeZoom.setStartAndEndDate(newRange);
                   }}
                 />
               </div>
@@ -447,6 +452,9 @@ const DashboardViewPage: FunctionComponent<ComponentProps> = (
           }}
           refreshTick={refreshTick}
           variables={dashboardVariables}
+          onDashboardTimeRangeSelect={timeRangeZoom.zoomToTimeRange}
+          onDashboardTimeRangeReset={timeRangeZoom.resetZoom}
+          isDashboardTimeRangeZoomed={timeRangeZoom.isZoomed}
         />
       </div>
 

--- a/App/Tests/Dashboard/DashboardTimeRangeZoomWiring.test.ts
+++ b/App/Tests/Dashboard/DashboardTimeRangeZoomWiring.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Issue #3530 wiring pins. The two dashboard SHELLS are the half of this
+ * feature no unit test can reach: DashboardView and the public
+ * DashboardViewPage each pull in ~60 widget modules, an API client and a
+ * router, and App's node test env cannot render React at all. So the
+ * load-bearing wiring is pinned as whitespace-squashed source strings (the
+ * MetricsCrossSignalPivot.test pattern), and the behaviour behind it is
+ * covered by the RTL suites in Common/Tests:
+ *
+ *   Common/Tests/Utils/Dashboard/DashboardTimeRangeZoom.test.ts   (state machine)
+ *   Common/Tests/UI/Utils/UseDashboardTimeRangeZoom.test.tsx      (hook)
+ *   Common/Tests/UI/Components/Charts/ChartDoubleClickReset.test.tsx
+ *   Common/Tests/UI/Components/Charts/ChartClickDoubleClickDisambiguation.test.tsx
+ *   Common/Tests/App/Dashboard/DashboardWideChartZoom.test.tsx    (widget)
+ *
+ * The public dashboard is the reason these pins exist at all: before
+ * #3530 nothing anywhere exercised its time range, so its half of the
+ * feature could regress in silence.
+ */
+
+function readSquashed(relative: string): string {
+  return fs
+    .readFileSync(path.join(__dirname, "../../..", relative), "utf8")
+    .replace(/\s+/g, " ");
+}
+
+const AUTHENTICATED_SHELL: string =
+  "App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx";
+const PUBLIC_SHELL: string =
+  "App/FeatureSet/PublicDashboard/src/Pages/DashboardView/DashboardViewPage.tsx";
+const CANVAS: string =
+  "App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index.tsx";
+const TOOLBAR: string =
+  "App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx";
+const METRIC_CHARTS: string =
+  "App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx";
+
+describe("dashboard-wide time range zoom wiring", () => {
+  test.each([
+    ["the authenticated dashboard", AUTHENTICATED_SHELL],
+    ["the public dashboard", PUBLIC_SHELL],
+  ])(
+    "%s owns its range through the shared zoom hook and hands the gesture to the canvas",
+    (_name: string, shellPath: string) => {
+      const shell: string = readSquashed(shellPath);
+
+      /*
+       * Both shells MUST go through the same hook. Re-deriving the
+       * push/restore semantics per shell is exactly how the public
+       * dashboard ended up with a "Reset Zoom" button that appeared after
+       * an ordinary picker change.
+       */
+      expect(shell).toContain(
+        "useDashboardTimeRangeZoom({ range: TimeRange.PAST_ONE_HOUR, })",
+      );
+      expect(shell).toContain(
+        "onDashboardTimeRangeSelect={timeRangeZoom.zoomToTimeRange}",
+      );
+      expect(shell).toContain(
+        "onDashboardTimeRangeReset={timeRangeZoom.resetZoom}",
+      );
+      expect(shell).toContain(
+        "isDashboardTimeRangeZoomed={timeRangeZoom.isZoomed}",
+      );
+    },
+  );
+
+  test("the picker goes through selectRange, not the zoom path", () => {
+    /*
+     * An explicit pick is a new baseline. Routing it through
+     * zoomToTimeRange instead would make "Reset zoom" offer to jump back
+     * to a range the user just deliberately left.
+     */
+    expect(readSquashed(AUTHENTICATED_SHELL)).toContain(
+      "timeRangeZoom.setStartAndEndDate(newStartAndEndDate);",
+    );
+    expect(readSquashed(PUBLIC_SHELL)).toContain(
+      "timeRangeZoom.setStartAndEndDate(newRange);",
+    );
+  });
+
+  test("the public dashboard's hand-rolled range stack is gone", () => {
+    const shell: string = readSquashed(PUBLIC_SHELL);
+
+    // Two sources of truth for "the range before the zoom" is one too many.
+    expect(shell).not.toContain("timeRangeStack");
+    expect(shell).toContain("{timeRangeZoom.isZoomed && (");
+  });
+
+  test("the authenticated toolbar carries a visible way out of the zoom", () => {
+    const shell: string = readSquashed(AUTHENTICATED_SHELL);
+    const toolbar: string = readSquashed(TOOLBAR);
+
+    expect(shell).toContain("isTimeRangeZoomed={timeRangeZoom.isZoomed}");
+    expect(shell).toContain("onResetTimeRangeZoom={timeRangeZoom.resetZoom}");
+
+    /*
+     * Double-click alone is undiscoverable, and once zoomed the picker
+     * just reads "Custom" — which says nothing about there being a way
+     * back.
+     */
+    expect(toolbar).toContain(
+      "props.isTimeRangeZoomed && props.onResetTimeRangeZoom &&",
+    );
+    expect(toolbar).toContain('aria-label="Reset zoom"');
+  });
+
+  test("entering edit mode drops the zoom rather than stranding the board", () => {
+    /*
+     * Edit mode hides both the picker and the reset button, so a board
+     * left zoomed would have no way out until the user leaves edit mode.
+     */
+    const shell: string = readSquashed(AUTHENTICATED_SHELL);
+    const editHandlerIndex: number = shell.indexOf("onEditClick={() => {");
+    expect(editHandlerIndex).toBeGreaterThan(-1);
+    expect(shell.slice(editHandlerIndex, editHandlerIndex + 400)).toContain(
+      "timeRangeZoom.resetZoom();",
+    );
+  });
+
+  test("the canvas threads the gesture down to every widget", () => {
+    const canvas: string = readSquashed(CANVAS);
+
+    expect(canvas).toContain(
+      "onDashboardTimeRangeSelect={props.onDashboardTimeRangeSelect}",
+    );
+    expect(canvas).toContain(
+      "onDashboardTimeRangeReset={props.onDashboardTimeRangeReset}",
+    );
+    expect(canvas).toContain(
+      "isDashboardTimeRangeZoomed={props.isDashboardTimeRangeZoomed}",
+    );
+  });
+
+  test("MetricCharts forwards the reset to both the query and formula panels", () => {
+    const source: string = readSquashed(METRIC_CHARTS);
+
+    /*
+     * Two chart bags are built — one per query chart, one per formula
+     * chart. A reset wired to only one of them leaves half a dashboard
+     * unable to undo the zoom.
+     */
+    const matches: RegExpMatchArray | null = source.match(
+      /onTimeRangeReset: props\.onTimeRangeReset,/g,
+    );
+    expect(matches?.length).toBe(2);
+  });
+});

--- a/App/Tests/Dashboard/InvestigationSurfaces.test.ts
+++ b/App/Tests/Dashboard/InvestigationSurfaces.test.ts
@@ -38,6 +38,18 @@ describe("investigation drawer wiring", () => {
     );
     expect(widget).toContain("<InvestigationDrawer");
     expect(widget).toContain("setInvestigationWindow(zoomWindow)");
+    /*
+     * The zoom pill only renders in the widget's standalone fallback now
+     * that a drag retimes the whole dashboard (#3530), so the entry point a
+     * real board actually reaches is the header button — on whatever
+     * window the widget is charting.
+     */
+    expect(widget).toContain(
+      "setInvestigationWindow(effectiveStartAndEndDate)",
+    );
+    expect(widget).toContain(
+      'aria-label="Investigate this time window in a side panel"',
+    );
 
     const explorer: string = readSquashed(
       "App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx",

--- a/App/Tests/Dashboard/MetricSeriesInvestigation.test.ts
+++ b/App/Tests/Dashboard/MetricSeriesInvestigation.test.ts
@@ -610,6 +610,28 @@ describe("investigation wiring", () => {
     expect(source).toContain("rangeToken: zoomWindow ? undefined :");
   });
 
+  test("the chart widget hands a drag-selection to the DASHBOARD, and only offers a reset while zoomed", () => {
+    const source: string = readSquashedSource(
+      "Components/Dashboard/Components/DashboardChartComponent.tsx",
+    );
+
+    /*
+     * Issue #3530: the drag retimes the whole board. `setZoomWindow` above
+     * is the standalone fallback for hosts that own no range — these pin
+     * the path that actually runs on a dashboard. Behaviour itself is
+     * covered by Common/Tests/App/Dashboard/DashboardWideChartZoom.test.tsx.
+     */
+    expect(source).toContain("onDashboardTimeRangeSelect(startTime, endTime);");
+    expect(source).toContain(
+      "onTimeRangeReset={ canResetChartZoom ? handleChartTimeRangeReset : undefined }",
+    );
+    /*
+     * The reset handler is withheld until there is something to undo — the
+     * chart library delays every plain click while it is present.
+     */
+    expect(source).toContain("props.isDashboardTimeRangeZoomed");
+  });
+
   test("the external Data Source chart widget never offers telemetry pivots", () => {
     const source: string = readSquashedSource(
       "Components/Dashboard/Components/DashboardDataSourceChartComponent.tsx",

--- a/Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardChartWidgetZoom.test.tsx
@@ -20,13 +20,23 @@ import * as React from "react";
 import getJestMockFunction, { MockFunction } from "../../MockType";
 
 /*
- * Drag-to-zoom on a dashboard chart widget is the "investigate this
- * spike" entry point: selecting a window must narrow THIS widget only
- * (never the dashboard-wide range), refetch for the narrowed window, and
- * offer a way back (Reset) and a way deeper (Open in Explorer, carrying
- * the zoomed window). Edit mode must not zoom — the drag gesture belongs
- * to widget move/resize there, and series pivots would navigate away from
- * unsaved dashboard changes.
+ * The chart widget's STANDALONE fallback: what drag-to-zoom does when the
+ * host hands down no onDashboardTimeRangeSelect — the edit-mode settings
+ * preview, and any future surface that mounts the widget without owning a
+ * time range. Selecting a window narrows THIS widget, refetches for the
+ * narrowed window, and offers a way back (Reset) and a way deeper (Open in
+ * Explorer, carrying the zoomed window).
+ *
+ * On a real dashboard the shell DOES take the drag and the whole board
+ * retimes (issue #3530) — that contract lives in
+ * DashboardWideChartZoom.test.tsx. Both paths are pinned because the
+ * widget picks between them purely on whether the callback prop is
+ * present, and a host that forgets to pass it should degrade to this
+ * rather than lose the gesture.
+ *
+ * Edit mode must not zoom either way — the drag gesture belongs to widget
+ * move/resize there, and series pivots would navigate away from unsaved
+ * dashboard changes.
  */
 
 const fetchResultsMock: MockFunction = getJestMockFunction();
@@ -215,7 +225,24 @@ afterEach(() => {
   cleanup();
 });
 
-describe("dashboard chart widget drag-to-zoom", () => {
+describe("dashboard chart widget drag-to-zoom (standalone fallback)", () => {
+  test("the fallback is what runs when the host offers no dashboard-wide zoom", async () => {
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    /*
+     * Guards the branch this whole suite depends on: these props are the
+     * switch between narrowing this widget and retiming the board, and
+     * buildBaseProps deliberately leaves them off.
+     */
+    const baseProps: DashboardBaseComponentProps = buildBaseProps();
+    expect(baseProps.onDashboardTimeRangeSelect).toBeUndefined();
+    expect(baseProps.onDashboardTimeRangeReset).toBeUndefined();
+  });
+
   test("drag-selecting a window refetches THIS widget for that window and shows the zoom bar", async () => {
     renderWidget();
 

--- a/Common/Tests/App/Dashboard/DashboardWideChartZoom.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardWideChartZoom.test.tsx
@@ -1,0 +1,401 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  RenderResult,
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Issue #3530: drag-selecting a window on a dashboard time-series panel is a
+ * statement about the whole board, not about that one panel — the same way
+ * filtering works in Traces and Logs. The widget therefore hands the
+ * selected window UP to the dashboard shell and lets the new board-wide
+ * range come back down as a prop, rather than narrowing itself and leaving
+ * every neighbouring panel showing a different hour.
+ *
+ * Double-clicking a panel is the way back out, and it must be inert while
+ * there is nothing to undo.
+ *
+ * The widget-local fallback (no shell callbacks) is a separate contract and
+ * is covered by DashboardChartWidgetZoom.test.tsx.
+ */
+
+const fetchResultsMock: MockFunction = getJestMockFunction();
+const metricChartsRenderMock: MockFunction = getJestMockFunction();
+const investigationDrawerRenderMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the
+ * compiled requires, so the mock variables above are still unassigned when
+ * the factory runs. Dereferencing them lazily, at call time, is what makes
+ * this work.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        fetchResults: (...args: Array<any>) => {
+          return fetchResultsMock(...args);
+        },
+        clearQueryTopNOverridesForScope: () => {
+          return undefined;
+        },
+      },
+    };
+  },
+);
+
+/*
+ * The widget's job under test is which window it ASKS for and which
+ * affordances it hands down; a real recharts surface in jsdom would test
+ * neither.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: Record<string, unknown>): React.ReactElement => {
+        metricChartsRenderMock(props);
+        return React.createElement(
+          "div",
+          { "data-testid": "metric-charts" },
+          "chart",
+        );
+      },
+    };
+  },
+);
+
+// The drawer itself pulls in the whole telemetry stack; only its mounting matters here.
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/InvestigationDrawer",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: Record<string, unknown>): React.ReactElement => {
+        investigationDrawerRenderMock(props);
+        return React.createElement(
+          "div",
+          { "data-testid": "investigation-drawer" },
+          "drawer",
+        );
+      },
+    };
+  },
+);
+
+import DashboardChartComponentElement from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent";
+import { DashboardBaseComponentProps } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import DashboardChartType from "../../../Types/Dashboard/Chart/ChartType";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardChartComponent from "../../../Types/Dashboard/DashboardComponents/DashboardChartComponent";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { ObjectType } from "../../../Types/JSON";
+import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import ObjectID from "../../../Types/ObjectID";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+const COMPONENT_ID: ObjectID = new ObjectID(
+  "33333333-1111-4111-8111-333333333333",
+);
+
+const BOARD_START: Date = new Date("2026-08-20T09:00:00.000Z");
+const BOARD_END: Date = new Date("2026-08-20T10:00:00.000Z");
+const DRAG_START: Date = new Date("2026-08-20T09:20:00.000Z");
+const DRAG_END: Date = new Date("2026-08-20T09:35:00.000Z");
+
+/*
+ * A CUSTOM range pins the window to fixed instants — a relative range
+ * would resolve against the wall clock and make the window assertions
+ * untestable.
+ */
+const BOARD_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(BOARD_START, BOARD_END),
+};
+
+/** What the shell hands back down once the drag has retimed the board. */
+const ZOOMED_BOARD_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(DRAG_START, DRAG_END),
+};
+
+const DASHBOARD_VIEW_CONFIG: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [],
+  heightInDashboardUnits: 60,
+};
+
+let onDashboardTimeRangeSelectMock: MockFunction;
+let onDashboardTimeRangeResetMock: MockFunction;
+
+function buildBaseProps(
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): DashboardBaseComponentProps {
+  return {
+    componentId: COMPONENT_ID,
+    isEditMode: false,
+    isSelected: false,
+    key: "chart-widget",
+    onComponentUpdate: (): void => {
+      // The widget under test never writes back through this.
+    },
+    totalCurrentDashboardWidthInPx: 1200,
+    dashboardCanvasTopInPx: 0,
+    dashboardCanvasLeftInPx: 0,
+    dashboardCanvasWidthInPx: 1200,
+    dashboardCanvasHeightInPx: 800,
+    dashboardComponentHeightInPx: 320,
+    dashboardComponentWidthInPx: 480,
+    dashboardViewConfig: DASHBOARD_VIEW_CONFIG,
+    dashboardStartAndEndDate: BOARD_RANGE,
+    metricTypes: [],
+    refreshTick: 0,
+    variables: undefined,
+    onDashboardTimeRangeSelect: onDashboardTimeRangeSelectMock as unknown as (
+      startTime: Date,
+      endTime: Date,
+    ) => void,
+    onDashboardTimeRangeReset:
+      onDashboardTimeRangeResetMock as unknown as () => void,
+    isDashboardTimeRangeZoomed: false,
+    ...overrides,
+  } as DashboardBaseComponentProps;
+}
+
+function buildChartComponent(): DashboardChartComponent {
+  return {
+    _type: ObjectType.DashboardComponent,
+    componentId: COMPONENT_ID,
+    componentType: DashboardComponentType.Chart,
+    topInDashboardUnits: 0,
+    leftInDashboardUnits: 0,
+    widthInDashboardUnits: 6,
+    heightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 6,
+    minHeightInDashboardUnits: 3,
+    arguments: {
+      chartTitle: "CPU by host",
+      chartType: DashboardChartType.Line,
+      metricQueryConfig: {
+        metricAliasData: { metricVariable: "a" },
+        metricQueryData: {
+          filterData: {
+            metricName: "cpu.usage",
+            aggegationType: MetricsAggregationType.Avg,
+          },
+          groupByAttributeKeys: ["host.name"],
+        },
+      },
+    },
+  } as unknown as DashboardChartComponent;
+}
+
+function renderWidget(
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): RenderResult {
+  return render(
+    <DashboardChartComponentElement
+      {...buildBaseProps(overrides)}
+      component={buildChartComponent()}
+    />,
+  );
+}
+
+interface CapturedChartProps {
+  metricViewData: MetricViewData;
+  onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  onTimeRangeReset?: (() => void) | undefined;
+}
+
+function lastChartProps(): CapturedChartProps {
+  const calls: Array<Array<unknown>> = metricChartsRenderMock.mock.calls;
+  return calls[calls.length - 1]?.[0] as CapturedChartProps;
+}
+
+function lastFetchWindow(): InBetween<Date> | null | undefined {
+  const calls: Array<Array<unknown>> = fetchResultsMock.mock.calls;
+  return (calls[calls.length - 1]?.[0] as { metricViewData: MetricViewData })
+    ?.metricViewData?.startAndEndDate;
+}
+
+beforeEach(() => {
+  onDashboardTimeRangeSelectMock = getJestMockFunction();
+  onDashboardTimeRangeResetMock = getJestMockFunction();
+  fetchResultsMock.mockReset();
+  metricChartsRenderMock.mockReset();
+  investigationDrawerRenderMock.mockReset();
+  fetchResultsMock.mockReturnValue(
+    Promise.resolve([{ data: [], truncated: false }]),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("dashboard-wide drag-to-zoom", () => {
+  test("a drag-selection is handed to the dashboard, not applied to this panel alone", async () => {
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    expect(lastFetchWindow()?.startValue).toEqual(BOARD_START);
+    const fetchCountBeforeDrag: number = fetchResultsMock.mock.calls.length;
+
+    act(() => {
+      lastChartProps().onTimeRangeSelect?.(DRAG_START, DRAG_END);
+    });
+
+    expect(onDashboardTimeRangeSelectMock.mock.calls.length).toBe(1);
+    expect(onDashboardTimeRangeSelectMock.mock.calls[0]).toEqual([
+      DRAG_START,
+      DRAG_END,
+    ]);
+
+    /*
+     * The widget must NOT retime itself off its own bat — the shell owns
+     * the range, and a panel that jumped ahead of it would be showing a
+     * different window from every one of its neighbours until the new
+     * range came back down.
+     */
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchResultsMock.mock.calls.length).toBe(fetchCountBeforeDrag);
+    expect(lastFetchWindow()?.startValue).toEqual(BOARD_START);
+    // …and no widget-local "Zoomed" pill appears either.
+    expect(screen.queryByText(/Zoomed:/)).toBeNull();
+  });
+
+  test("the new board range coming back down is what actually refetches the panel", async () => {
+    const rendered: RenderResult = renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    act(() => {
+      lastChartProps().onTimeRangeSelect?.(DRAG_START, DRAG_END);
+    });
+
+    // The shell applies the zoom and re-renders every widget with it.
+    rendered.rerender(
+      <DashboardChartComponentElement
+        {...buildBaseProps({
+          dashboardStartAndEndDate: ZOOMED_BOARD_RANGE,
+          isDashboardTimeRangeZoomed: true,
+        })}
+        component={buildChartComponent()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastFetchWindow()?.startValue).toEqual(DRAG_START);
+    });
+    expect(lastFetchWindow()?.endValue).toEqual(DRAG_END);
+  });
+
+  test("double-click-to-reset is only offered once the board is actually zoomed", async () => {
+    const rendered: RenderResult = renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    /*
+     * Nothing to undo yet. Withholding the handler is not cosmetic: the
+     * chart library delays every plain click while a reset handler is
+     * present, and a bucket click must stay instant on an unzoomed board.
+     */
+    expect(lastChartProps().onTimeRangeReset).toBeUndefined();
+
+    rendered.rerender(
+      <DashboardChartComponentElement
+        {...buildBaseProps({
+          dashboardStartAndEndDate: ZOOMED_BOARD_RANGE,
+          isDashboardTimeRangeZoomed: true,
+        })}
+        component={buildChartComponent()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastChartProps().onTimeRangeReset).toBeDefined();
+    });
+
+    act(() => {
+      lastChartProps().onTimeRangeReset?.();
+    });
+
+    expect(onDashboardTimeRangeResetMock.mock.calls.length).toBe(1);
+  });
+
+  test("edit mode offers neither zoom nor reset", async () => {
+    renderWidget({ isEditMode: true, isDashboardTimeRangeZoomed: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    /*
+     * In edit mode the drag gesture belongs to widget move/resize, and a
+     * board-wide retime mid-edit would be a surprise on top of unsaved
+     * layout changes.
+     */
+    expect(lastChartProps().onTimeRangeSelect).toBeUndefined();
+    expect(lastChartProps().onTimeRangeReset).toBeUndefined();
+  });
+
+  test("Investigate stays reachable from the panel header, on the window it is charting", async () => {
+    renderWidget({
+      dashboardStartAndEndDate: ZOOMED_BOARD_RANGE,
+      isDashboardTimeRangeZoomed: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-charts")).toBeInTheDocument();
+    });
+
+    /*
+     * The old entry point lived inside the widget-local "Zoomed" pill,
+     * which no longer renders on a real dashboard now that the shell owns
+     * the drag. It has to live somewhere that always shows.
+     */
+    expect(screen.queryByText(/Zoomed:/)).toBeNull();
+
+    fireEvent.click(
+      screen.getByLabelText("Investigate this time window in a side panel"),
+    );
+
+    expect(screen.getByTestId("investigation-drawer")).toBeInTheDocument();
+    const drawerProps: { window?: InBetween<Date> | undefined } =
+      investigationDrawerRenderMock.mock.calls[
+        investigationDrawerRenderMock.mock.calls.length - 1
+      ]?.[0] as { window?: InBetween<Date> | undefined };
+    expect(drawerProps.window?.startValue).toEqual(DRAG_START);
+    expect(drawerProps.window?.endValue).toEqual(DRAG_END);
+  });
+});

--- a/Common/Tests/UI/Components/Charts/ChartClickDoubleClickDisambiguation.test.tsx
+++ b/Common/Tests/UI/Components/Charts/ChartClickDoubleClickDisambiguation.test.tsx
@@ -1,0 +1,221 @@
+import "@testing-library/jest-dom";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { act, cleanup, render } from "@testing-library/react";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+/*
+ * A double-click is delivered as TWO plain clicks and only then a
+ * `dblclick`. On a dashboard panel a plain click already means something —
+ * it pins the bucket and opens the investigation inspector — so wiring
+ * double-click-to-reset naively would pop that inspector twice on the way
+ * to resetting the board, and leave it open on top of the result.
+ *
+ * The chart library solves it by holding the click open for
+ * DOUBLE_CLICK_DISAMBIGUATION_MS and cancelling it when the double-click
+ * lands. That delay is a real cost, so it is armed ONLY when a reset
+ * handler is supplied — every other chart in the product keeps instant
+ * clicks. These tests pin both halves of that bargain.
+ *
+ * recharts' own chart root is mocked here so the chart-level handlers can
+ * be invoked with a known active index: jsdom reports every element as
+ * 0x0, so a real click would never resolve to a bucket and the assertions
+ * would pass for the wrong reason. The wiring from recharts' DOM into
+ * these handlers is covered separately by ChartDoubleClickReset.test.tsx.
+ */
+
+/*
+ * Deliberately NOT a React props interface: the mock chart below takes an
+ * untyped bag and this is just how the captured handlers are read back.
+ * Typing the mock's parameter would trip react/no-unused-prop-types, since
+ * the mock renders none of them.
+ */
+type CapturedChartHandlers = {
+  onClick?: ((chartState: Record<string, unknown>) => void) | undefined;
+  onDoubleClick?: ((...args: Array<unknown>) => void) | undefined;
+};
+
+const mockChartPropsRef: { current: CapturedChartHandlers } = { current: {} };
+
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return children;
+    },
+    LineChart: (props: Record<string, unknown>): React.ReactElement => {
+      mockChartPropsRef.current = props as CapturedChartHandlers;
+      return React.createElement("div", { "data-testid": "chart-root" });
+    },
+  };
+});
+
+import { LineChart } from "../../../../UI/Components/Charts/ChartLibrary/LineChart/LineChart";
+import { DOUBLE_CLICK_DISAMBIGUATION_MS } from "../../../../UI/Components/Charts/ChartLibrary/Utils/DoubleClick";
+import {
+  CHART_DATA_POINT_DATE_KEY,
+  CHART_DATA_POINT_X_AXIS_KEY,
+} from "../../../../UI/Components/Charts/ChartLibrary/Types/ChartDataPoint";
+
+const BUCKET_MS: number = 60 * 1000;
+const FIRST_BUCKET: Date = new Date("2026-08-10T00:00:00.000Z");
+const CLICKED_ROW_INDEX: number = 2;
+
+function buildRows(): Array<Record<string, number | string>> {
+  const rows: Array<Record<string, number | string>> = [];
+  for (let index: number = 0; index < 6; index++) {
+    const bucketDate: Date = new Date(
+      FIRST_BUCKET.getTime() + index * BUCKET_MS,
+    );
+    rows.push({
+      [CHART_DATA_POINT_X_AXIS_KEY]: bucketDate.toISOString(),
+      [CHART_DATA_POINT_DATE_KEY]: bucketDate.getTime(),
+      CPU: 10 + index,
+    });
+  }
+  return rows;
+}
+
+function renderChart(options: {
+  onBucketClick: MockFunction;
+  onTimeRangeReset?: MockFunction | undefined;
+}): void {
+  render(
+    <LineChart
+      data={buildRows()}
+      index={CHART_DATA_POINT_X_AXIS_KEY}
+      categories={["CPU"]}
+      showLegend={false}
+      onBucketClick={
+        options.onBucketClick as unknown as (
+          bucketStart: Date,
+          bucketEnd: Date,
+          valuesAtBucket: Record<string, number | string>,
+        ) => void
+      }
+      onTimeRangeReset={
+        options.onTimeRangeReset as unknown as (() => void) | undefined
+      }
+    />,
+  );
+}
+
+function clickBucket(): void {
+  act(() => {
+    mockChartPropsRef.current.onClick?.({
+      activeTooltipIndex: CLICKED_ROW_INDEX,
+    });
+  });
+}
+
+function doubleClick(): void {
+  act(() => {
+    mockChartPropsRef.current.onDoubleClick?.({}, {});
+  });
+}
+
+function advancePastTheDoubleClickWindow(): void {
+  act(() => {
+    jest.advanceTimersByTime(DOUBLE_CLICK_DISAMBIGUATION_MS + 10);
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockChartPropsRef.current = {};
+});
+
+afterEach(() => {
+  cleanup();
+  jest.useRealTimers();
+});
+
+describe("chart click vs. double-click disambiguation", () => {
+  test("with no reset handler, a bucket click is delivered immediately", () => {
+    const onBucketClick: MockFunction = getJestMockFunction();
+    renderChart({ onBucketClick });
+
+    // No onDoubleClick is even handed to recharts when reset is off.
+    expect(mockChartPropsRef.current.onDoubleClick).toBeUndefined();
+
+    clickBucket();
+
+    expect(onBucketClick.mock.calls.length).toBe(1);
+    expect(onBucketClick.mock.calls[0]?.[0]).toEqual(
+      new Date(FIRST_BUCKET.getTime() + CLICKED_ROW_INDEX * BUCKET_MS),
+    );
+    // The bucket covers its full width, derived from the adjacent rows.
+    expect(onBucketClick.mock.calls[0]?.[1]).toEqual(
+      new Date(FIRST_BUCKET.getTime() + (CLICKED_ROW_INDEX + 1) * BUCKET_MS),
+    );
+  });
+
+  test("with a reset handler, a single click still reaches the bucket — just later", () => {
+    const onBucketClick: MockFunction = getJestMockFunction();
+    const onTimeRangeReset: MockFunction = getJestMockFunction();
+    renderChart({ onBucketClick, onTimeRangeReset });
+
+    clickBucket();
+
+    // Held open, in case a second click is coming.
+    expect(onBucketClick.mock.calls.length).toBe(0);
+
+    advancePastTheDoubleClickWindow();
+
+    expect(onBucketClick.mock.calls.length).toBe(1);
+    expect(onTimeRangeReset.mock.calls.length).toBe(0);
+  });
+
+  test("a double-click resets and never pins a bucket", () => {
+    const onBucketClick: MockFunction = getJestMockFunction();
+    const onTimeRangeReset: MockFunction = getJestMockFunction();
+    renderChart({ onBucketClick, onTimeRangeReset });
+
+    // Exactly what the browser delivers: click, click, then dblclick.
+    clickBucket();
+    clickBucket();
+    doubleClick();
+
+    expect(onTimeRangeReset.mock.calls.length).toBe(1);
+
+    advancePastTheDoubleClickWindow();
+
+    // Neither click may survive the reset.
+    expect(onBucketClick.mock.calls.length).toBe(0);
+  });
+
+  test("a click after a double-click still works", () => {
+    const onBucketClick: MockFunction = getJestMockFunction();
+    const onTimeRangeReset: MockFunction = getJestMockFunction();
+    renderChart({ onBucketClick, onTimeRangeReset });
+
+    clickBucket();
+    clickBucket();
+    doubleClick();
+    advancePastTheDoubleClickWindow();
+
+    clickBucket();
+    advancePastTheDoubleClickWindow();
+
+    expect(onBucketClick.mock.calls.length).toBe(1);
+    expect(onTimeRangeReset.mock.calls.length).toBe(1);
+  });
+
+  test("unmounting mid-gesture drops the pending click instead of firing it", () => {
+    const onBucketClick: MockFunction = getJestMockFunction();
+    const onTimeRangeReset: MockFunction = getJestMockFunction();
+    renderChart({ onBucketClick, onTimeRangeReset });
+
+    clickBucket();
+    cleanup();
+    advancePastTheDoubleClickWindow();
+
+    /*
+     * A widget can be unmounted by the very reset the user is performing
+     * (the board re-queries and re-renders); a timer that outlives it would
+     * call back into a dead component.
+     */
+    expect(onBucketClick.mock.calls.length).toBe(0);
+  });
+});

--- a/Common/Tests/UI/Components/Charts/ChartDoubleClickReset.test.tsx
+++ b/Common/Tests/UI/Components/Charts/ChartDoubleClickReset.test.tsx
@@ -1,0 +1,220 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import {
+  RenderResult,
+  cleanup,
+  fireEvent,
+  render,
+} from "@testing-library/react";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+/*
+ * ResponsiveContainer measures its parent, which is always 0x0 in jsdom, so
+ * the chart renders nothing — including no `.recharts-wrapper` for the
+ * events below to land on — without a fixed size. Same shim the other chart
+ * suites use.
+ */
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, { width: 600, height: 300 });
+    },
+  };
+});
+
+import AreaChartElement from "../../../../UI/Components/Charts/Area/AreaChart";
+import BarChartElement from "../../../../UI/Components/Charts/Bar/BarChart";
+import LineChartElement from "../../../../UI/Components/Charts/Line/LineChart";
+import ChartCurve from "../../../../UI/Components/Charts/Types/ChartCurve";
+import DataPoint from "../../../../UI/Components/Charts/Types/DataPoint";
+import SeriesPoint from "../../../../UI/Components/Charts/Types/SeriesPoints";
+import {
+  XAxis as ChartXAxis,
+  XAxisAggregateType,
+} from "../../../../UI/Components/Charts/Types/XAxis/XAxis";
+import XAxisType from "../../../../UI/Components/Charts/Types/XAxis/XAxisType";
+import YAxis, {
+  YAxisPrecision,
+} from "../../../../UI/Components/Charts/Types/YAxis/YAxis";
+import YAxisType from "../../../../UI/Components/Charts/Types/YAxis/YAxisType";
+
+/*
+ * Drag-to-select on a dashboard panel now retimes the WHOLE dashboard, so
+ * every panel needs a way back out of the zoom that does not depend on
+ * finding a particular widget: double-clicking any of them.
+ *
+ * That gesture is wired at the chart library, not at the widget card, for
+ * two reasons pinned here: it must reach recharts' own plot surface (the
+ * card sits under the edit overlay and the resize handles), and it must be
+ * OPT-IN — a chart handed no reset handler has to behave exactly as it did
+ * before, because a double-click is also two plain clicks and those still
+ * mean "pin this bucket" everywhere else in the product.
+ */
+
+const START: Date = new Date("2026-08-10T00:00:00.000Z");
+const END: Date = new Date("2026-08-10T01:00:00.000Z");
+
+function buildPoints(): Array<DataPoint> {
+  const points: Array<DataPoint> = [];
+  for (let index: number = 0; index < 10; index++) {
+    points.push({
+      x: new Date(START.getTime() + index * 60 * 1000),
+      y: 90 + index,
+    });
+  }
+  return points;
+}
+
+function buildSeries(): Array<SeriesPoint> {
+  return [{ seriesName: "CPU", data: buildPoints() }];
+}
+
+const X_AXIS: ChartXAxis = {
+  legend: "Time",
+  options: {
+    type: XAxisType.Time,
+    min: START,
+    max: END,
+    aggregateType: XAxisAggregateType.Average,
+  },
+};
+
+const Y_AXIS: YAxis = {
+  legend: "%",
+  options: {
+    type: YAxisType.Number,
+    min: "auto",
+    max: 100,
+    precision: YAxisPrecision.TwoDecimals,
+    formatter: (value: number): string => {
+      return `${value}%`;
+    },
+  },
+};
+
+interface ChartUnderTest {
+  name: string;
+  render: (onTimeRangeReset: (() => void) | undefined) => React.ReactElement;
+}
+
+const CHARTS: Array<ChartUnderTest> = [
+  {
+    name: "LineChart",
+    render: (
+      onTimeRangeReset: (() => void) | undefined,
+    ): React.ReactElement => {
+      return (
+        <LineChartElement
+          data={buildSeries()}
+          xAxis={X_AXIS}
+          yAxis={Y_AXIS}
+          curve={ChartCurve.MONOTONE}
+          heightInPx={300}
+          showLegend={false}
+          sync={false}
+          syncid="double-click-reset-test"
+          onTimeRangeReset={onTimeRangeReset}
+        />
+      );
+    },
+  },
+  {
+    name: "AreaChart",
+    render: (
+      onTimeRangeReset: (() => void) | undefined,
+    ): React.ReactElement => {
+      return (
+        <AreaChartElement
+          data={buildSeries()}
+          xAxis={X_AXIS}
+          yAxis={Y_AXIS}
+          curve={ChartCurve.MONOTONE}
+          heightInPx={300}
+          showLegend={false}
+          sync={false}
+          syncid="double-click-reset-test"
+          onTimeRangeReset={onTimeRangeReset}
+        />
+      );
+    },
+  },
+  {
+    /*
+     * A bar panel cannot ORIGINATE a zoom — it has no drag-to-select — but
+     * it must still be able to end one, or a board whose only panel under
+     * the pointer is a bar chart would be a dead end.
+     */
+    name: "BarChart",
+    render: (
+      onTimeRangeReset: (() => void) | undefined,
+    ): React.ReactElement => {
+      return (
+        <BarChartElement
+          data={buildSeries()}
+          xAxis={X_AXIS}
+          yAxis={Y_AXIS}
+          heightInPx={300}
+          showLegend={false}
+          sync={false}
+          syncid="double-click-reset-test"
+          onTimeRangeReset={onTimeRangeReset}
+        />
+      );
+    },
+  },
+];
+
+function plotSurface(rendered: RenderResult): Element {
+  const surface: Element | null =
+    rendered.container.querySelector(".recharts-wrapper");
+  if (!surface) {
+    throw new Error("chart did not render a plot surface");
+  }
+  return surface;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("chart double-click to reset the time range", () => {
+  for (const chart of CHARTS) {
+    describe(chart.name, () => {
+      test("double-clicking the plot calls back exactly once", () => {
+        const onTimeRangeReset: MockFunction = getJestMockFunction();
+        const rendered: RenderResult = render(
+          chart.render(onTimeRangeReset as unknown as () => void),
+        );
+
+        fireEvent.doubleClick(plotSurface(rendered));
+
+        expect(onTimeRangeReset.mock.calls.length).toBe(1);
+      });
+
+      test("a plain click is not a reset", () => {
+        const onTimeRangeReset: MockFunction = getJestMockFunction();
+        const rendered: RenderResult = render(
+          chart.render(onTimeRangeReset as unknown as () => void),
+        );
+
+        fireEvent.click(plotSurface(rendered));
+
+        expect(onTimeRangeReset.mock.calls.length).toBe(0);
+      });
+
+      test("a chart with no reset handler still renders and swallows the gesture", () => {
+        const rendered: RenderResult = render(chart.render(undefined));
+
+        // No handler wired, so this must be inert rather than throwing.
+        fireEvent.doubleClick(plotSurface(rendered));
+
+        expect(
+          rendered.container.querySelector(".recharts-wrapper"),
+        ).not.toBeNull();
+      });
+    });
+  }
+});

--- a/Common/Tests/UI/Utils/UseDashboardTimeRangeZoom.test.tsx
+++ b/Common/Tests/UI/Utils/UseDashboardTimeRangeZoom.test.tsx
@@ -1,0 +1,187 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import React, { FunctionComponent, ReactElement } from "react";
+import useDashboardTimeRangeZoom, {
+  DashboardTimeRangeZoom,
+} from "../../../UI/Utils/UseDashboardTimeRangeZoom";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+/*
+ * The dashboard shells hand this hook's three callbacks straight into a
+ * canvas full of React.memo'd widgets whose comparators deliberately do NOT
+ * compare function identity. So identity stability is not a nicety here —
+ * a callback that changes reference every render would be blocked from
+ * reaching the widget, leaving it holding a closure over a stale range, and
+ * the SECOND zoom of a session would silently do nothing.
+ *
+ * These tests read the hook through a real component lifecycle, and pin the
+ * identity contract explicitly.
+ */
+
+const ROLLING_HOUR: RangeStartAndEndDateTime = {
+  range: TimeRange.PAST_ONE_HOUR,
+};
+
+const PINNED_DAY: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(
+    new Date("2026-08-20T00:00:00.000Z"),
+    new Date("2026-08-21T00:00:00.000Z"),
+  ),
+};
+
+const DRAG_START: Date = new Date("2026-08-20T09:20:00.000Z");
+const DRAG_END: Date = new Date("2026-08-20T09:35:00.000Z");
+
+let latest: DashboardTimeRangeZoom | null = null;
+let renderCount: number = 0;
+const seenCallbacks: {
+  set: Array<unknown>;
+  zoom: Array<unknown>;
+  reset: Array<unknown>;
+} = { set: [], zoom: [], reset: [] };
+
+const ZoomProbe: FunctionComponent = (): ReactElement => {
+  const zoom: DashboardTimeRangeZoom = useDashboardTimeRangeZoom(ROLLING_HOUR);
+
+  latest = zoom;
+  renderCount++;
+  seenCallbacks.set.push(zoom.setStartAndEndDate);
+  seenCallbacks.zoom.push(zoom.zoomToTimeRange);
+  seenCallbacks.reset.push(zoom.resetZoom);
+
+  return (
+    <div>
+      <span data-testid="range">{zoom.startAndEndDate.range}</span>
+      <span data-testid="start">
+        {zoom.startAndEndDate.startAndEndDate?.startValue?.toISOString() || ""}
+      </span>
+      <span data-testid="end">
+        {zoom.startAndEndDate.startAndEndDate?.endValue?.toISOString() || ""}
+      </span>
+      <span data-testid="is-zoomed">{String(zoom.isZoomed)}</span>
+    </div>
+  );
+};
+
+function read(testId: string): string {
+  return screen.getByTestId(testId).textContent || "";
+}
+
+function zoomApi(): DashboardTimeRangeZoom {
+  if (!latest) {
+    throw new Error("probe has not rendered");
+  }
+  return latest;
+}
+
+function renderProbe(): void {
+  latest = null;
+  renderCount = 0;
+  seenCallbacks.set = [];
+  seenCallbacks.zoom = [];
+  seenCallbacks.reset = [];
+  render(<ZoomProbe />);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useDashboardTimeRangeZoom", () => {
+  test("starts on the initial range with nothing to reset", () => {
+    renderProbe();
+
+    expect(read("range")).toBe(TimeRange.PAST_ONE_HOUR);
+    expect(read("is-zoomed")).toBe("false");
+  });
+
+  test("a panel drag pins the board to the selected window", () => {
+    renderProbe();
+
+    act(() => {
+      zoomApi().zoomToTimeRange(DRAG_START, DRAG_END);
+    });
+
+    expect(read("range")).toBe(TimeRange.CUSTOM);
+    expect(read("start")).toBe(DRAG_START.toISOString());
+    expect(read("end")).toBe(DRAG_END.toISOString());
+    expect(read("is-zoomed")).toBe("true");
+  });
+
+  test("a double-click reset puts the board back on the pre-zoom range", () => {
+    renderProbe();
+
+    act(() => {
+      zoomApi().zoomToTimeRange(DRAG_START, DRAG_END);
+    });
+    act(() => {
+      zoomApi().resetZoom();
+    });
+
+    expect(read("range")).toBe(TimeRange.PAST_ONE_HOUR);
+    expect(read("is-zoomed")).toBe("false");
+  });
+
+  test("resetting an unzoomed board does not even re-render", () => {
+    renderProbe();
+    const rendersBefore: number = renderCount;
+
+    act(() => {
+      zoomApi().resetZoom();
+    });
+
+    /*
+     * The util returns the same state object, so React bails out of the
+     * update — a stray double-click on an unzoomed dashboard costs nothing
+     * and cannot make every widget refetch.
+     */
+    expect(renderCount).toBe(rendersBefore);
+    expect(read("range")).toBe(TimeRange.PAST_ONE_HOUR);
+  });
+
+  test("an explicit picker change replaces the range and retires the reset", () => {
+    renderProbe();
+
+    act(() => {
+      zoomApi().zoomToTimeRange(DRAG_START, DRAG_END);
+    });
+    expect(read("is-zoomed")).toBe("true");
+
+    act(() => {
+      zoomApi().setStartAndEndDate(PINNED_DAY);
+    });
+
+    expect(read("start")).toBe("2026-08-20T00:00:00.000Z");
+    expect(read("is-zoomed")).toBe("false");
+  });
+
+  test("the three callbacks keep their identity across every re-render", () => {
+    renderProbe();
+
+    act(() => {
+      zoomApi().zoomToTimeRange(DRAG_START, DRAG_END);
+    });
+    act(() => {
+      zoomApi().setStartAndEndDate(PINNED_DAY);
+    });
+    act(() => {
+      zoomApi().zoomToTimeRange(DRAG_START, DRAG_END);
+    });
+    act(() => {
+      zoomApi().resetZoom();
+    });
+
+    expect(renderCount).toBeGreaterThan(1);
+    for (const captured of [
+      seenCallbacks.set,
+      seenCallbacks.zoom,
+      seenCallbacks.reset,
+    ]) {
+      expect(new Set(captured).size).toBe(1);
+    }
+  });
+});

--- a/Common/Tests/Utils/Dashboard/DashboardTimeRangeZoom.test.ts
+++ b/Common/Tests/Utils/Dashboard/DashboardTimeRangeZoom.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "@jest/globals";
+import DashboardTimeRangeZoomUtil, {
+  DashboardTimeRangeZoomState,
+} from "../../../Utils/Dashboard/DashboardTimeRangeZoom";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+/*
+ * The state machine behind dashboard-wide drag-to-zoom. Its whole job is to
+ * make the gesture REVERSIBLE: a drag on any time-series panel retimes the
+ * whole board, and one double-click has to land back exactly where the
+ * investigation started — not one drag back, and not on "now".
+ *
+ * `baseline === null` is the contract the UI reads for "nothing to reset",
+ * so the no-op cases below are as load-bearing as the happy path: a stray
+ * double-click on an unzoomed board must not retime it, and must not even
+ * hand React a new object to re-render every widget over.
+ */
+
+const ROLLING_HOUR: RangeStartAndEndDateTime = {
+  range: TimeRange.PAST_ONE_HOUR,
+};
+
+const PINNED_DAY: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(
+    new Date("2026-08-20T00:00:00.000Z"),
+    new Date("2026-08-21T00:00:00.000Z"),
+  ),
+};
+
+const DRAG_START: Date = new Date("2026-08-20T09:20:00.000Z");
+const DRAG_END: Date = new Date("2026-08-20T09:35:00.000Z");
+const NARROWER_START: Date = new Date("2026-08-20T09:25:00.000Z");
+const NARROWER_END: Date = new Date("2026-08-20T09:27:00.000Z");
+
+describe("DashboardTimeRangeZoomUtil", () => {
+  describe("getInitialState", () => {
+    test("starts on the given range with nothing to reset", () => {
+      const state: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR);
+
+      expect(state.current).toBe(ROLLING_HOUR);
+      expect(state.baseline).toBeNull();
+      expect(DashboardTimeRangeZoomUtil.isZoomed(state)).toBe(false);
+    });
+  });
+
+  describe("zoomToWindow", () => {
+    test("pins the board to the dragged window and remembers the way back", () => {
+      const zoomed: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          DRAG_START,
+          DRAG_END,
+        );
+
+      expect(zoomed.current.range).toBe(TimeRange.CUSTOM);
+      expect(zoomed.current.startAndEndDate?.startValue).toEqual(DRAG_START);
+      expect(zoomed.current.startAndEndDate?.endValue).toEqual(DRAG_END);
+      expect(zoomed.baseline).toBe(ROLLING_HOUR);
+      expect(DashboardTimeRangeZoomUtil.isZoomed(zoomed)).toBe(true);
+    });
+
+    test("a right-to-left drag is the same window as left-to-right", () => {
+      const forward: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          DRAG_START,
+          DRAG_END,
+        );
+      const backward: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          DRAG_END,
+          DRAG_START,
+        );
+
+      expect(backward.current.startAndEndDate?.startValue).toEqual(
+        forward.current.startAndEndDate?.startValue,
+      );
+      expect(backward.current.startAndEndDate?.endValue).toEqual(
+        forward.current.startAndEndDate?.endValue,
+      );
+    });
+
+    test("zooming again keeps the ORIGINAL baseline, so one reset gets all the way out", () => {
+      const once: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          DRAG_START,
+          DRAG_END,
+        );
+      const twice: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          once,
+          NARROWER_START,
+          NARROWER_END,
+        );
+
+      expect(twice.current.startAndEndDate?.startValue).toEqual(NARROWER_START);
+      // NOT `once.current` — a reader should not have to climb out a drag at a time.
+      expect(twice.baseline).toBe(ROLLING_HOUR);
+
+      const reset: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.resetZoom(twice);
+      expect(reset.current).toBe(ROLLING_HOUR);
+      expect(reset.baseline).toBeNull();
+    });
+
+    test("a zero-width selection changes nothing at all", () => {
+      const state: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR);
+
+      /*
+       * The chart library can hand back start === end when a drag never
+       * leaves its starting bucket. Same reference back, so no widget
+       * re-renders and no refetch is spent.
+       */
+      expect(
+        DashboardTimeRangeZoomUtil.zoomToWindow(state, DRAG_START, DRAG_START),
+      ).toBe(state);
+    });
+
+    test("an invalid date changes nothing at all", () => {
+      const state: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR);
+
+      expect(
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          state,
+          new Date("not-a-date"),
+          DRAG_END,
+        ),
+      ).toBe(state);
+      expect(
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          state,
+          DRAG_START,
+          new Date("not-a-date"),
+        ),
+      ).toBe(state);
+      expect(
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          state,
+          null as unknown as Date,
+          DRAG_END,
+        ),
+      ).toBe(state);
+    });
+
+    test("the stored window is a copy — mutating the dragged dates cannot move the board", () => {
+      const dragStart: Date = new Date(DRAG_START.getTime());
+      const zoomed: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          dragStart,
+          DRAG_END,
+        );
+
+      dragStart.setFullYear(1999);
+
+      expect(zoomed.current.startAndEndDate?.startValue).toEqual(DRAG_START);
+    });
+  });
+
+  describe("resetZoom", () => {
+    test("restores the range the board had before the first drag", () => {
+      const zoomed: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(PINNED_DAY),
+          DRAG_START,
+          DRAG_END,
+        );
+
+      const reset: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.resetZoom(zoomed);
+
+      expect(reset.current).toBe(PINNED_DAY);
+      expect(reset.baseline).toBeNull();
+      expect(DashboardTimeRangeZoomUtil.isZoomed(reset)).toBe(false);
+    });
+
+    test("is a true no-op when nothing is zoomed", () => {
+      const state: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR);
+
+      // Same reference: a stray double-click cannot even cost a render.
+      expect(DashboardTimeRangeZoomUtil.resetZoom(state)).toBe(state);
+    });
+
+    test("a second reset does not keep unwinding", () => {
+      const zoomed: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          DRAG_START,
+          DRAG_END,
+        );
+      const once: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.resetZoom(zoomed);
+
+      expect(DashboardTimeRangeZoomUtil.resetZoom(once)).toBe(once);
+    });
+  });
+
+  describe("selectRange", () => {
+    test("an explicit pick becomes the new baseline and retires the reset", () => {
+      const zoomed: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          DRAG_START,
+          DRAG_END,
+        );
+
+      const picked: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.selectRange(zoomed, PINNED_DAY);
+
+      expect(picked.current).toBe(PINNED_DAY);
+      /*
+       * The picker is not an undo stack: offering to jump back to a range
+       * the user has deliberately left is worse than offering nothing.
+       */
+      expect(picked.baseline).toBeNull();
+      expect(DashboardTimeRangeZoomUtil.isZoomed(picked)).toBe(false);
+    });
+
+    test("picking then zooming makes the PICKED range the way back", () => {
+      const picked: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.selectRange(
+          DashboardTimeRangeZoomUtil.getInitialState(ROLLING_HOUR),
+          PINNED_DAY,
+        );
+      const zoomed: DashboardTimeRangeZoomState =
+        DashboardTimeRangeZoomUtil.zoomToWindow(picked, DRAG_START, DRAG_END);
+
+      expect(DashboardTimeRangeZoomUtil.resetZoom(zoomed).current).toBe(
+        PINNED_DAY,
+      );
+    });
+  });
+});

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -63,6 +63,12 @@ export interface ComponentProps {
    * buckets calls back with the [start, end) of the selected time range.
    */
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  /*
+   * Double-click on the plot: undoes whatever drag-to-select produced.
+   * Supply it only when a reset is actually possible — see ChartLibrary
+   * onTimeRangeReset for why an idle handler costs click latency.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
   // Plain click on a bucket — see ChartLibrary onBucketClick.
   onBucketClick?:
     | ((
@@ -241,6 +247,7 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
         }
         onExemplarClick={props.onExemplarClick}
         onTimeRangeSelect={props.onTimeRangeSelect}
+        onTimeRangeReset={props.onTimeRangeReset}
         onBucketClick={props.onBucketClick}
         ghostCategories={props.ghostSeriesNames}
         anomalyBandLowerKey={bandLower}

--- a/Common/UI/Components/Charts/Bar/BarChart.tsx
+++ b/Common/UI/Components/Charts/Bar/BarChart.tsx
@@ -58,6 +58,11 @@ export interface ComponentProps {
    * indexed by series position (index % length), matching the default palette.
    */
   colors?: Array<ChartColorValue> | undefined;
+  /*
+   * Double-click on the plot: undoes a board-wide zoom. Bar panels have no
+   * drag-to-select of their own but share the dashboard's time range.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
 }
 
 export interface BarInternalProps extends ComponentProps {
@@ -152,6 +157,7 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
             ? formattedReferenceRegions
             : undefined
         }
+        onTimeRangeReset={props.onTimeRangeReset}
       />
       {hasNoData && <NoDataMessage />}
     </div>

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -147,9 +147,17 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
       return <></>;
     }
 
+    /*
+     * The way back out is only worth naming while there is something to
+     * reset — the host supplies onTimeRangeReset exactly then.
+     */
+    const canReset: boolean = Boolean(
+      (chart.props as LineChartProps | AreaChartProps).onTimeRangeReset,
+    );
+
     return (
       <span className="ml-auto shrink-0 whitespace-nowrap text-[10px] text-gray-400">
-        Drag to zoom
+        {canReset ? "Drag to zoom · double-click to reset" : "Drag to zoom"}
       </span>
     );
   };

--- a/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
@@ -40,6 +40,7 @@ import useChartAnnotations, {
   UseChartAnnotationsResult,
 } from "../Annotations/UseChartAnnotations";
 import { cx } from "../Utils/Cx";
+import { DOUBLE_CLICK_DISAMBIGUATION_MS } from "../Utils/DoubleClick";
 import { getYAxisDomain } from "../Utils/GetYAxisDomain";
 import { hasOnlyOneValueForKey } from "../Utils/HasOnlyOneValueForKey";
 import {
@@ -626,6 +627,15 @@ interface AreaChartProps extends React.HTMLAttributes<HTMLDivElement> {
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
   /**
+   * Double-click on the plot surface: the counterpart to drag-to-select,
+   * for undoing the zoom it produced. Supplying it makes single clicks
+   * wait DOUBLE_CLICK_DISAMBIGUATION_MS before they act, so a double-click
+   * cannot also fire the bucket-click path twice on its way past — hosts
+   * that have nothing to reset should leave it undefined and keep clicks
+   * instant.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
+  /**
    * Plain click on a time bucket (the plot background — dot/legend clicks
    * and drag-selections never reach this). [bucketStart, bucketEnd) uses
    * the same adjacent-row width derivation as drag-to-select. Fires only
@@ -693,6 +703,7 @@ const AreaChart: React.ForwardRefExoticComponent<
       formattedTimeReferenceLines,
       formattedReferenceRegions,
       onTimeRangeSelect,
+      onTimeRangeReset,
       onBucketClick,
       ghostCategories,
       ...other
@@ -723,8 +734,25 @@ const AreaChart: React.ForwardRefExoticComponent<
       React.useRef<number | null>(null);
     const suppressNextClickRef: React.MutableRefObject<boolean> =
       React.useRef<boolean>(false);
+    const hasOnTimeRangeReset: boolean = Boolean(onTimeRangeReset);
+    /*
+     * A pending single-click, held open long enough for a second click to
+     * cancel it. Only armed when onTimeRangeReset is supplied.
+     */
+    const pendingClickTimeoutRef: React.MutableRefObject<ReturnType<
+      typeof setTimeout
+    > | null> = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const categoryColors: Map<string, ChartColorValue> =
       constructCategoryColors(categories, colors);
+
+    React.useEffect(() => {
+      return () => {
+        if (pendingClickTimeoutRef.current !== null) {
+          clearTimeout(pendingClickTimeoutRef.current);
+          pendingClickTimeoutRef.current = null;
+        }
+      };
+    }, []);
 
     /*
      * Annotations are drawn onto the categorical axis, so the layer needs
@@ -971,6 +999,51 @@ const AreaChart: React.ForwardRefExoticComponent<
       onTimeRangeSelect(startDate, endDate);
     }
 
+    /*
+     * The plain-click path, split out so it can either run inline (no
+     * reset handler) or be deferred behind the double-click window.
+     */
+    function handleChartClick(chartState: RangeSelectionChartState): void {
+      /*
+       * A click while a legend/dot selection is active keeps its
+       * long-standing meaning — clear the selection — and never
+       * also pins a bucket.
+       */
+      if (hasOnValueChange && (activeLegend || activeDot)) {
+        setActiveDot(undefined);
+        setActiveLegend(undefined);
+        onValueChange?.(null);
+        return;
+      }
+      if (!onBucketClick) {
+        return;
+      }
+      const rowIndex: number | null = getRowIndexFromChartState(chartState);
+      if (rowIndex === null) {
+        return;
+      }
+      const bucketStart: Date | null = getBucketDateAtIndex(rowIndex);
+      if (!bucketStart) {
+        return;
+      }
+      /*
+       * Cover the full bucket: width from adjacent row dates, the
+       * same derivation drag-to-select uses.
+       */
+      const adjacentBucketDate: Date | null =
+        rowIndex > 0
+          ? getBucketDateAtIndex(rowIndex - 1)
+          : getBucketDateAtIndex(rowIndex + 1);
+      const clickedBucketWidthInMs: number = adjacentBucketDate
+        ? Math.abs(bucketStart.getTime() - adjacentBucketDate.getTime())
+        : 0;
+      onBucketClick(
+        bucketStart,
+        new Date(bucketStart.getTime() + clickedBucketWidthInMs),
+        (data[rowIndex] || {}) as Record<string, number | string>,
+      );
+    }
+
     return (
       <div
         ref={ref}
@@ -1009,46 +1082,35 @@ const AreaChart: React.ForwardRefExoticComponent<
                 if (suppressNextClickRef.current) {
                   return;
                 }
-                /*
-                 * A click while a legend/dot selection is active keeps its
-                 * long-standing meaning — clear the selection — and never
-                 * also pins a bucket.
-                 */
-                if (hasOnValueChange && (activeLegend || activeDot)) {
-                  setActiveDot(undefined);
-                  setActiveLegend(undefined);
-                  onValueChange?.(null);
-                  return;
-                }
-                if (!onBucketClick) {
-                  return;
-                }
-                const rowIndex: number | null =
-                  getRowIndexFromChartState(chartState);
-                if (rowIndex === null) {
-                  return;
-                }
-                const bucketStart: Date | null = getBucketDateAtIndex(rowIndex);
-                if (!bucketStart) {
+                if (!hasOnTimeRangeReset) {
+                  handleChartClick(chartState);
                   return;
                 }
                 /*
-                 * Cover the full bucket: width from adjacent row dates, the
-                 * same derivation drag-to-select uses.
+                 * Reset is on, so hold the click open: both clicks of a
+                 * double-click arrive before dblclick does, and neither
+                 * may pin a bucket. The second click re-arms the timer,
+                 * dblclick clears it.
                  */
-                const adjacentDate: Date | null =
-                  rowIndex > 0
-                    ? getBucketDateAtIndex(rowIndex - 1)
-                    : getBucketDateAtIndex(rowIndex + 1);
-                const bucketWidthInMs: number = adjacentDate
-                  ? Math.abs(bucketStart.getTime() - adjacentDate.getTime())
-                  : 0;
-                onBucketClick(
-                  bucketStart,
-                  new Date(bucketStart.getTime() + bucketWidthInMs),
-                  (data[rowIndex] || {}) as Record<string, number | string>,
-                );
+                if (pendingClickTimeoutRef.current !== null) {
+                  clearTimeout(pendingClickTimeoutRef.current);
+                }
+                pendingClickTimeoutRef.current = setTimeout(() => {
+                  pendingClickTimeoutRef.current = null;
+                  handleChartClick(chartState);
+                }, DOUBLE_CLICK_DISAMBIGUATION_MS);
               }}
+              {...(hasOnTimeRangeReset
+                ? {
+                    onDoubleClick: () => {
+                      if (pendingClickTimeoutRef.current !== null) {
+                        clearTimeout(pendingClickTimeoutRef.current);
+                        pendingClickTimeoutRef.current = null;
+                      }
+                      onTimeRangeReset?.();
+                    },
+                  }
+                : {})}
               margin={{
                 bottom: (xAxisLabel
                   ? 40

--- a/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
@@ -692,6 +692,12 @@ interface BarChartProps extends React.HTMLAttributes<HTMLDivElement> {
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   formattedTimeReferenceLines?: Array<FormattedTimeReferenceLine> | undefined;
   formattedReferenceRegions?: Array<FormattedReferenceRegion> | undefined;
+  /**
+   * Double-click on the plot surface. Bar charts have no drag-to-select of
+   * their own, but they sit on the same dashboards as line/area panels and
+   * must offer the same way out of a board-wide zoom.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
 }
 
 const BarChart: React.ForwardRefExoticComponent<
@@ -735,6 +741,7 @@ const BarChart: React.ForwardRefExoticComponent<
       customTooltip,
       formattedTimeReferenceLines,
       formattedReferenceRegions,
+      onTimeRangeReset,
       ...other
     } = props;
     const CustomTooltip: React.ComponentType<any> | undefined = customTooltip;
@@ -875,6 +882,13 @@ const BarChart: React.ForwardRefExoticComponent<
               {...(hasOnValueChange && (activeLegend || activeBar)
                 ? {
                     onClick: handleChartClick,
+                  }
+                : {})}
+              {...(onTimeRangeReset
+                ? {
+                    onDoubleClick: () => {
+                      onTimeRangeReset();
+                    },
                   }
                 : {})}
               margin={{

--- a/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
@@ -41,6 +41,7 @@ import useChartAnnotations, {
   UseChartAnnotationsResult,
 } from "../Annotations/UseChartAnnotations";
 import { cx } from "../Utils/Cx";
+import { DOUBLE_CLICK_DISAMBIGUATION_MS } from "../Utils/DoubleClick";
 import { getYAxisDomain } from "../Utils/GetYAxisDomain";
 import { hasOnlyOneValueForKey } from "../Utils/HasOnlyOneValueForKey";
 import {
@@ -644,6 +645,15 @@ interface LineChartProps extends React.HTMLAttributes<HTMLDivElement> {
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
   /**
+   * Double-click on the plot surface: the counterpart to drag-to-select,
+   * for undoing the zoom it produced. Supplying it makes single clicks
+   * wait DOUBLE_CLICK_DISAMBIGUATION_MS before they act, so a double-click
+   * cannot also fire the bucket-click path twice on its way past — hosts
+   * that have nothing to reset should leave it undefined and keep clicks
+   * instant.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
+  /**
    * Plain click on a time bucket (the plot background — dot/legend clicks
    * and drag-selections never reach this). [bucketStart, bucketEnd) uses
    * the same adjacent-row width derivation as drag-to-select. Fires only
@@ -702,6 +712,7 @@ const LineChart: React.ForwardRefExoticComponent<
       formattedTimeReferenceLines,
       formattedReferenceRegions,
       onTimeRangeSelect,
+      onTimeRangeReset,
       onBucketClick,
       ghostCategories,
       ...other
@@ -732,8 +743,25 @@ const LineChart: React.ForwardRefExoticComponent<
       React.useRef<number | null>(null);
     const suppressNextClickRef: React.MutableRefObject<boolean> =
       React.useRef<boolean>(false);
+    const hasOnTimeRangeReset: boolean = Boolean(onTimeRangeReset);
+    /*
+     * A pending single-click, held open long enough for a second click to
+     * cancel it. Only armed when onTimeRangeReset is supplied.
+     */
+    const pendingClickTimeoutRef: React.MutableRefObject<ReturnType<
+      typeof setTimeout
+    > | null> = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const categoryColors: Map<string, ChartColorValue> =
       constructCategoryColors(categories, colors);
+
+    React.useEffect(() => {
+      return () => {
+        if (pendingClickTimeoutRef.current !== null) {
+          clearTimeout(pendingClickTimeoutRef.current);
+          pendingClickTimeoutRef.current = null;
+        }
+      };
+    }, []);
 
     /*
      * Annotations are drawn onto the categorical axis, so the layer needs
@@ -978,6 +1006,51 @@ const LineChart: React.ForwardRefExoticComponent<
       onTimeRangeSelect(startDate, endDate);
     }
 
+    /*
+     * The plain-click path, split out so it can either run inline (no
+     * reset handler) or be deferred behind the double-click window.
+     */
+    function handleChartClick(chartState: RangeSelectionChartState): void {
+      /*
+       * A click while a legend/dot selection is active keeps its
+       * long-standing meaning — clear the selection — and never
+       * also pins a bucket.
+       */
+      if (hasOnValueChange && (activeLegend || activeDot)) {
+        setActiveDot(undefined);
+        setActiveLegend(undefined);
+        onValueChange?.(null);
+        return;
+      }
+      if (!onBucketClick) {
+        return;
+      }
+      const rowIndex: number | null = getRowIndexFromChartState(chartState);
+      if (rowIndex === null) {
+        return;
+      }
+      const bucketStart: Date | null = getBucketDateAtIndex(rowIndex);
+      if (!bucketStart) {
+        return;
+      }
+      /*
+       * Cover the full bucket: width from adjacent row dates, the
+       * same derivation drag-to-select uses.
+       */
+      const adjacentBucketDate: Date | null =
+        rowIndex > 0
+          ? getBucketDateAtIndex(rowIndex - 1)
+          : getBucketDateAtIndex(rowIndex + 1);
+      const clickedBucketWidthInMs: number = adjacentBucketDate
+        ? Math.abs(bucketStart.getTime() - adjacentBucketDate.getTime())
+        : 0;
+      onBucketClick(
+        bucketStart,
+        new Date(bucketStart.getTime() + clickedBucketWidthInMs),
+        (data[rowIndex] || {}) as Record<string, number | string>,
+      );
+    }
+
     return (
       <div
         ref={ref}
@@ -1016,46 +1089,35 @@ const LineChart: React.ForwardRefExoticComponent<
                 if (suppressNextClickRef.current) {
                   return;
                 }
-                /*
-                 * A click while a legend/dot selection is active keeps its
-                 * long-standing meaning — clear the selection — and never
-                 * also pins a bucket.
-                 */
-                if (hasOnValueChange && (activeLegend || activeDot)) {
-                  setActiveDot(undefined);
-                  setActiveLegend(undefined);
-                  onValueChange?.(null);
-                  return;
-                }
-                if (!onBucketClick) {
-                  return;
-                }
-                const rowIndex: number | null =
-                  getRowIndexFromChartState(chartState);
-                if (rowIndex === null) {
-                  return;
-                }
-                const bucketStart: Date | null = getBucketDateAtIndex(rowIndex);
-                if (!bucketStart) {
+                if (!hasOnTimeRangeReset) {
+                  handleChartClick(chartState);
                   return;
                 }
                 /*
-                 * Cover the full bucket: width from adjacent row dates, the
-                 * same derivation drag-to-select uses.
+                 * Reset is on, so hold the click open: both clicks of a
+                 * double-click arrive before dblclick does, and neither
+                 * may pin a bucket. The second click re-arms the timer,
+                 * dblclick clears it.
                  */
-                const adjacentDate: Date | null =
-                  rowIndex > 0
-                    ? getBucketDateAtIndex(rowIndex - 1)
-                    : getBucketDateAtIndex(rowIndex + 1);
-                const bucketWidthInMs: number = adjacentDate
-                  ? Math.abs(bucketStart.getTime() - adjacentDate.getTime())
-                  : 0;
-                onBucketClick(
-                  bucketStart,
-                  new Date(bucketStart.getTime() + bucketWidthInMs),
-                  (data[rowIndex] || {}) as Record<string, number | string>,
-                );
+                if (pendingClickTimeoutRef.current !== null) {
+                  clearTimeout(pendingClickTimeoutRef.current);
+                }
+                pendingClickTimeoutRef.current = setTimeout(() => {
+                  pendingClickTimeoutRef.current = null;
+                  handleChartClick(chartState);
+                }, DOUBLE_CLICK_DISAMBIGUATION_MS);
               }}
+              {...(hasOnTimeRangeReset
+                ? {
+                    onDoubleClick: () => {
+                      if (pendingClickTimeoutRef.current !== null) {
+                        clearTimeout(pendingClickTimeoutRef.current);
+                        pendingClickTimeoutRef.current = null;
+                      }
+                      onTimeRangeReset?.();
+                    },
+                  }
+                : {})}
               margin={{
                 /*
                  * Tick labels are 10px font with a translate(0, 6) — they

--- a/Common/UI/Components/Charts/ChartLibrary/Utils/DoubleClick.ts
+++ b/Common/UI/Components/Charts/ChartLibrary/Utils/DoubleClick.ts
@@ -1,0 +1,13 @@
+/**
+ * How long a chart holds a single click open, waiting to see whether it is
+ * really the first half of a double-click.
+ *
+ * Charts that accept `onTimeRangeReset` have to tell a bucket click apart
+ * from a reset gesture, and the browser delivers BOTH clicks of a
+ * double-click before it delivers `dblclick` — so the only way a
+ * double-click can avoid also pinning a bucket twice is for the click path
+ * to wait. Kept just above the ~200ms most platforms use as their
+ * double-click threshold, and short enough that a real single click still
+ * feels immediate. Charts with no reset handler skip the wait entirely.
+ */
+export const DOUBLE_CLICK_DISAMBIGUATION_MS: number = 250;

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -62,6 +62,12 @@ export interface ComponentProps {
    * buckets calls back with the [start, end) of the selected time range.
    */
   onTimeRangeSelect?: ((startTime: Date, endTime: Date) => void) | undefined;
+  /*
+   * Double-click on the plot: undoes whatever drag-to-select produced.
+   * Supply it only when a reset is actually possible — see ChartLibrary
+   * onTimeRangeReset for why an idle handler costs click latency.
+   */
+  onTimeRangeReset?: (() => void) | undefined;
   // Plain click on a bucket — see ChartLibrary onBucketClick.
   onBucketClick?:
     | ((
@@ -221,6 +227,7 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
         }
         onExemplarClick={props.onExemplarClick}
         onTimeRangeSelect={props.onTimeRangeSelect}
+        onTimeRangeReset={props.onTimeRangeReset}
         onBucketClick={props.onBucketClick}
         ghostCategories={props.ghostSeriesNames}
       />

--- a/Common/UI/Utils/UseDashboardTimeRangeZoom.ts
+++ b/Common/UI/Utils/UseDashboardTimeRangeZoom.ts
@@ -1,0 +1,77 @@
+import DashboardTimeRangeZoomUtil, {
+  DashboardTimeRangeZoomState,
+} from "../../Utils/Dashboard/DashboardTimeRangeZoom";
+import RangeStartAndEndDateTime from "../../Types/Time/RangeStartAndEndDateTime";
+import { useCallback, useState } from "react";
+
+export interface DashboardTimeRangeZoom {
+  /** The window to hand every widget on the board. */
+  startAndEndDate: RangeStartAndEndDateTime;
+  /** True while a panel drag-selection is narrowing the board. */
+  isZoomed: boolean;
+  /** An explicit pick from the time-range picker — a new baseline. */
+  setStartAndEndDate: (range: RangeStartAndEndDateTime) => void;
+  /** A drag-selection on a time-series panel — zooms the whole board. */
+  zoomToTimeRange: (startTime: Date, endTime: Date) => void;
+  /** Double-click on a panel, or the toolbar's reset — undoes the zoom. */
+  resetZoom: () => void;
+}
+
+export type UseDashboardTimeRangeZoomFunction = (
+  initialRange: RangeStartAndEndDateTime,
+) => DashboardTimeRangeZoom;
+
+/**
+ * Owns the dashboard-wide time range and the one level of undo that makes
+ * drag-to-zoom reversible. Both dashboard shells (the authenticated
+ * DashboardView and the public DashboardViewPage) use this so a panel
+ * gesture means the same thing on both.
+ *
+ * All three callbacks are identity-stable for the life of the dashboard:
+ * they are handed down through the canvas into React.memo'd widgets whose
+ * comparators do not look at function props, so a changing reference would
+ * leave a widget holding a stale closure.
+ */
+const useDashboardTimeRangeZoom: UseDashboardTimeRangeZoomFunction = (
+  initialRange: RangeStartAndEndDateTime,
+): DashboardTimeRangeZoom => {
+  const [state, setState] = useState<DashboardTimeRangeZoomState>(() => {
+    return DashboardTimeRangeZoomUtil.getInitialState(initialRange);
+  });
+
+  const setStartAndEndDate: (range: RangeStartAndEndDateTime) => void =
+    useCallback((range: RangeStartAndEndDateTime): void => {
+      setState((previous: DashboardTimeRangeZoomState) => {
+        return DashboardTimeRangeZoomUtil.selectRange(previous, range);
+      });
+    }, []);
+
+  const zoomToTimeRange: (startTime: Date, endTime: Date) => void = useCallback(
+    (startTime: Date, endTime: Date): void => {
+      setState((previous: DashboardTimeRangeZoomState) => {
+        return DashboardTimeRangeZoomUtil.zoomToWindow(
+          previous,
+          startTime,
+          endTime,
+        );
+      });
+    },
+    [],
+  );
+
+  const resetZoom: () => void = useCallback((): void => {
+    setState((previous: DashboardTimeRangeZoomState) => {
+      return DashboardTimeRangeZoomUtil.resetZoom(previous);
+    });
+  }, []);
+
+  return {
+    startAndEndDate: state.current,
+    isZoomed: DashboardTimeRangeZoomUtil.isZoomed(state),
+    setStartAndEndDate,
+    zoomToTimeRange,
+    resetZoom,
+  };
+};
+
+export default useDashboardTimeRangeZoom;

--- a/Common/Utils/Dashboard/DashboardTimeRangeZoom.ts
+++ b/Common/Utils/Dashboard/DashboardTimeRangeZoom.ts
@@ -1,0 +1,118 @@
+import InBetween from "../../Types/BaseDatabase/InBetween";
+import RangeStartAndEndDateTime from "../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../Types/Time/TimeRange";
+
+/**
+ * The dashboard's time window, plus the window to go back to when a zoom
+ * is undone.
+ *
+ * A dashboard has exactly ONE time range and every widget renders it, so
+ * drag-selecting a window on a time-series panel is a statement about the
+ * whole board, not about that one panel. `baseline` is what makes the
+ * gesture reversible: the first zoom records the range that was in effect
+ * before it, later zooms keep that same original, and a reset restores it.
+ * `baseline === null` is the canonical "not zoomed" signal — the toolbar's
+ * reset affordance and the panels' double-click-to-reset both key off it.
+ */
+export interface DashboardTimeRangeZoomState {
+  /** The window every widget on the board is currently querying. */
+  current: RangeStartAndEndDateTime;
+  /** Window a reset returns to; null when no zoom is active. */
+  baseline: RangeStartAndEndDateTime | null;
+}
+
+export default class DashboardTimeRangeZoomUtil {
+  public static getInitialState(
+    range: RangeStartAndEndDateTime,
+  ): DashboardTimeRangeZoomState {
+    return {
+      current: range,
+      baseline: null,
+    };
+  }
+
+  public static isZoomed(state: DashboardTimeRangeZoomState): boolean {
+    return state.baseline !== null;
+  }
+
+  /**
+   * An explicit pick from the time-range picker. That is a new baseline,
+   * not a zoom: it drops any pending "return to" window, so the reset
+   * affordance disappears instead of offering to jump back to a range the
+   * user has deliberately moved on from.
+   */
+  public static selectRange(
+    _state: DashboardTimeRangeZoomState,
+    range: RangeStartAndEndDateTime,
+  ): DashboardTimeRangeZoomState {
+    return {
+      current: range,
+      baseline: null,
+    };
+  }
+
+  /**
+   * Drag-selected window from a time-series panel. Returns the state
+   * unchanged (same reference, so callers can skip a render) when the
+   * selection is not a usable window — the chart library can hand back a
+   * zero-width or invalid pair when a drag never left its starting bucket.
+   */
+  public static zoomToWindow(
+    state: DashboardTimeRangeZoomState,
+    startTime: Date,
+    endTime: Date,
+  ): DashboardTimeRangeZoomState {
+    if (!(startTime instanceof Date) || !(endTime instanceof Date)) {
+      return state;
+    }
+
+    const startTimeInMs: number = startTime.getTime();
+    const endTimeInMs: number = endTime.getTime();
+
+    if (Number.isNaN(startTimeInMs) || Number.isNaN(endTimeInMs)) {
+      return state;
+    }
+
+    // A drag right-to-left is the same window as left-to-right.
+    const lowerInMs: number = Math.min(startTimeInMs, endTimeInMs);
+    const upperInMs: number = Math.max(startTimeInMs, endTimeInMs);
+
+    if (lowerInMs === upperInMs) {
+      return state;
+    }
+
+    return {
+      current: {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date(lowerInMs),
+          new Date(upperInMs),
+        ),
+      },
+      /*
+       * Zooming again while already zoomed keeps the ORIGINAL baseline, so
+       * one reset always lands back where the investigation started rather
+       * than unwinding one drag at a time.
+       */
+      baseline: state.baseline || state.current,
+    };
+  }
+
+  /**
+   * Undo the zoom. A no-op (same state reference) when nothing is zoomed,
+   * so a stray double-click on an unzoomed dashboard cannot retime the
+   * board or spend a refetch.
+   */
+  public static resetZoom(
+    state: DashboardTimeRangeZoomState,
+  ): DashboardTimeRangeZoomState {
+    if (state.baseline === null) {
+      return state;
+    }
+
+    return {
+      current: state.baseline,
+      baseline: null,
+    };
+  }
+}


### PR DESCRIPTION
Fixes #3530

## What changed

Drag-selecting a window on a dashboard time-series panel used to narrow **that one panel**, leaving every neighbouring widget on a different window — the opposite of how filtering already works in Traces and Logs.

It now sets the **dashboard-wide** time range, so the whole board re-queries the window the user picked. **Double-clicking any chart** puts the board back on the range it had before the zoom.

```
Panel drag-selection  →  dashboard time range updated  →  every panel refetches
Panel double-click    →  pre-zoom range restored       →  every panel refetches
```

## How it works

**`Common/Utils/Dashboard/DashboardTimeRangeZoom.ts`** — the `{ current, baseline }` state machine behind the gesture:

- The first zoom records the pre-zoom range; later zooms keep that same original, so **one reset always lands where the investigation started** rather than unwinding a drag at a time.
- An explicit pick from the time-range picker clears the baseline — a new starting point, not an undo step. (The public dashboard's old stack pushed on *every* picker change, so "Reset Zoom" appeared after an ordinary range change and jumped back to a range the user had deliberately left.)
- Resetting an unzoomed board, and a zero-width or invalid selection, both return the *same state object* — so a stray double-click cannot even cost a render, let alone a board-wide refetch.

**`Common/UI/Utils/UseDashboardTimeRangeZoom.ts`** — the hook both dashboard shells use, with identity-stable callbacks. That matters: the widgets below are `React.memo`'d on comparators that deliberately don't compare function props, so a callback that changed reference each render would leave a widget holding a stale closure and the *second* zoom of a session would silently do nothing.

**Chart library** (`ChartLibrary/{LineChart,AreaChart,BarChart}`) gains an optional `onTimeRangeReset`. The subtle part: a double-click is delivered as **two plain clicks first**, and a plain click already means something on a dashboard panel (it pins the bucket and opens the investigation inspector). So the click path is held open for 250 ms and cancelled when the `dblclick` lands. That delay is a real cost, so it is armed **only** when a reset handler is supplied — every other chart in the product keeps instant clicks, and the widget only supplies the handler while the board is actually zoomed.

**The widget** hands the drag up when the shell offers to take it, and keeps its widget-local zoom as the standalone fallback (the edit-mode settings preview mounts it with no shell). Edit mode zooms neither way — the drag belongs to widget move/resize there — and *entering* edit mode drops the zoom rather than stranding a board whose picker and reset button are hidden.

**Both shells**: the authenticated toolbar gains a **Reset zoom** button next to the picker (once zoomed the picker just reads "Custom", which says nothing about there being a way back), and the public dashboard's hand-rolled `timeRangeStack` is replaced by the shared hook.

**Investigate** moved from the zoom pill into the panel header, since that pill no longer renders once the shell owns the drag — otherwise `InvestigationDrawer` would have become unreachable from a widget.

## Scope notes

- **Bar panels can end a zoom but not start one.** They have no drag-to-select, so double-click resets work there while the zoom must originate from a line or area panel.
- **Log / Trace / SecurityEventsFlow chart widgets render raw recharts**, so they *follow* the new board range but cannot originate a drag or accept a double-click.
- **A zoomed window is absolute**, so it stops rolling forward while auto-refresh is on. That is deliberate — a window sliding out from under a reader mid-investigation would be worse — and the Reset zoom button is the way back to a rolling range.

## Tests

New:

| Suite | Covers |
| --- | --- |
| `Common/Tests/Utils/Dashboard/DashboardTimeRangeZoom.test.ts` | the state machine — re-zoom keeps the original baseline, reversed drags, zero-width/NaN no-ops, reset idempotence, picker-clears-baseline |
| `Common/Tests/UI/Utils/UseDashboardTimeRangeZoom.test.tsx` | the hook through a real component lifecycle, including the callback-identity contract and "reset on an unzoomed board does not even re-render" |
| `Common/Tests/UI/Components/Charts/ChartDoubleClickReset.test.tsx` | double-click reaches the plot surface on Line, Area **and** Bar; a plain click is not a reset; a chart with no handler is inert |
| `Common/Tests/UI/Components/Charts/ChartClickDoubleClickDisambiguation.test.tsx` | the 250 ms bargain — instant clicks with no reset handler, deferred-then-delivered with one, never pinned by a double-click, and dropped on unmount |
| `Common/Tests/App/Dashboard/DashboardWideChartZoom.test.tsx` | the widget: the drag goes up and the panel does **not** retime itself, the board range coming back down is what refetches, reset is withheld until zoomed, edit mode offers neither, Investigate still reachable |
| `App/Tests/Dashboard/DashboardTimeRangeZoomWiring.test.ts` | both shells (unrenderable in App's node env) — same hook, canvas props, toolbar reset, edit-mode drop, no leftover `timeRangeStack` |

Updated: `DashboardChartWidgetZoom.test.tsx` is reframed as the standalone-fallback contract; `MetricSeriesInvestigation.test.ts` and `InvestigationSurfaces.test.ts` gain pins for the dashboard-wide path and the relocated Investigate button.

Green locally: **236 suites / 8192 tests** in `App/Tests/Dashboard`, plus the Common chart, dashboard and public-dashboard suites. `tsc` clean in both `Common` and `App`; eslint clean.

Docs: a "Zooming into a spike" section in `dashboards/authoring.md`.
