### PR TITLE
fix(dashboard): hide the monitor Template column by default

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
@@ -195,6 +195,21 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
    * Paired with the chip above: the column answers "which template is this
    * monitor on", the chip answers "which monitors are on that template", and
    * the answer to the second is what a user does after editing a template.
+   *
+   * Off by default, because most monitors are not created from a template at
+   * all, so on a typical project this column is a stripe of dashes crowding
+   * out status and labels - the columns people actually open this list for.
+   * The chip covers the same ground for the projects that do use templates,
+   * and the picker turns the column back on.
+   *
+   * A stored layout only protects the viewers who arranged THIS column:
+   * `order` listing it beats isHiddenByDefault (see
+   * ColumnPreference.getCustomizableColumns), but a layout saved before
+   * #3491 added the column names it nowhere, so it falls through to this
+   * default and the column is off. That is everyone who customized the table
+   * before that release - the intended outcome, since they never had the
+   * column to lose, but not the same thing as "only affects people who never
+   * opened the picker".
    */
   const monitorTemplateColumn: Column<Monitor> = {
     field: {
@@ -205,7 +220,16 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
     },
     title: "Template",
     type: FieldType.Entity,
-    hideOnMobile: true,
+    /*
+     * Deliberately NOT hideOnMobile. The two flags look complementary and are
+     * not: `hideOnMobile` is enforced at render (Table/TableHeader and
+     * Table/TableRow drop the column), while the picker knows nothing about
+     * it. Carrying both would let a phone viewer tick "Template", watch the
+     * shown-columns count go up, and get no column - and the picker is the
+     * only way back to a column that ships hidden. isHiddenByDefault already
+     * buys the screen space hideOnMobile was here for.
+     */
+    isHiddenByDefault: true,
     description: "The monitor template this monitor is linked to, if any.",
     getElement: (item: Monitor): ReactElement => {
       return <MonitorTemplateElement monitorTemplate={item.monitorTemplate} />;
@@ -636,7 +660,25 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
         modelType={Monitor}
         enableJsonImportExport={!props.disableCreate}
         name="Monitors"
-        userPreferencesKey="monitors-table"
+        /*
+         * Two keys, because the two mounts declare two different column sets:
+         * the template page's Linked Monitors card drops the Template column
+         * (see monitorTemplateColumn below). A saved layout only records the
+         * columns the picker was showing, so saving from the scoped page over
+         * a shared key would write "monitorTemplate" out of both `order` and
+         * `hidden` - and a column in neither list falls back to its declared
+         * default, which is now hidden. Sharing the key would silently switch
+         * the Template column back off for anyone who had turned it on.
+         *
+         * Accepted cost of the split: anyone who had arranged the Linked
+         * Monitors card while it shared the monitors-list key loses that one
+         * arrangement once, and the card returns to its declared columns.
+         */
+        userPreferencesKey={
+          isScopedToTemplate
+            ? "monitor-template-monitors-table"
+            : "monitors-table"
+        }
         customFieldsModelType={MonitorCustomField}
         id="Monitors-table"
         saveFilterProps={props.saveFilterProps}

--- a/Common/Tests/App/Dashboard/MonitorTemplateColumnAndFacet.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorTemplateColumnAndFacet.test.tsx
@@ -80,11 +80,17 @@ jest.mock("../../../UI/Utils/User", () => {
 type CapturedTableProps = {
   columns?: Array<CapturedColumn> | undefined;
   query?: Record<string, unknown> | undefined;
+  userPreferencesKey?: string | undefined;
+  disableColumnCustomization?: boolean | undefined;
 };
 
 type CapturedColumn = {
   title: string;
   field?: Record<string, unknown> | undefined;
+  isHiddenByDefault?: boolean | undefined;
+  isNotCustomizable?: boolean | undefined;
+  hideOnMobile?: boolean | undefined;
+  disableCsvExport?: boolean | undefined;
   getElement?: ((item: Monitor) => ReactElement) | undefined;
   getExportValue?: ((item: Monitor) => string) | undefined;
 };
@@ -196,6 +202,16 @@ import {
   MONITOR_TEMPLATE_FACET_QUERY_FIELD,
 } from "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/MonitorFacets";
 import { ResourceFacet } from "../../../../App/FeatureSet/Dashboard/src/Components/ResourceOwners/ResourceFacet";
+import Columns from "../../../UI/Components/ModelTable/Columns";
+import {
+  ColumnPreference,
+  CustomizableColumn,
+  applyColumnPreference,
+  getColumnBaseId,
+  getColumnIds,
+  getCustomizableColumns,
+} from "../../../UI/Components/ModelTable/ColumnPreference";
+import Column from "../../../UI/Components/ModelTable/Column";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import MonitorTemplate from "../../../Models/DatabaseModels/MonitorTemplate";
 import Includes from "../../../Types/BaseDatabase/Includes";
@@ -372,6 +388,235 @@ describe("the Template column on the monitor list", () => {
   });
 });
 
+/*
+ * Issue #3491 shipped the column switched on, which put a stripe of "—" down
+ * the middle of every monitor list: most monitors are not created from a
+ * template, and the ones that are still only need the answer occasionally.
+ * It is now off by default and turned on from the Customize Columns picker.
+ * "Hidden" and "reachable" have to hold together — a column hidden on a table
+ * with no picker is a column nobody can get back — so these run the real
+ * ColumnPreference rules over the column set the table actually declares,
+ * rather than reading the flag on its own.
+ */
+describe("the Template column's place in a first-time viewer's table", () => {
+  type DeclaredColumnsFunction = () => Columns<Monitor>;
+
+  const declaredColumns: DeclaredColumnsFunction = (): Columns<Monitor> => {
+    return (capturedTableProps?.columns || []) as unknown as Columns<Monitor>;
+  };
+
+  type TemplateColumnIdFunction = () => string;
+
+  const templateColumnId: TemplateColumnIdFunction = (): string => {
+    const columns: Columns<Monitor> = declaredColumns();
+
+    const index: number = columns.findIndex((column: { title: string }) => {
+      return column.title === "Template";
+    });
+
+    return getColumnIds<Monitor>(columns)[index] as string;
+  };
+
+  type VisibleTitlesFunction = (
+    preference: ColumnPreference | null,
+  ) => Array<string>;
+
+  const visibleTitles: VisibleTitlesFunction = (
+    preference: ColumnPreference | null,
+  ): Array<string> => {
+    return applyColumnPreference<Monitor>({
+      columns: declaredColumns(),
+      preference,
+    }).map((column: { title: string }) => {
+      return column.title;
+    });
+  };
+
+  /*
+   * The flag only means something if the table persists a layout: without a
+   * `userPreferencesKey` the picker is never rendered (see
+   * BaseModelTable.isColumnCustomizationEnabled), so a hidden-by-default
+   * column would be a column nobody could ever get back.
+   */
+  test("is switchable back on, because the table has a column picker", async () => {
+    const props: CapturedTableProps = await renderTable({
+      projectId: PROJECT_ID,
+    });
+
+    expect(props.userPreferencesKey).toBeTruthy();
+    expect(props.disableColumnCustomization).toBeFalsy();
+    expect(columnTitled("Template")!.isNotCustomizable).toBeFalsy();
+  });
+
+  test("is not rendered for a viewer with no stored layout", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    const titles: Array<string> = visibleTitles(null);
+
+    expect(titles).not.toContain("Template");
+    // Not because the table came back empty.
+    expect(titles).toContain("Name");
+    expect(titles).toContain("Monitor Status");
+    expect(titles).toContain("Labels");
+  });
+
+  test("is offered by the picker, switched off", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    const entry: CustomizableColumn<Monitor> | undefined =
+      getCustomizableColumns<Monitor>({
+        columns: declaredColumns(),
+        preference: null,
+      }).find((candidate: CustomizableColumn<Monitor>) => {
+        return candidate.column.title === "Template";
+      });
+
+    expect(entry).toBeDefined();
+    expect(entry!.isVisible).toBe(false);
+    expect(entry!.isPinned).toBe(false);
+    /*
+     * Off, not gone: the picker must not offer to remove a column the table
+     * ships, because nothing would put it back.
+     */
+    expect(entry!.isRemovable).toBe(false);
+  });
+
+  test("stays on for a viewer who already switched it on", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    const preference: ColumnPreference = {
+      order: [templateColumnId()],
+      hidden: [],
+    };
+
+    expect(visibleTitles(preference)).toContain("Template");
+  });
+
+  /*
+   * The id a viewer's "switch Template on" is stored under is the column's
+   * first field key, and getColumnIds breaks ties on that key with a title
+   * slug and then a POSITIONAL suffix. So the day someone adds a second column
+   * keyed on `monitorTemplate` - a "Template Version" column is entirely
+   * plausible - this column's persisted id changes under everyone who had it
+   * on, their stored entry stops matching, and the column falls back to its
+   * declared default, which is now off. Nobody would report that as a bug;
+   * they would just never see the column again.
+   */
+  test("has an id no other column competes for, so a stored layout keeps meaning it", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    const columns: Columns<Monitor> = declaredColumns();
+    const ids: Array<string> = getColumnIds<Monitor>(columns);
+
+    const baseIds: Array<string> = columns.map((column: Column<Monitor>) => {
+      return getColumnBaseId<Monitor>(column);
+    });
+
+    // Nothing had to be disambiguated, so no id depends on declaration order.
+    expect(ids).toEqual(baseIds);
+
+    expect(
+      ids.filter((id: string) => {
+        return id === templateColumnId();
+      }),
+    ).toHaveLength(1);
+
+    /*
+     * Titles are the first tie-breaker, so two columns sharing one would push
+     * the tie down to position - and the picker would show the viewer two rows
+     * they cannot tell apart either.
+     */
+    const titles: Array<string> = columns.map((column: Column<Monitor>) => {
+      return column.title;
+    });
+
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  /*
+   * The upgrade path almost every real viewer takes: they arranged this table
+   * before the Template column existed, so their stored `order` simply has no
+   * entry for it and it has to stay off rather than appear uninvited. The
+   * generic rule is pinned in ColumnPreference's own tests; this pins it
+   * against the ids MonitorTable actually declares, so that giving the column
+   * an explicit `id` - which those generic tests would not notice - cannot
+   * quietly change what an existing layout resolves to.
+   */
+  test("stays off for a viewer whose layout predates the column", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    const templateId: string = templateColumnId();
+
+    const preference: ColumnPreference = {
+      order: getColumnIds<Monitor>(declaredColumns()).filter((id: string) => {
+        return id !== templateId;
+      }),
+      hidden: [],
+    };
+
+    const titles: Array<string> = visibleTitles(preference);
+
+    expect(titles).not.toContain("Template");
+    // The rest of their arrangement survived, so this is not an empty result.
+    expect(titles).toContain("Name");
+    expect(titles).toContain("Labels");
+  });
+
+  /*
+   * `hideOnMobile` is enforced at render (Table/TableHeader and Table/TableRow
+   * drop the column outright) while the picker knows nothing about it, so a
+   * column carrying both flags is a dead control on a phone: the viewer ticks
+   * it, the shown-columns count goes up, and no column arrives. For a column
+   * that is hidden by default that is also a one-way door, since the picker is
+   * the only route back. Stated over the whole set so the next author cannot
+   * reintroduce the pair on a different column.
+   */
+  test("no column the picker can switch on is one the phone would throw away", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    const columns: Columns<Monitor> = declaredColumns();
+
+    /*
+     * An invariant over an empty set holds for the wrong reason, and this one
+     * is read off captured props - so prove the column it exists for is in
+     * there before believing the result.
+     */
+    expect(
+      columns.map((column: Column<Monitor>) => {
+        return column.title;
+      }),
+    ).toContain("Template");
+
+    const unreachable: Array<string> = columns
+      .filter((column: Column<Monitor>) => {
+        return (
+          Boolean(column.isHiddenByDefault) && Boolean(column.hideOnMobile)
+        );
+      })
+      .map((column: Column<Monitor>) => {
+        return column.title;
+      });
+
+    expect(unreachable).toEqual([]);
+  });
+
+  /*
+   * The default monitors CSV no longer carries a Template column, and it
+   * matters *why*: exports follow what is on screen (BaseModelTable attaches
+   * export keys only while walking the columns it is about to render), so the
+   * column leaves the CSV purely by being switched off, and comes back the
+   * moment the viewer switches it on. Someone chasing "the export lost the
+   * template" could reach for `disableCsvExport` or teach the exporter about
+   * visibility; both would break the column for the viewers who did switch it
+   * on. This records which lever is the real one.
+   */
+  test("does not opt out of the CSV", async () => {
+    await renderTable({ projectId: PROJECT_ID });
+
+    expect(columnTitled("Template")!.disableCsvExport).toBeFalsy();
+  });
+});
+
 describe("the Template chip in the monitor list's filter bar", () => {
   test("is one of the chips the bar is given", async () => {
     await renderTable({ projectId: PROJECT_ID });
@@ -501,5 +746,78 @@ describe("the same table scoped to one template", () => {
     expect(columnTitled("Labels")).toBeDefined();
     expect(facetKeyed("currentMonitorStatus")).toBeDefined();
     expect(facetKeyed("monitorType")).toBeDefined();
+  });
+});
+
+/*
+ * The two tables above are the same component with different column sets, and
+ * a saved layout records only the columns the picker was showing. Put those
+ * two facts together over one shared storage key and the template page becomes
+ * a trap: a viewer who tidies the Linked Monitors table writes a layout with
+ * no "monitorTemplate" entry in either `order` or `hidden`, and back on the
+ * monitors list a column named in neither list falls back to its declared
+ * default - which is now hidden. Their earlier "switch Template on" is gone,
+ * with no action that looks like it touched the monitors list.
+ *
+ * ModelTable is stubbed here, so no Save can be driven; what can be pinned is
+ * the precondition, and the precondition is what has to stay false.
+ */
+describe("the layout key each monitor table saves under", () => {
+  type ColumnIdsOfFunction = (props: CapturedTableProps) => Array<string>;
+
+  const columnIdsOf: ColumnIdsOfFunction = (
+    props: CapturedTableProps,
+  ): Array<string> => {
+    return getColumnIds<Monitor>(
+      (props.columns || []) as unknown as Columns<Monitor>,
+    );
+  };
+
+  test("cannot let the template page overwrite the monitor list's layout", async () => {
+    const unscoped: CapturedTableProps = await renderTable({
+      projectId: PROJECT_ID,
+    });
+
+    const unscopedKey: string | undefined = unscoped.userPreferencesKey;
+    const unscopedIds: Array<string> = columnIdsOf(unscoped);
+
+    /*
+     * A second render rather than a rerender: the two pages mount the table
+     * independently, and a stale capture would make this test agree with
+     * itself.
+     */
+    cleanup();
+    capturedTableProps = null;
+
+    const scoped: CapturedTableProps = await renderTable({
+      projectId: PROJECT_ID,
+      monitorTemplateId: TEMPLATE_ID,
+    });
+
+    const scopedKey: string | undefined = scoped.userPreferencesKey;
+    const scopedIds: Array<string> = columnIdsOf(scoped);
+
+    /*
+     * The invariant, stated so that either fix satisfies it: keep the two
+     * tables on separate keys, or make them offer the same columns. Only
+     * "shared key AND different columns" loses a viewer's choice.
+     */
+    const sharesKey: boolean = unscopedKey === scopedKey;
+    const offersSameColumns: boolean =
+      [...unscopedIds].sort().join(",") === [...scopedIds].sort().join(",");
+
+    expect(sharesKey && !offersSameColumns).toBe(false);
+
+    /*
+     * And the arrangement that satisfies it today, recorded so a rename of
+     * either key is a deliberate act - changing the unscoped key silently
+     * resets every existing viewer's monitor list layout.
+     */
+    expect(unscopedKey).toBe("monitors-table");
+    expect(scopedKey).toBe("monitor-template-monitors-table");
+
+    // The half of the invariant that is genuinely false, so it is the keys doing the work.
+    expect(unscopedIds).toContain("monitorTemplate");
+    expect(scopedIds).not.toContain("monitorTemplate");
   });
 });

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableColumnCustomization.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableColumnCustomization.test.tsx
@@ -8,7 +8,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import React from "react";
+import React, { ReactElement } from "react";
 
 /*
  * A real BaseModelTable mounts a card, a header, a full table and (in the
@@ -86,22 +86,31 @@ import BaseModelTable, {
   ComponentProps as BaseModelTableProps,
 } from "../../../../UI/Components/ModelTable/BaseModelTable";
 import Columns from "../../../../UI/Components/ModelTable/Columns";
+import TableColumnsToCsv from "../../../../UI/Utils/TableColumnsToCsv";
 import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
 import Filter from "../../../../UI/Components/ModelFilter/Filter";
 import FieldType from "../../../../UI/Components/Types/FieldType";
+import { ButtonStyleType } from "../../../../UI/Components/Button/Button";
 import Monitor from "../../../../Models/DatabaseModels/Monitor";
 import Query from "../../../../Types/BaseDatabase/Query";
 import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import UserPreferences, {
   UserPreferenceType,
 } from "../../../../Utils/UserPreferences";
-import { JSONObject } from "../../../../Types/JSON";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
 
 const PREFS_KEY: string = "monitors-columns-table";
 
 type GetListCall = {
   query: Query<Monitor>;
   select: JSONObject;
+  sort: JSONObject;
+};
+
+type DownloadedCsvFile = {
+  csv: string;
+  filename: string;
 };
 
 const FILTERS: Array<Filter<Monitor>> = [
@@ -111,6 +120,14 @@ const FILTERS: Array<Filter<Monitor>> = [
 type MakeColumnsOptions = {
   // Adds a `isHiddenByDefault` column ("Monitor Type") at the end.
   withHiddenByDefault?: boolean | undefined;
+  /*
+   * Adds a `isHiddenByDefault` *entity* column ("Template") at the end, shaped
+   * like the one on the real Monitors table: several nested fields, and a cell
+   * rendered from the relation rather than from a scalar on the row. A scalar
+   * column cannot stand in for it - the nested part of the request is built by
+   * a different function, and the cell it feeds is the one that goes blank.
+   */
+  withHiddenByDefaultEntity?: boolean | undefined;
   // Marks "Name" `isNotCustomizable`, i.e. pinned and kept out of the picker.
   pinName?: boolean | undefined;
 };
@@ -158,7 +175,78 @@ const makeColumns: MakeColumnsFunction = (
     });
   }
 
