### PR TITLE
perf: reduce telemetry CPU and monitor worker memory

### DIFF
--- a/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
@@ -29,6 +29,7 @@ import {
 } from "Common/Utils/Grok/Grok";
 import logger from "Common/Server/Utils/Logger";
 import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
+import getPipelineProcessorConfig from "../Utils/PipelineProcessorConfig";
 
 export interface LoadedPipeline {
   pipeline: LogPipeline;
@@ -173,35 +174,11 @@ export class LogPipelineService {
     return result;
   }
 
-  /**
-   * Processor configuration is stored in a jsonb column but the UI's JSON
-   * form field persists it as a JSON string literal, so TypeORM hands us
-   * back a string that still needs parsing. Accept either shape.
-   */
-  private static normalizeProcessorConfig(raw: unknown): JSONObject {
-    if (raw && typeof raw === "object") {
-      return raw as JSONObject;
-    }
-    if (typeof raw === "string") {
-      try {
-        const parsed: unknown = JSON.parse(raw);
-        if (parsed && typeof parsed === "object") {
-          return parsed as JSONObject;
-        }
-      } catch {
-        // fall through
-      }
-    }
-    return {};
-  }
-
   private static applyProcessor(
     logRow: JSONObject,
     processor: LogPipelineProcessor,
   ): JSONObject {
-    const config: JSONObject = LogPipelineService.normalizeProcessorConfig(
-      processor.configuration,
-    );
+    const config: JSONObject = getPipelineProcessorConfig(processor);
 
     switch (processor.processorType) {
       case LogPipelineProcessorType.AttributeRemapper:

--- a/App/FeatureSet/Telemetry/Services/TracePipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/TracePipelineService.ts
@@ -19,6 +19,7 @@ import {
 } from "../Utils/LogFilterEvaluator";
 import logger from "Common/Server/Utils/Logger";
 import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
+import getPipelineProcessorConfig from "../Utils/PipelineProcessorConfig";
 
 export interface LoadedTracePipeline {
   pipeline: TracePipeline;
@@ -143,35 +144,11 @@ export class TracePipelineService {
     return result;
   }
 
-  /**
-   * Processor configuration is stored in a jsonb column but the UI's JSON
-   * form field persists it as a JSON string literal, so TypeORM hands us
-   * back a string that still needs parsing. Accept either shape.
-   */
-  private static normalizeProcessorConfig(raw: unknown): JSONObject {
-    if (raw && typeof raw === "object") {
-      return raw as JSONObject;
-    }
-    if (typeof raw === "string") {
-      try {
-        const parsed: unknown = JSON.parse(raw);
-        if (parsed && typeof parsed === "object") {
-          return parsed as JSONObject;
-        }
-      } catch {
-        // fall through
-      }
-    }
-    return {};
-  }
-
   private static applyProcessor(
     spanRow: JSONObject,
     processor: TracePipelineProcessor,
   ): JSONObject {
-    const config: JSONObject = TracePipelineService.normalizeProcessorConfig(
-      processor.configuration,
-    );
+    const config: JSONObject = getPipelineProcessorConfig(processor);
 
     switch (processor.processorType) {
       case TracePipelineProcessorType.AttributeRemapper:

--- a/App/FeatureSet/Telemetry/Utils/PipelineProcessorConfig.ts
+++ b/App/FeatureSet/Telemetry/Utils/PipelineProcessorConfig.ts
@@ -1,0 +1,54 @@
+import { JSONObject } from "Common/Types/JSON";
+
+interface ProcessorWithConfiguration {
+  configuration?: unknown;
+}
+
+interface CachedConfiguration {
+  raw: unknown;
+  normalized: JSONObject;
+}
+
+/*
+ * Pipeline processors live in the bounded project cache. Keep the parsed
+ * configuration for exactly that processor's lifetime without retaining old
+ * processors after their pipeline is evicted or refreshed.
+ */
+const configurations: WeakMap<ProcessorWithConfiguration, CachedConfiguration> =
+  new WeakMap<ProcessorWithConfiguration, CachedConfiguration>();
+
+/**
+ * The UI can persist JSONB configuration as a JSON string. Parsing it for
+ * every record also discards the category filters compiled onto the parsed
+ * object, so both allocations and filter compilation repeat at ingest rate.
+ * Reuse the parsed object until configuration is replaced. Object configs
+ * retain their existing reference semantics, including in-place edits.
+ */
+export default function getPipelineProcessorConfig(
+  processor: ProcessorWithConfiguration,
+): JSONObject {
+  const raw: unknown = processor.configuration;
+  const cached: CachedConfiguration | undefined = configurations.get(processor);
+
+  if (cached && cached.raw === raw) {
+    return cached.normalized;
+  }
+
+  let normalized: JSONObject = {};
+
+  if (raw && typeof raw === "object") {
+    normalized = raw as JSONObject;
+  } else if (typeof raw === "string") {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        normalized = parsed as JSONObject;
+      }
+    } catch {
+      // Preserve the existing empty-config fallback, including for bad JSON.
+    }
+  }
+
+  configurations.set(processor, { raw, normalized });
+  return normalized;
+}

--- a/App/FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.ts
+++ b/App/FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.ts
@@ -1,4 +1,5 @@
 import RunCron from "../../Utils/Cron";
+import runMonitorSweep from "../../Utils/MonitorSweep";
 import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
 import IncomingEmailMonitorRequest from "Common/Types/Monitor/IncomingEmailMonitor/IncomingEmailMonitorRequest";
 import MonitorType from "Common/Types/Monitor/MonitorType";
@@ -9,7 +10,6 @@ import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import ProjectService from "Common/Server/Services/ProjectService";
 import OneUptimeDate from "Common/Types/Date";
-import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 
 RunCron(
@@ -23,77 +23,35 @@ RunCron(
         ),
     );
 
-    const newIncomingEmailMonitors: Array<Monitor> =
-      await MonitorService.findAllBy({
-        query: {
+    const sweepStartedAt: Date = OneUptimeDate.getCurrentDate();
+
+    await runMonitorSweep({
+      jobName: "IncomingEmailMonitor:CheckOnlineStatus",
+      queries: [
+        {
           ...MonitorService.getEnabledMonitorQuery(),
           monitorType: MonitorType.IncomingEmail,
-          project: {
-            ...ProjectService.getActiveProjectStatusQuery(),
-          },
+          project: { ...ProjectService.getActiveProjectStatusQuery() },
           incomingEmailMonitorHeartbeatCheckedAt: QueryHelper.isNull(),
         },
-        props: {
-          isRoot: true,
-        },
-        select: {
-          _id: true,
-          monitorSteps: true,
-          incomingEmailMonitorRequest: true,
-          incomingEmailMonitorHeartbeatCheckedAt: true,
-          createdAt: true,
-          projectId: true,
-        },
-        sort: {
-          createdAt: SortOrder.Ascending,
-        },
-      });
-
-    const incomingEmailMonitors: Array<Monitor> =
-      await MonitorService.findAllBy({
-        query: {
+        {
           ...MonitorService.getEnabledMonitorQuery(),
           monitorType: MonitorType.IncomingEmail,
-          project: {
-            ...ProjectService.getActiveProjectStatusQuery(),
-          },
-          incomingEmailMonitorHeartbeatCheckedAt: QueryHelper.notNull(),
+          project: { ...ProjectService.getActiveProjectStatusQuery() },
+          // Exclude monitors stamped in the never-checked phase above.
+          incomingEmailMonitorHeartbeatCheckedAt:
+            QueryHelper.lessThan(sweepStartedAt),
         },
-        props: {
-          isRoot: true,
-        },
-        select: {
-          _id: true,
-          monitorSteps: true,
-          incomingEmailMonitorRequest: true,
-          incomingEmailMonitorHeartbeatCheckedAt: true,
-          createdAt: true,
-          projectId: true,
-        },
-        sort: {
-          incomingEmailMonitorHeartbeatCheckedAt: SortOrder.Ascending,
-        },
-      });
-
-    const totalIncomingEmailMonitors: Array<Monitor> = [
-      ...newIncomingEmailMonitors,
-      ...incomingEmailMonitors,
-    ];
-
-    logger.debug(
-      `Found ${totalIncomingEmailMonitors.length} incoming email monitors`,
-    );
-
-    logger.debug(totalIncomingEmailMonitors);
-
-    for (const monitor of totalIncomingEmailMonitors) {
-      checkOnlineStatus(monitor).catch((error: Error) => {
-        logger.error(
-          `Error while processing incoming email monitor: ${monitor.id?.toString()}`,
-        );
-        logger.error(error);
-      });
-    }
+      ],
+      select: {
+        _id: true,
+        monitorSteps: true,
+        incomingEmailMonitorRequest: true,
+        createdAt: true,
+        projectId: true,
+      },
+      processMonitor: checkOnlineStatus,
+    });
   },
 );
 

--- a/App/FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.ts
+++ b/App/FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.ts
@@ -1,4 +1,5 @@
 import RunCron from "../../Utils/Cron";
+import runMonitorSweep from "../../Utils/MonitorSweep";
 import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
 import IncomingMonitorRequest from "Common/Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import MonitorType from "Common/Types/Monitor/MonitorType";
@@ -9,7 +10,6 @@ import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import ProjectService from "Common/Server/Services/ProjectService";
 import OneUptimeDate from "Common/Types/Date";
-import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 
 RunCron(
@@ -23,77 +23,35 @@ RunCron(
         ),
     );
 
-    const newIncomingRequestMonitors: Array<Monitor> =
-      await MonitorService.findAllBy({
-        query: {
+    const sweepStartedAt: Date = OneUptimeDate.getCurrentDate();
+
+    await runMonitorSweep({
+      jobName: "IncomingRequestMonitor:CheckHeartbeat",
+      queries: [
+        {
           ...MonitorService.getEnabledMonitorQuery(),
           monitorType: MonitorType.IncomingRequest,
-          project: {
-            ...ProjectService.getActiveProjectStatusQuery(),
-          },
+          project: { ...ProjectService.getActiveProjectStatusQuery() },
           incomingRequestMonitorHeartbeatCheckedAt: QueryHelper.isNull(),
         },
-        props: {
-          isRoot: true,
-        },
-        select: {
-          _id: true,
-          monitorSteps: true,
-          incomingMonitorRequest: true,
-          incomingRequestMonitorHeartbeatCheckedAt: true,
-          createdAt: true,
-          projectId: true,
-        },
-        sort: {
-          createdAt: SortOrder.Ascending,
-        },
-      });
-
-    const incomingRequestMonitors: Array<Monitor> =
-      await MonitorService.findAllBy({
-        query: {
+        {
           ...MonitorService.getEnabledMonitorQuery(),
           monitorType: MonitorType.IncomingRequest,
-          project: {
-            ...ProjectService.getActiveProjectStatusQuery(),
-          },
-          incomingRequestMonitorHeartbeatCheckedAt: QueryHelper.notNull(),
+          project: { ...ProjectService.getActiveProjectStatusQuery() },
+          // Exclude monitors stamped in the never-checked phase above.
+          incomingRequestMonitorHeartbeatCheckedAt:
+            QueryHelper.lessThan(sweepStartedAt),
         },
-        props: {
-          isRoot: true,
-        },
-        select: {
-          _id: true,
-          monitorSteps: true,
-          incomingMonitorRequest: true,
-          incomingRequestMonitorHeartbeatCheckedAt: true,
-          createdAt: true,
-          projectId: true,
-        },
-        sort: {
-          incomingRequestMonitorHeartbeatCheckedAt: SortOrder.Ascending,
-        },
-      });
-
-    const totalIncomingRequestMonitors: Array<Monitor> = [
-      ...newIncomingRequestMonitors,
-      ...incomingRequestMonitors,
-    ];
-
-    logger.debug(
-      `Found ${totalIncomingRequestMonitors.length} incoming request monitors`,
-    );
-
-    logger.debug(totalIncomingRequestMonitors);
-
-    for (const monitor of totalIncomingRequestMonitors) {
-      checkHeartBeat(monitor).catch((error: Error) => {
-        logger.error(
-          `Error while processing incoming request monitor: ${monitor.id?.toString()}`,
-        );
-        logger.error(error);
-      });
-    }
+      ],
+      select: {
+        _id: true,
+        monitorSteps: true,
+        incomingMonitorRequest: true,
+        createdAt: true,
+        projectId: true,
+      },
+      processMonitor: checkHeartBeat,
+    });
   },
 );
 

--- a/App/FeatureSet/Workers/Jobs/ServerMonitor/CheckOnlineStatus.ts
+++ b/App/FeatureSet/Workers/Jobs/ServerMonitor/CheckOnlineStatus.ts
@@ -1,4 +1,5 @@
 import RunCron from "../../Utils/Cron";
+import runMonitorSweep from "../../Utils/MonitorSweep";
 import OneUptimeDate from "Common/Types/Date";
 import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
 import MonitorType from "Common/Types/Monitor/MonitorType";
@@ -17,44 +18,37 @@ RunCron(
     try {
       const threeMinsAgo: Date = OneUptimeDate.getSomeMinutesAgo(3);
 
-      const serverMonitors: Array<Monitor> = await MonitorService.findAllBy({
-        query: {
-          monitorType: MonitorType.Server,
-          serverMonitorRequestReceivedAt:
-            QueryHelper.lessThanEqualToOrNull(threeMinsAgo),
-          ...MonitorService.getEnabledMonitorQuery(),
-          project: {
-            ...ProjectService.getActiveProjectStatusQuery(),
+      await runMonitorSweep({
+        jobName: "ServerMonitor:CheckOnlineStatus",
+        queries: [
+          {
+            monitorType: MonitorType.Server,
+            serverMonitorRequestReceivedAt:
+              QueryHelper.lessThanEqualToOrNull(threeMinsAgo),
+            ...MonitorService.getEnabledMonitorQuery(),
+            project: {
+              ...ProjectService.getActiveProjectStatusQuery(),
+            },
           },
-        },
-        props: {
-          isRoot: true,
-        },
+        ],
         select: {
           _id: true,
           monitorSteps: true,
         },
-        skip: 0,
-      });
+        processMonitor: async (monitor: Monitor): Promise<void> => {
+          if (!monitor.monitorSteps) {
+            return;
+          }
 
-      // Prepare all monitor resource tasks for parallel processing
-      const monitorResourceTasks: Array<Promise<void>> = [];
+          /*
+           * The sweep already selected monitorSteps, so filter out monitors
+           * with no Is Online criteria here — before paying a per-monitor
+           * re-fetch query for monitors that would be skipped anyway.
+           */
+          if (!shouldProcessRequest(monitor)) {
+            return;
+          }
 
-      for (const monitor of serverMonitors) {
-        if (!monitor.monitorSteps) {
-          continue;
-        }
-
-        /*
-         * The sweep already selected monitorSteps, so filter out monitors
-         * with no Is Online criteria here — before paying a per-monitor
-         * re-fetch query for monitors that would be skipped anyway.
-         */
-        if (!shouldProcessRequest(monitor)) {
-          continue;
-        }
-
-        const monitorTask: Promise<void> = (async () => {
           try {
             /*
              * Re-check freshness right before processing: the monitor may
@@ -112,13 +106,8 @@ RunCron(
             );
             logger.error(error);
           }
-        })();
-
-        monitorResourceTasks.push(monitorTask);
-      }
-
-      // Process all monitor resource tasks in parallel
-      await Promise.allSettled(monitorResourceTasks);
+        },
+      });
     } catch (error) {
       logger.error("Error in ServerMonitor:CheckOnlineStatus");
       logger.error(error);

--- a/App/FeatureSet/Workers/Utils/MonitorSweep.ts
+++ b/App/FeatureSet/Workers/Utils/MonitorSweep.ts
@@ -1,0 +1,112 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Semaphore, {
+  SemaphoreMutex,
+  SemaphoreLockTimeoutError,
+} from "Common/Server/Infrastructure/Semaphore";
+import MonitorService from "Common/Server/Services/MonitorService";
+import Query from "Common/Server/Types/Database/Query";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import Select from "Common/Server/Types/Database/Select";
+import logger from "Common/Server/Utils/Logger";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import ObjectID from "Common/Types/ObjectID";
+
+export const MONITOR_SWEEP_BATCH_SIZE: number = 100;
+export const MONITOR_SWEEP_CONCURRENCY: number = 10;
+
+/*
+ * Keep at most one page of monitor JSON and ten evaluations in memory. An
+ * immutable ID cursor avoids OFFSET skipping rows when processing changes the
+ * query's matching set. The renewing mutex also covers work that outlives the
+ * queue timeout: a later tick must not start another copy of the same sweep.
+ */
+export default async function runMonitorSweep(data: {
+  jobName: string;
+  queries: Array<Query<Monitor>>;
+  select: Select<Monitor>;
+  processMonitor: (monitor: Monitor) => Promise<void>;
+}): Promise<void> {
+  let mutex: SemaphoreMutex;
+
+  try {
+    mutex = await Semaphore.lock({
+      namespace: "monitor-heartbeat-sweep",
+      key: data.jobName,
+      lockTimeout: 60_000,
+      acquireAttemptsLimit: 1,
+    });
+  } catch (error) {
+    if (error instanceof SemaphoreLockTimeoutError) {
+      logger.debug(
+        `${data.jobName}: skipping tick because another sweep is running`,
+      );
+    } else {
+      logger.error(`${data.jobName}: could not acquire the sweep lock`);
+      logger.error(error);
+    }
+    return;
+  }
+
+  try {
+    for (const query of data.queries) {
+      let cursor: ObjectID | undefined;
+
+      while (mutex.isAcquired) {
+        const monitors: Array<Monitor> = await MonitorService.findBy({
+          query: {
+            ...query,
+            ...(cursor ? { _id: QueryHelper.greaterThan(cursor) } : {}),
+          },
+          select: { ...data.select, _id: true },
+          sort: { _id: SortOrder.Ascending },
+          skip: 0,
+          limit: MONITOR_SWEEP_BATCH_SIZE,
+          props: { isRoot: true },
+        });
+
+        if (monitors.length === 0) {
+          break;
+        }
+
+        const lastId: ObjectID | null = monitors[monitors.length - 1]!.id;
+        if (!lastId || (cursor && lastId.toString() <= cursor.toString())) {
+          throw new Error(
+            `${data.jobName}: monitor page did not advance its ID cursor`,
+          );
+        }
+        cursor = lastId;
+        let nextIndex: number = 0;
+
+        await Promise.all(
+          Array.from(
+            { length: Math.min(MONITOR_SWEEP_CONCURRENCY, monitors.length) },
+            async (): Promise<void> => {
+              while (nextIndex < monitors.length && mutex.isAcquired) {
+                const monitor: Monitor = monitors[nextIndex++]!;
+                try {
+                  await data.processMonitor(monitor);
+                } catch (error) {
+                  logger.error(
+                    `${data.jobName}: error processing monitor ${monitor.id}`,
+                  );
+                  logger.error(error);
+                }
+              }
+            },
+          ),
+        );
+
+        if (monitors.length < MONITOR_SWEEP_BATCH_SIZE) {
+          break;
+        }
+      }
+    }
+  } finally {
+    try {
+      await Semaphore.release(mutex);
+    } catch (error) {
+      logger.error(`${data.jobName}: failed to release sweep lock`);
+      logger.error(error);
+    }
+  }
+}

--- a/App/Tests/Telemetry/PipelineProcessorConfig.test.ts
+++ b/App/Tests/Telemetry/PipelineProcessorConfig.test.ts
@@ -1,0 +1,136 @@
+import getPipelineProcessorConfig from "../../FeatureSet/Telemetry/Utils/PipelineProcessorConfig";
+import { JSONObject } from "Common/Types/JSON";
+
+describe("pipeline configuration normalization", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("parses a persisted JSON string once across a large record batch", () => {
+    const raw: string = JSON.stringify({ sourceKey: "old", targetKey: "new" });
+    const processor: { configuration: string } = { configuration: raw };
+    const parse: jest.SpyInstance = jest.spyOn(JSON, "parse");
+    const first: JSONObject = getPipelineProcessorConfig(processor);
+    let allReferencesMatch: boolean = true;
+
+    for (let index: number = 0; index < 10_000; index++) {
+      allReferencesMatch =
+        getPipelineProcessorConfig(processor) === first && allReferencesMatch;
+    }
+
+    expect(allReferencesMatch).toBe(true);
+    expect(first).toEqual({ sourceKey: "old", targetKey: "new" });
+    expect(processor.configuration).toBe(raw);
+    expect(parse).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves object identity and observes in-place object edits", () => {
+    const configuration: JSONObject = { sourceKey: "old", targetKey: "first" };
+    const processor: { configuration: JSONObject } = { configuration };
+    const parse: jest.SpyInstance = jest.spyOn(JSON, "parse");
+
+    expect(getPipelineProcessorConfig(processor)).toBe(configuration);
+    configuration["targetKey"] = "second";
+    expect(getPipelineProcessorConfig(processor)["targetKey"]).toBe("second");
+    expect(parse).not.toHaveBeenCalled();
+  });
+
+  test("reuses compiled metadata added to a normalized string configuration", () => {
+    const processor: { configuration: string } = { configuration: "{}" };
+    const normalized: JSONObject = getPipelineProcessorConfig(processor);
+    normalized["compiledMetadata"] = { filter: "cached" };
+
+    expect(getPipelineProcessorConfig(processor)["compiledMetadata"]).toBe(
+      normalized["compiledMetadata"],
+    );
+    expect(processor.configuration).toBe("{}");
+  });
+
+  test("does not share parsed objects between processor instances", () => {
+    const first: { configuration: string } = { configuration: "{}" };
+    const second: { configuration: string } = { configuration: "{}" };
+
+    getPipelineProcessorConfig(first)["privateMetadata"] = "first";
+
+    expect(getPipelineProcessorConfig(second)).toEqual({});
+    expect(getPipelineProcessorConfig(second)).not.toBe(
+      getPipelineProcessorConfig(first),
+    );
+  });
+
+  test("replaces cached parsed configuration when the raw string changes", () => {
+    const processor: { configuration: string } = {
+      configuration: '{"value":1}',
+    };
+    const first: JSONObject = getPipelineProcessorConfig(processor);
+    first["compiledMetadata"] = true;
+    processor.configuration = '{"value":2}';
+
+    expect(getPipelineProcessorConfig(processor)).toEqual({ value: 2 });
+    expect(getPipelineProcessorConfig(processor)).not.toBe(first);
+  });
+
+  test("refreshes across string, object and absent configuration transitions", () => {
+    const processor: { configuration?: unknown } = {
+      configuration: '{"value":1}',
+    };
+    expect(getPipelineProcessorConfig(processor)).toEqual({ value: 1 });
+    const object: JSONObject = { value: 2 };
+    processor.configuration = object;
+    expect(getPipelineProcessorConfig(processor)).toBe(object);
+    processor.configuration = { value: 3 };
+    expect(getPipelineProcessorConfig(processor)).toEqual({ value: 3 });
+    delete processor.configuration;
+    expect(getPipelineProcessorConfig(processor)).toEqual({});
+    processor.configuration = '{"value":4}';
+    expect(getPipelineProcessorConfig(processor)).toEqual({ value: 4 });
+  });
+
+  test.each([
+    undefined,
+    null,
+    false,
+    true,
+    0,
+    10,
+    "",
+    "invalid json",
+    "null",
+    "false",
+    "1",
+    '"text"',
+  ])("retains the empty-object fallback for %p", (raw: unknown) => {
+    const processor: { configuration: unknown } = { configuration: raw };
+    const first: JSONObject = getPipelineProcessorConfig(processor);
+    expect(first).toEqual({});
+    expect(getPipelineProcessorConfig(processor)).toBe(first);
+  });
+
+  test("does not repeatedly parse malformed JSON and accepts a later repair", () => {
+    const processor: { configuration: string } = { configuration: "broken" };
+    const parse: jest.SpyInstance = jest.spyOn(JSON, "parse");
+    for (let index: number = 0; index < 100; index++) {
+      expect(getPipelineProcessorConfig(processor)).toEqual({});
+    }
+    expect(parse).toHaveBeenCalledTimes(1);
+    processor.configuration = '{"repaired":true}';
+    expect(getPipelineProcessorConfig(processor)).toEqual({ repaired: true });
+    expect(parse).toHaveBeenCalledTimes(2);
+  });
+
+  test("preserves the existing acceptance of array configurations", () => {
+    const configuration: Array<string> = ["value"];
+    expect(getPipelineProcessorConfig({ configuration })).toBe(configuration);
+    expect(getPipelineProcessorConfig({ configuration: '["value"]' })).toEqual(
+      configuration,
+    );
+  });
+
+  test("works with frozen processor instances without adding properties", () => {
+    const processor: Readonly<{ configuration: string }> = Object.freeze({
+      configuration: '{"value":1}',
+    });
+    expect(getPipelineProcessorConfig(processor)).toEqual({ value: 1 });
+    expect(Object.keys(processor)).toEqual(["configuration"]);
+  });
+});

--- a/App/Tests/Telemetry/PipelineProcessorConfigIntegration.test.ts
+++ b/App/Tests/Telemetry/PipelineProcessorConfigIntegration.test.ts
@@ -1,0 +1,413 @@
+import LogPipelineService, {
+  LoadedPipeline,
+} from "../../FeatureSet/Telemetry/Services/LogPipelineService";
+import TracePipelineService, {
+  LoadedTracePipeline,
+} from "../../FeatureSet/Telemetry/Services/TracePipelineService";
+import * as FilterEvaluator from "../../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
+import { CompiledFilter } from "../../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import LogPipelineProcessorType from "Common/Types/Log/LogPipelineProcessorType";
+import TracePipelineProcessorType from "Common/Types/Trace/TracePipelineProcessorType";
+
+jest.mock("Common/Server/Services/DatabaseService", () => {
+  return {
+    __esModule: true,
+    default: class DatabaseServiceStub {
+      public hardDeleteItemsOlderThanInDays(): void {}
+      public setDoNotAllowDelete(): void {}
+      public findBy(...args: Array<unknown>): Promise<Array<unknown>> {
+        return mockFindBy(...args);
+      }
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return { __esModule: true, default: { error: jest.fn() } };
+});
+
+const mockFindBy: jest.Mock = jest.fn();
+
+interface ProcessorSpec {
+  name: string;
+  processorType: string;
+  configuration: unknown;
+}
+
+interface PipelineSpec {
+  pipeline: { name: string };
+  compiledFilter: CompiledFilter;
+  processors: Array<ProcessorSpec>;
+}
+
+interface PipelineAdapter {
+  signal: string;
+  categoryType: string;
+  remapperType: string;
+  process: (row: JSONObject, pipelines: Array<PipelineSpec>) => JSONObject;
+  load: (projectId: ObjectID) => Promise<Array<PipelineSpec>>;
+}
+
+const adapters: Array<PipelineAdapter> = [
+  {
+    signal: "logs",
+    categoryType: LogPipelineProcessorType.CategoryProcessor,
+    remapperType: LogPipelineProcessorType.AttributeRemapper,
+    process: (row: JSONObject, pipelines: Array<PipelineSpec>): JSONObject => {
+      return LogPipelineService.processLog(
+        row,
+        pipelines as unknown as Array<LoadedPipeline>,
+      );
+    },
+    load: async (projectId: ObjectID): Promise<Array<PipelineSpec>> => {
+      return (await LogPipelineService.loadPipelines(
+        projectId,
+      )) as unknown as Array<PipelineSpec>;
+    },
+  },
+  {
+    signal: "traces",
+    categoryType: TracePipelineProcessorType.CategoryProcessor,
+    remapperType: TracePipelineProcessorType.AttributeRemapper,
+    process: (row: JSONObject, pipelines: Array<PipelineSpec>): JSONObject => {
+      return TracePipelineService.processSpan(
+        row,
+        pipelines as unknown as Array<LoadedTracePipeline>,
+      );
+    },
+    load: async (projectId: ObjectID): Promise<Array<PipelineSpec>> => {
+      return (await TracePipelineService.loadPipelines(
+        projectId,
+      )) as unknown as Array<PipelineSpec>;
+    },
+  },
+];
+
+function categoryConfiguration(name: string = "errors"): JSONObject {
+  return {
+    targetKey: "category",
+    categories: [
+      {
+        name,
+        filterQuery: "attributes.level = 'error' AND body LIKE 'request %'",
+      },
+      { name: "api", filterQuery: "attributes.service IN ('api', 'worker')" },
+    ],
+  };
+}
+
+function categoryProcessor(
+  adapter: PipelineAdapter,
+  configuration: unknown,
+): ProcessorSpec {
+  return {
+    name: "categorize",
+    processorType: adapter.categoryType,
+    configuration,
+  };
+}
+
+function pipelinesWith(
+  processors: Array<ProcessorSpec>,
+  filterQuery: string = "",
+): Array<PipelineSpec> {
+  return [
+    {
+      pipeline: { name: "test" },
+      compiledFilter: FilterEvaluator.compileFilter(filterQuery),
+      processors,
+    },
+  ];
+}
+
+function row(level: string = "error", service: string = "api"): JSONObject {
+  return {
+    body: "request failed",
+    name: "request failed",
+    attributes: { level, service },
+    attributeKeys: ["level", "service"],
+  };
+}
+
+describe.each(adapters)(
+  "$signal processor configuration reuse",
+  (adapter: PipelineAdapter) => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      mockFindBy.mockReset();
+    });
+
+    test("parses once and compiles each category once across 1,000 records", () => {
+      const processor: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration()),
+      );
+      const pipelines: Array<PipelineSpec> = pipelinesWith([processor]);
+      const parse: jest.SpyInstance = jest.spyOn(JSON, "parse");
+      const compile: jest.SpyInstance = jest.spyOn(
+        FilterEvaluator,
+        "compileFilter",
+      );
+
+      for (let index: number = 0; index < 1_000; index++) {
+        const level: string = index % 2 === 0 ? "error" : "info";
+        expect(adapter.process(row(level), pipelines)["attributes"]).toEqual({
+          level,
+          service: "api",
+          category: level === "error" ? "errors" : "api",
+        });
+      }
+
+      expect(parse).toHaveBeenCalledTimes(1);
+      expect(compile).toHaveBeenCalledTimes(2);
+      expect(typeof processor.configuration).toBe("string");
+    });
+
+    test("preserves category priority, unmatched rows and input immutability", () => {
+      const pipelines: Array<PipelineSpec> = pipelinesWith([
+        categoryProcessor(adapter, JSON.stringify(categoryConfiguration())),
+      ]);
+      const original: JSONObject = row();
+      const before: string = JSON.stringify(original);
+      const matched: JSONObject = adapter.process(original, pipelines);
+      expect((matched["attributes"] as JSONObject)["category"]).toBe("errors");
+      expect(matched["attributeKeys"]).toEqual([
+        "level",
+        "service",
+        "category",
+      ]);
+      expect(JSON.stringify(original)).toBe(before);
+      const unmatched: JSONObject = row("info", "other");
+      expect(adapter.process(unmatched, pipelines)).toEqual(unmatched);
+    });
+
+    test("produces identical rows for object and string configurations", () => {
+      const fromObject: Array<PipelineSpec> = pipelinesWith([
+        categoryProcessor(adapter, categoryConfiguration()),
+      ]);
+      const fromString: Array<PipelineSpec> = pipelinesWith([
+        categoryProcessor(adapter, JSON.stringify(categoryConfiguration())),
+      ]);
+      for (const level of ["error", "info", "debug"]) {
+        for (const service of ["api", "worker", "other"]) {
+          expect(adapter.process(row(level, service), fromString)).toEqual(
+            adapter.process(row(level, service), fromObject),
+          );
+        }
+      }
+    });
+
+    test("does not parse configurations in pipelines whose filters do not match", () => {
+      const pipelines: Array<PipelineSpec> = pipelinesWith(
+        [categoryProcessor(adapter, JSON.stringify(categoryConfiguration()))],
+        "attributes.service = 'other'",
+      );
+      const parse: jest.SpyInstance = jest.spyOn(JSON, "parse");
+      const compile: jest.SpyInstance = jest.spyOn(
+        FilterEvaluator,
+        "compileFilter",
+      );
+      expect(adapter.process(row(), pipelines)).toEqual(row());
+      expect(parse).not.toHaveBeenCalled();
+      expect(compile).not.toHaveBeenCalled();
+    });
+
+    test("invalidates category filters after a same-length config replacement", () => {
+      const processor: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration()),
+      );
+      const pipelines: Array<PipelineSpec> = pipelinesWith([processor]);
+      adapter.process(row(), pipelines);
+      const compile: jest.SpyInstance = jest.spyOn(
+        FilterEvaluator,
+        "compileFilter",
+      );
+      processor.configuration = JSON.stringify({
+        targetKey: "classification",
+        categories: [
+          { name: "info", filterQuery: "attributes.level = 'info'" },
+          { name: "fallback", filterQuery: "" },
+        ],
+      });
+      const output: JSONObject = adapter.process(row(), pipelines);
+      expect(output["attributes"]).toEqual({
+        level: "error",
+        service: "api",
+        classification: "fallback",
+      });
+      expect(compile).toHaveBeenCalledTimes(2);
+      expect(
+        (adapter.process(row("info"), pipelines)["attributes"] as JSONObject)[
+          "classification"
+        ],
+      ).toBe("info");
+      expect(compile).toHaveBeenCalledTimes(2);
+    });
+
+    test("observes in-place object configuration changes", () => {
+      const configuration: JSONObject = {
+        sourceKey: "level",
+        targetKey: "first",
+        preserveSource: true,
+      };
+      const processor: ProcessorSpec = {
+        name: "remap",
+        processorType: adapter.remapperType,
+        configuration,
+      };
+      const pipelines: Array<PipelineSpec> = pipelinesWith([processor]);
+      expect(
+        (adapter.process(row(), pipelines)["attributes"] as JSONObject)[
+          "first"
+        ],
+      ).toBe("error");
+      configuration["targetKey"] = "second";
+      expect(adapter.process(row(), pipelines)["attributes"]).toEqual({
+        level: "error",
+        service: "api",
+        second: "error",
+      });
+    });
+
+    test("retains processor order and lets later filters see earlier changes", () => {
+      const remapper: ProcessorSpec = {
+        name: "remap",
+        processorType: adapter.remapperType,
+        configuration: JSON.stringify({
+          sourceKey: "level",
+          targetKey: "remapped",
+          preserveSource: false,
+        }),
+      };
+      const category: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify({
+          targetKey: "category",
+          categories: [
+            {
+              name: "after-remap",
+              filterQuery: "attributes.remapped = 'error'",
+            },
+          ],
+        }),
+      );
+      const pipelines: Array<PipelineSpec> = [
+        ...pipelinesWith([remapper]),
+        ...pipelinesWith([category], "attributes.remapped = 'error'"),
+      ];
+      expect(adapter.process(row(), pipelines)["attributes"]).toEqual({
+        service: "api",
+        remapped: "error",
+        category: "after-remap",
+      });
+    });
+
+    test("handles malformed saved config without preventing later processors", () => {
+      const broken: ProcessorSpec = categoryProcessor(adapter, "not json");
+      const working: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration()),
+      );
+      const pipelines: Array<PipelineSpec> = pipelinesWith([broken, working]);
+      expect(
+        (adapter.process(row(), pipelines)["attributes"] as JSONObject)[
+          "category"
+        ],
+      ).toBe("errors");
+      broken.configuration = JSON.stringify(categoryConfiguration("repaired"));
+      pipelines[0]!.processors = [broken];
+      expect(
+        (adapter.process(row(), pipelines)["attributes"] as JSONObject)[
+          "category"
+        ],
+      ).toBe("repaired");
+    });
+
+    test("keeps processor configurations separate across projects", async () => {
+      const firstProcessor: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration("first")),
+      );
+      const secondProcessor: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration("second")),
+      );
+      mockFindBy
+        .mockResolvedValueOnce([
+          { _id: "pipeline", name: "first", filterQuery: "" },
+        ])
+        .mockResolvedValueOnce([firstProcessor]);
+      const first: Array<PipelineSpec> = await adapter.load(
+        ObjectID.generate(),
+      );
+      mockFindBy
+        .mockResolvedValueOnce([
+          { _id: "pipeline", name: "second", filterQuery: "" },
+        ])
+        .mockResolvedValueOnce([secondProcessor]);
+      const second: Array<PipelineSpec> = await adapter.load(
+        ObjectID.generate(),
+      );
+      expect(
+        (adapter.process(row(), first)["attributes"] as JSONObject)["category"],
+      ).toBe("first");
+      expect(
+        (adapter.process(row(), second)["attributes"] as JSONObject)[
+          "category"
+        ],
+      ).toBe("second");
+      expect(
+        (adapter.process(row(), first)["attributes"] as JSONObject)["category"],
+      ).toBe("first");
+    });
+
+    test("reuses loaded configs until expiry then compiles refreshed processor objects", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const now: jest.SpyInstance = jest
+        .spyOn(Date, "now")
+        .mockReturnValue(1_000_000);
+      const oldProcessor: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration("old")),
+      );
+      mockFindBy
+        .mockResolvedValueOnce([
+          { _id: "pipeline", name: "pipeline", filterQuery: "" },
+        ])
+        .mockResolvedValueOnce([oldProcessor]);
+      const first: Array<PipelineSpec> = await adapter.load(projectId);
+      const parse: jest.SpyInstance = jest.spyOn(JSON, "parse");
+      expect(
+        (adapter.process(row(), first)["attributes"] as JSONObject)["category"],
+      ).toBe("old");
+      const cached: Array<PipelineSpec> = await adapter.load(projectId);
+      expect(cached).toBe(first);
+      adapter.process(row(), cached);
+      expect(parse).toHaveBeenCalledTimes(1);
+      expect(mockFindBy).toHaveBeenCalledTimes(2);
+
+      now.mockReturnValue(1_060_001);
+      const newProcessor: ProcessorSpec = categoryProcessor(
+        adapter,
+        JSON.stringify(categoryConfiguration("new")),
+      );
+      mockFindBy
+        .mockResolvedValueOnce([
+          { _id: "pipeline", name: "pipeline", filterQuery: "" },
+        ])
+        .mockResolvedValueOnce([newProcessor]);
+      const refreshed: Array<PipelineSpec> = await adapter.load(projectId);
+      expect(refreshed).not.toBe(first);
+      expect(
+        (adapter.process(row(), refreshed)["attributes"] as JSONObject)[
+          "category"
+        ],
+      ).toBe("new");
+      expect(parse).toHaveBeenCalledTimes(2);
+      expect(mockFindBy).toHaveBeenCalledTimes(4);
+    });
+  },
+);

