### PR TITLE
feat(network): reorganize product side menu

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Network/NetworkSideMenu.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Network/NetworkSideMenu.tsx
@@ -11,9 +11,9 @@ import React, { FunctionComponent, ReactElement } from "react";
 /*
  * The one side menu for the whole Network area. Both the Network Devices
  * and Network Sites sections render this same component, so wherever the
- * user lands they see the entire product — fleet overview, device
- * inventory, site hierarchy, map, topology — as one coherent thing instead
- * of two disconnected page groups.
+ * user lands they see the entire product as one coherent thing instead of
+ * two disconnected page groups. Day-to-day inventory comes first, followed
+ * by topology, then the collapsed rule and definition sections.
  */
 const NetworkSideMenu: FunctionComponent = (): ReactElement => {
   const sections: SideMenuSectionProps[] = [
@@ -48,28 +48,6 @@ const NetworkSideMenu: FunctionComponent = (): ReactElement => {
           icon: IconProp.BuildingOffice,
         },
         {
-          /*
-           * Deliberately not the bare map route: the map keeps its drill
-           * position in the query string, and a link to the pathname the
-           * user is already on is swallowed by Navigation.navigate. See
-           * getNetworkMapRootRoute.
-           */
-          link: {
-            title: "Network Map",
-            to: getNetworkMapRootRoute(),
-          },
-          icon: IconProp.Map,
-        },
-        {
-          link: {
-            title: "Topology",
-            to: RouteUtil.populateRouteParams(
-              RouteMap[PageMap.NETWORK_DEVICE_TOPOLOGY] as Route,
-            ),
-          },
-          icon: IconProp.Graph,
-        },
-        {
           link: {
             title: "Endpoints",
             to: RouteUtil.populateRouteParams(
@@ -78,11 +56,53 @@ const NetworkSideMenu: FunctionComponent = (): ReactElement => {
           },
           icon: IconProp.Squares,
         },
+        {
+          link: {
+            title: "Discovery Scans",
+            to: RouteUtil.populateRouteParams(
+              RouteMap[PageMap.NETWORK_DEVICE_DISCOVERY] as Route,
+            ),
+          },
+          icon: IconProp.Search,
+        },
+        {
+          link: {
+            title: "Archived Devices",
+            to: RouteUtil.populateRouteParams(
+              RouteMap[PageMap.NETWORK_DEVICE_ARCHIVED] as Route,
+            ),
+          },
+          icon: IconProp.Archive,
+        },
       ],
     },
     {
-      title: "Analysis",
+      title: "Topology",
       items: [
+        {
+          /*
+           * `to` resets the map's query-backed drill state. `activeRoute`
+           * deliberately omits that query so the item still highlights on
+           * the map page and names itself in the mobile menu summary.
+           */
+          link: {
+            title: "Network Map",
+            to: getNetworkMapRootRoute(),
+          },
+          activeRoute: RouteUtil.populateRouteParams(
+            RouteMap[PageMap.NETWORK_SITE_MAP] as Route,
+          ),
+          icon: IconProp.Map,
+        },
+        {
+          link: {
+            title: "Device Topology",
+            to: RouteUtil.populateRouteParams(
+              RouteMap[PageMap.NETWORK_DEVICE_TOPOLOGY] as Route,
+            ),
+          },
+          icon: IconProp.Graph,
+        },
         {
           link: {
             title: "Latency Matrix",
@@ -113,27 +133,7 @@ const NetworkSideMenu: FunctionComponent = (): ReactElement => {
       ],
     },
     {
-      /*
-       * Site CSV import is not a menu entry: it is a bulk action on the
-       * Sites table (the ⋯ menu on Network > Sites), where every other bulk
-       * import in the product lives, so it sits next to the rows it creates
-       * instead of in a section of its own.
-       */
-      title: "Discovery",
-      items: [
-        {
-          link: {
-            title: "Discovery Scans",
-            to: RouteUtil.populateRouteParams(
-              RouteMap[PageMap.NETWORK_DEVICE_DISCOVERY] as Route,
-            ),
-          },
-          icon: IconProp.Search,
-        },
-      ],
-    },
-    {
-      title: "Automation",
+      title: "Rules",
       defaultCollapsed: true,
       items: [
         {
@@ -186,21 +186,6 @@ const NetworkSideMenu: FunctionComponent = (): ReactElement => {
             ),
           },
           icon: IconProp.Link,
-        },
-      ],
-    },
-    {
-      title: "Archive",
-      defaultCollapsed: true,
-      items: [
-        {
-          link: {
-            title: "Archived Devices",
-            to: RouteUtil.populateRouteParams(
-              RouteMap[PageMap.NETWORK_DEVICE_ARCHIVED] as Route,
-            ),
-          },
-          icon: IconProp.Archive,
         },
       ],
     },

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Utils/Breadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Utils/Breadcrumbs.ts
@@ -78,7 +78,7 @@ export function getNetworkDeviceBreadcrumbs(
     ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_DEVICE_DISCOVERY, [
       "Project",
       "Network",
-      "Discovery",
+      "Discovery Scans",
     ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_DEVICE_ENDPOINTS, [
       "Project",
@@ -89,31 +89,43 @@ export function getNetworkDeviceBreadcrumbs(
       "Project",
       "Network",
       "Topology",
+      "Device Topology",
     ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_DEVICE_LATENCY_MATRIX, [
       "Project",
       "Network",
+      "Topology",
       "Latency Matrix",
+    ]),
+    ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_DEVICE_LINKS, [
+      "Project",
+      "Network",
+      "Topology",
+      "Device Links",
     ]),
     ...BuildBreadcrumbLinksByTitles(
       PageMap.NETWORK_DEVICE_SETTINGS_OWNER_RULES,
-      ["Project", "Network", "Owner Rules"],
+      ["Project", "Network", "Rules", "Owner Rules"],
     ),
     ...BuildBreadcrumbLinksByTitles(
       PageMap.NETWORK_DEVICE_SETTINGS_LABEL_RULES,
-      ["Project", "Network", "Label Rules"],
+      ["Project", "Network", "Rules", "Label Rules"],
+    ),
+    ...BuildBreadcrumbLinksByTitles(
+      PageMap.NETWORK_DEVICE_SETTINGS_LINK_RULES,
+      ["Project", "Network", "Rules", "Link Rules"],
     ),
     ...BuildBreadcrumbLinksByTitles(
       PageMap.NETWORK_DEVICE_SETTINGS_AUTO_IMPORT_RULES,
-      ["Project", "Network", "Auto Import Rules"],
+      ["Project", "Network", "Rules", "Auto Import Rules"],
     ),
     ...BuildBreadcrumbLinksByTitles(
       PageMap.NETWORK_DEVICE_SETTINGS_OID_TEMPLATES,
-      ["Project", "Network", "OID Collection Templates"],
+      ["Project", "Network", "Settings", "OID Collection Templates"],
     ),
     ...BuildBreadcrumbLinksByTitles(
       PageMap.NETWORK_DEVICE_SETTINGS_DEVICE_ROLES,
-      ["Project", "Network", "Device Roles"],
+      ["Project", "Network", "Settings", "Device Roles"],
     ),
   };
   return breadcrumpLinksMap[path];

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Utils/Breadcrumbs.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Utils/Breadcrumbs.ts
@@ -60,17 +60,26 @@ export function getNetworkSiteBreadcrumbs(
     ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_SITE_MAP, [
       "Project",
       "Network",
+      "Topology",
       "Network Map",
     ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_SITE_ASSIGNMENT_RULES, [
       "Project",
       "Network",
+      "Rules",
       "Site Assignment Rules",
     ]),
     ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_SITE_LINKS, [
       "Project",
       "Network",
+      "Topology",
       "Site Links",
+    ]),
+    ...BuildBreadcrumbLinksByTitles(PageMap.NETWORK_SITE_SETTINGS_SITE_TYPES, [
+      "Project",
+      "Network",
+      "Settings",
+      "Site Types",
     ]),
   };
   return breadcrumpLinksMap[path];

--- a/Common/Tests/App/Dashboard/NetworkSideMenu.test.tsx
+++ b/Common/Tests/App/Dashboard/NetworkSideMenu.test.tsx
@@ -1,0 +1,590 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, cleanup, fireEvent, RenderResult } from "@testing-library/react";
+import * as React from "react";
+import { FunctionComponent } from "react";
+import NetworkSideMenu from "../../../../App/FeatureSet/Dashboard/src/Components/Network/NetworkSideMenu";
+import NetworkDeviceSideMenu from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkDevice/SideMenu";
+import { getNetworkDeviceBreadcrumbs } from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Utils/Breadcrumbs";
+import NetworkSiteSideMenu from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkSite/SideMenu";
+import { getNetworkSiteBreadcrumbs } from "../../../../App/FeatureSet/Dashboard/src/Pages/NetworkSite/Utils/Breadcrumbs";
+import PageMap from "../../../../App/FeatureSet/Dashboard/src/Utils/PageMap";
+import { RouteUtil } from "../../../../App/FeatureSet/Dashboard/src/Utils/RouteMap";
+import Link from "../../../Types/Link";
+import {
+  allLinks,
+  DESKTOP_WIDTH,
+  hrefsInMenu,
+  iconCountIn,
+  isExpanded,
+  linksIn,
+  MenuLink,
+  MOBILE_WIDTH,
+  mobileSummaryText,
+  PROJECT_ID,
+  goTo,
+  renderMenu,
+  routeFor,
+  sectionBody,
+  sectionTitlesInOrder,
+  sectionToggle,
+  setViewportWidth,
+  titlesInMenu,
+} from "./SideMenuHarness";
+
+/*
+ * Network Devices and Network Sites are two route families, but one product.
+ * The shared menu is the map of that product, so an organisational change has
+ * three independent failure modes worth pinning together:
+ *
+ *  - a page can move to the wrong section, disappear, or be duplicated;
+ *  - the two route-family wrappers can quietly stop rendering the same menu;
+ *  - breadcrumbs and the responsive summary can retain the old section name.
+ *
+ * These tests render the real menu against the real RouteMap. The complete
+ * expected taxonomy is written here rather than inferred from the component,
+ * so changing the production array alone cannot make the regression pass.
+ */
+
+type BreadcrumbGetter = (path: string) => Array<Link> | undefined;
+
+interface ExpectedMenuEntry {
+  title: string;
+  pageMapKey: string;
+  getBreadcrumbs: BreadcrumbGetter;
+  breadcrumbTitles: Array<string>;
+  resetsMapDrill?: boolean;
+}
+
+interface ExpectedMenuSection {
+  title: string;
+  defaultCollapsed: boolean;
+  entries: Array<ExpectedMenuEntry>;
+}
+
+interface SideMenuWrapper {
+  name: string;
+  Component: FunctionComponent;
+}
+
+const EXPECTED_SECTIONS: Array<ExpectedMenuSection> = [
+  {
+    title: "Network",
+    defaultCollapsed: false,
+    entries: [
+      {
+        title: "Overview",
+        pageMapKey: PageMap.NETWORK_OVERVIEW,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Overview"],
+      },
+      {
+        title: "Devices",
+        pageMapKey: PageMap.NETWORK_DEVICES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Devices"],
+      },
+      {
+        title: "Sites",
+        pageMapKey: PageMap.NETWORK_SITES,
+        getBreadcrumbs: getNetworkSiteBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Sites"],
+      },
+      {
+        title: "Endpoints",
+        pageMapKey: PageMap.NETWORK_DEVICE_ENDPOINTS,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Endpoints"],
+      },
+      {
+        title: "Discovery Scans",
+        pageMapKey: PageMap.NETWORK_DEVICE_DISCOVERY,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Discovery Scans"],
+      },
+      {
+        title: "Archived Devices",
+        pageMapKey: PageMap.NETWORK_DEVICE_ARCHIVED,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Archived Devices"],
+      },
+    ],
+  },
+  {
+    title: "Topology",
+    defaultCollapsed: false,
+    entries: [
+      {
+        title: "Network Map",
+        pageMapKey: PageMap.NETWORK_SITE_MAP,
+        getBreadcrumbs: getNetworkSiteBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Topology", "Network Map"],
+        resetsMapDrill: true,
+      },
+      {
+        title: "Device Topology",
+        pageMapKey: PageMap.NETWORK_DEVICE_TOPOLOGY,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Topology", "Device Topology"],
+      },
+      {
+        title: "Latency Matrix",
+        pageMapKey: PageMap.NETWORK_DEVICE_LATENCY_MATRIX,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Topology", "Latency Matrix"],
+      },
+      {
+        title: "Site Links",
+        pageMapKey: PageMap.NETWORK_SITE_LINKS,
+        getBreadcrumbs: getNetworkSiteBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Topology", "Site Links"],
+      },
+      {
+        title: "Device Links",
+        pageMapKey: PageMap.NETWORK_DEVICE_LINKS,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Topology", "Device Links"],
+      },
+    ],
+  },
+  {
+    title: "Rules",
+    defaultCollapsed: true,
+    entries: [
+      {
+        title: "Auto Import Rules",
+        pageMapKey: PageMap.NETWORK_DEVICE_SETTINGS_AUTO_IMPORT_RULES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Rules", "Auto Import Rules"],
+      },
+      {
+        title: "Site Assignment Rules",
+        pageMapKey: PageMap.NETWORK_SITE_ASSIGNMENT_RULES,
+        getBreadcrumbs: getNetworkSiteBreadcrumbs,
+        breadcrumbTitles: [
+          "Project",
+          "Network",
+          "Rules",
+          "Site Assignment Rules",
+        ],
+      },
+      {
+        title: "Owner Rules",
+        pageMapKey: PageMap.NETWORK_DEVICE_SETTINGS_OWNER_RULES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Rules", "Owner Rules"],
+      },
+      {
+        title: "Label Rules",
+        pageMapKey: PageMap.NETWORK_DEVICE_SETTINGS_LABEL_RULES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Rules", "Label Rules"],
+      },
+      {
+        title: "Link Rules",
+        pageMapKey: PageMap.NETWORK_DEVICE_SETTINGS_LINK_RULES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Rules", "Link Rules"],
+      },
+    ],
+  },
+  {
+    title: "Settings",
+    defaultCollapsed: true,
+    entries: [
+      {
+        title: "Device Roles",
+        pageMapKey: PageMap.NETWORK_DEVICE_SETTINGS_DEVICE_ROLES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Settings", "Device Roles"],
+      },
+      {
+        title: "OID Collection Templates",
+        pageMapKey: PageMap.NETWORK_DEVICE_SETTINGS_OID_TEMPLATES,
+        getBreadcrumbs: getNetworkDeviceBreadcrumbs,
+        breadcrumbTitles: [
+          "Project",
+          "Network",
+          "Settings",
+          "OID Collection Templates",
+        ],
+      },
+      {
+        title: "Site Types",
+        pageMapKey: PageMap.NETWORK_SITE_SETTINGS_SITE_TYPES,
+        getBreadcrumbs: getNetworkSiteBreadcrumbs,
+        breadcrumbTitles: ["Project", "Network", "Settings", "Site Types"],
+      },
+    ],
+  },
+];
+
+const EXPECTED_ENTRIES: Array<ExpectedMenuEntry> = EXPECTED_SECTIONS.flatMap(
+  (section: ExpectedMenuSection): Array<ExpectedMenuEntry> => {
+    return section.entries;
+  },
+);
+
+function expectedHref(entry: ExpectedMenuEntry): string {
+  const href: string = routeFor(entry.pageMapKey);
+  return entry.resetsMapDrill ? `${href}?site=` : href;
+}
+
+function expectedLinks(section: ExpectedMenuSection): Array<MenuLink> {
+  return section.entries.map((entry: ExpectedMenuEntry): MenuLink => {
+    return {
+      title: entry.title,
+      href: expectedHref(entry),
+    };
+  });
+}
+
+function findAnchor(title: string): HTMLAnchorElement {
+  const anchor: HTMLAnchorElement | undefined = Array.from(
+    document.querySelectorAll("a"),
+  ).find((candidate: Element): boolean => {
+    return (
+      candidate.querySelector("span.truncate")?.textContent?.trim() === title
+    );
+  }) as HTMLAnchorElement | undefined;
+
+  if (!anchor) {
+    throw new Error(`No side-menu link titled "${title}" was rendered.`);
+  }
+
+  return anchor;
+}
+
+function expectActiveLink(title: string): void {
+  const anchor: HTMLAnchorElement = findAnchor(title);
+
+  expect(anchor).toHaveClass("text-indigo-700");
+  expect(anchor).not.toHaveClass("text-gray-600");
+  expect(anchor.querySelector(".h-5.bg-indigo-600")).not.toBeNull();
+}
+
+function expectCompleteMenu(): void {
+  expect(sectionTitlesInOrder()).toEqual(
+    EXPECTED_SECTIONS.map((section: ExpectedMenuSection): string => {
+      return section.title;
+    }),
+  );
+
+  EXPECTED_SECTIONS.forEach((section: ExpectedMenuSection): void => {
+    expect(linksIn(section.title)).toEqual(expectedLinks(section));
+  });
+}
+
+function renderNetworkMenu(): Promise<RenderResult> {
+  return renderMenu(<NetworkSideMenu />);
+}
+
+describe("Network side menu", () => {
+  beforeEach(() => {
+    setViewportWidth(DESKTOP_WIDTH);
+    goTo(`/dashboard/${PROJECT_ID}/network-devices/overview`);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("taxonomy", () => {
+    test("renders Network, Topology, Rules and Settings in order", async () => {
+      await renderNetworkMenu();
+
+      expect(sectionTitlesInOrder()).toEqual([
+        "Network",
+        "Topology",
+        "Rules",
+        "Settings",
+      ]);
+    });
+
+    test("puts every page in its intended section and order", async () => {
+      await renderNetworkMenu();
+
+      expectCompleteMenu();
+    });
+
+    test("keeps day-to-day navigation open and configuration collapsed", async () => {
+      await renderNetworkMenu();
+
+      EXPECTED_SECTIONS.forEach((section: ExpectedMenuSection): void => {
+        expect(isExpanded(section.title)).toBe(!section.defaultCollapsed);
+      });
+    });
+  });
+
+  describe("collapsed sections", () => {
+    test("Rules expands and collapses without unmounting its links", async () => {
+      await renderNetworkMenu();
+
+      expect(isExpanded("Rules")).toBe(false);
+      expect(sectionBody("Rules")).toHaveClass("max-h-0", "opacity-0");
+      expect(linksIn("Rules")).toHaveLength(5);
+
+      fireEvent.click(sectionToggle("Rules"));
+
+      expect(isExpanded("Rules")).toBe(true);
+      expect(sectionBody("Rules")).not.toHaveClass("max-h-0", "opacity-0");
+      expect(sectionBody("Rules")).toHaveClass("opacity-100");
+
+      fireEvent.click(sectionToggle("Rules"));
+
+      expect(isExpanded("Rules")).toBe(false);
+      expect(sectionBody("Rules")).toHaveClass("max-h-0", "opacity-0");
+      expect(linksIn("Rules")).toEqual(expectedLinks(EXPECTED_SECTIONS[2]!));
+    });
+
+    test("Settings expands and collapses without unmounting its links", async () => {
+      await renderNetworkMenu();
+
+      expect(isExpanded("Settings")).toBe(false);
+      expect(linksIn("Settings")).toHaveLength(3);
+
+      fireEvent.click(sectionToggle("Settings"));
+      expect(isExpanded("Settings")).toBe(true);
+
+      fireEvent.click(sectionToggle("Settings"));
+      expect(isExpanded("Settings")).toBe(false);
+      expect(linksIn("Settings")).toEqual(expectedLinks(EXPECTED_SECTIONS[3]!));
+    });
+  });
+
+  describe("coverage", () => {
+    test("keeps all nineteen destinations reachable exactly once", async () => {
+      await renderNetworkMenu();
+
+      expect(EXPECTED_ENTRIES).toHaveLength(19);
+      expect(allLinks()).toHaveLength(19);
+      expect(hrefsInMenu().sort()).toEqual(
+        EXPECTED_ENTRIES.map(expectedHref).sort(),
+      );
+    });
+
+    test("does not duplicate a route, page key or title", async () => {
+      await renderNetworkMenu();
+
+      const hrefs: Array<string> = hrefsInMenu();
+      const titles: Array<string> = titlesInMenu();
+      const pageMapKeys: Array<string> = EXPECTED_ENTRIES.map(
+        (entry: ExpectedMenuEntry): string => {
+          return entry.pageMapKey;
+        },
+      );
+
+      expect(hrefs).toEqual(Array.from(new Set(hrefs)));
+      expect(titles).toEqual(Array.from(new Set(titles)));
+      expect(pageMapKeys).toEqual(Array.from(new Set(pageMapKeys)));
+    });
+
+    test("fully populates every project route", async () => {
+      await renderNetworkMenu();
+
+      allLinks().forEach((link: MenuLink): void => {
+        expect(link.href.startsWith(`/dashboard/${PROJECT_ID}/`)).toBe(true);
+        expect(link.href).not.toContain(":projectId");
+        expect(link.href).not.toContain(":modelId");
+        expect(link.title).not.toBe("");
+      });
+    });
+
+    test("gives every destination an icon", async () => {
+      await renderNetworkMenu();
+
+      EXPECTED_SECTIONS.forEach((section: ExpectedMenuSection): void => {
+        expect(iconCountIn(section.title)).toBe(section.entries.length);
+      });
+    });
+  });
+
+  describe("shared route-family wrappers", () => {
+    const WRAPPERS: Array<SideMenuWrapper> = [
+      { name: "Network Devices", Component: NetworkDeviceSideMenu },
+      { name: "Network Sites", Component: NetworkSiteSideMenu },
+    ];
+
+    test.each(WRAPPERS)(
+      "$name renders the complete shared product menu",
+      async ({ Component }: SideMenuWrapper): Promise<void> => {
+        await renderMenu(<Component />);
+
+        expectCompleteMenu();
+      },
+    );
+  });
+
+  describe("active routes", () => {
+    test("an active Rules deep link expands Rules and highlights its item", async () => {
+      goTo(routeFor(PageMap.NETWORK_DEVICE_SETTINGS_LINK_RULES));
+
+      await renderNetworkMenu();
+
+      expect(isExpanded("Rules")).toBe(true);
+      expect(sectionBody("Rules")).toHaveClass("opacity-100");
+      expect(isExpanded("Settings")).toBe(false);
+      expectActiveLink("Link Rules");
+    });
+
+    test("an active Settings deep link expands Settings and highlights its item", async () => {
+      goTo(routeFor(PageMap.NETWORK_SITE_SETTINGS_SITE_TYPES));
+
+      await renderNetworkMenu();
+
+      expect(isExpanded("Settings")).toBe(true);
+      expect(sectionBody("Settings")).toHaveClass("opacity-100");
+      expect(isExpanded("Rules")).toBe(false);
+      expectActiveLink("Site Types");
+    });
+
+    test("opens Rules when navigation moves to a Rules route", async () => {
+      const rendered: RenderResult = await renderNetworkMenu();
+
+      expect(isExpanded("Rules")).toBe(false);
+
+      goTo(routeFor(PageMap.NETWORK_DEVICE_SETTINGS_LINK_RULES));
+      await act(async () => {
+        rendered.rerender(<NetworkSideMenu />);
+      });
+
+      expect(isExpanded("Rules")).toBe(true);
+      expect(sectionBody("Rules")).toHaveClass("opacity-100");
+      expectActiveLink("Link Rules");
+    });
+
+    test("opens Settings after navigation moves from Rules to Settings", async () => {
+      goTo(routeFor(PageMap.NETWORK_DEVICE_SETTINGS_LINK_RULES));
+      const rendered: RenderResult = await renderNetworkMenu();
+
+      expect(isExpanded("Rules")).toBe(true);
+      expect(isExpanded("Settings")).toBe(false);
+
+      goTo(routeFor(PageMap.NETWORK_SITE_SETTINGS_SITE_TYPES));
+      await act(async () => {
+        rendered.rerender(<NetworkSideMenu />);
+      });
+
+      expect(isExpanded("Rules")).toBe(true);
+      expect(isExpanded("Settings")).toBe(true);
+      expect(sectionBody("Settings")).toHaveClass("opacity-100");
+      expectActiveLink("Site Types");
+    });
+  });
+
+  describe("Network Map", () => {
+    test("links to an explicit root reset instead of the bare map route", async () => {
+      await renderNetworkMenu();
+
+      const mapLink: MenuLink = linksIn("Topology")[0]!;
+      const bareMapRoute: string = routeFor(PageMap.NETWORK_SITE_MAP);
+
+      expect(mapLink).toEqual({
+        title: "Network Map",
+        href: `${bareMapRoute}?site=`,
+      });
+      expect(mapLink.href).not.toBe(bareMapRoute);
+    });
+
+    test("is active on the map page even though its navigation target carries the reset query", async () => {
+      goTo(routeFor(PageMap.NETWORK_SITE_MAP));
+
+      await renderNetworkMenu();
+
+      expect(isExpanded("Topology")).toBe(true);
+      expectActiveLink("Network Map");
+      expect(findAnchor("Network Map")).toHaveAttribute(
+        "href",
+        `${routeFor(PageMap.NETWORK_SITE_MAP)}?site=`,
+      );
+    });
+
+    test("names the active map page in the mobile summary", async () => {
+      setViewportWidth(MOBILE_WIDTH);
+      goTo(routeFor(PageMap.NETWORK_SITE_MAP));
+
+      await renderNetworkMenu();
+
+      expect(mobileSummaryText()).toContain("Topology / Network Map");
+    });
+  });
+
+  describe("mobile summaries", () => {
+    test.each([
+      [PageMap.NETWORK_DEVICE_ENDPOINTS, "Network / Endpoints"],
+      [PageMap.NETWORK_DEVICE_TOPOLOGY, "Topology / Device Topology"],
+      [PageMap.NETWORK_DEVICE_SETTINGS_OWNER_RULES, "Rules / Owner Rules"],
+      [PageMap.NETWORK_SITE_SETTINGS_SITE_TYPES, "Settings / Site Types"],
+    ])(
+      "%s reports its section and page",
+      async (pageMapKey: string, expectedSummary: string): Promise<void> => {
+        setViewportWidth(MOBILE_WIDTH);
+        goTo(routeFor(pageMapKey));
+
+        await renderNetworkMenu();
+
+        expect(mobileSummaryText()).toContain(expectedSummary);
+      },
+    );
+  });
+
+  describe("breadcrumbs", () => {
+    test("every rendered entry has a matching breadcrumb leaf and section", async () => {
+      await renderNetworkMenu();
+
+      const renderedLinks: Array<MenuLink> = allLinks();
+
+      for (const section of EXPECTED_SECTIONS) {
+        for (const entry of section.entries) {
+          const renderedLink: MenuLink | undefined = renderedLinks.find(
+            (link: MenuLink): boolean => {
+              return link.href === expectedHref(entry);
+            },
+          );
+
+          expect(renderedLink).toBeDefined();
+          expect(renderedLink?.title).toBe(entry.title);
+
+          goTo(routeFor(entry.pageMapKey));
+
+          const trail: Array<Link> | undefined = entry.getBreadcrumbs(
+            RouteUtil.getRouteString(entry.pageMapKey),
+          );
+          const trailTitles: Array<string> | undefined = trail?.map(
+            (link: Link): string => {
+              return link.title;
+            },
+          );
+
+          expect(trailTitles).toEqual(entry.breadcrumbTitles);
+          expect(trailTitles?.[trailTitles.length - 1]).toBe(
+            renderedLink?.title,
+          );
+
+          if (section.title === "Network") {
+            expect(trailTitles?.[1]).toBe(section.title);
+          } else {
+            expect(trailTitles?.[trailTitles.length - 2]).toBe(section.title);
+          }
+        }
+      }
+    });
+
+    test("every breadcrumb destination is a concrete dashboard route", () => {
+      for (const entry of EXPECTED_ENTRIES) {
+        goTo(routeFor(entry.pageMapKey));
+
+        const trail: Array<Link> | undefined = entry.getBreadcrumbs(
+          RouteUtil.getRouteString(entry.pageMapKey),
+        );
+
+        expect(trail).toBeDefined();
+        trail?.forEach((link: Link): void => {
+          expect(link.to.toString().startsWith("/dashboard/")).toBe(true);
+          expect(link.to.toString()).not.toContain(":projectId");
+          expect(link.to.toString()).not.toContain(":modelId");
+        });
+      }
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/SideMenuHarness.tsx
+++ b/Common/Tests/App/Dashboard/SideMenuHarness.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react";
+import { act, render, RenderResult } from "@testing-library/react";
 import { ReactElement } from "react";
 import { Location } from "react-router-dom";
 import Route from "../../../Types/API/Route";
@@ -180,8 +180,16 @@ export function mobileSummaryText(): string {
  * sets state when its (stubbed) count resolves, and an unawaited render
  * leaves that update outside the test.
  */
-export async function renderMenu(menu: ReactElement): Promise<void> {
+export async function renderMenu(menu: ReactElement): Promise<RenderResult> {
+  let rendered: RenderResult | undefined;
+
   await act(async () => {
-    render(menu);
+    rendered = render(menu);
   });
+
+  if (!rendered) {
+    throw new Error("The side menu did not render.");
+  }
+
+  return rendered;
 }

--- a/Common/Tests/Server/Services/NetworkDeviceRuleEngines.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceRuleEngines.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it, afterEach } from "@jest/globals";
  * the write-time validation in front of them.
  *
  * The pattern criteria are documented as case-insensitive regexes, but the
- * assignment rules right next to them in Network > Automation take '*'
+ * assignment rules right next to them in Network > Rules take '*'
  * wildcard globs. A rule written with the glob syntax - `*0664*` - used to
  * throw inside `new RegExp`, get swallowed, and silently label nothing
  * (OneUptime/oneuptime#2940). Both engines now accept either syntax, and a

--- a/Common/Tests/UI/Components/SideMenuItem.test.tsx
+++ b/Common/Tests/UI/Components/SideMenuItem.test.tsx
@@ -135,6 +135,36 @@ describe("Side Menu Item", () => {
     expect(mainLink).toHaveClass(highlightClassList);
   });
 
+  it("Should use activeRoute for highlighting without changing the link target", () => {
+    const linkTarget: Route = new Route("/network/map?site=");
+    const activeRoute: Route = new Route("/network/map");
+
+    Navigation.default.isOnThisPage = getJestMockFunction().mockImplementation(
+      (route: Route): boolean => {
+        return route === activeRoute;
+      },
+    );
+
+    render(
+      <SideMenuItem
+        link={{ title: "Network Map", to: linkTarget }}
+        activeRoute={activeRoute}
+      />,
+    );
+
+    const mainLink: HTMLAnchorElement = screen
+      .getByText("Network Map")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(Navigation.default.isOnThisPage).toHaveBeenCalledWith(activeRoute);
+    expect(mainLink).toHaveClass(highlightClassList);
+    expect(mainLink).toHaveAttribute("href", linkTarget.toString());
+
+    fireEvent.click(mainLink);
+
+    expect(Navigation.default.navigate).toHaveBeenCalledWith(linkTarget);
+  });
+
   it("Should highlights sub item link when on the same page", () => {
     const subLink: {
       title: string;

--- a/Common/UI/Components/SideMenu/CountModelSideMenuItem.tsx
+++ b/Common/UI/Components/SideMenu/CountModelSideMenuItem.tsx
@@ -21,6 +21,7 @@ export const REFRESH_SIDEBAR_COUNT_EVENT: string = "REFRESH_SIDEBAR_COUNTS";
 
 export interface ComponentProps<TBaseModel extends BaseModel> {
   link: Link;
+  activeRoute?: Link["to"] | undefined;
   modelType?: { new (): TBaseModel } | undefined;
   badgeType?: BadgeType | undefined;
   countQuery?: Query<TBaseModel> | undefined;
@@ -136,6 +137,7 @@ const CountModelSideMenuItem: <TBaseModel extends BaseModel>(
   return (
     <SideMenuItem
       link={props.link}
+      activeRoute={props.activeRoute}
       badge={!isLoading && !error ? count : undefined}
       badgeType={props.badgeType}
       icon={props.icon}

--- a/Common/UI/Components/SideMenu/SideMenu.tsx
+++ b/Common/UI/Components/SideMenu/SideMenu.tsx
@@ -20,6 +20,8 @@ import { RequestOptions } from "../../Utils/ModelAPI/ModelAPI";
 
 export interface SideMenuItemProps {
   link: Link;
+  // Use a different route for selection when the link target also changes query state.
+  activeRoute?: Link["to"] | undefined;
   showAlert?: boolean;
   showWarning?: boolean;
   badge?: number;
@@ -106,7 +108,7 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
     if (props.sections) {
       for (const section of props.sections) {
         for (const item of section.items) {
-          if (Navigation.isOnThisPage(item.link.to)) {
+          if (Navigation.isOnThisPage(item.activeRoute || item.link.to)) {
             const result: {
               sectionTitle: string;
               itemTitle: string;
@@ -127,7 +129,7 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
     // Check direct items
     if (props.items) {
       for (const item of props.items) {
-        if (Navigation.isOnThisPage(item.link.to)) {
+        if (Navigation.isOnThisPage(item.activeRoute || item.link.to)) {
           const result: {
             itemTitle: string;
             icon?: IconProp;
@@ -184,9 +186,13 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
             icon?: IconProp;
             defaultCollapsed?: boolean;
             collapsible?: boolean;
+            isActive: boolean;
           } = {
             key: `section-${sectionIndex}`,
             title: section.title,
+            isActive: section.items.some((item: SideMenuItemProps): boolean => {
+              return Navigation.isOnThisPage(item.activeRoute || item.link.to);
+            }),
           };
 
           if (section.icon) {
@@ -209,6 +215,7 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
                       <CountModelSideMenuItem
                         key={`section-${sectionIndex}-count-item-${itemIndex}`}
                         link={item.link}
+                        activeRoute={item.activeRoute}
                         badgeType={item.badgeType}
                         modelType={item.modelType as any}
                         countQuery={item.countQuery as any}
@@ -225,6 +232,7 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
                     <SideMenuItem
                       key={`section-${sectionIndex}-item-${itemIndex}`}
                       link={item.link}
+                      activeRoute={item.activeRoute}
                       showAlert={item.showAlert}
                       showWarning={item.showWarning}
                       badge={item.badge}
@@ -252,6 +260,7 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
             <CountModelSideMenuItem
               key={`count-item-${itemIndex}`}
               link={item.link}
+              activeRoute={item.activeRoute}
               badgeType={item.badgeType}
               modelType={item.modelType as any}
               countQuery={item.countQuery as any}
@@ -267,6 +276,7 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
             <SideMenuItem
               key={`item-${itemIndex}`}
               link={item.link}
+              activeRoute={item.activeRoute}
               showAlert={item.showAlert}
               showWarning={item.showWarning}
               badge={item.badge}

--- a/Common/UI/Components/SideMenu/SideMenuItem.tsx
+++ b/Common/UI/Components/SideMenu/SideMenuItem.tsx
@@ -9,6 +9,7 @@ import React, { FunctionComponent } from "react";
 
 export interface ComponentProps {
   link: Link;
+  activeRoute?: Link["to"] | undefined;
   showAlert?: undefined | boolean;
   showWarning?: undefined | boolean;
   badge?: undefined | number;
@@ -23,7 +24,9 @@ const SideMenuItem: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ) => {
   const { translateString } = useTranslateValue();
-  const isActive: boolean = Navigation.isOnThisPage(props.link.to);
+  const isActive: boolean = Navigation.isOnThisPage(
+    props.activeRoute || props.link.to,
+  );
   const isSubItemActive: boolean = props.subItemLink
     ? Navigation.isOnThisPage(props.subItemLink.to)
     : false;

--- a/Common/UI/Components/SideMenu/SideMenuSection.tsx
+++ b/Common/UI/Components/SideMenu/SideMenuSection.tsx
@@ -1,7 +1,12 @@
 import Icon from "../Icon/Icon";
 import useTranslateValue from "../../Utils/Translation";
 import IconProp from "../../../Types/Icon/IconProp";
-import React, { FunctionComponent, ReactElement, useState } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useState,
+} from "react";
 
 export interface ComponentProps {
   title: string;
@@ -9,6 +14,7 @@ export interface ComponentProps {
   defaultCollapsed?: boolean;
   collapsible?: boolean;
   icon?: IconProp;
+  isActive?: boolean;
 }
 
 const SideMenuSection: FunctionComponent<ComponentProps> = (
@@ -16,11 +22,17 @@ const SideMenuSection: FunctionComponent<ComponentProps> = (
 ) => {
   const { translateString } = useTranslateValue();
   const [isCollapsed, setIsCollapsed] = useState<boolean>(
-    props.defaultCollapsed || false,
+    Boolean(props.defaultCollapsed && !props.isActive),
   );
   const translatedTitle: string = translateString(props.title) || props.title;
 
   const isCollapsible: boolean = props.collapsible ?? true;
+
+  useEffect(() => {
+    if (props.isActive) {
+      setIsCollapsed(false);
+    }
+  }, [props.isActive]);
 
   const handleToggle: () => void = (): void => {
     if (isCollapsible) {

--- a/Common/Utils/Rules/RulePatternMatchUtil.ts
+++ b/Common/Utils/Rules/RulePatternMatchUtil.ts
@@ -4,7 +4,7 @@
  *
  * These fields are documented as case-insensitive regular expressions, but
  * the sibling Network Site assignment rules take '*' wildcard globs and the
- * two features sit next to each other under Network > Automation. A user who
+ * two features sit next to each other under Network > Rules. A user who
  * typed `*0664*` into a label rule got silence: `new RegExp("*0664*")` throws
  * "Nothing to repeat", the rule engine swallowed the SyntaxError, and the
  * rule matched nothing forever (OneUptime/oneuptime#2940).


### PR DESCRIPTION
## Summary

- Reorganize Network Monitoring into four task-oriented sections: Network, Topology, Rules, and Settings.
- Preserve all 19 destinations, including the Device Roles page added on current master, with Rules and Settings collapsed by default.
- Keep the Network Map reset URL while highlighting it correctly, and automatically open a collapsed section when navigation moves to an active child.
- Align Network Device and Network Site breadcrumbs with the new menu taxonomy.

## Test coverage

- 24 Network menu tests covering the full taxonomy, every route exactly once, ordering, icons, collapse behavior, deep links, route transitions, mobile summaries, wrappers, map reset behavior, and breadcrumbs.
- 13 focused shared side-menu tests covering activeRoute navigation/highlighting and count-item re-render guards.
- 80 adjacent Alerts, Incidents, Scheduled Maintenance, and product breadcrumb regression tests.
- 121 Network Site and OID collection policy regression tests.

## Validation

- `npm run compile` in `Common`
- `NODE_OPTIONS=--max-old-space-size=16384 npm run compile` in `App/FeatureSet/Dashboard`
- ESLint with fixes on all changed files
- Full-root `npm run fix` completed on the original base. On current master, the final full-root pass reaches two unrelated baseline errors in untouched files: `App/Tests/Dashboard/DeviceRolesPageWiring.test.ts:329` (`wrap-regex`) and `Common/Types/NetworkDevice/DefaultNetworkDeviceRole.ts:2` (`no-duplicate-imports`).

## UI verification

- Verified through real component rendering at desktop and mobile widths. The local browser session was signed out, so no authenticated manual walkthrough was claimed.
