### PR TITLE
fix(enterprise-license): deactivate silent instances after one week

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseActivityUtil.ts
+++ b/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseActivityUtil.ts
@@ -1,0 +1,78 @@
+import OneUptimeDate from "Common/Types/Date";
+import EnterpriseLicenseUsageSnapshot from "Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
+import EnterpriseLicenseUsageUtil, {
+  EnterpriseLicenseInstanceUsage,
+} from "Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+
+export const EnterpriseLicenseUsageRefreshIntervalInMilliseconds: number =
+  60 * 1000;
+export const EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds: number = 1000;
+
+export const isEnterpriseLicenseUsageRequestCurrent: (
+  requestId: number,
+  latestRequestId: number,
+) => boolean = (requestId: number, latestRequestId: number): boolean => {
+  return requestId === latestRequestId;
+};
+
+export const getEnterpriseLicenseUsageBoundaryRefreshDelay: (
+  snapshot: EnterpriseLicenseUsageSnapshot,
+  elapsedSinceRequestStartedInMilliseconds?: number,
+) => number | null = (
+  snapshot: EnterpriseLicenseUsageSnapshot,
+  elapsedSinceRequestStartedInMilliseconds: number = 0,
+): number | null => {
+  if (!snapshot.nextInstanceStatusChangeAt) {
+    return null;
+  }
+
+  const nextChangeAt: number = new Date(
+    snapshot.nextInstanceStatusChangeAt,
+  ).getTime();
+  const calculatedAt: number = new Date(snapshot.calculatedAt).getTime();
+
+  if (!Number.isFinite(nextChangeAt) || !Number.isFinite(calculatedAt)) {
+    return null;
+  }
+
+  const elapsedRequestTime: number = Number.isFinite(
+    elapsedSinceRequestStartedInMilliseconds,
+  )
+    ? Math.max(0, elapsedSinceRequestStartedInMilliseconds)
+    : 0;
+
+  /*
+   * Both timestamps come from the server. Using the browser clock here can
+   * turn clock skew into a zero-delay refresh loop while the server still
+   * considers the instance active. The timer starts only after the response,
+   * so subtract monotonic time elapsed since the request began as well.
+   */
+  return Math.max(
+    EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds,
+    nextChangeAt - calculatedAt - elapsedRequestTime,
+  );
+};
+
+export type EnterpriseLicenseInstanceActivityState = "active" | "inactive";
+
+export interface EnterpriseLicenseInstanceActivityInput {
+  instance: EnterpriseLicenseInstanceUsage;
+  isActive?: boolean | undefined;
+  now?: Date | undefined;
+}
+
+export const getEnterpriseLicenseInstanceActivityState: (
+  input: EnterpriseLicenseInstanceActivityInput,
+) => EnterpriseLicenseInstanceActivityState = (
+  input: EnterpriseLicenseInstanceActivityInput,
+): EnterpriseLicenseInstanceActivityState => {
+  const isActive: boolean =
+    typeof input.isActive === "boolean"
+      ? input.isActive
+      : EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+          input.instance,
+          input.now || OneUptimeDate.getCurrentDate(),
+        );
+
+  return isActive ? "active" : "inactive";
+};

--- a/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil.tsx
@@ -1,8 +1,57 @@
-import { Green, Red, Yellow } from "Common/Types/BrandColors";
+import { Gray500, Green, Red, Yellow } from "Common/Types/BrandColors";
 import OneUptimeDate from "Common/Types/Date";
+import EnterpriseLicenseUsageSnapshot from "Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
 import Pill, { PillSize } from "Common/UI/Components/Pill/Pill";
-import EnterpriseLicenseUsageUtil from "Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+import EnterpriseLicenseUsageUtil, {
+  EnterpriseLicenseInstanceUsage,
+} from "Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage";
 import React, { FunctionComponent, ReactElement } from "react";
+
+export const EnterpriseLicenseUsageRefreshIntervalInMilliseconds: number =
+  60 * 1000;
+export const EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds: number = 1000;
+
+export const isEnterpriseLicenseUsageRequestCurrent = (
+  requestId: number,
+  latestRequestId: number,
+): boolean => {
+  return requestId === latestRequestId;
+};
+
+export const getEnterpriseLicenseUsageBoundaryRefreshDelay = (
+  snapshot: EnterpriseLicenseUsageSnapshot,
+  elapsedSinceRequestStartedInMilliseconds: number = 0,
+): number | null => {
+  if (!snapshot.nextInstanceStatusChangeAt) {
+    return null;
+  }
+
+  const nextChangeAt: number = new Date(
+    snapshot.nextInstanceStatusChangeAt,
+  ).getTime();
+  const calculatedAt: number = new Date(snapshot.calculatedAt).getTime();
+
+  if (!Number.isFinite(nextChangeAt) || !Number.isFinite(calculatedAt)) {
+    return null;
+  }
+
+  const elapsedRequestTime: number = Number.isFinite(
+    elapsedSinceRequestStartedInMilliseconds,
+  )
+    ? Math.max(0, elapsedSinceRequestStartedInMilliseconds)
+    : 0;
+
+  /*
+   * Both timestamps come from the server. Using the browser clock here can
+   * turn clock skew into a zero-delay refresh loop while the server still
+   * considers the instance active. The timer starts only after the response,
+   * so subtract monotonic time elapsed since the request began as well.
+   */
+  return Math.max(
+    EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds,
+    nextChangeAt - calculatedAt - elapsedRequestTime,
+  );
+};
 
 export type LicenseLifecycleState = "active" | "expiring-soon" | "expired";
 
@@ -109,6 +158,49 @@ export const LicenseStatusPill: FunctionComponent<LicenseStatusPillProps> = (
   }
 
   return <Pill text="Active" color={Green} size={PillSize.Small} />;
