### PR TITLE
fix(charts): close the trailing data gap on metric charts

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -9,6 +9,10 @@ import React, {
 import ReactDOM from "react-dom";
 import OneUptimeDate from "Common/Types/Date";
 import XAxisType from "Common/UI/Components/Charts/Types/XAxis/XAxisType";
+import XAxisPrecision from "Common/UI/Components/Charts/Types/XAxis/XAxisPrecision";
+import XAxisUtil from "Common/UI/Components/Charts/Utils/XAxis";
+import AggregationInterval from "Common/Types/BaseDatabase/AggregationInterval";
+import AggregationIntervalUtil from "Common/Types/BaseDatabase/AggregationIntervalUtil";
 import ChartGroup, {
   Chart,
   ChartMetricInfo,
@@ -170,6 +174,14 @@ export interface ComponentProps {
    * instance's own panels only.
    */
   chartSyncId?: string | undefined;
+  /*
+   * The AggregationInterval the results were actually fetched with, when the
+   * host pinned one. Charts plot server-side buckets, so this is the axis's
+   * grid step — see getChartGridPrecision. Hosts that do not pin (they let
+   * the server derive the interval from the window) can omit it; the same
+   * derivation then runs here over the same window.
+   */
+  aggregationInterval?: AggregationInterval | undefined;
 }
 
 /*
@@ -2117,6 +2129,46 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
   };
 
   /*
+   * The grid step for every panel: the interval the ROWS were bucketed at,
+   * not one re-guessed from the window's length.
+   *
+   * These charts plot server-side buckets, so a slot is only meaningful if
+   * it corresponds to one. Left to XAxisUtil's duration ladder the two drift
+   * apart in both directions — see XAxisOptions.precision — and the drift is
+   * what the alert Metrics tab was showing: a 5-minute snapshot drew a
+   * 30-second grid over one-minute rows, so every other slot was blank and
+   * the axis ran a full minute past the last real point.
+   *
+   * `props.aggregationInterval` is the interval the query was actually
+   * pinned to, which is what a host that aligned its window has (aligning
+   * floors the start, and the derivation must stay on the RAW window or a
+   * window sitting on a tier boundary changes resolution). Hosts that render
+   * MetricCharts directly do not align, so deriving from their window
+   * reproduces the same answer the server did.
+   */
+  const getChartGridPrecision: () => XAxisPrecision | undefined = ():
+    | XAxisPrecision
+    | undefined => {
+    const startDate: Date | undefined = props.metricViewData.startAndEndDate
+      ?.startValue as Date | undefined;
+    const endDate: Date | undefined = props.metricViewData.startAndEndDate
+      ?.endValue as Date | undefined;
+
+    if (!startDate || !endDate) {
+      return undefined;
+    }
+
+    const interval: AggregationInterval =
+      AggregationIntervalUtil.getAggregationIntervalForWindow({
+        startDate: startDate,
+        endDate: endDate,
+        aggregationInterval: props.aggregationInterval,
+      });
+
+    return XAxisUtil.getPrecisionForAggregationInterval(interval);
+  };
+
+  /*
    * Write a new Top-N onto every member query of a panel. Preferred path:
    * hand the parent a full replacement queryConfigs array (persists
    * `metricQueryData.topN` and triggers the parent's fetch). Fallback when
@@ -2904,6 +2956,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
                   OneUptimeDate.getCurrentDate(),
                   -1,
                 ),
+              precision: getChartGridPrecision(),
               aggregateType: xAxisAggregationType,
             },
           },
@@ -3204,6 +3257,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
                   OneUptimeDate.getCurrentDate(),
                   -1,
                 ),
+              precision: getChartGridPrecision(),
               aggregateType: XAxisAggregateType.Average,
             },
           },

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -1349,6 +1349,15 @@ const MetricView: FunctionComponent<ComponentProps> = (
                     metricResults={metricResults}
                     metricTypes={metricTypes}
                     metricViewData={effectiveData}
+                    /*
+                     * The interval the results above were fetched with. The
+                     * charts use it as their grid step so every slot is one
+                     * backend bucket: re-deriving it from `effectiveData`
+                     * would run the ladder over the ALIGNED window, whose
+                     * floored start is slightly wider and can tip a window
+                     * sitting on a tier boundary into the next tier.
+                     */
+                    aggregationInterval={aggregationInterval}
                     chartCssClass={props.chartCssClass}
                     enableSeriesActions={props.enableSeriesActions}
                     metricResultsPrevious={

--- a/Common/Tests/UI/Components/Charts/ChartBucketIdentity.test.ts
+++ b/Common/Tests/UI/Components/Charts/ChartBucketIdentity.test.ts
@@ -106,7 +106,14 @@ describe("series data does not merge across days", () => {
     const rows: Array<ChartDataPoint> = chartRows(xAxis, hourlyPoints(48));
     const withData: Array<ChartDataPoint> = rowsCarryingData(rows);
 
-    expect(rows).toHaveLength(97);
+    /*
+     * 96, not the 97 slots the raw grid walks. The 97th is the start of the
+     * bucket CONTAINING the window end — [Mar 4 00:00, Mar 4 00:30), which
+     * this 48h window does not reach into at all — so nothing can ever land
+     * there and it is dropped rather than left as a blank slot stretching
+     * the axis past the data. See XAxisUtil.getRenderableIntervals.
+     */
+    expect(rows).toHaveLength(96);
     expect(withData).toHaveLength(48);
 
     for (const row of withData) {
@@ -125,8 +132,14 @@ describe("series data does not merge across days", () => {
       -1,
     );
 
-    // Hourly points on a half-hourly axis reach the second-to-last tick.
-    expect(lastRowWithData).toBe(rows.length - 3);
+    /*
+     * Hourly points on a half-hourly axis reach the second-to-last tick: the
+     * final hourly point is at 47h, and the tick after it is the 47:30 slot,
+     * which no hourly point lands on. (This used to read `length - 3`, back
+     * when the grid also carried an unfillable 48:00 slot past the end of
+     * the window.)
+     */
+    expect(lastRowWithData).toBe(rows.length - 2);
   });
 
   test("a Sum aggregate is not inflated by a merged day", () => {

--- a/Common/Tests/UI/Components/Charts/ChartTrailingBucketGap.test.ts
+++ b/Common/Tests/UI/Components/Charts/ChartTrailingBucketGap.test.ts
@@ -1,0 +1,691 @@
+/** @timezone UTC */
+
+import { describe, expect, test } from "@jest/globals";
+
+import AggregationInterval from "../../../../Types/BaseDatabase/AggregationInterval";
+import ChartDataPoint, {
+  CHART_DATA_POINT_DATE_KEY,
+  CHART_DATA_POINT_X_AXIS_KEY,
+} from "../../../../UI/Components/Charts/ChartLibrary/Types/ChartDataPoint";
+import DataPoint from "../../../../UI/Components/Charts/Types/DataPoint";
+import DataPointUtil from "../../../../UI/Components/Charts/Utils/DataPoint";
+import FormattedTimeReferenceLine from "../../../../UI/Components/Charts/ChartLibrary/Types/FormattedTimeReferenceLine";
+import SeriesPoints from "../../../../UI/Components/Charts/Types/SeriesPoints";
+import TimeAnnotationUtil from "../../../../UI/Components/Charts/Utils/TimeAnnotation";
+import XAxisUtil from "../../../../UI/Components/Charts/Utils/XAxis";
+import {
+  XAxis,
+  XAxisAggregateType,
+} from "../../../../UI/Components/Charts/Types/XAxis/XAxis";
+import XAxisPrecision from "../../../../UI/Components/Charts/Types/XAxis/XAxisPrecision";
+import XAxisType from "../../../../UI/Components/Charts/Types/XAxis/XAxisType";
+import YAxis, {
+  YAxisPrecision,
+} from "../../../../UI/Components/Charts/Types/YAxis/YAxis";
+import YAxisType from "../../../../UI/Components/Charts/Types/YAxis/YAxisType";
+
+/*
+ * The reported bug: an alert's Metrics tab drew each chart with roughly a
+ * fifth of its width blank on the right, the plotted area stopping a whole
+ * minute before the axis did.
+ *
+ * Two independent defects produced it, and the captured request shows both.
+ * The window was 2026-09-04T13:37:00.000Z .. 13:42:00.243Z — five minutes
+ * plus 243 ms, because a telemetry snapshot window ends at the instant the
+ * alert was declared, and that instant happened to fall just past a minute
+ * boundary. The server bucketed it by Minute and returned five rows
+ * (13:37..13:41).
+ *
+ *  1. The chart built its grid from a SECOND ladder keyed on the window's
+ *     duration, whose finest tiers are sub-minute even though no analytics
+ *     bucket is. 300.243 s landed on the 30-second tier: eleven slots over
+ *     five one-minute rows, so every other slot was structurally empty.
+ *  2. The grid walks inclusively to the window end, so its last slot is the
+ *     start of the bucket CONTAINING that end. Here that bucket is
+ *     [13:42:00, 13:43:00) and the window reaches 243 ms into it — the
+ *     server could only fill it from a sample inside that sliver, and did
+ *     not. Because the recharts x-axis is categorical over exactly these
+ *     slots, the empty one stretched the axis a full bucket past the last
+ *     real point.
+ *
+ * Pinned to UTC via the docblock pragma: bucket labels come from local-time
+ * formatters, so an unpinned run would assert against the machine's zone.
+ */
+
+const SERIES_NAME: string = "resource.k8s.pod.name=kubernetes-agent-logs-7t88f";
+
+const MINUTE_IN_MS: number = 60 * 1000;
+const HOUR_IN_MS: number = 60 * MINUTE_IN_MS;
+const DAY_IN_MS: number = 24 * HOUR_IN_MS;
+
+/** The captured alert-snapshot window, verbatim. */
+const ALERT_WINDOW_START: Date = new Date("2026-09-04T13:37:00.000Z");
+const ALERT_WINDOW_END: Date = new Date("2026-09-04T13:42:00.243Z");
+
+const Y_AXIS: YAxis = {
+  legend: "%",
+  options: {
+    type: YAxisType.Number,
+    min: "auto",
+    max: "auto",
+    precision: YAxisPrecision.TwoDecimals,
+    formatter: (value: number): string => {
+      return String(value);
+    },
+  },
+};
+
+type BuildXAxisFunction = (data: {
+  min: Date;
+  max: Date;
+  precision?: XAxisPrecision | undefined;
+  aggregateType?: XAxisAggregateType | undefined;
+}) => XAxis;
+
+const buildXAxis: BuildXAxisFunction = (data: {
+  min: Date;
+  max: Date;
+  precision?: XAxisPrecision | undefined;
+  aggregateType?: XAxisAggregateType | undefined;
+}): XAxis => {
+  return {
+    legend: "Time",
+    options: {
+      type: XAxisType.Time,
+      min: data.min,
+      max: data.max,
+      aggregateType: data.aggregateType ?? XAxisAggregateType.Average,
+      precision: data.precision,
+    },
+  };
+};
+
+type ChartRowsFunction = (
+  xAxis: XAxis,
+  seriesPoints: Array<SeriesPoints>,
+) => Array<ChartDataPoint>;
+
+const chartRows: ChartRowsFunction = (
+  xAxis: XAxis,
+  seriesPoints: Array<SeriesPoints>,
+): Array<ChartDataPoint> => {
+  return DataPointUtil.getChartDataPoints({
+    seriesPoints,
+    xAxis,
+    yAxis: Y_AXIS,
+  });
+};
+
+type HasValueFunction = (row: ChartDataPoint | undefined) => boolean;
+
+/*
+ * A row "carries data" when it holds any key beyond the two reserved ones
+ * the grid itself writes (the formatted label and the raw bucket start).
+ */
+const hasValue: HasValueFunction = (
+  row: ChartDataPoint | undefined,
+): boolean => {
+  if (!row) {
+    return false;
+  }
+  return Object.keys(row).some((key: string): boolean => {
+    return (
+      key !== CHART_DATA_POINT_X_AXIS_KEY && key !== CHART_DATA_POINT_DATE_KEY
+    );
+  });
+};
+
+type SeriesEveryFunction = (data: {
+  from: Date;
+  count: number;
+  stepMs: number;
+  value?: number | undefined;
+  seriesName?: string | undefined;
+}) => Array<SeriesPoints>;
+
+/** `count` points on a fixed step, i.e. what the server returns for buckets. */
+const seriesEvery: SeriesEveryFunction = (data: {
+  from: Date;
+  count: number;
+  stepMs: number;
+  value?: number | undefined;
+  seriesName?: string | undefined;
+}): Array<SeriesPoints> => {
+  const points: Array<DataPoint> = [];
+  for (let index: number = 0; index < data.count; index++) {
+    points.push({
+      x: new Date(data.from.getTime() + index * data.stepMs),
+      y: data.value ?? 1,
+    });
+  }
+  return [{ seriesName: data.seriesName ?? SERIES_NAME, data: points }];
+};
+
+describe("the reported alert-snapshot chart", () => {
+  /*
+   * MetricCharts pins the grid to the interval the query was bucketed at,
+   * which for this window is Minute.
+   */
+  const ALERT_X_AXIS: XAxis = buildXAxis({
+    min: ALERT_WINDOW_START,
+    max: ALERT_WINDOW_END,
+    precision: XAxisPrecision.EVERY_MINUTE,
+  });
+
+  /** The five rows the server actually returned, replayed. */
+  const ALERT_SERIES: Array<SeriesPoints> = seriesEvery({
+    from: ALERT_WINDOW_START,
+    count: 5,
+    stepMs: MINUTE_IN_MS,
+    value: 0.17,
+  });
+
+  test("plots every slot on the axis — no trailing gap at all", () => {
+    const rows: Array<ChartDataPoint> = chartRows(ALERT_X_AXIS, ALERT_SERIES);
+
+    /*
+     * This is the whole bug in one assertion. Before the fix the chart drew
+     * eleven slots and filled five, so the series ended at 80% of the plot
+     * width. Every slot now carries a value, so the area reaches the right
+     * edge.
+     */
+    expect(rows).toHaveLength(5);
+    for (const row of rows) {
+      expect(hasValue(row)).toBe(true);
+    }
+  });
+
+  test("the last plotted bucket is 13:41, the last one the query could fill", () => {
+    const rows: Array<ChartDataPoint> = chartRows(ALERT_X_AXIS, ALERT_SERIES);
+    const lastRow: ChartDataPoint = rows[rows.length - 1]!;
+
+    expect(lastRow[CHART_DATA_POINT_DATE_KEY]).toBe(
+      new Date("2026-09-04T13:41:00.000Z").getTime(),
+    );
+    expect(lastRow[SERIES_NAME]).toBe(0.17);
+  });
+
+  test("never emits a 13:42 slot, which only a sample inside 243ms could fill", () => {
+    const rows: Array<ChartDataPoint> = chartRows(ALERT_X_AXIS, ALERT_SERIES);
+
+    const bucketStarts: Array<number> = rows.map(
+      (row: ChartDataPoint): number => {
+        return Number(row[CHART_DATA_POINT_DATE_KEY]);
+      },
+    );
+
+    expect(bucketStarts).not.toContain(
+      new Date("2026-09-04T13:42:00.000Z").getTime(),
+    );
+  });
+
+  test("pinning the grid removes the half-empty 30-second comb", () => {
+    /*
+     * Defect 1 on its own. Unpinned, 300.243 s falls on the sub-minute tier
+     * and the grid is twice as fine as anything the server can return, so
+     * five of the eleven slots are interior blanks the curve interpolates
+     * across.
+     */
+    const unpinned: Array<ChartDataPoint> = chartRows(
+      buildXAxis({ min: ALERT_WINDOW_START, max: ALERT_WINDOW_END }),
+      ALERT_SERIES,
+    );
+    const unpinnedBlanks: number = unpinned.filter(
+      (row: ChartDataPoint): boolean => {
+        return !hasValue(row);
+      },
+    ).length;
+
+    expect(
+      XAxisUtil.getPrecision({
+        xAxisMin: ALERT_WINDOW_START,
+        xAxisMax: ALERT_WINDOW_END,
+      }),
+    ).toBe(XAxisPrecision.EVERY_THIRTY_SECONDS);
+    expect(unpinnedBlanks).toBeGreaterThan(0);
+
+    const pinned: Array<ChartDataPoint> = chartRows(ALERT_X_AXIS, ALERT_SERIES);
+    const pinnedBlanks: number = pinned.filter(
+      (row: ChartDataPoint): boolean => {
+        return !hasValue(row);
+      },
+    ).length;
+
+    expect(pinnedBlanks).toBe(0);
+  });
+
+  test("the declared-at marker still renders, on the last bucket on the axis", () => {
+    /*
+     * The marker sits at the window end, which is inside the bucket the grid
+     * no longer draws. Trimming a slot must not push a marker off the chart
+     * it exists to annotate — it resolves to the last bucket still on the
+     * axis, which is where its data is.
+     */
+    const rows: Array<ChartDataPoint> = chartRows(ALERT_X_AXIS, ALERT_SERIES);
+    const formatted: Array<FormattedTimeReferenceLine> =
+      TimeAnnotationUtil.formatTimeReferenceLines({
+        timeReferenceLines: [{ date: ALERT_WINDOW_END, label: "Declared" }],
+        xAxis: ALERT_X_AXIS,
+        seriesPoints: ALERT_SERIES,
+      });
+
+    expect(formatted).toHaveLength(1);
+    expect(formatted[0]!.bucketIndex).toBe(rows.length - 1);
+    expect(formatted[0]!.formattedX).toBe(
+      String(rows[rows.length - 1]![CHART_DATA_POINT_X_AXIS_KEY]),
+    );
+  });
+
+  test("annotations index into the same array the rows were built from", () => {
+    /*
+     * The invariant that makes trimming safe to do in the shared walker.
+     * Markers are resolved to an INDEX, so the two sides must agree on the
+     * slot count exactly — a marker one bucket in has to sit on the row one
+     * bucket in.
+     */
+    const rows: Array<ChartDataPoint> = chartRows(ALERT_X_AXIS, ALERT_SERIES);
+
+    for (let index: number = 0; index < rows.length; index++) {
+      const at: Date = new Date(
+        ALERT_WINDOW_START.getTime() + index * MINUTE_IN_MS,
+      );
+      const formatted: Array<FormattedTimeReferenceLine> =
+        TimeAnnotationUtil.formatTimeReferenceLines({
+          timeReferenceLines: [{ date: at, label: "event" }],
+          xAxis: ALERT_X_AXIS,
+          seriesPoints: ALERT_SERIES,
+        });
+
+      expect(formatted).toHaveLength(1);
+      expect(formatted[0]!.bucketIndex).toBe(index);
+    }
+  });
+});
+
+describe("which trailing slot gets dropped", () => {
+  test("a window ending exactly on a bucket boundary drops its empty tail slot", () => {
+    /*
+     * Zero coverage rather than the alert's 243 ms, and the same conclusion:
+     * [14:00:00, 14:01:00) is not in a window that ends at 14:00:00.000.
+     */
+    const start: Date = new Date("2026-09-04T13:00:00.000Z");
+    const end: Date = new Date("2026-09-04T14:00:00.000Z");
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+      seriesEvery({ from: start, count: 60, stepMs: MINUTE_IN_MS }),
+    );
+
+    expect(rows).toHaveLength(60);
+    expect(hasValue(rows[rows.length - 1])).toBe(true);
+    expect(rows[rows.length - 1]![CHART_DATA_POINT_DATE_KEY]).toBe(
+      new Date("2026-09-04T13:59:00.000Z").getTime(),
+    );
+  });
+
+  test("a populated in-progress bucket is kept, so live charts stay live", () => {
+    /*
+     * The opposite failure, and the reason the rule is not simply "drop any
+     * slot whose bucket runs past the window end". A now-anchored chart's
+     * newest bucket is always partial; dropping it would make every live
+     * chart lag by a whole bucket.
+     */
+    const start: Date = new Date("2026-09-04T13:42:00.000Z");
+    const end: Date = new Date("2026-09-04T14:42:37.000Z");
+    const series: Array<SeriesPoints> = seriesEvery({
+      from: start,
+      count: 61,
+      stepMs: MINUTE_IN_MS,
+    });
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+      series,
+    );
+
+    expect(rows).toHaveLength(61);
+    expect(hasValue(rows[rows.length - 1])).toBe(true);
+    expect(rows[rows.length - 1]![CHART_DATA_POINT_DATE_KEY]).toBe(
+      new Date("2026-09-04T14:42:00.000Z").getTime(),
+    );
+  });
+
+  test("an EMPTY bucket the window mostly spans is kept — an empty bar is information", () => {
+    /*
+     * "Last 7 days" of incident counts, read mid-afternoon. Today's bucket
+     * has nothing in it, which means "nothing today" — a fact the chart has
+     * to keep showing. Only a bucket the window barely touches is dropped.
+     *
+     * This is also the case that catches measuring coverage off the slot's
+     * DATE. The grid is anchored at the window start, so the final slot is
+     * dated 4 Sep 14:42 and sits a hair below the window end — 0% coverage
+     * by that reading, and the bar would be dropped. Its LABEL is "04 Sep",
+     * the bucket [4 Sep 00:00, 5 Sep 00:00), of which the window really does
+     * cover nearly fifteen hours.
+     */
+    const end: Date = new Date("2026-09-04T14:42:00.000Z");
+    const start: Date = new Date(end.getTime() - 7 * DAY_IN_MS);
+    const series: Array<SeriesPoints> = seriesEvery({
+      from: start,
+      count: 7,
+      stepMs: DAY_IN_MS,
+      seriesName: "Incidents",
+    });
+
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_DAY,
+        aggregateType: XAxisAggregateType.Sum,
+      }),
+      series,
+    );
+
+    // 8 day labels, and today's — empty — is still one of them.
+    expect(rows).toHaveLength(8);
+    expect(hasValue(rows[rows.length - 1])).toBe(false);
+  });
+
+  test("a BOUNDARY-aligned daily grid still keeps a mostly-covered empty day", () => {
+    /*
+     * The aligned twin of the case above, so "keep" is not an accident of
+     * mid-bucket anchoring. Starting the window at midnight puts every slot
+     * on a real day boundary, so the final slot's coverage is measured
+     * directly — and 14h42m of a 24-hour day is well over half, so an empty
+     * "today" is still a day the chart is entitled to show.
+     */
+    const start: Date = new Date("2026-08-28T00:00:00.000Z");
+    const end: Date = new Date("2026-09-04T14:42:00.000Z");
+    const series: Array<SeriesPoints> = seriesEvery({
+      from: start,
+      count: 7,
+      stepMs: DAY_IN_MS,
+      seriesName: "Incidents",
+    });
+
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_DAY,
+        aggregateType: XAxisAggregateType.Sum,
+      }),
+      series,
+    );
+
+    expect(rows).toHaveLength(8);
+    expect(hasValue(rows[rows.length - 1])).toBe(false);
+    expect(rows[rows.length - 1]![CHART_DATA_POINT_DATE_KEY]).toBe(
+      new Date("2026-09-04T00:00:00.000Z").getTime(),
+    );
+  });
+
+  test("a boundary-aligned day the window BARELY enters is dropped", () => {
+    /*
+     * The same aligned daily grid read just after midnight: today's bucket is
+     * minutes old, empty, and nothing but a blank bar stretching the axis a
+     * whole day past the last real one.
+     */
+    const start: Date = new Date("2026-08-28T00:00:00.000Z");
+    const end: Date = new Date("2026-09-04T00:04:00.000Z");
+    const series: Array<SeriesPoints> = seriesEvery({
+      from: start,
+      count: 7,
+      stepMs: DAY_IN_MS,
+      seriesName: "Incidents",
+    });
+
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_DAY,
+        aggregateType: XAxisAggregateType.Sum,
+      }),
+      series,
+    );
+
+    expect(rows).toHaveLength(7);
+    expect(hasValue(rows[rows.length - 1])).toBe(true);
+  });
+
+  test("a real trailing outage stays visible — at most one slot is ever dropped", () => {
+    /*
+     * The safety property. A source that stopped reporting well before the
+     * window end must not have its silence tidied away: shrinking the axis to
+     * the last datapoint would turn an outage into a chart that looks
+     * complete.
+     */
+    const start: Date = new Date("2026-09-04T13:00:00.000Z");
+    const end: Date = new Date("2026-09-04T14:00:00.000Z");
+    // Reports stop at 13:50 — the last ten minutes of the window are dead.
+    const series: Array<SeriesPoints> = seriesEvery({
+      from: start,
+      count: 51,
+      stepMs: MINUTE_IN_MS,
+    });
+
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+      series,
+    );
+
+    const blanks: Array<ChartDataPoint> = rows.filter(
+      (row: ChartDataPoint): boolean => {
+        return !hasValue(row);
+      },
+    );
+
+    // 61 slots, one uncoverable tail slot dropped; nine blanks are the outage.
+    expect(rows).toHaveLength(60);
+    expect(blanks).toHaveLength(9);
+    expect(hasValue(rows[rows.length - 1])).toBe(false);
+  });
+
+  test("a chart with no data anywhere keeps the whole window on the axis", () => {
+    /*
+     * Nothing to align the axis to, so there is nothing to trim towards —
+     * an empty chart should still show the range the user asked for.
+     */
+    const start: Date = new Date("2026-09-04T13:00:00.000Z");
+    const end: Date = new Date("2026-09-04T14:00:00.000Z");
+
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+      [{ seriesName: SERIES_NAME, data: [] as Array<DataPoint> }],
+    );
+
+    expect(rows).toHaveLength(61);
+  });
+
+  test("a single-slot grid is never trimmed away to nothing", () => {
+    const start: Date = new Date("2026-09-04T13:00:00.000Z");
+    const end: Date = new Date("2026-09-04T13:00:30.000Z");
+
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: start,
+        max: end,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+      seriesEvery({ from: start, count: 1, stepMs: MINUTE_IN_MS }),
+    );
+
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("callers that pass no series get the raw grid, unchanged", () => {
+    /*
+     * getPrecisionIntervals is a shared primitive with its own contract
+     * (XAxis.test.ts pins its counts). Trimming is opt-in through
+     * getRenderableIntervals, so nothing that walks the grid alone moves.
+     */
+    const raw: Array<Date> = XAxisUtil.getPrecisionIntervals({
+      xAxisMin: ALERT_WINDOW_START,
+      xAxisMax: ALERT_WINDOW_END,
+      precision: XAxisPrecision.EVERY_MINUTE,
+    });
+    const renderable: Array<Date> = XAxisUtil.getRenderableIntervals({
+      xAxisMin: ALERT_WINDOW_START,
+      xAxisMax: ALERT_WINDOW_END,
+      precision: XAxisPrecision.EVERY_MINUTE,
+    });
+
+    expect(raw).toHaveLength(6);
+    expect(renderable).toHaveLength(6);
+  });
+});
+
+describe("the grid step follows the interval the data was bucketed at", () => {
+  test.each([
+    [AggregationInterval.Minute, XAxisPrecision.EVERY_MINUTE],
+    [AggregationInterval.FiveMinutes, XAxisPrecision.EVERY_FIVE_MINUTES],
+    [AggregationInterval.FifteenMinutes, XAxisPrecision.EVERY_FIFTEEN_MINUTES],
+    [AggregationInterval.ThirtyMinutes, XAxisPrecision.EVERY_THIRTY_MINUTES],
+    [AggregationInterval.Hour, XAxisPrecision.EVERY_HOUR],
+    [AggregationInterval.Day, XAxisPrecision.EVERY_DAY],
+    [AggregationInterval.Week, XAxisPrecision.EVERY_WEEK],
+    [AggregationInterval.Month, XAxisPrecision.EVERY_MONTH],
+    [AggregationInterval.Year, XAxisPrecision.EVERY_YEAR],
+  ])(
+    "%s buckets are drawn one slot each",
+    (
+      interval: AggregationInterval,
+      expected: XAxisPrecision | undefined,
+    ): void => {
+      expect(XAxisUtil.getPrecisionForAggregationInterval(interval)).toBe(
+        expected,
+      );
+    },
+  );
+
+  test("Total pins nothing — it has no grid to pin", () => {
+    /*
+     * Total collapses the window into one aggregate whose timestamp is the
+     * earliest sample, not a bucket start, so there is no bucket grid to
+     * mirror and the duration ladder applies.
+     */
+    expect(
+      XAxisUtil.getPrecisionForAggregationInterval(AggregationInterval.Total),
+    ).toBeUndefined();
+  });
+
+  test("a pin overrides the duration ladder in the COARSER direction too", () => {
+    /*
+     * The second way the two ladders drift. Aligning a window to the bucket
+     * grid floors its start, which widens it — enough to tip a 3h preset past
+     * the duration ladder's 3h threshold and onto the five-minute tier while
+     * the query is still pinned to Minute. Unpinned, the chart would then
+     * re-average five one-minute rows into each slot: an average of averages.
+     */
+    const start: Date = new Date("2026-09-04T10:59:00.000Z");
+    const end: Date = new Date("2026-09-04T14:00:00.000Z");
+
+    expect(XAxisUtil.getPrecision({ xAxisMin: start, xAxisMax: end })).toBe(
+      XAxisPrecision.EVERY_FIVE_MINUTES,
+    );
+    expect(
+      XAxisUtil.getPrecision({
+        xAxisMin: start,
+        xAxisMax: end,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+    ).toBe(XAxisPrecision.EVERY_MINUTE);
+  });
+
+  test("a pinned axis labels its slots at the pinned step", () => {
+    /*
+     * The grid step and the formatter have to move together: DataPointUtil
+     * places a datapoint by matching FORMATTED LABELS, so a grid stepped one
+     * way and labelled another matches nothing and the series vanishes
+     * entirely rather than degrading.
+     */
+    const rows: Array<ChartDataPoint> = chartRows(
+      buildXAxis({
+        min: ALERT_WINDOW_START,
+        max: ALERT_WINDOW_END,
+        precision: XAxisPrecision.EVERY_MINUTE,
+      }),
+      seriesEvery({
+        from: ALERT_WINDOW_START,
+        count: 5,
+        stepMs: MINUTE_IN_MS,
+        value: 0.17,
+      }),
+    );
+
+    expect(
+      rows.map((row: ChartDataPoint): string => {
+        return String(row[CHART_DATA_POINT_X_AXIS_KEY]);
+      }),
+    ).toEqual(["13:37", "13:38", "13:39", "13:40", "13:41"]);
+  });
+});
+
+describe("trimming respects wall-clock bucket widths", () => {
+  test("a daylight-saving day is as wide as the grid says it is, not 24h", () => {
+    /*
+     * The trailing bucket's width is read off the grid rather than recomputed
+     * from the precision, so the coverage test stays correct on the days that
+     * are not 24 hours long. Europe/London springs forward on 2026-03-29, so
+     * that day is 23 hours.
+     *
+     * The window ends 20 hours into the 29th — over half of a 23-hour day, so
+     * the empty final bucket is kept. Computed against a fixed 24h width it
+     * would be 83% of a day and kept too, so this asserts the specific thing
+     * that differs: the grid's own step is what is measured.
+     */
+    const previousTimezone: string | undefined = process.env["TZ"];
+    process.env["TZ"] = "Europe/London";
+
+    try {
+      const start: Date = new Date("2026-03-25T00:00:00.000Z");
+      const end: Date = new Date("2026-03-29T20:00:00.000Z");
+
+      const intervals: Array<Date> = XAxisUtil.getPrecisionIntervals({
+        xAxisMin: start,
+        xAxisMax: end,
+        precision: XAxisPrecision.EVERY_DAY,
+      });
+
+      // The walk steps in wall-clock days, so every step is one calendar day.
+      expect(intervals.length).toBeGreaterThan(1);
+
+      const renderable: Array<Date> = XAxisUtil.getRenderableIntervals({
+        xAxisMin: start,
+        xAxisMax: end,
+        precision: XAxisPrecision.EVERY_DAY,
+        seriesPoints: [
+          {
+            seriesName: SERIES_NAME,
+            data: [{ x: start, y: 1 }],
+          },
+        ],
+      });
+
+      // Well over half the final bucket is inside the window, so it stays.
+      expect(renderable).toHaveLength(intervals.length);
+    } finally {
+      if (previousTimezone === undefined) {
+        delete process.env["TZ"];
+      } else {
+        process.env["TZ"] = previousTimezone;
+      }
+    }
+  });
+});

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -144,6 +144,13 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
     const formatter: (value: Date) => string = XAxisUtil.getFormatter({
       xAxisMax: props.xAxis.options.max,
       xAxisMin: props.xAxis.options.min,
+      /*
+       * Exemplars are placed by label with no index fallback, so they have
+       * to be formatted at the axis's own grid step — a pinned axis
+       * labelled at a different precision would put every exemplar on a
+       * category that does not exist, and they would silently vanish.
+       */
+      precision: props.xAxis.options.precision,
     });
 
     return props.exemplarPoints.map((exemplar: ExemplarPoint) => {
@@ -164,8 +171,10 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
       return TimeAnnotationUtil.formatTimeReferenceLines({
         timeReferenceLines: props.timeReferenceLines,
         xAxis: props.xAxis,
+        // Same series the rows were built from — keeps marker indexes aligned.
+        seriesPoints: props.data || [],
       });
-    }, [props.timeReferenceLines, props.xAxis]);
+    }, [props.timeReferenceLines, props.xAxis, props.data]);
 
   const formattedReferenceRegions: Array<FormattedReferenceRegion> =
     useMemo(() => {
@@ -175,8 +184,10 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
       return TimeAnnotationUtil.formatReferenceRegions({
         referenceRegions: props.referenceRegions,
         xAxis: props.xAxis,
+        // Same series the rows were built from — keeps region indexes aligned.
+        seriesPoints: props.data || [],
       });
-    }, [props.referenceRegions, props.xAxis]);
+    }, [props.referenceRegions, props.xAxis, props.data]);
 
   const hasNoData: boolean =
     !props.data ||

