### PR TITLE
fix(container-agents): detect severity in Monolog and zap log lines

### DIFF
--- a/App/FeatureSet/Docs/Content/da/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/da/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Udover metrikker skraber Docker Agent alle containeres `*-json.log`-filer via Op
 - `resource.container.id` – Det fulde container-ID
 - `resource.container.runtime` – altid `docker`
 - `attributes["log.iostream"]` – `stdout` eller `stderr`
-- `severityText` / `severityNumber` – Afledt fra strømmen: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` – Læses fra et niveau-nøgleord i linjen (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); linjer uden et genkendeligt niveau falder tilbage til strømmen: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` – Den rå loglinje udsendt af containerprocessen
 - `time` – Docker-dæmonens tidsstempel for linjen
 

--- a/App/FeatureSet/Docs/Content/de/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/de/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Zusätzlich zu Metriken liest der Docker Agent die `*-json.log`-Datei jedes Cont
 - `resource.container.id` — die vollständige Container-ID
 - `resource.container.runtime` — immer `docker`
 - `attributes["log.iostream"]` — `stdout` oder `stderr`
-- `severityText` / `severityNumber` — abgeleitet aus dem Stream: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — aus einem Level-Schlüsselwort in der Zeile gelesen (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); Zeilen ohne erkennbares Level greifen auf den Stream zurück: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — die rohe vom Container-Prozess ausgegebene Log-Zeile
 - `time` — der Zeitstempel des Docker-Daemons für die Zeile
 

--- a/App/FeatureSet/Docs/Content/en/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ In addition to metrics, the Docker Agent tails every container's `*-json.log` fi
 - `resource.container.id` — the full container ID
 - `resource.container.runtime` — always `docker`
 - `attributes["log.iostream"]` — `stdout` or `stderr`
-- `severityText` / `severityNumber` — derived from the stream: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — read from a level keyword in the line (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); lines with no recognisable level fall back to the stream: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — the raw log line emitted by the container process
 - `time` — the Docker daemon's timestamp for the line
 

--- a/App/FeatureSet/Docs/Content/en/monitor/podman-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/podman-monitor.md
@@ -155,7 +155,7 @@ In addition to metrics, the Podman Agent tails every container's log file via th
 - `resource.container.id` — the full container ID
 - `resource.container.runtime` — always `podman`
 - `attributes["log.iostream"]` — `stdout` or `stderr`
-- `severityText` / `severityNumber` — derived from the stream: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — read from a level keyword in the line (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); lines with no recognisable level fall back to the stream: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — the raw log line emitted by the container process
 - `time` — the container engine's timestamp for the line
 

--- a/App/FeatureSet/Docs/Content/es/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/es/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Además de las métricas, el Agente Docker rastrea el archivo `*-json.log` de ca
 - `resource.container.id`: el ID completo del contenedor
 - `resource.container.runtime`: siempre `docker`
 - `attributes["log.iostream"]`: `stdout` o `stderr`
-- `severityText` / `severityNumber`: derivado del flujo: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber`: leído de una palabra clave de nivel en la línea (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); las líneas sin un nivel reconocible recurren al flujo: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body`: la línea de registro sin procesar emitida por el proceso del contenedor
 - `time`: la marca de tiempo del daemon Docker para la línea
 

--- a/App/FeatureSet/Docs/Content/fr/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/fr/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ En plus des métriques, l'agent Docker suit le fichier `*-json.log` de chaque co
 - `resource.container.id` — l'identifiant complet du conteneur
 - `resource.container.runtime` — toujours `docker`
 - `attributes["log.iostream"]` — `stdout` ou `stderr`
