### PR TITLE
feat(monitor): add Database Health monitor for PostgreSQL, MySQL and SQL Server

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx
@@ -15,10 +15,20 @@ import {
   FilterType,
   NoDataPolicy,
 } from "Common/Types/Monitor/CriteriaFilter";
+import {
+  DatabaseMetricCategory,
+  DatabaseMetricDefinition,
+  getAllDatabaseMetrics,
+  getDatabaseMetricByMetricType,
+  getDatabaseMetricCategoryOrder,
+  getDatabaseMetricsForEngine,
+} from "Common/Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "Common/Types/Monitor/MonitorMetricType";
 import MonitorStep from "Common/Types/Monitor/MonitorStep";
 import MonitorStepMetricViewConfigUtil from "Common/Types/Monitor/MonitorStepMetricViewConfigUtil";
 import MonitorType from "Common/Types/Monitor/MonitorType";
 import SnmpOidListUtil from "Common/Types/Monitor/SnmpMonitor/SnmpOidListUtil";
+import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
 import Button, {
   ButtonSize,
   ButtonStyleType,
@@ -566,6 +576,127 @@ const CriteriaFilterElement: FunctionComponent<ComponentProps> = (
                     });
                   }}
                 />
+              </div>
+            );
+          })()}
+
+        {criteriaFilter?.checkOn === CheckOn.DatabaseMetric &&
+          (() => {
+            const databaseType: SqlDatabaseType | undefined =
+              props.monitorStep?.data?.databaseMonitor?.databaseType;
+
+            /*
+             * Offer only what the connected engine can actually produce.
+             * Stock MySQL has no deadlock counter and SQL Server has no
+             * fixed connection ceiling, so a threshold on either would sit
+             * permanently unmet - a rule that looks like coverage and is
+             * not. Before an engine has been chosen the whole catalog is
+             * the honest answer; the note below says so.
+             */
+            const metrics: Array<DatabaseMetricDefinition> = databaseType
+              ? getDatabaseMetricsForEngine(databaseType)
+              : getAllDatabaseMetrics();
+
+            const categoryOrder: Array<DatabaseMetricCategory> =
+              getDatabaseMetricCategoryOrder();
+
+            const metricOptions: Array<DropdownOption> = [...metrics]
+              .sort(
+                (
+                  a: DatabaseMetricDefinition,
+                  b: DatabaseMetricDefinition,
+                ): number => {
+                  const categoryDifference: number =
+                    categoryOrder.indexOf(a.category) -
+                    categoryOrder.indexOf(b.category);
+
+                  if (categoryDifference !== 0) {
+                    return categoryDifference;
+                  }
+
+                  return a.friendlyName.localeCompare(b.friendlyName);
+                },
+              )
+              .map((metric: DatabaseMetricDefinition): DropdownOption => {
+                return {
+                  value: metric.metricType,
+                  label: metric.unit
+                    ? `${metric.friendlyName} (${metric.unit})`
+                    : metric.friendlyName,
+                };
+              });
+
+            const savedMetricType: MonitorMetricType | undefined =
+              criteriaFilter?.databaseMonitorOptions?.metricType;
+
+            let selectedMetricOption: DropdownOption | undefined =
+              metricOptions.find((option: DropdownOption) => {
+                return option.value === savedMetricType;
+              });
+
+            /*
+             * Same rule as the OID picker above: never draw an empty
+             * control over a value that is saved. Switching the engine on
+             * the step below leaves criteria naming series the new engine
+             * never writes, and a blank dropdown would claim nothing was
+             * chosen while the monitor still evaluated that series.
+             */
+            if (savedMetricType && !selectedMetricOption) {
+              const staleMetric: DatabaseMetricDefinition | null =
+                getDatabaseMetricByMetricType(savedMetricType);
+
+              selectedMetricOption = {
+                value: savedMetricType,
+                label: staleMetric
+                  ? `${staleMetric.friendlyName} - not collected by ${databaseType}`
+                  : savedMetricType.toString(),
+              };
+
+              metricOptions.push(selectedMetricOption);
+            }
+
+            const selectedMetric: DatabaseMetricDefinition | null =
+              savedMetricType
+                ? getDatabaseMetricByMetricType(savedMetricType)
+                : null;
+
+            return (
+              <div className="mt-1">
+                <FieldLabelElement
+                  title="Metric"
+                  description="Which of the health metrics the probe collects should this criteria compare against?"
+                />
+                <Dropdown
+                  value={selectedMetricOption}
+                  options={metricOptions}
+                  onChange={(
+                    value: DropdownValue | Array<DropdownValue> | null,
+                  ) => {
+                    props.onChange?.({
+                      ...criteriaFilter,
+                      databaseMonitorOptions: {
+                        ...criteriaFilter?.databaseMonitorOptions,
+                        metricType: value?.toString() as MonitorMetricType,
+                      },
+                    });
+                  }}
+                />
+                {selectedMetric ? (
+                  <p className="text-xs text-gray-500 mt-2">
+                    {selectedMetric.description}
+                  </p>
+                ) : (
+                  <></>
+                )}
+                {!databaseType ? (
+                  <p className="text-xs text-gray-500 mt-2">
+                    Choose a database engine on the Monitor Details step first -
+                    every metric in the catalogue is listed until then,
+                    including ones your engine cannot report.
+                  </p>
+                ) : (
+                  <></>
+                )}
               </div>
             );
           })()}

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/DatabaseMonitor/DatabaseMonitorStepForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/DatabaseMonitor/DatabaseMonitorStepForm.tsx
@@ -1,0 +1,526 @@
+import React, { FunctionComponent, ReactElement, useState } from "react";
+import MonitorStepDatabaseMonitor, {
+  DEFAULT_DATABASE_METRIC_GROUPS,
+} from "Common/Types/Monitor/MonitorStepDatabaseMonitor";
+import {
+  DatabaseMetricDefinition,
+  DatabaseMetricGroup,
+  getDatabaseMetricsByGroup,
+} from "Common/Types/Monitor/DatabaseMetricCatalog";
+import SqlDatabaseType, {
+  SqlDatabaseTypeUtil,
+} from "Common/Types/Monitor/SqlDatabaseType";
+import Input, { InputType } from "Common/UI/Components/Input/Input";
+import Toggle from "Common/UI/Components/Toggle/Toggle";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
+import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Link from "Common/UI/Components/Link/Link";
+import URL from "Common/Types/API/URL";
+import { DOCS_URL } from "Common/UI/Config";
+
+export interface ComponentProps {
+  monitorStepDatabaseMonitor: MonitorStepDatabaseMonitor;
+  onChange: (value: MonitorStepDatabaseMonitor) => void;
+}
+
+const groupTitles: Record<DatabaseMetricGroup, string> = {
+  [DatabaseMetricGroup.Connections]: "Connections",
+  [DatabaseMetricGroup.Activity]: "Activity",
+  [DatabaseMetricGroup.Throughput]: "Throughput",
+  [DatabaseMetricGroup.Locks]: "Locks and Blocking",
+  [DatabaseMetricGroup.Storage]: "Storage",
+  [DatabaseMetricGroup.Replication]: "Replication",
+  [DatabaseMetricGroup.Maintenance]: "Maintenance",
+};
+
+const groupDescriptions: Record<DatabaseMetricGroup, string> = {
+  [DatabaseMetricGroup.Connections]:
+    "Session counts, the configured connection ceiling and server uptime.",
+  [DatabaseMetricGroup.Activity]:
+    "Open transactions, and the age of the longest running query and transaction.",
+  [DatabaseMetricGroup.Throughput]:
+    "Commits, rollbacks, rows read and written, and the cache hit ratio.",
+  [DatabaseMetricGroup.Locks]: "Held locks, blocked sessions and deadlocks.",
+  [DatabaseMetricGroup.Storage]:
+    "Database size on disk and work that spilled to temporary files.",
+  [DatabaseMetricGroup.Replication]:
+    "Replication lag and the number of connected replicas.",
+  [DatabaseMetricGroup.Maintenance]:
+    "Dead rows awaiting vacuum and transaction ID wraparound headroom.",
+};
+
+/*
+ * The exact statement to run on the server so this group can be collected.
+ * The operator sees it while configuring rather than after a week of blank
+ * charts: on PostgreSQL a monitoring login without pg_monitor still reads
+ * pg_stat_activity successfully, it simply sees nothing but its own session,
+ * so nothing about the connection itself reveals the missing grant.
+ */
+type GetPrivilegeHintFunction = (
+  databaseType: SqlDatabaseType,
+  group: DatabaseMetricGroup,
+) => string;
+
+const getPrivilegeHint: GetPrivilegeHintFunction = (
+  databaseType: SqlDatabaseType,
+  group: DatabaseMetricGroup,
+): string => {
+  if (databaseType === SqlDatabaseType.PostgreSQL) {
+    if (
+      group === DatabaseMetricGroup.Throughput ||
+      group === DatabaseMetricGroup.Storage
+    ) {
+      return "Readable by any login that can connect.";
+    }
+
+    return "Needs the pg_monitor role.";
+  }
+
+  if (databaseType === SqlDatabaseType.MySQL) {
+    if (group === DatabaseMetricGroup.Activity) {
+      return "Needs the PROCESS privilege.";
+    }
+
+    if (
+      group === DatabaseMetricGroup.Connections ||
+      group === DatabaseMetricGroup.Locks
+    ) {
+      return "Needs SELECT on performance_schema, and performance_schema switched on.";
+    }
+
+    return "Readable by any login that can connect.";
+  }
+
+  if (group === DatabaseMetricGroup.Storage) {
+    return "Readable by any login that can connect.";
+  }
+
+  return "Needs VIEW SERVER STATE.";
+};
+
+type GetGrantBlockFunction = (databaseType: SqlDatabaseType) => string;
+
+const getGrantBlock: GetGrantBlockFunction = (
+  databaseType: SqlDatabaseType,
+): string => {
+  if (databaseType === SqlDatabaseType.MySQL) {
+    return [
+      "GRANT PROCESS ON *.* TO '<monitoring_user>'@'%';",
+      "GRANT SELECT ON performance_schema.* TO '<monitoring_user>'@'%';",
+    ].join("\n");
+  }
+
+  if (databaseType === SqlDatabaseType.MicrosoftSqlServer) {
+    return "GRANT VIEW SERVER STATE TO [<monitoring_login>];";
+  }
+
+  return [
+    "GRANT CONNECT ON DATABASE <database_name> TO <monitoring_user>;",
+    "GRANT pg_monitor TO <monitoring_user>;",
+  ].join("\n");
+};
+
+/*
+ * A group with no catalog metric for the selected engine produces nothing at
+ * all there — stock MySQL has no deadlock counter, and neither MySQL nor SQL
+ * Server exposes an autovacuum backlog. Saying so next to the toggle stops an
+ * operator hunting for a grant that would not help.
+ */
+type IsGroupCollectableFunction = (
+  databaseType: SqlDatabaseType,
+  group: DatabaseMetricGroup,
+) => boolean;
+
+const isGroupCollectable: IsGroupCollectableFunction = (
+  databaseType: SqlDatabaseType,
+  group: DatabaseMetricGroup,
+): boolean => {
+  return getDatabaseMetricsByGroup(group).some(
+    (metric: DatabaseMetricDefinition) => {
+      return metric.engines.includes(databaseType);
+    },
+  );
+};
+
+const DatabaseMonitorStepForm: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [showAdvancedOptions, setShowAdvancedOptions] =
+    useState<boolean>(false);
+
+  const databaseTypeOptions: Array<DropdownOption> =
+    SqlDatabaseTypeUtil.getSupportedDatabaseTypes().map(
+      (type: SqlDatabaseType) => {
+        return { label: type, value: type };
+      },
+    );
+
+  const databaseType: SqlDatabaseType =
+    props.monitorStepDatabaseMonitor.databaseType;
+
+  const useWindowsIntegratedAuthentication: boolean =
+    databaseType === SqlDatabaseType.MicrosoftSqlServer &&
+    Boolean(
+      props.monitorStepDatabaseMonitor.useWindowsIntegratedAuthentication,
+    );
+
+  const enabledMetricGroups: Array<DatabaseMetricGroup> =
+    props.monitorStepDatabaseMonitor.enabledMetricGroups || [];
+
+  type ToggleMetricGroupFunction = (
+    group: DatabaseMetricGroup,
+    isEnabled: boolean,
+  ) => void;
+
+  const toggleMetricGroup: ToggleMetricGroupFunction = (
+    group: DatabaseMetricGroup,
+    isEnabled: boolean,
+  ): void => {
+    const selected: Set<DatabaseMetricGroup> = new Set<DatabaseMetricGroup>(
+      enabledMetricGroups,
+    );
+
+    if (isEnabled) {
+      selected.add(group);
+    } else {
+      selected.delete(group);
+    }
+
+    props.onChange({
+      ...props.monitorStepDatabaseMonitor,
+      // Store in the canonical order so the saved config is comparable.
+      enabledMetricGroups: DEFAULT_DATABASE_METRIC_GROUPS.filter(
+        (candidate: DatabaseMetricGroup) => {
+          return selected.has(candidate);
+        },
+      ),
+    });
+  };
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <FieldLabelElement
+          title="Database Type"
+          description="The database engine to connect to. PostgreSQL, MySQL, and Microsoft SQL Server are supported."
+          required={true}
+        />
+        <Dropdown
+          options={databaseTypeOptions}
+          initialValue={databaseTypeOptions.find((option: DropdownOption) => {
+            return option.value === databaseType;
+          })}
+          onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+            const newDatabaseType: SqlDatabaseType = value as SqlDatabaseType;
+            props.onChange({
+              ...props.monitorStepDatabaseMonitor,
+              databaseType: newDatabaseType,
+              port: SqlDatabaseTypeUtil.getDefaultPort(newDatabaseType),
+              useWindowsIntegratedAuthentication:
+                newDatabaseType === SqlDatabaseType.MicrosoftSqlServer
+                  ? props.monitorStepDatabaseMonitor
+                      .useWindowsIntegratedAuthentication
+                  : false,
+            });
+          }}
+        />
+      </div>
+
+      {databaseType === SqlDatabaseType.MicrosoftSqlServer && (
+        <div>
+          <Toggle
+            title="Use Windows Integrated Authentication"
+            description="Authenticate as the account running the probe (SSPI on Windows or Kerberos on Linux/macOS). Username and password are ignored."
+            initialValue={useWindowsIntegratedAuthentication}
+            onChange={(value: boolean) => {
+              props.onChange({
+                ...props.monitorStepDatabaseMonitor,
+                useWindowsIntegratedAuthentication: value,
+              });
+            }}
+          />
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <FieldLabelElement
+            title="Host"
+            description="Database host reachable from the probe (e.g. db.internal)"
+            required={true}
+          />
+          <Input
+            initialValue={props.monitorStepDatabaseMonitor.host}
+            placeholder="db.internal"
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepDatabaseMonitor,
+                host: value,
+              });
+            }}
+          />
+        </div>
+
+        <div>
+          <FieldLabelElement
+            title="Port"
+            description="Database port"
+            required={true}
+          />
+          <Input
+            initialValue={
+              props.monitorStepDatabaseMonitor.port?.toString() || "5432"
+            }
+            placeholder="5432"
+            type={InputType.NUMBER}
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepDatabaseMonitor,
+                port:
+                  parseInt(value) ||
+                  SqlDatabaseTypeUtil.getDefaultPort(databaseType),
+              });
+            }}
+          />
+        </div>
+      </div>
+
+      <div
+        className={`grid gap-4 ${
+          useWindowsIntegratedAuthentication ? "grid-cols-1" : "grid-cols-2"
+        }`}
+      >
+        <div>
+          <FieldLabelElement
+            title="Database Name"
+            description="The database to connect to. Server-wide metrics cover the whole instance; size and throughput are reported for this database."
+            required={true}
+          />
+          <Input
+            initialValue={props.monitorStepDatabaseMonitor.databaseName}
+            placeholder="orders"
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepDatabaseMonitor,
+                databaseName: value,
+              });
+            }}
+          />
+        </div>
+
+        {!useWindowsIntegratedAuthentication && (
+          <div>
+            <FieldLabelElement
+              title="Username"
+              description="Use a dedicated monitoring login. It needs to read statistics and nothing else."
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepDatabaseMonitor.username}
+              placeholder="oneuptime_monitor"
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepDatabaseMonitor,
+                  username: value,
+                });
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {!useWindowsIntegratedAuthentication && (
+        <div>
+          <FieldLabelElement
+            title="Password"
+            description={
+              <p>
+                Database password. We recommend referencing a monitor secret
+                with{" "}
+                <code className="bg-gray-100 px-1 rounded">
+                  {"{{monitorSecrets.name}}"}
+                </code>{" "}
+                instead of typing the password here, so it stays encrypted at
+                rest.{" "}
+                <Link
+                  className="underline"
+                  openInNewTab={true}
+                  to={URL.fromString(
+                    DOCS_URL.toString() + "/monitor/monitor-secrets",
+                  )}
+                >
+                  Learn more about secrets.
+                </Link>
+              </p>
+            }
+            required={false}
+          />
+          <Input
+            initialValue={props.monitorStepDatabaseMonitor.password}
+            placeholder="{{monitorSecrets.dbPassword}}"
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepDatabaseMonitor,
+                password: value,
+              });
+            }}
+          />
+        </div>
+      )}
+
+      <div>
+        <Toggle
+          title="Use SSL/TLS"
+          initialValue={props.monitorStepDatabaseMonitor.useSsl}
+          onChange={(value: boolean) => {
+            props.onChange({
+              ...props.monitorStepDatabaseMonitor,
+              useSsl: value,
+            });
+          }}
+        />
+      </div>
+
+      {props.monitorStepDatabaseMonitor.useSsl && (
+        <div>
+          <Toggle
+            title="Verify server certificate"
+            description="Turn off only if the database uses a self-signed certificate."
+            initialValue={
+              props.monitorStepDatabaseMonitor.rejectUnauthorizedSsl
+            }
+            onChange={(value: boolean) => {
+              props.onChange({
+                ...props.monitorStepDatabaseMonitor,
+                rejectUnauthorizedSsl: value,
+              });
+            }}
+          />
+        </div>
+      )}
+
+      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+        <h4 className="text-sm font-medium text-blue-900 mb-2">
+          Privileges this monitor needs on {databaseType}
+        </h4>
+        <p className="text-xs text-blue-700 mb-3">
+          OneUptime only reads. Anything it cannot read is reported as a missing
+          metric, never as an outage.
+        </p>
+        <pre className="text-xs text-blue-900 bg-white border border-blue-200 rounded p-3 overflow-x-auto whitespace-pre">
+          {getGrantBlock(databaseType)}
+        </pre>
+        {databaseType === SqlDatabaseType.PostgreSQL && (
+          <p className="text-xs text-blue-700 mt-3">
+            Without pg_monitor, PostgreSQL still answers every statistics query
+            — it just shows the monitoring session and nothing else, so
+            connection and lock counts would read as one and zero forever. The
+            probe checks for the role up front and reports those groups as
+            missing instead of recording numbers it knows are wrong.
+          </p>
+        )}
+        {databaseType === SqlDatabaseType.MySQL && (
+          <p className="text-xs text-blue-700 mt-3">
+            performance_schema must also be switched on (performance_schema = ON
+            in my.cnf). Stock MySQL exposes no deadlock counter, so that metric
+            is never collected here.
+          </p>
+        )}
+      </div>
+
+      <div>
+        <FieldLabelElement
+          title="Metric Groups"
+          description="Each group is one set of statistics queries and one unit of failure: if its grant is missing, that group's metrics are left blank and the monitor stays online. Turn a group off to stop querying for it — summing table sizes is the one that costs real work on a large schema. Turning every group off is the same as leaving them all on."
+          required={false}
+        />
+        <div className="space-y-4 border rounded-md p-4">
+          {DEFAULT_DATABASE_METRIC_GROUPS.map((group: DatabaseMetricGroup) => {
+            const isCollectable: boolean = isGroupCollectable(
+              databaseType,
+              group,
+            );
+
+            const description: string = isCollectable
+              ? `${groupDescriptions[group]} ${getPrivilegeHint(databaseType, group)}`
+              : `${groupDescriptions[group]} ${databaseType} does not report these, so this group collects nothing here.`;
+
+            return (
+              <Toggle
+                key={group}
+                title={groupTitles[group]}
+                description={description}
+                value={enabledMetricGroups.includes(group)}
+                onChange={(value: boolean) => {
+                  toggleMetricGroup(group, value);
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {!showAdvancedOptions && (
+        <div className="mt-1 -ml-3">
+          <Button
+            title="Advanced: Timeouts"
+            buttonStyle={ButtonStyleType.SECONDARY_LINK}
+            onClick={() => {
+              setShowAdvancedOptions(true);
+            }}
+          />
+        </div>
+      )}
+
+      {showAdvancedOptions && (
+        <div className="space-y-4 border p-4 rounded-md bg-gray-50">
+          <h4 className="font-medium">Advanced Options</h4>
+
+          <div>
+            <FieldLabelElement
+              title="Connection Timeout (ms)"
+              description="How long to wait to establish a connection (max 30000)"
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepDatabaseMonitor.connectionTimeoutInMs?.toString()}
+              placeholder="10000"
+              type={InputType.NUMBER}
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepDatabaseMonitor,
+                  connectionTimeoutInMs: parseInt(value) || 10000,
+                });
+              }}
+            />
+          </div>
+
+          <div>
+            <FieldLabelElement
+              title="Statement Timeout (ms)"
+              description="Hard cap on how long one statistics query may run before that group is abandoned (max 60000)"
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepDatabaseMonitor.statementTimeoutInMs?.toString()}
+              placeholder="10000"
+              type={InputType.NUMBER}
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepDatabaseMonitor,
+                  statementTimeoutInMs: parseInt(value) || 10000,
+                });
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DatabaseMonitorStepForm;

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorStep.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorStep.tsx
@@ -131,6 +131,10 @@ import SqlMonitorStepForm from "./SqlMonitor/SqlMonitorStepForm";
 import MonitorStepSqlMonitor, {
   MonitorStepSqlMonitorUtil,
 } from "Common/Types/Monitor/MonitorStepSqlMonitor";
+import DatabaseMonitorStepForm from "./DatabaseMonitor/DatabaseMonitorStepForm";
+import MonitorStepDatabaseMonitor, {
+  MonitorStepDatabaseMonitorUtil,
+} from "Common/Types/Monitor/MonitorStepDatabaseMonitor";
 import DomainMonitorStepForm from "./DomainMonitor/DomainMonitorStepForm";
 import MonitorStepDomainMonitor, {
   MonitorStepDomainMonitorUtil,
@@ -1785,6 +1789,24 @@ return {
             }
             onChange={(value: MonitorStepSqlMonitor) => {
               monitorStep.setSqlMonitor(value);
+              props.onChange?.(MonitorStep.clone(monitorStep));
+            }}
+          />
+        </Card>
+      )}
+
+      {props.monitorType === MonitorType.Database && (
+        <Card
+          title="Database Health Monitor Configuration"
+          description="Configure the database connection and the statistics this monitor collects. This monitor requires a probe with network access to your database."
+        >
+          <DatabaseMonitorStepForm
+            monitorStepDatabaseMonitor={
+              monitorStep.data?.databaseMonitor ||
+              MonitorStepDatabaseMonitorUtil.getDefault()
+            }
+            onChange={(value: MonitorStepDatabaseMonitor) => {
+              monitorStep.setDatabaseMonitor(value);
               props.onChange?.(MonitorStep.clone(monitorStep));
             }}
           />

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorMetrics.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorMetrics.tsx
@@ -31,6 +31,8 @@ import MetricQueryConfigData, {
   ChartSeries,
 } from "Common/Types/Metrics/MetricQueryConfigData";
 import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
 import TimeRange from "Common/Types/Time/TimeRange";
 
 export interface ComponentProps {
@@ -75,6 +77,14 @@ function resolveSeriesTitle(args: GetSeriesResolverArgs): ChartSeries {
     }
   }
 
+  /*
+   * Probe-pull monitors group by probe, because the probe is the only thing
+   * that varies between two rows of the same series. Database Health relies
+   * on that: every one of its series is single-valued per monitor, so it
+   * writes no dimension beyond probeId. A future change that fans a database
+   * series out per database or per table has to extend this function first,
+   * or every one of those series shares the probe's legend.
+   */
   if (MonitorTypeHelper.isProbableMonitor(monitorType)) {
     const probeIdString: string | undefined = (attributes as JSONObject)[
       "probeId"
@@ -112,6 +122,14 @@ const MonitorMetricsElement: FunctionComponent<ComponentProps> = (
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>("");
   const [probes, setProbes] = useState<Array<Probe>>([]);
+  /*
+   * Database Health only. The cards drop the series the configured engine can
+   * never write, so a MySQL monitor does not carry a permanently empty
+   * "Transaction ID Used" chart it can do nothing about.
+   */
+  const [databaseType, setDatabaseType] = useState<SqlDatabaseType | undefined>(
+    undefined,
+  );
   const [timeRange, setTimeRange] = useState<RangeStartAndEndDateTime>({
     range: TimeRange.PAST_ONE_HOUR,
   });
@@ -125,12 +143,24 @@ const MonitorMetricsElement: FunctionComponent<ComponentProps> = (
         id: props.monitorId,
         select: {
           monitorType: true,
+          monitorSteps: true,
         },
       });
 
       const monitorType: MonitorType = item?.monitorType || MonitorType.Manual;
 
       setMonitorType(monitorType);
+
+      if (monitorType === MonitorType.Database) {
+        const steps: Array<MonitorStep> =
+          item?.monitorSteps?.data?.monitorStepsInstanceArray || [];
+
+        setDatabaseType(
+          steps.find((step: MonitorStep) => {
+            return Boolean(step.data?.databaseMonitor?.databaseType);
+          })?.data?.databaseMonitor?.databaseType,
+        );
+      }
 
       const isProbeableMonitor: boolean =
         MonitorTypeHelper.isProbableMonitor(monitorType);
@@ -226,8 +256,9 @@ const MonitorMetricsElement: FunctionComponent<ComponentProps> = (
     }
     return MonitorMetricTypeUtil.getMonitorMetricCategoriesByMonitorType(
       monitorType,
+      databaseType,
     );
-  }, [monitorType]);
+  }, [monitorType, databaseType]);
 
   /*
    * Memoise the per-category query configs so each CategoryMetricsCard only

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/DatabaseMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/DatabaseMonitorView.tsx
@@ -1,0 +1,373 @@
+import OneUptimeDate from "Common/Types/Date";
+import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
+import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+  DatabaseMetricGroupUnavailableReason,
+} from "Common/Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import {
+  DatabaseMetricCategory,
+  DatabaseMetricDefinition,
+  DatabaseMetricGroup,
+  getDatabaseMetricCategoryDescription,
+  getDatabaseMetricCategoryOrder,
+  getDatabaseMetricsByCategory,
+} from "Common/Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "Common/Types/Monitor/MonitorMetricType";
+import ValueFormatter from "Common/Utils/ValueFormatter";
+import InfoCard from "Common/UI/Components/InfoCard/InfoCard";
+import React, { FunctionComponent, ReactElement } from "react";
+import ProbeAttemptsView from "./ProbeAttemptsView";
+
+export interface ComponentProps {
+  probeMonitorResponse: ProbeMonitorResponse;
+  probeName?: string | undefined;
+}
+
+/*
+ * A value the engine did not report is absent from the payload, and absence
+ * is the ordinary case: a group the operator switched off, a counter the
+ * engine does not keep, a grant that was never made. Rendering the row as
+ * "Not collected" rather than dropping it is the whole point of this view -
+ * an operator chasing a blank chart needs to see which series is blank.
+ */
+const NOT_COLLECTED: string = "Not collected";
+
+const formatMetricValue: (
+  definition: DatabaseMetricDefinition,
+  value: number | undefined,
+) => string = (
+  definition: DatabaseMetricDefinition,
+  value: number | undefined,
+): string => {
+  /*
+   * The payload arrives over the wire, so a key can be present and null as
+   * well as simply missing. Both mean the same thing here, and neither may
+   * be shown as a zero.
+   */
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return NOT_COLLECTED;
+  }
+
+  return ValueFormatter.formatValue(value, definition.unit);
+};
+
+/*
+ * One line per grant, not one per group. A login missing pg_monitor loses
+ * five groups at once, and five copies of the same GRANT reads as five
+ * separate problems.
+ */
+const groupStatusesByRemediation: (
+  statuses: Array<DatabaseMetricGroupStatus>,
+) => Array<Array<DatabaseMetricGroupStatus>> = (
+  statuses: Array<DatabaseMetricGroupStatus>,
+): Array<Array<DatabaseMetricGroupStatus>> => {
+  const buckets: Map<string, Array<DatabaseMetricGroupStatus>> = new Map<
+    string,
+    Array<DatabaseMetricGroupStatus>
+  >();
+
+  for (const status of statuses) {
+    const key: string = status.remediation || `no-remediation:${status.group}`;
+    const bucket: Array<DatabaseMetricGroupStatus> = buckets.get(key) || [];
+    bucket.push(status);
+    buckets.set(key, bucket);
+  }
+
+  return Array.from(buckets.values());
+};
+
+const DatabaseMonitorView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const dbResponse: DatabaseMonitorResponse | undefined =
+    props.probeMonitorResponse?.databaseMonitorResponse;
+
+  const isOnline: boolean = Boolean(
+    dbResponse ? dbResponse.isOnline : props.probeMonitorResponse.isOnline,
+  );
+
+  let responseTimeInMs: number = dbResponse?.responseTimeInMs || 0;
+
+  if (responseTimeInMs > 0) {
+    responseTimeInMs = Math.round(responseTimeInMs);
+  }
+
+  const metrics: Partial<Record<MonitorMetricType, number>> =
+    dbResponse?.metrics || {};
+
+  const collectedGroups: Array<DatabaseMetricGroup> =
+    dbResponse?.collectedGroups || [];
+
+  const unavailableGroups: Array<DatabaseMetricGroupStatus> =
+    dbResponse?.unavailableGroups || [];
+
+  /*
+   * A group the probe never attempted - disabled by the operator, or gated
+   * out by engine version - contributes no rows at all. Only a group that
+   * ran, or that ran and failed, has metrics worth accounting for.
+   */
+  const attemptedGroups: Set<DatabaseMetricGroup> =
+    new Set<DatabaseMetricGroup>([
+      ...collectedGroups,
+      ...unavailableGroups.map((status: DatabaseMetricGroupStatus) => {
+        return status.group;
+      }),
+    ]);
+
+  const degradedStatuses: Array<DatabaseMetricGroupStatus> =
+    unavailableGroups.filter((status: DatabaseMetricGroupStatus) => {
+      return (
+        status.reason !==
+        DatabaseMetricGroupUnavailableReason.NotSupportedByEngine
+      );
+    });
+
+  const unsupportedStatuses: Array<DatabaseMetricGroupStatus> =
+    unavailableGroups.filter((status: DatabaseMetricGroupStatus) => {
+      return (
+        status.reason ===
+        DatabaseMetricGroupUnavailableReason.NotSupportedByEngine
+      );
+    });
+
+  const probeAttempts: Array<ProbeAttempt> =
+    props.probeMonitorResponse.probeAttempts || [];
+  const totalAttempts: number =
+    props.probeMonitorResponse.totalAttempts ?? probeAttempts.length;
+  const hadRetries: boolean = totalAttempts > 1;
+
+  /*
+   * A check that never connected collected nothing, and reporting that as
+   * "Healthy" - which an empty unavailableGroups list would - reads as the
+   * opposite of what happened.
+   */
+  const collectionSummary: string = !isOnline
+    ? "Not attempted"
+    : unavailableGroups.length === 0
+      ? "Healthy"
+      : `${unavailableGroups.length} group${
+          unavailableGroups.length === 1 ? "" : "s"
+        } unavailable`;
+
+  const getMetricRows: (
+    category: DatabaseMetricCategory,
+  ) => Array<DatabaseMetricDefinition> = (
+    category: DatabaseMetricCategory,
+  ): Array<DatabaseMetricDefinition> => {
+    return getDatabaseMetricsByCategory(category).filter(
+      (definition: DatabaseMetricDefinition) => {
+        return (
+          metrics[definition.metricType] !== undefined ||
+          attemptedGroups.has(definition.group)
+        );
+      },
+    );
+  };
+
+  const renderGroupStatus: (
+    status: DatabaseMetricGroupStatus,
+  ) => ReactElement = (status: DatabaseMetricGroupStatus): ReactElement => {
+    return (
+      <div key={status.group}>
+        <span className="font-medium">{status.group}</span>
+        <span className="mx-2 text-gray-400">—</span>
+        <span>{status.message}</span>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="flex space-x-3">
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Probe"
+          value={props.probeName || "-"}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Status"
+          value={isOnline ? "Online" : "Offline"}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Engine"
+          value={dbResponse?.engineVersion || "-"}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Response Time"
+          value={responseTimeInMs ? responseTimeInMs + " ms" : "-"}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Collection"
+          value={collectionSummary}
+        />
+      </div>
+
+      <div className="flex space-x-3">
+        <InfoCard
+          className="w-1/2 shadow-none border-2 border-gray-100"
+          title="Metric Groups Collected"
+          value={
+            collectedGroups.length > 0 ? collectedGroups.join(", ") : "None"
+          }
+        />
+        <InfoCard
+          className="w-1/2 shadow-none border-2 border-gray-100"
+          title="Monitored At"
+          value={
+            props.probeMonitorResponse?.monitoredAt
+              ? OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+                  props.probeMonitorResponse.monitoredAt,
+                )
+              : "-"
+          }
+        />
+      </div>
+
+      {(dbResponse?.connectionError ||
+        props.probeMonitorResponse.failureCause) && (
+        <div className="flex space-x-3">
+          <InfoCard
+            className="w-full shadow-none border-2 border-gray-100"
+            title="Error"
+            value={
+              dbResponse?.connectionError ||
+              props.probeMonitorResponse.failureCause?.toString() ||
+              "-"
+            }
+          />
+        </div>
+      )}
+
+      {unavailableGroups.length > 0 && (
+        <div className="rounded-md border-2 border-amber-200 bg-amber-50 p-4">
+          <div className="text-sm font-medium text-amber-900 mb-1">
+            Some metrics were not collected
+          </div>
+          <div className="text-xs text-amber-800 mb-3">
+            The database answered, so the monitor stays online. These groups are
+            missing from this check, and their charts have a gap here.
+          </div>
+
+          {degradedStatuses.length > 0 && (
+            <div className="space-y-3">
+              {groupStatusesByRemediation(degradedStatuses).map(
+                (
+                  statuses: Array<DatabaseMetricGroupStatus>,
+                  index: number,
+                ): ReactElement => {
+                  const remediation: string | undefined =
+                    statuses[0]?.remediation;
+
+                  return (
+                    <div key={index} className="text-sm text-amber-900">
+                      {statuses.map(renderGroupStatus)}
+                      {remediation && (
+                        <code className="mt-1 block select-all rounded bg-amber-100 px-2 py-1 font-mono text-xs text-amber-900 break-all">
+                          {remediation}
+                        </code>
+                      )}
+                    </div>
+                  );
+                },
+              )}
+            </div>
+          )}
+
+          {unsupportedStatuses.length > 0 && (
+            <div
+              className={`text-xs text-gray-500 ${
+                degradedStatuses.length > 0
+                  ? "mt-4 border-t border-amber-200 pt-3"
+                  : ""
+              }`}
+            >
+              <div className="mb-1 font-medium text-gray-600">
+                Not available on this engine
+              </div>
+              {unsupportedStatuses.map(renderGroupStatus)}
+            </div>
+          )}
+        </div>
+      )}
+
+      {getDatabaseMetricCategoryOrder().map(
+        (category: DatabaseMetricCategory): ReactElement | null => {
+          const definitions: Array<DatabaseMetricDefinition> =
+            getMetricRows(category);
+
+          if (definitions.length === 0) {
+            return null;
+          }
+
+          return (
+            <div key={category} className="space-y-3">
+              <div>
+                <h3 className="text-sm font-medium text-gray-700">
+                  {category}
+                </h3>
+                <p className="text-xs text-gray-500">
+                  {getDatabaseMetricCategoryDescription(category)}
+                </p>
+              </div>
+              <div className="border rounded-md overflow-hidden">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Metric
+                      </th>
+                      <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Value
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {definitions.map(
+                      (definition: DatabaseMetricDefinition): ReactElement => {
+                        const formatted: string = formatMetricValue(
+                          definition,
+                          metrics[definition.metricType],
+                        );
+
+                        return (
+                          <tr key={definition.id}>
+                            <td className="px-4 py-2 text-sm text-gray-500">
+                              {definition.friendlyName}
+                            </td>
+                            <td
+                              className={`px-4 py-2 text-sm ${
+                                formatted === NOT_COLLECTED
+                                  ? "text-gray-400 italic"
+                                  : "text-gray-900 font-mono"
+                              }`}
+                            >
+                              {formatted}
+                            </td>
+                          </tr>
+                        );
+                      },
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          );
+        },
+      )}
+
+      {hadRetries && (
+        <ProbeAttemptsView
+          attempts={probeAttempts}
+          totalAttempts={totalAttempts}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DatabaseMonitorView;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
@@ -10,6 +10,7 @@ import WebsiteMonitorSummaryView from "./WebsiteMonitorView";
 import SnmpMonitorView from "./SnmpMonitorView";
 import DnsMonitorView from "./DnsMonitorView";
 import SqlMonitorView from "./SqlMonitorView";
+import DatabaseMonitorView from "./DatabaseMonitorView";
 import DomainMonitorView from "./DomainMonitorView";
 import DnssecMonitorView from "./DnssecMonitorView";
 import ExternalStatusPageMonitorView from "./ExternalStatusPageMonitorView";
@@ -175,6 +176,15 @@ const SummaryInfo: FunctionComponent<ComponentProps> = (
     if (props.monitorType === MonitorType.SQLQuery) {
       summaryComponent = (
         <SqlMonitorView
+          probeMonitorResponse={probeMonitorResponse}
+          probeName={props.probeName}
+        />
+      );
+    }
+
+    if (props.monitorType === MonitorType.Database) {
+      summaryComponent = (
+        <DatabaseMonitorView
           probeMonitorResponse={probeMonitorResponse}
           probeName={props.probeName}
         />

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -8,6 +8,10 @@ import {
   EvaluateOverTimeType,
   FilterType,
 } from "Common/Types/Monitor/CriteriaFilter";
+import {
+  DatabaseMetricDefinition,
+  getDatabaseMetricByMetricType,
+} from "Common/Types/Monitor/DatabaseMetricCatalog";
 import MonitorType, {
   MonitorTypeHelper,
 } from "Common/Types/Monitor/MonitorType";
@@ -54,6 +58,22 @@ export default class CriteriaFilterUtil {
       criteriaFilter?.checkOn === CheckOn.Jitter ||
       criteriaFilter?.checkOn === CheckOn.PortDnsLookupTime ||
       criteriaFilter?.checkOn === CheckOn.PortTcpConnectTime;
+
+    /*
+     * A Database Health filter names its series in databaseMonitorOptions,
+     * not in the check, so its unit is per-metric - the same check reads a
+     * percentage, a byte count or a number of seconds depending on which
+     * metric was picked. The catalog is the only place that knows which,
+     * which is also why "Database Metric" is deliberately absent from the
+     * two flat lists above: they would label a byte count a percentage.
+     */
+    const databaseMetric: DatabaseMetricDefinition | null =
+      criteriaFilter?.checkOn === CheckOn.DatabaseMetric &&
+      criteriaFilter?.databaseMonitorOptions?.metricType
+        ? getDatabaseMetricByMetricType(
+            criteriaFilter.databaseMonitorOptions.metricType,
+          )
+        : null;
 
     // check evaluation over time values.
     if (
@@ -129,7 +149,15 @@ export default class CriteriaFilterUtil {
         criteriaFilter?.value +
         " - evaluates to true.";
     } else {
-      text += `"${criteriaFilter?.checkOn.toString()}" `;
+      /*
+       * Name the metric rather than the check: "Database Metric is greater
+       * than 90" says nothing about what is being measured, and every
+       * database filter would read identically in the criteria list.
+       */
+      const checkOnLabel: string =
+        databaseMetric?.friendlyName || criteriaFilter?.checkOn.toString();
+
+      text += `"${checkOnLabel}" `;
 
       if (criteriaFilter?.serverMonitorOptions?.diskPath) {
         text += "on " + criteriaFilter?.serverMonitorOptions?.diskPath + " ";
@@ -173,9 +201,13 @@ export default class CriteriaFilterUtil {
             ? ` ${criteriaFilter.metricMonitorOptions.thresholdUnit}`
             : "";
 
+        const databaseUnitSuffix: string = databaseMetric?.unit
+          ? ` ${databaseMetric.unit}`
+          : "";
+
         text += `${criteriaFilter?.value.toString()}${
           isPercentage ? "%" : ""
-        }${isMilliseconds ? "ms" : ""}${thresholdUnitSuffix} `;
+        }${isMilliseconds ? "ms" : ""}${thresholdUnitSuffix}${databaseUnitSuffix} `;
       }
     }
 
@@ -451,6 +483,23 @@ export default class CriteriaFilterUtil {
           i.value === CheckOn.SqlQueryScalarValue ||
           i.value === CheckOn.SqlQueryExecutionTime ||
           i.value === CheckOn.SqlQueryError ||
+          i.value === CheckOn.JavaScriptExpression
+        );
+      });
+    }
+
+    /*
+     * Every collected series is reachable through the one DatabaseMetric
+     * check, which names it in databaseMonitorOptions.metricType - the same
+     * shape as SnmpOidValue and its OID. A check per metric would put forty
+     * entries in this dropdown and forty branches in the evaluator.
+     */
+    if (monitorType === MonitorType.Database) {
+      options = options.filter((i: DropdownOption) => {
+        return (
+          i.value === CheckOn.DatabaseIsOnline ||
+          i.value === CheckOn.DatabaseMetric ||
+          i.value === CheckOn.DatabaseCollectionError ||
           i.value === CheckOn.JavaScriptExpression
         );
       });
@@ -957,6 +1006,54 @@ export default class CriteriaFilterUtil {
       });
     }
 
+    if (checkOn === CheckOn.DatabaseIsOnline) {
+      options = options.filter((i: DropdownOption) => {
+        return i.value === FilterType.True || i.value === FilterType.False;
+      });
+    }
+
+    if (checkOn === CheckOn.DatabaseMetric) {
+      /*
+       * Listed in reading order instead of being filtered out of the enum,
+       * because the default a new filter opens on is options[0] and a
+       * database metric is a measurement: "connections used equal to 90" is
+       * almost never the rule anyone means. Equality still has to be
+       * offered - "replicas connected equal to 0" is a real alert.
+       */
+      options = [
+        FilterType.GreaterThan,
+        FilterType.LessThan,
+        FilterType.GreaterThanOrEqualTo,
+        FilterType.LessThanOrEqualTo,
+        FilterType.EqualTo,
+        FilterType.NotEqualTo,
+      ].map((filterType: FilterType): DropdownOption => {
+        return {
+          label: filterType.toString(),
+          value: filterType,
+        };
+      });
+    }
+
+    if (checkOn === CheckOn.DatabaseCollectionError) {
+      /*
+       * Ordered for the same reason: the rule worth writing about a
+       * collection error is "there is one at all", so Is Not Empty leads
+       * even though FilterType declares Is Empty first.
+       */
+      options = [
+        FilterType.IsNotEmpty,
+        FilterType.IsEmpty,
+        FilterType.Contains,
+        FilterType.NotContains,
+      ].map((filterType: FilterType): DropdownOption => {
+        return {
+          label: filterType.toString(),
+          value: filterType,
+        };
+      });
+    }
+
     if (checkOn === CheckOn.ExternalStatusPageIsOnline) {
       options = options.filter((i: DropdownOption) => {
         return i.value === FilterType.True || i.value === FilterType.False;
@@ -1384,6 +1481,9 @@ export default class CriteriaFilterUtil {
       if (monitorType === MonitorType.SQLQuery) {
         return "{{scalarValue}} > 50";
       }
+      if (monitorType === MonitorType.Database) {
+        return "{{metrics['oneuptime.monitor.database.connections.used.percent']}} > 90";
+      }
       return "{{responseBody.result}} === true";
     }
 
@@ -1401,6 +1501,15 @@ export default class CriteriaFilterUtil {
 
     if (checkOn === CheckOn.SqlQueryError) {
       return "connection refused";
+    }
+
+    if (checkOn === CheckOn.DatabaseMetric) {
+      return "90";
+    }
+
+    if (checkOn === CheckOn.DatabaseCollectionError) {
+      // The group name or the grant named in the collection issue.
+      return "pg_monitor";
     }
 
     if (checkOn === CheckOn.ResponseStatusCode) {

--- a/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
@@ -404,6 +404,8 @@ export default class MonitorStepViewModel {
         return MonitorStepViewModel.getDnssecRows(data);
       case MonitorType.SQLQuery:
         return MonitorStepViewModel.getSqlRows(data);
+      case MonitorType.Database:
+        return MonitorStepViewModel.getDatabaseRows(data);
       case MonitorType.ExternalStatusPage:
         return MonitorStepViewModel.getExternalStatusPageRows(data);
       case MonitorType.Logs:
@@ -895,6 +897,94 @@ export default class MonitorStepViewModel {
         valueType: MonitorStepViewValueType.Number,
         value: sqlMonitor?.maxRows,
         placeholder: "Default",
+      }),
+    ]);
+  }
+
+  /*
+   * The password is deliberately absent, here and everywhere else this step
+   * is rendered. It is often a {{monitorSecrets.name}} reference rather than
+   * a literal, but naming the secret is still naming a credential, and this
+   * page is visible to anyone who can read the monitor.
+   */
+  private static getDatabaseRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const databaseMonitor: MonitorStepType["databaseMonitor"] =
+      data.databaseMonitor;
+
+    const database: string | undefined = databaseMonitor?.host
+      ? `${databaseMonitor.databaseType} · ${databaseMonitor.host}:${databaseMonitor.port}/${databaseMonitor.databaseName}`
+      : undefined;
+
+    return compact([
+      {
+        key: "databaseConnection",
+        title: "Database",
+        description: "The database server this monitor collects health from.",
+        valueType: MonitorStepViewValueType.Text,
+        value: database,
+        placeholder: "No data entered",
+      },
+      optional({
+        key: "databaseUsername",
+        title: "Username",
+        description: "The database user this monitor connects as.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(databaseMonitor?.username),
+        placeholder: "No data entered",
+      }),
+      optional({
+        key: "databaseWindowsAuthentication",
+        title: "Windows Integrated Authentication",
+        description:
+          "When set, the probe authenticates as the identity it runs under instead of using a username and password.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: databaseMonitor?.useWindowsIntegratedAuthentication,
+        placeholder: "No",
+      }),
+      optional({
+        key: "databaseUseSsl",
+        title: "Use SSL",
+        description: "Whether the connection to the database is encrypted.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: databaseMonitor?.useSsl,
+        placeholder: "No",
+      }),
+      optional({
+        key: "databaseRejectUnauthorizedSsl",
+        title: "Verify Server Certificate",
+        description:
+          "Whether the database's TLS certificate must be signed by a trusted authority.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: databaseMonitor?.rejectUnauthorizedSsl,
+        placeholder: "No",
+      }),
+      optional({
+        key: "databaseConnectionTimeoutInMs",
+        title: "Connection Timeout",
+        description: "How long the probe waits to establish a connection.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toMilliseconds(databaseMonitor?.connectionTimeoutInMs),
+        placeholder: "Default",
+      }),
+      optional({
+        key: "databaseStatementTimeoutInMs",
+        title: "Statement Timeout",
+        description:
+          "How long one statistics query may run before that group is abandoned.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toMilliseconds(databaseMonitor?.statementTimeoutInMs),
+        placeholder: "Default",
+      }),
+      optional({
+        key: "databaseMetricGroups",
+        title: "Collected Metric Groups",
+        description:
+          "The groups of statistics this monitor collects. A group whose grant is missing is reported as unavailable, not as an outage.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: databaseMonitor?.enabledMetricGroups,
+        placeholder: "All groups",
       }),
     ]);
   }

--- a/App/FeatureSet/Docs/Content/en/monitor/database-health-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/database-health-monitor.md
@@ -1,0 +1,304 @@
+# Database Health Monitor
+
+The Database Health Monitor connects to PostgreSQL, MySQL, or Microsoft SQL Server on a schedule and reports the server's own health signals — connection headroom, blocked sessions, replication lag, cache hit ratio, database size, transaction ID wraparound, and thirty-odd more — so you can alert on them the same way you alert on a website being down.
+
+You write no SQL. The probe runs a fixed set of read-only catalog queries chosen by engine, and reports a small set of named numbers.
+
+## Database Health or SQL Query?
+
+The two database monitor types answer different questions and are meant to be used together.
+
+| | Database Health | [SQL Query](/docs/monitor/sql-monitor) |
+|---|---|---|
+| Question it answers | "Is the database itself healthy?" | "Is my data what I expect it to be?" |
+| Query | Built in, per engine, read-only | Yours |
+| Reports | Named numeric metrics (see [Metrics collected](#metrics-collected)) | Row count, scalar value, first row, execution time |
+| Typical alert | Connections used above 90% | Cancelled orders above 50 in the last five minutes |
+| Grants needed | Statistics/DMV read access — see [Create a monitoring user](#create-a-monitoring-user) | `SELECT` on the tables your query touches |
+
+If you want to alert on a business condition, use the SQL Query Monitor. If you want to know that the server is running out of connections before the business condition ever gets a chance to fail, use this one.
+
+## Supported databases
+
+- **PostgreSQL** (default port `5432`)
+- **MySQL** (default port `3306`)
+- **Microsoft SQL Server** (default port `1433`)
+
+PostgreSQL- and MySQL-compatible engines that speak the same wire protocol usually work, but they may expose fewer statistics views, in which case the affected metrics are reported as unavailable rather than collected. Only the three engines above are officially tested.
+
+## How it works
+
+On every check, a probe:
+
+1. Connects to the database with the credentials you configure.
+2. Runs one lightweight probe query. **This is the only statement whose failure can take the monitor offline.**
+3. Runs the catalog queries for each enabled [metric group](#metric-groups), each one inside a read-only transaction and under a statement timeout.
+4. Reports the numbers it collected, plus a note for each group it could not collect and why.
+
+Only named numeric aggregates are sent to OneUptime. No query text, no rows from your tables, and no schema names leave your network — the queries read the engine's own statistics views (`pg_stat_activity`, `performance_schema.global_status`, `sys.dm_exec_sessions` and friends), never your data.
+
+Because the check runs from a probe, the database only needs to be reachable from the probe. Put a [custom probe](/docs/probe/custom-probe) inside your network and OneUptime never needs a route to the database at all.
+
+## Create a monitoring user
+
+**This is the most important step.** The monitor reads statistics views that ordinary logins are not allowed to see, and the failure mode of an under-privileged login is not always an error — on PostgreSQL it is a wrong answer. Create a dedicated login with exactly these grants and nothing else.
+
+### PostgreSQL
+
+```sql
+CREATE USER oneuptime_health WITH PASSWORD 'a-strong-password';
+GRANT CONNECT ON DATABASE mydb TO oneuptime_health;
+-- The one grant that matters. Without it, see the note below.
+GRANT pg_monitor TO oneuptime_health;
+```
+
+`pg_monitor` is a built-in role (PostgreSQL 10 and later) that grants read access to the statistics and monitoring views. It grants no access to your tables.
+
+> **Why `pg_monitor` is not optional on PostgreSQL.** Without it, `pg_stat_activity` does not fail — it succeeds and returns only the monitoring session's own row. Connection counts would read `1`, blocked sessions `0`, and replication lag `0`, forever, on a server that is actually on fire. So the probe checks `pg_has_role(current_user, 'pg_monitor', 'member')` **before** it runs those queries, and when the answer is no it reports the Connections, Activity, Locks, Replication and Maintenance groups as unavailable with the `GRANT` you need. Reporting nothing is the honest answer; reporting `1` is not.
+
+On a managed service where `pg_monitor` is unavailable, `pg_read_all_stats` covers the same views. On Amazon RDS, `GRANT rds_superuser` is not needed — `GRANT pg_monitor TO oneuptime_health;` works as a member of `rds_superuser`.
+
+### MySQL
+
+```sql
+CREATE USER 'oneuptime_health'@'%' IDENTIFIED BY 'a-strong-password';
+-- INNODB_TRX (open transactions, longest query) and replication status.
+GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'oneuptime_health'@'%';
+-- Status counters, server variables, and lock waits.
+GRANT SELECT ON performance_schema.* TO 'oneuptime_health'@'%';
+-- Database size: information_schema.TABLES only shows tables the login can see.
+GRANT SELECT ON mydb.* TO 'oneuptime_health'@'%';
+FLUSH PRIVILEGES;
+```
+
+MySQL's `performance_schema` must be enabled (`performance_schema = ON`, the default since 5.6). When it is off, the Connections, Throughput and Locks groups report as unavailable and the fix is a server restart, not a grant.
+
+### Microsoft SQL Server
+
+```sql
+CREATE LOGIN oneuptime_health WITH PASSWORD = 'a-strong-password';
+-- Every server-scoped DMV the monitor reads.
+GRANT VIEW SERVER STATE TO oneuptime_health;
+
+USE mydb;
+CREATE USER oneuptime_health FOR LOGIN oneuptime_health;
+-- Database size and transaction log space.
+GRANT VIEW DATABASE STATE TO oneuptime_health;
+```
+
+On Azure SQL Database, `VIEW SERVER STATE` does not exist; use `GRANT VIEW DATABASE STATE TO oneuptime_health;` alone. The server-scoped groups then report as unavailable, and the database-scoped Storage group still collects.
+
+## Prerequisites
+
+- A **probe** with network access to the database host and port. Use a OneUptime-hosted probe if the database is reachable from the internet, or a [custom probe](/docs/probe/custom-probe) inside your network if it is not.
+- A **monitoring user** created as above, and its connection details.
+
+## Configuration
+
+Create a monitor and choose **Database Health** as the monitor type, then fill in:
+
+- **Database Type** — PostgreSQL, MySQL, or Microsoft SQL Server. Choosing a type sets the default port and decides which queries run.
+- **Host** — the database host reachable from the probe (for example `db.internal`).
+- **Port** — the database port.
+- **Database Name** — the database to connect to. Database-scoped metrics (size, cache hit ratio, temp spill) are reported for this database; server-scoped metrics (connections, uptime, replication) are reported for the whole server.
+- **Use Windows Integrated Authentication** — Microsoft SQL Server only. Authenticate with the identity of the probe process instead of a username and password. See [Windows Integrated Authentication](/docs/monitor/sql-monitor#windows-integrated-authentication) on the SQL Query Monitor page — the setup is identical.
+- **Username** — the monitoring user.
+- **Password** — the password. Reference a [Monitor Secret](/docs/monitor/monitor-secrets) with `{{monitorSecrets.name}}` rather than typing it in plain text (see [Using a Monitor Secret](#using-a-monitor-secret-for-the-password)).
+- **Use SSL/TLS** — connect over TLS. When enabled you can turn off **Verify server certificate** for a self-signed certificate.
+- **Collected Metric Groups** — which groups to run. All are on by default; see [Metric groups](#metric-groups).
+
+### Advanced options
+
+- **Connection Timeout (ms)** — how long to wait to establish a connection. Default `10000`, maximum `30000`.
+- **Statement Timeout (ms)** — the cap on any single catalog query. Default `10000`, maximum `60000`. The default is deliberately tighter than the SQL Query Monitor's: these queries return in milliseconds on a healthy server, so if `pg_stat_activity` takes ten seconds the useful signal is "this server is in trouble", not a longer wait.
+
+Collection as a whole is also bounded. If the enabled groups have not finished within the collection budget, the check returns with what it has and records every remaining group as timed out — a slow server produces a partial result, never a missing check.
+
+## Using a Monitor Secret for the password
+
+So the password is never stored in plain text on the monitor:
+
+1. Go to OneUptime Dashboard → Monitors → Settings → Secrets → Create Monitor Secret.
+2. Create a secret (for example `dbPassword`) and grant this monitor access to it.
+3. In the Password field, enter `{{monitorSecrets.dbPassword}}`.
+
+The secret is resolved server-side before the configuration is handed to a probe. The Host, Username, and Database Name fields accept the same reference. Credentials are never written to logs, monitor feeds, or alert templates.
+
+## Metric groups
+
+A group is one collection unit: the queries in it run together, succeed together, and fail together. Groups exist so that one missing grant costs you one group rather than the whole monitor.
+
+| Group | What it collects | Needs |
+|---|---|---|
+| Connections | Connection counts, the configured ceiling, aborted connects, server uptime | PostgreSQL: `pg_monitor`. MySQL: `performance_schema`. SQL Server: `VIEW SERVER STATE` |
+| Activity | Longest running query, longest open transaction, open transactions | PostgreSQL: `pg_monitor`. MySQL: `PROCESS`. SQL Server: `VIEW SERVER STATE` |
+| Throughput | Transactions, queries, cache hit ratio, disk reads and writes, I/O time | PostgreSQL: none beyond `CONNECT`. MySQL: `performance_schema`. SQL Server: `VIEW SERVER STATE` |
+| Locks | Blocked sessions, lock waits, deadlocks, table lock waits | PostgreSQL: `pg_monitor`. MySQL: `performance_schema`. SQL Server: `VIEW SERVER STATE` |
+| Storage | Database size, temp spill, log space, tempdb free space | PostgreSQL: none beyond `CONNECT`. MySQL: `SELECT` on the database. SQL Server: `VIEW DATABASE STATE` |
+| Replication | Connected replicas, replication lag in seconds and bytes, inactive slots, recovery state | PostgreSQL: `pg_monitor`. MySQL: `REPLICATION CLIENT`. SQL Server: `VIEW SERVER STATE` |
+| Maintenance | Transaction ID wraparound headroom, dead tuples, tables never autovacuumed, checkpoints | PostgreSQL: `pg_monitor` |
+
+Turning a group off is silent: no metrics, no collection issue, no alert. It is the right move in two cases.
+
+- **You cannot get the grant.** Turning the group off stops the collection issue from recurring on every check.
+- **The queries are too expensive.** On MySQL, **Storage** is the usual candidate: database size comes from summing `information_schema.TABLES`, which on a schema with tens of thousands of tables is not free and runs on every check. Turn it off, or move that monitor to a five-minute interval.
+
+Clearing every group is not a way to collect nothing — an empty list is normalized back to all groups, so a monitor can never be saved in a state where it silently collects nothing.
+
+## What happens when a metric cannot be collected
+
+**A missing grant never takes the monitor offline.** This is the single most important behaviour of this monitor type, and it is worth stating precisely.
+
+- **The connection fails**, or the probe query fails — bad credentials, refused connection, TLS failure, connect timeout. The monitor goes **offline**. `Database Is Online` is false, and whatever incident and on-call policy you attached to it fires.
+- **A group cannot run** — a missing grant, a disabled `performance_schema`, a statement timeout. The monitor **stays online**. That group's metrics are **absent**, not zero. No chart line is drawn, no threshold on those series can match, and no incident can be raised from them. The check records one collection issue naming the group, the reason, and — where there is one — the exact `GRANT` to run, which is shown on the monitor's summary and counted in **Metric Groups Failed**.
+- **The engine cannot produce a metric at all** — stock MySQL has no deadlock counter; SQL Server leaves its connection ceiling unlimited by default so a "used percent" would be meaningless; PostgreSQL only populates I/O timing when `track_io_timing` is on. The metric is simply absent. This is **not** a collection issue, does not count toward Metric Groups Failed, and is not something to fix. See the Engines column in [Metrics collected](#metrics-collected).
+
+Absent always means absent. A value that was not measured is never reported as `0`, because a chart of fabricated zeroes is worse than a gap — you can see a gap.
+
+To alert on lost visibility, use `Database Collection Error`, or a threshold on **Metric Groups Failed**. Make both of them alerts rather than incidents: a revoked grant is a ticket, not a page.
+
+## Metrics collected
+
+Forty-one series across eight categories. Engines lists the engines that can actually produce the series; on any other engine it is simply absent. Group is the collection group the series belongs to, which is what you toggle and what degrades together.
+
+### Availability
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Uptime** (s) | `oneuptime.monitor.database.uptime.seconds` | Connections | PostgreSQL, MySQL, SQL Server |
+| **Metric Groups Failed** | `oneuptime.monitor.database.metric.groups.failed` | Connections | PostgreSQL, MySQL, SQL Server |
+
+### Connections
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Connections** | `oneuptime.monitor.database.connections.total` | Connections | PostgreSQL, MySQL, SQL Server |
+| **Active Connections** | `oneuptime.monitor.database.connections.active` | Connections | PostgreSQL, MySQL, SQL Server |
+| **Maximum Connections** | `oneuptime.monitor.database.connections.max` | Connections | PostgreSQL, MySQL |
+| **Connections Used** (%) | `oneuptime.monitor.database.connections.used.percent` | Connections | PostgreSQL, MySQL |
+| **Idle In Transaction** | `oneuptime.monitor.database.connections.idle.in.transaction` | Connections | PostgreSQL |
+| **Aborted Connects** | `oneuptime.monitor.database.connections.aborted.total` | Connections | MySQL |
+
+### Throughput
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Transactions** | `oneuptime.monitor.database.transactions.total` | Throughput | PostgreSQL, SQL Server |
+| **Queries** | `oneuptime.monitor.database.queries.total` | Throughput | MySQL, SQL Server |
+| **Slow Queries** | `oneuptime.monitor.database.queries.slow.total` | Throughput | MySQL |
+| **Rollback Ratio** (%) | `oneuptime.monitor.database.rollback.percent` | Throughput | PostgreSQL |
+| **Longest Running Query** (s) | `oneuptime.monitor.database.query.longest.seconds` | Activity | PostgreSQL, MySQL, SQL Server |
+| **Longest Open Transaction** (s) | `oneuptime.monitor.database.transaction.longest.seconds` | Activity | PostgreSQL, MySQL, SQL Server |
+| **Open Transactions** | `oneuptime.monitor.database.transaction.open.count` | Activity | MySQL |
+
+### Locks and Blocking
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Blocked Sessions** | `oneuptime.monitor.database.sessions.blocked` | Locks | PostgreSQL, MySQL, SQL Server |
+| **Lock Waits** | `oneuptime.monitor.database.locks.waiting` | Locks | PostgreSQL, MySQL, SQL Server |
+| **Deadlocks** | `oneuptime.monitor.database.deadlocks.total` | Locks | PostgreSQL, SQL Server |
+| **Table Lock Waits** | `oneuptime.monitor.database.table.locks.waited.total` | Locks | MySQL |
+
+Stock MySQL exposes no deadlock counter of any kind, which is why Deadlocks is PostgreSQL and SQL Server only.
+
+### Cache and I/O
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Cache Hit Ratio** (%) | `oneuptime.monitor.database.cache.hit.percent` | Throughput | PostgreSQL, MySQL, SQL Server |
+| **Disk Reads** | `oneuptime.monitor.database.disk.reads.total` | Throughput | PostgreSQL, MySQL, SQL Server |
+| **Disk Writes** | `oneuptime.monitor.database.disk.writes.total` | Throughput | MySQL, SQL Server |
+| **I/O Read Time** (ms) | `oneuptime.monitor.database.io.read.time.ms` | Throughput | PostgreSQL, SQL Server |
+| **I/O Write Time** (ms) | `oneuptime.monitor.database.io.write.time.ms` | Throughput | PostgreSQL, SQL Server |
+| **Page Life Expectancy** (s) | `oneuptime.monitor.database.page.life.expectancy.seconds` | Throughput | SQL Server |
+| **Memory Grants Pending** | `oneuptime.monitor.database.memory.grants.pending` | Throughput | SQL Server |
+
+PostgreSQL only fills in I/O read and write time when `track_io_timing` is on. It is off by default, so those two series are commonly absent on a fully-granted PostgreSQL server. That is a server setting, not a permissions problem.
+
+### Storage
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Database Size** (bytes) | `oneuptime.monitor.database.size.bytes` | Storage | PostgreSQL, MySQL, SQL Server |
+| **Temp Bytes Written** (bytes) | `oneuptime.monitor.database.temp.bytes.total` | Storage | PostgreSQL |
+| **Temp Disk Tables** | `oneuptime.monitor.database.temp.disk.tables.total` | Storage | MySQL |
+| **Log Space Used** (%) | `oneuptime.monitor.database.log.space.used.percent` | Storage | SQL Server |
+| **TempDB Free Space** (bytes) | `oneuptime.monitor.database.tempdb.free.bytes` | Storage | SQL Server |
+
+### Replication
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Connected Replicas** | `oneuptime.monitor.database.replica.count` | Replication | PostgreSQL, SQL Server |
+| **Replication Lag** (s) | `oneuptime.monitor.database.replication.lag.seconds` | Replication | PostgreSQL, MySQL, SQL Server |
+| **Replication Lag (Bytes)** (bytes) | `oneuptime.monitor.database.replication.lag.bytes` | Replication | PostgreSQL, SQL Server |
+| **Is In Recovery** | `oneuptime.monitor.database.is.in.recovery` | Replication | PostgreSQL |
+| **Inactive Replication Slots** | `oneuptime.monitor.database.replication.slots.inactive` | Replication | PostgreSQL |
+
+Replication metrics are reported from whichever side of the link the monitor is connected to. Point a monitor at the primary to see connected replicas and the send queue; point one at each standby to see how far behind that standby actually is.
+
+Lag in seconds reads as zero on an idle primary even when a replica is far behind, because nothing new has been written. **Replication Lag (Bytes)** does not have that blind spot, so alert on both.
+
+### Maintenance
+
+| Metric | Series | Group | Engines |
+|---|---|---|---|
+| **Transaction ID Used** (%) | `oneuptime.monitor.database.transaction.id.used.percent` | Maintenance | PostgreSQL |
+| **Dead Tuples** | `oneuptime.monitor.database.dead.tuples` | Maintenance | PostgreSQL |
+| **Tables Never Autovacuumed** | `oneuptime.monitor.database.tables.never.autovacuumed` | Maintenance | PostgreSQL |
+| **Requested Checkpoints** | `oneuptime.monitor.database.checkpoints.requested.total` | Maintenance | PostgreSQL |
+| **Timed Checkpoints** | `oneuptime.monitor.database.checkpoints.timed.total` | Maintenance | PostgreSQL |
+
+**Transaction ID Used** deserves a criterion on every PostgreSQL monitor you create. PostgreSQL refuses all writes when it reaches 100%, recovery means a single-user-mode vacuum with the database down, and almost nobody watches it. Alert well below the cliff — 80% leaves days of headroom on most workloads.
+
+Counters ending in `total` are cumulative since the server started. Compare two points in time to get a rate; a single value is only meaningful against its own history, and it resets to zero when the server restarts (which **Uptime** will show you).
+
+## Setting up criteria
+
+- **Database Is Online** — whether the database was reachable and the probe query succeeded. This is the offline criterion the monitor is created with, and it is the only check that reflects reachability.
+- **Database Metric** — pick a metric, then compare it. The metric picker offers only the metrics your selected engine can produce, so you cannot build a criterion that would sit permanently unmet. If the metric was not collected on a check — the group failed, or the engine does not report it — the filter does not match, and does not match "false" either: it is skipped. A permissions problem cannot page anyone.
+- **Database Collection Error** — the collection issue summary for the check. Alert when it is not empty to catch lost visibility, or use Contains to watch for one specific group or one named grant.
+- **JavaScript Expression** — full control. See [JavaScript Expressions](/docs/monitor/javascript-expression).
+
+Thresholds are whole numbers. Write `90`, not `90.5` — percentages and seconds are compared as integers.
+
+### JavaScript expression variables
+
+For a Database Health monitor the expression has access to:
+
+| Variable | Type | |
+|---|---|---|
+| `isOnline` | boolean | Whether the connection and the probe query both succeeded |
+| `engineVersion` | string | The version string the server reported |
+| `connectionError` | string | Sanitized connection error, empty when there was none |
+| `collectedGroups` | array | The groups that produced values on this check |
+| `unavailableGroups` | array | The groups that did not, each with a reason and a remediation |
+| `metrics` | object | Collected values keyed by series name; a series that was not collected is absent |
+
+```javascript
+{{isOnline}} === true && {{collectedGroups}}.length >= 5
+```
+
+For a threshold on a single metric, reach for **Database Metric** rather than an expression: it resolves the series for you, only offers what your engine can produce, and skips the check when the value was not collected instead of comparing against nothing.
+
+### Example: a PostgreSQL primary
+
+- **Criteria: Offline** — `Database Is Online` is `false`.
+- **Criteria: Degraded** — `Database Metric` → Connections Used is greater than `90`, evaluated over 5 minutes with All Values so a single spike does not page.
+- **Criteria: Degraded** — `Database Metric` → Transaction ID Used is greater than `80`.
+- **Criteria: Degraded** — `Database Metric` → Blocked Sessions is greater than `0`, over 5 minutes.
+- **Criteria: Online** — `Database Is Online` is `true`.
+
+Criteria are evaluated top to bottom and the first match wins, so list the alerting criteria first and the healthy one last.
+
+Attach an on-call policy to the offline criterion, and leave anything derived from **Metric Groups Failed** or `Database Collection Error` as an alert with no on-call policy attached.
+
+## Things to consider
+
+- **The queries run on every check.** They are cheap by design, but "cheap" is relative to the interval. A one-minute interval against a server with thousands of sessions is more `pg_stat_activity` scanning than you may want; five minutes is plenty for capacity metrics.
+- **Point the monitor at the database you care about.** Size, cache hit ratio, and temp spill are per-database. Connections, uptime, and replication are per-server and will read the same from any database on that instance.
+- **One monitor per instance, not per database**, unless you specifically want per-database size and cache metrics — otherwise you multiply the server-scoped queries for no new information.
+- **Alert on rates, not on counters.** Anything ending in `total` only climbs, so a "greater than" threshold on it fires once and never recovers. Chart it, or compare it across a window.
+- **Prefer a Monitor Secret over a plain-text password.** The credential then stays encrypted at rest and never appears on the monitor.
+- The monitor never writes. Every query is a read against a statistics view, in a read-only transaction where the engine supports one. Anything it cannot read is reported as a missing metric, never as an outage.

--- a/App/FeatureSet/Docs/Content/en/monitor/incident-alert-templating.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incident-alert-templating.md
@@ -164,6 +164,24 @@ Synthetic monitors run the same script across multiple browsers (Chromium, Firef
 | `trapSourceIp`         | Source IP the trap was received from — trap-triggered checks only. | `string`         |
 | `trapVarbinds`         | Varbinds carried by the trap, as `{oid, value}` — trap-triggered checks only. | `Array<Object>` |
 
+### Database Health Monitors
+
+| Variable                  | Description                                                                                                          | Type            |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `isOnline`                | Whether the probe could connect and run the baseline query. Missing metrics never make this false.                     | `boolean`       |
+| `responseTimeInMs`        | Time to connect and run the baseline query.                                                                            | `number`        |
+| `failureCause`            | The reason the check failed, when it did.                                                                              | `string`        |
+| `connectionError`         | Sanitized connection error. Never contains credentials or a connection string.                                         | `string`        |
+| `engineVersion`           | Version string the database server reported.                                                                           | `string`        |
+| `collectedGroups`         | Metric groups that produced values on this check.                                                                      | `Array<string>` |
+| `unavailableGroups`       | Groups that could not be collected, as `{group, reason, message, remediation}`.                                        | `Array<Object>` |
+| `collectionIssueSummary`  | One line summarising every unavailable group, ready to paste into an alert.                                            | `string`        |
+| `metrics`                 | Collected values keyed by series name, e.g. `{{metrics['oneuptime.monitor.database.connections.used.percent']}}`.      | `Object`        |
+
+A metric that was not collected is **absent** from `metrics` rather than zero,
+so template it defensively — `{{#if metrics.[...]}}` — when a group may be
+unavailable on the database you are monitoring.
+
 ## Basic Usage
 
 In the Incident / Alert form inside a Monitor Criteria instance, you can write:

--- a/App/FeatureSet/Docs/Content/en/self-hosted/private-network-access.md
+++ b/App/FeatureSet/Docs/Content/en/self-hosted/private-network-access.md
@@ -13,7 +13,7 @@ This page explains how to allow it, deliberately and narrowly. There are two ind
 | Workflows, project webhooks, on-call user webhooks | The **API server**'s environment |
 | Custom JavaScript Code **monitors**                | The **probe**'s own environment  |
 
-**Most monitoring already works.** Every monitor type except Custom JavaScript Code — API, Website, Ping, Port, SSL Certificate, DNS, DNSSEC, SNMP / Network Device, SQL Query, Synthetic, External Status Page, Network Path — already reaches whatever host you point it at, with no address check at all. If you only want to monitor an internal service, deploy a [custom probe](/docs/probe/custom-probe) inside that network and nothing else on this page applies.
+**Most monitoring already works.** Every monitor type except Custom JavaScript Code — API, Website, Ping, Port, SSL Certificate, DNS, DNSSEC, SNMP / Network Device, SQL Query, Database Health, Synthetic, External Status Page, Network Path — already reaches whatever host you point it at, with no address check at all. If you only want to monitor an internal service, deploy a [custom probe](/docs/probe/custom-probe) inside that network and nothing else on this page applies.
 
 ## What is blocked, and what can be unblocked
 

--- a/App/FeatureSet/Docs/Content/en/terraform/monitor-steps.md
+++ b/App/FeatureSet/Docs/Content/en/terraform/monitor-steps.md
@@ -143,7 +143,7 @@ Each element of `monitor_steps` is one probe target:
 | `retry_count_on_error` | number | Synthetic | Retries on script error. |
 | `criteria` | list (required) | all | The decision tree — see below. |
 
-Telemetry and infrastructure monitor types carry their query configuration in per-type **escape hatch** attributes — optional strings holding the sub-config's raw JSON, written with `jsonencode()`: `log_monitor`, `trace_monitor`, `metric_monitor`, `exception_monitor`, `profile_monitor`, `dns_monitor`, `domain_monitor`, `dnssec_monitor`, `sql_monitor`, `external_status_page_monitor`, `network_device_monitor`, `kubernetes_monitor`, `docker_monitor`, `docker_swarm_monitor`, `host_monitor`, `podman_monitor`, `proxmox_monitor`, `ceph_monitor`, `iot_monitor`. Example for a Logs monitor:
+Telemetry and infrastructure monitor types carry their query configuration in per-type **escape hatch** attributes — optional strings holding the sub-config's raw JSON, written with `jsonencode()`: `log_monitor`, `trace_monitor`, `metric_monitor`, `exception_monitor`, `profile_monitor`, `dns_monitor`, `domain_monitor`, `dnssec_monitor`, `sql_monitor`, `database_monitor`, `external_status_page_monitor`, `network_device_monitor`, `kubernetes_monitor`, `docker_monitor`, `docker_swarm_monitor`, `host_monitor`, `podman_monitor`, `proxmox_monitor`, `ceph_monitor`, `iot_monitor`. Example for a Logs monitor:
 
 ```hcl
 monitor_steps = [{
@@ -251,6 +251,7 @@ Common `check_on` values by monitor type:
 | Custom Code / Synthetic | `Result Value`, `Error`, `Execution Time (in ms)` |
 | DNS / Domain / DNSSEC | `DNS Is Online`, `DNS Record Value`, `Domain Is Expired`, `DNSSEC Chain Is Valid` |
 | SQL Query | `SQL Is Online`, `SQL Query Row Count`, `SQL Query Scalar Value` |
+| Database Health | `Database Is Online`, `Database Metric` (requires `database_monitor_options` JSON naming the series, e.g. `jsonencode({ metricType = "oneuptime.monitor.database.connections.used.percent" })`), `Database Collection Error` |
 | External Status Page | `External Status Page Is Online`, `External Status Page Active Incidents`, `External Status Page Component Status` |
 | Network Device (SNMP) | `SNMP Device Is Online`, `SNMP OID Value` (SNMP filters can carry `snmp_monitor_options` JSON) |
 

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -266,6 +266,10 @@ const DocsNav: NavGroup[] = [
         url: "/docs/monitor/sql-monitor",
       },
       {
+        title: "Database Health Monitor",
+        url: "/docs/monitor/database-health-monitor",
+      },
+      {
         title: "Synthetic Monitor",
         url: "/docs/monitor/synthetic-monitor",
       },

--- a/App/FeatureSet/Telemetry/Utils/Monitor.ts
+++ b/App/FeatureSet/Telemetry/Utils/Monitor.ts
@@ -408,6 +408,40 @@ export default class MonitorUtil {
       }
     }
 
+    if (monitorType === MonitorType.Database) {
+      for (const monitorStep of monitorSteps?.data?.monitorStepsInstanceArray ||
+        []) {
+        if (!monitorStep.data?.databaseMonitor) {
+          continue;
+        }
+
+        /*
+         * Same opt-in secret references as the SQL Query monitor, minus the
+         * query - Database Health has no user-authored SQL. Resolving these
+         * here is what turns a stored {{monitorSecrets.name}} into a usable
+         * credential before the step reaches the probe.
+         */
+        const databaseSecretFields: Array<
+          "password" | "username" | "host" | "databaseName"
+        > = ["password", "username", "host", "databaseName"];
+
+        for (const field of databaseSecretFields) {
+          const currentValue: string | undefined =
+            monitorStep.data.databaseMonitor[field];
+
+          if (currentValue && this.hasSecrets(currentValue)) {
+            const monitorSecrets: MonitorSecret[] = await getSecrets();
+
+            monitorStep.data.databaseMonitor[field] =
+              (await MonitorUtil.fillSecretsInStringOrJSON({
+                secrets: monitorSecrets,
+                populateSecretsIn: currentValue,
+              })) as string;
+          }
+        }
+      }
+    }
+
     if (monitorType === MonitorType.ExternalStatusPage) {
       for (const monitorStep of monitorSteps?.data?.monitorStepsInstanceArray ||
         []) {

--- a/App/Tests/Dashboard/MonitorStepViewModel.test.ts
+++ b/App/Tests/Dashboard/MonitorStepViewModel.test.ts
@@ -12,6 +12,7 @@ import IP from "Common/Types/IP/IP";
 import LogSeverity from "Common/Types/Log/LogSeverity";
 import OcsfSeverity from "Common/Types/SecurityEvent/OcsfSeverity";
 import MetricsViewConfig from "Common/Types/Metrics/MetricsViewConfig";
+import { DatabaseMetricGroup } from "Common/Types/Monitor/DatabaseMetricCatalog";
 import DnsRecordType from "Common/Types/Monitor/DnsMonitor/DnsRecordType";
 import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
 import ExternalStatusPageProviderType from "Common/Types/Monitor/ExternalStatusPageProviderType";
@@ -223,6 +224,27 @@ function buildStepForMonitorType(monitorType: MonitorType): MonitorStep {
           connectionTimeoutInMs: 10000,
           statementTimeoutInMs: 15000,
           maxRows: 100,
+        },
+      });
+    case MonitorType.Database:
+      return buildStep({
+        databaseMonitor: {
+          databaseType: SqlDatabaseType.MySQL,
+          host: "replica.example.com",
+          port: 3306,
+          databaseName: "warehouse",
+          username: "oneuptime_monitor",
+          password: "super-secret-database-password",
+          useWindowsIntegratedAuthentication: false,
+          useSsl: true,
+          rejectUnauthorizedSsl: true,
+          connectionTimeoutInMs: 10000,
+          statementTimeoutInMs: 5000,
+          enabledMetricGroups: [
+            DatabaseMetricGroup.Connections,
+            DatabaseMetricGroup.Throughput,
+            DatabaseMetricGroup.Locks,
+          ],
         },
       });
     case MonitorType.ExternalStatusPage:
@@ -616,7 +638,7 @@ describe("MonitorStepViewModel.getRows — probe monitors", () => {
   });
 });
 
-describe("MonitorStepViewModel.getRows — DNS, domain and SQL monitors", () => {
+describe("MonitorStepViewModel.getRows — DNS, domain and database monitors", () => {
   it("shows the DNS query, record type and resolver, which used to render nothing", () => {
     expect(getRow(MonitorType.DNS, "queryName")?.value).toBe("example.com");
     expect(getRow(MonitorType.DNS, "recordType")?.value).toBe(DnsRecordType.A);
@@ -695,6 +717,44 @@ describe("MonitorStepViewModel.getRows — DNS, domain and SQL monitors", () => 
     expect(JSON.stringify(getRows(MonitorType.SQLQuery))).not.toContain(
       "super-secret-password",
     );
+  });
+
+  it("summarizes the database connection and the groups it collects", () => {
+    expect(getRow(MonitorType.Database, "databaseConnection")?.value).toBe(
+      "MySQL · replica.example.com:3306/warehouse",
+    );
+    expect(getRow(MonitorType.Database, "databaseUsername")?.value).toBe(
+      "oneuptime_monitor",
+    );
+    expect(getRow(MonitorType.Database, "databaseMetricGroups")?.value).toEqual(
+      [
+        DatabaseMetricGroup.Connections,
+        DatabaseMetricGroup.Throughput,
+        DatabaseMetricGroup.Locks,
+      ],
+    );
+    expect(
+      getRow(MonitorType.Database, "databaseStatementTimeoutInMs")?.value,
+    ).toBe("5000 ms");
+  });
+
+  /*
+   * The credential never reaches this page in any form. There is not even a
+   * masked row for it: a row titled "Password" whose value is dots still
+   * tells a reader the field is set, and a step often holds a
+   * {{monitorSecrets.name}} reference there, which names the secret.
+   */
+  it("never exposes the database password", () => {
+    const rows: Array<MonitorStepViewRow> = getRows(MonitorType.Database);
+
+    expect(JSON.stringify(rows)).not.toContain(
+      "super-secret-database-password",
+    );
+
+    for (const row of rows) {
+      expect(row.key.toLowerCase()).not.toContain("password");
+      expect(row.title.toLowerCase()).not.toContain("password");
+    }
   });
 
   it("shows the external status page URL, provider and component filters", () => {

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -237,6 +237,21 @@ export class Service extends DatabaseService<Model> {
             monitorDestination = `${sql.host}:${sql.port}/${sql.databaseName}`;
           }
         }
+
+        // For Database Health monitors, show host:port/database (never the credentials).
+        if (
+          monitorType === MonitorType.Database &&
+          firstStep?.data?.databaseMonitor
+        ) {
+          const database: {
+            host: string;
+            port: number;
+            databaseName: string;
+          } = firstStep.data.databaseMonitor;
+          if (database.host) {
+            monitorDestination = `${database.host}:${database.port}/${database.databaseName}`;
+          }
+        }
       }
     }
 

--- a/Common/Server/Utils/LogRedaction.ts
+++ b/Common/Server/Utils/LogRedaction.ts
@@ -75,6 +75,14 @@ const SENSITIVE_KEY_FRAGMENTS: Array<string> = [
   "onetimecode",
   "logincode",
   "resetcode",
+  /*
+   * A DSN carries the password inline, so the key name is the only signal
+   * we get before the value is already in the log line.
+   */
+  "connectionstring",
+  "connectionuri",
+  "dsn",
+  "sslkey",
 ];
 
 /*

--- a/Common/Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria.ts
@@ -1,0 +1,190 @@
+import DataToProcess from "../DataToProcess";
+import CompareCriteria from "./CompareCriteria";
+import EvaluateOverTime, { OverTimeCriteriaValue } from "./EvaluateOverTime";
+import {
+  CheckOn,
+  CriteriaFilter,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import {
+  DatabaseMetricDefinition,
+  getDatabaseMetricByMetricType,
+} from "../../../../Types/Monitor/DatabaseMetricCatalog";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+} from "../../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import MonitorMetricType from "../../../../Types/Monitor/MonitorMetricType";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+export default class DatabaseMonitorCriteria {
+  @CaptureSpan()
+  public static async isMonitorInstanceCriteriaFilterMet(input: {
+    dataToProcess: DataToProcess;
+    criteriaFilter: CriteriaFilter;
+    /*
+     * The monitor's monitoringInterval cron. Over-time filters use it to
+     * work out how many samples a fully covered window should hold, so a
+     * monitor that has only just started is not mistaken for one whose
+     * whole window is breaching.
+     */
+    monitoringInterval?: string | undefined;
+  }): Promise<string | null> {
+    const dataToProcess: ProbeMonitorResponse =
+      input.dataToProcess as ProbeMonitorResponse;
+
+    const databaseResponse: DatabaseMonitorResponse | undefined =
+      dataToProcess.databaseMonitorResponse;
+
+    /*
+     * Resolved once for every CheckOn. Database Metric filters name their
+     * series in databaseMonitorOptions.metricType rather than in the CheckOn,
+     * which is why EvaluateOverTime resolves the series from the whole filter.
+     */
+    const overTime: OverTimeCriteriaValue =
+      await EvaluateOverTime.getOverTimeValueForCriteriaFilter({
+        projectId: dataToProcess.projectId,
+        monitorId: input.dataToProcess.monitorId!,
+        criteriaFilter: input.criteriaFilter,
+        monitoringInterval: input.monitoringInterval,
+      });
+
+    /*
+     * The window could not back this over-time filter, so the no-data policy
+     * has already decided it - do not fall through to the value that arrived
+     * with this one check. That fallback is what let "all values over the
+     * last N minutes" fire off a single bad reading.
+     *
+     * "Database Is Online" is exempt, mirroring the server monitor. An
+     * unreachable database is the one signal that must always reach its
+     * criteria: a monitor whose window is still filling, or whose metric
+     * write has not caught up, would otherwise be unable to go offline at
+     * all while the dashboard shows the connection failing.
+     */
+    if (
+      overTime.earlyReturn &&
+      input.criteriaFilter.checkOn !== CheckOn.DatabaseIsOnline
+    ) {
+      return overTime.earlyReturn.result;
+    }
+
+    const overTimeValue:
+      | Array<number | boolean>
+      | number
+      | boolean
+      | undefined = overTime.value;
+
+    // Could the probe connect and run the baseline probe query?
+    if (input.criteriaFilter.checkOn === CheckOn.DatabaseIsOnline) {
+      const currentIsOnline: boolean | Array<boolean> =
+        (overTimeValue as Array<boolean>) ?? dataToProcess.isOnline;
+
+      return CompareCriteria.compareCriteriaBoolean({
+        value: currentIsOnline,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    /*
+     * One branch for all of the catalog's series: the filter names the one it
+     * reads in databaseMonitorOptions.metricType, exactly as disk usage names
+     * a mount and an SNMP value names an OID.
+     *
+     * Thresholds are whole numbers - CompareCriteria.convertToNumber parses
+     * with parseInt, so "99.5" is compared as 99. Every catalog unit is
+     * chosen so an integral threshold is the natural one to type.
+     */
+    if (input.criteriaFilter.checkOn === CheckOn.DatabaseMetric) {
+      const metricType: MonitorMetricType | undefined =
+        input.criteriaFilter.databaseMonitorOptions?.metricType;
+
+      if (!metricType) {
+        return null;
+      }
+
+      const definition: DatabaseMetricDefinition | null =
+        getDatabaseMetricByMetricType(metricType);
+
+      if (!definition) {
+        return null;
+      }
+
+      const value: number | undefined = databaseResponse?.metrics[metricType];
+
+      /*
+       * The metric was not collected on this check - the engine cannot report
+       * it, the monitoring login is missing the grant its group needs, or the
+       * group timed out. Absent is not zero, and a criteria that cannot see a
+       * value must never claim one breached: a revoked grant would otherwise
+       * raise an incident about a database that is perfectly healthy.
+       * CheckOn.DatabaseCollectionError is how an operator alerts on lost
+       * visibility.
+       */
+      if (value === undefined || value === null) {
+        return null;
+      }
+
+      const threshold: number | null = CompareCriteria.convertToNumber(
+        input.criteriaFilter.value,
+      );
+
+      if (threshold === null) {
+        return null;
+      }
+
+      const result: string | null = CompareCriteria.compareCriteriaNumbers({
+        value: (overTimeValue as Array<number>) ?? value,
+        threshold: threshold,
+        criteriaFilter: input.criteriaFilter,
+        unit: definition.unit || undefined,
+      });
+
+      if (result) {
+        return `${definition.friendlyName} - ${result}`;
+      }
+
+      return null;
+    }
+
+    // Groups that could not be collected, as one operator-facing line each.
+    if (input.criteriaFilter.checkOn === CheckOn.DatabaseCollectionError) {
+      const collectionIssues: string = (
+        databaseResponse?.unavailableGroups || []
+      )
+        .map((status: DatabaseMetricGroupStatus) => {
+          return `${status.group}: ${status.message}`;
+        })
+        .join("; ");
+
+      /*
+       * compareEmptyAndNotEmpty tests for null/undefined, and an empty string
+       * would read as "not empty" - so a check with nothing to report has to
+       * arrive as undefined for "Is Empty" to mean "collection was clean".
+       */
+      const emptyNotEmptyResult: string | null =
+        CompareCriteria.compareEmptyAndNotEmpty({
+          value: collectionIssues || undefined,
+          criteriaFilter: input.criteriaFilter,
+        });
+
+      if (emptyNotEmptyResult) {
+        return emptyNotEmptyResult;
+      }
+
+      if (
+        input.criteriaFilter.value !== null &&
+        input.criteriaFilter.value !== undefined &&
+        collectionIssues
+      ) {
+        return CompareCriteria.compareCriteriaStrings({
+          value: collectionIssues,
+          threshold: input.criteriaFilter.value.toString(),
+          criteriaFilter: input.criteriaFilter,
+        });
+      }
+
+      return null;
+    }
+
+    return null;
+  }
+}

--- a/Common/Server/Utils/Monitor/Criteria/EvaluateOverTime.ts
+++ b/Common/Server/Utils/Monitor/Criteria/EvaluateOverTime.ts
@@ -177,6 +177,7 @@ export default class EvaluateOverTime {
         data.criteriaFilter.checkOn === CheckOn.IsRequestTimeout ||
         data.criteriaFilter.checkOn === CheckOn.DnsIsOnline ||
         data.criteriaFilter.checkOn === CheckOn.SnmpIsOnline ||
+        data.criteriaFilter.checkOn === CheckOn.DatabaseIsOnline ||
         data.criteriaFilter.checkOn === CheckOn.ExternalStatusPageIsOnline;
 
       return {
@@ -220,9 +221,15 @@ export default class EvaluateOverTime {
       };
     }
 
+    /*
+     * Resolved from the whole filter, not from the CheckOn alone: a Database
+     * Metric filter names its series in databaseMonitorOptions.metricType, so
+     * the CheckOn-only lookup would return null for every one of them and
+     * silently downgrade the filter to an instantaneous comparison.
+     */
     const metricName: MonitorMetricType | null =
-      MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(
-        data.criteriaFilter.checkOn,
+      MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+        data.criteriaFilter,
       );
 
     if (!metricName) {

--- a/Common/Server/Utils/Monitor/MonitorCriteriaDataExtractor.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaDataExtractor.ts
@@ -9,6 +9,7 @@ import MetricMonitorResponse from "../../../Types/Monitor/MetricMonitor/MetricMo
 import CustomCodeMonitorResponse from "../../../Types/Monitor/CustomCodeMonitor/CustomCodeMonitorResponse";
 import SyntheticMonitorResponse from "../../../Types/Monitor/SyntheticMonitors/SyntheticMonitorResponse";
 import SslMonitorResponse from "../../../Types/Monitor/SSLMonitor/SslMonitorResponse";
+import DatabaseMonitorResponse from "../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
 import { CriteriaFilter } from "../../../Types/Monitor/CriteriaFilter";
 import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
@@ -137,6 +138,19 @@ export default class MonitorCriteriaDataExtractor {
 
     if (probeResponse?.sslResponse) {
       return probeResponse.sslResponse;
+    }
+
+    return null;
+  }
+
+  public static getDatabaseMonitorResponse(
+    dataToProcess: DataToProcess,
+  ): DatabaseMonitorResponse | null {
+    const probeResponse: ProbeMonitorResponse | null =
+      MonitorCriteriaDataExtractor.getProbeMonitorResponse(dataToProcess);
+
+    if (probeResponse?.databaseMonitorResponse) {
+      return probeResponse.databaseMonitorResponse;
     }
 
     return null;

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -25,6 +25,7 @@ import DnsMonitorCriteria from "./Criteria/DnsMonitorCriteria";
 import DomainMonitorCriteria from "./Criteria/DomainMonitorCriteria";
 import DnssecMonitorCriteria from "./Criteria/DnssecMonitorCriteria";
 import SqlMonitorCriteria from "./Criteria/SqlMonitorCriteria";
+import DatabaseMonitorCriteria from "./Criteria/DatabaseMonitorCriteria";
 import ExternalStatusPageMonitorCriteria from "./Criteria/ExternalStatusPageMonitorCriteria";
 import MonitorCriteriaMessageBuilder from "./MonitorCriteriaMessageBuilder";
 import MonitorCriteriaDataExtractor from "./MonitorCriteriaDataExtractor";
@@ -48,6 +49,9 @@ import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
 import RequestFailedDetails from "../../../Types/Probe/RequestFailedDetails";
 import IncomingMonitorRequest from "../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import SqlMonitorResponse from "../../../Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+} from "../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
 import MonitorType from "../../../Types/Monitor/MonitorType";
 import { CheckOn, CriteriaFilter } from "../../../Types/Monitor/CriteriaFilter";
 import OneUptimeDate from "../../../Types/Date";
@@ -883,6 +887,38 @@ ${contextBlock}
         };
       }
 
+      if (input.monitor.monitorType === MonitorType.Database) {
+        const databaseResponse: DatabaseMonitorResponse | undefined = (
+          input.dataToProcess as ProbeMonitorResponse
+        ).databaseMonitorResponse;
+
+        /*
+         * metrics is exposed raw, keyed by series name, so an expression can
+         * read any of the catalog's series without a variable per metric:
+         * {{metrics['oneuptime.monitor.database.connections.used.percent']}} > 90
+         *
+         * Connection details are deliberately absent - host, username and
+         * password never travel into an expression sandbox.
+         */
+        storageMap = {
+          isOnline: (input.dataToProcess as ProbeMonitorResponse).isOnline,
+          engineVersion: databaseResponse?.engineVersion,
+          connectionError: databaseResponse?.connectionError,
+          collectedGroups: databaseResponse?.collectedGroups,
+          unavailableGroups: (databaseResponse?.unavailableGroups || []).map(
+            (status: DatabaseMetricGroupStatus): JSONObject => {
+              return {
+                group: status.group,
+                reason: status.reason,
+                message: status.message,
+                remediation: status.remediation,
+              };
+            },
+          ),
+          metrics: databaseResponse?.metrics,
+        };
+      }
+
       let expression: string = input.criteriaFilter.value as string;
       expression = VMUtil.replaceValueInPlace(storageMap, expression, false);
 
@@ -1170,6 +1206,19 @@ ${contextBlock}
 
       if (sqlMonitorResult) {
         return sqlMonitorResult;
+      }
+    }
+
+    if (input.monitor.monitorType === MonitorType.Database) {
+      const databaseMonitorResult: string | null =
+        await DatabaseMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: input.dataToProcess,
+          criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+        });
+
+      if (databaseMonitorResult) {
+        return databaseMonitorResult;
       }
     }
 

--- a/Common/Server/Utils/Monitor/MonitorCriteriaObservationBuilder.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaObservationBuilder.ts
@@ -24,6 +24,15 @@ import ExceptionMonitorResponse from "../../../Types/Monitor/ExceptionMonitor/Ex
 import SnmpMonitorResponse, {
   SnmpOidResponse,
 } from "../../../Types/Monitor/SnmpMonitor/SnmpMonitorResponse";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+  DatabaseMetricGroupUnavailableReason,
+} from "../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import {
+  DatabaseMetricDefinition,
+  getDatabaseMetricByMetricType,
+} from "../../../Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
 import MonitorCriteriaMessageFormatter from "./MonitorCriteriaMessageFormatter";
 import MonitorCriteriaDataExtractor from "./MonitorCriteriaDataExtractor";
 import MonitorCriteriaExpectationBuilder from "./MonitorCriteriaExpectationBuilder";
@@ -193,6 +202,18 @@ export default class MonitorCriteriaObservationBuilder {
         );
       case CheckOn.SnmpOidValue:
         return MonitorCriteriaObservationBuilder.describeSnmpOidValueObservation(
+          input,
+        );
+      case CheckOn.DatabaseIsOnline:
+        return MonitorCriteriaObservationBuilder.describeDatabaseIsOnlineObservation(
+          input,
+        );
+      case CheckOn.DatabaseMetric:
+        return MonitorCriteriaObservationBuilder.describeDatabaseMetricObservation(
+          input,
+        );
+      case CheckOn.DatabaseCollectionError:
+        return MonitorCriteriaObservationBuilder.describeDatabaseCollectionErrorObservation(
           input,
         );
       default:
@@ -1374,6 +1395,24 @@ export default class MonitorCriteriaObservationBuilder {
     dataToProcess: DataToProcess;
     monitorStep: MonitorStep;
   }): string | undefined {
+    /*
+     * Database Health thresholds are typed in the metric's own unit, which
+     * only the catalog knows - without this the expectation clause reads
+     * "greater than 90" next to an observation of "95.0%".
+     */
+    if (input.criteriaFilter.checkOn === CheckOn.DatabaseMetric) {
+      const metricType: MonitorMetricType | undefined =
+        input.criteriaFilter.databaseMonitorOptions?.metricType;
+
+      const definition: DatabaseMetricDefinition | null = metricType
+        ? getDatabaseMetricByMetricType(metricType)
+        : null;
+
+      return MonitorCriteriaObservationBuilder.normalizeDisplayUnit(
+        definition?.unit,
+      );
+    }
+
     if (input.criteriaFilter.checkOn !== CheckOn.MetricValue) {
       return undefined;
     }
@@ -1540,5 +1579,180 @@ export default class MonitorCriteriaObservationBuilder {
     }
 
     return String(value);
+  }
+
+  private static describeDatabaseIsOnlineObservation(input: {
+    dataToProcess: DataToProcess;
+  }): string | null {
+    const probeResponse: ProbeMonitorResponse | null =
+      MonitorCriteriaDataExtractor.getProbeMonitorResponse(input.dataToProcess);
+
+    if (!probeResponse) {
+      return null;
+    }
+
+    const databaseResponse: DatabaseMonitorResponse | null =
+      MonitorCriteriaDataExtractor.getDatabaseMonitorResponse(
+        input.dataToProcess,
+      );
+
+    if (databaseResponse?.isOnline ?? probeResponse.isOnline) {
+      return "The database was reachable.";
+    }
+
+    /*
+     * Both of these are sanitized by the collector before they leave the
+     * probe - the connection string, the password and the login never reach
+     * an operator-facing sentence.
+     */
+    const failureCause: string =
+      databaseResponse?.connectionError ||
+      databaseResponse?.failureCause ||
+      probeResponse.failureCause ||
+      "";
+
+    if (failureCause) {
+      return `The database was not reachable: ${failureCause}`;
+    }
+
+    return "The database was not reachable.";
+  }
+
+  private static describeDatabaseMetricObservation(input: {
+    criteriaFilter: CriteriaFilter;
+    dataToProcess: DataToProcess;
+  }): string | null {
+    const metricType: MonitorMetricType | undefined =
+      input.criteriaFilter.databaseMonitorOptions?.metricType;
+
+    if (!metricType) {
+      return "No database metric is configured on this criteria. Pick one from the metric dropdown in the criteria editor.";
+    }
+
+    const definition: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(metricType);
+
+    if (!definition) {
+      return `${metricType} is not a metric the Database Health monitor collects.`;
+    }
+
+    const databaseResponse: DatabaseMonitorResponse | null =
+      MonitorCriteriaDataExtractor.getDatabaseMonitorResponse(
+        input.dataToProcess,
+      );
+
+    const value: number | undefined = databaseResponse?.metrics[metricType];
+
+    /*
+     * An absent metric is the normal outcome of partial collection, and the
+     * operator's next action depends entirely on why: a grant to run, an
+     * engine that has no such counter, or a group that timed out. Saying so -
+     * rather than declining to describe the check at all - is what turns a
+     * blank chart into something fixable.
+     */
+    if (value === undefined || value === null) {
+      return MonitorCriteriaObservationBuilder.describeUncollectedDatabaseMetric(
+        {
+          definition: definition,
+          databaseResponse: databaseResponse,
+        },
+      );
+    }
+
+    return `${definition.friendlyName} was ${MonitorCriteriaObservationBuilder.formatDatabaseMetricValue(
+      value,
+      definition.unit,
+    )}.`;
+  }
+
+  private static describeUncollectedDatabaseMetric(input: {
+    definition: DatabaseMetricDefinition;
+    databaseResponse: DatabaseMonitorResponse | null;
+  }): string {
+    const status: DatabaseMetricGroupStatus | undefined =
+      input.databaseResponse?.unavailableGroups?.find(
+        (groupStatus: DatabaseMetricGroupStatus) => {
+          return groupStatus.group === input.definition.group;
+        },
+      );
+
+    if (!status) {
+      return `${input.definition.friendlyName} was not collected on this check.`;
+    }
+
+    let message: string = `${input.definition.friendlyName} was not collected on this check: ${MonitorCriteriaObservationBuilder.describeDatabaseGroupUnavailableReason(
+      status.reason,
+    )}`;
+
+    if (status.remediation) {
+      message += ` (${status.remediation})`;
+    }
+
+    return `${message}.`;
+  }
+
+  private static describeDatabaseGroupUnavailableReason(
+    reason: DatabaseMetricGroupUnavailableReason,
+  ): string {
+    switch (reason) {
+      case DatabaseMetricGroupUnavailableReason.MissingPermission:
+        return "the monitoring login is missing a grant";
+      case DatabaseMetricGroupUnavailableReason.NotSupportedByEngine:
+        return "the connected engine does not report it";
+      case DatabaseMetricGroupUnavailableReason.Timeout:
+        return "its metric group timed out";
+      default:
+        return "its metric group could not be collected";
+    }
+  }
+
+  private static formatDatabaseMetricValue(
+    value: number,
+    unit: string,
+  ): string {
+    if (unit === "%") {
+      return (
+        MonitorCriteriaMessageFormatter.formatPercentage(value) ?? String(value)
+      );
+    }
+
+    if (unit === "bytes") {
+      return (
+        MonitorCriteriaMessageFormatter.formatBytes(value) ?? String(value)
+      );
+    }
+
+    const formatted: string =
+      MonitorCriteriaMessageFormatter.formatNumber(value, {
+        maximumFractionDigits: 2,
+      }) ?? String(value);
+
+    return unit ? `${formatted} ${unit}` : formatted;
+  }
+
+  private static describeDatabaseCollectionErrorObservation(input: {
+    dataToProcess: DataToProcess;
+  }): string | null {
+    const databaseResponse: DatabaseMonitorResponse | null =
+      MonitorCriteriaDataExtractor.getDatabaseMonitorResponse(
+        input.dataToProcess,
+      );
+
+    if (!databaseResponse) {
+      return null;
+    }
+
+    const statuses: Array<DatabaseMetricGroupStatus> =
+      databaseResponse.unavailableGroups || [];
+
+    if (!statuses.length) {
+      return "All metric groups were collected.";
+    }
+
+    return `Collection issues: ${statuses
+      .map((status: DatabaseMetricGroupStatus) => {
+        return `${status.group}: ${status.message}`;
+      })
+      .join("; ")}.`;
   }
 }

--- a/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
@@ -19,6 +19,8 @@ import BasicInfrastructureMetrics, {
 import Dictionary from "../../../Types/Dictionary";
 import { JSONObject } from "../../../Types/JSON";
 import CapturedMetric from "../../../Types/Monitor/CustomCodeMonitor/CapturedMetric";
+import { getAllDatabaseMetrics } from "../../../Types/Monitor/DatabaseMetricCatalog";
+import DatabaseMonitorResponse from "../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
 import HttpPhaseTimings from "../../../Types/Monitor/HttpPhaseTimings";
 import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
 import PingMonitorResponse from "../../../Types/Monitor/PingMonitor/PingMonitorResponse";
@@ -954,6 +956,45 @@ export default class MonitorMetricUtil {
       metricType.unit = "ms";
 
       metricNameServiceNameMap[MonitorMetricType.ResponseTime] = metricType;
+    }
+
+    const databaseResponse: DatabaseMonitorResponse | undefined = (
+      data.dataToProcess as ProbeMonitorResponse
+    ).databaseMonitorResponse;
+
+    if (databaseResponse) {
+      const extraAttributes: JSONObject = {
+        probeId: (
+          data.dataToProcess as ProbeMonitorResponse
+        ).probeId.toString(),
+      };
+
+      /*
+       * Driven off the catalog rather than a list here so a metric is wired
+       * end to end the moment it is added there. Every database series is
+       * single-valued per check, so there is no per-series fan-out to cap
+       * and probeId is the only attribute worth carrying.
+       *
+       * A metric the engine could not report, or whose group was skipped,
+       * is simply absent from the map and pushMonitorMetric writes no row
+       * for it. Absent must never become zero: a replication lag that was
+       * not measured and a replication lag of zero mean opposite things.
+       */
+      for (const definition of getAllDatabaseMetrics()) {
+        await this.pushMonitorMetric({
+          projectId: data.projectId,
+          monitorId: data.monitorId,
+          monitorName: data.monitorName,
+          probeName: data.probeName,
+          metricName: definition.metricType,
+          value: databaseResponse.metrics[definition.metricType],
+          description: definition.description,
+          unit: definition.unit,
+          extraAttributes: extraAttributes,
+          metricRows: metricRows,
+          metricNameServiceNameMap: metricNameServiceNameMap,
+        });
+      }
     }
 
     const snmpInterfaces: Array<SnmpInterface> | undefined = (

--- a/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
@@ -24,6 +24,9 @@ import DnsMonitorResponse, {
 } from "../../../Types/Monitor/DnsMonitor/DnsMonitorResponse";
 import DomainMonitorResponse from "../../../Types/Monitor/DomainMonitor/DomainMonitorResponse";
 import DnssecMonitorResponse from "../../../Types/Monitor/DnssecMonitor/DnssecMonitorResponse";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+} from "../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
 import ExternalStatusPageMonitorResponse, {
   ExternalStatusPageComponentStatus,
 } from "../../../Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
@@ -461,6 +464,46 @@ export default class MonitorTemplateUtil {
           dnskeyCount: dnssecResponse?.dnskeys?.length,
           dsRecordCount: dnssecResponse?.parentDsRecords?.length,
           rrsigCount: dnssecResponse?.rrsigs?.length,
+        } as JSONObject;
+      }
+
+      if (data.monitorType === MonitorType.Database) {
+        const databaseResponse: DatabaseMonitorResponse | undefined = (
+          data.dataToProcess as ProbeMonitorResponse
+        ).databaseMonitorResponse;
+
+        const unavailableGroups: Array<DatabaseMetricGroupStatus> =
+          databaseResponse?.unavailableGroups || [];
+
+        storageMap = {
+          isOnline: (data.dataToProcess as ProbeMonitorResponse).isOnline,
+          responseTimeInMs: databaseResponse?.responseTimeInMs,
+          failureCause: databaseResponse?.failureCause,
+          connectionError: databaseResponse?.connectionError,
+          engineVersion: databaseResponse?.engineVersion,
+          collectedGroups: databaseResponse?.collectedGroups || [],
+          unavailableGroups: unavailableGroups.map(
+            (status: DatabaseMetricGroupStatus) => {
+              return {
+                group: status.group,
+                reason: status.reason,
+                message: status.message,
+                remediation: status.remediation,
+              };
+            },
+          ),
+          /*
+           * Partial collection is the normal state of this monitor, so the
+           * ready-made sentence matters more here than the array does - an
+           * incident title has room for one line, not a loop.
+           */
+          collectionIssueSummary: unavailableGroups
+            .map((status: DatabaseMetricGroupStatus) => {
+              return `${status.group}: ${status.message}`;
+            })
+            .join("; "),
+          // A metric absent from this map was not collected on this check.
+          metrics: databaseResponse?.metrics || {},
         } as JSONObject;
       }
 

--- a/Common/Tests/App/Dashboard/MonitorTypePicker.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorTypePicker.test.tsx
@@ -121,7 +121,7 @@ describe("Monitor type picker", () => {
 
     /*
      * The whole point of the change. Every type used to render at once - nine
-     * headings and 29 cards, about six thousand pixels of them.
+     * headings and 31 cards, about six thousand pixels of them.
      */
     test("the long tail starts folded away behind its headings", () => {
       renderPicker();
@@ -175,7 +175,9 @@ describe("Monitor type picker", () => {
   describe("finding a type by the words a user already knows", () => {
     test.each([
       ["k8s", MonitorType.Kubernetes],
-      ["postgres", MonitorType.SQLQuery],
+      // An engine name means health series; "query" means the escape hatch.
+      ["postgres", MonitorType.Database],
+      ["query", MonitorType.SQLQuery],
       ["heartbeat", MonitorType.IncomingRequest],
       ["tls", MonitorType.SSLCertificate],
       ["snmp", MonitorType.NetworkDevice],

--- a/Common/Tests/Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria.test.ts
@@ -1,0 +1,633 @@
+import DatabaseMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/DatabaseMonitorCriteria";
+import EvaluateOverTime, {
+  OverTimeCriteriaValue,
+} from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import {
+  DatabaseMetricDefinition,
+  DatabaseMetricGroup,
+  getAllDatabaseMetrics,
+} from "../../../../../Types/Monitor/DatabaseMetricCatalog";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+  DatabaseMetricGroupUnavailableReason,
+} from "../../../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import MonitorMetricType from "../../../../../Types/Monitor/MonitorMetricType";
+import ProbeMonitorResponse from "../../../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../../../Types/ObjectID";
+
+/*
+ * `metrics` defaults to {} so "the metric was not collected" is the default
+ * state a test has to opt out of, matching the collector: a metric is present
+ * only when the probe actually read it.
+ */
+function buildDataToProcess(input: {
+  isOnline?: boolean;
+  responseTimeInMs?: number;
+  failureCause?: string;
+  connectionError?: string | null;
+  metrics?: Partial<Record<MonitorMetricType, number>>;
+  collectedGroups?: Array<DatabaseMetricGroup>;
+  unavailableGroups?: Array<DatabaseMetricGroupStatus>;
+}): ProbeMonitorResponse {
+  const databaseResponse: DatabaseMonitorResponse = {
+    isOnline: input.isOnline ?? true,
+    responseTimeInMs: input.responseTimeInMs ?? 12,
+    failureCause: input.failureCause ?? "",
+    metrics: input.metrics ?? {},
+    collectedGroups: input.collectedGroups ?? [],
+    unavailableGroups: input.unavailableGroups ?? [],
+    connectionError: input.connectionError ?? null,
+  };
+
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: input.failureCause ?? "",
+    isOnline: input.isOnline ?? true,
+    responseTimeInMs: input.responseTimeInMs ?? 12,
+    databaseMonitorResponse: databaseResponse,
+    monitoredAt: new Date(),
+  };
+}
+
+async function evaluate(
+  dataToProcess: ProbeMonitorResponse,
+  criteriaFilter: CriteriaFilter,
+): Promise<string | null> {
+  return DatabaseMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess,
+    criteriaFilter,
+  });
+}
+
+function metricFilter(
+  metricType: MonitorMetricType,
+  filterType: FilterType,
+  value: string | number | undefined,
+): CriteriaFilter {
+  return {
+    checkOn: CheckOn.DatabaseMetric,
+    filterType: filterType,
+    value: value,
+    databaseMonitorOptions: { metricType: metricType },
+  };
+}
+
+describe("DatabaseMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("DatabaseIsOnline", () => {
+    test("online + True -> met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true }),
+        {
+          checkOn: CheckOn.DatabaseIsOnline,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("online + False -> not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true }),
+        {
+          checkOn: CheckOn.DatabaseIsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+      expect(result).toBeNull();
+    });
+
+    test("offline + False -> met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: false,
+          connectionError: "connection refused",
+        }),
+        {
+          checkOn: CheckOn.DatabaseIsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    /*
+     * The whole point of the degradation contract: every group failed, yet
+     * the handshake succeeded, so the monitor is online and the offline
+     * criteria must not fire.
+     */
+    test("every group unavailable but reachable + False -> not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          unavailableGroups: [
+            {
+              group: DatabaseMetricGroup.Connections,
+              reason: DatabaseMetricGroupUnavailableReason.MissingPermission,
+              message: "pg_stat_activity requires the pg_monitor role.",
+              remediation: "GRANT pg_monitor TO monitoring_user;",
+            },
+            {
+              group: DatabaseMetricGroup.Replication,
+              reason: DatabaseMetricGroupUnavailableReason.MissingPermission,
+              message: "pg_stat_replication requires the pg_monitor role.",
+            },
+          ],
+        }),
+        {
+          checkOn: CheckOn.DatabaseIsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("DatabaseMetric", () => {
+    test("percent metric 95 > 90 -> met and names the metric", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 95,
+          },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          FilterType.GreaterThan,
+          "90",
+        ),
+      );
+
+      expect(result).toContain("Connections Used");
+      expect(result).toContain("95");
+    });
+
+    test("percent metric 40 > 90 -> not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 40,
+          },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          FilterType.GreaterThan,
+          "90",
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("seconds metric exactly at the threshold is not greater than it", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseReplicationLagSeconds]: 300,
+          },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseReplicationLagSeconds,
+          FilterType.GreaterThan,
+          "300",
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("seconds metric exactly at the threshold is greater than or equal to it", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseReplicationLagSeconds]: 300,
+          },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseReplicationLagSeconds,
+          FilterType.GreaterThanOrEqualTo,
+          "300",
+        ),
+      );
+
+      expect(result).toContain("Replication Lag");
+    });
+
+    /*
+     * A cumulative counter reading zero is a real measurement - it must be
+     * compared, not mistaken for the absent case below.
+     */
+    test("cumulative counter at zero is compared, not treated as absent", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: { [MonitorMetricType.DatabaseQueriesTotal]: 0 },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseQueriesTotal,
+          FilterType.EqualTo,
+          "0",
+        ),
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    /*
+     * THE degradation guarantee. A metric the probe could not read is absent
+     * from the map, and an absent metric may never satisfy a filter - a
+     * revoked grant must not raise an incident about a healthy database.
+     * Written as a sweep so a metric added to the catalog later cannot skip
+     * it.
+     */
+    test.each(
+      getAllDatabaseMetrics().map((definition: DatabaseMetricDefinition) => {
+        return [definition.friendlyName, definition.metricType] as [
+          string,
+          MonitorMetricType,
+        ];
+      }),
+    )(
+      "%s is not met by any comparison when it was not collected",
+      async (_friendlyName: string, metricType: MonitorMetricType) => {
+        const dataToProcess: ProbeMonitorResponse = buildDataToProcess({
+          unavailableGroups: [
+            {
+              group: DatabaseMetricGroup.Connections,
+              reason: DatabaseMetricGroupUnavailableReason.MissingPermission,
+              message: "The monitoring login cannot read this view.",
+              remediation: "GRANT pg_monitor TO monitoring_user;",
+            },
+          ],
+        });
+
+        const filterTypes: Array<FilterType> = [
+          FilterType.GreaterThan,
+          FilterType.LessThan,
+          FilterType.EqualTo,
+          FilterType.NotEqualTo,
+          FilterType.GreaterThanOrEqualTo,
+          FilterType.LessThanOrEqualTo,
+        ];
+
+        for (const filterType of filterTypes) {
+          const result: string | null = await evaluate(
+            dataToProcess,
+            metricFilter(metricType, filterType, "0"),
+          );
+
+          expect(result).toBeNull();
+        }
+      },
+    );
+
+    test("no databaseMonitorOptions -> null", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 95,
+          },
+        }),
+        {
+          checkOn: CheckOn.DatabaseMetric,
+          filterType: FilterType.GreaterThan,
+          value: "90",
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("metricType outside the database catalog -> null", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: { [MonitorMetricType.CPUUsagePercent]: 95 },
+        }),
+        metricFilter(
+          MonitorMetricType.CPUUsagePercent,
+          FilterType.GreaterThan,
+          "90",
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("missing threshold -> null", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 95,
+          },
+        }),
+        metricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          FilterType.GreaterThan,
+          undefined,
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("no database response at all -> null", async () => {
+      const dataToProcess: ProbeMonitorResponse = buildDataToProcess({});
+      delete dataToProcess.databaseMonitorResponse;
+
+      const result: string | null = await evaluate(
+        dataToProcess,
+        metricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          FilterType.GreaterThan,
+          "0",
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("DatabaseCollectionError", () => {
+    const degradedGroups: Array<DatabaseMetricGroupStatus> = [
+      {
+        group: DatabaseMetricGroup.Locks,
+        reason: DatabaseMetricGroupUnavailableReason.MissingPermission,
+        message: "pg_locks requires the pg_monitor role.",
+        remediation: "GRANT pg_monitor TO monitoring_user;",
+      },
+    ];
+
+    test("no unavailable groups + IsEmpty -> met", async () => {
+      const result: string | null = await evaluate(buildDataToProcess({}), {
+        checkOn: CheckOn.DatabaseCollectionError,
+        filterType: FilterType.IsEmpty,
+        value: undefined,
+      });
+
+      expect(result).toBeTruthy();
+    });
+
+    test("no unavailable groups + IsNotEmpty -> not met", async () => {
+      const result: string | null = await evaluate(buildDataToProcess({}), {
+        checkOn: CheckOn.DatabaseCollectionError,
+        filterType: FilterType.IsNotEmpty,
+        value: undefined,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("unavailable group + IsNotEmpty -> met and reports the group", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ unavailableGroups: degradedGroups }),
+        {
+          checkOn: CheckOn.DatabaseCollectionError,
+          filterType: FilterType.IsNotEmpty,
+          value: undefined,
+        },
+      );
+
+      expect(result).toContain(DatabaseMetricGroup.Locks);
+      expect(result).toContain("pg_monitor");
+    });
+
+    test("unavailable group + IsEmpty -> not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ unavailableGroups: degradedGroups }),
+        {
+          checkOn: CheckOn.DatabaseCollectionError,
+          filterType: FilterType.IsEmpty,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("Contains matches the joined message", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ unavailableGroups: degradedGroups }),
+        {
+          checkOn: CheckOn.DatabaseCollectionError,
+          filterType: FilterType.Contains,
+          value: "pg_locks",
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("Contains does not match an unrelated needle", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ unavailableGroups: degradedGroups }),
+        {
+          checkOn: CheckOn.DatabaseCollectionError,
+          filterType: FilterType.Contains,
+          value: "replication",
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  /*
+   * The over-time window is read from the metric store, so it is spied here
+   * to keep these deterministic. The seam is the same one the server monitor
+   * criteria tests use.
+   */
+  describe("evaluate over time", () => {
+    function usable(
+      value: Array<number | boolean> | number | boolean,
+    ): OverTimeCriteriaValue {
+      return { earlyReturn: null, value: value };
+    }
+
+    function mockOverTime(
+      result: OverTimeCriteriaValue,
+    ): ReturnType<typeof jest.spyOn> {
+      return jest
+        .spyOn(EvaluateOverTime, "getOverTimeValueForCriteriaFilter")
+        .mockResolvedValue(result) as ReturnType<typeof jest.spyOn>;
+    }
+
+    function overTimeMetricFilter(
+      metricType: MonitorMetricType,
+      value: string,
+    ): CriteriaFilter {
+      return {
+        checkOn: CheckOn.DatabaseMetric,
+        filterType: FilterType.GreaterThan,
+        value: value,
+        databaseMonitorOptions: { metricType: metricType },
+        evaluateOverTime: true,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 5,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+        },
+      };
+    }
+
+    test("compares the window instead of the value from this one check", async () => {
+      mockOverTime(usable([95, 96]));
+
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 10,
+          },
+        }),
+        overTimeMetricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          "90",
+        ),
+      );
+
+      expect(result).toContain("95");
+      expect(result).toContain("96");
+    });
+
+    test("a window that cannot back the filter is honoured verbatim", async () => {
+      mockOverTime({
+        earlyReturn: {
+          result: "Database Metric has no data over the last 5 minutes.",
+        },
+        value: undefined,
+      });
+
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 99,
+          },
+        }),
+        overTimeMetricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          "90",
+        ),
+      );
+
+      expect(result).toBe(
+        "Database Metric has no data over the last 5 minutes.",
+      );
+    });
+
+    /*
+     * The regression this seam exists for: an unusable window must not fall
+     * through to the reading that arrived with this single check, or "all
+     * values over the last 5 minutes" fires off one bad sample.
+     */
+    test("an unusable window does not fall back to this check's breaching value", async () => {
+      mockOverTime({ earlyReturn: { result: null }, value: undefined });
+
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 99,
+          },
+        }),
+        overTimeMetricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          "90",
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    /*
+     * Reachability is exempt from that early return: an unreachable database
+     * must still be able to take the monitor offline while its window is
+     * still filling up.
+     */
+    test("Database Is Online still evaluates when the window is unusable", async () => {
+      mockOverTime({ earlyReturn: { result: null }, value: undefined });
+
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: false }),
+        {
+          checkOn: CheckOn.DatabaseIsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+          evaluateOverTime: true,
+          evaluateOverTimeOptions: {
+            timeValueInMinutes: 5,
+            evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          },
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("the filter is passed through so the window resolves the named series", async () => {
+      const spy: ReturnType<typeof jest.spyOn> = mockOverTime(usable([95]));
+
+      await evaluate(
+        buildDataToProcess({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 95,
+          },
+        }),
+        overTimeMetricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          "90",
+        ),
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          criteriaFilter: expect.objectContaining({
+            databaseMonitorOptions: {
+              metricType: MonitorMetricType.DatabaseConnectionsUsedPercent,
+            },
+          }),
+        }),
+      );
+    });
+
+    /*
+     * An absent metric is decided before the window is compared: a monitor
+     * whose grant was revoked mid-window must stop firing, not keep alerting
+     * off history.
+     */
+    test("an absent metric is still not met even with a breaching window", async () => {
+      mockOverTime(usable([95, 96]));
+
+      const result: string | null = await evaluate(
+        buildDataToProcess({}),
+        overTimeMetricFilter(
+          MonitorMetricType.DatabaseConnectionsUsedPercent,
+          "90",
+        ),
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  test("unrelated checkOn -> null", async () => {
+    const result: string | null = await evaluate(buildDataToProcess({}), {
+      checkOn: CheckOn.ResponseBody,
+      filterType: FilterType.Contains,
+      value: "x",
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/DatabaseMetricWrite.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/DatabaseMetricWrite.test.ts
@@ -1,0 +1,367 @@
+import { MetricPointType } from "../../../../Models/AnalyticsModels/Metric";
+import MetricType from "../../../../Models/DatabaseModels/MetricType";
+import GlobalConfigService from "../../../../Server/Services/GlobalConfigService";
+import MetricService from "../../../../Server/Services/MetricService";
+import MonitorMetricUtil from "../../../../Server/Utils/Monitor/MonitorMetricUtil";
+import TelemetryUtil from "../../../../Server/Utils/Telemetry/Telemetry";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
+import {
+  DatabaseMetricDefinition,
+  DatabaseMetricGroup,
+  getAllDatabaseMetrics,
+  getDatabaseMetricsByGroup,
+} from "../../../../Types/Monitor/DatabaseMetricCatalog";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+  DatabaseMetricGroupUnavailableReason,
+} from "../../../../Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import MonitorMetricType from "../../../../Types/Monitor/MonitorMetricType";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const PROBE_ID: ObjectID = new ObjectID("66666666-6666-4666-8666-666666666666");
+
+function buildDatabaseResponse(input: {
+  metrics?: Partial<Record<MonitorMetricType, number>>;
+  isOnline?: boolean;
+  unavailableGroups?: Array<DatabaseMetricGroupStatus>;
+  collectedGroups?: Array<DatabaseMetricGroup>;
+}): DatabaseMonitorResponse {
+  return {
+    isOnline: input.isOnline ?? true,
+    responseTimeInMs: 12,
+    failureCause: "",
+    metrics: input.metrics ?? {},
+    collectedGroups: input.collectedGroups ?? [],
+    unavailableGroups: input.unavailableGroups ?? [],
+    connectionError: null,
+    engineVersion: "PostgreSQL 15.18",
+  };
+}
+
+function buildProbeResponse(
+  databaseMonitorResponse: DatabaseMonitorResponse,
+): ProbeMonitorResponse {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    monitorStepId: ObjectID.generate(),
+    probeId: PROBE_ID,
+    failureCause: databaseMonitorResponse.failureCause,
+    monitoredAt: new Date("2026-09-02T10:00:00.000Z"),
+    isOnline: databaseMonitorResponse.isOnline,
+    responseTimeInMs: databaseMonitorResponse.responseTimeInMs,
+    databaseMonitorResponse: databaseMonitorResponse,
+  };
+}
+
+describe("MonitorMetricUtil Database Health metric write path", () => {
+  let insertedRows: Array<JSONObject>;
+  let indexedMaps: Array<Dictionary<MetricType>>;
+
+  beforeEach(() => {
+    insertedRows = [];
+    indexedMaps = [];
+
+    jest
+      .spyOn(GlobalConfigService, "findOneBy")
+      .mockResolvedValue(null as never);
+    jest
+      .spyOn(MetricService, "insertJsonRows")
+      .mockImplementation(async (rows: Array<JSONObject>): Promise<void> => {
+        insertedRows.push(...rows);
+      });
+    jest
+      .spyOn(TelemetryUtil, "indexMetricNameServiceNameMap")
+      .mockImplementation(
+        async (data: {
+          projectId: ObjectID;
+          metricNameServiceNameMap: Dictionary<MetricType>;
+        }): Promise<void> => {
+          indexedMaps.push(data.metricNameServiceNameMap);
+        },
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function save(response: ProbeMonitorResponse): Promise<void> {
+    await MonitorMetricUtil.saveMonitorMetrics({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      dataToProcess: response,
+      monitorName: "Orders Primary",
+      probeName: "Frankfurt Probe",
+    });
+  }
+
+  function rowsByName(name: MonitorMetricType): Array<JSONObject> {
+    return insertedRows.filter((row: JSONObject) => {
+      return row["name"] === name;
+    });
+  }
+
+  function databaseRows(): Array<JSONObject> {
+    const databaseMetricNames: Set<string> = new Set<string>(
+      getAllDatabaseMetrics().map((definition: DatabaseMetricDefinition) => {
+        return definition.metricType.toString();
+      }),
+    );
+
+    return insertedRows.filter((row: JSONObject) => {
+      return databaseMetricNames.has(String(row["name"]));
+    });
+  }
+
+  test("writes one row per collected metric, keyed by its own metric type", async () => {
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsTotal]: 42,
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 21,
+          },
+          collectedGroups: [DatabaseMetricGroup.Connections],
+        }),
+      ),
+    );
+
+    expect(databaseRows()).toHaveLength(2);
+    expect(rowsByName(MonitorMetricType.DatabaseConnectionsTotal)).toHaveLength(
+      1,
+    );
+    expect(
+      rowsByName(MonitorMetricType.DatabaseConnectionsTotal)[0]?.["value"],
+    ).toBe(42);
+    expect(
+      rowsByName(MonitorMetricType.DatabaseConnectionsUsedPercent)[0]?.[
+        "value"
+      ],
+    ).toBe(21);
+  });
+
+  test("carries only monitor, project and probe identity on database rows", async () => {
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: { [MonitorMetricType.DatabaseCacheHitPercent]: 99 },
+        }),
+      ),
+    );
+
+    const row: JSONObject | undefined = rowsByName(
+      MonitorMetricType.DatabaseCacheHitPercent,
+    )[0];
+
+    expect(row?.["primaryEntityId"]).toBe(MONITOR_ID.toString());
+    expect(row?.["metricPointType"]).toBe(MetricPointType.Sum);
+    expect(row?.["attributes"]).toEqual({
+      monitorId: MONITOR_ID.toString(),
+      projectId: PROJECT_ID.toString(),
+      probeId: PROBE_ID.toString(),
+      monitorName: "Orders Primary",
+      probeName: "Frankfurt Probe",
+    });
+  });
+
+  test("writes no row for a metric the check did not collect", async () => {
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: { [MonitorMetricType.DatabaseConnectionsTotal]: 7 },
+        }),
+      ),
+    );
+
+    for (const definition of getAllDatabaseMetrics()) {
+      if (
+        definition.metricType === MonitorMetricType.DatabaseConnectionsTotal
+      ) {
+        continue;
+      }
+
+      expect(rowsByName(definition.metricType)).toEqual([]);
+    }
+  });
+
+  /*
+   * The degradation contract: a group the monitoring login cannot read must
+   * leave its series with no datapoint at all. A zero here would read as a
+   * healthy measurement and silently resolve whatever it was meant to catch.
+   */
+  test("writes nothing - not zero - for the metrics of an unavailable group", async () => {
+    const lockMetrics: Array<DatabaseMetricDefinition> =
+      getDatabaseMetricsByGroup(DatabaseMetricGroup.Locks);
+
+    expect(lockMetrics.length).toBeGreaterThan(0);
+
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: { [MonitorMetricType.DatabaseConnectionsTotal]: 15 },
+          collectedGroups: [DatabaseMetricGroup.Connections],
+          unavailableGroups: [
+            {
+              group: DatabaseMetricGroup.Locks,
+              reason: DatabaseMetricGroupUnavailableReason.MissingPermission,
+              message: "The monitoring login cannot read lock statistics.",
+              remediation: "GRANT pg_monitor TO monitoring_user;",
+            },
+          ],
+        }),
+      ),
+    );
+
+    for (const definition of lockMetrics) {
+      expect(rowsByName(definition.metricType)).toEqual([]);
+    }
+
+    expect(
+      rowsByName(MonitorMetricType.DatabaseConnectionsTotal)[0]?.["value"],
+    ).toBe(15);
+  });
+
+  test("keeps a measured zero, which is a real value for every catalog metric", async () => {
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: {
+            [MonitorMetricType.DatabaseReplicationLagSeconds]: 0,
+            [MonitorMetricType.DatabaseMetricGroupsFailed]: 0,
+          },
+        }),
+      ),
+    );
+
+    expect(
+      rowsByName(MonitorMetricType.DatabaseReplicationLagSeconds)[0]?.["value"],
+    ).toBe(0);
+    expect(
+      rowsByName(MonitorMetricType.DatabaseMetricGroupsFailed)[0]?.["value"],
+    ).toBe(0);
+  });
+
+  test("still records availability and response time when no metric was collected", async () => {
+    await save(buildProbeResponse(buildDatabaseResponse({ metrics: {} })));
+
+    expect(databaseRows()).toEqual([]);
+    expect(rowsByName(MonitorMetricType.IsOnline)[0]?.["value"]).toBe(1);
+    expect(rowsByName(MonitorMetricType.ResponseTime)[0]?.["value"]).toBe(12);
+  });
+
+  test("records the outage when the connection itself failed", async () => {
+    const offline: DatabaseMonitorResponse = buildDatabaseResponse({
+      isOnline: false,
+      metrics: {},
+    });
+    offline.connectionError = "Connection refused.";
+    offline.failureCause = "Connection refused.";
+
+    const probeResponse: ProbeMonitorResponse = buildProbeResponse(offline);
+
+    await save(probeResponse);
+
+    expect(databaseRows()).toEqual([]);
+    expect(rowsByName(MonitorMetricType.IsOnline)[0]?.["value"]).toBe(0);
+  });
+
+  test("writes every catalog series on a fully collected check", async () => {
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+    let nextValue: number = 1;
+
+    for (const definition of getAllDatabaseMetrics()) {
+      metrics[definition.metricType] = nextValue;
+      nextValue = nextValue + 1;
+    }
+
+    await save(buildProbeResponse(buildDatabaseResponse({ metrics: metrics })));
+
+    expect(databaseRows()).toHaveLength(getAllDatabaseMetrics().length);
+
+    for (const definition of getAllDatabaseMetrics()) {
+      expect(rowsByName(definition.metricType)).toHaveLength(1);
+    }
+  });
+
+  test("registers each series with the catalog's own description and unit", async () => {
+    const percentMetric: DatabaseMetricDefinition | undefined =
+      getAllDatabaseMetrics().find((definition: DatabaseMetricDefinition) => {
+        return (
+          definition.metricType ===
+          MonitorMetricType.DatabaseConnectionsUsedPercent
+        );
+      });
+
+    expect(percentMetric).toBeDefined();
+
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: {
+            [MonitorMetricType.DatabaseConnectionsUsedPercent]: 55,
+          },
+        }),
+      ),
+    );
+
+    expect(indexedMaps).toHaveLength(1);
+    const metricMap: Dictionary<MetricType> = indexedMaps[0]!;
+    const registered: MetricType | undefined =
+      metricMap[MonitorMetricType.DatabaseConnectionsUsedPercent];
+
+    expect(registered?.unit).toBe(percentMetric!.unit);
+    expect(registered?.description).toBe(percentMetric!.description);
+  });
+
+  test("skips a non-finite value rather than writing a bogus datapoint", async () => {
+    await save(
+      buildProbeResponse(
+        buildDatabaseResponse({
+          metrics: {
+            [MonitorMetricType.DatabaseSizeBytes]: Number.NaN,
+            [MonitorMetricType.DatabaseDeadTuples]: Number.POSITIVE_INFINITY,
+            [MonitorMetricType.DatabaseQueriesTotal]: 900,
+          },
+        }),
+      ),
+    );
+
+    expect(databaseRows()).toHaveLength(1);
+    expect(
+      rowsByName(MonitorMetricType.DatabaseQueriesTotal)[0]?.["value"],
+    ).toBe(900);
+  });
+
+  test("leaves database series untouched for a check that carries no database payload", async () => {
+    await save({
+      projectId: PROJECT_ID,
+      monitorId: MONITOR_ID,
+      monitorStepId: ObjectID.generate(),
+      probeId: PROBE_ID,
+      failureCause: "",
+      monitoredAt: new Date("2026-09-02T10:00:00.000Z"),
+      isOnline: true,
+      responseTimeInMs: 80,
+    });
+
+    expect(databaseRows()).toEqual([]);
+    expect(rowsByName(MonitorMetricType.ResponseTime)[0]?.["value"]).toBe(80);
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorStepResourceIdentity.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorStepResourceIdentity.test.ts
@@ -372,6 +372,11 @@ describe("MonitorStepResourceIdentity — monitor types with no resource identit
     MonitorType.Domain,
     MonitorType.DNS,
     MonitorType.SQLQuery,
+    /*
+     * A database health step names a host:port, which is not one of the
+     * buckets SeriesResourceRefs carries.
+     */
+    MonitorType.Database,
     MonitorType.SyntheticMonitor,
     MonitorType.CustomJavaScriptCode,
     MonitorType.IncomingRequest,

--- a/Common/Tests/Types/Monitor/DatabaseMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/DatabaseMetricCatalog.test.ts
@@ -1,0 +1,388 @@
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import {
+  DatabaseMetricCategory,
+  DatabaseMetricDefinition,
+  DatabaseMetricGroup,
+  getAllDatabaseMetrics,
+  getDatabaseMetricById,
+  getDatabaseMetricByMetricType,
+  getDatabaseMetricCategoryDescription,
+  getDatabaseMetricCategoryOrder,
+  getDatabaseMetricsByCategory,
+  getDatabaseMetricsByGroup,
+  getDatabaseMetricsForEngine,
+  isDatabaseMetricType,
+} from "../../../Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
+import SqlDatabaseType, {
+  SqlDatabaseTypeUtil,
+} from "../../../Types/Monitor/SqlDatabaseType";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The catalog is the only place a Database Health metric is declared: title,
+ * legend, unit, description, aggregation, display card, collection group and
+ * engine support all resolve through it. A row that is malformed here does
+ * not throw - it produces a blank chart legend, a chart that is aggregated
+ * the wrong way, or a criterion an operator can set but that can never be
+ * met. These tests are what turns those into failures.
+ */
+
+const DATABASE_METRIC_PREFIX: string = "oneuptime.monitor.database.";
+
+const allMetrics: Array<DatabaseMetricDefinition> = getAllDatabaseMetrics();
+const orderedCategories: Array<DatabaseMetricCategory> =
+  getDatabaseMetricCategoryOrder();
+const supportedEngines: Array<SqlDatabaseType> =
+  SqlDatabaseTypeUtil.getSupportedDatabaseTypes();
+
+/*
+ * Units are not free text: the summary view and the criteria expectation
+ * builder pick a formatter from this value, so an invented unit renders as a
+ * raw number with a stray suffix.
+ */
+const KNOWN_UNITS: Array<string> = ["", "%", "s", "ms", "bytes"];
+
+describe("DatabaseMetricCatalog", () => {
+  test("returns a non-empty catalog", () => {
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("getAllDatabaseMetrics hands back a copy, not the live array", () => {
+    const first: Array<DatabaseMetricDefinition> = getAllDatabaseMetrics();
+    first.pop();
+    expect(getAllDatabaseMetrics().length).toBe(allMetrics.length);
+  });
+
+  test("every definition has the fields the UI renders", () => {
+    for (const metric of allMetrics) {
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricType.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("ids are stable kebab-case identifiers and are unique", () => {
+    const ids: Array<string> = allMetrics.map(
+      (metric: DatabaseMetricDefinition) => {
+        return metric.id;
+      },
+    );
+
+    for (const id of ids) {
+      expect(id).toMatch(/^database-[a-z0-9-]+$/);
+    }
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric types are unique", () => {
+    const metricTypes: Array<MonitorMetricType> = allMetrics.map(
+      (metric: DatabaseMetricDefinition) => {
+        return metric.metricType;
+      },
+    );
+
+    expect(new Set(metricTypes).size).toBe(metricTypes.length);
+  });
+
+  test("every definition uses a declared aggregation, category and group", () => {
+    for (const metric of allMetrics) {
+      expect(Object.values(AggregationType)).toContain(
+        metric.defaultAggregation,
+      );
+      expect(Object.values(DatabaseMetricCategory)).toContain(metric.category);
+      expect(Object.values(DatabaseMetricGroup)).toContain(metric.group);
+    }
+  });
+
+  test("every definition uses a unit the formatters understand", () => {
+    for (const metric of allMetrics) {
+      expect(KNOWN_UNITS).toContain(metric.unit);
+    }
+  });
+
+  /*
+   * Averaging a counter inside a time bucket produces a number that means
+   * nothing. Max returns the latest sample, which the chart differences into
+   * a rate. Counters are identified by their description because the series
+   * name is not a reliable signal - "connections.total" is a gauge.
+   */
+  test("cumulative counters aggregate with Max", () => {
+    const counters: Array<DatabaseMetricDefinition> = allMetrics.filter(
+      (metric: DatabaseMetricDefinition) => {
+        return metric.description.startsWith("Cumulative");
+      },
+    );
+
+    // Guards against a wording change quietly emptying the set.
+    expect(counters.length).toBeGreaterThanOrEqual(10);
+
+    for (const counter of counters) {
+      expect(counter.defaultAggregation).toBe(AggregationType.Max);
+    }
+  });
+
+  /*
+   * Open connections is a gauge despite the ".total" suffix its series name
+   * inherited. Averaging it is correct; treating it as a counter would chart
+   * a meaningless step function.
+   */
+  test("open connections is a gauge, not a counter", () => {
+    const connections: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(MonitorMetricType.DatabaseConnectionsTotal);
+
+    expect(connections?.metricType.endsWith(".total")).toBe(true);
+    expect(connections?.defaultAggregation).toBe(AggregationType.Avg);
+  });
+
+  test("every definition names at least one engine that can produce it", () => {
+    for (const metric of allMetrics) {
+      expect(metric.engines.length).toBeGreaterThan(0);
+
+      for (const engine of metric.engines) {
+        expect(supportedEngines).toContain(engine);
+      }
+
+      // A duplicated engine would double a metric in the picker.
+      expect(new Set(metric.engines).size).toBe(metric.engines.length);
+    }
+  });
+});
+
+/*
+ * The enum carries the series names because MonitorMetricUtil writes rows
+ * keyed by MonitorMetricType; the catalog carries everything else. A member
+ * added to one and not the other fails silently - a series with no title and
+ * no description, or a catalog row that never gets written.
+ */
+describe("catalog and MonitorMetricType do not drift apart", () => {
+  test("every database series in the enum has a catalog definition", () => {
+    const undeclared: Array<string> = Object.values(MonitorMetricType).filter(
+      (metricType: MonitorMetricType) => {
+        return (
+          metricType.startsWith(DATABASE_METRIC_PREFIX) &&
+          getDatabaseMetricByMetricType(metricType) === null
+        );
+      },
+    );
+
+    expect(undeclared).toEqual([]);
+  });
+
+  test("every catalog definition points at a database series in the enum", () => {
+    const enumValues: Array<string> = Object.values(MonitorMetricType);
+
+    for (const metric of allMetrics) {
+      expect(enumValues).toContain(metric.metricType);
+      expect(metric.metricType.startsWith(DATABASE_METRIC_PREFIX)).toBe(true);
+    }
+  });
+
+  /*
+   * isDatabaseMetricType gates a prelude in front of five metadata switches
+   * in MonitorMetricTypeUtil. If a shared probe series ever matched, the
+   * catalog would hijack the title and unit of every monitor type that uses
+   * it, not just Database Health.
+   */
+  test("shared probe series are not database metrics", () => {
+    for (const metric of allMetrics) {
+      expect(isDatabaseMetricType(metric.metricType)).toBe(true);
+    }
+
+    for (const shared of [
+      MonitorMetricType.IsOnline,
+      MonitorMetricType.ResponseTime,
+      MonitorMetricType.CPUUsagePercent,
+      MonitorMetricType.ExecutionTime,
+    ]) {
+      expect(isDatabaseMetricType(shared)).toBe(false);
+    }
+  });
+});
+
+describe("categories", () => {
+  test("the display order lists every category exactly once", () => {
+    expect(new Set(orderedCategories).size).toBe(orderedCategories.length);
+    expect([...orderedCategories].sort()).toEqual(
+      Object.values(DatabaseMetricCategory).sort(),
+    );
+  });
+
+  test("every category has at least one metric and a description", () => {
+    for (const category of orderedCategories) {
+      expect(getDatabaseMetricsByCategory(category).length).toBeGreaterThan(0);
+      expect(
+        getDatabaseMetricCategoryDescription(category).length,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  test("getDatabaseMetricsByCategory returns only that category", () => {
+    for (const category of orderedCategories) {
+      for (const metric of getDatabaseMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("an unknown category has no description rather than undefined", () => {
+    expect(
+      getDatabaseMetricCategoryDescription(
+        "Not A Category" as DatabaseMetricCategory,
+      ),
+    ).toBe("");
+  });
+});
+
+/*
+ * Groups are the unit of graceful degradation: the probe runs one query per
+ * group and reports a group it could not read. A group with no metrics would
+ * be a degradation notice an operator can do nothing with.
+ */
+describe("collection groups", () => {
+  test("every declared group has at least one metric", () => {
+    for (const group of Object.values(DatabaseMetricGroup)) {
+      expect(getDatabaseMetricsByGroup(group).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getDatabaseMetricsByGroup returns only that group", () => {
+    for (const group of Object.values(DatabaseMetricGroup)) {
+      for (const metric of getDatabaseMetricsByGroup(group)) {
+        expect(metric.group).toBe(group);
+      }
+    }
+  });
+
+  test("grouping partitions the catalog", () => {
+    const grouped: number = Object.values(DatabaseMetricGroup).reduce(
+      (total: number, group: DatabaseMetricGroup) => {
+        return total + getDatabaseMetricsByGroup(group).length;
+      },
+      0,
+    );
+
+    expect(grouped).toBe(allMetrics.length);
+  });
+});
+
+describe("lookups", () => {
+  test("getDatabaseMetricByMetricType round-trips every definition", () => {
+    for (const metric of allMetrics) {
+      expect(getDatabaseMetricByMetricType(metric.metricType)).toEqual(metric);
+    }
+  });
+
+  test("getDatabaseMetricById round-trips every definition", () => {
+    for (const metric of allMetrics) {
+      expect(getDatabaseMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  /*
+   * Null rather than undefined: DatabaseMonitorCriteria returns early on a
+   * null definition, which is how a criterion naming a metric that no longer
+   * exists stops evaluating instead of throwing on every check.
+   */
+  test("unknown keys resolve to null", () => {
+    expect(getDatabaseMetricById("does-not-exist")).toBeNull();
+    expect(getDatabaseMetricById("")).toBeNull();
+    expect(
+      getDatabaseMetricByMetricType("not.a.series" as MonitorMetricType),
+    ).toBeNull();
+  });
+});
+
+/*
+ * Engine support is verified against live servers (PostgreSQL 15.18, MySQL
+ * 8.4.11, SQL Server 2022), not inferred from documentation. The picker
+ * builds from these lists, so a wrong entry offers an operator a threshold on
+ * a series their engine will never write - a criterion that sits permanently
+ * unmet and looks like a working alert.
+ */
+describe("engine support", () => {
+  test("every supported engine can produce some metric", () => {
+    for (const engine of supportedEngines) {
+      const metrics: Array<DatabaseMetricDefinition> =
+        getDatabaseMetricsForEngine(engine);
+
+      expect(metrics.length).toBeGreaterThan(0);
+
+      for (const metric of metrics) {
+        expect(metric.engines).toContain(engine);
+      }
+    }
+  });
+
+  test("no metric is stranded with no engine that can write it", () => {
+    const reachable: Set<MonitorMetricType> = new Set<MonitorMetricType>();
+
+    for (const engine of supportedEngines) {
+      for (const metric of getDatabaseMetricsForEngine(engine)) {
+        reachable.add(metric.metricType);
+      }
+    }
+
+    expect(reachable.size).toBe(allMetrics.length);
+  });
+
+  test("PostgreSQL-only maintenance metrics are absent from MySQL", () => {
+    const mysql: Array<MonitorMetricType> = getDatabaseMetricsForEngine(
+      SqlDatabaseType.MySQL,
+    ).map((metric: DatabaseMetricDefinition) => {
+      return metric.metricType;
+    });
+
+    expect(mysql).not.toContain(
+      MonitorMetricType.DatabaseTransactionIdUsedPercent,
+    );
+    expect(mysql).not.toContain(MonitorMetricType.DatabaseDeadTuples);
+    expect(mysql).toContain(MonitorMetricType.DatabaseTempDiskTablesTotal);
+  });
+
+  // Stock MySQL exposes no deadlock counter at all.
+  test("deadlocks are PostgreSQL and SQL Server only", () => {
+    const deadlocks: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(MonitorMetricType.DatabaseDeadlocksTotal);
+
+    expect(deadlocks?.engines).toEqual([
+      SqlDatabaseType.PostgreSQL,
+      SqlDatabaseType.MicrosoftSqlServer,
+    ]);
+  });
+
+  /*
+   * SQL Server's `user connections` setting defaults to 0, meaning
+   * unlimited, so a percentage of the ceiling has no denominator there.
+   */
+  test("the connection ceiling and its percentage skip SQL Server", () => {
+    for (const metricType of [
+      MonitorMetricType.DatabaseConnectionsMax,
+      MonitorMetricType.DatabaseConnectionsUsedPercent,
+    ]) {
+      expect(getDatabaseMetricByMetricType(metricType)?.engines).not.toContain(
+        SqlDatabaseType.MicrosoftSqlServer,
+      );
+    }
+  });
+
+  /*
+   * The degradation counter is produced by the collector, not read from the
+   * engine, so it must survive on every engine - it is the series an
+   * operator alerts on to notice they have lost visibility.
+   */
+  test("the failed-group counter is available on every engine", () => {
+    const failed: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(
+        MonitorMetricType.DatabaseMetricGroupsFailed,
+      );
+
+    expect(failed).not.toBeNull();
+
+    for (const engine of supportedEngines) {
+      expect(failed?.engines).toContain(engine);
+    }
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorStepDatabaseMonitor.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepDatabaseMonitor.test.ts
@@ -1,0 +1,243 @@
+import { DatabaseMetricGroup } from "../../../Types/Monitor/DatabaseMetricCatalog";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorStepDatabaseMonitor, {
+  DEFAULT_DATABASE_CONNECTION_TIMEOUT_IN_MS,
+  DEFAULT_DATABASE_METRIC_GROUPS,
+  DEFAULT_DATABASE_STATEMENT_TIMEOUT_IN_MS,
+  MonitorStepDatabaseMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepDatabaseMonitor";
+import {
+  MAX_SQL_CONNECTION_TIMEOUT_IN_MS,
+  MAX_SQL_STATEMENT_TIMEOUT_IN_MS,
+} from "../../../Types/Monitor/MonitorStepSqlMonitor";
+import SqlDatabaseType from "../../../Types/Monitor/SqlDatabaseType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("MonitorStepDatabaseMonitorUtil", () => {
+  describe("getDefault", () => {
+    test("starts on PostgreSQL with its own port and validated TLS", () => {
+      const config: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.getDefault();
+
+      expect(config.databaseType).toBe(SqlDatabaseType.PostgreSQL);
+      expect(config.port).toBe(5432);
+      // Opting out of chain validation must be a decision, never a default.
+      expect(config.rejectUnauthorizedSsl).toBe(true);
+      expect(config.useWindowsIntegratedAuthentication).toBe(false);
+    });
+
+    test("collects every metric group by default", () => {
+      /*
+       * Safe to default on only because a group the login cannot read
+       * reports itself unavailable instead of failing the check. If that
+       * contract ever changes, this default has to change with it.
+       */
+      const config: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.getDefault();
+
+      expect(config.enabledMetricGroups).toEqual(
+        DEFAULT_DATABASE_METRIC_GROUPS,
+      );
+      expect(config.enabledMetricGroups).toHaveLength(
+        Object.values(DatabaseMetricGroup).length,
+      );
+    });
+
+    test("returns a fresh group array each time", () => {
+      // A shared array would let one monitor's edit reconfigure every other.
+      const first: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.getDefault();
+      const second: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.getDefault();
+
+      first.enabledMetricGroups.pop();
+
+      expect(second.enabledMetricGroups).toEqual(
+        DEFAULT_DATABASE_METRIC_GROUPS,
+      );
+      expect(DEFAULT_DATABASE_METRIC_GROUPS).toHaveLength(
+        Object.values(DatabaseMetricGroup).length,
+      );
+    });
+
+    test("defaults to a tighter statement timeout than a user query would get", () => {
+      /*
+       * Health queries are introspection and should return in milliseconds.
+       * If pg_stat_activity takes ten seconds the useful signal is "this
+       * server is in trouble", not a longer wait.
+       */
+      const config: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.getDefault();
+
+      expect(config.statementTimeoutInMs).toBe(
+        DEFAULT_DATABASE_STATEMENT_TIMEOUT_IN_MS,
+      );
+      expect(config.statementTimeoutInMs).toBeLessThan(
+        MAX_SQL_STATEMENT_TIMEOUT_IN_MS,
+      );
+      expect(config.connectionTimeoutInMs).toBe(
+        DEFAULT_DATABASE_CONNECTION_TIMEOUT_IN_MS,
+      );
+    });
+  });
+
+  describe("sanitizeMetricGroups", () => {
+    test("keeps recognized groups and drops anything else", () => {
+      expect(
+        MonitorStepDatabaseMonitorUtil.sanitizeMetricGroups([
+          DatabaseMetricGroup.Locks,
+          "Telepathy",
+          DatabaseMetricGroup.Storage,
+          42,
+          null,
+        ]),
+        // Canonical order, not input order: Locks precedes Storage.
+      ).toEqual([DatabaseMetricGroup.Locks, DatabaseMetricGroup.Storage]);
+    });
+
+    test("normalizes to the canonical order regardless of input order", () => {
+      // Keeps the config form and the collector iterating in one order.
+      expect(
+        MonitorStepDatabaseMonitorUtil.sanitizeMetricGroups([
+          DatabaseMetricGroup.Maintenance,
+          DatabaseMetricGroup.Connections,
+        ]),
+      ).toEqual([
+        DatabaseMetricGroup.Connections,
+        DatabaseMetricGroup.Maintenance,
+      ]);
+    });
+
+    test("de-duplicates repeated groups", () => {
+      expect(
+        MonitorStepDatabaseMonitorUtil.sanitizeMetricGroups([
+          DatabaseMetricGroup.Locks,
+          DatabaseMetricGroup.Locks,
+        ]),
+      ).toEqual([DatabaseMetricGroup.Locks]);
+    });
+
+    test.each([
+      ["an empty list", []],
+      ["a list of only unknown values", ["nope", "also-nope"]],
+      ["a non-array", "Locks"],
+      ["undefined", undefined],
+      ["null", null],
+    ])("falls back to every group for %s", (_label: string, input: unknown) => {
+      /*
+       * A monitor that silently collects nothing is worse than one that
+       * collects what it can, so an unusable list means "everything"
+       * rather than "nothing".
+       */
+      expect(
+        MonitorStepDatabaseMonitorUtil.sanitizeMetricGroups(input),
+      ).toEqual(DEFAULT_DATABASE_METRIC_GROUPS);
+    });
+  });
+
+  describe("fromJSON", () => {
+    test("round-trips a full configuration through toJSON", () => {
+      const config: MonitorStepDatabaseMonitor = {
+        ...MonitorStepDatabaseMonitorUtil.getDefault(),
+        databaseType: SqlDatabaseType.MicrosoftSqlServer,
+        host: "sql.internal",
+        port: 1433,
+        databaseName: "orders",
+        username: "monitoring",
+        password: "{{monitorSecrets.dbPassword}}",
+        useSsl: true,
+        enabledMetricGroups: [
+          DatabaseMetricGroup.Connections,
+          DatabaseMetricGroup.Replication,
+        ],
+      };
+
+      const restored: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.fromJSON(
+          MonitorStepDatabaseMonitorUtil.toJSON(config),
+        );
+
+      expect(restored).toEqual(config);
+    });
+
+    test("preserves a monitor-secret reference verbatim", () => {
+      /*
+       * The server resolves {{monitorSecrets.name}} on the way to the probe.
+       * Any mangling here turns into an authentication failure that looks
+       * like a wrong password.
+       */
+      const restored: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.fromJSON({
+          host: "db.internal",
+          password: "{{monitorSecrets.dbPassword}}",
+        } as JSONObject);
+
+      expect(restored.password).toBe("{{monitorSecrets.dbPassword}}");
+    });
+
+    test("clamps timeouts to the shared SQL ceilings", () => {
+      const restored: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.fromJSON({
+          statementTimeoutInMs: 999999,
+          connectionTimeoutInMs: 999999,
+        } as JSONObject);
+
+      expect(restored.statementTimeoutInMs).toBe(
+        MAX_SQL_STATEMENT_TIMEOUT_IN_MS,
+      );
+      expect(restored.connectionTimeoutInMs).toBe(
+        MAX_SQL_CONNECTION_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("falls back to safe values for an empty payload", () => {
+      const restored: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.fromJSON({});
+
+      expect(restored.databaseType).toBe(SqlDatabaseType.PostgreSQL);
+      expect(restored.rejectUnauthorizedSsl).toBe(true);
+      expect(restored.enabledMetricGroups).toEqual(
+        DEFAULT_DATABASE_METRIC_GROUPS,
+      );
+    });
+
+    test("treats an explicitly false rejectUnauthorizedSsl as a real choice", () => {
+      /*
+       * Distinguishing "absent" from "false" matters: absent must default to
+       * validating the chain, but a user who turned validation off for a
+       * self-signed certificate must keep that setting.
+       */
+      expect(
+        MonitorStepDatabaseMonitorUtil.fromJSON({
+          rejectUnauthorizedSsl: false,
+        } as JSONObject).rejectUnauthorizedSsl,
+      ).toBe(false);
+
+      expect(
+        MonitorStepDatabaseMonitorUtil.fromJSON({}).rejectUnauthorizedSsl,
+      ).toBe(true);
+    });
+
+    test("normalizes an unusable group list rather than trusting it", () => {
+      expect(
+        MonitorStepDatabaseMonitorUtil.fromJSON({
+          enabledMetricGroups: ["Locks", "not-a-group"],
+        } as JSONObject).enabledMetricGroups,
+      ).toEqual([DatabaseMetricGroup.Locks]);
+    });
+  });
+
+  describe("toJSON", () => {
+    test("copies the group array instead of aliasing it", () => {
+      const config: MonitorStepDatabaseMonitor =
+        MonitorStepDatabaseMonitorUtil.getDefault();
+
+      const json: JSONObject = MonitorStepDatabaseMonitorUtil.toJSON(config);
+      (json["enabledMetricGroups"] as Array<DatabaseMetricGroup>).pop();
+
+      expect(config.enabledMetricGroups).toEqual(
+        DEFAULT_DATABASE_METRIC_GROUPS,
+      );
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorStepDefaultTelemetryConfig.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepDefaultTelemetryConfig.test.ts
@@ -113,6 +113,7 @@ describe("MonitorStep.getDefaultMonitorStep telemetry sub-config seeding", () =>
       MonitorType.SyntheticMonitor,
       MonitorType.CustomJavaScriptCode,
       MonitorType.SQLQuery,
+      MonitorType.Database,
       MonitorType.Manual,
       MonitorType.Profiles,
       MonitorType.Kubernetes,

--- a/Common/Tests/Types/Monitor/MonitorType.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorType.test.ts
@@ -124,6 +124,7 @@ describe("MonitorTypeHelper", () => {
       MonitorType.DNSSEC,
       MonitorType.Domain,
       MonitorType.ExternalStatusPage,
+      MonitorType.Database,
     ])("returns true for %s", (monitorType: MonitorType) => {
       expect(MonitorTypeHelper.isProbableMonitor(monitorType)).toBe(true);
     });

--- a/Common/Tests/Types/Monitor/MonitorTypeKeywords.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorTypeKeywords.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../UI/Components/CardSelect/CardSelect";
 
 /*
- * The monitor type picker offers 29 types. Whether someone finds the right one
+ * The monitor type picker offers 31 types. Whether someone finds the right one
  * comes down to whether the words they already use - "k8s", "postgres",
  * "heartbeat", "tls" - are attached to the card, because none of them appear
  * in its title or its copy. These are the searches this catalog promises to
@@ -192,8 +192,8 @@ describe("MonitorType keywords", () => {
   describe("card copy is scannable", () => {
     /*
      * Every description used to open with "This monitor type lets you
-     * monitor", so the first five words of all 29 cards were identical and
-     * carried nothing. Reading the grid meant skipping them 29 times.
+     * monitor", so the first five words of every card were identical and
+     * carried nothing. Reading the grid meant skipping them on every card.
      */
     test("no description opens with the old boilerplate", () => {
       for (const props of allProps) {
@@ -230,10 +230,19 @@ describe("MonitorType keywords", () => {
       ["k8s", MonitorType.Kubernetes],
       ["kubernetes", MonitorType.Kubernetes],
       ["eks", MonitorType.Kubernetes],
-      ["postgres", MonitorType.SQLQuery],
-      ["postgresql", MonitorType.SQLQuery],
-      ["mysql", MonitorType.SQLQuery],
-      ["database", MonitorType.SQLQuery],
+      /*
+       * Both database cards answer to the engine names. Someone typing an
+       * engine into a monitoring product wants its health series, not the
+       * escape hatch for a query they have to write themselves - so the
+       * engine words rank Database Health first, and SQL Query keeps the
+       * searches that describe what only it does.
+       */
+      ["postgres", MonitorType.Database],
+      ["postgresql", MonitorType.Database],
+      ["mysql", MonitorType.Database],
+      ["database", MonitorType.Database],
+      ["query", MonitorType.SQLQuery],
+      ["row count", MonitorType.SQLQuery],
       ["heartbeat", MonitorType.IncomingRequest],
       ["cron", MonitorType.IncomingRequest],
       ["webhook", MonitorType.IncomingRequest],

--- a/Common/Tests/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.test.ts
+++ b/Common/Tests/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.test.ts
@@ -235,6 +235,21 @@ const PER_TYPE_EXPECTATIONS: Array<PerTypeExpectation> = [
     ],
   },
   {
+    monitorType: MonitorType.Database,
+    title: "Database Health",
+    keys: [
+      "isOnline",
+      "responseTimeInMs",
+      "failureCause",
+      "connectionError",
+      "engineVersion",
+      "collectedGroups",
+      "unavailableGroups",
+      "collectionIssueSummary",
+      "metrics",
+    ],
+  },
+  {
     monitorType: MonitorType.ExternalStatusPage,
     title: "External Status Page",
     keys: [

--- a/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
@@ -1,9 +1,20 @@
 import AggregationType from "../../../Types/BaseDatabase/AggregationType";
-import { CheckOn } from "../../../Types/Monitor/CriteriaFilter";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../Types/Monitor/CriteriaFilter";
+import {
+  DatabaseMetricCategory,
+  DatabaseMetricDefinition,
+  getAllDatabaseMetrics,
+  getDatabaseMetricsForEngine,
+} from "../../../Types/Monitor/DatabaseMetricCatalog";
 import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
 import MonitorType, {
   MonitorTypeHelper,
 } from "../../../Types/Monitor/MonitorType";
+import SqlDatabaseType from "../../../Types/Monitor/SqlDatabaseType";
 import MonitorMetricTypeUtil, {
   MonitorMetricCategory,
 } from "../../../Utils/Monitor/MonitorMetricType";
@@ -476,5 +487,273 @@ describe("getMonitorMetricTypeByCheckOnOrNull", () => {
     expect(() => {
       MonitorMetricTypeUtil.getMonitorMeticTypeByCheckOn(CheckOn.ResponseBody);
     }).toThrow();
+  });
+});
+
+/*
+ * Database Health declares its ~40 series in DatabaseMetricCatalog rather
+ * than in the five metadata switches in this util; a short prelude in each
+ * switch resolves them. A prelude that is missing does not throw - it
+ * renders a chart with a blank legend, no unit, or the wrong aggregation.
+ * These sweep the whole catalog through the public lookups so a metric can
+ * never end up half-wired.
+ */
+describe("Database Health metric metadata", () => {
+  const catalog: Array<DatabaseMetricDefinition> = getAllDatabaseMetrics();
+
+  test("every catalog metric resolves its display metadata", () => {
+    for (const metric of catalog) {
+      expect(
+        MonitorMetricTypeUtil.getTitleByMonitorMetricType(metric.metricType),
+      ).toBe(metric.friendlyName);
+      expect(
+        MonitorMetricTypeUtil.getLegendByMonitorMetricType(metric.metricType),
+      ).toBe(metric.friendlyName);
+      expect(
+        MonitorMetricTypeUtil.getLegendUnitByMonitorMetricType(
+          metric.metricType,
+        ),
+      ).toBe(metric.unit);
+      expect(
+        MonitorMetricTypeUtil.getDescriptionByMonitorMetricType(
+          metric.metricType,
+        ).length,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  test("every catalog metric aggregates the way the catalog says", () => {
+    for (const metric of catalog) {
+      expect(
+        MonitorMetricTypeUtil.getAggregationTypeByMonitorMetricType(
+          metric.metricType,
+        ),
+      ).toBe(metric.defaultAggregation);
+    }
+  });
+
+  /*
+   * The preludes run before the switches, so a catalog row that ever matched
+   * a shared series would rewrite the metadata of every monitor type using
+   * it, not just Database Health.
+   */
+  test("the catalog does not shadow the shared probe series", () => {
+    expect(
+      MonitorMetricTypeUtil.getLegendUnitByMonitorMetricType(
+        MonitorMetricType.ResponseTime,
+      ),
+    ).toBe("ms");
+    expect(
+      MonitorMetricTypeUtil.getAggregationTypeByMonitorMetricType(
+        MonitorMetricType.IsOnline,
+      ),
+    ).toBe(AggregationType.Min);
+  });
+});
+
+describe("Database Health metric lists and cards", () => {
+  const catalog: Array<DatabaseMetricDefinition> = getAllDatabaseMetrics();
+
+  test("Database exposes availability plus every catalog series", () => {
+    const metrics: Array<MonitorMetricType> =
+      MonitorMetricTypeUtil.getMonitorMetricTypesByMonitorType(
+        MonitorType.Database,
+      );
+
+    expect(metrics[0]).toBe(MonitorMetricType.IsOnline);
+    expect(metrics[1]).toBe(MonitorMetricType.ResponseTime);
+
+    for (const metric of catalog) {
+      expect(metrics).toContain(metric.metricType);
+    }
+
+    expect(metrics.length).toBe(catalog.length + 2);
+  });
+
+  test("with no engine chosen the cards show the full capability set", () => {
+    const categories: Array<MonitorMetricCategory> =
+      MonitorMetricTypeUtil.getDatabaseMetricCategories();
+
+    const shown: Array<MonitorMetricType> = categories.flatMap(
+      (category: MonitorMetricCategory) => {
+        return category.metrics;
+      },
+    );
+
+    for (const metric of catalog) {
+      expect(shown).toContain(metric.metricType);
+    }
+  });
+
+  /*
+   * A card of permanently empty charts is worse than no card: it reads as a
+   * broken monitor rather than as an engine that does not report the data.
+   */
+  test("a MySQL monitor drops the cards its engine can never fill", () => {
+    const mysqlMetrics: Array<MonitorMetricType> = getDatabaseMetricsForEngine(
+      SqlDatabaseType.MySQL,
+    ).map((metric: DatabaseMetricDefinition) => {
+      return metric.metricType;
+    });
+
+    const categories: Array<MonitorMetricCategory> =
+      MonitorMetricTypeUtil.getDatabaseMetricCategories(SqlDatabaseType.MySQL);
+
+    const titles: Array<string> = categories.map(
+      (category: MonitorMetricCategory) => {
+        return category.title;
+      },
+    );
+
+    // Every PostgreSQL-only vacuum and wraparound metric lives on this card.
+    expect(titles).not.toContain(DatabaseMetricCategory.Maintenance);
+
+    for (const category of categories) {
+      expect(category.title.length).toBeGreaterThan(0);
+      expect(category.description.length).toBeGreaterThan(0);
+      expect(category.metrics.length).toBeGreaterThan(0);
+
+      for (const metric of category.metrics) {
+        if (
+          metric === MonitorMetricType.IsOnline ||
+          metric === MonitorMetricType.ResponseTime
+        ) {
+          continue;
+        }
+
+        expect(mysqlMetrics).toContain(metric);
+      }
+    }
+  });
+
+  test("PostgreSQL keeps the maintenance card", () => {
+    const categories: Array<MonitorMetricCategory> =
+      MonitorMetricTypeUtil.getDatabaseMetricCategories(
+        SqlDatabaseType.PostgreSQL,
+      );
+
+    const titles: Array<string> = categories.map(
+      (category: MonitorMetricCategory) => {
+        return category.title;
+      },
+    );
+
+    expect(titles).toContain(DatabaseMetricCategory.Maintenance);
+  });
+
+  /*
+   * Availability carries the shared probe series on top of its catalog
+   * metrics, so it is the one card that must render whatever the engine.
+   */
+  test("availability is the first card on every engine", () => {
+    for (const engine of [
+      SqlDatabaseType.PostgreSQL,
+      SqlDatabaseType.MySQL,
+      SqlDatabaseType.MicrosoftSqlServer,
+    ]) {
+      const categories: Array<MonitorMetricCategory> =
+        MonitorMetricTypeUtil.getDatabaseMetricCategories(engine);
+
+      expect(categories[0]?.title).toBe(DatabaseMetricCategory.Availability);
+      expect(categories[0]?.metrics).toContain(MonitorMetricType.IsOnline);
+      expect(categories[0]?.metrics).toContain(MonitorMetricType.ResponseTime);
+    }
+  });
+
+  test("the monitor type routes through the database cards", () => {
+    expect(
+      MonitorMetricTypeUtil.getMonitorMetricCategoriesByMonitorType(
+        MonitorType.Database,
+        SqlDatabaseType.MySQL,
+      ),
+    ).toEqual(
+      MonitorMetricTypeUtil.getDatabaseMetricCategories(SqlDatabaseType.MySQL),
+    );
+  });
+});
+
+/*
+ * Database Health filters name their series in databaseMonitorOptions rather
+ * than in the CheckOn, because one CheckOn covers all 40. Resolving from the
+ * CheckOn alone returns null, which turns "evaluate over time" back into an
+ * instantaneous comparison while the UI still offers the toggle - so
+ * EvaluateOverTime has to ask with the whole filter.
+ */
+describe("getMonitorMetricTypeByCriteriaFilterOrNull", () => {
+  const buildFilter: (filter: Partial<CriteriaFilter>) => CriteriaFilter = (
+    filter: Partial<CriteriaFilter>,
+  ): CriteriaFilter => {
+    return {
+      checkOn: CheckOn.DatabaseMetric,
+      filterType: FilterType.GreaterThan,
+      value: "90",
+      ...filter,
+    };
+  };
+
+  test("resolves the series a database metric filter names", () => {
+    for (const metric of getAllDatabaseMetrics()) {
+      expect(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+          buildFilter({
+            databaseMonitorOptions: { metricType: metric.metricType },
+          }),
+        ),
+      ).toBe(metric.metricType);
+    }
+  });
+
+  test("returns null when the filter names no series", () => {
+    expect(
+      MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+        buildFilter({}),
+      ),
+    ).toBeNull();
+    expect(
+      MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+        buildFilter({ databaseMonitorOptions: {} }),
+      ),
+    ).toBeNull();
+  });
+
+  test("the database online check reads the shared online series", () => {
+    expect(
+      MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+        buildFilter({
+          checkOn: CheckOn.DatabaseIsOnline,
+          filterType: FilterType.True,
+          value: undefined,
+        }),
+      ),
+    ).toBe(MonitorMetricType.IsOnline);
+  });
+
+  test("collection errors are text, not a series", () => {
+    expect(
+      MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+        buildFilter({
+          checkOn: CheckOn.DatabaseCollectionError,
+          filterType: FilterType.IsNotEmpty,
+          value: undefined,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("every other CheckOn still resolves the way it always did", () => {
+    for (const checkOn of [
+      CheckOn.CPUUsagePercent,
+      CheckOn.ResponseTime,
+      CheckOn.DnsIsOnline,
+      CheckOn.JavaScriptExpression,
+    ]) {
+      expect(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCriteriaFilterOrNull(
+          buildFilter({ checkOn: checkOn }),
+        ),
+      ).toBe(
+        MonitorMetricTypeUtil.getMonitorMetricTypeByCheckOnOrNull(checkOn),
+      );
+    }
   });
 });

--- a/Common/Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts
@@ -98,6 +98,7 @@ const EXPECTED_PAYLOAD_KIND: Record<MonitorType, PayloadKind> = {
   [MonitorType.DNSSEC]: PayloadKind.Probe,
   [MonitorType.Domain]: PayloadKind.Probe,
   [MonitorType.SQLQuery]: PayloadKind.Probe,
+  [MonitorType.Database]: PayloadKind.Probe,
   [MonitorType.ExternalStatusPage]: PayloadKind.Probe,
   /*
    * Not a "probeable" monitor - the device owns its polling schedule - but

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -1,5 +1,6 @@
 import Zod, { ZodSchema } from "../../Utils/Schema/Zod";
 import MetricCriteriaContext from "./MetricMonitor/MetricCriteriaContext";
+import MonitorMetricType from "./MonitorMetricType";
 
 export enum CheckOn {
   ResponseTime = "Response Time (in ms)",
@@ -110,6 +111,21 @@ export enum CheckOn {
   SqlQueryExecutionTime = "SQL Query Execution Time (in ms)",
   SqlQueryError = "SQL Query Error",
 
+  /*
+   * Database Health monitors.
+   *
+   * Deliberately three CheckOns rather than one per metric. The catalog
+   * carries ~40 series and grows with every engine we add; putting each in
+   * this enum would flood a dropdown shared with every other monitor type
+   * and force a new case in five switch statements per metric. Instead
+   * DatabaseMetric names the series in databaseMonitorOptions.metricType,
+   * the same way Server monitors name a disk in serverMonitorOptions and
+   * SNMP monitors name an OID in snmpMonitorOptions.
+   */
+  DatabaseIsOnline = "Database Is Online",
+  DatabaseMetric = "Database Metric",
+  DatabaseCollectionError = "Database Collection Error",
+
   // External Status Page monitors.
   ExternalStatusPageIsOnline = "External Status Page Is Online",
   ExternalStatusPageOverallStatus = "External Status Page Overall Status",
@@ -132,6 +148,16 @@ export interface SnmpMonitorOptions {
    * every monitored interface, the historical behavior.
    */
   interfaceName?: string | undefined;
+}
+
+export interface DatabaseMonitorOptions {
+  /*
+   * Which collected series this filter compares against, e.g.
+   * MonitorMetricType.DatabaseConnectionsUsedPercent. Required whenever
+   * checkOn is CheckOn.DatabaseMetric; a filter without it can never be
+   * met and is reported as misconfigured rather than silently ignored.
+   */
+  metricType?: MonitorMetricType | undefined;
 }
 
 export enum EvaluateOverTimeType {
@@ -242,6 +268,7 @@ export interface CriteriaFilter {
   serverMonitorOptions?: ServerMonitorOptions | undefined;
   metricMonitorOptions?: MetricMonitorOptions | undefined;
   snmpMonitorOptions?: SnmpMonitorOptions | undefined;
+  databaseMonitorOptions?: DatabaseMonitorOptions | undefined;
   filterType: FilterType | undefined;
   value: string | number | undefined;
   evaluateOverTime?: boolean | undefined;
@@ -328,6 +355,7 @@ export class CriteriaFilterUtil {
       checkOn === CheckOn.DnssecResolverConsensus ||
       checkOn === CheckOn.DnssecNameserverConsistent ||
       checkOn === CheckOn.SqlIsOnline ||
+      checkOn === CheckOn.DatabaseIsOnline ||
       checkOn === CheckOn.ExternalStatusPageIsOnline
     ) {
       return false;
@@ -373,7 +401,14 @@ export class CriteriaFilterUtil {
       return [];
     }
 
-    if (criteriaFilter.checkOn === CheckOn.IsOnline) {
+    /*
+     * Boolean series. Averaging or summing an up/down series is meaningless,
+     * so these offer only the two set-shaped choices.
+     */
+    if (
+      criteriaFilter.checkOn === CheckOn.IsOnline ||
+      criteriaFilter.checkOn === CheckOn.DatabaseIsOnline
+    ) {
       return [EvaluateOverTimeType.AllValues, EvaluateOverTimeType.AnyValue];
     }
 
@@ -428,7 +463,14 @@ export class CriteriaFilterUtil {
       checkOn === CheckOn.DnsResponseTime ||
       checkOn === CheckOn.DnsIsOnline ||
       checkOn === CheckOn.ExternalStatusPageResponseTime ||
-      checkOn === CheckOn.ExternalStatusPageIsOnline
+      checkOn === CheckOn.ExternalStatusPageIsOnline ||
+      /*
+       * Over time is the most useful shape for database thresholds: a single
+       * sample of "connections above 90%" is a spike, five minutes of it is
+       * an incident.
+       */
+      checkOn === CheckOn.DatabaseIsOnline ||
+      checkOn === CheckOn.DatabaseMetric
     );
   }
 }
@@ -453,6 +495,9 @@ export const CriteriaFilterSchema: ZodSchema = Zod.object({
   snmpMonitorOptions: Zod.object({
     oid: Zod.string().optional(),
     interfaceName: Zod.string().optional(),
+  }).optional(),
+  databaseMonitorOptions: Zod.object({
+    metricType: Zod.string().optional(),
   }).optional(),
   filterType: Zod.string().optional(),
   value: Zod.union([Zod.string(), Zod.number()]).optional(),

--- a/Common/Types/Monitor/DatabaseMetricCatalog.ts
+++ b/Common/Types/Monitor/DatabaseMetricCatalog.ts
@@ -1,0 +1,693 @@
+import AggregationType from "../BaseDatabase/AggregationType";
+import MonitorMetricType from "./MonitorMetricType";
+import SqlDatabaseType from "./SqlDatabaseType";
+
+/*
+ * The single source of truth for the Database Health monitor.
+ *
+ * Every other database-monitor surface is derived from this catalog rather
+ * than repeating the list:
+ *
+ *   - MonitorMetricTypeUtil consults it for aggregation, title, legend, unit
+ *     and description, so a new metric never has to be added to five
+ *     switch statements (and can never be added to only four of them).
+ *   - The probe collector keys its returned values by MonitorMetricType, and
+ *     only emits values for metrics the connected engine supports.
+ *   - The criteria UI builds its metric dropdown from getDatabaseMetricsForEngine.
+ *   - DatabaseMonitorCriteria resolves CheckOn.DatabaseMetric through it.
+ *
+ * ENGINE SUPPORT IS NOT DECORATIVE. Each `engines` list records what the
+ * engine can actually produce, verified against live servers (PostgreSQL
+ * 15.18, MySQL 8.4.11, SQL Server 2022 16.0.4265.3). Notable absences that
+ * are real, not oversights:
+ *
+ *   - Deadlocks: stock MySQL exposes no deadlock counter at all (there is no
+ *     `%deadlock%` row in performance_schema.global_status). PostgreSQL and
+ *     SQL Server both do.
+ *   - Connection ceiling: SQL Server's `user connections` setting defaults to
+ *     0, meaning unlimited, so a "used percent" would be meaningless there.
+ *   - I/O timing: PostgreSQL only populates blk_read_time / blk_write_time
+ *     when track_io_timing is on, so those series can legitimately be absent
+ *     on a supported engine. That is reported as a metric-group note, never
+ *     as a monitor outage.
+ */
+
+export enum DatabaseMetricCategory {
+  Availability = "Availability",
+  Connections = "Connections",
+  Throughput = "Throughput",
+  LocksAndBlocking = "Locks and Blocking",
+  CacheAndIo = "Cache and I/O",
+  Storage = "Storage",
+  Replication = "Replication",
+  Maintenance = "Maintenance",
+}
+
+/*
+ * Collection groups map one-to-one onto the queries the probe runs. They are
+ * the unit of graceful degradation: if the login lacks the grant a group
+ * needs, that group alone is skipped and reported, and every other group is
+ * still collected.
+ */
+export enum DatabaseMetricGroup {
+  Connections = "Connections",
+  Activity = "Activity",
+  Throughput = "Throughput",
+  Locks = "Locks",
+  Storage = "Storage",
+  Replication = "Replication",
+  Maintenance = "Maintenance",
+}
+
+export interface DatabaseMetricDefinition {
+  // Stable identifier used in the UI and in tests. Never reuse or renumber.
+  id: string;
+  metricType: MonitorMetricType;
+  friendlyName: string;
+  description: string;
+  category: DatabaseMetricCategory;
+  group: DatabaseMetricGroup;
+  defaultAggregation: AggregationType;
+  // Display unit. Empty string for dimensionless counts.
+  unit: string;
+  // Engines that can actually produce this series.
+  engines: Array<SqlDatabaseType>;
+}
+
+const ALL_ENGINES: Array<SqlDatabaseType> = [
+  SqlDatabaseType.PostgreSQL,
+  SqlDatabaseType.MySQL,
+  SqlDatabaseType.MicrosoftSqlServer,
+];
+
+const databaseMetricCatalog: Array<DatabaseMetricDefinition> = [
+  // ---------------------------------------------------------------- Availability
+  {
+    id: "database-uptime-seconds",
+    metricType: MonitorMetricType.DatabaseUptimeSeconds,
+    friendlyName: "Uptime",
+    description:
+      "Seconds since the database server started. A sudden drop means the server restarted - often the real story behind a burst of connection errors.",
+    category: DatabaseMetricCategory.Availability,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Max,
+    unit: "s",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-metric-groups-failed",
+    metricType: MonitorMetricType.DatabaseMetricGroupsFailed,
+    friendlyName: "Metric Groups Failed",
+    description:
+      "How many collection groups failed on the last check, usually because the monitoring login is missing a grant or an engine feature is off. Alert on this to catch lost visibility - a partial failure never takes the monitor offline.",
+    category: DatabaseMetricCategory.Availability,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: ALL_ENGINES,
+  },
+
+  // ----------------------------------------------------------------- Connections
+  {
+    id: "database-connections-total",
+    metricType: MonitorMetricType.DatabaseConnectionsTotal,
+    friendlyName: "Connections",
+    description:
+      "Client connections currently open to the server. Compare against the maximum to see how much headroom is left.",
+    category: DatabaseMetricCategory.Connections,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Avg,
+    unit: "",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-connections-active",
+    metricType: MonitorMetricType.DatabaseConnectionsActive,
+    friendlyName: "Active Connections",
+    description:
+      "Connections actually executing a statement right now, as opposed to sitting idle. Sustained growth here is the earliest sign of saturation.",
+    category: DatabaseMetricCategory.Connections,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Avg,
+    unit: "",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-connections-max",
+    metricType: MonitorMetricType.DatabaseConnectionsMax,
+    friendlyName: "Maximum Connections",
+    description:
+      "The server's configured connection ceiling. SQL Server leaves this unlimited by default, so it is not reported there.",
+    category: DatabaseMetricCategory.Connections,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MySQL],
+  },
+  {
+    id: "database-connections-used-percent",
+    metricType: MonitorMetricType.DatabaseConnectionsUsedPercent,
+    friendlyName: "Connections Used",
+    description:
+      "Open connections as a percentage of the configured ceiling. The single best connection-exhaustion alert: page at 90%, warn at 75%.",
+    category: DatabaseMetricCategory.Connections,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Max,
+    unit: "%",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MySQL],
+  },
+  {
+    id: "database-connections-idle-in-transaction",
+    metricType: MonitorMetricType.DatabaseConnectionsIdleInTransaction,
+    friendlyName: "Idle In Transaction",
+    description:
+      "PostgreSQL backends holding an open transaction while doing nothing. These pin the xmin horizon, block vacuum, and quietly cause table bloat.",
+    category: DatabaseMetricCategory.Connections,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-connections-aborted-total",
+    metricType: MonitorMetricType.DatabaseConnectionsAbortedTotal,
+    friendlyName: "Aborted Connects",
+    description:
+      "Cumulative failed connection attempts since server start. A rising rate points at bad credentials, TLS problems, or a client pool misconfiguration.",
+    category: DatabaseMetricCategory.Connections,
+    group: DatabaseMetricGroup.Connections,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL],
+  },
+
+  // ------------------------------------------------------------------ Throughput
+  {
+    id: "database-transactions-total",
+    metricType: MonitorMetricType.DatabaseTransactionsTotal,
+    friendlyName: "Transactions",
+    description:
+      "Cumulative committed plus rolled-back transactions. Difference two points in time to get transactions per second.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-queries-total",
+    metricType: MonitorMetricType.DatabaseQueriesTotal,
+    friendlyName: "Queries",
+    description:
+      "Cumulative statements (MySQL) or batch requests (SQL Server) executed since server start. Difference it to get throughput.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-queries-slow-total",
+    metricType: MonitorMetricType.DatabaseSlowQueriesTotal,
+    friendlyName: "Slow Queries",
+    description:
+      "Cumulative statements that exceeded MySQL's long_query_time. Requires the slow query log threshold to be set meaningfully.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL],
+  },
+  {
+    id: "database-rollback-percent",
+    metricType: MonitorMetricType.DatabaseRollbackPercent,
+    friendlyName: "Rollback Ratio",
+    description:
+      "Share of transactions that rolled back rather than committed. A step change usually means the application started throwing where it used to succeed.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Avg,
+    unit: "%",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-query-longest-seconds",
+    metricType: MonitorMetricType.DatabaseLongestQuerySeconds,
+    friendlyName: "Longest Running Query",
+    description:
+      "Age of the oldest statement currently executing. Catches a runaway report holding resources long before it shows up as a timeout somewhere else.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Activity,
+    defaultAggregation: AggregationType.Max,
+    unit: "s",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-transaction-longest-seconds",
+    metricType: MonitorMetricType.DatabaseLongestTransactionSeconds,
+    friendlyName: "Longest Open Transaction",
+    description:
+      "Age of the oldest open transaction. Long transactions block vacuum on PostgreSQL and grow the log on MySQL and SQL Server.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Activity,
+    defaultAggregation: AggregationType.Max,
+    unit: "s",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-transaction-open-count",
+    metricType: MonitorMetricType.DatabaseOpenTransactions,
+    friendlyName: "Open Transactions",
+    description: "Transactions currently open against the InnoDB engine.",
+    category: DatabaseMetricCategory.Throughput,
+    group: DatabaseMetricGroup.Activity,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL],
+  },
+
+  // ----------------------------------------------------------- Locks and Blocking
+  {
+    id: "database-sessions-blocked",
+    metricType: MonitorMetricType.DatabaseSessionsBlocked,
+    friendlyName: "Blocked Sessions",
+    description:
+      "Sessions waiting on a lock held by another session. Anything sustained above zero is a user-visible stall.",
+    category: DatabaseMetricCategory.LocksAndBlocking,
+    group: DatabaseMetricGroup.Locks,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-locks-waiting",
+    metricType: MonitorMetricType.DatabaseLocksWaiting,
+    friendlyName: "Lock Waits",
+    description:
+      "Lock requests that have not been granted yet. Rises before blocked sessions does, so it makes a good early warning.",
+    category: DatabaseMetricCategory.LocksAndBlocking,
+    group: DatabaseMetricGroup.Locks,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-deadlocks-total",
+    metricType: MonitorMetricType.DatabaseDeadlocksTotal,
+    friendlyName: "Deadlocks",
+    description:
+      "Cumulative deadlocks detected and broken by the server. Stock MySQL exposes no deadlock counter, so this is PostgreSQL and SQL Server only.",
+    category: DatabaseMetricCategory.LocksAndBlocking,
+    group: DatabaseMetricGroup.Locks,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-table-locks-waited-total",
+    metricType: MonitorMetricType.DatabaseTableLocksWaitedTotal,
+    friendlyName: "Table Lock Waits",
+    description:
+      "Cumulative table-level lock requests that had to wait. Typically points at MyISAM tables or explicit LOCK TABLES usage.",
+    category: DatabaseMetricCategory.LocksAndBlocking,
+    group: DatabaseMetricGroup.Locks,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL],
+  },
+
+  // ---------------------------------------------------------------- Cache and I/O
+  {
+    id: "database-cache-hit-percent",
+    metricType: MonitorMetricType.DatabaseCacheHitPercent,
+    friendlyName: "Cache Hit Ratio",
+    description:
+      "Share of block reads served from the buffer cache instead of disk. A sustained fall means the working set no longer fits in memory.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Avg,
+    unit: "%",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-disk-reads-total",
+    metricType: MonitorMetricType.DatabaseDiskReadsTotal,
+    friendlyName: "Disk Reads",
+    description:
+      "Cumulative reads that had to go to disk rather than the cache. Difference it to get read rate.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-disk-writes-total",
+    metricType: MonitorMetricType.DatabaseDiskWritesTotal,
+    friendlyName: "Disk Writes",
+    description: "Cumulative physical writes issued by the storage engine.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-io-read-time-ms",
+    metricType: MonitorMetricType.DatabaseIoReadTimeMs,
+    friendlyName: "I/O Read Time",
+    description:
+      "Cumulative milliseconds spent waiting on read I/O. PostgreSQL only reports this when track_io_timing is on; the series is simply absent otherwise.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "ms",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-io-write-time-ms",
+    metricType: MonitorMetricType.DatabaseIoWriteTimeMs,
+    friendlyName: "I/O Write Time",
+    description:
+      "Cumulative milliseconds spent waiting on write I/O. Same track_io_timing caveat as read time on PostgreSQL.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "ms",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-page-life-expectancy-seconds",
+    metricType: MonitorMetricType.DatabasePageLifeExpectancySeconds,
+    friendlyName: "Page Life Expectancy",
+    description:
+      "How long SQL Server expects a page to stay in the buffer pool. Falling PLE is the classic memory-pressure signal.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Min,
+    unit: "s",
+    engines: [SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-memory-grants-pending",
+    metricType: MonitorMetricType.DatabaseMemoryGrantsPending,
+    friendlyName: "Memory Grants Pending",
+    description:
+      "Queries waiting for a memory grant before they can run. Anything above zero means queries are queueing on memory.",
+    category: DatabaseMetricCategory.CacheAndIo,
+    group: DatabaseMetricGroup.Throughput,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MicrosoftSqlServer],
+  },
+
+  // --------------------------------------------------------------------- Storage
+  {
+    id: "database-size-bytes",
+    metricType: MonitorMetricType.DatabaseSizeBytes,
+    friendlyName: "Database Size",
+    description:
+      "On-disk size of the monitored database. Chart it over weeks to turn capacity planning into arithmetic.",
+    category: DatabaseMetricCategory.Storage,
+    group: DatabaseMetricGroup.Storage,
+    defaultAggregation: AggregationType.Max,
+    unit: "bytes",
+    engines: ALL_ENGINES,
+  },
+  {
+    id: "database-temp-bytes-total",
+    metricType: MonitorMetricType.DatabaseTempBytesTotal,
+    friendlyName: "Temp Bytes Written",
+    description:
+      "Cumulative bytes PostgreSQL spilled to temporary files because work_mem was too small for a sort or hash.",
+    category: DatabaseMetricCategory.Storage,
+    group: DatabaseMetricGroup.Storage,
+    defaultAggregation: AggregationType.Max,
+    unit: "bytes",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-temp-disk-tables-total",
+    metricType: MonitorMetricType.DatabaseTempDiskTablesTotal,
+    friendlyName: "Temp Disk Tables",
+    description:
+      "Cumulative internal temporary tables MySQL had to materialize on disk instead of in memory.",
+    category: DatabaseMetricCategory.Storage,
+    group: DatabaseMetricGroup.Storage,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.MySQL],
+  },
+  {
+    id: "database-log-space-used-percent",
+    metricType: MonitorMetricType.DatabaseLogSpaceUsedPercent,
+    friendlyName: "Log Space Used",
+    description:
+      "Percentage of the SQL Server transaction log in use. A log that fills stops all writes, so this is worth paging on.",
+    category: DatabaseMetricCategory.Storage,
+    group: DatabaseMetricGroup.Storage,
+    defaultAggregation: AggregationType.Max,
+    unit: "%",
+    engines: [SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-tempdb-free-bytes",
+    metricType: MonitorMetricType.DatabaseTempDbFreeBytes,
+    friendlyName: "TempDB Free Space",
+    description:
+      "Unallocated space left in tempdb. Running tempdb dry takes down every session that needs a spill or a version store.",
+    category: DatabaseMetricCategory.Storage,
+    group: DatabaseMetricGroup.Storage,
+    defaultAggregation: AggregationType.Min,
+    unit: "bytes",
+    engines: [SqlDatabaseType.MicrosoftSqlServer],
+  },
+
+  // ----------------------------------------------------------------- Replication
+  {
+    id: "database-replica-count",
+    metricType: MonitorMetricType.DatabaseReplicaCount,
+    friendlyName: "Connected Replicas",
+    description:
+      "Replicas currently streaming from this server. Alert on a drop to catch a replica that detached silently.",
+    category: DatabaseMetricCategory.Replication,
+    group: DatabaseMetricGroup.Replication,
+    defaultAggregation: AggregationType.Min,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-replication-lag-seconds",
+    metricType: MonitorMetricType.DatabaseReplicationLagSeconds,
+    friendlyName: "Replication Lag",
+    description:
+      "How far behind the replica is, in seconds. Reported from whichever side of the replication link this monitor is connected to. SQL Server availability groups do not publish a delay in seconds - use Replication Lag (Bytes) there.",
+    category: DatabaseMetricCategory.Replication,
+    group: DatabaseMetricGroup.Replication,
+    defaultAggregation: AggregationType.Max,
+    unit: "s",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MySQL],
+  },
+  {
+    id: "database-replication-lag-bytes",
+    metricType: MonitorMetricType.DatabaseReplicationLagBytes,
+    friendlyName: "Replication Lag (Bytes)",
+    description:
+      "Bytes of WAL sent but not yet replayed, or the SQL Server send and redo queue. Survives an idle primary, where lag in seconds reads as zero.",
+    category: DatabaseMetricCategory.Replication,
+    group: DatabaseMetricGroup.Replication,
+    defaultAggregation: AggregationType.Max,
+    unit: "bytes",
+    engines: [SqlDatabaseType.PostgreSQL, SqlDatabaseType.MicrosoftSqlServer],
+  },
+  {
+    id: "database-is-in-recovery",
+    metricType: MonitorMetricType.DatabaseIsInRecovery,
+    friendlyName: "Is In Recovery",
+    description:
+      "1 when this PostgreSQL server is a standby, 0 when it is a primary. Alert on a change to catch an unplanned failover.",
+    category: DatabaseMetricCategory.Replication,
+    group: DatabaseMetricGroup.Replication,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-replication-slots-inactive",
+    metricType: MonitorMetricType.DatabaseReplicationSlotsInactive,
+    friendlyName: "Inactive Replication Slots",
+    description:
+      "PostgreSQL replication slots with no consumer attached. Each one pins WAL forever and will eventually fill the disk.",
+    category: DatabaseMetricCategory.Replication,
+    group: DatabaseMetricGroup.Replication,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+
+  // ----------------------------------------------------------------- Maintenance
+  {
+    id: "database-transaction-id-used-percent",
+    metricType: MonitorMetricType.DatabaseTransactionIdUsedPercent,
+    friendlyName: "Transaction ID Used",
+    description:
+      "How far the oldest unfrozen transaction ID has advanced toward wraparound. PostgreSQL shuts down writes if this ever reaches 100%, which makes it the most important PostgreSQL metric almost nobody watches.",
+    category: DatabaseMetricCategory.Maintenance,
+    group: DatabaseMetricGroup.Maintenance,
+    defaultAggregation: AggregationType.Max,
+    unit: "%",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-dead-tuples",
+    metricType: MonitorMetricType.DatabaseDeadTuples,
+    friendlyName: "Dead Tuples",
+    description:
+      "Dead rows waiting to be reclaimed by vacuum across user tables. Growth without a matching vacuum means bloat and worsening plans.",
+    category: DatabaseMetricCategory.Maintenance,
+    group: DatabaseMetricGroup.Maintenance,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-tables-never-autovacuumed",
+    metricType: MonitorMetricType.DatabaseTablesNeverAutovacuumed,
+    friendlyName: "Tables Never Autovacuumed",
+    description:
+      "User tables that have dead rows but have never been autovacuumed - usually a sign autovacuum is starved or disabled for them.",
+    category: DatabaseMetricCategory.Maintenance,
+    group: DatabaseMetricGroup.Maintenance,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-checkpoints-requested-total",
+    metricType: MonitorMetricType.DatabaseCheckpointsRequestedTotal,
+    friendlyName: "Requested Checkpoints",
+    description:
+      "Cumulative checkpoints forced by WAL volume rather than by the timer. A high ratio against timed checkpoints means max_wal_size is too small.",
+    category: DatabaseMetricCategory.Maintenance,
+    group: DatabaseMetricGroup.Maintenance,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+  {
+    id: "database-checkpoints-timed-total",
+    metricType: MonitorMetricType.DatabaseCheckpointsTimedTotal,
+    friendlyName: "Timed Checkpoints",
+    description:
+      "Cumulative checkpoints triggered on schedule. The healthy counterpart to requested checkpoints.",
+    category: DatabaseMetricCategory.Maintenance,
+    group: DatabaseMetricGroup.Maintenance,
+    defaultAggregation: AggregationType.Max,
+    unit: "",
+    engines: [SqlDatabaseType.PostgreSQL],
+  },
+];
+
+/*
+ * Display order of the metric cards on the monitor's metrics tab. Availability
+ * first because it answers "is this thing even reporting", then the groups an
+ * operator walks in order during an incident.
+ */
+const categoryOrder: Array<DatabaseMetricCategory> = [
+  DatabaseMetricCategory.Availability,
+  DatabaseMetricCategory.Connections,
+  DatabaseMetricCategory.Throughput,
+  DatabaseMetricCategory.LocksAndBlocking,
+  DatabaseMetricCategory.CacheAndIo,
+  DatabaseMetricCategory.Storage,
+  DatabaseMetricCategory.Replication,
+  DatabaseMetricCategory.Maintenance,
+];
+
+const categoryDescriptions: Record<DatabaseMetricCategory, string> = {
+  [DatabaseMetricCategory.Availability]:
+    "Whether the database is reachable and whether collection is complete.",
+  [DatabaseMetricCategory.Connections]:
+    "Connection counts, headroom against the configured ceiling, and failed connects.",
+  [DatabaseMetricCategory.Throughput]:
+    "Transaction and query volume, plus the age of the longest running work.",
+  [DatabaseMetricCategory.LocksAndBlocking]:
+    "Sessions waiting on each other: lock waits, blocked sessions, and deadlocks.",
+  [DatabaseMetricCategory.CacheAndIo]:
+    "How much work is served from memory rather than disk, and what the disk costs.",
+  [DatabaseMetricCategory.Storage]:
+    "Database size, temporary spill, and log or tempdb space.",
+  [DatabaseMetricCategory.Replication]:
+    "Replica connectivity and how far behind replicas are running.",
+  [DatabaseMetricCategory.Maintenance]:
+    "Vacuum, bloat, checkpoints, and transaction ID wraparound headroom.",
+};
+
+export function getAllDatabaseMetrics(): Array<DatabaseMetricDefinition> {
+  return [...databaseMetricCatalog];
+}
+
+export function getDatabaseMetricCategoryOrder(): Array<DatabaseMetricCategory> {
+  return [...categoryOrder];
+}
+
+export function getDatabaseMetricCategoryDescription(
+  category: DatabaseMetricCategory,
+): string {
+  return categoryDescriptions[category] || "";
+}
+
+export function getDatabaseMetricByMetricType(
+  metricType: MonitorMetricType,
+): DatabaseMetricDefinition | null {
+  return (
+    databaseMetricCatalog.find((metric: DatabaseMetricDefinition) => {
+      return metric.metricType === metricType;
+    }) || null
+  );
+}
+
+export function getDatabaseMetricById(
+  id: string,
+): DatabaseMetricDefinition | null {
+  return (
+    databaseMetricCatalog.find((metric: DatabaseMetricDefinition) => {
+      return metric.id === id;
+    }) || null
+  );
+}
+
+export function isDatabaseMetricType(metricType: MonitorMetricType): boolean {
+  return getDatabaseMetricByMetricType(metricType) !== null;
+}
+
+/**
+ * Metrics the given engine can actually produce. The criteria metric picker
+ * uses this so an operator is never offered a threshold on a series their
+ * engine will never write - a criterion that would sit permanently unmet.
+ */
+export function getDatabaseMetricsForEngine(
+  databaseType: SqlDatabaseType,
+): Array<DatabaseMetricDefinition> {
+  return databaseMetricCatalog.filter((metric: DatabaseMetricDefinition) => {
+    return metric.engines.includes(databaseType);
+  });
+}
+
+export function getDatabaseMetricsByCategory(
+  category: DatabaseMetricCategory,
+): Array<DatabaseMetricDefinition> {
+  return databaseMetricCatalog.filter((metric: DatabaseMetricDefinition) => {
+    return metric.category === category;
+  });
+}
+
+export function getDatabaseMetricsByGroup(
+  group: DatabaseMetricGroup,
+): Array<DatabaseMetricDefinition> {
+  return databaseMetricCatalog.filter((metric: DatabaseMetricDefinition) => {
+    return metric.group === group;
+  });
+}
+
+export default databaseMetricCatalog;

--- a/Common/Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse.ts
+++ b/Common/Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse.ts
@@ -1,0 +1,83 @@
+import ProbeAttempt from "../../Probe/ProbeAttempt";
+import { DatabaseMetricGroup } from "../DatabaseMetricCatalog";
+import MonitorMetricType from "../MonitorMetricType";
+
+/*
+ * Why a metric group produced nothing. Kept as a closed set so the dashboard
+ * can render an actionable message (and, for MissingPermission, the exact
+ * GRANT to run) instead of echoing a driver error at the operator.
+ */
+export enum DatabaseMetricGroupUnavailableReason {
+  // The monitoring login lacks the grant this group's views need.
+  MissingPermission = "MissingPermission",
+  /*
+   * The engine does not expose this data at all: an older major version, a
+   * disabled extension, or a feature the engine simply does not have (there
+   * is no deadlock counter in stock MySQL, for instance).
+   */
+  NotSupportedByEngine = "NotSupportedByEngine",
+  // The group's query exceeded the statement timeout.
+  Timeout = "Timeout",
+  // Anything else. `message` carries the sanitized detail.
+  Error = "Error",
+}
+
+export interface DatabaseMetricGroupStatus {
+  group: DatabaseMetricGroup;
+  reason: DatabaseMetricGroupUnavailableReason;
+  /*
+   * Sanitized, operator-facing explanation. Never contains a DSN, a
+   * password, or a raw driver error - SqlMonitor.sanitizeError is applied
+   * before anything lands here.
+   */
+  message: string;
+  /*
+   * The grant that would fix it, when we know it (e.g.
+   * "GRANT pg_read_all_stats TO monitoring_user"). Rendered verbatim in the
+   * monitor's summary view so the fix is copy-pasteable.
+   */
+  remediation?: string | undefined;
+}
+
+/*
+ * What a probe reports back for one Database Health check.
+ *
+ * The central contract here is that COLLECTION IS PARTIAL BY DESIGN.
+ * `isOnline` answers exactly one question - could we connect and run the
+ * baseline probe query - and nothing else in this payload can change it. A
+ * login without VIEW SERVER STATE, a replica group that times out, or an
+ * engine that has no deadlock counter all produce entries in
+ * `unavailableGroups` while the monitor stays online, because the database
+ * being monitored is fine; it is our visibility into it that is reduced.
+ *
+ * No rows of customer data ever appear here. Values are numeric aggregates
+ * read from engine catalog views, keyed by the metric series they feed.
+ */
+export default interface DatabaseMonitorResponse {
+  isOnline: boolean;
+  // Time to connect and run the baseline probe query.
+  responseTimeInMs: number;
+  failureCause: string;
+  /*
+   * Collected values, keyed by the series each one writes. A metric absent
+   * from this map is simply not written - the engine did not report it,
+   * or its group was skipped. Never zero-fill: a missing replication lag
+   * and a replication lag of zero mean opposite things.
+   */
+  metrics: Partial<Record<MonitorMetricType, number>>;
+  // Groups that ran and produced values.
+  collectedGroups: Array<DatabaseMetricGroup>;
+  // Groups that could not be collected, with the reason and the fix.
+  unavailableGroups: Array<DatabaseMetricGroupStatus>;
+  /*
+   * Engine version string as the server reports it, for the summary view.
+   * Also what the collector version-gates on (PostgreSQL moved the
+   * checkpoint counters out of pg_stat_bgwriter in 17, for example).
+   */
+  engineVersion?: string | undefined;
+  // Sanitized connection error, present only when isOnline is false.
+  connectionError: string | null;
+  isTimeout?: boolean | undefined;
+  probeAttempts?: Array<ProbeAttempt> | undefined;
+  totalAttempts?: number | undefined;
+}

--- a/Common/Types/Monitor/MonitorCriteriaInstance.ts
+++ b/Common/Types/Monitor/MonitorCriteriaInstance.ts
@@ -568,6 +568,40 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
       return monitorCriteriaInstance;
     }
 
+    if (arg.monitorType === MonitorType.Database) {
+      const monitorCriteriaInstance: MonitorCriteriaInstance =
+        new MonitorCriteriaInstance();
+
+      /*
+       * Online means one thing only: the probe connected and collected. It
+       * deliberately does NOT assert anything about the metrics. A database
+       * with a 97% cache hit ratio is not "down", and a monitor that treats
+       * every threshold as an outage teaches its operators to ignore it.
+       * Metric thresholds ship as templates the user opts into instead.
+       */
+      monitorCriteriaInstance.data = {
+        id: ObjectID.generate().toString(),
+        monitorStatusId: arg.monitorStatusId,
+        filterCondition: FilterCondition.All,
+        filters: [
+          {
+            checkOn: CheckOn.DatabaseIsOnline,
+            filterType: FilterType.True,
+            value: undefined,
+          },
+        ],
+        incidents: [],
+        alerts: [],
+        createAlerts: false,
+        changeMonitorStatus: true,
+        createIncidents: false,
+        name: `Check if ${arg.monitorName} is online`,
+        description: `This criteria checks if ${arg.monitorName} is reachable and its health metrics were collected`,
+      };
+
+      return monitorCriteriaInstance;
+    }
+
     if (arg.monitorType === MonitorType.Domain) {
       const monitorCriteriaInstance: MonitorCriteriaInstance =
         new MonitorCriteriaInstance();
@@ -799,6 +833,48 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         name: `Check if ${arg.monitorName} is offline`,
         description: `This criteria checks if the ${arg.monitorName} DNS resolution is failing`,
       };
+    }
+
+    if (arg.monitorType === MonitorType.Database) {
+      monitorCriteriaInstance.data = {
+        id: ObjectID.generate().toString(),
+        monitorStatusId: arg.monitorStatusId,
+        filterCondition: FilterCondition.Any,
+        filters: [
+          {
+            checkOn: CheckOn.DatabaseIsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        ],
+        incidents: [
+          {
+            title: `${arg.monitorName} is offline`,
+            description: `${arg.monitorName} is not reachable, or the health check could not connect.`,
+            incidentSeverityId: arg.incidentSeverityId,
+            autoResolveIncident: true,
+            id: ObjectID.generate().toString(),
+            onCallPolicyIds: [],
+          },
+        ],
+        changeMonitorStatus: true,
+        createIncidents: true,
+        createAlerts: false,
+        alerts: [
+          {
+            title: `${arg.monitorName} is offline`,
+            description: `${arg.monitorName} is not reachable, or the health check could not connect.`,
+            alertSeverityId: arg.alertSeverityId,
+            autoResolveAlert: true,
+            id: ObjectID.generate().toString(),
+            onCallPolicyIds: [],
+          },
+        ],
+        name: `Check if ${arg.monitorName} is offline`,
+        description: `This criteria checks if ${arg.monitorName} is offline`,
+      };
+
+      return monitorCriteriaInstance;
     }
 
     if (arg.monitorType === MonitorType.SQLQuery) {

--- a/Common/Types/Monitor/MonitorMetricType.ts
+++ b/Common/Types/Monitor/MonitorMetricType.ts
@@ -83,6 +83,77 @@ enum MonitorMetricType {
 
   HostUptimeSeconds = "oneuptime.monitor.host.uptime.seconds",
   ProcessCountTotal = "oneuptime.monitor.process.count.total",
+
+  /*
+   * Database Health monitor series. A probe connects to PostgreSQL / MySQL /
+   * Microsoft SQL Server on a schedule and runs built-in read-only catalog
+   * queries; each value below is one normalized series.
+   *
+   * Not every engine can produce every series - MySQL has no deadlock
+   * counter, SQL Server has no fixed connection ceiling by default, and
+   * PostgreSQL's I/O timings need track_io_timing on. The authoritative
+   * per-engine support matrix lives in DatabaseMetricCatalog.ts, which is
+   * also the single source of truth for each series' title, unit,
+   * aggregation and display category. Add a member here and an entry there
+   * together - a member without a catalog entry is invisible to the UI and
+   * fails the metric-invariant tests.
+   */
+  DatabaseUptimeSeconds = "oneuptime.monitor.database.uptime.seconds",
+
+  DatabaseConnectionsTotal = "oneuptime.monitor.database.connections.total",
+  DatabaseConnectionsActive = "oneuptime.monitor.database.connections.active",
+  DatabaseConnectionsMax = "oneuptime.monitor.database.connections.max",
+  DatabaseConnectionsUsedPercent = "oneuptime.monitor.database.connections.used.percent",
+  DatabaseConnectionsIdleInTransaction = "oneuptime.monitor.database.connections.idle.in.transaction",
+  DatabaseConnectionsAbortedTotal = "oneuptime.monitor.database.connections.aborted.total",
+
+  DatabaseLongestQuerySeconds = "oneuptime.monitor.database.query.longest.seconds",
+  DatabaseLongestTransactionSeconds = "oneuptime.monitor.database.transaction.longest.seconds",
+  DatabaseOpenTransactions = "oneuptime.monitor.database.transaction.open.count",
+
+  DatabaseSessionsBlocked = "oneuptime.monitor.database.sessions.blocked",
+  DatabaseLocksWaiting = "oneuptime.monitor.database.locks.waiting",
+  DatabaseDeadlocksTotal = "oneuptime.monitor.database.deadlocks.total",
+  DatabaseTableLocksWaitedTotal = "oneuptime.monitor.database.table.locks.waited.total",
+
+  DatabaseTransactionsTotal = "oneuptime.monitor.database.transactions.total",
+  DatabaseQueriesTotal = "oneuptime.monitor.database.queries.total",
+  DatabaseSlowQueriesTotal = "oneuptime.monitor.database.queries.slow.total",
+  DatabaseRollbackPercent = "oneuptime.monitor.database.rollback.percent",
+
+  DatabaseCacheHitPercent = "oneuptime.monitor.database.cache.hit.percent",
+  DatabaseDiskReadsTotal = "oneuptime.monitor.database.disk.reads.total",
+  DatabaseDiskWritesTotal = "oneuptime.monitor.database.disk.writes.total",
+  DatabaseIoReadTimeMs = "oneuptime.monitor.database.io.read.time.ms",
+  DatabaseIoWriteTimeMs = "oneuptime.monitor.database.io.write.time.ms",
+  DatabasePageLifeExpectancySeconds = "oneuptime.monitor.database.page.life.expectancy.seconds",
+  DatabaseMemoryGrantsPending = "oneuptime.monitor.database.memory.grants.pending",
+
+  DatabaseSizeBytes = "oneuptime.monitor.database.size.bytes",
+  DatabaseTempBytesTotal = "oneuptime.monitor.database.temp.bytes.total",
+  DatabaseTempDiskTablesTotal = "oneuptime.monitor.database.temp.disk.tables.total",
+  DatabaseLogSpaceUsedPercent = "oneuptime.monitor.database.log.space.used.percent",
+  DatabaseTempDbFreeBytes = "oneuptime.monitor.database.tempdb.free.bytes",
+
+  DatabaseReplicaCount = "oneuptime.monitor.database.replica.count",
+  DatabaseReplicationLagSeconds = "oneuptime.monitor.database.replication.lag.seconds",
+  DatabaseReplicationLagBytes = "oneuptime.monitor.database.replication.lag.bytes",
+  DatabaseIsInRecovery = "oneuptime.monitor.database.is.in.recovery",
+  DatabaseReplicationSlotsInactive = "oneuptime.monitor.database.replication.slots.inactive",
+
+  DatabaseTransactionIdUsedPercent = "oneuptime.monitor.database.transaction.id.used.percent",
+  DatabaseDeadTuples = "oneuptime.monitor.database.dead.tuples",
+  DatabaseTablesNeverAutovacuumed = "oneuptime.monitor.database.tables.never.autovacuumed",
+  DatabaseCheckpointsRequestedTotal = "oneuptime.monitor.database.checkpoints.requested.total",
+  DatabaseCheckpointsTimedTotal = "oneuptime.monitor.database.checkpoints.timed.total",
+
+  /*
+   * Meta-series: how many collection groups failed on this check (a missing
+   * grant, a disabled extension, a per-group timeout). Lets an operator
+   * alert on "I have lost visibility" without the monitor itself going
+   * offline, which is what a partial failure must never do.
+   */
+  DatabaseMetricGroupsFailed = "oneuptime.monitor.database.metric.groups.failed",
 }
 
 export default MonitorMetricType;

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -50,6 +50,9 @@ import MonitorStepDnssecMonitor, {
 import MonitorStepSqlMonitor, {
   MonitorStepSqlMonitorUtil,
 } from "./MonitorStepSqlMonitor";
+import MonitorStepDatabaseMonitor, {
+  MonitorStepDatabaseMonitorUtil,
+} from "./MonitorStepDatabaseMonitor";
 import SqlDatabaseType from "./SqlDatabaseType";
 import MonitorStepExternalStatusPageMonitor, {
   MonitorStepExternalStatusPageMonitorUtil,
@@ -204,6 +207,9 @@ export interface MonitorStepType {
   // SQL Query monitor
   sqlMonitor?: MonitorStepSqlMonitor | undefined;
 
+  // Database Health monitor (built-in catalog metrics, no user query)
+  databaseMonitor?: MonitorStepDatabaseMonitor | undefined;
+
   // External Status Page monitor
   externalStatusPageMonitor?: MonitorStepExternalStatusPageMonitor | undefined;
 
@@ -269,6 +275,7 @@ export default class MonitorStep extends DatabaseProperty {
       domainMonitor: undefined,
       dnssecMonitor: undefined,
       sqlMonitor: undefined,
+      databaseMonitor: undefined,
       externalStatusPageMonitor: undefined,
       kubernetesMonitor: undefined,
       dockerMonitor: undefined,
@@ -345,6 +352,16 @@ export default class MonitorStep extends DatabaseProperty {
       domainMonitor: undefined,
       dnssecMonitor: undefined,
       sqlMonitor: undefined,
+      /*
+       * Seeded, unlike sqlMonitor. The SQL form always writes its config
+       * because the query field is required; a Database Health step has no
+       * required field, so an untouched step would reach the probe with no
+       * connection details at all and the monitor would never run.
+       */
+      databaseMonitor:
+        arg.monitorType === MonitorType.Database
+          ? MonitorStepDatabaseMonitorUtil.getDefault()
+          : undefined,
       externalStatusPageMonitor: undefined,
       kubernetesMonitor: undefined,
       dockerMonitor: undefined,
@@ -620,6 +637,13 @@ export default class MonitorStep extends DatabaseProperty {
     return this;
   }
 
+  public setDatabaseMonitor(
+    databaseMonitor: MonitorStepDatabaseMonitor,
+  ): MonitorStep {
+    this.data!.databaseMonitor = databaseMonitor;
+    return this;
+  }
+
   public setExternalStatusPageMonitor(
     externalStatusPageMonitor: MonitorStepExternalStatusPageMonitor,
   ): MonitorStep {
@@ -876,6 +900,42 @@ export default class MonitorStep extends DatabaseProperty {
       }
     }
 
+    if (monitorType === MonitorType.Database) {
+      if (!value.data.databaseMonitor) {
+        return "Database monitor configuration is required";
+      }
+
+      if (!value.data.databaseMonitor.host) {
+        return "Database host is required";
+      }
+
+      if (!value.data.databaseMonitor.databaseName) {
+        return "Database name is required";
+      }
+
+      /*
+       * Deliberately no query check - that is the difference between this
+       * monitor and the SQL Query monitor. Nor is a metric group required:
+       * an empty list is normalized back to every group rather than
+       * rejected, so a step can never be saved in a state that silently
+       * collects nothing.
+       */
+      if (
+        value.data.databaseMonitor.useWindowsIntegratedAuthentication &&
+        value.data.databaseMonitor.databaseType !==
+          SqlDatabaseType.MicrosoftSqlServer
+      ) {
+        return "Windows Integrated Authentication is only supported for Microsoft SQL Server";
+      }
+
+      if (
+        !value.data.databaseMonitor.useWindowsIntegratedAuthentication &&
+        !value.data.databaseMonitor.username
+      ) {
+        return "Database username is required";
+      }
+    }
+
     if (monitorType === MonitorType.ExternalStatusPage) {
       if (!value.data.externalStatusPageMonitor) {
         return "External status page configuration is required";
@@ -1048,6 +1108,9 @@ export default class MonitorStep extends DatabaseProperty {
             : undefined,
           sqlMonitor: this.data.sqlMonitor
             ? MonitorStepSqlMonitorUtil.toJSON(this.data.sqlMonitor)
+            : undefined,
+          databaseMonitor: this.data.databaseMonitor
+            ? MonitorStepDatabaseMonitorUtil.toJSON(this.data.databaseMonitor)
             : undefined,
           externalStatusPageMonitor: this.data.externalStatusPageMonitor
             ? MonitorStepExternalStatusPageMonitorUtil.toJSON(
@@ -1250,6 +1313,18 @@ export default class MonitorStep extends DatabaseProperty {
       sqlMonitor: json["sqlMonitor"]
         ? (json["sqlMonitor"] as JSONObject)
         : undefined,
+      /*
+       * Normalized on the way in, like metricMonitor above: the group list
+       * and the timeouts are clamped here so no consumer downstream has to
+       * defend against a step written by an older build or by hand.
+       */
+      databaseMonitor: json["databaseMonitor"]
+        ? MonitorStepDatabaseMonitorUtil.toJSON(
+            MonitorStepDatabaseMonitorUtil.fromJSON(
+              json["databaseMonitor"] as JSONObject,
+            ),
+          )
+        : undefined,
       externalStatusPageMonitor: json["externalStatusPageMonitor"]
         ? (json["externalStatusPageMonitor"] as JSONObject)
         : undefined,
@@ -1315,6 +1390,7 @@ export default class MonitorStep extends DatabaseProperty {
         domainMonitor: Zod.any().optional(),
         dnssecMonitor: Zod.any().optional(),
         sqlMonitor: Zod.any().optional(),
+        databaseMonitor: Zod.any().optional(),
         externalStatusPageMonitor: Zod.any().optional(),
         kubernetesMonitor: Zod.any().optional(),
         dockerMonitor: Zod.any().optional(),

--- a/Common/Types/Monitor/MonitorStepDatabaseMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepDatabaseMonitor.ts
@@ -1,0 +1,171 @@
+import { JSONObject } from "../JSON";
+import { DatabaseMetricGroup } from "./DatabaseMetricCatalog";
+import {
+  clampSqlConnectionTimeoutInMs,
+  clampSqlStatementTimeoutInMs,
+} from "./MonitorStepSqlMonitor";
+import SqlConnectionConfig from "./SqlConnectionConfig";
+import SqlDatabaseType from "./SqlDatabaseType";
+
+/*
+ * Connection + collection configuration for a Database Health monitor.
+ *
+ * The connection block deliberately mirrors MonitorStepSqlMonitor field for
+ * field: the two monitor types point at the same kind of server, and an
+ * operator who has configured one should not have to learn a second form.
+ * What differs is everything after the connection - there is no user query
+ * here. The probe runs built-in read-only catalog queries chosen by engine,
+ * grouped so a missing grant degrades one group instead of the monitor.
+ *
+ * As with the SQL Query monitor, `password` (or any other field) may hold a
+ * {{monitorSecrets.name}} reference that the server resolves before the
+ * config is handed to a probe. OneUptime never creates those secrets itself.
+ */
+
+/*
+ * Health queries are introspection, not user workload: they should return in
+ * milliseconds against a healthy server. A tighter default than the SQL Query
+ * monitor's is deliberate - if pg_stat_activity takes ten seconds, the useful
+ * signal is "this server is in trouble", and we want the check to say so
+ * rather than to sit and wait.
+ */
+export const DEFAULT_DATABASE_STATEMENT_TIMEOUT_IN_MS: number = 10000;
+export const DEFAULT_DATABASE_CONNECTION_TIMEOUT_IN_MS: number = 10000;
+
+/*
+ * Every group is on by default. A group whose grant is missing reports itself
+ * as unavailable rather than failing the check, so a default-on configuration
+ * degrades into "the metrics you are entitled to" instead of an error.
+ */
+export const DEFAULT_DATABASE_METRIC_GROUPS: Array<DatabaseMetricGroup> = [
+  DatabaseMetricGroup.Connections,
+  DatabaseMetricGroup.Activity,
+  DatabaseMetricGroup.Throughput,
+  DatabaseMetricGroup.Locks,
+  DatabaseMetricGroup.Storage,
+  DatabaseMetricGroup.Replication,
+  DatabaseMetricGroup.Maintenance,
+];
+
+export default interface MonitorStepDatabaseMonitor
+  extends SqlConnectionConfig {
+  connectionTimeoutInMs: number;
+  statementTimeoutInMs: number;
+  /*
+   * Which collection groups to run. Trimming this list is how an operator
+   * opts out of a group they cannot grant, or one whose queries they would
+   * rather not pay for on a busy server (Storage is the usual candidate -
+   * summing information_schema.TABLES is not free on a large MySQL server).
+   */
+  enabledMetricGroups: Array<DatabaseMetricGroup>;
+}
+
+export class MonitorStepDatabaseMonitorUtil {
+  public static getDefault(): MonitorStepDatabaseMonitor {
+    return {
+      databaseType: SqlDatabaseType.PostgreSQL,
+      host: "",
+      port: 5432,
+      databaseName: "",
+      username: "",
+      password: "",
+      useWindowsIntegratedAuthentication: false,
+      useSsl: false,
+      rejectUnauthorizedSsl: true,
+      connectionTimeoutInMs: DEFAULT_DATABASE_CONNECTION_TIMEOUT_IN_MS,
+      statementTimeoutInMs: DEFAULT_DATABASE_STATEMENT_TIMEOUT_IN_MS,
+      enabledMetricGroups: [...DEFAULT_DATABASE_METRIC_GROUPS],
+    };
+  }
+
+  /**
+   * Keep only recognized groups. An unknown string (an older or newer
+   * dashboard, a hand-written API call) is dropped rather than passed to the
+   * probe, which would otherwise have to defend against it at collection
+   * time. An empty or absent list falls back to every group, because a
+   * monitor that silently collects nothing is worse than one that collects
+   * what it can.
+   */
+  public static sanitizeMetricGroups(
+    groups: unknown,
+  ): Array<DatabaseMetricGroup> {
+    if (!Array.isArray(groups)) {
+      return [...DEFAULT_DATABASE_METRIC_GROUPS];
+    }
+
+    const validGroups: Array<DatabaseMetricGroup> =
+      Object.values(DatabaseMetricGroup);
+
+    const sanitized: Array<DatabaseMetricGroup> = groups.filter(
+      (group: unknown) => {
+        return validGroups.includes(group as DatabaseMetricGroup);
+      },
+    ) as Array<DatabaseMetricGroup>;
+
+    // De-duplicate while preserving the canonical group order.
+    const seen: Set<DatabaseMetricGroup> = new Set<DatabaseMetricGroup>(
+      sanitized,
+    );
+
+    const ordered: Array<DatabaseMetricGroup> =
+      DEFAULT_DATABASE_METRIC_GROUPS.filter((group: DatabaseMetricGroup) => {
+        return seen.has(group);
+      });
+
+    if (ordered.length === 0) {
+      return [...DEFAULT_DATABASE_METRIC_GROUPS];
+    }
+
+    return ordered;
+  }
+
+  public static fromJSON(json: JSONObject): MonitorStepDatabaseMonitor {
+    return {
+      databaseType:
+        (json["databaseType"] as SqlDatabaseType) || SqlDatabaseType.PostgreSQL,
+      host: (json["host"] as string) || "",
+      port: (json["port"] as number) || 5432,
+      databaseName: (json["databaseName"] as string) || "",
+      username: (json["username"] as string) || "",
+      password: (json["password"] as string) || "",
+      useWindowsIntegratedAuthentication: Boolean(
+        json["useWindowsIntegratedAuthentication"],
+      ),
+      useSsl: Boolean(json["useSsl"]),
+      rejectUnauthorizedSsl:
+        json["rejectUnauthorizedSsl"] === undefined ||
+        json["rejectUnauthorizedSsl"] === null
+          ? true
+          : Boolean(json["rejectUnauthorizedSsl"]),
+      connectionTimeoutInMs: clampSqlConnectionTimeoutInMs(
+        (json["connectionTimeoutInMs"] as number) ||
+          DEFAULT_DATABASE_CONNECTION_TIMEOUT_IN_MS,
+      ),
+      statementTimeoutInMs: clampSqlStatementTimeoutInMs(
+        (json["statementTimeoutInMs"] as number) ||
+          DEFAULT_DATABASE_STATEMENT_TIMEOUT_IN_MS,
+      ),
+      enabledMetricGroups: this.sanitizeMetricGroups(
+        json["enabledMetricGroups"],
+      ),
+    };
+  }
+
+  public static toJSON(monitor: MonitorStepDatabaseMonitor): JSONObject {
+    return {
+      databaseType: monitor.databaseType,
+      host: monitor.host,
+      port: monitor.port,
+      databaseName: monitor.databaseName,
+      username: monitor.username,
+      password: monitor.password,
+      useWindowsIntegratedAuthentication:
+        monitor.useWindowsIntegratedAuthentication,
+      useSsl: monitor.useSsl,
+      rejectUnauthorizedSsl: monitor.rejectUnauthorizedSsl,
+      connectionTimeoutInMs: monitor.connectionTimeoutInMs,
+      statementTimeoutInMs: monitor.statementTimeoutInMs,
+      enabledMetricGroups: [...monitor.enabledMetricGroups],
+    };
+  }
+}

--- a/Common/Types/Monitor/MonitorStepSqlMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepSqlMonitor.ts
@@ -1,4 +1,5 @@
 import { JSONObject } from "../JSON";
+import SqlConnectionConfig from "./SqlConnectionConfig";
 import SqlDatabaseType from "./SqlDatabaseType";
 
 /*
@@ -56,26 +57,7 @@ export const clampSqlMaxRows: (value: number) => number = (
  * the config is handed to a probe. OneUptime never creates these secrets for
  * the user; referencing one is the user's choice.
  */
-export default interface MonitorStepSqlMonitor {
-  databaseType: SqlDatabaseType;
-  host: string;
-  port: number;
-  databaseName: string;
-  username: string;
-  // Raw password OR a {{monitorSecrets.name}} reference resolved server-side.
-  password: string;
-  /*
-   * Microsoft SQL Server only: authenticate with the identity under which the
-   * probe is running (SSPI on Windows, Kerberos on Linux/macOS). Username and
-   * password are ignored when this is enabled.
-   */
-  useWindowsIntegratedAuthentication: boolean;
-  useSsl: boolean;
-  /*
-   * When SSL is on, whether the server certificate chain must validate. Users
-   * connecting to a DB with a self-signed cert set this to false.
-   */
-  rejectUnauthorizedSsl: boolean;
+export default interface MonitorStepSqlMonitor extends SqlConnectionConfig {
   // The read-only SQL query to run. A single statement is expected.
   query: string;
   connectionTimeoutInMs: number;

--- a/Common/Types/Monitor/MonitorType.ts
+++ b/Common/Types/Monitor/MonitorType.ts
@@ -24,6 +24,18 @@ enum MonitorType {
   // Database monitoring — runs a read-only SQL query on a schedule from a probe.
   SQLQuery = "SQL Query",
 
+  /*
+   * Database health monitoring. Where SQLQuery runs the query the user
+   * wrote, this runs the queries we wrote: a probe connects to the engine
+   * and reads its own catalog views (pg_stat_*, performance_schema,
+   * sys.dm_*) to produce connection, throughput, lock, cache, storage and
+   * replication series without the user knowing a single system table.
+   * The two are deliberately separate types - a health check has no user
+   * query, needs different grants, and runs a different number of
+   * statements per interval.
+   */
+  Database = "Database",
+
   // These two monitor types are same but we are keeping them separate for now - this is for marketing purposes
   SyntheticMonitor = "Synthetic Monitor",
   CustomJavaScriptCode = "Custom JavaScript Code",
@@ -103,7 +115,7 @@ export class MonitorTypeHelper {
       },
       {
         label: "Database Monitoring",
-        monitorTypes: [MonitorType.SQLQuery],
+        monitorTypes: [MonitorType.Database, MonitorType.SQLQuery],
       },
       {
         label: "Synthetic Monitoring",
@@ -496,6 +508,37 @@ export class MonitorTypeHelper {
         ],
       },
       {
+        monitorType: MonitorType.Database,
+        title: "Database Health",
+        description:
+          "Connections, locks, replication and cache health for PostgreSQL, MySQL and SQL Server.",
+        icon: IconProp.Database,
+        keywords: [
+          "database",
+          "db",
+          "health",
+          "performance",
+          "postgres",
+          "postgresql",
+          "mysql",
+          "mariadb",
+          "mssql",
+          "sql server",
+          "connections",
+          "replication",
+          "replica",
+          "lag",
+          "locks",
+          "deadlock",
+          "vacuum",
+          "bloat",
+          "buffer",
+          "cache hit",
+          "slow query",
+          "wraparound",
+        ],
+      },
+      {
         monitorType: MonitorType.SyntheticMonitor,
         title: "Synthetic Monitor",
         description:
@@ -780,6 +823,7 @@ export class MonitorTypeHelper {
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
       monitorType === MonitorType.SQLQuery ||
+      monitorType === MonitorType.Database ||
       monitorType === MonitorType.ExternalStatusPage;
     return isProbeableMonitor;
   }
@@ -808,6 +852,7 @@ export class MonitorTypeHelper {
       MonitorType.DNSSEC,
       MonitorType.Domain,
       MonitorType.SQLQuery,
+      MonitorType.Database,
       MonitorType.ExternalStatusPage,
       MonitorType.Kubernetes,
       MonitorType.Docker,
@@ -855,6 +900,7 @@ export class MonitorTypeHelper {
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
       monitorType === MonitorType.SQLQuery ||
+      monitorType === MonitorType.Database ||
       monitorType === MonitorType.ExternalStatusPage
     ) {
       return true;

--- a/Common/Types/Monitor/SqlConnectionConfig.ts
+++ b/Common/Types/Monitor/SqlConnectionConfig.ts
@@ -1,0 +1,31 @@
+import SqlDatabaseType from "./SqlDatabaseType";
+
+/*
+ * The connection half of a SQL-speaking monitor's configuration.
+ *
+ * Extracted so the SQL Query monitor and the Database Health monitor can
+ * share one implementation of the fiddly parts - TLS options, and especially
+ * the SQL Server integrated-authentication path, which has to detect the
+ * host's ODBC driver and build a connection string by hand. Duplicating that
+ * for a second monitor type would guarantee the two drift.
+ *
+ * Both MonitorStepSqlMonitor and MonitorStepDatabaseMonitor extend this, so
+ * anything that only needs to CONNECT should take this type rather than
+ * either step type.
+ */
+export default interface SqlConnectionConfig {
+  databaseType: SqlDatabaseType;
+  host: string;
+  port: number;
+  databaseName: string;
+  username: string;
+  // Raw password OR a {{monitorSecrets.name}} reference resolved server-side.
+  password: string;
+  /*
+   * Microsoft SQL Server only: authenticate as the identity the probe runs
+   * as (SSPI on Windows, Kerberos elsewhere).
+   */
+  useWindowsIntegratedAuthentication: boolean;
+  useSsl: boolean;
+  rejectUnauthorizedSsl: boolean;
+}

--- a/Common/Types/Probe/ProbeMonitorResponse.ts
+++ b/Common/Types/Probe/ProbeMonitorResponse.ts
@@ -13,6 +13,7 @@ import PingMonitorResponse from "../Monitor/PingMonitor/PingMonitorResponse";
 import DomainMonitorResponse from "../Monitor/DomainMonitor/DomainMonitorResponse";
 import DnssecMonitorResponse from "../Monitor/DnssecMonitor/DnssecMonitorResponse";
 import SqlMonitorResponse from "../Monitor/SqlMonitor/SqlMonitorResponse";
+import DatabaseMonitorResponse from "../Monitor/DatabaseMonitor/DatabaseMonitorResponse";
 import ExternalStatusPageMonitorResponse from "../Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import HttpPhaseTimings from "../Monitor/HttpPhaseTimings";
 import MonitorEvaluationSummary from "../Monitor/MonitorEvaluationSummary";
@@ -68,6 +69,12 @@ export default interface ProbeMonitorResponse {
   domainResponse?: DomainMonitorResponse | undefined;
   dnssecResponse?: DnssecMonitorResponse | undefined;
   sqlQueryMonitorResponse?: SqlMonitorResponse | undefined;
+  /*
+   * Database Health monitor payload: normalized metric values plus the
+   * groups that could not be collected. Partial collection is normal here -
+   * see DatabaseMonitorResponse for why it never implies an outage.
+   */
+  databaseMonitorResponse?: DatabaseMonitorResponse | undefined;
   externalStatusPageResponse?: ExternalStatusPageMonitorResponse | undefined;
   monitoredAt: Date;
   isTimeout?: boolean | undefined;

--- a/Common/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.ts
+++ b/Common/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.ts
@@ -538,6 +538,50 @@ export default class TemplateVariablesCatalog {
           ],
         };
 
+      case MonitorType.Database:
+        return {
+          title: "Database Health",
+          variables: [
+            {
+              key: "isOnline",
+              description: "True if the database accepted the connection.",
+            },
+            {
+              key: "responseTimeInMs",
+              description: "Time to connect and run the baseline query.",
+            },
+            { key: "failureCause", description: "Failure reason." },
+            {
+              key: "connectionError",
+              description:
+                "Connection error, when the database was unreachable.",
+            },
+            {
+              key: "engineVersion",
+              description: "Version string the database server reported.",
+            },
+            {
+              key: "collectedGroups",
+              description: "Metric groups that produced values on this check.",
+            },
+            {
+              key: "unavailableGroups",
+              description:
+                "Array of {group, reason, message, remediation} for groups that produced nothing.",
+            },
+            {
+              key: "collectionIssueSummary",
+              description:
+                "One-line summary of the unavailable groups - empty when everything was collected.",
+            },
+            {
+              key: "metrics",
+              description:
+                "Collected values keyed by metric name. A metric that was not collected is absent.",
+            },
+          ],
+        };
+
       case MonitorType.ExternalStatusPage:
         return {
           title: "External Status Page",

--- a/Common/Utils/Monitor/MonitorMetricType.ts
+++ b/Common/Utils/Monitor/MonitorMetricType.ts
@@ -1,5 +1,16 @@
 import AggregationType from "../../Types/BaseDatabase/AggregationType";
-import { CheckOn } from "../../Types/Monitor/CriteriaFilter";
+import { CheckOn, CriteriaFilter } from "../../Types/Monitor/CriteriaFilter";
+import {
+  DatabaseMetricCategory,
+  DatabaseMetricDefinition,
+  getAllDatabaseMetrics,
+  getDatabaseMetricByMetricType,
+  getDatabaseMetricCategoryDescription,
+  getDatabaseMetricCategoryOrder,
+  getDatabaseMetricsByCategory,
+  getDatabaseMetricsForEngine,
+} from "../../Types/Monitor/DatabaseMetricCatalog";
+import SqlDatabaseType from "../../Types/Monitor/SqlDatabaseType";
 import MonitorMetricType from "../../Types/Monitor/MonitorMetricType";
 import MonitorType, {
   MonitorTypeHelper,
@@ -20,6 +31,19 @@ class MonitorMetricTypeUtil {
   public static getAggregationTypeByMonitorMetricType(
     monitorMetricType: MonitorMetricType,
   ): AggregationType {
+    /*
+     * Database Health series carry their own aggregation in the catalog, so
+     * they resolve here instead of adding ~40 cases to this switch (and to
+     * the four other switches in this file). The catalog is the one place a
+     * new database metric has to be declared.
+     */
+    const databaseMetric: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(monitorMetricType);
+
+    if (databaseMetric) {
+      return databaseMetric.defaultAggregation;
+    }
+
     switch (monitorMetricType) {
       case MonitorMetricType.ResponseTime:
         return AggregationType.Avg;
@@ -275,6 +299,22 @@ class MonitorMetricTypeUtil {
       ];
     }
 
+    if (monitorType === MonitorType.Database) {
+      /*
+       * Availability first, then every catalog series in category order.
+       * Engine filtering happens in getDatabaseMetricCategories, which is
+       * the only caller that knows which engine the monitor points at - this
+       * list is the full capability set for the monitor type.
+       */
+      return [
+        MonitorMetricType.IsOnline,
+        MonitorMetricType.ResponseTime,
+        ...getAllDatabaseMetrics().map((metric: DatabaseMetricDefinition) => {
+          return metric.metricType;
+        }),
+      ];
+    }
+
     if (
       monitorType === MonitorType.DNS ||
       monitorType === MonitorType.DNSSEC ||
@@ -308,6 +348,14 @@ class MonitorMetricTypeUtil {
    */
   public static getMonitorMetricCategoriesByMonitorType(
     monitorType: MonitorType,
+    /*
+     * Database Health only. When the caller knows which engine the monitor
+     * is pointed at, pass it and the cards drop the series that engine can
+     * never write - so a MySQL monitor does not show a permanently empty
+     * "Transaction ID Used" chart. Omitting it shows the full capability
+     * set, which is the right fallback when the engine is not loaded yet.
+     */
+    databaseType?: SqlDatabaseType | undefined,
   ): Array<MonitorMetricCategory> {
     if (monitorType === MonitorType.Server) {
       return [
@@ -375,6 +423,10 @@ class MonitorMetricTypeUtil {
       ];
     }
 
+    if (monitorType === MonitorType.Database) {
+      return this.getDatabaseMetricCategories(databaseType);
+    }
+
     if (monitorType === MonitorType.NetworkDevice) {
       return [
         {
@@ -421,6 +473,13 @@ class MonitorMetricTypeUtil {
       monitorMetricType === MonitorMetricType.ResponseTime
     ) {
       return "Total Connection Time (DNS + TCP)";
+    }
+
+    const databaseMetric: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(monitorMetricType);
+
+    if (databaseMetric) {
+      return databaseMetric.friendlyName;
     }
 
     switch (monitorMetricType) {
@@ -534,6 +593,13 @@ class MonitorMetricTypeUtil {
   public static getLegendUnitByMonitorMetricType(
     monitorMetricType: MonitorMetricType,
   ): string {
+    const databaseMetric: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(monitorMetricType);
+
+    if (databaseMetric) {
+      return databaseMetric.unit;
+    }
+
     switch (monitorMetricType) {
       case MonitorMetricType.ResponseTime:
         return "ms";
@@ -617,6 +683,13 @@ class MonitorMetricTypeUtil {
       monitorMetricType === MonitorMetricType.ResponseTime
     ) {
       return "Total time spent resolving the hostname (when needed) and establishing the TCP connection.";
+    }
+
+    const databaseMetric: DatabaseMetricDefinition | null =
+      getDatabaseMetricByMetricType(monitorMetricType);
+
+    if (databaseMetric) {
+      return databaseMetric.description;
     }
 
     switch (monitorMetricType) {
@@ -713,6 +786,85 @@ class MonitorMetricTypeUtil {
       default:
         return "";
     }
+  }
+
+  /**
+   * One card per catalog category, in the order an operator walks them
+   * during an incident. When `databaseType` is given, a category whose
+   * metrics are all unsupported on that engine is dropped entirely rather
+   * than rendered as a card of empty charts.
+   */
+  public static getDatabaseMetricCategories(
+    databaseType?: SqlDatabaseType | undefined,
+  ): Array<MonitorMetricCategory> {
+    const supported: Array<MonitorMetricType> | null = databaseType
+      ? getDatabaseMetricsForEngine(databaseType).map(
+          (metric: DatabaseMetricDefinition) => {
+            return metric.metricType;
+          },
+        )
+      : null;
+
+    const categories: Array<MonitorMetricCategory> = [];
+
+    for (const category of getDatabaseMetricCategoryOrder()) {
+      const metrics: Array<MonitorMetricType> = getDatabaseMetricsByCategory(
+        category,
+      )
+        .filter((metric: DatabaseMetricDefinition) => {
+          return !supported || supported.includes(metric.metricType);
+        })
+        .map((metric: DatabaseMetricDefinition) => {
+          return metric.metricType;
+        });
+
+      /*
+       * Availability additionally carries the shared probe series, so it is
+       * never empty even if every catalog metric in it were filtered out.
+       */
+      if (category === DatabaseMetricCategory.Availability) {
+        metrics.unshift(
+          MonitorMetricType.IsOnline,
+          MonitorMetricType.ResponseTime,
+        );
+      }
+
+      if (metrics.length === 0) {
+        continue;
+      }
+
+      categories.push({
+        title: category,
+        description: getDatabaseMetricCategoryDescription(category),
+        metrics: metrics,
+      });
+    }
+
+    return categories;
+  }
+
+  /**
+   * The metric series a criteria filter reads.
+   *
+   * Database Health filters name their series in
+   * databaseMonitorOptions.metricType rather than in the CheckOn itself, so
+   * resolving from the CheckOn alone would return null and silently turn
+   * "evaluate over time" into an instantaneous comparison. Callers that hold
+   * the whole filter - EvaluateOverTime does - must use this instead of
+   * getMonitorMetricTypeByCheckOnOrNull.
+   */
+  public static getMonitorMetricTypeByCriteriaFilterOrNull(
+    criteriaFilter: CriteriaFilter,
+  ): MonitorMetricType | null {
+    if (criteriaFilter.checkOn === CheckOn.DatabaseMetric) {
+      return criteriaFilter.databaseMonitorOptions?.metricType || null;
+    }
+
+    if (criteriaFilter.checkOn === CheckOn.DatabaseIsOnline) {
+      return MonitorMetricType.IsOnline;
+    }
+
+    return this.getMonitorMetricTypeByCheckOnOrNull(criteriaFilter.checkOn);
   }
 }
 

--- a/MobileApp/src/components/MonitorCard.tsx
+++ b/MobileApp/src/components/MonitorCard.tsx
@@ -29,6 +29,7 @@ function getMonitorTypeLabel(monitorType?: string): string {
     Domain: "Domain",
     Server: "Server",
     IncomingRequest: "Incoming",
+    Database: "Database",
     SyntheticMonitor: "Synthetic",
     CustomJavaScriptCode: "Custom",
     Logs: "Logs",

--- a/MobileApp/src/screens/MonitorDetailScreen.tsx
+++ b/MobileApp/src/screens/MonitorDetailScreen.tsx
@@ -37,6 +37,7 @@ function getMonitorTypeLabel(monitorType?: string): string {
     Domain: "Domain",
     Server: "Server",
     IncomingRequest: "Incoming Request",
+    Database: "Database Health",
     SyntheticMonitor: "Synthetic Monitor",
     CustomJavaScriptCode: "Custom JavaScript",
     Logs: "Logs",

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseHealthQueries.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseHealthQueries.test.ts
@@ -1,0 +1,430 @@
+// Set required env vars before importing anything that reaches Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  DatabaseHealthQuery,
+  DatabaseQueryColumnMapping,
+  getDatabaseHealthQueries,
+  getProbeQuery,
+} from "../../../../../Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseHealthQueries";
+import {
+  DatabaseMetricDefinition,
+  DatabaseMetricGroup,
+  getDatabaseMetricByMetricType,
+  getDatabaseMetricsForEngine,
+} from "Common/Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "Common/Types/Monitor/MonitorMetricType";
+import SqlDatabaseType, {
+  SqlDatabaseTypeUtil,
+} from "Common/Types/Monitor/SqlDatabaseType";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * These tests police the RELATIONSHIP between the query table and the metric
+ * catalog. They cannot tell you a column name is wrong - only a live server
+ * can, and every statement in the table has been run against one - but they
+ * do catch the class of mistake that silently ships: a query that produces a
+ * metric its engine is not declared to support, or a metric filed under a
+ * collection group that no query in that group actually produces.
+ */
+
+const ENGINES: Array<SqlDatabaseType> =
+  SqlDatabaseTypeUtil.getSupportedDatabaseTypes();
+
+describe("DatabaseHealthQueries", () => {
+  test("every supported engine has queries, and unsupported engines have none", () => {
+    for (const engine of ENGINES) {
+      expect(getDatabaseHealthQueries(engine).length).toBeGreaterThan(0);
+    }
+
+    expect(
+      getDatabaseHealthQueries("Cassandra" as SqlDatabaseType),
+    ).toHaveLength(0);
+  });
+
+  test("every supported engine has a probe query, and it is a bare SELECT", () => {
+    for (const engine of ENGINES) {
+      const probeQuery: string = getProbeQuery(engine);
+      expect(probeQuery.trim().toUpperCase().startsWith("SELECT")).toBe(true);
+    }
+  });
+
+  test("the PostgreSQL probe query carries the stats-access preflight", () => {
+    /*
+     * The preflight is the only thing standing between an under-privileged
+     * monitor and a permanent, confident "1 connection". If this assertion
+     * ever fails, the monitor has gone back to reporting numbers it is not
+     * entitled to read.
+     */
+    const probeQuery: string = getProbeQuery(SqlDatabaseType.PostgreSQL);
+    expect(probeQuery).toContain("has_stats_access");
+    expect(probeQuery).toContain("pg_monitor");
+    expect(probeQuery).toContain("pg_read_all_stats");
+  });
+
+  describe.each(ENGINES)("%s", (engine: SqlDatabaseType) => {
+    const queries: Array<DatabaseHealthQuery> =
+      getDatabaseHealthQueries(engine);
+
+    test("query ids are unique", () => {
+      const ids: Array<string> = queries.map((query: DatabaseHealthQuery) => {
+        return query.id;
+      });
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    test("every query is a single read-only statement", () => {
+      const forbidden: Array<string> = [
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "DROP",
+        "ALTER",
+        "CREATE",
+        "TRUNCATE",
+        "GRANT",
+        "REVOKE",
+        "EXEC",
+      ];
+
+      for (const query of queries) {
+        const upperCased: string = query.sql.toUpperCase();
+
+        for (const keyword of forbidden) {
+          expect({
+            id: query.id,
+            containsWriteKeyword: new RegExp(`\\b${keyword}\\b`).test(
+              upperCased,
+            ),
+          }).toEqual({ id: query.id, containsWriteKeyword: false });
+        }
+
+        /*
+         * One statement per query. The drivers are configured to reject
+         * stacked statements, but a stray semicolon would turn a silent
+         * driver rejection into a confusing per-group failure.
+         */
+        expect({
+          id: query.id,
+          trailingStatements: query.sql.replace(/;\s*$/, "").includes(";"),
+        }).toEqual({ id: query.id, trailingStatements: false });
+      }
+    });
+
+    test("every mapped column produces a metric this engine is declared to support", () => {
+      for (const query of queries) {
+        for (const mapping of query.columnMappings) {
+          const definition: DatabaseMetricDefinition | null =
+            getDatabaseMetricByMetricType(mapping.metricType);
+
+          expect({
+            query: query.id,
+            column: mapping.column,
+            inCatalog: definition !== null,
+          }).toEqual({
+            query: query.id,
+            column: mapping.column,
+            inCatalog: true,
+          });
+
+          expect({
+            query: query.id,
+            metric: mapping.metricType,
+            supportsEngine: definition?.engines.includes(engine),
+          }).toEqual({
+            query: query.id,
+            metric: mapping.metricType,
+            supportsEngine: true,
+          });
+        }
+      }
+    });
+
+    test("a metric is produced by the collection group the catalog files it under", () => {
+      /*
+       * A query's group is what an operator switches off. If the catalog
+       * says database size is Storage but the only query producing it is
+       * tagged Throughput, then disabling Throughput silently takes size
+       * with it and enabling Storage does nothing - which is exactly the
+       * mismatch this assertion was written after finding.
+       */
+      for (const query of queries) {
+        for (const mapping of query.columnMappings) {
+          const definition: DatabaseMetricDefinition | null =
+            getDatabaseMetricByMetricType(mapping.metricType);
+
+          expect({
+            query: query.id,
+            metric: mapping.metricType,
+            group: query.group,
+          }).toEqual({
+            query: query.id,
+            metric: mapping.metricType,
+            group: definition?.group,
+          });
+        }
+      }
+    });
+
+    test("every column mapping is distinct within a query", () => {
+      for (const query of queries) {
+        const columns: Array<string> = query.columnMappings.map(
+          (mapping: DatabaseQueryColumnMapping) => {
+            return mapping.column.toLowerCase();
+          },
+        );
+
+        expect({ id: query.id, unique: new Set(columns).size }).toEqual({
+          id: query.id,
+          unique: columns.length,
+        });
+      }
+    });
+
+    test("every mapped column is actually selected by its query", () => {
+      /*
+       * Catches the rename that updates the SQL but not the mapping (or the
+       * other way round), which would otherwise show up only as a metric
+       * that quietly stopped being written.
+       */
+      for (const query of queries) {
+        /*
+         * SHOW statements name no columns - the engine decides them - so
+         * there is nothing in the SQL text to match against.
+         */
+        if (query.sql.trim().toUpperCase().startsWith("SHOW")) {
+          continue;
+        }
+
+        for (const mapping of query.columnMappings) {
+          expect({
+            query: query.id,
+            column: mapping.column,
+            selected: query.sql
+              .toLowerCase()
+              .includes(mapping.column.toLowerCase()),
+          }).toEqual({
+            query: query.id,
+            column: mapping.column,
+            selected: true,
+          });
+        }
+      }
+    });
+
+    test("groups used by queries are real collection groups", () => {
+      const validGroups: Array<DatabaseMetricGroup> =
+        Object.values(DatabaseMetricGroup);
+
+      for (const query of queries) {
+        expect(validGroups).toContain(query.group);
+      }
+    });
+
+    test("version gates are ordered and non-overlapping where both are set", () => {
+      for (const query of queries) {
+        if (
+          query.minServerVersionNum !== undefined &&
+          query.maxServerVersionNum !== undefined
+        ) {
+          expect(query.minServerVersionNum).toBeLessThanOrEqual(
+            query.maxServerVersionNum,
+          );
+        }
+      }
+    });
+  });
+
+  test("PostgreSQL gates the checkpoint counters so exactly one variant runs per version", () => {
+    /*
+     * PostgreSQL 17 moved the checkpoint counters out of pg_stat_bgwriter
+     * into pg_stat_checkpointer and renamed them. Both variants exist in the
+     * table; running both on any version would report one as a failed group.
+     */
+    const queries: Array<DatabaseHealthQuery> = getDatabaseHealthQueries(
+      SqlDatabaseType.PostgreSQL,
+    );
+
+    const legacy: DatabaseHealthQuery | undefined = queries.find(
+      (query: DatabaseHealthQuery) => {
+        return query.id === "pg-checkpoints-legacy";
+      },
+    );
+    const modern: DatabaseHealthQuery | undefined = queries.find(
+      (query: DatabaseHealthQuery) => {
+        return query.id === "pg-checkpoints-modern";
+      },
+    );
+
+    expect(legacy).toBeDefined();
+    expect(modern).toBeDefined();
+    expect(legacy?.sql).toContain("pg_stat_bgwriter");
+    expect(modern?.sql).toContain("pg_stat_checkpointer");
+
+    // The gates must abut, leaving no version served by both or by neither.
+    expect(legacy?.maxServerVersionNum).toBe(169999);
+    expect(modern?.minServerVersionNum).toBe(170000);
+  });
+
+  test("PostgreSQL replication queries are split by recovery state", () => {
+    /*
+     * pg_current_wal_lsn() and pg_stat_replication are primary-only;
+     * pg_last_xact_replay_timestamp() is standby-only. Running the wrong one
+     * raises an error rather than returning nothing, so the split is a
+     * correctness gate.
+     */
+    const queries: Array<DatabaseHealthQuery> = getDatabaseHealthQueries(
+      SqlDatabaseType.PostgreSQL,
+    );
+
+    const primary: DatabaseHealthQuery | undefined = queries.find(
+      (query: DatabaseHealthQuery) => {
+        return query.id === "pg-replication-primary";
+      },
+    );
+    const standby: DatabaseHealthQuery | undefined = queries.find(
+      (query: DatabaseHealthQuery) => {
+        return query.id === "pg-replication-standby";
+      },
+    );
+
+    expect(primary?.runOnlyWhenInRecovery).toBe(false);
+    expect(standby?.runOnlyWhenInRecovery).toBe(true);
+  });
+
+  test("the PostgreSQL queries that silently under-report are the ones flagged for preflight", () => {
+    const queries: Array<DatabaseHealthQuery> = getDatabaseHealthQueries(
+      SqlDatabaseType.PostgreSQL,
+    );
+
+    for (const query of queries) {
+      /*
+       * pg_stat_activity and pg_locks are the two views that return only the
+       * caller's own rows without pg_monitor. Any query reading either must
+       * be gated, or it will record confident, wrong numbers.
+       */
+      const readsRestrictedView: boolean =
+        query.sql.includes("pg_stat_activity") ||
+        query.sql.includes("pg_locks");
+
+      if (readsRestrictedView) {
+        expect({
+          id: query.id,
+          gated: query.requiresPostgresStatsAccess === true,
+        }).toEqual({ id: query.id, gated: true });
+      }
+    }
+  });
+
+  test("every query needing a grant explains which one", () => {
+    for (const engine of ENGINES) {
+      for (const query of getDatabaseHealthQueries(engine)) {
+        if (query.remediation !== undefined) {
+          expect(query.remediation.length).toBeGreaterThan(10);
+        }
+      }
+    }
+
+    /*
+     * SQL Server's server-scoped DMVs are useless without VIEW SERVER STATE,
+     * and that is the single most common reason a SQL Server health monitor
+     * comes back half empty - so those queries must carry the fix.
+     */
+    const sqlServerQueries: Array<DatabaseHealthQuery> =
+      getDatabaseHealthQueries(SqlDatabaseType.MicrosoftSqlServer);
+
+    const dmvQueries: Array<DatabaseHealthQuery> = sqlServerQueries.filter(
+      (query: DatabaseHealthQuery) => {
+        return query.sql.includes("sys.dm_");
+      },
+    );
+
+    expect(dmvQueries.length).toBeGreaterThan(0);
+
+    for (const query of dmvQueries) {
+      if (query.id === "mssql-storage") {
+        // Database-scoped; readable without VIEW SERVER STATE.
+        continue;
+      }
+
+      expect({
+        id: query.id,
+        mentionsGrant:
+          query.remediation?.includes("VIEW SERVER STATE") === true,
+      }).toEqual({ id: query.id, mentionsGrant: true });
+    }
+  });
+
+  test("every metric an engine claims to support is actually produced for it", () => {
+    /*
+     * The mirror of the mapping test above, and the direction that actually
+     * shipped a gap: the catalog listed MySQL under replication lag while
+     * the MySQL query table had no Replication group at all, so the metric
+     * was advertised in the criteria picker and could never have a value.
+     *
+     * Derived metrics are the exception - they are computed by the collector
+     * from raw columns rather than mapped from one - so they are listed
+     * here explicitly rather than skipped by a pattern, which would let a
+     * genuine gap hide behind a naming coincidence.
+     */
+    const derivedByEngine: Record<string, Array<MonitorMetricType>> = {
+      /*
+       * Written by the collector on every check rather than read from the
+       * database, so it belongs to every engine.
+       */
+      [SqlDatabaseType.PostgreSQL]: [
+        MonitorMetricType.DatabaseMetricGroupsFailed,
+        MonitorMetricType.DatabaseConnectionsUsedPercent,
+        MonitorMetricType.DatabaseCacheHitPercent,
+        MonitorMetricType.DatabaseTransactionsTotal,
+        MonitorMetricType.DatabaseRollbackPercent,
+      ],
+      [SqlDatabaseType.MySQL]: [
+        MonitorMetricType.DatabaseMetricGroupsFailed,
+        MonitorMetricType.DatabaseConnectionsUsedPercent,
+        MonitorMetricType.DatabaseCacheHitPercent,
+      ],
+      [SqlDatabaseType.MicrosoftSqlServer]: [
+        MonitorMetricType.DatabaseMetricGroupsFailed,
+        MonitorMetricType.DatabaseCacheHitPercent,
+      ],
+    };
+
+    for (const engine of ENGINES) {
+      const produced: Set<MonitorMetricType> = new Set<MonitorMetricType>([
+        ...getDatabaseHealthQueries(engine).flatMap(
+          (query: DatabaseHealthQuery) => {
+            return query.columnMappings.map(
+              (mapping: DatabaseQueryColumnMapping) => {
+                return mapping.metricType;
+              },
+            );
+          },
+        ),
+        ...(derivedByEngine[engine] || []),
+      ]);
+
+      for (const metric of getDatabaseMetricsForEngine(engine)) {
+        expect({
+          engine,
+          metric: metric.metricType,
+          produced: produced.has(metric.metricType),
+        }).toEqual({ engine, metric: metric.metricType, produced: true });
+      }
+    }
+  });
+
+  test("MySQL never claims to produce a deadlock counter", () => {
+    /*
+     * Stock MySQL exposes no deadlock counter - confirmed on 8.4.11, where
+     * performance_schema.global_status has no row matching '%deadlock%'.
+     * A mapping claiming otherwise would write a permanently absent series
+     * and make the Locks card look broken on MySQL.
+     */
+    for (const query of getDatabaseHealthQueries(SqlDatabaseType.MySQL)) {
+      expect(query.sql.toLowerCase()).not.toContain("deadlock");
+    }
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseMonitor.test.ts
@@ -1,0 +1,455 @@
+// Set required env vars before importing DatabaseMonitor (which reaches Config.ts).
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import DatabaseMonitor from "../../../../../Utils/Monitors/MonitorTypes/DatabaseMonitor";
+import { DatabaseHealthQuery } from "../../../../../Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseHealthQueries";
+import { DatabaseMetricGroup } from "Common/Types/Monitor/DatabaseMetricCatalog";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupUnavailableReason,
+} from "Common/Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import MonitorMetricType from "Common/Types/Monitor/MonitorMetricType";
+import MonitorStepDatabaseMonitor, {
+  MonitorStepDatabaseMonitorUtil,
+} from "Common/Types/Monitor/MonitorStepDatabaseMonitor";
+import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
+import { describe, expect, test } from "@jest/globals";
+
+const buildQuery: (
+  overrides?: Partial<DatabaseHealthQuery>,
+) => DatabaseHealthQuery = (
+  overrides: Partial<DatabaseHealthQuery> = {},
+): DatabaseHealthQuery => {
+  return {
+    id: "test-query",
+    group: DatabaseMetricGroup.Connections,
+    sql: "SELECT 1",
+    columnMappings: [],
+    ...overrides,
+  };
+};
+
+describe("DatabaseMonitor.classifyQueryFailure", () => {
+  test.each([
+    ["permission denied for view pg_stat_activity"],
+    ["Access denied; you need (at least one of) the PROCESS privilege(s)"],
+    [
+      "The user does not have permission to perform this action. VIEW SERVER STATE permission was denied on object 'server'",
+    ],
+    ["must be superuser or a member of pg_read_all_stats"],
+  ])("classifies %s as a missing permission", (message: string) => {
+    expect(DatabaseMonitor.classifyQueryFailure(message)).toBe(
+      DatabaseMetricGroupUnavailableReason.MissingPermission,
+    );
+  });
+
+  test.each([
+    ['relation "pg_stat_checkpointer" does not exist'],
+    ["Table 'performance_schema.data_lock_waits' doesn't exist"],
+    ["Unknown column 'redo_queue_size' in 'field list'"],
+    ["Invalid object name 'sys.dm_hadr_database_replica_states'"],
+  ])("classifies %s as unsupported by the engine", (message: string) => {
+    expect(DatabaseMonitor.classifyQueryFailure(message)).toBe(
+      DatabaseMetricGroupUnavailableReason.NotSupportedByEngine,
+    );
+  });
+
+  test.each([
+    ["canceling statement due to statement timeout"],
+    [
+      "Query execution was interrupted, maximum statement execution time exceeded",
+    ],
+    ["RequestError: Timeout: Request failed to complete in 10000ms"],
+  ])("classifies %s as a timeout", (message: string) => {
+    expect(DatabaseMonitor.classifyQueryFailure(message)).toBe(
+      DatabaseMetricGroupUnavailableReason.Timeout,
+    );
+  });
+
+  test("falls back to a generic error rather than guessing", () => {
+    expect(
+      DatabaseMonitor.classifyQueryFailure("connection reset by peer"),
+    ).toBe(DatabaseMetricGroupUnavailableReason.Error);
+  });
+
+  test("a timeout inside a permission-shaped message is still a timeout", () => {
+    /*
+     * Order matters: a statement that times out while reading a privileged
+     * view must not be reported as a missing grant, or the operator will go
+     * and change permissions that were never the problem.
+     */
+    expect(
+      DatabaseMonitor.classifyQueryFailure(
+        "canceling statement due to statement timeout on pg_stat_activity: permission denied",
+      ),
+    ).toBe(DatabaseMetricGroupUnavailableReason.Timeout);
+  });
+});
+
+describe("DatabaseMonitor.shouldRunQuery", () => {
+  test("runs an ungated query on any version", () => {
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query: buildQuery(),
+        serverVersionNum: 150018,
+        isInRecovery: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("respects a maximum version gate", () => {
+    const query: DatabaseHealthQuery = buildQuery({
+      maxServerVersionNum: 169999,
+    });
+
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query,
+        serverVersionNum: 150018,
+        isInRecovery: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query,
+        serverVersionNum: 170000,
+        isInRecovery: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("respects a minimum version gate", () => {
+    const query: DatabaseHealthQuery = buildQuery({
+      minServerVersionNum: 170000,
+    });
+
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query,
+        serverVersionNum: 150018,
+        isInRecovery: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query,
+        serverVersionNum: 170000,
+        isInRecovery: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("runs a version-gated query when the version is unknown", () => {
+    /*
+     * A gate encodes a KNOWN incompatibility. With no version in hand,
+     * attempting and reporting the failure tells an operator more than
+     * silently collecting nothing would.
+     */
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query: buildQuery({ minServerVersionNum: 170000 }),
+        serverVersionNum: null,
+        isInRecovery: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("splits replication queries by recovery state in both directions", () => {
+    const primaryOnly: DatabaseHealthQuery = buildQuery({
+      runOnlyWhenInRecovery: false,
+    });
+    const standbyOnly: DatabaseHealthQuery = buildQuery({
+      runOnlyWhenInRecovery: true,
+    });
+
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query: primaryOnly,
+        serverVersionNum: 150018,
+        isInRecovery: false,
+      }),
+    ).toBe(true);
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query: primaryOnly,
+        serverVersionNum: 150018,
+        isInRecovery: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query: standbyOnly,
+        serverVersionNum: 150018,
+        isInRecovery: true,
+      }),
+    ).toBe(true);
+    expect(
+      DatabaseMonitor.shouldRunQuery({
+        query: standbyOnly,
+        serverVersionNum: 150018,
+        isInRecovery: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("DatabaseMonitor.readNumber", () => {
+  test("reads the numeric shapes the drivers actually return", () => {
+    /*
+     * node-postgres returns bigint and numeric as STRINGS to avoid silently
+     * losing precision, and MySQL returns every global_status value as a
+     * string, so the string branch is the common case rather than the edge.
+     */
+    expect(DatabaseMonitor.readNumber({ v: 42 }, "v")).toBe(42);
+    expect(DatabaseMonitor.readNumber({ v: "42" }, "v")).toBe(42);
+    expect(DatabaseMonitor.readNumber({ v: "42.5" }, "v")).toBe(42.5);
+    expect(DatabaseMonitor.readNumber({ v: BigInt(42) }, "v")).toBe(42);
+    expect(DatabaseMonitor.readNumber({ v: true }, "v")).toBe(1);
+    expect(DatabaseMonitor.readNumber({ v: false }, "v")).toBe(0);
+  });
+
+  test("returns null rather than a wrong number", () => {
+    expect(DatabaseMonitor.readNumber({ v: null }, "v")).toBeNull();
+    expect(DatabaseMonitor.readNumber({ v: "" }, "v")).toBeNull();
+    expect(DatabaseMonitor.readNumber({ v: "n/a" }, "v")).toBeNull();
+    expect(DatabaseMonitor.readNumber({ v: Infinity }, "v")).toBeNull();
+    expect(DatabaseMonitor.readNumber({}, "missing")).toBeNull();
+  });
+
+  test("matches columns case-insensitively", () => {
+    // Engines disagree about case; SHOW REPLICA STATUS is mixed-case.
+    expect(
+      DatabaseMonitor.readNumber(
+        { Seconds_Behind_Source: "7" },
+        "seconds_behind_source",
+      ),
+    ).toBe(7);
+    expect(DatabaseMonitor.readNumber({ BYTES: "9" }, "bytes")).toBe(9);
+  });
+});
+
+describe("DatabaseMonitor.applyColumnMappings", () => {
+  test("records mapped values and applies the unit multiplier", () => {
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+
+    DatabaseMonitor.applyColumnMappings({
+      row: { connections_total: "12", log_send_queue_kb: "3" },
+      mappings: [
+        {
+          column: "connections_total",
+          metricType: MonitorMetricType.DatabaseConnectionsTotal,
+        },
+        {
+          column: "log_send_queue_kb",
+          metricType: MonitorMetricType.DatabaseReplicationLagBytes,
+          multiplier: 1024,
+        },
+      ],
+      metrics,
+    });
+
+    expect(metrics[MonitorMetricType.DatabaseConnectionsTotal]).toBe(12);
+    // SQL Server reports queue sizes in KB; the series is bytes.
+    expect(metrics[MonitorMetricType.DatabaseReplicationLagBytes]).toBe(3072);
+  });
+
+  test("leaves an absent value absent instead of writing zero", () => {
+    /*
+     * The whole point of the contract. A replication lag of zero means a
+     * replica that is caught up; an absent replication lag means there is
+     * no replica at all. Zero-filling would merge the two and make a
+     * "lag > 60s" criterion look permanently healthy on a broken setup.
+     */
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+
+    DatabaseMonitor.applyColumnMappings({
+      row: { replication_lag_seconds: null },
+      mappings: [
+        {
+          column: "replication_lag_seconds",
+          metricType: MonitorMetricType.DatabaseReplicationLagSeconds,
+        },
+      ],
+      metrics,
+    });
+
+    expect(MonitorMetricType.DatabaseReplicationLagSeconds in metrics).toBe(
+      false,
+    );
+  });
+});
+
+describe("DatabaseMonitor.applyDerivedMetrics", () => {
+  test("derives connection headroom from total and max", () => {
+    const metrics: Partial<Record<MonitorMetricType, number>> = {
+      [MonitorMetricType.DatabaseConnectionsTotal]: 51,
+      [MonitorMetricType.DatabaseConnectionsMax]: 100,
+    };
+
+    DatabaseMonitor.applyDerivedMetrics({
+      databaseType: SqlDatabaseType.PostgreSQL,
+      rawColumns: {},
+      metrics,
+    });
+
+    expect(metrics[MonitorMetricType.DatabaseConnectionsUsedPercent]).toBe(51);
+  });
+
+  test("does not divide by a zero or absent connection ceiling", () => {
+    /*
+     * SQL Server leaves the ceiling at 0 meaning unlimited, so this is a
+     * real configuration rather than a defensive hypothetical.
+     */
+    const metrics: Partial<Record<MonitorMetricType, number>> = {
+      [MonitorMetricType.DatabaseConnectionsTotal]: 51,
+      [MonitorMetricType.DatabaseConnectionsMax]: 0,
+    };
+
+    DatabaseMonitor.applyDerivedMetrics({
+      databaseType: SqlDatabaseType.MicrosoftSqlServer,
+      rawColumns: {},
+      metrics,
+    });
+
+    expect(MonitorMetricType.DatabaseConnectionsUsedPercent in metrics).toBe(
+      false,
+    );
+  });
+
+  test("derives PostgreSQL cache hit ratio and rollback ratio", () => {
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+
+    DatabaseMonitor.applyDerivedMetrics({
+      databaseType: SqlDatabaseType.PostgreSQL,
+      rawColumns: {
+        blks_hit: 999,
+        blks_read: 1,
+        xact_commit: 90,
+        xact_rollback: 10,
+      },
+      metrics,
+    });
+
+    expect(metrics[MonitorMetricType.DatabaseCacheHitPercent]).toBeCloseTo(
+      99.9,
+    );
+    expect(metrics[MonitorMetricType.DatabaseTransactionsTotal]).toBe(100);
+    expect(metrics[MonitorMetricType.DatabaseRollbackPercent]).toBe(10);
+  });
+
+  test("derives the MySQL buffer pool hit ratio", () => {
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+
+    DatabaseMonitor.applyDerivedMetrics({
+      databaseType: SqlDatabaseType.MySQL,
+      rawColumns: { bp_read_requests: 1000, bp_disk_reads: 50 },
+      metrics,
+    });
+
+    expect(metrics[MonitorMetricType.DatabaseCacheHitPercent]).toBe(95);
+  });
+
+  test("divides the SQL Server buffer cache hit ratio by its base counter", () => {
+    /*
+     * The raw counter alone is meaningless - on a live server it read 108,
+     * which as a percentage is nonsense. It is only a ratio once divided by
+     * the companion base counter.
+     */
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+
+    DatabaseMonitor.applyDerivedMetrics({
+      databaseType: SqlDatabaseType.MicrosoftSqlServer,
+      rawColumns: {
+        buffer_cache_hit_ratio_raw: 108,
+        buffer_cache_hit_ratio_base: 108,
+      },
+      metrics,
+    });
+
+    expect(metrics[MonitorMetricType.DatabaseCacheHitPercent]).toBe(100);
+  });
+
+  test("skips a ratio whose inputs are absent rather than writing NaN", () => {
+    const metrics: Partial<Record<MonitorMetricType, number>> = {};
+
+    DatabaseMonitor.applyDerivedMetrics({
+      databaseType: SqlDatabaseType.PostgreSQL,
+      rawColumns: { blks_hit: 0, blks_read: 0 },
+      metrics,
+    });
+
+    expect(MonitorMetricType.DatabaseCacheHitPercent in metrics).toBe(false);
+  });
+});
+
+describe("DatabaseMonitor.execute", () => {
+  const buildConfig: (
+    overrides?: Partial<MonitorStepDatabaseMonitor>,
+  ) => MonitorStepDatabaseMonitor = (
+    overrides: Partial<MonitorStepDatabaseMonitor> = {},
+  ): MonitorStepDatabaseMonitor => {
+    return {
+      ...MonitorStepDatabaseMonitorUtil.getDefault(),
+      host: "db.internal",
+      databaseName: "orders",
+      username: "monitoring",
+      password: "super-secret",
+      ...overrides,
+    };
+  };
+
+  test("refuses an engine it cannot speak without attempting a connection", async () => {
+    const response: DatabaseMonitorResponse | null =
+      await DatabaseMonitor.execute(
+        buildConfig({ databaseType: "Cassandra" as SqlDatabaseType }),
+        { isOnlineCheckRequest: true },
+      );
+
+    expect(response?.isOnline).toBe(false);
+    expect(response?.failureCause).toContain("not supported");
+    expect(response?.metrics).toEqual({});
+  });
+
+  test("rejects integrated authentication on a non-SQL-Server engine", async () => {
+    const response: DatabaseMonitorResponse | null =
+      await DatabaseMonitor.execute(
+        buildConfig({
+          databaseType: SqlDatabaseType.PostgreSQL,
+          useWindowsIntegratedAuthentication: true,
+        }),
+        { isOnlineCheckRequest: true },
+      );
+
+    expect(response?.isOnline).toBe(false);
+    expect(response?.failureCause).toContain(
+      "Windows Integrated Authentication",
+    );
+  });
+
+  test("reports an unreachable database as offline without leaking the password", async () => {
+    /*
+     * Port 1 is reserved and never listening, so this exercises the real
+     * connect-failure path rather than a mocked one.
+     */
+    const response: DatabaseMonitorResponse | null =
+      await DatabaseMonitor.execute(
+        buildConfig({
+          databaseType: SqlDatabaseType.PostgreSQL,
+          host: "127.0.0.1",
+          port: 1,
+          connectionTimeoutInMs: 1000,
+        }),
+        { retry: 1, isOnlineCheckRequest: true },
+      );
+
+    expect(response?.isOnline).toBe(false);
+    expect(response?.connectionError).toBeTruthy();
+    expect(JSON.stringify(response)).not.toContain("super-secret");
+    // A failed connection collects nothing, and says so rather than inventing groups.
+    expect(response?.collectedGroups).toEqual([]);
+    expect(response?.metrics).toEqual({});
+  }, 30000);
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -26,6 +26,9 @@ import MonitorStepDnssecMonitor from "Common/Types/Monitor/MonitorStepDnssecMoni
 import SqlMonitor from "./MonitorTypes/SqlMonitor";
 import SqlMonitorResponse from "Common/Types/Monitor/SqlMonitor/SqlMonitorResponse";
 import MonitorStepSqlMonitor from "Common/Types/Monitor/MonitorStepSqlMonitor";
+import DatabaseMonitor from "./MonitorTypes/DatabaseMonitor";
+import DatabaseMonitorResponse from "Common/Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import MonitorStepDatabaseMonitor from "Common/Types/Monitor/MonitorStepDatabaseMonitor";
 import ExternalStatusPageMonitorUtil from "./MonitorTypes/ExternalStatusPageMonitor";
 import ExternalStatusPageMonitorResponse from "Common/Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import MonitorStepExternalStatusPageMonitor from "Common/Types/Monitor/MonitorStepExternalStatusPageMonitor";
@@ -972,6 +975,40 @@ export default class MonitorUtil {
       result.responseTimeInMs = response.responseTimeInMs;
       result.failureCause = response.failureCause;
       result.sqlQueryMonitorResponse = response;
+      result.probeAttempts = response.probeAttempts;
+      result.totalAttempts = response.totalAttempts;
+    }
+
+    if (monitorType === MonitorType.Database) {
+      if (!monitorStep.data?.databaseMonitor) {
+        result.failureCause = "Database monitor configuration not specified";
+        return result;
+      }
+
+      const databaseConfig: MonitorStepDatabaseMonitor =
+        monitorStep.data.databaseMonitor;
+
+      if (!databaseConfig.host) {
+        result.failureCause = "Database host not specified";
+        return result;
+      }
+
+      const response: DatabaseMonitorResponse | null =
+        await DatabaseMonitor.execute(databaseConfig, {
+          retry: retryCount,
+          monitorId: monitorId,
+          timeout: requestTimeoutInMs,
+        });
+
+      if (!response) {
+        return null;
+      }
+
+      result.isOnline = response.isOnline;
+      result.isTimeout = response.isTimeout;
+      result.responseTimeInMs = response.responseTimeInMs;
+      result.failureCause = response.failureCause;
+      result.databaseMonitorResponse = response;
       result.probeAttempts = response.probeAttempts;
       result.totalAttempts = response.totalAttempts;
     }

--- a/Probe/Utils/Monitors/MonitorTypes/DatabaseMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DatabaseMonitor.ts
@@ -1,0 +1,886 @@
+import OnlineCheck from "../../OnlineCheck";
+import SqlMonitor, {
+  buildMicrosoftSqlServerPoolConfig,
+  loadMicrosoftSqlServerDriver,
+  MicrosoftSqlServerPoolConfig,
+  resolveSqlServerOdbcDriver,
+} from "./SqlMonitor";
+import DatabaseMonitorResponse, {
+  DatabaseMetricGroupStatus,
+  DatabaseMetricGroupUnavailableReason,
+} from "Common/Types/Monitor/DatabaseMonitor/DatabaseMonitorResponse";
+import {
+  DatabaseHealthQuery,
+  DatabaseQueryColumnMapping,
+  getDatabaseHealthQueries,
+  getProbeQuery,
+} from "./DatabaseMonitor/DatabaseHealthQueries";
+import { DatabaseMetricGroup } from "Common/Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "Common/Types/Monitor/MonitorMetricType";
+import MonitorStepDatabaseMonitor from "Common/Types/Monitor/MonitorStepDatabaseMonitor";
+import ObjectID from "Common/Types/ObjectID";
+import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
+import Sleep from "Common/Types/Sleep";
+import SqlDatabaseType, {
+  SqlDatabaseTypeUtil,
+} from "Common/Types/Monitor/SqlDatabaseType";
+import {
+  clampSqlConnectionTimeoutInMs,
+  clampSqlStatementTimeoutInMs,
+} from "Common/Types/Monitor/MonitorStepSqlMonitor";
+import logger from "Common/Server/Utils/Logger";
+import * as mssql from "mssql";
+import { Client, ClientConfig, QueryResult } from "pg";
+import {
+  Connection as MySqlConnection,
+  ConnectionOptions as MySqlConnectionOptions,
+  createConnection as createMySqlConnection,
+} from "mysql2/promise";
+
+export interface DatabaseMonitorExecuteOptions {
+  monitorId?: ObjectID | undefined;
+  retry?: number | undefined;
+  currentRetryCount?: number | undefined;
+  attempts?: Array<ProbeAttempt> | undefined;
+  isOnlineCheckRequest?: boolean | undefined;
+  timeout?: number | undefined;
+}
+
+/*
+ * One connection, opened for the whole check, that can run a statement and
+ * be closed. Each engine implements it once; everything above this line is
+ * engine-agnostic.
+ */
+interface DatabaseHealthSession {
+  runQuery(sql: string): Promise<Array<Record<string, unknown>>>;
+  close(): Promise<void>;
+}
+
+/*
+ * The Database Health monitor's collector.
+ *
+ * The shape of this class follows from one rule: A DATABASE THAT ANSWERS IS
+ * ONLINE. Only the probe query - a single trivial statement - can set
+ * isOnline to false. Every catalog query after it runs inside its own
+ * try/catch, and a failure there produces an entry in unavailableGroups
+ * instead of an outage. That is what makes it safe to enable every group by
+ * default: the worst case for a locked-down monitoring login is a monitor
+ * that reports fewer metrics, never one that pages at 3am because it cannot
+ * read sys.dm_os_performance_counters.
+ */
+export default class DatabaseMonitor {
+  public static async execute(
+    config: MonitorStepDatabaseMonitor,
+    options?: DatabaseMonitorExecuteOptions,
+  ): Promise<DatabaseMonitorResponse | null> {
+    if (!options) {
+      options = {};
+    }
+
+    if (options.currentRetryCount === undefined) {
+      options.currentRetryCount = 1;
+    }
+
+    if (!options.attempts) {
+      options.attempts = [];
+    }
+
+    if (!SqlDatabaseTypeUtil.isSupported(config.databaseType)) {
+      const message: string = `Database type "${config.databaseType}" is not supported yet. Supported: ${SqlDatabaseTypeUtil.getSupportedDatabaseTypes().join(
+        ", ",
+      )}.`;
+      return this.buildOfflineResponse(message, 0);
+    }
+
+    if (
+      config.useWindowsIntegratedAuthentication &&
+      config.databaseType !== SqlDatabaseType.MicrosoftSqlServer
+    ) {
+      const message: string =
+        "Windows Integrated Authentication is only supported for Microsoft SQL Server.";
+      return this.buildOfflineResponse(message, 0);
+    }
+
+    const statementTimeoutInMs: number = clampSqlStatementTimeoutInMs(
+      config.statementTimeoutInMs,
+    );
+    const connectionTimeoutInMs: number = clampSqlConnectionTimeoutInMs(
+      config.connectionTimeoutInMs,
+    );
+
+    const startTime: [number, number] = process.hrtime();
+    const attemptedAt: Date = new Date();
+
+    let session: DatabaseHealthSession | undefined;
+
+    try {
+      session = await this.openSession({
+        config,
+        statementTimeoutInMs,
+        connectionTimeoutInMs,
+      });
+
+      /*
+       * The one statement whose failure means "offline". It doubles as the
+       * source of the engine version and, on PostgreSQL, of the recovery
+       * state that decides which replication query is valid to run.
+       */
+      const probeRows: Array<Record<string, unknown>> = await session.runQuery(
+        getProbeQuery(config.databaseType),
+      );
+
+      const responseTimeInMs: number = this.elapsedMs(startTime);
+
+      const probeRow: Record<string, unknown> = probeRows[0] || {};
+      const engineVersion: string | undefined = this.readString(
+        probeRow,
+        "engine_version",
+      );
+      const serverVersionNum: number | null = this.readNumber(
+        probeRow,
+        "server_version_num",
+      );
+      const isInRecovery: boolean = this.readBoolean(
+        probeRow,
+        "is_in_recovery",
+      );
+
+      /*
+       * PostgreSQL only, and absent for other engines - which is why the
+       * default is `true` there: only PostgreSQL has the silent
+       * under-reporting mode this flag guards against.
+       */
+      const hasPostgresStatsAccess: boolean =
+        config.databaseType === SqlDatabaseType.PostgreSQL
+          ? this.readBoolean(probeRow, "has_stats_access")
+          : true;
+
+      const metrics: Partial<Record<MonitorMetricType, number>> = {};
+      const rawColumns: Record<string, number> = {};
+      const collectedGroups: Array<DatabaseMetricGroup> = [];
+      const unavailableGroups: Array<DatabaseMetricGroupStatus> = [];
+
+      const enabledGroups: Array<DatabaseMetricGroup> =
+        config.enabledMetricGroups || [];
+
+      for (const query of getDatabaseHealthQueries(config.databaseType)) {
+        if (!enabledGroups.includes(query.group)) {
+          continue;
+        }
+
+        /*
+         * Refusing to run beats running and believing the answer. A
+         * pg_stat_activity query without pg_monitor succeeds and returns
+         * the monitoring session alone, so "connections = 1" would be
+         * recorded as fact and would never alert.
+         */
+        if (query.requiresPostgresStatsAccess && !hasPostgresStatsAccess) {
+          this.recordUnavailableGroup({
+            unavailableGroups,
+            group: query.group,
+            message:
+              "The monitoring role cannot read other sessions' statistics. PostgreSQL does not report this as an error - it silently returns only this connection's own rows - so these metrics are skipped rather than recorded as wrong values.",
+            remediation: query.remediation,
+            forceReason: DatabaseMetricGroupUnavailableReason.MissingPermission,
+          });
+          continue;
+        }
+
+        if (!this.shouldRunQuery({ query, serverVersionNum, isInRecovery })) {
+          continue;
+        }
+
+        try {
+          const rows: Array<Record<string, unknown>> = await session.runQuery(
+            query.sql,
+          );
+
+          /*
+           * Zero rows is a legitimate answer, not a failure: SHOW REPLICA
+           * STATUS returns nothing at all on a server that is not a replica.
+           * The group counts as collected and simply contributes no values.
+           */
+          const row: Record<string, unknown> = rows[0] || {};
+
+          this.applyColumnMappings({
+            row,
+            mappings: query.columnMappings,
+            metrics,
+          });
+
+          this.collectRawColumns({ row, rawColumns });
+
+          if (!collectedGroups.includes(query.group)) {
+            collectedGroups.push(query.group);
+          }
+        } catch (err: unknown) {
+          const sanitized: string = SqlMonitor.sanitizeError(
+            err,
+            config.password,
+            [config.host, config.username, config.databaseName],
+          );
+
+          logger.debug(
+            `Database monitor ${options.monitorId?.toString()}: query ${query.id} failed - ${sanitized}`,
+          );
+
+          this.recordUnavailableGroup({
+            unavailableGroups,
+            group: query.group,
+            message: sanitized,
+            remediation: query.remediation,
+          });
+        }
+      }
+
+      this.applyDerivedMetrics({
+        databaseType: config.databaseType,
+        rawColumns,
+        metrics,
+      });
+
+      /*
+       * A group that produced values in one query and failed in another is
+       * both collected and unavailable - the operator should see the
+       * remediation while still getting what did come back. Report the
+       * failure count so it can be alerted on.
+       */
+      metrics[MonitorMetricType.DatabaseMetricGroupsFailed] =
+        unavailableGroups.length;
+
+      return {
+        isOnline: true,
+        responseTimeInMs,
+        failureCause: "",
+        metrics,
+        collectedGroups,
+        unavailableGroups,
+        engineVersion,
+        connectionError: null,
+        probeAttempts: options.attempts,
+        totalAttempts: options.attempts.length + 1,
+      };
+    } catch (err: unknown) {
+      const sanitized: string = SqlMonitor.sanitizeError(err, config.password, [
+        config.host,
+        config.username,
+        config.databaseName,
+      ]);
+
+      logger.debug(
+        `Database monitor error: ${options.monitorId?.toString()} ${config.host}:${config.port} - ${sanitized}`,
+      );
+
+      const responseTimeInMs: number = this.elapsedMs(startTime);
+
+      options.attempts.push({
+        attemptNumber: options.currentRetryCount || 1,
+        attemptedAt,
+        responseReceivedAt: new Date(),
+        responseTimeInMs,
+        isOnline: false,
+        failureCause: sanitized,
+      });
+
+      if (options.currentRetryCount < (options.retry || 3)) {
+        options.currentRetryCount++;
+        await Sleep.sleep(1000);
+        return await DatabaseMonitor.execute(config, options);
+      }
+
+      /*
+       * Same guard the other probe monitors use: if the probe itself cannot
+       * reach anything, returning null suppresses the check rather than
+       * reporting every monitored database as down.
+       */
+      if (!options.isOnlineCheckRequest) {
+        if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
+          logger.error(
+            `DatabaseMonitor - Probe is not online. Cannot reach ${options.monitorId?.toString()} ${config.host} - ERROR: ${sanitized}`,
+          );
+          return null;
+        }
+      }
+
+      return {
+        ...this.buildOfflineResponse(sanitized, responseTimeInMs),
+        isTimeout: this.isTimeoutMessage(sanitized),
+        probeAttempts: options.attempts,
+        totalAttempts: options.attempts.length,
+      };
+    } finally {
+      if (session) {
+        try {
+          await session.close();
+        } catch (closeErr) {
+          logger.debug(`Database monitor connection close failed: ${closeErr}`);
+        }
+      }
+    }
+  }
+
+  private static buildOfflineResponse(
+    failureCause: string,
+    responseTimeInMs: number,
+  ): DatabaseMonitorResponse {
+    return {
+      isOnline: false,
+      responseTimeInMs,
+      failureCause,
+      metrics: {},
+      collectedGroups: [],
+      unavailableGroups: [],
+      connectionError: failureCause,
+    };
+  }
+
+  public static isTimeoutMessage(message: string): boolean {
+    const lowerCased: string = message.toLowerCase();
+    return (
+      lowerCased.includes("timeout") ||
+      lowerCased.includes("timed out") ||
+      lowerCased.includes("etimedout") ||
+      // PostgreSQL statement_timeout.
+      lowerCased.includes("canceling statement") ||
+      // MySQL MAX_EXECUTION_TIME (ER_QUERY_TIMEOUT).
+      lowerCased.includes("maximum statement execution time") ||
+      lowerCased.includes("execution was interrupted") ||
+      // SQL Server request timeout.
+      lowerCased.includes("request timed out")
+    );
+  }
+
+  /**
+   * Turn a failed catalog query into an operator-actionable reason.
+   *
+   * The distinction that matters is permission versus capability: "you are
+   * missing a grant, here is the GRANT statement" and "your engine cannot
+   * report this, nothing to do" call for completely different reactions, and
+   * both are common enough that collapsing them into "error" would make the
+   * summary view useless.
+   */
+  public static classifyQueryFailure(
+    message: string,
+  ): DatabaseMetricGroupUnavailableReason {
+    const lowerCased: string = message.toLowerCase();
+
+    if (this.isTimeoutMessage(message)) {
+      return DatabaseMetricGroupUnavailableReason.Timeout;
+    }
+
+    if (
+      lowerCased.includes("permission denied") ||
+      lowerCased.includes("access denied") ||
+      lowerCased.includes("must be superuser") ||
+      lowerCased.includes("insufficient privilege") ||
+      // SQL Server: "VIEW SERVER STATE permission was denied".
+      lowerCased.includes("permission was denied") ||
+      lowerCased.includes("is not allowed to")
+    ) {
+      return DatabaseMetricGroupUnavailableReason.MissingPermission;
+    }
+
+    if (
+      // PostgreSQL: relation "pg_stat_checkpointer" does not exist.
+      lowerCased.includes("does not exist") ||
+      // MySQL: Table 'performance_schema.x' doesn't exist / Unknown column.
+      lowerCased.includes("doesn't exist") ||
+      lowerCased.includes("unknown column") ||
+      lowerCased.includes("unknown table") ||
+      // SQL Server: Invalid object name / Invalid column name.
+      lowerCased.includes("invalid object name") ||
+      lowerCased.includes("invalid column name") ||
+      lowerCased.includes("syntax error")
+    ) {
+      return DatabaseMetricGroupUnavailableReason.NotSupportedByEngine;
+    }
+
+    return DatabaseMetricGroupUnavailableReason.Error;
+  }
+
+  private static recordUnavailableGroup(input: {
+    unavailableGroups: Array<DatabaseMetricGroupStatus>;
+    group: DatabaseMetricGroup;
+    message: string;
+    remediation?: string | undefined;
+    /*
+     * Set when the caller already knows the reason and must not have it
+     * inferred from the message text - the privilege preflight, whose
+     * message is ours rather than a driver's.
+     */
+    forceReason?: DatabaseMetricGroupUnavailableReason | undefined;
+  }): void {
+    const { unavailableGroups, group, message } = input;
+
+    const reason: DatabaseMetricGroupUnavailableReason =
+      input.forceReason || this.classifyQueryFailure(message);
+
+    const existing: DatabaseMetricGroupStatus | undefined =
+      unavailableGroups.find((status: DatabaseMetricGroupStatus) => {
+        return status.group === group;
+      });
+
+    if (existing) {
+      // One entry per group; the first failure is the one worth showing.
+      return;
+    }
+
+    const status: DatabaseMetricGroupStatus = {
+      group,
+      reason,
+      message,
+    };
+
+    /*
+     * The GRANT is only useful advice when a grant is actually the problem.
+     * Showing it next to "relation does not exist" would send an operator
+     * off to change permissions that are already correct.
+     */
+    if (
+      input.remediation &&
+      reason === DatabaseMetricGroupUnavailableReason.MissingPermission
+    ) {
+      status.remediation = input.remediation;
+    }
+
+    unavailableGroups.push(status);
+  }
+
+  public static shouldRunQuery(input: {
+    query: DatabaseHealthQuery;
+    serverVersionNum: number | null;
+    isInRecovery: boolean;
+  }): boolean {
+    const { query, serverVersionNum, isInRecovery } = input;
+
+    if (
+      query.runOnlyWhenInRecovery !== undefined &&
+      query.runOnlyWhenInRecovery !== isInRecovery
+    ) {
+      return false;
+    }
+
+    /*
+     * An unknown server version runs the query rather than skipping it. A
+     * version gate exists to avoid a KNOWN incompatibility; when we do not
+     * know the version, attempting and reporting the failure tells the
+     * operator more than silently collecting nothing.
+     */
+    if (serverVersionNum === null) {
+      return true;
+    }
+
+    if (
+      query.minServerVersionNum !== undefined &&
+      serverVersionNum < query.minServerVersionNum
+    ) {
+      return false;
+    }
+
+    if (
+      query.maxServerVersionNum !== undefined &&
+      serverVersionNum > query.maxServerVersionNum
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public static applyColumnMappings(input: {
+    row: Record<string, unknown>;
+    mappings: Array<DatabaseQueryColumnMapping>;
+    metrics: Partial<Record<MonitorMetricType, number>>;
+  }): void {
+    for (const mapping of input.mappings) {
+      const value: number | null = this.readNumber(input.row, mapping.column);
+
+      /*
+       * Absent stays absent. Zero-filling would make "no replication
+       * configured" indistinguishable from "replication lag is zero", which
+       * is the difference between a healthy replica and no replica at all.
+       */
+      if (value === null) {
+        continue;
+      }
+
+      input.metrics[mapping.metricType] = mapping.multiplier
+        ? value * mapping.multiplier
+        : value;
+    }
+  }
+
+  private static collectRawColumns(input: {
+    row: Record<string, unknown>;
+    rawColumns: Record<string, number>;
+  }): void {
+    for (const key of Object.keys(input.row)) {
+      const value: number | null = this.readNumber(input.row, key);
+      if (value !== null) {
+        input.rawColumns[key.toLowerCase()] = value;
+      }
+    }
+  }
+
+  /**
+   * Ratios the engines do not hand us directly.
+   *
+   * These are computed here rather than in SQL so the arithmetic is testable
+   * without a database, and so a divide-by-zero on an idle server yields "no
+   * value" rather than NaN written into a metric series.
+   */
+  public static applyDerivedMetrics(input: {
+    databaseType: SqlDatabaseType;
+    rawColumns: Record<string, number>;
+    metrics: Partial<Record<MonitorMetricType, number>>;
+  }): void {
+    const { databaseType, rawColumns, metrics } = input;
+
+    const connectionsTotal: number | undefined =
+      metrics[MonitorMetricType.DatabaseConnectionsTotal];
+    const connectionsMax: number | undefined =
+      metrics[MonitorMetricType.DatabaseConnectionsMax];
+
+    if (
+      connectionsTotal !== undefined &&
+      connectionsMax !== undefined &&
+      connectionsMax > 0
+    ) {
+      metrics[MonitorMetricType.DatabaseConnectionsUsedPercent] =
+        (connectionsTotal / connectionsMax) * 100;
+    }
+
+    if (databaseType === SqlDatabaseType.PostgreSQL) {
+      const hit: number | undefined = rawColumns["blks_hit"];
+      const read: number | undefined = rawColumns["blks_read"];
+
+      if (hit !== undefined && read !== undefined && hit + read > 0) {
+        metrics[MonitorMetricType.DatabaseCacheHitPercent] =
+          (hit / (hit + read)) * 100;
+      }
+
+      const commit: number | undefined = rawColumns["xact_commit"];
+      const rollback: number | undefined = rawColumns["xact_rollback"];
+
+      if (
+        commit !== undefined &&
+        rollback !== undefined &&
+        commit + rollback > 0
+      ) {
+        metrics[MonitorMetricType.DatabaseTransactionsTotal] =
+          commit + rollback;
+        metrics[MonitorMetricType.DatabaseRollbackPercent] =
+          (rollback / (commit + rollback)) * 100;
+      }
+    }
+
+    if (databaseType === SqlDatabaseType.MySQL) {
+      const requests: number | undefined = rawColumns["bp_read_requests"];
+      const diskReads: number | undefined = rawColumns["bp_disk_reads"];
+
+      if (requests !== undefined && diskReads !== undefined && requests > 0) {
+        metrics[MonitorMetricType.DatabaseCacheHitPercent] =
+          (1 - diskReads / requests) * 100;
+      }
+    }
+
+    if (databaseType === SqlDatabaseType.MicrosoftSqlServer) {
+      const raw: number | undefined = rawColumns["buffer_cache_hit_ratio_raw"];
+      const base: number | undefined =
+        rawColumns["buffer_cache_hit_ratio_base"];
+
+      /*
+       * SQL Server's buffer cache hit ratio is a raw counter that is only
+       * meaningful divided by its companion base counter - reading the raw
+       * value alone reports a "hit ratio" of 108.
+       */
+      if (raw !== undefined && base !== undefined && base > 0) {
+        metrics[MonitorMetricType.DatabaseCacheHitPercent] = (raw / base) * 100;
+      }
+    }
+  }
+
+  // ------------------------------------------------------------- value readers
+
+  public static readNumber(
+    row: Record<string, unknown>,
+    column: string,
+  ): number | null {
+    const value: unknown = this.readColumn(row, column);
+
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === "number") {
+      return isFinite(value) ? value : null;
+    }
+
+    if (typeof value === "bigint") {
+      return Number(value);
+    }
+
+    /*
+     * PostgreSQL returns bigint and numeric as strings (node-postgres will
+     * not silently lose precision), and MySQL returns global_status values
+     * as strings too, so this branch is the common case rather than the
+     * exception.
+     */
+    if (typeof value === "string") {
+      const trimmed: string = value.trim();
+      if (trimmed === "") {
+        return null;
+      }
+      const parsed: number = Number(trimmed);
+      return isNaN(parsed) ? null : parsed;
+    }
+
+    if (typeof value === "boolean") {
+      return value ? 1 : 0;
+    }
+
+    return null;
+  }
+
+  private static readString(
+    row: Record<string, unknown>,
+    column: string,
+  ): string | undefined {
+    const value: unknown = this.readColumn(row, column);
+
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+
+    return String(value);
+  }
+
+  private static readBoolean(
+    row: Record<string, unknown>,
+    column: string,
+  ): boolean {
+    const value: unknown = this.readColumn(row, column);
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const lowerCased: string = value.trim().toLowerCase();
+      return lowerCased === "t" || lowerCased === "true" || lowerCased === "1";
+    }
+
+    return value === 1;
+  }
+
+  /*
+   * Case-insensitive column lookup. Engines disagree: PostgreSQL folds
+   * unquoted identifiers to lower case, MySQL's information_schema returns
+   * upper case, and SHOW REPLICA STATUS returns mixed case.
+   */
+  private static readColumn(
+    row: Record<string, unknown>,
+    column: string,
+  ): unknown {
+    if (column in row) {
+      return row[column];
+    }
+
+    const target: string = column.toLowerCase();
+
+    for (const key of Object.keys(row)) {
+      if (key.toLowerCase() === target) {
+        return row[key];
+      }
+    }
+
+    return undefined;
+  }
+
+  private static elapsedMs(startTime: [number, number]): number {
+    const endTime: [number, number] = process.hrtime(startTime);
+    return Math.ceil((endTime[0] * 1000000000 + endTime[1]) / 1000000);
+  }
+
+  // ---------------------------------------------------------------- sessions
+
+  private static async openSession(input: {
+    config: MonitorStepDatabaseMonitor;
+    statementTimeoutInMs: number;
+    connectionTimeoutInMs: number;
+  }): Promise<DatabaseHealthSession> {
+    switch (input.config.databaseType) {
+      case SqlDatabaseType.MySQL:
+        return await this.openMySqlSession(input);
+      case SqlDatabaseType.MicrosoftSqlServer:
+        return await this.openSqlServerSession(input);
+      case SqlDatabaseType.PostgreSQL:
+      default:
+        return await this.openPostgresSession(input);
+    }
+  }
+
+  private static async openPostgresSession(input: {
+    config: MonitorStepDatabaseMonitor;
+    statementTimeoutInMs: number;
+    connectionTimeoutInMs: number;
+  }): Promise<DatabaseHealthSession> {
+    const { config, statementTimeoutInMs, connectionTimeoutInMs } = input;
+
+    const clientConfig: ClientConfig = {
+      host: config.host,
+      port: config.port,
+      database: config.databaseName,
+      user: config.username,
+      password: config.password,
+      connectionTimeoutMillis: connectionTimeoutInMs,
+      statement_timeout: statementTimeoutInMs,
+      query_timeout: statementTimeoutInMs + 2000,
+      application_name: "OneUptimeProbe-DatabaseMonitor",
+      ssl: config.useSsl
+        ? { rejectUnauthorized: config.rejectUnauthorizedSsl }
+        : false,
+    };
+
+    const client: Client = new Client(clientConfig);
+    await client.connect();
+
+    /*
+     * Read-only for the whole check. The statements here are ours and are
+     * all SELECTs, but a read-only transaction is a guarantee rather than a
+     * convention - and it is what lets a reviewer confirm this monitor
+     * cannot write without reading every query in the catalog.
+     */
+    await client.query("START TRANSACTION READ ONLY");
+
+    return {
+      runQuery: async (
+        sql: string,
+      ): Promise<Array<Record<string, unknown>>> => {
+        const result: QueryResult = await client.query(sql);
+        return (result.rows as Array<Record<string, unknown>>) || [];
+      },
+      close: async (): Promise<void> => {
+        try {
+          await client.query("ROLLBACK");
+        } catch (rollbackErr) {
+          logger.debug(`Database monitor rollback failed: ${rollbackErr}`);
+        }
+        await client.end();
+      },
+    };
+  }
+
+  private static async openMySqlSession(input: {
+    config: MonitorStepDatabaseMonitor;
+    statementTimeoutInMs: number;
+    connectionTimeoutInMs: number;
+  }): Promise<DatabaseHealthSession> {
+    const { config, statementTimeoutInMs, connectionTimeoutInMs } = input;
+
+    const connectionOptions: MySqlConnectionOptions = {
+      host: config.host,
+      port: config.port,
+      database: config.databaseName,
+      user: config.username,
+      password: config.password,
+      connectTimeout: connectionTimeoutInMs,
+      // One statement per call, never a multi-statement batch.
+      multipleStatements: false,
+    };
+
+    /*
+     * Assigned conditionally rather than set to undefined: the project
+     * compiles with exactOptionalPropertyTypes, so an explicit undefined is
+     * not the same as an absent property.
+     */
+    if (config.useSsl) {
+      connectionOptions.ssl = {
+        rejectUnauthorized: config.rejectUnauthorizedSsl,
+      };
+    }
+
+    const connection: MySqlConnection =
+      await createMySqlConnection(connectionOptions);
+
+    try {
+      await connection.query("SET SESSION TRANSACTION READ ONLY");
+      await connection.query(
+        `SET SESSION MAX_EXECUTION_TIME = ${Math.floor(statementTimeoutInMs)}`,
+      );
+    } catch (err) {
+      /*
+       * Best effort. Neither statement is available on every MySQL-compatible
+       * server (MariaDB names the timeout differently), and failing the whole
+       * check because a hardening statement was rejected would be worse than
+       * running without it - every query we issue is a SELECT regardless.
+       */
+      logger.debug(`Database monitor MySQL session setup failed: ${err}`);
+    }
+
+    return {
+      runQuery: async (
+        sql: string,
+      ): Promise<Array<Record<string, unknown>>> => {
+        const [rows] = await connection.query(sql);
+        if (!Array.isArray(rows)) {
+          return [];
+        }
+        return rows as Array<Record<string, unknown>>;
+      },
+      close: async (): Promise<void> => {
+        await connection.end();
+      },
+    };
+  }
+
+  private static async openSqlServerSession(input: {
+    config: MonitorStepDatabaseMonitor;
+    statementTimeoutInMs: number;
+    connectionTimeoutInMs: number;
+  }): Promise<DatabaseHealthSession> {
+    const { config, statementTimeoutInMs, connectionTimeoutInMs } = input;
+
+    /*
+     * Only trusted connections need the ODBC connection string, so only pay
+     * for host driver detection in that mode - same rule the SQL Query
+     * monitor follows, using the same shared builder.
+     */
+    const odbcDriver: string | undefined =
+      config.useWindowsIntegratedAuthentication
+        ? await resolveSqlServerOdbcDriver()
+        : undefined;
+
+    const poolConfig: MicrosoftSqlServerPoolConfig =
+      buildMicrosoftSqlServerPoolConfig({
+        config,
+        statementTimeoutInMs,
+        connectionTimeoutInMs,
+        odbcDriver,
+      });
+
+    const sqlServerDriver: typeof mssql = loadMicrosoftSqlServerDriver(
+      config.useWindowsIntegratedAuthentication,
+    );
+
+    const pool: mssql.ConnectionPool = new sqlServerDriver.ConnectionPool(
+      poolConfig,
+    );
+
+    await pool.connect();
+
+    return {
+      runQuery: async (
+        sql: string,
+      ): Promise<Array<Record<string, unknown>>> => {
+        const request: mssql.Request = new sqlServerDriver.Request(pool);
+        const result: mssql.IResult<Record<string, unknown>> =
+          await request.query<Record<string, unknown>>(sql);
+        return result.recordset || [];
+      },
+      close: async (): Promise<void> => {
+        await pool.close();
+      },
+    };
+  }
+}

--- a/Probe/Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseHealthQueries.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DatabaseMonitor/DatabaseHealthQueries.ts
@@ -1,0 +1,769 @@
+import { DatabaseMetricGroup } from "Common/Types/Monitor/DatabaseMetricCatalog";
+import MonitorMetricType from "Common/Types/Monitor/MonitorMetricType";
+import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
+
+/*
+ * The built-in catalog queries behind the Database Health monitor.
+ *
+ * EVERY statement in this file has been executed against a real server -
+ * PostgreSQL 15.18, MySQL 8.4.11 and SQL Server 2022 (16.0.4265.3) - and its
+ * output column names checked against the mapping below. That matters more
+ * than it sounds: catalog SQL is exactly the kind of code that looks right
+ * and is not. Three examples this validation actually caught, all of which
+ * would otherwise have shipped:
+ *
+ *   - PostgreSQL: FILTER attaches to the AGGREGATE, not to the expression
+ *     wrapping it. `EXTRACT(EPOCH FROM max(x)) FILTER (WHERE ...)` is a
+ *     syntax error; `EXTRACT(EPOCH FROM max(x) FILTER (WHERE ...))` is not.
+ *   - MySQL: there is no deadlock counter at all in stock MySQL, so the
+ *     obvious `Innodb_deadlocks` status variable does not exist.
+ *   - SQL Server: counting active requests by `session_id > 50` counts
+ *     background tasks (42 on a freshly started, idle server). Joining
+ *     dm_exec_sessions on is_user_process = 1 gives the 0 you expect.
+ *
+ * When you add or change a statement here, run it against a live server of
+ * that engine before committing. The unit tests assert the SHAPE of this
+ * table - they cannot tell you that a column name is wrong.
+ */
+
+/*
+ * How a returned column becomes a metric. `column` is matched
+ * case-insensitively because engines disagree about case (SHOW REPLICA
+ * STATUS returns Seconds_Behind_Source, information_schema returns
+ * upper-case, PostgreSQL lower-cases everything unquoted).
+ */
+export interface DatabaseQueryColumnMapping {
+  column: string;
+  metricType: MonitorMetricType;
+  /*
+   * Applied to the raw numeric value before it is recorded. Used where the
+   * engine's unit differs from the series' unit - SQL Server reports queue
+   * sizes in KB, we record bytes.
+   */
+  multiplier?: number | undefined;
+}
+
+export interface DatabaseHealthQuery {
+  // Stable identifier, used in logs and in the unavailable-group message.
+  id: string;
+  /*
+   * PostgreSQL only. Marks a query that reads pg_stat_activity or pg_locks,
+   * which SILENTLY return only the caller's own rows without pg_monitor -
+   * no error, just wrong numbers. The collector refuses to run these unless
+   * the probe query proved the role has stats access.
+   */
+  requiresPostgresStatsAccess?: boolean | undefined;
+  group: DatabaseMetricGroup;
+  sql: string;
+  columnMappings: Array<DatabaseQueryColumnMapping>;
+  /*
+   * The grant that fixes a permission failure on this query, shown verbatim
+   * to the operator. Absent when the query needs no special grant.
+   */
+  remediation?: string | undefined;
+  /*
+   * Version gate, compared against the engine's numeric server version
+   * (PostgreSQL server_version_num, e.g. 150018). A query outside the range
+   * is skipped silently rather than run and failed - the checkpoint counters
+   * legitimately live in a different view on PostgreSQL 17.
+   */
+  minServerVersionNum?: number | undefined;
+  maxServerVersionNum?: number | undefined;
+  /*
+   * PostgreSQL only. `true` runs the query only on a primary, `false` only
+   * on a standby. pg_current_wal_lsn() raises an error during recovery, so
+   * this is a correctness gate, not an optimization.
+   */
+  runOnlyWhenInRecovery?: boolean | undefined;
+}
+
+/*
+ * PostgreSQL. Requires no more than CONNECT plus the pg_monitor role (or
+ * pg_read_all_stats) to see other sessions' rows - without it pg_stat_activity
+ * shows only the monitoring session's own row, so counts read as 1 rather than
+ * failing. That is the one degradation mode that is silent rather than loud,
+ * which is why the connection group's remediation names the role explicitly.
+ */
+const postgresQueries: Array<DatabaseHealthQuery> = [
+  {
+    id: "pg-connections",
+    requiresPostgresStatsAccess: true,
+    group: DatabaseMetricGroup.Connections,
+    sql: `SELECT
+  (SELECT count(*) FROM pg_stat_activity WHERE backend_type = 'client backend')::bigint AS connections_total,
+  (SELECT count(*) FROM pg_stat_activity WHERE state = 'active')::bigint AS connections_active,
+  (SELECT count(*) FROM pg_stat_activity WHERE state = 'idle in transaction')::bigint AS connections_idle_in_transaction,
+  (SELECT setting::bigint FROM pg_settings WHERE name = 'max_connections') AS connections_max,
+  EXTRACT(EPOCH FROM (now() - pg_postmaster_start_time()))::float8 AS uptime_seconds`,
+    columnMappings: [
+      {
+        column: "connections_total",
+        metricType: MonitorMetricType.DatabaseConnectionsTotal,
+      },
+      {
+        column: "connections_active",
+        metricType: MonitorMetricType.DatabaseConnectionsActive,
+      },
+      {
+        column: "connections_idle_in_transaction",
+        metricType: MonitorMetricType.DatabaseConnectionsIdleInTransaction,
+      },
+      {
+        column: "connections_max",
+        metricType: MonitorMetricType.DatabaseConnectionsMax,
+      },
+      {
+        column: "uptime_seconds",
+        metricType: MonitorMetricType.DatabaseUptimeSeconds,
+      },
+    ],
+    remediation:
+      "GRANT pg_monitor TO <monitoring_user>; -- without it pg_stat_activity shows only this session and connection counts read as 1",
+  },
+  {
+    id: "pg-activity-age",
+    requiresPostgresStatsAccess: true,
+    group: DatabaseMetricGroup.Activity,
+    sql: `SELECT
+  COALESCE(EXTRACT(EPOCH FROM max(now() - query_start) FILTER (WHERE state = 'active')), 0)::float8 AS longest_query_seconds,
+  COALESCE(EXTRACT(EPOCH FROM max(now() - xact_start)), 0)::float8 AS longest_transaction_seconds
+FROM pg_stat_activity
+WHERE backend_type = 'client backend' AND pid <> pg_backend_pid()`,
+    columnMappings: [
+      {
+        column: "longest_query_seconds",
+        metricType: MonitorMetricType.DatabaseLongestQuerySeconds,
+      },
+      {
+        column: "longest_transaction_seconds",
+        metricType: MonitorMetricType.DatabaseLongestTransactionSeconds,
+      },
+    ],
+    remediation: "GRANT pg_monitor TO <monitoring_user>;",
+  },
+  {
+    /*
+     * Split by GROUP, not by convenience. pg_stat_database could serve
+     * throughput, storage and deadlocks in one round trip, but a query's
+     * group is what an operator disables - so a metric must be produced by
+     * the group the catalog files it under, or turning off "Throughput"
+     * would silently take database size with it.
+     */
+    id: "pg-database-stats",
+    group: DatabaseMetricGroup.Throughput,
+    sql: `SELECT
+  xact_commit::bigint,
+  xact_rollback::bigint,
+  blks_read::bigint,
+  blks_hit::bigint,
+  blk_read_time::float8,
+  blk_write_time::float8
+FROM pg_stat_database WHERE datname = current_database()`,
+    columnMappings: [
+      {
+        column: "blks_read",
+        metricType: MonitorMetricType.DatabaseDiskReadsTotal,
+      },
+      {
+        column: "blk_read_time",
+        metricType: MonitorMetricType.DatabaseIoReadTimeMs,
+      },
+      {
+        column: "blk_write_time",
+        metricType: MonitorMetricType.DatabaseIoWriteTimeMs,
+      },
+    ],
+  },
+  {
+    id: "pg-storage",
+    group: DatabaseMetricGroup.Storage,
+    sql: `SELECT
+  pg_database_size(current_database())::bigint AS database_size_bytes,
+  (SELECT temp_bytes FROM pg_stat_database WHERE datname = current_database())::bigint AS temp_bytes`,
+    columnMappings: [
+      {
+        column: "database_size_bytes",
+        metricType: MonitorMetricType.DatabaseSizeBytes,
+      },
+      {
+        column: "temp_bytes",
+        metricType: MonitorMetricType.DatabaseTempBytesTotal,
+      },
+    ],
+  },
+  {
+    id: "pg-locks",
+    requiresPostgresStatsAccess: true,
+    group: DatabaseMetricGroup.Locks,
+    sql: `SELECT
+  (SELECT count(*) FROM pg_locks WHERE NOT granted)::bigint AS locks_waiting,
+  (SELECT count(*) FROM pg_stat_activity WHERE cardinality(pg_blocking_pids(pid)) > 0)::bigint AS blocked_sessions,
+  (SELECT deadlocks FROM pg_stat_database WHERE datname = current_database())::bigint AS deadlocks_total`,
+    columnMappings: [
+      {
+        column: "locks_waiting",
+        metricType: MonitorMetricType.DatabaseLocksWaiting,
+      },
+      {
+        column: "blocked_sessions",
+        metricType: MonitorMetricType.DatabaseSessionsBlocked,
+      },
+      {
+        column: "deadlocks_total",
+        metricType: MonitorMetricType.DatabaseDeadlocksTotal,
+      },
+    ],
+    remediation: "GRANT pg_monitor TO <monitoring_user>;",
+  },
+  {
+    id: "pg-replication-primary",
+    group: DatabaseMetricGroup.Replication,
+    sql: `SELECT
+  count(*)::bigint AS replica_count,
+  COALESCE(max(pg_wal_lsn_diff(sent_lsn, replay_lsn)), 0)::float8 AS replication_lag_bytes,
+  COALESCE(max(EXTRACT(EPOCH FROM replay_lag)), 0)::float8 AS replication_lag_seconds
+FROM pg_stat_replication`,
+    columnMappings: [
+      {
+        column: "replica_count",
+        metricType: MonitorMetricType.DatabaseReplicaCount,
+      },
+      {
+        column: "replication_lag_bytes",
+        metricType: MonitorMetricType.DatabaseReplicationLagBytes,
+      },
+      {
+        column: "replication_lag_seconds",
+        metricType: MonitorMetricType.DatabaseReplicationLagSeconds,
+      },
+    ],
+    runOnlyWhenInRecovery: false,
+    remediation: "GRANT pg_monitor TO <monitoring_user>;",
+  },
+  {
+    id: "pg-replication-standby",
+    group: DatabaseMetricGroup.Replication,
+    sql: `SELECT
+  1::bigint AS is_in_recovery,
+  COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()), 0)::float8 AS replication_lag_seconds`,
+    columnMappings: [
+      {
+        column: "is_in_recovery",
+        metricType: MonitorMetricType.DatabaseIsInRecovery,
+      },
+      {
+        column: "replication_lag_seconds",
+        metricType: MonitorMetricType.DatabaseReplicationLagSeconds,
+      },
+    ],
+    runOnlyWhenInRecovery: true,
+  },
+  {
+    id: "pg-replication-slots",
+    group: DatabaseMetricGroup.Replication,
+    sql: `SELECT count(*) FILTER (WHERE NOT active)::bigint AS inactive_slots
+FROM pg_replication_slots`,
+    columnMappings: [
+      {
+        column: "inactive_slots",
+        metricType: MonitorMetricType.DatabaseReplicationSlotsInactive,
+      },
+    ],
+    remediation: "GRANT pg_monitor TO <monitoring_user>;",
+  },
+  {
+    id: "pg-wraparound",
+    group: DatabaseMetricGroup.Maintenance,
+    sql: `SELECT (max(age(datfrozenxid))::float8 / 2147483648.0 * 100.0)::float8 AS transaction_id_used_percent
+FROM pg_database`,
+    columnMappings: [
+      {
+        column: "transaction_id_used_percent",
+        metricType: MonitorMetricType.DatabaseTransactionIdUsedPercent,
+      },
+    ],
+  },
+  {
+    id: "pg-vacuum",
+    group: DatabaseMetricGroup.Maintenance,
+    sql: `SELECT
+  COALESCE(sum(n_dead_tup), 0)::bigint AS dead_tuples,
+  count(*) FILTER (WHERE last_autovacuum IS NULL AND n_dead_tup > 0)::bigint AS tables_never_autovacuumed
+FROM pg_stat_user_tables`,
+    columnMappings: [
+      {
+        column: "dead_tuples",
+        metricType: MonitorMetricType.DatabaseDeadTuples,
+      },
+      {
+        column: "tables_never_autovacuumed",
+        metricType: MonitorMetricType.DatabaseTablesNeverAutovacuumed,
+      },
+    ],
+  },
+  {
+    /*
+     * Checkpoint counters live in pg_stat_bgwriter up to and including
+     * PostgreSQL 16. PostgreSQL 17 moved them to pg_stat_checkpointer and
+     * renamed them, so each variant is version-gated and the other is
+     * skipped rather than run and reported as a failure.
+     */
+    id: "pg-checkpoints-legacy",
+    group: DatabaseMetricGroup.Maintenance,
+    sql: `SELECT checkpoints_timed::bigint, checkpoints_req::bigint FROM pg_stat_bgwriter`,
+    columnMappings: [
+      {
+        column: "checkpoints_timed",
+        metricType: MonitorMetricType.DatabaseCheckpointsTimedTotal,
+      },
+      {
+        column: "checkpoints_req",
+        metricType: MonitorMetricType.DatabaseCheckpointsRequestedTotal,
+      },
+    ],
+    maxServerVersionNum: 169999,
+  },
+  {
+    id: "pg-checkpoints-modern",
+    group: DatabaseMetricGroup.Maintenance,
+    sql: `SELECT num_timed::bigint AS checkpoints_timed, num_requested::bigint AS checkpoints_req FROM pg_stat_checkpointer`,
+    columnMappings: [
+      {
+        column: "checkpoints_timed",
+        metricType: MonitorMetricType.DatabaseCheckpointsTimedTotal,
+      },
+      {
+        column: "checkpoints_req",
+        metricType: MonitorMetricType.DatabaseCheckpointsRequestedTotal,
+      },
+    ],
+    minServerVersionNum: 170000,
+  },
+];
+
+/*
+ * MySQL. The status pivot reads performance_schema.global_status rather than
+ * SHOW GLOBAL STATUS so the result arrives as one row of named columns
+ * instead of a key/value result set that has to be reshaped client side.
+ */
+const mySqlQueries: Array<DatabaseHealthQuery> = [
+  {
+    id: "mysql-status",
+    group: DatabaseMetricGroup.Connections,
+    sql: `SELECT
+  MAX(IF(VARIABLE_NAME='Threads_connected',VARIABLE_VALUE,NULL)) AS connections_total,
+  MAX(IF(VARIABLE_NAME='Threads_running',VARIABLE_VALUE,NULL)) AS connections_active,
+  MAX(IF(VARIABLE_NAME='Aborted_connects',VARIABLE_VALUE,NULL)) AS aborted_connects,
+  MAX(IF(VARIABLE_NAME='Uptime',VARIABLE_VALUE,NULL)) AS uptime_seconds
+FROM performance_schema.global_status`,
+    columnMappings: [
+      {
+        column: "connections_total",
+        metricType: MonitorMetricType.DatabaseConnectionsTotal,
+      },
+      {
+        column: "connections_active",
+        metricType: MonitorMetricType.DatabaseConnectionsActive,
+      },
+      {
+        column: "aborted_connects",
+        metricType: MonitorMetricType.DatabaseConnectionsAbortedTotal,
+      },
+      {
+        column: "uptime_seconds",
+        metricType: MonitorMetricType.DatabaseUptimeSeconds,
+      },
+    ],
+    remediation:
+      "performance_schema must be enabled (performance_schema = ON in my.cnf)",
+  },
+  {
+    id: "mysql-max-connections",
+    group: DatabaseMetricGroup.Connections,
+    sql: `SELECT VARIABLE_VALUE AS connections_max
+FROM performance_schema.global_variables WHERE VARIABLE_NAME='max_connections'`,
+    columnMappings: [
+      {
+        column: "connections_max",
+        metricType: MonitorMetricType.DatabaseConnectionsMax,
+      },
+    ],
+  },
+  {
+    id: "mysql-throughput",
+    group: DatabaseMetricGroup.Throughput,
+    sql: `SELECT
+  MAX(IF(VARIABLE_NAME='Queries',VARIABLE_VALUE,NULL)) AS queries_total,
+  MAX(IF(VARIABLE_NAME='Slow_queries',VARIABLE_VALUE,NULL)) AS slow_queries_total,
+  MAX(IF(VARIABLE_NAME='Innodb_buffer_pool_read_requests',VARIABLE_VALUE,NULL)) AS bp_read_requests,
+  MAX(IF(VARIABLE_NAME='Innodb_buffer_pool_reads',VARIABLE_VALUE,NULL)) AS bp_disk_reads,
+  MAX(IF(VARIABLE_NAME='Innodb_data_reads',VARIABLE_VALUE,NULL)) AS disk_reads_total,
+  MAX(IF(VARIABLE_NAME='Innodb_data_writes',VARIABLE_VALUE,NULL)) AS disk_writes_total
+FROM performance_schema.global_status`,
+    columnMappings: [
+      {
+        column: "queries_total",
+        metricType: MonitorMetricType.DatabaseQueriesTotal,
+      },
+      {
+        column: "slow_queries_total",
+        metricType: MonitorMetricType.DatabaseSlowQueriesTotal,
+      },
+      {
+        column: "disk_reads_total",
+        metricType: MonitorMetricType.DatabaseDiskReadsTotal,
+      },
+      {
+        column: "disk_writes_total",
+        metricType: MonitorMetricType.DatabaseDiskWritesTotal,
+      },
+    ],
+  },
+  {
+    id: "mysql-locks",
+    group: DatabaseMetricGroup.Locks,
+    sql: `SELECT
+  MAX(IF(VARIABLE_NAME='Innodb_row_lock_current_waits',VARIABLE_VALUE,NULL)) AS locks_waiting,
+  MAX(IF(VARIABLE_NAME='Table_locks_waited',VARIABLE_VALUE,NULL)) AS table_locks_waited_total
+FROM performance_schema.global_status`,
+    columnMappings: [
+      {
+        column: "locks_waiting",
+        metricType: MonitorMetricType.DatabaseLocksWaiting,
+      },
+      {
+        column: "table_locks_waited_total",
+        metricType: MonitorMetricType.DatabaseTableLocksWaitedTotal,
+      },
+    ],
+  },
+  {
+    id: "mysql-blocked",
+    group: DatabaseMetricGroup.Locks,
+    sql: `SELECT COUNT(*) AS blocked_sessions FROM performance_schema.data_lock_waits`,
+    columnMappings: [
+      {
+        column: "blocked_sessions",
+        metricType: MonitorMetricType.DatabaseSessionsBlocked,
+      },
+    ],
+    remediation:
+      "performance_schema must be enabled, and the monitoring user needs SELECT on performance_schema.*",
+  },
+  {
+    id: "mysql-transactions",
+    group: DatabaseMetricGroup.Activity,
+    sql: `SELECT
+  COUNT(*) AS open_transactions,
+  COALESCE(MAX(TIMESTAMPDIFF(SECOND, trx_started, NOW())), 0) AS longest_transaction_seconds,
+  COALESCE(MAX(TIMESTAMPDIFF(SECOND, trx_started, NOW())), 0) AS longest_query_seconds
+FROM information_schema.INNODB_TRX`,
+    columnMappings: [
+      {
+        column: "open_transactions",
+        metricType: MonitorMetricType.DatabaseOpenTransactions,
+      },
+      {
+        column: "longest_transaction_seconds",
+        metricType: MonitorMetricType.DatabaseLongestTransactionSeconds,
+      },
+      {
+        column: "longest_query_seconds",
+        metricType: MonitorMetricType.DatabaseLongestQuerySeconds,
+      },
+    ],
+    remediation: "GRANT PROCESS ON *.* TO '<monitoring_user>'@'%';",
+  },
+  {
+    /*
+     * SHOW REPLICA STATUS rather than a performance_schema view because it
+     * is the only place MySQL exposes Seconds_Behind_Source, the number
+     * operators actually alert on. On a server that is not a replica it
+     * returns ZERO ROWS rather than an error (verified on 8.4.11), so the
+     * group counts as collected and simply contributes nothing.
+     *
+     * MySQL below 8.0.22 spells this SHOW SLAVE STATUS; there the statement
+     * fails and the group is reported as NotSupportedByEngine rather than
+     * silently producing nothing.
+     */
+    id: "mysql-replication",
+    group: DatabaseMetricGroup.Replication,
+    sql: `SHOW REPLICA STATUS`,
+    columnMappings: [
+      {
+        column: "Seconds_Behind_Source",
+        metricType: MonitorMetricType.DatabaseReplicationLagSeconds,
+      },
+    ],
+    remediation: "GRANT REPLICATION CLIENT ON *.* TO '<monitoring_user>'@'%';",
+  },
+  {
+    id: "mysql-storage",
+    group: DatabaseMetricGroup.Storage,
+    /*
+     * Scoped to DATABASE() - the database the monitor was configured with -
+     * rather than every non-system schema. Summing the whole server would
+     * report a number that does not match the monitor's own name, and would
+     * move when an unrelated schema grew.
+     */
+    sql: `SELECT
+  (SELECT COALESCE(SUM(data_length + index_length), 0)
+     FROM information_schema.TABLES
+    WHERE table_schema = DATABASE()) AS database_size_bytes,
+  (SELECT VARIABLE_VALUE FROM performance_schema.global_status
+    WHERE VARIABLE_NAME = 'Created_tmp_disk_tables') AS temp_disk_tables_total`,
+    columnMappings: [
+      {
+        column: "database_size_bytes",
+        metricType: MonitorMetricType.DatabaseSizeBytes,
+      },
+      {
+        column: "temp_disk_tables_total",
+        metricType: MonitorMetricType.DatabaseTempDiskTablesTotal,
+      },
+    ],
+  },
+];
+
+/*
+ * Microsoft SQL Server. Everything here needs VIEW SERVER STATE except the
+ * per-database storage and log queries, which is why they are in their own
+ * group - a login without VIEW SERVER STATE still gets size and log space.
+ */
+const sqlServerQueries: Array<DatabaseHealthQuery> = [
+  {
+    id: "mssql-sessions",
+    group: DatabaseMetricGroup.Connections,
+    sql: `SELECT
+ (SELECT COUNT(*) FROM sys.dm_exec_sessions WHERE is_user_process = 1) AS connections_total,
+ (SELECT COUNT(*) FROM sys.dm_exec_requests r
+    JOIN sys.dm_exec_sessions s ON r.session_id = s.session_id
+   WHERE s.is_user_process = 1 AND r.session_id <> @@SPID) AS connections_active,
+ (SELECT DATEDIFF(SECOND, sqlserver_start_time, GETDATE()) FROM sys.dm_os_sys_info) AS uptime_seconds`,
+    columnMappings: [
+      {
+        column: "connections_total",
+        metricType: MonitorMetricType.DatabaseConnectionsTotal,
+      },
+      {
+        column: "connections_active",
+        metricType: MonitorMetricType.DatabaseConnectionsActive,
+      },
+      {
+        column: "uptime_seconds",
+        metricType: MonitorMetricType.DatabaseUptimeSeconds,
+      },
+    ],
+    remediation: "GRANT VIEW SERVER STATE TO [<monitoring_login>];",
+  },
+  {
+    id: "mssql-activity",
+    group: DatabaseMetricGroup.Activity,
+    sql: `SELECT
+ (SELECT ISNULL(MAX(DATEDIFF(SECOND, r.start_time, GETDATE())), 0)
+    FROM sys.dm_exec_requests r
+    JOIN sys.dm_exec_sessions s ON r.session_id = s.session_id
+   WHERE s.is_user_process = 1 AND r.session_id <> @@SPID) AS longest_query_seconds,
+ (SELECT ISNULL(MAX(DATEDIFF(SECOND, t.transaction_begin_time, GETDATE())), 0)
+    FROM sys.dm_tran_active_transactions t
+    JOIN sys.dm_tran_session_transactions st ON t.transaction_id = st.transaction_id) AS longest_transaction_seconds`,
+    columnMappings: [
+      {
+        column: "longest_query_seconds",
+        metricType: MonitorMetricType.DatabaseLongestQuerySeconds,
+      },
+      {
+        column: "longest_transaction_seconds",
+        metricType: MonitorMetricType.DatabaseLongestTransactionSeconds,
+      },
+    ],
+    remediation: "GRANT VIEW SERVER STATE TO [<monitoring_login>];",
+  },
+  {
+    /*
+     * counter_name and instance_name are space-padded CHAR columns, so every
+     * comparison has to RTRIM. Buffer cache hit ratio is a raw pair - the
+     * ratio is only meaningful divided by its base counter, which the
+     * collector derives.
+     */
+    id: "mssql-perf-counters",
+    group: DatabaseMetricGroup.Throughput,
+    sql: `SELECT
+ MAX(CASE WHEN RTRIM(counter_name)='Page life expectancy' THEN cntr_value END) AS page_life_expectancy,
+ MAX(CASE WHEN RTRIM(counter_name)='Batch Requests/sec' THEN cntr_value END) AS queries_total,
+ MAX(CASE WHEN RTRIM(counter_name)='Buffer cache hit ratio' THEN cntr_value END) AS buffer_cache_hit_ratio_raw,
+ MAX(CASE WHEN RTRIM(counter_name)='Buffer cache hit ratio base' THEN cntr_value END) AS buffer_cache_hit_ratio_base,
+ MAX(CASE WHEN RTRIM(counter_name)='Transactions/sec' AND RTRIM(instance_name)='_Total' THEN cntr_value END) AS transactions_total,
+ MAX(CASE WHEN RTRIM(counter_name)='Memory Grants Pending' THEN cntr_value END) AS memory_grants_pending
+FROM sys.dm_os_performance_counters`,
+    columnMappings: [
+      {
+        column: "page_life_expectancy",
+        metricType: MonitorMetricType.DatabasePageLifeExpectancySeconds,
+      },
+      {
+        column: "queries_total",
+        metricType: MonitorMetricType.DatabaseQueriesTotal,
+      },
+      {
+        column: "transactions_total",
+        metricType: MonitorMetricType.DatabaseTransactionsTotal,
+      },
+      {
+        column: "memory_grants_pending",
+        metricType: MonitorMetricType.DatabaseMemoryGrantsPending,
+      },
+    ],
+    remediation: "GRANT VIEW SERVER STATE TO [<monitoring_login>];",
+  },
+  {
+    /*
+     * Lock waits comes from dm_os_waiting_tasks, NOT from the "Lock
+     * Waits/sec" performance counter. That counter is cumulative since
+     * server start, so charting it as the gauge that PostgreSQL and MySQL
+     * report would show a number that only ever climbs - on an idle test
+     * server it already read 26 while nothing was waiting at all.
+     */
+    id: "mssql-blocking",
+    group: DatabaseMetricGroup.Locks,
+    sql: `SELECT
+ (SELECT COUNT(*) FROM sys.dm_exec_requests WHERE blocking_session_id <> 0) AS blocked_sessions,
+ (SELECT COUNT(*) FROM sys.dm_os_waiting_tasks WHERE blocking_session_id IS NOT NULL) AS locks_waiting,
+ (SELECT MAX(CASE WHEN RTRIM(counter_name)='Number of Deadlocks/sec' AND RTRIM(instance_name)='_Total' THEN cntr_value END)
+    FROM sys.dm_os_performance_counters) AS deadlocks_total`,
+    columnMappings: [
+      {
+        column: "blocked_sessions",
+        metricType: MonitorMetricType.DatabaseSessionsBlocked,
+      },
+      {
+        column: "locks_waiting",
+        metricType: MonitorMetricType.DatabaseLocksWaiting,
+      },
+      {
+        column: "deadlocks_total",
+        metricType: MonitorMetricType.DatabaseDeadlocksTotal,
+      },
+    ],
+    remediation: "GRANT VIEW SERVER STATE TO [<monitoring_login>];",
+  },
+  {
+    id: "mssql-io",
+    group: DatabaseMetricGroup.Throughput,
+    sql: `SELECT
+ SUM(io_stall_read_ms) AS io_read_time_ms,
+ SUM(io_stall_write_ms) AS io_write_time_ms,
+ SUM(num_of_reads) AS disk_reads_total,
+ SUM(num_of_writes) AS disk_writes_total
+FROM sys.dm_io_virtual_file_stats(NULL, NULL)`,
+    columnMappings: [
+      {
+        column: "io_read_time_ms",
+        metricType: MonitorMetricType.DatabaseIoReadTimeMs,
+      },
+      {
+        column: "io_write_time_ms",
+        metricType: MonitorMetricType.DatabaseIoWriteTimeMs,
+      },
+      {
+        column: "disk_reads_total",
+        metricType: MonitorMetricType.DatabaseDiskReadsTotal,
+      },
+      {
+        column: "disk_writes_total",
+        metricType: MonitorMetricType.DatabaseDiskWritesTotal,
+      },
+    ],
+    remediation: "GRANT VIEW SERVER STATE TO [<monitoring_login>];",
+  },
+  {
+    id: "mssql-storage",
+    group: DatabaseMetricGroup.Storage,
+    sql: `SELECT
+ (SELECT SUM(CAST(size AS BIGINT)) * 8 * 1024 FROM sys.database_files) AS database_size_bytes,
+ (SELECT TOP 1 used_log_space_in_percent FROM sys.dm_db_log_space_usage) AS log_space_used_percent,
+ (SELECT SUM(unallocated_extent_page_count) * 8 * 1024 FROM tempdb.sys.dm_db_file_space_usage) AS tempdb_free_bytes`,
+    columnMappings: [
+      {
+        column: "database_size_bytes",
+        metricType: MonitorMetricType.DatabaseSizeBytes,
+      },
+      {
+        column: "log_space_used_percent",
+        metricType: MonitorMetricType.DatabaseLogSpaceUsedPercent,
+      },
+      {
+        column: "tempdb_free_bytes",
+        metricType: MonitorMetricType.DatabaseTempDbFreeBytes,
+      },
+    ],
+  },
+  {
+    /*
+     * Returns a single row of zeroes when no availability group is
+     * configured - verified, not assumed - so this needs no gate.
+     */
+    id: "mssql-replication",
+    group: DatabaseMetricGroup.Replication,
+    sql: `SELECT
+ COUNT(*) AS replica_count,
+ ISNULL(MAX(log_send_queue_size), 0) AS log_send_queue_kb,
+ ISNULL(MAX(redo_queue_size), 0) AS redo_queue_kb
+FROM sys.dm_hadr_database_replica_states`,
+    columnMappings: [
+      {
+        column: "replica_count",
+        metricType: MonitorMetricType.DatabaseReplicaCount,
+      },
+      {
+        column: "log_send_queue_kb",
+        metricType: MonitorMetricType.DatabaseReplicationLagBytes,
+        multiplier: 1024,
+      },
+    ],
+    remediation: "GRANT VIEW SERVER STATE TO [<monitoring_login>];",
+  },
+];
+
+export function getDatabaseHealthQueries(
+  databaseType: SqlDatabaseType,
+): Array<DatabaseHealthQuery> {
+  switch (databaseType) {
+    case SqlDatabaseType.PostgreSQL:
+      return postgresQueries;
+    case SqlDatabaseType.MySQL:
+      return mySqlQueries;
+    case SqlDatabaseType.MicrosoftSqlServer:
+      return sqlServerQueries;
+    default:
+      return [];
+  }
+}
+
+/*
+ * The query used to prove the connection works and to time the check. Kept
+ * separate from the metric groups on purpose: this is the ONLY statement
+ * whose failure can take the monitor offline.
+ */
+export function getProbeQuery(databaseType: SqlDatabaseType): string {
+  switch (databaseType) {
+    case SqlDatabaseType.PostgreSQL:
+      /*
+       * has_stats_access is a PREFLIGHT, not a nicety. Without pg_monitor
+       * (or pg_read_all_stats, or superuser) PostgreSQL does not refuse a
+       * pg_stat_activity query - it returns only the monitoring session's
+       * own backend. Verified on 15.18: the same query returns 1 for an
+       * unprivileged role and 3 for a privileged one, with no error either
+       * way. A monitor that reports "1 connection" forever and never fires
+       * is worse than one that reports nothing, so the collector uses this
+       * flag to skip those groups and say why.
+       */
+      return "SELECT current_setting('server_version_num')::int AS server_version_num, pg_is_in_recovery() AS is_in_recovery, version() AS engine_version, (pg_has_role(current_user,'pg_monitor','member') OR pg_has_role(current_user,'pg_read_all_stats','member') OR COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false)) AS has_stats_access";
+    case SqlDatabaseType.MySQL:
+      return "SELECT VERSION() AS engine_version";
+    case SqlDatabaseType.MicrosoftSqlServer:
+      return "SELECT CAST(SERVERPROPERTY('ProductVersion') AS NVARCHAR(128)) AS engine_version";
+    default:
+      return "SELECT 1";
+  }
+}

--- a/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
@@ -4,6 +4,7 @@ import ObjectID from "Common/Types/ObjectID";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import Sleep from "Common/Types/Sleep";
 import { JSONObject } from "Common/Types/JSON";
+import SqlConnectionConfig from "Common/Types/Monitor/SqlConnectionConfig";
 import MonitorStepSqlMonitor, {
   clampSqlConnectionTimeoutInMs,
   clampSqlMaxRows,
@@ -284,13 +285,19 @@ export type SqlServerDriverLoader = (moduleId: string) => unknown;
  * the normal Tedious driver, while a trusted connection has only an ODBC
  * connection string and cannot accidentally forward a saved username/password.
  */
+/*
+ * Takes SqlConnectionConfig rather than MonitorStepSqlMonitor so the Database
+ * Health monitor can reuse it: the integrated-authentication path has to
+ * detect the host's ODBC driver and hand-build a connection string, and a
+ * second copy of that would drift from this one.
+ */
 export const buildMicrosoftSqlServerPoolConfig: (input: {
-  config: MonitorStepSqlMonitor;
+  config: SqlConnectionConfig;
   statementTimeoutInMs: number;
   connectionTimeoutInMs: number;
   odbcDriver?: string | undefined;
 }) => MicrosoftSqlServerPoolConfig = (input: {
-  config: MonitorStepSqlMonitor;
+  config: SqlConnectionConfig;
   statementTimeoutInMs: number;
   connectionTimeoutInMs: number;
   odbcDriver?: string | undefined;

--- a/Scripts/TerraformProvider/StaticFiles/monitorsteps.go
+++ b/Scripts/TerraformProvider/StaticFiles/monitorsteps.go
@@ -186,6 +186,9 @@ var monitorStepsCheckOnValues = []string{
 	"SQL Query Scalar Value",
 	"SQL Query Execution Time (in ms)",
 	"SQL Query Error",
+	"Database Is Online",
+	"Database Metric",
+	"Database Collection Error",
 	"External Status Page Is Online",
 	"External Status Page Overall Status",
 	"External Status Page Component Status",
@@ -262,6 +265,7 @@ var monitorStepsSubConfigs = []monitorStepsSubConfig{
 	{"domain_monitor", "domainMonitor"},
 	{"dnssec_monitor", "dnssecMonitor"},
 	{"sql_monitor", "sqlMonitor"},
+	{"database_monitor", "databaseMonitor"},
 	{"external_status_page_monitor", "externalStatusPageMonitor"},
 	{"kubernetes_monitor", "kubernetesMonitor"},
 	{"docker_monitor", "dockerMonitor"},
@@ -289,6 +293,7 @@ func monitorStepsFilterAttrTypes() map[string]attr.Type {
 		"disk_path":                         types.StringType,
 		"metric_monitor_options":            types.StringType,
 		"snmp_monitor_options":              types.StringType,
+		"database_monitor_options":          types.StringType,
 	}
 }
 
@@ -605,6 +610,11 @@ func monitorStepsFilterSchema() schema.NestedAttributeObject {
 				Optional:            true,
 				Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
 			},
+			"database_monitor_options": schema.StringAttribute{
+				MarkdownDescription: "Raw JSON escape hatch for Database Health filter options (metricType). Required on every `Database Metric` filter — it names the series the threshold applies to. Write it with `jsonencode()`.",
+				Optional:            true,
+				Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+			},
 		},
 	}
 }
@@ -918,6 +928,7 @@ func monitorStepsStepSchema() schema.NestedAttributeObject {
 		"domain_monitor":               "Raw JSON escape hatch for the Domain monitor config (domainName, lookupMethod, timeout, retries). lookupMethod is one of Auto, RDAP, WHOIS and defaults to Auto.",
 		"dnssec_monitor":               "Raw JSON escape hatch for the DNSSEC monitor config (domainName, resolvers).",
 		"sql_monitor":                  "Raw JSON escape hatch for the SQL Query monitor config (databaseType, host, port, databaseName, query, ...).",
+		"database_monitor":             "Raw JSON escape hatch for the Database Health monitor config (databaseType, host, port, databaseName, username, password, enabledMetricGroups, ...).",
 		"external_status_page_monitor": "Raw JSON escape hatch for the External Status Page monitor config (statusPageUrl, providerType).",
 		"kubernetes_monitor":           "Raw JSON escape hatch for the Kubernetes monitor config (clusterIdentifier, ...).",
 		"docker_monitor":               "Raw JSON escape hatch for the Docker monitor config (hostIdentifier, ...).",
@@ -1095,6 +1106,9 @@ func monitorStepsFilterToAPI(attrs map[string]attr.Value, attrPath string, diags
 	}
 	if v, ok := monitorStepsAttrJSON(attrs, "snmp_monitor_options", attrPath, diags); ok {
 		out["snmpMonitorOptions"] = v
+	}
+	if v, ok := monitorStepsAttrJSON(attrs, "database_monitor_options", attrPath, diags); ok {
+		out["databaseMonitorOptions"] = v
 	}
 	return out
 }
@@ -1564,6 +1578,9 @@ func monitorStepsFilterFromAPI(v interface{}, diags *diag.Diagnostics) (types.Ob
 	}
 	if s, ok := monitorStepsAPIJSONString(m["snmpMonitorOptions"]); ok {
 		attrs["snmp_monitor_options"] = types.StringValue(s)
+	}
+	if s, ok := monitorStepsAPIJSONString(m["databaseMonitorOptions"]); ok {
+		attrs["database_monitor_options"] = types.StringValue(s)
 	}
 	// metricCriteriaContext (evaluation-time context) and any unknown keys
 	// are intentionally dropped.


### PR DESCRIPTION
Closes #3557.

## What this does

The SQL Query monitor answers *"did my query run"*. That is the wrong shape for database health: to watch connections, locks, replication, cache or storage today you have to write catalog SQL per engine and know `pg_stat_activity`, `performance_schema` and `sys.dm_*` by heart — which is exactly what the issue reports.

This adds a **separate `MonitorType.Database` ("Database Health")** that connects from a probe and runs *built-in* read-only catalog queries, recording **41 normalized metrics** across PostgreSQL, MySQL and SQL Server. Availability, Connections, Throughput, Locks & Blocking, Cache & I/O, Storage, Replication and Maintenance each get their own card on the metrics tab.

The SQL Query monitor is **unchanged** and remains the escape hatch for custom business checks. They are deliberately separate types: a health check has no user query, needs different grants, and issues a different number of statements per interval.

## Design

- **One catalog drives everything.** `Common/Types/Monitor/DatabaseMetricCatalog.ts` owns each metric's title, unit, aggregation, display category, collection group and per-engine support. The five metric-metadata switches consult it, so a new metric is one catalog entry instead of five switch cases that can drift apart.
- **Three CheckOns, not forty.** `CheckOn.DatabaseMetric` names its series in `databaseMonitorOptions.metricType` — the same options-bag pattern Server monitors use for a disk path and SNMP monitors use for an OID. The criteria UI offers a metric picker filtered to what the configured engine can actually produce.
- **Collection is partial by design.** Only a connection or probe-query failure can take the monitor offline. A missing grant marks *that group* unavailable, shows the exact `GRANT` to run, and the check stays online with the metrics it could read. `Metric Groups Failed` is a series of its own so you can alert on lost visibility.

## Verified against live databases, not just review

Every statement was executed against **PostgreSQL 15.18, MySQL 8.4.11 and SQL Server 2022 (16.0.4265.3)**, and the collector was run end to end against all three. That caught five bugs that would otherwise have shipped:

| Found | Why it mattered |
|---|---|
| PostgreSQL `FILTER` binds to the **aggregate**, not the wrapping `EXTRACT` | Syntax error at runtime |
| Stock MySQL has **no deadlock counter at all** | The metric is now PostgreSQL + SQL Server only, instead of a permanently empty chart |
| SQL Server `Lock Waits/sec` is **cumulative** — it read 26 on an idle server | Lock waits now comes from `dm_os_waiting_tasks`, a real gauge |
| Without `pg_monitor`, `pg_stat_activity` **succeeds** and returns only our own row (1 instead of 3) | A preflight now skips those groups rather than recording confident, wrong numbers forever |
| MySQL database size summed **every** schema | Now scoped to the configured database |

The last one is the important one: the failure mode was silent. A monitor reporting "1 connection" and never alerting is worse than one reporting nothing, so it refuses rather than guesses.

## Tests

New: catalog invariants, config round-trip, collector behaviour, criteria evaluation, and the metric write path. The catalog tests also police the *relationship* between the query table and the catalog in both directions — a query producing a metric its engine does not declare, or a metric an engine claims that no query produces. That second direction caught a real gap (MySQL replication lag was advertised in the picker with nothing to fill it).

Verification run locally:
- `Common` type check clean; **317 tests pass** across the new and updated suites
- The full safety-net suites (`CriteriaFilterDefaults`, `CriteriaFilterMonitorTypeChange`, `MetricAndProfileDefaultCriteria`, `MonitorCriteriaActionValidation`, `CardSelect`) pass **1234/1234 unedited**
- eslint clean on all changed files

## Two things a reviewer should decide

1. **Search ranking changed on purpose.** Typing `postgres`, `postgresql`, `mysql` or `database` in the monitor picker now surfaces Database Health above SQL Query, on the grounds that someone typing an engine name wants health metrics rather than a query editor. The affected ranking assertions are updated, and rows pinning SQL Query's own searches (`query`, `row count`) are added alongside. If you disagree, the fix is to drop the engine names from the Database keywords.
2. **Counters ship raw.** Cumulative counters (`transactions`, `queries`, `disk reads`) are stored as-is with `Max` aggregation so charts can difference buckets. A threshold criterion on a monotonic counter fires forever once crossed, so none of them are recommended for alerting yet; server-side rate derivation is the natural follow-up.

## Not included

- Curated alert templates (a `DatabaseAlertPack` in the shape of the Ceph one) — genuinely useful, but cleanly separable and left out to keep this reviewable.
- `App/FeatureSet/Workers/DataMigrations/BackfillNetworkDeviceRoles.ts` fails the App type check with an unused-import `TS6133`. **This is pre-existing on `master`** (introduced in 9b0198a939) and untouched here; I left it alone rather than mixing an unrelated fix into this PR, but it will make the App type check red until someone drops that import.
- Probe unit tests could not be executed locally — `Probe/node_modules` is missing `@jest/globals`, so its jest 28 runtime loads the root's jest 30 and every Probe suite fails to start, including ones untouched by this branch. The probe code is instead verified by `tsc` and by running the real collector against all three live engines.