+  if (options.withHiddenByDefaultEntity) {
+    columns.push({
+      field: { monitorTemplate: { _id: true, templateName: true } },
+      title: "Template",
+      type: FieldType.Entity,
+      isHiddenByDefault: true,
+      getElement: (item: Monitor): ReactElement => {
+        return <span>{item.monitorTemplate?.templateName || ""}</span>;
+      },
+    });
+  }
+
   return columns as unknown as Columns<Monitor>;
+};
+
+const TEMPLATE_NAME: string = "Standard HTTP Template";
+
+/*
+ * One fully populated row. The relation is nested exactly as the API returns
+ * it, because the point of these tests is what survives the round trip from
+ * the request's `select` into the rendered cell.
+ */
+const ROWS: Array<JSONObject> = [
+  {
+    _id: "monitor-1",
+    name: "api-gateway",
+    description: "The public API gateway",
+    monitorTemplate: {
+      _id: "template-1",
+      templateName: TEMPLATE_NAME,
+    },
+  },
+];
+
+type ProjectRowFunction = (row: JSONObject, select: JSONObject) => JSONObject;
+
+/*
+ * The API hands back exactly the fields the request asked for and nothing
+ * else, so the fake has to as well. A fake that returned the whole row
+ * whatever the select said would keep rendering a value for a field the table
+ * had stopped asking for - which is precisely the regression these tests are
+ * here to catch.
+ */
+const projectRow: ProjectRowFunction = (
+  row: JSONObject,
+  select: JSONObject,
+): JSONObject => {
+  const projected: JSONObject = {};
+
+  for (const key of Object.keys(select)) {
+    const value: JSONValue | undefined = row[key];
+    const selected: JSONValue | undefined = select[key];
+
+    if (value === undefined) {
+      continue;
+    }
+
+    // A nested select projects the relation, not just the presence of it.
+    if (
+      selected !== null &&
+      typeof selected === "object" &&
+      value !== null &&
+      typeof value === "object"
+    ) {
+      projected[key] = projectRow(value as JSONObject, selected as JSONObject);
+      continue;
+    }
+
+    projected[key] = value;
+  }
+
+  return projected;
 };
 
 const ALL_TITLES: Array<string> = [
@@ -230,52 +318,79 @@ const getPickerRowIds: GetPickerRowIdsFunction = (): Array<string> => {
 
 describe("BaseModelTable column customization", () => {
   let calls: Array<GetListCall> = [];
+  let downloadedCsvFiles: Array<DownloadedCsvFile> = [];
 
-  type MakeCallbacksFunction = () => BaseTableCallbacks<Monitor>;
+  type MakeCallbacksFunction = (
+    rows: Array<JSONObject>,
+  ) => BaseTableCallbacks<Monitor>;
 
-  const makeCallbacks: MakeCallbacksFunction =
-    (): BaseTableCallbacks<Monitor> => {
-      return {
-        deleteItem: async () => {
-          return undefined;
-        },
-        getModelFromJSON: (item: JSONObject) => {
-          return item as unknown as Monitor;
-        },
-        getJSONFromModel: (item: Monitor) => {
-          return item as unknown as JSONObject;
-        },
-        addSlugToSelect: (select: unknown) => {
-          return select;
-        },
-        getList: async (data: {
-          query: Query<Monitor>;
-          limit: number;
-          select: JSONObject;
-        }): Promise<ListResult<Monitor>> => {
-          calls.push({
-            query: data.query,
-            select: (data.select || {}) as unknown as JSONObject,
-          });
-          return { data: [], count: 0, skip: 0, limit: data.limit };
-        },
-        toJSONArray: () => {
-          return [];
-        },
-        updateById: async () => {
-          return undefined;
-        },
-        showCreateEditModal: () => {
-          return <></>;
-        },
-      } as unknown as BaseTableCallbacks<Monitor>;
-    };
+  const makeCallbacks: MakeCallbacksFunction = (
+    rows: Array<JSONObject>,
+  ): BaseTableCallbacks<Monitor> => {
+    return {
+      deleteItem: async () => {
+        return undefined;
+      },
+      getModelFromJSON: (item: JSONObject) => {
+        return item as unknown as Monitor;
+      },
+      getJSONFromModel: (item: Monitor) => {
+        return item as unknown as JSONObject;
+      },
+      addSlugToSelect: (select: unknown) => {
+        return select;
+      },
+      getList: async (data: {
+        query: Query<Monitor>;
+        limit: number;
+        select: JSONObject;
+        sort: JSONObject;
+      }): Promise<ListResult<Monitor>> => {
+        const select: JSONObject = (data.select || {}) as unknown as JSONObject;
+
+        calls.push({
+          query: data.query,
+          select: select,
+          sort: (data.sort || {}) as unknown as JSONObject,
+        });
+
+        return {
+          data: rows.map((row: JSONObject) => {
+            return projectRow(row, select);
+          }) as unknown as Array<Monitor>,
+          count: rows.length,
+          skip: 0,
+          limit: data.limit,
+        };
+      },
+      toJSONArray: () => {
+        return [];
+      },
+      updateById: async () => {
+        return undefined;
+      },
+      showCreateEditModal: () => {
+        return <></>;
+      },
+    } as unknown as BaseTableCallbacks<Monitor>;
+  };
 
   type RenderTableOptions = {
     userPreferencesKey?: string | undefined;
     columns?: Columns<Monitor> | undefined;
     isDeleteable?: boolean | undefined;
     disableColumnCustomization?: boolean | undefined;
+    /*
+     * The rows the fake API has. Defaults to none, as most of this suite only
+     * looks at headers.
+     */
+    rows?: Array<JSONObject> | undefined;
+    /*
+     * Gives the table a bulk action. Table grows its row checkboxes - and
+     * offers "Export CSV" - only when this array is non-empty, so it is the
+     * only way to reach the export from here.
+     */
+    withBulkActions?: boolean | undefined;
   };
 
   type RenderTableFunction = (
@@ -303,9 +418,24 @@ describe("BaseModelTable column customization", () => {
       isEditable: false,
       // This suite is about columns; keep the URL out of it entirely.
       disableUrlState: true,
-      callbacks: makeCallbacks(),
+      callbacks: makeCallbacks(options.rows || []),
       ...(options.disableColumnCustomization
         ? { disableColumnCustomization: true }
+        : {}),
+      ...(options.withBulkActions
+        ? {
+            bulkActions: {
+              buttons: [
+                {
+                  title: "Archive",
+                  buttonStyleType: ButtonStyleType.NORMAL,
+                  onClick: async (): Promise<void> => {
+                    return Promise.resolve();
+                  },
+                },
+              ],
+            },
+          }
         : {}),
     } as unknown as BaseModelTableProps<Monitor>;
 
@@ -321,6 +451,31 @@ describe("BaseModelTable column customization", () => {
 
     await waitFor(() => {
       expect(screen.getAllByRole("columnheader").length).toBeGreaterThan(0);
+    });
+  };
+
+  type WaitForCallCountFunction = (count: number) => Promise<void>;
+
+  const waitForCallCount: WaitForCallCountFunction = async (
+    count: number,
+  ): Promise<void> => {
+    await waitFor(() => {
+      expect(calls.length).toBe(count);
+    });
+  };
+
+  type SortByColumnFunction = (title: string) => Promise<void>;
+
+  /*
+   * The real click path for sorting: the header cell is a button, so this is
+   * what a viewer does, and it drives the same sortBy/sortOrder state the
+   * picker later has to reason about.
+   */
+  const sortByColumn: SortByColumnFunction = async (
+    title: string,
+  ): Promise<void> => {
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: title }));
     });
   };
 
@@ -363,8 +518,65 @@ describe("BaseModelTable column customization", () => {
     });
   };
 
+  type SelectRowsFunction = (container: HTMLElement) => Promise<void>;
+
+  /*
+   * Ticks the header checkbox, which selects every row on the page and is what
+   * puts the bulk bar - and with it "Export CSV" - on screen at all.
+   */
+  const selectRows: SelectRowsFunction = async (
+    container: HTMLElement,
+  ): Promise<void> => {
+    // The header checkbox is disabled until the first page has rendered.
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('input[type="checkbox"]:not([disabled])')
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    await click(
+      container.querySelectorAll<HTMLInputElement>(
+        'input[type="checkbox"]',
+      )[0]!,
+    );
+  };
+
+  type ExportCsvFunction = () => Promise<Array<string>>;
+
+  /*
+   * The real click path, run end to end and read back as the lines a viewer
+   * would open in a spreadsheet. Every bulk action lives behind the bulk bar's
+   * "Bulk Actions" menu, so the export takes two clicks. Intercepted at the
+   * download rather than at the Blob, so the assertions are on the exact bytes
+   * that would have been written to disk.
+   */
+  const exportCsv: ExportCsvFunction = async (): Promise<Array<string>> => {
+    await click(screen.getByText("Bulk Actions"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Export CSV")).not.toBeNull();
+    });
+
+    await click(screen.getByText("Export CSV"));
+
+    await waitFor(() => {
+      expect(downloadedCsvFiles.length).toBe(1);
+    });
+
+    return (downloadedCsvFiles[0]?.csv || "").split("\r\n");
+  };
+
   beforeEach(() => {
     calls = [];
+    downloadedCsvFiles = [];
+
+    jest
+      .spyOn(TableColumnsToCsv, "downloadCsv")
+      .mockImplementation((data: DownloadedCsvFile): void => {
+        downloadedCsvFiles.push(data);
+      });
+
     window.history.replaceState(
       window.history.state,
       "",
@@ -498,6 +710,226 @@ describe("BaseModelTable column customization", () => {
        */
       expect(calls[0]?.select["description"]).toBe(true);
       expect(calls[0]?.select["name"]).toBe(true);
+    });
+
+    test("a hidden entity column's relation is still selected, in full", async () => {
+      /*
+       * "monitorTemplate" is deliberately absent from the stored order: a
+       * column the layout does not mention falls back to its declared
+       * default, so this covers both ways an entity column ends up off
+       * screen - the viewer switched it off, and the table ships it off.
+       */
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["name", "description", "currentMonitorStatus", "labels"],
+        hidden: ["currentMonitorStatus"],
+      });
+
+      renderTable({
+        columns: makeColumns({ withHiddenByDefaultEntity: true }),
+      });
+
+      await waitForTable();
+
+      expect(getHeaders()).not.toContain("Monitor Status");
+      expect(getHeaders()).not.toContain("Template");
+
+      /*
+       * A relation is not selected by naming it - it is selected by the shape
+       * nested under it, and that shape is built by a *different* function
+       * (getRelationSelectFromColumns) with its own reference to the full
+       * column set. Narrowing only that one would leave every scalar
+       * assertion in this file green while every hidden entity cell came back
+       * as a bare id, so the column would paint blank the moment a viewer
+       * switched it on. Deep equality, because dropping the second key of a
+       * multi-field relation is the same bug one field smaller.
+       */
+      expect(calls[0]?.select["currentMonitorStatus"]).toEqual({ name: true });
+      expect(calls[0]?.select["monitorTemplate"]).toEqual({
+        _id: true,
+        templateName: true,
+      });
+    });
+
+    test("a column that ships hidden is selected even with no stored layout", async () => {
+      renderTable({ columns: makeColumns({ withHiddenByDefault: true }) });
+
+      await waitForTable();
+
+      /*
+       * Hidden because the table author said so, not because this viewer
+       * chose it - there is nothing in localStorage at all. The two states
+       * reach the same select today, and an optimisation that only widened
+       * the request "when the viewer has a stored layout" would look
+       * perfectly reasonable and would break exactly the shipped default,
+       * which is the state almost every viewer is in.
+       */
+      expect(getHeaders()).not.toContain("Monitor Type");
+      expect(readPreference(PREFS_KEY)).toBeNull();
+      expect(calls[0]?.select["monitorType"]).toBe(true);
+    });
+  });
+
+  describe("switching a hidden column back on", () => {
+    test("paints its value without asking the API again", async () => {
+      renderTable({
+        columns: makeColumns({ withHiddenByDefaultEntity: true }),
+        rows: ROWS,
+      });
+
+      await waitForTable();
+
+      expect(getHeaders()).not.toContain("Template");
+      expect(screen.queryByText(TEMPLATE_NAME)).toBeNull();
+
+      const callsBefore: number = calls.length;
+
+      await openPicker();
+      await click(screen.getByTestId("column-toggle-monitorTemplate"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toContain("Template");
+      });
+
+      /*
+       * The whole contract this table's hidden columns rest on, in one test.
+       *
+       * The request is built from the DECLARED columns, never the visible
+       * ones, and the fetch effect does not depend on the column set - so a
+       * column the viewer switches on is painted from the page already in
+       * hand, with its relation intact and no spinner. Wire the request up to
+       * the visible columns instead (there is a preference-filtered
+       * `selectFields` sitting unused in serializeToTableColumns that invites
+       * exactly that) and this cell comes back empty, with nothing to refetch
+       * it: the viewer's click would produce a column of blanks.
+       */
+      expect(screen.getByText(TEMPLATE_NAME)).toBeInTheDocument();
+      expect(calls.length).toBe(callsBefore);
+    });
+  });
+
+  describe("what the viewer's layout does to the CSV export", () => {
+    test("a column that ships hidden is not in the exported file", async () => {
+      const { container } = renderTable({
+        columns: makeColumns({ withHiddenByDefaultEntity: true }),
+        rows: ROWS,
+        withBulkActions: true,
+      });
+
+      await waitForTable();
+
+      await selectRows(container);
+
+      const lines: Array<string> = await exportCsv();
+
+      /*
+       * "Export what you see". The export is built from the table's own
+       * column set, so a column the table ships switched off has no header
+       * and no cell in the file.
+       *
+       * This is the one assertion in the suite that is about data leaving the
+       * product rather than about pixels. Every other test here is happy for
+       * a hidden column's field to be fetched - it has to be, or switching
+       * the column on would paint blanks - so the row in memory is carrying
+       * the relation the whole time. Only the column filtering keeps it out
+       * of a file the viewer opens, mails and uploads.
+       *
+       * Build the Table columns from the unfiltered `allColumns` instead of
+       * the preference-filtered `columnsToRender` in serializeToTableColumns
+       * - a one-word change, and the first thing anyone would reach for after
+       * a ticket saying "the CSV lost my Template column" - and every table
+       * in the app starts exporting columns nobody asked to see.
+       */
+      expect(lines[0]).toBe("Name,Description,Monitor Status,Labels");
+      expect(lines[1]).toBe("api-gateway,The public API gateway,,");
+      expect(lines.join("\r\n")).not.toContain(TEMPLATE_NAME);
+    });
+
+    test("switching it on puts it in the exported file", async () => {
+      const { container } = renderTable({
+        columns: makeColumns({ withHiddenByDefaultEntity: true }),
+        rows: ROWS,
+        withBulkActions: true,
+      });
+
+      await waitForTable();
+
+      await openPicker();
+      await click(screen.getByTestId("column-toggle-monitorTemplate"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toContain("Template");
+      });
+
+      await selectRows(container);
+
+      const lines: Array<string> = await exportCsv();
+
+      /*
+       * The other half of the same contract, and the reason the test above
+       * cannot be satisfied by simply never exporting an `isHiddenByDefault`
+       * column: the file follows this viewer's layout, not the table author's
+       * default. Someone who switches Template on has almost certainly done
+       * it *because* they want it in the export, and freezing the export
+       * columns at the shipped default would hand them a file missing the one
+       * column they went to the picker for.
+       */
+      expect(lines[0]).toBe("Name,Description,Monitor Status,Labels,Template");
+      expect(lines[1]).toContain(TEMPLATE_NAME);
+    });
+  });
+
+  describe("the sort a hidden column leaves behind", () => {
+    test("showing a column does not refetch; hiding the sorted one does", async () => {
+      renderTable({
+        columns: makeColumns({ withHiddenByDefaultEntity: true }),
+        rows: ROWS,
+      });
+
+      await waitForTable();
+
+      await sortByColumn("Description");
+      await waitForCallCount(2);
+      expect(calls[1]?.sort).toEqual({
+        description: SortOrder.Descending,
+      });
+
+      await openPicker();
+      await click(screen.getByTestId("column-toggle-monitorTemplate"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toContain("Template");
+      });
+
+      /*
+       * Adding a column changes nothing the server was asked for, so the
+       * guard in onColumnCustomizationSave has to leave the sort alone. A
+       * reset-on-every-save would throw the viewer's ordering away - and
+       * their page - every time they ticked a box.
+       */
+      expect(calls.length).toBe(2);
+      expect(screen.getByText(TEMPLATE_NAME)).toBeInTheDocument();
+
+      await openPicker();
+      await click(screen.getByTestId("column-toggle-description"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).not.toContain("Description");
+      });
+
+      /*
+       * Hiding the column the table is sorted by is different: the header
+       * that ordering came from is gone, so the viewer can neither see it nor
+       * click it off. The sort falls back to the table's default (here: none)
+       * and the page is refetched, rather than leaving them staring at rows
+       * in an order they cannot explain or undo.
+       */
+      await waitForCallCount(3);
+      expect(calls[2]?.sort).toEqual({});
     });
   });
 