+};
+
+export interface EnterpriseLicenseInstanceStatusPillProps {
+  instance: EnterpriseLicenseInstanceUsage;
+  isActive?: boolean | undefined;
+  now?: Date | undefined;
+}
+
+/*
+ * Activity is derived from the communication timestamp instead of stored as a
+ * second piece of state that could drift. The same predicate drives this badge
+ * and the seat aggregation.
+ */
+export const EnterpriseLicenseInstanceStatusPill: FunctionComponent<
+  EnterpriseLicenseInstanceStatusPillProps
+> = (props: EnterpriseLicenseInstanceStatusPillProps): ReactElement => {
+  const isActive: boolean =
+    typeof props.isActive === "boolean"
+      ? props.isActive
+      : EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+          props.instance,
+          props.now || OneUptimeDate.getCurrentDate(),
+        );
+
+  if (isActive) {
+    return (
+      <Pill
+        text="Active"
+        color={Green}
+        size={PillSize.Small}
+        tooltip={`Registered or sent a usage report within the past ${EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays} days and is included in seat usage.`}
+      />
+    );
+  }
+
+  return (
+    <Pill
+      text="Inactive"
+      color={Gray500}
+      size={PillSize.Small}
+      tooltip={`Has not registered or sent a usage report for ${EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays} days and is not included in seat usage.`}
+    />
+  );
 };
 
 export interface SeatUsageMeterProps {

--- a/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil.tsx
@@ -1,60 +1,14 @@
 import { Gray500, Green, Red, Yellow } from "Common/Types/BrandColors";
 import OneUptimeDate from "Common/Types/Date";
-import EnterpriseLicenseUsageSnapshot from "Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
 import Pill, { PillSize } from "Common/UI/Components/Pill/Pill";
 import EnterpriseLicenseUsageUtil, {
   EnterpriseLicenseInstanceUsage,
 } from "Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage";
 import React, { FunctionComponent, ReactElement } from "react";
-
-export const EnterpriseLicenseUsageRefreshIntervalInMilliseconds: number =
-  60 * 1000;
-export const EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds: number = 1000;
-
-export const isEnterpriseLicenseUsageRequestCurrent: (
-  requestId: number,
-  latestRequestId: number,
-) => boolean = (requestId: number, latestRequestId: number): boolean => {
-  return requestId === latestRequestId;
-};
-
-export const getEnterpriseLicenseUsageBoundaryRefreshDelay: (
-  snapshot: EnterpriseLicenseUsageSnapshot,
-  elapsedSinceRequestStartedInMilliseconds?: number,
-) => number | null = (
-  snapshot: EnterpriseLicenseUsageSnapshot,
-  elapsedSinceRequestStartedInMilliseconds: number = 0,
-): number | null => {
-  if (!snapshot.nextInstanceStatusChangeAt) {
-    return null;
-  }
-
-  const nextChangeAt: number = new Date(
-    snapshot.nextInstanceStatusChangeAt,
-  ).getTime();
-  const calculatedAt: number = new Date(snapshot.calculatedAt).getTime();
-
-  if (!Number.isFinite(nextChangeAt) || !Number.isFinite(calculatedAt)) {
-    return null;
-  }
-
-  const elapsedRequestTime: number = Number.isFinite(
-    elapsedSinceRequestStartedInMilliseconds,
-  )
-    ? Math.max(0, elapsedSinceRequestStartedInMilliseconds)
-    : 0;
-
-  /*
-   * Both timestamps come from the server. Using the browser clock here can
-   * turn clock skew into a zero-delay refresh loop while the server still
-   * considers the instance active. The timer starts only after the response,
-   * so subtract monotonic time elapsed since the request began as well.
-   */
-  return Math.max(
-    EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds,
-    nextChangeAt - calculatedAt - elapsedRequestTime,
-  );
-};
+import {
+  EnterpriseLicenseInstanceActivityState,
+  getEnterpriseLicenseInstanceActivityState,
+} from "./LicenseActivityUtil";
 
 export type LicenseLifecycleState = "active" | "expiring-soon" | "expired";
 
@@ -177,15 +131,14 @@ export interface EnterpriseLicenseInstanceStatusPillProps {
 export const EnterpriseLicenseInstanceStatusPill: FunctionComponent<
   EnterpriseLicenseInstanceStatusPillProps
 > = (props: EnterpriseLicenseInstanceStatusPillProps): ReactElement => {
-  const isActive: boolean =
-    typeof props.isActive === "boolean"
-      ? props.isActive
-      : EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
-          props.instance,
-          props.now || OneUptimeDate.getCurrentDate(),
-        );
+  const activityState: EnterpriseLicenseInstanceActivityState =
+    getEnterpriseLicenseInstanceActivityState({
+      instance: props.instance,
+      isActive: props.isActive,
+      now: props.now,
+    });
 
-  if (isActive) {
+  if (activityState === "active") {
     return (
       <Pill
         text="Active"

--- a/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil.tsx
@@ -11,14 +11,17 @@ export const EnterpriseLicenseUsageRefreshIntervalInMilliseconds: number =
   60 * 1000;
 export const EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds: number = 1000;
 
-export const isEnterpriseLicenseUsageRequestCurrent = (
+export const isEnterpriseLicenseUsageRequestCurrent: (
   requestId: number,
   latestRequestId: number,
-): boolean => {
+) => boolean = (requestId: number, latestRequestId: number): boolean => {
   return requestId === latestRequestId;
 };
 
-export const getEnterpriseLicenseUsageBoundaryRefreshDelay = (
+export const getEnterpriseLicenseUsageBoundaryRefreshDelay: (
+  snapshot: EnterpriseLicenseUsageSnapshot,
+  elapsedSinceRequestStartedInMilliseconds?: number,
+) => number | null = (
   snapshot: EnterpriseLicenseUsageSnapshot,
   elapsedSinceRequestStartedInMilliseconds: number = 0,
 ): number | null => {

--- a/App/FeatureSet/AdminDashboard/src/Pages/EnterpriseLicenses/View/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/EnterpriseLicenses/View/Index.tsx
@@ -2,13 +2,15 @@ import AdminModelAPI from "../../../Utils/ModelAPI";
 import PageMap from "../../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
 import {
-  EnterpriseLicenseUsageRefreshIntervalInMilliseconds,
   EnterpriseLicenseInstanceStatusPill,
-  getEnterpriseLicenseUsageBoundaryRefreshDelay,
-  isEnterpriseLicenseUsageRequestCurrent,
   LicenseStatusPill,
   SeatUsageMeter,
 } from "../../../Components/EnterpriseLicense/LicenseUtil";
+import {
+  EnterpriseLicenseUsageRefreshIntervalInMilliseconds,
+  getEnterpriseLicenseUsageBoundaryRefreshDelay,
+  isEnterpriseLicenseUsageRequestCurrent,
+} from "../../../Components/EnterpriseLicense/LicenseActivityUtil";
 import Route from "Common/Types/API/Route";
 import URL from "Common/Types/API/URL";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";

--- a/App/FeatureSet/AdminDashboard/src/Pages/EnterpriseLicenses/View/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/EnterpriseLicenses/View/Index.tsx
@@ -2,14 +2,22 @@ import AdminModelAPI from "../../../Utils/ModelAPI";
 import PageMap from "../../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
 import {
+  EnterpriseLicenseUsageRefreshIntervalInMilliseconds,
+  EnterpriseLicenseInstanceStatusPill,
+  getEnterpriseLicenseUsageBoundaryRefreshDelay,
+  isEnterpriseLicenseUsageRequestCurrent,
   LicenseStatusPill,
   SeatUsageMeter,
 } from "../../../Components/EnterpriseLicense/LicenseUtil";
 import Route from "Common/Types/API/Route";
-import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import URL from "Common/Types/API/URL";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
 import IconProp from "Common/Types/Icon/IconProp";
 import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
+import { JSONObject } from "Common/Types/JSON";
+import EnterpriseLicenseUsageSnapshot from "Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
 import EnterpriseLicenseUsageUtil from "Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage";
 import VersionUtil from "Common/Utils/VersionUtil";
 import Card from "Common/UI/Components/Card/Card";
@@ -22,24 +30,57 @@ import ModelPage from "Common/UI/Components/Page/ModelPage";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import API from "Common/UI/Utils/API/API";
-import { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
+import { APP_API_URL } from "Common/UI/Config";
 import EnterpriseLicense from "Common/Models/DatabaseModels/EnterpriseLicense";
 import EnterpriseLicenseInstance from "Common/Models/DatabaseModels/EnterpriseLicenseInstance";
 import GlobalConfig from "Common/Models/DatabaseModels/GlobalConfig";
 import React, {
   FunctionComponent,
   ReactElement,
+  useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
 
+const fetchEnterpriseLicenseUsageSnapshot = async (
+  modelId: string,
+): Promise<EnterpriseLicenseUsageSnapshot> => {
+  const usageResponse: HTTPResponse<JSONObject> | HTTPErrorResponse =
+    await API.get<JSONObject>({
+      url: URL.fromString(APP_API_URL.toString()).addRoute(
+        `/enterprise-license/${modelId}/active-usage`,
+      ),
+    });
+
+  if (usageResponse instanceof HTTPErrorResponse) {
+    throw usageResponse;
+  }
+
+  return usageResponse.data as unknown as EnterpriseLicenseUsageSnapshot;
+};
+
+interface TimedEnterpriseLicenseUsageSnapshot {
+  snapshot: EnterpriseLicenseUsageSnapshot;
+  requestStartedAt: number;
+}
+
 const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
   const { t } = useTranslation();
   const modelId: ObjectID = Navigation.getLastParamAsObjectID();
+  const modelIdString: string = modelId.toString();
 
   const [license, setLicense] = useState<EnterpriseLicense | null>(null);
+  const [timedUsageSnapshot, setTimedUsageSnapshot] =
+    useState<TimedEnterpriseLicenseUsageSnapshot | null>(null);
+  const usageSnapshot: EnterpriseLicenseUsageSnapshot | null =
+    timedUsageSnapshot?.snapshot || null;
+  const [instanceTableRefreshCounter, setInstanceTableRefreshCounter] =
+    useState<number>(0);
+  const usageSnapshotRequestIdRef: React.MutableRefObject<number> =
+    useRef<number>(0);
   const [masterAdminEmails, setMasterAdminEmails] = useState<Array<string>>([]);
   const [reminderDays, setReminderDays] = useState<number>(
     EnterpriseLicenseUsageUtil.defaultExpiryReminderDays,
@@ -51,23 +92,57 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
    */
   const [latestReleaseVersion, setLatestReleaseVersion] = useState<string>("");
 
+  const refreshUsageSnapshot: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      const requestId: number = ++usageSnapshotRequestIdRef.current;
+      const requestStartedAt: number = performance.now();
+
+      try {
+        const snapshot: EnterpriseLicenseUsageSnapshot =
+          await fetchEnterpriseLicenseUsageSnapshot(modelIdString);
+
+        /* A slower, older request must never replace a newer snapshot. */
+        if (
+          !isEnterpriseLicenseUsageRequestCurrent(
+            requestId,
+            usageSnapshotRequestIdRef.current,
+          )
+        ) {
+          return;
+        }
+
+        setTimedUsageSnapshot({
+          snapshot,
+          requestStartedAt,
+        });
+        setMasterAdminEmails([...snapshot.masterAdminEmails].sort());
+        setUsageError("");
+      } catch (err) {
+        /* A stale failure must not cover a newer successful snapshot. */
+        if (
+          isEnterpriseLicenseUsageRequestCurrent(
+            requestId,
+            usageSnapshotRequestIdRef.current,
+          )
+        ) {
+          setUsageError(API.getFriendlyMessage(err));
+        }
+      }
+    }, [modelIdString]);
+
   useEffect(() => {
     const loadUsage: () => Promise<void> = async (): Promise<void> => {
       try {
         const fetchedLicense: EnterpriseLicense | null =
           await AdminModelAPI.getItem<EnterpriseLicense>({
             modelType: EnterpriseLicense,
-            id: modelId,
+            id: new ObjectID(modelIdString),
             select: {
               companyName: true,
               expiresAt: true,
               userLimit: true,
-              currentUserCount: true,
-              userCountUpdatedAt: true,
             },
           });
-
-        setLicense(fetchedLicense);
 
         const globalConfig: GlobalConfig | null =
           await AdminModelAPI.getItem<GlobalConfig>({
@@ -86,32 +161,8 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
 
         setLatestReleaseVersion(globalConfig?.latestReleaseVersion || "");
 
-        const instances: ListResult<EnterpriseLicenseInstance> =
-          await AdminModelAPI.getList<EnterpriseLicenseInstance>({
-            modelType: EnterpriseLicenseInstance,
-            query: {
-              enterpriseLicenseId: modelId,
-            },
-            limit: LIMIT_MAX,
-            skip: 0,
-            select: {
-              masterAdminEmails: true,
-            },
-            sort: {},
-          });
-
-        const emails: Set<string> = new Set<string>();
-
-        for (const instance of instances.data) {
-          for (const email of instance.masterAdminEmails || []) {
-            if (email) {
-              emails.add(email.toLowerCase());
-            }
-          }
-        }
-
-        setMasterAdminEmails(Array.from(emails).sort());
-        setUsageError("");
+        await refreshUsageSnapshot();
+        setLicense(fetchedLicense);
       } catch (err) {
         setUsageError(API.getFriendlyMessage(err));
       }
@@ -120,7 +171,52 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
     loadUsage().catch((err: Error) => {
       setUsageError(API.getFriendlyMessage(err));
     });
-  }, []);
+  }, [modelIdString, refreshUsageSnapshot]);
+
+  /*
+   * Reports can arrive while this page stays open. Polling keeps the headline
+   * and row statuses current, while the boundary timer flips the next active
+   * instance at the exact seven-day mark instead of waiting for a poll.
+   */
+  useEffect(() => {
+    const refreshInstanceTable: () => void = (): void => {
+      setInstanceTableRefreshCounter((counter: number): number => {
+        return counter + 1;
+      });
+    };
+    const refreshUsageAndInstanceTable: () => void = (): void => {
+      /* Start both requests together; table latency must not delay the badge. */
+      refreshInstanceTable();
+      refreshUsageSnapshot().catch((err: Error) => {
+        setUsageError(API.getFriendlyMessage(err));
+      });
+    };
+    const interval: ReturnType<typeof setInterval> = setInterval(
+      refreshUsageAndInstanceTable,
+      EnterpriseLicenseUsageRefreshIntervalInMilliseconds,
+    );
+    const elapsedSinceRequestStarted: number = timedUsageSnapshot
+      ? performance.now() - timedUsageSnapshot.requestStartedAt
+      : 0;
+    const boundaryDelay: number | null = timedUsageSnapshot
+      ? getEnterpriseLicenseUsageBoundaryRefreshDelay(
+          timedUsageSnapshot.snapshot,
+          elapsedSinceRequestStarted,
+        )
+      : null;
+    const boundaryTimer: ReturnType<typeof setTimeout> | undefined =
+      boundaryDelay !== null
+        ? setTimeout(refreshUsageAndInstanceTable, boundaryDelay)
+        : undefined;
+
+    return () => {
+      clearInterval(interval);
+
+      if (boundaryTimer !== undefined) {
+        clearTimeout(boundaryTimer);
+      }
+    };
+  }, [refreshUsageSnapshot, timedUsageSnapshot]);
 
   return (
     <ModelPage
@@ -297,7 +393,7 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
                 <div className="text-sm text-gray-500">Seats in use</div>
                 <div className="mt-1 text-4xl font-semibold text-gray-900">
                   {license
-                    ? (license.currentUserCount || 0).toLocaleString()
+                    ? (usageSnapshot?.currentUserCount || 0).toLocaleString()
                     : "—"}
                   {license?.userLimit ? (
                     <span className="ml-2 text-lg font-normal text-gray-500">
@@ -311,16 +407,23 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
                 </div>
                 <div className="mt-3">
                   <SeatUsageMeter
-                    currentUserCount={license?.currentUserCount}
+                    currentUserCount={
+                      usageSnapshot?.currentUserCount ?? undefined
+                    }
                     userLimit={license?.userLimit}
                   />
                 </div>
                 <div className="mt-3 text-sm text-gray-500">
-                  {license?.userCountUpdatedAt
+                  {usageSnapshot?.lastUsageReportedAt
                     ? `Last reported ${OneUptimeDate.getDateAsUserFriendlyFormattedString(
-                        license.userCountUpdatedAt,
+                        new Date(usageSnapshot.lastUsageReportedAt),
                       )}`
                     : "This license has not reported usage yet."}
+                </div>
+                <div className="mt-1 text-xs text-gray-400">
+                  Only instances active within the past{" "}
+                  {EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays} days
+                  are included.
                 </div>
                 <div className="mt-2">
                   <LicenseStatusPill
@@ -389,6 +492,11 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
           isCreateable={false}
           isViewable={false}
           showRefreshButton={true}
+          refreshToggle={instanceTableRefreshCounter.toString()}
+          onFetchSuccess={async () => {
+            /* Keep the rows, status snapshot and headline count together. */
+            await refreshUsageSnapshot();
+          }}
           query={{
             enterpriseLicenseId: modelId,
           }}
@@ -443,6 +551,32 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
                   <span className="font-mono text-xs text-gray-600">
                     {item.instanceId || "-"}
                   </span>
+                );
+              },
+            },
+            {
+              field: {
+                _id: true,
+                createdAt: true,
+                lastReportedAt: true,
+              },
+              title: "Status",
+              type: FieldType.Element,
+              getElement: (item: EnterpriseLicenseInstance): ReactElement => {
+                return (
+                  <EnterpriseLicenseInstanceStatusPill
+                    instance={item}
+                    isActive={
+                      usageSnapshot
+                        ? Boolean(
+                            item.id &&
+                              usageSnapshot.activeInstanceIds.includes(
+                                item.id.toString(),
+                              ),
+                          )
+                        : undefined
+                    }
+                  />
                 );
               },
             },
@@ -534,32 +668,47 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
             },
             {
               field: {
+                _id: true,
+                createdAt: true,
                 lastReportedAt: true,
               },
-              title: "Last Reported",
+              title: "Last Activity",
               type: FieldType.Element,
               hideOnMobile: true,
               getElement: (item: EnterpriseLicenseInstance): ReactElement => {
-                if (!item.lastReportedAt) {
-                  return <span className="text-gray-400">Never reported</span>;
+                const lastCommunicatedAt: Date | undefined =
+                  EnterpriseLicenseUsageUtil.getInstanceLastCommunicatedAt(
+                    item,
+                  );
+
+                if (!lastCommunicatedAt) {
+                  return (
+                    <span className="text-gray-400">Never communicated</span>
+                  );
                 }
 
-                const isStale: boolean =
-                  !EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
-                    item,
-                    OneUptimeDate.getCurrentDate(),
-                  );
+                const isInactive: boolean = usageSnapshot
+                  ? !Boolean(
+                      item.id &&
+                        usageSnapshot.activeInstanceIds.includes(
+                          item.id.toString(),
+                        ),
+                    )
+                  : !EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+                      item,
+                      OneUptimeDate.getCurrentDate(),
+                    );
 
                 return (
                   <div>
                     <div className="text-sm text-gray-700">
                       {OneUptimeDate.getDateAsUserFriendlyFormattedString(
-                        item.lastReportedAt,
+                        lastCommunicatedAt,
                       )}
                     </div>
-                    {isStale ? (
+                    {isInactive ? (
                       <div className="text-xs text-gray-400">
-                        Stale — not counted towards seats
+                        Inactive — not counted towards seats
                       </div>
                     ) : (
                       <></>

--- a/App/FeatureSet/AdminDashboard/src/Pages/EnterpriseLicenses/View/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/EnterpriseLicenses/View/Index.tsx
@@ -45,7 +45,9 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 
-const fetchEnterpriseLicenseUsageSnapshot = async (
+const fetchEnterpriseLicenseUsageSnapshot: (
+  modelId: string,
+) => Promise<EnterpriseLicenseUsageSnapshot> = async (
   modelId: string,
 ): Promise<EnterpriseLicenseUsageSnapshot> => {
   const usageResponse: HTTPResponse<JSONObject> | HTTPErrorResponse =
@@ -688,11 +690,11 @@ const EnterpriseLicenseView: FunctionComponent = (): ReactElement => {
                 }
 
                 const isInactive: boolean = usageSnapshot
-                  ? !Boolean(
+                  ? !(
                       item.id &&
-                        usageSnapshot.activeInstanceIds.includes(
-                          item.id.toString(),
-                        ),
+                      usageSnapshot.activeInstanceIds.includes(
+                        item.id.toString(),
+                      )
                     )
                   : !EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
                       item,

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -299,6 +299,8 @@ import "./Jobs/PaymentProvider/SendDailyEmailsToOwnersIfSubscriptionIsOverdue";
 // Enterprise License usage reporting (self-hosted only).
 import "./Jobs/EnterpriseLicense/ReportUserCount";
 import "./Jobs/EnterpriseLicense/SendLicenseNotificationEmails";
+// Hosted license counts derived from active instance reports.
+import "./Jobs/EnterpriseLicense/ReconcileInstanceUsage";
 
 // Checks GitHub for a newer OneUptime release so admins can be told to upgrade.
 import "./Jobs/InstanceUpdate/CheckForNewVersion";

--- a/App/FeatureSet/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage.ts
+++ b/App/FeatureSet/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage.ts
@@ -1,0 +1,173 @@
+import RunCron from "../../Utils/Cron";
+import { EVERY_FIVE_MINUTE, EVERY_HOUR } from "Common/Utils/CronTime";
+import {
+  IsBillingEnabled,
+  IsDevelopment,
+} from "Common/Server/EnvironmentConfig";
+import EnterpriseLicenseService from "Common/Server/Services/EnterpriseLicenseService";
+import EnterpriseLicenseInstanceService from "Common/Server/Services/EnterpriseLicenseInstanceService";
+import EnterpriseLicense from "Common/Models/DatabaseModels/EnterpriseLicense";
+import EnterpriseLicenseInstance from "Common/Models/DatabaseModels/EnterpriseLicenseInstance";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import OneUptimeDate from "Common/Types/Date";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import EnterpriseLicenseUsageUtil from "Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+import logger from "Common/Server/Utils/Logger";
+
+RunCron(
+  "EnterpriseLicense:ReconcileInstanceUsage",
+  {
+    schedule: IsDevelopment ? EVERY_FIVE_MINUTE : EVERY_HOUR,
+    runOnStartup: true,
+  },
+  async () => {
+    /*
+     * Instance usage is stored only on hosted oneuptime.com. Self-hosted
+     * installations report into it, but do not own the EnterpriseLicense
+     * rows this sweep reconciles.
+     */
+    if (!IsBillingEnabled) {
+      return;
+    }
+
+    let skip: number = 0;
+
+    for (;;) {
+      const licenses: Array<EnterpriseLicense> =
+        await EnterpriseLicenseService.findBy({
+          query: {},
+          select: {
+            _id: true,
+            currentUserCount: true,
+            userCountUpdatedAt: true,
+            userCountSource: true,
+            legacyUserCount: true,
+            legacyUserCountUpdatedAt: true,
+          },
+          sort: {
+            createdAt: SortOrder.Ascending,
+            _id: SortOrder.Ascending,
+          },
+          skip: skip,
+          limit: LIMIT_MAX,
+          props: {
+            isRoot: true,
+          },
+        });
+
+      for (const license of licenses) {
+        try {
+          await EnterpriseLicenseService.runWithUsageAggregationLock({
+            licenseId: license.id!,
+            fn: async (): Promise<void> => {
+              /*
+               * Capture the cutoff only after acquiring this license's lock.
+               * A delayed older sweep must not run after a newer report/sweep
+               * while still evaluating activity with its earlier wall time.
+               */
+              const now: Date = OneUptimeDate.getCurrentDate();
+
+              /*
+               * Validation creates registration-only rows. Re-read both the
+               * license and its instances after taking their shared lock so a
+               * just-registered instance cannot be missed by a stale sweep.
+               */
+              const currentLicense: EnterpriseLicense | null =
+                await EnterpriseLicenseService.findOneById({
+                  id: license.id!,
+                  select: {
+                    currentUserCount: true,
+                    userCountUpdatedAt: true,
+                    userCountSource: true,
+                    legacyUserCount: true,
+                    legacyUserCountUpdatedAt: true,
+                  },
+                  props: {
+                    isRoot: true,
+                  },
+                });
+
+              if (!currentLicense) {
+                return;
+              }
+
+              const instances: Array<EnterpriseLicenseInstance> =
+                await EnterpriseLicenseInstanceService.findBy({
+                  query: {
+                    enterpriseLicenseId: license.id!,
+                  },
+                  select: {
+                    createdAt: true,
+                    userCount: true,
+                    userEmailHashes: true,
+                    lastReportedAt: true,
+                  },
+                  sort: {
+                    createdAt: SortOrder.Ascending,
+                  },
+                  skip: 0,
+                  limit: LIMIT_MAX,
+                  props: {
+                    isRoot: true,
+                  },
+                });
+
+              const reconciledUserCount: number | null =
+                EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+                  instances,
+                  storedUserCount: currentLicense.currentUserCount,
+                  storedUserCountUpdatedAt: currentLicense.userCountUpdatedAt,
+                  storedUserCountSource: currentLicense.userCountSource,
+                  legacyUserCount: currentLicense.legacyUserCount,
+                  legacyUserCountUpdatedAt:
+                    currentLicense.legacyUserCountUpdatedAt,
+                  now,
+                });
+              const previousUserCount: number | null =
+                currentLicense.currentUserCount ?? null;
+
+              if (
+                reconciledUserCount === previousUserCount ||
+                reconciledUserCount === null
+              ) {
+                return;
+              }
+
+              /*
+               * The shared lock covers every known usage writer. Keep a
+               * compare-and-set as an additional guard for older processes
+               * during a rolling deployment. The derived write deliberately
+               * leaves userCountUpdatedAt untouched because only real
+               * communication may advance that timestamp.
+               */
+              await EnterpriseLicenseService.updateColumnsByIdWithoutHooks({
+                id: license.id!,
+                data: {
+                  currentUserCount: reconciledUserCount,
+                },
+                expectedData: {
+                  currentUserCount: previousUserCount,
+                  userCountUpdatedAt: currentLicense.userCountUpdatedAt ?? null,
+                  userCountSource: currentLicense.userCountSource ?? null,
+                  legacyUserCount: currentLicense.legacyUserCount ?? null,
+                  legacyUserCountUpdatedAt:
+                    currentLicense.legacyUserCountUpdatedAt ?? null,
+                },
+              });
+            },
+          });
+        } catch (error) {
+          logger.error(
+            `EnterpriseLicense:ReconcileInstanceUsage: Error while processing license ${license.id?.toString() || "unknown"}: ${error}`,
+          );
+        }
+      }
+
+      if (licenses.length < LIMIT_MAX) {
+        break;
+      }
+
+      skip += licenses.length;
+    }
+  },
+);

--- a/App/FeatureSet/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails.ts
+++ b/App/FeatureSet/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails.ts
@@ -147,6 +147,10 @@ RunCron(
           expiresAt: true,
           userLimit: true,
           currentUserCount: true,
+          userCountUpdatedAt: true,
+          userCountSource: true,
+          legacyUserCount: true,
+          legacyUserCountUpdatedAt: true,
         },
         sort: {
           createdAt: SortOrder.Ascending,
@@ -158,8 +162,6 @@ RunCron(
         },
       });
 
-    const now: Date = OneUptimeDate.getCurrentDate();
-
     for (const license of licenses) {
       try {
         const instances: Array<EnterpriseLicenseInstance> =
@@ -169,6 +171,7 @@ RunCron(
             },
             select: {
               _id: true,
+              createdAt: true,
               userCount: true,
               userEmailHashes: true,
               masterAdminEmails: true,
@@ -183,6 +186,7 @@ RunCron(
               isRoot: true,
             },
           });
+        const now: Date = OneUptimeDate.getCurrentDate();
 
         const recipients: Array<string> = getRecipients({
           instances,
@@ -203,9 +207,15 @@ RunCron(
         // --- Seat limit breach ---
 
         const currentUserCount: number =
-          instances.length > 0
-            ? EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now)
-            : license.currentUserCount || 0;
+          EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+            instances,
+            storedUserCount: license.currentUserCount,
+            storedUserCountUpdatedAt: license.userCountUpdatedAt,
+            storedUserCountSource: license.userCountSource,
+            legacyUserCount: license.legacyUserCount,
+            legacyUserCountUpdatedAt: license.legacyUserCountUpdatedAt,
+            now,
+          }) ?? 0;
 
         const userLimit: number | undefined = license.userLimit;
 

--- a/App/Tests/AdminDashboard/EnterpriseLicenseInstanceStatusWiring.test.ts
+++ b/App/Tests/AdminDashboard/EnterpriseLicenseInstanceStatusWiring.test.ts
@@ -3,12 +3,12 @@ import fs from "fs";
 import nodePath from "path";
 import EnterpriseLicenseUsageSnapshot from "Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
 import {
-  EnterpriseLicenseInstanceStatusPill,
   EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds,
   EnterpriseLicenseUsageRefreshIntervalInMilliseconds,
+  getEnterpriseLicenseInstanceActivityState,
   getEnterpriseLicenseUsageBoundaryRefreshDelay,
   isEnterpriseLicenseUsageRequestCurrent,
-} from "../../FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil";
+} from "../../FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseActivityUtil";
 
 /*
  * The Admin Dashboard package has no React render harness, so this suite pins
@@ -50,6 +50,16 @@ const licenseUtilSource: string = stripComments(
   ),
 );
 
+const licenseActivityUtilSource: string = stripComments(
+  fs.readFileSync(
+    nodePath.join(
+      ADMIN_DASHBOARD_SRC,
+      "Components/EnterpriseLicense/LicenseActivityUtil.ts",
+    ),
+    "utf8",
+  ),
+);
+
 const instanceTableSource: string = (
   viewSource.split('id="enterprise-license-instances-table"')[1] || ""
 ).split("<ModelDelete")[0] as string;
@@ -59,12 +69,6 @@ const usageCardSource: string = (
     'title={t("pages.enterpriseLicenseView.usageCardTitle")}',
   )[1] || ""
 ).split("<ModelTable")[0] as string;
-
-interface PillElement {
-  props: {
-    text: string;
-  };
-}
 
 describe("Admin Dashboard > Enterprise License instance activity", () => {
   test("shows an explicit status for every instance", () => {
@@ -81,11 +85,11 @@ describe("Admin Dashboard > Enterprise License instance activity", () => {
   });
 
   test("derives the badge from the same predicate used for seat counting", () => {
-    expect(licenseUtilSource).toContain(
+    expect(licenseActivityUtilSource).toContain(
       "EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage",
     );
-    expect(licenseUtilSource).not.toContain("instance.isActive");
-    expect(licenseUtilSource).not.toMatch(/7\s*\*\s*24\s*\*\s*60/);
+    expect(licenseActivityUtilSource).not.toContain("instance.isActive");
+    expect(licenseActivityUtilSource).not.toMatch(/7\s*\*\s*24\s*\*\s*60/);
   });
 
   test("uses one server-side snapshot for both status and seat count", () => {
@@ -166,7 +170,7 @@ describe("Admin Dashboard > Enterprise License instance activity", () => {
     };
 
     expect(getEnterpriseLicenseUsageBoundaryRefreshDelay(snapshot)).toBe(5000);
-    expect(licenseUtilSource).not.toContain("Date.now()");
+    expect(licenseActivityUtilSource).not.toContain("Date.now()");
   });
 
   test("subtracts response latency before scheduling the inactivity boundary", () => {
@@ -210,38 +214,38 @@ describe("Admin Dashboard > Enterprise License instance activity", () => {
     expect(usageCardSource).not.toContain("license.userCountUpdatedAt");
   });
 
-  test("maps a recent report to the Active pill", () => {
+  test("maps a recent report to the active state", () => {
     const now: Date = new Date("2026-09-02T12:00:00.000Z");
-    const element: PillElement = EnterpriseLicenseInstanceStatusPill({
-      instance: {
-        lastReportedAt: new Date("2026-09-01T12:00:00.000Z"),
-      },
-      now,
-    }) as PillElement;
-
-    expect(element.props.text).toBe("Active");
+    expect(
+      getEnterpriseLicenseInstanceActivityState({
+        instance: {
+          lastReportedAt: new Date("2026-09-01T12:00:00.000Z"),
+        },
+        now,
+      }),
+    ).toBe("active");
   });
 
-  test("maps a week without a report to the Inactive pill", () => {
+  test("maps a week without a report to the inactive state", () => {
     const now: Date = new Date("2026-09-02T12:00:00.000Z");
-    const element: PillElement = EnterpriseLicenseInstanceStatusPill({
-      instance: {
-        lastReportedAt: new Date("2026-08-26T12:00:00.000Z"),
-      },
-      now,
-    }) as PillElement;
-
-    expect(element.props.text).toBe("Inactive");
+    expect(
+      getEnterpriseLicenseInstanceActivityState({
+        instance: {
+          lastReportedAt: new Date("2026-08-26T12:00:00.000Z"),
+        },
+        now,
+      }),
+    ).toBe("inactive");
   });
 
   test("honors the status from the same snapshot as the displayed count", () => {
-    const element: PillElement = EnterpriseLicenseInstanceStatusPill({
-      instance: {
-        lastReportedAt: new Date("2026-09-02T12:00:00.000Z"),
-      },
-      isActive: false,
-    }) as PillElement;
-
-    expect(element.props.text).toBe("Inactive");
+    expect(
+      getEnterpriseLicenseInstanceActivityState({
+        instance: {
+          lastReportedAt: new Date("2026-09-02T12:00:00.000Z"),
+        },
+        isActive: false,
+      }),
+    ).toBe("inactive");
   });
 });

--- a/App/Tests/AdminDashboard/EnterpriseLicenseInstanceStatusWiring.test.ts
+++ b/App/Tests/AdminDashboard/EnterpriseLicenseInstanceStatusWiring.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import nodePath from "path";
+import EnterpriseLicenseUsageSnapshot from "Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
+import {
+  EnterpriseLicenseInstanceStatusPill,
+  EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds,
+  EnterpriseLicenseUsageRefreshIntervalInMilliseconds,
+  getEnterpriseLicenseUsageBoundaryRefreshDelay,
+  isEnterpriseLicenseUsageRequestCurrent,
+} from "../../FeatureSet/AdminDashboard/src/Components/EnterpriseLicense/LicenseUtil";
+
+/*
+ * The Admin Dashboard package has no React render harness, so this suite pins
+ * the table/component wiring against comment-stripped source just like the
+ * other AdminDashboard regression suites. The time-boundary and accounting
+ * behavior behind the shared predicate are covered by Common unit/API tests.
+ */
+
+const ADMIN_DASHBOARD_SRC: string = nodePath.join(
+  __dirname,
+  "../../FeatureSet/AdminDashboard/src",
+);
+
+type StripCommentsFunction = (source: string) => string;
+
+const stripComments: StripCommentsFunction = (source: string): string => {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+};
+
+const viewSource: string = stripComments(
+  fs.readFileSync(
+    nodePath.join(
+      ADMIN_DASHBOARD_SRC,
+      "Pages/EnterpriseLicenses/View/Index.tsx",
+    ),
+    "utf8",
+  ),
+);
+
+const licenseUtilSource: string = stripComments(
+  fs.readFileSync(
+    nodePath.join(
+      ADMIN_DASHBOARD_SRC,
+      "Components/EnterpriseLicense/LicenseUtil.tsx",
+    ),
+    "utf8",
+  ),
+);
+
+const instanceTableSource: string = (
+  viewSource.split('id="enterprise-license-instances-table"')[1] || ""
+).split("<ModelDelete")[0] as string;
+
+const usageCardSource: string = (
+  viewSource.split(
+    'title={t("pages.enterpriseLicenseView.usageCardTitle")}',
+  )[1] || ""
+).split("<ModelTable")[0] as string;
+
+interface PillElement {
+  props: {
+    text: string;
+  };
+}
+
+describe("Admin Dashboard > Enterprise License instance activity", () => {
+  test("shows an explicit status for every instance", () => {
+    expect(instanceTableSource).toContain('title: "Status"');
+    expect(instanceTableSource).toContain(
+      "<EnterpriseLicenseInstanceStatusPill",
+    );
+    expect(instanceTableSource).toContain("instance={item}");
+  });
+
+  test("renders both Active and Inactive states", () => {
+    expect(licenseUtilSource).toContain('text="Active"');
+    expect(licenseUtilSource).toContain('text="Inactive"');
+  });
+
+  test("derives the badge from the same predicate used for seat counting", () => {
+    expect(licenseUtilSource).toContain(
+      "EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage",
+    );
+    expect(licenseUtilSource).not.toContain("instance.isActive");
+    expect(licenseUtilSource).not.toMatch(/7\s*\*\s*24\s*\*\s*60/);
+  });
+
+  test("uses one server-side snapshot for both status and seat count", () => {
+    expect(viewSource).toContain("/enterprise-license/${modelId}/active-usage");
+    expect(usageCardSource).toContain("usageSnapshot?.currentUserCount");
+    expect(usageCardSource).not.toContain("license.currentUserCount");
+    expect(instanceTableSource).toContain(
+      "usageSnapshot.activeInstanceIds.includes",
+    );
+  });
+
+  test("refreshes the usage snapshot whenever the instance table fetches", () => {
+    expect(instanceTableSource).toContain("onFetchSuccess={async () => {");
+    expect(instanceTableSource).toContain("await refreshUsageSnapshot()");
+  });
+
+  test("polls while the page remains open", () => {
+    expect(EnterpriseLicenseUsageRefreshIntervalInMilliseconds).toBe(60_000);
+    expect(viewSource).toContain("setInterval(");
+    expect(viewSource).toContain(
+      "EnterpriseLicenseUsageRefreshIntervalInMilliseconds",
+    );
+    expect(instanceTableSource).toContain(
+      "refreshToggle={instanceTableRefreshCounter.toString()}",
+    );
+    expect(viewSource).toContain("setInstanceTableRefreshCounter");
+  });
+
+  test("prevents an older overlapping response from replacing newer state", () => {
+    expect(viewSource).toContain("usageSnapshotRequestIdRef");
+    expect(isEnterpriseLicenseUsageRequestCurrent(1, 2)).toBe(false);
+    expect(isEnterpriseLicenseUsageRequestCurrent(2, 2)).toBe(true);
+
+    const requestGuardUses: Array<string> | null = viewSource.match(
+      /isEnterpriseLicenseUsageRequestCurrent\(/g,
+    );
+    expect(requestGuardUses).toHaveLength(2);
+  });
+
+  test("schedules a refresh at the next exact inactivity boundary", () => {
+    const now: Date = new Date("2026-09-02T12:00:00.000Z");
+    const snapshot: EnterpriseLicenseUsageSnapshot = {
+      currentUserCount: 2,
+      activeInstanceIds: [],
+      masterAdminEmails: [],
+      calculatedAt: now.toISOString(),
+      lastUsageReportedAt: null,
+      nextInstanceStatusChangeAt: new Date(
+        now.getTime() + 12_345,
+      ).toISOString(),
+    };
+
+    expect(getEnterpriseLicenseUsageBoundaryRefreshDelay(snapshot)).toBe(
+      12_345,
+    );
+    expect(
+      getEnterpriseLicenseUsageBoundaryRefreshDelay({
+        ...snapshot,
+        nextInstanceStatusChangeAt: new Date(now.getTime() - 1).toISOString(),
+      }),
+    ).toBe(EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds);
+    expect(
+      getEnterpriseLicenseUsageBoundaryRefreshDelay({
+        ...snapshot,
+        nextInstanceStatusChangeAt: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("uses server timestamps so browser clock skew cannot cause a refresh loop", () => {
+    const snapshot: EnterpriseLicenseUsageSnapshot = {
+      currentUserCount: 2,
+      activeInstanceIds: [],
+      masterAdminEmails: [],
+      calculatedAt: "2026-09-02T12:00:00.000Z",
+      lastUsageReportedAt: null,
+      nextInstanceStatusChangeAt: "2026-09-02T12:00:05.000Z",
+    };
+
+    expect(getEnterpriseLicenseUsageBoundaryRefreshDelay(snapshot)).toBe(5000);
+    expect(licenseUtilSource).not.toContain("Date.now()");
+  });
+
+  test("subtracts response latency before scheduling the inactivity boundary", () => {
+    const snapshot: EnterpriseLicenseUsageSnapshot = {
+      currentUserCount: 2,
+      activeInstanceIds: [],
+      masterAdminEmails: [],
+      calculatedAt: "2026-09-02T12:00:00.000Z",
+      lastUsageReportedAt: null,
+      nextInstanceStatusChangeAt: "2026-09-02T12:00:12.345Z",
+    };
+
+    expect(getEnterpriseLicenseUsageBoundaryRefreshDelay(snapshot, 5000)).toBe(
+      7345,
+    );
+    expect(
+      getEnterpriseLicenseUsageBoundaryRefreshDelay(snapshot, 15_000),
+    ).toBe(EnterpriseLicenseUsageMinimumRefreshDelayInMilliseconds);
+    expect(viewSource).toContain("performance.now()");
+    expect(viewSource).toContain("elapsedSinceRequestStarted");
+  });
+
+  test("does not send user email hashes to the browser", () => {
+    expect(viewSource).not.toContain("userEmailHashes: true");
+  });
+
+  test("makes the billing effect explicit next to the last report", () => {
+    expect(instanceTableSource).toContain(
+      "Inactive — not counted towards seats",
+    );
+    expect(licenseUtilSource).toContain("is not included in seat usage");
+  });
+
+  test("keeps the last-activity timestamp visible for diagnosing inactivity", () => {
+    expect(instanceTableSource).toContain('title: "Last Activity"');
+    expect(instanceTableSource).toContain(
+      "OneUptimeDate.getDateAsUserFriendlyFormattedString",
+    );
+    expect(instanceTableSource).toContain("Never communicated");
+    expect(usageCardSource).toContain("usageSnapshot?.lastUsageReportedAt");
+    expect(usageCardSource).not.toContain("license.userCountUpdatedAt");
+  });
+
+  test("maps a recent report to the Active pill", () => {
+    const now: Date = new Date("2026-09-02T12:00:00.000Z");
+    const element: PillElement = EnterpriseLicenseInstanceStatusPill({
+      instance: {
+        lastReportedAt: new Date("2026-09-01T12:00:00.000Z"),
+      },
+      now,
+    }) as PillElement;
+
+    expect(element.props.text).toBe("Active");
+  });
+
+  test("maps a week without a report to the Inactive pill", () => {
+    const now: Date = new Date("2026-09-02T12:00:00.000Z");
+    const element: PillElement = EnterpriseLicenseInstanceStatusPill({
+      instance: {
+        lastReportedAt: new Date("2026-08-26T12:00:00.000Z"),
+      },
+      now,
+    }) as PillElement;
+
+    expect(element.props.text).toBe("Inactive");
+  });
+
+  test("honors the status from the same snapshot as the displayed count", () => {
+    const element: PillElement = EnterpriseLicenseInstanceStatusPill({
+      instance: {
+        lastReportedAt: new Date("2026-09-02T12:00:00.000Z"),
+      },
+      isActive: false,
+    }) as PillElement;
+
+    expect(element.props.text).toBe("Inactive");
+  });
+});

--- a/App/Tests/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage.test.ts
+++ b/App/Tests/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage.test.ts
@@ -156,20 +156,24 @@ interface CompareAndSetArgs {
   expectedData: Record<string, unknown>;
 }
 
-type MakeLicenseFunction = (data?: {
+interface MakeLicenseData {
   currentUserCount?: number | undefined;
   userCountUpdatedAt?: Date | undefined;
   userCountSource?: EnterpriseLicenseUserCountSource | undefined;
   legacyUserCount?: number | undefined;
   legacyUserCountUpdatedAt?: Date | undefined;
-}) => EnterpriseLicense;
+}
+
+type MakeLicenseFunction = (data?: MakeLicenseData) => EnterpriseLicense;
 
 const licensesById: Map<string, EnterpriseLicense> = new Map<
   string,
   EnterpriseLicense
 >();
 
-const makeLicense: MakeLicenseFunction = (data): EnterpriseLicense => {
+const makeLicense: MakeLicenseFunction = (
+  data?: MakeLicenseData,
+): EnterpriseLicense => {
   const license: EnterpriseLicense = new EnterpriseLicense(ObjectID.generate());
 
   if (data?.currentUserCount !== undefined) {
@@ -197,16 +201,20 @@ const makeLicense: MakeLicenseFunction = (data): EnterpriseLicense => {
   return license;
 };
 
-type MakeInstanceFunction = (data: {
+interface MakeInstanceData {
   createdAt?: Date | undefined;
   daysSinceReport?: number | undefined;
   lastReportedAt?: Date | undefined;
   userCount?: number | undefined;
   userEmailHashes?: Array<string> | undefined;
-}) => EnterpriseLicenseInstance;
+}
+
+type MakeInstanceFunction = (
+  data: MakeInstanceData,
+) => EnterpriseLicenseInstance;
 
 const makeInstance: MakeInstanceFunction = (
-  data,
+  data: MakeInstanceData,
 ): EnterpriseLicenseInstance => {
   const instance: EnterpriseLicenseInstance = new EnterpriseLicenseInstance();
 
@@ -856,7 +864,9 @@ describe("EnterpriseLicense:ReconcileInstanceUsage", () => {
       3,
     );
     expect(
-      compareAndSetCalls().map((call: CompareAndSetArgs) => call.id),
+      compareAndSetCalls().map((call: CompareAndSetArgs) => {
+        return call.id;
+      }),
     ).toEqual([writeFailure.id, healthy.id]);
     expect(logger.error).toHaveBeenCalledTimes(2);
     expect(logger.error).toHaveBeenCalledWith(

--- a/App/Tests/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage.test.ts
+++ b/App/Tests/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage.test.ts
@@ -1,0 +1,869 @@
+import fs from "fs";
+import path from "path";
+import { afterAll, beforeEach, describe, expect, test } from "@jest/globals";
+import { EVERY_HOUR } from "Common/Utils/CronTime";
+
+/*
+ * The hosted reconciliation pass turns the seven-day instance freshness rule
+ * into the license-wide count shown by the admin dashboard. Reports update the
+ * count immediately, but time passing does not write anything; without this
+ * job an abandoned instance therefore consumes seats forever.
+ *
+ * The suite captures the side-effect-only cron registration and drives its
+ * handler directly. It pins the billing gate, deliberately narrow reads,
+ * freshness boundary, cross-instance deduplication, legacy fallback, no-op
+ * behavior, atomic compare-and-set guard, and per-license failure isolation.
+ */
+
+type CronHandler = () => Promise<void>;
+
+interface CronOptions {
+  schedule: string;
+  runOnStartup: boolean;
+}
+
+interface CapturedJob {
+  options: CronOptions;
+  handler: CronHandler;
+}
+
+interface EnterpriseLicenseServiceMock {
+  findBy: jest.Mock;
+  findOneById: jest.Mock;
+  runWithUsageAggregationLock: jest.Mock;
+  updateColumnsByIdWithoutHooks: jest.Mock;
+}
+
+interface EnterpriseLicenseInstanceServiceMock {
+  findBy: jest.Mock;
+}
+
+const mockCapturedJobs: Record<string, CapturedJob> = {};
+const mockEnterpriseLicenseService: EnterpriseLicenseServiceMock = {
+  findBy: jest.fn(),
+  findOneById: jest.fn(),
+  runWithUsageAggregationLock: jest.fn(),
+  updateColumnsByIdWithoutHooks: jest.fn(),
+};
+const mockEnterpriseLicenseInstanceService: EnterpriseLicenseInstanceServiceMock =
+  {
+    findBy: jest.fn(),
+  };
+
+let mockBillingEnabled: boolean = true;
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (
+        jobName: string,
+        options: CronOptions,
+        runFunction: CronHandler,
+      ): void => {
+        mockCapturedJobs[jobName] = {
+          options: options,
+          handler: runFunction,
+        };
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Services/EnterpriseLicenseService", () => {
+  return {
+    __esModule: true,
+    default: mockEnterpriseLicenseService,
+  };
+});
+
+jest.mock("Common/Server/Services/EnterpriseLicenseInstanceService", () => {
+  return {
+    __esModule: true,
+    default: mockEnterpriseLicenseInstanceService,
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/* Two rows make pagination behavior exhaustive without 10,000-row fixtures. */
+jest.mock("Common/Types/Database/LimitMax", () => {
+  return {
+    __esModule: true,
+    default: 2,
+  };
+});
+
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  const mocked: Record<string, unknown> = {
+    ...actual,
+    __esModule: true,
+    IsDevelopment: false,
+  };
+
+  Object.defineProperty(mocked, "IsBillingEnabled", {
+    get: (): boolean => {
+      return mockBillingEnabled;
+    },
+  });
+
+  return mocked;
+});
+
+// Imported for its RunCron registration side effect, after all mocks above.
+import "../../../../FeatureSet/Workers/Jobs/EnterpriseLicense/ReconcileInstanceUsage";
+import EnterpriseLicense from "Common/Models/DatabaseModels/EnterpriseLicense";
+import EnterpriseLicenseInstance from "Common/Models/DatabaseModels/EnterpriseLicenseInstance";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import ObjectID from "Common/Types/ObjectID";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import OneUptimeDate from "Common/Types/Date";
+import EnterpriseLicenseUserCountSource from "Common/Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
+import logger from "Common/Server/Utils/Logger";
+
+const JOB_NAME: string = "EnterpriseLicense:ReconcileInstanceUsage";
+const NOW: Date = new Date("2026-09-02T12:00:00.000Z");
+
+const mockCurrentDate: jest.SpiedFunction<typeof OneUptimeDate.getCurrentDate> =
+  jest.spyOn(OneUptimeDate, "getCurrentDate");
+
+interface FindByArgs {
+  query: Record<string, unknown>;
+  select: Record<string, boolean>;
+  sort: Record<string, SortOrder>;
+  skip: number;
+  limit: number;
+  props: Record<string, unknown>;
+}
+
+interface CompareAndSetArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+  expectedData: Record<string, unknown>;
+}
+
+type MakeLicenseFunction = (data?: {
+  currentUserCount?: number | undefined;
+  userCountUpdatedAt?: Date | undefined;
+  userCountSource?: EnterpriseLicenseUserCountSource | undefined;
+  legacyUserCount?: number | undefined;
+  legacyUserCountUpdatedAt?: Date | undefined;
+}) => EnterpriseLicense;
+
+const licensesById: Map<string, EnterpriseLicense> = new Map<
+  string,
+  EnterpriseLicense
+>();
+
+const makeLicense: MakeLicenseFunction = (data): EnterpriseLicense => {
+  const license: EnterpriseLicense = new EnterpriseLicense(ObjectID.generate());
+
+  if (data?.currentUserCount !== undefined) {
+    license.currentUserCount = data.currentUserCount;
+  }
+
+  if (data?.userCountUpdatedAt !== undefined) {
+    license.userCountUpdatedAt = data.userCountUpdatedAt;
+  }
+
+  if (data?.userCountSource !== undefined) {
+    license.userCountSource = data.userCountSource;
+  }
+
+  if (data?.legacyUserCount !== undefined) {
+    license.legacyUserCount = data.legacyUserCount;
+  }
+
+  if (data?.legacyUserCountUpdatedAt !== undefined) {
+    license.legacyUserCountUpdatedAt = data.legacyUserCountUpdatedAt;
+  }
+
+  licensesById.set(license.id!.toString(), license);
+
+  return license;
+};
+
+type MakeInstanceFunction = (data: {
+  createdAt?: Date | undefined;
+  daysSinceReport?: number | undefined;
+  lastReportedAt?: Date | undefined;
+  userCount?: number | undefined;
+  userEmailHashes?: Array<string> | undefined;
+}) => EnterpriseLicenseInstance;
+
+const makeInstance: MakeInstanceFunction = (
+  data,
+): EnterpriseLicenseInstance => {
+  const instance: EnterpriseLicenseInstance = new EnterpriseLicenseInstance();
+
+  if (data.createdAt !== undefined) {
+    instance.createdAt = data.createdAt;
+  }
+
+  if (data.lastReportedAt !== undefined) {
+    instance.lastReportedAt = data.lastReportedAt;
+  } else if (data.daysSinceReport !== undefined) {
+    instance.lastReportedAt = OneUptimeDate.addRemoveDays(
+      NOW,
+      -data.daysSinceReport,
+    );
+  }
+
+  if (data.userCount !== undefined) {
+    instance.userCount = data.userCount;
+  }
+
+  if (data.userEmailHashes !== undefined) {
+    instance.userEmailHashes = data.userEmailHashes;
+  }
+
+  return instance;
+};
+
+const runTick: CronHandler = async (): Promise<void> => {
+  const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+  if (!captured) {
+    throw new Error(
+      "EnterpriseLicense:ReconcileInstanceUsage did not register a cron handler.",
+    );
+  }
+
+  await captured.handler();
+};
+
+const firstLicenseRead: () => FindByArgs = (): FindByArgs => {
+  return mockEnterpriseLicenseService.findBy.mock.calls[0]![0] as FindByArgs;
+};
+
+const firstInstanceRead: () => FindByArgs = (): FindByArgs => {
+  return mockEnterpriseLicenseInstanceService.findBy.mock
+    .calls[0]![0] as FindByArgs;
+};
+
+const compareAndSetCalls: () => Array<CompareAndSetArgs> =
+  (): Array<CompareAndSetArgs> => {
+    return mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks.mock.calls.map(
+      (call: Array<unknown>): CompareAndSetArgs => {
+        return call[0] as CompareAndSetArgs;
+      },
+    );
+  };
+
+describe("EnterpriseLicense:ReconcileInstanceUsage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    licensesById.clear();
+
+    mockBillingEnabled = true;
+    mockCurrentDate.mockReturnValue(NOW);
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([]);
+    mockEnterpriseLicenseService.findOneById.mockImplementation(
+      async (args: { id: ObjectID }): Promise<EnterpriseLicense | null> => {
+        return licensesById.get(args.id.toString()) || null;
+      },
+    );
+    mockEnterpriseLicenseService.runWithUsageAggregationLock.mockImplementation(
+      async (data: { fn: () => Promise<void> }): Promise<void> => {
+        await data.fn();
+      },
+    );
+    mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+      undefined,
+    );
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([]);
+  });
+
+  afterAll(() => {
+    mockCurrentDate.mockRestore();
+  });
+
+  describe("registration", () => {
+    test("is wired into the worker entry point", () => {
+      const workersIndex: string = fs.readFileSync(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "..",
+          "..",
+          "FeatureSet",
+          "Workers",
+          "Index.ts",
+        ),
+        "utf8",
+      );
+
+      expect(workersIndex).toContain(
+        'import "./Jobs/EnterpriseLicense/ReconcileInstanceUsage"',
+      );
+    });
+
+    test("runs hourly in production and immediately after startup", () => {
+      expect(mockCapturedJobs[JOB_NAME]).toEqual({
+        options: {
+          schedule: EVERY_HOUR,
+          runOnStartup: true,
+        },
+        handler: expect.any(Function),
+      });
+    });
+
+    test("uses the five-minute development schedule", () => {
+      const jobSource: string = fs.readFileSync(
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "..",
+          "..",
+          "FeatureSet",
+          "Workers",
+          "Jobs",
+          "EnterpriseLicense",
+          "ReconcileInstanceUsage.ts",
+        ),
+        "utf8",
+      );
+
+      expect(jobSource).toContain(
+        "schedule: IsDevelopment ? EVERY_FIVE_MINUTE : EVERY_HOUR",
+      );
+    });
+  });
+
+  test("does nothing outside hosted billing deployments", async () => {
+    mockBillingEnabled = false;
+
+    await runTick();
+
+    expect(mockEnterpriseLicenseService.findBy).not.toHaveBeenCalled();
+    expect(mockEnterpriseLicenseInstanceService.findBy).not.toHaveBeenCalled();
+    expect(
+      mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks,
+    ).not.toHaveBeenCalled();
+    expect(mockCurrentDate).not.toHaveBeenCalled();
+  });
+
+  test("reads only the license columns needed to reconcile safely", async () => {
+    await runTick();
+
+    expect(firstLicenseRead()).toEqual({
+      query: {},
+      select: {
+        _id: true,
+        currentUserCount: true,
+        userCountUpdatedAt: true,
+        userCountSource: true,
+        legacyUserCount: true,
+        legacyUserCountUpdatedAt: true,
+      },
+      sort: {
+        createdAt: SortOrder.Ascending,
+        _id: SortOrder.Ascending,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
+  });
+
+  test("reads usage and lastReportedAt for each license without an activity column", async () => {
+    const license: EnterpriseLicense = makeLicense({ currentUserCount: 3 });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+
+    await runTick();
+
+    expect(firstInstanceRead()).toEqual({
+      query: {
+        enterpriseLicenseId: license.id,
+      },
+      select: {
+        createdAt: true,
+        userCount: true,
+        userEmailHashes: true,
+        lastReportedAt: true,
+      },
+      sort: {
+        createdAt: SortOrder.Ascending,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
+    expect(firstInstanceRead().select).not.toHaveProperty("isActive");
+  });
+
+  test("takes the shared lock before re-reading a registration created during the sweep", async () => {
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 23,
+      userCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -8),
+    });
+    const freshRegistration: EnterpriseLicenseInstance = makeInstance({
+      createdAt: OneUptimeDate.addRemoveDays(NOW, -1),
+    });
+    let instanceRows: Array<EnterpriseLicenseInstance> = [];
+    let isInsideUsageLock: boolean = false;
+
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseService.runWithUsageAggregationLock.mockImplementation(
+      async (data: { fn: () => Promise<void> }): Promise<void> => {
+        /* Simulate /validate completing while this license waited for its lock. */
+        instanceRows = [freshRegistration];
+        isInsideUsageLock = true;
+
+        try {
+          await data.fn();
+        } finally {
+          isInsideUsageLock = false;
+        }
+      },
+    );
+    mockEnterpriseLicenseService.findOneById.mockImplementation(
+      async (): Promise<EnterpriseLicense> => {
+        expect(isInsideUsageLock).toBe(true);
+        return license;
+      },
+    );
+    mockEnterpriseLicenseInstanceService.findBy.mockImplementation(
+      async (): Promise<Array<EnterpriseLicenseInstance>> => {
+        expect(isInsideUsageLock).toBe(true);
+        return instanceRows;
+      },
+    );
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.runWithUsageAggregationLock,
+    ).toHaveBeenCalledWith({
+      licenseId: license.id,
+      fn: expect.any(Function),
+    });
+    expect(
+      mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("uses lock acquisition time so a delayed sweep cannot restore expired usage", async () => {
+    const beforeBoundary: Date = new Date("2026-09-02T11:59:59.000Z");
+    const afterBoundary: Date = new Date("2026-09-02T12:00:01.000Z");
+    let currentTime: Date = beforeBoundary;
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 10,
+      userCountSource: EnterpriseLicenseUserCountSource.Instance,
+    });
+    const instance: EnterpriseLicenseInstance = makeInstance({
+      lastReportedAt: new Date("2026-08-26T12:00:00.000Z"),
+      userCount: 10,
+    });
+    let lockCallCount: number = 0;
+    let delayedCallback: (() => Promise<void>) | undefined;
+    let finishDelayedLock: () => void = (): void => {};
+    let markDelayedLockQueued: () => void = (): void => {};
+    const delayedLockQueued: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        markDelayedLockQueued = resolve;
+      },
+    );
+
+    mockCurrentDate.mockImplementation((): Date => {
+      return currentTime;
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([instance]);
+    mockEnterpriseLicenseService.runWithUsageAggregationLock.mockImplementation(
+      (data: { fn: () => Promise<void> }): Promise<void> => {
+        lockCallCount += 1;
+
+        if (lockCallCount === 1) {
+          delayedCallback = data.fn;
+          markDelayedLockQueued();
+
+          return new Promise<void>((resolve: () => void) => {
+            finishDelayedLock = resolve;
+          });
+        }
+
+        return (async (): Promise<void> => {
+          /* The newer sweep gets the lock first. */
+          await data.fn();
+          await delayedCallback!();
+          finishDelayedLock();
+        })();
+      },
+    );
+    mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks.mockImplementation(
+      async (args: CompareAndSetArgs): Promise<void> => {
+        license.currentUserCount = args.data["currentUserCount"] as number;
+      },
+    );
+
+    const delayedSweep: Promise<void> = runTick();
+    await delayedLockQueued;
+
+    currentTime = afterBoundary;
+    const newerSweep: Promise<void> = runTick();
+
+    await Promise.all([delayedSweep, newerSweep]);
+
+    expect(license.currentUserCount).toBe(0);
+    expect(compareAndSetCalls()).toHaveLength(1);
+  });
+
+  test("continues through every license page", async () => {
+    const licenses: Array<EnterpriseLicense> = [
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+    ];
+
+    mockEnterpriseLicenseService.findBy
+      .mockResolvedValueOnce(licenses.slice(0, 2))
+      .mockResolvedValueOnce(licenses.slice(2, 4))
+      .mockResolvedValueOnce(licenses.slice(4));
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.findBy.mock.calls.map(
+        (call: Array<unknown>): number => {
+          return (call[0] as FindByArgs).skip;
+        },
+      ),
+    ).toEqual([0, 2, 4]);
+    expect(mockEnterpriseLicenseInstanceService.findBy).toHaveBeenCalledTimes(
+      5,
+    );
+  });
+
+  test("fetches an empty trailing page after an exact multiple", async () => {
+    const licenses: Array<EnterpriseLicense> = [
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+      makeLicense({ currentUserCount: 0 }),
+    ];
+
+    mockEnterpriseLicenseService.findBy
+      .mockResolvedValueOnce(licenses.slice(0, 2))
+      .mockResolvedValueOnce(licenses.slice(2))
+      .mockResolvedValueOnce([]);
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.findBy.mock.calls.map(
+        (call: Array<unknown>): number => {
+          return (call[0] as FindByArgs).skip;
+        },
+      ),
+    ).toEqual([0, 2, 4]);
+  });
+
+  test("reconciles a license containing only stale instances down to zero", async () => {
+    const updatedAt: Date = new Date("2026-08-20T10:00:00.000Z");
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 8,
+      userCountUpdatedAt: updatedAt,
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ daysSinceReport: 8, userCount: 5 }),
+      makeInstance({ daysSinceReport: 7, userEmailHashes: ["a", "b", "c"] }),
+      makeInstance({ userCount: 12 }),
+    ]);
+
+    await runTick();
+
+    expect(compareAndSetCalls()).toEqual([
+      {
+        id: license.id,
+        data: {
+          currentUserCount: 0,
+        },
+        expectedData: {
+          currentUserCount: 8,
+          userCountUpdatedAt: updatedAt,
+          userCountSource: null,
+          legacyUserCount: null,
+          legacyUserCountUpdatedAt: null,
+        },
+      },
+    ]);
+  });
+
+  test("preserves a fresh legacy count after every modern instance becomes inactive", async () => {
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 8,
+      userCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -7),
+      userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      legacyUserCount: 8,
+      legacyUserCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -1),
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ daysSinceReport: 7, userCount: 50 }),
+    ]);
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("does not preserve an inactive modern aggregate because a newer instance is still registering", async () => {
+    const inactiveAt: Date = OneUptimeDate.addRemoveDays(NOW, -7);
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 50,
+      userCountUpdatedAt: inactiveAt,
+      userCountSource: EnterpriseLicenseUserCountSource.Instance,
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ lastReportedAt: inactiveAt, userCount: 50 }),
+      makeInstance({
+        createdAt: OneUptimeDate.addRemoveDays(NOW, -1),
+        userCount: undefined,
+      }),
+    ]);
+
+    await runTick();
+
+    expect(compareAndSetCalls()[0]!.data).toEqual({ currentUserCount: 0 });
+  });
+
+  test("deduplicates active hashed users, counts legacy users, and ignores stale users", async () => {
+    const license: EnterpriseLicense = makeLicense({ currentUserCount: 99 });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({
+        daysSinceReport: 1,
+        userCount: 3,
+        userEmailHashes: ["alice", "bob", "carol"],
+      }),
+      makeInstance({
+        daysSinceReport: 2,
+        userCount: 4,
+        userEmailHashes: ["bob", "dana"],
+      }),
+      makeInstance({ daysSinceReport: 3, userCount: 5 }),
+      makeInstance({
+        daysSinceReport: 8,
+        userCount: 50,
+        userEmailHashes: ["stale-user"],
+      }),
+    ]);
+
+    await runTick();
+
+    /*
+     * Four unique hashes + two overflow users from the second instance +
+     * five unhashable legacy users. The stale instance contributes nothing.
+     */
+    expect(compareAndSetCalls()[0]!.data).toEqual({
+      currentUserCount: 11,
+    });
+  });
+
+  test("preserves a recently reported legacy license-wide count when there are no instance rows", async () => {
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 23,
+      userCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -1),
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([]);
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("preserves a legacy count when an instance has registered but not reported usage", async () => {
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 23,
+      userCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -8),
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({
+        createdAt: OneUptimeDate.addRemoveDays(NOW, -1),
+        userCount: undefined,
+        userEmailHashes: undefined,
+      }),
+    ]);
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("drops a legacy count when its report and registration reach the exact one-week boundary", async () => {
+    const inactiveAt: Date = OneUptimeDate.addRemoveDays(NOW, -7);
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 23,
+      userCountUpdatedAt: inactiveAt,
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({
+        createdAt: inactiveAt,
+        userCount: undefined,
+        userEmailHashes: undefined,
+      }),
+    ]);
+
+    await runTick();
+
+    expect(compareAndSetCalls()[0]!.data).toEqual({ currentUserCount: 0 });
+  });
+
+  test("drops an abandoned legacy count even when no instance row was created", async () => {
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 23,
+      userCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -7),
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([]);
+
+    await runTick();
+
+    expect(compareAndSetCalls()[0]!.data).toEqual({ currentUserCount: 0 });
+  });
+
+  test("does not write when the derived count is unchanged", async () => {
+    const license: EnterpriseLicense = makeLicense({ currentUserCount: 2 });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({
+        daysSinceReport: 1,
+        userEmailHashes: ["alice", "bob"],
+      }),
+    ]);
+
+    await runTick();
+
+    expect(
+      mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("CAS guards both prior values and never writes userCountUpdatedAt", async () => {
+    const updatedAt: Date = new Date("2026-09-01T11:00:00.000Z");
+    const license: EnterpriseLicense = makeLicense({
+      currentUserCount: 4,
+      userCountUpdatedAt: updatedAt,
+    });
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ daysSinceReport: 1, userCount: 2 }),
+    ]);
+
+    await runTick();
+
+    const update: CompareAndSetArgs = compareAndSetCalls()[0]!;
+
+    expect(update.expectedData).toEqual({
+      currentUserCount: 4,
+      userCountUpdatedAt: updatedAt,
+      userCountSource: null,
+      legacyUserCount: null,
+      legacyUserCountUpdatedAt: null,
+    });
+    expect(update.data).toEqual({ currentUserCount: 2 });
+    expect(update.data).not.toHaveProperty("userCountUpdatedAt");
+  });
+
+  test("uses null-safe CAS expectations for a license with no prior report", async () => {
+    const license: EnterpriseLicense = makeLicense();
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([license]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ daysSinceReport: 1, userCount: 1 }),
+    ]);
+
+    await runTick();
+
+    expect(compareAndSetCalls()[0]!.expectedData).toEqual({
+      currentUserCount: null,
+      userCountUpdatedAt: null,
+      userCountSource: null,
+      legacyUserCount: null,
+      legacyUserCountUpdatedAt: null,
+    });
+  });
+
+  test("isolates instance-read and CAS-write failures to their licenses", async () => {
+    const readFailure: EnterpriseLicense = makeLicense({
+      currentUserCount: 7,
+    });
+    const writeFailure: EnterpriseLicense = makeLicense({
+      currentUserCount: 7,
+    });
+    const healthy: EnterpriseLicense = makeLicense({ currentUserCount: 7 });
+
+    mockEnterpriseLicenseService.findBy
+      .mockResolvedValueOnce([readFailure, writeFailure])
+      .mockResolvedValueOnce([healthy]);
+    mockEnterpriseLicenseInstanceService.findBy.mockImplementation(
+      async (args: FindByArgs): Promise<Array<EnterpriseLicenseInstance>> => {
+        const licenseId: ObjectID = args.query[
+          "enterpriseLicenseId"
+        ] as ObjectID;
+
+        if (licenseId.toString() === readFailure.id!.toString()) {
+          throw new Error("instance read failed");
+        }
+
+        return [makeInstance({ daysSinceReport: 8, userCount: 7 })];
+      },
+    );
+    mockEnterpriseLicenseService.updateColumnsByIdWithoutHooks.mockImplementation(
+      async (args: CompareAndSetArgs): Promise<void> => {
+        if (args.id.toString() === writeFailure.id!.toString()) {
+          throw new Error("CAS write failed");
+        }
+      },
+    );
+
+    await expect(runTick()).resolves.toBeUndefined();
+
+    expect(mockEnterpriseLicenseInstanceService.findBy).toHaveBeenCalledTimes(
+      3,
+    );
+    expect(
+      compareAndSetCalls().map((call: CompareAndSetArgs) => call.id),
+    ).toEqual([writeFailure.id, healthy.id]);
+    expect(logger.error).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(readFailure.id!.toString()),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(writeFailure.id!.toString()),
+    );
+  });
+});