--- a/Common/UI/Components/Charts/Bar/BarChart.tsx
+++ b/Common/UI/Components/Charts/Bar/BarChart.tsx
@@ -97,8 +97,10 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
       return TimeAnnotationUtil.formatTimeReferenceLines({
         timeReferenceLines: props.timeReferenceLines,
         xAxis: props.xAxis,
+        // Same series the rows were built from — keeps marker indexes aligned.
+        seriesPoints: props.data || [],
       });
-    }, [props.timeReferenceLines, props.xAxis]);
+    }, [props.timeReferenceLines, props.xAxis, props.data]);
 
   const formattedReferenceRegions: Array<FormattedReferenceRegion> =
     useMemo(() => {
@@ -108,8 +110,10 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
       return TimeAnnotationUtil.formatReferenceRegions({
         referenceRegions: props.referenceRegions,
         xAxis: props.xAxis,
+        // Same series the rows were built from — keeps region indexes aligned.
+        seriesPoints: props.data || [],
       });
-    }, [props.referenceRegions, props.xAxis]);
+    }, [props.referenceRegions, props.xAxis, props.data]);
 
   const hasNoData: boolean =
     !props.data ||

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -122,6 +122,13 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
     const formatter: (value: Date) => string = XAxisUtil.getFormatter({
       xAxisMax: props.xAxis.options.max,
       xAxisMin: props.xAxis.options.min,
+      /*
+       * Exemplars are placed by label with no index fallback, so they have
+       * to be formatted at the axis's own grid step — a pinned axis
+       * labelled at a different precision would put every exemplar on a
+       * category that does not exist, and they would silently vanish.
+       */
+      precision: props.xAxis.options.precision,
     });
 
     return props.exemplarPoints.map((exemplar: ExemplarPoint) => {
@@ -142,8 +149,10 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
       return TimeAnnotationUtil.formatTimeReferenceLines({
         timeReferenceLines: props.timeReferenceLines,
         xAxis: props.xAxis,
+        // Same series the rows were built from — keeps marker indexes aligned.
+        seriesPoints: props.data || [],
       });
-    }, [props.timeReferenceLines, props.xAxis]);
+    }, [props.timeReferenceLines, props.xAxis, props.data]);
 
   const formattedReferenceRegions: Array<FormattedReferenceRegion> =
     useMemo(() => {
@@ -153,8 +162,10 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
       return TimeAnnotationUtil.formatReferenceRegions({
         referenceRegions: props.referenceRegions,
         xAxis: props.xAxis,
+        // Same series the rows were built from — keeps region indexes aligned.
+        seriesPoints: props.data || [],
       });
-    }, [props.referenceRegions, props.xAxis]);
+    }, [props.referenceRegions, props.xAxis, props.data]);
 
   const hasNoData: boolean =
     !props.data ||