--- a/Common/Tests/UI/Components/ModelTable/ColumnPreference.test.ts
+++ b/Common/Tests/UI/Components/ModelTable/ColumnPreference.test.ts
@@ -1675,4 +1675,93 @@ describe("a stored layout replayed against a changed column set", () => {
     expect(rendered).toHaveLength(4);
     expect(titlesOf(rendered)).toEqual(["Name", "Actions", "Actions", ""]);
   });
+
+  test("a layout saved against a column set missing a default-hidden column switches it back off", () => {
+    /*
+     * A column set changes between surfaces, not just between releases: the
+     * same table component is embedded on a detail page with one column
+     * spliced out (there is no point showing "Template" on the template's own
+     * page). If both surfaces persist under one storage key, the narrow one
+     * writes the layout for the wide one.
+     *
+     * buildColumnPreference records only what the picker was showing, so the
+     * spliced-out id lands in neither `order` nor `hidden` — and reading it
+     * back falls through to the column's DECLARED default.
+     *
+     * That fallback is why this stayed invisible until now, and why it is the
+     * hazard the moment a column ships hidden: a dropped column that defaults
+     * to visible is restored by accident, so nobody ever noticed the drop,
+     * while a dropped column that defaults to hidden silently un-picks the one
+     * choice the viewer made — and the picker is the only way back to it. A
+     * table embedded on a second surface must therefore key its stored layout
+     * per surface; this is the loss it is avoiding.
+     */
+    const fullColumns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({
+        field: { monitorTemplate: { _id: true, templateName: true } },
+        title: "Template",
+        isHiddenByDefault: true,
+      }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    // The embedded surface drops the default-hidden column and one other.
+    const scopedColumns: Columns<Monitor> = fullColumns.filter(
+      (column: Column<Monitor>): boolean => {
+        return column.title !== "Template" && column.title !== "Labels";
+      },
+    );
+
+    // The viewer switches Template on from the full table and saves.
+    const preferenceA: ColumnPreference = buildColumnPreference<Monitor>(
+      getCustomizableColumns<Monitor>({
+        columns: fullColumns,
+        preference: {
+          order: ["description", "monitorTemplate", "labels"],
+          hidden: [],
+        },
+      }),
+    );
+
+    expect(
+      findEntry(
+        getCustomizableColumns<Monitor>({
+          columns: fullColumns,
+          preference: preferenceA,
+        }),
+        "monitorTemplate",
+      ).isVisible,
+    ).toBe(true);
+
+    /*
+     * Now the picker is saved from the embedded surface without the viewer
+     * changing anything there.
+     */
+    const preferenceB: ColumnPreference = buildColumnPreference<Monitor>(
+      getCustomizableColumns<Monitor>({
+        columns: scopedColumns,
+        preference: preferenceA,
+      }),
+    );
+
+    expect(preferenceB.order).not.toContain("monitorTemplate");
+    expect(preferenceB.hidden).not.toContain("monitorTemplate");
+
+    const replayed: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns: fullColumns,
+        preference: preferenceB,
+      });
+
+    // The viewer's one opt-in is gone...
+    expect(findEntry(replayed, "monitorTemplate").isVisible).toBe(false);
+    // ...while a column dropped exactly the same way comes back unharmed.
+    expect(findEntry(replayed, "labels").isVisible).toBe(true);
+  });
 });

