### PR TITLE
fix(dashboard): reserve Command+K for search

### DIFF
--- a/App/Tests/Dashboard/CommandPaletteWiring.test.ts
+++ b/App/Tests/Dashboard/CommandPaletteWiring.test.ts
@@ -48,6 +48,13 @@ const COMMON_NAVBAR: string = readCommonCode(
   "NavBar.tsx",
 );
 
+const COMMON_NAVBAR_MENU_MODAL: string = readCommonCode(
+  "UI",
+  "Components",
+  "Navbar",
+  "NavBarMenuModal.tsx",
+);
+
 const DASHBOARD_NAVBAR: string = readAppCode(
   "Components",
   "NavBar",
@@ -60,6 +67,34 @@ const PALETTE_HOST: string = readAppCode(
   "DashboardCommandPalette.tsx",
 );
 
+/*
+ * Effects contain nested handlers, so matching one by a meaningful state
+ * update is less fragile than pinning the handler's local variable name.
+ */
+function findEffectContaining(
+  source: string,
+  marker: RegExp,
+): string | undefined {
+  const effects: Array<string> =
+    source.match(
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]*?\n\s*\},\s*\[[^\]]*\]\s*\);/g,
+    ) || [];
+
+  return effects.find((effect: string): boolean => {
+    return marker.test(effect);
+  });
+}
+
+function expectExactCommandKRecognition(source: string): void {
+  expect(source).toMatch(/event\.metaKey\s*\|\|\s*event\.ctrlKey/);
+  // Accept either an affirmative allow-list or an early-return reject guard.
+  expect(source).toMatch(/(?:!event\.shiftKey|event\.shiftKey\s*\|\|)/);
+  expect(source).toMatch(/(?:!event\.altKey|event\.altKey\s*\|\|)/);
+  expect(source).toMatch(
+    /event\.key\.toLowerCase\(\)\s*(?:===|!==)\s*["']k["']/,
+  );
+}
+
 describe("command palette wiring", () => {
   test("the toggle event exists in the shared EventName enum", () => {
     /*
@@ -70,23 +105,59 @@ describe("command palette wiring", () => {
     expect(EventName.COMMAND_PALETTE_TOGGLE).toBe("COMMAND_PALETTE_TOGGLE");
   });
 
-  test("the Common NavBar can surrender Cmd/Ctrl+K, and the guard sits on the listener registration", () => {
+  test("the Common NavBar only owns the exact Cmd/Ctrl+K chord when the products shortcut is enabled", () => {
     // The prop exists on the component's props contract...
     expect(COMMON_NAVBAR).toMatch(/disableCommandKShortcut\??:\s*boolean/);
+    expectExactCommandKRecognition(COMMON_NAVBAR);
 
     /*
-     * ...and it short-circuits BEFORE the document keydown listener is added.
-     * A guard inside the handler would still leave a listener registered that
-     * could race the palette's. The window is sized to span the handler
-     * definition that sits between the early return and the registration,
-     * without reaching a keydown registration in some unrelated effect.
+     * The ordinary toggle effect is absent when another surface owns the
+     * shortcut (and when no products menu exists). When active, it respects a
+     * previously claimed chord before claiming and toggling it itself.
      */
-    expect(COMMON_NAVBAR).toMatch(
-      /disableCommandKShortcut[\s\S]{0,700}?document\.addEventListener\(\s*["']keydown["']/,
+    const toggleEffect: string | undefined = findEffectContaining(
+      COMMON_NAVBAR,
+      /setIsMoreMenuVisible\s*\(\s*\([^)]*\)\s*=>/,
     );
+
+    expect(toggleEffect).toBeDefined();
+    expect(toggleEffect).toMatch(
+      /props\.disableCommandKShortcut\s*\|\|\s*!hasMoreMenu/,
+    );
+    expect(toggleEffect).toMatch(/event\.defaultPrevented/);
+    expect(toggleEffect).toMatch(/event\.preventDefault\s*\(\s*\)/);
+    expect(toggleEffect).toMatch(/return\s+!visible/);
   });
 
-  test("the Dashboard NavBar hands the shortcut to the palette", () => {
+  test("an open products menu closes on surrendered Cmd/Ctrl+K without consuming the palette's event", () => {
+    const closeOnlyEffect: string | undefined = findEffectContaining(
+      COMMON_NAVBAR,
+      /setIsMoreMenuVisible\s*\(\s*false\s*\)/,
+    );
+
+    expect(closeOnlyEffect).toBeDefined();
+    expect(closeOnlyEffect).toMatch(/!props\.disableCommandKShortcut/);
+    expect(closeOnlyEffect).toMatch(/!hasMoreMenu/);
+    expect(closeOnlyEffect).toMatch(/!isMoreMenuVisible/);
+    expect(closeOnlyEffect).toMatch(/isCommandKShortcut\s*\(\s*event\s*\)/);
+    expect(closeOnlyEffect).toMatch(
+      /document\.addEventListener\(\s*["']keydown["']/,
+    );
+    expect(closeOnlyEffect).toMatch(
+      /document\.removeEventListener\(\s*["']keydown["']/,
+    );
+
+    /*
+     * Closing is housekeeping, not shortcut ownership. In particular this
+     * listener must still run if listener order means the palette claimed the
+     * event first, and it must never hide the chord from that owner.
+     */
+    expect(closeOnlyEffect).not.toMatch(/defaultPrevented/);
+    expect(closeOnlyEffect).not.toMatch(/preventDefault\s*\(/);
+    expect(closeOnlyEffect).not.toMatch(/stopPropagation\s*\(/);
+  });
+
+  test("the Dashboard NavBar surrenders the shortcut and its products-menu Mod+K hint", () => {
     /*
      * Passing the prop (and not `={false}`) is what actually frees the chord
      * on the dashboard. Tolerant of `disableCommandKShortcut` shorthand and
@@ -94,6 +165,19 @@ describe("command palette wiring", () => {
      */
     expect(DASHBOARD_NAVBAR).toMatch(
       /<NavBar[\s\S]*?disableCommandKShortcut(?!\s*=\s*\{\s*false)/,
+    );
+
+    /*
+     * The generic products modal still advertises Mod+K to legacy consumers,
+     * but the NavBar suppresses that one keycap when it has surrendered the
+     * chord. Its arrows/Enter/Escape footer hint remains independent.
+     */
+    expect(COMMON_NAVBAR).toMatch(
+      /showCommandKShortcutHint\s*=\s*\{\s*!props\.disableCommandKShortcut\s*\}/,
+    );
+    expect(DASHBOARD_NAVBAR).toMatch(/moreMenuKeyboardHint\s*=/);
+    expect(COMMON_NAVBAR_MENU_MODAL).toMatch(
+      /props\.showCommandKShortcutHint\s*!==\s*false\s*\?[\s\S]{0,180}?<KeyboardShortcut[\s\S]{0,180}?KeyboardKey\.Mod/,
     );
   });
 
@@ -120,11 +204,20 @@ describe("command palette wiring", () => {
     );
   });
 
-  test("the palette's shortcut handler is a polite citizen: respects claimed events, then claims its own", () => {
+  test("the palette remains the exact Cmd/Ctrl+K owner: it respects claimed events, then claims and toggles its own", () => {
+    const shortcutEffect: string | undefined = findEffectContaining(
+      PALETTE_HOST,
+      /document\.addEventListener\(\s*["']keydown["']/,
+    );
+
+    expect(shortcutEffect).toBeDefined();
+    expectExactCommandKRecognition(shortcutEffect || "");
     // Bails when another handler already took the chord...
-    expect(PALETTE_HOST).toMatch(/defaultPrevented/);
+    expect(shortcutEffect).toMatch(/defaultPrevented/);
     // ...and prevents the browser default once it decides to act.
-    expect(PALETTE_HOST).toMatch(/preventDefault\s*\(\s*\)/);
+    expect(shortcutEffect).toMatch(/preventDefault\s*\(\s*\)/);
+    expect(shortcutEffect).toMatch(/setIsOpen\s*\(\s*\([^)]*\)\s*=>/);
+    expect(shortcutEffect).toMatch(/return\s+!open/);
   });
 
   test("the palette host subscribes to the global toggle event and unsubscribes symmetrically", () => {

--- a/Common/Tests/App/Dashboard/DashboardCommandPalette.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardCommandPalette.test.tsx
@@ -1,5 +1,6 @@
 import {
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -70,6 +71,12 @@ jest.mock("../../../UI/Utils/Navigation", () => {
   return {
     __esModule: true,
     default: {
+      isOnThisPage: () => {
+        return false;
+      },
+      isStartWith: () => {
+        return false;
+      },
       navigate: (...args: Array<unknown>) => {
         return navigateMock(...args);
       },
@@ -112,8 +119,8 @@ jest.mock("../../../UI/Utils/Project", () => {
 
 /*
  * The real catalog hook walks the full RouteMap through useTranslation; the
- * host only needs SOME catalog, so a single-page one keeps the suite about
- * the host's event wiring rather than the NavBar's contents.
+ * host and dashboard NavBar only need a compact catalog, so one page plus one
+ * product keeps the suite about shortcut ownership rather than catalog data.
  */
 jest.mock(
   "../../../../App/FeatureSet/Dashboard/src/Utils/NavigationItems",
@@ -137,7 +144,16 @@ jest.mock(
             route: new RouteClass("/dashboard/abc123/home"),
           },
         ],
-        moreMenuItems: [],
+        moreMenuItems: [
+          {
+            title: "Monitors",
+            description: "Monitor anything that can go down.",
+            icon: "AltGlobe",
+            iconColor: "blue",
+            category: "Essentials",
+            route: new RouteClass("/dashboard/abc123/monitors"),
+          },
+        ],
         rightElement: {
           id: "user-profile-nav-bar-item",
           title: "User Profile",
@@ -158,11 +174,25 @@ jest.mock(
 );
 
 import DashboardCommandPalette from "../../../../App/FeatureSet/Dashboard/src/Components/CommandPalette/DashboardCommandPalette";
+import DashboardNavbar from "../../../../App/FeatureSet/Dashboard/src/Components/NavBar/NavBar";
 import EventName from "../../../../App/FeatureSet/Dashboard/src/Utils/EventName";
 import GlobalEvents from "../../../UI/Utils/GlobalEvents";
 
 function palette(): HTMLElement | null {
   return screen.queryByTestId("command-palette");
+}
+
+function productsMenu(): HTMLElement | null {
+  return screen.queryByRole("dialog", { name: "Products menu" });
+}
+
+function renderDashboardChrome(): void {
+  render(
+    <>
+      <DashboardNavbar show={true} />
+      <DashboardCommandPalette />
+    </>,
+  );
 }
 
 /*
@@ -172,6 +202,11 @@ function palette(): HTMLElement | null {
 function pressChord(init: KeyboardEventInit): void {
   fireEvent.keyDown(document.body, init);
 }
+
+beforeAll(() => {
+  // The products menu keeps its keyboard selection in view when it opens.
+  Element.prototype.scrollIntoView = (): void => {};
+});
 
 beforeEach(() => {
   /*
@@ -262,6 +297,75 @@ describe("DashboardCommandPalette Cmd/Ctrl+K chord", () => {
 
     expect(palette()).toBeNull();
   });
+});
+
+describe("dashboard Cmd/Ctrl+K ownership with the products menu mounted", () => {
+  test.each([
+    ["Cmd+K", { key: "k", metaKey: true }],
+    ["Ctrl+K", { key: "k", ctrlKey: true }],
+  ] as Array<[string, KeyboardEventInit]>)(
+    "%s opens Search only",
+    (_label: string, chord: KeyboardEventInit) => {
+      renderDashboardChrome();
+
+      pressChord(chord);
+
+      expect(palette()).toBeInTheDocument();
+      expect(productsMenu()).not.toBeInTheDocument();
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    },
+  );
+
+  test("the Products button still opens Products without advertising Cmd/Ctrl+K", () => {
+    renderDashboardChrome();
+
+    fireEvent.click(screen.getByRole("button", { name: /Products/i }));
+
+    const dialog: HTMLElement = screen.getByRole("dialog", {
+      name: "Products menu",
+    });
+    expect(palette()).not.toBeInTheDocument();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+
+    /*
+     * The dashboard surrendered this chord to Search, so Products must not
+     * leave either the visible keycaps or their screen-reader label behind.
+     */
+    const commandKKeycaps: HTMLElement[] = Array.from(
+      dialog.querySelectorAll<HTMLElement>("kbd"),
+    ).filter((keycap: HTMLElement): boolean => {
+      return keycap.textContent === "K";
+    });
+    expect(commandKKeycaps).toHaveLength(0);
+    expect(dialog).not.toHaveTextContent(/(?:Command|Control) \+ K/);
+  });
+
+  test.each([
+    ["Cmd+K", { key: "k", metaKey: true }],
+    ["Ctrl+K", { key: "k", ctrlKey: true }],
+  ] as Array<[string, KeyboardEventInit]>)(
+    "%s replaces an open Products dialog with one Search dialog",
+    (_label: string, chord: KeyboardEventInit) => {
+      renderDashboardChrome();
+      fireEvent.click(screen.getByRole("button", { name: /Products/i }));
+
+      const productsDialog: HTMLElement = screen.getByRole("dialog", {
+        name: "Products menu",
+      });
+      const productsSearch: HTMLElement = screen.getByRole("combobox", {
+        name: "navbar.search.placeholder",
+      });
+      expect(productsDialog).toBeInTheDocument();
+      expect(document.activeElement).toBe(productsSearch);
+
+      // Real keystrokes originate in the focused Products search input.
+      fireEvent.keyDown(productsSearch, chord);
+
+      expect(productsMenu()).not.toBeInTheDocument();
+      expect(palette()).toBeInTheDocument();
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    },
+  );
 });
 
 describe("DashboardCommandPalette global toggle event", () => {

--- a/Common/Tests/UI/Components/NavBarCommandKGating.test.tsx
+++ b/Common/Tests/UI/Components/NavBarCommandKGating.test.tsx
@@ -1,10 +1,12 @@
 /*
  * The dashboard's command palette owns Cmd/Ctrl+K, so the NavBar grew a
- * `disableCommandKShortcut` prop that stops it registering its own document
- * keydown for the products menu. These tests pin the contract in BOTH
- * directions: with the prop the menu must NOT open on Cmd+K (or the palette
- * and the menu would double-fire on one keystroke), and without the prop the
- * legacy shortcut must keep working for every other NavBar consumer.
+ * `disableCommandKShortcut` prop that surrenders the chord to the dashboard
+ * command palette. These tests pin the contract in BOTH directions: with the
+ * prop the menu must NOT open or advertise Cmd+K (or the two surfaces would
+ * claim the same shortcut), and without the prop the legacy shortcut must
+ * keep working for every other NavBar consumer. An already-open products menu
+ * still listens just long enough to close without consuming the palette's
+ * keydown, preventing two modal dialogs from being stacked.
  */
 
 /*
@@ -98,6 +100,10 @@ function pressCommandK(): void {
   fireEvent.keyDown(document, { key: "k", metaKey: true });
 }
 
+function commandKHint(): HTMLElement | null {
+  return screen.queryByText(/^(Command|Control) \+ K$/);
+}
+
 describe("NavBar Cmd/Ctrl+K gating", () => {
   afterEach(() => {
     cleanup();
@@ -110,6 +116,7 @@ describe("NavBar Cmd/Ctrl+K gating", () => {
 
     pressCommandK();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(commandKHint()).toBeInTheDocument();
 
     // And the same chord closes it again — it is a toggle, not just an opener.
     pressCommandK();
@@ -138,7 +145,7 @@ describe("NavBar Cmd/Ctrl+K gating", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  test("with disableCommandKShortcut, the menu still opens from its trigger button", () => {
+  test("with disableCommandKShortcut, the menu still opens from its trigger button without advertising Cmd/Ctrl+K", () => {
     /*
      * Disabling the shortcut must not disable the menu: the button path is the
      * remaining way in, so it has to keep working.
@@ -153,6 +160,94 @@ describe("NavBar Cmd/Ctrl+K gating", () => {
 
     fireEvent.click(screen.getByText("Products"));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(commandKHint()).not.toBeInTheDocument();
+  });
+
+  test("with disableCommandKShortcut, Cmd+K closes an already-open products menu without consuming the palette's event", () => {
+    render(
+      <Navbar
+        items={[homeItem]}
+        moreMenuItems={moreMenuItems}
+        disableCommandKShortcut={true}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Products"));
+    expect(screen.getByRole("dialog", { name: "Products menu" })).toBeVisible();
+
+    const defaultAllowed: boolean = fireEvent.keyDown(document, {
+      key: "k",
+      metaKey: true,
+    });
+
+    expect(defaultAllowed).toBe(true);
+    expect(
+      screen.queryByRole("dialog", { name: "Products menu" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("the enabled products shortcut ignores extra modifiers and a chord claimed by an earlier handler", () => {
+    render(<Navbar items={[homeItem]} moreMenuItems={moreMenuItems} />);
+
+    fireEvent.keyDown(document, { key: "k", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true, altKey: true });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const claimChord: (event: KeyboardEvent) => void = (
+      event: KeyboardEvent,
+    ): void => {
+      event.preventDefault();
+    };
+    window.addEventListener("keydown", claimChord, { capture: true });
+
+    try {
+      pressCommandK();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    } finally {
+      window.removeEventListener("keydown", claimChord, { capture: true });
+    }
+
+    pressCommandK();
+    expect(screen.getByRole("dialog", { name: "Products menu" })).toBeVisible();
+  });
+
+  test("a NavBar without a products menu leaves Cmd+K untouched", () => {
+    render(<Navbar items={[homeItem]} />);
+
+    const defaultAllowed: boolean = fireEvent.keyDown(document, {
+      key: "k",
+      metaKey: true,
+    });
+
+    expect(defaultAllowed).toBe(true);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("the close-only listener dismisses Products even when the shortcut owner ran first", () => {
+    render(
+      <Navbar
+        items={[homeItem]}
+        moreMenuItems={moreMenuItems}
+        disableCommandKShortcut={true}
+      />,
+    );
+    fireEvent.click(screen.getByText("Products"));
+
+    const claimChord: (event: KeyboardEvent) => void = (
+      event: KeyboardEvent,
+    ): void => {
+      event.preventDefault();
+    };
+    window.addEventListener("keydown", claimChord, { capture: true });
+
+    try {
+      pressCommandK();
+      expect(
+        screen.queryByRole("dialog", { name: "Products menu" }),
+      ).not.toBeInTheDocument();
+    } finally {
+      window.removeEventListener("keydown", claimChord, { capture: true });
+    }
   });
 
   test("with disableCommandKShortcut, Cmd+K's default is not prevented (the palette may claim it)", () => {
@@ -166,8 +261,8 @@ describe("NavBar Cmd/Ctrl+K gating", () => {
 
     /*
      * fireEvent returns false when some handler called preventDefault. With
-     * the NavBar listener unregistered, nothing here may swallow the chord —
-     * the whole point is leaving it free for the command palette's handler.
+     * Products closed, no close-only listener is needed and nothing here may
+     * swallow the chord — the palette is free to claim it.
      */
     const defaultAllowed: boolean = fireEvent.keyDown(document, {
       key: "k",

--- a/Common/UI/Components/Navbar/NavBar.tsx
+++ b/Common/UI/Components/Navbar/NavBar.tsx
@@ -66,11 +66,11 @@ export interface ComponentProps {
     link: URL;
   };
   /*
-   * When true, the document-level Cmd/Ctrl+K shortcut that toggles the
-   * products menu is not registered — for apps where another surface (e.g. a
-   * command palette) owns that shortcut. The menu itself stays fully usable
-   * via its trigger button. Defaults to false: existing consumers keep the
-   * shortcut.
+   * When true, Cmd/Ctrl+K never opens or toggles the products menu — for apps
+   * where another surface (e.g. a command palette) owns that shortcut. The
+   * menu itself stays usable via its trigger button; if it is already open,
+   * the owner's chord dismisses it without consuming the event. Defaults to
+   * false so existing consumers keep the products shortcut.
    */
   disableCommandKShortcut?: boolean | undefined;
   className?: string;
@@ -85,6 +85,22 @@ export interface ComponentProps {
 const MOBILE_MENU_BOTTOM_GAP_IN_PX: number = 16;
 const MOBILE_MENU_MIN_HEIGHT_IN_PX: number = 160;
 
+/*
+ * Keep the products-menu shortcut and the dashboard command palette on the
+ * same definition of Cmd/Ctrl+K. In particular, modified chords such as
+ * Cmd+Shift+K must be left alone for the browser or another feature.
+ */
+const isCommandKShortcut: (event: KeyboardEvent) => boolean = (
+  event: KeyboardEvent,
+): boolean => {
+  return (
+    (event.metaKey || event.ctrlKey) &&
+    !event.shiftKey &&
+    !event.altKey &&
+    event.key.toLowerCase() === "k"
+  );
+};
+
 const Navbar: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
@@ -96,6 +112,9 @@ const Navbar: FunctionComponent<ComponentProps> = (
   const [mobileMenuMaxHeight, setMobileMenuMaxHeight] = useState<
     number | undefined
   >(undefined);
+  const hasMoreMenu: boolean = Boolean(
+    !props.children && props.moreMenuItems && props.moreMenuItems.length > 0,
+  );
 
   // Use the existing outside click hook for mobile menu
   const {
@@ -173,27 +192,56 @@ const Navbar: FunctionComponent<ComponentProps> = (
 
   // Open/close the products menu with Cmd/Ctrl + K from anywhere.
   useEffect(() => {
-    if (props.disableCommandKShortcut) {
-      // Another surface (e.g. a command palette) owns Cmd/Ctrl+K.
+    if (props.disableCommandKShortcut || !hasMoreMenu) {
+      // Another surface owns Cmd/Ctrl+K, or there is no products menu to open.
       return;
     }
 
     const handleGlobalKeyDown: (event: KeyboardEvent) => void = (
       event: KeyboardEvent,
     ): void => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        setIsMoreMenuVisible((visible: boolean) => {
-          return !visible;
-        });
+      if (!isCommandKShortcut(event) || event.defaultPrevented) {
+        return;
       }
+
+      event.preventDefault();
+      setIsMoreMenuVisible((visible: boolean) => {
+        return !visible;
+      });
     };
 
     document.addEventListener("keydown", handleGlobalKeyDown);
     return () => {
       document.removeEventListener("keydown", handleGlobalKeyDown);
     };
-  }, [props.disableCommandKShortcut]);
+  }, [hasMoreMenu, props.disableCommandKShortcut]);
+
+  /*
+   * When the dashboard has surrendered Cmd/Ctrl+K to its command palette, an
+   * already-open products modal must get out of the way before the palette
+   * opens. This close-only listener deliberately does not prevent or stop the
+   * event: the real shortcut owner still needs to receive the same keydown.
+   * It also ignores defaultPrevented so the result is deterministic regardless
+   * of which document listener React registered first.
+   */
+  useEffect(() => {
+    if (!props.disableCommandKShortcut || !hasMoreMenu || !isMoreMenuVisible) {
+      return;
+    }
+
+    const closeProductsOnCommandK: (event: KeyboardEvent) => void = (
+      event: KeyboardEvent,
+    ): void => {
+      if (isCommandKShortcut(event)) {
+        setIsMoreMenuVisible(false);
+      }
+    };
+
+    document.addEventListener("keydown", closeProductsOnCommandK);
+    return () => {
+      document.removeEventListener("keydown", closeProductsOnCommandK);
+    };
+  }, [hasMoreMenu, isMoreMenuVisible, props.disableCommandKShortcut]);
 
   // More menu open/close.
   const openMoreMenu: () => void = (): void => {
@@ -488,6 +536,7 @@ const Navbar: FunctionComponent<ComponentProps> = (
             footer={props.moreMenuFooter}
             searchPlaceholder={props.moreMenuSearchPlaceholder}
             noResultsText={props.moreMenuNoResultsText}
+            showCommandKShortcutHint={!props.disableCommandKShortcut}
             keyboardHint={props.moreMenuKeyboardHint}
             recentLabel={props.moreMenuRecentLabel}
             onClose={closeMoreMenu}

--- a/Common/UI/Components/Navbar/NavBarMenuModal.tsx
+++ b/Common/UI/Components/Navbar/NavBarMenuModal.tsx
@@ -129,6 +129,11 @@ export interface ComponentProps {
     | undefined;
   searchPlaceholder?: string | undefined;
   noResultsText?: string | undefined;
+  /*
+   * Defaults to visible for direct/legacy consumers. Dashboard hides it when
+   * its command palette owns Cmd/Ctrl+K instead of this products menu.
+   */
+  showCommandKShortcutHint?: boolean | undefined;
   keyboardHint?: string | undefined;
   recentLabel?: string | undefined;
   onClose: () => void;
@@ -502,14 +507,14 @@ const NavBarMenuModal: FunctionComponent<ComponentProps> = (
                 >
                   <Icon icon={IconProp.Close} className="h-4 w-4" />
                 </button>
-              ) : (
+              ) : props.showCommandKShortcutHint !== false ? (
                 /* OS-appropriate hint: ⌘ K on a Mac, Ctrl K elsewhere. */
                 <KeyboardShortcut
                   keys={[KeyboardKey.Mod, "K"]}
                   size={KeyboardShortcutSize.Small}
                   className="hidden sm:inline-flex"
                 />
-              )}
+              ) : null}
             </div>
 
             {/* Body */}


### PR DESCRIPTION
## Summary

- reserve exact Cmd/Ctrl+K for Search in the Dashboard while preserving the Products shortcut in other apps
- when Products is already open, dismiss it without consuming the shortcut so Search replaces it instead of stacking a second modal
- hide the stale Cmd/Ctrl+K hint from the Dashboard Products menu and avoid swallowing the shortcut when no Products menu exists
- add regression coverage at shared component, mounted Dashboard integration, and source-wiring levels

## Validation

- 31 focused Jest tests pass across 3 suites
- focused ESLint with fixes passes for all 5 changed files
- Common and App TypeScript compiles pass locally
- `git diff --check` passes
- local app container observed hot-reloading and returning to its running state
- all 18 GitHub workflows pass, including Compile, Build, Common Test, App Test, and Common Jobs
