### PR TITLE
fix(ai-chat): freeze the page behind the Ask AI panel

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
@@ -8,6 +8,7 @@ import KeyboardShortcut, {
 import KeyboardKey from "Common/UI/Components/KeyboardShortcut/KeyboardKey";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import Navigation from "Common/UI/Utils/Navigation";
+import { usePageScrollLock } from "Common/UI/Utils/PageScrollLock";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -118,6 +119,16 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
       window.removeEventListener("keydown", onKeyDown);
     };
   }, []);
+
+  /*
+   * The panel is a modal surface — it declares aria-modal, dims the page and
+   * closes on a click outside — so the page behind it has to be inert. Without
+   * this the wheel fell through the backdrop (and off the end of the chat) to
+   * the document, and the incident list the user was asking about slid around
+   * underneath the answer. Shared, counted lock: a Modal or command palette
+   * opened over the panel must not hand scrolling back when it closes.
+   */
+  usePageScrollLock(isOpen);
 
   useEffect(() => {
     if (!isOpen) {
@@ -349,7 +360,14 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
         <div
           ref={chat.scrollContainerRef}
           onScroll={chat.onBodyScroll}
-          className="min-h-0 flex-1 overflow-y-auto"
+          /*
+           * overscroll-contain in addition to the page lock, not instead of
+           * it: it stops the wheel past the end of the thread from chaining
+           * outward at all, so no rubber-band or pull-to-refresh fires on the
+           * surface behind, and the panel still behaves if it is ever rendered
+           * inside a scrolling ancestor of its own.
+           */
+          className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
         >
           {!chat.isConversationView && (
             <ChatHomeView

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/ChatInput.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/ChatInput.tsx
@@ -96,7 +96,7 @@ const ChatInput: FunctionComponent<ComponentProps> = (
                 trySend();
               }
             }}
-            className="max-h-40 flex-1 resize-none border-0 bg-transparent p-0 text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0"
+            className="max-h-40 flex-1 resize-none overscroll-contain border-0 bg-transparent p-0 text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0"
           />
           {props.isWorking && props.onStop ? (
             <button

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/ProviderPicker.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/ProviderPicker.tsx
@@ -134,7 +134,7 @@ const ProviderPicker: FunctionComponent<ComponentProps> = (
               AI provider
             </div>
           </div>
-          <div className="max-h-72 overflow-y-auto py-1">
+          <div className="max-h-72 overflow-y-auto overscroll-contain py-1">
             {props.providers.length === 0 && (
               <div className="px-3 py-3 text-xs text-gray-500">
                 No AI providers configured yet. Add one in Settings → AI → LLM

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/Widgets/DataTableWidget.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/Widgets/DataTableWidget.tsx
@@ -44,7 +44,7 @@ const DataTableWidget: FunctionComponent<ComponentProps> = (
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto overscroll-x-contain">
       <table className="w-full border-collapse text-left text-xs">
         <thead>
           <tr className="border-b border-gray-200 text-[11px] uppercase tracking-wide text-gray-400">

--- a/App/Tests/Dashboard/AIChatPanelScrollLock.test.ts
+++ b/App/Tests/Dashboard/AIChatPanelScrollLock.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Issue #3553: with the Ask AI panel open, the page behind it — an incident
+ * list, say — kept scrolling under the same wheel that scrolled the chat, so
+ * the cards and buttons the user was asking about slid around beneath the
+ * answer.
+ *
+ * The panel had always presented itself as a modal surface: role="dialog",
+ * aria-modal, a full-bleed dimmed backdrop, click-outside and Escape to close.
+ * It simply never adopted the behaviour that goes with that, while Modal,
+ * SideOver and the command palette all did. Two things close the gap, and both
+ * are pinned here:
+ *
+ *   1. the panel takes the app's one shared, counted page-scroll lock for as
+ *      long as it is open, so the document cannot scroll at all; and
+ *   2. every scroller inside the panel contains its own overscroll, so a wheel
+ *      past the end of the thread does not chain outward even if it could.
+ *
+ * These are assertions about source text rather than about a rendered tree
+ * because the App suite runs in a plain Node environment (App/jest.config.json
+ * sets testEnvironment: "node"), and no stylesheet is loaded even under jsdom,
+ * so getComputedStyle can never resolve a Tailwind class. The behaviour of the
+ * lock itself — acquire, release, nesting, paint ordering — is tested for real
+ * against a DOM in Common/Tests/UI/Utils/PageScrollLock.test.tsx. What is left
+ * to defend here is the wiring, which is exactly what regressed.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+const COMMON_ROOT: string = path.join(__dirname, "..", "..", "..", "Common");
+
+const AI_CHAT_DIR: string = path.join(DASHBOARD_SRC, "Components", "AIChat");
+
+/*
+ * Comments are stripped before anything is matched. The block above the lock in
+ * AIChatPanel.tsx explains the bug in prose that names both `usePageScrollLock`
+ * and `overscroll-contain`; an assertion about the code has to read the code
+ * and not the commentary describing it.
+ */
+type StripCommentsFunction = (raw: string) => string;
+
+const stripComments: StripCommentsFunction = (raw: string): string => {
+  return raw.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+};
+
+type ReadCodeFunction = (
+  root: string,
+  ...relativeParts: Array<string>
+) => string;
+
+const readCode: ReadCodeFunction = (
+  root: string,
+  ...relativeParts: Array<string>
+): string => {
+  return stripComments(
+    fs.readFileSync(path.join(root, ...relativeParts), "utf8"),
+  );
+};
+
+type SquashFunction = (source: string) => string;
+
+const squash: SquashFunction = (source: string): string => {
+  return source.replace(/\s+/g, " ");
+};
+
+const PANEL_SOURCE: string = readCode(
+  DASHBOARD_SRC,
+  "Components",
+  "AIChat",
+  "AIChatPanel.tsx",
+);
+
+const PANEL_SQUASHED: string = squash(PANEL_SOURCE);
+
+describe("Ask AI panel: the page behind it", () => {
+  test("takes the shared page scroll lock, keyed on whether the panel is open", () => {
+    /*
+     * The whole of issue #3553 in one line. `isOpen`, not a literal `true`:
+     * unlike Modal and SideOver, this panel is mounted for the life of the app
+     * and closes by flipping its own flag, so a lock keyed on mount would be
+     * taken once at startup and never released.
+     */
+    expect(PANEL_SQUASHED).toContain("usePageScrollLock(isOpen)");
+  });
+
+  test("takes it from the one module every dialog surface shares", () => {
+    expect(PANEL_SQUASHED).toContain(
+      'import { usePageScrollLock } from "Common/UI/Utils/PageScrollLock";',
+    );
+  });
+
+  test("never reaches for document.body itself, which would fight that counter", () => {
+    /*
+     * A hand-rolled `document.body.style.overflow = "hidden"` looks like it
+     * works and then loses: it snapshots and restores a value the shared
+     * counter is already managing, so a modal opened over the panel — or the
+     * command palette on Cmd+K — hands scrolling back to a page that is still
+     * covered, or strands it locked with nothing on screen.
+     */
+    expect(PANEL_SOURCE).not.toContain("document.body.style");
+    expect(PANEL_SOURCE).not.toContain("document.documentElement.style");
+  });
+
+  test("takes the lock above the early return, so closing the panel releases it", () => {
+    /*
+     * `if (!isOpen) { return <></>; }` sits between the hooks and the markup.
+     * A lock call that drifted below it would be a conditionally-called hook —
+     * React throws on the render after the panel closes — and, worse, would
+     * never reach its own cleanup.
+     */
+    const lockIndex: number = PANEL_SQUASHED.indexOf("usePageScrollLock(");
+    const earlyReturnIndex: number = PANEL_SQUASHED.indexOf("if (!isOpen)");
+
+    expect(lockIndex).toBeGreaterThan(-1);
+    expect(earlyReturnIndex).toBeGreaterThan(-1);
+    expect(lockIndex).toBeLessThan(earlyReturnIndex);
+  });
+
+  test("is still the modal surface the lock is there for", () => {
+    /*
+     * The premise, pinned so it cannot quietly change underneath the lock: if
+     * the panel ever stops dimming the page and stops closing on an outside
+     * click, it is no longer modal and freezing the page behind it would be the
+     * wrong behaviour rather than the fix.
+     */
+    expect(PANEL_SQUASHED).toContain('role="dialog"');
+    expect(PANEL_SQUASHED).toContain('aria-modal="true"');
+    expect(PANEL_SQUASHED).toContain("fixed inset-0 bg-gray-900");
+  });
+
+  test("shares one counter with every dialog that can open over the panel", () => {
+    /*
+     * Cmd+K over an open Ask AI panel, or any Modal a chat action opens. Each
+     * of these managing its own private lock is the race PageScrollLock exists
+     * to prevent, so the panel is only safe for as long as its neighbours keep
+     * routing through the same hook.
+     */
+    const surfaces: Array<Array<string>> = [
+      ["UI", "Components", "Modal", "Modal.tsx"],
+      ["UI", "Components", "SideOver", "SideOver.tsx"],
+      ["UI", "Components", "CommandPalette", "CommandPalette.tsx"],
+    ];
+
+    for (const parts of surfaces) {
+      const source: string = squash(readCode(COMMON_ROOT, ...parts));
+
+      expect(source).toContain("usePageScrollLock(");
+      expect(source).not.toContain("document.body.style");
+    }
+  });
+});
+
+/*
+ * Scroll containment, the second half of the fix.
+ *
+ * The page lock stops the document scrolling; overscroll-contain stops the
+ * wheel chaining out of a panel scroller in the first place, which is what
+ * suppresses the rubber-band and the browser's own pull-to-refresh and
+ * swipe-back gestures on the surface behind. They are not alternatives — the
+ * panel wants both, the same way SideOver and Modal do.
+ */
+
+type ClassStringsInFunction = (source: string) => Array<string>;
+
+const classStringsIn: ClassStringsInFunction = (
+  source: string,
+): Array<string> => {
+  const found: Array<string> = [];
+  const literals: RegExp = /(["'`])((?:(?!\1)[\s\S])*)\1/g;
+
+  let match: RegExpExecArray | null = literals.exec(source);
+
+  while (match !== null) {
+    if (match[2] !== undefined) {
+      found.push(match[2]);
+    }
+
+    match = literals.exec(source);
+  }
+
+  return found;
+};
+
+type TsxFilesInFunction = (directory: string) => Array<string>;
+
+const tsxFilesIn: TsxFilesInFunction = (directory: string): Array<string> => {
+  const found: Array<string> = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const full: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      found.push(...tsxFilesIn(full));
+      continue;
+    }
+
+    if (entry.name.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+
+  return found.sort();
+};
+
+/** A class list that scrolls on the given axis and is missing containment. */
+type LeaksOnAxisFunction = (classes: string, axis: "x" | "y") => boolean;
+
+const leaksOnAxis: LeaksOnAxisFunction = (
+  classes: string,
+  axis: "x" | "y",
+): boolean => {
+  const scrolls: boolean = new RegExp(
+    `(?<![\\w-])overflow(?:-${axis})?-(?:auto|scroll)(?![\\w-])`,
+  ).test(classes);
+
+  if (!scrolls) {
+    return false;
+  }
+
+  return !new RegExp(
+    `(?<![\\w-])overscroll-(?:${axis}-)?(?:contain|none)(?![\\w-])`,
+  ).test(classes);
+};
+
+describe("Ask AI panel: scroll containment", () => {
+  test("the conversation body scrolls on demand and contains its overscroll", () => {
+    expect(PANEL_SQUASHED).toContain(
+      'className="min-h-0 flex-1 overflow-y-auto overscroll-contain"',
+    );
+  });
+
+  test("the composer contains its overscroll once it stops growing", () => {
+    /*
+     * The textarea auto-grows to max-h-40 and then scrolls natively, with no
+     * overflow-* class of its own for the sweep below to catch.
+     */
+    const composer: string = squash(
+      readCode(DASHBOARD_SRC, "Components", "AIChat", "ChatInput.tsx"),
+    );
+
+    expect(composer).toContain("max-h-40");
+    expect(composer).toMatch(/className="[^"]*\boverscroll-contain\b[^"]*"/);
+  });
+
+  test("every scroller anywhere in the Ask AI tree contains its overscroll", () => {
+    /*
+     * A sweep rather than a list, because the leak comes back the moment
+     * someone adds the next scrollable region — a taller provider list, a
+     * wide table in a chat widget — and forgets. A horizontal scroller counts
+     * too: chaining a two-finger swipe out of a chat table is what triggers
+     * the browser's back gesture.
+     */
+    const leaks: Array<string> = [];
+
+    for (const file of tsxFilesIn(AI_CHAT_DIR)) {
+      const source: string = stripComments(fs.readFileSync(file, "utf8"));
+
+      for (const classes of classStringsIn(source)) {
+        if (leaksOnAxis(classes, "y") || leaksOnAxis(classes, "x")) {
+          leaks.push(`${path.relative(AI_CHAT_DIR, file)}: ${classes}`);
+        }
+      }
+    }
+
+    expect(leaks).toEqual([]);
+  });
+
+  test("the sweep can actually tell a contained scroller from a leaking one", () => {
+    /*
+     * The sweep passes vacuously if its matcher is wrong, and a green vacuous
+     * test is worse than no test, so exercise the matcher directly.
+     */
+    expect(leaksOnAxis("min-h-0 flex-1 overflow-y-auto", "y")).toBe(true);
+    expect(leaksOnAxis("overflow-auto p-2", "y")).toBe(true);
+    expect(leaksOnAxis("max-h-72 overflow-y-scroll", "y")).toBe(true);
+    expect(leaksOnAxis("overflow-x-auto", "x")).toBe(true);
+
+    expect(leaksOnAxis("overflow-y-auto overscroll-contain", "y")).toBe(false);
+    expect(leaksOnAxis("overflow-y-auto overscroll-y-contain", "y")).toBe(
+      false,
+    );
+    expect(leaksOnAxis("overflow-auto overscroll-none", "y")).toBe(false);
+    expect(leaksOnAxis("overflow-x-auto overscroll-x-contain", "x")).toBe(
+      false,
+    );
+
+    // Clipping is not scrolling, and neither is a class that merely spells it.
+    expect(leaksOnAxis("overflow-hidden rounded-xl", "y")).toBe(false);
+    expect(leaksOnAxis("group-overflow-y-auto-ish", "y")).toBe(false);
+
+    /*
+     * Containment on the other axis must not count: an x-contained scroller
+     * still chains vertically.
+     */
+    expect(leaksOnAxis("overflow-y-auto overscroll-x-contain", "y")).toBe(true);
+  });
+});

--- a/Common/Tests/UI/Utils/PageScrollLock.test.tsx
+++ b/Common/Tests/UI/Utils/PageScrollLock.test.tsx
@@ -1,0 +1,377 @@
+import {
+  lockPageScroll,
+  resetPageScrollLockForTesting,
+  unlockPageScroll,
+  usePageScrollLock,
+} from "../../../UI/Utils/PageScrollLock";
+import { render, RenderResult } from "@testing-library/react";
+import React, { FunctionComponent, ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Issue #3553: the Ask AI panel dimmed the page, declared aria-modal, and then
+ * let the incident list behind it scroll away under the wheel, because nothing
+ * ever took this lock. The panel now takes it through usePageScrollLock, which
+ * is the surface every dialog is meant to use — so the guarantees it makes are
+ * pinned here, at the one place they are implemented, rather than re-derived in
+ * each component suite.
+ *
+ * The counter is module state that outlives a single test, so every case starts
+ * from a known zero and a known body.
+ */
+
+type SetBodyFunction = (overflow: string, paddingRight?: string) => void;
+
+const setBody: SetBodyFunction = (
+  overflow: string,
+  paddingRight: string = "",
+): void => {
+  /*
+   * setProperty/removeProperty rather than assignment: jsdom's CSS layer
+   * silently ignores `style.paddingRight = ""`, so an assigning reset would
+   * carry one case's gutter into the next and quietly hand a later assertion
+   * the wrong page to look at.
+   */
+  document.body.style.setProperty("overflow", overflow);
+  document.body.style.setProperty("padding-right", paddingRight);
+};
+
+/*
+ * jsdom reports innerWidth === clientWidth, so it never has a scrollbar to
+ * reclaim. Faking the gap is the only way to exercise the padding compensation,
+ * which is the half of the lock a user notices as the page jumping sideways.
+ */
+type SetScrollbarWidthFunction = (width: number) => void;
+
+const setScrollbarWidth: SetScrollbarWidthFunction = (width: number): void => {
+  Object.defineProperty(document.documentElement, "clientWidth", {
+    configurable: true,
+    value: window.innerWidth - width,
+  });
+};
+
+const Locker: FunctionComponent<{ isLocked: boolean }> = (props: {
+  isLocked: boolean;
+}): ReactElement => {
+  usePageScrollLock(props.isLocked);
+
+  return <div data-testid="locker" />;
+};
+
+describe("PageScrollLock", () => {
+  beforeEach(() => {
+    resetPageScrollLockForTesting();
+    setBody("");
+    setScrollbarWidth(0);
+  });
+
+  afterEach(() => {
+    resetPageScrollLockForTesting();
+    setBody("");
+    setScrollbarWidth(0);
+  });
+
+  describe("lockPageScroll / unlockPageScroll", () => {
+    test("hides the page scrollbar while a dialog is up", () => {
+      setBody("auto");
+
+      lockPageScroll();
+
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    test("puts back whatever the page had before, not a hardcoded default", () => {
+      setBody("scroll");
+
+      lockPageScroll();
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("scroll");
+    });
+
+    test("restores an empty inline overflow rather than inventing one", () => {
+      setBody("");
+
+      lockPageScroll();
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("");
+    });
+
+    test("keeps the page locked while an inner dialog closes over an outer one", () => {
+      setBody("auto");
+
+      lockPageScroll();
+      lockPageScroll();
+
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("hidden");
+
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("restores the page exactly once no matter how deep the nesting went", () => {
+      setBody("auto");
+
+      lockPageScroll();
+      lockPageScroll();
+      lockPageScroll();
+      unlockPageScroll();
+      unlockPageScroll();
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("leaves the page alone when unlocked with nothing open", () => {
+      /*
+       * A stray release — a surface unlocking twice, a cleanup outliving the
+       * lock it was paired with — used to paint the snapshot from some earlier
+       * dialog straight over the live page, wiping whatever overflow the page
+       * had set for itself. Nothing is open, so there is nothing to put back.
+       */
+      setBody("auto", "8px");
+
+      unlockPageScroll();
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("auto");
+      expect(document.body.style.paddingRight).toBe("8px");
+    });
+
+    test("counts the next lock after a stray unlock as a first lock", () => {
+      /*
+       * The stray unlocks must not leave a credit behind either: one lock still
+       * has to inert the page, and one unlock still has to hand it back. A
+       * counter allowed to run negative would need three locks before anything
+       * happened at all.
+       */
+      setBody("auto");
+
+      unlockPageScroll();
+      unlockPageScroll();
+
+      lockPageScroll();
+
+      expect(document.body.style.overflow).toBe("hidden");
+
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("re-reads the page on every fresh lock instead of reusing a stale snapshot", () => {
+      setBody("auto");
+
+      lockPageScroll();
+      unlockPageScroll();
+
+      setBody("scroll");
+
+      lockPageScroll();
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("scroll");
+    });
+
+    test("pads the page by the width of the scrollbar it just hid", () => {
+      setScrollbarWidth(15);
+
+      lockPageScroll();
+
+      expect(document.body.style.paddingRight).toBe("15px");
+    });
+
+    test("removes that padding again on unlock", () => {
+      setScrollbarWidth(15);
+
+      lockPageScroll();
+      unlockPageScroll();
+
+      expect(document.body.style.paddingRight).toBe("");
+    });
+
+    test("preserves padding the page already had of its own", () => {
+      setBody("auto", "8px");
+      setScrollbarWidth(15);
+
+      lockPageScroll();
+
+      expect(document.body.style.paddingRight).toBe("15px");
+
+      unlockPageScroll();
+
+      expect(document.body.style.paddingRight).toBe("8px");
+    });
+
+    test("adds no padding on overlay-scrollbar platforms, where nothing was reclaimed", () => {
+      setScrollbarWidth(0);
+
+      lockPageScroll();
+
+      expect(document.body.style.paddingRight).toBe("");
+    });
+
+    test("pads only for the outermost dialog, so nesting does not stack gutters", () => {
+      setScrollbarWidth(15);
+
+      lockPageScroll();
+      lockPageScroll();
+
+      expect(document.body.style.paddingRight).toBe("15px");
+    });
+  });
+
+  describe("usePageScrollLock", () => {
+    test("locks the page for a surface that mounts open", () => {
+      setBody("auto");
+
+      render(<Locker isLocked={true} />);
+
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    test("leaves the page alone for a surface that is mounted but closed", () => {
+      setBody("auto");
+
+      render(<Locker isLocked={false} />);
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("locks when a mounted-but-closed surface opens", () => {
+      setBody("auto");
+
+      const rendered: RenderResult = render(<Locker isLocked={false} />);
+
+      rendered.rerender(<Locker isLocked={true} />);
+
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    test("releases when the surface closes without unmounting", () => {
+      /*
+       * AIChatPanel's shape exactly: it stays mounted for the life of the app
+       * and swaps its own open flag, so a lock keyed on mount alone would never
+       * be handed back.
+       */
+      setBody("auto");
+
+      const rendered: RenderResult = render(<Locker isLocked={true} />);
+
+      rendered.rerender(<Locker isLocked={false} />);
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("releases when the surface unmounts while still open", () => {
+      setBody("auto");
+
+      const rendered: RenderResult = render(<Locker isLocked={true} />);
+
+      rendered.unmount();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("survives being opened and closed repeatedly", () => {
+      setBody("auto");
+
+      const rendered: RenderResult = render(<Locker isLocked={false} />);
+
+      for (let index: number = 0; index < 5; index++) {
+        rendered.rerender(<Locker isLocked={true} />);
+        expect(document.body.style.overflow).toBe("hidden");
+
+        rendered.rerender(<Locker isLocked={false} />);
+        expect(document.body.style.overflow).toBe("auto");
+      }
+    });
+
+    test("does not re-take the lock on a re-render that leaves it open", () => {
+      setBody("auto");
+
+      const rendered: RenderResult = render(<Locker isLocked={true} />);
+
+      rendered.rerender(<Locker isLocked={true} />);
+      rendered.rerender(<Locker isLocked={true} />);
+
+      /*
+       * A dependency array that missed would acquire once per render and leave
+       * the counter far above zero, so one unmount could never unlock the page.
+       */
+      rendered.unmount();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("shares one lock across two surfaces open at the same time", () => {
+      setBody("auto");
+
+      const first: RenderResult = render(<Locker isLocked={true} />);
+      const second: RenderResult = render(<Locker isLocked={true} />);
+
+      first.unmount();
+
+      expect(document.body.style.overflow).toBe("hidden");
+
+      second.unmount();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("shares that lock with imperative callers too", () => {
+      setBody("auto");
+
+      lockPageScroll();
+
+      const rendered: RenderResult = render(<Locker isLocked={true} />);
+
+      rendered.unmount();
+
+      expect(document.body.style.overflow).toBe("hidden");
+
+      unlockPageScroll();
+
+      expect(document.body.style.overflow).toBe("auto");
+    });
+
+    test("locks before paint, so a right-pinned surface never draws in the wrong place", () => {
+      /*
+       * useLayoutEffect, not useEffect. Hiding the scrollbar widens the
+       * viewport a fixed overlay resolves `right: 0` against, so a lock that
+       * landed after paint would shift the panel sideways by the scrollbar's
+       * width on its first frame — the jump SideOver used to document.
+       *
+       * React flushes every layout effect in a commit before any passive one,
+       * so a passive effect ordered AHEAD of the locker in the tree is the
+       * discriminator: it sees "hidden" only if the lock was taken during
+       * layout. Were the hook a plain useEffect, this probe would run first and
+       * still see the page scrolling.
+       */
+      setBody("auto");
+
+      let overflowSeenAfterPaint: string = "";
+
+      const Probe: FunctionComponent = (): ReactElement => {
+        React.useEffect(() => {
+          overflowSeenAfterPaint = document.body.style.overflow;
+        }, []);
+
+        return <div />;
+      };
+
+      render(
+        <React.Fragment>
+          <Probe />
+          <Locker isLocked={true} />
+        </React.Fragment>,
+      );
+
+      expect(overflowSeenAfterPaint).toBe("hidden");
+    });
+  });
+});

--- a/Common/UI/Components/CommandPalette/CommandPalette.tsx
+++ b/Common/UI/Components/CommandPalette/CommandPalette.tsx
@@ -8,7 +8,7 @@ import KeyboardKey, {
 } from "../KeyboardShortcut/KeyboardKey";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
-import { lockPageScroll, unlockPageScroll } from "../../Utils/PageScrollLock";
+import { usePageScrollLock } from "../../Utils/PageScrollLock";
 import {
   PaletteCommand,
   PaletteSearchProvider,
@@ -194,13 +194,7 @@ const CommandPalettePanel: FunctionComponent<PanelProps> = (
   }, []);
 
   // The page behind the palette must not scroll while it is open.
-  useEffect(() => {
-    lockPageScroll();
-
-    return () => {
-      unlockPageScroll();
-    };
-  }, []);
+  usePageScrollLock(true);
 
   useEffect(() => {
     inputRef.current?.focus();

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -8,7 +8,7 @@ import { VeryLightGray } from "../../../Types/BrandColors";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
 import { wasPressConsumedByAnAnchoredPopup } from "../../Types/LayeredDismissal";
-import { lockPageScroll, unlockPageScroll } from "../../Utils/PageScrollLock";
+import { usePageScrollLock } from "../../Utils/PageScrollLock";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -125,13 +125,7 @@ const Modal: FunctionComponent<ComponentProps> = (
     };
   }, []);
 
-  useEffect(() => {
-    lockPageScroll();
-
-    return () => {
-      unlockPageScroll();
-    };
-  }, []);
+  usePageScrollLock(true);
 
   useEffect(() => {
     const content: HTMLDivElement | null = contentRef.current;

--- a/Common/UI/Components/SideOver/SideOver.tsx
+++ b/Common/UI/Components/SideOver/SideOver.tsx
@@ -1,13 +1,12 @@
 import Button, { ButtonStyleType } from "../Button/Button";
 import Icon from "../Icon/Icon";
 import IconProp from "../../../Types/Icon/IconProp";
-import { lockPageScroll, unlockPageScroll } from "../../Utils/PageScrollLock";
+import { usePageScrollLock } from "../../Utils/PageScrollLock";
 import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
   useId,
-  useLayoutEffect,
   useState,
 } from "react";
 import { createPortal } from "react-dom";
@@ -127,24 +126,7 @@ const SideOver: FunctionComponent<ComponentProps> = (
     };
   }, []);
 
-  /*
-   * A layout effect, not an ordinary one. Hiding the page scrollbar widens the
-   * viewport that `right: 0` resolves against, so a panel that painted before
-   * the lock landed would visibly jump sideways by the scrollbar's width on
-   * every platform that draws a classic scrollbar. Locking before paint means
-   * the panel is only ever drawn in its final position.
-   */
-  useLayoutEffect(() => {
-    if (props.disablePageScrollLock) {
-      return undefined;
-    }
-
-    lockPageScroll();
-
-    return () => {
-      unlockPageScroll();
-    };
-  }, [props.disablePageScrollLock]);
+  usePageScrollLock(!props.disablePageScrollLock);
 
   const sideOver: ReactElement = (
     /*

--- a/Common/UI/Utils/PageScrollLock.ts
+++ b/Common/UI/Utils/PageScrollLock.ts
@@ -12,6 +12,8 @@
  * under a dialog that is still open or locked forever with no dialog on screen.
  */
 
+import { useLayoutEffect } from "react";
+
 let openDialogCount: number = 0;
 let bodyOverflowBeforeLock: string = "";
 let bodyPaddingRightBeforeLock: string = "";
@@ -42,15 +44,89 @@ export const lockPageScroll: PageScrollLockFunction = (): void => {
   document.body.style.overflow = "hidden";
 };
 
+/*
+ * Restoring means putting the page back exactly as it was found, and "as it
+ * was found" is usually no inline value at all rather than an empty one. Going
+ * through removeProperty for that case says so directly — and it is also the
+ * only spelling jsdom honours for a longhand like padding-right, so the
+ * restore is assertable in a test instead of being taken on trust.
+ */
+type RestoreBodyStyleFunction = (property: string, value: string) => void;
+
+const restoreBodyStyle: RestoreBodyStyleFunction = (
+  property: string,
+  value: string,
+): void => {
+  if (value === "") {
+    document.body.style.removeProperty(property);
+
+    return;
+  }
+
+  document.body.style.setProperty(property, value);
+};
+
 export const unlockPageScroll: PageScrollLockFunction = (): void => {
-  openDialogCount = Math.max(0, openDialogCount - 1);
+  /*
+   * Nothing is open, so there is nothing of ours on the page to put back. A
+   * stray unlock — one surface releasing twice, a cleanup that outlives the
+   * lock it was paired with — has to be inert rather than paint a snapshot
+   * taken for some earlier dialog over whatever the page is wearing now.
+   */
+  if (openDialogCount === 0) {
+    return;
+  }
+
+  openDialogCount--;
 
   if (openDialogCount > 0 || typeof document === "undefined") {
     return;
   }
 
-  document.body.style.overflow = bodyOverflowBeforeLock;
-  document.body.style.paddingRight = bodyPaddingRightBeforeLock;
+  restoreBodyStyle("overflow", bodyOverflowBeforeLock);
+  restoreBodyStyle("padding-right", bodyPaddingRightBeforeLock);
+};
+
+/*
+ * The declarative form, and the one new surfaces should reach for.
+ *
+ * Every caller of the pair above writes the same effect: acquire on the way
+ * in, release from the cleanup, keyed on whether the surface is up. Written by
+ * hand that is four lines with three ways to get it wrong — release omitted,
+ * the wrong dependency, or the call placed after an early `return` so it stops
+ * running once the surface closes. Issue #3553 is what the first two look like
+ * from the outside: the Ask AI panel declared aria-modal, dimmed the page
+ * behind it, and let that page scroll away under the wheel because nothing
+ * ever took the lock.
+ *
+ * Passing the open flag straight in keeps the invariant to one line, and keeps
+ * it correct for surfaces like AIChatPanel that stay mounted while closed
+ * rather than being unmounted by their parent.
+ *
+ * A layout effect, not an ordinary one, and that is load-bearing for every
+ * caller rather than a detail of one. Hiding the page scrollbar widens the
+ * viewport that a fixed overlay resolves against, so a surface that painted
+ * before the lock landed jumps sideways by the scrollbar's width on any
+ * platform drawing a classic scrollbar — the full width for a panel pinned to
+ * `right: 0`, half of it for a centred dialog. Locking before paint means the
+ * surface is only ever drawn in its final position.
+ */
+export type UsePageScrollLockFunction = (isLocked: boolean) => void;
+
+export const usePageScrollLock: UsePageScrollLockFunction = (
+  isLocked: boolean,
+): void => {
+  useLayoutEffect(() => {
+    if (!isLocked) {
+      return undefined;
+    }
+
+    lockPageScroll();
+
+    return () => {
+      unlockPageScroll();
+    };
+  }, [isLocked]);
 };
 
 /*


### PR DESCRIPTION
Fixes #3553.

## The bug is real

`AIChatPanel` has presented itself as a modal surface since it shipped — `role="dialog"`, `aria-modal="true"`, a full-bleed dimmed backdrop, click-outside and Escape to close — but never adopted the behaviour that goes with one. Nothing stopped the document scrolling, so the same wheel that scrolled the chat also scrolled the page behind it, and the incident cards and buttons the user was asking about slid around beneath the answer. Two paths leaked:

- the cursor over the backdrop, the panel header or the composer — none of them scrollable, so the wheel walked up to the document; and
- the cursor over the conversation body once it hit its end — scroll chaining out to the document.

`Modal`, `SideOver` and `CommandPalette` all take a shared, reference-counted page-scroll lock (`Common/UI/Utils/PageScrollLock`). The panel simply never called it.

## What I did instead of what the issue asked for

The issue asks for `document.body` scroll lock. Written by hand that is the wrong fix here: the panel can have a `Modal` or the command palette (Cmd+K) opened over it, and a private snapshot/restore pair races the shared counter — whichever surface closes first hands scrolling back to a page that is still covered, or strands it locked with nothing on screen. So the panel joins the existing counter rather than growing its own.

And rather than add a fourth hand-rolled `useEffect(lock, () => unlock)`, `PageScrollLock` now exposes **`usePageScrollLock(isLocked)`**. Four lines with three ways to get it wrong (release omitted, wrong dependency, call placed below an early `return`) become one line that can't be. Two of those three mistakes are what this bug looked like from the outside.

- `AIChatPanel` passes its own **open flag**, not `true`. Unlike Modal and SideOver it stays mounted for the life of the app and closes by flipping state, so a lock keyed on mount would be taken once at startup and never handed back.
- The three existing callers move to the same hook, so there is one way to express the invariant instead of a hand-rolled example inviting the next omission.

**The hook is a layout effect, and that turned out to matter for everyone.** Hiding the scrollbar widens the viewport a fixed overlay resolves against, so a lock landing after paint shifts the surface sideways by the scrollbar's width on its first frame — the full width for a panel pinned to `right: 0`, half of it for a centred dialog. `SideOver` had discovered this alone and used `useLayoutEffect`; folding it into the hook hands the same guarantee to `Modal`, `CommandPalette` and the Ask AI panel, all of which were paying for it silently.

## Overscroll containment, as well as the lock

The page lock stops the document scrolling. `overscroll-contain` stops the wheel chaining out of a panel scroller in the first place, which is what suppresses the rubber-band, pull-to-refresh and two-finger swipe-back on the surface behind. They are not alternatives — `SideOver` and `Modal` use both, and now so does every scroller in the Ask AI tree: the conversation body, the auto-growing composer, the provider list, and the tables in chat widgets.

## Two defects in the lock itself, found by testing it

- **A stray unlock with nothing open clobbered the live page.** It restored a snapshot taken for some earlier dialog over whatever the page was wearing. It is now inert, and the next lock still counts as a first lock.
- **Restoring "no inline value" went through `style.prop = ""`,** which is a silent no-op on a longhand like `padding-right` in jsdom. `removeProperty` says what is meant and makes the restore assertable rather than a matter of trust.

## Tests

**`Common/Tests/UI/Utils/PageScrollLock.test.tsx`** — 23 cases against a real DOM: acquire and restore (including preserving whatever the page already had), nesting and depth, imbalance, scrollbar-width compensation and its absence on overlay-scrollbar platforms, the whole hook lifecycle including the *mounted-but-closed* shape the panel actually has, sharing across surfaces and with imperative callers, and paint ordering.

**`App/Tests/Dashboard/AIChatPanelScrollLock.test.ts`** — 10 cases pinning the wiring. The App suite runs in a plain Node environment and no stylesheet is loaded even under jsdom, so these read the source, the way `NetworkTopologyPanelLayering` already does; comments are stripped first so prose about the fix can't satisfy an assertion about the code. It also carries a **sweep that fails on any future scroller added anywhere in the Ask AI tree without containment**, plus a self-check proving the sweep's matcher isn't vacuous.

Both suites were verified to fail against the unfixed code — 5 of 10 App cases fail on the pre-fix panel, and mutating the layout effect back to `useEffect` or dropping the stray-unlock guard fails exactly the cases written for them, and nothing else.

```
Common  9 suites / 165 tests   (SideOver, SideOverMotion, Modal, CommandPalette ×3, PageScrollLock)
App     6 suites /  69 tests   (AIChatPanelScrollLock, InvestigationFindings, NetworkTopologyPanelLayering,
                                AppShellWiring, MapChromeHeaderLayering, MarkdownEagerGraph)
```

`tsc` is clean in both projects and eslint is clean on every changed file.

## Not in this PR

Three other surfaces declare `aria-modal="true"` and take no scroll lock — `FunctionFocusPanel`, `NavBarMenuModal` and `FullPageModal`. Same defect, different surfaces. `NavBarMenuModal` in particular is the mobile nav overlay with its own full-screen scroller, so locking it wants its own look on a device rather than a drive-by change inside an Ask AI fix. Worth a follow-up now that the invariant is one line.
