### PR TITLE
fix(network-devices): make bulk Delete reachable and honest about failures

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Archived.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Archived.tsx
@@ -33,14 +33,21 @@ const NetworkDeviceArchivedPage: FunctionComponent<
         isEditable={false}
         isCreateable={false}
         isViewable={true}
+        /*
+         * This is where a fleet clean-up ends up: archive the stale devices,
+         * check the list, then delete them for good. ModelTable supplies the
+         * bulk "Delete" itself; the warning is the part it cannot know.
+         */
         bulkActions={{
           buttons: [...unarchiveBulkActions],
+          deleteConfirmationWarning:
+            "Their interfaces, links, endpoints and any monitor OneUptime created for them - with that monitor's history - are deleted too. Unarchive them instead if you only want them back in the main list.",
         }}
         name="Archived Network Devices"
         cardProps={{
           title: "Archived Network Devices",
           description:
-            "Devices you have archived. They are hidden from the main list. Select devices to unarchive them.",
+            "Devices you have archived. They are hidden from the main list. Select devices to unarchive them, or to delete them for good.",
         }}
         showViewIdButton={true}
         noItemsMessage={"No archived devices."}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
@@ -386,12 +386,22 @@ const NetworkDevices: FunctionComponent<
         isEditable={false}
         isCreateable={true}
         showRefreshButton={true}
+        /*
+         * Bulk "Delete" is not listed here - ModelTable adds it to every table
+         * that offers bulk actions, for anyone who may delete the model (issue
+         * #3559: cleaning up a fleet of stale or duplicated devices one row at
+         * a time is not a real option). What is set here is what the default
+         * confirmation cannot know: what else leaves with the devices, and
+         * that Archive is the reversible alternative.
+         */
         bulkActions={{
           buttons: [
             ...labelBulkActions,
             ...oidTemplateBulkActions,
             ...archiveBulkActions,
           ],
+          deleteConfirmationWarning:
+            "Their interfaces, links, endpoints and any monitor OneUptime created for them - with that monitor's history - are deleted too. To take devices off this list without losing any of that, archive them instead: archived devices can be restored at any time.",
         }}
         name="Network Devices"
         isViewable={true}

