### PR TITLE
fix(identity): expire password reset links when an account's email changes

### DIFF
--- a/App/Tests/FeatureSet/Identity/PasswordResetLinkEmailChangeTakeover.test.ts
+++ b/App/Tests/FeatureSet/Identity/PasswordResetLinkEmailChangeTakeover.test.ts
@@ -1,0 +1,649 @@
+import {
+  buildRequest,
+  buildResponse,
+  createMockIdentityRouter,
+  MockIdentityRouter,
+  RouteHandler,
+} from "./IdentityRouterTestUtil";
+import { EncryptionSecret } from "Common/Server/EnvironmentConfig";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import Exception from "Common/Types/Exception/Exception";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import HashedString from "Common/Types/HashedString";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+const mockRouter: MockIdentityRouter = createMockIdentityRouter();
+
+/*
+ * ---------------------------------------------------------------------------------------------
+ * THE ENDPOINT HALF OF "Broken Authentication Leads To Account Takeover".
+ *
+ * `POST /reset-password` identifies the account to re-password by ONE thing: the SHA-256 of the
+ * token in the link. It does not look at the email address on the row, and it cannot -- the reset
+ * page has no address to offer it, and asking for one would turn a reset link into a link plus a
+ * guess. That design is fine, but it has a consequence: the token column IS the authorization,
+ * so anything that should invalidate a link has to remove the token, at the moment it happens.
+ *
+ * That is why the fix for the reported takeover lives in `UserService.onBeforeUpdate` (covered by
+ * Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts) rather than here. This
+ * file pins down the endpoint behaviour that the fix depends on, and would otherwise be free to
+ * drift:
+ *
+ *  - the row is found by token hash ALONE, so a token left on a row after the account moved to a
+ *    new address is a complete, working credential for the account at its new address;
+ *  - the raw token is never what is stored, so the fix cannot be "compare the link to the column";
+ *  - once the token column is cleared, the very same link is refused and NO password is written.
+ *
+ * The user store below is a single in-memory row rather than a bag of `mockResolvedValue`s, so
+ * the hash comparison in the "the link still works" and "the link no longer works" cases is a
+ * real one, computed by the same `HashedString.hashValue` the route uses.
+ * ---------------------------------------------------------------------------------------------
+ */
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      getRouter: (): MockIdentityRouter => {
+        return mockRouter;
+      },
+    },
+    getClientIp: (): string => {
+      return "127.0.0.1";
+    },
+    extractDeviceInfo: (): Record<string, unknown> => {
+      return {};
+    },
+    headerValueToString: (): string => {
+      return "";
+    },
+  };
+});
+
+/*
+ * The single row every mocked UserService method reads and writes. `resetPasswordToken` holds the
+ * HASH, exactly as the column does.
+ */
+type UserRow = {
+  id: ObjectID;
+  email: string;
+  password: string;
+  resetPasswordToken: string | null;
+  resetPasswordExpires: Date | null;
+};
+
+const VICTIM_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+
+const COMPROMISED_EMAIL: string = "victim@compromised-mailbox.example.com";
+const RESCUED_EMAIL: string = "victim@rescued-mailbox.example.com";
+
+let row: UserRow;
+
+type RowAsUserFunction = () => Record<string, unknown>;
+
+/* The row in the shape `findOneBy` hands back: a model-ish object with an id. */
+const rowAsUser: RowAsUserFunction = (): Record<string, unknown> => {
+  return {
+    id: row.id,
+    _id: row.id.toString(),
+    email: {
+      toString: (): string => {
+        return row.email;
+      },
+    },
+    password: row.password,
+    name: undefined,
+    isMasterAdmin: false,
+    resetPasswordExpires: row.resetPasswordExpires,
+    resetPasswordToken: row.resetPasswordToken,
+  };
+};
+
+const userFindOneBy: jest.Mock = jest.fn();
+const userUpdateOneBy: jest.Mock = jest.fn();
+const userUpdateOneById: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return userFindOneBy(...args);
+      },
+      updateOneBy: (...args: Array<unknown>): unknown => {
+        return userUpdateOneBy(...args);
+      },
+      updateOneById: (...args: Array<unknown>): unknown => {
+        return userUpdateOneById(...args);
+      },
+      updateOneByIdAndFetch: jest.fn(),
+      create: jest.fn(),
+      createUserOnSignup: jest.fn(),
+      countBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/EmailVerificationTokenService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn(), create: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/TeamMemberService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/AccessTokenService", () => {
+  return {
+    __esModule: true,
+    default: { refreshUserAllPermissions: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/UserTotpAuthService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserWebAuthnService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      verifyAuthentication: jest.fn(),
+    },
+  };
+});
+
+const revokeAllSessionsByUserId: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserSessionService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createSession: jest.fn(),
+      findActiveSessionByRefreshToken: jest.fn(),
+      revokeSessionById: jest.fn(),
+      revokeSessionByRefreshToken: jest.fn(),
+      renewSessionWithNewRefreshToken: jest.fn(),
+      revokeAllSessionsByUserId: (...args: Array<unknown>): unknown => {
+        return revokeAllSessionsByUserId(...args);
+      },
+    },
+  };
+});
+
+const sendMail: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: (...args: Array<unknown>): Promise<void> => {
+        sendMail(...args);
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/DatabaseConfig", () => {
+  return {
+    __esModule: true,
+    default: {
+      shouldDisableSignup: (): Promise<boolean> => {
+        return Promise.resolve(false);
+      },
+      getHost: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "localhost";
+          },
+        });
+      },
+      getHttpProtocol: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "http://";
+          },
+        });
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Cookie", () => {
+  return {
+    __esModule: true,
+    default: {
+      setUserCookie: jest.fn(),
+      removeAllCookies: jest.fn(),
+      removeCookie: jest.fn(),
+      getRefreshTokenFromExpressRequest: jest.fn(),
+      getUserTokenKey: jest.fn(),
+      getRefreshTokenKey: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Captcha", () => {
+  return {
+    __esModule: true,
+    default: {
+      verifyCaptcha: (): Promise<void> => {
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/JsonWebToken", () => {
+  return {
+    __esModule: true,
+    default: {
+      sign: (): string => {
+        return "signed-token";
+      },
+      signUserLoginToken: (): string => {
+        return "signed-user-token";
+      },
+    },
+  };
+});
+
+jest.mock("../../../FeatureSet/Identity/Utils/AuthenticationEmail", () => {
+  return {
+    __esModule: true,
+    default: { sendVerificationEmail: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+    getLogAttributesFromRequest: (): Record<string, unknown> => {
+      return {};
+    },
+  };
+});
+
+const sendErrorResponse: jest.Mock = jest.fn();
+const sendEmptySuccessResponse: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: (...args: Array<unknown>): unknown => {
+        return sendErrorResponse(...args);
+      },
+      sendEmptySuccessResponse: (...args: Array<unknown>): unknown => {
+        return sendEmptySuccessResponse(...args);
+      },
+      sendEntityResponse: jest.fn(),
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+// Importing the router registers every handler on the mock router above.
+import "../../../FeatureSet/Identity/API/Authentication";
+
+type InvokeResult = {
+  nextError: Exception | null;
+};
+
+type InvokeFunction = (uri: string, body: unknown) => Promise<InvokeResult>;
+
+const invoke: InvokeFunction = async (
+  uri: string,
+  body: unknown,
+): Promise<InvokeResult> => {
+  const handler: RouteHandler = mockRouter.match("post", uri);
+  const req: ExpressRequest = buildRequest(body);
+  const res: ExpressResponse = buildResponse();
+
+  let nextError: Exception | null = null;
+
+  const next: NextFunction = ((err?: Exception): void => {
+    if (err) {
+      nextError = err;
+    }
+  }) as unknown as NextFunction;
+
+  await handler(req, res, next);
+
+  return { nextError };
+};
+
+type RequestResetLinkFunction = () => Promise<string>;
+
+/*
+ * Drive the real `/forgot-password` handler and pull the raw token back out of the link it
+ * mailed -- which is all an attacker with access to the mailbox has.
+ */
+const requestResetLink: RequestResetLinkFunction =
+  async (): Promise<string> => {
+    sendMail.mockClear();
+
+    await invoke("/forgot-password", { data: { email: row.email } });
+
+    /*
+     * `/forgot-password` answers with an empty success of its own, so the
+     * response spies are reset here. Every assertion about `sendErrorResponse` /
+     * `sendEmptySuccessResponse` in a test below is therefore about the
+     * `/reset-password` call it is actually testing.
+     */
+    sendErrorResponse.mockClear();
+    sendEmptySuccessResponse.mockClear();
+
+    const vars: JSONObject = (
+      sendMail.mock.calls[0]![0] as unknown as { vars: JSONObject }
+    ).vars;
+
+    const tokenVerifyUrl: string = vars["tokenVerifyUrl"] as string;
+
+    return tokenVerifyUrl.split("/reset-password/")[1] as string;
+  };
+
+type ErrorMessageFunction = () => string;
+
+const lastErrorMessage: ErrorMessageFunction = (): string => {
+  const err: Exception = sendErrorResponse.mock.calls[
+    sendErrorResponse.mock.calls.length - 1
+  ]![2] as Exception;
+
+  return err.message;
+};
+
+describe("Identity password reset — a link must not outlive the address it was mailed to", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    row = {
+      id: VICTIM_ID,
+      email: COMPROMISED_EMAIL,
+      password: "the-old-hashed-password",
+      resetPasswordToken: null,
+      resetPasswordExpires: null,
+    };
+
+    /*
+     * A store, not a canned answer: `/forgot-password` looks a user up by email and
+     * `/reset-password` looks one up by token hash, and the difference between those two
+     * lookups is the whole subject of this file.
+     */
+    userFindOneBy.mockImplementation(
+      (findBy: { query: Record<string, unknown> }): Promise<unknown> => {
+        const query: Record<string, unknown> = findBy.query;
+
+        if (query["resetPasswordToken"] !== undefined) {
+          if (
+            row.resetPasswordToken !== null &&
+            row.resetPasswordToken === String(query["resetPasswordToken"])
+          ) {
+            return Promise.resolve(rowAsUser());
+          }
+
+          return Promise.resolve(null);
+        }
+
+        if (query["email"] !== undefined) {
+          if (String(query["email"]) === row.email) {
+            return Promise.resolve(rowAsUser());
+          }
+
+          return Promise.resolve(null);
+        }
+
+        return Promise.resolve(null);
+      },
+    );
+
+    const applyPatch: (data: Record<string, unknown>) => Promise<number> = (
+      data: Record<string, unknown>,
+    ): Promise<number> => {
+      if ("resetPasswordToken" in data) {
+        row.resetPasswordToken = data["resetPasswordToken"] as string | null;
+      }
+
+      if ("resetPasswordExpires" in data) {
+        row.resetPasswordExpires = data["resetPasswordExpires"] as Date | null;
+      }
+
+      if ("password" in data) {
+        row.password = String(data["password"]);
+      }
+
+      if ("email" in data) {
+        row.email = String(data["email"]);
+      }
+
+      return Promise.resolve(1);
+    };
+
+    userUpdateOneBy.mockImplementation(
+      (updateBy: { data: Record<string, unknown> }): Promise<number> => {
+        return applyPatch(updateBy.data);
+      },
+    );
+
+    userUpdateOneById.mockImplementation(
+      (updateBy: { data: Record<string, unknown> }): Promise<number> => {
+        return applyPatch(updateBy.data);
+      },
+    );
+  });
+
+  describe("what the token column is worth", () => {
+    it("stores only a hash of the token, never the link's own token", async () => {
+      /*
+       * Load-bearing for the fix's shape. Because the column is a digest, "does this link belong
+       * to this address?" cannot be answered at redemption time by comparing strings -- the only
+       * way to retire a link is to remove the digest when the thing that invalidated it happens.
+       */
+      const token: string = await requestResetLink();
+
+      expect(row.resetPasswordToken).not.toBe(token);
+      expect(row.resetPasswordToken).toBe(
+        await HashedString.hashValue(token, EncryptionSecret),
+      );
+    });
+
+    it("redeems a link by token hash alone, never by the address it was mailed to", async () => {
+      /*
+       * The reason a stale token is a complete credential: no part of this query, and no check
+       * after it, mentions the account's email. Add one and this test should be revisited --
+       * deliberately -- rather than silently made to pass.
+       */
+      const token: string = await requestResetLink();
+
+      userFindOneBy.mockClear();
+
+      await invoke("/reset-password", {
+        data: { resetPasswordToken: token, password: "aVeryG00dPassword!" },
+      });
+
+      const query: Record<string, unknown> = (
+        userFindOneBy.mock.calls[0]![0] as unknown as {
+          query: Record<string, unknown>;
+        }
+      ).query;
+
+      expect(Object.keys(query)).toEqual(["resetPasswordToken"]);
+    });
+  });
+
+  describe("the control: an untouched account", () => {
+    it("accepts the mailed link and sets the new password", async () => {
+      const token: string = await requestResetLink();
+
+      const result: InvokeResult = await invoke("/reset-password", {
+        data: { resetPasswordToken: token, password: "aVeryG00dPassword!" },
+      });
+
+      expect(result.nextError).toBeNull();
+      expect(sendErrorResponse).not.toHaveBeenCalled();
+      expect(sendEmptySuccessResponse).toHaveBeenCalledTimes(1);
+      expect(row.password).toBe("aVeryG00dPassword!");
+    });
+
+    it("spends the link, so it cannot be replayed", async () => {
+      const token: string = await requestResetLink();
+
+      await invoke("/reset-password", {
+        data: { resetPasswordToken: token, password: "aVeryG00dPassword!" },
+      });
+
+      expect(row.resetPasswordToken).toBeNull();
+
+      const replay: InvokeResult = await invoke("/reset-password", {
+        data: { resetPasswordToken: token, password: "attackerPassword1!" },
+      });
+
+      expect(replay.nextError).toBeNull();
+      expect(lastErrorMessage()).toContain("Invalid link");
+      expect(row.password).toBe("aVeryG00dPassword!");
+    });
+  });
+
+  describe("the reported attack, once the account has moved address", () => {
+    it("refuses a link minted before the address change", async () => {
+      /*
+       * The full scenario. The attacker requests the link while they can still read the mailbox
+       * and does not spend it; the victim moves the account to an address the attacker cannot
+       * read, which -- with the fix in UserService.onBeforeUpdate -- clears the token column;
+       * the attacker then spends the link.
+       *
+       * `resetPasswordToken: null` here is exactly what that hook writes, and
+       * Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts is what proves
+       * the hook writes it. This test is the other half: that a cleared column actually stops
+       * the endpoint.
+       */
+      const attackerToken: string = await requestResetLink();
+
+      row.email = RESCUED_EMAIL;
+      row.resetPasswordToken = null;
+      row.resetPasswordExpires = null;
+
+      const result: InvokeResult = await invoke("/reset-password", {
+        data: {
+          resetPasswordToken: attackerToken,
+          password: "attackerPassword1!",
+        },
+      });
+
+      expect(result.nextError).toBeNull();
+      expect(lastErrorMessage()).toContain("Invalid link");
+    });
+
+    it("writes no password and revokes no sessions when it refuses", async () => {
+      /*
+       * "Answered with an error" is not enough on its own. The account must come out of the
+       * attempt exactly as it went in -- same password, no sessions torn out from under the
+       * victim, who is by this point the only person who should be signed in.
+       */
+      const attackerToken: string = await requestResetLink();
+
+      row.email = RESCUED_EMAIL;
+      row.resetPasswordToken = null;
+      row.resetPasswordExpires = null;
+
+      userUpdateOneById.mockClear();
+
+      await invoke("/reset-password", {
+        data: {
+          resetPasswordToken: attackerToken,
+          password: "attackerPassword1!",
+        },
+      });
+
+      expect(userUpdateOneById).not.toHaveBeenCalled();
+      expect(revokeAllSessionsByUserId).not.toHaveBeenCalled();
+      expect(row.password).toBe("the-old-hashed-password");
+    });
+
+    it("the victim can still reset their own password at the new address", async () => {
+      /*
+       * The fix must not cost the victim the recovery route they were using. A fresh request
+       * from the new address mints a new token and that link works.
+       */
+      await requestResetLink();
+
+      row.email = RESCUED_EMAIL;
+      row.resetPasswordToken = null;
+      row.resetPasswordExpires = null;
+
+      const freshToken: string = await requestResetLink();
+
+      const result: InvokeResult = await invoke("/reset-password", {
+        data: {
+          resetPasswordToken: freshToken,
+          password: "aVeryG00dPassword!",
+        },
+      });
+
+      expect(result.nextError).toBeNull();
+      expect(sendErrorResponse).not.toHaveBeenCalled();
+      expect(row.password).toBe("aVeryG00dPassword!");
+    });
+  });
+
+  describe("the neighbouring guard", () => {
+    it("still refuses a token that is present but expired", async () => {
+      const token: string = await requestResetLink();
+
+      row.resetPasswordExpires = new Date(Date.now() - 60 * 1000);
+
+      const result: InvokeResult = await invoke("/reset-password", {
+        data: { resetPasswordToken: token, password: "aVeryG00dPassword!" },
+      });
+
+      expect(result.nextError).toBeNull();
+      expect(lastErrorMessage()).toContain("Expired link");
+      expect(row.password).toBe("the-old-hashed-password");
+    });
+
+    it("still refuses a reset with no token at all", async () => {
+      const result: InvokeResult = await invoke("/reset-password", {
+        data: { password: "aVeryG00dPassword!" },
+      });
+
+      expect(userFindOneBy).not.toHaveBeenCalled();
+      expect(result.nextError).toBeInstanceOf(BadDataException);
+    });
+  });
+});

--- a/Common/Server/Services/StatusPagePrivateUserService.ts
+++ b/Common/Server/Services/StatusPagePrivateUserService.ts
@@ -1,6 +1,7 @@
 import DatabaseConfig from "../DatabaseConfig";
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate } from "../Types/Database/Hooks";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import logger from "../Utils/Logger";
 import DatabaseService from "./DatabaseService";
 import MailService from "./MailService";