--- a/Common/Tests/UI/Utils/TableColumnsToCsv.test.ts
+++ b/Common/Tests/UI/Utils/TableColumnsToCsv.test.ts
@@ -25,6 +25,7 @@ interface Row {
   hosts?: Array<{ name: string }> | undefined;
   services?: Array<{ name: string }> | undefined;
   monitors?: Array<{ name: string }> | undefined;
+  monitorTemplate?: { templateName?: string } | undefined;
 }
 
 /*
@@ -445,6 +446,35 @@ describe("TableColumnsToCsv", () => {
       ]);
 
       expect(result).toEqual([]);
+    });
+
+    test("keeps a column that is only hidden on mobile", () => {
+      /*
+       * hideOnMobile is a render-time decision taken by TableHeader / TableRow,
+       * and this utility never sees a viewport. The monitors list Template
+       * column sits at the intersection of the two different kinds of "hidden"
+       * a column can now have: a phone viewer who switched it on in Customize
+       * Columns gets it in their file, while a desktop viewer on the defaults
+       * does not - because the "which columns am I seeing" question is answered
+       * upstream in BaseModelTable, never here. Teaching the exporter about
+       * hideOnMobile would silently strip columns from the export of anyone on
+       * a narrow screen, and nobody would notice until a support ticket.
+       */
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        { title: "Name", type: FieldType.Text, key: "name" },
+        {
+          title: "Template",
+          type: FieldType.Entity,
+          key: "monitorTemplate",
+          hideOnMobile: true,
+        },
+      ]);
+
+      expect(
+        result.map((c: Column<Row>) => {
+          return c.title;
+        }),
+      ).toEqual(["Name", "Template"]);
     });
   });
 


