### PR TITLE
fix(table): let a column's cell wrap, so a long status message stays in it

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsTable.tsx
@@ -581,7 +581,13 @@ const TelemetryExceptionTable: FunctionComponent<ComponentProps> = (
               message: true,
             },
             title: "Exception Message",
-            contentClassName: "max-w-3xl whitespace-normal break-words",
+            /*
+             * The one hand-spelled instance of the wrap idiom that predates
+             * the option, moved onto it so exactly one way of asking for a
+             * wrapping cell is left in the tree (OneUptime issue #3585).
+             */
+            wrapContent: true,
+            wrapMaxWidthClassName: "max-w-3xl",
             type: FieldType.Element,
             getElement: (exception: TelemetryException) => {
               return (

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -1356,6 +1356,17 @@ const NetworkDeviceDiscovery: FunctionComponent<
             },
             title: "Responded Hosts",
             type: FieldType.Element,
+            /*
+             * This cell carries whole sentences written by the server and by
+             * the probe - the requeue note an edit writes (RETIRE_RUN_PAYLOAD
+             * in Common/Server/Services/NetworkDeviceDiscoveryScanService.ts),
+             * the probe's account of an ICMP-only sweep, the unclaimed-scan
+             * diagnosis - and statusMessage is a 500-character column. Without
+             * this the cell inherits the row's `whitespace-nowrap` and the
+             * sentence is painted straight over the Recurrence and Started
+             * cells beside it (OneUptime issue #3585).
+             */
+            wrapContent: true,
             getElement: (item: NetworkDeviceDiscoveryScan): ReactElement => {
               const outcome: DiscoveryScanOutcome =
                 summarizeDiscoveryScan(item);
@@ -1378,7 +1389,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
 
                 return (
                   <div
-                    className="text-xs text-gray-500 max-w-md"
+                    className="text-xs text-gray-500"
                     title={outcome.explanation}
                   >
                     {outcome.explanation}
@@ -1407,7 +1418,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
                   )}
                   {outcome.explanation && (
                     <div
-                      className="text-xs text-gray-500 mt-1 max-w-md"
+                      className="text-xs text-gray-500 mt-1"
                       title={outcome.explanation}
                     >
                       {outcome.explanation}
@@ -1424,6 +1435,21 @@ const NetworkDeviceDiscovery: FunctionComponent<
             title: "Recurrence",
             type: FieldType.Element,
             hideOnMobile: true,
+            /*
+             * Both of this column's second lines are sentences rather than
+             * labels - "Next scan is scheduled when this run finishes" (45
+             * characters) and "No next scan is scheduled. Open Edit and save
+             * to schedule one." (62) - and one of them renders in the very row
+             * that reports #3585: the same RETIRE_RUN_PAYLOAD write that sets
+             * the status message also sets status Pending and nextScanAt NULL,
+             * which is exactly the first of those two branches. This column
+             * has no width cap of its own, so its symptom is a column stretched
+             * to fit one long line rather than an overlap - the other half of
+             * the deformed row in the report. Capped narrower than Responded
+             * Hosts on purpose: this column's headline is "Every 60 min".
+             */
+            wrapContent: true,
+            wrapMaxWidthClassName: "max-w-xs",
             getElement: (item: NetworkDeviceDiscoveryScan): ReactElement => {
               if (!item.isRecurring) {
                 return <span className="text-sm text-gray-400">One-time</span>;

--- a/App/Tests/Dashboard/TableWrapContentInvariants.test.ts
+++ b/App/Tests/Dashboard/TableWrapContentInvariants.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * OneUptime issue #3585: on the Discovery Scans table, editing a scan makes
+ * the server write a 156-character sentence into `statusMessage`
+ * (RETIRE_RUN_PAYLOAD in
+ * Common/Server/Services/NetworkDeviceDiscoveryScanService.ts), the Discovery
+ * page rendered it in the "Responded Hosts" cell, and the sentence painted
+ * straight over the "Recurrence" and "Started" cells beside it.
+ *
+ * The cause is one line of CSS and one property of CSS: every desktop body
+ * `<td>` in Common/UI/Components/Table/TableRow.tsx declares
+ * `whitespace-nowrap`, and `white-space` is an INHERITED property — so the
+ * nowrap reaches whatever element `getElement` returns, no matter what
+ * classes that element carries. The `max-w-md` the page had put on its own
+ * explanation div then made things WORSE rather than better: a capped box
+ * around an unbreakable line is exactly an overflow, so the text left the
+ * column instead of merely widening it.
+ *
+ * That defect is invisible to every kind of test this repo can run. The App
+ * suite is `testEnvironment: "node"` with no DOM at all, and even under jsdom
+ * there is NO LAYOUT: getBoundingClientRect returns zeros, `white-space` is
+ * never resolved, nothing wraps, nothing overflows and no column has a width.
+ * A test that "checks the text does not overlap" cannot be written here, or
+ * anywhere in CI as it stands. So the only durable guard is a source-level
+ * one — every assertion below is a class / attribute / call-site assertion
+ * over the source TEXT, deliberately, in the places a reader would expect a
+ * visual assertion.
+ *
+ * Sources are whitespace-squashed and matched with regexes rather than exact
+ * lines, so a prettier run that re-wraps a JSX attribute or a ternary cannot
+ * turn a standing invariant into a false alarm. An invariant test that breaks
+ * on a reformat is worse than no invariant test at all.
+ *
+ * The shape (fs/path over Dashboard and Common sources, squash + regex) is
+ * the one NetworkFormStepsInvariants.test.ts and
+ * SummaryTileFilteringInvariants.test.ts already use in this directory.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+const COMMON_TABLE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "Common",
+  "UI",
+  "Components",
+  "Table",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readSource(root: string, ...relativeParts: Array<string>): string {
+  return squash(fs.readFileSync(path.join(root, ...relativeParts), "utf8"));
+}
+
+// Every .ts/.tsx file under a directory, recursively.
+function sourceFilePaths(directory: string): Array<string> {
+  const filePaths: Array<string> = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      filePaths.push(...sourceFilePaths(entryPath));
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      filePaths.push(entryPath);
+    }
+  }
+
+  return filePaths;
+}
+
+function matchAll(pattern: RegExp, text: string): Array<string> {
+  const values: Array<string> = [];
+  // Cloned so a shared /g regex cannot carry lastIndex between calls.
+  const scanner: RegExp = new RegExp(pattern.source, "g");
+
+  let match: RegExpExecArray | null = scanner.exec(text);
+
+  while (match !== null) {
+    values.push(match[1]!);
+    match = scanner.exec(text);
+  }
+
+  return values;
+}
+
+function countOccurrences(pattern: RegExp, text: string): number {
+  return (text.match(new RegExp(pattern.source, "g")) || []).length;
+}
+
+/**
+ * The body of one column declaration, found by its `title:` and running to the
+ * next column's `title:` (or to the end of the file for the last one).
+ *
+ * Deliberately crude: a real parser is not worth it here, and the JSX inside a
+ * `getElement` spells its own title as `title={...}`, never `title: "..."`, so
+ * the next `title: "` really is the next column.
+ */
+function columnBlockByTitle(source: string, title: string): string {
+  const needle: string = `title: "${title}"`;
+  const startIndex: number = source.indexOf(needle);
+
+  expect(startIndex).toBeGreaterThan(-1);
+
+  const rest: string = source.slice(startIndex + needle.length);
+  const nextTitleIndex: number = rest.search(/title:\s*"/);
+
+  return nextTitleIndex === -1 ? rest : rest.slice(0, nextTitleIndex);
+}
+
+const TABLE_ROW: string = readSource(COMMON_TABLE, "TableRow.tsx");
+const TABLE_SKELETON_ROWS: string = readSource(
+  COMMON_TABLE,
+  "TableSkeletonRows.tsx",
+);
+const DISCOVERY_PAGE: string = readSource(
+  DASHBOARD_SRC,
+  "Pages",
+  "NetworkDevice",
+  "Discovery.tsx",
+);
+
+/*
+ * The composite `<td>` class string that TableRow and TableSkeletonRows each
+ * used to hard-code, in either padding variant. Matched loosely — any
+ * whitespace mode, any right padding — because the point is that NOBODY
+ * spells this string inline any more, not that one particular spelling of it
+ * is gone.
+ */
+const HARD_CODED_CELL_CLASS_LITERAL: RegExp =
+  /"whitespace-[a-z]+ py-4 pl-4 pr-\d/;
+
+const CELL_CLASS_HELPER_CALL: RegExp =
+  /getTableCellClassName\s*(<[^>]*>)?\s*\(/;
+
+/*
+ * A ModelTable that renders as a List rather than a table. Its cells go
+ * through Detail, not TableRow.
+ */
+const LIST_MODE_TABLE: RegExp = /showAs=\{\s*ShowAs\.List\s*\}/;
+
+/*
+ * `max-w-full` and `max-w-none` are named max-widths that cap nothing, so
+ * neither can generate the overlap this rule is about.
+ */
+function isRealWidthCap(value: string): boolean {
+  return value
+    .replace(/max-w-full/g, "")
+    .replace(/max-w-none/g, "")
+    .includes("max-w-");
+}
+
+/*
+ * GROUP 1 — on a table, the pairing that generated #3585 must stay unspellable.
+ *
+ * Inside a `<td>`, `contentClassName` lands on a div that inherits the row's
+ * nowrap, so a `max-w-*` written there is a cap around a line that cannot
+ * break: the overlap generator itself. A width cap belongs in
+ * `wrapMaxWidthClassName`, which `getTableCellContentClassName` only ever
+ * emits alongside `whitespace-normal break-words` — so through that option the
+ * bad pairing cannot be expressed at all.
+ *
+ * SCOPE, deliberately narrow, because the rule is only true where there IS a
+ * `<td>`. Files whose ModelTable renders `showAs={ShowAs.List}` are skipped: a
+ * List goes through Detail rather than TableRow, never produces a `<td>` and
+ * never inherits a nowrap, so a width cap there is harmless — and
+ * `wrapMaxWidthClassName` is not read on that path at all (BaseModelTable's
+ * Detail-field mapping forwards `contentClassName` alone), so banning it would
+ * leave those authors no way to say what they mean. That is not a hypothetical
+ * carve-out: every `contentClassName` in the Dashboard today except Discovery's
+ * own is on such a table — the Incident / Alert / ScheduledMaintenance note
+ * lists.
+ *
+ * Note what is NOT asserted: a `whitespace-*` utility inside
+ * `contentClassName` is perfectly legitimate — those same note tables declare
+ * `whitespace-nowrap` there on purpose. Only a real width cap is banned.
+ *
+ * The scan reads the value expression rather than only string literals, so a
+ * cap written as a variable or a template literal is caught too. It stops at
+ * the value's terminating comma, so one buried inside a multi-argument call
+ * (`clsx("a", "max-w-md")`) would slip past. Accepted: nothing in the tree is
+ * spelled that way, and a regex is not a parser.
+ */
+describe("a table column never caps its width through contentClassName", () => {
+  test("no contentClassName on a <td>-rendering table declares a width cap", () => {
+    const filePaths: Array<string> = sourceFilePaths(DASHBOARD_SRC);
+
+    // Guards against a broken walk quietly asserting over nothing.
+    expect(filePaths.length).toBeGreaterThan(100);
+
+    const offenders: Array<string> = [];
+    let declarationCount: number = 0;
+    let skippedListFiles: number = 0;
+
+    for (const filePath of filePaths) {
+      const source: string = squash(fs.readFileSync(filePath, "utf8"));
+
+      if (LIST_MODE_TABLE.test(source)) {
+        skippedListFiles++;
+        continue;
+      }
+
+      for (const value of matchAll(/contentClassName:\s*([^,}]*)/, source)) {
+        declarationCount++;
+
+        if (isRealWidthCap(value)) {
+          offenders.push(`${path.relative(DASHBOARD_SRC, filePath)}: ${value}`);
+        }
+      }
+    }
+
+    /*
+     * Both halves of the scope did something: table-mode declarations were
+     * examined, and List-mode files were really found and skipped rather than
+     * the exclusion being dead code that silently stops excluding anything.
+     */
+    expect(declarationCount).toBeGreaterThan(0);
+    expect(skippedListFiles).toBeGreaterThan(0);
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+/*
+ * GROUP 2 — the shared cell class must keep coming from one place.
+ *
+ * The nowrap default is load-bearing for every date, count, badge and actions
+ * cell in the product — roughly two hundred column declarations with no
+ * layout coverage of their own — so the fix could not simply drop it; it made
+ * the class a function of the column instead. If a renderer goes back to
+ * writing the literal inline, the `wrapContent` opt-out silently stops
+ * working for every cell that renderer draws, and nothing else in CI notices.
+ */
+describe("Table cell classes are built by the shared helper", () => {
+  test("TableRow builds its <td> class with getTableCellClassName", () => {
+    expect(TABLE_ROW).toMatch(CELL_CLASS_HELPER_CALL);
+  });
+
+  test("TableRow no longer hard-codes the <td> class literal", () => {
+    /*
+     * If this fails, someone re-inlined the cell classes in TableRow. The
+     * shared nowrap default is load-bearing for every date, count, badge and
+     * actions cell in the product, and inlining it takes `wrapContent` — the
+     * fix for issue #3585 — out of the path for every table at once.
+     */
+    expect(TABLE_ROW).not.toMatch(HARD_CODED_CELL_CLASS_LITERAL);
+  });
+
+  test("TableRow builds its content wrapper class with getTableCellContentClassName", () => {
+    expect(TABLE_ROW).toMatch(
+      /getTableCellContentClassName\s*(<[^>]*>)?\s*\(\s*column\s*\)/,
+    );
+
+    /*
+     * And reads `column.contentClassName` nowhere itself: the width cap for a
+     * wrapping column has to be merged with it in one place, or a column that
+     * declares both ends up with only one of the two on the div.
+     */
+    expect(TABLE_ROW).not.toMatch(/column\.contentClassName/);
+  });
+
+  test("TableSkeletonRows shares the same helper rather than its own copy", () => {
+    /*
+     * The skeleton's classes were originally copied out of TableRow by hand,
+     * which is how two spellings of one cell come to exist in the first
+     * place. Routing both through the helper is what stops the placeholder
+     * rows from drifting out of alignment with the real rows that replace
+     * them.
+     */
+    expect(TABLE_SKELETON_ROWS).toMatch(CELL_CLASS_HELPER_CALL);
+    expect(TABLE_SKELETON_ROWS).not.toMatch(HARD_CODED_CELL_CLASS_LITERAL);
+  });
+});
+
+/*
+ * WHAT IS DELIBERATELY *NOT* ASSERTED HERE
+ *
+ * Nothing in this file pins how CellClassName.ts is written — not the ternary
+ * that keeps `whitespace-nowrap` the default, not the `if (column.wrapContent)`
+ * that gates the width cap, not the exact class string a plain column gets.
+ * Those are the most important guarantees in the change, and source text is the
+ * wrong way to hold them: a regex over the helper's body stays green when the
+ * fix is reverted at the renderers (the helper is still spelled correctly, it
+ * has simply stopped being called), and goes red for edits that emit exactly
+ * the same classes — `??` for `||`, a renamed local, an early return, the two
+ * literals lifted into constants.
+ *
+ * They are held behaviourally instead, against exact strings, in
+ * Common/Tests/UI/Components/TableCellWrapping.test.tsx: "a column that
+ * declares nothing keeps the pre-#3585 cell classes" pins both padding
+ * variants byte-for-byte, "with no width named, the wrapper takes the exported
+ * default cap" pins the default, and "a width cap alone emits nothing" pins the
+ * gate. What THIS file adds is only the part no rendering test can see: that
+ * the renderers still call the helper at all.
+ */
+
+/*
+ * GROUP 3 — the page that reported #3585 stays fixed.
+ *
+ * Two columns opt in. "Responded Hosts" is the cell whose sentence overlapped.
+ * "Recurrence" is the other half of the same deformed row: the server write
+ * that sets the status message also blanks nextScanAt, so that column renders
+ * a sentence of its own in the very same row, on one unbreakable line, with no
+ * width cap at all. And the `max-w-md` the page used to put on its own
+ * explanation divs is gone: capping the width is the helper's job now, and left
+ * on a div that inherits nowrap that cap IS the overflow.
+ */
+describe("Discovery page columns opt into wrapping", () => {
+  test("at least two columns declare wrapContent", () => {
+    expect(
+      countOccurrences(/wrapContent:\s*true/, DISCOVERY_PAGE),
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  test("Responded Hosts wraps and no longer caps its own explanation divs", () => {
+    const block: string = columnBlockByTitle(DISCOVERY_PAGE, "Responded Hosts");
+
+    expect(block).toMatch(/wrapContent:\s*true/);
+
+    /*
+     * jsdom cannot be asked whether the text overflows — there is no layout
+     * anywhere in CI — so the assertion is on the class that CAUSED the
+     * overflow. A `max-w-*` anywhere inside this column, on an element that
+     * inherits the row's whitespace mode, is the exact shape of the bug.
+     */
+    expect(block).not.toMatch(/max-w-/);
+  });
+
+  test("Recurrence wraps with its own narrower cap", () => {
+    const block: string = columnBlockByTitle(DISCOVERY_PAGE, "Recurrence");
+
+    expect(block).toMatch(/wrapContent:\s*true/);
+    expect(block).toMatch(/wrapMaxWidthClassName:\s*"max-w-xs"/);
+  });
+
+  test("both explanation divs keep title={outcome.explanation}", () => {
+    /*
+     * The width cap means a long enough message can still be clipped by the
+     * column, so the hover affordance that shows the whole sentence is not
+     * decoration — it is the fallback. It sits on the two divs that render
+     * `outcome.explanation`, and the cleanup that removed their `max-w-md`
+     * neighbours must not take it with them.
+     */
+    const block: string = columnBlockByTitle(DISCOVERY_PAGE, "Responded Hosts");
+
+    expect(countOccurrences(/title=\{outcome\.explanation\}/, block)).toBe(2);
+  });
+});

--- a/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
+++ b/Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx
@@ -120,6 +120,17 @@ type CapturedColumn = {
   isRemovable?: boolean | undefined;
   disableSort?: boolean | undefined;
   noValueMessage?: string | undefined;
+  /*
+   * The three properties that decide whether a cell's text may occupy more
+   * than one line, captured for issue #3585. They are configuration in
+   * exactly the same way the layout flags above are — a column declares them
+   * and TableRow renders through them — so the only place they can be
+   * asserted is here, off the props the page handed the table. See the
+   * "long status messages wrap inside their own column" block at the bottom.
+   */
+  contentClassName?: string | undefined;
+  wrapContent?: boolean | undefined;
+  wrapMaxWidthClassName?: string | undefined;
   getElement?:
     | ((item: NetworkDeviceDiscoveryScan) => React.ReactElement)
     | undefined;
@@ -205,6 +216,23 @@ import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDe
 import ObjectID from "../../../Types/ObjectID";
 import Route from "../../../Types/API/Route";
 import FieldType from "../../../UI/Components/Types/FieldType";
+/*
+ * The renderer's own cell-class helpers (issue #3585). The page declares
+ * `wrapContent` on a column; these two functions are what TableRow turns that
+ * declaration into, so running the page's real column objects through them
+ * asserts the flag has the effect it is being set for — rather than asserting
+ * that a property the page sets is a property the page sets.
+ */
+import TableColumn from "../../../UI/Components/Table/Types/Column";
+import {
+  getTableCellClassName,
+  getTableCellContentClassName,
+} from "../../../UI/Components/Table/CellClassName";
+/*
+ * The Recurrence cell hangs the fully formatted date off a `title`, so the
+ * expectation is computed with the same utility the cell formats with.
+ */
+import OneUptimeDate from "../../../Types/Date";
 import ModelTableColumn from "../../../UI/Components/ModelTable/Column";
 import ModelTableColumns from "../../../UI/Components/ModelTable/Columns";
 import {
@@ -350,6 +378,53 @@ function renderRecurrenceCell(
   );
 
   return container.textContent || "";
+}
+
+/*
+ * The same cells as element trees rather than as strings, for issue #3585.
+ *
+ * The helpers above return textContent, which is the right shape for the
+ * questions they answer ("what does an operator read on this row") and the
+ * wrong one for #3585, where both the defect and the fix are carried by
+ * classes and attributes rather than by words.
+ *
+ * jsdom performs NO layout: there is no getBoundingClientRect, no computed
+ * `white-space`, no column width, so the overlap the issue reports cannot be
+ * observed here at all. What CAN be observed is the markup pairing that
+ * produced it — a width-capped box nested inside an inherited nowrap line —
+ * and the configuration that now tells the renderer to unset that nowrap.
+ * Every assertion in that block is therefore a class, attribute, DOM-shape or
+ * text assertion, deliberately, and never a visual one.
+ */
+function renderCellContainer(
+  columnKey: string,
+  scan: Partial<NetworkDeviceDiscoveryScan>,
+): HTMLElement {
+  const column: CapturedColumn = columnNamed(columnKey);
+
+  if (!column.getElement) {
+    throw new Error(`The "${columnKey}" column renders no element`);
+  }
+
+  const { container } = render(
+    <MemoryRouter>
+      {column.getElement(scan as NetworkDeviceDiscoveryScan)}
+    </MemoryRouter>,
+  );
+
+  return container;
+}
+
+function renderRespondedHostsCell(
+  scan: Partial<NetworkDeviceDiscoveryScan>,
+): HTMLElement {
+  return renderCellContainer("respondedHostCount", scan);
+}
+
+function renderRecurrenceCellElement(
+  scan: Partial<NetworkDeviceDiscoveryScan>,
+): HTMLElement {
+  return renderCellContainer("isRecurring", scan);
 }
 
 /*
@@ -2577,5 +2652,398 @@ describe("Scan Target says how big the sweep is while it is being typed", () => 
     expect(renderTargetSizeHint("  192.168.1.0/24  ")).toBe(
       "This target sweeps 254 addresses.",
     );
+  });
+});
+
+/*
+ * OneUptime issue #3585: "status message overlaps the columns next to it on
+ * the Discovery Scans table".
+ *
+ * WHAT WENT WRONG, because the shape of it decides the shape of these tests.
+ * Saving an edit retires the scan's run, and the retire payload
+ * (RETIRE_RUN_PAYLOAD in
+ * Common/Server/Services/NetworkDeviceDiscoveryScanService.ts) writes a
+ * 156-character sentence into statusMessage explaining why the results
+ * vanished. The Responded Hosts cell renders that sentence. Every desktop body
+ * <td> in Common/UI/Components/Table/TableRow.tsx declares `whitespace-nowrap`,
+ * and `white-space` is an INHERITED property — so the nowrap reached the div
+ * this page rendered inside the cell no matter what classes that div carried.
+ * The div carried `max-w-md`, which capped the BOX while the LINE inside it
+ * stayed unbreakable, so the sentence ran straight out of the cell and painted
+ * over the Recurrence and Started cells beside it. A max-width paired with a
+ * nowrap does not contain long text; it is precisely what turns "the table
+ * gets wider" into "the text lands on top of its neighbours".
+ *
+ * THE FIX, and therefore what is asserted here: the wrapping is asked for at
+ * COLUMN level (`wrapContent`, with an optional `wrapMaxWidthClassName`), the
+ * renderer emits `whitespace-normal break-words` on the <td> and the width cap
+ * on its content div, and the inner `max-w-md` this page used to spell by hand
+ * is DELETED rather than left in place beside the new option.
+ *
+ * HOW IT IS ASSERTED. jsdom performs no layout whatsoever — no
+ * getBoundingClientRect, no computed `white-space`, no column widths, no
+ * overflow — so the overlap itself is not observable in any test that could
+ * live in this repo. Every assertion below is therefore a configuration,
+ * class, attribute, DOM-shape or text assertion: the flags the page declares,
+ * the classes the real TableRow helpers derive from those flags, and the
+ * markup the cell renders for the exact row the issue was filed about. The
+ * negative ones matter as much as the positive ones — a `max-w-*` left behind
+ * inside the cell re-creates the original pairing exactly, and a wrap flag
+ * that spread to the timestamp and badge columns would be a page-wide restyle
+ * wearing this fix's name.
+ */
+describe("long status messages wrap inside their own column (issue #3585)", () => {
+  /*
+   * The sentence the server actually writes, inlined rather than imported:
+   * Common/Server/Services/NetworkDeviceDiscoveryScanService.ts is a server
+   * module that pulls in the database layer, and this is a UI test. Copying it
+   * is deliberate — a reword on the server side surfaces here as a failure,
+   * which is the moment to re-check that the reworded sentence still wraps.
+   */
+  const RETIRE_MESSAGE: string =
+    "Settings changed, so this scan is queued to run again. The hosts the previous run found have been cleared - they described settings this scan no longer has.";
+
+  /*
+   * The retired row itself: no host counts (the payload nulls them) and the
+   * sentence above. This is the row an operator sees straight after pressing
+   * Save on the Edit dialog, and the row screenshotted in the issue.
+   */
+  const RETIRED_SCAN: Partial<NetworkDeviceDiscoveryScan> = {
+    respondedHostCount: null,
+    statusMessage: RETIRE_MESSAGE,
+  } as unknown as Partial<NetworkDeviceDiscoveryScan>;
+
+  /*
+   * The captured column as the type TableRow's helpers take. The mock stores
+   * the page's own column objects under a looser local type, so this is a cast
+   * rather than a copy — the helpers run over the very objects the page
+   * declared.
+   */
+  function tableColumnFor(
+    title: string,
+  ): TableColumn<NetworkDeviceDiscoveryScan> {
+    return columnByTitle(
+      title,
+    ) as unknown as TableColumn<NetworkDeviceDiscoveryScan>;
+  }
+
+  function cellClassNameFor(title: string): string {
+    return getTableCellClassName<NetworkDeviceDiscoveryScan>({
+      column: tableColumnFor(title),
+      isLastRenderedColumn: false,
+    });
+  }
+
+  beforeEach(() => {
+    capturedTableProps = null;
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+
+    const probe: Probe = new Probe();
+    probe.id = new ObjectID("22222222-2222-4222-8222-222222222222");
+    probe.name = "Datacenter Probe";
+
+    jest.spyOn(ProbeUtil, "getAllProbes").mockResolvedValue([probe] as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    capturedTableProps = null;
+  });
+
+  /*
+   * THE assertion that tells the fixed page from the broken one. Everything
+   * else in this block describes the shape of the fix; this one line is the
+   * fix. Delete `wrapContent` from the Responded Hosts column and the cell is
+   * back to inheriting the row's nowrap, with the status message back on top
+   * of the two columns to its right.
+   */
+  test("the Responded Hosts column asks for its prose to wrap", async () => {
+    await renderPage();
+
+    expect(columnByTitle("Responded Hosts").wrapContent).toBe(true);
+  });
+
+  /*
+   * And the flag has to REACH the markup. Asserted through the two helpers
+   * TableRow and TableSkeletonRows render with, rather than by restating the
+   * class strings this test would like them to produce: the claim is "this
+   * column's cell wraps", and the code that decides that is what is asked.
+   */
+  test("that flag makes the rendered cell a wrapping one, not a nowrap one", async () => {
+    await renderPage();
+
+    const className: string = cellClassNameFor("Responded Hosts");
+
+    expect(className).toContain("whitespace-normal");
+    expect(className).toContain("break-words");
+    /*
+     * The inherited declaration that caused #3585. Its absence here is the
+     * whole point: it is unset on the cell, so it is unset on every element
+     * getElement returns beneath it.
+     */
+    expect(className).not.toContain("whitespace-nowrap");
+  });
+
+  /*
+   * The width cap is not spelled on this column, so it takes the shared
+   * default — one place to change if 28rem turns out to be wrong for prose,
+   * rather than a number copied into every column that holds a sentence. The
+   * contentClassName check is the other half: the cap now arrives through the
+   * wrap option, and a hand-written `max-w-*` sitting beside it would be
+   * resolved by stylesheet order rather than by intent.
+   */
+  test("it takes the shared default width cap rather than naming one", async () => {
+    await renderPage();
+
+    const column: CapturedColumn = columnByTitle("Responded Hosts");
+
+    expect(column.wrapMaxWidthClassName).toBeUndefined();
+    expect(column.contentClassName).toBeUndefined();
+
+    expect(
+      getTableCellContentClassName<NetworkDeviceDiscoveryScan>(
+        tableColumnFor("Responded Hosts"),
+      ),
+    ).toBe("max-w-md");
+  });
+
+  /*
+   * Recurrence wraps too, and narrower. The same RETIRE_RUN_PAYLOAD write that
+   * sets the status message also sets status Pending and nextScanAt NULL, so
+   * the row that reports #3585 renders a sentence in this cell as well — and
+   * this column's headline is "Every 60 min", so it has no business being as
+   * wide as the results cell.
+   */
+  test("the Recurrence column wraps, capped narrower than Responded Hosts", async () => {
+    await renderPage();
+
+    const column: CapturedColumn = columnByTitle("Recurrence");
+
+    expect(column.wrapContent).toBe(true);
+    expect(column.wrapMaxWidthClassName).toBe("max-w-xs");
+
+    expect(
+      getTableCellContentClassName<NetworkDeviceDiscoveryScan>(
+        tableColumnFor("Recurrence"),
+      ),
+    ).toBe("max-w-xs");
+    expect(cellClassNameFor("Recurrence")).toContain("whitespace-normal");
+  });
+
+  /*
+   * Started is one of the two columns the message used to be painted over, and
+   * it must not be "fixed" by being allowed to wrap: a timestamp folded onto
+   * two lines is a regression of its own, and `whitespace-nowrap` on date
+   * cells is what keeps "Mar 12 2026, 16:05" whole.
+   */
+  test("the Started timestamp is left on its single line", async () => {
+    await renderPage();
+
+    expect(columnByTitle("Started").wrapContent).toBeFalsy();
+    expect(cellClassNameFor("Started")).toContain("whitespace-nowrap");
+  });
+
+  /*
+   * The scope check. Two columns hold prose; the rest hold a name, an entity,
+   * a badge and an address, and every one of them still gets the default
+   * single-line cell. This is what separates a targeted fix from "the whole
+   * table now wraps", which is a much larger visual change than #3585 asked
+   * for and which no screenshot in the issue would justify.
+   */
+  test.each(["Scan", "Probe", "Status", "Scan Target"])(
+    "the %s column is untouched and still renders on one line",
+    async (title: string) => {
+      await renderPage();
+
+      expect(columnByTitle(title).wrapContent).toBeFalsy();
+      expect(columnByTitle(title).wrapMaxWidthClassName).toBeUndefined();
+      expect(cellClassNameFor(title)).toContain("whitespace-nowrap");
+    },
+  );
+
+  /*
+   * The page's one pre-existing contentClassName, left exactly as it was. It
+   * is a type/colour class with no width in it, which is the only kind of
+   * contentClassName that was ever safe on a nowrap cell — and the migration
+   * of the wrap idiom must not have gone rewriting the ones that were fine.
+   */
+  test("the one pre-existing contentClassName on this page is unchanged", async () => {
+    await renderPage();
+
+    expect(columnByTitle("Scan Target").contentClassName).toBe(
+      "text-sm text-gray-900",
+    );
+  });
+
+  /*
+   * The rule that makes the class of bug in #3585 unspellable on this page: a
+   * width cap may only arrive through `wrapMaxWidthClassName`, which the
+   * renderer emits ONLY together with `whitespace-normal`. A `max-w-*` written
+   * into a contentClassName is the pairing that overlaps, whichever column it
+   * is written on, so no column here may hold one.
+   */
+  test("no column caps its width through contentClassName", async () => {
+    await renderPage();
+
+    const columns: Array<CapturedColumn> = capturedTableProps?.columns || [];
+
+    expect(columns.length).toBeGreaterThan(0);
+
+    for (const column of columns) {
+      expect(column.contentClassName || "").not.toContain("max-w-");
+    }
+  });
+
+  /*
+   * THE ROW FROM THE ISSUE. An operator edits a scan, the server retires the
+   * run, and this is the cell they are looking at. The sentence has to be
+   * there in full — the fix wraps it, it does not truncate it, and nothing
+   * about #3585 justifies hiding what happened to the results — and the hover
+   * tooltip that predates the fix has to survive it, because the same cell
+   * still carries probe explanations far longer than this one.
+   */
+  test("the retired-run sentence renders in full, and still on a tooltip", async () => {
+    await renderPage();
+
+    const container: HTMLElement = renderRespondedHostsCell(RETIRED_SCAN);
+
+    expect(container.textContent).toContain(RETIRE_MESSAGE);
+    expect(container.querySelector(`[title="${RETIRE_MESSAGE}"]`)).toBeTruthy();
+  });
+
+  /*
+   * The negative half, and the one that would catch a "fix" that only added
+   * the option without cleaning up after it. The inner `max-w-md` had to be
+   * DELETED, not supplemented: leaving it re-creates the exact capped-box
+   * pairing that caused the overlap, and it would now sit inside a cell that
+   * ALSO has a cap — two `max-w-*` on nested elements, resolved by stylesheet
+   * order rather than by intent.
+   *
+   * (No layout is being measured here — jsdom has none. This asserts that the
+   * markup which made the overlap possible is gone.)
+   */
+  test("nothing inside the cell caps its own width any more", async () => {
+    await renderPage();
+
+    const container: HTMLElement = renderRespondedHostsCell(RETIRED_SCAN);
+
+    expect(container.querySelectorAll("[class*='max-w-']")).toHaveLength(0);
+  });
+
+  /*
+   * The reporting branch, which is the cell as it renders on a normal day. The
+   * three things it says all predate #3585 and all have issues of their own
+   * behind them — the headline count, the ping-only tally (#3445) and the
+   * probe's explanation (#3287) — so this is the regression test for "the
+   * layout change quietly dropped a line".
+   */
+  test("a reported scan still says everything it said before", async () => {
+    await renderPage();
+
+    const container: HTMLElement = renderRespondedHostsCell({
+      respondedHostCount: 0,
+      scannedHostCount: 254,
+      discoveredDevices: [
+        { ipAddress: "10.0.0.4", snmpReachable: false },
+        { ipAddress: "10.0.0.9", snmpReachable: false },
+      ],
+      statusMessage: RETIRE_MESSAGE,
+    } as unknown as Partial<NetworkDeviceDiscoveryScan>);
+
+    // The count — a zero alone reads as "empty subnet" (issue #3287).
+    expect(container.textContent).toContain("0 of 254 hosts");
+    // ...which is why the ping-only tally sits under it (issue #3445).
+    expect(container.textContent).toContain("+ 2 alive without SNMP");
+    // ...and the probe's account of the sweep under that (issue #3287).
+    expect(container.textContent).toContain(RETIRE_MESSAGE);
+    expect(container.querySelector(`[title="${RETIRE_MESSAGE}"]`)).toBeTruthy();
+
+    expect(container.querySelectorAll("[class*='max-w-']")).toHaveLength(0);
+  });
+
+  /*
+   * And the empty branch: a scan with nothing to report and nothing to explain
+   * is still a bare em-dash, exactly like every other empty cell on this
+   * table.
+   */
+  test("a scan with nothing to say still renders a bare em-dash", async () => {
+    await renderPage();
+
+    const container: HTMLElement = renderRespondedHostsCell({});
+
+    expect(container.textContent).toBe("—");
+    expect(container.querySelectorAll("[class*='max-w-']")).toHaveLength(0);
+  });
+
+  /*
+   * The Recurrence cell in the state RETIRE_RUN_PAYLOAD actually writes:
+   * recurring, Pending, nextScanAt NULL. This row is the sibling of the one
+   * above — the same save produces both — so the wrap flag added to this
+   * column has to leave its wording alone.
+   */
+  test("a retired recurring scan still says the next run waits for this one", async () => {
+    await renderPage();
+
+    expect(
+      renderRecurrenceCell({
+        isRecurring: true,
+        rescanIntervalInMinutes: 60,
+        status: "Pending",
+        nextScanAt: null,
+      } as unknown as Partial<NetworkDeviceDiscoveryScan>),
+    ).toContain("Next scan is scheduled when this run finishes");
+  });
+
+  /*
+   * The warning branch from issue #3444 — a recurring scan that has finished
+   * with nothing scheduled will never run again — including the colour that
+   * makes it read as a warning rather than as a caption.
+   */
+  test("the never-again warning keeps its wording and its colour", async () => {
+    await renderPage();
+
+    const container: HTMLElement = renderRecurrenceCellElement({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+      status: "Completed",
+      nextScanAt: null,
+    } as unknown as Partial<NetworkDeviceDiscoveryScan>);
+
+    expect(container.textContent).toContain(
+      "No next scan is scheduled. Open Edit and save to schedule one.",
+    );
+    expect(container.querySelector(".text-yellow-600")).toBeTruthy();
+  });
+
+  // The two branches the fix had no business touching at all.
+  test("a one-time scan still reads as one-time", async () => {
+    await renderPage();
+
+    expect(renderRecurrenceCell({ isRecurring: false })).toBe("One-time");
+  });
+
+  test("a scheduled scan still hangs the exact date off a tooltip", async () => {
+    await renderPage();
+
+    const nextScanAt: Date = new Date(Date.now() + 30 * 60000);
+
+    const container: HTMLElement = renderRecurrenceCellElement({
+      isRecurring: true,
+      rescanIntervalInMinutes: 60,
+      status: "Completed",
+      nextScanAt: nextScanAt,
+    });
+
+    expect(container.textContent).toContain("Next scan");
+    /*
+     * The cell shows a relative time and keeps the absolute one on the title,
+     * formatted by the same utility this expectation is built with.
+     */
+    expect(
+      container.querySelector(
+        `[title="${OneUptimeDate.getDateAsLocalFormattedString(nextScanAt)}"]`,
+      ),
+    ).toBeTruthy();
   });
 });

--- a/Common/Tests/UI/Components/ModelTable/ModelTableWrapContent.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/ModelTableWrapContent.test.tsx
@@ -1,0 +1,561 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  configure,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React, { ReactElement } from "react";
+
+/*
+ * A real BaseModelTable mounts a card, a header and a full table before the
+ * first row exists. That comfortably outruns the 1s default when the whole
+ * Common suite is competing for the same box. A regression still fails, just
+ * later.
+ */
+configure({ asyncUtilTimeout: 15000 });
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * ============================================================================
+ * WHY THIS FILE EXISTS - OneUptime issue #3585
+ * ============================================================================
+ *
+ * Every desktop body <td> is `whitespace-nowrap`, and `white-space` is an
+ * INHERITED CSS property, so that nowrap reaches whatever element a column's
+ * `getElement` returns. On the Discovery Scans page the "Responded Hosts"
+ * cell renders a 156-character server-authored sentence (RETIRE_RUN_PAYLOAD
+ * in Common/Server/Services/NetworkDeviceDiscoveryScanService.ts) inside a
+ * `max-w-md` div: a capped box holding one unbreakable line, so the sentence
+ * painted straight over the Recurrence and Started cells beside it.
+ *
+ * The fix gives a column two declarative options - `wrapContent` and
+ * `wrapMaxWidthClassName` - which Common/UI/Components/Table/CellClassName.ts
+ * turns into `whitespace-normal break-words` on the <td> and the width cap on
+ * the <td>'s content <div> (max-width is ignored on a table-cell box, so the
+ * cap has to live on the child).
+ *
+ * The reason the tests live at the ModelTable level rather than against
+ * TableRow directly: Common/UI/Components/ModelTable/BaseModelTable.tsx has
+ * exactly ONE ModelTable-column to Table-column conversion, the
+ * `columns.push({ ...column, ... })` inside `serializeToTableColumns`. Both
+ * new fields travel on that SPREAD. Nothing names them, nothing type-checks
+ * the hop, and TypeScript is perfectly happy if a future refactor replaces
+ * the spread with an explicit list of copied fields - which would silently
+ * reintroduce #3585, with a green TableRow unit test and nothing else to show
+ * for it. These tests drive a real BaseModelTable end to end so that hop is
+ * covered, and they are the only thing that would catch it.
+ *
+ * NOTE ON WHAT CAN BE ASSERTED: jsdom performs no layout. There is no
+ * getBoundingClientRect worth reading, no computed line breaking, no overflow
+ * and no column widths. Where a reader would reasonably expect "assert the
+ * text does not overlap the next column", these tests assert instead the
+ * exact classes and DOM structure that a browser turns into that behaviour -
+ * the class strings ARE the contract here.
+ * ============================================================================
+ */
+
+/*
+ * BaseModelTable pulls in permissions, the current project and the i18n
+ * provider. None of those are what these tests are about, so they are stubbed
+ * to their permissive / no-op form and the tests focus on one thing: the
+ * wrapping options surviving the trip from a ModelTable column into the
+ * rendered <td>.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return true;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined) => {
+          return value;
+        },
+        translateValue: (value: unknown) => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import Filter from "../../../../UI/Components/ModelFilter/Filter";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import ActionButtonSchema from "../../../../UI/Components/ActionButton/ActionButtonSchema";
+import { ButtonStyleType } from "../../../../UI/Components/Button/Button";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Query from "../../../../Types/BaseDatabase/Query";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+const PREFS_KEY: string = "monitors-wrap-content-table";
+
+/*
+ * The exact <td> class string every non-wrapping body cell had BEFORE the fix,
+ * character for character, and still has after it. Spelled out as a literal
+ * rather than imported from CellClassName.ts on purpose: importing the helper
+ * would only prove the helper agrees with itself, while this literal is the
+ * frozen "no column asked for anything, so nothing changed" contract that
+ * roughly two hundred column declarations with no layout coverage of their
+ * own are relying on.
+ */
+const NOWRAP_CELL_CLASS_NAME: string =
+  "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+
+// Same, for the last rendered column, which takes the wider right padding.
+const NOWRAP_LAST_CELL_CLASS_NAME: string =
+  "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+
+/*
+ * The default cap a wrapping column gets when it names no width of its own.
+ * Hard-coded rather than imported for the same reason as above: this is the
+ * shipped value ("Responded Hosts" on the Discovery page relies on it), so
+ * changing it should have to be a deliberate edit here too.
+ */
+const DEFAULT_WRAP_WIDTH_CLASS_NAME: string = "max-w-md";
+
+const FILTERS: Array<Filter<Monitor>> = [
+  { title: "Name", type: FieldType.Text, field: { name: true } },
+] as unknown as Array<Filter<Monitor>>;
+
+/*
+ * One row is all these tests need - they are about the cell shell, not about
+ * the values in it. Every column below declares a real Monitor field, because
+ * TableRow only calls `getElement` for a column that resolved to a `key`, and
+ * the key is derived from the declared field.
+ */
+const ROWS: Array<JSONObject> = [
+  {
+    _id: "monitor-1",
+    name: "api-gateway",
+    description:
+      "Settings changed, so this scan is queued to run again. The previous run was retired.",
+    monitorType: "Website",
+    slug: "api-gateway",
+  },
+];
+
+type MakeColumnsFunction = () => Columns<Monitor>;
+
+/*
+ * Four columns covering the whole option matrix, plus the generated Actions
+ * column that BaseModelTable appends. They are deliberately in ONE table: the
+ * bug report is a row where one cell wraps and its neighbours must not, so
+ * "per column, not per table" is part of the contract being pinned.
+ */
+const makeColumns: MakeColumnsFunction = (): Columns<Monitor> => {
+  const columns: Array<unknown> = [
+    /*
+     * The control. Declares neither option, exactly like almost every column
+     * in the product, and must come out byte-identical to how it rendered
+     * before the fix existed.
+     */
+    {
+      field: { name: true },
+      title: "Name",
+      type: FieldType.Element,
+      getElement: (): ReactElement => {
+        return <span data-testid="cell-name">api-gateway</span>;
+      },
+    },
+    /*
+     * The #3585 shape: a cell holding a server-authored sentence, opting into
+     * wrapping without naming a width. This is the "Responded Hosts" column
+     * on App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx.
+     */
+    {
+      field: { description: true },
+      title: "Status Message",
+      type: FieldType.Element,
+      wrapContent: true,
+      getElement: (): ReactElement => {
+        return (
+          <span data-testid="cell-status-message">
+            Settings changed, so this scan is queued to run again.
+          </span>
+        );
+      },
+    },
+    /*
+     * A wrapping column that names its own, wider cap. This is the shape
+     * ExceptionsTable.tsx's "Exception Message" column was migrated to.
+     */
+    {
+      field: { monitorType: true },
+      title: "Exception Message",
+      type: FieldType.Element,
+      wrapContent: true,
+      wrapMaxWidthClassName: "max-w-3xl",
+      getElement: (): ReactElement => {
+        return <span data-testid="cell-exception-message">TypeError</span>;
+      },
+    },
+    /*
+     * The pre-existing contract: a column that only styles its content and
+     * never asked to wrap. It has to pass through untouched, and must NOT
+     * acquire a width cap.
+     */
+    {
+      field: { slug: true },
+      title: "Note",
+      type: FieldType.Element,
+      contentClassName: "text-xs text-gray-500",
+      getElement: (): ReactElement => {
+        return <span data-testid="cell-note">a note</span>;
+      },
+    },
+  ];
+
+  return columns as unknown as Columns<Monitor>;
+};
+
+/*
+ * One row action, which is the cheapest way to make BaseModelTable decide it
+ * needs the generated Actions column at all (see `showActionsColumn` in
+ * serializeToTableColumns).
+ */
+const ACTION_BUTTONS: Array<ActionButtonSchema<Monitor>> = [
+  {
+    title: "Edit",
+    buttonStyleType: ButtonStyleType.NORMAL,
+    onClick: (): void => {
+      return undefined;
+    },
+  },
+] as unknown as Array<ActionButtonSchema<Monitor>>;
+
+describe("ModelTable column wrapping options (OneUptime issue #3585)", () => {
+  type MakeCallbacksFunction = (
+    rows: Array<JSONObject>,
+  ) => BaseTableCallbacks<Monitor>;
+
+  /*
+   * Server-free: `getList` is a plain function returning a page of rows, and
+   * the model/JSON conversions are the identity, so the JSONObject rows above
+   * reach `getElement` untouched.
+   */
+  const makeCallbacks: MakeCallbacksFunction = (
+    rows: Array<JSONObject>,
+  ): BaseTableCallbacks<Monitor> => {
+    return {
+      deleteItem: async () => {
+        return undefined;
+      },
+      getModelFromJSON: (item: JSONObject) => {
+        return item as unknown as Monitor;
+      },
+      getJSONFromModel: (item: Monitor) => {
+        return item as unknown as JSONObject;
+      },
+      addSlugToSelect: (select: unknown) => {
+        return select;
+      },
+      getList: async (data: {
+        query: Query<Monitor>;
+        limit: number;
+        select: JSONObject;
+        sort: JSONObject;
+      }): Promise<ListResult<Monitor>> => {
+        return {
+          data: rows as unknown as Array<Monitor>,
+          count: rows.length,
+          skip: 0,
+          limit: data.limit,
+        };
+      },
+      toJSONArray: () => {
+        return [];
+      },
+      updateById: async () => {
+        return undefined;
+      },
+      showCreateEditModal: () => {
+        return <></>;
+      },
+    } as unknown as BaseTableCallbacks<Monitor>;
+  };
+
+  type RenderTableFunction = () => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (): ReturnType<typeof render> => {
+    const props: BaseModelTableProps<Monitor> = {
+      modelType: Monitor,
+      id: "monitors-table",
+      name: "Monitors",
+      userPreferencesKey: PREFS_KEY,
+      cardProps: { title: "Monitors" },
+      columns: makeColumns(),
+      filters: FILTERS,
+      isDeleteable: false,
+      isCreateable: false,
+      isViewable: false,
+      isEditable: false,
+      actionButtons: ACTION_BUTTONS,
+      // This suite is about cell classes; keep the URL out of it entirely.
+      disableUrlState: true,
+      callbacks: makeCallbacks(ROWS),
+    } as unknown as BaseModelTableProps<Monitor>;
+
+    return render(<BaseModelTable<Monitor> {...props} />);
+  };
+
+  type WaitForRowFunction = () => Promise<void>;
+
+  const waitForRow: WaitForRowFunction = async (): Promise<void> => {
+    await waitFor(() => {
+      expect(screen.queryByTestId("cell-name")).not.toBeNull();
+    });
+  };
+
+  type GetContentWrapperFunction = (testId: string) => HTMLElement;
+
+  /*
+   * TableRow renders a cell as <td><div className={content}>{element}</div>,
+   * so the wrapper is the marker span's direct parent. Reached that way
+   * rather than by index so a column reorder cannot quietly retarget an
+   * assertion.
+   */
+  const getContentWrapper: GetContentWrapperFunction = (
+    testId: string,
+  ): HTMLElement => {
+    return screen.getByTestId(testId).parentElement as HTMLElement;
+  };
+
+  type GetCellFunction = (testId: string) => HTMLElement;
+
+  const getCell: GetCellFunction = (testId: string): HTMLElement => {
+    return screen.getByTestId(testId).closest("td") as HTMLElement;
+  };
+
+  beforeEach(() => {
+    /*
+     * BaseModelTable reads any stored column layout out of localStorage on
+     * mount, and the runner shares one jsdom across files.
+     */
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("a column that opts into wrapping", () => {
+    /*
+     * The heart of #3585. `whitespace-nowrap` on the <td> is what the
+     * sentence inherited; `whitespace-normal break-words` is what replaces
+     * it. jsdom cannot break a line, so the class list is the assertion.
+     */
+    test("renders a <td> that declares whitespace-normal and break-words, never whitespace-nowrap", async () => {
+      renderTable();
+
+      await waitForRow();
+
+      const cell: HTMLElement = getCell("cell-status-message");
+
+      expect(cell).toHaveClass("whitespace-normal");
+      expect(cell).toHaveClass("break-words");
+      expect(cell).not.toHaveClass("whitespace-nowrap");
+
+      /*
+       * Pinned as a whole string, not just as three classes: the padding,
+       * text and alignment utilities are what keep a wrapping cell in the
+       * same visual rhythm as its neighbours, and a rewrite that produced the
+       * right whitespace classes while dropping those would look fine here
+       * and wrong on screen.
+       */
+      expect(cell.className).toBe(
+        "whitespace-normal break-words py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top",
+      );
+    });
+
+    /*
+     * The width cap belongs on the content <div>, never on the <td>:
+     * `max-width` on a `display: table-cell` box is ignored outright, so a
+     * cap that drifted onto the <td> would do nothing at all - and the
+     * original bug was precisely a capped box around an unbreakable line.
+     */
+    test("caps the content wrapper, not the <td>, when no width is named", async () => {
+      renderTable();
+
+      await waitForRow();
+
+      expect(getContentWrapper("cell-status-message").className).toBe(
+        DEFAULT_WRAP_WIDTH_CLASS_NAME,
+      );
+
+      expect(getCell("cell-status-message").className).not.toMatch(/max-w-/);
+    });
+
+    /*
+     * `wrapMaxWidthClassName` is the second of the two fields riding the
+     * BaseModelTable spread, and the one ExceptionsTable.tsx depends on: its
+     * "Exception Message" column was migrated from a hand-spelled
+     * "max-w-3xl whitespace-normal break-words" contentClassName onto these
+     * options, so if this field stops making the hop that table silently
+     * loses its width cap.
+     */
+    test("uses wrapMaxWidthClassName on the wrapper when the column names one", async () => {
+      renderTable();
+
+      await waitForRow();
+
+      const wrapper: HTMLElement = getContentWrapper("cell-exception-message");
+
+      expect(wrapper.className).toBe("max-w-3xl");
+      // The named width replaces the default rather than stacking with it.
+      expect(wrapper).not.toHaveClass(DEFAULT_WRAP_WIDTH_CLASS_NAME);
+
+      // ...and the cell it sits in is still a wrapping cell.
+      expect(getCell("cell-exception-message")).toHaveClass(
+        "whitespace-normal",
+        "break-words",
+      );
+    });
+  });
+
+  describe("columns that opt into nothing", () => {
+    /*
+     * The regression that would hurt most: wrapping leaking from one column
+     * onto the rest of the row. "12 Mar 2026, 4:05 pm" folding onto two lines
+     * across every table in the product is a far bigger blast radius than the
+     * bug being fixed, so a sibling in the SAME rendered row is asserted to
+     * still be nowrap.
+     */
+    test("a sibling column in the same row still renders a nowrap <td>", async () => {
+      renderTable();
+
+      await waitForRow();
+
+      const wrappingCell: HTMLElement = getCell("cell-status-message");
+      const plainCell: HTMLElement = getCell("cell-name");
+
+      // Same row - so this really is per column, not per table.
+      expect(plainCell.parentElement).toBe(wrappingCell.parentElement);
+
+      expect(plainCell.className).toBe(NOWRAP_CELL_CLASS_NAME);
+    });
+
+    /*
+     * A column that declares neither option must produce the DOM it produced
+     * before the options existed - down to an empty wrapper className, so
+     * that not one class shifts for the columns nobody touched.
+     */
+    test("a column that declares neither option gets an empty content wrapper", async () => {
+      renderTable();
+
+      await waitForRow();
+
+      expect(getContentWrapper("cell-name").className).toBe("");
+    });
+
+    /*
+     * `contentClassName` predates this work and is a different thing: styling
+     * for the content, with no opinion on wrapping. It has to pass through
+     * untouched, and - the important half - must NOT acquire a width cap,
+     * because a max-width on a still-nowrap cell is exactly the overlap
+     * generator #3585 was.
+     */
+    test("a contentClassName-only column keeps its exact string, with no width injected", async () => {
+      renderTable();
+
+      await waitForRow();
+
+      expect(getContentWrapper("cell-note").className).toBe(
+        "text-xs text-gray-500",
+      );
+      expect(getContentWrapper("cell-note").className).not.toMatch(/max-w-/);
+
+      // And the cell itself is untouched: no opt-in, no wrapping.
+      expect(getCell("cell-note").className).toBe(NOWRAP_CELL_CLASS_NAME);
+    });
+  });
+
+  describe("the generated Actions column", () => {
+    /*
+     * BaseModelTable appends the Actions column itself (the second
+     * `columns.push` in serializeToTableColumns) with a title and a type and
+     * nothing else. It is the one column no caller can annotate, so it is the
+     * one most likely to be broken by a change to the shared cell helper: a
+     * width cap here would squeeze the row's buttons, and wrapping here would
+     * stack them.
+     */
+    test("renders a nowrap last cell and an uncapped 'flex justify-end' container", async () => {
+      const { container } = renderTable();
+
+      await waitForRow();
+
+      const actionsContainer: HTMLElement = container.querySelector(
+        "tbody div.justify-end",
+      ) as HTMLElement;
+
+      expect(actionsContainer).not.toBeNull();
+      /*
+       * Exactly this string: the actions container is built by appending the
+       * cell's content classes to "flex justify-end", so anything the helper
+       * wrongly handed a no-option column would show up here as extra
+       * classes.
+       */
+      expect(actionsContainer.className).toBe("flex justify-end");
+
+      const actionsCell: HTMLElement = actionsContainer.closest(
+        "td",
+      ) as HTMLElement;
+
+      // Appended last, and so it takes the last column's wider right padding.
+      const cells: Array<Element> = Array.from(
+        (actionsCell.parentElement as HTMLElement).querySelectorAll("td"),
+      );
+
+      expect(cells[cells.length - 1]).toBe(actionsCell);
+      expect(actionsCell.className).toBe(NOWRAP_LAST_CELL_CLASS_NAME);
+
+      // Nothing inside the actions cell is width-capped either.
+      expect(actionsCell.querySelector('[class*="max-w-"]')).toBeNull();
+    });
+  });
+});

--- a/Common/Tests/UI/Components/TableCellWrapping.test.tsx
+++ b/Common/Tests/UI/Components/TableCellWrapping.test.tsx
@@ -1,0 +1,625 @@
+import "@testing-library/jest-dom";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { RenderResult, cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { ReactElement } from "react";
+import Table from "../../../UI/Components/Table/Table";
+import Column from "../../../UI/Components/Table/Types/Column";
+import Columns from "../../../UI/Components/Table/Types/Columns";
+import {
+  DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME,
+  getTableCellClassName,
+  getTableCellContentClassName,
+} from "../../../UI/Components/Table/CellClassName";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+
+/*
+ * OneUptime issue #3585 - a status sentence painted over the columns beside it.
+ *
+ * The Discovery Scans table renders a server-written sentence in its "Responded
+ * Hosts" cell (RETIRE_RUN_PAYLOAD in
+ * Common/Server/Services/NetworkDeviceDiscoveryScanService.ts, 156 characters).
+ * Every desktop body <td> in TableRow.tsx declares `whitespace-nowrap`, and
+ * `white-space` is an INHERITED property, so the nowrap reached the sentence
+ * whatever classes its own element carried. The cell also carried `max-w-md`,
+ * which capped the BOX the unbreakable line then overflowed out of - so the
+ * sentence was painted straight across the Recurrence and Started cells rather
+ * than merely widening the table. A width cap on a nowrap cell is the overlap
+ * generator, not the fix.
+ *
+ * The fix routes both class strings through
+ * Common/UI/Components/Table/CellClassName.ts and adds two column options,
+ * `wrapContent` and `wrapMaxWidthClassName`, such that a width cap can only
+ * ever be emitted together with a wrapping mode.
+ *
+ * IMPORTANT, and the reason every assertion below is a class / attribute /
+ * DOM-structure / text assertion: jsdom performs NO layout. There is no
+ * getBoundingClientRect worth reading, no computed line breaking, no overflow
+ * and no column widths. Where a reader would reasonably expect "assert the text
+ * did not overlap its neighbour", what is asserted instead is the exact class
+ * contract the browser would have applied - which is the whole of what the fix
+ * changes.
+ */
+
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, opts?: { defaultValue?: string }): string => {
+          return opts?.defaultValue ?? key;
+        },
+      };
+    },
+  };
+});
+
+interface Row {
+  _id?: string | undefined;
+  name?: string | undefined;
+  message?: string | undefined;
+}
+
+/*
+ * The literal sentence from RETIRE_RUN_PAYLOAD - the text that was on screen
+ * when #3585 was reported. Kept verbatim so the fixture is the bug's own data.
+ */
+const STATUS_MESSAGE: string =
+  "Settings changed, so this scan is queued to run again. The hosts the previous run found have been cleared - they described settings this scan no longer has.";
+
+/*
+ * A 400-character sentence for the default-renderer path (a column with a key
+ * and no getElement). Longer than anything a nowrap cell can hold on a laptop.
+ */
+const LONG_TEXT: string =
+  `A very long status sentence written by the server. ${"The scan reported nothing and this is the reason why. ".repeat(
+    8,
+  )}`.slice(0, 400);
+
+/*
+ * The two strings the cell renderers hard-coded before CellClassName.ts
+ * existed. They are spelled out here, in full, on purpose: the point of the
+ * refactor is that roughly two hundred column declarations across the product
+ * - dates, counts, badges, ids, none of which have layout coverage of their
+ * own - keep byte-for-byte the classes they had. Anything that shifts a single
+ * utility in these strings has changed every table in OneUptime.
+ */
+const DEFAULT_CELL_CLASS_NAME: string =
+  "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+const DEFAULT_LAST_CELL_CLASS_NAME: string =
+  "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+
+const data: Array<Row> = [
+  { _id: "1", name: "10.0.0.0/24", message: STATUS_MESSAGE },
+];
+
+type RenderTableFunction = (columns: Columns<Row>) => RenderResult;
+
+const renderTable: RenderTableFunction = (
+  columns: Columns<Row>,
+): RenderResult => {
+  return render(
+    <Table<Row>
+      id="test-table"
+      data={data}
+      columns={columns}
+      currentPageNumber={1}
+      totalItemsCount={data.length}
+      itemsOnPage={10}
+      error=""
+      isLoading={false}
+      singularLabel="Scan"
+      pluralLabel="Scans"
+      sortOrder={SortOrder.Ascending}
+      sortBy={null}
+      onSortChanged={() => {}}
+      onNavigateToPage={() => {}}
+    />,
+  );
+};
+
+/*
+ * The table decides mobile vs desktop from window.innerWidth at mount
+ * (< 768 = mobile). jsdom defaults to 1024, so desktop is the baseline and the
+ * mobile test must set the width BEFORE rendering.
+ */
+const setViewportWidth: (width: number) => void = (width: number): void => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+};
+
+type GetBodyCellsFunction = (container: HTMLElement) => Array<HTMLElement>;
+
+const getBodyCells: GetBodyCellsFunction = (
+  container: HTMLElement,
+): Array<HTMLElement> => {
+  return Array.from(container.querySelectorAll<HTMLElement>("tbody tr td"));
+};
+
+/*
+ * The <div> TableRow puts directly inside the <td> around a cell's content.
+ * The width cap of a wrapping column has to live here rather than on the <td>,
+ * because `max-width` on a `display: table-cell` box is ignored outright.
+ */
+type GetContentWrapperFunction = (cell: HTMLElement) => HTMLElement;
+
+const getContentWrapper: GetContentWrapperFunction = (
+  cell: HTMLElement,
+): HTMLElement => {
+  const wrapper: Element | null = cell.firstElementChild;
+
+  if (!(wrapper instanceof HTMLElement)) {
+    throw new Error("The cell rendered no content wrapper element.");
+  }
+
+  return wrapper;
+};
+
+afterEach(() => {
+  cleanup();
+  setViewportWidth(1024);
+});
+
+/*
+ * The helpers on their own, with hand-built column objects. Cheap, exact, and
+ * they pin the two strings without paying for a render - so a failure here
+ * says "the class contract moved" rather than "some table broke".
+ */
+describe("CellClassName helpers", () => {
+  test("a column that declares nothing keeps the pre-#3585 cell classes", () => {
+    const column: Column<Row> = { title: "Name", type: FieldType.Text };
+
+    expect(
+      getTableCellClassName<Row>({
+        column: column,
+        isLastRenderedColumn: false,
+      }),
+    ).toBe(DEFAULT_CELL_CLASS_NAME);
+
+    expect(
+      getTableCellClassName<Row>({
+        column: column,
+        isLastRenderedColumn: true,
+      }),
+    ).toBe(DEFAULT_LAST_CELL_CLASS_NAME);
+  });
+
+  test("wrapContent swaps nowrap for whitespace-normal break-words, and nothing else", () => {
+    const column: Column<Row> = {
+      title: "Message",
+      type: FieldType.Text,
+      wrapContent: true,
+    };
+
+    expect(
+      getTableCellClassName<Row>({
+        column: column,
+        isLastRenderedColumn: false,
+      }),
+    ).toBe(
+      DEFAULT_CELL_CLASS_NAME.replace(
+        "whitespace-nowrap",
+        "whitespace-normal break-words",
+      ),
+    );
+  });
+
+  test("the content wrapper is empty unless the column asked for something", () => {
+    expect(
+      getTableCellContentClassName<Row>({
+        title: "Name",
+        type: FieldType.Text,
+      }),
+    ).toBe("");
+  });
+
+  test("a wrapping column gets the default width cap, and a named one replaces it", () => {
+    expect(
+      getTableCellContentClassName<Row>({
+        title: "Message",
+        type: FieldType.Text,
+        wrapContent: true,
+      }),
+    ).toBe(DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME);
+
+    /*
+     * Replaced, not appended: two max-w-* utilities on one element are resolved
+     * by Tailwind's stylesheet order rather than the order they were written,
+     * so the narrower one would silently lose.
+     */
+    expect(
+      getTableCellContentClassName<Row>({
+        title: "Message",
+        type: FieldType.Text,
+        wrapContent: true,
+        wrapMaxWidthClassName: "max-w-3xl",
+      }),
+    ).toBe("max-w-3xl");
+  });
+
+  test("a width cap alone emits nothing - the #3585 pairing is unspellable", () => {
+    /*
+     * This is the assertion that matters most. `max-w-md` on a cell that is
+     * still `whitespace-nowrap` is precisely the combination that painted the
+     * status sentence over the Recurrence and Started columns. Through the new
+     * API it cannot be expressed: the width is only ever emitted alongside the
+     * wrapping mode that makes it safe.
+     */
+    const column: Column<Row> = {
+      title: "Message",
+      type: FieldType.Text,
+      wrapMaxWidthClassName: "max-w-md",
+    };
+
+    expect(getTableCellContentClassName<Row>(column)).toBe("");
+    expect(
+      getTableCellClassName<Row>({
+        column: column,
+        isLastRenderedColumn: false,
+      }),
+    ).toBe(DEFAULT_CELL_CLASS_NAME);
+  });
+
+  test("contentClassName still reaches the wrapper, alone and alongside a wrap", () => {
+    expect(
+      getTableCellContentClassName<Row>({
+        title: "Name",
+        type: FieldType.Text,
+        contentClassName: "text-sm text-gray-900",
+      }),
+    ).toBe("text-sm text-gray-900");
+
+    expect(
+      getTableCellContentClassName<Row>({
+        title: "Message",
+        type: FieldType.Text,
+        wrapContent: true,
+        contentClassName: "text-sm text-gray-900",
+      }),
+    ).toBe(`${DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME} text-sm text-gray-900`);
+  });
+});
+
+/*
+ * The rendered table, which is what the ~200 existing column declarations
+ * actually go through. A column that says nothing about wrapping must come out
+ * of the refactor with not one class moved, in either the <td> or the wrapper.
+ */
+describe("columns that declare no wrapping are untouched", () => {
+  const columns: Columns<Row> = [
+    { title: "Network", type: FieldType.Text, key: "name" },
+    {
+      title: "Message",
+      type: FieldType.Text,
+      key: "message",
+      getElement: (item: Row): ReactElement => {
+        return <span>{item.message}</span>;
+      },
+    },
+  ];
+
+  test("the cell is still nowrap and never wraps", () => {
+    const { container } = renderTable(columns);
+    const cells: Array<HTMLElement> = getBodyCells(container);
+
+    expect(cells.length).toBe(2);
+
+    for (const cell of cells) {
+      expect(cell).toHaveClass("whitespace-nowrap");
+      expect(cell).not.toHaveClass("whitespace-normal");
+      expect(cell).not.toHaveClass("break-words");
+    }
+  });
+
+  test("the cell class string is byte-for-byte what it was before the fix", () => {
+    const { container } = renderTable(columns);
+    const cells: Array<HTMLElement> = getBodyCells(container);
+
+    // Non-last cell: pr-3. Last rendered cell: pr-6.
+    expect(cells[0]!.getAttribute("class")).toBe(DEFAULT_CELL_CLASS_NAME);
+    expect(cells[1]!.getAttribute("class")).toBe(DEFAULT_LAST_CELL_CLASS_NAME);
+  });
+
+  test("the content wrapper carries an empty class, not a stray space or a width", () => {
+    /*
+     * Exactly "" - no separator left behind by the join, and above all no
+     * injected max-w-*. A width silently added here would recreate #3585 on
+     * every table in the product at once.
+     */
+    const { container } = renderTable(columns);
+    const cells: Array<HTMLElement> = getBodyCells(container);
+
+    expect(getContentWrapper(cells[0]!).getAttribute("class")).toBe("");
+    expect(getContentWrapper(cells[1]!).getAttribute("class")).toBe("");
+  });
+});
+
+/*
+ * The Discovery "Responded Hosts" column, in the shape the fix gives it.
+ */
+describe("columns that opt into wrapping", () => {
+  type BuildColumnsFunction = (message: Column<Row>) => Columns<Row>;
+
+  const buildColumns: BuildColumnsFunction = (
+    message: Column<Row>,
+  ): Columns<Row> => {
+    return [{ title: "Network", type: FieldType.Text, key: "name" }, message];
+  };
+
+  const messageColumn: Column<Row> = {
+    title: "Responded Hosts",
+    type: FieldType.Element,
+    key: "message",
+    wrapContent: true,
+    getElement: (item: Row): ReactElement => {
+      return (
+        <div className="text-xs text-gray-500" title={item.message}>
+          {item.message}
+        </div>
+      );
+    },
+  };
+
+  test("the cell wraps instead of forcing one unbreakable line", () => {
+    /*
+     * jsdom does no line breaking, so what is checked is the declaration the
+     * browser would break on: nowrap gone, whitespace-normal and break-words
+     * present. break-words matters as much as the wrap - a single long token
+     * (a URL, a 60-character hostname) has no break opportunity without it.
+     */
+    const { container } = renderTable(buildColumns(messageColumn));
+    const cell: HTMLElement = getBodyCells(container)[1]!;
+
+    expect(cell).toHaveClass("whitespace-normal");
+    expect(cell).toHaveClass("break-words");
+    expect(cell).not.toHaveClass("whitespace-nowrap");
+  });
+
+  test("with no width named, the wrapper takes the exported default cap", () => {
+    const { container } = renderTable(buildColumns(messageColumn));
+    const wrapper: HTMLElement = getContentWrapper(getBodyCells(container)[1]!);
+
+    // Asserted against the exported constant, so the two cannot drift apart.
+    expect(wrapper).toHaveClass(DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME);
+    expect(wrapper.getAttribute("class")).toBe(
+      DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME,
+    );
+  });
+
+  test("a named width replaces the default rather than joining it", () => {
+    const { container } = renderTable(
+      buildColumns({
+        ...messageColumn,
+        wrapMaxWidthClassName: "max-w-3xl",
+      }),
+    );
+    const wrapper: HTMLElement = getContentWrapper(getBodyCells(container)[1]!);
+
+    expect(wrapper).toHaveClass("max-w-3xl");
+    /*
+     * Both present would not be "the last one wins": Tailwind emits max-w-md
+     * and max-w-3xl as equally specific rules, so the winner is whichever the
+     * stylesheet happens to define later - not the one the column asked for.
+     */
+    expect(wrapper).not.toHaveClass(DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME);
+  });
+
+  test("contentClassName is kept and sits alongside the cap", () => {
+    const { container } = renderTable(
+      buildColumns({
+        ...messageColumn,
+        contentClassName: "text-sm text-gray-900",
+      }),
+    );
+    const wrapper: HTMLElement = getContentWrapper(getBodyCells(container)[1]!);
+
+    expect(wrapper).toHaveClass(DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME);
+    expect(wrapper).toHaveClass("text-sm");
+    expect(wrapper).toHaveClass("text-gray-900");
+  });
+
+  test("the row's padding and vertical rhythm survive the refactor", () => {
+    /*
+     * A wrapping cell must still line up with the nowrap cells beside it -
+     * same padding, same type scale, same top alignment. Only the white-space
+     * pair is allowed to differ.
+     */
+    const { container } = renderTable(buildColumns(messageColumn));
+    const cells: Array<HTMLElement> = getBodyCells(container);
+    const wrappingCell: HTMLElement = cells[1]!;
+
+    for (const className of [
+      "py-4",
+      "pl-4",
+      "sm:pl-6",
+      "align-top",
+      "text-sm",
+      "font-medium",
+      "text-gray-500",
+    ]) {
+      expect(wrappingCell).toHaveClass(className);
+    }
+
+    expect(cells[0]).toHaveClass("pr-3");
+    expect(wrappingCell).toHaveClass("pr-6");
+    expect(wrappingCell).not.toHaveClass("pr-3");
+  });
+
+  test("a width cap without wrapContent changes nothing at all", () => {
+    /*
+     * The rendered proof of the helper-level assertion above: this is the
+     * exact declaration #3585 was, and through the new API it produces a plain
+     * nowrap cell with an empty wrapper - no capped box for an unbreakable
+     * line to overflow out of.
+     */
+    const { container } = renderTable(
+      buildColumns({
+        title: "Responded Hosts",
+        type: FieldType.Element,
+        key: "message",
+        wrapMaxWidthClassName: "max-w-md",
+        getElement: (item: Row): ReactElement => {
+          return <span>{item.message}</span>;
+        },
+      }),
+    );
+    const cell: HTMLElement = getBodyCells(container)[1]!;
+
+    expect(cell).toHaveClass("whitespace-nowrap");
+    expect(cell.getAttribute("class")).toBe(DEFAULT_LAST_CELL_CLASS_NAME);
+    expect(getContentWrapper(cell).getAttribute("class")).toBe("");
+  });
+
+  test("a plain text column with no getElement can wrap too", () => {
+    /*
+     * The default-renderer path. #3585 was reported on a getElement column,
+     * but the great majority of prose cells in the product are plain keyed
+     * text; the option is only worth having if it reaches them as well.
+     */
+    const { container } = renderTable([
+      { title: "Network", type: FieldType.Text, key: "name" },
+      {
+        title: "Message",
+        type: FieldType.Text,
+        key: "message",
+        wrapContent: true,
+      },
+    ]);
+    const cell: HTMLElement = getBodyCells(container)[1]!;
+
+    expect(cell).toHaveClass("whitespace-normal");
+    expect(cell).toHaveClass("break-words");
+    expect(cell).not.toHaveClass("whitespace-nowrap");
+    expect(getContentWrapper(cell)).toHaveClass(
+      DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME,
+    );
+    expect(cell.textContent).toBe(STATUS_MESSAGE);
+  });
+
+  test("a 400-character value still lands in a wrapping default-rendered cell", () => {
+    const { container } = render(
+      <Table<Row>
+        id="long-text-table"
+        data={[{ _id: "1", name: "10.0.0.0/24", message: LONG_TEXT }]}
+        columns={[
+          { title: "Network", type: FieldType.Text, key: "name" },
+          {
+            title: "Message",
+            type: FieldType.Text,
+            key: "message",
+            wrapContent: true,
+          },
+        ]}
+        currentPageNumber={1}
+        totalItemsCount={1}
+        itemsOnPage={10}
+        error=""
+        isLoading={false}
+        singularLabel="Scan"
+        pluralLabel="Scans"
+        sortOrder={SortOrder.Ascending}
+        sortBy={null}
+        onSortChanged={() => {}}
+        onNavigateToPage={() => {}}
+      />,
+    );
+    const cell: HTMLElement = getBodyCells(container)[1]!;
+
+    expect(LONG_TEXT.length).toBe(400);
+    expect(cell.textContent).toBe(LONG_TEXT);
+    expect(cell).toHaveClass("whitespace-normal");
+    expect(getContentWrapper(cell)).toHaveClass(
+      DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME,
+    );
+  });
+});
+
+/*
+ * Two things the refactor could have broken quietly, because neither is what
+ * the issue was about.
+ */
+describe("what the shared helper must not disturb", () => {
+  test("the extra right padding is decided by rendered columns, not declared ones", () => {
+    /*
+     * The last-cell test in TableRow compares against the RENDERED column
+     * count. A hideOnMobile column is in the fixture because that is where
+     * declared and rendered part company; at this width it is rendered, so it
+     * is the last cell and it is the one that must carry pr-6. If the helper
+     * were ever handed a declared index, the wider padding would land on the
+     * wrong cell - or on none.
+     */
+    setViewportWidth(1280);
+
+    const { container } = renderTable([
+      { title: "Network", type: FieldType.Text, key: "name" },
+      { title: "Message", type: FieldType.Text, key: "message" },
+      {
+        title: "Recurrence",
+        type: FieldType.Text,
+        key: "name",
+        hideOnMobile: true,
+        wrapContent: true,
+        wrapMaxWidthClassName: "max-w-xs",
+      },
+    ]);
+    const cells: Array<HTMLElement> = getBodyCells(container);
+
+    expect(cells.length).toBe(3);
+    expect(cells[0]).toHaveClass("pr-3");
+    expect(cells[1]).toHaveClass("pr-3");
+    expect(cells[2]).toHaveClass("pr-6");
+    expect(cells[2]).not.toHaveClass("pr-3");
+    expect(getContentWrapper(cells[2]!).getAttribute("class")).toBe("max-w-xs");
+  });
+
+  test("an actions column still gets a bare right-aligned button row", () => {
+    /*
+     * The actions container now composes onto the same string the content
+     * wrapper uses. A column that declares nothing must still produce exactly
+     * "flex justify-end": a width cap leaking in here would squeeze the Edit
+     * and Delete buttons of every table in the product.
+     */
+    const { container } = renderTable([
+      { title: "Network", type: FieldType.Text, key: "name" },
+      { title: "Actions", type: FieldType.Actions, key: null },
+    ]);
+    const cell: HTMLElement = getBodyCells(container)[1]!;
+
+    expect(getContentWrapper(cell).getAttribute("class")).toBe(
+      "flex justify-end",
+    );
+  });
+});
+
+/*
+ * Mobile is a different layout entirely - cards, not a table - and it declares
+ * no nowrap of its own, so it never had #3585 and needs neither new option. It
+ * deliberately reads neither wrapContent nor contentClassName, which is why the
+ * assertions here are about text rather than classes: what must hold is that
+ * the label and the whole sentence are on screen.
+ */
+describe("the mobile card", () => {
+  test("renders no table cells, and shows the wrapping column in full", () => {
+    setViewportWidth(375);
+
+    renderTable([
+      { title: "Network", type: FieldType.Text, key: "name" },
+      {
+        title: "Responded Hosts",
+        type: FieldType.Element,
+        key: "message",
+        wrapContent: true,
+        getElement: (item: Row): ReactElement => {
+          return <div className="text-xs text-gray-500">{item.message}</div>;
+        },
+      },
+    ]);
+
+    expect(document.querySelectorAll("td").length).toBe(0);
+    expect(screen.getByText("Responded Hosts")).toBeInTheDocument();
+    expect(screen.getByText(STATUS_MESSAGE)).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/TableLoadingStates.test.tsx
+++ b/Common/Tests/UI/Components/TableLoadingStates.test.tsx
@@ -277,3 +277,208 @@ describe("after loading finishes", () => {
     expect(screen.queryByTestId("table-skeleton-loader")).toBeNull();
   });
 });
+
+/*
+ * OneUptime issue #3585 - the wrapping opt-in, seen from the skeleton.
+ *
+ * Background: every desktop body <td> this table renders is
+ * `whitespace-nowrap`, and `white-space` is an INHERITED CSS property, so the
+ * nowrap declared on the cell reaches whatever `getElement` returned, no
+ * matter what classes that element carries. A 156-character status sentence
+ * therefore painted as one unbreakable line straight across the columns to
+ * its right. The fix gives a column `wrapContent`, which swaps that one class
+ * on the <td> for `whitespace-normal break-words`.
+ *
+ * Those classes used to be spelled out as string literals in four places -
+ * twice in TableRow (last cell / not last) and twice in TableSkeletonRows.
+ * The fix routes all four through getTableCellClassName in
+ * UI/Components/Table/CellClassName.ts, and the tests below exist to keep
+ * them routed there. A skeleton that re-hard-coded `whitespace-nowrap` would
+ * still look correct on a table of dates while silently un-wrapping the
+ * loading state of every prose column: exactly the drift that produced #3585.
+ *
+ * jsdom runs no layout engine, so nothing here can observe wrapping,
+ * overflow or a column width - getBoundingClientRect is all zeroes and no
+ * stylesheet is applied. What IS observable, and what actually decides the
+ * bug, is which class string each <td> is handed, so every assertion below is
+ * a class assertion.
+ */
+
+interface WrapRow {
+  _id?: string | undefined;
+  name?: string | undefined;
+  statusMessage?: string | undefined;
+  notes?: string | undefined;
+}
+
+const wrappingColumns: Columns<WrapRow> = [
+  // Declares nothing: the ordinary case, and the control for the rest.
+  { title: "Name", type: FieldType.Text, key: "name" },
+  // Wrapping, not last: prose in the middle of the table.
+  {
+    title: "Status Message",
+    type: FieldType.Text,
+    key: "statusMessage",
+    wrapContent: true,
+  },
+  // Wrapping AND last: opting into wrapping must not cost the cell its pr-6.
+  {
+    title: "Notes",
+    type: FieldType.Text,
+    key: "notes",
+    wrapContent: true,
+    wrapMaxWidthClassName: "max-w-xs",
+  },
+];
+
+const wrappingData: Array<WrapRow> = [
+  {
+    _id: "1",
+    name: "Alpha",
+    statusMessage:
+      "Settings changed, so this scan is queued to run again. The hosts below are from the previous run.",
+    notes: "Queued",
+  },
+];
+
+interface RenderWrappingTableOptions {
+  isLoading?: boolean | undefined;
+  data?: Array<WrapRow> | undefined;
+}
+
+type RenderWrappingTableFunction = (
+  options: RenderWrappingTableOptions,
+) => void;
+
+/*
+ * Its own fixture rather than a mutation of the shared `columns` above: the
+ * tests further up assert exact skeleton cell counts against that one.
+ */
+const renderWrappingTable: RenderWrappingTableFunction = (
+  options: RenderWrappingTableOptions,
+): void => {
+  render(
+    <Table<WrapRow>
+      id="wrapping-table"
+      data={options.data ?? []}
+      columns={wrappingColumns}
+      currentPageNumber={1}
+      totalItemsCount={(options.data ?? []).length}
+      itemsOnPage={10}
+      error=""
+      isLoading={options.isLoading ?? false}
+      singularLabel="Scan"
+      pluralLabel="Scans"
+      sortOrder={SortOrder.Ascending}
+      sortBy={null}
+      onSortChanged={(): void => {}}
+      onNavigateToPage={(): void => {}}
+    />,
+  );
+};
+
+type GetSkeletonCellsFunction = () => NodeListOf<Element>;
+
+const getSkeletonCells: GetSkeletonCellsFunction = (): NodeListOf<Element> => {
+  const loader: HTMLElement = screen.getByTestId("table-skeleton-loader");
+  return loader.querySelectorAll("tr")[0]!.querySelectorAll("td");
+};
+
+describe("skeleton cells honour a column's wrapContent flag", () => {
+  test("a wrapContent column's placeholder cell wraps instead of nowrapping", () => {
+    renderWrappingTable({ isLoading: true, data: [] });
+
+    const cells: NodeListOf<Element> = getSkeletonCells();
+
+    /*
+     * The whole point of #3585: nowrap has to be GONE, not merely joined by
+     * a wrapping class. Both would sit in the class list, and which one won
+     * would be a stylesheet-order coin toss that jsdom cannot resolve and a
+     * reader cannot predict.
+     */
+    expect(cells[1]).toHaveClass("whitespace-normal", "break-words");
+    expect(cells[1]).not.toHaveClass("whitespace-nowrap");
+  });
+
+  test("wrapping does not cost the cell its padding, alignment or type styles", () => {
+    renderWrappingTable({ isLoading: true, data: [] });
+
+    const cells: NodeListOf<Element> = getSkeletonCells();
+
+    /*
+     * Everything except the whitespace class is shared with a plain cell, so
+     * a wrapping placeholder keeps the same rhythm as the rows around it.
+     */
+    expect(cells[1]).toHaveClass(
+      "py-4",
+      "pl-4",
+      "sm:pl-6",
+      "align-top",
+      "text-sm",
+      "font-medium",
+      "text-gray-500",
+    );
+  });
+
+  test("last vs non-last right padding still applies to wrapping cells", () => {
+    renderWrappingTable({ isLoading: true, data: [] });
+
+    const cells: NodeListOf<Element> = getSkeletonCells();
+
+    // Wrapping mid-table cell.
+    expect(cells[1]).toHaveClass("pr-3");
+    expect(cells[1]).not.toHaveClass("pr-6");
+    // Wrapping last cell: the extra right padding is keyed off position only.
+    expect(cells[2]).toHaveClass("pr-6");
+    expect(cells[2]).not.toHaveClass("pr-3");
+  });
+
+  test("the flag is per column, not per row: a mixed set gets mixed cells", () => {
+    renderWrappingTable({ isLoading: true, data: [] });
+
+    const cells: NodeListOf<Element> = getSkeletonCells();
+
+    expect(cells).toHaveLength(wrappingColumns.length);
+    // Column 0 declares nothing, so it keeps the product-wide nowrap default.
+    expect(cells[0]).toHaveClass("whitespace-nowrap");
+    expect(cells[0]).not.toHaveClass("whitespace-normal");
+    // Columns 1 and 2 opted in.
+    expect(cells[1]).toHaveClass("whitespace-normal");
+    expect(cells[2]).toHaveClass("whitespace-normal");
+  });
+
+  /*
+   * The drift guard, stated as the equality it actually is. If either
+   * renderer goes back to spelling its own literal, this fails even when
+   * both literals are individually plausible - a placeholder that nowraps
+   * and then swaps to a wrapping real row is a visible reflow on every load,
+   * and is the shape the #3585 regression would take next time.
+   */
+  test("a wrapping column's skeleton cell and real cell carry the same classes", () => {
+    renderWrappingTable({ isLoading: true, data: [] });
+    const skeletonClassNames: Array<string> = Array.from(
+      getSkeletonCells(),
+    ).map((cell: Element): string => {
+      return cell.className;
+    });
+
+    cleanup();
+
+    renderWrappingTable({ isLoading: false, data: wrappingData });
+    const realCells: NodeListOf<Element> = screen
+      .getByTestId("table-content")
+      .querySelectorAll("tbody tr")[0]!
+      .querySelectorAll("td");
+    const realClassNames: Array<string> = Array.from(realCells).map(
+      (cell: Element): string => {
+        return cell.className;
+      },
+    );
+
+    // Every column, not only the wrapping one: the helper owns them all.
+    expect(realClassNames).toEqual(skeletonClassNames);
+    // Guard against both sides being empty and the equality passing vacuously.
+    expect(realClassNames).toHaveLength(wrappingColumns.length);
+    expect(realClassNames[1]).toContain("whitespace-normal");
+  });
+});

--- a/Common/UI/Components/ModelTable/Column.ts
+++ b/Common/UI/Components/ModelTable/Column.ts
@@ -45,6 +45,21 @@ export default interface Columns<
    */
   isRemovable?: boolean | undefined;
   contentClassName?: string | undefined;
+  /*
+   * Let this cell's content wrap onto more than one line, instead of forcing
+   * it onto the single `whitespace-nowrap` line every body cell gets by
+   * default. Set it on any column whose cell can hold server- or
+   * operator-authored prose; leave it unset for dates, counts, badges and
+   * ids. See Common/UI/Components/Table/Types/Column.ts for the full
+   * reasoning, including why a `max-w-*` on the rendered element is not a
+   * substitute and in fact makes the overlap worse (OneUptime issue #3585).
+   */
+  wrapContent?: boolean | undefined;
+  /*
+   * Width cap for a wrapping cell, e.g. "max-w-3xl". Read ONLY when
+   * `wrapContent` is set; defaults to "max-w-md" (28rem).
+   */
+  wrapMaxWidthClassName?: string | undefined;
   colSpan?: number | undefined;
   disableSort?: boolean;
   description?: string | undefined;

--- a/Common/UI/Components/Table/CellClassName.ts
+++ b/Common/UI/Components/Table/CellClassName.ts
@@ -1,0 +1,81 @@
+import Column from "./Types/Column";
+import GenericObject from "../../../Types/GenericObject";
+
+/*
+ * Width cap for a cell that opts into wrapping without naming its own.
+ *
+ * 28rem is wide enough for a two-line status sentence and narrow enough that
+ * one long message cannot starve the columns beside it.
+ */
+export const DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME: string = "max-w-md";
+
+export interface TableCellClassNameOptions<T extends GenericObject> {
+  column: Column<T>;
+  /*
+   * Compared against the RENDERED column count, not the declared one: with
+   * any column filtered out (hideOnMobile, permissions, the viewer's own
+   * layout) the two differ, and the extra right padding would land on the
+   * wrong cell - or on none.
+   */
+  isLastRenderedColumn: boolean;
+}
+
+/**
+ * The classes for one desktop body `<td>`.
+ *
+ * `whitespace-nowrap` is the default and is load-bearing for every date,
+ * count, badge and actions cell in the product - it is what keeps
+ * "12 Mar 2026, 4:05 pm" from folding onto two lines, in roughly two hundred
+ * column declarations that have no layout coverage of their own. Columns that
+ * hold prose opt out with `wrapContent`; see Types/Column.ts for why a
+ * max-width alone does not work and in fact makes the overlap worse
+ * (OneUptime issue #3585).
+ *
+ * For a column that declares no wrapping this returns the exact string the
+ * two cell renderers hard-coded before it existed, character for character.
+ */
+export function getTableCellClassName<T extends GenericObject>(
+  options: TableCellClassNameOptions<T>,
+): string {
+  const whitespaceClassName: string = options.column.wrapContent
+    ? "whitespace-normal break-words"
+    : "whitespace-nowrap";
+
+  const paddingRightClassName: string = options.isLastRenderedColumn
+    ? "pr-6"
+    : "pr-3";
+
+  return `${whitespaceClassName} py-4 pl-4 ${paddingRightClassName} text-sm font-medium text-gray-500 sm:pl-6 align-top`;
+}
+
+/**
+ * The classes for the `<div>` that wraps a cell's content.
+ *
+ * Empty for a column that asks for nothing, which is the overwhelming
+ * majority - deliberately, so neither the DOM nor a single class shifts for a
+ * column that declares neither option.
+ *
+ * A wrapping column always gets its width cap HERE, on the `<td>`'s direct
+ * child, never on the `<td>` itself: CSS leaves the effect of `max-width` on
+ * a table-cell box undefined and browsers ignore it, while a max-width on a
+ * block child DOES cap the column's max-content contribution under
+ * `table-layout: auto` - which is what Table.tsx renders, its `<table>`
+ * carrying no table-layout utility.
+ */
+export function getTableCellContentClassName<T extends GenericObject>(
+  column: Column<T>,
+): string {
+  const classNames: Array<string> = [];
+
+  if (column.wrapContent) {
+    classNames.push(
+      column.wrapMaxWidthClassName || DEFAULT_WRAP_MAX_WIDTH_CLASS_NAME,
+    );
+  }
+
+  if (column.contentClassName) {
+    classNames.push(column.contentClassName);
+  }
+
+  return classNames.join(" ");
+}

--- a/Common/UI/Components/Table/TableRow.tsx
+++ b/Common/UI/Components/Table/TableRow.tsx
@@ -6,6 +6,10 @@ import Icon, { ThickProp } from "../Icon/Icon";
 import ConfirmModal from "../Modal/ConfirmModal";
 import FieldType from "../Types/FieldType";
 import Column from "./Types/Column";
+import {
+  getTableCellClassName,
+  getTableCellContentClassName,
+} from "./CellClassName";
 import Columns from "./Types/Columns";
 import Color from "../../../Types/Color";
 import OneUptimeDate from "../../../Types/Date";
@@ -395,17 +399,15 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
           )}
           {props.columns &&
             renderedColumns.map((column: Column<T>, i: number) => {
-              let className: string =
-                "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
               /*
-               * Compared against the rendered count, not the declared one:
-               * with any column filtered out the two differ, and the extra
-               * right padding would land on the wrong cell - or on none.
+               * Shared with the loading skeleton, so the two can no longer
+               * drift, and the one place that decides whether this cell's
+               * text may wrap.
                */
-              if (i === renderedColumns.length - 1) {
-                className =
-                  "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
-              }
+              const className: string = getTableCellClassName<T>({
+                column: column,
+                isLastRenderedColumn: i === renderedColumns.length - 1,
+              });
 
               let columnContent: React.ReactNode = null;
 
@@ -479,12 +481,16 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
                 columnContent = column.getElement(props.item);
               }
 
-              const contentWrapperClassName: string = column.contentClassName
-                ? column.contentClassName
-                : "";
+              /*
+               * The column's own classes, plus the width cap a wrapping
+               * column gets - which has to sit on this div rather than on the
+               * <td>, because max-width is ignored on a table-cell box.
+               */
+              const contentWrapperClassName: string =
+                getTableCellContentClassName<T>(column);
 
-              const actionsContainerClassName: string = column.contentClassName
-                ? `flex justify-end ${column.contentClassName}`
+              const actionsContainerClassName: string = contentWrapperClassName
+                ? `flex justify-end ${contentWrapperClassName}`
                 : "flex justify-end";
 
               return (

--- a/Common/UI/Components/Table/TableSkeletonRows.tsx
+++ b/Common/UI/Components/Table/TableSkeletonRows.tsx
@@ -1,5 +1,6 @@
 import Skeleton from "../Skeleton/Skeleton";
 import Column from "./Types/Column";
+import { getTableCellClassName } from "./CellClassName";
 import Columns from "./Types/Columns";
 import GenericObject from "../../../Types/GenericObject";
 import React, { ReactElement } from "react";
@@ -107,17 +108,16 @@ const TableSkeletonRows: TableSkeletonRowsFunction = <T extends GenericObject>(
                 </div>
               </td>
             )}
-            {visibleColumns.map((_column: Column<T>, columnIndex: number) => {
+            {visibleColumns.map((column: Column<T>, columnIndex: number) => {
               /*
-               * Cell classes copied from TableRow's real cells so the
-               * skeleton's rhythm and padding match the rows that replace it.
+               * The same classes TableRow gives its real cells, from the same
+               * helper, so the skeleton's rhythm and padding match the rows
+               * that replace it - and cannot drift from them again.
                */
-              let className: string =
-                "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
-              if (columnIndex === visibleColumns.length - 1) {
-                className =
-                  "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
-              }
+              const className: string = getTableCellClassName<T>({
+                column: column,
+                isLastRenderedColumn: columnIndex === visibleColumns.length - 1,
+              });
 
               return (
                 <td key={columnIndex} className={className}>

--- a/Common/UI/Components/Table/Types/Column.ts
+++ b/Common/UI/Components/Table/Types/Column.ts
@@ -14,6 +14,42 @@ export default interface Column<T extends GenericObject> {
   colSpan?: number | undefined;
   noValueMessage?: string | undefined;
   contentClassName?: string | undefined;
+  /*
+   * Let this cell's content wrap onto more than one line.
+   *
+   * Body cells are `whitespace-nowrap` by default, and `white-space` is an
+   * INHERITED property - so the nowrap declared on the <td> reaches every
+   * element `getElement` returns, whatever classes that element carries. A
+   * cell holding a free-text sentence (a status message, a probe error, an
+   * operator note) therefore renders as one long line that paints straight
+   * over the columns to its right, and a `max-w-*` on the inner element makes
+   * that WORSE rather than better: it caps the box the line overflows out of,
+   * so the text overlaps its neighbours instead of merely widening the table
+   * (OneUptime issue #3585). Never pair a max-width with a nowrap cell - that
+   * pairing is what this option exists to make unspellable.
+   *
+   * Set it on any column whose cell can hold server- or operator-authored
+   * prose. The cell then declares `whitespace-normal break-words` and its
+   * content is capped at `wrapMaxWidthClassName`, so long text wraps inside
+   * the column's own width. Leave it unset - the default, and no change for
+   * every column that has one today - for dates, counts, badges, ids and
+   * anything else that must stay on a single line.
+   *
+   * Desktop only, by construction: the mobile card layout declares no nowrap
+   * and already wraps, and it reads neither this nor `contentClassName`.
+   */
+  wrapContent?: boolean | undefined;
+  /*
+   * Width cap for a wrapping cell, e.g. "max-w-3xl". Read ONLY when
+   * `wrapContent` is set; defaults to "max-w-md" (28rem).
+   *
+   * It belongs here rather than in `contentClassName` for two reasons. Two
+   * `max-w-*` utilities on one element are resolved by Tailwind's stylesheet
+   * order, not by the order they were written, so the narrower one silently
+   * loses; and a width that is only emitted alongside a wrapping mode can
+   * never be the overlap generator described above.
+   */
+  wrapMaxWidthClassName?: string | undefined;
   alignItem?: AlignItem | undefined;
   key?: keyof T | null; //can be null because actions column does not have a key.
   hideOnMobile?: boolean | undefined; // Hide column on mobile devices


### PR DESCRIPTION
Fixes #3585.

## The bug

Editing a Discovery Scan makes the server write a whole sentence into the scan's `statusMessage` — "Settings changed, so this scan is queued to run again. The hosts the previous run found have been cleared…" (`RETIRE_RUN_PAYLOAD`, `Common/Server/Services/NetworkDeviceDiscoveryScanService.ts`) — and the Discovery Scans table renders it under **Responded Hosts**. It did not stay there: it stretched across the row and was painted over the **Recurrence** and **Started** cells, exactly as the issue's screenshot shows.

## Why

One declaration, and one property of CSS.

Every desktop body `<td>` in `TableRow` is `whitespace-nowrap`, and `white-space` is an **inherited** property — so the nowrap reaches whatever element a column's `getElement` returns, however that element is classed. The `max-w-md` the cell already carried then made things *worse* rather than better: a capped box around a line that cannot break is exactly an overflow, so the sentence left the column instead of merely widening it.

A width cap on a nowrap cell is not a guard. It is the overlap generator.

## The fix

Not another hand-spelled class string on one page. Columns get a typed, opt-in option:

```ts
wrapContent?: boolean;            // whitespace-normal break-words instead of nowrap
wrapMaxWidthClassName?: string;   // the cap, default max-w-md
```

The two halves are now inseparable — the width is only ever emitted alongside the wrapping mode — so **the pairing that caused this cannot be spelled through the option at all**.

- New `Common/UI/Components/Table/CellClassName.ts` owns the cell classes. `TableRow` and `TableSkeletonRows` both build from it, which also settles the two copies of that class string that had already been hand-copied apart.
- For a column that declares nothing the string is **byte-identical** to before. The nowrap default is load-bearing for every date, count, badge and actions cell in the product — roughly two hundred column declarations with no layout coverage of their own — and is deliberately untouched.
- Discovery Scans: **Responded Hosts** opts in, and so does **Recurrence**. The same write that sets the status message also sets `status: Pending` and `nextScanAt: NULL`, so that column renders a sentence of its own in the very same row, on one unbreakable line, with no width cap at all — the other half of the deformed row in the report.
- `ExceptionsTable` had spelled the idiom by hand before the option existed (`contentClassName: "max-w-3xl whitespace-normal break-words"` — the only correct instance in the tree). It moves onto the option so one way of asking for a wrapping cell is left.
- The explanation divs keep their `title`, so the full text is still on hover.

## Tests

jsdom computes no layout, so nothing in CI can assert "does not overlap" — every assertion here is the class that decides it, and the test files say so where a reader would expect a visual check.

| File | Covers |
| --- | --- |
| `Common/Tests/UI/Components/TableCellWrapping.test.tsx` (new, 20) | The byte-identical default for a non-wrapping column; the wrapping classes and the cap for a wrapping one; that a cap **without** `wrapContent` emits nothing; padding/rhythm; last-column padding against *rendered* columns; the Actions container; the plain-text (no `getElement`) path; the mobile card |
| `Common/Tests/UI/Components/ModelTable/ModelTableWrapContent.test.tsx` (new, 7) | The `columns.push({ ...column })` spread in `BaseModelTable` that carries the fields through — nothing type-checks that hop, so a refactor enumerating the copied fields would silently reintroduce this bug |
| `Common/Tests/UI/Components/TableLoadingStates.test.tsx` (+5) | The skeleton honours the flag, and its cells carry the *same* classes as the real row — the drift guard as a direct equality. The pre-existing padding canary is untouched and still passes |
| `Common/Tests/App/Dashboard/DiscoveryScanWizardValidation.test.tsx` (+19) | The two columns' declarations, that the other five are untouched, the issue's own repro row (the sentence renders in full and still on a tooltip), and that nothing inside the cell caps its own width any more. Plus no content regression for #3287 / #3444 / #3445 |
| `App/Tests/Dashboard/TableWrapContentInvariants.test.ts` (new, 9) | Source-level guards for the parts a reformat could silently undo: the renderers still call the helper, and a table column never caps its width through `contentClassName` |

`Common` and `App` both `tsc --noEmit` clean; eslint clean on every changed file. Locally: Common 27 suites / 752 tests and App 251 suites / 8587 tests green across `Tests/UI/Components/Table*`, `Tests/UI/Components/ModelTable`, `Tests/App/Dashboard/DiscoveryScan*` and `App/Tests/Dashboard`.

## Deliberately out of scope

No line-clamp or expand affordance. Wrapping is what the issue asks for and is the smaller change; a clamp needs a keyboard-reachable toggle with a per-cell accessible name, sized against measured messages rather than a guessed character threshold — its own component with its own tests, not a rider on a bug fix. The visible consequence is honest and bounded: a long message makes that row taller, and `align-top` keeps its neighbours aligned.

Also unchanged, and pre-existing rather than introduced here: the Scan / Probe / Scan Target identity cells, and the four NetworkDevice Settings tables that render a 500-character `description` as `FieldType.Text`. Those widen their column and produce horizontal scroll — the same defect class, a different symptom, and `wrapContent` is now exactly the tool they need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqExUGZcwvV32hC8YdPjuc
