### PR TITLE
fix(threat-intel): send a descriptive User-Agent on outbound feed and data-source requests

### DIFF
--- a/App/FeatureSet/Docs/Content/en/telemetry/threat-intelligence.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/threat-intelligence.md
@@ -14,6 +14,8 @@ OneUptime enriches your [security events](/docs/telemetry/security-events) again
 | **Poll Interval (Minutes)** | How often new objects are fetched. Whole minutes, `1`–`1440`; default `60`. |
 | **Minimum Confidence** | Skip indicators whose STIX `confidence` is below this (0–100). `0` ingests everything. Indicators that carry no confidence always pass, so an unscored feed does not go silently empty when you set a minimum. |
 
+Polls identify themselves as `User-Agent: OneUptime/<version> (+https://oneuptime.com)`. Providers whose WAF blocks anonymous HTTP-library user agents (a common default rule, and one that answers `403` before the request reaches the TAXII API) should allowlist that string.
+
 The poller tracks each feed with an `added_after` cursor (the server's `X-TAXII-Date-Added-Last` header), fetching up to ten pages per poll — a large initial sync progresses across successive polls, one poll interval apart, and **Last Poll Summary** on the feed row says how far it got. To drain a big collection quickly, set a short poll interval (down to 1 minute) until the sync catches up.
 
 ## What gets ingested

--- a/Common/Server/Utils/DataSource/HttpFetch.ts
+++ b/Common/Server/Utils/DataSource/HttpFetch.ts
@@ -6,6 +6,7 @@ import {
   DATA_SOURCE_MAX_RESPONSE_SIZE_IN_BYTES,
   DATA_SOURCE_QUERY_TIMEOUT_IN_MS,
 } from "../../../Types/DataSource/DataSourceLimits";
+import OutboundUserAgent from "../OutboundUserAgent";
 import DataSourceEgressGuard, { EgressGuardOptions } from "./EgressGuard";
 import { DataSourceConnectionSettings } from "./Types";
 
@@ -20,7 +21,11 @@ import { DataSourceConnectionSettings } from "./Types";
  *    window while TLS still verifies against the original hostname;
  *  - refuses redirects (maxRedirects: 0) — a 3xx from the target could
  *    otherwise bounce the request to an unvalidated host;
- *  - caps response size and wall-clock time.
+ *  - caps response size and wall-clock time;
+ *  - identifies itself with OneUptime's User-Agent unless the caller set
+ *    one. Left to axios, every request would go out as `axios/<version>`,
+ *    which WAFs and bot-management products block by default — a target
+ *    that answers 403 to a bare library UA never gets to see the query.
  *
  * Uses axios directly (not Common/Utils/API.fetch) because the shared
  * wrapper does not expose maxContentLength, and the response-size cap is a
@@ -99,7 +104,9 @@ export default class DataSourceHttpFetch {
         request.egressOptions,
       );
 
-    const headers: Dictionary<string> = { ...(request.headers || {}) };
+    const headers: Dictionary<string> = OutboundUserAgent.withDefault(
+      request.headers,
+    );
 
     let data: string | URLSearchParams | undefined = undefined;
     if (request.method === "POST" && request.body !== undefined) {

--- a/Common/Server/Utils/OutboundUserAgent.ts
+++ b/Common/Server/Utils/OutboundUserAgent.ts
@@ -1,0 +1,152 @@
+import Dictionary from "../../Types/Dictionary";
+import { AppVersion } from "../EnvironmentConfig";
+
+/*
+ * The User-Agent this platform presents when it calls somebody else's HTTP
+ * server on a project's behalf — TAXII threat-intel feeds and the external
+ * Data Source connectors (Prometheus, Loki, Elasticsearch, REST API).
+ *
+ * This is not cosmetic. With no User-Agent of our own, axios stamps its
+ * default `axios/<version>` on every request, and a bare HTTP-library UA is
+ * a stock rule in most WAFs, CDNs and bot-management products: the operator
+ * on the far end sees an anonymous script rather than a named product, and
+ * answers 403 before the request reaches their API at all. A product token
+ * plus a URL is what makes the traffic allowlistable, and what lets the far
+ * end's logs and abuse contact attribute it to something.
+ *
+ * Shape follows RFC 9110 §10.1.5 — a product/product-version token
+ * followed by a comment:
+ *
+ *   OneUptime/8.0.1234 (+https://oneuptime.com)
+ *
+ * The version is dropped rather than printed as "unknown" when APP_VERSION
+ * is unset (development, and any deployment that does not inject it), so
+ * the UA never advertises a version that is not one.
+ */
+
+export const OUTBOUND_USER_AGENT_HEADER_NAME: string = "User-Agent";
+export const OUTBOUND_USER_AGENT_PRODUCT: string = "OneUptime";
+export const OUTBOUND_USER_AGENT_URL: string = "https://oneuptime.com";
+
+/*
+ * APP_VERSION is supplied by whoever deployed the instance, and a header
+ * value carrying CR/LF is a request-smuggling primitive, so the version is
+ * filtered down to RFC 9110 token characters instead of being trusted. The
+ * length cap keeps a junk value from becoming a multi-kilobyte header.
+ */
+const VERSION_DISALLOWED_CHARACTERS: RegExp = /[^A-Za-z0-9._+-]/g;
+const MAX_VERSION_LENGTH: number = 64;
+
+/*
+ * EnvironmentConfig's own placeholder when APP_VERSION is unset — a
+ * sentinel, not a version, so it never reaches the wire.
+ */
+const UNKNOWN_VERSION: string = "unknown";
+
+export default class OutboundUserAgent {
+  // The User-Agent for this running instance.
+  public static get(): string {
+    return this.build(AppVersion);
+  }
+
+  /*
+   * Pure builder — takes the version rather than reading it, so the format
+   * is testable without reaching into the process environment.
+   */
+  public static build(version?: string | undefined): string {
+    const sanitizedVersion: string = this.sanitizeVersion(version);
+
+    const product: string = sanitizedVersion
+      ? `${OUTBOUND_USER_AGENT_PRODUCT}/${sanitizedVersion}`
+      : OUTBOUND_USER_AGENT_PRODUCT;
+
+    return `${product} (+${OUTBOUND_USER_AGENT_URL})`;
+  }
+
+  /*
+   * A version safe to put in a header, or "" when there is nothing worth
+   * printing (unset, the "unknown" sentinel, or nothing left after
+   * filtering).
+   */
+  public static sanitizeVersion(version?: string | undefined): string {
+    const trimmed: string = (version || "").trim();
+
+    if (trimmed === "" || trimmed.toLowerCase() === UNKNOWN_VERSION) {
+      return "";
+    }
+
+    return trimmed
+      .replace(VERSION_DISALLOWED_CHARACTERS, "")
+      .substring(0, MAX_VERSION_LENGTH);
+  }
+
+  /*
+   * Whether the caller already set a User-Agent of its own. Header names
+   * are case-insensitive on the wire, so the check is too — otherwise a
+   * caller's lowercase `user-agent` would end up alongside ours rather
+   * than replacing it. A present-but-blank value counts as absent: an
+   * empty UA is the same anonymous-client problem this whole file exists
+   * to avoid.
+   */
+  public static hasUserAgent(
+    headers?: Dictionary<string> | undefined,
+  ): boolean {
+    if (!headers) {
+      return false;
+    }
+
+    for (const headerName of Object.keys(headers)) {
+      if (
+        headerName.toLowerCase() !==
+        OUTBOUND_USER_AGENT_HEADER_NAME.toLowerCase()
+      ) {
+        continue;
+      }
+
+      const value: string | undefined = headers[headerName];
+
+      if (typeof value === "string" && value.trim() !== "") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /*
+   * The headers to send: the caller's, plus our User-Agent when the caller
+   * did not set one. An explicit User-Agent always wins — a REST API data
+   * source whose provider demands a particular UA configures it as a custom
+   * header, and that must reach the wire untouched.
+   *
+   * Returns a new dictionary; the caller's is never mutated.
+   */
+  public static withDefault(
+    headers?: Dictionary<string> | undefined,
+  ): Dictionary<string> {
+    const merged: Dictionary<string> = { ...(headers || {}) };
+
+    if (this.hasUserAgent(merged)) {
+      return merged;
+    }
+
+    /*
+     * A blank `user-agent` in any casing is dropped rather than left
+     * beside ours: two keys differing only in case are one header on the
+     * wire, and which of them survives normalization is not something to
+     * leave to the HTTP client.
+     */
+    for (const headerName of Object.keys(merged)) {
+      if (
+        headerName.toLowerCase() ===
+        OUTBOUND_USER_AGENT_HEADER_NAME.toLowerCase()
+      ) {
+        delete merged[headerName];
+      }
+    }
+
+    merged[OUTBOUND_USER_AGENT_HEADER_NAME] = this.get();
+
+    return merged;
+  }
+}

--- a/Common/Tests/Server/Utils/DataSource/HttpFetch.test.ts
+++ b/Common/Tests/Server/Utils/DataSource/HttpFetch.test.ts
@@ -9,6 +9,7 @@ import DataSourceHttpFetch, {
   DataSourceHttpRequest,
   DataSourceHttpResponse,
 } from "../../../../Server/Utils/DataSource/HttpFetch";
+import OutboundUserAgent from "../../../../Server/Utils/OutboundUserAgent";
 import { DataSourceConnectionSettings } from "../../../../Server/Utils/DataSource/Types";
 import {
   DATA_SOURCE_MAX_RESPONSE_SIZE_IN_BYTES,
@@ -367,14 +368,17 @@ describe("DataSourceHttpFetch.fetch - egress guard runs before axios", () => {
 });
 
 describe("DataSourceHttpFetch.fetch - headers and body encoding", () => {
-  test("passes request headers through to axios untouched", async () => {
+  test("passes request headers through to axios untouched, plus our User-Agent", async () => {
     const headers: Dictionary<string> = {
       "X-Api-Key": "secret-key",
       Authorization: "Bearer token-123",
     };
     await DataSourceHttpFetch.fetch(makeRequest({ headers: headers }));
     const config: AxiosRequestConfig = getAxiosConfig();
-    expect(config.headers).toEqual(headers);
+    expect(config.headers).toEqual({
+      ...headers,
+      "User-Agent": OutboundUserAgent.get(),
+    });
   });
 
   test("GET requests never send a body, even when one is provided", async () => {
@@ -436,6 +440,96 @@ describe("DataSourceHttpFetch.fetch - headers and body encoding", () => {
     expect((config.headers as Dictionary<string>)["Content-Type"]).toBe(
       "application/json",
     );
+  });
+});
+
+/*
+ * Regression cover for issue #3555: a bare `axios/<version>` User-Agent got
+ * every outbound request 403'd by the target's WAF before it reached the
+ * API. The transport now names the product on every request unless the
+ * caller deliberately set its own UA.
+ */
+describe("DataSourceHttpFetch.fetch - outbound User-Agent", () => {
+  function getSentHeaders(callIndex: number = 0): Dictionary<string> {
+    return getAxiosConfig(callIndex).headers as Dictionary<string>;
+  }
+
+  test("sends a descriptive User-Agent when the caller set none", async () => {
+    await DataSourceHttpFetch.fetch(makeRequest());
+    expect(getSentHeaders()["User-Agent"]).toBe(OutboundUserAgent.get());
+  });
+
+  test("the User-Agent names OneUptime and is never axios' default", async () => {
+    await DataSourceHttpFetch.fetch(makeRequest());
+    const userAgent: string = getSentHeaders()["User-Agent"] as string;
+
+    expect(userAgent.startsWith("OneUptime")).toBe(true);
+    expect(userAgent).toContain("https://oneuptime.com");
+    expect(userAgent.toLowerCase()).not.toContain("axios");
+  });
+
+  test("axios is never left to pick the User-Agent itself — the header is always set", async () => {
+    await DataSourceHttpFetch.fetch(makeRequest({ headers: {} }));
+    await DataSourceHttpFetch.fetch(
+      makeRequest({ method: "POST", body: { q: "up" } }),
+    );
+
+    for (const callIndex of [0, 1]) {
+      const userAgent: string | undefined =
+        getSentHeaders(callIndex)["User-Agent"];
+      expect(typeof userAgent).toBe("string");
+      expect((userAgent as string).trim()).not.toBe("");
+    }
+  });
+
+  test("a caller's explicit User-Agent wins — a data source may demand its own", async () => {
+    await DataSourceHttpFetch.fetch(
+      makeRequest({
+        headers: { "User-Agent": "AcmeSOC/3.1 (soc@acme.example)" },
+      }),
+    );
+    expect(getSentHeaders()["User-Agent"]).toBe(
+      "AcmeSOC/3.1 (soc@acme.example)",
+    );
+  });
+
+  test("a caller's lowercase user-agent wins without a second casing being sent", async () => {
+    await DataSourceHttpFetch.fetch(
+      makeRequest({ headers: { "user-agent": "AcmeSOC/3.1" } }),
+    );
+    const headers: Dictionary<string> = getSentHeaders();
+
+    expect(headers["user-agent"]).toBe("AcmeSOC/3.1");
+    expect(headers["User-Agent"]).toBeUndefined();
+  });
+
+  test("a blank User-Agent is replaced rather than sent as-is", async () => {
+    await DataSourceHttpFetch.fetch(
+      makeRequest({ headers: { "User-Agent": "   " } }),
+    );
+    expect(getSentHeaders()["User-Agent"]).toBe(OutboundUserAgent.get());
+  });
+
+  test("it rides alongside auth headers rather than displacing them", async () => {
+    const headers: Dictionary<string> = DataSourceHttpFetch.buildAuthHeaders({
+      dataSourceType: DataSourceType.RestApi,
+      url: "https://api.example.com",
+      apiToken: "tok-abc",
+    });
+
+    await DataSourceHttpFetch.fetch(makeRequest({ headers: headers }));
+    const sent: Dictionary<string> = getSentHeaders();
+
+    expect(sent["Authorization"]).toBe("Bearer tok-abc");
+    expect(sent["User-Agent"]).toBe(OutboundUserAgent.get());
+  });
+
+  test("the caller's header dictionary is not mutated — pagination reuses it", async () => {
+    const headers: Dictionary<string> = { Accept: "application/json" };
+
+    await DataSourceHttpFetch.fetch(makeRequest({ headers: headers }));
+
+    expect(headers).toEqual({ Accept: "application/json" });
   });
 });
 

--- a/Common/Tests/Server/Utils/OutboundUserAgent.test.ts
+++ b/Common/Tests/Server/Utils/OutboundUserAgent.test.ts
@@ -1,0 +1,266 @@
+import OutboundUserAgent, {
+  OUTBOUND_USER_AGENT_HEADER_NAME,
+  OUTBOUND_USER_AGENT_PRODUCT,
+  OUTBOUND_USER_AGENT_URL,
+} from "../../../Server/Utils/OutboundUserAgent";
+import Dictionary from "../../../Types/Dictionary";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The outbound identity contract. Two things matter to the servers on the
+ * far end of a threat-intel feed or a data source: that the UA names this
+ * product (so it can be allowlisted rather than blocked as an anonymous
+ * HTTP library — issue #3555), and that whatever a deployment put in
+ * APP_VERSION can never turn a header into two headers.
+ */
+
+// OneUptime, an optional /version, then the URL comment. Nothing else.
+const USER_AGENT_FORMAT: RegExp =
+  /^OneUptime(?:\/[A-Za-z0-9._+-]+)? \(\+https:\/\/oneuptime\.com\)$/;
+
+describe("OutboundUserAgent.build — format", () => {
+  test("a known version renders as product/version plus the URL comment", () => {
+    expect(OutboundUserAgent.build("8.0.1234")).toBe(
+      "OneUptime/8.0.1234 (+https://oneuptime.com)",
+    );
+  });
+
+  test("every build output matches the RFC 9110 product + comment shape", () => {
+    const versions: Array<string | undefined> = [
+      "8.0.1234",
+      "1.0.0-rc.1+build.5",
+      undefined,
+      "",
+      "   ",
+      "unknown",
+      "!!!",
+    ];
+
+    for (const version of versions) {
+      expect(OutboundUserAgent.build(version)).toMatch(USER_AGENT_FORMAT);
+    }
+  });
+
+  test("semver prerelease and build metadata survive intact", () => {
+    expect(OutboundUserAgent.build("1.0.0-rc.1+build.5")).toBe(
+      "OneUptime/1.0.0-rc.1+build.5 (+https://oneuptime.com)",
+    );
+  });
+
+  test("surrounding whitespace on the version is trimmed, not embedded", () => {
+    expect(OutboundUserAgent.build("  7.1.2  ")).toBe(
+      "OneUptime/7.1.2 (+https://oneuptime.com)",
+    );
+  });
+
+  test("an unset version drops the version rather than printing one", () => {
+    const expected: string = "OneUptime (+https://oneuptime.com)";
+
+    expect(OutboundUserAgent.build(undefined)).toBe(expected);
+    expect(OutboundUserAgent.build("")).toBe(expected);
+    expect(OutboundUserAgent.build("   ")).toBe(expected);
+  });
+
+  test('the "unknown" APP_VERSION sentinel never reaches the wire, in any casing', () => {
+    const expected: string = "OneUptime (+https://oneuptime.com)";
+
+    expect(OutboundUserAgent.build("unknown")).toBe(expected);
+    expect(OutboundUserAgent.build("Unknown")).toBe(expected);
+    expect(OutboundUserAgent.build("UNKNOWN")).toBe(expected);
+    expect(OutboundUserAgent.build("  unknown  ")).toBe(expected);
+  });
+
+  test("a version made only of disallowed characters degrades to the bare product", () => {
+    expect(OutboundUserAgent.build('()<>@,;:\\"/[]?={} \t')).toBe(
+      "OneUptime (+https://oneuptime.com)",
+    );
+  });
+
+  test("the composed string uses the exported product and URL constants", () => {
+    const userAgent: string = OutboundUserAgent.build("2.0.0");
+
+    expect(userAgent.startsWith(`${OUTBOUND_USER_AGENT_PRODUCT}/`)).toBe(true);
+    expect(userAgent).toContain(`(+${OUTBOUND_USER_AGENT_URL})`);
+  });
+
+  test("it never identifies as a bare HTTP library", () => {
+    expect(OutboundUserAgent.build("8.0.1234").toLowerCase()).not.toContain(
+      "axios",
+    );
+  });
+});
+
+describe("OutboundUserAgent.sanitizeVersion — header safety", () => {
+  test("CR, LF and other header-injection characters are stripped", () => {
+    const injected: string = "1.0\r\nX-Injected: yes";
+
+    expect(OutboundUserAgent.sanitizeVersion(injected)).toBe(
+      "1.0X-Injectedyes",
+    );
+
+    const userAgent: string = OutboundUserAgent.build(injected);
+    expect(userAgent).not.toContain("\r");
+    expect(userAgent).not.toContain("\n");
+    expect(userAgent.split("\n")).toHaveLength(1);
+    expect(userAgent).toMatch(USER_AGENT_FORMAT);
+  });
+
+  test("a null byte and control characters cannot survive into the header", () => {
+    const userAgent: string = OutboundUserAgent.build("1.0\u0000\u0007\u007F");
+
+    expect(userAgent).toBe("OneUptime/1.0 (+https://oneuptime.com)");
+  });
+
+  test("spaces inside the version are removed so the token stays one token", () => {
+    expect(OutboundUserAgent.build("8.0 (evil comment)")).toBe(
+      "OneUptime/8.0evilcomment (+https://oneuptime.com)",
+    );
+  });
+
+  test("an absurdly long version is capped at 64 characters", () => {
+    const sanitized: string = OutboundUserAgent.sanitizeVersion(
+      "9".repeat(500),
+    );
+
+    expect(sanitized).toHaveLength(64);
+    expect(OutboundUserAgent.build("9".repeat(500))).toMatch(USER_AGENT_FORMAT);
+  });
+
+  test("the cap counts sanitized characters, not raw input", () => {
+    // 200 spaces between two digits: only the digits survive the filter.
+    expect(OutboundUserAgent.sanitizeVersion(`1${" ".repeat(200)}2`)).toBe(
+      "12",
+    );
+  });
+
+  test("every character it keeps is an RFC 9110 token character", () => {
+    const sanitized: string = OutboundUserAgent.sanitizeVersion(
+      "aZ0._+-/\\|`~!@#$%^&*(){}[]<>?,;:'\"= \t\r\n",
+    );
+
+    expect(sanitized).toBe("aZ0._+-");
+  });
+});
+
+describe("OutboundUserAgent.get — this instance's identity", () => {
+  test("matches the documented shape and names the product", () => {
+    const userAgent: string = OutboundUserAgent.get();
+
+    expect(userAgent).toMatch(USER_AGENT_FORMAT);
+    expect(userAgent.startsWith(OUTBOUND_USER_AGENT_PRODUCT)).toBe(true);
+  });
+
+  test("is never axios' default, which is the whole point", () => {
+    expect(OutboundUserAgent.get().toLowerCase()).not.toContain("axios");
+  });
+
+  test("is a single-line, non-empty header value", () => {
+    const userAgent: string = OutboundUserAgent.get();
+
+    expect(userAgent.trim()).not.toBe("");
+    expect(userAgent).not.toMatch(/[\r\n]/);
+  });
+});
+
+describe("OutboundUserAgent.hasUserAgent", () => {
+  test("no headers at all counts as absent", () => {
+    expect(OutboundUserAgent.hasUserAgent(undefined)).toBe(false);
+    expect(OutboundUserAgent.hasUserAgent({})).toBe(false);
+  });
+
+  test("finds the header whatever its casing", () => {
+    expect(OutboundUserAgent.hasUserAgent({ "User-Agent": "mine" })).toBe(true);
+    expect(OutboundUserAgent.hasUserAgent({ "user-agent": "mine" })).toBe(true);
+    expect(OutboundUserAgent.hasUserAgent({ "USER-AGENT": "mine" })).toBe(true);
+    expect(OutboundUserAgent.hasUserAgent({ "uSeR-aGeNt": "mine" })).toBe(true);
+  });
+
+  test("a blank value counts as absent — an empty UA is no UA", () => {
+    expect(OutboundUserAgent.hasUserAgent({ "User-Agent": "" })).toBe(false);
+    expect(OutboundUserAgent.hasUserAgent({ "user-agent": "   " })).toBe(false);
+  });
+
+  test("a header that merely contains the name does not count", () => {
+    expect(OutboundUserAgent.hasUserAgent({ "X-User-Agent": "mine" })).toBe(
+      false,
+    );
+    expect(OutboundUserAgent.hasUserAgent({ "User-Agent-Hint": "mine" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("OutboundUserAgent.withDefault", () => {
+  test("adds the User-Agent when the caller sent none", () => {
+    expect(OutboundUserAgent.withDefault(undefined)).toEqual({
+      [OUTBOUND_USER_AGENT_HEADER_NAME]: OutboundUserAgent.get(),
+    });
+    expect(OutboundUserAgent.withDefault({})).toEqual({
+      [OUTBOUND_USER_AGENT_HEADER_NAME]: OutboundUserAgent.get(),
+    });
+  });
+
+  test("keeps every other header the caller set", () => {
+    const headers: Dictionary<string> = OutboundUserAgent.withDefault({
+      Accept: "application/taxii+json;version=2.1",
+      Authorization: "Bearer secret-token",
+    });
+
+    expect(headers["Accept"]).toBe("application/taxii+json;version=2.1");
+    expect(headers["Authorization"]).toBe("Bearer secret-token");
+    expect(headers[OUTBOUND_USER_AGENT_HEADER_NAME]).toBe(
+      OutboundUserAgent.get(),
+    );
+  });
+
+  test("an explicit User-Agent wins and is not duplicated", () => {
+    const headers: Dictionary<string> = OutboundUserAgent.withDefault({
+      "User-Agent": "AcmeSOC/3.1 (soc@acme.example)",
+    });
+
+    expect(headers).toEqual({ "User-Agent": "AcmeSOC/3.1 (soc@acme.example)" });
+  });
+
+  test("an explicit lowercase user-agent wins without a second casing being added", () => {
+    const headers: Dictionary<string> = OutboundUserAgent.withDefault({
+      "user-agent": "AcmeSOC/3.1",
+    });
+
+    expect(headers).toEqual({ "user-agent": "AcmeSOC/3.1" });
+    expect(Object.keys(headers)).toHaveLength(1);
+  });
+
+  test("a blank User-Agent is replaced rather than left beside ours", () => {
+    const headers: Dictionary<string> = OutboundUserAgent.withDefault({
+      "user-agent": "  ",
+      Accept: "application/json",
+    });
+
+    const userAgentKeys: Array<string> = Object.keys(headers).filter(
+      (key: string): boolean => {
+        return key.toLowerCase() === "user-agent";
+      },
+    );
+
+    expect(userAgentKeys).toEqual(["User-Agent"]);
+    expect(headers["User-Agent"]).toBe(OutboundUserAgent.get());
+    expect(headers["Accept"]).toBe("application/json");
+  });
+
+  test("the caller's dictionary is never mutated", () => {
+    const original: Dictionary<string> = { Accept: "application/json" };
+
+    OutboundUserAgent.withDefault(original);
+
+    expect(original).toEqual({ Accept: "application/json" });
+  });
+
+  test("the value it adds is this instance's User-Agent, not a library default", () => {
+    const headers: Dictionary<string> = OutboundUserAgent.withDefault({});
+
+    expect(headers[OUTBOUND_USER_AGENT_HEADER_NAME]).toMatch(USER_AGENT_FORMAT);
+    expect(
+      (headers[OUTBOUND_USER_AGENT_HEADER_NAME] as string).toLowerCase(),
+    ).not.toContain("axios");
+  });
+});

--- a/Common/Tests/Server/Utils/SecurityEvent/ThreatIntel/TaxiiClientUserAgent.test.ts
+++ b/Common/Tests/Server/Utils/SecurityEvent/ThreatIntel/TaxiiClientUserAgent.test.ts
@@ -1,0 +1,141 @@
+import axios, { AxiosRequestConfig } from "axios";
+import OutboundUserAgent from "../../../../../Server/Utils/OutboundUserAgent";
+import TaxiiClient, {
+  TAXII_MEDIA_TYPE,
+} from "../../../../../Server/Utils/SecurityEvent/ThreatIntel/TaxiiClient";
+import Dictionary from "../../../../../Types/Dictionary";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Regression test for issue #3555: threat-intel feed polls went out with
+ * axios' default `axios/<version>` User-Agent, and feed providers' WAFs
+ * answered 403 ("Bare axios User-Agent detected") before the request ever
+ * reached the TAXII API.
+ *
+ * The other TaxiiClient tests inject a fake transport, which is exactly
+ * where a UA regression would hide — the header is added by the transport,
+ * not by the client. So this file drives the client through its REAL
+ * default transport (DataSourceHttpFetch) with axios mocked at the module
+ * boundary, and asserts against the config axios actually received: the
+ * closest thing to the wire without opening a socket.
+ *
+ * The API root is a literal public IP so the egress guard validates it
+ * without touching DNS — no network, no resolver, in any environment.
+ */
+jest.mock("axios", () => {
+  type IsAxiosErrorFunction = (candidate: unknown) => boolean;
+  const isAxiosError: IsAxiosErrorFunction = (candidate: unknown): boolean => {
+    return Boolean(
+      candidate &&
+        typeof candidate === "object" &&
+        (candidate as { isAxiosError?: boolean }).isAxiosError === true,
+    );
+  };
+  const axiosFunction: jest.Mock = Object.assign(jest.fn(), {
+    isAxiosError: isAxiosError,
+  });
+  return {
+    __esModule: true,
+    default: axiosFunction,
+  };
+});
+
+const axiosMock: jest.Mock = axios as unknown as jest.Mock;
+
+// A public, non-private literal address: no DNS lookup, never blocked.
+const API_ROOT: string = "https://93.184.216.34/api1/";
+const COLLECTION_ID: string = "91a7b528-80eb-42ed-a74d-c6fbd5a26116";
+
+function buildClient(options?: { apiToken?: string | undefined }): TaxiiClient {
+  return new TaxiiClient({
+    apiRootUrl: API_ROOT,
+    collectionId: COLLECTION_ID,
+    apiToken: options?.apiToken,
+  });
+}
+
+function getSentHeaders(callIndex: number = 0): Dictionary<string> {
+  expect(axiosMock.mock.calls.length).toBeGreaterThan(callIndex);
+  const config: AxiosRequestConfig = axiosMock.mock.calls[
+    callIndex
+  ]![0] as AxiosRequestConfig;
+  return config.headers as Dictionary<string>;
+}
+
+beforeEach(() => {
+  axiosMock.mockReset();
+  axiosMock.mockResolvedValue({
+    status: 200,
+    data: JSON.stringify({ objects: [], more: false }),
+    headers: {},
+  });
+});
+
+describe("TAXII feed polling — outbound User-Agent (issue #3555)", () => {
+  test("a poll identifies itself as OneUptime instead of a bare HTTP library", async () => {
+    await buildClient().fetchIndicatorObjects({ limit: 500 });
+
+    const userAgent: string = getSentHeaders()["User-Agent"] as string;
+
+    expect(userAgent).toBe(OutboundUserAgent.get());
+    expect(userAgent.startsWith("OneUptime")).toBe(true);
+    expect(userAgent).toContain("https://oneuptime.com");
+    expect(userAgent.toLowerCase()).not.toContain("axios");
+  });
+
+  test("the User-Agent header is present on the request axios is given, so axios never supplies its own", async () => {
+    await buildClient().fetchIndicatorObjects({ limit: 500 });
+
+    const headers: Dictionary<string> = getSentHeaders();
+    const userAgentKeys: Array<string> = Object.keys(headers).filter(
+      (key: string): boolean => {
+        return key.toLowerCase() === "user-agent";
+      },
+    );
+
+    expect(userAgentKeys).toEqual(["User-Agent"]);
+    expect((headers["User-Agent"] as string).trim()).not.toBe("");
+  });
+
+  test("it does not displace the TAXII media type or the feed's credentials", async () => {
+    await buildClient({ apiToken: "feed-token" }).fetchIndicatorObjects({
+      limit: 500,
+    });
+
+    const headers: Dictionary<string> = getSentHeaders();
+
+    expect(headers["Accept"]).toBe(TAXII_MEDIA_TYPE);
+    expect(headers["Authorization"]).toBe("Bearer feed-token");
+    expect(headers["User-Agent"]).toBe(OutboundUserAgent.get());
+  });
+
+  test("every page of a paginated sync carries it, not just the first", async () => {
+    const client: TaxiiClient = buildClient();
+
+    await client.fetchIndicatorObjects({ limit: 500 });
+    await client.fetchIndicatorObjects({
+      limit: 500,
+      addedAfter: "2026-08-01T00:00:00.000Z",
+      next: "page-2-token",
+    });
+
+    expect(axiosMock).toHaveBeenCalledTimes(2);
+    expect(getSentHeaders(0)["User-Agent"]).toBe(OutboundUserAgent.get());
+    expect(getSentHeaders(1)["User-Agent"]).toBe(OutboundUserAgent.get());
+  });
+
+  test("the header comes from the transport, not the client — buildHeaders stays protocol-only", () => {
+    const headers: Dictionary<string> = buildClient({
+      apiToken: "feed-token",
+    }).buildHeaders();
+
+    const userAgentKeys: Array<string> = Object.keys(headers).filter(
+      (key: string): boolean => {
+        return key.toLowerCase() === "user-agent";
+      },
+    );
+
+    expect(userAgentKeys).toEqual([]);
+    expect(headers["Accept"]).toBe(TAXII_MEDIA_TYPE);
+  });
+});


### PR DESCRIPTION
Fixes #3555.

## The bug is real

`Common/Server/Utils/DataSource/HttpFetch.ts` — the SSRF-hardened transport behind the TAXII threat-intel poller *and* every external Data Source connector (Prometheus, Loki, Elasticsearch, REST API) — built its axios config without a `User-Agent`. axios' Node adapter then fills one in (`headers.set('User-Agent', 'axios/' + VERSION, false)`), so every outbound request left the instance identifying as `axios/1.x.x`.

A bare HTTP-library UA is a stock block rule in most WAF, CDN and bot-management default rulesets, so the request is refused before it reaches the target's API. That is exactly what the reporter hit: their STIX/TAXII provider answered `403 — "Bare axios User-Agent detected"`, and the feed's **Last Error** showed the 403 body. Nothing about the fix depends on that particular provider; any feed behind Cloudflare/Akamai-style filtering fails the same way.

The reporter's other two suggestions need no code: API-key auth is already supported per feed (bearer token or HTTP basic), and registering with that specific vendor is a commercial matter for whoever runs the instance, not something OneUptime should encode.

## The fix

New `Common/Server/Utils/OutboundUserAgent.ts` builds the identity this platform presents to third-party servers, in RFC 9110 product-plus-comment shape:

```
OneUptime/8.0.1234 (+https://oneuptime.com)
```

- `APP_VERSION` is deployment-supplied, so it is filtered to token characters and length-capped before it goes anywhere near a header — a value carrying CR/LF is a header-injection primitive.
- The `"unknown"` `APP_VERSION` placeholder is dropped rather than printed, so the UA never advertises a version that is not one.

`DataSourceHttpFetch.fetch` now sends it on every request, unless the caller set a `User-Agent` of its own — a REST API data source whose provider demands a specific UA configures it as a custom header, and that still reaches the wire untouched. The check is case-insensitive, and a blank UA is treated as no UA rather than left beside ours (two keys differing only in case are one header on the wire).

The header is added by the transport, not the TAXII client, so it covers every data-source connector at the same time.

Deliberately out of scope: probe monitors, whose outbound headers are the monitor author's to choose (`ExternalStatusPageMonitor` already sends `OneUptime-Probe/1.0`).

## Tests

- `Common/Tests/Server/Utils/OutboundUserAgent.test.ts` (new, 29 tests) — UA format, the version-unset and `"unknown"` paths, CR/LF and control-character stripping, the length cap, case-insensitive detection, explicit-UA precedence, blank-UA replacement, and non-mutation of the caller's headers.
- `Common/Tests/Server/Utils/SecurityEvent/ThreatIntel/TaxiiClientUserAgent.test.ts` (new) — the regression test for this issue. The existing TaxiiClient tests inject a fake transport, which is exactly where a UA regression would hide, so this one drives the client through its **real** default transport with axios mocked at the module boundary and asserts on the config axios actually received. The API root is a literal public IP, so the egress guard validates it without touching DNS.
- `Common/Tests/Server/Utils/DataSource/HttpFetch.test.ts` — a new `outbound User-Agent` block (8 tests) covering the transport contract, plus the existing "headers through untouched" assertion updated for the added header.

All three suites pass (62 tests), `eslint` clean, `tsc --noEmit` clean.

## Docs

`telemetry/threat-intelligence.md` now states the UA feeds will see, so operators can allowlist it.