--- a/Common/Tests/App/Dashboard/NetworkDeviceBulkDelete.test.tsx
+++ b/Common/Tests/App/Dashboard/NetworkDeviceBulkDelete.test.tsx
@@ -1,0 +1,357 @@
+import "@testing-library/jest-dom";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import React, { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Issue #3559, on the two screens it was reported against.
+ *
+ * Network -> Devices offered Add/Remove Labels, Set/Clear OID Template,
+ * Archive and Export CSV over a selection of 916 devices, and no way to
+ * delete any of them. Deleting a batch of stale, duplicated or test devices
+ * out of a fleet of 7,489 meant deleting them one at a time.
+ *
+ * The action itself is ModelTable's - it adds a default bulk "Delete" to any
+ * table that already offers bulk actions, for anyone the model lets delete
+ * (asserted end to end in BaseModelTableBulkDelete.test.tsx). Two things about
+ * these pages have to hold for that to reach the user, and neither is visible
+ * from the component:
+ *
+ *   1. the page keeps handing ModelTable a non-empty `bulkActions` - the
+ *      default Delete is not injected into a table that offers none, because
+ *      the row checkboxes only exist for tables that do;
+ *   2. the page fills in what the generic confirmation cannot know. Deleting
+ *      a device takes its interfaces, links, endpoints and auto-created
+ *      monitor with it, and Archive is the reversible alternative. "This
+ *      action cannot be undone" on its own does not say that, and at 900 rows
+ *      the difference is not recoverable.
+ *
+ * ModelTable is replaced by a prop recorder here: the point is what these two
+ * pages hand it, not re-testing the table.
+ */
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string): string => {
+          return key;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return false;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+type CapturedBulkActions = {
+  buttons?: Array<{ title?: string | undefined }> | undefined;
+  deleteConfirmationWarning?: string | undefined;
+};
+
+type CapturedTableProps = {
+  bulkActions?: CapturedBulkActions | undefined;
+  isDeleteable?: boolean | undefined;
+  cardProps?: { description?: string | undefined } | undefined;
+};
+
+let capturedTableProps: CapturedTableProps | null = null;
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedTableProps) => {
+      capturedTableProps = props;
+      return null;
+    },
+  };
+});
+
+/*
+ * The facet bar fetches sites, labels and probes on mount and owns the query
+ * the table is given. None of that is what these tests are about.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners",
+  () => {
+    const actual: Record<string, unknown> = jest.requireActual(
+      "../../../../App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners",
+    ) as Record<string, unknown>;
+
+    return {
+      ...actual,
+      __esModule: true,
+      default: () => {
+        return {
+          filterBar: null,
+          mergeFiltersIntoQuery: (
+            base: Record<string, unknown> | undefined,
+          ) => {
+            return base || {};
+          },
+          hasActiveFilters: false,
+          facetSelections: {},
+          facetOperators: {},
+          setFacetSelection: () => {
+            // no-op
+          },
+          clearAllFacets: () => {
+            // no-op
+          },
+          facetSaveState: {},
+          restoreFacetState: () => {
+            // no-op
+          },
+          getOwnersForResource: () => {
+            return [];
+          },
+          isLoadingOwners: false,
+          onResourcesFetched: () => {
+            // no-op
+          },
+        };
+      },
+    };
+  },
+);
+
+jest.mock("../../../UI/Components/BulkUpdate/BulkLabelActions", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        bulkActions: [{ title: "Add Labels" }, { title: "Remove Labels" }],
+        modals: null,
+      };
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/NetworkDevice/useBulkOidTemplateActions",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return {
+          bulkActions: [
+            { title: "Set OID Collection Template" },
+            { title: "Clear OID Collection Template" },
+          ],
+          modals: null,
+        };
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return null;
+      },
+    };
+  },
+);
+
+jest.mock("../../../../App/FeatureSet/Dashboard/src/Utils/Probe", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllProbes: async () => {
+        return [];
+      },
+    },
+  };
+});
+
+import NetworkDevicesPage from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices";
+import NetworkDeviceArchivedPage from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Archived";
+import PageComponentProps from "../../../../App/FeatureSet/Dashboard/src/Pages/PageComponentProps";
+import Route from "../../../Types/API/Route";
+
+const PAGE_PROPS: PageComponentProps = {
+  pageRoute: new Route("/dashboard/network-devices"),
+  currentProject: null,
+  hasPaymentMethod: true,
+};
+
+type RenderPageFunction = (
+  page: (props: PageComponentProps) => ReactElement,
+) => Promise<CapturedTableProps>;
+
+const renderPage: RenderPageFunction = async (
+  page: (props: PageComponentProps) => ReactElement,
+): Promise<CapturedTableProps> => {
+  const Page: (props: PageComponentProps) => ReactElement = page;
+
+  render(
+    <MemoryRouter>
+      <Page {...PAGE_PROPS} />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => {
+    expect(capturedTableProps).not.toBeNull();
+  });
+
+  return capturedTableProps!;
+};
+
+type ButtonTitlesFunction = (props: CapturedTableProps) => Array<string>;
+
+const buttonTitles: ButtonTitlesFunction = (
+  props: CapturedTableProps,
+): Array<string> => {
+  return (props.bulkActions?.buttons || []).map(
+    (button: { title?: string | undefined }): string => {
+      return button.title || "";
+    },
+  );
+};
+
+describe("Network Devices bulk delete wiring", () => {
+  beforeEach(() => {
+    capturedTableProps = null;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  describe("the Devices list", () => {
+    test("still offers bulk actions, so the default Delete is added to them", async () => {
+      const props: CapturedTableProps = await renderPage(
+        NetworkDevicesPage as unknown as (
+          props: PageComponentProps,
+        ) => ReactElement,
+      );
+
+      expect(buttonTitles(props)).toEqual(
+        expect.arrayContaining([
+          "Add Labels",
+          "Remove Labels",
+          "Set OID Collection Template",
+          "Archive",
+        ]),
+      );
+      expect(props.bulkActions?.buttons?.length).toBeGreaterThan(0);
+    });
+
+    /*
+     * The page deliberately has no per-row Delete. Bulk deletion does not hang
+     * off that flag, and this is here so that stays a deliberate pairing
+     * rather than looking like an oversight in either direction.
+     */
+    test("has no per-row Delete button", async () => {
+      const props: CapturedTableProps = await renderPage(
+        NetworkDevicesPage as unknown as (
+          props: PageComponentProps,
+        ) => ReactElement,
+      );
+
+      expect(props.isDeleteable).toBe(false);
+    });
+
+    test("warns what leaves with the devices, and points at Archive", async () => {
+      const props: CapturedTableProps = await renderPage(
+        NetworkDevicesPage as unknown as (
+          props: PageComponentProps,
+        ) => ReactElement,
+      );
+
+      const warning: string =
+        props.bulkActions?.deleteConfirmationWarning || "";
+
+      expect(warning).toContain("interfaces");
+      expect(warning).toContain("links");
+      expect(warning).toContain("monitor");
+      expect(warning.toLowerCase()).toContain("archive");
+    });
+  });
+
+  describe("the Archived devices list", () => {
+    test("still offers bulk actions, so the default Delete is added to them", async () => {
+      const props: CapturedTableProps = await renderPage(
+        NetworkDeviceArchivedPage as unknown as (
+          props: PageComponentProps,
+        ) => ReactElement,
+      );
+
+      expect(buttonTitles(props)).toEqual(
+        expect.arrayContaining(["Unarchive"]),
+      );
+    });
+
+    /*
+     * Archiving then deleting is the clean-up path the issue describes, so
+     * the warning here points back at Unarchive rather than at Archive.
+     */
+    test("warns what leaves with the devices, and points at Unarchive", async () => {
+      const props: CapturedTableProps = await renderPage(
+        NetworkDeviceArchivedPage as unknown as (
+          props: PageComponentProps,
+        ) => ReactElement,
+      );
+
+      const warning: string =
+        props.bulkActions?.deleteConfirmationWarning || "";
+
+      expect(warning).toContain("interfaces");
+      expect(warning).toContain("monitor");
+      expect(warning.toLowerCase()).toContain("unarchive");
+    });
+
+    test("tells the reader the list is where devices get deleted for good", async () => {
+      const props: CapturedTableProps = await renderPage(
+        NetworkDeviceArchivedPage as unknown as (
+          props: PageComponentProps,
+        ) => ReactElement,
+      );
+
+      expect(props.cardProps?.description || "").toContain("delete");
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableBulkDelete.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableBulkDelete.test.tsx
@@ -1,0 +1,751 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  configure,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Rendering a real table several times over comfortably outruns the 1s
+ * default when the whole suite is competing for the same box.
+ */
+configure({ asyncUtilTimeout: 15000 });
+
+/*
+ * Bulk-deleting the rows you selected.
+ *
+ * Issue #3559 came from Network -> Devices: 916 devices selected out of 7,489,
+ * "Bulk Actions" open, and every action in it except the one the user wanted -
+ * Add/Remove Labels, Set/Clear OID Template, Archive, Export CSV. Deleting a
+ * batch of stale or duplicated devices meant deleting them one at a time.
+ *
+ * The action is not written per page: ModelTable adds a default "Delete" to
+ * any table that already offers bulk actions, for anyone the model lets
+ * delete. What is asserted here is that behaviour end to end - it is offered,
+ * it asks first, it deletes exactly what was selected - plus the two things
+ * that only matter once the selection is large:
+ *
+ *   - the confirmation can carry what else leaves with the rows
+ *     (`deleteConfirmationWarning`), because a devices page knows things the
+ *     generic sentence cannot;
+ *   - a delete that FAILS is reported. Failures used to be collected but
+ *     never handed to the progress modal unless a later row happened to
+ *     succeed, so a run whose trailing rows failed under-reported, and a run
+ *     where everything failed - a permission or FK problem, which is what a
+ *     900-row delete actually hits - finished looking like it had done
+ *     nothing at all.
+ */
+
+let isMasterAdminForTest: boolean = false;
+let permissionsForTest: Array<unknown> = [];
+
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import PermissionGate from "../../../../UI/Utils/PermissionGate";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import { ButtonStyleType } from "../../../../UI/Components/Button/Button";
+import NetworkDevice from "../../../../Models/DatabaseModels/NetworkDevice";
+import Permission from "../../../../Types/Permission";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+type Row = {
+  _id: string;
+  name: string;
+};
+
+const ROWS: Array<Row> = [
+  { _id: "device-1", name: "core-router-1" },
+  { _id: "device-2", name: "core-router-2" },
+  { _id: "device-3", name: "core-router-3" },
+];
+
+const ARCHIVE_ACTION: unknown = {
+  title: "Archive",
+  buttonStyleType: ButtonStyleType.NORMAL,
+  onClick: async (): Promise<void> => {
+    return Promise.resolve();
+  },
+};
+
+const DEVICE_DELETE_WARNING: string =
+  "Their interfaces, links, endpoints and any monitor OneUptime created for them are deleted too.";
+
+type TableOptions = {
+  bulkActionButtons?: Array<unknown> | undefined;
+  deleteConfirmationWarning?: string | undefined;
+  deleteItem?: ((item: NetworkDevice) => Promise<void>) | undefined;
+};
+
+describe("BaseModelTable bulk Delete", () => {
+  let deletedIds: Array<string> = [];
+  let getListCallCount: number = 0;
+
+  type MakePropsFunction = (
+    options: TableOptions,
+  ) => BaseModelTableProps<NetworkDevice>;
+
+  const makeProps: MakePropsFunction = (
+    options: TableOptions,
+  ): BaseModelTableProps<NetworkDevice> => {
+    const callbacks: BaseTableCallbacks<NetworkDevice> = {
+      deleteItem: async (item: NetworkDevice): Promise<void> => {
+        if (options.deleteItem) {
+          await options.deleteItem(item);
+        }
+
+        deletedIds.push(String((item as unknown as Row)._id));
+      },
+      getModelFromJSON: (item: JSONObject): NetworkDevice => {
+        return item as unknown as NetworkDevice;
+      },
+      getJSONFromModel: (item: NetworkDevice): JSONObject => {
+        return item as unknown as JSONObject;
+      },
+      addSlugToSelect: (select: unknown): unknown => {
+        return select;
+      },
+      getList: async (data: {
+        skip: number;
+        limit: number;
+      }): Promise<ListResult<NetworkDevice>> => {
+        getListCallCount++;
+
+        return {
+          data: ROWS as unknown as Array<NetworkDevice>,
+          count: ROWS.length,
+          skip: data.skip,
+          limit: data.limit,
+        };
+      },
+      toJSONArray: (): Array<JSONObject> => {
+        return [];
+      },
+      updateById: async (): Promise<void> => {
+        return undefined;
+      },
+      showCreateEditModal: (): React.ReactElement => {
+        return <div data-testid="create-edit-modal" />;
+      },
+    } as unknown as BaseTableCallbacks<NetworkDevice>;
+
+    return {
+      modelType: NetworkDevice,
+      id: "network-devices-table",
+      name: "Network Devices",
+      userPreferencesKey: "network-devices-bulk-delete-table",
+      urlStateKey: "network-devices-bulk-delete-table",
+      columns: [{ field: { name: true }, title: "Name", type: FieldType.Text }],
+      filters: [],
+      cardProps: {
+        title: "Network Devices",
+        description: "Every device in this project",
+      },
+      /*
+       * Exactly how the Devices page is configured: no per-row Delete button.
+       * Bulk deletion is deliberately not tied to that flag - `isDeleteable`
+       * is about the Actions column, not about the selection bar.
+       */
+      isCreateable: true,
+      isEditable: false,
+      isDeleteable: false,
+      isViewable: true,
+      callbacks: callbacks,
+      bulkActions: {
+        buttons: options.bulkActionButtons ?? [ARCHIVE_ACTION],
+        ...(options.deleteConfirmationWarning
+          ? { deleteConfirmationWarning: options.deleteConfirmationWarning }
+          : {}),
+      },
+    } as unknown as BaseModelTableProps<NetworkDevice>;
+  };
+
+  type RenderTableFunction = (
+    options?: TableOptions | undefined,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    options?: TableOptions | undefined,
+  ): ReturnType<typeof render> => {
+    return render(
+      <BaseModelTable<NetworkDevice> {...makeProps(options || {})} />,
+    );
+  };
+
+  type SelectRowsFunction = (
+    container: HTMLElement,
+    count: number,
+  ) => Promise<void>;
+
+  /* Ticks the first `count` row checkboxes, skipping the header's select-all. */
+  const selectRows: SelectRowsFunction = async (
+    container: HTMLElement,
+    count: number,
+  ): Promise<void> => {
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('input[type="checkbox"]:not([disabled])')
+          .length,
+      ).toBeGreaterThan(ROWS.length);
+    });
+
+    const checkboxes: Array<HTMLInputElement> = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    );
+
+    /*
+     * The header carries its own select-all box, so the row boxes are the
+     * trailing ones. Taking them from the end keeps this independent of where
+     * the header box sits in the DOM.
+     */
+    const rowCheckboxes: Array<HTMLInputElement> = checkboxes.slice(
+      checkboxes.length - ROWS.length,
+    );
+
+    for (let index: number = 0; index < count; index++) {
+      fireEvent.click(rowCheckboxes[index]!);
+    }
+  };
+
+  type OpenBulkMenuFunction = () => Promise<void>;
+
+  const openBulkMenu: OpenBulkMenuFunction = async (): Promise<void> => {
+    await waitFor(() => {
+      expect(screen.getByText("Bulk Actions")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Bulk Actions"));
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[role="menuitem"]').length,
+      ).toBeGreaterThan(0);
+    });
+  };
+
+  type FindMenuItemFunction = (label: string) => HTMLElement | undefined;
+
+  const findMenuItem: FindMenuItemFunction = (
+    label: string,
+  ): HTMLElement | undefined => {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item: HTMLElement) => {
+      return (item.textContent || "").trim() === label;
+    });
+  };
+
+  type MenuItemLabelsFunction = () => Array<string>;
+
+  const menuItemLabels: MenuItemLabelsFunction = (): Array<string> => {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).map((item: HTMLElement) => {
+      return (item.textContent || "").trim();
+    });
+  };
+
+  type ConfirmFunction = () => Promise<void>;
+
+  /* Presses the danger button in the confirmation dialog's footer. */
+  const confirmDelete: ConfirmFunction = async (): Promise<void> => {
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="modal-footer"]'),
+      ).not.toBeNull();
+    });
+
+    const footer: HTMLElement = document.querySelector<HTMLElement>(
+      '[data-testid="modal-footer"]',
+    )!;
+
+    const submitButton: HTMLButtonElement | undefined = Array.from(
+      footer.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button: HTMLButtonElement) => {
+      return (button.textContent || "").trim() === "Delete";
+    });
+
+    expect(submitButton).toBeDefined();
+
+    fireEvent.click(submitButton!);
+  };
+
+  type CloseProgressModalFunction = () => Promise<void>;
+
+  /*
+   * The results modal stays up until the user dismisses it - that is when the
+   * table drops the selection and refetches.
+   */
+  const closeProgressModal: CloseProgressModalFunction =
+    async (): Promise<void> => {
+      await waitFor(() => {
+        expect(
+          Array.from(
+            document.querySelectorAll<HTMLButtonElement>(
+              '[data-testid="modal-footer"] button',
+            ),
+          ).find((button: HTMLButtonElement) => {
+            return (
+              (button.textContent || "").trim() === "Close" && !button.disabled
+            );
+          }),
+        ).toBeDefined();
+      });
+
+      const closeButton: HTMLButtonElement = Array.from(
+        document.querySelectorAll<HTMLButtonElement>(
+          '[data-testid="modal-footer"] button',
+        ),
+      ).find((button: HTMLButtonElement) => {
+        return (
+          (button.textContent || "").trim() === "Close" && !button.disabled
+        );
+      })!;
+
+      fireEvent.click(closeButton);
+    };
+
+  type StartBulkDeleteFunction = (
+    options?: TableOptions | undefined,
+  ) => Promise<ReturnType<typeof render>>;
+
+  /* Select two rows, open the menu, click Delete. Stops before confirming. */
+  const startBulkDelete: StartBulkDeleteFunction = async (
+    options?: TableOptions | undefined,
+  ): Promise<ReturnType<typeof render>> => {
+    const result: ReturnType<typeof render> = renderTable(options);
+
+    await selectRows(result.container, 2);
+    await openBulkMenu();
+
+    fireEvent.click(findMenuItem("Delete")!);
+
+    return result;
+  };
+
+  type ConfirmationTextFunction = () => string;
+
+  const confirmationText: ConfirmationTextFunction = (): string => {
+    return (
+      document.querySelector('[data-testid="confirm-modal-description"]')
+        ?.textContent || ""
+    );
+  };
+
+  beforeEach(() => {
+    isMasterAdminForTest = false;
+    permissionsForTest = [Permission.ProjectAdmin];
+    deletedIds = [];
+    getListCallCount = 0;
+    PermissionGate.clearPermissionPropsCache();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/dashboard/network-devices",
+    );
+    TableFilterUrlState.resetClaimedKeys();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("the action is offered", () => {
+    /*
+     * The report itself: a devices table whose bulk menu had Archive and
+     * Export CSV in it and no way to delete anything.
+     */
+    test("Delete sits in the bulk menu alongside the page's own actions", async () => {
+      const { container } = renderTable();
+
+      await selectRows(container, 1);
+      await openBulkMenu();
+
+      expect(menuItemLabels()).toEqual(
+        expect.arrayContaining(["Archive", "Export CSV", "Delete"]),
+      );
+      expect(findMenuItem("Delete")).not.toBeDisabled();
+    });
+
+    /* `isDeleteable={false}` is about the row's Actions column, nothing else. */
+    test("is offered even though the table has no per-row Delete button", async () => {
+      const { container } = renderTable();
+
+      await selectRows(container, 1);
+
+      const rowDeleteButton: HTMLButtonElement | undefined = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button"),
+      ).find((button: HTMLButtonElement) => {
+        return (button.textContent || "").trim() === "Delete";
+      });
+
+      expect(rowDeleteButton).toBeUndefined();
+
+      await openBulkMenu();
+
+      expect(findMenuItem("Delete")).toBeDefined();
+    });
+
+    /* One Delete, whoever supplied it - not the page's plus an injected one. */
+    test("is not duplicated when the page supplies its own Delete", async () => {
+      const { container } = renderTable({
+        bulkActionButtons: [
+          ARCHIVE_ACTION,
+          {
+            title: "Delete",
+            buttonStyleType: ButtonStyleType.DANGER,
+            onClick: async (): Promise<void> => {
+              return Promise.resolve();
+            },
+          },
+        ],
+      });
+
+      await selectRows(container, 1);
+      await openBulkMenu();
+
+      expect(
+        menuItemLabels().filter((label: string) => {
+          return label === "Delete";
+        }).length,
+      ).toBe(1);
+    });
+  });
+
+  describe("the confirmation", () => {
+    test("names the count and the model, and warns it cannot be undone", async () => {
+      await startBulkDelete();
+
+      await waitFor(() => {
+        expect(confirmationText()).not.toBe("");
+      });
+
+      expect(confirmationText()).toContain("delete 2 Network Devices");
+      expect(confirmationText()).toContain("cannot be undone");
+    });
+
+    test("uses the singular when one row is selected", async () => {
+      const { container } = renderTable();
+
+      await selectRows(container, 1);
+      await openBulkMenu();
+
+      fireEvent.click(findMenuItem("Delete")!);
+
+      await waitFor(() => {
+        expect(confirmationText()).not.toBe("");
+      });
+
+      expect(confirmationText()).toContain("delete 1 Network Device?");
+    });
+
+    /*
+     * A devices page knows what leaves with a device - its interfaces, links
+     * and auto-created monitor - and that Archive is the reversible option.
+     * The default sentence cannot know any of that.
+     */
+    test("carries the table's own warning when it sets one", async () => {
+      await startBulkDelete({
+        deleteConfirmationWarning: DEVICE_DELETE_WARNING,
+      });
+
+      await waitFor(() => {
+        expect(confirmationText()).not.toBe("");
+      });
+
+      expect(confirmationText()).toContain("cannot be undone");
+      expect(confirmationText()).toContain(DEVICE_DELETE_WARNING);
+    });
+
+    test("says nothing extra when the table sets no warning", async () => {
+      await startBulkDelete();
+
+      await waitFor(() => {
+        expect(confirmationText()).not.toBe("");
+      });
+
+      expect(confirmationText().trim()).toBe(
+        "Are you sure you want to delete 2 Network Devices? This action cannot be undone.",
+      );
+    });
+
+    test("deletes nothing until it is confirmed", async () => {
+      await startBulkDelete();
+
+      await waitFor(() => {
+        expect(confirmationText()).not.toBe("");
+      });
+
+      expect(deletedIds).toEqual([]);
+    });
+  });
+
+  describe("running the delete", () => {
+    test("deletes every selected row, and only those", async () => {
+      await startBulkDelete();
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(deletedIds.length).toBe(2);
+      });
+
+      expect(deletedIds.sort()).toEqual(["device-1", "device-2"]);
+    });
+
+    test("reloads the table once the results are dismissed", async () => {
+      await startBulkDelete();
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(deletedIds.length).toBe(2);
+      });
+
+      const callsBefore: number = getListCallCount;
+
+      await closeProgressModal();
+
+      await waitFor(() => {
+        expect(getListCallCount).toBeGreaterThan(callsBefore);
+      });
+    });
+
+    test("reports how many succeeded", async () => {
+      await startBulkDelete();
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(screen.queryByText(/succeeded/)).not.toBeNull();
+      });
+
+      expect(
+        screen.getByText("2 Network Devices succeeded"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("reporting failures", () => {
+    type FailingDeleteFunction = (
+      failingIds: Array<string>,
+    ) => (item: NetworkDevice) => Promise<void>;
+
+    const failFor: FailingDeleteFunction = (
+      failingIds: Array<string>,
+    ): ((item: NetworkDevice) => Promise<void>) => {
+      return (item: NetworkDevice): Promise<void> => {
+        if (failingIds.includes(String((item as unknown as Row)._id))) {
+          return Promise.reject(
+            new Error("Device is referenced by a monitor you cannot delete"),
+          );
+        }
+
+        return Promise.resolve();
+      };
+    };
+
+    test("names the failures and their reason alongside the successes", async () => {
+      await startBulkDelete({ deleteItem: failFor(["device-1"]) });
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(screen.queryByText(/failed/)).not.toBeNull();
+      });
+
+      expect(screen.getByText("1 Network Device failed")).toBeInTheDocument();
+      expect(
+        screen.getByText("1 Network Device succeeded"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Device is referenced by a monitor you cannot delete"),
+      ).toBeInTheDocument();
+    });
+
+    /*
+     * A trailing failure used to reach the modal only by accident: the
+     * progress info handed React the live `failed` array, so a push after the
+     * last report mutated the snapshot already in state. The fix hands out
+     * copies, which is the honest thing to do and removes that accident - so
+     * this case now depends entirely on reporting from the catch, and is
+     * pinned here.
+     */
+    test("reports a failure on the last row of the run", async () => {
+      await startBulkDelete({ deleteItem: failFor(["device-2"]) });
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(screen.queryByText(/failed/)).not.toBeNull();
+      });
+
+      expect(screen.getByText("1 Network Device failed")).toBeInTheDocument();
+    });
+
+    /*
+     * The shape that was plainly broken: with nothing succeeding, the progress
+     * info was never reported at all, so the modal fell back on the snapshot
+     * taken before the run and finished completely blank - no successes, no
+     * failures, no explanation of why nothing had been deleted.
+     */
+    test("reports failures when every row fails", async () => {
+      await startBulkDelete({
+        deleteItem: failFor(["device-1", "device-2"]),
+      });
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(screen.queryByText(/failed/)).not.toBeNull();
+      });
+
+      expect(screen.getByText("2 Network Devices failed")).toBeInTheDocument();
+      expect(screen.queryByText(/succeeded/)).toBeNull();
+    });
+
+    test("keeps deleting the rest of the selection after one fails", async () => {
+      await startBulkDelete({ deleteItem: failFor(["device-1"]) });
+      await confirmDelete();
+
+      await waitFor(() => {
+        expect(deletedIds).toEqual(["device-2"]);
+      });
+    });
+  });
+
+  describe("permission", () => {
+    test("is locked, with a reason, for someone who may not delete", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable();
+
+      await selectRows(container, 1);
+      await openBulkMenu();
+
+      const deleteItem: HTMLElement | undefined = findMenuItem("Delete");
+
+      expect(deleteItem).toBeDefined();
+      expect(deleteItem).toBeDisabled();
+
+      fireEvent.mouseEnter(deleteItem!.parentElement as HTMLElement);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "You do not have permission to delete this Network Device.",
+      );
+    });
+
+    /*
+     * A master admin is allowed everything by the gate, but holds no project
+     * permission for the model-level check to find - so the menu offered them
+     * every action except the one they were most entitled to.
+     */
+    test("is offered to a master admin holding no project permissions", async () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      const { container } = renderTable();
+
+      await selectRows(container, 1);
+      await openBulkMenu();
+
+      expect(findMenuItem("Delete")).toBeDefined();
+      expect(findMenuItem("Delete")).not.toBeDisabled();
+    });
+
+    /*
+     * The row checkboxes exist only because the table has bulk actions at all,
+     * so a table with none must not grow a selection column just because
+     * somebody may delete. This is the reason the gate is not consulted on its
+     * own, and it holds for a master admin too.
+     */
+    test("is not injected into a table that offers no bulk actions", async () => {
+      isMasterAdminForTest = true;
+      permissionsForTest = [];
+
+      const { container } = renderTable({ bulkActionButtons: [] });
+
+      await waitFor(() => {
+        expect(screen.getByText("core-router-1")).toBeInTheDocument();
+      });
+
+      expect(container.querySelectorAll('input[type="checkbox"]').length).toBe(
+        0,
+      );
+    });
+
+    test("a locked Delete does not open the confirmation", async () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const { container } = renderTable();
+
+      await selectRows(container, 1);
+      await openBulkMenu();
+
+      fireEvent.click(findMenuItem("Delete")!);
+
+      expect(
+        document.querySelector('[data-testid="confirm-modal-description"]'),
+      ).toBeNull();
+      expect(deletedIds).toEqual([]);
+    });
+  });
+});

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -201,6 +201,13 @@ export enum ModalTableBulkDefaultActions {
 export interface BulkActionProps<T extends BaseModel | AnalyticsBaseModel> {
   buttons: Array<BulkActionButtonSchema<T> | ModalTableBulkDefaultActions>;
   matchBulkSelectedItemByField?: keyof T | undefined; // which field to use to match selected items. For exmaple this could be '_id'
+  /**
+   * Appended to the bulk Delete confirmation, for a surface where deleting the
+   * selected rows also removes records the user did not select, or where a
+   * reversible alternative exists. The default sentence only says the deletion
+   * cannot be undone - it cannot know what else goes with it.
+   */
+  deleteConfirmationWarning?: string | undefined;
 }
 
 export interface BaseTableProps<
@@ -2923,7 +2930,12 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
             items.length === 1
               ? props.singularName || model.singularName || "item"
               : props.pluralName || model.pluralName || "items";
-          return `Are you sure you want to delete ${items.length} ${itemLabel}? This action cannot be undone.`;
+
+          const warning: string = props.bulkActions?.deleteConfirmationWarning
+            ? ` ${props.bulkActions.deleteConfirmationWarning}`
+            : "";
+
+          return `Are you sure you want to delete ${items.length} ${itemLabel}? This action cannot be undone.${warning}`;
         },
         confirmTitle: (items: Array<TBaseModel>) => {
           const itemLabel: string =
@@ -2946,26 +2958,41 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           const failedItems: Array<BulkActionFailed<TBaseModel>> = [];
 
           for (let i: number = 0; i < items.length; i++) {
-            try {
-              const item: TBaseModel = items[i]!;
-              // remove items from inProgressItems
-              inProgressItems.splice(inProgressItems.indexOf(item), 1);
+            const item: TBaseModel = items[i]!;
 
+            // remove items from inProgressItems
+            inProgressItems.splice(inProgressItems.indexOf(item), 1);
+
+            try {
               await props.callbacks.deleteItem(item);
               successItems.push(item);
-
-              onProgressInfo({
-                inProgressItems: inProgressItems,
-                successItems: successItems,
-                failed: failedItems,
-                totalItems: items,
-              });
             } catch (err) {
               failedItems.push({
-                item: items[i]!,
+                item: item,
                 failedMessage: API.getFriendlyMessage(err),
               });
             }
+
+            /*
+             * Reported after a failure as well as after a success. This used to
+             * sit inside the `try`, so a row that failed moved neither the
+             * progress bar nor the failure list until some later row succeeded
+             * - and a run whose trailing rows all failed (or one where every
+             * row failed, which is what a permission or constraint problem
+             * looks like) ended with the modal still showing the counts from
+             * before them. Deleting hundreds of rows at once is exactly where
+             * partial failure is expected, so it has to be visible.
+             *
+             * Copies, not the live arrays: the progress info goes into React
+             * state, and pushing into the same array reference leaves the
+             * previous render's snapshot mutated underneath it.
+             */
+            onProgressInfo({
+              inProgressItems: [...inProgressItems],
+              successItems: [...successItems],
+              failed: [...failedItems],
+              totalItems: items,
+            });
           }
 
           onBulkActionEnd();
@@ -3116,9 +3143,17 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
             },
           );
 
