### PR TITLE
fix(dashboard): gate the dashboard editor on the permission its save needs

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
@@ -85,10 +85,18 @@ import TimeRange from "Common/Types/Time/TimeRange";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
 import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
 import DashboardVariableUrlState from "Common/Utils/Dashboard/VariableUrlState";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "Common/UI/Utils/PermissionGate";
 
 export interface ComponentProps {
   dashboardId: ObjectID;
 }
+
+type SaveDashboardViewConfigFunction = (
+  configToSave: DashboardViewConfig,
+) => Promise<boolean>;
 
 const DashboardViewer: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -109,6 +117,32 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
     timeRangeZoom.startAndEndDate;
 
   const [isSaving, setIsSaving] = useState<boolean>(false);
+
+  /*
+   * A save that was refused, kept apart from the page-level `error`. That one
+   * replaces the whole board with a bare message; on a failed save it took
+   * every unsaved widget the user had just placed with it.
+   */
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  /*
+   * Whether this user may write to the dashboard at all.
+   *
+   * The board is a bespoke screen: it does not go through ModelTable or
+   * ModelForm, so none of the generic gates ever ran over it. Every reader -
+   * including a project-wide `Viewer`, whose whole definition is "read-only
+   * access across all project resources" - was offered Edit, Add Widget,
+   * Variables and Save Changes, could rearrange the whole board, and only
+   * found out at Save that the API had never been going to accept it
+   * (github.com/OneUptime/oneuptime/issues/3550). The write is refused by
+   * TablePermission either way; what was broken is that the UI never said so,
+   * and the work was lost when it finally did.
+   */
+  const editGate: PermissionGateResult = useMemo(() => {
+    return PermissionGate.check(new Dashboard(), ModelAction.Update);
+  }, []);
+
+  const canEditDashboard: boolean = editGate.isAllowed;
 
   // Auto-refresh state
   const [autoRefreshInterval, setAutoRefreshInterval] =
@@ -174,24 +208,55 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
     setDashboardTotalWidth(dashboardViewRef.current?.offsetWidth || 0);
   };
 
-  const saveDashboardViewConfig: PromiseVoidFunction =
-    async (): Promise<void> => {
-      try {
-        setIsSaving(true);
-        await ModelAPI.updateById({
-          modelType: Dashboard,
-          id: props.dashboardId,
-          data: {
-            dashboardViewConfig:
-              JSONFunctions.serializeValue(dashboardViewConfig),
-          },
-        });
-      } catch (err) {
-        setError(API.getFriendlyErrorMessage(err as Error));
-      }
+  /*
+   * Takes the config to persist as an argument rather than reading the
+   * `dashboardViewConfig` state. The caller stamps the auto-refresh interval
+   * onto the config immediately before saving, and a setState is not visible
+   * to the closure that scheduled it - so reading the state here wrote the
+   * board the user had *before* their last change to the refresh interval,
+   * and that setting only landed on the following save.
+   *
+   * Returns whether the write actually happened, so the caller can keep the
+   * user in edit mode with their work intact when it did not.
+   */
+  const saveDashboardViewConfig: SaveDashboardViewConfigFunction = async (
+    configToSave: DashboardViewConfig,
+  ): Promise<boolean> => {
+    /*
+     * Belt and braces: edit mode is already gated, but nothing should be able
+     * to reach the write path without the permission the write needs.
+     */
+    if (!canEditDashboard) {
+      setSaveError(
+        editGate.disabledReason ||
+          PermissionGate.getMissingPermissionMessage(
+            new Dashboard(),
+            ModelAction.Update,
+          ),
+      );
+      return false;
+    }
 
+    try {
+      setIsSaving(true);
+      setSaveError(null);
+      await ModelAPI.updateById({
+        modelType: Dashboard,
+        id: props.dashboardId,
+        data: {
+          dashboardViewConfig: JSONFunctions.serializeValue(configToSave),
+        },
+      });
+    } catch (err) {
+      // A failed save leaves the board on screen, in edit mode, and says why.
+      setSaveError(API.getFriendlyErrorMessage(err as Error));
       setIsSaving(false);
-    };
+      return false;
+    }
+
+    setIsSaving(false);
+    return true;
+  };
 
   useEffect(() => {
     setDashboardTotalWidth(dashboardViewRef.current?.offsetWidth || 0);
@@ -350,7 +415,14 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
     };
   }, [autoRefreshInterval, dashboardMode, triggerRefresh]);
 
-  const isEditMode: boolean = dashboardMode === DashboardMode.Edit;
+  /*
+   * `canEditDashboard` is ANDed in here rather than only at the point the
+   * mode is set, so the canvas and the toolbar cannot disagree with the gate
+   * even if the mode were somehow left over from a permission that has since
+   * been revoked.
+   */
+  const isEditMode: boolean =
+    dashboardMode === DashboardMode.Edit && canEditDashboard;
 
   useEffect(() => {
     handleResize();
@@ -432,7 +504,7 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
       }}
     >
       <DashboardToolbar