@@ -13,6 +14,8 @@ import Protocol from "../../Types/API/Protocol";
 import URL from "../../Types/API/URL";
 import OneUptimeDate from "../../Types/Date";
 import EmailTemplateType from "../../Types/Email/EmailTemplateType";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
+import Email from "../../Types/Email";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import StatusPage from "../../Models/DatabaseModels/StatusPage";
@@ -51,6 +54,86 @@ export class Service extends DatabaseService<Model> {
 
     return {
       createBy: createBy,
+      carryForward: null,
+    };
+  }
+
+  /**
+   * Kill any outstanding password-reset link for a status page user whose
+   * email address is about to change.
+   *
+   * Same invariant, and the same reasoning, as
+   * `UserService.expirePasswordResetTokensForEmailChange`: the link is a
+   * bearer credential addressed to one mailbox, and `/status-page-api/
+   * reset-password` finds the row by token hash and status page alone, never
+   * by the address the link was mailed to. Left unexpired, a link sent to the
+   * old address keeps working against the account at its new one.
+   *
+   * This path is worth closing even though a status page user cannot edit
+   * their own email: project admins can (the column carries `update` for
+   * ProjectAdmin and StatusPageAdmin), and `StatusPageSCIM.ts` rewrites it
+   * from the directory. "Move this subscriber to their new address" is the
+   * same rescue action, done by somebody else on the user's behalf, and it has
+   * to invalidate old links for the same reason.
+   *
+   * Cleared before the write, and only for rows whose address actually
+   * changes, so a SCIM push that re-sends an unchanged address does not
+   * invalidate a reset link the user is part-way through using.
+   */
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    if (updateBy.data.email) {
+      const newEmail: string = (updateBy.data.email as Email)
+        .toString()
+        .toLowerCase();
+
+      const existingUsers: Array<Model> = await this.findBy({
+        query: updateBy.query,
+        select: {
+          _id: true,
+          email: true,
+        },
+        props: updateBy.props,
+        limit: LIMIT_MAX,
+        skip: 0,
+      });
+
+      for (const user of existingUsers) {
+        if (!user.id) {
+          continue;
+        }
+
+        /*
+         * A row whose `email` did not come back is treated as changed -- that
+         * only happens when the caller could not read the column, and on a
+         * credential the safe assumption is the one that expires the token.
+         */
+        const currentEmail: string | undefined = user.email
+          ?.toString()
+          .toLowerCase();
+
+        if (currentEmail === newEmail) {
+          continue;
+        }
+
+        await this.updateOneById({
+          id: user.id,
+          data: {
+            resetPasswordToken: null!,
+            resetPasswordExpires: null!,
+          },
+          props: {
+            isRoot: true,
+            ignoreHooks: true,
+          },
+        });
+      }
+    }
+
+    return {
+      updateBy: updateBy,
       carryForward: null,
     };
   }

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -353,6 +353,13 @@ export class Service extends DatabaseService<Model> {
       carryForward = users;
     }
 