--- a/App/Tests/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails.test.ts
+++ b/App/Tests/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails.test.ts
@@ -16,16 +16,24 @@ interface CapturedJob {
 type AsyncMockFunction = (...args: Array<unknown>) => Promise<unknown>;
 
 const mockCapturedJobs: Record<string, CapturedJob> = {};
-const mockEnterpriseLicenseService = {
+const mockEnterpriseLicenseService: {
+  findBy: ReturnType<typeof jest.fn<AsyncMockFunction>>;
+} = {
   findBy: jest.fn<AsyncMockFunction>(),
 };
-const mockEnterpriseLicenseInstanceService = {
+const mockEnterpriseLicenseInstanceService: {
+  findBy: ReturnType<typeof jest.fn<AsyncMockFunction>>;
+} = {
   findBy: jest.fn<AsyncMockFunction>(),
 };
-const mockGlobalConfigService = {
+const mockGlobalConfigService: {
+  findOneById: ReturnType<typeof jest.fn<AsyncMockFunction>>;
+} = {
   findOneById: jest.fn<AsyncMockFunction>(),
 };
-const mockMailService = {
+const mockMailService: {
+  sendMail: ReturnType<typeof jest.fn<AsyncMockFunction>>;
+} = {
   sendMail: jest.fn<AsyncMockFunction>(),
 };
 
@@ -117,16 +125,24 @@ const runTick: CronHandler = async (): Promise<void> => {
   await job.handler();
 };
 
-const makeLicense: (data: {
+interface MakeLicenseData {
   currentUserCount: number;
   userLimit: number;
   userCountUpdatedAt?: Date | undefined;
   userCountSource?: EnterpriseLicenseUserCountSource | undefined;
   legacyUserCount?: number | undefined;
   legacyUserCountUpdatedAt?: Date | undefined;
-}) => EnterpriseLicense = (data): EnterpriseLicense => {
+}
+
+const makeLicense: (data: MakeLicenseData) => EnterpriseLicense = (
+  data: MakeLicenseData,
+): EnterpriseLicense => {
   return {
-    id: { toString: (): string => "license-id" },
+    id: {
+      toString: (): string => {
+        return "license-id";
+      },
+    },
     companyName: "Acme Inc",
     licenseKey: "abcd-license-wxyz",
     currentUserCount: data.currentUserCount,
@@ -138,11 +154,15 @@ const makeLicense: (data: {
   } as unknown as EnterpriseLicense;
 };
 
-const makeInstance: (data: {
+interface MakeInstanceData {
   createdAt?: Date | undefined;
   lastReportedAt?: Date | undefined;
   userCount?: number | undefined;
-}) => EnterpriseLicenseInstance = (data): EnterpriseLicenseInstance => {
+}
+
+const makeInstance: (data: MakeInstanceData) => EnterpriseLicenseInstance = (
+  data: MakeInstanceData,
+): EnterpriseLicenseInstance => {
   return {
     createdAt: data.createdAt || OneUptimeDate.addRemoveDays(NOW, -1),
     lastReportedAt: data.lastReportedAt,
@@ -158,7 +178,9 @@ describe("EnterpriseLicense:SendLicenseNotificationEmails usage source", () => {
 
     mockGlobalConfigService.findOneById.mockResolvedValue({});
     mockMailService.sendMail.mockResolvedValue({
-      isSuccess: (): boolean => true,
+      isSuccess: (): boolean => {
+        return true;
+      },
     });
   });
 
@@ -296,9 +318,9 @@ describe("EnterpriseLicense:SendLicenseNotificationEmails usage source", () => {
     const afterBoundary: Date = new Date("2026-09-02T12:00:01.000Z");
     let currentTime: Date = beforeBoundary;
 
-    jest
-      .spyOn(OneUptimeDate, "getCurrentDate")
-      .mockImplementation((): Date => currentTime);
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation((): Date => {
+      return currentTime;
+    });
     mockEnterpriseLicenseService.findBy.mockResolvedValue([
       makeLicense({ currentUserCount: 12, userLimit: 10 }),
       makeLicense({
@@ -325,7 +347,9 @@ describe("EnterpriseLicense:SendLicenseNotificationEmails usage source", () => {
         /* The first license's serial email send crosses the next boundary. */
         currentTime = afterBoundary;
         return {
-          isSuccess: (): boolean => true,
+          isSuccess: (): boolean => {
+            return true;
+          },
         };
       },
     );

--- a/App/Tests/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails.test.ts
+++ b/App/Tests/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails.test.ts
@@ -1,0 +1,337 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+type CronHandler = () => Promise<void>;
+
+interface CapturedJob {
+  handler: CronHandler;
+}
+
+type AsyncMockFunction = (...args: Array<unknown>) => Promise<unknown>;
+
+const mockCapturedJobs: Record<string, CapturedJob> = {};
+const mockEnterpriseLicenseService = {
+  findBy: jest.fn<AsyncMockFunction>(),
+};
+const mockEnterpriseLicenseInstanceService = {
+  findBy: jest.fn<AsyncMockFunction>(),
+};
+const mockGlobalConfigService = {
+  findOneById: jest.fn<AsyncMockFunction>(),
+};
+const mockMailService = {
+  sendMail: jest.fn<AsyncMockFunction>(),
+};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (
+        jobName: string,
+        _options: Record<string, unknown>,
+        runFunction: CronHandler,
+      ): void => {
+        mockCapturedJobs[jobName] = { handler: runFunction };
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    IsBillingEnabled: true,
+    IsDevelopment: false,
+  };
+});
+
+jest.mock("Common/Server/Services/EnterpriseLicenseService", () => {
+  return {
+    __esModule: true,
+    default: mockEnterpriseLicenseService,
+  };
+});
+
+jest.mock("Common/Server/Services/EnterpriseLicenseInstanceService", () => {
+  return {
+    __esModule: true,
+    default: mockEnterpriseLicenseInstanceService,
+  };
+});
+
+jest.mock("Common/Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: mockGlobalConfigService,
+  };
+});
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: mockMailService,
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+import "../../../../FeatureSet/Workers/Jobs/EnterpriseLicense/SendLicenseNotificationEmails";
+import EnterpriseLicense from "Common/Models/DatabaseModels/EnterpriseLicense";
+import EnterpriseLicenseInstance from "Common/Models/DatabaseModels/EnterpriseLicenseInstance";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import OneUptimeDate from "Common/Types/Date";
+import EnterpriseLicenseUserCountSource from "Common/Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
+
+const JOB_NAME: string = "EnterpriseLicense:SendLicenseNotificationEmails";
+const NOW: Date = new Date("2026-09-02T12:00:00.000Z");
+
+const runTick: CronHandler = async (): Promise<void> => {
+  const job: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+  if (!job) {
+    throw new Error(`${JOB_NAME} did not register a cron handler.`);
+  }
+
+  await job.handler();
+};
+
+const makeLicense: (data: {
+  currentUserCount: number;
+  userLimit: number;
+  userCountUpdatedAt?: Date | undefined;
+  userCountSource?: EnterpriseLicenseUserCountSource | undefined;
+  legacyUserCount?: number | undefined;
+  legacyUserCountUpdatedAt?: Date | undefined;
+}) => EnterpriseLicense = (data): EnterpriseLicense => {
+  return {
+    id: { toString: (): string => "license-id" },
+    companyName: "Acme Inc",
+    licenseKey: "abcd-license-wxyz",
+    currentUserCount: data.currentUserCount,
+    userLimit: data.userLimit,
+    userCountUpdatedAt: data.userCountUpdatedAt,
+    userCountSource: data.userCountSource,
+    legacyUserCount: data.legacyUserCount,
+    legacyUserCountUpdatedAt: data.legacyUserCountUpdatedAt,
+  } as unknown as EnterpriseLicense;
+};
+
+const makeInstance: (data: {
+  createdAt?: Date | undefined;
+  lastReportedAt?: Date | undefined;
+  userCount?: number | undefined;
+}) => EnterpriseLicenseInstance = (data): EnterpriseLicenseInstance => {
+  return {
+    createdAt: data.createdAt || OneUptimeDate.addRemoveDays(NOW, -1),
+    lastReportedAt: data.lastReportedAt,
+    userCount: data.userCount,
+    masterAdminEmails: ["admin@acme.com"],
+  } as unknown as EnterpriseLicenseInstance;
+};
+
+describe("EnterpriseLicense:SendLicenseNotificationEmails usage source", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockReturnValue(NOW);
+
+    mockGlobalConfigService.findOneById.mockResolvedValue({});
+    mockMailService.sendMail.mockResolvedValue({
+      isSuccess: (): boolean => true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("preserves an over-limit legacy count when the only row is a registration without usage", async () => {
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([
+      makeLicense({ currentUserCount: 12, userLimit: 10 }),
+    ]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({}),
+    ]);
+
+    await runTick();
+
+    expect(mockMailService.sendMail).toHaveBeenCalledTimes(1);
+    expect(mockMailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateType: EmailTemplateType.EnterpriseLicenseUserLimitBreach,
+        vars: expect.objectContaining({
+          currentUserCount: "12",
+          userLimit: "10",
+          usersOverLimit: "2",
+        }),
+      }),
+    );
+  });
+
+  test("uses instance aggregation after an instance has submitted usage", async () => {
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([
+      makeLicense({ currentUserCount: 50, userLimit: 10 }),
+    ]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({
+        lastReportedAt: OneUptimeDate.addRemoveDays(NOW, -1),
+        userCount: 12,
+      }),
+    ]);
+
+    await runTick();
+
+    expect(mockMailService.sendMail).toHaveBeenCalledTimes(1);
+    expect(mockMailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateType: EmailTemplateType.EnterpriseLicenseUserLimitBreach,
+        vars: expect.objectContaining({
+          currentUserCount: "12",
+          userLimit: "10",
+          usersOverLimit: "2",
+        }),
+      }),
+    );
+  });
+
+  test("uses a fresh legacy heartbeat after every modern instance becomes stale", async () => {
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([
+      makeLicense({
+        currentUserCount: 12,
+        userLimit: 10,
+        userCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -7),
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+        legacyUserCount: 12,
+        legacyUserCountUpdatedAt: OneUptimeDate.addRemoveDays(NOW, -1),
+      }),
+    ]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({
+        lastReportedAt: OneUptimeDate.addRemoveDays(NOW, -7),
+        userCount: 50,
+      }),
+    ]);
+
+    await runTick();
+
+    expect(mockMailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateType: EmailTemplateType.EnterpriseLicenseUserLimitBreach,
+        vars: expect.objectContaining({
+          currentUserCount: "12",
+          usersOverLimit: "2",
+        }),
+      }),
+    );
+  });
+
+  test("does not bill an inactive modern aggregate because a different instance just registered", async () => {
+    const inactiveAt: Date = OneUptimeDate.addRemoveDays(NOW, -7);
+
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([
+      makeLicense({
+        currentUserCount: 12,
+        userLimit: 10,
+        userCountUpdatedAt: inactiveAt,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      }),
+    ]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ lastReportedAt: inactiveAt, userCount: 12 }),
+      makeInstance({ createdAt: OneUptimeDate.addRemoveDays(NOW, -1) }),
+    ]);
+
+    await runTick();
+
+    expect(mockMailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  test("drops stale legacy usage at the exact one-week boundary", async () => {
+    const inactiveAt: Date = OneUptimeDate.addRemoveDays(NOW, -7);
+
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([
+      makeLicense({
+        currentUserCount: 12,
+        userLimit: 10,
+        userCountUpdatedAt: inactiveAt,
+      }),
+    ]);
+    mockEnterpriseLicenseInstanceService.findBy.mockResolvedValue([
+      makeInstance({ createdAt: inactiveAt }),
+    ]);
+
+    await runTick();
+
+    expect(mockMailService.sendMail).not.toHaveBeenCalled();
+    expect(mockEnterpriseLicenseService.findBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ userCountUpdatedAt: true }),
+      }),
+    );
+  });
+
+  test("evaluates each license after earlier notification sends have completed", async () => {
+    const beforeBoundary: Date = new Date("2026-09-02T11:59:59.000Z");
+    const afterBoundary: Date = new Date("2026-09-02T12:00:01.000Z");
+    let currentTime: Date = beforeBoundary;
+
+    jest
+      .spyOn(OneUptimeDate, "getCurrentDate")
+      .mockImplementation((): Date => currentTime);
+    mockEnterpriseLicenseService.findBy.mockResolvedValue([
+      makeLicense({ currentUserCount: 12, userLimit: 10 }),
+      makeLicense({
+        currentUserCount: 12,
+        userLimit: 10,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      }),
+    ]);
+    mockEnterpriseLicenseInstanceService.findBy
+      .mockResolvedValueOnce([
+        makeInstance({
+          lastReportedAt: OneUptimeDate.addRemoveDays(beforeBoundary, -1),
+          userCount: 12,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makeInstance({
+          lastReportedAt: new Date("2026-08-26T12:00:00.000Z"),
+          userCount: 12,
+        }),
+      ]);
+    mockMailService.sendMail.mockImplementation(
+      async (): Promise<{ isSuccess: () => boolean }> => {
+        /* The first license's serial email send crosses the next boundary. */
+        currentTime = afterBoundary;
+        return {
+          isSuccess: (): boolean => true,
+        };
+      },
+    );
+
+    await runTick();
+
+    expect(mockMailService.sendMail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Models/DatabaseModels/EnterpriseLicense.ts
+++ b/Common/Models/DatabaseModels/EnterpriseLicense.ts
@@ -4,6 +4,7 @@ import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccess
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
+import EnterpriseLicenseUserCountSource from "../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
@@ -199,4 +200,59 @@ export default class EnterpriseLicense extends BaseModel {
     type: ColumnType.Date,
   })
   public userCountUpdatedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "User Count Source",
+    description:
+      "Whether the current user count came from per-instance usage or a legacy license-wide report.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public userCountSource?: EnterpriseLicenseUserCountSource = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Number,
+    title: "Legacy User Count",
+    description:
+      "Most recent license-wide user count from an older installation that cannot identify its instance.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Number,
+  })
+  public legacyUserCount?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Date,
+    title: "Legacy User Count Updated At",
+    description:
+      "Timestamp of the most recent license-wide user count report from an older installation.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Date,
+  })
+  public legacyUserCountUpdatedAt?: Date = undefined;
 }

--- a/Common/Server/API/EnterpriseLicenseAPI.ts
+++ b/Common/Server/API/EnterpriseLicenseAPI.ts
@@ -3,11 +3,14 @@ import EnterpriseLicenseInstance from "../../Models/DatabaseModels/EnterpriseLic
 import BadDataException from "../../Types/Exception/BadDataException";
 import PartialEntity from "../../Types/Database/PartialEntity";
 import EnterpriseLicenseInstanceSummary from "../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+import EnterpriseLicenseUsageSnapshot from "../../Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot";
+import EnterpriseLicenseUserCountSource from "../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
 import EnterpriseLicenseUsageUtil from "../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
 import VersionUtil from "../../Utils/VersionUtil";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
+import { JSONObject } from "../../Types/JSON";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import EnterpriseLicenseService, {
   Service as EnterpriseLicenseServiceType,
@@ -23,6 +26,7 @@ import {
   NextFunction,
 } from "../Utils/Express";
 import BaseAPI from "./BaseAPI";
+import MasterAdminAuthorization from "../Middleware/MasterAdminAuthorization";
 // import { Host } from "../EnvironmentConfig";
 
 /*
@@ -52,6 +56,19 @@ export interface LicenseInstanceUpsert {
   lastReportedAt?: Date | undefined;
 }
 
+interface LicenseUsageReportResult {
+  reportedAt: Date;
+  instances: Array<EnterpriseLicenseInstance>;
+  currentUserCount: number;
+}
+
+interface LicenseValidationResult {
+  instances: Array<EnterpriseLicenseInstance>;
+  currentUserCount: number | null;
+  userCountUpdatedAt: Date | null;
+  calculatedAt: Date;
+}
+
 /*
  * Bounds how many instance rows one license key can register. Real customers
  * run a handful of instances; this stops a leaked key from being used to
@@ -65,6 +82,224 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
 > {
   public constructor() {
     super(EnterpriseLicense, EnterpriseLicenseService);
+
+    /*
+     * The dashboard needs a count and instance statuses from one cutoff
+     * instant. Calculate both on the server so the per-user hashes used for
+     * cross-instance deduplication never have to be sent to the browser.
+     */
+    this.router.get(
+      `${new this.entityType().getCrudApiPath()?.toString()}/:enterpriseLicenseId/active-usage`,
+      MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const licenseId: ObjectID = new ObjectID(
+            req.params["enterpriseLicenseId"] as string,
+          );
+          const snapshot: EnterpriseLicenseUsageSnapshot =
+            await EnterpriseLicenseService.runWithUsageAggregationLock({
+              licenseId,
+              fn: async (): Promise<EnterpriseLicenseUsageSnapshot> => {
+                /*
+                 * A report updates its instance row and then the license-wide
+                 * timestamp. Read both under the same lock so the dashboard
+                 * can never combine the new instance state with the previous
+                 * license state (or vice versa).
+                 */
+                const license: EnterpriseLicense | null =
+                  await EnterpriseLicenseService.findOneById({
+                    id: licenseId,
+                    select: {
+                      _id: true,
+                      currentUserCount: true,
+                      userCountUpdatedAt: true,
+                      userCountSource: true,
+                      legacyUserCount: true,
+                      legacyUserCountUpdatedAt: true,
+                    },
+                    props: {
+                      isRoot: true,
+                    },
+                  });
+
+                if (!license) {
+                  throw new BadDataException("Enterprise license not found");
+                }
+
+                const instances: Array<EnterpriseLicenseInstance> =
+                  await this.findLicenseInstances(licenseId);
+                const calculatedAt: Date = OneUptimeDate.getCurrentDate();
+                const activeInstances: Array<EnterpriseLicenseInstance> =
+                  instances.filter(
+                    (instance: EnterpriseLicenseInstance): boolean => {
+                      return EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+                        instance,
+                        calculatedAt,
+                      );
+                    },
+                  );
+                const currentUserCount: number | null =
+                  EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+                    instances,
+                    storedUserCount: license.currentUserCount,
+                    storedUserCountUpdatedAt: license.userCountUpdatedAt,
+                    storedUserCountSource: license.userCountSource,
+                    legacyUserCount: license.legacyUserCount,
+                    legacyUserCountUpdatedAt: license.legacyUserCountUpdatedAt,
+                    now: calculatedAt,
+                  });
+                const masterAdminEmailSet: Set<string> = new Set<string>();
+
+                for (const instance of instances) {
+                  for (const email of instance.masterAdminEmails || []) {
+                    const normalizedEmail: string = email.trim().toLowerCase();
+
+                    if (normalizedEmail) {
+                      masterAdminEmailSet.add(normalizedEmail);
+                    }
+                  }
+                }
+
+                const masterAdminEmails: Array<string> =
+                  Array.from(masterAdminEmailSet).sort();
+                const nextInstanceStatusChangeAt: Date | null =
+                  activeInstances.reduce(
+                    (
+                      earliestChange: Date | null,
+                      instance: EnterpriseLicenseInstance,
+                    ): Date | null => {
+                      const lastCommunicatedAt: Date | undefined =
+                        EnterpriseLicenseUsageUtil.getInstanceLastCommunicatedAt(
+                          instance,
+                        );
+
+                      if (!lastCommunicatedAt) {
+                        return earliestChange;
+                      }
+
+                      const inactiveAt: Date = new Date(
+                        lastCommunicatedAt.getTime() +
+                          EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays *
+                            24 *
+                            60 *
+                            60 *
+                            1000,
+                      );
+
+                      return !earliestChange || inactiveAt < earliestChange
+                        ? inactiveAt
+                        : earliestChange;
+                    },
+                    null,
+                  );
+                const usesActiveModernUsage: boolean =
+                  EnterpriseLicenseUsageUtil.hasActiveReportedInstanceUsage(
+                    instances,
+                    calculatedAt,
+                  );
+                let activeLegacyUsageUpdatedAt: Date | undefined;
+
+                if (!usesActiveModernUsage) {
+                  if (
+                    EnterpriseLicenseUsageUtil.isTimestampWithinUsageWindow(
+                      license.legacyUserCountUpdatedAt,
+                      calculatedAt,
+                    )
+                  ) {
+                    activeLegacyUsageUpdatedAt =
+                      license.legacyUserCountUpdatedAt;
+                  } else if (
+                    !license.legacyUserCountUpdatedAt &&
+                    license.userCountSource !==
+                      EnterpriseLicenseUserCountSource.Instance &&
+                    (license.userCountSource ===
+                      EnterpriseLicenseUserCountSource.Legacy ||
+                      !EnterpriseLicenseUsageUtil.hasReportedInstanceUsage(
+                        instances,
+                      )) &&
+                    EnterpriseLicenseUsageUtil.isTimestampWithinUsageWindow(
+                      license.userCountUpdatedAt,
+                      calculatedAt,
+                    )
+                  ) {
+                    /*
+                     * Compatibility for rows written before the dedicated
+                     * legacy heartbeat columns were introduced.
+                     */
+                    activeLegacyUsageUpdatedAt = license.userCountUpdatedAt;
+                  }
+                }
+
+                const legacyUsageChangeAt: Date | null =
+                  activeLegacyUsageUpdatedAt
+                    ? new Date(
+                        activeLegacyUsageUpdatedAt.getTime() +
+                          EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays *
+                            24 *
+                            60 *
+                            60 *
+                            1000,
+                      )
+                    : null;
+                let nextUsageChangeAt: Date | null = nextInstanceStatusChangeAt;
+
+                if (
+                  legacyUsageChangeAt &&
+                  (!nextUsageChangeAt ||
+                    legacyUsageChangeAt < nextUsageChangeAt)
+                ) {
+                  nextUsageChangeAt = legacyUsageChangeAt;
+                }
+                const usageReportTimestamps: Array<Date> = (
+                  [
+                    license.userCountUpdatedAt,
+                    license.legacyUserCountUpdatedAt,
+                    ...instances.map(
+                      (
+                        instance: EnterpriseLicenseInstance,
+                      ): Date | undefined => {
+                        return instance.lastReportedAt;
+                      },
+                    ),
+                  ] as Array<Date | undefined>
+                ).filter((timestamp: Date | undefined): timestamp is Date => {
+                  return Boolean(timestamp);
+                });
+                const lastUsageReportedAt: Date | null =
+                  usageReportTimestamps.reduce(
+                    (latest: Date | null, timestamp: Date): Date => {
+                      return !latest || timestamp > latest ? timestamp : latest;
+                    },
+                    null,
+                  );
+
+                return {
+                  currentUserCount,
+                  activeInstanceIds: activeInstances.map(
+                    (instance: EnterpriseLicenseInstance): string => {
+                      return instance.id!.toString();
+                    },
+                  ),
+                  masterAdminEmails,
+                  calculatedAt: calculatedAt.toISOString(),
+                  lastUsageReportedAt:
+                    lastUsageReportedAt?.toISOString() || null,
+                  nextInstanceStatusChangeAt:
+                    nextUsageChangeAt?.toISOString() || null,
+                };
+              },
+            });
+
+          return Response.sendJsonObjectResponse(
+            req,
+            res,
+            snapshot as unknown as JSONObject,
+          );
+        } catch (err) {
+          next(err);
+        }
+      },
+    );
 
     this.router.post(
       `${new this.entityType().getCrudApiPath()?.toString()}/validate`,
@@ -138,17 +373,67 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
             req.body["version"],
           );
 