+          /*
+           * On a table that already offers bulk actions the gate decides on
+           * its own, because there is no selection column left to grow: the
+           * row checkboxes are already there. That covers the locked case, and
+           * it also covers a master admin - allowed everything by the gate, but
+           * holding no project permission for `userCanDelete` to find, so the
+           * Delete they are entitled to used to be missing from a menu whose
+           * every other action worked (issue #3559).
+           */
           const canAutoInjectDelete: boolean =
-            userCanDelete ||
-            (bulkDeleteGate.disabled && sourceButtons.length > 0);
+            userCanDelete || (bulkDeleteGate.show && sourceButtons.length > 0);
 
           if (canAutoInjectDelete && !alreadyHasDeleteAction) {
             sourceButtons.push(ModalTableBulkDefaultActions.Delete);


### PR DESCRIPTION
Fixes #3559.

## The report

Network → Devices, 916 of 7,489 devices selected, "Bulk Actions" open: Add Labels, Remove Labels, Set OID Collection Template, Clear OID Collection Template, Archive, Export CSV — and no Delete. Clearing stale, duplicated or test devices out of a fleet that size meant deleting them one at a time.

## What was actually wrong

`ModelTable` already adds a default bulk **Delete** to any table that offers bulk actions, so most users on current `master` do see it on Devices. Three things kept that from being the whole answer.

**1. A master admin never got it.** The auto-injection asked `model.hasDeletePermissions(getAllPermissions())` — the project permission snapshot, which a master admin does not hold — while the gate that decides whether the action renders locked allows them everything. So the one menu entry they were most entitled to was the one missing, next to an Archive that worked. On a table that already offers bulk actions there is no selection column left to grow, which was the only reason the gate was not trusted on its own there, so it now is:

```diff
-  userCanDelete || (bulkDeleteGate.disabled && sourceButtons.length > 0);
+  userCanDelete || (bulkDeleteGate.show && sourceButtons.length > 0);
```

A table with *no* bulk actions still grows no checkboxes.

**2. Failures were invisible — exactly at the scale the report describes.** The delete loop collected failures but only reported progress from inside the `try`. A run where every row failed (a permission problem, or the `RESTRICT` FK on an auto-provisioned monitor — what a 900-row delete really hits) never called `onProgressInfo` at all, so the results modal fell back on the snapshot taken *before* the run: no successes, no failures, no explanation of why nothing had been deleted. Trailing failures only surfaced by accident, because the live `failed` array was aliased into React state and mutated after the last report. Reporting now happens after a failure as well as a success, and hands out copies.

**3. "This action cannot be undone" does not say what leaves with a device.** Deleting one takes its interfaces, links, endpoints and any monitor OneUptime created for it — with that monitor's history. New optional `bulkActions.deleteConfirmationWarning` lets a table append what the generic sentence cannot know; both device lists now use it and point at Archive / Unarchive as the reversible alternative.

## Changes

| File | |
|---|---|
| `Common/UI/Components/ModelTable/BaseModelTable.tsx` | gate-driven injection; failure reporting; `deleteConfirmationWarning` |
| `App/…/NetworkDevice/Devices.tsx` | delete warning, pointing at Archive |
| `App/…/NetworkDevice/Archived.tsx` | delete warning pointing at Unarchive; card copy says the list is where devices go for good |

## Tests

`Common/Tests/UI/Components/ModelTable/BaseModelTableBulkDelete.test.tsx` — 19 tests driving a **real** `BaseModelTable` over `NetworkDevice`: Delete is in the menu beside the page's own actions, is offered although the page sets `isDeleteable={false}`, is never duplicated when a page supplies its own; the confirmation names the count and model, singularises at one row, carries the page warning and says nothing extra without one, and deletes nothing until submitted; the run deletes exactly the selection, reports successes, reloads on dismiss; failures are named with their reason, on the last row, and when every row fails; and it is locked with a reason for a viewer, inert while locked, offered to a master admin, and still absent from a table with no bulk actions.

`Common/Tests/App/Dashboard/NetworkDeviceBulkDelete.test.tsx` — 6 tests rendering the real Devices and Archived pages and reading what they hand `ModelTable`: both keep a non-empty `bulkActions` (the precondition for the injection), Devices keeps no per-row Delete, and each warning names what is lost and the right reversible action.

Verified the new tests fail against the unfixed code: the warning test, the all-rows-fail test and the master-admin test all go red on `HEAD`.

```
Test Suites: 21 passed, 21 total
Tests:       556 passed, 556 total
```

(every `ModelTable` and bulk-action suite, not just the new ones). `npx tsc --noEmit` clean in `Common` and `App`; `eslint` clean on the touched files.