--- a/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
@@ -1,3 +1,4 @@
+import { FindOperator } from "typeorm";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "Common/Types/Date";
@@ -21,8 +22,8 @@ import ObjectID from "Common/Types/ObjectID";
  *      incomingEmailMonitorHeartbeatCheckedAt column, and updateOneById is
  *      never called (the regression the change removes),
  *   2. the per-monitor control flow around the stamp is unchanged: both
- *      findAllBy batches (never-checked isNull first, then notNull) are
- *      concatenated; a monitor without monitorSteps is skipped with no
+ *      findBy phases (never-checked first, then checked before this sweep)
+ *      are processed; a monitor without monitorSteps is skipped with no
  *      write; only a monitor whose criteria check CheckOn.EmailReceivedAt
  *      (NOT the request monitor's CheckOn.IncomingRequest) is handed to
  *      MonitorResourceUtil.monitorResource; one failing monitor does not
@@ -69,11 +70,24 @@ jest.mock("Common/Server/Utils/Logger", () => {
  * prove it is never called: if the job regressed back to the hooked pipeline,
  * the assertion would flag it instead of the mock throwing "not a function".
  */
+jest.mock("Common/Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    SemaphoreLockTimeoutError: class extends Error {},
+    default: {
+      lock: jest.fn().mockImplementation(async () => {
+        return { isAcquired: true };
+      }),
+      release: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
 jest.mock("Common/Server/Services/MonitorService", () => {
   return {
     __esModule: true,
     default: {
-      findAllBy: jest.fn(),
+      findBy: jest.fn(),
       getEnabledMonitorQuery: jest.fn(),
       updateColumnsByIdWithoutHooks: jest.fn(),
       updateOneById: jest.fn(),
@@ -109,7 +123,7 @@ import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
 import "../../../../FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus";
 
 interface MonitorServiceMock {
-  findAllBy: jest.Mock;
+  findBy: jest.Mock;
   getEnabledMonitorQuery: jest.Mock;
   updateColumnsByIdWithoutHooks: jest.Mock;
   updateOneById: jest.Mock;
@@ -186,7 +200,7 @@ function makeMonitor(data: {
   return monitor;
 }
 
-interface FindAllByArgs {
+interface FindByArgs {
   query: Record<string, unknown>;
   sort: Record<string, unknown>;
   select: Record<string, unknown>;
@@ -216,17 +230,6 @@ async function runWorkerTick(): Promise<void> {
   }
 
   await handler();
-
-  /*
-   * The per-monitor work is fire-and-forget (`checkOnlineStatus(m).catch(...)`),
-   * so the handler resolves before the stamps do. A couple of macrotask turns
-   * let every mocked-promise chain settle.
-   */
-  for (let turn: number = 0; turn < 3; turn++) {
-    await new Promise<void>((resolve: () => void) => {
-      setImmediate(resolve);
-    });
-  }
 }
 
 describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
@@ -241,7 +244,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
       return new Date(NOW);
     });
 
-    monitorService.findAllBy.mockResolvedValue([]);
+    monitorService.findBy.mockResolvedValue([]);
     monitorService.getEnabledMonitorQuery.mockReturnValue(
       ENABLED_MONITOR_QUERY,
     );
@@ -253,7 +256,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
     monitorResourceMock.mockResolvedValue(undefined);
   });
 
-  test("concatenates the never-checked and already-checked batches and stamps each through the hookless fast path only", async () => {
+  test("processes the never-checked and already-checked pages and stamps each through the hookless fast path only", async () => {
     const neverChecked: Monitor = makeMonitor({
       id: MONITOR_A_ID,
       monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
@@ -263,19 +266,19 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
       monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([neverChecked])
       .mockResolvedValueOnce([alreadyChecked]);
 
     await runWorkerTick();
 
-    // Two batches: isNull (sorted by createdAt) then notNull (sorted by last check).
-    expect(monitorService.findAllBy).toHaveBeenCalledTimes(2);
+    // Never-checked first, then previously checked; both use an immutable ID cursor.
+    expect(monitorService.findBy).toHaveBeenCalledTimes(2);
 
-    const firstBatch: FindAllByArgs = monitorService.findAllBy.mock
-      .calls[0]![0] as FindAllByArgs;
-    const secondBatch: FindAllByArgs = monitorService.findAllBy.mock
-      .calls[1]![0] as FindAllByArgs;
+    const firstBatch: FindByArgs = monitorService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+    const secondBatch: FindByArgs = monitorService.findBy.mock
+      .calls[1]![0] as FindByArgs;
 
     for (const batch of [firstBatch, secondBatch]) {
       expect(batch.query["monitorType"]).toBe(MonitorType.IncomingEmail);
@@ -287,9 +290,9 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
       ).toBeDefined();
     }
 
-    expect(firstBatch.sort).toEqual({ createdAt: SortOrder.Ascending });
+    expect(firstBatch.sort).toEqual({ _id: SortOrder.Ascending });
     expect(secondBatch.sort).toEqual({
-      incomingEmailMonitorHeartbeatCheckedAt: SortOrder.Ascending,
+      _id: SortOrder.Ascending,
     });
 
     // One fast-path stamp per monitor, batches concatenated in order.
@@ -317,8 +320,51 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
     expect(monitorService.updateOneById).not.toHaveBeenCalled();
   });
 
+  test("the cron waits for bounded email evaluations before completing", async () => {
+    const rows: Array<Monitor> = Array.from(
+      { length: 25 },
+      (_: unknown, index: number) => {
+        return makeMonitor({
+          id: new ObjectID(`monitor-${String(index).padStart(3, "0")}`),
+          monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
+        });
+      },
+    );
+    monitorService.findBy.mockResolvedValueOnce(rows);
+    let resolveEvaluation!: () => void;
+    const evaluation: Promise<void> = new Promise((resolve: () => void) => {
+      resolveEvaluation = resolve;
+    });
+    monitorResourceMock.mockReturnValue(evaluation);
+    let finished: boolean = false;
+    const work: Promise<void> = runWorkerTick().then(() => {
+      finished = true;
+    });
+    await new Promise<void>((resolve: () => void) => {
+      setImmediate(resolve);
+    });
+    expect(monitorResourceMock).toHaveBeenCalledTimes(10);
+    expect(monitorService.findBy).toHaveBeenCalledTimes(1);
+    expect(finished).toBe(false);
+    resolveEvaluation();
+    await work;
+    expect(monitorResourceMock).toHaveBeenCalledTimes(25);
+    expect(finished).toBe(true);
+  });
+
+  test("the previously checked phase excludes this sweep's heartbeat stamps", async () => {
+    await runWorkerTick();
+    const args: FindByArgs = monitorService.findBy.mock
+      .calls[1]![0] as FindByArgs;
+    const filter: FindOperator<Date> = args.query[
+      "incomingEmailMonitorHeartbeatCheckedAt"
+    ] as FindOperator<Date>;
+    expect(filter.getSql!("checkedAt")).toMatch(/checkedAt < :/);
+    expect(Object.values(filter.objectLiteralParameters!)).toEqual([NOW]);
+  });
+
   test("a monitor without monitorSteps is skipped with no write at all", async () => {
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([makeMonitor({ id: MONITOR_A_ID })])
       .mockResolvedValueOnce([]);
 
@@ -340,7 +386,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
       } as IncomingEmailMonitorRequest,
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([monitor])
       .mockResolvedValueOnce([]);
 
@@ -375,7 +421,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
       monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([monitor])
       .mockResolvedValueOnce([]);
 
@@ -388,7 +434,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("criteria checking only CheckOn.IncomingRequest (the request monitor's filter) are stamped but never evaluated", async () => {
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([
         makeMonitor({
           id: MONITOR_A_ID,
@@ -414,7 +460,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
    * above covers.
    */
   test("a monitor on the default body criteria is stamped but never evaluated", async () => {
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([
         makeMonitor({
           id: MONITOR_A_ID,
@@ -447,7 +493,7 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
       monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([failing])
       .mockResolvedValueOnce([healthy]);
 

--- a/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
@@ -1,3 +1,4 @@
+import { FindOperator } from "typeorm";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "Common/Types/Date";
@@ -20,8 +21,8 @@ import ObjectID from "Common/Types/ObjectID";
  *      incomingRequestMonitorHeartbeatCheckedAt column, and updateOneById is
  *      never called (the regression the change removes),
  *   2. the per-monitor control flow around the stamp is unchanged: both
- *      findAllBy batches (never-checked isNull first, then notNull) are
- *      concatenated; a monitor without monitorSteps is skipped with no write;
+ *      findBy phases (never-checked first, then checked before this sweep)
+ *      are processed; a monitor without monitorSteps is skipped with no write;
  *      only a monitor whose criteria check CheckOn.IncomingRequest is handed
  *      to MonitorResourceUtil.monitorResource; one failing monitor does not
  *      prevent the others.
@@ -67,11 +68,24 @@ jest.mock("Common/Server/Utils/Logger", () => {
  * prove it is never called: if the job regressed back to the hooked pipeline,
  * the assertion would flag it instead of the mock throwing "not a function".
  */
+jest.mock("Common/Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    SemaphoreLockTimeoutError: class extends Error {},
+    default: {
+      lock: jest.fn().mockImplementation(async () => {
+        return { isAcquired: true };
+      }),
+      release: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
 jest.mock("Common/Server/Services/MonitorService", () => {
   return {
     __esModule: true,
     default: {
-      findAllBy: jest.fn(),
+      findBy: jest.fn(),
       getEnabledMonitorQuery: jest.fn(),
       updateColumnsByIdWithoutHooks: jest.fn(),
       updateOneById: jest.fn(),
@@ -107,7 +121,7 @@ import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
 import "../../../../FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat";
 
 interface MonitorServiceMock {
-  findAllBy: jest.Mock;
+  findBy: jest.Mock;
   getEnabledMonitorQuery: jest.Mock;
   updateColumnsByIdWithoutHooks: jest.Mock;
   updateOneById: jest.Mock;
@@ -184,7 +198,7 @@ function makeMonitor(data: {
   return monitor;
 }
 
-interface FindAllByArgs {
+interface FindByArgs {
   query: Record<string, unknown>;
   sort: Record<string, unknown>;
   select: Record<string, unknown>;
@@ -214,17 +228,6 @@ async function runWorkerTick(): Promise<void> {
   }
 
   await handler();
-
-  /*
-   * The per-monitor work is fire-and-forget (`checkHeartBeat(m).catch(...)`),
-   * so the handler resolves before the stamps do. A couple of macrotask turns
-   * let every mocked-promise chain settle.
-   */
-  for (let turn: number = 0; turn < 3; turn++) {
-    await new Promise<void>((resolve: () => void) => {
-      setImmediate(resolve);
-    });
-  }
 }
 
 describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
@@ -239,7 +242,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
       return new Date(NOW);
     });
 
-    monitorService.findAllBy.mockResolvedValue([]);
+    monitorService.findBy.mockResolvedValue([]);
     monitorService.getEnabledMonitorQuery.mockReturnValue(
       ENABLED_MONITOR_QUERY,
     );
@@ -251,7 +254,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
     monitorResourceMock.mockResolvedValue(undefined);
   });
 
-  test("concatenates the never-checked and already-checked batches and stamps each through the hookless fast path only", async () => {
+  test("processes the never-checked and already-checked pages and stamps each through the hookless fast path only", async () => {
     const neverChecked: Monitor = makeMonitor({
       id: MONITOR_A_ID,
       monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
@@ -261,19 +264,19 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
       monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([neverChecked])
       .mockResolvedValueOnce([alreadyChecked]);
 
     await runWorkerTick();
 
-    // Two batches: isNull (sorted by createdAt) then notNull (sorted by last check).
-    expect(monitorService.findAllBy).toHaveBeenCalledTimes(2);
+    // Never-checked first, then previously checked; both use an immutable ID cursor.
+    expect(monitorService.findBy).toHaveBeenCalledTimes(2);
 
-    const firstBatch: FindAllByArgs = monitorService.findAllBy.mock
-      .calls[0]![0] as FindAllByArgs;
-    const secondBatch: FindAllByArgs = monitorService.findAllBy.mock
-      .calls[1]![0] as FindAllByArgs;
+    const firstBatch: FindByArgs = monitorService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+    const secondBatch: FindByArgs = monitorService.findBy.mock
+      .calls[1]![0] as FindByArgs;
 
     for (const batch of [firstBatch, secondBatch]) {
       expect(batch.query["monitorType"]).toBe(MonitorType.IncomingRequest);
@@ -285,9 +288,9 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
       ).toBeDefined();
     }
 
-    expect(firstBatch.sort).toEqual({ createdAt: SortOrder.Ascending });
+    expect(firstBatch.sort).toEqual({ _id: SortOrder.Ascending });
     expect(secondBatch.sort).toEqual({
-      incomingRequestMonitorHeartbeatCheckedAt: SortOrder.Ascending,
+      _id: SortOrder.Ascending,
     });
 
     // One fast-path stamp per monitor, batches concatenated in order.
@@ -315,8 +318,51 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
     expect(monitorService.updateOneById).not.toHaveBeenCalled();
   });
 
+  test("the cron waits for bounded request evaluations before completing", async () => {
+    const rows: Array<Monitor> = Array.from(
+      { length: 25 },
+      (_: unknown, index: number) => {
+        return makeMonitor({
+          id: new ObjectID(`monitor-${String(index).padStart(3, "0")}`),
+          monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+        });
+      },
+    );
+    monitorService.findBy.mockResolvedValueOnce(rows);
+    let resolveEvaluation!: () => void;
+    const evaluation: Promise<void> = new Promise((resolve: () => void) => {
+      resolveEvaluation = resolve;
+    });
+    monitorResourceMock.mockReturnValue(evaluation);
+    let finished: boolean = false;
+    const work: Promise<void> = runWorkerTick().then(() => {
+      finished = true;
+    });
+    await new Promise<void>((resolve: () => void) => {
+      setImmediate(resolve);
+    });
+    expect(monitorResourceMock).toHaveBeenCalledTimes(10);
+    expect(monitorService.findBy).toHaveBeenCalledTimes(1);
+    expect(finished).toBe(false);
+    resolveEvaluation();
+    await work;
+    expect(monitorResourceMock).toHaveBeenCalledTimes(25);
+    expect(finished).toBe(true);
+  });
+
+  test("the previously checked phase excludes this sweep's heartbeat stamps", async () => {
+    await runWorkerTick();
+    const args: FindByArgs = monitorService.findBy.mock
+      .calls[1]![0] as FindByArgs;
+    const filter: FindOperator<Date> = args.query[
+      "incomingRequestMonitorHeartbeatCheckedAt"
+    ] as FindOperator<Date>;
+    expect(filter.getSql!("checkedAt")).toMatch(/checkedAt < :/);
+    expect(Object.values(filter.objectLiteralParameters!)).toEqual([NOW]);
+  });
+
   test("a monitor without monitorSteps is skipped with no write at all", async () => {
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([makeMonitor({ id: MONITOR_A_ID })])
       .mockResolvedValueOnce([]);
 
@@ -337,7 +383,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
       } as IncomingMonitorRequest,
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([monitor])
       .mockResolvedValueOnce([]);
 
@@ -369,7 +415,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
       monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([monitor])
       .mockResolvedValueOnce([]);
 
@@ -384,7 +430,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
   });
 
   test("a monitor with steps but no IncomingRequest criteria is stamped but never evaluated", async () => {
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([
         makeMonitor({
           id: MONITOR_A_ID,
@@ -410,7 +456,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
    * test above covers.
    */
   test("a monitor on the default body criteria is stamped but never evaluated", async () => {
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([
         makeMonitor({
           id: MONITOR_A_ID,
@@ -443,7 +489,7 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
       monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
     });
 
-    monitorService.findAllBy
+    monitorService.findBy
       .mockResolvedValueOnce([failing])
       .mockResolvedValueOnce([healthy]);
 

--- a/App/Tests/Workers/Jobs/ServerMonitor/CheckOnlineStatus.test.ts
+++ b/App/Tests/Workers/Jobs/ServerMonitor/CheckOnlineStatus.test.ts
@@ -68,11 +68,24 @@ jest.mock("Common/Server/Utils/Logger", () => {
   };
 });
 
+jest.mock("Common/Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    SemaphoreLockTimeoutError: class extends Error {},
+    default: {
+      lock: jest.fn().mockImplementation(async () => {
+        return { isAcquired: true };
+      }),
+      release: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
 jest.mock("Common/Server/Services/MonitorService", () => {
   return {
     __esModule: true,
     default: {
-      findAllBy: jest.fn(),
+      findBy: jest.fn(),
       findOneBy: jest.fn(),
       getEnabledMonitorQuery: jest.fn(),
     },
@@ -107,7 +120,7 @@ import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
 import "../../../../FeatureSet/Workers/Jobs/ServerMonitor/CheckOnlineStatus";
 
 interface MonitorServiceMock {
-  findAllBy: jest.Mock;
+  findBy: jest.Mock;
   findOneBy: jest.Mock;
   getEnabledMonitorQuery: jest.Mock;
 }
@@ -257,7 +270,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
         return lteOrNullSentinel(value as Date) as never;
       });
 
-    monitorService.findAllBy.mockResolvedValue([]);
+    monitorService.findBy.mockResolvedValue([]);
     monitorService.findOneBy.mockResolvedValue(null);
     monitorService.getEnabledMonitorQuery.mockReturnValue(
       ENABLED_MONITOR_QUERY,
@@ -271,10 +284,9 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   test("sweeps stale Server monitors with monitorSteps in the select and the enabled/active gates", async () => {
     await runWorkerTick();
 
-    expect(monitorService.findAllBy).toHaveBeenCalledTimes(1);
+    expect(monitorService.findBy).toHaveBeenCalledTimes(1);
 
-    const sweep: FindArgs = monitorService.findAllBy.mock
-      .calls[0]![0] as FindArgs;
+    const sweep: FindArgs = monitorService.findBy.mock.calls[0]![0] as FindArgs;
 
     expect(sweep.query["monitorType"]).toBe(MonitorType.Server);
     expect(sweep.query["disableActiveMonitoring"]).toBe(false);
@@ -288,7 +300,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("a monitor whose steps have no Is Online filter is dropped on the sweep row: no re-fetch, no evaluation", async () => {
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
@@ -304,7 +316,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("a monitor with no monitorSteps at all is skipped before everything", async () => {
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({ id: MONITOR_A_ID }),
     ]);
 
@@ -318,7 +330,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   test("a monitor with an Is Online filter is re-fetched WITHOUT monitorSteps, against the same staleness threshold, and evaluated from the re-fetched row", async () => {
     const refetchedReceivedAt: Date = new Date("2026-07-27T09:50:00.000Z");
 
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.IsOnline),
@@ -381,7 +393,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   test("requestReceivedAt falls back to the stored response's requestReceivedAt when the column is unset", async () => {
     const responseReceivedAt: Date = new Date("2026-07-27T09:45:00.000Z");
 
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.IsOnline),
@@ -408,7 +420,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("a monitor that never received any response falls back to createdAt and an empty hostname", async () => {
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.IsOnline),
@@ -428,7 +440,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("a null re-fetch (a response arrived since the sweep) is skipped silently", async () => {
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.IsOnline),
@@ -444,7 +456,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("a re-fetched row missing projectId is logged and skipped", async () => {
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.IsOnline),
@@ -463,7 +475,7 @@ describe("ServerMonitor:CheckOnlineStatus worker", () => {
   });
 
   test("one monitor's evaluation rejecting does not prevent processing of the others", async () => {
-    monitorService.findAllBy.mockResolvedValue([
+    monitorService.findBy.mockResolvedValue([
       makeSweepMonitor({
         id: MONITOR_A_ID,
         monitorSteps: stepsWithCheckOn(CheckOn.IsOnline),

--- a/App/Tests/Workers/Utils/MonitorSweep.test.ts
+++ b/App/Tests/Workers/Utils/MonitorSweep.test.ts
@@ -1,0 +1,348 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Semaphore, {
+  SemaphoreLockTimeoutError,
+} from "Common/Server/Infrastructure/Semaphore";
+import MonitorService from "Common/Server/Services/MonitorService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import FindBy from "Common/Server/Types/Database/FindBy";
+import logger from "Common/Server/Utils/Logger";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import ObjectID from "Common/Types/ObjectID";
+import { FindOperator } from "typeorm";
+import runMonitorSweep, {
+  MONITOR_SWEEP_BATCH_SIZE,
+  MONITOR_SWEEP_CONCURRENCY,
+} from "../../../FeatureSet/Workers/Utils/MonitorSweep";
+
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return { __esModule: true, default: { findBy: jest.fn() } };
+});
+jest.mock("Common/Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    SemaphoreLockTimeoutError: class extends Error {},
+    default: { lock: jest.fn(), release: jest.fn() },
+  };
+});
+jest.mock("Common/Server/Utils/Logger", () => {
+  return { __esModule: true, default: { debug: jest.fn(), error: jest.fn() } };
+});
+
+const findBy: jest.Mock = MonitorService.findBy as jest.Mock;
+const lock: jest.Mock = Semaphore.lock as jest.Mock;
+const release: jest.Mock = Semaphore.release as jest.Mock;
+let mutex: { isAcquired: boolean };
+
+function monitors(count: number, offset: number = 0): Array<Monitor> {
+  return Array.from({ length: count }, (_: unknown, index: number) => {
+    return new Monitor(
+      new ObjectID(`monitor-${String(index + offset).padStart(6, "0")}`),
+    );
+  });
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+function run(
+  processMonitor: (monitor: Monitor) => Promise<void> = async () => {},
+): Promise<void> {
+  return runMonitorSweep({
+    jobName: "test-sweep",
+    queries: [{ disableActiveMonitoring: false }],
+    select: { monitorSteps: true },
+    processMonitor,
+  });
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mutex = { isAcquired: true };
+  lock.mockResolvedValue(mutex);
+  release.mockResolvedValue(undefined);
+  findBy.mockResolvedValue([]);
+});
+
+describe("bounded monitor sweeps", () => {
+  test("acquires one renewing cluster lock without waiting behind another tick", async () => {
+    await run();
+    expect(lock).toHaveBeenCalledWith({
+      namespace: "monitor-heartbeat-sweep",
+      key: "test-sweep",
+      lockTimeout: 60_000,
+      acquireAttemptsLimit: 1,
+    });
+    expect(release).toHaveBeenCalledWith(mutex);
+  });
+
+  test("lock contention skips the tick quietly without querying monitors", async () => {
+    lock.mockRejectedValue(new SemaphoreLockTimeoutError("already locked"));
+    await run();
+    expect(findBy).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  test("overlapping worker ticks cannot start a second sweep before pending evaluations settle", async () => {
+    let held: boolean = false;
+    lock.mockImplementation(async () => {
+      if (held) {
+        throw new SemaphoreLockTimeoutError("already locked");
+      }
+      held = true;
+      return mutex;
+    });
+    release.mockImplementation(async () => {
+      held = false;
+    });
+    findBy.mockResolvedValue(monitors(1));
+    let finish!: () => void;
+    const pending: Promise<void> = new Promise((resolve: () => void) => {
+      finish = resolve;
+    });
+    const first: Promise<void> = run(async () => {
+      await pending;
+    });
+    await tick();
+    const secondProcess: jest.Mock = jest.fn();
+    await run(secondProcess);
+    expect(secondProcess).not.toHaveBeenCalled();
+    expect(findBy).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+    finish();
+    await first;
+    await run(secondProcess);
+    expect(secondProcess).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  test("Redis acquisition failures skip the tick with a visible error", async () => {
+    const failure: Error = new Error("Redis client is not connected");
+    lock.mockRejectedValue(failure);
+    await run();
+    expect(findBy).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(failure);
+  });
+
+  test("empty pages require no processing and release the lock", async () => {
+    const process: jest.Mock = jest.fn();
+    await run(process);
+    expect(process).not.toHaveBeenCalled();
+    expect(findBy).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    1,
+    MONITOR_SWEEP_BATCH_SIZE - 1,
+    MONITOR_SWEEP_BATCH_SIZE,
+    MONITOR_SWEEP_BATCH_SIZE + 1,
+    1003,
+  ])(
+    "processes all %i monitors once using bounded pages and immutable ID cursors",
+    async (count: number) => {
+      const rows: Array<Monitor> = monitors(count);
+      findBy.mockImplementation(async (args: FindBy<Monitor>) => {
+        expect(args.skip).toBe(0);
+        expect(args.limit).toBe(MONITOR_SWEEP_BATCH_SIZE);
+        expect(args.sort).toEqual({ _id: SortOrder.Ascending });
+        expect(args.select).toEqual({ _id: true, monitorSteps: true });
+        expect(args.props).toEqual({ isRoot: true });
+        expect(args.query.disableActiveMonitoring).toBe(false);
+        const cursor: FindOperator<ObjectID> | undefined = args.query._id as
+          | FindOperator<ObjectID>
+          | undefined;
+        if (cursor) {
+          expect(cursor.getSql!("_id")).toMatch(/_id > :/);
+        }
+        const after: string = cursor
+          ? String(Object.values(cursor.objectLiteralParameters!)[0])
+          : "";
+        return rows
+          .filter((row: Monitor) => {
+            return row.id!.toString() > after;
+          })
+          .slice(0, Number(args.limit));
+      });
+      const process: jest.Mock = jest.fn().mockResolvedValue(undefined);
+      await run(process);
+      expect(
+        process.mock.calls.map((call: Array<Monitor>) => {
+          return call[0]!.id!.toString();
+        }),
+      ).toEqual(
+        rows.map((row: Monitor) => {
+          return row.id!.toString();
+        }),
+      );
+      expect(findBy).toHaveBeenCalledTimes(
+        Math.floor(count / MONITOR_SWEEP_BATCH_SIZE) + 1,
+      );
+    },
+  );
+
+  test("a malformed page cannot turn into an endless sweep", async () => {
+    findBy.mockResolvedValueOnce([new Monitor()]);
+    await expect(run()).rejects.toThrow("did not advance its ID cursor");
+    expect(findBy).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test("a repeated page fails instead of continuously processing the same monitors", async () => {
+    findBy.mockResolvedValue(monitors(MONITOR_SWEEP_BATCH_SIZE));
+    const process: jest.Mock = jest.fn().mockResolvedValue(undefined);
+    await expect(run(process)).rejects.toThrow("did not advance its ID cursor");
+    expect(process).toHaveBeenCalledTimes(MONITOR_SWEEP_BATCH_SIZE);
+    expect(findBy).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test("holds at most ten evaluations and fetches no next page until all active work completes", async () => {
+    findBy
+      .mockResolvedValueOnce(monitors(MONITOR_SWEEP_BATCH_SIZE))
+      .mockResolvedValueOnce(monitors(1, MONITOR_SWEEP_BATCH_SIZE));
+    const pending: Array<() => void> = [];
+    let active: number = 0;
+    let peak: number = 0;
+    let completed: boolean = false;
+    const work: Promise<void> = run(async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise<void>((resolve: () => void) => {
+        pending.push(resolve);
+      });
+      active--;
+    }).then(() => {
+      completed = true;
+    });
+    await tick();
+    expect(active).toBe(MONITOR_SWEEP_CONCURRENCY);
+    expect(findBy).toHaveBeenCalledTimes(1);
+    expect(completed).toBe(false);
+    expect(release).not.toHaveBeenCalled();
+    for (
+      let batch: number = 0;
+      batch < MONITOR_SWEEP_BATCH_SIZE / MONITOR_SWEEP_CONCURRENCY;
+      batch++
+    ) {
+      pending.splice(0).forEach((resolve: () => void) => {
+        resolve();
+      });
+      await tick();
+      if (batch < MONITOR_SWEEP_BATCH_SIZE / MONITOR_SWEEP_CONCURRENCY - 1) {
+        expect(findBy).toHaveBeenCalledTimes(1);
+      }
+    }
+    expect(findBy).toHaveBeenCalledTimes(2);
+    expect(active).toBe(1);
+    expect(completed).toBe(false);
+    pending.splice(0).forEach((resolve: () => void) => {
+      resolve();
+    });
+    await work;
+    expect(peak).toBe(MONITOR_SWEEP_CONCURRENCY);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues through synchronous and asynchronous per-monitor failures", async () => {
+    const rows: Array<Monitor> = monitors(MONITOR_SWEEP_BATCH_SIZE + 1);
+    findBy
+      .mockResolvedValueOnce(rows.slice(0, MONITOR_SWEEP_BATCH_SIZE))
+      .mockResolvedValueOnce(rows.slice(MONITOR_SWEEP_BATCH_SIZE));
+    const process: jest.Mock = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("sync failure");
+      })
+      .mockRejectedValueOnce(new Error("async failure"))
+      .mockResolvedValue(undefined);
+    await run(process);
+    expect(process).toHaveBeenCalledTimes(rows.length);
+    expect(logger.error).toHaveBeenCalledTimes(4);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test("releases the lock and propagates a page query failure", async () => {
+    const failure: Error = new Error("database offline");
+    findBy.mockRejectedValue(failure);
+    await expect(run()).rejects.toBe(failure);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  test("release failures do not hide the original query failure", async () => {
+    const failure: Error = new Error("database offline");
+    findBy.mockRejectedValue(failure);
+    release.mockRejectedValue(new Error("redis offline"));
+    await expect(run()).rejects.toBe(failure);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  test("stops starting work after losing the renewing lock", async () => {
+    findBy.mockResolvedValueOnce(monitors(MONITOR_SWEEP_BATCH_SIZE));
+    const process: jest.Mock = jest.fn().mockImplementation(async () => {
+      mutex.isAcquired = false;
+    });
+    await run(process);
+    expect(process).toHaveBeenCalledTimes(1);
+    expect(findBy).toHaveBeenCalledTimes(1);
+  });
+
+  test("changing membership during processing does not skip later rows or revisit newly stamped rows in the second phase", async () => {
+    const startedAt: Date = new Date("2026-09-04T12:00:00Z");
+    const rows: Array<Monitor> = monitors(253);
+    rows.forEach((row: Monitor, index: number) => {
+      if (index >= 203) {
+        row.incomingRequestMonitorHeartbeatCheckedAt = new Date(
+          "2026-09-04T11:00:00Z",
+        );
+      }
+    });
+    findBy.mockImplementation(async (args: FindBy<Monitor>) => {
+      const stamp: FindOperator<Date> = args.query
+        .incomingRequestMonitorHeartbeatCheckedAt as FindOperator<Date>;
+      const isNull: boolean = stamp.getSql!("stamp").includes("IS NULL");
+      const cursor: FindOperator<ObjectID> | undefined = args.query._id as
+        | FindOperator<ObjectID>
+        | undefined;
+      const after: string = cursor
+        ? String(Object.values(cursor.objectLiteralParameters!)[0])
+        : "";
+      return rows
+        .filter((row: Monitor) => {
+          return (
+            row.id!.toString() > after &&
+            (isNull
+              ? !row.incomingRequestMonitorHeartbeatCheckedAt
+              : Boolean(
+                  row.incomingRequestMonitorHeartbeatCheckedAt &&
+                    row.incomingRequestMonitorHeartbeatCheckedAt < startedAt,
+                ))
+          );
+        })
+        .slice(0, Number(args.limit));
+    });
+    const processed: Array<string> = [];
+    await runMonitorSweep({
+      jobName: "heartbeat",
+      queries: [
+        { incomingRequestMonitorHeartbeatCheckedAt: QueryHelper.isNull() },
+        {
+          incomingRequestMonitorHeartbeatCheckedAt:
+            QueryHelper.lessThan(startedAt),
+        },
+      ],
+      select: { _id: true },
+      processMonitor: async (row: Monitor) => {
+        processed.push(row.id!.toString());
+        row.incomingRequestMonitorHeartbeatCheckedAt = startedAt;
+      },
+    });
+    expect(processed).toHaveLength(rows.length);
+    expect(new Set(processed).size).toBe(rows.length);
+    expect(findBy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/App/scripts/benchmark-pipeline-config.ts
+++ b/App/scripts/benchmark-pipeline-config.ts
@@ -1,0 +1,109 @@
+/*
+ * Run from App:
+ * node --require ts-node/register/transpile-only scripts/benchmark-pipeline-config.ts
+ *
+ * Measures configuration normalization + category filter evaluation only.
+ * The baseline reproduces the previous string-config path. Neither mode
+ * includes database access, row construction or the rest of telemetry ingest.
+ */
+import { performance } from "perf_hooks";
+import getPipelineProcessorConfig from "../FeatureSet/Telemetry/Utils/PipelineProcessorConfig";
+import {
+  compileFilter,
+  CompiledFilter,
+  evaluateCompiledFilter,
+} from "../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
+import { JSONObject } from "Common/Types/JSON";
+
+interface CategoryConfig {
+  categories: Array<{ name: string; filterQuery: string }>;
+  _compiledCategoryFilters?: Array<CompiledFilter>;
+}
+
+interface BenchmarkResult {
+  mode: string;
+  records: number;
+  milliseconds: number;
+  cpuMilliseconds: number;
+  configurationsParsed: number;
+  filtersCompiled: number;
+  matches: number;
+}
+
+const recordCount: number = 100_000;
+const rounds: number = 5;
+const configuration: string = JSON.stringify({
+  categories: Array.from({ length: 8 }, (_: unknown, index: number) => {
+    return {
+      name: `category-${index}`,
+      filterQuery: `attributes.level = 'level-${index}' AND body LIKE 'request %'`,
+    };
+  }),
+});
+const row: JSONObject = {
+  body: "request failed",
+  attributes: { level: "level-7" },
+};
+
+function measure(cached: boolean, records: number): BenchmarkResult {
+  const processor: { configuration: string } = { configuration };
+  let filtersCompiled: number = 0;
+  let matches: number = 0;
+  const cpuStart: NodeJS.CpuUsage = process.cpuUsage();
+  const start: number = performance.now();
+
+  for (let index: number = 0; index < records; index++) {
+    const config: CategoryConfig = cached
+      ? (getPipelineProcessorConfig(processor) as unknown as CategoryConfig)
+      : (JSON.parse(processor.configuration) as CategoryConfig);
+
+    if (!config._compiledCategoryFilters) {
+      filtersCompiled += config.categories.length;
+      config._compiledCategoryFilters = config.categories.map(
+        (category: CategoryConfig["categories"][number]) => {
+          return compileFilter(category.filterQuery);
+        },
+      );
+    }
+
+    for (const filter of config._compiledCategoryFilters) {
+      if (evaluateCompiledFilter(row, filter)) {
+        matches++;
+        break;
+      }
+    }
+  }
+
+  const milliseconds: number = performance.now() - start;
+  const cpu: NodeJS.CpuUsage = process.cpuUsage(cpuStart);
+  return {
+    mode: cached ? "cached" : "baseline",
+    records,
+    milliseconds: Math.round(milliseconds * 100) / 100,
+    cpuMilliseconds: Math.round((cpu.user + cpu.system) / 10) / 100,
+    configurationsParsed: cached ? 1 : records,
+    filtersCompiled,
+    matches,
+  };
+}
+
+measure(false, 5_000);
+measure(true, 5_000);
+
+const results: Array<BenchmarkResult> = [];
+for (let round: number = 0; round < rounds; round++) {
+  // Alternate ordering to reduce warmup and thermal bias.
+  for (const cached of round % 2 === 0 ? [false, true] : [true, false]) {
+    const result: BenchmarkResult = measure(cached, recordCount);
+    if (result.matches !== recordCount) {
+      throw new Error(
+        `Category evaluation mismatch: ${JSON.stringify(result)}`,
+      );
+    }
+    results.push(result);
+  }
+}
+
+process.stdout.write(
+  `${JSON.stringify({ node: process.version, results }, null, 2)}\n`,
+);

--- a/Common/Server/Infrastructure/QueueWorker.ts
+++ b/Common/Server/Infrastructure/QueueWorker.ts
@@ -1,10 +1,6 @@
 import { QueueJob, QueueName } from "./Queue";
 import TimeoutException from "../../Types/Exception/TimeoutException";
-import {
-  PromiseRejectErrorFunction,
-  PromiseVoidFunction,
-  VoidFunction,
-} from "../../Types/FunctionTypes";
+import { PromiseVoidFunction } from "../../Types/FunctionTypes";
 import { Worker } from "bullmq";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import AppMetrics from "../Utils/Telemetry/AppMetrics";
@@ -252,18 +248,28 @@ export default class QueueWorker {
     timeoutInMS: number,
     jobCallback: PromiseVoidFunction,
   ): Promise<void> {
-    type TimeoutPromise = (ms: number) => Promise<void>;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
 
-    const timeoutPromise: TimeoutPromise = (ms: number): Promise<void> => {
-      return new Promise(
-        (_resolve: VoidFunction, reject: PromiseRejectErrorFunction) => {
-          setTimeout(() => {
-            return reject(new TimeoutException("Job Timeout"));
-          }, ms);
+    try {
+      const timeoutPromise: Promise<void> = new Promise<void>(
+        (_resolve: () => void, reject: (reason: Error) => void) => {
+          timeout = setTimeout(() => {
+            reject(new TimeoutException("Job Timeout"));
+          }, timeoutInMS);
         },
       );
-    };
 
-    return await Promise.race([timeoutPromise(timeoutInMS), jobCallback()]);
+      await Promise.race([timeoutPromise, jobCallback()]);
+    } finally {
+      /*
+       * A settled job no longer needs its deadline. Leaving this timer alive
+       * retains its async context until the timeout and schedules needless
+       * callbacks for every completed job. This also covers synchronous throws
+       * from jobCallback. A timeout still does not cancel the underlying job.
+       */
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    }
   }
 }

--- a/Common/Server/Infrastructure/Semaphore.ts
+++ b/Common/Server/Infrastructure/Semaphore.ts
@@ -6,6 +6,8 @@ import {
 } from "redis-semaphore";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 
+export { TimeoutError as SemaphoreLockTimeoutError } from "redis-semaphore";
+
 export type SemaphoreMutex = Mutex;
 export type SemaphorePermit = RedisSemaphore;
 

--- a/Common/Tests/Server/Infrastructure/QueueWorkerTimeout.test.ts
+++ b/Common/Tests/Server/Infrastructure/QueueWorkerTimeout.test.ts
@@ -1,0 +1,210 @@
+import QueueWorker from "../../../Server/Infrastructure/QueueWorker";
+import TimeoutException from "../../../Types/Exception/TimeoutException";
+
+jest.mock("../../../Server/Utils/Telemetry/CaptureSpan", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return (
+        _target: unknown,
+        _name: string,
+        descriptor: PropertyDescriptor,
+      ): PropertyDescriptor => {
+        return descriptor;
+      };
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Telemetry", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Utils/Telemetry/AppMetrics", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Infrastructure/Redis", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Utils/GracefulShutdown", () => {
+  return { __esModule: true, default: {} };
+});
+jest.mock("../../../Server/Utils/Logger", () => {
+  return { __esModule: true, default: {} };
+});
+
+interface DeferredJob {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferredJob(): DeferredJob {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise: Promise<void> = new Promise<void>(
+    (res: () => void, rej: (reason: unknown) => void) => {
+      resolve = res;
+      reject = rej;
+    },
+  );
+  return { promise, resolve, reject };
+}
+
+describe("QueueWorker.runJobWithTimeout timer lifecycle", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it.each([0, 1, 300_000, 3_600_000])(
+    "releases a %i ms deadline immediately when the job succeeds",
+    async (deadline: number) => {
+      const callback: jest.Mock = jest.fn().mockResolvedValue(undefined);
+      await expect(
+        QueueWorker.runJobWithTimeout(deadline, callback),
+      ).resolves.toBeUndefined();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each([new Error("failed"), "non-error rejection", null])(
+    "preserves rejection identity and clears the deadline (%p)",
+    async (error: unknown) => {
+      await expect(
+        QueueWorker.runJobWithTimeout(300_000, () => {
+          return Promise.reject(error);
+        }),
+      ).rejects.toBe(error);
+      expect(jest.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("clears the timer when the callback throws before returning a promise", async () => {
+    const error: Error = new Error("synchronous failure");
+    await expect(
+      QueueWorker.runJobWithTimeout(300_000, () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("holds a deadline only while a job is pending", async () => {
+    const job: DeferredJob = deferredJob();
+    const result: Promise<void> = QueueWorker.runJobWithTimeout(100, () => {
+      return job.promise;
+    });
+    expect(jest.getTimerCount()).toBe(1);
+    jest.advanceTimersByTime(99);
+    job.resolve();
+    await result;
+    expect(jest.getTimerCount()).toBe(0);
+    jest.advanceTimersByTime(1);
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it("rejects at the deadline with the existing timeout error", async () => {
+    const job: DeferredJob = deferredJob();
+    const result: Promise<void> = QueueWorker.runJobWithTimeout(100, () => {
+      return job.promise;
+    });
+    const rejection: Promise<void> = expect(result).rejects.toEqual(
+      new TimeoutException("Job Timeout"),
+    );
+    jest.advanceTimersByTime(100);
+    await rejection;
+    expect(jest.getTimerCount()).toBe(0);
+    // The timeout is a deadline, not cancellation of the underlying work.
+    job.resolve();
+    await job.promise;
+  });
+
+  it("observes a job rejection after its deadline without an unhandled rejection", async () => {
+    const job: DeferredJob = deferredJob();
+    const result: Promise<void> = QueueWorker.runJobWithTimeout(10, () => {
+      return job.promise;
+    });
+    const rejection: Promise<void> =
+      expect(result).rejects.toBeInstanceOf(TimeoutException);
+    jest.advanceTimersByTime(10);
+    await rejection;
+    job.reject(new Error("late failure"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("keeps another concurrent job's deadline active", async () => {
+    const first: DeferredJob = deferredJob();
+    const second: DeferredJob = deferredJob();
+    const firstResult: Promise<void> = QueueWorker.runJobWithTimeout(
+      100,
+      () => {
+        return first.promise;
+      },
+    );
+    const secondResult: Promise<void> = QueueWorker.runJobWithTimeout(
+      200,
+      () => {
+        return second.promise;
+      },
+    );
+    const secondRejection: Promise<void> =
+      expect(secondResult).rejects.toBeInstanceOf(TimeoutException);
+
+    first.resolve();
+    await firstResult;
+    expect(jest.getTimerCount()).toBe(1);
+    jest.advanceTimersByTime(200);
+    await secondRejection;
+    expect(jest.getTimerCount()).toBe(0);
+    second.resolve();
+  });
+
+  it("does not clear timers created by the job itself", async () => {
+    const jobTimer: jest.Mock = jest.fn();
+    await QueueWorker.runJobWithTimeout(100, async () => {
+      setTimeout(jobTimer, 200);
+    });
+    expect(jest.getTimerCount()).toBe(1);
+    jest.advanceTimersByTime(200);
+    expect(jobTimer).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the original deadline-first ordering for equal-time completion", async () => {
+    const result: Promise<void> = QueueWorker.runJobWithTimeout(100, () => {
+      return new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 100);
+      });
+    });
+    const rejection: Promise<void> =
+      expect(result).rejects.toBeInstanceOf(TimeoutException);
+    jest.advanceTimersByTime(100);
+    await rejection;
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("does not accumulate timeout handles across 10,000 completed jobs", async () => {
+    for (let batch: number = 0; batch < 100; batch++) {
+      const jobs: Array<Promise<void>> = Array.from(
+        { length: 100 },
+        (_value: unknown, index: number): Promise<void> => {
+          return QueueWorker.runJobWithTimeout(300_000, async () => {
+            if (index % 2 === 0) {
+              throw new Error("expected job failure");
+            }
+          }).catch(() => {
+            // Failed jobs must release their timers too.
+          });
+        },
+      );
+      await Promise.all(jobs);
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  });
+});

--- a/Internal/Performance/RuntimeResourceUsage.md
+++ b/Internal/Performance/RuntimeResourceUsage.md
@@ -1,0 +1,117 @@
+# Runtime CPU and memory improvements
+
+This audit started from master commit `f74d205650`. It targets redundant work and
+object retention in telemetry pipelines, probes, and background workers. The
+measurements below are isolated benchmarks on Node 26.5.1, not estimates of the
+percentage improvement for a production deployment.
+
+## Implemented changes
+
+| Path | Previous behavior | New behavior |
+| --- | --- | --- |
+| Log and trace processors | JSON-string configurations were parsed for every record. Category processors consequently recompiled their filters for every record. | Normalize once per processor instance and reuse compiled filters. Replacing the configuration invalidates the entry. Weak ownership lets expired processors and their configurations be collected. |
+| Request, email, and server heartbeat sweeps | Loaded every matching monitor into arrays and launched every evaluation at once. Request/email jobs returned before evaluations finished, allowing successive ticks to overlap. | Fetch 100-row pages using an immutable ID cursor, run at most 10 evaluations, and await completion. A renewing lease prevents overlapping sweeps of the same type across workers. |
+| Periodic probe checks | Retained already-ingested response bodies and screenshots in step result arrays, then in settled promises until the slowest monitor finished. | Ingest and log each step before moving on. Periodic tasks resolve without retaining response arrays. Interactive monitor tests still return their results. |
+| Queue job deadlines | Successful and failed jobs left their deadline timer alive until its original expiration. | Clear the timer on success, rejection, synchronous failure, or timeout. Underlying work is still not cancelled when a deadline expires. |
+
+The sweep limits are per monitor type. They bound selected row count and active
+evaluations, not the size of any one monitor's JSON. Never-checked incoming
+monitors still run first; within each phase, ID ordering replaces mutable
+last-check ordering. A large backlog may take longer to sweep than unrestricted
+fan-out. Measure detection delay as well as memory when evaluating this tradeoff.
+
+## Reproducible measurements
+
+### Configuration parsing and category filters
+
+From `App`, run:
+
+```sh
+node --require ts-node/register/transpile-only scripts/benchmark-pipeline-config.ts
+```
+
+The script compares the previous normalization path with the new helper using
+100,000 records and eight categories, with five alternating rounds. Both paths
+evaluate the same filters and verify identical match counts.
+
+| Measurement per round | Before | After |
+| --- | ---: | ---: |
+| Median process CPU time | 3,775.37 ms | 167.34 ms |
+| Configuration parses | 100,000 | 1 |
+| Filter compilations | 800,000 | 8 |
+
+That is approximately 95.6% less CPU in this isolated parsing/filtering path.
+Database access, row construction, network traffic, and other ingestion work are
+outside the measurement. Workloads without these processors will not see this
+particular benefit. Other builds were running concurrently, so wall-clock timings
+are deliberately not used as the headline result.
+
+### Completed probe response retention
+
+From the repository root, run:
+
+```sh
+git show f74d205650:Probe/Utils/Monitors/Monitor.ts > /tmp/oneuptime-monitor-before.ts
+node --expose-gc Probe/scripts/benchmark-response-lifetime.js /tmp/oneuptime-monitor-before.ts
+node --expose-gc Probe/scripts/benchmark-response-lifetime.js
+```
+
+This harness loads the actual monitor implementation with I/O and telemetry
+context mocked. Each of 100 monitors ingests a 512 KiB first response and waits on
+a second step. Garbage collection occurs while every monitor is still pending.
+
+| Measurement | Before | After |
+| --- | ---: | ---: |
+| Already-ingested response objects still retained | 100 | 0 |
+| Additional live JavaScript heap in the recorded run | 50.21 MiB | 0.14 MiB |
+
+Heap deltas vary between runs. The useful invariant is that completed response
+objects are collectible while later work remains pending. This is not a claim
+about total probe RSS, browser memory, or response memory still needed for an
+active ingestion request.
+
+### Deterministic regression coverage
+
+- Pipeline unit and integration tests cover configuration replacement, malformed
+  input, object mutation, tenant isolation, cache refresh, category precedence,
+  and one parse/compile per processor across large batches.
+- Monitor tests traverse 1,003 rows, hold evaluations pending to verify the
+  concurrency/page limits, change query membership, exercise overlapping worker
+  invocations, and cover lock loss, database failures, cursor errors, and existing
+  heartbeat/status behavior.
+- Probe tests cover step ingestion, completion ordering, errors, mixed-speed
+  batches, deadlines, worker slots, and interactive results.
+- Queue deadline tests cover success and all failure paths, concurrent jobs,
+  unrelated timers, late settlement, and 10,000 completed jobs without lingering
+  deadline handles.
+
+## Next recommendations
+
+1. **Measure each production role under the same workload.** The existing
+   `Common/Server/Utils/Telemetry/RuntimeMetrics.ts` exports CPU utilization, heap,
+   RSS, external memory, and event-loop delay. Pair those with worker/probe
+   durations, queue depth, ingest rate, and heartbeat detection delay. Compare
+   equal traffic, fleet size, and deployment settings, including bursts and a
+   sustained run. The local Docker development app also runs five frontend build
+   watchers, so its container memory is not a production API-process baseline.
+2. **Coalesce concurrent telemetry cache misses and batch processor reads.**
+   The log/trace pipeline loaders cache projects for 60 seconds but still load
+   processor lists per pipeline. Concurrent cold loads can repeat the same
+   database work. A follow-up should share in-flight loads and fetch processors
+   in batches, with rejection/retry, tenant-isolation, and invalidation tests.
+3. **Bound the remaining on-call backlog sweeps.**
+   `UserOnCallLog/ExecutePendingExecutions.ts` and
+   `OnCallDutyPolicyExecutionLog/ExecutePendingExecutions.ts` still collect whole
+   backlogs and process them concurrently. Apply pagination and backpressure
+   after pinning escalation order, idempotency, and duplicate-tick behavior in
+   tests; these notification paths need a separate focused review.
+4. **Use measured service-specific deployment sizing.** The repository already
+   supports dedicated queue workers and a telemetry fan-in writer. Review those
+   existing settings against database capacity, queue wait times, and ClickHouse
+   insert behavior before increasing worker replicas or concurrency. Increasing
+   heap limits alone does not remove redundant work or retained objects.
+
+No database migration or deployment configuration change is required for this
+patch. Local validation runs against the isolated worktree; the existing Compose
+stack mounts the original checkout, so its health is not evidence that this branch
+has been exercised under production load.

--- a/Probe/Jobs/Monitor/FetchList.ts
+++ b/Probe/Jobs/Monitor/FetchList.ts
@@ -13,7 +13,6 @@ import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
 import APIException from "Common/Types/Exception/ApiException";
 import { JSONArray } from "Common/Types/JSON";
-import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
 import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
@@ -66,7 +65,7 @@ export function resetProbeWorkerRunState(): void {
 export async function probeMonitorWithDeadline(
   monitor: Monitor,
   deadlineInMs: number = PROBE_MONITOR_CHECK_TIMEOUT_IN_MS,
-): Promise<Array<ProbeMonitorResponse | null>> {
+): Promise<void> {
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 
   const deadline: Promise<never> = new Promise<never>(
@@ -220,9 +219,7 @@ export class FetchListAndProbe {
         Monitor,
       );
 
-      const probeMonitorPromises: Array<
-        Promise<Array<ProbeMonitorResponse | null>>
-      > = []; // Array of promises to probe monitors
+      const probeMonitorPromises: Array<Promise<void>> = [];
 
       for (const monitor of monitors) {
         /*
@@ -230,32 +227,14 @@ export class FetchListAndProbe {
          * monitor implementation that never settles keeps this
          * Promise.allSettled — and therefore this worker — pending forever.
          */
-        probeMonitorPromises.push(probeMonitorWithDeadline(monitor));
+        probeMonitorPromises.push(this.probeAndLogMonitor(monitor));
       }
 
-      // all settled
-      // eslint-disable-next-line no-undef
-      const results: PromiseSettledResult<(ProbeMonitorResponse | null)[]>[] =
-        await Promise.allSettled(probeMonitorPromises);
-
-      let resultIndex: number = 0;
-
-      for (const result of results) {
-        if (monitors && monitors[resultIndex]) {
-          logger.debug("Monitor:");
-          logger.debug(monitors[resultIndex]);
-        }
-
-        if (result.status === "rejected") {
-          logger.error("Error in probing monitor:");
-          logger.error(result.reason);
-        } else {
-          logger.debug("Probed monitor: ");
-          logger.debug(result.value);
-        }
-
-        resultIndex++;
-      }
+      /*
+       * Each task consumes its result/error immediately and resolves void,
+       * so waiting for a slow check cannot retain other checks' payloads.
+       */
+      await Promise.allSettled(probeMonitorPromises);
     } catch (err) {
       logger.error("Error in fetching monitor list");
       logger.error(err);
@@ -264,6 +243,19 @@ export class FetchListAndProbe {
         logger.error("API Exception Error");
         logger.error(JSON.stringify((err as APIException).error, null, 2));
       }
+    }
+  }
+
+  private async probeAndLogMonitor(monitor: Monitor): Promise<void> {
+    try {
+      await probeMonitorWithDeadline(monitor);
+      logger.debug(`Probed monitor ${monitor.id?.toString()}`);
+    } catch (err) {
+      logger.error("Error in probing monitor:");
+      logger.error(err);
+    } finally {
+      logger.debug("Monitor:");
+      logger.debug(monitor);
     }
   }
 }

--- a/Probe/Tests/Jobs/Monitor/FetchListGuardAndDeadline.test.ts
+++ b/Probe/Tests/Jobs/Monitor/FetchListGuardAndDeadline.test.ts
@@ -44,7 +44,6 @@ jest.mock("Common/Server/Utils/BasicCron", () => {
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorType from "Common/Types/Monitor/MonitorType";
 import ObjectID from "Common/Types/ObjectID";
-import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
 import Sleep from "Common/Types/Sleep";
 import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
@@ -125,7 +124,7 @@ beforeEach(() => {
   fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: [] } as never);
   probeSpy = jest
     .spyOn(MonitorUtil, "probeMonitor")
-    .mockResolvedValue([] as never);
+    .mockResolvedValue(undefined as never);
   errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {
     // Keep test output clean; asserted on where it matters.
   });
@@ -147,7 +146,7 @@ describe("monitor probing — per-check deadline", () => {
   });
 
   test("a check that never settles is abandoned at the deadline instead of pending forever", async () => {
-    probeSpy.mockReturnValue(neverSettles<Array<ProbeMonitorResponse>>());
+    probeSpy.mockReturnValue(neverSettles<void>());
 
     const startedAt: number = Date.now();
 
@@ -169,18 +168,15 @@ describe("monitor probing — per-check deadline", () => {
     );
   });
 
-  test("a check that finishes in time returns its results and clears its deadline timer", async () => {
-    const response: Array<ProbeMonitorResponse> = [
-      { monitorId: monitorIdOne } as unknown as ProbeMonitorResponse,
-    ];
-    probeSpy.mockResolvedValue(response as never);
+  test("a check that finishes in time returns no payload and clears its deadline timer", async () => {
+    probeSpy.mockResolvedValue(undefined as never);
 
     // eslint-disable-next-line @typescript-eslint/typedef
     const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
 
     await expect(
       probeMonitorWithDeadline(makeMonitor(monitorIdOne), 150),
-    ).resolves.toBe(response);
+    ).resolves.toBeUndefined();
 
     /*
      * The deadline timer must be cleared on the success path too: one
@@ -209,16 +205,12 @@ describe("monitor probing — per-check deadline", () => {
       ],
     } as never);
 
-    const healthyResponse: Array<ProbeMonitorResponse> = [
-      { monitorId: monitorIdTwo } as unknown as ProbeMonitorResponse,
-    ];
-
     probeSpy.mockImplementation((monitor: Monitor): Promise<never> => {
       if (monitor.id?.toString() === monitorIdOne.toString()) {
         // The wedged implementation — no timeout of its own, ever.
         return neverSettles<never>();
       }
-      return Promise.resolve(healthyResponse) as unknown as Promise<never>;
+      return Promise.resolve() as unknown as Promise<never>;
     });
 
     const startedAt: number = Date.now();
@@ -358,5 +350,144 @@ describe("monitor fetch-list cron — per-slot in-flight guard", () => {
      * returns, so node-cron is never held by a probing cycle.
      */
     await expect(runFunction()).resolves.toBeUndefined();
+  });
+});
+
+describe("monitor batch completion logging", () => {
+  beforeEach(() => {
+    fetchSpy.mockResolvedValue({
+      data: [
+        { _id: monitorIdOne.toString(), monitorType: MonitorType.Website },
+        { _id: monitorIdTwo.toString(), monitorType: MonitorType.Website },
+      ],
+    } as never);
+  });
+
+  test("logs a completed monitor while another check is still pending", async () => {
+    let finishSlowCheck: () => void = (): void => {};
+    const slowCheck: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        finishSlowCheck = resolve;
+      },
+    );
+    probeSpy.mockReturnValueOnce(slowCheck);
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {});
+    let completed: boolean = false;
+    const run: Promise<void> = new FetchListAndProbe("Worker 1")
+      .run()
+      .then(() => {
+        completed = true;
+      });
+
+    try {
+      await flushMicrotasks();
+      expect(probeSpy).toHaveBeenCalledTimes(2);
+      expect(completed).toBe(false);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Probed monitor ${monitorIdTwo.toString()}`,
+      );
+      expect(debugSpy).not.toHaveBeenCalledWith(
+        `Probed monitor ${monitorIdOne.toString()}`,
+      );
+    } finally {
+      finishSlowCheck();
+      await run;
+    }
+    expect(debugSpy).toHaveBeenCalledWith(
+      `Probed monitor ${monitorIdOne.toString()}`,
+    );
+  });
+
+  test("reports a failed monitor immediately and still waits for another check", async () => {
+    let finishSlowCheck: () => void = (): void => {};
+    const slowCheck: Promise<void> = new Promise<void>(
+      (resolve: () => void) => {
+        finishSlowCheck = resolve;
+      },
+    );
+    const failure: Error = new Error("failed check with response context");
+    probeSpy.mockRejectedValueOnce(failure);
+    probeSpy.mockReturnValueOnce(slowCheck);
+    let completed: boolean = false;
+    const run: Promise<void> = new FetchListAndProbe("Worker 1")
+      .run()
+      .then(() => {
+        completed = true;
+      });
+
+    try {
+      await flushMicrotasks();
+      expect(completed).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(failure);
+      expect(errorSpy).toHaveBeenCalledWith("Error in probing monitor:");
+    } finally {
+      finishSlowCheck();
+      await run;
+    }
+    expect(completed).toBe(true);
+  });
+
+  test("starts every check in a large batch without serializing monitoring", async () => {
+    const monitorCount: number = 200;
+    fetchSpy.mockResolvedValue({
+      data: Array.from({ length: monitorCount }, () => {
+        return {
+          _id: ObjectID.generate().toString(),
+          monitorType: MonitorType.Website,
+        };
+      }),
+    } as never);
+    const finishChecks: Array<() => void> = [];
+    probeSpy.mockImplementation(() => {
+      return new Promise<void>((resolve: () => void) => {
+        finishChecks.push(resolve);
+      });
+    });
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {});
+    const run: Promise<void> = new FetchListAndProbe("Worker 1").run();
+
+    try {
+      await flushMicrotasks();
+      expect(probeSpy).toHaveBeenCalledTimes(monitorCount);
+      expect(finishChecks).toHaveLength(monitorCount);
+    } finally {
+      for (const finish of finishChecks.reverse()) {
+        finish();
+      }
+      await run;
+    }
+
+    expect(
+      debugSpy.mock.calls.filter(
+        ([message]: Parameters<typeof logger.debug>) => {
+          return (
+            typeof message === "string" && message.startsWith("Probed monitor ")
+          );
+        },
+      ),
+    ).toHaveLength(monitorCount);
+  });
+
+  test("a rejection after the deadline remains observed", async () => {
+    let rejectCheck: (error: Error) => void = (): void => {};
+    probeSpy.mockImplementationOnce(() => {
+      return new Promise<void>(
+        (_resolve: () => void, reject: (reason?: unknown) => void) => {
+          rejectCheck = reject;
+        },
+      );
+    });
+
+    await expect(
+      probeMonitorWithDeadline(makeMonitor(monitorIdOne), 10),
+    ).rejects.toThrow("exceeded the 10ms deadline");
+    rejectCheck(new Error("late failure"));
+    await flushMicrotasks();
+    /*
+     * Jest treats an unobserved rejection as a test failure. The deadline
+     * must continue observing the underlying check after releasing its slot.
+     */
   });
 });

--- a/Probe/Tests/Utils/Monitors/MonitorResponseLifetime.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorResponseLifetime.test.ts
@@ -1,0 +1,304 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import MonitorUtil from "../../../Utils/Monitors/Monitor";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorTest from "Common/Models/DatabaseModels/MonitorTest";
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
+import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
+import HTTPMethod from "Common/Types/API/HTTPMethod";
+import API from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import TelemetryContext from "Common/Server/Utils/Telemetry/TelemetryContext";
+
+type ProbeStepInput = Parameters<typeof MonitorUtil.probeMonitorStep>[0];
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = (): void => {};
+  const promise: Promise<T> = new Promise<T>(
+    (resolvePromise: (value: T | PromiseLike<T>) => void) => {
+      resolve = resolvePromise;
+    },
+  );
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+function makeMonitor(stepCount: number = 2): Monitor {
+  const monitorSteps: MonitorSteps = new MonitorSteps();
+  monitorSteps.setMonitorStepsInstanceArray(
+    Array.from({ length: stepCount }, () => {
+      return new MonitorStep();
+    }),
+  );
+  return {
+    id: ObjectID.generate(),
+    projectId: ObjectID.generate(),
+    monitorType: MonitorType.Website,
+    monitorSteps,
+  } as Monitor;
+}
+
+function makeResponse(
+  data: Parameters<typeof MonitorUtil.probeMonitorStep>[0],
+): ProbeMonitorResponse {
+  return {
+    monitorId: data.monitorId,
+    projectId: data.projectId,
+    monitorStepId: data.monitorStep.id,
+    probeId: new ObjectID("11111111-2222-3333-4444-555555555555"),
+    monitoredAt: new Date(),
+    isOnline: true,
+    failureCause: "",
+    responseBody: "response body",
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let stepSpy = jest.spyOn(MonitorUtil, "probeMonitorStep");
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+// eslint-disable-next-line @typescript-eslint/typedef
+let debugSpy = jest.spyOn(logger, "debug");
+
+beforeEach(() => {
+  stepSpy = jest
+    .spyOn(MonitorUtil, "probeMonitorStep")
+    .mockImplementation(
+      async (data: ProbeStepInput): Promise<ProbeMonitorResponse> => {
+        return makeResponse(data);
+      },
+    );
+  fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: {} } as never);
+  debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {});
+  jest.spyOn(logger, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("periodic monitor response lifetime", () => {
+  test("ingests every step and resolves without retaining response bodies", async () => {
+    const monitor: Monitor = makeMonitor();
+
+    await expect(MonitorUtil.probeMonitor(monitor)).resolves.toBeUndefined();
+
+    expect(stepSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (let index: number = 0; index < 2; index++) {
+      const request: Parameters<typeof API.fetch>[0] =
+        fetchSpy.mock.calls[index]![0];
+      expect(request.method).toBe(HTTPMethod.POST);
+      expect(request.url.toString()).toBe(
+        "https://oneuptime.example.com/probe-ingest/probe/response/ingest",
+      );
+      expect(request.data).toMatchObject({
+        probeKey: "test-probe-key",
+        probeId: "11111111-2222-3333-4444-555555555555",
+        probeMonitorResponse: {
+          monitorId: monitor.id,
+          monitorStepId:
+            monitor.monitorSteps!.data!.monitorStepsInstanceArray[index]!.id,
+          responseBody: "response body",
+        },
+      });
+      expect(request.options?.timeout).toBe(45000);
+      expect(request.options?.onRequestComplete).toEqual(expect.any(Function));
+    }
+  });
+
+  test("logs an ingested step before a later step finishes", async () => {
+    const nextStep: Deferred<ProbeMonitorResponse | null> =
+      deferred<ProbeMonitorResponse | null>();
+    stepSpy.mockImplementationOnce(async (data: ProbeStepInput) => {
+      return makeResponse(data);
+    });
+    stepSpy.mockReturnValueOnce(nextStep.promise);
+
+    let completed: boolean = false;
+    const run: Promise<void> = MonitorUtil.probeMonitor(makeMonitor()).then(
+      () => {
+        completed = true;
+      },
+    );
+    await flushMicrotasks();
+
+    expect(completed).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ responseBody: "response body" }),
+    );
+
+    nextStep.resolve(null);
+    await run;
+    expect(completed).toBe(true);
+  });
+
+  test("awaits ingestion before logging or starting the following step", async () => {
+    const ingest: Deferred<never> = deferred<never>();
+    fetchSpy.mockReturnValueOnce(ingest.promise);
+    const run: Promise<void> = MonitorUtil.probeMonitor(makeMonitor());
+    await flushMicrotasks();
+
+    expect(stepSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).not.toHaveBeenCalledWith("Probed monitor step:");
+
+    ingest.resolve({ data: {} } as never);
+    await run;
+    expect(stepSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("null step responses are not ingested and do not block later steps", async () => {
+    stepSpy.mockResolvedValueOnce(null);
+
+    await expect(
+      MonitorUtil.probeMonitor(makeMonitor()),
+    ).resolves.toBeUndefined();
+
+    expect(stepSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith(null);
+  });
+
+  test.each(["missing", "empty"])(
+    "a monitor with %s steps returns no payload",
+    async (scenario: string) => {
+      const monitor: Monitor = makeMonitor(0);
+      if (scenario === "missing") {
+        delete monitor.monitorSteps;
+      }
+
+      await expect(MonitorUtil.probeMonitor(monitor)).resolves.toBeUndefined();
+
+      expect(stepSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("skips missing step entries while ingesting the remaining steps", async () => {
+    const monitor: Monitor = makeMonitor(1);
+    monitor.monitorSteps!.data!.monitorStepsInstanceArray.unshift(
+      null as unknown as MonitorStep,
+    );
+
+    await MonitorUtil.probeMonitor(monitor);
+
+    expect(stepSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a thrown check as offline and continues through later steps", async () => {
+    const monitor: Monitor = makeMonitor();
+    stepSpy.mockRejectedValueOnce(new Error("check failed"));
+
+    await expect(MonitorUtil.probeMonitor(monitor)).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0]![0].data).toMatchObject({
+      probeMonitorResponse: {
+        monitorId: monitor.id,
+        isOnline: false,
+        failureCause: "check failed",
+      },
+    });
+    expect(fetchSpy.mock.calls[1]![0].data).toMatchObject({
+      probeMonitorResponse: { isOnline: true },
+    });
+    expect(logger.error).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test("propagates an ingest failure and does not start further steps", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("ingest unavailable"));
+
+    await expect(MonitorUtil.probeMonitor(makeMonitor())).rejects.toThrow(
+      "ingest unavailable",
+    );
+
+    expect(stepSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).not.toHaveBeenCalledWith("Probed monitor step:");
+  });
+
+  test("keeps monitor and project context around checking and ingesting", async () => {
+    const monitor: Monitor = makeMonitor(1);
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const contextSpy = jest.spyOn(TelemetryContext, "runWithContext");
+
+    await MonitorUtil.probeMonitor(monitor);
+
+    expect(contextSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        monitorId: monitor.id!.toString(),
+        projectId: monitor.projectId!.toString(),
+        monitorType: MonitorType.Website,
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test("a large batch of multi-step checks returns only completion signals", async () => {
+    const monitorCount: number = 100;
+    const stepsPerMonitor: number = 4;
+    stepSpy.mockImplementation(async (data: ProbeStepInput) => {
+      return {
+        ...makeResponse(data),
+        responseBody: data.monitorId.toString() + "x".repeat(64 * 1024),
+      };
+    });
+
+    const completions: Array<void> = await Promise.all(
+      Array.from({ length: monitorCount }, () => {
+        return MonitorUtil.probeMonitor(makeMonitor(stepsPerMonitor));
+      }),
+    );
+
+    /*
+     * Completed promises must not keep 400 bodies alive in the worker's
+     * pending batch while a different check waits for its deadline.
+     */
+    expect(completions).toEqual(Array.from({ length: monitorCount }));
+    expect(fetchSpy).toHaveBeenCalledTimes(monitorCount * stepsPerMonitor);
+    expect(stepSpy).toHaveBeenCalledTimes(monitorCount * stepsPerMonitor);
+  });
+
+  test("interactive monitor tests still return their original results", async () => {
+    const monitor: Monitor = makeMonitor();
+    stepSpy.mockResolvedValueOnce(null);
+
+    const results: Array<ProbeMonitorResponse | null> =
+      await MonitorUtil.probeMonitorTest(monitor as unknown as MonitorTest);
+
+    expect(results).toEqual([
+      null,
+      expect.objectContaining({ responseBody: "response body" }),
+    ]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]![0].url.toString()).toContain(
+      "/probe/response/monitor-test-ingest/" + monitor.id!.toString(),
+    );
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -216,9 +216,7 @@ export default class MonitorUtil {
     return results;
   }
 
-  public static async probeMonitor(
-    monitor: Monitor,
-  ): Promise<Array<ProbeMonitorResponse | null>> {
+  public static async probeMonitor(monitor: Monitor): Promise<void> {
     /*
      * Seed telemetry context so every span/log for this check carries the
      * monitor + project identity.
@@ -243,17 +241,13 @@ export default class MonitorUtil {
     );
   }
 
-  private static async probeMonitorInternal(
-    monitor: Monitor,
-  ): Promise<Array<ProbeMonitorResponse | null>> {
-    const results: Array<ProbeMonitorResponse | null> = [];
-
+  private static async probeMonitorInternal(monitor: Monitor): Promise<void> {
     if (
       !monitor.monitorSteps ||
       monitor.monitorSteps.data?.monitorStepsInstanceArray.length === 0
     ) {
       logger.debug("No monitor steps found");
-      return [];
+      return;
     }
 
     for (const monitorStep of monitor.monitorSteps.data
@@ -317,10 +311,14 @@ export default class MonitorUtil {
         });
       }
 
-      results.push(result);
+      /*
+       * The response has already been ingested. Log it now and release it
+       * before the next step, rather than keeping every body/screenshot in
+       * an array until the slowest monitor in the worker's batch finishes.
+       */
+      logger.debug("Probed monitor step:");
+      logger.debug(result);
     }
-
-    return results;
   }
 
   public static isHeadRequest(monitorStep: MonitorStep): boolean {

--- a/Probe/scripts/benchmark-response-lifetime.js
+++ b/Probe/scripts/benchmark-response-lifetime.js
@@ -1,0 +1,176 @@
+/*
+ * Isolated heap benchmark for the periodic monitor response lifecycle.
+ * Run from the repository root with the supported Node runtime:
+ *
+ *   node --expose-gc Probe/scripts/benchmark-response-lifetime.js
+ *
+ * The optional argument selects another Monitor.ts source. To compare with
+ * master before this change is merged, extract the baseline without changing
+ * the checkout, then run it in a separate process:
+ *
+ *   git show master:Probe/Utils/Monitors/Monitor.ts > /tmp/oneuptime-monitor-before.ts
+ *   node --expose-gc Probe/scripts/benchmark-response-lifetime.js /tmp/oneuptime-monitor-before.ts
+ *
+ * After merging, replace master in the extraction command with the commit
+ * preceding the response-lifetime change (for example, the merge's first
+ * parent). Each run transpiles the selected source and uses its actual
+ * probeMonitor implementation. Monitor I/O, logging and telemetry context
+ * are stubbed; no network connections or production resources are used.
+ *
+ * All 100 monitors ingest a 512 KiB first-step body, then wait on a second
+ * step. After forced garbage collection, WeakRefs show how many ingested
+ * responses remain reachable while those monitors are still pending. Heap
+ * deltas isolate this workload and are not estimates of total production
+ * memory savings. Run before and after in separate processes; exact heap
+ * values vary with Node/V8 versions.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const ts = require("typescript");
+
+if (typeof global.gc !== "function") {
+  throw new Error("Run this benchmark with node --expose-gc.");
+}
+
+const monitorCount = 100;
+const responseBodyBytes = 512 * 1024;
+const sourcePath = path.resolve(
+  process.argv[2] || path.join(__dirname, "../Utils/Monitors/Monitor.ts"),
+);
+const source = fs.readFileSync(sourcePath, "utf8");
+const code = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+    esModuleInterop: true,
+  },
+}).outputText;
+
+const url = {
+  toString: () => "https://example.test",
+  addRoute() {
+    return this;
+  },
+};
+let ingested = 0;
+const overrides = {
+  "../../Config": { PROBE_INGEST_URL: url },
+  "../Probe": { getProbeId: () => "probe" },
+  "../ProbeAPIRequest": {
+    getDefaultRequestBody: () => ({}),
+    getDefaultRequestOptions: () => ({}),
+  },
+  "Common/Types/API/URL": { fromString: () => url },
+  "Common/Types/API/HTTPMethod": { POST: "POST" },
+  "Common/Utils/API": {
+    fetch: async () => {
+      ingested++;
+    },
+  },
+  "Common/Server/Utils/Logger": { debug() {}, error() {} },
+  "Common/Server/Utils/Telemetry/TelemetryContext": {
+    runWithContext: (_attributes, fn) => fn(),
+  },
+  "Common/Types/Telemetry/UnitOfWork": {
+    UnitOfWork: { ProbeCheck: "check" },
+    TelemetryComponent: { Probe: "probe" },
+  },
+};
+const sandbox = {
+  exports: {},
+  require: (name) => overrides[name] || {},
+  process,
+};
+vm.runInNewContext(code, sandbox, { filename: sourcePath });
+const MonitorUtil = sandbox.exports.default;
+const references = [];
+const finishChecks = [];
+
+MonitorUtil.probeMonitorStep = async ({ monitorStep, monitorId }) => {
+  if (monitorStep.id === "second") {
+    return new Promise((resolve) => {
+      finishChecks.push(() => resolve(null));
+    });
+  }
+
+  const response = {
+    monitorId,
+    // Materialize a flat string so V8 cannot represent the body as a cheap
+    // repeated-string node. Hex encoding doubles the allocated byte count.
+    responseBody: Buffer.alloc(
+      responseBodyBytes / 2,
+      monitorId.charCodeAt(0),
+    ).toString("hex"),
+  };
+  references.push(new WeakRef(response));
+  return response;
+};
+
+async function nextTurn() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function main() {
+  // Let temporary transpiler/module-loading allocations become collectible
+  // before the baseline, using the same collection cadence as the result.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    global.gc();
+    await nextTurn();
+  }
+  const before = process.memoryUsage().heapUsed;
+  const runs = Array.from({ length: monitorCount }, (_, index) => {
+    return MonitorUtil.probeMonitor({
+      id: String(index),
+      projectId: "project",
+      monitorType: "Website",
+      monitorSteps: {
+        data: {
+          monitorStepsInstanceArray: [{ id: "first" }, { id: "second" }],
+        },
+      },
+    });
+  });
+
+  try {
+    await nextTurn();
+    if (ingested !== monitorCount || finishChecks.length !== monitorCount) {
+      throw new Error("The selected source did not reach the expected pending state.");
+    }
+
+    // WeakRefs keep targets alive for the current JS job. Yield before GC
+    // and between attempts, and only dereference once measurements are done.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      global.gc();
+      await nextTurn();
+    }
+    const heapDeltaMiB =
+      (process.memoryUsage().heapUsed - before) / 1024 / 1024;
+    const retained = references.filter((reference) => {
+      return reference.deref() !== undefined;
+    }).length;
+
+    console.log(
+      JSON.stringify({
+        sourcePath,
+        monitorCount,
+        responseBodyBytes,
+        completedStepResponses: ingested,
+        stillPendingMonitors: finishChecks.length,
+        retainedResponseObjects: retained,
+        heapDeltaMiB: Number(heapDeltaMiB.toFixed(2)),
+      }),
+    );
+  } finally {
+    for (const finish of finishChecks) {
+      finish();
+    }
+    await Promise.all(runs);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
High-volume telemetry and monitor work repeatedly allocated configurations, retained already-ingested response bodies, and launched whole-fleet heartbeat evaluations. This change removes those costs and cleans up completed queue-job deadline timers.

## Changes

- Reuse normalized log/trace processor configurations and compiled category filters. Weak ownership follows the existing processor cache lifetime; configuration replacement invalidates immediately.
- Page request, email, and server heartbeat sweeps in groups of 100 with at most 10 active evaluations. Await completion and hold a renewing Redis lease to prevent overlapping sweeps across workers. Preserve heartbeat payloads and server freshness rechecks.
- Release periodic probe responses after ingestion, including earlier steps and completed monitors in mixed-speed batches. Preserve interactive test results, deadline handling, and worker guards.
- Clear queue deadline timers on success, asynchronous rejection, synchronous failure, and timeout.
- Add reproducible benchmarks and an audit with follow-up recommendations in `Internal/Performance/RuntimeResourceUsage.md`.

## Measured effects

On Node 26.5.1:

- Configuration/category-filter benchmark, 100,000 records and eight categories: median CPU **3,775.37 ms → 167.34 ms** across five rounds (95.6% less in this isolated path); parses **100,000 → 1**, filter compilations **800,000 → 8**, identical matches.
- Response-retention benchmark, 100 pending two-step monitors with already-ingested 512 KiB responses: retained response objects **100 → 0**, additional live heap **50.21 MiB → 0.14 MiB** in the recorded run.

These are isolated measurements, not estimates of total production CPU/RAM savings. Heap measurements vary between runs.

## Validation

- **222 targeted tests passed across 16 suites**, including 94 added cases: configuration/cache lifecycle and tenant isolation; 1,003-monitor pagination; concurrency and overlapping ticks; probe ingestion/deadlines; and 10,000 completed queue jobs without retained timers.
- `npm run compile` passed in **Common, App, and Probe**, using Node 26.5.1.
- Repository-wide `npm run fix` passed; all changed code is lint-clean.
- `git diff --check` passed.
- Independent cross-review of the telemetry cache, sweep pagination/locking, timer cleanup, and benchmark claims found no remaining actionable issues.

## Operational considerations

The sweep cap reduces peak resource pressure but may increase full-sweep/detection latency during a large backlog. Never-checked incoming monitors remain first; ordering within each phase now follows immutable IDs. Monitor detection delay and queue duration alongside CPU, heap, and RSS during rollout.

No schema migration or deployment configuration change is required. Queue/probe deadlines still do not cancel underlying work. Tests exercised the isolated worktree; the existing development Compose stack mounts a different checkout, and no production-scale end-to-end load test is claimed.

Follow-up recommendations include coalescing telemetry cache misses, batching pipeline processor queries, and bounding on-call execution backlogs with separate escalation/idempotency regression coverage.