+    if (updateBy.data.email) {
+      await this.expirePasswordResetTokensForEmailChange({
+        newEmail: updateBy.data.email as Email,
+        existingUsers: carryForward,
+      });
+    }
+
     /*
      * There used to be a guard here refusing to set `enableTwoFactorAuth` on
      * an account with no verified authenticator, on the grounds that doing so
@@ -410,6 +417,94 @@ export class Service extends DatabaseService<Model> {
     }
 
     return { updateBy, carryForward: carryForward };
+  }
+
+  /**
+   * Kill any outstanding password-reset link for every account whose email
+   * address this update is about to change.
+   *
+   * A reset link is a bearer credential addressed to ONE mailbox: holding it
+   * proves only that somebody could read mail sent to the address the account
+   * had when the link was minted. Move the account to a different address and
+   * that proof is about a mailbox the account no longer uses, so the link has
+   * to die with the address it was sent to.
+   *
+   * Without this, changing your email is not the account-recovery step that
+   * users -- and our own "You have changed your email" mail -- take it to be:
+   *
+   *   1. An attacker who can read the victim's mailbox requests a password
+   *      reset and does NOT spend the link. Nothing about the account looks
+   *      wrong, because nothing has changed yet.
+   *   2. The victim notices the mailbox is compromised and moves the account
+   *      to an address the attacker cannot read. This is exactly the advice
+   *      they would be given, and they now believe they are safe.
+   *   3. The attacker spends the link from step 1. `/reset-password` finds the
+   *      row BY TOKEN HASH ALONE -- it never looks at the email address -- so
+   *      it happily sets a new password on the account at its NEW address, and
+   *      the victim is locked out of an account they had just rescued.
+   *
+   * Cleared BEFORE the email is written rather than afterwards in
+   * `onUpdateSuccess`, so there is no instant in which the new address is
+   * committed while a link mailed to the old one is still redeemable. The
+   * price of that ordering is that an email update which subsequently fails
+   * has still burned a pending link, and the user has to request another one.
+   * For a credential that is the right way round.
+   *
+   * Only rows whose address actually CHANGES are touched. Directory syncs
+   * rewrite `email` with the value it already has on every push (see
+   * `App/FeatureSet/Identity/API/SCIM.ts`, which updates whenever either the
+   * email or the name is present), and clearing on those would let an
+   * unrelated SCIM run invalidate a reset link the user is part-way through
+   * using.
+   *
+   * A row that came back with no `email` at all is treated as changed. That
+   * happens when the caller could not read the column, and on a credential the
+   * safe assumption is the one that expires the token.
+   *
+   * NOTE: this runs from `onBeforeUpdate`, so an email write made with
+   * `ignoreHooks: true` would slip past it. Nothing does that today -- the
+   * dashboard, the SCIM endpoints and the admin API all go through the hooks
+   * -- and any new caller that writes `email` hook-free has to clear these two
+   * columns itself.
+   */
+  @CaptureSpan()
+  private async expirePasswordResetTokensForEmailChange(data: {
+    newEmail: Email;
+    existingUsers: Array<Model>;
+  }): Promise<void> {
+    const newEmail: string = data.newEmail.toString().toLowerCase();
+
+    for (const user of data.existingUsers) {
+      if (!user.id) {
+        continue;
+      }
+
+      const currentEmail: string | undefined = user.email
+        ?.toString()
+        .toLowerCase();
+
+      if (currentEmail === newEmail) {
+        continue;
+      }
+
+      await this.updateOneById({
+        id: user.id,
+        data: {
+          resetPasswordToken: null!,
+          resetPasswordExpires: null!,
+        },
+        /*
+         * Root because `resetPasswordToken` is declared with `update: []` --
+         * no permission can write it -- and hook-free because this IS the
+         * update hook; re-entering it would have this write go looking for an
+         * email change of its own.
+         */
+        props: {
+          isRoot: true,
+          ignoreHooks: true,
+        },
+      });
+    }
   }
 
   @CaptureSpan()