-        dashboardMode={dashboardMode}
+        dashboardMode={isEditMode ? DashboardMode.Edit : DashboardMode.View}
         onFullScreenClick={() => {
           const canvasElement: HTMLDivElement | null =
             dashboardCanvasRef.current;
@@ -462,10 +534,20 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
           };
           setDashboardViewConfig(configWithRefresh);
 
-          saveDashboardViewConfig().catch((err: Error) => {
-            setError(API.getFriendlyErrorMessage(err));
-          });
-          setDashboardMode(DashboardMode.View);
+          saveDashboardViewConfig(configWithRefresh)
+            .then((didSave: boolean) => {
+              /*
+               * Only leave edit mode once the board is actually persisted.
+               * Dropping straight back to view mode meant a refused save
+               * looked exactly like a successful one.
+               */
+              if (didSave) {
+                setDashboardMode(DashboardMode.View);
+              }
+            })
+            .catch((err: Error) => {
+              setSaveError(API.getFriendlyErrorMessage(err));
+            });
         }}
         startAndEndDate={startAndEndDate}
         onStartAndEndDateChange={(
@@ -477,10 +559,18 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
         onResetTimeRangeZoom={timeRangeZoom.resetZoom}
         onCancelEditClick={async () => {
           // load the dashboard view config again
+          setSaveError(null);
           setDashboardMode(DashboardMode.View);
           await fetchDashboardViewConfig();
         }}
+        canEditDashboard={canEditDashboard}
+        editDashboardDisabledReason={editGate.disabledReason}
         onEditClick={() => {
+          // Readers get no editor. See `editGate` above.
+          if (!canEditDashboard) {
+            return;
+          }
+          setSaveError(null);
           /*
            * Editing hides the time-range picker and the reset button, so a
            * board left zoomed would be stranded on a Custom window with no
@@ -830,6 +920,13 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
           setPendingScrollComponentId(newComponent.componentId);
         }}
       />
+      {saveError ? (
+        <div className="mx-3 mb-3">
+          <ErrorMessage message={saveError} />
+        </div>
+      ) : (
+        <></>
+      )}
       <div
         ref={dashboardCanvasRef}
         className="px-1 pb-4 mx-3 mb-4 rounded-2xl border border-gray-200/60"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx
@@ -65,6 +65,20 @@ export interface ComponentProps {
     | ((variables: Array<DashboardVariable>) => void)
     | undefined;
   telemetryAttributeOptions?: Array<string> | undefined;
+  /*
+   * Whether the signed-in user may write to this dashboard. False hides or
+   * locks every affordance that leads to a save - the toolbar is the only
+   * way into edit mode, so this is where a reader is turned back.
+   */
+  canEditDashboard: boolean;
+  /*
+   * Why editing is locked, ready for the tooltip on the disabled menu item.
+   * Undefined means there is nothing honest to say yet (the permission
+   * snapshot has not landed), and the item is hidden instead of accusing the
+   * user of missing a permission they may well hold - same contract as
+   * PermissionGate.
+   */
+  editDashboardDisabledReason?: string | undefined;
 }
 
 interface CountdownCircleProps {
@@ -411,12 +425,22 @@ const DashboardToolbar: FunctionComponent<ComponentProps> = (
                   </button>
                 }
               >
-                <MoreMenuItem
-                  text={"Edit Dashboard"}
-                  icon={IconProp.Pencil}
-                  key={"edit"}
-                  onClick={props.onEditClick}
-                />
+                {props.canEditDashboard || props.editDashboardDisabledReason ? (
+                  <MoreMenuItem
+                    text={"Edit Dashboard"}
+                    icon={IconProp.Pencil}
+                    key={"edit"}
+                    isDisabled={!props.canEditDashboard}
+                    tooltip={
+                      props.canEditDashboard
+                        ? undefined
+                        : props.editDashboardDisabledReason
+                    }
+                    onClick={props.onEditClick}
+                  />
+                ) : (
+                  <></>
+                )}
                 <MoreMenuItem
                   text={"Full Screen"}
                   icon={IconProp.Expand}
@@ -427,7 +451,7 @@ const DashboardToolbar: FunctionComponent<ComponentProps> = (
             )}
 
             {/* Edit mode actions */}
-            {!isSaving && isEditMode && (
+            {!isSaving && isEditMode && props.canEditDashboard && (
               <div className="flex items-center gap-2">
                 {/* Construction tools — segmented pill */}
                 <div className="flex items-center gap-0.5 rounded-lg bg-gray-50 border border-gray-200/60 p-0.5">

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
@@ -64,6 +64,11 @@ import {
   resolveServiceNamesByIds,
 } from "../../Utils/MetricsCrossSignalPivot";
 import Includes from "Common/Types/BaseDatabase/Includes";
+import Dashboard from "Common/Models/DatabaseModels/Dashboard";
+import PermissionGate, {
+  ModelAction,
+  PermissionGateResult,
+} from "Common/UI/Utils/PermissionGate";
 import { DictionaryEntryValue } from "Common/UI/Components/Dictionary/DictionaryFilterOperator";
 import useEventTimeReferenceLines, {
   EventTimeReferenceLines,
@@ -660,6 +665,10 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
   const [showAddToDashboardModal, setShowAddToDashboardModal] =
     useState<boolean>(false);
 
+  const addToDashboardGate: PermissionGateResult = useMemo(() => {
+    return PermissionGate.check(new Dashboard(), ModelAction.Update);
+  }, []);
+
   return (
     <div>
       <div className="mb-5 space-y-2">
@@ -843,14 +852,34 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
                 text="Create monitor from this view"
                 onClick={navigateToCreateMonitor}
               />
-              <MoreMenuItem
-                key="add-to-dashboard"
-                icon={IconProp.ChartPie}
-                text="Add to dashboard"
-                onClick={() => {
-                  setShowAddToDashboardModal(true);
-                }}
-              />
+              {/*
+               * Appending this view to a dashboard is a write to that
+               * dashboard, so it is gated on the same permission the
+               * dashboard editor is - otherwise this is a second, unguarded
+               * door into the same refused update.
+               */}
+              {addToDashboardGate.isAllowed ||
+              addToDashboardGate.disabledReason ? (
+                <MoreMenuItem
+                  key="add-to-dashboard"
+                  icon={IconProp.ChartPie}
+                  text="Add to dashboard"
+                  isDisabled={!addToDashboardGate.isAllowed}
+                  tooltip={
+                    addToDashboardGate.isAllowed
+                      ? undefined
+                      : addToDashboardGate.disabledReason
+                  }
+                  onClick={() => {
+                    if (!addToDashboardGate.isAllowed) {
+                      return;
+                    }
+                    setShowAddToDashboardModal(true);
+                  }}
+                />
+              ) : (
+                <></>
+              )}
             </MoreMenu>
           </div>
         </div>

--- a/App/Tests/Dashboard/DashboardWriteEntryPointInvariants.test.ts
+++ b/App/Tests/Dashboard/DashboardWriteEntryPointInvariants.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Issue #3550: the dashboard board is a bespoke screen, so none of the generic
+ * permission gates (ModelTable, ModelForm, ModelDelete) ever ran over it, and
+ * a project-wide `Viewer` was handed the whole editing surface.
+ *
+ * The board itself is covered behaviourally, as a reader and as an editor, in
+ * Common/Tests/App/Dashboard/DashboardEditPermissions.test.tsx - it renders the
+ * real DashboardViewer. This file is the cheap net under the OTHER way into a
+ * dashboard write, which no renderer in this repo can reach: the metric
+ * explorer's "Add to dashboard", which read-modify-writes somebody else's
+ * dashboardViewConfig from a menu item on a completely different page.
+ * MetricExplorer pulls in the chart stack and App's test env is plain Node
+ * with no DOM, so the wiring is pinned by reading the source - the same way
+ * CreateEntryPointPermissionInvariants and DashboardTimeRangeZoomWiring do.
+ *
+ * Sources are whitespace-squashed first so prettier re-wrapping a line cannot
+ * turn a real regression check into a red herring.
+ */
+
+function readSquashed(relative: string): string {
+  return fs
+    .readFileSync(path.join(__dirname, "../../..", relative), "utf8")
+    .replace(/\s+/g, " ");
+}
+
+const METRIC_EXPLORER: string =
+  "App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx";
+const DASHBOARD_VIEW: string =
+  "App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx";
+const DASHBOARD_TOOLBAR: string =
+  "App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/DashboardToolbar.tsx";
+
+describe("every entry point into a dashboard write is permission-gated", () => {
+  test("the metric explorer gates Add to dashboard on Dashboard update", () => {
+    const source: string = readSquashed(METRIC_EXPLORER);
+
+    /*
+     * The gate has to be the Dashboard's UPDATE permission specifically.
+     * Appending a chart is a write to a dashboard the user may only be able
+     * to read - being allowed to look at the metric explorer says nothing
+     * about it.
+     */
+    expect(source).toContain(
+      "PermissionGate.check(new Dashboard(), ModelAction.Update)",
+    );
+
+    /* The menu item is locked, and the locked item does not open the picker. */
+    expect(source).toContain("isDisabled={!addToDashboardGate.isAllowed}");
+    expect(source).toContain(
+      "if (!addToDashboardGate.isAllowed) { return; } setShowAddToDashboardModal(true);",
+    );
+  });
+
+  test("the board gates edit mode on the same permission", () => {
+    const source: string = readSquashed(DASHBOARD_VIEW);
+
+    expect(source).toContain(
+      "PermissionGate.check(new Dashboard(), ModelAction.Update)",
+    );
+
+    /*
+     * ANDed into the derived mode rather than only checked where the mode is
+     * set, so the canvas and the toolbar cannot disagree with the gate.
+     */
+    expect(source).toContain(
+      "dashboardMode === DashboardMode.Edit && canEditDashboard",
+    );
+
+    /* And the write path refuses on its own, not only because of the UI. */
+    expect(source).toContain("if (!canEditDashboard) { setSaveError(");
+  });
+
+  test("the toolbar renders no write controls without the permission", () => {
+    const source: string = readSquashed(DASHBOARD_TOOLBAR);
+
+    /*
+     * Add Widget, Variables, Cancel and Save Changes all live in this one
+     * block. Gating the block is what keeps them from being reachable.
+     */
+    expect(source).toContain(
+      "{!isSaving && isEditMode && props.canEditDashboard && (",
+    );
+  });
+
+  /*
+   * A save that is refused must not look like one that worked. The old code
+   * dropped back to view mode unconditionally and put the failure in the
+   * page-level `error`, which replaced the whole board - so the user could
+   * not tell the two apart and lost their unsaved widgets either way.
+   */
+  test("a refused save keeps the user in edit mode with their work", () => {
+    const source: string = readSquashed(DASHBOARD_VIEW);
+
+    expect(source).toContain(
+      "if (didSave) { setDashboardMode(DashboardMode.View); }",
+    );
+    expect(source).not.toContain(
+      "saveDashboardViewConfig().catch((err: Error) => { setError(",
+    );
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardEditPermissions.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardEditPermissions.test.tsx
@@ -1,0 +1,517 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import React, { act } from "react";
+import { JSONObject, ObjectType } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import DefaultDashboardSize from "../../../Types/Dashboard/DashboardSize";
+import DashboardTextComponentUtil from "../../../Utils/Dashboard/Components/DashboardTextComponent";
+
+/*
+ * github.com/OneUptime/oneuptime/issues/3550.
+ *
+ * A user whose only roles were `Viewer` and `Monitor Viewer` - both read-only
+ * by definition - opened a dashboard, pressed Edit, added and removed widgets,
+ * rearranged the board and pressed Save Changes.
+ *
+ * The API was never going to accept that write: Dashboard's update ACL is
+ * [ProjectOwner, ProjectAdmin, EditDashboard] and TablePermission refuses
+ * anything else (Common/Tests/Server/.../DashboardAccessPermission.test.ts
+ * pins that). The bug was that nothing in the UI said so. The dashboard is a
+ * bespoke screen - no ModelTable, no ModelForm - so none of the generic
+ * permission gates ever ran over it, and the first and only sign of the
+ * refusal came after all the work was done. Worse, the failed save set the
+ * page-level error, which replaced the entire board with a bare message and
+ * took every unsaved widget with it.
+ *
+ * So there are two things to hold onto here, and both are asserted below:
+ *
+ *   1. A reader is turned back at the door - no Edit, no Add Widget, no Save.
+ *   2. If a save is ever refused anyway, the board and the work survive it.
+ *
+ * The suite drives the real DashboardViewer against a fake dashboard API, the
+ * way DashboardVariablesDiscard does, so what is asserted is what a person
+ * actually sees.
+ */
+
+/*
+ * Mounting the real DashboardViewer pulls in ~60 widget modules. The default
+ * 5s budget is a machine-speed check, not an assertion about this code.
+ */
+jest.setTimeout(120000);
+
+const DASHBOARD_ID: string = "33333333-3333-4333-8333-333333333333";
+
+let permissionsForTest: Array<unknown> = [];
+let isMasterAdminForTest: boolean = false;
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: (): Array<unknown> => {
+        return permissionsForTest;
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): { globalPermissions: Array<unknown> } => {
+        return { globalPermissions: [...permissionsForTest] };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: (): boolean => {
+        return isMasterAdminForTest;
+      },
+      getUserId: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined): string | undefined => {
+          return value;
+        },
+        translateValue: (value: unknown): unknown => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+/* The fake server's copy of the board. */
+const serverState: { dashboardViewConfig: JSONObject | null } = {
+  dashboardViewConfig: null,
+};
+
+const getItemMock: jest.Mock<any, any> = jest.fn() as jest.Mock<any, any>;
+const updateByIdMock: jest.Mock<any, any> = jest.fn() as jest.Mock<any, any>;
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      updateById: (...args: Array<any>) => {
+        return updateByIdMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      getFriendlyErrorMessage: (err: Error) => {
+        return err.message;
+      },
+      getFriendlyMessage: (err: Error) => {
+        return err.message;
+      },
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        loadAllMetricsTypes: () => {
+          return Promise.resolve({ metricTypes: [], telemetryAttributes: [] });
+        },
+        getTelemetryAttributes: () => {
+          return Promise.resolve([]);
+        },
+        getTelemetryAttributeValues: () => {
+          return Promise.resolve([]);
+        },
+      },
+    };
+  },
+);
+
+/*
+ * The canvas is ~60 widget implementations deep and none of them are under
+ * test here. The stub publishes the edit flag it was handed, so "is the board
+ * editable" is directly observable rather than inferred from the toolbar.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/Index",
+  () => {
+    const reactModule: typeof React = jest.requireActual(
+      "react",
+    ) as typeof React;
+    return {
+      __esModule: true,
+      default: (props: { isEditMode?: boolean | undefined }) => {
+        return reactModule.createElement("div", {
+          "data-testid": "canvas-stub",
+          "data-is-edit-mode": props.isEditMode ? "true" : "false",
+        });
+      },
+    };
+  },
+);
+
+import DashboardViewer from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView";
+import PermissionGate from "../../../UI/Utils/PermissionGate";
+import Permission from "../../../Types/Permission";
+
+type MakeConfigFunction = () => DashboardViewConfig;
+
+const makeConfig: MakeConfigFunction = (): DashboardViewConfig => {
+  return {
+    _type: ObjectType.DashboardViewConfig,
+    components: [DashboardTextComponentUtil.getDefaultComponent()],
+    heightInDashboardUnits: DefaultDashboardSize.heightInDashboardUnits,
+  };
+};
+
+type SettleFunction = () => Promise<void>;
+
+const settle: SettleFunction = async (): Promise<void> => {
+  await act(async () => {
+    for (let turn: number = 0; turn < 5; turn++) {
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 0);
+      });
+    }
+  });
+};
+
+type RenderDashboardFunction = () => Promise<void>;
+
+const renderDashboard: RenderDashboardFunction = async (): Promise<void> => {
+  render(<DashboardViewer dashboardId={new ObjectID(DASHBOARD_ID)} />);
+  await waitFor(() => {
+    expect(screen.getByTestId("canvas-stub")).toBeInTheDocument();
+  });
+};
+
+type OpenMoreMenuFunction = () => Promise<void>;
+
+const openMoreMenu: OpenMoreMenuFunction = async (): Promise<void> => {
+  await act(async () => {
+    fireEvent.click(screen.getByLabelText("More dashboard options"));
+  });
+};
+
+type EnterEditModeFunction = () => Promise<void>;
+
+const enterEditMode: EnterEditModeFunction = async (): Promise<void> => {
+  await openMoreMenu();
+  await act(async () => {
+    fireEvent.click(screen.getByText("Edit Dashboard"));
+  });
+};
+
+type IsCanvasEditableFunction = () => boolean;
+
+const isCanvasEditable: IsCanvasEditableFunction = (): boolean => {
+  return (
+    screen.getByTestId("canvas-stub").getAttribute("data-is-edit-mode") ===
+    "true"
+  );
+};
+
+/* The exact roles from the report. */
+const READ_ONLY_ROLES: Array<Permission> = [
+  Permission.Viewer,
+  Permission.MonitorViewer,
+];
+
+beforeEach(() => {
+  permissionsForTest = [];
+  isMasterAdminForTest = false;
+  PermissionGate.clearPermissionPropsCache();
+  serverState.dashboardViewConfig = makeConfig() as unknown as JSONObject;
+  window.history.replaceState({}, "", `/dashboard/${DASHBOARD_ID}`);
+
+  getItemMock.mockImplementation(() => {
+    return Promise.resolve({
+      dashboardViewConfig: serverState.dashboardViewConfig,
+      name: "Monitor status",
+      description: "A dashboard",
+      pageTitle: null,
+      pageDescription: null,
+    });
+  });
+
+  updateByIdMock.mockImplementation((args: any) => {
+    serverState.dashboardViewConfig = args.data
+      .dashboardViewConfig as JSONObject;
+    return Promise.resolve();
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+describe("DashboardView - a reader cannot edit the board (issue #3550)", () => {
+  describe("a user holding only Viewer and Monitor Viewer", () => {
+    beforeEach(() => {
+      permissionsForTest = [...READ_ONLY_ROLES];
+    });
+
+    test("still sees the dashboard", async () => {
+      await renderDashboard();
+
+      expect(screen.getByTestId("canvas-stub")).toBeInTheDocument();
+      expect(screen.getAllByText("Monitor status").length).toBeGreaterThan(0);
+    });
+
+    test("is offered a locked Edit Dashboard, not a working one", async () => {
+      await renderDashboard();
+      await openMoreMenu();
+
+      const editItem: HTMLElement = screen.getByText("Edit Dashboard");
+      const editButton: HTMLElement = editItem.closest("button") as HTMLElement;
+
+      expect(editButton).toBeDisabled();
+    });
+
+    test("is told which permission the Edit would need", async () => {
+      await renderDashboard();
+      await openMoreMenu();
+
+      const editButton: HTMLElement = screen
+        .getByText("Edit Dashboard")
+        .closest("button") as HTMLElement;
+
+      fireEvent.mouseEnter(editButton.parentElement as HTMLElement);
+
+      const tooltip: HTMLElement = screen.getByRole("tooltip");
+
+      expect(tooltip).toHaveTextContent(
+        "You do not have permission to update this Dashboard.",
+      );
+      /* The human title, not the raw `EditDashboard` enum value. */
+      expect(tooltip).toHaveTextContent("Edit Dashboard");
+      expect(tooltip).toHaveTextContent("Project Admin");
+    });
+
+    /*
+     * The heart of the report. Clicking through must not put the board into
+     * edit mode, because everything downstream of edit mode - Add Widget,
+     * drag, resize, Save Changes - ends in a refused write.
+     */
+    test("cannot get the board into edit mode by clicking the locked item", async () => {
+      await renderDashboard();
+      await enterEditMode();
+
+      expect(isCanvasEditable()).toBe(false);
+      expect(screen.queryByText("Save Changes")).not.toBeInTheDocument();
+      expect(screen.queryByText("Add Widget")).not.toBeInTheDocument();
+      expect(screen.queryByText("Editing")).not.toBeInTheDocument();
+    });
+
+    test("never reaches the update endpoint", async () => {
+      await renderDashboard();
+      await enterEditMode();
+      await settle();
+
+      expect(updateByIdMock).not.toHaveBeenCalled();
+    });
+
+    /*
+     * View-mode affordances are untouched: this is about writing to the
+     * board, not about looking at it.
+     */
+    test("keeps the read-only tools it is entitled to", async () => {
+      await renderDashboard();
+      await openMoreMenu();
+
+      expect(screen.getByText("Full Screen")).toBeInTheDocument();
+    });
+  });
+
+  describe("a user holding Edit Dashboard", () => {
+    beforeEach(() => {
+      permissionsForTest = [Permission.Viewer, Permission.EditDashboard];
+    });
+
+    test("gets a working Edit Dashboard", async () => {
+      await renderDashboard();
+      await openMoreMenu();
+
+      expect(
+        screen.getByText("Edit Dashboard").closest("button"),
+      ).not.toBeDisabled();
+    });
+
+    test("can put the board into edit mode and save it", async () => {
+      await renderDashboard();
+      await enterEditMode();
+
+      expect(isCanvasEditable()).toBe(true);
+      expect(screen.getByText("Save Changes")).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Save Changes"));
+      });
+      await settle();
+
+      expect(updateByIdMock).toHaveBeenCalledTimes(1);
+      expect(isCanvasEditable()).toBe(false);
+    });
+  });
+
+  /*
+   * Dashboard is @OperationalResource, so the server's table-level check
+   * accepts the EditAllOperationalResources wildcard for it even though the
+   * model's ACL does not enumerate it. A gate that did not know that would
+   * lock the editor for somebody the API would have let through.
+   */
+  describe("a user holding only the operational-resource wildcard", () => {
+    beforeEach(() => {
+      permissionsForTest = [
+        Permission.Viewer,
+        Permission.EditAllOperationalResources,
+      ];
+    });
+
+    test("can edit the board", async () => {
+      await renderDashboard();
+      await enterEditMode();
+
+      expect(isCanvasEditable()).toBe(true);
+    });
+  });
+
+  /*
+   * The permission snapshot arrives on a response header, so it is empty for
+   * the first paint after a login and for a beat after a project switch.
+   * Telling a project owner they need a permission they hold is worse than
+   * briefly not offering the button - PermissionGate's documented contract.
+   */
+  describe("before the permission snapshot has landed", () => {
+    test("hides Edit Dashboard rather than accusing the user", async () => {
+      permissionsForTest = [];
+
+      await renderDashboard();
+      await openMoreMenu();
+
+      expect(screen.queryByText("Edit Dashboard")).not.toBeInTheDocument();
+      /* The rest of the menu still works. */
+      expect(screen.getByText("Full Screen")).toBeInTheDocument();
+    });
+  });
+
+  describe("a master admin", () => {
+    test("is allowed everything, snapshot or not", async () => {
+      permissionsForTest = [];
+      isMasterAdminForTest = true;
+
+      await renderDashboard();
+      await enterEditMode();
+
+      expect(isCanvasEditable()).toBe(true);
+    });
+  });
+
+  /*
+   * The second half of the damage. Even for somebody who IS allowed to edit,
+   * a save can fail - a revoked permission, a lost connection, a conflict.
+   * That used to drop straight back to view mode and swap the whole board for
+   * a bare error, so the user could not tell a refused save from a successful
+   * one and lost every unsaved widget either way.
+   */
+  describe("when a save is refused", () => {
+    beforeEach(() => {
+      permissionsForTest = [Permission.Viewer, Permission.EditDashboard];
+      updateByIdMock.mockImplementation(() => {
+        return Promise.reject(
+          new Error(
+            "You do not have permissions to update Dashboard. You need one of these permissions: Project Owner, Project Admin, Edit Dashboard",
+          ),
+        );
+      });
+    });
+
+    test("says so instead of looking like it worked", async () => {
+      await renderDashboard();
+      await enterEditMode();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Save Changes"));
+      });
+      await settle();
+
+      expect(
+        screen.getByText(/You do not have permissions to update Dashboard/),
+      ).toBeInTheDocument();
+    });
+
+    test("keeps the user in edit mode with the board still on screen", async () => {
+      await renderDashboard();
+      await enterEditMode();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Save Changes"));
+      });
+      await settle();
+
+      expect(screen.getByTestId("canvas-stub")).toBeInTheDocument();
+      expect(isCanvasEditable()).toBe(true);
+      expect(screen.getByText("Save Changes")).toBeInTheDocument();
+    });
+
+    test("lets the user try again once the cause is gone", async () => {
+      await renderDashboard();
+      await enterEditMode();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Save Changes"));
+      });
+      await settle();
+
+      updateByIdMock.mockImplementation(() => {
+        return Promise.resolve();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Save Changes"));
+      });
+      await settle();
+
+      expect(isCanvasEditable()).toBe(false);
+      expect(
+        screen.queryByText(/You do not have permissions to update Dashboard/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/DashboardVariablesDiscard.test.tsx
+++ b/Common/Tests/App/Dashboard/DashboardVariablesDiscard.test.tsx
@@ -69,6 +69,32 @@ const serverState: { dashboardViewConfig: JSONObject | null } = {
 const getItemMock: jest.Mock<any, any> = jest.fn() as jest.Mock<any, any>;
 const updateByIdMock: jest.Mock<any, any> = jest.fn() as jest.Mock<any, any>;
 
+/*
+ * Editing the board is permission-gated (issue #3550), so the toolbar only
+ * offers "Edit Dashboard" to somebody who may write to it. These tests are
+ * about variables, not permissions, so they run as a user who can edit.
+ */
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      /*
+       * Permission.ProjectAdmin - a literal, because a jest.mock factory is
+       * hoisted above the imports and cannot close over the enum.
+       */
+      getAllPermissions: (): Array<string> => {
+        return ["ProjectAdmin"];
+      },
+      getProjectPermissions: (): null => {
+        return null;
+      },
+      getGlobalPermissions: (): null => {
+        return null;
+      },
+    },
+  };
+});
+
 jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
   return {
     __esModule: true,

--- a/Common/Tests/Server/Types/Database/Permissions/DashboardAccessPermission.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/DashboardAccessPermission.test.ts
@@ -1,0 +1,321 @@
+import DatabaseRequestType from "../../../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import OwnedScopePermission from "../../../../../Server/Types/Database/Permissions/OwnedScopePermission";
+import TablePermission from "../../../../../Server/Types/Database/Permissions/TablePermission";
+import Dashboard from "../../../../../Models/DatabaseModels/Dashboard";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import PermissionScope from "../../../../../Types/Database/AccessControl/PermissionScope";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../../../Types/Permission";
+import { FindOperator } from "typeorm";
+
+/*
+ * github.com/OneUptime/oneuptime/issues/3550 reported that a user holding only
+ * the read-only `Viewer` and `MonitorViewer` roles could open a dashboard they
+ * were not an owner of AND save changes to it.
+ *
+ * These tests pin down what the server actually does, because the two halves of
+ * that report have different answers:
+ *
+ *   - Reading is allowed, and is meant to be. `Viewer` is documented as
+ *     "read-only access across all project resources", and the reported team
+ *     granted it at scope "All resources in project". Narrowing visibility to
+ *     the resources somebody owns is what the `Owned` scope on the permission
+ *     row is for - the last two tests here are the proof that it reaches
+ *     dashboards.
+ *
+ *   - Writing was never allowed. Dashboard's update ACL is
+ *     [ProjectOwner, ProjectAdmin, EditDashboard], so the PUT the editor
+ *     eventually sends is refused. What was broken lived entirely in the UI,
+ *     which offered the whole editing surface to a reader and only surfaced the
+ *     refusal after the work was done (see
+ *     Common/Tests/App/Dashboard/DashboardEditPermissions.test.tsx). These
+ *     cases stand guard over the ACL that makes that refusal happen.
+ */
+describe("Dashboard access control (issue #3550)", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+
+  type MakePropsFunction = (
+    permissions: Array<Permission>,
+    scope?: PermissionScope | undefined,
+  ) => DatabaseCommonInteractionProps;
+
+  /*
+   * The permission set a member of the reported team actually carries:
+   * whatever their team grants, plus the implicit grants every signed-in
+   * project member gets (see UserPermissionUtil).
+   */
+  const makeProps: MakePropsFunction = (
+    permissions: Array<Permission>,
+    scope?: PermissionScope | undefined,
+  ): DatabaseCommonInteractionProps => {
+    const userPermissions: Array<UserPermission> = permissions.map(
+      (permission: Permission) => {
+        return {
+          _type: "UserPermission" as const,
+          permission: permission,
+          labelIds: [],
+          isBlockPermission: false,
+          ...(scope ? { scope: scope } : {}),
+        };
+      },
+    );
+
+    // Implicit grants - never scoped, never stored on a TeamPermission row.
+    for (const implicitPermission of [
+      Permission.CurrentUser,
+      Permission.ProjectUser,
+      Permission.UnAuthorizedSsoUser,
+    ]) {
+      userPermissions.push({
+        _type: "UserPermission",
+        permission: implicitPermission,
+        labelIds: [],
+        isBlockPermission: false,
+      });
+    }
+
+    const tenantPermission: UserTenantAccessPermission = {
+      projectId,
+      _type: "UserTenantAccessPermission",
+      permissions: userPermissions,
+    };
+
+    return {
+      userId,
+      tenantId: projectId,
+      userTenantAccessPermission: {
+        [projectId.toString()]: tenantPermission,
+      },
+    };
+  };
+
+  type CheckFunction = (
+    permissions: Array<Permission>,
+    type: DatabaseRequestType,
+  ) => Error | null;
+
+  const check: CheckFunction = (
+    permissions: Array<Permission>,
+    type: DatabaseRequestType,
+  ): Error | null => {
+    try {
+      TablePermission.checkTableLevelPermissions(
+        Dashboard,
+        makeProps(permissions),
+        type,
+      );
+    } catch (err) {
+      return err as Error;
+    }
+
+    return null;
+  };
+
+  const readOnlyRoles: Array<Permission> = [
+    Permission.Viewer,
+    Permission.MonitorViewer,
+  ];
+
+  describe("the roles from the report", () => {
+    test("Viewer + Monitor Viewer may READ a dashboard", () => {
+      expect(check(readOnlyRoles, DatabaseRequestType.Read)).toBeNull();
+    });
+
+    test("Viewer + Monitor Viewer may NOT update a dashboard", () => {
+      const error: Error | null = check(
+        readOnlyRoles,
+        DatabaseRequestType.Update,
+      );
+
+      expect(error).not.toBeNull();
+      expect(error?.message).toContain(
+        "You do not have permissions to update Dashboard",
+      );
+      /*
+       * The message names the permissions that would work, in their human
+       * titles. The UI gate reproduces this same sentence so the two do not
+       * read like different products.
+       */
+      expect(error?.message).toContain("Edit Dashboard");
+      expect(error?.message).toContain("Project Admin");
+      expect(error?.message).toContain("Project Owner");
+    });
+
+    test("Viewer + Monitor Viewer may NOT create a dashboard", () => {
+      const error: Error | null = check(
+        readOnlyRoles,
+        DatabaseRequestType.Create,
+      );
+
+      expect(error).not.toBeNull();
+      expect(error?.message).toContain(
+        "You do not have permissions to create Dashboard",
+      );
+    });
+
+    test("Viewer + Monitor Viewer may NOT delete a dashboard", () => {
+      const error: Error | null = check(
+        readOnlyRoles,
+        DatabaseRequestType.Delete,
+      );
+
+      expect(error).not.toBeNull();
+      expect(error?.message).toContain(
+        "You do not have permissions to delete Dashboard",
+      );
+    });
+
+    /*
+     * The project-wide Viewer role is read-only by definition, so it must not
+     * pick up write access to a dashboard by any route - not through the
+     * granular Dashboard permissions and not through the operational
+     * wildcards, neither of which it holds.
+     */
+    test("no combination of the reported roles grants a write", () => {
+      for (const type of [
+        DatabaseRequestType.Create,
+        DatabaseRequestType.Update,
+        DatabaseRequestType.Delete,
+      ]) {
+        expect(check([Permission.Viewer], type)).not.toBeNull();
+        expect(check([Permission.MonitorViewer], type)).not.toBeNull();
+        expect(check(readOnlyRoles, type)).not.toBeNull();
+      }
+    });
+  });
+
+  describe("the permissions that DO grant a write", () => {
+    test("Edit Dashboard allows an update", () => {
+      expect(
+        check([Permission.EditDashboard], DatabaseRequestType.Update),
+      ).toBeNull();
+    });
+
+    test("Project Admin allows an update", () => {
+      expect(
+        check([Permission.ProjectAdmin], DatabaseRequestType.Update),
+      ).toBeNull();
+    });
+
+    /*
+     * Dashboard is @OperationalResource, so the wildcard covers it even though
+     * it is not enumerated in the model's ACL. The UI gate has to know this
+     * too, or it would lock the editor for somebody the API would let through.
+     */
+    test("Edit All Operational Resources allows an update", () => {
+      expect(
+        check(
+          [Permission.EditAllOperationalResources],
+          DatabaseRequestType.Update,
+        ),
+      ).toBeNull();
+    });
+
+    test("Read All Operational Resources does NOT allow an update", () => {
+      expect(
+        check(
+          [Permission.ReadAllOperationalResources],
+          DatabaseRequestType.Update,
+        ),
+      ).not.toBeNull();
+    });
+  });
+
+  /*
+   * The half of the report that is a configuration answer rather than a bug:
+   * "a dashboard with no assigned Owner should not be visible to arbitrary
+   * team members". That is exactly what scope `Owned` does, and Dashboard is
+   * registered in the owner-table registry so it resolves through
+   * DashboardOwnerUser / DashboardOwnerTeam.
+   */
+  describe("restricting visibility to owners via the Owned scope", () => {
+    const ownedDashboardId: ObjectID = ObjectID.generate();
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    /*
+     * The ids end up as bound parameters on a Raw operator, so the values are
+     * read off objectLiteralParameters rather than off `value`.
+     */
+    type BoundValuesFunction = (operator: FindOperator<any>) => Array<string>;
+
+    const boundValues: BoundValuesFunction = (
+      operator: FindOperator<any>,
+    ): Array<string> => {
+      /*
+       * `in` binds the whole id list to a single parameter, `equalTo` binds one
+       * value per parameter - flatten so both shapes read the same here.
+       */
+      return Object.values(
+        (operator.objectLiteralParameters || {}) as Record<string, unknown>,
+      ).flatMap((value: unknown) => {
+        return Array.isArray(value) ? value.map(String) : [String(value)];
+      });
+    };
+
+    test("an Owned-scoped Viewer only sees dashboards they own", async () => {
+      jest
+        .spyOn(OwnedScopePermission as any, "getAllowedResourceIds")
+        .mockResolvedValue([ownedDashboardId]);
+
+      const query: any = await OwnedScopePermission.addOwnedScopeToQuery(
+        Dashboard,
+        { projectId } as any,
+        makeProps([Permission.Viewer], PermissionScope.Owned),
+        DatabaseRequestType.Read,
+      );
+
+      expect(query._id).toBeInstanceOf(FindOperator);
+      expect(boundValues(query._id)).toEqual([ownedDashboardId.toString()]);
+    });
+
+    test("an Owned-scoped Viewer who owns no dashboard sees none", async () => {
+      jest
+        .spyOn(OwnedScopePermission as any, "getAllowedResourceIds")
+        .mockResolvedValue([]);
+
+      const query: any = await OwnedScopePermission.addOwnedScopeToQuery(
+        Dashboard,
+        { projectId } as any,
+        makeProps([Permission.Viewer], PermissionScope.Owned),
+        DatabaseRequestType.Read,
+      );
+
+      /*
+       * Matches nothing rather than everything. A dashboard with an empty
+       * Owners list is owned by nobody, so it drops out of the result for
+       * every Owned-scoped reader - which is the behaviour the report asked
+       * for.
+       */
+      expect(query._id).toBeInstanceOf(FindOperator);
+      expect(boundValues(query._id)).toEqual([
+        ObjectID.getZeroObjectID().toString(),
+      ]);
+    });
+
+    /*
+     * The scope the reported team actually had. Documented here so the
+     * difference between the two configurations is not folklore.
+     */
+    test("an All-scoped Viewer is not narrowed to owned dashboards", async () => {
+      jest
+        .spyOn(OwnedScopePermission as any, "getAllowedResourceIds")
+        .mockResolvedValue([ownedDashboardId]);
+
+      const query: any = await OwnedScopePermission.addOwnedScopeToQuery(
+        Dashboard,
+        { projectId } as any,
+        makeProps([Permission.Viewer], PermissionScope.All),
+        DatabaseRequestType.Read,
+      );
+
+      expect(query._id).toBeUndefined();
+    });
+  });
+});

--- a/Common/Tests/UI/Utils/PermissionGate.test.ts
+++ b/Common/Tests/UI/Utils/PermissionGate.test.ts
@@ -70,6 +70,7 @@ import PermissionGate, {
 } from "../../../UI/Utils/PermissionGate";
 import { CardButtonSchema } from "../../../UI/Components/Card/Card";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Team from "../../../Models/DatabaseModels/Team";
 import Log from "../../../Models/AnalyticsModels/Log";
 import IconProp from "../../../Types/Icon/IconProp";
 import Permission from "../../../Types/Permission";
@@ -294,6 +295,83 @@ describe("PermissionGate", () => {
 
       expect(denied.isAllowed).toBe(false);
       expect(denied.disabledReason).toBeTruthy();
+    });
+  });
+
+  /*
+   * The server widens a model's declared ACL with the matching
+   * *AllOperationalResources wildcard for anything marked @OperationalResource
+   * (TablePermission.getEffectiveModelPermissions). The gate has to do the
+   * same, or it is stricter than the endpoint it stands in front of: somebody
+   * granted "Edit All Operational Resources" and nothing else was told by every
+   * edit button in the product that they could not edit, while the API would
+   * have accepted the write.
+   */
+  describe("operational resource wildcards", () => {
+    test("a wildcard grants the operation on an operational resource", () => {
+      permissionsForTest = [Permission.EditAllOperationalResources];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Update,
+      );
+
+      expect(result.isAllowed).toBe(true);
+      expect(result.disabledReason).toBeUndefined();
+    });
+
+    test("each wildcard only covers its own operation", () => {
+      permissionsForTest = [Permission.ReadAllOperationalResources];
+
+      const monitor: Monitor = new Monitor();
+
+      expect(PermissionGate.check(monitor, ModelAction.Read).isAllowed).toBe(
+        true,
+      );
+      expect(PermissionGate.check(monitor, ModelAction.Update).isAllowed).toBe(
+        false,
+      );
+      expect(PermissionGate.check(monitor, ModelAction.Create).isAllowed).toBe(
+        false,
+      );
+      expect(PermissionGate.check(monitor, ModelAction.Delete).isAllowed).toBe(
+        false,
+      );
+    });
+
+    test("a wildcard does not cover a model that is not an operational resource", () => {
+      permissionsForTest = [Permission.EditAllOperationalResources];
+
+      /*
+       * Team is a settings model - deliberately outside the wildcard, so that
+       * "edit every operational resource" never quietly becomes "administer
+       * the project".
+       */
+      const result: PermissionGateResult = PermissionGate.check(
+        new Team(),
+        ModelAction.Update,
+      );
+
+      expect(result.isAllowed).toBe(false);
+    });
+
+    /*
+     * The wildcard widens the decision, not the explanation. The server names
+     * only the model's own permissions when it refuses, and telling a viewer
+     * they need "Edit All Operational Resources" would point them at a
+     * project-wide grant instead of the one permission they actually want.
+     */
+    test("the wildcard is not named in the reason the operation is refused", () => {
+      permissionsForTest = [Permission.Viewer];
+
+      const result: PermissionGateResult = PermissionGate.check(
+        new Monitor(),
+        ModelAction.Update,
+      );
+
+      expect(result.isAllowed).toBe(false);
+      expect(result.disabledReason).toContain("Edit Monitor");
+      expect(result.disabledReason).not.toContain("Operational Resources");
     });
   });
 

--- a/Common/UI/Utils/PermissionGate.ts
+++ b/Common/UI/Utils/PermissionGate.ts
@@ -51,6 +51,11 @@ export interface PermissionCheckableModel {
   getReadPermissions: () => Array<Permission>;
   getUpdatePermissions: () => Array<Permission>;
   getDeletePermissions: () => Array<Permission>;
+  /*
+   * Set by the @OperationalResource() decorator. Optional here because the
+   * analytics models that are not decorated never define it at all.
+   */
+  isOperationalResource?: boolean | undefined;
 }
 
 /*
@@ -229,6 +234,33 @@ export default class PermissionGate {
     action: ModelAction,
     userPermissions: Array<Permission>,
   ): boolean {
+    if (this.hasDeclaredPermission(model, action, userPermissions)) {
+      return true;
+    }
+
+    /*
+     * The server widens a model's declared permissions with the matching
+     * *AllOperationalResources wildcard for anything marked
+     * @OperationalResource (TablePermission.getEffectiveModelPermissions, and
+     * its analytics twin). Without the same step here, somebody granted
+     * "Edit All Operational Resources" - and nothing else - was told by every
+     * gate in the UI that they could not edit a monitor, an incident or a
+     * dashboard, while the API happily accepted the write. The gate must not
+     * be stricter than the endpoint it is standing in front of.
+     */
+    const wildcard: Permission | null = this.getOperationalWildcard(
+      model,
+      action,
+    );
+
+    return Boolean(wildcard && userPermissions.includes(wildcard));
+  }
+
+  private static hasDeclaredPermission(
+    model: PermissionCheckableModel,
+    action: ModelAction,
+    userPermissions: Array<Permission>,
+  ): boolean {
     switch (action) {
       case ModelAction.Create:
         return model.hasCreatePermissions(userPermissions);
@@ -240,6 +272,35 @@ export default class PermissionGate {
         return model.hasDeletePermissions(userPermissions);
       default:
         return false;
+    }
+  }
+
+  /*
+   * The wildcard that covers this operation on this model, or null when the
+   * model is not an operational resource. Kept out of getModelPermissions on
+   * purpose: that list is what the "you need one of these permissions"
+   * sentence is built from, and the server names only the model's own
+   * permissions there too.
+   */
+  private static getOperationalWildcard(
+    model: PermissionCheckableModel,
+    action: ModelAction,
+  ): Permission | null {
+    if (!model.isOperationalResource) {
+      return null;
+    }
+
+    switch (action) {
+      case ModelAction.Create:
+        return Permission.CreateAllOperationalResources;
+      case ModelAction.Read:
+        return Permission.ReadAllOperationalResources;
+      case ModelAction.Update:
+        return Permission.EditAllOperationalResources;
+      case ModelAction.Delete:
+        return Permission.DeleteAllOperationalResources;
+      default:
+        return null;
     }
   }
 


### PR DESCRIPTION
Fixes #3550.

## What the report claims, and what is actually true

The report has two halves and they have different answers.

**"A Viewer can see a dashboard that has no owners."** True, and working as configured. `Viewer` is documented as *"read-only access across all project resources"*, and the reported team granted it at scope **All resources in project** (visible in the issue's own screenshot). Narrowing visibility to the people who own a resource is what the **`Owned`** scope on the permission row is for — Dashboard is `@OperationalResource` and registered in the owner-table registry, so an `Owned`-scoped role resolves through `DashboardOwnerUser` / `DashboardOwnerTeam` and a dashboard with an empty Owners list drops out for everybody. There are tests for that below, but no code change: turning the project-wide Viewer role into an owner-scoped one would silently re-scope every resource in the product.

**"A Viewer can edit the dashboard and Save Changes."** The editing is real. The save is not — and never was. `Dashboard`'s update ACL is `[ProjectOwner, ProjectAdmin, EditDashboard]`, and `TablePermission` refuses the `PUT /dashboard/:id` that Save Changes sends. So nothing was ever persisted by a reader; there is no data-integrity hole here.

## Root cause

The dashboard board is a **bespoke screen**. It does not go through `ModelTable`, `ModelForm` or `ModelDelete`, so **none of the generic `PermissionGate` checks ever ran over it**. `DashboardToolbar` rendered "Edit Dashboard", "Add Widget", "Variables" and "Save Changes" to anybody who could read the dashboard.

This is the same class of bug as #3306 ("a fully working create page that only failed at submit"), one screen further along: the user does all the work first and is refused at the end.

And the ending was worse than a refusal. `onSaveClick` did:

```ts
saveDashboardViewConfig().catch(...);   // not awaited
setDashboardMode(DashboardMode.View);   // unconditional
```

with the save's own `catch` putting the message into the **page-level** `error` — the one whose render branch is `if (error) return <ErrorMessage/>`. So a refused save dropped out of edit mode exactly like a successful one *and* replaced the entire board with a bare sentence, discarding every unsaved widget.

## The fix

- **`DashboardView`** asks `PermissionGate` for `Dashboard` update once and ANDs the answer into the derived `isEditMode`, so the toolbar and the canvas cannot disagree with it. The mode switch and the write path each refuse on their own rather than trusting that the control was hidden.
- **`DashboardToolbar`** locks "Edit Dashboard" with the reason in its tooltip — the same sentence the API returns, so the two don't read like different products — and renders none of Add Widget / Variables / Cancel / Save Changes without the permission. When the permission snapshot has not landed yet the item is hidden rather than accusing the user, per `PermissionGate`'s documented contract.
- **`MetricExplorer`'s "Add to dashboard"** is the other door into a dashboard write (it read-modify-writes someone else's `dashboardViewConfig` from a different page). Gated the same way.
- **A refused save** now keeps the user in edit mode with the board intact and shows the failure above it, instead of looking identical to a success.
- **`PermissionGate`** gains the operational-resource wildcards the server has always honoured (`TablePermission.getEffectiveModelPermissions`). Without this the new gate — and every existing gate on a monitor, incident or alert — would lock the UI for somebody granted "Edit All Operational Resources", which the API accepts. The wildcard widens the *decision* only; the "you need one of these permissions" sentence still names the model's own permissions, matching the server.

One incidental correctness fix in the function being rewritten: the save now persists the config it is handed rather than re-reading `dashboardViewConfig` state the caller had just replaced, so a changed auto-refresh interval lands on *this* save instead of the next one.

## Tests

**`Common/Tests/App/Dashboard/DashboardEditPermissions.test.tsx`** (14 tests) — renders the real `DashboardViewer` against a fake dashboard API:

- Viewer + Monitor Viewer: still sees the board; gets a *locked* Edit with a tooltip naming Edit Dashboard / Project Admin; clicking it does not reach edit mode; no Save Changes, no Add Widget; `updateById` is never called; Full Screen still works.
- Edit Dashboard: working Edit, enters edit mode, saves, returns to view mode.
- `EditAllOperationalResources` alone: can edit (the wildcard parity).
- Empty snapshot: Edit is hidden, not accused. Master admin: allowed.
- Refused save: says so, keeps edit mode and the board, and lets the user retry once the cause is gone.

**`Common/Tests/Server/Types/Database/Permissions/DashboardAccessPermission.test.ts`** (12 tests) — the ACL the refusal rests on: read allowed for the reported roles, create/update/delete refused with the message that names Edit Dashboard; `EditDashboard`, `ProjectAdmin` and `EditAllOperationalResources` allowed; `ReadAllOperationalResources` not. Plus the `Owned`-scope behaviour that answers the visibility half of the report.

**`Common/Tests/UI/Utils/PermissionGate.test.ts`** — four new cases for the wildcards: they grant, each covers only its own operation, they do not reach non-operational models (`Team`), and they are not named in the refusal message.

**`App/Tests/Dashboard/DashboardWriteEntryPointInvariants.test.ts`** — the cheap net under the metric explorer, which App's Node test env cannot render (the `CreateEntryPointPermissionInvariants` pattern).

`Common/Tests/App/Dashboard/DashboardVariablesDiscard.test.tsx` picks up a permission mock — it drives the board through edit mode, which is now gated.

## Verification

- 42 tests across the four suites pass, including the 16 pre-existing ones in `DashboardVariablesDiscard` and the 8 in `DashboardTimeRangeZoomWiring` (which pins source strings in the same edit handler).
- `tsc --noEmit` clean in `Common`; `eslint` clean on every changed file.