--- a/Common/UI/Components/Charts/Types/XAxis/XAxis.ts
+++ b/Common/UI/Components/Charts/Types/XAxis/XAxis.ts
@@ -1,4 +1,5 @@
 import XAxisMaxMin from "./XAxisMaxMin";
+import XAxisPrecision from "./XAxisPrecision";
 import XAxisType from "./XAxisType";
 
 export enum XAxisAggregateType {
@@ -13,6 +14,34 @@ export interface XAxisOptions {
   min: XAxisMaxMin;
   max: XAxisMaxMin;
   aggregateType: XAxisAggregateType;
+  /*
+   * Pin the grid step instead of letting XAxisUtil derive one from the
+   * window's duration.
+   *
+   * The derived ladder is a SECOND ladder: it guesses the bucket size the
+   * data was aggregated at from how long the window is. A caller that
+   * already knows the real bucket size does not have to guess, and must
+   * not — the two ladders disagree in both directions:
+   *
+   *  - Finer. The derived ladder has four sub-minute tiers (<=15s / 75s /
+   *    150s / 450s) while the analytics backend's finest bucket is one
+   *    minute, so every window under 7.5 minutes got a grid the data could
+   *    never fill. A 5-minute metric window drew an 11-slot 30-second grid
+   *    over 5 one-minute rows: every other slot empty, and the axis running
+   *    a full minute past the last real point.
+   *  - Coarser. Aligning a window to the bucket grid widens it slightly
+   *    (the start is floored), which can tip a window sitting exactly on a
+   *    tier threshold — a 3h preset, say — into the next tier. The query is
+   *    still pinned to the interval derived from the RAW window, so the
+   *    chart then re-averages five one-minute rows into each five-minute
+   *    slot: an unweighted average of averages.
+   *
+   * Set this to the interval the DATA was actually bucketed at and each
+   * slot maps to exactly one backend bucket. Left undefined, the duration
+   * ladder applies, which is right for callers whose points are raw
+   * samples rather than server-side buckets.
+   */
+  precision?: XAxisPrecision | undefined;
 }
 
 export interface XAxis {

--- a/Common/UI/Components/Charts/Utils/DataPoint.ts
+++ b/Common/UI/Components/Charts/Utils/DataPoint.ts
@@ -15,6 +15,7 @@ import ChartDataPoint, {
 import SeriesPoints from "../Types/SeriesPoints";
 import { XAxis, XAxisAggregateType } from "../Types/XAxis/XAxis";
 import XAxisMaxMin from "../Types/XAxis/XAxisMaxMin";
+import XAxisPrecision from "../Types/XAxis/XAxisPrecision";
 import YAxis from "../Types/YAxis/YAxis";
 import XAxisUtil from "./XAxis";
 
@@ -31,7 +32,10 @@ export default class DataPointUtil {
     xAxis: XAxis;
     yAxis: YAxis;
   }): Array<ChartDataPoint> {
-    const { intervals, formatter } = this.initializeXAxisData(data.xAxis);
+    const { intervals, formatter } = this.initializeXAxisData(
+      data.xAxis,
+      data.seriesPoints,
+    );
     const arrayOfData: ChartDataPoint[] = this.initializeArrayOfData(
       intervals,
       formatter,
@@ -45,7 +49,10 @@ export default class DataPointUtil {
     return arrayOfData;
   }
 
-  private static initializeXAxisData(xAxis: XAxis): {
+  private static initializeXAxisData(
+    xAxis: XAxis,
+    seriesPoints: Array<SeriesPoints>,
+  ): {
     xAxisMax: XAxisMaxMin;
     xAxisMin: XAxisMaxMin;
     intervals: Array<Date>;
@@ -53,13 +60,25 @@ export default class DataPointUtil {
   } {
     const xAxisMax: XAxisMaxMin = xAxis.options.max;
     const xAxisMin: XAxisMaxMin = xAxis.options.min;
-    const intervals: Array<Date> = XAxisUtil.getPrecisionIntervals({
+    const precision: XAxisPrecision | undefined = xAxis.options.precision;
+    /*
+     * Renderable, not raw: the grid's final slot is the bucket holding the
+     * window end, which the query only partly covered and which therefore
+     * comes back empty whenever the window ends on or just past a bucket
+     * boundary. XAxisUtil drops that one slot (and only that one, and only
+     * when nothing landed in it) so the axis stops at the last point there
+     * is data for instead of a bucket beyond it.
+     */
+    const intervals: Array<Date> = XAxisUtil.getRenderableIntervals({
       xAxisMax,
       xAxisMin,
+      precision,
+      seriesPoints,
     });
     const formatter: (value: Date) => string = XAxisUtil.getFormatter({
       xAxisMax,
       xAxisMin,
+      precision,
     });
     return { xAxisMax, xAxisMin, intervals, formatter };
   }

--- a/Common/UI/Components/Charts/Utils/TimeAnnotation.ts
+++ b/Common/UI/Components/Charts/Utils/TimeAnnotation.ts
@@ -2,7 +2,9 @@ import ChartReferenceRegionProps from "../Types/ReferenceRegionProps";
 import ChartTimeReferenceLineProps from "../Types/TimeReferenceLineProps";
 import FormattedReferenceRegion from "../ChartLibrary/Types/FormattedReferenceRegion";
 import FormattedTimeReferenceLine from "../ChartLibrary/Types/FormattedTimeReferenceLine";
+import SeriesPoints from "../Types/SeriesPoints";
 import { XAxis } from "../Types/XAxis/XAxis";
+import XAxisMaxMin from "../Types/XAxis/XAxisMaxMin";
 import XAxisUtil from "./XAxis";
 
 interface AxisBuckets {
@@ -16,17 +18,38 @@ interface AxisBuckets {
    */
   labelToIndex: Map<string, number>;
   formatter: (value: Date) => string;
+  /*
+   * The axis's own maximum, kept alongside the slots because the slots no
+   * longer imply it — see getWindowEndInMs.
+   */
+  xAxisMax: XAxisMaxMin;
 }
 
 export default class TimeAnnotationUtil {
-  private static getAxisBuckets(xAxis: XAxis): AxisBuckets {
-    const intervals: Array<Date> = XAxisUtil.getPrecisionIntervals({
+  /*
+   * `seriesPoints` is not used to place anything — it is what lets this
+   * rebuild the SAME slot array DataPointUtil built. XAxisUtil drops an
+   * unfillable trailing slot, and whether it does depends on the series, so
+   * an annotation resolved against a grid built without them would index
+   * into an array one longer than the chart's rows: every marker in the
+   * final bucket would land past the end of the axis. Chart wrappers pass
+   * the series they are drawing; callers that pass none get the raw grid,
+   * which is what DataPointUtil gives them too.
+   */
+  private static getAxisBuckets(
+    xAxis: XAxis,
+    seriesPoints?: Array<SeriesPoints> | undefined,
+  ): AxisBuckets {
+    const intervals: Array<Date> = XAxisUtil.getRenderableIntervals({
       xAxisMin: xAxis.options.min,
       xAxisMax: xAxis.options.max,
+      precision: xAxis.options.precision,
+      seriesPoints: seriesPoints,
     });
     const formatter: (value: Date) => string = XAxisUtil.getFormatter({
       xAxisMin: xAxis.options.min,
       xAxisMax: xAxis.options.max,
+      precision: xAxis.options.precision,
     });
     const labels: Array<string> = intervals.map((interval: Date) => {
       return formatter(interval);
@@ -38,14 +61,32 @@ export default class TimeAnnotationUtil {
         labelToIndex.set(label, index);
       }
     }
-    return { intervals, labels, labelToIndex, formatter };
+    return {
+      intervals,
+      labels,
+      labelToIndex,
+      formatter,
+      xAxisMax: xAxis.options.max,
+    };
   }
 
   /*
    * End of the charted window: last bucket start plus one bucket width
    * (buckets extend past their start date).
+   *
+   * Held up to the axis's own maximum, because the grid can legitimately
+   * stop SHORT of it — XAxisUtil drops a trailing slot no data could land
+   * in. Reconstructing the window from the slots alone would then pull this
+   * bound backwards by a bucket and start rejecting the very markers that
+   * sit at the window edge as "outside the charted window": on an alert the
+   * declared-at marker is at the window end exactly, and it would vanish
+   * from the chart it exists to annotate. Such a marker resolves instead to
+   * the last bucket that is still on the axis, which is where its data is.
    */
-  private static getWindowEndInMs(intervals: Array<Date>): number {
+  private static getWindowEndInMs(
+    intervals: Array<Date>,
+    xAxisMax: XAxisMaxMin,
+  ): number {
     const lastInterval: Date | undefined = intervals[intervals.length - 1];
     if (!lastInterval) {
       return Number.NEGATIVE_INFINITY;
@@ -55,7 +96,11 @@ export default class TimeAnnotationUtil {
     const bucketWidthInMs: number = secondToLastInterval
       ? lastInterval.getTime() - secondToLastInterval.getTime()
       : 0;
-    return lastInterval.getTime() + bucketWidthInMs;
+    const gridEndInMs: number = lastInterval.getTime() + bucketWidthInMs;
+    const axisMaxInMs: number =
+      typeof xAxisMax === "number" ? xAxisMax : xAxisMax.getTime();
+
+    return Math.max(gridEndInMs, axisMaxInMs);
   }
 
   /*
@@ -113,7 +158,10 @@ export default class TimeAnnotationUtil {
     if (!firstInterval || data.date.getTime() < firstInterval.getTime()) {
       return null;
     }
-    if (data.date.getTime() > this.getWindowEndInMs(intervals)) {
+    if (
+      data.date.getTime() >
+      this.getWindowEndInMs(intervals, data.buckets.xAxisMax)
+    ) {
       return null;
     }
 
@@ -130,8 +178,16 @@ export default class TimeAnnotationUtil {
   public static formatTimeReferenceLines(data: {
     timeReferenceLines: Array<ChartTimeReferenceLineProps>;
     xAxis: XAxis;
+    /*
+     * The series the chart is drawing. Only used to rebuild the same slot
+     * array the rows were built from — see getAxisBuckets.
+     */
+    seriesPoints?: Array<SeriesPoints> | undefined;
   }): Array<FormattedTimeReferenceLine> {
-    const buckets: AxisBuckets = this.getAxisBuckets(data.xAxis);
+    const buckets: AxisBuckets = this.getAxisBuckets(
+      data.xAxis,
+      data.seriesPoints,
+    );
 
     const formatted: Array<FormattedTimeReferenceLine> = [];
     for (const timeReferenceLine of data.timeReferenceLines) {
@@ -154,15 +210,26 @@ export default class TimeAnnotationUtil {
   public static formatReferenceRegions(data: {
     referenceRegions: Array<ChartReferenceRegionProps>;
     xAxis: XAxis;
+    /*
+     * The series the chart is drawing. Only used to rebuild the same slot
+     * array the rows were built from — see getAxisBuckets.
+     */
+    seriesPoints?: Array<SeriesPoints> | undefined;
   }): Array<FormattedReferenceRegion> {
-    const buckets: AxisBuckets = this.getAxisBuckets(data.xAxis);
+    const buckets: AxisBuckets = this.getAxisBuckets(
+      data.xAxis,
+      data.seriesPoints,
+    );
     const firstInterval: Date | undefined = buckets.intervals[0];
     const lastIndex: number = buckets.labels.length - 1;
     const lastLabel: string | undefined = buckets.labels[lastIndex];
     if (!firstInterval || lastLabel === undefined) {
       return [];
     }
-    const windowEndInMs: number = this.getWindowEndInMs(buckets.intervals);
+    const windowEndInMs: number = this.getWindowEndInMs(
+      buckets.intervals,
+      buckets.xAxisMax,
+    );
 
     const formatted: Array<FormattedReferenceRegion> = [];
     for (const referenceRegion of data.referenceRegions) {

--- a/Common/UI/Components/Charts/Utils/XAxis.ts
+++ b/Common/UI/Components/Charts/Utils/XAxis.ts
@@ -1,11 +1,56 @@
+import AggregationInterval from "../../../../Types/BaseDatabase/AggregationInterval";
 import OneUptimeDate from "../../../../Types/Date";
 import NotImplementedException from "../../../../Types/Exception/NotImplementedException";
+import SeriesPoints from "../Types/SeriesPoints";
 import XAxisMaxMin from "../Types/XAxis/XAxisMaxMin";
 import XAxisPrecision from "../Types/XAxis/XAxisPrecision";
 
 export default class XAxisUtil {
   private static cloneDate(value: Date): Date {
     return new Date(value.getTime());
+  }
+
+  /*
+   * The grid step a caller should pin when its points are buckets the
+   * analytics backend produced, rather than raw samples.
+   *
+   * This is the bridge between the two ladders. AggregationInterval is what
+   * the server was asked to bucket by (AggregationIntervalUtil owns that
+   * decision, and the server compiles it into `toStartOfInterval`);
+   * XAxisPrecision is the step this file walks the axis at. Pinning the
+   * translation of one to the other is what makes "one slot == one backend
+   * bucket" a fact rather than a coincidence of two duration ladders
+   * agreeing.
+   *
+   * `Total` is the one interval with no grid at all — it collapses the whole
+   * window into a single aggregate whose timestamp is the earliest sample,
+   * not a bucket start — so it pins nothing and the duration ladder applies.
+   */
+  public static getPrecisionForAggregationInterval(
+    interval: AggregationInterval,
+  ): XAxisPrecision | undefined {
+    switch (interval) {
+      case AggregationInterval.Minute:
+        return XAxisPrecision.EVERY_MINUTE;
+      case AggregationInterval.FiveMinutes:
+        return XAxisPrecision.EVERY_FIVE_MINUTES;
+      case AggregationInterval.FifteenMinutes:
+        return XAxisPrecision.EVERY_FIFTEEN_MINUTES;
+      case AggregationInterval.ThirtyMinutes:
+        return XAxisPrecision.EVERY_THIRTY_MINUTES;
+      case AggregationInterval.Hour:
+        return XAxisPrecision.EVERY_HOUR;
+      case AggregationInterval.Day:
+        return XAxisPrecision.EVERY_DAY;
+      case AggregationInterval.Week:
+        return XAxisPrecision.EVERY_WEEK;
+      case AggregationInterval.Month:
+        return XAxisPrecision.EVERY_MONTH;
+      case AggregationInterval.Year:
+        return XAxisPrecision.EVERY_YEAR;
+      default:
+        return undefined;
+    }
   }
 
   /*
@@ -110,7 +155,18 @@ export default class XAxisUtil {
   public static getPrecision(data: {
     xAxisMin: XAxisMaxMin;
     xAxisMax: XAxisMaxMin;
+    precision?: XAxisPrecision | undefined;
   }): XAxisPrecision {
+    /*
+     * An explicit pin wins outright — see XAxisOptions.precision for why a
+     * caller that knows the bucket size must not have it re-guessed from the
+     * window duration. Checked before the Date guard so a pinned axis stays
+     * pinned regardless of how its bounds are expressed.
+     */
+    if (data.precision) {
+      return data.precision;
+    }
+
     if (
       typeof data.xAxisMax === "number" ||
       typeof data.xAxisMin === "number"
@@ -184,6 +240,7 @@ export default class XAxisUtil {
   public static getPrecisionIntervals(data: {
     xAxisMin: XAxisMaxMin;
     xAxisMax: XAxisMaxMin;
+    precision?: XAxisPrecision | undefined;
   }): Array<Date> {
     const precision: XAxisPrecision = XAxisUtil.getPrecision(data);
 
@@ -280,9 +337,169 @@ export default class XAxisUtil {
     return intervals;
   }
 
+  /*
+   * How much of the LAST slot's bucket has to lie inside the window before
+   * an empty slot is worth an axis position. Half.
+   *
+   * The bound has to sit somewhere between the two ends it separates, and
+   * both ends are real:
+   *
+   *  - Near zero coverage means the bucket is not in the window in any
+   *    meaningful sense. The alert snapshot that prompted this covered
+   *    243 MILLISECONDS of a 60-second bucket (its window ends at the
+   *    instant the alert was declared, which fell just past a minute
+   *    boundary); a window that ends exactly on a boundary covers none of
+   *    the next bucket at all. Those slots cannot carry data, and an
+   *    unfillable slot at the right-hand edge is the reported gap.
+   *  - Most-of-the-bucket coverage means an empty slot is INFORMATION.
+   *    "Last 7 days" ends mid-afternoon, so today's bucket is ~60% inside
+   *    the window; if a count chart has nothing in it, that empty final bar
+   *    says "nothing today", and dropping the tick would hide it.
+   *
+   * A half-covered bucket is the natural line between "barely touched" and
+   * "genuinely part of this window", and it keeps every rolling window
+   * anchored at `now` — where the in-progress bucket is on average half
+   * elapsed — on the safe side.
+   */
+  private static readonly MIN_TRAILING_BUCKET_COVERAGE: number = 0.5;
+
+  /*
+   * The intervals a chart should actually RENDER, which is the raw grid
+   * minus a trailing slot that no data could ever land in.
+   *
+   * getPrecisionIntervals walks inclusively to the window end, so the final
+   * slot is the start of whichever bucket CONTAINS that end. That bucket
+   * runs past the end of the window, so the query never covered all of it —
+   * and when the window ends at or just after a bucket boundary it covered
+   * essentially none of it. The backend returns rows only for buckets that
+   * had samples, so such a slot comes back empty every time; and because the
+   * recharts x-axis is categorical over exactly these slots, an empty one at
+   * the end is not a rounding detail — it stretches the axis a whole bucket
+   * past the last plotted point. On a 5-minute alert snapshot that is a
+   * fifth of the chart left blank.
+   *
+   * Only ever ONE slot is dropped, and only when BOTH hold:
+   *
+   *  - it carries no data, so a live in-progress bucket keeps rendering
+   *    (dropping populated trailing buckets would make every now-anchored
+   *    chart lag by a bucket — the opposite complaint), and
+   *  - the window covers less than half of it, so an empty bucket that the
+   *    window really does span stays on the axis.
+   *
+   * Dropping at most one is what keeps a genuine outage visible: a source
+   * that stopped reporting three buckets before the window end still leaves
+   * two blank slots on the axis, which is the truth. Callers with no series
+   * to check get the raw grid unchanged.
+   */
+  public static getRenderableIntervals(data: {
+    xAxisMin: XAxisMaxMin;
+    xAxisMax: XAxisMaxMin;
+    precision?: XAxisPrecision | undefined;
+    seriesPoints?: Array<SeriesPoints> | undefined;
+  }): Array<Date> {
+    const intervals: Array<Date> = XAxisUtil.getPrecisionIntervals(data);
+
+    if (!data.seriesPoints || intervals.length < 2) {
+      return intervals;
+    }
+
+    const lastInterval: Date = intervals[intervals.length - 1]!;
+    const previousInterval: Date = intervals[intervals.length - 2]!;
+
+    /*
+     * Bucket width read off the grid itself rather than recomputed from the
+     * precision: the walk steps in wall-clock time, so a month, a year or a
+     * daylight-saving day is exactly as wide as the grid says it is.
+     */
+    const bucketWidthInMs: number =
+      lastInterval.getTime() - previousInterval.getTime();
+    if (bucketWidthInMs <= 0) {
+      return intervals;
+    }
+
+    /*
+     * Emptiness — and the bucket boundary below — are decided with the SAME
+     * formatter that DataPointUtil uses to place a datapoint on a row.
+     * Anything else would let the two disagree about which bucket the last
+     * slot IS, and the whole point of trimming here rather than in
+     * DataPointUtil is that the rows, the categorical axis and the
+     * annotation indexes are built from one array.
+     */
+    const formatter: (value: Date) => string = XAxisUtil.getFormatter(data);
+    const lastLabel: string = formatter(lastInterval);
+
+    /*
+     * A slot's DATE and the bucket it collects into are not the same thing.
+     * The walk starts at the window's own start, so on most charts the grid
+     * is anchored mid-bucket: a "last 7 days" axis stepping a day from
+     * 28 Aug 14:42 ends on a slot dated 4 Sep 14:42, which the formatter
+     * floors to the label "4 Sep" — the bucket [4 Sep 00:00, 5 Sep 00:00),
+     * of which the window covers nearly fifteen hours.
+     *
+     * Coverage can therefore only be measured off the slot's date when the
+     * slot IS its bucket's start, which is what this asks: a slot on a
+     * boundary has a different label one millisecond before it. When the
+     * grid is anchored mid-bucket the window necessarily spans everything
+     * from the bucket's real start up to the window end, which is most of
+     * it, so the slot stays — the conservative answer, and the one that
+     * keeps an empty "today" bar on a daily count chart.
+     *
+     * The alert snapshot is the aligned case (MetricView floors the window
+     * start onto the bucket grid), which is exactly when the slot date is
+     * the bucket start and the coverage measured below is the real one.
+     */
+    const isSlotOnBucketBoundary: boolean =
+      formatter(new Date(lastInterval.getTime() - 1)) !== lastLabel;
+    if (!isSlotOnBucketBoundary) {
+      return intervals;
+    }
+
+    const windowEndInMs: number =
+      typeof data.xAxisMax === "number"
+        ? data.xAxisMax
+        : OneUptimeDate.fromString(data.xAxisMax).getTime();
+    const coverage: number =
+      (windowEndInMs - lastInterval.getTime()) / bucketWidthInMs;
+    if (coverage >= XAxisUtil.MIN_TRAILING_BUCKET_COVERAGE) {
+      return intervals;
+    }
+
+    const slotLabels: Set<string> = new Set<string>(
+      intervals.map((interval: Date) => {
+        return formatter(interval);
+      }),
+    );
+
+    let hasAnyData: boolean = false;
+    for (const series of data.seriesPoints) {
+      for (const point of series.data) {
+        const label: string = formatter(point.x);
+        if (label === lastLabel) {
+          // The trailing bucket is populated — it stays.
+          return intervals;
+        }
+        if (!hasAnyData && slotLabels.has(label)) {
+          hasAnyData = true;
+        }
+      }
+    }
+
+    /*
+     * A chart with nothing on it anywhere keeps its full grid, so an empty
+     * chart still draws an axis spanning the window the user asked for
+     * instead of one silently a bucket short.
+     */
+    if (!hasAnyData) {
+      return intervals;
+    }
+
+    return intervals.slice(0, intervals.length - 1);
+  }
+
   public static getFormatter(data: {
     xAxisMin: XAxisMaxMin;
     xAxisMax: XAxisMaxMin;
+    precision?: XAxisPrecision | undefined;
   }): (value: Date) => string {
     const precision: XAxisPrecision = XAxisUtil.getPrecision(data);
 


### PR DESCRIPTION
## The bug

On an alert's **Metrics** tab every chart drew with roughly a fifth of its width blank on the right — the plotted area stopped a whole minute before the axis did.

Reproduced on the reported alert ([ALT-49](https://test.oneuptime.com/dashboard/dde060c6-fe0d-49ce-b44c-4035a13bc1db/alerts/17e03001-a2a6-4dd1-bdf7-a850cacab738)) by capturing the real request and reading the rendered `data` prop back out of the React fiber:

- window: `2026-09-04T13:37:00.000Z .. 13:42:00.243Z`, `aggregationInterval: "Minute"`
- server returned **5 rows**: `13:37, 13:38, 13:39, 13:40, 13:41`
- the chart drew **11 slots** and filled 5, the last four `:30` labels and `14:42:00` blank

The `.243` is not noise: a telemetry snapshot window ends at the instant the alert was declared, and that instant happened to land just past a minute boundary.

## Root cause

Two independent defects. **Fixing either alone leaves the gap exactly the same width** — under recharts' categorical point scale the blank fraction is `(windowEnd − lastFilledBucket) / windowLength`, which does not depend on the grid step.

### 1. The grid step came from a second, duplicate ladder

`XAxisUtil.getPrecision` guesses the bucket size from the window's *duration*, independently of what the query was actually bucketed at. Its four sub-minute tiers have no counterpart on the metrics path, whose finest bucket is `Minute` (it is served from a 1-minute rollup MV), so a 300.243 s window drew a 30-second grid over one-minute rows and half the slots could never be filled.

The same duplication drifts the other way too: aligning a window floors its start, which widens it enough to tip a 3h preset onto the five-minute tier while the query stays pinned to `Minute` — and the chart then silently re-averages five rows into each slot.

**Fix:** `XAxisOptions` gains an optional `precision`, and `MetricCharts` pins it to the `AggregationInterval` the results were fetched with. One slot is now one backend bucket by construction, rather than by two ladders happening to agree.

The duration ladder is unchanged for callers whose points are raw samples — the topology `EdgeDetailPanel` deliberately mirrors those sub-minute tiers against an API that *does* serve second-width buckets, so removing them would have broken it.

### 2. The grid emitted a trailing slot no data could land in

`getPrecisionIntervals` walks inclusively to the window end, so its last slot is the start of the bucket *containing* that end — a bucket the query only partly covered, and here covered for **243 ms**. The server returns rows only for buckets that had samples, so the slot came back empty, and because the axis is categorical over exactly those rows it stretched a full bucket past the last real point.

**Fix:** `XAxisUtil.getRenderableIntervals` drops that slot, but only when it is **both empty and less than half covered** by the window:

- never more than one, so a source that stopped reporting three buckets early still leaves its silence visible on the axis;
- never a populated one, so live charts keep their in-progress bucket;
- never one the window genuinely spans, so an empty "today" bar on a daily count chart still reads as *nothing today*.

Trimming lives in the shared walker rather than in `DataPointUtil` because `TimeAnnotationUtil` resolves markers to an **index** into the same array — the chart wrappers now pass their series to both, so rows, the categorical axis and annotation indexes stay one array. Annotation window bounds are held up to the axis maximum so a marker at the window edge (an alert's declared-at line) lands on the last bucket on the axis instead of being rejected as out-of-window.

## Result

Measured by replaying the captured response through the real `DataPointUtil`:

| configuration | slots | blank at right |
|---|---|---|
| before | 11 | **20%** |
| trim only | 10 | 11.1% |
| pin only | 6 | 20% |
| **both (this PR)** | **5** | **0%** |

## Tests

New `Common/Tests/UI/Components/Charts/ChartTrailingBucketGap.test.ts` (26 cases), including a regression test that replays the captured alert window verbatim. Covers: no trailing gap and every slot filled; the declared-at marker still rendering; annotation indexes matching row indexes; window ending exactly on a boundary; a populated in-progress bucket kept; an empty-but-mostly-spanned bucket kept (both mid-bucket-anchored and boundary-aligned grids); a barely-entered bucket dropped; a genuine trailing outage staying visible; empty and single-slot charts; the full `AggregationInterval → XAxisPrecision` mapping; a pin overriding the ladder in the coarser direction; and DST-safe bucket widths.

Two assertions in `ChartBucketIdentity.test.ts` were amended with comments explaining why the old numbers were wrong: a 48h window's 97th slot is the start of `[Mar 4 00:00, Mar 4 00:30)`, which that window never reaches into.

All 100 tests pass across the six affected suites; `Common` typechecks clean.