-          if (instanceId) {
-            await this.upsertLicenseInstance({
+          const validationResult: LicenseValidationResult =
+            await EnterpriseLicenseService.runWithUsageAggregationLock({
               licenseId: license.id!,
-              instanceId: instanceId,
-              host: instanceHost || undefined,
-              oneuptimeVersion: instanceVersion,
-            });
-          }
+              fn: async (): Promise<LicenseValidationResult> => {
+                /*
+                 * Registration is the instance's first communication and can
+                 * keep an upgrade-era count in its grace window. Serialize it
+                 * with reporting and reconciliation so a sweep cannot read the
+                 * old rows, then overwrite the count after this row appears.
+                 */
+                if (instanceId) {
+                  await this.upsertLicenseInstance({
+                    licenseId: license.id!,
+                    instanceId: instanceId,
+                    host: instanceHost || undefined,
+                    oneuptimeVersion: instanceVersion,
+                  });
+                }
 
-          const instances: Array<EnterpriseLicenseInstance> =
-            await this.findLicenseInstances(license.id!);
+                const instances: Array<EnterpriseLicenseInstance> =
+                  await this.findLicenseInstances(license.id!);
+                const currentLicense: EnterpriseLicense | null =
+                  await EnterpriseLicenseService.findOneById({
+                    id: license.id!,
+                    select: {
+                      currentUserCount: true,
+                      userCountUpdatedAt: true,
+                      userCountSource: true,
+                      legacyUserCount: true,
+                      legacyUserCountUpdatedAt: true,
+                    },
+                    props: {
+                      isRoot: true,
+                    },
+                  });
+
+                if (!currentLicense) {
+                  throw new BadDataException("License key is invalid");
+                }
+
+                const calculatedAt: Date = OneUptimeDate.getCurrentDate();
+                const currentUserCount: number | null =
+                  EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+                    instances,
+                    storedUserCount: currentLicense.currentUserCount,
+                    storedUserCountUpdatedAt: currentLicense.userCountUpdatedAt,
+                    storedUserCountSource: currentLicense.userCountSource,
+                    legacyUserCount: currentLicense.legacyUserCount,
+                    legacyUserCountUpdatedAt:
+                      currentLicense.legacyUserCountUpdatedAt,
+                    now: calculatedAt,
+                  });
+
+                return {
+                  instances,
+                  currentUserCount,
+                  userCountUpdatedAt: currentLicense.userCountUpdatedAt || null,
+                  calculatedAt,
+                };
+              },
+            });
 
           const terms: LicenseTerms = this.getLicenseTerms(license);
 
@@ -159,15 +444,15 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
             expiresAt: terms.expiresAt,
             licenseKey: terms.licenseKey,
             userLimit: terms.userLimit,
-            currentUserCount:
-              typeof license.currentUserCount === "number"
-                ? license.currentUserCount
-                : null,
-            userCountUpdatedAt: license.userCountUpdatedAt
-              ? license.userCountUpdatedAt.toISOString()
+            currentUserCount: validationResult.currentUserCount,
+            userCountUpdatedAt: validationResult.userCountUpdatedAt
+              ? validationResult.userCountUpdatedAt.toISOString()
               : null,
             isEvaluationLicense: Boolean(license.isEvaluationLicense),
-            instances: this.getInstanceSummaries(instances),
+            instances: this.getInstanceSummaries(
+              validationResult.instances,
+              validationResult.calculatedAt,
+            ),
             token,
           });
         } catch (err) {
@@ -231,8 +516,6 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
             throw new BadDataException("License key is invalid");
           }
 
-          const reportedAt: Date = OneUptimeDate.getCurrentDate();
-
           const instanceId: string = this.parseShortText(
             req.body["instanceId"],
           );
@@ -248,54 +531,90 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
             EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails(
               req.body["masterAdminEmails"],
             );