-- `severityText` / `severityNumber` — dérivés du flux : `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — lus depuis un mot-clé de niveau présent dans la ligne (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`) ; les lignes sans niveau reconnaissable retombent sur le flux : `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — la ligne de journal brute émise par le processus du conteneur
 - `time` — l'horodatage du démon Docker pour la ligne
 

--- a/App/FeatureSet/Docs/Content/hi/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/hi/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Metrics के अलावा, Docker Agent OpenTelemetry filelog receiver क�
 - `resource.container.id` — पूर्ण container ID
 - `resource.container.runtime` — हमेशा `docker`
 - `attributes["log.iostream"]` — `stdout` या `stderr`
-- `severityText` / `severityNumber` — stream से derived: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — लाइन में मौजूद level keyword से पढ़ा जाता है (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); जिन लाइनों में कोई पहचान योग्य level नहीं है वे stream पर fallback करती हैं: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — container process द्वारा emit की गई raw log line
 - `time` — line के लिए Docker daemon का timestamp
 

--- a/App/FeatureSet/Docs/Content/it/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/it/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Oltre alle metriche, l'Agente Docker monitora il file `*-json.log` di ogni conta
 - `resource.container.id` — l'ID completo del container
 - `resource.container.runtime` — sempre `docker`
 - `attributes["log.iostream"]` — `stdout` o `stderr`
-- `severityText` / `severityNumber` — derivati dallo stream: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — letti da una parola chiave di livello nella riga (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); le righe senza un livello riconoscibile ricadono sullo stream: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — la riga di log grezza emessa dal processo del container
 - `time` — il timestamp del daemon Docker per la riga
 

--- a/App/FeatureSet/Docs/Content/ja/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/ja/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ OneUptimeは一般的なDockerモニタリングシナリオのテンプレー�
 - `resource.container.id` — 完全なコンテナID
 - `resource.container.runtime` — 常に `docker`
 - `attributes["log.iostream"]` — `stdout` または `stderr`
-- `severityText` / `severityNumber` — ストリームから導出：`stderr` → `ERROR`、`stdout` → `INFO`
+- `severityText` / `severityNumber` — 行内のレベルキーワードから読み取り（`app.INFO:`、`{"level":"warn"}`、`[ERROR]`）。認識できるレベルがない行はストリームにフォールバック：`stderr` → `ERROR`、`stdout` → `INFO`
 - `body` — コンテナプロセスが出力した生のログ行
 - `time` — Dockerデーモンがその行に記録したタイムスタンプ
 

--- a/App/FeatureSet/Docs/Content/ko/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/ko/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ OneUptime은 일반적인 Docker 모니터링 시나리오에 대한 템플릿�
 - `resource.container.id` — 전체 컨테이너 ID
 - `resource.container.runtime` — 항상 `docker`
 - `attributes["log.iostream"]` — `stdout` 또는 `stderr`
-- `severityText` / `severityNumber` — 스트림에서 파생됨: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — 줄에 있는 레벨 키워드에서 읽음(`app.INFO:`, `{"level":"warn"}`, `[ERROR]`). 인식 가능한 레벨이 없는 줄은 스트림으로 폴백: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — 컨테이너 프로세스에서 내보낸 원시 로그 줄
 - `time` — 해당 줄에 대한 Docker 데몬의 타임스탬프
 

--- a/App/FeatureSet/Docs/Content/nl/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/nl/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Naast metrics volgt de Docker Agent elk containerbestand `*-json.log` via de Ope
 - `resource.container.id` — het volledige container-ID
 - `resource.container.runtime` — altijd `docker`
 - `attributes["log.iostream"]` — `stdout` of `stderr`
-- `severityText` / `severityNumber` — afgeleid van de stream: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — gelezen uit een niveautrefwoord in de regel (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); regels zonder herkenbaar niveau vallen terug op de stream: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — de ruwe logregel die door het containerproces wordt uitgestoten
 - `time` — de tijdstempel van de Docker-daemon voor de regel
 

--- a/App/FeatureSet/Docs/Content/no/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/no/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ I tillegg til metrikker haler Docker-agenten alle containerens `*-json.log`-file
 - `resource.container.id` – den fullstendige container-ID-en
 - `resource.container.runtime` – alltid `docker`
 - `attributes["log.iostream"]` – `stdout` eller `stderr`
-- `severityText` / `severityNumber` – utledet fra strømmen: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` – lest fra et nivånøkkelord i linjen (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); linjer uten et gjenkjennelig nivå faller tilbake til strømmen: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` – den rå logglinjen sendt av containerprosessen
 - `time` – Docker-daemonens tidsstempel for linjen
 

--- a/App/FeatureSet/Docs/Content/pt/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/pt/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Além das métricas, o Agente Docker acompanha o arquivo `*-json.log` de cada co
 - `resource.container.id` — o ID completo do contêiner
 - `resource.container.runtime` — sempre `docker`
 - `attributes["log.iostream"]` — `stdout` ou `stderr`
-- `severityText` / `severityNumber` — derivado do stream: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — lido de uma palavra-chave de nível na linha (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); linhas sem um nível reconhecível recorrem ao stream: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — a linha de log bruta emitida pelo processo do contêiner
 - `time` — o timestamp do daemon Docker para a linha
 

--- a/App/FeatureSet/Docs/Content/ru/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/ru/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ OneUptime предоставляет шаблоны для типовых сце
 - `resource.container.id` — полный идентификатор контейнера
 - `resource.container.runtime` — всегда `docker`
 - `attributes["log.iostream"]` — `stdout` или `stderr`
-- `severityText` / `severityNumber` — определяется по потоку: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` — считывается из ключевого слова уровня в строке (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); строки без распознаваемого уровня используют поток: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` — необработанная строка журнала, выведенная процессом контейнера
 - `time` — временная метка Docker daemon для данной строки
 

--- a/App/FeatureSet/Docs/Content/sv/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/sv/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ Utöver mätvärden läser Docker Agent varje containers `*-json.log`-fil via Op
 - `resource.container.id` – Fullständigt container-ID
 - `resource.container.runtime` – Alltid `docker`
 - `attributes["log.iostream"]` – `stdout` eller `stderr`
-- `severityText` / `severityNumber` – Härledd från strömmen: `stderr` → `ERROR`, `stdout` → `INFO`
+- `severityText` / `severityNumber` – Läses från ett nivånyckelord i raden (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); rader utan en igenkännbar nivå faller tillbaka på strömmen: `stderr` → `ERROR`, `stdout` → `INFO`
 - `body` – Den råa loggraden som containerprocessen skickade ut
 - `time` – Docker-daemonens tidsstämpel för raden
 

--- a/App/FeatureSet/Docs/Content/zh-CN/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/zh-CN/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ OneUptime 为常见的 Docker 监控场景提供模板：
 - `resource.container.id` — 完整的容器 ID
 - `resource.container.runtime` — 始终为 `docker`
 - `attributes["log.iostream"]` — `stdout` 或 `stderr`
-- `severityText` / `severityNumber` — 从流中派生：`stderr` → `ERROR`，`stdout` → `INFO`
+- `severityText` / `severityNumber` — 从行中的级别关键字读取（`app.INFO:`、`{"level":"warn"}`、`[ERROR]`）；没有可识别级别的行回退到流：`stderr` → `ERROR`，`stdout` → `INFO`
 - `body` — 容器进程输出的原始日志行
 - `time` — Docker 守护进程对该行的时间戳
 

--- a/App/FeatureSet/Docs/Content/zh-TW/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/zh-TW/monitor/docker-monitor.md
@@ -154,7 +154,7 @@ OneUptime 為常見的 Docker 監控情境提供範本：
 - `resource.container.id`——完整的容器 ID
 - `resource.container.runtime`——永遠為 `docker`
 - `attributes["log.iostream"]`——`stdout` 或 `stderr`
-- `severityText` / `severityNumber`——由串流推導而來：`stderr` → `ERROR`，`stdout` → `INFO`
+- `severityText` / `severityNumber`——從行中的層級關鍵字讀取（`app.INFO:`、`{"level":"warn"}`、`[ERROR]`）；沒有可辨識層級的行則回退至串流：`stderr` → `ERROR`，`stdout` → `INFO`
 - `body`——容器行程所發出的原始日誌行
 - `time`——Docker daemon 為該行記錄的時間戳記
 

--- a/DockerAgent/README.md
+++ b/DockerAgent/README.md
@@ -70,7 +70,7 @@ docker compose up -d
 
 ## Collected Logs
 
-Container logs are automatically collected from `/var/lib/docker/containers/*/*-json.log` and enriched with container metadata (container id, image, runtime, host name) plus a derived severity — lines written to stderr become `ERROR` and lines written to stdout become `INFO`. Logs are shipped in the native OpenTelemetry log record format, so `severityText`, `severityNumber`, `body`, `attributes`, `traceId`, and `spanId` are all populated.
+Container logs are automatically collected from `/var/lib/docker/containers/*/*-json.log` and enriched with container metadata (container id, image, runtime, host name) plus a derived severity. The severity is read from a level keyword in the line itself (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); only lines with no recognisable level fall back to the stream, where stderr becomes `ERROR` and stdout becomes `INFO`. The keyword scan is a best-effort heuristic — it takes the first level word anywhere in the line, so a message that mentions one in passing can be classified by it. Logs are shipped in the native OpenTelemetry log record format, so `severityText`, `severityNumber`, `body`, `attributes`, `traceId`, and `spanId` are all populated.
 
 ### Log Driver Requirement
 

--- a/DockerAgent/otel-collector-config.yaml
+++ b/DockerAgent/otel-collector-config.yaml
@@ -80,14 +80,21 @@ receivers:
         max_log_size: 1048576
       # Docker's json-file driver does not record a severity; OTel log records
       # have dedicated severity_number / severity_text fields that downstream
-      # viewers rely on for filtering. Derive a best-effort severity from the
-      # stdout/stderr stream: stderr -> ERROR, stdout -> INFO.
-      # First try to read a level keyword out of the body. PSR-3/Monolog
-      # ("app.INFO:") and Go zap ({"level":"info"}) put the keyword next to a
-      # dot or a quote, so a plain word-boundary match misses them and every
-      # such line would fall through to the stream default below and be stamped
-      # ERROR. Route on whether the body carries a recognisable keyword; only
-      # lines without one take the stdout/stderr default.
+      # viewers rely on for filtering. Derive a best-effort severity: read a
+      # level keyword out of the body when there is one, and fall back to the
+      # stdout/stderr stream when there is not.
+      #
+      # The delimiter class has to admit the dot and the double quote, not just
+      # whitespace and brackets: PSR-3/Monolog ("app.INFO:") and Go zap
+      # ({"level":"info"}) write the keyword next to one of those, and a plain
+      # word-boundary match misses both — which is what left every line from
+      # such a service taking the stream default and being stamped ERROR.
+      #
+      # Best-effort really is best-effort. The keyword scan is an unanchored
+      # search over the whole (recombined) body, so it takes the FIRST level
+      # word anywhere in the line — a message that merely mentions one is
+      # classified by it, and a level written as `level=error` is missed
+      # because `=` is not a leading delimiter. Tests/Ops pins both.
       - type: router
         id: severity-router
         routes:

--- a/DockerAgent/otel-collector-config.yaml
+++ b/DockerAgent/otel-collector-config.yaml
@@ -82,19 +82,47 @@ receivers:
       # have dedicated severity_number / severity_text fields that downstream
       # viewers rely on for filtering. Derive a best-effort severity from the
       # stdout/stderr stream: stderr -> ERROR, stdout -> INFO.
+      # First try to read a level keyword out of the body. PSR-3/Monolog
+      # ("app.INFO:") and Go zap ({"level":"info"}) put the keyword next to a
+      # dot or a quote, so a plain word-boundary match misses them and every
+      # such line would fall through to the stream default below and be stamped
+      # ERROR. Route on whether the body carries a recognisable keyword; only
+      # lines without one take the stdout/stderr default.
+      - type: router
+        id: severity-router
+        routes:
+          - output: parse-severity-from-body
+            expr: 'body matches "(?i)(?:^|[\\s.\\[(\"])(TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\\s\\]:=,)\"])"'
+        default: add-fallback-severity
+      - type: regex_parser
+        id: parse-severity-from-body
+        regex: '(?i)(?:^|[\s.\[("])(?P<severity_text>TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\s\]:=,)"])'
+        parse_from: body
+        output: severity-parser
+      # No keyword in the body: fall back to the stream. Docker's json-file
+      # driver records no severity of its own. stderr -> ERROR, stdout -> INFO.
       - type: add
-        id: add-severity-text
+        id: add-fallback-severity
         field: attributes.severity_text
         value: 'EXPR(attributes["log.iostream"] == "stderr" ? "ERROR" : "INFO")'
+        output: severity-parser
       # Promote the textual severity onto the LogRecord itself so OTel log
-      # consumers see a real severity_number (17 for ERROR, 9 for INFO) rather
-      # than Unspecified.
+      # consumers see a real severity_number rather than Unspecified.
       - type: severity_parser
         id: severity-parser
         parse_from: attributes.severity_text
+        preset: default
         mapping:
-          error: ERROR
-          info: INFO
+          warn:
+            - warning
+          error:
+            - err
+            - crit
+            - critical
+          fatal:
+            - panic
+          info:
+            - notice
       # Remove the now-redundant attribute so we don't duplicate the value
       # both as an attribute and as the record's severity field.
       - type: remove

--- a/DockerSwarmAgent/otel-collector-config.yaml
+++ b/DockerSwarmAgent/otel-collector-config.yaml
@@ -54,16 +54,45 @@ receivers:
         source_identifier: attributes["log.file.path"]
         force_flush_period: 5s
         max_log_size: 1048576
+      # First try to read a level keyword out of the body. PSR-3/Monolog
+      # ("app.INFO:") and Go zap ({"level":"info"}) put the keyword next to a
+      # dot or a quote, so a plain word-boundary match misses them and every
+      # such line would fall through to the stream default below and be stamped
+      # ERROR. Route on whether the body carries a recognisable keyword; only
+      # lines without one take the stdout/stderr default.
+      - type: router
+        id: severity-router
+        routes:
+          - output: parse-severity-from-body
+            expr: 'body matches "(?i)(?:^|[\\s.\\[(\"])(TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\\s\\]:=,)\"])"'
+        default: add-fallback-severity
+      - type: regex_parser
+        id: parse-severity-from-body
+        regex: '(?i)(?:^|[\s.\[("])(?P<severity_text>TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\s\]:=,)"])'
+        parse_from: body
+        output: severity-parser
+      # No keyword in the body: fall back to the stream. The json-file driver
+      # records no severity of its own. stderr -> ERROR, stdout -> INFO.
       - type: add
-        id: add-severity-text
+        id: add-fallback-severity
         field: attributes.severity_text
         value: 'EXPR(attributes["log.iostream"] == "stderr" ? "ERROR" : "INFO")'
+        output: severity-parser
       - type: severity_parser
         id: severity-parser
         parse_from: attributes.severity_text
+        preset: default
         mapping:
-          error: ERROR
-          info: INFO
+          warn:
+            - warning
+          error:
+            - err
+            - crit
+            - critical
+          fatal:
+            - panic
+          info:
+            - notice
       - type: remove
         id: remove-severity-attr
         field: attributes.severity_text

--- a/DockerSwarmAgent/otel-collector-config.yaml
+++ b/DockerSwarmAgent/otel-collector-config.yaml
@@ -54,12 +54,21 @@ receivers:
         source_identifier: attributes["log.file.path"]
         force_flush_period: 5s
         max_log_size: 1048576
-      # First try to read a level keyword out of the body. PSR-3/Monolog
-      # ("app.INFO:") and Go zap ({"level":"info"}) put the keyword next to a
-      # dot or a quote, so a plain word-boundary match misses them and every
-      # such line would fall through to the stream default below and be stamped
-      # ERROR. Route on whether the body carries a recognisable keyword; only
-      # lines without one take the stdout/stderr default.
+      # The json-file driver records no severity; derive a best-effort one by
+      # reading a level keyword out of the body, falling back to the
+      # stdout/stderr stream when there is no keyword to read.
+      #
+      # The delimiter class has to admit the dot and the double quote, not just
+      # whitespace and brackets: PSR-3/Monolog ("app.INFO:") and Go zap
+      # ({"level":"info"}) write the keyword next to one of those, and a plain
+      # word-boundary match misses both — which is what left every line from
+      # such a service taking the stream default and being stamped ERROR.
+      #
+      # Best-effort really is best-effort. The keyword scan is an unanchored
+      # search over the whole (recombined) body, so it takes the FIRST level
+      # word anywhere in the line — a message that merely mentions one is
+      # classified by it, and a level written as `level=error` is missed
+      # because `=` is not a leading delimiter. Tests/Ops pins both.
       - type: router
         id: severity-router
         routes:

--- a/PodmanAgent/README.md
+++ b/PodmanAgent/README.md
@@ -72,7 +72,7 @@ These metrics come from the `docker_stats` receiver, which works against Podman'
 
 ## Collected Logs
 
-Container logs are automatically collected from `/var/lib/containers/storage/overlay-containers/*/userdata/ctr.log` (the k8s-file log driver's location) and enriched with container metadata (container id, image, runtime, host name) plus a derived severity — lines written to stderr become `ERROR` and lines written to stdout become `INFO`. Logs are shipped in the native OpenTelemetry log record format, so `severityText`, `severityNumber`, `body`, `attributes`, `traceId`, and `spanId` are all populated.
+Container logs are automatically collected from `/var/lib/containers/storage/overlay-containers/*/userdata/ctr.log` (the k8s-file log driver's location) and enriched with container metadata (container id, image, runtime, host name) plus a derived severity. The severity is read from a level keyword in the line itself (`app.INFO:`, `{"level":"warn"}`, `[ERROR]`); only lines with no recognisable level fall back to the stream, where stderr becomes `ERROR` and stdout becomes `INFO`. The keyword scan is a best-effort heuristic — it takes the first level word anywhere in the line, so a message that mentions one in passing can be classified by it. Logs are shipped in the native OpenTelemetry log record format, so `severityText`, `severityNumber`, `body`, `attributes`, `traceId`, and `spanId` are all populated.
 
 ### Log Driver Requirement
 

--- a/PodmanAgent/otel-collector-config.yaml
+++ b/PodmanAgent/otel-collector-config.yaml
@@ -93,16 +93,23 @@ receivers:
         source_identifier: attributes["log.file.path"]
         force_flush_period: 5s
         max_log_size: 1048576
-      # Podman's log driver does not record a severity; OTel log records
+      # Podman's k8s-file driver does not record a severity; OTel log records
       # have dedicated severity_number / severity_text fields that downstream
-      # viewers rely on for filtering. Derive a best-effort severity from the
-      # stdout/stderr stream: stderr -> ERROR, stdout -> INFO.
-      # First try to read a level keyword out of the body. PSR-3/Monolog
-      # ("app.INFO:") and Go zap ({"level":"info"}) put the keyword next to a
-      # dot or a quote, so a plain word-boundary match misses them and every
-      # such line would fall through to the stream default below and be stamped
-      # ERROR. Route on whether the body carries a recognisable keyword; only
-      # lines without one take the stdout/stderr default.
+      # viewers rely on for filtering. Derive a best-effort severity: read a
+      # level keyword out of the body when there is one, and fall back to the
+      # stdout/stderr stream when there is not.
+      #
+      # The delimiter class has to admit the dot and the double quote, not just
+      # whitespace and brackets: PSR-3/Monolog ("app.INFO:") and Go zap
+      # ({"level":"info"}) write the keyword next to one of those, and a plain
+      # word-boundary match misses both — which is what left every line from
+      # such a service taking the stream default and being stamped ERROR.
+      #
+      # Best-effort really is best-effort. The keyword scan is an unanchored
+      # search over the whole (recombined) body, so it takes the FIRST level
+      # word anywhere in the line — a message that merely mentions one is
+      # classified by it, and a level written as `level=error` is missed
+      # because `=` is not a leading delimiter. Tests/Ops pins both.
       - type: router
         id: severity-router
         routes:
@@ -114,7 +121,7 @@ receivers:
         regex: '(?i)(?:^|[\s.\[("])(?P<severity_text>TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\s\]:=,)"])'
         parse_from: body
         output: severity-parser
-      # No keyword in the body: fall back to the stream. Podman's json-file
+      # No keyword in the body: fall back to the stream. Podman's k8s-file
       # driver records no severity of its own. stderr -> ERROR, stdout -> INFO.
       - type: add
         id: add-fallback-severity

--- a/PodmanAgent/otel-collector-config.yaml
+++ b/PodmanAgent/otel-collector-config.yaml
@@ -97,19 +97,47 @@ receivers:
       # have dedicated severity_number / severity_text fields that downstream
       # viewers rely on for filtering. Derive a best-effort severity from the
       # stdout/stderr stream: stderr -> ERROR, stdout -> INFO.
+      # First try to read a level keyword out of the body. PSR-3/Monolog
+      # ("app.INFO:") and Go zap ({"level":"info"}) put the keyword next to a
+      # dot or a quote, so a plain word-boundary match misses them and every
+      # such line would fall through to the stream default below and be stamped
+      # ERROR. Route on whether the body carries a recognisable keyword; only
+      # lines without one take the stdout/stderr default.
+      - type: router
+        id: severity-router
+        routes:
+          - output: parse-severity-from-body
+            expr: 'body matches "(?i)(?:^|[\\s.\\[(\"])(TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\\s\\]:=,)\"])"'
+        default: add-fallback-severity
+      - type: regex_parser
+        id: parse-severity-from-body
+        regex: '(?i)(?:^|[\s.\[("])(?P<severity_text>TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|ERR|FATAL|CRITICAL|CRIT|PANIC)(?:[\s\]:=,)"])'
+        parse_from: body
+        output: severity-parser
+      # No keyword in the body: fall back to the stream. Podman's json-file
+      # driver records no severity of its own. stderr -> ERROR, stdout -> INFO.
       - type: add
-        id: add-severity-text
+        id: add-fallback-severity
         field: attributes.severity_text
         value: 'EXPR(attributes["log.iostream"] == "stderr" ? "ERROR" : "INFO")'
+        output: severity-parser
       # Promote the textual severity onto the LogRecord itself so OTel log
-      # consumers see a real severity_number (17 for ERROR, 9 for INFO) rather
-      # than Unspecified.
+      # consumers see a real severity_number rather than Unspecified.
       - type: severity_parser
         id: severity-parser
         parse_from: attributes.severity_text
+        preset: default
         mapping:
-          error: ERROR
-          info: INFO
+          warn:
+            - warning
+          error:
+            - err
+            - crit
+            - critical
+          fatal:
+            - panic
+          info:
+            - notice
       # Remove the now-redundant attribute so we don't duplicate the value
       # both as an attribute and as the record's severity field.
       - type: remove

--- a/Tests/Ops/ContainerAgentLogSeverity.test.js
+++ b/Tests/Ops/ContainerAgentLogSeverity.test.js
@@ -1,0 +1,726 @@
+"use strict";
+
+/**
+ * The container agents (DockerAgent, PodmanAgent, DockerSwarmAgent) ship a
+ * baked-in OpenTelemetry Collector config. Container runtimes record no
+ * severity on a log line, so the config has to derive one, and for a long time
+ * it derived it from the stream alone: stderr -> ERROR, stdout -> INFO.
+ *
+ * That is wrong for any service that writes structured logs to stderr, which
+ * PSR-3/Monolog and Go's zap and logrus all do by default. Their entire log
+ * stream — INFO, DEBUG, the lot — arrived stamped ERROR. The chain now reads a
+ * level keyword out of the body first and only falls back to the stream when
+ * there is no keyword to read.
+ *
+ * These tests exist because that chain has no other guard rail. It is YAML
+ * baked into three separate images; nothing compiles it, and `otelcol validate`
+ * only proves each operator is individually well-formed — it will happily
+ * accept a router whose regex has drifted away from the parser's, or a keyword
+ * list that has outgrown the severity mapping. Both of those failure modes are
+ * silent and both make the agent WORSE than the stream-only behaviour it
+ * replaced, so each one gets a test below:
+ *
+ *   1. structure — the operator graph resolves and nothing is unreachable
+ *   2. escaping  — the router's regex and the parser's regex are the same
+ *                  pattern after their two different layers of quoting
+ *   3. coverage  — every keyword the regex can capture resolves to a real OTel
+ *                  severity number (stanza's built-in preset does NOT know
+ *                  notice / crit / critical / panic)
+ *   4. ingest    — every severity number the chain can emit survives
+ *                  OneUptime's ingest as a real LogSeverity, not Unspecified
+ *   5. behaviour — a corpus of real log lines maps to the level a human would
+ *                  read off them, and the lines that merely mention a level
+ *                  word in prose do not
+ *   6. lockstep  — the three agents and the Kubernetes agent's DaemonSet
+ *                  ConfigMap carry one identical chain
+ *
+ * The expectations were cross-checked against the real thing: each config was
+ * run through otelcol-contrib 0.154.0 (the version the images are built FROM)
+ * over a fixture log file, and the severityNumber/severityText this suite
+ * predicts is the severityNumber/severityText the collector emitted.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+
+const {
+  compileRe2AsJs,
+  extractMatchesPattern,
+  indexOperatorsById,
+  oneUptimeLogSeverity,
+  outputTargets,
+  resolveSeverityNumber,
+  severityKeywordsFromRegex,
+  unescapeGoStringLiteral,
+} = require("./Utils/StanzaSeverity.js");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+/** The three agents whose `filelog` receiver carries the severity chain. */
+const AGENTS = ["DockerAgent", "PodmanAgent", "DockerSwarmAgent"];
+
+/**
+ * The Kubernetes agent grew this chain first. It lives in a Helm template, so
+ * it cannot be parsed as YAML wholesale — the block itself is plain YAML and is
+ * lifted out textually below.
+ */
+const KUBERNETES_CONFIGMAP_PATH = path.join(
+  REPO_ROOT,
+  "HelmChart",
+  "Public",
+  "kubernetes-agent",
+  "templates",
+  "configmap-daemonset.yaml",
+);
+
+/** The chain, in the order the operators must appear in the list. */
+const SEVERITY_CHAIN_IDS = [
+  "severity-router",
+  "parse-severity-from-body",
+  "add-fallback-severity",
+  "severity-parser",
+  "remove-severity-attr",
+];
+
+/** The scratch attribute the chain writes and must clean up again. */
+const SCRATCH_ATTRIBUTE = "attributes.severity_text";
+
+function readAgentOperators(agent) {
+  const configPath = path.join(REPO_ROOT, agent, "otel-collector-config.yaml");
+  const config = yaml.load(fs.readFileSync(configPath, "utf8"));
+  const operators = config.receivers.filelog.operators;
+
+  if (!Array.isArray(operators) || operators.length === 0) {
+    throw new Error(`${agent}: receivers.filelog.operators is empty`);
+  }
+
+  return operators;
+}
+
+/**
+ * Lift the severity chain out of the Kubernetes agent's Helm template as text
+ * and parse just that block.
+ *
+ * Deliberately strict: if a `{{ … }}` action ever appears inside the block the
+ * extraction stops and the lockstep test fails loudly, rather than quietly
+ * comparing half a chain.
+ */
+function readKubernetesOperators() {
+  const lines = fs.readFileSync(KUBERNETES_CONFIGMAP_PATH, "utf8").split("\n");
+  const start = lines.findIndex((line, index) => {
+    return (
+      /^\s*- type: router\s*$/.test(line) &&
+      /^\s*id: severity-router\s*$/.test(lines[index + 1] || "")
+    );
+  });
+
+  if (start === -1) {
+    throw new Error(
+      `${KUBERNETES_CONFIGMAP_PATH}: no 'severity-router' operator found`,
+    );
+  }
+
+  const markerIndent = lines[start].length - lines[start].trimStart().length;
+  const block = [];
+
+  for (let index = start; index < lines.length; index++) {
+    const line = lines[index];
+
+    if (line.trim() === "") {
+      continue;
+    }
+
+    if (line.includes("{{")) {
+      break;
+    }
+
+    const indent = line.length - line.trimStart().length;
+
+    if (indent < markerIndent) {
+      break;
+    }
+
+    block.push(line.slice(markerIndent));
+  }
+
+  return severityChain(KUBERNETES_CONFIGMAP_PATH, yaml.load(block.join("\n")));
+}
+
+const AGENT_OPERATORS = new Map(
+  AGENTS.map((agent) => {
+    return [agent, readAgentOperators(agent)];
+  }),
+);
+
+/**
+ * A corpus of log lines as the agents actually see them, with the level a human
+ * reads off each one.
+ *
+ * `keyword` is what the regex is expected to capture, or null when the line
+ * carries no level and must therefore fall through to the stdout/stderr
+ * fallback. Every non-null expectation here was produced by running the real
+ * collector over the same line.
+ */
+const CORPUS = [
+  // PSR-3 / Monolog. The keyword sits after a dot ("app.INFO:"), which a plain
+  // word-boundary or whitespace match misses — this is half the reason the
+  // stream-only behaviour branded whole PHP services ERROR.
+  {
+    body: '[2026-08-31 07:25:04] app.INFO: user logged in {"id":7} []',
+    keyword: "INFO",
+  },
+  {
+    body: "[2026-08-31 07:25:04] request.WARNING: slow response",
+    keyword: "WARNING",
+  },
+  {
+    body: "[2026-08-31 07:25:04] app.ERROR: connection refused",
+    keyword: "ERROR",
+  },
+  { body: "[2026-08-31 07:25:04] doctrine.DEBUG: SELECT 1", keyword: "DEBUG" },
+  {
+    body: "[2026-08-31 07:25:04] php.CRITICAL: out of memory",
+    keyword: "CRITICAL",
+  },
+
+  // Go zap / logrus / slog. The keyword sits between double quotes — the other
+  // half of the reason.
+  {
+    body: '{"level":"info","ts":1756628704.1,"msg":"started"}',
+    keyword: "info",
+  },
+  {
+    body: '{"level":"warn","ts":1756628704.1,"msg":"retrying"}',
+    keyword: "warn",
+  },
+  {
+    body: '{"level":"error","ts":1756628704.1,"msg":"conn refused"}',
+    keyword: "error",
+  },
+  {
+    body: '{"time":"2026-08-31T07:25:04Z","level":"INFO","msg":"ready"}',
+    keyword: "INFO",
+  },
+
+  // Shapes a whitespace/bracket match already handled — kept so the widened
+  // delimiter class cannot regress them.
+  { body: "[ERROR] something bad happened", keyword: "ERROR" },
+  { body: "WARN: disk almost full", keyword: "WARN" },
+  { body: "2026-08-31 07:25:04 INFO starting up", keyword: "INFO" },
+  { body: "[INFO] plugin/reload: Running configuration MD5", keyword: "INFO" },
+  {
+    body: "2026/08/31 07:25:04 [error] 12#12: *1 open() failed",
+    keyword: "error",
+  },
+  { body: "2026-08-31 07:25:04,123 - myapp - INFO - ready", keyword: "INFO" },
+  { body: "07:25:04.123 [main] INFO  c.e.App - started", keyword: "INFO" },
+  { body: "info: Microsoft.Hosting.Lifetime[14]", keyword: "info" },
+
+  // Aliases stanza's built-in preset does NOT know. Each of these is
+  // Unspecified unless the config's own `mapping:` block supplies it.
+  { body: "[NOTICE] configuration reloaded", keyword: "NOTICE" },
+  { body: "[CRIT] disk failing", keyword: "CRIT" },
+  { body: "[PANIC] goroutine died", keyword: "PANIC" },
+
+  // Aliases the built-in preset does know.
+  { body: "[TRACE] entering handler", keyword: "TRACE" },
+  { body: "[ERR] short alias", keyword: "ERR" },
+  { body: "[FATAL] cannot bind port", keyword: "FATAL" },
+
+  // Lines with no level. These must NOT match: the fallback is only correct
+  // because it is reached exactly when there is nothing to read.
+  { body: "Server listening on port 8080", keyword: null },
+  { body: "    at com.example.Foo.bar(Foo.java:42)", keyword: null },
+  { body: "GET https://api.example.com/v1/errors?x=1 200", keyword: null },
+  { body: "there were 3 errors", keyword: null },
+  { body: "informational message", keyword: null },
+  { body: "loaded config from /etc/app/warning.yaml", keyword: null },
+  { body: "service.warning.example.com resolved", keyword: null },
+  // klog's single-letter prefix would need its own letter-to-level mapping.
+  {
+    body: "I0831 07:25:04.123456       1 server.go:100] Serving",
+    keyword: null,
+  },
+  // An ANSI colour escape sits between the delimiter and the keyword, so the
+  // keyword is not seen. Colour-coded stdout falls back to INFO, as before.
+  { body: "\u001b[32mINFO\u001b[0m starting", keyword: null },
+];
+
+/**
+ * The five operators, in chain order, or a hard error naming what is missing.
+ * Loud on purpose: every test below reaches into these, and "cannot read
+ * property 'regex' of undefined" is a bad way to be told the chain is gone.
+ */
+function severityChain(source, operators) {
+  const byId = indexOperatorsById(operators);
+  const missing = SEVERITY_CHAIN_IDS.filter((id) => {
+    return !byId.has(id);
+  });
+
+  if (missing.length > 0) {
+    throw new Error(
+      `${source}: severity chain is missing ${missing.join(", ")}`,
+    );
+  }
+
+  return SEVERITY_CHAIN_IDS.map((id) => {
+    return byId.get(id);
+  });
+}
+
+describe.each(AGENTS)("%s severity operator chain", (agent) => {
+  const operators = AGENT_OPERATORS.get(agent);
+  const byId = indexOperatorsById(operators);
+  const chain = severityChain(agent, operators);
+  const [router, bodyParser, fallback, severityParser, cleanup] = chain;
+
+  test("carries all five severity operators, in order, with the right types", () => {
+    const positions = SEVERITY_CHAIN_IDS.map((id) => {
+      return operators.findIndex((operator) => {
+        return operator.id === id;
+      });
+    });
+
+    expect(positions).toEqual(
+      [...positions].sort((a, b) => {
+        return a - b;
+      }),
+    );
+
+    expect(router.type).toBe("router");
+    expect(bodyParser.type).toBe("regex_parser");
+    expect(fallback.type).toBe("add");
+    expect(severityParser.type).toBe("severity_parser");
+    expect(cleanup.type).toBe("remove");
+  });
+
+  test("every operator output names an operator that exists", () => {
+    for (const operator of operators) {
+      for (const target of outputTargets(operator)) {
+        expect(byId.has(target)).toBe(true);
+      }
+    }
+  });
+
+  /*
+   * A stanza router has no implicit fall-through: an entry that matches no
+   * route and has no `default` is dropped on the floor. Without `default` here,
+   * every log line WITHOUT a level keyword — the majority of container output —
+   * would silently vanish. That is log loss, not a mislabelled severity, so it
+   * gets its own assertion.
+   */
+  test("the router sends keyword-less lines to the stream fallback rather than dropping them", () => {
+    expect(router.default).toBe("add-fallback-severity");
+    expect(router.routes).toHaveLength(1);
+    expect(router.routes[0].output).toBe("parse-severity-from-body");
+  });
+
+  /*
+   * Both branches have to converge on the severity parser, and the scratch
+   * attribute has to be removed on both. If the cleanup were reachable from
+   * only one branch, half the records would ship a stray `severity_text`
+   * attribute that duplicates the record's own severity field.
+   */
+  test("both branches converge on the severity parser and then the cleanup", () => {
+    expect(bodyParser.output).toBe("severity-parser");
+    expect(fallback.output).toBe("severity-parser");
+
+    // severity-parser has no explicit output, so it flows to the next operator
+    // in the list — which must be the cleanup.
+    expect(severityParser.output).toBeUndefined();
+
+    const severityParserIndex = operators.findIndex((operator) => {
+      return operator.id === "severity-parser";
+    });
+
+    expect(operators[severityParserIndex + 1].id).toBe("remove-severity-attr");
+    expect(cleanup.field).toBe(SCRATCH_ATTRIBUTE);
+    expect(severityParser.parse_from).toBe(SCRATCH_ATTRIBUTE);
+    expect(fallback.field).toBe(SCRATCH_ATTRIBUTE);
+  });
+
+  /*
+   * The fallback reads attributes["log.iostream"]. That attribute is not set by
+   * the receiver — an earlier `move` puts it there from the runtime's own
+   * stream field. If the chain were ever reordered above that move, the
+   * expression would compare undefined against "stderr" and quietly stamp every
+   * record INFO, including the genuine errors.
+   */
+  test("log.iostream is populated before the fallback reads it", () => {
+    const moveIndex = operators.findIndex((operator) => {
+      return (
+        operator.type === "move" &&
+        operator.from === "attributes.stream" &&
+        operator.to === 'attributes["log.iostream"]'
+      );
+    });
+
+    expect(moveIndex).toBeGreaterThanOrEqual(0);
+
+    const fallbackIndex = operators.findIndex((operator) => {
+      return operator.id === "add-fallback-severity";
+    });
+
+    expect(moveIndex).toBeLessThan(fallbackIndex);
+    expect(fallback.value).toBe(
+      'EXPR(attributes["log.iostream"] == "stderr" ? "ERROR" : "INFO")',
+    );
+  });
+
+  /*
+   * `body matches …` errors at runtime if body is not a string, and the router
+   * then falls through to its default — every keyword-carrying line would take
+   * the stream fallback and the fix would be a no-op. An earlier `move … to:
+   * body` is what guarantees body is the log text and not the parsed envelope.
+   */
+  test("body holds the log text by the time the router matches on it", () => {
+    const moveIndex = operators.findIndex((operator) => {
+      return operator.type === "move" && operator.to === "body";
+    });
+
+    expect(moveIndex).toBeGreaterThanOrEqual(0);
+
+    const routerIndex = operators.findIndex((operator) => {
+      return operator.id === "severity-router";
+    });
+
+    expect(moveIndex).toBeLessThan(routerIndex);
+  });
+
+  /*
+   * THE ESCAPING TEST.
+   *
+   * The router's pattern is a regex inside an expr-lang string literal inside a
+   * YAML scalar, so it is written with doubled backslashes and escaped quotes;
+   * the parser's pattern is a bare YAML scalar written with single backslashes.
+   * They are different bytes on disk that must become the same RE2 pattern, and
+   * nothing in the collector notices when they stop agreeing — the router would
+   * admit lines the parser cannot parse (leaving them Unspecified) or reject
+   * lines that carry a level (undoing the fix entirely).
+   */
+  test("the router's regex and the parser's regex are the same pattern", () => {
+    const routerPattern = extractMatchesPattern(router.routes[0].expr);
+    const parserPattern = bodyParser.regex;
+
+    expect(routerPattern).toBe(
+      parserPattern.replace("(?P<severity_text>", "("),
+    );
+  });
+
+  test("the parser reads the body and writes the attribute the severity parser reads", () => {
+    expect(bodyParser.parse_from).toBe("body");
+    expect(severityKeywordsFromRegex(bodyParser.regex).length).toBeGreaterThan(
+      0,
+    );
+    // parse_to is left at its default (`attributes`), which MERGES the capture
+    // into the existing attribute map rather than replacing it — verified
+    // against otelcol-contrib 0.154.0, where log.iostream and log.file.path
+    // both survive this operator.
+    expect(bodyParser.parse_to).toBeUndefined();
+  });
+
+  /*
+   * THE COVERAGE TEST.
+   *
+   * stanza's built-in `default` preset knows trace/debug/info/warn/warning/
+   * error/err/fatal and nothing else — no notice, no crit, no critical, no
+   * panic. A keyword the regex captures but the mapping cannot resolve does not
+   * error and does not drop the record: severity_parser leaves it Unspecified,
+   * which is strictly worse than the stderr->ERROR guess it replaced. So the
+   * keyword list and the mapping have to stay in step, and this is the test
+   * that makes adding a keyword without a mapping fail.
+   */
+  test("every keyword the regex can capture resolves to a real severity number", () => {
+    const unresolved = severityKeywordsFromRegex(bodyParser.regex).filter(
+      (keyword) => {
+        return resolveSeverityNumber(keyword, severityParser) === 0;
+      },
+    );
+
+    expect(unresolved).toEqual([]);
+  });
+
+  /*
+   * The same list, one layer further down: OneUptime's ingest discards the
+   * severityText a client sends and re-derives it from severityNumber
+   * (OtelLogsIngestService.getSeverityText), bucketing 1-4/5-8/9-12/13-16/
+   * 17-20/21-24 onto the seven LogSeverity members. A number outside those
+   * ranges lands on "Unspecified" and the Logs page cannot filter it.
+   */
+  test("every severity the chain can emit survives OneUptime ingest as a real level", () => {
+    const severities = severityKeywordsFromRegex(bodyParser.regex).map(
+      (keyword) => {
+        return oneUptimeLogSeverity(
+          resolveSeverityNumber(keyword, severityParser),
+        );
+      },
+    );
+
+    expect(severities).not.toContain("Unspecified");
+    // And the fallback's own two values, which never go through the regex.
+    expect(
+      oneUptimeLogSeverity(resolveSeverityNumber("ERROR", severityParser)),
+    ).toBe("Error");
+    expect(
+      oneUptimeLogSeverity(resolveSeverityNumber("INFO", severityParser)),
+    ).toBe("Information");
+  });
+
+  test("the aliases the built-in preset does not know are supplied by the config", () => {
+    // Named explicitly rather than derived, so dropping one of them from the
+    // mapping fails here with the alias in the message.
+    expect(resolveSeverityNumber("notice", severityParser)).toBe(9);
+    expect(resolveSeverityNumber("crit", severityParser)).toBe(17);
+    expect(resolveSeverityNumber("critical", severityParser)).toBe(17);
+    expect(resolveSeverityNumber("panic", severityParser)).toBe(21);
+  });
+
+  test("matching is case-insensitive, as stanza lower-cases before lookup", () => {
+    for (const text of ["ERROR", "error", "Error", "eRRoR"]) {
+      expect(resolveSeverityNumber(text, severityParser)).toBe(17);
+    }
+  });
+
+  describe("reads the level a human would read off the line", () => {
+    const regex = compileRe2AsJs(bodyParser.regex);
+
+    test.each(
+      CORPUS.map((entry) => {
+        return [entry.body, entry.keyword];
+      }),
+    )("%s -> %s", (body, keyword) => {
+      const match = regex.exec(body);
+
+      if (keyword === null) {
+        expect(match).toBeNull();
+        return;
+      }
+
+      expect(match).not.toBeNull();
+      expect(match.groups.severity_text).toBe(keyword);
+    });
+
+    test("the levels it reads carry the severity numbers OTel defines", () => {
+      const expected = {
+        "[TRACE] x": 1,
+        "[DEBUG] x": 5,
+        "[INFO] x": 9,
+        "[NOTICE] x": 9,
+        "[WARN] x": 13,
+        "[WARNING] x": 13,
+        "[ERROR] x": 17,
+        "[ERR] x": 17,
+        "[CRIT] x": 17,
+        "[CRITICAL] x": 17,
+        "[FATAL] x": 21,
+        "[PANIC] x": 21,
+      };
+
+      for (const [body, severityNumber] of Object.entries(expected)) {
+        const match = regex.exec(body);
+
+        expect(match).not.toBeNull();
+        expect(
+          resolveSeverityNumber(match.groups.severity_text, severityParser),
+        ).toBe(severityNumber);
+      }
+    });
+
+    /*
+     * The alternation lists WARN before WARNING and ERR before ERROR. Both RE2
+     * and JS take the leftmost match and, within it, the first alternative that
+     * lets the whole pattern succeed — so "[WARNING]" captures WARNING (WARN
+     * fails because "I" is not a closing delimiter), not a truncated WARN.
+     * Getting this wrong would still resolve to the right severity here, but it
+     * would matter the moment an alias maps somewhere the prefix does not.
+     */
+    test("a longer keyword is not truncated to the shorter alternative before it", () => {
+      expect(regex.exec("[WARNING] x").groups.severity_text).toBe("WARNING");
+      expect(regex.exec("[ERROR] x").groups.severity_text).toBe("ERROR");
+      expect(regex.exec("[CRITICAL] x").groups.severity_text).toBe("CRITICAL");
+    });
+
+    /*
+     * The pattern takes the LEFTMOST match, so a line whose message mentions a
+     * level word before the real level field is read wrong. Pinned rather than
+     * fixed: the alternative is parsing every line as JSON, and this shape is
+     * rare next to the Monolog/zap shapes the chain does get right. If someone
+     * later teaches the chain to prefer a `"level":` key, this test is the one
+     * that should change.
+     */
+    test("known limitation: the leftmost level word wins, even inside the message", () => {
+      expect(
+        regex.exec('{"msg":"error, retrying","level":"info"}').groups
+          .severity_text,
+      ).toBe("error");
+
+      // The Monolog shape puts the level first, so the same message is fine.
+      expect(
+        regex.exec("[2026-08-31 07:25:04] app.INFO: error, retrying").groups
+          .severity_text,
+      ).toBe("INFO");
+    });
+
+    /*
+     * The pattern requires a delimiter AFTER the keyword, so a body that ENDS
+     * on the level matches only when something follows it. Docker's json-file
+     * driver keeps the trailing newline in the `log` field, so Docker and Swarm
+     * bodies match; Podman's k8s-file (CRI) format does not, so the same line
+     * from Podman falls back to the stream. Pinned so the divergence is a known
+     * quantity rather than a surprise.
+     */
+    test("known limitation: a body ending on the keyword needs a trailing delimiter", () => {
+      expect(regex.exec("log level is set to WARN")).toBeNull();
+      expect(
+        regex.exec("log level is set to WARN\n").groups.severity_text,
+      ).toBe("WARN");
+    });
+
+    /*
+     * CHARACTERIZATION, NOT APPROVAL.
+     *
+     * Everything below is a line the chain gets WRONG. None of it is a bug in
+     * the operator graph — the graph does exactly what it says — it is the
+     * price of deciding severity by scanning for a keyword, and it is worth
+     * writing down because the price is not free and the PR that introduced
+     * this chain described only the upside.
+     *
+     * Two directions of damage, both reproduced against otelcol-contrib
+     * 0.154.0:
+     *
+     *   ESCALATION  a benign stdout line that mentions a level word in prose
+     *               used to be Information and is now Error or Fatal;
+     *   INVERSION   a genuine stderr ERROR whose message happens to contain an
+     *               earlier level word used to be Error and is now Information
+     *               — a real error hidden, which is the worse of the two.
+     *
+     * The inversion is sharpest for logfmt (`level=error msg="…"`), because
+     * `=` is in the pattern's TRAILING delimiter class but not its leading one:
+     * the real `level=` token can never be captured, while a level word later
+     * in the message can. That is the whole Go/CNCF ecosystem — Grafana,
+     * Traefik, Prometheus, Loki, the Docker daemon, the HashiCorp tools.
+     *
+     * Fixing it properly means making the scan field-aware, or at minimum
+     * adding `=` to the leading class, in all four copies of the chain at
+     * once. Until that happens these tests are the record of what is
+     * happening, and the day someone changes them should be a deliberate one.
+     */
+    describe("characterization: what the keyword scan gets wrong", () => {
+      const severityOf = (body) => {
+        const match = regex.exec(body);
+
+        return match
+          ? oneUptimeLogSeverity(
+              resolveSeverityNumber(match.groups.severity_text, severityParser),
+            )
+          : null;
+      };
+
+      test("escalates benign stdout prose that used to be Information", () => {
+        // A success envelope. Every OK response in this service is now Error.
+        expect(severityOf('{"status":"ok","error":null,"took_ms":12}\n')).toBe(
+          "Error",
+        );
+        // logrus WithError(err).Info(...) — logged AT info, stored as Error.
+        expect(
+          severityOf('{"error":"conn refused","level":"info","msg":"retry"}\n'),
+        ).toBe("Error");
+        // And the worst of them: a recovery notice stored in the top bucket.
+        expect(severityOf("Recovered from panic, continuing\n")).toBe("Fatal");
+        expect(severityOf("Connection error, retrying in 5s\n")).toBe("Error");
+      });
+
+      test("inverts a real stderr error into Information when the message mentions a level first", () => {
+        // logfmt: the real level is `error`, but `=` is not a leading
+        // delimiter, so `level=error` is invisible and ` info,` wins.
+        expect(
+          severityOf(
+            'level=error msg="upstream returned info, aborting" component=proxy\n',
+          ),
+        ).toBe("Information");
+      });
+
+      test("cannot see a logfmt level at all, because `=` is only a trailing delimiter", () => {
+        expect(regex.exec("level=info msg=ready\n")).toBeNull();
+        expect(regex.exec("level=error msg=boom\n")).toBeNull();
+        // The very same keyword IS seen when quoted, which is what proves the
+        // leading class — not the keyword list — is what excludes logfmt.
+        expect(
+          regex.exec('level="error" msg=boom\n').groups.severity_text,
+        ).toBe("error");
+      });
+
+      test("misses the two most severe PSR-3 levels, which the commit set out to support", () => {
+        // Monolog defines eight levels; the alternation carries six. ALERT and
+        // EMERGENCY — the two above CRITICAL — fall back to the stream, so on
+        // stdout a site-is-down line is stored as Information.
+        expect(
+          regex.exec("[2026-08-31 07:25:04] app.EMERGENCY: site down\n"),
+        ).toBeNull();
+        expect(
+          regex.exec("[2026-08-31 07:25:04] app.ALERT: replica lag\n"),
+        ).toBeNull();
+        // nginx writes the same level as [emerg], and misses for the same reason.
+        expect(
+          regex.exec("2026/08/31 [emerg] 1#1: bind() failed\n"),
+        ).toBeNull();
+      });
+    });
+  });
+});
+
+describe("the severity chain is identical everywhere it ships", () => {
+  /*
+   * Three agent images and a Helm ConfigMap carry this chain. They were written
+   * as copies of one another, and a fix applied to one of them and not the rest
+   * is the obvious way for them to rot. Comparing the parsed operators (not the
+   * text) means comments and indentation are free to differ per file while the
+   * behaviour cannot.
+   */
+  const reference = severityChain(
+    "DockerAgent",
+    AGENT_OPERATORS.get("DockerAgent"),
+  );
+
+  test.each(AGENTS.slice(1))("%s matches DockerAgent", (agent) => {
+    expect(severityChain(agent, AGENT_OPERATORS.get(agent))).toEqual(reference);
+  });
+
+  test("the Kubernetes agent DaemonSet ConfigMap matches too", () => {
+    expect(readKubernetesOperators()).toEqual(reference);
+  });
+});
+
+describe("Go string-literal unescaping", () => {
+  /*
+   * The escaping test above is only worth anything if this helper is right, so
+   * it gets its own cases — including the one that actually appears in the
+   * config, where a doubled backslash and an escaped quote sit inside the same
+   * character class.
+   */
+  test("collapses doubled backslashes and escaped quotes", () => {
+    expect(unescapeGoStringLiteral('[\\\\s.\\\\[(\\")]')).toBe('[\\s.\\[(")]');
+    expect(unescapeGoStringLiteral("\\\\d+")).toBe("\\d+");
+    expect(unescapeGoStringLiteral('say \\"hi\\"')).toBe('say "hi"');
+  });
+
+  /*
+   * The failure this catches: writing the router's pattern with the parser's
+   * single-backslash escaping. `\s` is not a Go escape, so expr-lang rejects it
+   * and the collector refuses to start — but a lenient unescaper would quietly
+   * hand back `\s` and make the two patterns compare EQUAL, reporting agreement
+   * on a config that cannot boot.
+   */
+  test("rejects an escape Go has no meaning for, as expr-lang does", () => {
+    expect(() => {
+      return unescapeGoStringLiteral('[\\s.\\[(")]');
+    }).toThrow(/invalid char escape/);
+  });
+
+  test("rejects an expr that is not a plain `body matches` test", () => {
+    expect(() => {
+      return extractMatchesPattern('attributes.foo == "bar"');
+    }).toThrow(/body matches/);
+  });
+});

--- a/Tests/Ops/README.md
+++ b/Tests/Ops/README.md
@@ -79,6 +79,75 @@ refer to — the coherence that was previously missing, when `backup.sh` wrote
 Both scripts are also checked with `bash -n`, and with `shellcheck` when it is
 on PATH (skipped, not failed, when it is not).
 
+### `ContainerAgentLogSeverity.test.js`
+
+Container runtimes record no severity on a log line, so `DockerAgent`,
+`PodmanAgent` and `DockerSwarmAgent` derive one in their baked-in collector
+config. That used to be the stream alone (`stderr -> ERROR, stdout -> INFO`),
+which brands the entire output of any service that logs structured lines to
+stderr — PSR-3/Monolog and Go zap/logrus both do by default — as ERROR. The
+config now reads a level keyword out of the body first and keeps the stream
+mapping as the fallback.
+
+The chain is five stanza operators of YAML, duplicated across three agent images
+**and** the Kubernetes agent's DaemonSet ConfigMap
+(`HelmChart/Public/kubernetes-agent/templates/configmap-daemonset.yaml`).
+Nothing compiles it. `otelcol validate` only proves each operator is
+individually well-formed, so the two failure modes that matter are both silent
+and both leave the agent worse than the stream-only behaviour it replaced:
+
+- **The router's regex and the parser's regex drift apart.** They are the same
+  pattern written with two different amounts of escaping — the router's lives
+  inside an expr-lang string literal (`\\s`), the parser's is a bare YAML
+  scalar (`\s`). The suite decodes the router's the way expr-lang does and
+  asserts the two are identical. The decode is deliberately strict about unknown
+  escapes, because `\s` in a Go string literal is not "backslash-s", it is a
+  config the collector refuses to start on.
+- **A keyword the regex captures has no severity mapping.** stanza's built-in
+  `default` preset knows trace/debug/info/warn/warning/error/err/fatal and
+  nothing else — `notice`, `crit`, `critical` and `panic` are supplied by the
+  config's own `mapping:` block. A keyword without one does not error and does
+  not drop the record: `severity_parser` leaves it **Unspecified**. So the suite
+  walks every alternative in the regex and asserts each resolves to a real OTel
+  severity number, and then that each survives OneUptime's ingest
+  (`OtelLogsIngestService.getSeverityText`, which re-derives severityText from
+  severityNumber) as a real `LogSeverity` rather than Unspecified.
+
+On top of that it pins the operator graph (nothing unreachable, `log.iostream`
+populated before the fallback reads it, both branches converging on the severity
+parser and then the cleanup), runs the real regex over a corpus of Monolog, zap,
+nginx, logback, Python, .NET and klog lines, and holds the three agents and the
+Kubernetes ConfigMap to one identical chain.
+
+The expectations are not guesses: each config was run through the real
+`otelcol-contrib` 0.154.0 — the version the images are built `FROM` — over a
+fixture log file, and the severity this suite predicts is the severity the
+collector emitted.
+
+The last block, **`characterization: what the keyword scan gets wrong`**, is not
+a list of things the suite approves of. Deciding severity by scanning for a
+keyword has a price, and these tests are the record of it:
+
+- **Escalation.** A benign stdout line that mentions a level word in prose used
+  to be `Information` and is now `Error`, or `Fatal`. `{"status":"ok","error":null}`
+  → Error. `Recovered from panic, continuing` → Fatal.
+- **Inversion.** A genuine stderr error whose message contains an earlier level
+  word used to be `Error` and is now `Information` — a real error hidden, which
+  is the worse of the two.
+- **logfmt is invisible.** `=` is in the pattern's _trailing_ delimiter class
+  but not its leading one, so `level=error` can never be captured while a level
+  word later in the same message can. That is Grafana, Traefik, Prometheus,
+  Loki, the Docker daemon and the HashiCorp tools.
+- **PSR-3 `ALERT` and `EMERGENCY` are missing** from the keyword list, so
+  Monolog's two most severe levels fall back to the stream.
+
+Fixing those means making the scan field-aware — or at minimum adding `=` to the
+leading class — in all four copies of the chain at once. Until then these tests
+say what is actually happening, and changing them should be a deliberate act.
+Two smaller limitations are pinned the same way: the **leftmost** level word
+wins, and a body ending on the keyword needs a trailing delimiter (Docker keeps
+the newline in the log field, Podman's CRI format does not).
+
 ## Utils
 
 `Utils/Xml.js` is a small strict XML parser. The repo root has no XML parser

--- a/Tests/Ops/Utils/StanzaSeverity.js
+++ b/Tests/Ops/Utils/StanzaSeverity.js
@@ -1,0 +1,358 @@
+"use strict";
+
+/**
+ * Helpers for reading the log-severity operator chain out of an agent's
+ * OpenTelemetry Collector config and reasoning about it the way the collector
+ * does.
+ *
+ * The three container agents (DockerAgent, PodmanAgent, DockerSwarmAgent) and
+ * the Kubernetes agent's DaemonSet ConfigMap all carry the SAME five-operator
+ * chain inside `receivers.filelog.operators`:
+ *
+ *   router(severity-router)                 body has a level keyword?
+ *     -> regex_parser(parse-severity-from-body)   yes: lift it out of the body
+ *     -> add(add-fallback-severity)               no:  stderr -> ERROR, else INFO
+ *   both -> severity_parser(severity-parser)  text -> LogRecord severity number
+ *        -> remove(remove-severity-attr)      drop the scratch attribute
+ *
+ * Everything in here is derived from opentelemetry-collector-contrib v0.154.0,
+ * which is the collector the three agent images are built FROM (see
+ * DockerAgent/Dockerfile.tpl: `FROM otel/opentelemetry-collector-contrib:0.154.0`).
+ */
+
+const OTEL_COLLECTOR_VERSION = "0.154.0";
+
+/**
+ * The OTel severity numbers, from the logs data model.
+ * https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+ */
+const SEVERITY_NUMBER = {
+  trace: 1,
+  trace2: 2,
+  trace3: 3,
+  trace4: 4,
+  debug: 5,
+  debug2: 6,
+  debug3: 7,
+  debug4: 8,
+  info: 9,
+  info2: 10,
+  info3: 11,
+  info4: 12,
+  warn: 13,
+  warn2: 14,
+  warn3: 15,
+  warn4: 16,
+  error: 17,
+  error2: 18,
+  error3: 19,
+  error4: 20,
+  fatal: 21,
+  fatal2: 22,
+  fatal3: 23,
+  fatal4: 24,
+};
+
+/**
+ * stanza's BUILT-IN `default` severity preset, transcribed from
+ * pkg/stanza/operator/helper/severity_builder.go @ v0.154.0 (`getBuiltinMapping`).
+ *
+ * The "default" branch of that switch is `aliases` PLUS four warning aliases and
+ * four err aliases:
+ *
+ *     default:
+ *         mapping := getBuiltinMapping("aliases")
+ *         mapping.add(entry.Warn, "warning")   ... "warning2".."warning4"
+ *         mapping.add(entry.Error, "err")      ... "err2".."err4"
+ *
+ * and `aliases` is trace/trace2../fatal4 plus the numeric strings "1".."24".
+ *
+ * The point of transcribing it here rather than hand-waving it: WHAT IS NOT IN
+ * THIS TABLE is what the agent configs have to supply themselves. `notice`,
+ * `crit`, `critical` and `panic` are all absent, so a log line carrying one of
+ * those keywords resolves to NO severity number at all — severity_parser leaves
+ * the record Unspecified — unless the config's own `mapping:` block adds it.
+ * That is the invariant `every keyword the regex can capture resolves to a real
+ * severity` in ContainerAgentLogSeverity.test.js exists to hold.
+ *
+ * Verified against the real binary: running otelcol-contrib 0.154.0 with the
+ * agent config minus its `mapping:` block emits severityNumber for
+ * TRACE/DEBUG/INFO/WARN/WARNING/ERROR/ERR/FATAL and *no* severityNumber for
+ * NOTICE/CRIT/CRITICAL/PANIC.
+ */
+function buildBuiltinDefaultPreset() {
+  const mapping = {};
+
+  for (const [level, number] of Object.entries(SEVERITY_NUMBER)) {
+    mapping[level] = number;
+    mapping[String(number)] = number;
+  }
+
+  // The four extra warn aliases and four extra err aliases the "default" preset
+  // layers on top of "aliases".
+  for (const suffix of ["", "2", "3", "4"]) {
+    mapping[`warning${suffix}`] = SEVERITY_NUMBER[`warn${suffix}`];
+    mapping[`err${suffix}`] = SEVERITY_NUMBER[`error${suffix}`];
+  }
+
+  return mapping;
+}
+
+/**
+ * Resolve a severity keyword the way stanza's severity_parser does: lower-case
+ * the incoming text (parseableValues() calls strings.ToLower), then look it up
+ * in (built-in preset ∪ the operator's own `mapping:` block).
+ *
+ * Returns the OTel severity number, or 0 for "no match" — which is what the
+ * collector actually emits in that case: the record keeps severityNumber
+ * Unspecified rather than being dropped.
+ */
+function resolveSeverityNumber(text, severityParserOperator) {
+  const table = buildBuiltinDefaultPreset();
+
+  // `mapping:` is keyed by the TARGET level, valued by the source strings that
+  // should land on it — the inverse of the lookup direction, so invert it here.
+  const configured = severityParserOperator.mapping || {};
+
+  for (const [level, sources] of Object.entries(configured)) {
+    const number = SEVERITY_NUMBER[String(level).toLowerCase()];
+
+    if (number === undefined) {
+      throw new Error(
+        `severity_parser mapping targets an unknown level "${level}"`,
+      );
+    }
+
+    for (const source of Array.isArray(sources) ? sources : [sources]) {
+      table[String(source).toLowerCase()] = number;
+    }
+  }
+
+  return table[String(text).trim().toLowerCase()] || 0;
+}
+
+/**
+ * OneUptime's ingest throws away whatever severityText a client sent and
+ * re-derives it from severityNumber — see OtelLogsIngestService.getSeverityText,
+ * which buckets 1-4/5-8/9-12/13-16/17-20/21-24 onto the seven LogSeverity enum
+ * members. Mirrored here so the tests can assert that every severity these
+ * agents can emit survives ingest as a real level rather than "Unspecified".
+ */
+function oneUptimeLogSeverity(severityNumber) {
+  if (severityNumber >= 1 && severityNumber <= 4) {
+    return "Trace";
+  }
+  if (severityNumber >= 5 && severityNumber <= 8) {
+    return "Debug";
+  }
+  if (severityNumber >= 9 && severityNumber <= 12) {
+    return "Information";
+  }
+  if (severityNumber >= 13 && severityNumber <= 16) {
+    return "Warning";
+  }
+  if (severityNumber >= 17 && severityNumber <= 20) {
+    return "Error";
+  }
+  if (severityNumber >= 21 && severityNumber <= 24) {
+    return "Fatal";
+  }
+  return "Unspecified";
+}
+
+/**
+ * Undo one layer of Go-style double-quoted string escaping.
+ *
+ * This is the step that makes the router's `expr` and the regex_parser's
+ * `regex` two DIFFERENT strings on disk that must nevertheless compile to the
+ * SAME pattern. The router's regex is written inside a string literal inside an
+ * expr-lang expression, so it is escaped twice on the way in:
+ *
+ *   YAML single-quoted scalar   'body matches "...[\\s.\\[(\"]..."'
+ *     -> YAML gives expr-lang    body matches "...[\\s.\\[(\"]..."
+ *     -> expr-lang gives RE2     ...[\s.\[("]...
+ *
+ * while the regex_parser's `regex:` is a plain YAML scalar and reaches RE2 with
+ * only one layer removed. Get the doubling wrong in either direction and the
+ * two stop agreeing: the router would admit lines the parser cannot parse, or
+ * reject lines that carry a level. Nothing in the collector cross-checks them —
+ * `otelcol validate` compiles each in isolation and is happy — so the check has
+ * to live in a test.
+ *
+ * expr-lang lexes double-quoted literals with Go's escape set, so this is
+ * STRICT about unknown escapes rather than passing them through. That is not
+ * pedantry: a pattern written with one backslash too few (`[\s...` where the
+ * literal needs `[\\s...`) reads as the escape `\s`, which Go has no meaning
+ * for, and the collector refuses to start with
+ *
+ *     failed to compile expression …: invalid char escape (1:26)
+ *
+ * Passing it through instead would make the two patterns compare equal and this
+ * helper would report agreement on a config that cannot boot.
+ */
+const GO_STRING_ESCAPES = {
+  a: "\u0007",
+  b: "\b",
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+  v: "\v",
+  "\\": "\\",
+  "'": "'",
+  '"': '"',
+};
+
+function unescapeGoStringLiteral(literal) {
+  let out = "";
+
+  for (let index = 0; index < literal.length; index++) {
+    const char = literal[index];
+
+    if (char !== "\\") {
+      out += char;
+      continue;
+    }
+
+    const next = literal[index + 1];
+    const replacement = GO_STRING_ESCAPES[next];
+
+    if (replacement === undefined) {
+      throw new Error(
+        `invalid char escape \\${next === undefined ? "<end of string>" : next} at offset ${index}: ${literal}`,
+      );
+    }
+
+    out += replacement;
+    index++;
+  }
+
+  return out;
+}
+
+/**
+ * Pull the RE2 pattern out of an expr-lang expression of the form
+ *   body matches "<pattern>"
+ * returning the pattern with expr-lang's string escaping already removed.
+ */
+function extractMatchesPattern(expression) {
+  const match = /^body matches "(.*)"$/s.exec(String(expression).trim());
+
+  if (!match) {
+    throw new Error(
+      `router expr is not of the form 'body matches "<regex>"': ${expression}`,
+    );
+  }
+
+  return unescapeGoStringLiteral(match[1]);
+}
+
+/**
+ * Compile a Go RE2 pattern as a JavaScript RegExp.
+ *
+ * Only two dialect differences matter for the patterns in these configs:
+ *   - named groups are (?P<name>…) in RE2 and (?<name>…) in JS;
+ *   - the inline (?i) flag is legal in RE2 and illegal in JS, so it is lifted
+ *     to the `i` flag instead.
+ *
+ * Everything else in these patterns — non-capturing groups, character classes,
+ * alternation, anchors — behaves identically, and both engines pick the
+ * leftmost match with Perl-style leftmost-first alternation. The expectations
+ * in ContainerAgentLogSeverity.test.js were cross-checked against the real
+ * otelcol-contrib 0.154.0 binary, so a dialect surprise would show up as a
+ * disagreement there rather than passing quietly.
+ */
+function compileRe2AsJs(pattern) {
+  let flags = "";
+  let source = pattern;
+
+  while (source.startsWith("(?i)")) {
+    flags = "i";
+    source = source.slice("(?i)".length);
+  }
+
+  if (source.includes("(?i)")) {
+    throw new Error(
+      `inline (?i) away from the start of the pattern is not translatable: ${pattern}`,
+    );
+  }
+
+  return new RegExp(source.replace(/\(\?P</g, "(?<"), flags);
+}
+
+/**
+ * The alternatives of the first capturing group in the severity regex — i.e.
+ * every keyword the chain can lift off a log body.
+ */
+function severityKeywordsFromRegex(pattern) {
+  const group = /\(\?P<severity_text>([^)]+)\)/.exec(pattern);
+
+  if (!group) {
+    throw new Error(
+      `severity regex has no (?P<severity_text>…) capture group: ${pattern}`,
+    );
+  }
+
+  return group[1].split("|");
+}
+
+/**
+ * Index a filelog operator list by `id`, failing loudly on a duplicate — stanza
+ * would too, and an operator graph with two operators answering to one id is
+ * not something a test should paper over.
+ */
+function indexOperatorsById(operators) {
+  const byId = new Map();
+
+  for (const operator of operators) {
+    if (!operator.id) {
+      continue;
+    }
+
+    if (byId.has(operator.id)) {
+      throw new Error(`duplicate operator id: ${operator.id}`);
+    }
+
+    byId.set(operator.id, operator);
+  }
+
+  return byId;
+}
+
+/**
+ * Every operator id an operator hands entries off to: its own `output`, plus a
+ * router's per-route outputs and its `default`.
+ */
+function outputTargets(operator) {
+  const targets = [];
+
+  if (operator.output) {
+    targets.push(operator.output);
+  }
+
+  if (operator.default) {
+    targets.push(operator.default);
+  }
+
+  for (const route of operator.routes || []) {
+    if (route.output) {
+      targets.push(route.output);
+    }
+  }
+
+  return targets;
+}
+
+module.exports = {
+  OTEL_COLLECTOR_VERSION,
+  SEVERITY_NUMBER,
+  buildBuiltinDefaultPreset,
+  compileRe2AsJs,
+  extractMatchesPattern,
+  indexOperatorsById,
+  oneUptimeLogSeverity,
+  outputTargets,
+  resolveSeverityNumber,
+  severityKeywordsFromRegex,
+  unescapeGoStringLiteral,
+};


### PR DESCRIPTION
### Title of this pull request?

fix(container-agents): detect severity in Monolog and zap log lines

### Small Description?

The Docker, Podman and Docker Swarm agents derive a log record's severity purely from the stdout/stderr stream: `stderr -> ERROR`, `stdout -> INFO`. Any service that logs structured lines to stderr — which PSR-3/Monolog and Go zap/logrus both do by default — therefore has its **entire** log stream stamped ERROR regardless of the level each line actually carries.

This is the same gap that was fixed for the Kubernetes agent in #3534, and this ports the same operator chain into the `filelog` receiver of all three container agents (`DockerAgent`, `PodmanAgent`, `DockerSwarmAgent`):

- a `router` keyed on whether the body carries a recognisable level keyword — the delimiter class includes the dot and the double quote that Monolog (`app.INFO:`) and zap (`{"level":"info"}`) use, which a plain whitespace/bracket match misses;
- a `regex_parser` that lifts the keyword out of the body;
- the existing stream-based rule kept as the **fallback** for lines with no keyword;
- the `severity_parser` mapping widened the same way (`err`/`crit`/`critical` → error, `warning` → warn, `panic` → fatal, `notice` → info).

Behaviour is unchanged for a line with no recognisable keyword: it still takes the stdout/stderr fallback, so nothing regresses. Lines that do carry a level stop being mislabelled — a service that logs INFO/WARN to stderr no longer has those records stamped ERROR.

**Please note this changes observable behaviour for existing installations.** Severity drives log retention and severity-based alerting, so an installation whose containers ship Monolog or zap will see its Error volume fall once the agent image is upgraded. Dashboards and monitors tuned to today's inflated Error counts on container logs need retuning.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate? — the change is collector config baked into the agent images; there is no test harness for the rendered config in this repo. Verified by loading each config as YAML, checking the operator graph resolves (router → parse-severity-from-body / add-fallback-severity → severity-parser → remove), and confirming the escaping survives YAML → the expr-lang string → RE2 identically to the merged #3534 chain, which runs the same operators in production.

### Related Issue?

No issue filed — found while auditing log severity on a self-hosted installation, as the container-agent counterpart to #3534.

### Screenshots (if appropriate):

n/a