### PR DESCRIPTION
## What

The monitor list's **Template** column now ships switched off. Viewers turn it on from Customize Columns.

Most monitors are not created from a template, so on a typical project the column was a stripe of `—` taking space from status and labels — the columns people actually open that list for. The Template *filter chip* is unchanged, so "which monitors are on this template?" is still answerable without turning the column on.

## Two bugs this surfaced

Hiding the column promoted two latent defects into user-visible ones. Both are fixed here.

**1. The template page could silently switch the column back off.**

Every `MonitorTable` mount shared the layout key `"monitors-table"`, but the template page's *Linked Monitors* card declares a different column set — it splices the Template column out. `buildColumnPreference` only records the columns the picker was showing, so saving a layout from that page wrote `monitorTemplate` out of both `order` and `hidden`. Back on the monitor list, a column in neither list falls back to its declared default.

That fallback used to be *visible*, so the viewer's choice was restored by accident and nobody ever noticed. With the column shipping hidden, the fallback is *hidden* — the choice is lost.

Fixed by giving the scoped mount its own key. Accepted cost: anyone who had arranged the Linked Monitors card loses that one arrangement once.

**2. On a phone, the Template checkbox did nothing.**

The column carried `hideOnMobile` as well. That flag is enforced at render — `TableHeader` and `TableRow` drop the column — while the picker knows nothing about it. So a phone viewer could tick "Template", watch the shown-columns count go up, and get no column. For a hidden-by-default column that is a one-way door, because the picker is the only route back.