--- a/Common/Tests/Server/Services/StatusPagePrivateUserEmailChangePasswordResetExpiry.test.ts
+++ b/Common/Tests/Server/Services/StatusPagePrivateUserEmailChangePasswordResetExpiry.test.ts
@@ -1,0 +1,269 @@
+import StatusPagePrivateUserService from "../../../Server/Services/StatusPagePrivateUserService";
+import { OnUpdate } from "../../../Server/Types/Database/Hooks";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import StatusPagePrivateUser from "../../../Models/DatabaseModels/StatusPagePrivateUser";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Email from "../../../Types/Email";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * The status page half of the same invariant.
+ *
+ * `POST /status-page-api/reset-password` (App/FeatureSet/Identity/API/
+ * StatusPageAuthentication.ts) finds the account by TOKEN HASH and status page
+ * id -- never by the address the link was mailed to -- exactly as the
+ * dashboard's endpoint does. So a reset link sent to a private status page
+ * user's old address keeps working against that account after somebody moves
+ * it to a new one, which is the takeover described in
+ * UserEmailChangePasswordResetExpiry.test.ts with a different table underneath.
+ *
+ * It reaches the same end by a different route, and that difference is why the
+ * test file exists separately. A status page user cannot edit their own email:
+ * the column is writable by ProjectAdmin / StatusPageAdmin, and by
+ * StatusPageSCIM.ts syncing from a directory. So the address change here is
+ * something done FOR the user -- "move this subscriber to their new address" --
+ * which is the same rescue action, and has to invalidate old links for the same
+ * reason.
+ *
+ * Stubbed at the service boundary; no database. The hook is protected and is
+ * reached through a structural cast.
+ * ---------------------------------------------------------------------------
+ */
+
+const USER_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+
+const OLD_EMAIL: string = "subscriber@compromised-mailbox.example.com";
+const NEW_EMAIL: string = "subscriber@rescued-mailbox.example.com";
+
+interface StatusPagePrivateUserServiceInternals {
+  onBeforeUpdate: (
+    updateBy: UpdateBy<StatusPagePrivateUser>,
+  ) => Promise<OnUpdate<StatusPagePrivateUser>>;
+}
+
+function service(): StatusPagePrivateUserServiceInternals {
+  return StatusPagePrivateUserService as unknown as StatusPagePrivateUserServiceInternals;
+}
+
+type PersistedUserData = {
+  id?: ObjectID | undefined;
+  email?: string | undefined;
+};
+
+function persistedUser(data: PersistedUserData = {}): StatusPagePrivateUser {
+  const user: StatusPagePrivateUser = new StatusPagePrivateUser();
+
+  if (data.id !== undefined) {
+    user.id = data.id;
+    user._id = data.id.toString();
+  }
+
+  if (data.email !== undefined) {
+    user.email = new Email(data.email);
+  }
+
+  return user;
+}
+
+/* A project admin editing somebody else's status page subscription. */
+function adminProps(): DatabaseCommonInteractionProps {
+  return {
+    userId: new ObjectID("88888888-8888-4888-8888-888888888888"),
+    tenantId: PROJECT_ID,
+  };
+}
+
+type UpdatePayloadData = {
+  patch: Record<string, unknown>;
+  query?: Record<string, unknown> | undefined;
+};
+
+function updatePayload(
+  data: UpdatePayloadData,
+): UpdateBy<StatusPagePrivateUser> {
+  return {
+    query: (data.query || {
+      _id: USER_ID.toString(),
+    }) as unknown as UpdateBy<StatusPagePrivateUser>["query"],
+    data: data.patch as unknown as UpdateBy<StatusPagePrivateUser>["data"],
+    props: adminProps(),
+    limit: 10,
+    skip: 0,
+  };
+}
+
+type Stubs = {
+  findBy: jest.SpyInstance;
+  updateOneById: jest.SpyInstance;
+};
+
+let stubs: Stubs;
+
+describe("StatusPagePrivateUserService.onBeforeUpdate — a reset link dies with the address it was mailed to", () => {
+  beforeEach(() => {
+    stubs = {
+      findBy: jest
+        .spyOn(StatusPagePrivateUserService, "findBy")
+        .mockResolvedValue([
+          persistedUser({ id: USER_ID, email: OLD_EMAIL }),
+        ] as never),
+      updateOneById: jest
+        .spyOn(StatusPagePrivateUserService, "updateOneById")
+        .mockResolvedValue(undefined as never),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("moving a subscriber to a new address kills the outstanding link first", async () => {
+    /*
+     * `onBeforeUpdate` returns before the caller's UPDATE runs, so the write
+     * having already happened here is what rules out any interval in which the
+     * account answers to the new address while the old link still works.
+     */
+    await service().onBeforeUpdate(
+      updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+    );
+
+    const write: {
+      id: ObjectID;
+      data: Record<string, unknown>;
+      props: DatabaseCommonInteractionProps;
+    } = stubs.updateOneById.mock.calls[0]![0] as unknown as {
+      id: ObjectID;
+      data: Record<string, unknown>;
+      props: DatabaseCommonInteractionProps;
+    };
+
+    expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+    expect(write.id.toString()).toBe(USER_ID.toString());
+    expect(write.data).toEqual({
+      resetPasswordToken: null,
+      resetPasswordExpires: null,
+    });
+    expect(write.props.isRoot).toBe(true);
+    expect(write.props.ignoreHooks).toBe(true);
+  });
+
+  test("the admin's own update is left exactly as it was", async () => {
+    /*
+     * Same reason as on the dashboard user: `resetPasswordToken` is declared
+     * `update: []`, and the permission check runs after this hook, so folding
+     * the nulls into the caller's data would turn every admin email edit into
+     * a permission error.
+     */
+    const payload: UpdateBy<StatusPagePrivateUser> = updatePayload({
+      patch: { email: new Email(NEW_EMAIL) },
+    });
+
+    await service().onBeforeUpdate(payload);
+
+    expect(Object.keys(payload.data)).toEqual(["email"]);
+  });
+
+  test("a SCIM push that re-sends the address unchanged leaves the link alone", async () => {
+    await service().onBeforeUpdate(
+      updatePayload({ patch: { email: new Email(OLD_EMAIL) } }),
+    );
+
+    expect(stubs.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("the same address in different case is not a change", async () => {
+    /*
+     * `Email` lowercases on construction, and the comparison lowercases too,
+     * so this keeps holding if a raw string ever reaches `data.email`.
+     */
+    stubs.findBy.mockResolvedValue([
+      persistedUser({ id: USER_ID, email: "Subscriber@Example.com" }),
+    ] as never);
+
+    await service().onBeforeUpdate(
+      updatePayload({ patch: { email: new Email("subscriber@example.com") } }),
+    );
+
+    expect(stubs.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("an update that does not touch the address loads nothing and clears nothing", async () => {
+    await service().onBeforeUpdate(
+      updatePayload({ patch: { name: new Name("Subscriber") } }),
+    );
+
+    expect(stubs.findBy).not.toHaveBeenCalled();
+    expect(stubs.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("across several matched rows only the ones actually changing are cleared", async () => {
+    stubs.findBy.mockResolvedValue([
+      persistedUser({ id: USER_ID, email: OLD_EMAIL }),
+      persistedUser({ id: OTHER_USER_ID, email: NEW_EMAIL }),
+    ] as never);
+
+    await service().onBeforeUpdate(
+      updatePayload({
+        patch: { email: new Email(NEW_EMAIL) },
+        query: { statusPageId: STATUS_PAGE_ID.toString() },
+      }),
+    );
+
+    const clearedIds: Array<string> = stubs.updateOneById.mock.calls.map(
+      (call: Array<unknown>) => {
+        return (call[0] as { id: ObjectID }).id.toString();
+      },
+    );
+
+    expect(clearedIds).toEqual([USER_ID.toString()]);
+  });
+
+  test("a row whose address could not be read is treated as changed", async () => {
+    stubs.findBy.mockResolvedValue([persistedUser({ id: USER_ID })] as never);
+
+    await service().onBeforeUpdate(
+      updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+    );
+
+    expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("a row that came back without an id is skipped rather than throwing", async () => {
+    stubs.findBy.mockResolvedValue([
+      persistedUser({ email: OLD_EMAIL }),
+      persistedUser({ id: USER_ID, email: OLD_EMAIL }),
+    ] as never);
+
+    await expect(
+      service().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("the hook hands the caller's update straight back", async () => {
+    const payload: UpdateBy<StatusPagePrivateUser> = updatePayload({
+      patch: { email: new Email(NEW_EMAIL) },
+    });
+
+    const result: OnUpdate<StatusPagePrivateUser> =
+      await service().onBeforeUpdate(payload);
+
+    expect(result.updateBy).toBe(payload);
+    expect(result.carryForward).toBeNull();
+  });
+});

--- a/Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts
+++ b/Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts
@@ -1,0 +1,472 @@
+import UserService from "../../../Server/Services/UserService";
+import { OnUpdate } from "../../../Server/Types/Database/Hooks";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import User from "../../../Models/DatabaseModels/User";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Email from "../../../Types/Email";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+import HashedString from "../../../Types/HashedString";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * A PASSWORD RESET LINK MUST NOT SURVIVE THE ADDRESS IT WAS MAILED TO.
+ *
+ * The bug this file pins down, reported against oneuptime.com as "Broken
+ * Authentication Leads To Account Takeover":
+ *
+ *   1. Somebody who can read the victim's mailbox requests a password reset
+ *      and DOES NOT click the link. The account is untouched, so nothing looks
+ *      wrong to the victim -- this is the step that makes the whole thing
+ *      work.
+ *   2. The victim realises the mailbox is compromised and moves the account to
+ *      an address the attacker cannot read. This is the standard remedy, and
+ *      the product's own "You have changed your email" mail implies it worked.
+ *   3. The attacker spends the link from step 1. `POST /reset-password` finds
+ *      the account BY TOKEN HASH ALONE -- it never looks at the email address
+ *      on the row -- so it sets a new password on the account at its NEW
+ *      address, and the victim loses the account they had just rescued.
+ *
+ * The fix is one invariant, enforced in `UserService.onBeforeUpdate`: writing a
+ * DIFFERENT email address to a user row clears `resetPasswordToken` and
+ * `resetPasswordExpires` on that row first. Every test below is about some way
+ * that invariant can be broken while the product still appears to work:
+ *
+ *  - clearing AFTER the email write (in `onUpdateSuccess`) leaves a window in
+ *    which the new address is committed and the old link still redeemable, so
+ *    the assertions below are about the state of the row when `onBeforeUpdate`
+ *    RETURNS, before the caller's UPDATE has run at all;
+ *  - clearing by adding the two columns to `updateBy.data` would look correct
+ *    and pass a naive test, but `resetPasswordToken` is declared `update: []`,
+ *    so the permission check that runs after this hook would reject the whole
+ *    write and no user could change their own email again. Hence the explicit
+ *    test that `updateBy.data` is left alone;
+ *  - clearing on EVERY email write, rather than on a change, would let a SCIM
+ *    directory sync -- which rewrites `email` with the value it already has on
+ *    every push -- silently invalidate a reset link a user is part-way through
+ *    using.
+ *
+ * No database is involved. `findBy` and `updateOneById` on the UserService
+ * singleton are jest.spyOn stubs, and the hook -- protected, but an ordinary
+ * prototype method at runtime -- is reached through a structural cast.
+ * ---------------------------------------------------------------------------
+ */
+
+const USER_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const THIRD_USER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const OLD_EMAIL: string = "victim@compromised-mailbox.example.com";
+const NEW_EMAIL: string = "victim@rescued-mailbox.example.com";
+
+// The digest a live reset link would have left on the row.
+const PENDING_TOKEN_HASH: string = "a-live-reset-token-digest";
+
+interface UserServiceInternals {
+  onBeforeUpdate: (updateBy: UpdateBy<User>) => Promise<OnUpdate<User>>;
+}
+
+function userService(): UserServiceInternals {
+  return UserService as unknown as UserServiceInternals;
+}
+
+type PersistedUserData = {
+  id?: ObjectID | undefined;
+  email?: string | undefined;
+};
+
+/*
+ * A row as `onBeforeUpdate`'s own `findBy` returns it: `_id` and `email` only,
+ * because that is precisely what the hook selects. `email` is omitted when the
+ * caller asks for it, which is the shape a column the caller may not read
+ * comes back as.
+ */
+function persistedUser(data: PersistedUserData = {}): User {
+  const user: User = new User();
+
+  if (data.id !== undefined) {
+    user.id = data.id;
+    user._id = data.id.toString();
+  }
+
+  if (data.email !== undefined) {
+    user.email = new Email(data.email);
+  }
+
+  return user;
+}
+
+type UpdatePayloadData = {
+  patch: Record<string, unknown>;
+  query?: Record<string, unknown> | undefined;
+  props?: DatabaseCommonInteractionProps | undefined;
+};
+
+/* An ordinary signed-in user editing their own profile: no root, no role. */
+function currentUserProps(): DatabaseCommonInteractionProps {
+  return {
+    userId: USER_ID,
+  };
+}
+
+function updatePayload(data: UpdatePayloadData): UpdateBy<User> {
+  return {
+    query: (data.query || {
+      _id: USER_ID.toString(),
+    }) as unknown as UpdateBy<User>["query"],
+    data: data.patch as unknown as UpdateBy<User>["data"],
+    props: data.props || currentUserProps(),
+    limit: 10,
+    skip: 0,
+  };
+}
+
+type Stubs = {
+  findBy: jest.SpyInstance;
+  updateOneById: jest.SpyInstance;
+};
+
+let stubs: Stubs;
+
+describe("UserService.onBeforeUpdate — a password reset link dies with the address it was mailed to", () => {
+  beforeEach(() => {
+    stubs = {
+      findBy: jest
+        .spyOn(UserService, "findBy")
+        .mockResolvedValue([
+          persistedUser({ id: USER_ID, email: OLD_EMAIL }),
+        ] as never),
+      updateOneById: jest
+        .spyOn(UserService, "updateOneById")
+        .mockResolvedValue(undefined as never),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("the reported attack", () => {
+    test("a link minted before the address change is gone once the address changes", async () => {
+      /*
+       * The end-to-end shape of the report, with the row standing in for the
+       * database. What matters is the LAST line: after the victim moves the
+       * account, `/reset-password`'s lookup -- `findOneBy({ resetPasswordToken:
+       * <hash> })` -- has nothing left to match, so the link the attacker is
+       * holding resolves to no user and the endpoint answers "Invalid link".
+       */
+      const row: {
+        email: string;
+        resetPasswordToken: string | null;
+        resetPasswordExpires: Date | null;
+      } = {
+        email: OLD_EMAIL,
+        // Step 1: the attacker requested a reset and never spent the link.
+        resetPasswordToken: PENDING_TOKEN_HASH,
+        resetPasswordExpires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      };
+
+      stubs.findBy.mockResolvedValue([
+        persistedUser({ id: USER_ID, email: row.email }),
+      ] as never);
+
+      stubs.updateOneById.mockImplementation(
+        (updateBy: { data: Record<string, unknown> }): Promise<number> => {
+          if ("resetPasswordToken" in updateBy.data) {
+            row.resetPasswordToken = updateBy.data["resetPasswordToken"] as
+              | string
+              | null;
+          }
+
+          if ("resetPasswordExpires" in updateBy.data) {
+            row.resetPasswordExpires = updateBy.data[
+              "resetPasswordExpires"
+            ] as Date | null;
+          }
+
+          return Promise.resolve(1);
+        },
+      );
+
+      // Step 2: the victim moves the account to a mailbox the attacker cannot read.
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      // Step 3: there is no longer anything for the attacker's link to match.
+      expect(row.resetPasswordToken).toBeNull();
+      expect(row.resetPasswordExpires).toBeNull();
+    });
+
+    test("the link is dead BEFORE the new address is written, not after", async () => {
+      /*
+       * The ordering is the security property, not an implementation detail.
+       * Clearing in `onUpdateSuccess` would also make the test above pass while
+       * leaving an interval -- however short -- in which the account answers to
+       * the new address and the old link still works. `onBeforeUpdate` returns
+       * to the caller BEFORE the caller's UPDATE runs, so asserting the write
+       * has already happened by the time it returns is asserting that no such
+       * interval exists.
+       */
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("what the clearing write looks like", () => {
+    test("it nulls both the token and its expiry, and touches nothing else", async () => {
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      const write: Record<string, unknown> = (
+        stubs.updateOneById.mock.calls[0]![0] as unknown as {
+          data: Record<string, unknown>;
+        }
+      ).data;
+
+      expect(write).toEqual({
+        resetPasswordToken: null,
+        resetPasswordExpires: null,
+      });
+    });
+
+    test("it is aimed at the row whose address is changing", async () => {
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      const write: { id: ObjectID } = stubs.updateOneById.mock
+        .calls[0]![0] as unknown as { id: ObjectID };
+
+      expect(write.id.toString()).toBe(USER_ID.toString());
+    });
+
+    test("it is a root, hook-free write", async () => {
+      /*
+       * Root because `resetPasswordToken` carries `update: []` -- there is no
+       * permission that can write it, so the ordinary caller's props would be
+       * refused. Hook-free because this IS the update hook: re-entering it
+       * would send this write looking for an email change of its own.
+       */
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      const write: { props: DatabaseCommonInteractionProps } = stubs
+        .updateOneById.mock.calls[0]![0] as unknown as {
+        props: DatabaseCommonInteractionProps;
+      };
+
+      expect(write.props.isRoot).toBe(true);
+      expect(write.props.ignoreHooks).toBe(true);
+    });
+
+    test("the caller's own update is left exactly as it was", async () => {
+      /*
+       * The tempting one-line fix is to fold the two nulls into `updateBy.data`
+       * so they ride along on the caller's UPDATE. It cannot be done here:
+       * `ModelPermission.checkUpdateQueryPermissions` runs AFTER this hook and
+       * refuses any column whose `update` list is empty, so a user changing
+       * their own email would get a permission error instead of an email
+       * change -- a regression that no test about tokens would catch.
+       */
+      const payload: UpdateBy<User> = updatePayload({
+        patch: { email: new Email(NEW_EMAIL) },
+      });
+
+      await userService().onBeforeUpdate(payload);
+
+      expect(Object.keys(payload.data)).toEqual(["email"]);
+    });
+
+    test("an ordinary user changing their own address still gets the token cleared", async () => {
+      /*
+       * The victim in the report is not an admin. The clearing write must not
+       * inherit the caller's props, or it would be refused for exactly the
+       * person the fix exists to protect.
+       */
+      await userService().onBeforeUpdate(
+        updatePayload({
+          patch: { email: new Email(NEW_EMAIL) },
+          props: currentUserProps(),
+        }),
+      );
+
+      expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("writes that must NOT invalidate a pending link", () => {
+    test("re-writing the address the account already has", async () => {
+      /*
+       * SCIM pushes `email` on every sync whether or not it changed (see
+       * App/FeatureSet/Identity/API/SCIM.ts, which updates whenever the email
+       * OR the name is present). If those cleared tokens, a directory sync
+       * firing between "send me a reset link" and "here is my new password"
+       * would break the reset for no reason at all.
+       */
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(OLD_EMAIL) } }),
+      );
+
+      expect(stubs.updateOneById).not.toHaveBeenCalled();
+    });
+
+    test("re-writing the same address in different case", async () => {
+      /*
+       * The address the user types is not necessarily the one on the row,
+       * character for character. Today `Email` lowercases on construction so
+       * the two agree by the time they get here; the comparison lowercases as
+       * well, so this keeps holding if a raw string ever reaches `data.email`.
+       */
+      stubs.findBy.mockResolvedValue([
+        persistedUser({ id: USER_ID, email: "Victim@Example.com" }),
+      ] as never);
+
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email("victim@example.com") } }),
+      );
+
+      expect(stubs.updateOneById).not.toHaveBeenCalled();
+    });
+
+    test("a password change, which has its own session revocation", async () => {
+      await userService().onBeforeUpdate(
+        updatePayload({
+          patch: { password: new HashedString("a-new-password") },
+        }),
+      );
+
+      expect(stubs.updateOneById).not.toHaveBeenCalled();
+    });
+
+    test("a profile edit that does not touch the address at all", async () => {
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { name: new Name("Victim") } }),
+      );
+
+      expect(stubs.findBy).not.toHaveBeenCalled();
+      expect(stubs.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updates that match more than one row", () => {
+    test("every row whose address changes is cleared, and only those", async () => {
+      /*
+       * `updateBy.query` is a query, not an id, so one call can carry the same
+       * new address onto several rows -- and the ones already at that address
+       * are not changing. A fix written against `updateOneById` alone would
+       * quietly clear only the first.
+       */
+      stubs.findBy.mockResolvedValue([
+        persistedUser({ id: USER_ID, email: OLD_EMAIL }),
+        persistedUser({ id: OTHER_USER_ID, email: NEW_EMAIL }),
+        persistedUser({ id: THIRD_USER_ID, email: "third@example.com" }),
+      ] as never);
+
+      await userService().onBeforeUpdate(
+        updatePayload({
+          patch: { email: new Email(NEW_EMAIL) },
+          query: { isEmailVerified: true },
+        }),
+      );
+
+      const clearedIds: Array<string> = stubs.updateOneById.mock.calls.map(
+        (call: Array<unknown>) => {
+          return (call[0] as { id: ObjectID }).id.toString();
+        },
+      );
+
+      expect(clearedIds).toEqual([
+        USER_ID.toString(),
+        THIRD_USER_ID.toString(),
+      ]);
+    });
+
+    test("a row that came back without an id is skipped rather than throwing", async () => {
+      stubs.findBy.mockResolvedValue([
+        persistedUser({ email: OLD_EMAIL }),
+        persistedUser({ id: USER_ID, email: OLD_EMAIL }),
+      ] as never);
+
+      await expect(
+        userService().onBeforeUpdate(
+          updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+        ),
+      ).resolves.toBeDefined();
+
+      expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("fail-closed behaviour", () => {
+    test("a row whose address could not be read is treated as changed", async () => {
+      /*
+       * `email` comes back absent only when the caller could not read the
+       * column. There is then no way to tell whether the address is changing,
+       * and the two answers are not equally bad: guessing "unchanged" leaves a
+       * live reset link on an account that may have just moved, while guessing
+       * "changed" costs the user one more trip to the forgot-password page.
+       */
+      stubs.findBy.mockResolvedValue([persistedUser({ id: USER_ID })] as never);
+
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      expect(stubs.updateOneById).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("the rest of the hook still works", () => {
+    test("carryForward still holds the rows as they were before the write", async () => {
+      /*
+       * `onUpdateSuccess` diffs `carryForward` against the re-read rows to
+       * decide whether to send the "please verify your new address" mail and
+       * clear `isEmailVerified`. Clearing tokens must not disturb that: if
+       * carryForward came back empty, an email change would silently stop
+       * requiring re-verification.
+       */
+      const result: OnUpdate<User> = await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      expect(result.carryForward).toHaveLength(1);
+      expect((result.carryForward as Array<User>)[0]!.email!.toString()).toBe(
+        OLD_EMAIL,
+      );
+    });
+
+    test("the rows are loaded once, not once per concern", async () => {
+      await userService().onBeforeUpdate(
+        updatePayload({ patch: { email: new Email(NEW_EMAIL) } }),
+      );
+
+      expect(stubs.findBy).toHaveBeenCalledTimes(1);
+    });
+
+    test("turning off two factor auth as a non-root caller is still refused", async () => {
+      /*
+       * The guard that lives immediately after the new code in the same hook.
+       * Cheap to assert here, and it is the thing an edit to this method is
+       * most likely to displace.
+       */
+      await expect(
+        userService().onBeforeUpdate(
+          updatePayload({ patch: { enableTwoFactorAuth: false } }),
+        ),
+      ).rejects.toThrow(
+        "Only an administrator can turn off two factor authentication for this account.",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## The report

An external researcher reported "Broken Authentication Leads To Account Takeover" against oneuptime.com. The claim checks out against the code.

## The bug

`POST /forgot-password` writes a hashed reset token and a 24-hour expiry onto the user row and mails the raw token to the account's **current** address.

Changing the account's email goes through `UserService.onUpdateSuccess`, which sends a "please verify your new address" mail and sets `isEmailVerified: false` — but leaves `resetPasswordToken` and `resetPasswordExpires` exactly where they are.

`POST /reset-password` then finds the account **by token hash alone** (`App/FeatureSet/Identity/API/Authentication.ts:762`). It never looks at the email address on the row.

So:

1. Someone who can read the victim's mailbox requests a password reset and does **not** spend the link. Nothing about the account changes, so nothing looks wrong.
2. The victim notices the mailbox compromise and moves the account to an address the attacker cannot read — the standard remedy, and the one our own "You have changed your email" mail implies has worked.
3. The attacker spends the link from step 1. It sets a new password on the account at its **new** address.

The victim loses the account they had just rescued.

## The fix

`UserService.onBeforeUpdate` now clears `resetPasswordToken` and `resetPasswordExpires` for every row whose email address the update is about to change.

Three details are load-bearing:

- **Before the write, not after.** Clearing in `onUpdateSuccess` would leave an interval in which the new address is committed and the old link is still redeemable. `onBeforeUpdate` returns before the caller's `UPDATE` runs, so no such interval exists. The cost is that an email update which then fails has still burned a pending link — the right trade for a credential.
- **Not folded into `updateBy.data`.** `resetPasswordToken` is declared `update: []`, and `ModelPermission.checkUpdateQueryPermissions` runs *after* this hook, so riding along on the caller's update would turn every self-service email change into a permission error. The clear is a separate root, hook-free write.
- **Only rows that actually change.** SCIM pushes `email` on every sync whether or not it changed; clearing on those would let an unrelated directory sync invalidate a reset link a user is part-way through using. A row whose `email` could not be read is treated as changed — fail-closed.

`StatusPagePrivateUserService` gets the same hook. Its `/status-page-api/reset-password` looks accounts up the same way, and while a status page user cannot edit their own email, project admins and `StatusPageSCIM` can — "move this subscriber to their new address" is the same rescue action performed on the user's behalf.

## Tests

**`Common/Tests/Server/Services/UserEmailChangePasswordResetExpiry.test.ts`** (17 tests) — the hook:
- the reported attack end to end, with a row standing in for the database, and the ordering assertion that rules out the post-write window
- the shape of the clearing write: both columns nulled, aimed at the right row, root and hook-free
- `updateBy.data` left untouched, so a normal user can still change their own email
- writes that must **not** invalidate a link: same address re-written, same address in different case, a password change, a name-only edit
- multi-row updates: only the rows actually changing are cleared; a row with no id is skipped
- fail-closed when `email` could not be read
- the rest of the hook still works — `carryForward` intact (the verification-mail flow depends on it), rows loaded once, and the neighbouring two-factor guard still fires

**`Common/Tests/Server/Services/StatusPagePrivateUserEmailChangePasswordResetExpiry.test.ts`** (9 tests) — the same invariant on the status page side.

**`App/Tests/FeatureSet/Identity/PasswordResetLinkEmailChangeTakeover.test.ts`** (9 tests) — the endpoint half, driving the real `/forgot-password` and `/reset-password` handlers against a single in-memory row so the token hashing is real:
- the column holds a hash, not the link's token — which is *why* the fix has to be a write-side clear rather than a comparison at redemption
- redemption queries on `resetPasswordToken` and nothing else
- control: the link works, and is spent on use
- the attack: with the token cleared, the same link is refused, no password is written and no sessions are revoked
- the victim can still reset from the new address afterwards
- the neighbouring guards (expired token, missing token) still fire

## Not in this PR

While reading the surrounding code I noticed that `StatusPagePrivateUserService.onCreateSuccess` stores the **raw** invite token while `/status-page-api/reset-password` looks it up by hash, so status page invite links appear to be unredeemable. That is a separate defect and is not touched here.