-
-          if (instanceId) {
-            /*
-             * Multi-instance report: track usage per instance and count
-             * users uniquely across all instances of this license.
-             */
-            await this.upsertLicenseInstance({
+          const usageReport: LicenseUsageReportResult =
+            await EnterpriseLicenseService.runWithUsageAggregationLock({
               licenseId: license.id!,
-              instanceId: instanceId,
-              host: instanceHost || undefined,
-              oneuptimeVersion: instanceVersion,
-              userCount: userCount,
-              userEmailHashes: userEmailHashes,
-              masterAdminEmails: masterAdminEmails,
-              lastReportedAt: reportedAt,
-            });
-          }
+              fn: async (): Promise<LicenseUsageReportResult> => {
+                /*
+                 * Capture this after acquiring the lock. Waiting reports can
+                 * never complete later with an earlier timestamp, and the
+                 * upsert/read/aggregate/write sequence is one serialized
+                 * critical section across every API replica.
+                 */
+                const reportedAt: Date = OneUptimeDate.getCurrentDate();
 
-          const instances: Array<EnterpriseLicenseInstance> =
-            await this.findLicenseInstances(license.id!);
+                if (instanceId) {
+                  /*
+                   * Multi-instance report: track usage per instance and count
+                   * users uniquely across all instances of this license.
+                   */
+                  await this.upsertLicenseInstance({
+                    licenseId: license.id!,
+                    instanceId: instanceId,
+                    host: instanceHost || undefined,
+                    oneuptimeVersion: instanceVersion,
+                    userCount: userCount,
+                    userEmailHashes: userEmailHashes,
+                    masterAdminEmails: masterAdminEmails,
+                    lastReportedAt: reportedAt,
+                  });
+                }
 
-          let currentUserCount: number = userCount;
+                const instances: Array<EnterpriseLicenseInstance> =
+                  await this.findLicenseInstances(license.id!);
+                const hasActiveReportedInstanceUsage: boolean =
+                  EnterpriseLicenseUsageUtil.hasActiveReportedInstanceUsage(
+                    instances,
+                    reportedAt,
+                  );
+                const currentUserCount: number = hasActiveReportedInstanceUsage
+                  ? EnterpriseLicenseUsageUtil.getUniqueUserCount(
+                      instances,
+                      reportedAt,
+                    )
+                  : userCount;
+                const usageUpdate: PartialEntity<EnterpriseLicense> = {};
 
-          if (instances.length > 0) {
-            currentUserCount = EnterpriseLicenseUsageUtil.getUniqueUserCount(
-              instances,
-              reportedAt,
-            );
-          }
+                /*
+                 * Legacy reports (no instanceId) drive the license-wide count
+                 * only while no modern instance is active. Their separate
+                 * heartbeat is always retained, though, so a legacy reporter
+                 * can take over immediately when the last modern report ages
+                 * out instead of disappearing until its next daily call.
+                 */
+                if (!instanceId) {
+                  usageUpdate.legacyUserCount = userCount;
+                  usageUpdate.legacyUserCountUpdatedAt = reportedAt;
+                }
 
-          /*
-           * Legacy reports (no instanceId) only drive the license-wide count
-           * while no instance has registered — otherwise they would stomp
-           * the deduplicated multi-instance count.
-           */
-          if (instanceId || instances.length === 0) {
-            await EnterpriseLicenseService.updateOneById({
-              id: license.id!,
-              data: {
-                currentUserCount: currentUserCount,
-                userCountUpdatedAt: reportedAt,
+                if (instanceId || !hasActiveReportedInstanceUsage) {
+                  usageUpdate.currentUserCount = currentUserCount;
+                  usageUpdate.userCountUpdatedAt = reportedAt;
+                  usageUpdate.userCountSource = instanceId
+                    ? EnterpriseLicenseUserCountSource.Instance
+                    : EnterpriseLicenseUserCountSource.Legacy;
+                }
+
+                if (Object.keys(usageUpdate).length > 0) {
+                  await EnterpriseLicenseService.updateOneById({
+                    id: license.id!,
+                    data: usageUpdate,
+                    props: {
+                      isRoot: true,
+                      ignoreHooks: true,
+                    },
+                  });
+                }
+
+                return {
+                  reportedAt,
+                  instances,
+                  currentUserCount,
+                };
               },
-              props: {
-                isRoot: true,
-                ignoreHooks: true,
-              },
             });
-          }
+
+          const { reportedAt, instances, currentUserCount } = usageReport;
 
           const terms: LicenseTerms = this.getLicenseTerms(license);
 
@@ -307,7 +626,7 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
             currentUserCount: currentUserCount,
             userCountUpdatedAt: reportedAt.toISOString(),
             isEvaluationLicense: Boolean(license.isEvaluationLicense),
-            instances: this.getInstanceSummaries(instances),
+            instances: this.getInstanceSummaries(instances, reportedAt),
             /*
              * Null once the license has expired. Unlike /validate this route
              * does not reject an expired license - the instance is still
@@ -414,10 +733,12 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
       },
       select: {
         _id: true,
+        createdAt: true,
         instanceId: true,
         host: true,
         userCount: true,
         userEmailHashes: true,
+        masterAdminEmails: true,
         lastReportedAt: true,
         oneuptimeVersion: true,
       },
@@ -434,6 +755,7 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
 
   private getInstanceSummaries(
     instances: Array<EnterpriseLicenseInstance>,
+    calculatedAt: Date,
   ): Array<EnterpriseLicenseInstanceSummary> {
     return instances.map(
       (
@@ -444,6 +766,11 @@ export default class EnterpriseLicenseAPI extends BaseAPI<
           host: instance.host || null,
           userCount:
             typeof instance.userCount === "number" ? instance.userCount : null,
+          isCountedTowardsUsage:
+            EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+              instance,
+              calculatedAt,
+            ),
           lastReportedAt: instance.lastReportedAt
             ? instance.lastReportedAt.toISOString()
             : null,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788374340973-AddEnterpriseLicenseUsageProvenance.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1788374340973-AddEnterpriseLicenseUsageProvenance.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddEnterpriseLicenseUsageProvenance1788374340973
+  implements MigrationInterface
+{
+  public name: string = "AddEnterpriseLicenseUsageProvenance1788374340973";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "EnterpriseLicense" ADD "userCountSource" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "EnterpriseLicense" ADD "legacyUserCount" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "EnterpriseLicense" ADD "legacyUserCountUpdatedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "EnterpriseLicense" DROP COLUMN "legacyUserCountUpdatedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "EnterpriseLicense" DROP COLUMN "legacyUserCount"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "EnterpriseLicense" DROP COLUMN "userCountSource"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1790900000000-AddEnterpriseLicenseUsageProvenance.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1790900000000-AddEnterpriseLicenseUsageProvenance.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class AddEnterpriseLicenseUsageProvenance1788374340973
+export class AddEnterpriseLicenseUsageProvenance1790900000000
   implements MigrationInterface
 {
-  public name: string = "AddEnterpriseLicenseUsageProvenance1788374340973";
+  public name: string = "AddEnterpriseLicenseUsageProvenance1790900000000";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -567,6 +567,7 @@ import { AddOnCallCalendarFeeds1790400000000 } from "./1790400000000-AddOnCallCa
 import { AddNetworkDeviceOidTemplate1790500000000 } from "./1790500000000-AddNetworkDeviceOidTemplate";
 import { AddAutoImportRuleOidTemplate1790600000000 } from "./1790600000000-AddAutoImportRuleOidTemplate";
 import { AddNetworkDeviceRoleTable1790800000000 } from "./1790800000000-AddNetworkDeviceRoleTable";
+import { AddEnterpriseLicenseUsageProvenance1788374340973 } from "./1788374340973-AddEnterpriseLicenseUsageProvenance";
 
 export default [
   InitialMigration,
@@ -1138,4 +1139,5 @@ export default [
   AddNetworkDeviceOidTemplate1790500000000,
   AddAutoImportRuleOidTemplate1790600000000,
   AddNetworkDeviceRoleTable1790800000000,
+  AddEnterpriseLicenseUsageProvenance1788374340973,
 ];

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -567,7 +567,7 @@ import { AddOnCallCalendarFeeds1790400000000 } from "./1790400000000-AddOnCallCa
 import { AddNetworkDeviceOidTemplate1790500000000 } from "./1790500000000-AddNetworkDeviceOidTemplate";
 import { AddAutoImportRuleOidTemplate1790600000000 } from "./1790600000000-AddAutoImportRuleOidTemplate";
 import { AddNetworkDeviceRoleTable1790800000000 } from "./1790800000000-AddNetworkDeviceRoleTable";
-import { AddEnterpriseLicenseUsageProvenance1788374340973 } from "./1788374340973-AddEnterpriseLicenseUsageProvenance";
+import { AddEnterpriseLicenseUsageProvenance1790900000000 } from "./1790900000000-AddEnterpriseLicenseUsageProvenance";
 
 export default [
   InitialMigration,
@@ -1139,5 +1139,5 @@ export default [
   AddNetworkDeviceOidTemplate1790500000000,
   AddAutoImportRuleOidTemplate1790600000000,
   AddNetworkDeviceRoleTable1790800000000,
-  AddEnterpriseLicenseUsageProvenance1788374340973,
+  AddEnterpriseLicenseUsageProvenance1790900000000,
 ];

--- a/Common/Server/Services/EnterpriseLicenseInstanceService.ts
+++ b/Common/Server/Services/EnterpriseLicenseInstanceService.ts
@@ -1,9 +1,206 @@
 import DatabaseService from "./DatabaseService";
 import EnterpriseLicenseInstance from "../../Models/DatabaseModels/EnterpriseLicenseInstance";
+import EnterpriseLicense from "../../Models/DatabaseModels/EnterpriseLicense";
+import EnterpriseLicenseService from "./EnterpriseLicenseService";
+import EnterpriseLicenseUsageUtil, {
+  EffectiveEnterpriseLicenseUserCount,
+} from "../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+import EnterpriseLicenseUserCountSource from "../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
+import DeleteById from "../Types/Database/DeleteById";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
+import OneUptimeDate from "../../Types/Date";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
+import ObjectID from "../../Types/ObjectID";
+import PartialEntity from "../../Types/Database/PartialEntity";
+import ModelPermission from "../Types/Database/Permissions/Index";
 
 export class Service extends DatabaseService<EnterpriseLicenseInstance> {
   public constructor() {
     super(EnterpriseLicenseInstance);
+  }
+
+  public override async deleteOneById(deleteById: DeleteById): Promise<number> {
+    /*
+     * A source marker is written before deleting some upgrade-era rows. Check
+     * permission first so a refused delete can never produce that write. The
+     * inherited deletion below deliberately performs its normal check again.
+     */
+    await ModelPermission.checkDeletePermissionByModel({
+      modelType: this.modelType,
+      fetchModelWithAccessControlIds: async () => {
+        return await this.findOneById({
+          id: deleteById.id,
+          select: {},
+          props: {
+            isRoot: true,
+          },
+        });
+      },
+      props: deleteById.props,
+    });
+
+    /*
+     * Resolve the owning license before taking its lock. The actual delete
+     * still goes through DatabaseService below with the caller's original
+     * props, so this root read does not bypass delete permission checks.
+     */
+    const instance: EnterpriseLicenseInstance | null = await this.findOneById({
+      id: deleteById.id,
+      select: {
+        enterpriseLicenseId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+    const licenseId: ObjectID | undefined = instance?.enterpriseLicenseId;
+
+    if (!licenseId) {
+      return await super.deleteOneById(deleteById);
+    }
+
+    return await EnterpriseLicenseService.runWithUsageAggregationLock({
+      licenseId,
+      fn: async (): Promise<number> => {
+        /*
+         * A report for this row uses the same lock. Re-read its provenance in
+         * the critical section so the fallback decision cannot race a report.
+         */
+        const lockedInstance: EnterpriseLicenseInstance | null =
+          await this.findOneById({
+            id: deleteById.id,
+            select: {
+              lastReportedAt: true,
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+        const deletedTargetHadReportedUsage: boolean = Boolean(
+          lockedInstance?.lastReportedAt,
+        );
+
+        if (deletedTargetHadReportedUsage) {
+          const sourceLicense: EnterpriseLicense | null =
+            await EnterpriseLicenseService.findOneById({
+              id: licenseId,
+              select: {
+                userCountSource: true,
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          /*
+           * Old rows predate the persisted provenance column. Mark the stored
+           * aggregate before deleting its last evidence, so even a later
+           * aggregate-write failure cannot resurrect it as legacy usage.
+           */
+          if (sourceLicense && !sourceLicense.userCountSource) {
+            await EnterpriseLicenseService.updateOneById({
+              id: licenseId,
+              data: {
+                userCountSource: EnterpriseLicenseUserCountSource.Instance,
+              },
+              props: {
+                isRoot: true,
+                ignoreHooks: true,
+              },
+            });
+          }
+        }
+
+        const deletedCount: number = await super.deleteOneById(deleteById);
+
+        /*
+         * The row may have disappeared between the ownership lookup and lock
+         * acquisition. Preserve DatabaseService's zero-row result and avoid
+         * changing an aggregate for a deletion this call did not perform.
+         */
+        if (deletedCount === 0) {
+          return 0;
+        }
+
+        const now: Date = OneUptimeDate.getCurrentDate();
+        const remainingInstances: Array<EnterpriseLicenseInstance> =
+          await this.findBy({
+            query: {
+              enterpriseLicenseId: licenseId,
+            },
+            select: {
+              createdAt: true,
+              userCount: true,
+              userEmailHashes: true,
+              lastReportedAt: true,
+            },
+            sort: {
+              createdAt: SortOrder.Ascending,
+            },
+            skip: 0,
+            limit: LIMIT_MAX,
+            props: {
+              isRoot: true,
+            },
+          });
+        const license: EnterpriseLicense | null =
+          await EnterpriseLicenseService.findOneById({
+            id: licenseId,
+            select: {
+              currentUserCount: true,
+              userCountUpdatedAt: true,
+              userCountSource: true,
+              legacyUserCount: true,
+              legacyUserCountUpdatedAt: true,
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+
+        if (!license) {
+          return deletedCount;
+        }
+
+        const effectiveUsage: EffectiveEnterpriseLicenseUserCount =
+          EnterpriseLicenseUsageUtil.getEffectiveUserCountAndSource({
+            instances: remainingInstances,
+            storedUserCount: license.currentUserCount,
+            storedUserCountUpdatedAt: license.userCountUpdatedAt,
+            storedUserCountSource:
+              license.userCountSource ||
+              (deletedTargetHadReportedUsage
+                ? EnterpriseLicenseUserCountSource.Instance
+                : undefined),
+            legacyUserCount: license.legacyUserCount,
+            legacyUserCountUpdatedAt: license.legacyUserCountUpdatedAt,
+            allowStoredUserCountAsLegacyFallback:
+              !deletedTargetHadReportedUsage,
+            now,
+          });
+
+        if (effectiveUsage.userCount !== null) {
+          const usageUpdate: PartialEntity<EnterpriseLicense> = {
+            currentUserCount: effectiveUsage.userCount,
+          };
+
+          if (effectiveUsage.source !== null) {
+            usageUpdate.userCountSource = effectiveUsage.source;
+          }
+
+          await EnterpriseLicenseService.updateOneById({
+            id: licenseId,
+            data: usageUpdate,
+            props: {
+              isRoot: true,
+              ignoreHooks: true,
+            },
+          });
+        }
+
+        return deletedCount;
+      },
+    });
   }
 }
 

--- a/Common/Server/Services/EnterpriseLicenseService.ts
+++ b/Common/Server/Services/EnterpriseLicenseService.ts
@@ -5,10 +5,65 @@ import { MarketingEventType } from "../../Types/Marketing/MarketingEvent";
 import { OnCreate } from "../Types/Database/Hooks";
 import OneUptimeDate from "../../Types/Date";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import ObjectID from "../../Types/ObjectID";
+import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
+import logger from "../Utils/Logger";
+
+export const ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_NAMESPACE: string =
+  "EnterpriseLicenseService.usageAggregation";
+
+export const ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS: Readonly<{
+  namespace: string;
+  lockTimeout: number;
+  acquireTimeout: number;
+}> = Object.freeze({
+  namespace: ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_NAMESPACE,
+  lockTimeout: 60_000,
+  acquireTimeout: 10_000,
+});
 
 export class Service extends DatabaseService<EnterpriseLicense> {
   public constructor() {
     super(EnterpriseLicense);
+  }
+
+  /**
+   * Serialize usage aggregation for one enterprise license across every API
+   * and worker process. Callers must put the complete read-compute-write
+   * operation inside `fn`; locking only the write would leave the stale-read
+   * race intact.
+   */
+  public async runWithUsageAggregationLock<TResult>(data: {
+    licenseId: ObjectID;
+    fn: () => Promise<TResult>;
+  }): Promise<TResult> {
+    /*
+     * Acquisition is deliberately outside the callback try/finally. If Redis
+     * is unavailable or contention exceeds the bounded acquire timeout, the
+     * operation fails closed and there is no unowned mutex to release.
+     */
+    const mutex: SemaphoreMutex = await Semaphore.lock({
+      key: data.licenseId.toString(),
+      ...ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS,
+    });
+
+    try {
+      return await data.fn();
+    } finally {
+      try {
+        await Semaphore.release(mutex);
+      } catch (error) {
+        /*
+         * redis-semaphore refreshes held locks and lets them expire after the
+         * lock timeout if explicit release fails. Logging is best effort: a
+         * release error must not replace either the callback's value or its
+         * more useful error.
+         */
+        logger.error(
+          `Failed to release enterprise license usage aggregation lock for ${data.licenseId.toString()}; it will expire automatically: ${error}`,
+        );
+      }
+    }
   }
 
   @CaptureSpan()

--- a/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
+++ b/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
@@ -13,6 +13,10 @@ import { JSONObject } from "../../../Types/JSON";
 import EnterpriseLicenseSyncUtil, {
   EnterpriseLicenseSyncResult,
 } from "../../../Utils/EnterpriseLicense/EnterpriseLicenseSync";
+import EnterpriseLicenseUsageUtil from "../../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+import EnterpriseLicenseUserCountSource from "../../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
+import EnterpriseLicenseInstanceSummary from "../../../Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary";
+import MasterAdminAuthorization from "../../../Server/Middleware/MasterAdminAuthorization";
 import {
   NextFunction,
   OneUptimeRequest,
@@ -117,6 +121,8 @@ jest.mock("../../../Server/Services/EnterpriseLicenseInstanceService");
 
 const REPORT_ROUTE: string = "/enterprise-license/report-user-count";
 const VALIDATE_ROUTE: string = "/enterprise-license/validate";
+const ACTIVE_USAGE_ROUTE: string =
+  "/enterprise-license/:enterpriseLicenseId/active-usage";
 
 const LICENSE_ID: ObjectID = ObjectID.generate();
 const LICENSE_KEY: string = "acme-license-key";
@@ -159,6 +165,12 @@ const makeLicense: MakeLicenseFunction = (
 type MakeInstanceFunction = (
   overrides?: Record<string, unknown>,
 ) => EnterpriseLicenseInstance;
+
+interface LicenseUsageReportResultForTest {
+  reportedAt: Date;
+  instances: Array<EnterpriseLicenseInstance>;
+  currentUserCount: number;
+}
 
 const makeInstance: MakeInstanceFunction = (
   overrides?: Record<string, unknown>,
@@ -217,6 +229,13 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
     EnterpriseLicenseService.updateOneById = jest
       .fn()
       .mockResolvedValue(undefined);
+    EnterpriseLicenseService.runWithUsageAggregationLock = jest
+      .fn()
+      .mockImplementation(
+        async (data: { fn: () => Promise<unknown> }): Promise<unknown> => {
+          return await data.fn();
+        },
+      );
 
     EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([]);
     EnterpriseLicenseInstanceService.findOneBy = jest
@@ -468,6 +487,146 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
           }),
         }),
       );
+      expect(
+        EnterpriseLicenseService.runWithUsageAggregationLock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          licenseId: LICENSE_ID,
+          fn: expect.any(Function),
+        }),
+      );
+    });
+
+    it("serializes concurrent reports so an older partial snapshot cannot win", async () => {
+      const instanceRows: Array<EnterpriseLicenseInstance> = [];
+      const events: Array<string> = [];
+      let lockTail: Promise<void> = Promise.resolve();
+
+      EnterpriseLicenseService.runWithUsageAggregationLock = jest
+        .fn()
+        .mockImplementation(
+          async (data: {
+            fn: () => Promise<LicenseUsageReportResultForTest>;
+          }): Promise<LicenseUsageReportResultForTest> => {
+            const predecessor: Promise<void> = lockTail;
+            let releaseLock: () => void = (): void => {};
+            lockTail = new Promise<void>((resolve: () => void) => {
+              releaseLock = resolve;
+            });
+
+            await predecessor;
+            try {
+              return await data.fn();
+            } finally {
+              releaseLock();
+            }
+          },
+        );
+      EnterpriseLicenseInstanceService.findOneBy = jest
+        .fn()
+        .mockImplementation(
+          async (args: {
+            query: { instanceId: string };
+          }): Promise<EnterpriseLicenseInstance | null> => {
+            return (
+              instanceRows.find(
+                (instance: EnterpriseLicenseInstance): boolean => {
+                  return instance.instanceId === args.query.instanceId;
+                },
+              ) || null
+            );
+          },
+        );
+      EnterpriseLicenseInstanceService.create = jest
+        .fn()
+        .mockImplementation(
+          async (args: {
+            data: EnterpriseLicenseInstance;
+          }): Promise<EnterpriseLicenseInstance> => {
+            instanceRows.push(args.data);
+            events.push(`upsert:${args.data.instanceId}`);
+            await Promise.resolve();
+            return args.data;
+          },
+        );
+      EnterpriseLicenseInstanceService.findBy = jest
+        .fn()
+        .mockImplementation(
+          async (): Promise<Array<EnterpriseLicenseInstance>> => {
+            events.push(
+              `read:${instanceRows
+                .map((instance: EnterpriseLicenseInstance): string => {
+                  return instance.instanceId || "";
+                })
+                .join(",")}`,
+            );
+            await Promise.resolve();
+            return [...instanceRows];
+          },
+        );
+      EnterpriseLicenseService.updateOneById = jest
+        .fn()
+        .mockImplementation(
+          async (args: {
+            data: { currentUserCount: number };
+          }): Promise<number> => {
+            events.push(`write:${args.data.currentUserCount}`);
+            await Promise.resolve();
+            return 1;
+          },
+        );
+
+      const makeConcurrentRequest: (
+        instanceId: string,
+        hash: string,
+      ) => OneUptimeRequest = (
+        instanceId: string,
+        hash: string,
+      ): OneUptimeRequest => {
+        return {
+          body: {
+            licenseKey: LICENSE_KEY,
+            userCount: 1,
+            instanceId,
+            userEmailHashes: [hash],
+          },
+        } as unknown as OneUptimeRequest;
+      };
+      const firstNext: NextFunction = jest.fn();
+      const secondNext: NextFunction = jest.fn();
+      const route = mockRouter.match("post", REPORT_ROUTE);
+
+      await Promise.all([
+        route.handlerFunction(
+          makeConcurrentRequest("instance-a", hashOf("a")),
+          mockResponse,
+          firstNext,
+        ),
+        route.handlerFunction(
+          makeConcurrentRequest("instance-b", hashOf("b")),
+          mockResponse,
+          secondNext,
+        ),
+      ]);
+
+      expect(firstNext).not.toHaveBeenCalled();
+      expect(secondNext).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        "upsert:instance-a",
+        "read:instance-a",
+        "write:1",
+        "upsert:instance-b",
+        "read:instance-a,instance-b",
+        "write:2",
+      ]);
+      expect(
+        (
+          EnterpriseLicenseService.updateOneById as unknown as jest.Mock
+        ).mock.calls.map((call: Array<unknown>): number => {
+          return (call[0] as { data: { currentUserCount: number } }).data
+            .currentUserCount;
+        }),
+      ).toEqual([1, 2]);
     });
 
     it("counts a user on two instances once", async () => {
@@ -521,23 +680,36 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
       expect(Object.keys(updateCall["data"] as JSONObject)).toEqual([
         "currentUserCount",
         "userCountUpdatedAt",
+        "userCountSource",
       ]);
+      expect((updateCall["data"] as JSONObject)["userCountSource"]).toBe(
+        EnterpriseLicenseUserCountSource.Instance,
+      );
     });
 
-    it("leaves a decommissioned instance out of the seat count but still lists it", async () => {
+    it("marks a week-silent instance inactive, excludes its users, and still lists it", async () => {
+      const reportedAt: Date = new Date("2026-09-02T12:00:00.000Z");
+
+      jest.spyOn(OneUptimeDate, "getCurrentDate").mockReturnValue(reportedAt);
+
       EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
         makeInstance({
           instanceId: "live",
           userCount: 1,
           userEmailHashes: [hashOf("1")],
+          lastReportedAt: reportedAt,
         }),
         makeInstance({
-          instanceId: "retired",
+          instanceId: "inactive",
           userCount: 2,
           userEmailHashes: [hashOf("2"), hashOf("3")],
-          lastReportedAt: OneUptimeDate.addRemoveDays(
-            OneUptimeDate.getCurrentDate(),
-            -400,
+          lastReportedAt: new Date(
+            reportedAt.getTime() -
+              EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays *
+                24 *
+                60 *
+                60 *
+                1000,
           ),
         }),
       ]);
@@ -548,6 +720,25 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
 
       expect(body["currentUserCount"]).toBe(1);
       expect(body["instances"]).toHaveLength(2);
+      expect(body["instances"]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            instanceId: "live",
+            isCountedTowardsUsage: true,
+          }),
+          expect.objectContaining({
+            instanceId: "inactive",
+            userCount: 2,
+            isCountedTowardsUsage: false,
+          }),
+        ]),
+      );
+      expect(EnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: LICENSE_ID,
+          data: expect.objectContaining({ currentUserCount: 1 }),
+        }),
+      );
     });
 
     it("counts users an instance could not send hashes for, so a huge install is not undercounted", async () => {
@@ -569,7 +760,7 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
       expect(getResponseBody()["currentUserCount"]).toBe(10);
     });
 
-    it("does not let a legacy report with no instance id stomp the deduplicated count", async () => {
+    it("retains a legacy heartbeat without letting it stomp the active modern count", async () => {
       mockRequest.body["instanceId"] = undefined;
       mockRequest.body["userCount"] = 99;
 
@@ -580,8 +771,541 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
       await callRoute();
 
       expect(getResponseBody()["currentUserCount"]).toBe(2);
-      expect(EnterpriseLicenseService.updateOneById).not.toHaveBeenCalled();
+      expect(EnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: LICENSE_ID,
+          data: {
+            legacyUserCount: 99,
+            legacyUserCountUpdatedAt: expect.any(Date),
+          },
+        }),
+      );
     });
+
+    it("accepts a live legacy report after every modern instance becomes inactive", async () => {
+      const reportedAt: Date = new Date("2026-09-02T12:00:00.000Z");
+      jest.spyOn(OneUptimeDate, "getCurrentDate").mockReturnValue(reportedAt);
+      mockRequest.body["instanceId"] = undefined;
+      mockRequest.body["userCount"] = 19;
+
+      EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+        makeInstance({
+          lastReportedAt: OneUptimeDate.addRemoveDays(reportedAt, -7),
+          userCount: 50,
+        }),
+      ]);
+
+      await callRoute();
+
+      expect(getResponseBody()["currentUserCount"]).toBe(19);
+      expect(EnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            currentUserCount: 19,
+            legacyUserCount: 19,
+            legacyUserCountUpdatedAt: reportedAt,
+            userCountSource: EnterpriseLicenseUserCountSource.Legacy,
+          }),
+        }),
+      );
+    });
+
+    it("accepts a legacy report while the only tracked instance has registered but not reported usage", async () => {
+      mockRequest.body["instanceId"] = undefined;
+      mockRequest.body["userCount"] = 19;
+
+      EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+        makeInstance({
+          createdAt: OneUptimeDate.addRemoveDays(
+            OneUptimeDate.getCurrentDate(),
+            -1,
+          ),
+          lastReportedAt: undefined,
+          userCount: undefined,
+          userEmailHashes: undefined,
+        }),
+      ]);
+
+      await callRoute();
+
+      expect(getResponseBody()["currentUserCount"]).toBe(19);
+      expect(EnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: LICENSE_ID,
+          data: expect.objectContaining({ currentUserCount: 19 }),
+        }),
+      );
+    });
+  });
+});
+
+describe("EnterpriseLicenseAPI GET active usage snapshot", () => {
+  let mockRequest: OneUptimeRequest;
+  let mockResponse: OneUptimeResponse;
+  let nextFunction: NextFunction;
+  const calculatedAt: Date = new Date("2026-09-02T12:00:00.000Z");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    new EnterpriseLicenseAPI();
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockReturnValue(calculatedAt);
+
+    EnterpriseLicenseService.findOneById = jest
+      .fn()
+      .mockResolvedValue(makeLicense({ userCountUpdatedAt: calculatedAt }));
+    EnterpriseLicenseService.runWithUsageAggregationLock = jest
+      .fn()
+      .mockImplementation(
+        async (data: { fn: () => Promise<unknown> }): Promise<unknown> => {
+          return await data.fn();
+        },
+      );
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([]);
+
+    mockRequest = {
+      params: {
+        enterpriseLicenseId: LICENSE_ID.toString(),
+      },
+    } as unknown as OneUptimeRequest;
+    mockResponse = {
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as OneUptimeResponse;
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const callRoute: () => Promise<void> = async (): Promise<void> => {
+    await mockRouter
+      .match("get", ACTIVE_USAGE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+  };
+
+  it("is restricted to authenticated master admins", () => {
+    expect(mockRouter.match("get", ACTIVE_USAGE_ROUTE).middleware).toBe(
+      MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+    );
+  });
+
+  it("returns one cutoff-aligned count and active-instance list without hashes", async () => {
+    const active: EnterpriseLicenseInstance = makeInstance({
+      lastReportedAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+      userEmailHashes: [hashOf("1"), hashOf("2")],
+      masterAdminEmails: [" Admin@Acme.com "],
+    });
+    const newlyRegistered: EnterpriseLicenseInstance = makeInstance({
+      lastReportedAt: undefined,
+      createdAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+      userCount: undefined,
+      userEmailHashes: undefined,
+      masterAdminEmails: ["admin@acme.com", "owner@acme.com"],
+    });
+    const inactive: EnterpriseLicenseInstance = makeInstance({
+      lastReportedAt: OneUptimeDate.addRemoveDays(calculatedAt, -7),
+      userCount: 2,
+      userEmailHashes: [hashOf("2"), hashOf("3")],
+    });
+
+    EnterpriseLicenseInstanceService.findBy = jest
+      .fn()
+      .mockResolvedValue([active, newlyRegistered, inactive]);
+
+    await callRoute();
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(getResponseBody()).toEqual({
+      currentUserCount: 2,
+      activeInstanceIds: [
+        active.id!.toString(),
+        newlyRegistered.id!.toString(),
+      ],
+      masterAdminEmails: ["admin@acme.com", "owner@acme.com"],
+      calculatedAt: calculatedAt.toISOString(),
+      lastUsageReportedAt: calculatedAt.toISOString(),
+      nextInstanceStatusChangeAt: OneUptimeDate.addRemoveDays(
+        calculatedAt,
+        6,
+      ).toISOString(),
+    });
+    expect(JSON.stringify(getResponseBody())).not.toContain(hashOf("1"));
+  });
+
+  it("returns zero when every tracked instance is inactive", async () => {
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+      makeInstance({
+        lastReportedAt: OneUptimeDate.addRemoveDays(calculatedAt, -8),
+        userCount: 50,
+      }),
+    ]);
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 0,
+        activeInstanceIds: [],
+        nextInstanceStatusChangeAt: null,
+      }),
+    );
+  });
+
+  it("uses a fresh legacy count after every modern instance becomes inactive", async () => {
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 17,
+        userCountUpdatedAt: OneUptimeDate.addRemoveDays(calculatedAt, -7),
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+      }),
+    );
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+      makeInstance({
+        lastReportedAt: OneUptimeDate.addRemoveDays(calculatedAt, -7),
+        userCount: 50,
+      }),
+    ]);
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 17,
+        activeInstanceIds: [],
+      }),
+    );
+  });
+
+  it("does not preserve an inactive modern aggregate because another instance registered later", async () => {
+    const inactiveAt: Date = OneUptimeDate.addRemoveDays(calculatedAt, -7);
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 50,
+        userCountUpdatedAt: inactiveAt,
+      }),
+    );
+    const newlyRegistered: EnterpriseLicenseInstance = makeInstance({
+      createdAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+      lastReportedAt: undefined,
+      userCount: undefined,
+      userEmailHashes: undefined,
+    });
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+      makeInstance({
+        lastReportedAt: inactiveAt,
+        userCount: 50,
+      }),
+      newlyRegistered,
+    ]);
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 0,
+        activeInstanceIds: [newlyRegistered.id!.toString()],
+      }),
+    );
+  });
+
+  it("schedules an exact refresh when a legacy-only heartbeat expires", async () => {
+    const legacyReportedAt: Date = OneUptimeDate.addRemoveDays(
+      calculatedAt,
+      -1,
+    );
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 17,
+        userCountUpdatedAt: legacyReportedAt,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: legacyReportedAt,
+      }),
+    );
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 17,
+        activeInstanceIds: [],
+        nextInstanceStatusChangeAt: OneUptimeDate.addRemoveDays(
+          calculatedAt,
+          6,
+        ).toISOString(),
+      }),
+    );
+  });
+
+  it("preserves a legacy stored count when no instance rows exist", async () => {
+    EnterpriseLicenseService.findOneById = jest
+      .fn()
+      .mockResolvedValue(makeLicense({ currentUserCount: 17 }));
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 17,
+        activeInstanceIds: [],
+        nextInstanceStatusChangeAt: OneUptimeDate.addRemoveDays(
+          calculatedAt,
+          7,
+        ).toISOString(),
+      }),
+    );
+  });
+
+  it("preserves a legacy stored count when an instance has registered but not reported usage", async () => {
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 17,
+        userCountUpdatedAt: OneUptimeDate.addRemoveDays(calculatedAt, -8),
+      }),
+    );
+    const registeredInstance: EnterpriseLicenseInstance = makeInstance({
+      createdAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+      lastReportedAt: undefined,
+      userCount: undefined,
+      userEmailHashes: undefined,
+    });
+    EnterpriseLicenseInstanceService.findBy = jest
+      .fn()
+      .mockResolvedValue([registeredInstance]);
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 17,
+        activeInstanceIds: [registeredInstance.id!.toString()],
+      }),
+    );
+  });
+
+  it("drops a legacy count when its report and every registration reach one week old", async () => {
+    const inactiveAt: Date = OneUptimeDate.addRemoveDays(calculatedAt, -7);
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 17,
+        userCountUpdatedAt: inactiveAt,
+      }),
+    );
+    EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([
+      makeInstance({
+        createdAt: inactiveAt,
+        lastReportedAt: undefined,
+        userCount: undefined,
+        userEmailHashes: undefined,
+      }),
+    ]);
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 0,
+        activeInstanceIds: [],
+        nextInstanceStatusChangeAt: null,
+      }),
+    );
+  });
+
+  it("does not extend an expired dedicated legacy heartbeat with a newer modern timestamp", async () => {
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 17,
+        userCountUpdatedAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+        userCountSource: EnterpriseLicenseUserCountSource.Legacy,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: OneUptimeDate.addRemoveDays(calculatedAt, -7),
+      }),
+    );
+
+    await callRoute();
+
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 0,
+        activeInstanceIds: [],
+        nextInstanceStatusChangeAt: null,
+      }),
+    );
+  });
+
+  it("selects the legacy report timestamp needed for the bounded fallback", async () => {
+    await callRoute();
+
+    expect(EnterpriseLicenseService.findOneById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          currentUserCount: true,
+          userCountUpdatedAt: true,
+          userCountSource: true,
+          legacyUserCount: true,
+          legacyUserCountUpdatedAt: true,
+        }),
+      }),
+    );
+  });
+
+  it("serializes the license and instance reads with usage reports", async () => {
+    await callRoute();
+
+    expect(
+      EnterpriseLicenseService.runWithUsageAggregationLock,
+    ).toHaveBeenCalledWith({
+      licenseId: LICENSE_ID,
+      fn: expect.any(Function),
+    });
+    expect(
+      (EnterpriseLicenseService.findOneById as unknown as jest.Mock).mock
+        .invocationCallOrder[0],
+    ).toBeGreaterThan(
+      (
+        EnterpriseLicenseService.runWithUsageAggregationLock as unknown as jest.Mock
+      ).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("cannot expose a reported instance with the previous license timestamp", async () => {
+    const previousReportAt: Date = OneUptimeDate.addRemoveDays(
+      calculatedAt,
+      -8,
+    );
+    const licenseState: EnterpriseLicense = makeLicense({
+      currentUserCount: 50,
+      userCountUpdatedAt: previousReportAt,
+    });
+    const instanceState: EnterpriseLicenseInstance = makeInstance({
+      lastReportedAt: previousReportAt,
+      userCount: 50,
+    });
+    let lockTail: Promise<void> = Promise.resolve();
+    let releaseInstanceUpdate: () => void = (): void => {};
+    let markInstanceUpdateStarted: () => void = (): void => {};
+    const instanceUpdateStarted: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        markInstanceUpdateStarted = resolve;
+      },
+    );
+    const instanceUpdateGate: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        releaseInstanceUpdate = resolve;
+      },
+    );
+
+    EnterpriseLicenseService.runWithUsageAggregationLock = jest
+      .fn()
+      .mockImplementation(
+        async (data: { fn: () => Promise<unknown> }): Promise<unknown> => {
+          const predecessor: Promise<void> = lockTail;
+          let releaseLock: () => void = (): void => {};
+          lockTail = new Promise<void>((resolve: () => void) => {
+            releaseLock = resolve;
+          });
+
+          await predecessor;
+          try {
+            return await data.fn();
+          } finally {
+            releaseLock();
+          }
+        },
+      );
+    EnterpriseLicenseService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(licenseState);
+    EnterpriseLicenseService.findOneById = jest
+      .fn()
+      .mockImplementation(async (): Promise<EnterpriseLicense> => {
+        return licenseState;
+      });
+    EnterpriseLicenseService.updateOneById = jest
+      .fn()
+      .mockImplementation(
+        async (args: { data: Partial<EnterpriseLicense> }): Promise<number> => {
+          Object.assign(licenseState, args.data);
+          return 1;
+        },
+      );
+    EnterpriseLicenseInstanceService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(instanceState);
+    EnterpriseLicenseInstanceService.updateOneById = jest
+      .fn()
+      .mockImplementation(
+        async (args: {
+          data: Partial<EnterpriseLicenseInstance>;
+        }): Promise<number> => {
+          Object.assign(instanceState, args.data);
+          markInstanceUpdateStarted();
+          await instanceUpdateGate;
+          return 1;
+        },
+      );
+    EnterpriseLicenseInstanceService.findBy = jest
+      .fn()
+      .mockImplementation(
+        async (): Promise<Array<EnterpriseLicenseInstance>> => {
+          return [instanceState];
+        },
+      );
+
+    const reportRequest: OneUptimeRequest = {
+      body: {
+        licenseKey: LICENSE_KEY,
+        userCount: 2,
+        instanceId: "instance-1",
+        userEmailHashes: [hashOf("1"), hashOf("2")],
+      },
+    } as unknown as OneUptimeRequest;
+    const reportPromise: Promise<void> = Promise.resolve(
+      mockRouter
+        .match("post", REPORT_ROUTE)
+        .handlerFunction(reportRequest, mockResponse, nextFunction),
+    );
+
+    await instanceUpdateStarted;
+
+    const snapshotPromise: Promise<void> = callRoute();
+
+    releaseInstanceUpdate();
+    await Promise.all([reportPromise, snapshotPromise]);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    const responseBodies: Array<JSONObject> = (
+      Response.sendJsonObjectResponse as unknown as jest.Mock
+    ).mock.calls.map((call: Array<unknown>): JSONObject => {
+      return call[2] as JSONObject;
+    });
+    const snapshotBody: JSONObject = responseBodies.find(
+      (body: JSONObject): boolean => {
+        return Array.isArray(body["activeInstanceIds"]);
+      },
+    )!;
+
+    expect(snapshotBody["currentUserCount"]).toBe(2);
+    expect(snapshotBody["activeInstanceIds"]).toEqual([
+      instanceState.id!.toString(),
+    ]);
+    expect(snapshotBody["lastUsageReportedAt"]).toBe(
+      calculatedAt.toISOString(),
+    );
+  });
+
+  it("does not disclose whether an unknown license has instance usage", async () => {
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(nextFunction).toHaveBeenCalledWith(
+      new BadDataException("Enterprise license not found"),
+    );
+    expect(EnterpriseLicenseInstanceService.findBy).not.toHaveBeenCalled();
   });
 });
 