Fixed by dropping `hideOnMobile`; `isHiddenByDefault` already buys the screen space it was there for. This was the only column in the Dashboard carrying both flags.

## Behaviour worth knowing

- **The API request is not narrowed.** `getSelect` and `getRelationSelect` are built from the unfiltered column set, so `monitorTemplate` is on the wire from the first request. Switching the column on paints real values immediately — no refetch, no blank cells.
- **The default CSV export no longer contains a Template column.** Export keys are attached while walking the columns the table is about to render, so the export follows what is on screen. The column returns to the file the moment a viewer switches it on. This is the exporter's existing "export what you see" contract, not something new — but it does mean "export the list and diff it after a template change" now needs the column turned on first. Changing it would mean exporting from the unfiltered set for every table in the app, so it is left alone and pinned with tests instead.
- **Applying a saved view still resets columns.** A view created before views carried columns has none, which restores the table's default layout — now with Template off. That is the documented, intended behaviour of views (`BaseModelTable.tsx`), unchanged here, but it is a second route by which a viewer can lose the column.

## Tests

Regression coverage across four existing suites — no new files, since ts-jest compile time dominates.

**`MonitorTemplateColumnAndFacet.test.tsx`** — the column is absent for a first-time viewer but offered by the picker switched-off-and-not-removable; it stays on for a viewer whose stored layout lists it, and stays off for one whose layout predates it; its persisted id is not one another column could take over; no column carries both `isHiddenByDefault` and `hideOnMobile`; the two mounts cannot share a layout key while declaring different column sets; the column does not opt out of the CSV.

**`BaseModelTableColumnCustomization.test.tsx`** — switching a hidden column on paints its value **without another API call**; a hidden entity column's relation select is still requested in full (nested, not `true`); a column that ships hidden with no stored layout at all is still selected; showing a column does not refetch while hiding the sorted one does.

**`ColumnPreference.test.ts`** — a layout saved against a column set that omits a default-hidden column switches it back off. This is bug 1 stated as a property of the persistence model rather than a MonitorTable quirk, because two surfaces sharing one key while declaring different columns is a shape that will recur.

**`TableColumnsToCsv.test.ts`** — a column hidden only on mobile still reaches the CSV, so the two kinds of "hidden" stay distinguishable at the layer where someone would be tempted to conflate them.
