### PR TITLE
fix(security): keep password reset tokens out of third-party analytics

### DIFF
--- a/App/FeatureSet/Accounts/src/App.tsx
+++ b/App/FeatureSet/Accounts/src/App.tsx
@@ -58,11 +58,24 @@ function App(): ReactElement {
               path="/accounts/forgot-password"
               element={<ForgotPasswordPage />}
             />
+            {/*
+             * Both forms of each token-bearing route are registered. The head
+             * bootstrap in Common/Server/Views/Partials/SensitiveUrlToken.ejs
+             * normally takes the token out of the path before the router ever
+             * sees it, which lands the visitor on the token-free form; the
+             * :token form is what remains when that bootstrap could not run.
+             * Either way the page reads the token through SensitiveUrlToken.
+             */}
+            <Route
+              path="/accounts/reset-password"
+              element={<ResetPasswordPage />}
+            />
             <Route
               path="/accounts/reset-password/:token"
               element={<ResetPasswordPage />}
             />
             <Route path="/accounts/register" element={<RegisterPage />} />
+            <Route path="/accounts/verify-email" element={<VerifyEmail />} />
             <Route
               path="/accounts/verify-email/:token"
               element={<VerifyEmail />}

--- a/App/FeatureSet/Accounts/src/Pages/ResetPassword.tsx
+++ b/App/FeatureSet/Accounts/src/Pages/ResetPassword.tsx
@@ -5,7 +5,7 @@ import ModelForm, { FormType } from "Common/UI/Components/Forms/ModelForm";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import Link from "Common/UI/Components/Link/Link";
 import OneUptimeLogo from "Common/UI/Images/logos/OneUptimeSVG/3-transparent.svg";
-import Navigation from "Common/UI/Utils/Navigation";
+import SensitiveUrlToken from "Common/UI/Utils/SensitiveUrlToken";
 import User from "Common/Models/DatabaseModels/User";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -48,11 +48,12 @@ const ResetPasswordPage: () => JSX.Element = () => {
               id="register-form"
               name="Reset Password"
               onBeforeCreate={(item: User): Promise<User> => {
-                item.resetPasswordToken =
-                  Navigation.getLastParam()
-                    ?.toString()
-                    .replace("/", "")
-                    .toString() || "";
+                /*
+                 * Not a route param: the head bootstrap moves the token out of
+                 * the path before any third-party tag can report the URL. See
+                 * Common/UI/Utils/SensitiveUrlToken.
+                 */
+                item.resetPasswordToken = SensitiveUrlToken.read();
                 return Promise.resolve(item);
               }}
               showAsColumns={1}
@@ -93,6 +94,12 @@ const ResetPasswordPage: () => JSX.Element = () => {
               formType={FormType.Create}
               submitButtonText={t("resetPassword.submitButton")}
               onSuccess={() => {
+                /*
+                 * Only on success. A rejected reset (expired token, refused
+                 * password) has to keep the stash so the retry still has a
+                 * token to submit.
+                 */
+                SensitiveUrlToken.clear();
                 setIsSuccess(true);
               }}
             />

--- a/App/FeatureSet/Accounts/src/Pages/VerifyEmail.tsx
+++ b/App/FeatureSet/Accounts/src/Pages/VerifyEmail.tsx
@@ -11,7 +11,7 @@ import PageLoader from "Common/UI/Components/Loader/PageLoader";
 import OneUptimeLogo from "Common/UI/Images/logos/OneUptimeSVG/3-transparent.svg";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
-import Navigation from "Common/UI/Utils/Navigation";
+import SensitiveUrlToken from "Common/UI/Utils/SensitiveUrlToken";
 import EmailVerificationToken from "Common/Models/DatabaseModels/EmailVerificationToken";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -31,9 +31,12 @@ const VerifyEmail: () => JSX.Element = () => {
       // strip data.
       const emailverificationToken: EmailVerificationToken =
         new EmailVerificationToken();
-      emailverificationToken.token = new ObjectID(
-        Navigation.getLastParam()?.toString().replace("/", "") || "",
-      );
+      /*
+       * Not a route param: the head bootstrap moves the token out of the path
+       * before any third-party tag can report the URL. See
+       * Common/UI/Utils/SensitiveUrlToken.
+       */
+      emailverificationToken.token = new ObjectID(SensitiveUrlToken.read());
 
       await ModelAPI.createOrUpdate<EmailVerificationToken>({
         model: emailverificationToken,
@@ -44,6 +47,9 @@ const VerifyEmail: () => JSX.Element = () => {
           overrideRequestUrl: apiUrl,
         },
       });
+
+      // Verified; the token is spent and must not outlive the page.
+      SensitiveUrlToken.clear();
     } catch (err) {
       setError(API.getFriendlyMessage(err));
     }

--- a/App/FeatureSet/Accounts/views/index.ejs
+++ b/App/FeatureSet/Accounts/views/index.ejs
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
+  <%- include('../../../../Common/Server/Views/Partials/SensitiveUrlToken') -%>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -19,6 +20,13 @@
   <% if(typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false){ %> 
   <!-- Google Tag Manager -->
   <script>(function (w, d, s, l, i) {
+      /*
+       * Do not start the container while a single-use bearer token is still in
+       * the address bar. See Common/Server/Views/Partials/SensitiveUrlToken.ejs:
+       * the bootstrap normally removes the token before this runs, and this
+       * guard only fires when it could not.
+       */
+      if (w.__ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__) { return; }
       w[l] = w[l] || []; w[l].push({
         'gtm.start':
           new Date().getTime(), event: 'gtm.js'

--- a/App/FeatureSet/StatusPage/src/App.tsx
+++ b/App/FeatureSet/StatusPage/src/App.tsx
@@ -197,6 +197,21 @@ const PageForbidden: React.LazyExoticComponent<
   });
 });
 
+/*
+ * The token-free form of a token-bearing route.
+ *
+ * Common/Server/Views/Partials/SensitiveUrlToken.ejs takes the reset token out
+ * of the path in <head>, before any third-party tag can report the URL, so by
+ * the time the router runs the visitor is on /reset-password rather than
+ * /reset-password/<token>. Both forms have to resolve to the same page: the
+ * :token form is what remains when that bootstrap could not run.
+ */
+type TokenFreeRouteFunction = (route: string) => string;
+
+const tokenFreeRoute: TokenFreeRouteFunction = (route: string): string => {
+  return route.replace(/\/:token$/, "");
+};
+
 const App: () => JSX.Element = () => {
   Navigation.setNavigateHook(useNavigate());
   Navigation.setLocation(useLocation());
@@ -446,6 +461,19 @@ const App: () => JSX.Element = () => {
               <Sso
                 statusPageName={statusPageName}
                 logoFileId={new ObjectID(statusPageLogoFileId)}
+              />
+            }
+          />
+
+          <PageRoute
+            path={tokenFreeRoute(
+              RouteMap[PageMap.RESET_PASSWORD]?.toString() || "",
+            )}
+            element={
+              <ResetPassword
+                statusPageName={statusPageName}
+                logoFileId={new ObjectID(statusPageLogoFileId)}
+                forceSSO={forceSSO}
               />
             }
           />
@@ -1007,6 +1035,19 @@ const App: () => JSX.Element = () => {
               <MasterPassword
                 statusPageName={statusPageName}
                 logoFileId={new ObjectID(statusPageLogoFileId)}
+              />
+            }
+          />
+
+          <PageRoute
+            path={tokenFreeRoute(
+              RouteMap[PageMap.PREVIEW_RESET_PASSWORD]?.toString() || "",
+            )}
+            element={
+              <ResetPassword
+                statusPageName={statusPageName}
+                logoFileId={new ObjectID(statusPageLogoFileId)}
+                forceSSO={forceSSO}
               />
             }
           />

--- a/App/FeatureSet/StatusPage/src/Pages/Accounts/ResetPassword.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Accounts/ResetPassword.tsx
@@ -12,6 +12,7 @@ import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchem
 import Link from "Common/UI/Components/Link/Link";
 import { STATUS_PAGE_API_URL } from "Common/UI/Config";
 import Navigation from "Common/UI/Utils/Navigation";
+import SensitiveUrlToken from "Common/UI/Utils/SensitiveUrlToken";
 import StatusPagePrivateUser from "Common/Models/DatabaseModels/StatusPagePrivateUser";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -112,11 +113,12 @@ const ResetPassword: FunctionComponent<ComponentProps> = (
               onBeforeCreate={(
                 item: StatusPagePrivateUser,
               ): Promise<StatusPagePrivateUser> => {
-                item.resetPasswordToken =
-                  Navigation.getLastParam()
-                    ?.toString()
-                    .replace("/", "")
-                    .toString() || "";
+                /*
+                 * Not a route param: the head bootstrap moves the token out of
+                 * the path before any third-party tag can report the URL. See
+                 * Common/UI/Utils/SensitiveUrlToken.
+                 */
+                item.resetPasswordToken = SensitiveUrlToken.read();
 
                 item.statusPageId = StatusPageUtil.getStatusPageId()!;
                 return Promise.resolve(item);
@@ -159,6 +161,12 @@ const ResetPassword: FunctionComponent<ComponentProps> = (
               formType={FormType.Create}
               submitButtonText={t("accounts.resetPassword.submit")}
               onSuccess={() => {
+                /*
+                 * Only on success. A rejected reset (expired token, refused
+                 * password) has to keep the stash so the retry still has a
+                 * token to submit.
+                 */
+                SensitiveUrlToken.clear();
                 setIsSuccess(true);
               }}
             />

--- a/App/FeatureSet/StatusPage/views/index.ejs
+++ b/App/FeatureSet/StatusPage/views/index.ejs
@@ -2,7 +2,7 @@
 <html lang="<%= typeof lang !== 'undefined' && lang ? lang : 'en' %>">
   <head>
     <meta charset="utf-8" />
-    <meta name="referrer" content="no-referrer" />
+    <%- include('../../../../Common/Server/Views/Partials/SensitiveUrlToken') -%>
     <script>
       (function (handoffWindow) {
         var storageKey = "oneuptime-status-page-login-code";
@@ -123,7 +123,7 @@
     
     <% if(typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false){ %> 
         <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){if(w.__ONEUPTIME_STATUS_PAGE_LOGIN_HANDOFF_PENDING__){return;}w[l]=w[l]||[];w[l].push({'gtm.start':
+<script>(function(w,d,s,l,i){if(w.__ONEUPTIME_STATUS_PAGE_LOGIN_HANDOFF_PENDING__||w.__ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__){return;}w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);

--- a/Common/Server/Views/Partials/SensitiveUrlToken.ejs
+++ b/Common/Server/Views/Partials/SensitiveUrlToken.ejs
@@ -1,0 +1,140 @@
+<%#
+    Takes single-use bearer tokens out of the address bar before any
+    third-party tag can read them.
+
+    Password reset and email verification links carry their token in the URL
+    *path* — /accounts/reset-password/<token>, /accounts/verify-email/<token>,
+    /reset-password/<token> on a status page. Every analytics and advertising
+    tag on the page reports the page URL as a matter of course, so the token
+    left the browser to whoever the container happened to be loading. Measured
+    on production before this partial existed, a single visit to
+    /accounts/reset-password/<token> sent the token to five third parties:
+    region1.analytics.google.com, www.google.com, bat.bing.com, q.quora.com and
+    alb.reddit.com. A reset token is a bearer credential for the account, so
+    anyone with read access to any of those ad or analytics dashboards — inside
+    OneUptime or at the vendor — could take the account over for as long as the
+    token stayed valid.
+
+    Two mechanisms, in this order:
+
+    1.  The token is moved into sessionStorage and `history.replaceState`
+        rewrites the path to the token-free route. This runs synchronously in
+        <head>, before the Google Tag Manager snippet below it, so every tag the
+        container loads sees only /accounts/reset-password. Analytics is NOT
+        disabled by this — the signup funnel still reports — it just no longer
+        sees the credential. It also keeps the token out of the browser's own
+        history, which replaceState overwrites rather than appends to.
+
+    2.  If step 1 did not finish — no History API, a storage exception, a URL
+        the parser rejected — the token is still in the address bar, and the
+        partial fails closed by setting
+        __ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__. The Google Tag Manager
+        snippet on each page checks that flag and does not start the container
+        at all. Losing a page view is the cheaper failure.
+
+    The reset flow itself keeps working in both cases: the client reads the
+    token through Common/UI/Utils/SensitiveUrlToken, which prefers the
+    stash and falls back to the path when the bootstrap could not clean it.
+
+    MUST be included as the first thing in <head>, ahead of Google Tag Manager
+    and ahead of every external <script>. A tag that loads before this runs is
+    a tag that sees the token. Common/Tests/App/SensitiveUrlTokenBootstrap.test.ts
+    asserts that ordering for each page that includes it.
+
+    TOKEN_ROUTES below is duplicated in Common/UI/Utils/SensitiveUrlToken.ts,
+    which has to agree about which routes carry a token; the same test asserts
+    the two lists match. Add a route to both or to neither.
+-%>
+<meta name="referrer" content="no-referrer" />
+<script>
+    (function (win) {
+        var STORAGE_KEY = "oneuptime-sensitive-url-token";
+
+        /*
+         * Route segments whose NEXT path segment is a single-use bearer token.
+         * Matched against the second-to-last segment, so this covers
+         * /accounts/reset-password/<token>, /reset-password/<token> and
+         * /status-page/<id>/reset-password/<token> alike.
+         */
+        var TOKEN_ROUTES = ["reset-password", "verify-email"];
+
+        function segmentsOf(pathname) {
+            var parts = String(pathname || "").split("/");
+            var kept = [];
+
+            for (var i = 0; i < parts.length; i++) {
+                if (parts[i] !== "") {
+                    kept.push(parts[i]);
+                }
+            }
+
+            return kept;
+        }
+
+        /* True when the last segment of this path is a bearer token. */
+        function carriesToken(pathname) {
+            var segments = segmentsOf(pathname);
+
+            if (segments.length < 2) {
+                return false;
+            }
+
+            var parent = segments[segments.length - 2];
+
+            for (var i = 0; i < TOKEN_ROUTES.length; i++) {
+                if (parent === TOKEN_ROUTES[i]) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        var pending = true;
+
+        try {
+            var url = new URL(win.location.href);
+
+            if (carriesToken(url.pathname)) {
+                var segments = segmentsOf(url.pathname);
+                var token = segments.pop();
+
+                try {
+                    token = decodeURIComponent(token);
+                } catch (_decodeError) {
+                    /* A malformed escape sequence is handed on verbatim. */
+                }
+
+                try {
+                    win.sessionStorage.setItem(STORAGE_KEY, token);
+                } catch (_storageError) {
+                    /*
+                     * Private mode and blocked storage. The in-memory handoff
+                     * does not survive a reload, but it does survive the SPA
+                     * boot, which is all the flow needs.
+                     */
+                    win.__ONEUPTIME_SENSITIVE_URL_TOKEN__ = token;
+                }
+
+                win.history.replaceState(
+                    win.history.state,
+                    "",
+                    "/" + segments.join("/") + url.search + url.hash
+                );
+            }
+
+            /*
+             * Read the address bar back rather than trusting the rewrite. This
+             * is the whole safety condition: analytics runs only if the token
+             * is demonstrably no longer in the URL those tags are about to
+             * report.
+             */
+            pending = carriesToken(win.location.pathname);
+        } catch (_bootstrapError) {
+            /* Fail closed: something went wrong, so assume the token is exposed. */
+            pending = true;
+        }
+
+        win.__ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__ = pending;
+    })(window);
+</script>

--- a/Common/Tests/App/SensitiveUrlTokenBootstrap.test.ts
+++ b/Common/Tests/App/SensitiveUrlTokenBootstrap.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "@jest/globals";
+import ejs from "ejs";
+import fs from "fs";
+import { JSDOM } from "jsdom";
+import path from "path";
+
+/*
+ * Password reset and email verification links carry a single-use bearer token
+ * in the URL path. Every analytics and advertising tag on the page reports the
+ * page URL as a matter of course, so the token used to leave the browser to
+ * whoever the Google Tag Manager container happened to be loading. Measured on
+ * production before the fix, one visit to /accounts/reset-password/<token> sent
+ * the token to region1.analytics.google.com, www.google.com, bat.bing.com,
+ * q.quora.com and alb.reddit.com.
+ *
+ * Common/Server/Views/Partials/SensitiveUrlToken.ejs closes that by rewriting
+ * the path before the container starts, and by refusing to start the container
+ * at all if the rewrite did not take. Both halves are load-order sensitive and
+ * invisible at runtime when they break — a tag moved above the partial, or a
+ * `return` dropped from the GTM guard, leaks silently and no other suite would
+ * notice — so they are pinned here.
+ */
+
+const REPOSITORY_ROOT: string = path.resolve(__dirname, "..", "..", "..");
+
+const STORAGE_KEY: string = "oneuptime-sensitive-url-token";
+
+const PARTIAL_PATH: string = path.join(
+  REPOSITORY_ROOT,
+  "Common",
+  "Server",
+  "Views",
+  "Partials",
+  "SensitiveUrlToken.ejs",
+);
+
+const CLIENT_UTIL_PATH: string = path.join(
+  REPOSITORY_ROOT,
+  "Common",
+  "UI",
+  "Utils",
+  "SensitiveUrlToken.ts",
+);
+
+interface Origin {
+  label: string;
+  viewPath: string;
+  // The first external script tag on the page; the bootstrap must precede it.
+  firstExternalScript: string;
+  // A token-bearing URL served by this origin, and the path it must become.
+  tokenUrl: string;
+  cleanedPath: string;
+  // A page on the same origin that carries no token.
+  ordinaryUrl: string;
+}
+
+const ORIGINS: Array<Origin> = [
+  {
+    label: "accounts",
+    viewPath: path.join(
+      REPOSITORY_ROOT,
+      "App",
+      "FeatureSet",
+      "Accounts",
+      "views",
+      "index.ejs",
+    ),
+    firstExternalScript: '<script src="/accounts/env.js">',
+    tokenUrl:
+      "https://oneuptime.com/accounts/reset-password/1522e9be-84cd-44b7-8fc9-606545bfa732",
+    cleanedPath: "/accounts/reset-password",
+    ordinaryUrl: "https://oneuptime.com/accounts/login",
+  },
+  {
+    label: "status page",
+    viewPath: path.join(
+      REPOSITORY_ROOT,
+      "App",
+      "FeatureSet",
+      "StatusPage",
+      "views",
+      "index.ejs",
+    ),
+    firstExternalScript: '<script src="/status-page/env.js">',
+    tokenUrl:
+      "https://status.example/reset-password/1522e9be-84cd-44b7-8fc9-606545bfa732",
+    cleanedPath: "/reset-password",
+    ordinaryUrl: "https://status.example/login",
+  },
+];
+
+const TOKEN: string = "1522e9be-84cd-44b7-8fc9-606545bfa732";
+
+function render(origin: Origin, enableGoogleTagManager: boolean): string {
+  return ejs.render(
+    fs.readFileSync(origin.viewPath, "utf8"),
+    { title: "Acme Status", enableGoogleTagManager },
+    { filename: origin.viewPath },
+  );
+}
+
+function loadPage(origin: Origin, url: string): JSDOM {
+  return new JSDOM(render(origin, true), {
+    url,
+    runScripts: "dangerously",
+    beforeParse: (pageWindow: JSDOM["window"]): void => {
+      (pageWindow as any).tailwind = { config: {} };
+    },
+  });
+}
+
+function gtmScript(page: JSDOM): Element | null {
+  return page.window.document.querySelector(
+    'script[src^="https://www.googletagmanager.com/gtm.js"]',
+  );
+}
+
+describe("the sensitive-URL-token partial", () => {
+  it("keeps its route list in step with the client that reads the stash", () => {
+    /*
+     * The partial decides which paths to strip; Common/UI/Utils/SensitiveUrlToken
+     * decides which paths still hold a token when the strip did not run. A route
+     * added to one and not the other either leaks (stripped nowhere) or breaks
+     * the flow (stripped, then unreadable).
+     */
+    const routeList: string = `["reset-password", "verify-email"]`;
+
+    expect(fs.readFileSync(PARTIAL_PATH, "utf8")).toContain(routeList);
+    expect(fs.readFileSync(CLIENT_UTIL_PATH, "utf8")).toContain(routeList);
+  });
+
+  it("agrees with the client on the storage key", () => {
+    expect(fs.readFileSync(PARTIAL_PATH, "utf8")).toContain(`"${STORAGE_KEY}"`);
+    expect(fs.readFileSync(CLIENT_UTIL_PATH, "utf8")).toContain(
+      `"${STORAGE_KEY}"`,
+    );
+  });
+});
+
+for (const origin of ORIGINS) {
+  describe(`${origin.label}: sensitive URL tokens`, () => {
+    it("runs the bootstrap before any external script and declares no-referrer", () => {
+      const html: string = render(origin, true);
+      const bootstrap: number = html.indexOf(
+        `var STORAGE_KEY = "${STORAGE_KEY}"`,
+      );
+
+      expect(bootstrap).toBeGreaterThan(-1);
+      expect(html).toContain('<meta name="referrer" content="no-referrer" />');
+
+      /*
+       * Ordering is the whole mechanism. Anything that loads before the
+       * bootstrap sees the token.
+       */
+      expect(html.indexOf(origin.firstExternalScript)).toBeGreaterThan(
+        bootstrap,
+      );
+      expect(html.indexOf("googletagmanager.com/gtm.js")).toBeGreaterThan(
+        bootstrap,
+      );
+    });
+
+    it("moves the token out of the address bar before page scripts run", () => {
+      const page: JSDOM = loadPage(origin, origin.tokenUrl);
+
+      expect(page.window.location.pathname).toBe(origin.cleanedPath);
+      expect(page.window.location.href).not.toContain(TOKEN);
+      expect(page.window.sessionStorage.getItem(STORAGE_KEY)).toBe(TOKEN);
+
+      page.window.close();
+    });
+
+    it("still starts analytics once the token is out of the URL", () => {
+      /*
+       * The fix must not cost the signup funnel its reporting. Stripping the
+       * token is what makes the page safe to measure, not switching measurement
+       * off.
+       */
+      const page: JSDOM = loadPage(origin, origin.tokenUrl);
+
+      expect(
+        (page.window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__,
+      ).toBe(false);
+      expect(gtmScript(page)).not.toBeNull();
+
+      page.window.close();
+    });
+
+    it("suppresses analytics entirely when the token cannot be removed", () => {
+      /*
+       * Fail closed. If replaceState is unavailable, the token is still in the
+       * URL every tag is about to report, so no tag may load. Losing a page
+       * view is the cheaper failure.
+       */
+      const page: JSDOM = new JSDOM(render(origin, true), {
+        url: origin.tokenUrl,
+        runScripts: "dangerously",
+        beforeParse: (pageWindow: JSDOM["window"]): void => {
+          (pageWindow as any).tailwind = { config: {} };
+          pageWindow.history.replaceState = (): void => {
+            throw new Error("replaceState unavailable");
+          };
+        },
+      });
+
+      expect(page.window.location.href).toContain(TOKEN);
+      expect(
+        (page.window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__,
+      ).toBe(true);
+      expect(gtmScript(page)).toBeNull();
+
+      page.window.close();
+    });
+
+    it("leaves ordinary pages untouched", () => {
+      const page: JSDOM = loadPage(origin, origin.ordinaryUrl);
+
+      expect(page.window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(
+        (page.window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN_PENDING__,
+      ).toBe(false);
+      expect(gtmScript(page)).not.toBeNull();
+
+      page.window.close();
+    });
+  });
+}
+
+describe("accounts: email verification tokens", () => {
+  const accounts: Origin = ORIGINS[0]!;
+
+  it("strips the verify-email token too", () => {
+    const page: JSDOM = loadPage(
+      accounts,
+      `https://oneuptime.com/accounts/verify-email/${TOKEN}`,
+    );
+
+    expect(page.window.location.pathname).toBe("/accounts/verify-email");
+    expect(page.window.sessionStorage.getItem(STORAGE_KEY)).toBe(TOKEN);
+
+    page.window.close();
+  });
+
+  it("preserves the query string and fragment around the stripped token", () => {
+    const page: JSDOM = loadPage(
+      accounts,
+      `https://oneuptime.com/accounts/reset-password/${TOKEN}?utm_source=email#top`,
+    );
+
+    expect(page.window.location.pathname).toBe("/accounts/reset-password");
+    expect(page.window.location.search).toBe("?utm_source=email");
+    expect(page.window.location.hash).toBe("#top");
+
+    page.window.close();
+  });
+});

--- a/Common/Tests/App/StatusPage/StatusPageLoginCodeBootstrap.test.ts
+++ b/Common/Tests/App/StatusPage/StatusPageLoginCodeBootstrap.test.ts
@@ -20,10 +20,15 @@ const INDEX_TEMPLATE: string = path.join(
 const STORAGE_KEY: string = "oneuptime-status-page-login-code";
 
 function renderIndexPage(enableGoogleTagManager: boolean): string {
-  return ejs.render(fs.readFileSync(INDEX_TEMPLATE, "utf8"), {
-    title: "Acme Status",
-    enableGoogleTagManager,
-  });
+  return ejs.render(
+    fs.readFileSync(INDEX_TEMPLATE, "utf8"),
+    {
+      title: "Acme Status",
+      enableGoogleTagManager,
+    },
+    // The template includes the shared sensitive-URL-token partial.
+    { filename: INDEX_TEMPLATE },
+  );
 }
 
 function loadPage(url: string, existingCode?: string): JSDOM {

--- a/Common/Tests/UI/Utils/SensitiveUrlToken.test.ts
+++ b/Common/Tests/UI/Utils/SensitiveUrlToken.test.ts
@@ -1,0 +1,140 @@
+import SensitiveUrlToken from "../../../UI/Utils/SensitiveUrlToken";
+import { describe, expect, it, beforeEach } from "@jest/globals";
+
+/*
+ * The client half of the reset/verify token handoff.
+ *
+ * The head bootstrap normally leaves the token in sessionStorage and a clean
+ * URL behind it, but it has three failure modes that all have to keep the flow
+ * working: storage blocked (private mode), the bootstrap not having run at all
+ * (so the token is still in the path), and a spent token that must not linger.
+ */
+
+const STORAGE_KEY: string = "oneuptime-sensitive-url-token";
+
+function setPath(pathname: string): void {
+  window.history.replaceState({}, "", pathname);
+}
+
+describe("SensitiveUrlToken.readFromPath", () => {
+  it("reads the token out of a reset-password path", () => {
+    expect(
+      SensitiveUrlToken.readFromPath("/accounts/reset-password/abc-123"),
+    ).toBe("abc-123");
+  });
+
+  it("reads the token out of a verify-email path", () => {
+    expect(
+      SensitiveUrlToken.readFromPath("/accounts/verify-email/abc-123"),
+    ).toBe("abc-123");
+  });
+
+  it("reads the token out of a status page path, with or without a preview prefix", () => {
+    expect(SensitiveUrlToken.readFromPath("/reset-password/abc-123")).toBe(
+      "abc-123",
+    );
+    expect(
+      SensitiveUrlToken.readFromPath(
+        "/status-page/6392f2a1/reset-password/abc-123",
+      ),
+    ).toBe("abc-123");
+  });
+
+  it("returns nothing for the cleaned form of the same route", () => {
+    /*
+     * This is the ordinary case after the bootstrap has run. Returning
+     * "reset-password" here would submit the route name as the token.
+     */
+    expect(SensitiveUrlToken.readFromPath("/accounts/reset-password")).toBe("");
+    expect(SensitiveUrlToken.readFromPath("/reset-password")).toBe("");
+  });
+
+  it("returns nothing for unrelated routes", () => {
+    expect(SensitiveUrlToken.readFromPath("/accounts/login")).toBe("");
+    expect(SensitiveUrlToken.readFromPath("/accounts/forgot-password")).toBe(
+      "",
+    );
+    expect(SensitiveUrlToken.readFromPath("/")).toBe("");
+    expect(SensitiveUrlToken.readFromPath("")).toBe("");
+  });
+
+  it("tolerates a trailing slash", () => {
+    expect(
+      SensitiveUrlToken.readFromPath("/accounts/reset-password/abc-123/"),
+    ).toBe("abc-123");
+  });
+
+  it("percent-decodes the token, and passes a malformed escape through", () => {
+    expect(
+      SensitiveUrlToken.readFromPath("/accounts/reset-password/a%2Bb"),
+    ).toBe("a+b");
+    expect(
+      SensitiveUrlToken.readFromPath("/accounts/reset-password/a%zz"),
+    ).toBe("a%zz");
+  });
+});
+
+describe("SensitiveUrlToken.read", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    delete (window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN__;
+    setPath("/accounts/reset-password");
+  });
+
+  it("prefers the stash the head bootstrap wrote", () => {
+    window.sessionStorage.setItem(STORAGE_KEY, "stashed-token");
+
+    expect(SensitiveUrlToken.read()).toBe("stashed-token");
+  });
+
+  it("falls back to the in-memory handoff when storage is unavailable", () => {
+    (window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN__ = "in-memory-token";
+
+    expect(SensitiveUrlToken.read()).toBe("in-memory-token");
+  });
+
+  it("falls back to the path when the bootstrap did not run", () => {
+    setPath("/accounts/reset-password/path-token");
+
+    expect(SensitiveUrlToken.read()).toBe("path-token");
+  });
+
+  it("returns nothing when there is no token anywhere", () => {
+    expect(SensitiveUrlToken.read()).toBe("");
+  });
+
+  it("prefers the stash over a token still in the path", () => {
+    /*
+     * Both can be present when storage worked but replaceState did not. The
+     * stash is the value the bootstrap actually captured.
+     */
+    setPath("/accounts/reset-password/path-token");
+    window.sessionStorage.setItem(STORAGE_KEY, "stashed-token");
+
+    expect(SensitiveUrlToken.read()).toBe("stashed-token");
+  });
+});
+
+describe("SensitiveUrlToken.clear", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    delete (window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN__;
+    setPath("/accounts/reset-password");
+  });
+
+  it("drops a spent token from both stashes", () => {
+    window.sessionStorage.setItem(STORAGE_KEY, "stashed-token");
+    (window as any).__ONEUPTIME_SENSITIVE_URL_TOKEN__ = "in-memory-token";
+
+    SensitiveUrlToken.clear();
+
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(SensitiveUrlToken.read()).toBe("");
+  });
+
+  it("is safe to call when nothing was stashed", () => {
+    expect(() => {
+      return SensitiveUrlToken.clear();
+    }).not.toThrow();
+  });
+});

--- a/Common/UI/Utils/SensitiveUrlToken.ts
+++ b/Common/UI/Utils/SensitiveUrlToken.ts
@@ -1,0 +1,112 @@
+/*
+ * Client half of the sensitive-URL-token handoff.
+ *
+ * Common/Server/Views/Partials/SensitiveUrlToken.ejs runs in <head>, moves the
+ * bearer token out of the path into sessionStorage and rewrites the address bar
+ * to the token-free route. By the time React mounts, the token is no longer a
+ * route parameter, so pages read it from here instead of from the router.
+ *
+ * Deliberately not routed through Common/UI/Utils/Navigation: this is read
+ * during the reset and verification flows, where the value has to be available
+ * whether or not the bootstrap managed to clean the URL, and Navigation only
+ * ever sees whatever the router was given.
+ *
+ * TOKEN_ROUTES is duplicated in the partial. The two lists have to agree about
+ * which routes carry a token; Common/Tests/App/SensitiveUrlTokenBootstrap.test.ts
+ * asserts that they do.
+ */
+
+const STORAGE_KEY: string = "oneuptime-sensitive-url-token";
+
+/*
+ * Route segments whose NEXT path segment is a single-use bearer token. Matched
+ * against the second-to-last segment, so this covers
+ * /accounts/reset-password/<token>, /reset-password/<token> and
+ * /status-page/<id>/reset-password/<token> alike.
+ */
+const TOKEN_ROUTES: Array<string> = ["reset-password", "verify-email"];
+
+interface HandoffWindow extends Window {
+  __ONEUPTIME_SENSITIVE_URL_TOKEN__?: string | undefined;
+}
+
+export default class SensitiveUrlToken {
+  /*
+   * The token for the current page, or "" when there is none.
+   *
+   * Order matters. sessionStorage is where the bootstrap normally puts it and
+   * is the only source that survives a reload of the cleaned URL. The in-memory
+   * handoff covers blocked storage. The path is the last resort: it only holds
+   * a token when the bootstrap could not run, and reading it keeps the flow
+   * working on the browsers where that happens.
+   */
+  public static read(): string {
+    try {
+      const stored: string | null = window.sessionStorage.getItem(STORAGE_KEY);
+
+      if (stored) {
+        return stored;
+      }
+    } catch {
+      /* Private mode or storage disabled; fall through. */
+    }
+
+    const handedOff: string | undefined = (window as HandoffWindow)
+      .__ONEUPTIME_SENSITIVE_URL_TOKEN__;
+
+    if (handedOff) {
+      return handedOff;
+    }
+
+    return SensitiveUrlToken.readFromPath(window.location.pathname);
+  }
+
+  /*
+   * Pull the token out of a path, if that path is a token-bearing route.
+   * Returns "" for the cleaned form of the same route, which is what the
+   * address bar holds once the bootstrap has run.
+   */
+  public static readFromPath(pathname: string): string {
+    const segments: Array<string> = SensitiveUrlToken.segmentsOf(pathname);
+
+    if (segments.length < 2) {
+      return "";
+    }
+
+    if (!TOKEN_ROUTES.includes(segments[segments.length - 2]!)) {
+      return "";
+    }
+
+    const token: string = segments[segments.length - 1]!;
+
+    try {
+      return decodeURIComponent(token);
+    } catch {
+      // A malformed escape sequence is handed on verbatim.
+      return token;
+    }
+  }
+
+  /*
+   * Drop the stashed token once the flow that needed it has completed.
+   *
+   * Only call this on success. A failed reset (an expired token, a password the
+   * server rejected) has to leave the stash intact, or the retry — and any
+   * reload of the now token-free URL — has nothing to submit.
+   */
+  public static clear(): void {
+    try {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* Nothing was stored, so nothing to remove. */
+    }
+
+    delete (window as HandoffWindow).__ONEUPTIME_SENSITIVE_URL_TOKEN__;
+  }
+
+  private static segmentsOf(pathname: string): Array<string> {
+    return (pathname || "").split("/").filter((segment: string): boolean => {
+      return segment !== "";
+    });
+  }
+}


### PR DESCRIPTION
## The report

An external reporter mailed security@ claiming "Password Reset Link Disclosing To Third-Party Sites". The mail is a templated beg-bounty (Gmail sender, Mailtrack, blasted to security/support/legal/privacy at once) and claims Critical, which it is not. The finding underneath is real, and was verified rather than taken on trust.

## Verified on production

Loading `https://oneuptime.com/accounts/reset-password/<dummy-token>` in a browser and asking the page which outbound requests carried the token:

```
hostsLeakingToken: ["q.quora.com", "alb.reddit.com", "www.google.com",
                    "region1.analytics.google.com", "bat.bing.com"]
```

The token sits in the URL *path*, and the Accounts page loads a full tracker stack through GTM (GA4, Google Ads, Bing, Reddit, Quora, Meta, X, PostHog x2, Apollo, RB2B). All of them report the page URL as routine behaviour, so a bearer credential for the account was landing in ad and analytics dashboards.

`/accounts/verify-email/<token>` and the status page's `/reset-password/<token>` leaked identically.

## Severity

Not Critical — there is no anonymous remote path; exploiting it needs read access to one of those dashboards (a marketing seat, or vendor-side). But it is a live account-takeover primitive sitting in reports a lot of people can read, plus account-recovery tokens being handed to ad networks. Cheap to fix, so the calculus is not close.

## The fix

`Common/Server/Views/Partials/SensitiveUrlToken.ejs` runs first in `<head>`, moves the token into sessionStorage and `replaceState`s the path to the token-free route before the container starts. This is the pattern the status page already used for its single-use login codes, generalised to path tokens and shared between the two apps.

Two deliberate choices:

- **Analytics stays on.** Stripping the token is what makes the page safe to measure, so the signup funnel keeps reporting. No conversion tracking is lost.
- **It fails closed.** The partial re-reads the address bar rather than trusting its own rewrite. If the token is still there, the GTM snippet does not start the container at all. Losing a page view beats leaking a credential.

Pages read the token via `Common/UI/Utils/SensitiveUrlToken`, which prefers the stash and falls back to the path when the bootstrap could not clean it, so the flow works either way. Both forms of each token-bearing route are registered for the same reason. Also drops the token from browser history as a side benefit.

## Tests

- `Common/Tests/App/SensitiveUrlTokenBootstrap.test.ts` — renders both `index.ejs` in jsdom and pins the load-order (bootstrap before every external script), the strip, analytics staying enabled on a cleaned URL, the fail-closed suppression when `replaceState` throws, and the route-list/storage-key parity between the partial and the TS client. These are invisible at runtime when they break — a tag moved above the partial leaks silently — so they are pinned.
- `Common/Tests/UI/Utils/SensitiveUrlToken.test.ts` — the three failure modes of the handoff: blocked storage, bootstrap never ran, spent token.

33 tests pass across the two new suites plus the existing status-page one. The analytics-consent suite (34 tests) still passes. `Common` compiles clean. The bootstrap was additionally confirmed in real Chrome, not just jsdom.

## Not addressed here

The initial GET still carries the token in the path, so it reaches nginx and CDN access logs. Closing that means changing the emailed link format (fragment or POST handoff) with a backward-compatibility window for links already in inboxes — a larger change than this report warrants, and those logs are first-party rather than a third party's.