@@ -598,11 +1322,24 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
     EnterpriseLicenseService.findOneBy = jest
       .fn()
       .mockResolvedValue(makeLicense());
+    EnterpriseLicenseService.findOneById = jest
+      .fn()
+      .mockResolvedValue(makeLicense());
+    EnterpriseLicenseService.runWithUsageAggregationLock = jest
+      .fn()
+      .mockImplementation(
+        async (data: { fn: () => Promise<unknown> }): Promise<unknown> => {
+          return await data.fn();
+        },
+      );
     EnterpriseLicenseInstanceService.findBy = jest.fn().mockResolvedValue([]);
     EnterpriseLicenseInstanceService.findOneBy = jest
       .fn()
       .mockResolvedValue(null);
     EnterpriseLicenseInstanceService.create = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    EnterpriseLicenseInstanceService.updateOneById = jest
       .fn()
       .mockResolvedValue(undefined);
     EnterpriseLicenseInstanceService.countBy = jest
@@ -656,6 +1393,122 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
     expect(body["token"]).toBe("signed.jwt.token");
   });
 
+  it("serializes registration and re-reads usage inside the aggregation lock", async () => {
+    const events: Array<string> = [];
+    let isInsideUsageLock: boolean = false;
+
+    EnterpriseLicenseService.runWithUsageAggregationLock = jest
+      .fn()
+      .mockImplementation(
+        async (data: { fn: () => Promise<unknown> }): Promise<unknown> => {
+          events.push("lock");
+          isInsideUsageLock = true;
+
+          try {
+            return await data.fn();
+          } finally {
+            isInsideUsageLock = false;
+          }
+        },
+      );
+    EnterpriseLicenseInstanceService.create = jest
+      .fn()
+      .mockImplementation(async (): Promise<void> => {
+        expect(isInsideUsageLock).toBe(true);
+        events.push("register");
+      });
+    EnterpriseLicenseInstanceService.findBy = jest
+      .fn()
+      .mockImplementation(
+        async (): Promise<Array<EnterpriseLicenseInstance>> => {
+          expect(isInsideUsageLock).toBe(true);
+          events.push("instances");
+          return [];
+        },
+      );
+    EnterpriseLicenseService.findOneById = jest
+      .fn()
+      .mockImplementation(async (): Promise<EnterpriseLicense> => {
+        expect(isInsideUsageLock).toBe(true);
+        events.push("license");
+        return makeLicense({
+          currentUserCount: 17,
+          userCountUpdatedAt: new Date("2026-09-01T12:00:00.000Z"),
+        });
+      });
+
+    await mockRouter
+      .match("post", VALIDATE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(events).toEqual(["lock", "register", "instances", "license"]);
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 17,
+        userCountUpdatedAt: "2026-09-01T12:00:00.000Z",
+      }),
+    );
+    expect(
+      EnterpriseLicenseService.runWithUsageAggregationLock,
+    ).toHaveBeenCalledWith({
+      licenseId: LICENSE_ID,
+      fn: expect.any(Function),
+    });
+  });
+
+  it("returns an active-only aggregate with matching per-instance provenance", async () => {
+    const calculatedAt: Date = new Date("2026-09-02T12:00:00.000Z");
+    const inactiveInstance: EnterpriseLicenseInstance = makeInstance({
+      instanceId: "instance-1",
+      userCount: 80,
+      lastReportedAt: OneUptimeDate.addRemoveDays(calculatedAt, -7),
+    });
+    const activeInstance: EnterpriseLicenseInstance = makeInstance({
+      instanceId: "instance-2",
+      userCount: 100,
+      lastReportedAt: OneUptimeDate.addRemoveDays(calculatedAt, -1),
+    });
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockReturnValue(calculatedAt);
+    EnterpriseLicenseInstanceService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(inactiveInstance);
+    EnterpriseLicenseInstanceService.findBy = jest
+      .fn()
+      .mockResolvedValue([inactiveInstance, activeInstance]);
+    EnterpriseLicenseService.findOneById = jest.fn().mockResolvedValue(
+      makeLicense({
+        currentUserCount: 180,
+        userCountUpdatedAt: calculatedAt,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      }),
+    );
+
+    await mockRouter
+      .match("post", VALIDATE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(getResponseBody()).toEqual(
+      expect.objectContaining({
+        currentUserCount: 100,
+        instances: expect.arrayContaining([
+          expect.objectContaining({
+            instanceId: "instance-1",
+            userCount: 80,
+            isCountedTowardsUsage: false,
+          }),
+          expect.objectContaining({
+            instanceId: "instance-2",
+            userCount: 100,
+            isCountedTowardsUsage: true,
+          }),
+        ]),
+      }),
+    );
+  });
+
   it("keeps rejecting an expired license, unlike the report route", async () => {
     EnterpriseLicenseService.findOneBy = jest.fn().mockResolvedValue(
       makeLicense({
@@ -690,6 +1543,13 @@ describe("the contract between the two halves of the sync", () => {
     EnterpriseLicenseService.updateOneById = jest
       .fn()
       .mockResolvedValue(undefined);
+    EnterpriseLicenseService.runWithUsageAggregationLock = jest
+      .fn()
+      .mockImplementation(
+        async (data: { fn: () => Promise<unknown> }): Promise<unknown> => {
+          return await data.fn();
+        },
+      );
     EnterpriseLicenseInstanceService.findBy = jest
       .fn()
       .mockResolvedValue([makeInstance()]);
@@ -754,6 +1614,13 @@ describe("the contract between the two halves of the sync", () => {
     expect(result.updateData.enterpriseLicenseToken).toBe("signed.jwt.token");
     expect(result.updateData.enterpriseLicenseExpiresAt).toBeInstanceOf(Date);
     expect(result.updateData.enterpriseLicenseInstances).toHaveLength(1);
+    expect(
+      (
+        result.updateData.enterpriseLicenseInstances as
+          | Array<EnterpriseLicenseInstanceSummary>
+          | undefined
+      )?.[0]?.isCountedTowardsUsage,
+    ).toBe(true);
 
     // The installation never adopts a key handed to it by a response.
     expect(Object.keys(result.updateData)).not.toContain(

--- a/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
+++ b/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
@@ -1396,6 +1396,80 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/validate", () => {
     expect(body["token"]).toBe("signed.jwt.token");
   });
 
+  it("registers a new instance without treating validation as a usage heartbeat", async () => {
+    await mockRouter
+      .match("post", VALIDATE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(
+      EnterpriseLicenseInstanceService.updateOneById,
+    ).not.toHaveBeenCalled();
+
+    const createArguments: {
+      data: EnterpriseLicenseInstance;
+    } = (EnterpriseLicenseInstanceService.create as unknown as jest.Mock).mock
+      .calls[0]![0] as {
+      data: EnterpriseLicenseInstance;
+    };
+
+    expect(createArguments.data).toEqual(
+      expect.objectContaining({
+        enterpriseLicenseId: LICENSE_ID,
+        instanceId: "instance-1",
+        host: "oneuptime.acme.internal",
+        oneuptimeVersion: "12.0.19",
+      }),
+    );
+    expect(createArguments.data.lastReportedAt).toBeUndefined();
+    expect(createArguments.data.createdAt).toBeUndefined();
+  });
+
+  it("updates instance metadata without refreshing its activity timestamps", async () => {
+    const registeredAt: Date = new Date("2026-08-01T12:00:00.000Z");
+    const lastReportedAt: Date = new Date("2026-08-20T12:00:00.000Z");
+    const existingInstance: EnterpriseLicenseInstance = makeInstance({
+      createdAt: registeredAt,
+      lastReportedAt,
+    });
+
+    EnterpriseLicenseInstanceService.findOneBy = jest
+      .fn()
+      .mockResolvedValue(existingInstance);
+
+    await mockRouter
+      .match("post", VALIDATE_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(EnterpriseLicenseInstanceService.create).not.toHaveBeenCalled();
+
+    const updateArguments: {
+      data: Partial<EnterpriseLicenseInstance>;
+    } = (EnterpriseLicenseInstanceService.updateOneById as unknown as jest.Mock)
+      .mock.calls[0]![0] as {
+      data: Partial<EnterpriseLicenseInstance>;
+    };
+
+    expect(updateArguments.data).toEqual(
+      expect.objectContaining({
+        host: "oneuptime.acme.internal",
+        oneuptimeVersion: "12.0.19",
+      }),
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        updateArguments.data,
+        "lastReportedAt",
+      ),
+    ).toBe(false);
+    expect(
+      Object.prototype.hasOwnProperty.call(updateArguments.data, "createdAt"),
+    ).toBe(false);
+    expect(existingInstance.lastReportedAt).toBe(lastReportedAt);
+    expect(existingInstance.createdAt).toBe(registeredAt);
+  });
+
   it("serializes registration and re-reads usage inside the aggregation lock", async () => {
     const events: Array<string> = [];
     let isInsideUsageLock: boolean = false;

--- a/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
+++ b/Common/Tests/Server/API/EnterpriseLicenseReportUserCount.test.ts
@@ -594,7 +594,10 @@ describe("EnterpriseLicenseAPI POST /enterprise-license/report-user-count", () =
       };
       const firstNext: NextFunction = jest.fn();
       const secondNext: NextFunction = jest.fn();
-      const route = mockRouter.match("post", REPORT_ROUTE);
+      const route: ReturnType<typeof mockRouter.match> = mockRouter.match(
+        "post",
+        REPORT_ROUTE,
+      );
 
       await Promise.all([
         route.handlerFunction(

--- a/Common/Tests/Server/Services/EnterpriseLicenseInstanceServiceDeletionUsage.test.ts
+++ b/Common/Tests/Server/Services/EnterpriseLicenseInstanceServiceDeletionUsage.test.ts
@@ -66,7 +66,7 @@ type MakeInstanceFunction = (
 ) => EnterpriseLicenseInstance;
 
 const makeInstance: MakeInstanceFunction = (
-  data,
+  data: Parameters<MakeInstanceFunction>[0],
 ): EnterpriseLicenseInstance => {
   return {
     id: ObjectID.generate(),
@@ -88,7 +88,9 @@ type MakeLicenseFunction = (
   }>,
 ) => EnterpriseLicense;
 
-const makeLicense: MakeLicenseFunction = (data): EnterpriseLicense => {
+const makeLicense: MakeLicenseFunction = (
+  data: Parameters<MakeLicenseFunction>[0],
+): EnterpriseLicense => {
   return {
     id: LICENSE_ID,
     currentUserCount: data?.currentUserCount,

--- a/Common/Tests/Server/Services/EnterpriseLicenseInstanceServiceDeletionUsage.test.ts
+++ b/Common/Tests/Server/Services/EnterpriseLicenseInstanceServiceDeletionUsage.test.ts
@@ -1,0 +1,705 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+interface UsageLockRequest {
+  licenseId: import("../../../Types/ObjectID").default;
+  fn: () => Promise<number>;
+}
+
+interface EnterpriseLicenseServiceMock {
+  runWithUsageAggregationLock: jest.Mock;
+  findOneById: jest.Mock;
+  updateOneById: jest.Mock;
+}
+
+const mockEnterpriseLicenseService: EnterpriseLicenseServiceMock = {
+  runWithUsageAggregationLock: jest.fn() as unknown as jest.Mock,
+  findOneById: jest.fn() as unknown as jest.Mock,
+  updateOneById: jest.fn() as unknown as jest.Mock,
+};
+
+jest.mock("../../../Server/Services/EnterpriseLicenseService", () => {
+  return {
+    __esModule: true,
+    default: mockEnterpriseLicenseService,
+  };
+});
+
+import EnterpriseLicenseInstanceService from "../../../Server/Services/EnterpriseLicenseInstanceService";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import DeleteById from "../../../Server/Types/Database/DeleteById";
+import EnterpriseLicense from "../../../Models/DatabaseModels/EnterpriseLicense";
+import EnterpriseLicenseInstance from "../../../Models/DatabaseModels/EnterpriseLicenseInstance";
+import User from "../../../Models/DatabaseModels/User";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import OneUptimeDate from "../../../Types/Date";
+import ObjectID from "../../../Types/ObjectID";
+import EnterpriseLicenseUserCountSource from "../../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
+import EnterpriseLicenseUsageUtil from "../../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+import { getJestSpyOn } from "../../Spy";
+
+const LICENSE_ID: ObjectID = new ObjectID(
+  "550e8400-e29b-41d4-a716-446655440081",
+);
+const INSTANCE_ID: ObjectID = new ObjectID(
+  "550e8400-e29b-41d4-a716-446655440082",
+);
+const NOW: Date = new Date("2026-09-02T12:00:00.000Z");
+const ONE_DAY_AGO: Date = OneUptimeDate.addRemoveDays(NOW, -1);
+const EXACTLY_ONE_WEEK_AGO: Date = OneUptimeDate.addRemoveDays(NOW, -7);
+
+type MakeInstanceFunction = (
+  data?: Partial<{
+    enterpriseLicenseId: ObjectID | undefined;
+    createdAt: Date | undefined;
+    lastReportedAt: Date | undefined;
+    userCount: number | undefined;
+    userEmailHashes: Array<string> | undefined;
+  }>,
+) => EnterpriseLicenseInstance;
+
+const makeInstance: MakeInstanceFunction = (
+  data,
+): EnterpriseLicenseInstance => {
+  return {
+    id: ObjectID.generate(),
+    enterpriseLicenseId: data?.enterpriseLicenseId || LICENSE_ID,
+    createdAt: data?.createdAt,
+    lastReportedAt: data?.lastReportedAt,
+    userCount: data?.userCount,
+    userEmailHashes: data?.userEmailHashes,
+  } as unknown as EnterpriseLicenseInstance;
+};
+
+type MakeLicenseFunction = (
+  data?: Partial<{
+    currentUserCount: number;
+    userCountUpdatedAt: Date;
+    userCountSource: EnterpriseLicenseUserCountSource;
+    legacyUserCount: number;
+    legacyUserCountUpdatedAt: Date;
+  }>,
+) => EnterpriseLicense;
+
+const makeLicense: MakeLicenseFunction = (data): EnterpriseLicense => {
+  return {
+    id: LICENSE_ID,
+    currentUserCount: data?.currentUserCount,
+    userCountUpdatedAt: data?.userCountUpdatedAt,
+    userCountSource: data?.userCountSource,
+    legacyUserCount: data?.legacyUserCount,
+    legacyUserCountUpdatedAt: data?.legacyUserCountUpdatedAt,
+  } as unknown as EnterpriseLicense;
+};
+
+describe("EnterpriseLicenseInstanceService deletion usage reconciliation", () => {
+  let resolvedInstance: EnterpriseLicenseInstance | null;
+  let remainingInstances: Array<EnterpriseLicenseInstance>;
+  let license: EnterpriseLicense | null;
+  let deleteAffected: number;
+  let operationEvents: Array<string>;
+  let deleteOneBySpy: jest.SpyInstance;
+  let findOneByIdSpy: jest.SpyInstance;
+  let findBySpy: jest.SpyInstance;
+  let permissionSpy: jest.SpyInstance;
+  let currentDateSpy: jest.SpyInstance;
+  let deleteInput: DeleteById;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    resolvedInstance = makeInstance({
+      lastReportedAt: ONE_DAY_AGO,
+    });
+    remainingInstances = [];
+    license = makeLicense({
+      currentUserCount: 9,
+      userCountUpdatedAt: NOW,
+      userCountSource: EnterpriseLicenseUserCountSource.Instance,
+    });
+    deleteAffected = 1;
+    operationEvents = [];
+
+    permissionSpy = getJestSpyOn(
+      ModelPermission,
+      "checkDeletePermissionByModel",
+    ).mockResolvedValue(undefined as never);
+    currentDateSpy = getJestSpyOn(
+      OneUptimeDate,
+      "getCurrentDate",
+    ).mockReturnValue(NOW);
+    findOneByIdSpy = getJestSpyOn(
+      EnterpriseLicenseInstanceService,
+      "findOneById",
+    ).mockImplementation(
+      async (request: { select?: Record<string, boolean> }) => {
+        if (request.select?.["enterpriseLicenseId"]) {
+          operationEvents.push("instance:ownership-read");
+        } else if (request.select?.["lastReportedAt"]) {
+          operationEvents.push("instance:locked-read");
+        } else {
+          operationEvents.push("instance:permission-read");
+        }
+
+        return resolvedInstance;
+      },
+    );
+    deleteOneBySpy = getJestSpyOn(
+      EnterpriseLicenseInstanceService,
+      "deleteOneBy",
+    ).mockImplementation(async () => {
+      operationEvents.push("instance:delete");
+      return deleteAffected;
+    });
+    findBySpy = getJestSpyOn(
+      EnterpriseLicenseInstanceService,
+      "findBy",
+    ).mockImplementation(async () => {
+      operationEvents.push("instances:read");
+      return remainingInstances;
+    });
+
+    mockEnterpriseLicenseService.runWithUsageAggregationLock.mockReset();
+    mockEnterpriseLicenseService.runWithUsageAggregationLock.mockImplementation(
+      async (request: UsageLockRequest): Promise<number> => {
+        operationEvents.push("lock:start");
+        try {
+          return await request.fn();
+        } finally {
+          operationEvents.push("lock:end");
+        }
+      },
+    );
+    mockEnterpriseLicenseService.findOneById.mockReset();
+    mockEnterpriseLicenseService.findOneById.mockImplementation(
+      async (request: { select: Record<string, boolean> }) => {
+        if (
+          request.select["userCountSource"] &&
+          Object.keys(request.select).length === 1
+        ) {
+          operationEvents.push("license:source-read");
+        } else {
+          operationEvents.push("license:usage-read");
+        }
+
+        return license;
+      },
+    );
+    mockEnterpriseLicenseService.updateOneById.mockReset();
+    mockEnterpriseLicenseService.updateOneById.mockImplementation(
+      async (request: {
+        data: Partial<{
+          currentUserCount: number;
+          userCountSource: EnterpriseLicenseUserCountSource;
+        }>;
+      }) => {
+        if (request.data.currentUserCount === undefined) {
+          operationEvents.push("license:source-marker");
+
+          if (license && request.data.userCountSource) {
+            license.userCountSource = request.data.userCountSource;
+          }
+        } else {
+          operationEvents.push("license:aggregate-update");
+        }
+      },
+    );
+
+    const deletedByUser: User = new User();
+    deletedByUser._id = "550e8400-e29b-41d4-a716-446655440083";
+    deleteInput = {
+      id: INSTANCE_ID,
+      deletedByUser,
+      deletionReason: "Instance decommissioned",
+      props: {
+        isMasterAdmin: true,
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("deletes under the license lock and reconciles the last modern instance to zero", async () => {
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).resolves.toBe(1);
+
+    expect(operationEvents).toEqual([
+      "instance:ownership-read",
+      "lock:start",
+      "instance:locked-read",
+      "license:source-read",
+      "instance:delete",
+      "instances:read",
+      "license:usage-read",
+      "license:aggregate-update",
+      "lock:end",
+    ]);
+    expect(
+      mockEnterpriseLicenseService.runWithUsageAggregationLock,
+    ).toHaveBeenCalledWith({
+      licenseId: LICENSE_ID,
+      fn: expect.any(Function),
+    });
+    expect(findOneByIdSpy).toHaveBeenNthCalledWith(1, {
+      id: INSTANCE_ID,
+      select: {
+        enterpriseLicenseId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+    expect(findOneByIdSpy).toHaveBeenNthCalledWith(2, {
+      id: INSTANCE_ID,
+      select: {
+        lastReportedAt: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith({
+      id: LICENSE_ID,
+      data: {
+        currentUserCount: 0,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      },
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+    expect(currentDateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("recomputes the deduplicated aggregate from the remaining active modern instances", async () => {
+    remainingInstances = [
+      makeInstance({
+        lastReportedAt: ONE_DAY_AGO,
+        userCount: 2,
+        userEmailHashes: ["alice", "shared"],
+      }),
+      makeInstance({
+        lastReportedAt: ONE_DAY_AGO,
+        userCount: 2,
+        userEmailHashes: ["shared", "bob"],
+      }),
+    ];
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          currentUserCount: 3,
+          userCountSource: EnterpriseLicenseUserCountSource.Instance,
+        },
+      }),
+    );
+    expect(findBySpy).toHaveBeenCalledWith({
+      query: {
+        enterpriseLicenseId: LICENSE_ID,
+      },
+      select: {
+        createdAt: true,
+        userCount: true,
+        userEmailHashes: true,
+        lastReportedAt: true,
+      },
+      sort: {
+        createdAt: SortOrder.Ascending,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
+  });
+
+  test("excludes remaining instances at the exact inactivity boundary", async () => {
+    remainingInstances = [
+      makeInstance({
+        lastReportedAt: ONE_DAY_AGO,
+        userCount: 1,
+        userEmailHashes: ["active"],
+      }),
+      makeInstance({
+        lastReportedAt: EXACTLY_ONE_WEEK_AGO,
+        userCount: 50,
+        userEmailHashes: ["inactive"],
+      }),
+    ];
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          currentUserCount: 1,
+          userCountSource: EnterpriseLicenseUserCountSource.Instance,
+        },
+      }),
+    );
+  });
+
+  test("falls back to a fresh explicitly-provenanced legacy report when no active modern report remains", async () => {
+    remainingInstances = [
+      makeInstance({
+        lastReportedAt: EXACTLY_ONE_WEEK_AGO,
+        userCount: 50,
+      }),
+    ];
+    license = makeLicense({
+      currentUserCount: 50,
+      userCountUpdatedAt: NOW,
+      legacyUserCount: 7,
+      legacyUserCountUpdatedAt: ONE_DAY_AGO,
+    });
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          currentUserCount: 7,
+          userCountSource: EnterpriseLicenseUserCountSource.Legacy,
+        },
+      }),
+    );
+    expect(mockEnterpriseLicenseService.findOneById).toHaveBeenCalledWith({
+      id: LICENSE_ID,
+      select: {
+        currentUserCount: true,
+        userCountUpdatedAt: true,
+        userCountSource: true,
+        legacyUserCount: true,
+        legacyUserCountUpdatedAt: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+  });
+
+  test("does not let the newer modern aggregate timestamp extend legacy freshness after deletion", async () => {
+    const legacyReportedAt: Date = OneUptimeDate.addRemoveDays(NOW, -6);
+    const modernReportedAt: Date = ONE_DAY_AGO;
+    license = makeLicense({
+      currentUserCount: 50,
+      userCountUpdatedAt: modernReportedAt,
+      userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      legacyUserCount: 7,
+      legacyUserCountUpdatedAt: legacyReportedAt,
+    });
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    const updateData: {
+      currentUserCount: number;
+      userCountSource: EnterpriseLicenseUserCountSource;
+    } = (
+      mockEnterpriseLicenseService.updateOneById.mock.calls[0]![0] as {
+        data: {
+          currentUserCount: number;
+          userCountSource: EnterpriseLicenseUserCountSource;
+        };
+      }
+    ).data;
+
+    expect(updateData).toEqual({
+      currentUserCount: 7,
+      userCountSource: EnterpriseLicenseUserCountSource.Legacy,
+    });
+    expect(updateData).not.toHaveProperty("userCountUpdatedAt");
+    expect(updateData).not.toHaveProperty("legacyUserCountUpdatedAt");
+
+    const legacyExpiryBoundary: Date = OneUptimeDate.addRemoveDays(
+      legacyReportedAt,
+      7,
+    );
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        storedUserCount: updateData.currentUserCount,
+        storedUserCountUpdatedAt: modernReportedAt,
+        storedUserCountSource: updateData.userCountSource,
+        legacyUserCount: license.legacyUserCount,
+        legacyUserCountUpdatedAt: license.legacyUserCountUpdatedAt,
+        now: legacyExpiryBoundary,
+      }),
+    ).toBe(0);
+  });
+
+  test("preserves DatabaseService permission and deletion metadata handling when the row is already absent", async () => {
+    resolvedInstance = null;
+    deleteAffected = 0;
+
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).resolves.toBe(0);
+
+    expect(permissionSpy).toHaveBeenCalledTimes(2);
+    expect(deleteOneBySpy).toHaveBeenCalledWith({
+      query: {
+        _id: INSTANCE_ID.toString(),
+      },
+      deletedByUser: deleteInput.deletedByUser,
+      deletionReason: "Instance decommissioned",
+      props: deleteInput.props,
+    });
+    expect(operationEvents).toEqual([
+      "instance:ownership-read",
+      "instance:delete",
+    ]);
+    expect(
+      mockEnterpriseLicenseService.runWithUsageAggregationLock,
+    ).not.toHaveBeenCalled();
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(mockEnterpriseLicenseService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("preserves a fresh pre-migration legacy count when deleting its sole registration-only row", async () => {
+    resolvedInstance = makeInstance({
+      createdAt: ONE_DAY_AGO,
+      lastReportedAt: undefined,
+    });
+    license = makeLicense({
+      currentUserCount: 12,
+      userCountUpdatedAt: ONE_DAY_AGO,
+    });
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith({
+      id: LICENSE_ID,
+      data: {
+        currentUserCount: 12,
+        userCountSource: EnterpriseLicenseUserCountSource.Legacy,
+      },
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+  });
+
+  test("does not resurrect an instance aggregate marked as modern when deleting a registration-only row", async () => {
+    resolvedInstance = makeInstance({
+      createdAt: ONE_DAY_AGO,
+      lastReportedAt: undefined,
+    });
+    license = makeLicense({
+      currentUserCount: 12,
+      userCountUpdatedAt: ONE_DAY_AGO,
+      userCountSource: EnterpriseLicenseUserCountSource.Instance,
+    });
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith({
+      id: LICENSE_ID,
+      data: {
+        currentUserCount: 0,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      },
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+  });
+
+  test("persists zero for a stale pre-migration count after deleting its sole registration-only row", async () => {
+    resolvedInstance = makeInstance({
+      createdAt: EXACTLY_ONE_WEEK_AGO,
+      lastReportedAt: undefined,
+    });
+    license = makeLicense({
+      currentUserCount: 12,
+      userCountUpdatedAt: EXACTLY_ONE_WEEK_AGO,
+    });
+
+    await EnterpriseLicenseInstanceService.deleteOneById(deleteInput);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledWith({
+      id: LICENSE_ID,
+      data: {
+        currentUserCount: 0,
+      },
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+  });
+
+  test("does not reconcile when the locked delete loses a race and affects no row", async () => {
+    deleteAffected = 0;
+
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).resolves.toBe(0);
+
+    expect(operationEvents).toEqual([
+      "instance:ownership-read",
+      "lock:start",
+      "instance:locked-read",
+      "license:source-read",
+      "instance:delete",
+      "lock:end",
+    ]);
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(mockEnterpriseLicenseService.findOneById).toHaveBeenCalledTimes(1);
+    expect(mockEnterpriseLicenseService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("propagates delete failures, releases the lock, and performs no reconciliation", async () => {
+    const deleteError: Error = new Error("delete failed");
+    deleteOneBySpy.mockImplementation(async () => {
+      operationEvents.push("instance:delete");
+      throw deleteError;
+    });
+
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).rejects.toBe(deleteError);
+
+    expect(operationEvents).toEqual([
+      "instance:ownership-read",
+      "lock:start",
+      "instance:locked-read",
+      "license:source-read",
+      "instance:delete",
+      "lock:end",
+    ]);
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(mockEnterpriseLicenseService.findOneById).toHaveBeenCalledTimes(1);
+    expect(mockEnterpriseLicenseService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("persists an upgrade-era modern marker before deletion when the aggregate update later fails", async () => {
+    const aggregateError: Error = new Error("aggregate update failed");
+    license = makeLicense({
+      currentUserCount: 9,
+      userCountUpdatedAt: NOW,
+    });
+    mockEnterpriseLicenseService.updateOneById.mockImplementation(
+      async (request: {
+        data: Partial<{
+          currentUserCount: number;
+          userCountSource: EnterpriseLicenseUserCountSource;
+        }>;
+      }) => {
+        if (request.data.currentUserCount === undefined) {
+          operationEvents.push("license:source-marker");
+          license!.userCountSource = EnterpriseLicenseUserCountSource.Instance;
+          return;
+        }
+
+        operationEvents.push("license:aggregate-update");
+        throw aggregateError;
+      },
+    );
+
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).rejects.toBe(aggregateError);
+
+    expect(operationEvents).toEqual([
+      "instance:ownership-read",
+      "lock:start",
+      "instance:locked-read",
+      "license:source-read",
+      "license:source-marker",
+      "instance:delete",
+      "instances:read",
+      "license:usage-read",
+      "license:aggregate-update",
+      "lock:end",
+    ]);
+    expect(
+      mockEnterpriseLicenseService.updateOneById.mock.calls.map(
+        (call: Array<unknown>): unknown => {
+          return (call[0] as { data: unknown }).data;
+        },
+      ),
+    ).toEqual([
+      {
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      },
+      {
+        currentUserCount: 0,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      },
+    ]);
+    expect(license?.userCountSource).toBe(
+      EnterpriseLicenseUserCountSource.Instance,
+    );
+  });
+
+  test("persists zero when deleting the only reported row from an otherwise empty license", async () => {
+    license = makeLicense();
+
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).resolves.toBe(1);
+
+    expect(mockEnterpriseLicenseService.updateOneById).toHaveBeenCalledTimes(2);
+    expect(
+      mockEnterpriseLicenseService.updateOneById.mock.calls.map(
+        (call: Array<unknown>): unknown => {
+          return (call[0] as { data: unknown }).data;
+        },
+      ),
+    ).toEqual([
+      {
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      },
+      {
+        currentUserCount: 0,
+        userCountSource: EnterpriseLicenseUserCountSource.Instance,
+      },
+    ]);
+    expect(operationEvents).toEqual([
+      "instance:ownership-read",
+      "lock:start",
+      "instance:locked-read",
+      "license:source-read",
+      "license:source-marker",
+      "instance:delete",
+      "instances:read",
+      "license:usage-read",
+      "license:aggregate-update",
+      "lock:end",
+    ]);
+  });
+
+  test("does not delete or reconcile when DatabaseService refuses permission", async () => {
+    const permissionError: Error = new Error("not allowed");
+    permissionSpy.mockRejectedValue(permissionError);
+
+    await expect(
+      EnterpriseLicenseInstanceService.deleteOneById(deleteInput),
+    ).rejects.toBe(permissionError);
+
+    expect(deleteOneBySpy).not.toHaveBeenCalled();
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(mockEnterpriseLicenseService.updateOneById).not.toHaveBeenCalled();
+    expect(operationEvents).toEqual([]);
+    expect(
+      mockEnterpriseLicenseService.runWithUsageAggregationLock,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/EnterpriseLicenseServiceUsageAggregationLock.test.ts
+++ b/Common/Tests/Server/Services/EnterpriseLicenseServiceUsageAggregationLock.test.ts
@@ -162,7 +162,9 @@ describe("EnterpriseLicenseService usage aggregation lock", () => {
     const result: { users: number } =
       await EnterpriseLicenseService.runWithUsageAggregationLock({
         licenseId: ObjectID.generate(),
-        fn: async (): Promise<{ users: number }> => ({ users: 17 }),
+        fn: async (): Promise<{ users: number }> => {
+          return { users: 17 };
+        },
       });
 
     expect(result).toEqual({ users: 17 });
@@ -190,10 +192,11 @@ describe("EnterpriseLicenseService usage aggregation lock", () => {
 
     await firstStarted.promise;
 
-    const secondCallback = jest.fn(async (): Promise<string> => {
-      events.push("second:start");
-      return "second";
-    });
+    const secondCallback: ReturnType<typeof jest.fn<() => Promise<string>>> =
+      jest.fn(async (): Promise<string> => {
+        events.push("second:start");
+        return "second";
+      });
     const second: Promise<string> =
       EnterpriseLicenseService.runWithUsageAggregationLock({
         licenseId,
@@ -270,7 +273,9 @@ describe("EnterpriseLicenseService usage aggregation lock", () => {
 
   test("fails closed without invoking or releasing when acquisition fails", async () => {
     const acquireError: Error = new Error("Redis unavailable");
-    const callback = jest.fn(async (): Promise<void> => {});
+    const callback: ReturnType<typeof jest.fn<() => Promise<void>>> = jest.fn(
+      async (): Promise<void> => {},
+    );
     lockMock.mockRejectedValue(acquireError);
 
     await expect(
@@ -292,7 +297,9 @@ describe("EnterpriseLicenseService usage aggregation lock", () => {
     await expect(
       EnterpriseLicenseService.runWithUsageAggregationLock({
         licenseId,
-        fn: async (): Promise<string> => "complete",
+        fn: async (): Promise<string> => {
+          return "complete";
+        },
       }),
     ).resolves.toBe("complete");
 

--- a/Common/Tests/Server/Services/EnterpriseLicenseServiceUsageAggregationLock.test.ts
+++ b/Common/Tests/Server/Services/EnterpriseLicenseServiceUsageAggregationLock.test.ts
@@ -1,0 +1,322 @@
+jest.mock("../../../Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    default: {
+      lock: jest.fn(),
+      release: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      error: jest.fn(),
+    },
+  };
+});
+
+import EnterpriseLicenseService, {
+  ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_NAMESPACE,
+  ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS,
+} from "../../../Server/Services/EnterpriseLicenseService";
+import Semaphore from "../../../Server/Infrastructure/Semaphore";
+import logger from "../../../Server/Utils/Logger";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+interface FakeMutex {
+  key: string;
+}
+
+interface LockRequest {
+  key: string;
+  namespace: string;
+}
+
+class FakeSemaphore {
+  private readonly heldKeys: Set<string> = new Set<string>();
+  private readonly waitersByKey: Map<string, Array<() => void>> = new Map<
+    string,
+    Array<() => void>
+  >();
+
+  public async lock(data: LockRequest): Promise<FakeMutex> {
+    const key: string = `${data.namespace}-${data.key}`;
+
+    if (this.heldKeys.has(key)) {
+      await new Promise<void>((resolve: () => void) => {
+        const waiters: Array<() => void> = this.waitersByKey.get(key) || [];
+        waiters.push(resolve);
+        this.waitersByKey.set(key, waiters);
+      });
+    } else {
+      this.heldKeys.add(key);
+    }
+
+    return { key };
+  }
+
+  public async release(mutex: FakeMutex): Promise<void> {
+    const waiters: Array<() => void> | undefined = this.waitersByKey.get(
+      mutex.key,
+    );
+    const next: (() => void) | undefined = waiters?.shift();
+
+    if (next) {
+      next();
+      return;
+    }
+
+    this.waitersByKey.delete(mutex.key);
+    this.heldKeys.delete(mutex.key);
+  }
+}
+
+interface Gate {
+  promise: Promise<void>;
+  open: () => void;
+}
+
+function createGate(): Gate {
+  let open: () => void = (): void => {};
+  const promise: Promise<void> = new Promise<void>((resolve: () => void) => {
+    open = resolve;
+  });
+
+  return { promise, open };
+}
+
+const lockMock: jest.Mock = Semaphore.lock as unknown as jest.Mock;
+const releaseMock: jest.Mock = Semaphore.release as unknown as jest.Mock;
+const loggerErrorMock: jest.Mock = logger.error as unknown as jest.Mock;
+
+function installFakeSemaphore(): void {
+  const fakeSemaphore: FakeSemaphore = new FakeSemaphore();
+
+  lockMock.mockImplementation(async (data: LockRequest) => {
+    return await fakeSemaphore.lock(data);
+  });
+  releaseMock.mockImplementation(async (mutex: unknown) => {
+    await fakeSemaphore.release(mutex as FakeMutex);
+  });
+}
+
+describe("EnterpriseLicenseService usage aggregation lock", () => {
+  beforeEach(() => {
+    lockMock.mockReset();
+    releaseMock.mockReset();
+    loggerErrorMock.mockReset();
+    lockMock.mockResolvedValue({ key: "mutex" });
+    releaseMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("uses the stable per-license key, namespace, and bounded timeout options", async () => {
+    const licenseId: ObjectID = ObjectID.generate();
+    const mutex: FakeMutex = { key: "returned-mutex" };
+    lockMock.mockResolvedValue(mutex);
+
+    await EnterpriseLicenseService.runWithUsageAggregationLock({
+      licenseId,
+      fn: async (): Promise<void> => {},
+    });
+
+    expect(ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_NAMESPACE).toBe(
+      "EnterpriseLicenseService.usageAggregation",
+    );
+    expect(ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS).toEqual({
+      namespace: "EnterpriseLicenseService.usageAggregation",
+      lockTimeout: 60_000,
+      acquireTimeout: 10_000,
+    });
+    expect(
+      Object.isFrozen(ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS),
+    ).toBe(true);
+    expect(
+      ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS.acquireTimeout,
+    ).toBeLessThan(
+      ENTERPRISE_LICENSE_USAGE_AGGREGATION_LOCK_OPTIONS.lockTimeout,
+    );
+    expect(lockMock).toHaveBeenCalledWith({
+      key: licenseId.toString(),
+      namespace: "EnterpriseLicenseService.usageAggregation",
+      lockTimeout: 60_000,
+      acquireTimeout: 10_000,
+    });
+    expect(releaseMock).toHaveBeenCalledWith(mutex);
+  });
+
+  test("returns the callback value after releasing the mutex", async () => {
+    const result: { users: number } =
+      await EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId: ObjectID.generate(),
+        fn: async (): Promise<{ users: number }> => ({ users: 17 }),
+      });
+
+    expect(result).toEqual({ users: 17 });
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("serializes concurrent callbacks for the same license", async () => {
+    installFakeSemaphore();
+    const licenseId: ObjectID = ObjectID.generate();
+    const firstStarted: Gate = createGate();
+    const allowFirstToFinish: Gate = createGate();
+    const events: Array<string> = [];
+
+    const first: Promise<string> =
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId,
+        fn: async (): Promise<string> => {
+          events.push("first:start");
+          firstStarted.open();
+          await allowFirstToFinish.promise;
+          events.push("first:end");
+          return "first";
+        },
+      });
+
+    await firstStarted.promise;
+
+    const secondCallback = jest.fn(async (): Promise<string> => {
+      events.push("second:start");
+      return "second";
+    });
+    const second: Promise<string> =
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId,
+        fn: secondCallback,
+      });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondCallback).not.toHaveBeenCalled();
+
+    allowFirstToFinish.open();
+
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBe("second");
+    expect(events).toEqual(["first:start", "first:end", "second:start"]);
+  });
+
+  test("allows callbacks for different licenses to run concurrently", async () => {
+    installFakeSemaphore();
+    const allowCallbacksToFinish: Gate = createGate();
+    const bothCallbacksStarted: Gate = createGate();
+    const started: Set<string> = new Set<string>();
+
+    const callback: (name: string) => Promise<string> = async (
+      name: string,
+    ): Promise<string> => {
+      started.add(name);
+      if (started.size === 2) {
+        bothCallbacksStarted.open();
+      }
+      await allowCallbacksToFinish.promise;
+      return name;
+    };
+
+    const first: Promise<string> =
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId: ObjectID.generate(),
+        fn: async (): Promise<string> => {
+          return await callback("first");
+        },
+      });
+    const second: Promise<string> =
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId: ObjectID.generate(),
+        fn: async (): Promise<string> => {
+          return await callback("second");
+        },
+      });
+
+    await bothCallbacksStarted.promise;
+    expect(started).toEqual(new Set<string>(["first", "second"]));
+
+    allowCallbacksToFinish.open();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  test("releases the mutex when the callback throws", async () => {
+    const callbackError: Error = new Error("aggregation failed");
+
+    await expect(
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId: ObjectID.generate(),
+        fn: async (): Promise<never> => {
+          throw callbackError;
+        },
+      }),
+    ).rejects.toBe(callbackError);
+
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails closed without invoking or releasing when acquisition fails", async () => {
+    const acquireError: Error = new Error("Redis unavailable");
+    const callback = jest.fn(async (): Promise<void> => {});
+    lockMock.mockRejectedValue(acquireError);
+
+    await expect(
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId: ObjectID.generate(),
+        fn: callback,
+      }),
+    ).rejects.toBe(acquireError);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  test("does not mask a successful callback when release fails", async () => {
+    const licenseId: ObjectID = ObjectID.generate();
+    const releaseError: Error = new Error("release failed");
+    releaseMock.mockRejectedValue(releaseError);
+
+    await expect(
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId,
+        fn: async (): Promise<string> => "complete",
+      }),
+    ).resolves.toBe("complete");
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining(licenseId.toString()),
+    );
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining(releaseError.toString()),
+    );
+  });
+
+  test("does not mask a callback error when release also fails", async () => {
+    const callbackError: Error = new Error("callback failed");
+    releaseMock.mockRejectedValue(new Error("release failed"));
+
+    await expect(
+      EnterpriseLicenseService.runWithUsageAggregationLock({
+        licenseId: ObjectID.generate(),
+        fn: async (): Promise<never> => {
+          throw callbackError;
+        },
+      }),
+    ).rejects.toBe(callbackError);
+
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Utils/EnterpriseLicenseSeats.test.ts
+++ b/Common/Tests/Utils/EnterpriseLicenseSeats.test.ts
@@ -41,6 +41,7 @@ const makeInstance: MakeInstanceFunction = (
     instanceId: "instance-1",
     host: "oneuptime.acme.internal",
     userCount: 10,
+    isCountedTowardsUsage: true,
     lastReportedAt: "2026-01-01T00:00:00.000Z",
     version: "12.0.30",
     ...overrides,
@@ -347,6 +348,74 @@ describe("EnterpriseLicenseSeatsUtil - several instances on one licence", () => 
 
     expect(usage.seatsUsedByOtherInstances).toBe(0);
     expect(usage.seatsInUse).toBe(70);
+  });
+
+  it("does not subtract this installation's stale count from an active-only aggregate", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 80,
+      aggregatedUserCount: 100,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({
+          instanceId: "instance-1",
+          userCount: 80,
+          isCountedTowardsUsage: false,
+        }),
+        makeInstance({
+          instanceId: "instance-2",
+          userCount: 100,
+          isCountedTowardsUsage: true,
+        }),
+      ],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(0);
+    expect(usage.seatsInUse).toBe(100);
+    expect(usage.hasSeatForNewUser).toBe(false);
+  });
+
+  it("does not double-count overlapping users when this installation is inactive", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 100,
+      localUserCount: 80,
+      aggregatedUserCount: 80,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({
+          instanceId: "instance-1",
+          userCount: 80,
+          isCountedTowardsUsage: false,
+        }),
+        makeInstance({
+          instanceId: "instance-2",
+          userCount: 80,
+          isCountedTowardsUsage: true,
+        }),
+      ],
+    });
+
+    expect(usage.seatsInUse).toBe(80);
+    expect(usage.hasSeatForNewUser).toBe(true);
+  });
+
+  it("retains subtraction for older license servers without activity provenance", () => {
+    const usage: SeatUsage = seats({
+      userLimit: 150,
+      localUserCount: 80,
+      aggregatedUserCount: 100,
+      thisInstanceId: "instance-1",
+      instances: [
+        makeInstance({
+          instanceId: "instance-1",
+          userCount: 80,
+          isCountedTowardsUsage: undefined,
+        }),
+      ],
+    });
+
+    expect(usage.seatsUsedByOtherInstances).toBe(20);
+    expect(usage.seatsInUse).toBe(100);
   });
 });
 

--- a/Common/Tests/Utils/EnterpriseLicenseSync.test.ts
+++ b/Common/Tests/Utils/EnterpriseLicenseSync.test.ts
@@ -72,6 +72,7 @@ const serverResponse: ServerResponseFunction = (
         instanceId: "instance-1",
         host: "oneuptime.acme.internal",
         userCount: 42,
+        isCountedTowardsUsage: true,
         lastReportedAt: "2026-08-24T09:59:00.000Z",
         version: "12.0.19",
       },
@@ -434,7 +435,11 @@ describe("EnterpriseLicenseSyncUtil - token", () => {
 describe("EnterpriseLicenseSyncUtil - instances", () => {
   it("stores the instance list", () => {
     const instances: Array<JSONObject> = [
-      { instanceId: "a", host: "a.example.com" },
+      {
+        instanceId: "a",
+        host: "a.example.com",
+        isCountedTowardsUsage: false,
+      },
     ];
 
     expect(
@@ -526,6 +531,7 @@ describe("EnterpriseLicenseSyncUtil - the whole response at once", () => {
           instanceId: "instance-1",
           host: "oneuptime.acme.internal",
           userCount: 42,
+          isCountedTowardsUsage: true,
           lastReportedAt: "2026-08-24T09:59:00.000Z",
           version: "12.0.19",
         },

--- a/Common/Tests/Utils/EnterpriseLicenseUsage.test.ts
+++ b/Common/Tests/Utils/EnterpriseLicenseUsage.test.ts
@@ -1,5 +1,6 @@
 import EnterpriseLicenseUsageUtil from "../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
 import OneUptimeDate from "../../Types/Date";
+import EnterpriseLicenseUserCountSource from "../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
 import { describe, expect, it } from "@jest/globals";
 
 type HashFunction = (seed: string) => string;
@@ -50,10 +51,413 @@ describe("EnterpriseLicenseUsageUtil.sanitizeUserEmailHashes", () => {
   });
 });
 
+describe("EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage", () => {
+  const now: Date = new Date("2026-09-02T12:00:00.000Z");
+  const inactiveAt: Date = new Date(
+    now.getTime() -
+      EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays *
+        24 *
+        60 *
+        60 *
+        1000,
+  );
+
+  it("uses a seven-day inactivity window", () => {
+    expect(EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays).toBe(7);
+  });
+
+  it("keeps an instance active until the full week has elapsed", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        {
+          lastReportedAt: new Date(inactiveAt.getTime() + 1),
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("marks an instance inactive at exactly seven days without communication", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        {
+          lastReportedAt: inactiveAt,
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps an instance inactive after more than seven days", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        {
+          lastReportedAt: new Date(inactiveAt.getTime() - 1),
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a newly registered instance active before its first usage report", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        {
+          createdAt: new Date(inactiveAt.getTime() + 1),
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("marks an unreported registration inactive at its exact one-week boundary", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        {
+          createdAt: inactiveAt,
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an instance with no known communication timestamp as inactive", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage({}, now),
+    ).toBe(false);
+  });
+
+  it("accepts a current or future report as active", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        { lastReportedAt: now },
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        {
+          lastReportedAt: OneUptimeDate.addRemoveDays(now, 1),
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("fails closed for an invalid report timestamp", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+        { lastReportedAt: new Date("not-a-date") },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("uses a real usage report in preference to the registration time", () => {
+    const reportedAt: Date = OneUptimeDate.addRemoveDays(now, -1);
+
+    expect(
+      EnterpriseLicenseUsageUtil.getInstanceLastCommunicatedAt({
+        createdAt: OneUptimeDate.addRemoveDays(now, -3),
+        lastReportedAt: reportedAt,
+      }),
+    ).toBe(reportedAt);
+  });
+});
+
+describe("EnterpriseLicenseUsageUtil.hasActiveReportedInstanceUsage", () => {
+  const now: Date = new Date("2026-09-02T12:00:00.000Z");
+
+  it("does not treat registration alone as authoritative seat data", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.hasActiveReportedInstanceUsage(
+        [{ createdAt: now }],
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is authoritative while an instance usage report remains active", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.hasActiveReportedInstanceUsage(
+        [
+          { createdAt: now },
+          { lastReportedAt: new Date("2026-09-01T12:00:00.000Z") },
+        ],
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("stops suppressing legacy reports once every modern report is inactive", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.hasActiveReportedInstanceUsage(
+        [{ lastReportedAt: new Date("2026-08-26T12:00:00.000Z") }],
+        now,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("EnterpriseLicenseUsageUtil.getEffectiveUserCount", () => {
+  const now: Date = new Date("2026-09-02T12:00:00.000Z");
+  const oneMillisecondBeforeInactive: Date = new Date(
+    now.getTime() -
+      EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays *
+        24 *
+        60 *
+        60 *
+        1000 +
+      1,
+  );
+  const inactiveAt: Date = new Date(oneMillisecondBeforeInactive.getTime() - 1);
+
+  it("uses modern per-instance reports instead of the stored legacy count", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [
+          {
+            lastReportedAt: oneMillisecondBeforeInactive,
+            userCount: 3,
+          },
+        ],
+        storedUserCount: 99,
+        storedUserCountUpdatedAt: now,
+        now,
+      }),
+    ).toBe(3);
+  });
+
+  it("preserves a recently reported legacy count without instance rows", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: oneMillisecondBeforeInactive,
+        now,
+      }),
+    ).toBe(17);
+  });
+
+  it("uses a separately tracked legacy heartbeat after every modern instance becomes stale", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [
+          {
+            lastReportedAt: inactiveAt,
+            userCount: 99,
+          },
+        ],
+        storedUserCount: 99,
+        storedUserCountUpdatedAt: inactiveAt,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: oneMillisecondBeforeInactive,
+        now,
+      }),
+    ).toBe(17);
+  });
+
+  it("keeps active modern usage authoritative over a fresh legacy heartbeat", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [
+          {
+            lastReportedAt: oneMillisecondBeforeInactive,
+            userCount: 3,
+          },
+        ],
+        storedUserCount: 3,
+        storedUserCountUpdatedAt: oneMillisecondBeforeInactive,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: now,
+        now,
+      }),
+    ).toBe(3);
+  });
+
+  it("does not let a newer registration preserve an inactive modern aggregate", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [
+          {
+            lastReportedAt: inactiveAt,
+            userCount: 99,
+          },
+          {
+            createdAt: now,
+          },
+        ],
+        storedUserCount: 99,
+        storedUserCountUpdatedAt: inactiveAt,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("uses a retained legacy heartbeat as soon as modern usage expires", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [
+          {
+            lastReportedAt: inactiveAt,
+            userCount: 99,
+          },
+        ],
+        storedUserCount: 99,
+        storedUserCountUpdatedAt: inactiveAt,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: oneMillisecondBeforeInactive,
+        now,
+      }),
+    ).toBe(17);
+  });
+
+  it("gives a newly registered instance a week to submit its first usage report", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [{ createdAt: oneMillisecondBeforeInactive }],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: inactiveAt,
+        now,
+      }),
+    ).toBe(17);
+  });
+
+  it("drops an abandoned legacy count at the exact one-week boundary", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [{ createdAt: inactiveAt }],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: inactiveAt,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("drops a dedicated legacy heartbeat at the exact one-week boundary", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: inactiveAt,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("can suppress the pre-migration fallback when a caller knows the stored count was modern", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [{ createdAt: oneMillisecondBeforeInactive }],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: now,
+        allowStoredUserCountAsLegacyFallback: false,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("never treats an explicitly modern stored aggregate as legacy", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [{ createdAt: now }],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: now,
+        storedUserCountSource: EnterpriseLicenseUserCountSource.Instance,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("retains an explicitly legacy stored aggregate during migration", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: oneMillisecondBeforeInactive,
+        storedUserCountSource: EnterpriseLicenseUserCountSource.Legacy,
+        now,
+      }),
+    ).toBe(17);
+  });
+
+  it("reports the provenance of the effective count", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCountAndSource({
+        instances: [
+          {
+            lastReportedAt: oneMillisecondBeforeInactive,
+            userCount: 3,
+          },
+        ],
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: now,
+        now,
+      }),
+    ).toEqual({
+      userCount: 3,
+      source: EnterpriseLicenseUserCountSource.Instance,
+    });
+  });
+
+  it("does not resurrect an expired dedicated legacy count during a new registration grace period", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [{ createdAt: now }],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: oneMillisecondBeforeInactive,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: inactiveAt,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("does not extend dedicated legacy usage with a newer modern aggregate timestamp", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        storedUserCount: 17,
+        storedUserCountUpdatedAt: now,
+        storedUserCountSource: EnterpriseLicenseUserCountSource.Legacy,
+        legacyUserCount: 17,
+        legacyUserCountUpdatedAt: inactiveAt,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns zero for an undated stored count because no communication can be proven", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        storedUserCount: 17,
+        now,
+      }),
+    ).toBe(0);
+  });
+
+  it("keeps never-reported usage distinguishable from an inactive count", () => {
+    expect(
+      EnterpriseLicenseUsageUtil.getEffectiveUserCount({
+        instances: [],
+        now,
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("EnterpriseLicenseUsageUtil.getUniqueUserCount", () => {
   const now: Date = OneUptimeDate.getCurrentDate();
   const fresh: Date = OneUptimeDate.addRemoveDays(now, -1);
-  const stale: Date = OneUptimeDate.addRemoveDays(now, -60);
+  const stale: Date = new Date(
+    now.getTime() -
+      EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays *
+        24 *
+        60 *
+        60 *
+        1000,
+  );
 
   it("counts the same user on multiple instances once", () => {
     const sharedUser: string = fakeHash("shared");
@@ -119,7 +523,7 @@ describe("EnterpriseLicenseUsageUtil.getUniqueUserCount", () => {
     expect(count).toBe(250_000);
   });
 
-  it("ignores instances that stopped reporting", () => {
+  it("ignores an instance at the seven-day inactivity boundary", () => {
     const count: number = EnterpriseLicenseUsageUtil.getUniqueUserCount(
       [
         {
@@ -142,6 +546,33 @@ describe("EnterpriseLicenseUsageUtil.getUniqueUserCount", () => {
     );
 
     expect(count).toBe(4);
+  });
+
+  it("deduplicates active users without letting an inactive overlap add seats", () => {
+    const shared: string = fakeHash("shared");
+    const activeOnly: string = fakeHash("active");
+
+    const count: number = EnterpriseLicenseUsageUtil.getUniqueUserCount(
+      [
+        {
+          userCount: 2,
+          userEmailHashes: [shared, activeOnly],
+          lastReportedAt: fresh,
+        },
+        {
+          /*
+           * Neither the shared hash, the inactive-only hash, nor the large
+           * unhashed overflow may leak into the active seat total.
+           */
+          userCount: 100,
+          userEmailHashes: [shared, fakeHash("inactive")],
+          lastReportedAt: stale,
+        },
+      ],
+      now,
+    );
+
+    expect(count).toBe(2);
   });
 
   it("ignores instances that never reported", () => {

--- a/Common/Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary.ts
+++ b/Common/Types/EnterpriseLicense/EnterpriseLicenseInstanceSummary.ts
@@ -11,6 +11,11 @@ type EnterpriseLicenseInstanceSummary = {
   instanceId: string;
   host: string | null;
   userCount: number | null;
+  /*
+   * Whether this row contributed to currentUserCount at the server's cutoff.
+   * Optional so installations remain compatible with older license servers.
+   */
+  isCountedTowardsUsage?: boolean | undefined;
   // ISO date string of the most recent usage report from this instance.
   lastReportedAt: string | null;
   /*

--- a/Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot.ts
+++ b/Common/Types/EnterpriseLicense/EnterpriseLicenseUsageSnapshot.ts
@@ -1,0 +1,13 @@
+/*
+ * A point-in-time, privacy-preserving view of enterprise license usage for
+ * the Admin Dashboard. Email hashes stay on the server; instance ids are
+ * enough to render statuses from the exact same cutoff as the aggregate.
+ */
+export default interface EnterpriseLicenseUsageSnapshot {
+  currentUserCount: number | null;
+  activeInstanceIds: Array<string>;
+  masterAdminEmails: Array<string>;
+  calculatedAt: string;
+  lastUsageReportedAt: string | null;
+  nextInstanceStatusChangeAt: string | null;
+}

--- a/Common/Types/EnterpriseLicense/EnterpriseLicenseUserCountSource.ts
+++ b/Common/Types/EnterpriseLicense/EnterpriseLicenseUserCountSource.ts
@@ -1,0 +1,6 @@
+enum EnterpriseLicenseUserCountSource {
+  Instance = "instance",
+  Legacy = "legacy",
+}
+
+export default EnterpriseLicenseUserCountSource;

--- a/Common/UI/Components/EditionLabel/EditionLabel.tsx
+++ b/Common/UI/Components/EditionLabel/EditionLabel.tsx
@@ -92,6 +92,10 @@ const parseLicenseInstances: ParseLicenseInstancesFunction = (
         typeof instance["userCount"] === "number"
           ? instance["userCount"]
           : null,
+      isCountedTowardsUsage:
+        typeof instance["isCountedTowardsUsage"] === "boolean"
+          ? instance["isCountedTowardsUsage"]
+          : undefined,
       lastReportedAt:
         typeof instance["lastReportedAt"] === "string"
           ? instance["lastReportedAt"]

--- a/Common/Utils/EnterpriseLicense/EnterpriseLicenseSeats.ts
+++ b/Common/Utils/EnterpriseLicense/EnterpriseLicenseSeats.ts
@@ -222,6 +222,22 @@ export default class EnterpriseLicenseSeatsUtil {
       return null;
     }
 
+    /*
+     * The active-only aggregate contains none of this installation's stale
+     * reported users. Subtracting that old count would remove users belonging
+     * to active instances and under-enforce the license. Treat the complete
+     * aggregate as other-instance usage. We also cannot add the two counts:
+     * the same users may exist on both this installation and active ones.
+     * Return null to use the existing uncertainty fallback, which takes the
+     * larger complete-or-live total without subtracting or double-counting.
+     *
+     * Undefined retains the legacy behavior for responses from older license
+     * servers that did not send activity provenance.
+     */
+    if (thisInstance.isCountedTowardsUsage === false) {
+      return null;
+    }
+
     const ownReportedCount: number | null = this.parseCount(
       thisInstance.userCount,
     );

--- a/Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage.ts
+++ b/Common/Utils/EnterpriseLicense/EnterpriseLicenseUsage.ts
@@ -1,4 +1,4 @@
-import OneUptimeDate from "../../Types/Date";
+import EnterpriseLicenseUserCountSource from "../../Types/EnterpriseLicense/EnterpriseLicenseUserCountSource";
 
 /*
  * Usage reported by one self-hosted instance of an enterprise license.
@@ -7,9 +7,35 @@ import OneUptimeDate from "../../Types/Date";
  * on staging, production and gov-cloud consumes a single seat.
  */
 export interface EnterpriseLicenseInstanceUsage {
+  /*
+   * Registration is the initial communication until the instance sends its
+   * first usage report.
+   */
+  createdAt?: Date | undefined;
   userCount?: number | undefined;
   userEmailHashes?: Array<string> | undefined;
   lastReportedAt?: Date | undefined;
+}
+
+export interface EffectiveEnterpriseLicenseUserCountOptions {
+  instances: Array<EnterpriseLicenseInstanceUsage>;
+  storedUserCount?: number | null | undefined;
+  storedUserCountUpdatedAt?: Date | undefined;
+  storedUserCountSource?: EnterpriseLicenseUserCountSource | undefined;
+  legacyUserCount?: number | null | undefined;
+  legacyUserCountUpdatedAt?: Date | undefined;
+  /*
+   * Callers that just replaced/deleted modern rows know the stored aggregate
+   * came from those rows. They can suppress the one-time compatibility path
+   * for license records created before dedicated legacy fields existed.
+   */
+  allowStoredUserCountAsLegacyFallback?: boolean | undefined;
+  now: Date;
+}
+
+export interface EffectiveEnterpriseLicenseUserCount {
+  userCount: number | null;
+  source: EnterpriseLicenseUserCountSource | null;
 }
 
 export default class EnterpriseLicenseUsageUtil {
@@ -41,11 +67,11 @@ export default class EnterpriseLicenseUsageUtil {
     )}`;
   }
   /*
-   * Instances that stopped reporting (for example a decommissioned staging
-   * environment) stop counting towards the seat total after this many days,
-   * but are still listed so the customer can see them.
+   * An instance is inactive once it has gone this many complete days without
+   * communicating with oneuptime.com. Inactive instances stay visible, but
+   * their users no longer consume seats.
    */
-  public static readonly InstanceUsageFreshnessInDays: number = 30;
+  public static readonly InstanceUsageFreshnessInDays: number = 7;
 
   // SHA-256 hex digest.
   private static readonly emailHashRegex: RegExp = /^[a-f0-9]{64}$/;
@@ -136,17 +162,171 @@ export default class EnterpriseLicenseUsageUtil {
     instance: EnterpriseLicenseInstanceUsage,
     now: Date,
   ): boolean {
-    if (!instance.lastReportedAt) {
-      // Registered (license key validated) but never reported usage yet.
+    const lastCommunicatedAt: Date | undefined =
+      this.getInstanceLastCommunicatedAt(instance);
+
+    if (!lastCommunicatedAt) {
       return false;
     }
 
-    const staleBefore: Date = OneUptimeDate.addRemoveDays(
-      now,
-      -this.InstanceUsageFreshnessInDays,
-    );
+    const inactiveAfterInMilliseconds: number =
+      this.InstanceUsageFreshnessInDays * 24 * 60 * 60 * 1000;
+    const staleBefore: number = now.getTime() - inactiveAfterInMilliseconds;
 
-    return instance.lastReportedAt.getTime() >= staleBefore.getTime();
+    /*
+     * Strictly greater than: at the exact seven-day boundary the instance has
+     * gone a full week without communicating and must already be inactive.
+     * Elapsed milliseconds are intentional; a daylight-saving transition
+     * must not shorten or extend the week.
+     */
+    return lastCommunicatedAt.getTime() > staleBefore;
+  }
+
+  public static getInstanceLastCommunicatedAt(
+    instance: EnterpriseLicenseInstanceUsage,
+  ): Date | undefined {
+    return instance.lastReportedAt || instance.createdAt;
+  }
+
+  /* A registration is active, but only a real report is modern seat data. */
+  public static hasActiveReportedInstanceUsage(
+    instances: Array<EnterpriseLicenseInstanceUsage>,
+    now: Date,
+  ): boolean {
+    return instances.some(
+      (instance: EnterpriseLicenseInstanceUsage): boolean => {
+        return (
+          Boolean(instance.lastReportedAt) &&
+          this.isInstanceCountedTowardsUsage(instance, now)
+        );
+      },
+    );
+  }
+
+  public static isTimestampWithinUsageWindow(
+    timestamp: Date | undefined,
+    now: Date,
+  ): boolean {
+    return timestamp
+      ? this.isInstanceCountedTowardsUsage({ lastReportedAt: timestamp }, now)
+      : false;
+  }
+
+  public static hasReportedInstanceUsage(
+    instances: Array<EnterpriseLicenseInstanceUsage>,
+  ): boolean {
+    return instances.some(
+      (instance: EnterpriseLicenseInstanceUsage): boolean => {
+        return Boolean(instance.lastReportedAt);
+      },
+    );
+  }
+
+  /*
+   * Choose between modern per-instance reports and a separately persisted
+   * legacy license-wide heartbeat. The stored count fallback exists only for
+   * records written before those dedicated legacy columns were introduced;
+   * seeing any historical modern report proves that aggregate is not legacy.
+   * Once every authoritative communication timestamp is a week old, usage is
+   * zero.
+   */
+  public static getEffectiveUserCount(
+    options: EffectiveEnterpriseLicenseUserCountOptions,
+  ): number | null {
+    return this.getEffectiveUserCountAndSource(options).userCount;
+  }
+
+  public static getEffectiveUserCountAndSource(
+    options: EffectiveEnterpriseLicenseUserCountOptions,
+  ): EffectiveEnterpriseLicenseUserCount {
+    if (this.hasActiveReportedInstanceUsage(options.instances, options.now)) {
+      return {
+        userCount: this.getUniqueUserCount(options.instances, options.now),
+        source: EnterpriseLicenseUserCountSource.Instance,
+      };
+    }
+
+    if (
+      this.isTimestampWithinUsageWindow(
+        options.legacyUserCountUpdatedAt,
+        options.now,
+      )
+    ) {
+      return {
+        userCount: options.legacyUserCount ?? null,
+        source: EnterpriseLicenseUserCountSource.Legacy,
+      };
+    }
+
+    const hasRecentRegistration: boolean = options.instances.some(
+      (instance: EnterpriseLicenseInstanceUsage): boolean => {
+        return (
+          !instance.lastReportedAt &&
+          this.isInstanceCountedTowardsUsage(instance, options.now)
+        );
+      },
+    );
+    const hasRecentLegacyReport: boolean = options.storedUserCountUpdatedAt
+      ? this.isTimestampWithinUsageWindow(
+          options.storedUserCountUpdatedAt,
+          options.now,
+        )
+      : false;
+    const isExplicitLegacyFallback: boolean =
+      options.storedUserCountSource ===
+        EnterpriseLicenseUserCountSource.Legacy &&
+      !options.legacyUserCountUpdatedAt &&
+      hasRecentLegacyReport;
+    const canUseCompatibilityFallback: boolean =
+      options.allowStoredUserCountAsLegacyFallback !== false &&
+      options.storedUserCountSource !==
+        EnterpriseLicenseUserCountSource.Instance &&
+      !options.legacyUserCountUpdatedAt &&
+      !this.hasReportedInstanceUsage(options.instances);
+
+    if (
+      isExplicitLegacyFallback ||
+      (canUseCompatibilityFallback &&
+        (hasRecentRegistration || hasRecentLegacyReport))
+    ) {
+      return {
+        userCount: options.storedUserCount ?? null,
+        source: EnterpriseLicenseUserCountSource.Legacy,
+      };
+    }
+
+    if (
+      options.instances.length === 0 &&
+      (options.storedUserCount === undefined ||
+        options.storedUserCount === null) &&
+      !options.storedUserCountUpdatedAt &&
+      (options.legacyUserCount === undefined ||
+        options.legacyUserCount === null) &&
+      !options.legacyUserCountUpdatedAt &&
+      !options.storedUserCountSource
+    ) {
+      return {
+        userCount: null,
+        source: null,
+      };
+    }
+
+    let inactiveUsageSource: EnterpriseLicenseUserCountSource | null =
+      options.storedUserCountSource || null;
+
+    if (
+      !inactiveUsageSource &&
+      this.hasReportedInstanceUsage(options.instances)
+    ) {
+      inactiveUsageSource = EnterpriseLicenseUserCountSource.Instance;
+    } else if (!inactiveUsageSource && options.legacyUserCountUpdatedAt) {
+      inactiveUsageSource = EnterpriseLicenseUserCountSource.Legacy;
+    }
+
+    return {
+      userCount: 0,
+      source: inactiveUsageSource,
+    };
   }
 
   /*


### PR DESCRIPTION
### Title of this pull request?

Automatically deactivate silent enterprise-license instances after one week

### Small Description?

Enterprise-license instances are now considered inactive once seven full days have elapsed since their last usage report. A newly registered instance uses its creation time as the initial communication timestamp until its first report. Inactive instances are excluded from the distinct-user aggregate shown and enforced across the admin dashboard, license responses, notification emails, and self-hosted seat checks.

This also adds:

- an hourly reconciliation worker so stored aggregate usage converges when an instance crosses the inactivity boundary without another request;
- per-license distributed locking around report, validation, deletion, snapshot, and reconciliation paths;
- an atomic admin-dashboard usage snapshot with Active/Inactive status and boundary-aware refresh;
- explicit legacy-count provenance for backward-compatible upgrades;
- a generated and registered PostgreSQL migration for the provenance fields;
- extensive boundary, concurrency, legacy-compatibility, API, dashboard, worker, notification, deletion, and seat-enforcement regression coverage.

Local verification:

- 273 targeted tests passed across 9 suites;
- `npm run fix` passed;
- Common, App, and Admin Dashboard TypeScript compiles passed;
- PostgreSQL schema-drift check passed with all 570 registered migrations.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). (N/A — no issue supplied.)
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None supplied.

### Screenshots (if appropriate):

Not applicable; dashboard state and refresh behavior are covered by regression tests.
