### PR TITLE
fix(dashboard): move Security Events to the end of the Observability nav

### DIFF
--- a/App/FeatureSet/Dashboard/src/Utils/NavigationItems.tsx
+++ b/App/FeatureSet/Dashboard/src/Utils/NavigationItems.tsx
@@ -130,20 +130,6 @@ export function useDashboardNavigationItems(): DashboardNavigationItems {
       category: observabilityCategory,
     },
     {
-      title: t("navbar.items.securityEventsTitle", "Security Events"),
-      description: t(
-        "navbar.items.securityEventsDescription",
-        "SIEM signals correlated with your observability data.",
-      ),
-      route: RouteUtil.populateRouteParams(
-        RouteMap[PageMap.SECURITY_EVENTS] as Route,
-      ),
-      activeRoute: RouteMap[PageMap.SECURITY_EVENTS],
-      icon: IconProp.ShieldExclamation,
-      iconColor: "rose",
-      category: observabilityCategory,
-    },
-    {
       title: t("navbar.items.metricsTitle"),
       description: t("navbar.items.metricsDescription"),
       route: RouteUtil.populateRouteParams(RouteMap[PageMap.METRICS] as Route),
@@ -191,6 +177,20 @@ export function useDashboardNavigationItems(): DashboardNavigationItems {
       activeRoute: RouteMap[PageMap.LLM],
       icon: IconProp.Sparkles,
       iconColor: "violet",
+      category: observabilityCategory,
+    },
+    {
+      title: t("navbar.items.securityEventsTitle", "Security Events"),
+      description: t(
+        "navbar.items.securityEventsDescription",
+        "SIEM signals correlated with your observability data.",
+      ),
+      route: RouteUtil.populateRouteParams(
+        RouteMap[PageMap.SECURITY_EVENTS] as Route,
+      ),
+      activeRoute: RouteMap[PageMap.SECURITY_EVENTS],
+      icon: IconProp.ShieldExclamation,
+      iconColor: "rose",
       category: observabilityCategory,
     },
     // AI


### PR DESCRIPTION
Security Events sat second in the Observability section of the dashboard nav, ahead of Metrics and Traces. It is a newer, narrower surface than the core telemetry pages, so it now renders after AI / LLM — on the last row of the section, alongside Topology.

New Observability order: Logs, Metrics, Traces, Performance Profiles, Exceptions, AI / LLM, Security Events, Topology.

Pure array reorder in `App/FeatureSet/Dashboard/src/Utils/NavigationItems.tsx` — no routes, icons, copy or behaviour changed. That file is the only place the section order is defined.